### PR TITLE
Fix choppy playback

### DIFF
--- a/src/framework/audio/driver/platform/lin/alsaaudiodriver.cpp
+++ b/src/framework/audio/driver/platform/lin/alsaaudiodriver.cpp
@@ -39,29 +39,60 @@
 #include <cmath>
 #include <cstring>
 
-#define ALSA_REALTIME
+#define DEBUG_AUDIO
+// #define ALSA_REALTIME
+#define ALSA_POLL_MMAP
+// #define ALSA_PERIOD_EVENT
+// #define MIMIC_MASTER
+
+#ifdef DEBUG_AUDIO
+#define LOG_AUDIO LOGD
+#else
+#define LOG_AUDIO LOGN
+#endif
+
+#ifdef MIMIC_MASTER
+#undef ALSA_REALTIME
+#undef ALSA_POLL_MMAP
+#endif
+
+#ifdef ALSA_POLL_MMAP
+#undef ALSA_REALTIME
+#endif
+
+#ifndef ALSA_POLL_MMAP
+#undef ALSA_PERIOD_EVENT
+#endif
 
 using namespace muse;
 using namespace muse::audio;
 
 namespace {
+struct AlsaParams
+{
+    snd_pcm_access_t access;
+    snd_pcm_format_t format;
+    unsigned int channels;
+    unsigned int sampleRate;
+    snd_pcm_uframes_t periodSize;
+    unsigned int periods; // num periods in the ring buffer
+    snd_pcm_uframes_t ringBufferSize;
+};
+
 struct ALSAData
 {
-    float* buffer = nullptr;
     snd_pcm_t* alsaDeviceHandle = nullptr;
-    unsigned long samples = 0;
-    int channels = 0;
+    AlsaParams params;
     bool audioProcessingDone = false;
     pthread_t threadHandle = 0;
     IAudioDriver::Callback callback;
-    void* userdata = nullptr;
 };
 
 static ALSAData* s_alsaData{ nullptr };
 static muse::audio::IAudioDriver::Spec s_format;
 
 #ifdef ALSA_REALTIME
-static bool alsaAcquireRealtime(pthread_t th)
+static bool alsaAcquireRealtime(pthread_t th, const std::vector<float>& buffer)
 {
     const int min_prio = sched_get_priority_min(SCHED_FIFO);
     const int max_prio = sched_get_priority_max(SCHED_FIFO);
@@ -81,19 +112,396 @@ static bool alsaAcquireRealtime(pthread_t th)
         return false;
     }
 
-    // Pinning to RAM the data accessed during the realtime thread
+    // Pinning to RAM the buffer accessed during the realtime thread
     // (optional and require CAP_IPC_LOCK capability)
-    const auto bufLen = s_alsaData->samples * s_alsaData->channels;
-    if (mlock(reinterpret_cast<void*>(s_alsaData), sizeof(ALSAData))) {
-        LOGW() << "Could not lock ALSA data to RAM: " << strerror(errno);
-    }
-    if (mlock(reinterpret_cast<void*>(s_alsaData->buffer), bufLen * sizeof(float))) {
+    const void* addr = static_cast<const void*>(&buffer[0]);
+    const auto len = buffer.capacity() * sizeof(float);
+    if (mlock(addr, len)) {
         LOGW() << "Could not lock ALSA buffer to RAM: " << strerror(errno);
     }
 
     return true;
 }
+
 #endif
+
+static bool alsaConfigureDevice(snd_pcm_t* deviceHandle, AlsaParams& params)
+{
+    snd_pcm_hw_params_t* hwparams;
+    snd_pcm_hw_params_alloca(&hwparams);
+
+    int rc = snd_pcm_hw_params_any(deviceHandle, hwparams);
+    if (rc < 0) {
+        LOGE() << "Broken playback configuration. No configuration available: " << snd_strerror(rc);
+        return false;
+    }
+
+#ifdef ALSA_POLL_MMAP
+    const snd_pcm_access_t access = SND_PCM_ACCESS_MMAP_INTERLEAVED;
+#else
+    const snd_pcm_access_t access = SND_PCM_ACCESS_RW_INTERLEAVED;
+#endif
+
+    rc = snd_pcm_hw_params_set_access(deviceHandle, hwparams, access);
+    if (rc < 0) {
+        LOGE() << "Access type not available for playback: " << snd_strerror(rc);
+        return false;
+    }
+
+    rc = snd_pcm_hw_params_set_format(deviceHandle, hwparams, SND_PCM_FORMAT_FLOAT_LE);
+    if (rc < 0) {
+        LOGE() << "Sample format not available for playback: " << snd_strerror(rc);
+        return false;
+    }
+
+    rc = snd_pcm_hw_params_set_channels(deviceHandle, hwparams, params.channels);
+    if (rc < 0) {
+        LOGE() << "Channel count (" << params.channels << ") not available for playback: " << snd_strerror(rc);
+        return false;
+    }
+
+#ifdef MIMIC_MASTER
+    params.sampleRate = 48000;
+#endif
+
+    unsigned int rate = params.sampleRate;
+    rc = snd_pcm_hw_params_set_rate_near(deviceHandle, hwparams, &rate, nullptr);
+    if (rc < 0) {
+        LOGE() << "Sample rate " << params.sampleRate << "Hz not available for playback: " << snd_strerror(rc);
+        return false;
+    }
+    if (rate != params.sampleRate) {
+        LOGW() << "Sample rate doesn't match request. Requested " << params.sampleRate << "Hz, obtained " << rate << "Hz.";
+        params.sampleRate = rate;
+    }
+
+#ifdef MIMIC_MASTER
+    snd_pcm_hw_params_set_buffer_size_near(deviceHandle, hwparams, &params.periodSize);
+#else
+    rc = snd_pcm_hw_params_set_period_size_near(deviceHandle, hwparams, &params.periodSize, 0);
+    if (rc < 0) {
+        LOGE() << "Could not set period size (" << params.periodSize << "): " << snd_strerror(rc);
+        return false;
+    }
+
+    unsigned int nperiods = params.periods;
+    snd_pcm_hw_params_get_periods_min(hwparams, &nperiods, 0);
+    LOGI() << "nperiods: " << nperiods;
+    nperiods = std::max(params.periods, nperiods);
+
+    rc = snd_pcm_hw_params_set_periods_near(deviceHandle, hwparams, &nperiods, 0);
+    if (rc < 0) {
+        LOGE() << "Could not set periods (" << nperiods << "): " << snd_strerror(rc);
+        return false;
+    }
+    if (nperiods < params.periods) {
+        LOGE() << "Could not get requested periods";
+        return false;
+    }
+
+    params.ringBufferSize = nperiods * params.periodSize;
+    rc = snd_pcm_hw_params_set_buffer_size(deviceHandle, hwparams, params.ringBufferSize);
+    if (rc < 0) {
+        LOGE() << "Could not set ring buffer size (" << params.ringBufferSize << "): " << snd_strerror(rc);
+        return false;
+    }
+#endif // MIMIC_MASTER
+
+    rc = snd_pcm_hw_params(deviceHandle, hwparams);
+    if (rc < 0) {
+        LOGE() << "Could not set hardware parameters: " << snd_strerror(rc);
+        return false;
+    }
+
+#ifndef MIMIC_MASTER
+    snd_pcm_sw_params_t* swparams;
+    snd_pcm_sw_params_alloca(&swparams);
+
+    /* get the current swparams */
+    rc = snd_pcm_sw_params_current(deviceHandle, swparams);
+    if (rc < 0) {
+        LOGE() << "Unable to determine current swparams for playback: " << snd_strerror(rc);
+        return false;
+    }
+
+    rc = snd_pcm_sw_params_set_start_threshold(deviceHandle, swparams, params.periodSize);
+    if (rc < 0) {
+        LOGE() << "Unable to set start threshold for playback: " << snd_strerror(rc);
+        return false;
+    }
+
+    rc = snd_pcm_sw_params_set_stop_threshold(deviceHandle, swparams, params.ringBufferSize);
+    if (rc < 0) {
+        LOGE() << "Unable to set stop threshold for playback: " << snd_strerror(rc);
+        return false;
+    }
+
+    /* allow the transfer when at least period_size samples can be processed */
+    /* or disable this mechanism when period event is enabled (aka interrupt like style processing) */
+#ifdef ALSA_PERIOD_EVENT
+    const snd_pcm_uframes_t availMin = params.ringBufferSize;
+#else
+    const snd_pcm_uframes_t availMin = params.periodSize * (nperiods - params.periods + 1);
+#endif
+    rc = snd_pcm_sw_params_set_avail_min(deviceHandle, swparams, availMin);
+    if (rc < 0) {
+        LOGE() << "Unable to set avail min for playback: " << snd_strerror(rc);
+        return false;
+    }
+    params.periods = nperiods;
+
+    /* enable period events when requested */
+#ifdef ALSA_PERIOD_EVENT
+    rc = snd_pcm_sw_params_set_period_event(deviceHandle, swparams, 1);
+    if (rc < 0) {
+        LOGE() << "Unable to set period event for playback: " << snd_strerror(rc);
+        return false;
+    }
+#endif //ALSA_PERIOD_EVENT
+
+    /* write the parameters to the playback device */
+    rc = snd_pcm_sw_params(deviceHandle, swparams);
+    if (rc < 0) {
+        LOGE() << "Unable to set sw params for playback: " << snd_strerror(rc);
+        return false;
+    }
+#endif // MIMIC_MASTER
+
+    return true;
+}
+
+/*
+ *   Underrun and suspend recovery
+ */
+static int xrunRecovery(snd_pcm_t* deviceHandle, int err)
+{
+    LOG_AUDIO() << "xrun recovery";
+
+    if (err == -EPIPE) {   /* under-run */
+        err = snd_pcm_prepare(deviceHandle);
+        if (err < 0) {
+            LOGE() << "Can't recovery from underrun, prepare failed: " << snd_strerror(err);
+        }
+        return 0;
+    } else if (err == -ESTRPIPE) {
+        // hardware is suspended, possibly due to low battery
+        while ((err = snd_pcm_resume(deviceHandle)) == -EAGAIN) {
+            sleep(1);       /* wait until the suspend flag is released */
+        }
+        if (err < 0) {
+            err = snd_pcm_prepare(deviceHandle);
+            if (err < 0) {
+                LOGE() << "Can't recovery from suspend, prepare failed: " << snd_strerror(err);
+            }
+        }
+        return 0;
+    }
+    return err;
+}
+
+#ifdef ALSA_POLL_MMAP
+
+// returns true if success
+static bool waitForPoll(snd_pcm_t* deviceHandle, struct pollfd* ufds,
+                        unsigned int count)
+{
+    unsigned short revents;
+
+    while (true) {
+        poll(ufds, count, -1);
+        snd_pcm_poll_descriptors_revents(deviceHandle, ufds, count, &revents);
+
+        if (revents & POLLERR) {
+            const auto state = snd_pcm_state(deviceHandle);
+            switch (state) {
+            case SND_PCM_STATE_XRUN:
+                xrunRecovery(deviceHandle, -EPIPE);
+                break;
+            case SND_PCM_STATE_SUSPENDED:
+                xrunRecovery(deviceHandle, -ESTRPIPE);
+                break;
+            default:
+                break;
+            }
+            return false;
+        }
+
+        if (revents & POLLOUT) {
+            return true;
+        }
+    }
+}
+
+static void alsaPollLoop(ALSAData* data)
+{
+    auto deviceHandle = data->alsaDeviceHandle;
+    auto callback = data->callback;
+    const auto periodSize = data->params.periodSize;
+    const auto channels = data->params.channels;
+
+    const auto count = snd_pcm_poll_descriptors_count(deviceHandle);
+    if (count <= 0) {
+        LOGE() << "Invalid poll descriptors count";
+        return;
+    }
+    auto ufds = std::vector<struct pollfd>(count);
+
+    int err = snd_pcm_poll_descriptors(deviceHandle, &ufds[0], count);
+    if (err < 0) {
+        LOGE() << "Unable to obtain poll descriptors for playback: " << snd_strerror(err);
+        return;
+    }
+
+    err = snd_pcm_prepare(deviceHandle);
+    if (err < 0) {
+        LOGE() << "Unable to prepare device: " << snd_strerror(err);
+        return;
+    }
+
+    const auto avail = snd_pcm_avail_update(deviceHandle);
+    if (static_cast<snd_pcm_uframes_t>(avail) != data->params.ringBufferSize) {
+        LOGE() << "Full buffer not available at start";
+        return;
+    }
+
+    const snd_pcm_channel_area_t* areas = nullptr;
+    snd_pcm_uframes_t offset = 0;
+    snd_pcm_uframes_t frames = avail;
+    snd_pcm_mmap_begin(deviceHandle, &areas, &offset, &frames);
+
+    // Double check the area
+    const void* expectedAddr = areas[0].addr;
+    unsigned int expectedFirst = 0;
+    const unsigned expectedStep = sizeof(float) * 8 * channels;
+    for (unsigned int c = 0; c < channels; c++) {
+        if (areas[c].first != expectedFirst || areas[c].step != expectedStep || areas[c].addr != expectedAddr) {
+            LOGE() << "MMAP areas mismatch, not interleaved as expected";
+            return;
+        }
+        expectedFirst += sizeof(float) * 8;
+    }
+
+    // Zero the buffer
+    float* addr = static_cast<float*>(areas[0].addr) + offset * channels;
+    size_t bytes = frames * channels * sizeof(float);
+    std::memset(addr, 0, bytes);
+
+    snd_pcm_mmap_commit(deviceHandle, offset, frames);
+
+    if ((err = snd_pcm_start(deviceHandle)) < 0) {
+        LOGE() << "Unable to start device: " << snd_strerror(err);
+        return;
+    }
+
+    bool restartPcm = false;
+
+    // Start the loop
+    while (!data->audioProcessingDone) {
+        const auto avail = snd_pcm_avail_update(deviceHandle);
+        if (avail < 0) {
+            xrunRecovery(deviceHandle, avail);
+            continue;
+        }
+        if (static_cast<snd_pcm_uframes_t>(avail) < periodSize) {
+            if (restartPcm) {
+                snd_pcm_start(deviceHandle);
+            }
+            waitForPoll(deviceHandle, &ufds[0], count);
+            continue;
+        }
+
+        frames = periodSize;
+        while (frames) {
+            snd_pcm_uframes_t contiguous = frames;
+            if ((err = snd_pcm_mmap_begin(deviceHandle, &areas, &offset, &contiguous)) < 0) {
+                xrunRecovery(deviceHandle, err);
+                restartPcm = true;
+                break;
+            };
+
+            uint8_t* stream = reinterpret_cast<uint8_t*>(areas[0].addr) + offset * channels * sizeof(float);
+            const auto len = contiguous * channels * sizeof(float);
+
+            callback(stream, len);
+
+            snd_pcm_sframes_t commitres = snd_pcm_mmap_commit(deviceHandle, offset, contiguous);
+            if (commitres < 0) {
+                xrunRecovery(deviceHandle, static_cast<int>(commitres));
+                restartPcm = true;
+                break;
+            }
+            frames -= contiguous;
+        }
+
+
+    //     snd_pcm_uframes_t frames = periodSize;
+
+    //     while (frames > 0) {
+    //         const auto rc = snd_pcm_writei(deviceHandle, ptr, frames);
+    //         if (rc < 0) {
+    //             xrunRecovery(deviceHandle, rc);
+    //             break;
+    //         }
+    //         frames -= rc;
+    //         ptr += rc * channels;
+
+    //         if (frames == 0) {
+    //             break;
+    //         }
+
+    //         waitForPoll(deviceHandle, &ufds[0], count);
+    //     }
+
+    //     if (snd_pcm_state(deviceHandle) == SND_PCM_STATE_RUNNING) {
+    //         waitForPoll(deviceHandle, &ufds[0], count);
+    //     }
+    }
+}
+
+#else // ALSA_POLL_MMAP
+
+void alsaWriteLoop(ALSAData* data, std::vector<float> buffer)
+{
+    auto callback = data->callback;
+    auto userdata = data->userdata;
+    auto deviceHandle = data->alsaDeviceHandle;
+    const auto periodSize = data->params.periodSize;
+    const auto channels = data->params.channels;
+
+#ifdef ALSA_REALTIME
+    if (!alsaAcquireRealtime(data->threadHandle, buffer)) {
+        LOGW() << "Could not acquire realtime priority";
+    } else {
+        LOGI() << "Successfully acquired realtime priority";
+    }
+#endif
+
+    while (!data->audioProcessingDone) {
+        uint8_t* stream = reinterpret_cast<uint8_t*>(&buffer[0]);
+        const auto len = buffer.size() * sizeof(float);
+
+        callback(userdata, stream, len);
+
+        snd_pcm_uframes_t frames = periodSize;
+        float* ptr = &buffer[0];
+
+        while (frames > 0) {
+            const auto rc = snd_pcm_writei(deviceHandle, ptr, frames);
+            if (rc < 0) {
+                xrunRecovery(deviceHandle, rc);
+                break;
+            }
+            frames -= rc;
+            ptr += rc * channels;
+
+            if (frames == 0) {
+                break;
+            }
+        }
+    }
+}
+
+#endif // ALSA_POLL_MMAP
 
 static void* alsaThread(void* aParam)
 {
@@ -105,33 +513,15 @@ static void* alsaThread(void* aParam)
         return nullptr;
     }
 
-#ifdef ALSA_REALTIME
-    if (!alsaAcquireRealtime(data->threadHandle)) {
-        LOGW() << "Could not acquire realtime priority";
-    } else {
-        LOGI() << "Successfully acquired realtime priority";
-    }
+
+#ifdef ALSA_POLL_MMAP
+    alsaPollLoop(data);
+#else
+    auto buffer = std::vector<float>(data->params.periodSize * data->params.channels);
+    alsaWriteLoop(data, std::move(buffer));
 #endif
 
-    while (!data->audioProcessingDone)
-    {
-        uint8_t* stream = (uint8_t*)data->buffer;
-        int len = data->samples * data->channels * sizeof(float);
-
-        data->callback(stream, len);
-
-        snd_pcm_uframes_t frames = data->samples;
-        while (frames > 0) {
-            auto ret = snd_pcm_writei(data->alsaDeviceHandle, data->buffer, frames);
-            if (ret == -EPIPE) {
-                snd_pcm_prepare(data->alsaDeviceHandle);
-                break;
-            }
-            frames -= ret;
-        }
-    }
-
-    LOGI() << "exit";
+    LOGI() << "Exiting ALSA thread";
     return nullptr;
 }
 
@@ -148,10 +538,6 @@ static void alsaCleanup()
     if (nullptr != s_alsaData->alsaDeviceHandle) {
         snd_pcm_drain(s_alsaData->alsaDeviceHandle);
         snd_pcm_close(s_alsaData->alsaDeviceHandle);
-    }
-
-    if (nullptr != s_alsaData->buffer) {
-        delete[] s_alsaData->buffer;
     }
 
     delete s_alsaData;
@@ -195,70 +581,29 @@ bool AlsaAudioDriver::open(const Spec& spec, Spec* activeSpec)
         return false;
     }
 
-    s_alsaData = new ALSAData();
-    s_alsaData->samples = spec.output.samplesPerChannel;
-    s_alsaData->channels = spec.output.audioChannelCount;
+    snd_pcm_t* deviceHandle;
+    int rc = snd_pcm_open(&deviceHandle, spec.deviceId.c_str(), SND_PCM_STREAM_PLAYBACK, 0);
+    if (rc < 0) {
+        LOGE() << "Could not open ALSA device (" << spec.deviceId << "): " << snd_strerror(rc);
+        return false;
+    }
+
+    AlsaParams params {
+        .access = SND_PCM_ACCESS_RW_INTERLEAVED,
+        .format = SND_PCM_FORMAT_FLOAT_LE,
+        .channels = spec.output.audioChannelCount,
+        .sampleRate = spec.output.sampleRate,
+        .periodSize = spec.output.samplesPerChannel,
+        .periods = 2u,
+        .ringBufferSize = 0u,
+    };
+    if (!alsaConfigureDevice(deviceHandle, params)) {
+        LOGE() << "Could not configure ALSA device";
+    }
+    s_alsaData = new ALSAData {};
+    s_alsaData->params = params;
     s_alsaData->callback = spec.callback;
-
-    snd_pcm_t* handle;
-    int rc = snd_pcm_open(&handle, spec.deviceId.c_str(), SND_PCM_STREAM_PLAYBACK, 0);
-    if (rc < 0) {
-        LOGE() << "Unable to open device: " << spec.deviceId << ", err code: " << rc;
-        return false;
-    }
-
-    s_alsaData->alsaDeviceHandle = handle;
-
-    snd_pcm_hw_params_t* params;
-    snd_pcm_hw_params_alloca(&params);
-    snd_pcm_hw_params_any(handle, params);
-
-    snd_pcm_hw_params_set_access(handle, params, SND_PCM_ACCESS_RW_INTERLEAVED);
-    snd_pcm_hw_params_set_format(handle, params, SND_PCM_FORMAT_FLOAT_LE);
-    snd_pcm_hw_params_set_channels(handle, params, spec.output.audioChannelCount);
-
-    unsigned int aSamplerate = spec.output.sampleRate;
-    unsigned int val = aSamplerate;
-    int dir = 0;
-    rc = snd_pcm_hw_params_set_rate_near(handle, params, &val, &dir);
-    if (rc < 0) {
-        LOGE() << "Unable to set sample rate: " << val << ", err code: " << rc;
-        return false;
-    }
-
-    snd_pcm_uframes_t ringBufferSize = s_alsaData->samples * 2;
-    rc = snd_pcm_hw_params_set_buffer_size_near(handle, params, &ringBufferSize);
-    if (rc < 0) {
-        LOGE() << "Unable to set ring buffer size, err code: " << rc;
-        return false;
-    }
-
-    rc = snd_pcm_hw_params_set_period_size_near(handle, params, &s_alsaData->samples, 0);
-    if (rc < 0) {
-        LOGE() << "Unable to set period buffer size, err code: " << rc;
-        return false;
-    }
-
-    rc = snd_pcm_hw_params(handle, params);
-    if (rc < 0) {
-        LOGE() << "Unable to set params, err code: " << rc;
-        return false;
-    }
-
-    snd_pcm_hw_params_get_rate(params, &val, &dir);
-    aSamplerate = val;
-
-    const auto bufLen = s_alsaData->samples * s_alsaData->channels;
-    s_alsaData->buffer = new float[bufLen];
-
-    s_format = spec;
-    s_format.output.sampleRate = aSamplerate;
-    m_activeSpecChanged.send(s_format);
-
-    if (activeSpec) {
-        *activeSpec = s_format;
-    }
-
+    s_alsaData->alsaDeviceHandle = deviceHandle;
     s_alsaData->threadHandle = 0;
 
     rc = pthread_create(&s_alsaData->threadHandle, nullptr, alsaThread, (void*)s_alsaData);
@@ -268,11 +613,19 @@ bool AlsaAudioDriver::open(const Spec& spec, Spec* activeSpec)
         return false;
     }
 
-    LOGI() << "Connected to " << spec.deviceId
-           << " with bufferSize " << s_format.output.samplesPerChannel
-           << ", sampleRate " << s_format.output.sampleRate
-           << ", channels:  " << s_format.output.audioChannelCount;
+    s_format = spec;
+    m_activeSpecChanged.send(s_format);
 
+    if (activeSpec) {
+        *activeSpec = spec;
+        activeSpec->deviceId = spec.deviceId;
+        activeSpec->output.samplesPerChannel = params.periodSize;
+        activeSpec->output.sampleRate = params.sampleRate;
+        activeSpec->output.audioChannelCount = params.channels;
+        s_format = *activeSpec;
+    }
+
+    LOGD() << "Connected to " << spec.deviceId;
     return true;
 }
 

--- a/src/framework/audio/driver/platform/lin/alsaaudiodriver.cpp
+++ b/src/framework/audio/driver/platform/lin/alsaaudiodriver.cpp
@@ -472,7 +472,7 @@ void alsaPollLoop(AlsaData* data)
     }
 }
 
-#endif
+#else  // ALSA_POLL
 
 void alsaWriteLoop(AlsaData* data)
 {
@@ -509,6 +509,7 @@ void alsaWriteLoop(AlsaData* data)
         }
     }
 }
+#endif  // ALSA_POLL
 
 static void* alsaThread(void* aParam)
 {

--- a/src/framework/audio/driver/platform/lin/alsaaudiodriver.cpp
+++ b/src/framework/audio/driver/platform/lin/alsaaudiodriver.cpp
@@ -70,10 +70,14 @@ static void* alsaThread(void* aParam)
 
         data->callback(stream, len);
 
-        snd_pcm_sframes_t pcm = snd_pcm_writei(data->alsaDeviceHandle, data->buffer, data->samples);
-        if (pcm != -EPIPE) {
-        } else {
-            snd_pcm_prepare(data->alsaDeviceHandle);
+        snd_pcm_uframes_t frames = data->samples;
+        while (frames > 0) {
+            auto ret = snd_pcm_writei(data->alsaDeviceHandle, data->buffer, frames);
+            if (ret == -EPIPE) {
+                snd_pcm_prepare(data->alsaDeviceHandle);
+                break;
+            }
+            frames -= ret;
         }
     }
 

--- a/src/framework/audio/driver/platform/lin/alsaaudiodriver.cpp
+++ b/src/framework/audio/driver/platform/lin/alsaaudiodriver.cpp
@@ -21,18 +21,25 @@
  */
 #include "alsaaudiodriver.h"
 
+#include "translation.h"
+#include "log.h"
+#include "runtime.h"
+
 #define ALSA_PCM_NEW_HW_PARAMS_API
 #include <alsa/asoundlib.h>
 
 #include <fcntl.h>
 #include <unistd.h>
-#include <string.h>
-#include <math.h>
 #include <pthread.h>
 
-#include "translation.h"
-#include "log.h"
-#include "runtime.h"
+#include <sys/mman.h>
+#include <sched.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+
+#define ALSA_REALTIME
 
 using namespace muse;
 using namespace muse::audio;
@@ -53,6 +60,41 @@ struct ALSAData
 static ALSAData* s_alsaData{ nullptr };
 static muse::audio::IAudioDriver::Spec s_format;
 
+#ifdef ALSA_REALTIME
+static bool alsaAcquireRealtime(pthread_t th)
+{
+    const int min_prio = sched_get_priority_min(SCHED_FIFO);
+    const int max_prio = sched_get_priority_max(SCHED_FIFO);
+    // priority is normally anything from 0 to 99
+    // No need to have a too high value though as it can make problems in the kernel scheduling.
+    const int desired_prio = 20;
+    const int sched_prio = std::max(min_prio, std::min(max_prio, desired_prio));
+    struct sched_param param = {
+        .sched_priority = sched_prio,
+    };
+    LOGD() << "Requesting RT priority " << sched_prio;
+
+    /* Set scheduler policy and priority of pthread */
+    int ret = pthread_setschedparam(th, SCHED_FIFO, &param);
+    if (ret) {
+        LOGW() << "pthread setschedparam failed: " << strerror(ret);
+        return false;
+    }
+
+    // Pinning to RAM the data accessed during the realtime thread
+    // (optional and require CAP_IPC_LOCK capability)
+    const auto bufLen = s_alsaData->samples * s_alsaData->channels;
+    if (mlock(reinterpret_cast<void*>(s_alsaData), sizeof(ALSAData))) {
+        LOGW() << "Could not lock ALSA data to RAM: " << strerror(errno);
+    }
+    if (mlock(reinterpret_cast<void*>(s_alsaData->buffer), bufLen * sizeof(float))) {
+        LOGW() << "Could not lock ALSA buffer to RAM: " << strerror(errno);
+    }
+
+    return true;
+}
+#endif
+
 static void* alsaThread(void* aParam)
 {
     muse::runtime::setThreadName("audio_driver");
@@ -62,6 +104,14 @@ static void* alsaThread(void* aParam)
     IF_ASSERT_FAILED(ret > 0) {
         return nullptr;
     }
+
+#ifdef ALSA_REALTIME
+    if (!alsaAcquireRealtime(data->threadHandle)) {
+        LOGW() << "Could not acquire realtime priority";
+    } else {
+        LOGI() << "Successfully acquired realtime priority";
+    }
+#endif
 
     while (!data->audioProcessingDone)
     {
@@ -198,8 +248,8 @@ bool AlsaAudioDriver::open(const Spec& spec, Spec* activeSpec)
     snd_pcm_hw_params_get_rate(params, &val, &dir);
     aSamplerate = val;
 
-    s_alsaData->buffer = new float[s_alsaData->samples * s_alsaData->channels];
-    //_alsaData->sampleBuffer = new short[_alsaData->samples * _alsaData->channels];
+    const auto bufLen = s_alsaData->samples * s_alsaData->channels;
+    s_alsaData->buffer = new float[bufLen];
 
     s_format = spec;
     s_format.output.sampleRate = aSamplerate;
@@ -210,10 +260,11 @@ bool AlsaAudioDriver::open(const Spec& spec, Spec* activeSpec)
     }
 
     s_alsaData->threadHandle = 0;
-    int ret = pthread_create(&s_alsaData->threadHandle, NULL, alsaThread, (void*)s_alsaData);
 
-    if (0 != ret) {
-        LOGE() << "Unable to create audio thread, err code: " << ret;
+    rc = pthread_create(&s_alsaData->threadHandle, nullptr, alsaThread, (void*)s_alsaData);
+
+    if (0 != rc) {
+        LOGE() << "Could not start ALSA thread: " << strerror(errno);
         return false;
     }
 

--- a/src/framework/audio/driver/platform/lin/alsaaudiodriver.cpp
+++ b/src/framework/audio/driver/platform/lin/alsaaudiodriver.cpp
@@ -509,6 +509,7 @@ void alsaWriteLoop(AlsaData* data)
         }
     }
 }
+
 #endif  // ALSA_POLL
 
 static void* alsaThread(void* aParam)

--- a/src/framework/audio/driver/platform/lin/alsaaudiodriver.cpp
+++ b/src/framework/audio/driver/platform/lin/alsaaudiodriver.cpp
@@ -619,7 +619,7 @@ bool AlsaAudioDriver::open(const Spec& spec, Spec* activeSpec)
         .access = preferredAccess,
         .format = SND_PCM_FORMAT_FLOAT_LE,
         .channels = spec.output.audioChannelCount,
-        .sampleRate = spec.output.sampleRate,
+        .sampleRate = static_cast<unsigned int>(spec.output.sampleRate),
         .periodSize = spec.output.samplesPerChannel,
         .periods = 2u,
         .ringBufferSize = 0u,

--- a/src/framework/audio/driver/platform/lin/alsaaudiodriver.cpp
+++ b/src/framework/audio/driver/platform/lin/alsaaudiodriver.cpp
@@ -41,7 +41,7 @@
 #include <cstring>
 #include <vector>
 
-#define DEBUG_AUDIO
+// #define DEBUG_AUDIO
 // #define ALSA_POLL
 
 #ifdef DEBUG_AUDIO

--- a/src/framework/audio/driver/platform/lin/alsaaudiodriver.cpp
+++ b/src/framework/audio/driver/platform/lin/alsaaudiodriver.cpp
@@ -172,9 +172,17 @@ bool AlsaAudioDriver::open(const Spec& spec, Spec* activeSpec)
         return false;
     }
 
-    rc = snd_pcm_hw_params_set_buffer_size_near(handle, params, &s_alsaData->samples);
+    snd_pcm_uframes_t ringBufferSize = s_alsaData->samples * 2;
+    rc = snd_pcm_hw_params_set_buffer_size_near(handle, params, &ringBufferSize);
     if (rc < 0) {
-        LOGE() << "Unable to set buffer size: " << s_alsaData->samples << ", err code: " << rc;
+        LOGE() << "Unable to set ring buffer size, err code: " << rc;
+        return false;
+    }
+
+    rc = snd_pcm_hw_params_set_period_size_near(handle, params, &s_alsaData->samples, 0);
+    if (rc < 0) {
+        LOGE() << "Unable to set period buffer size, err code: " << rc;
+        return false;
     }
 
     rc = snd_pcm_hw_params(handle, params);

--- a/src/framework/audio/driver/platform/lin/alsaaudiodriver.cpp
+++ b/src/framework/audio/driver/platform/lin/alsaaudiodriver.cpp
@@ -463,11 +463,10 @@ static void alsaPollWriteLoop(ALSAData* data, std::vector<struct pollfd> ufds)
         return;
     }
 
-    std::vector<float> buffer(periodSize * channels);
+    auto buffer = std::vector<float>(periodSize * channels);
 
     // Start the loop
     while (!data->audioProcessingDone) {
-
         uint8_t* stream = reinterpret_cast<uint8_t*>(&buffer[0]);
         const auto len = buffer.size() * sizeof(float);
 

--- a/src/framework/uicomponents/qml/Muse/UiComponents/filteredflyoutmodel.cpp
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/filteredflyoutmodel.cpp
@@ -22,6 +22,8 @@
 
 #include "filteredflyoutmodel.h"
 
+#include "translation.h"
+
 using namespace muse::uicomponents;
 
 // Recursively traverse a flyout tree, collect all "leaves" (items without a sub item)...


### PR DESCRIPTION
Request ALSA to allocate a ring buffer that is twice the MuseScore buffer size.

Resolves (linux only): #18701 

Alsa has the concept of ring buffer, allocated and managed by the driver.
The ring buffer must be greater than the "period buffer", which is the one managed by the application.

https://www.alsa-project.org/wiki/FramesPeriods

My understanding of the stuttering issue is that MS attempts to write to the entire ring buffer at once. If Alsa need to perform treatment on the signal (i.e. resampling to a different rate), it must stop the playback the time to process the entire buffer (under-run).

This PR effectively ensures that the ring buffer is twice the size as the period buffer that MS writes to.
As a downside, this effectively doubles the latency as well.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [X] I created a ~unit test or vtest to verify~ a video to demonstrate the changes I made (if applicable)


Master branch:

https://github.com/musescore/MuseScore/assets/3889105/7e0f05bf-b385-45cd-96a7-82be9f15221d

This PR:

https://github.com/musescore/MuseScore/assets/3889105/88ce951f-41b6-4db5-8768-3dafb3f2b235

