### PR TITLE
Add snap to next/previous to shortcuts and context menus (#23329)

### DIFF
--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -131,6 +131,8 @@ public:
     virtual void nudge(MoveDirection d, bool quickly) = 0;
     virtual void moveChordRestToStaff(MoveDirection d) = 0;
     virtual void swapChordRest(MoveDirection d) = 0;
+    virtual void toggleSnapToPrevious() = 0;
+    virtual void toggleSnapToNext() = 0;
 
     // Text edit
     virtual bool isTextSelected() const = 0;

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -241,6 +241,8 @@ void NotationActionController::init()
     registerAction("move-down", &Interaction::moveChordRestToStaff, MoveDirection::Down, &Controller::hasSelection);
     registerAction("move-left", &Interaction::swapChordRest, MoveDirection::Left, &Controller::isNoteInputMode);
     registerAction("move-right", &Interaction::swapChordRest, MoveDirection::Right, &Controller::isNoteInputMode);
+    registerAction("toggle-snap-to-previous", &Interaction::toggleSnapToPrevious, &Controller::hasSelection);
+    registerAction("toggle-snap-to-next", &Interaction::toggleSnapToNext, &Controller::hasSelection);
     registerAction("next-segment-element", &Interaction::moveSegmentSelection, MoveDirection::Right, PlayMode::PlayNote);
     registerAction("prev-segment-element", &Interaction::moveSegmentSelection, MoveDirection::Left, PlayMode::PlayNote);
 

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -136,6 +136,8 @@ public:
     void moveChordRestToStaff(MoveDirection d) override;
     void moveLyrics(MoveDirection d) override;
     void swapChordRest(MoveDirection d) override;
+    void toggleSnapToPrevious() override;
+    void toggleSnapToNext() override;
 
     // Text edit
     bool isTextSelected() const override;

--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -239,6 +239,20 @@ const UiActionList NotationUiActions::m_actions = {
              TranslatableString("action", "Move chord/rest right"),
              TranslatableString("action", "Move chord/rest right")
              ),
+    UiAction("toggle-snap-to-previous",
+             mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
+             TranslatableString("action", "Snap to &previous"),
+             TranslatableString("action", "Snap to previous"),
+             Checkable::Yes
+             ),
+    UiAction("toggle-snap-to-next",
+             mu::context::UiCtxNotationOpened,
+             mu::context::CTX_ANY,
+             TranslatableString("action", "Snap to &next"),
+             TranslatableString("action", "Snap to next"),
+             Checkable::Yes
+             ),
     UiAction("pitch-up",
              mu::context::UiCtxNotationOpened,
              mu::context::CTX_NOTATION_NOT_NOTE_INPUT_STAFF_TAB,

--- a/src/notation/tests/mocks/notationinteractionmock.h
+++ b/src/notation/tests/mocks/notationinteractionmock.h
@@ -97,6 +97,8 @@ public:
     MOCK_METHOD(void, nudge, (MoveDirection, bool), (override));
     MOCK_METHOD(void, moveChordRestToStaff, (MoveDirection), (override));
     MOCK_METHOD(void, swapChordRest, (MoveDirection), (override));
+    MOCK_METHOD(void, toggleSnapToPrevious, (), (override));
+    MOCK_METHOD(void, toggleSnapToNext, (), (override));
 
     MOCK_METHOD(bool, isTextSelected, (), (const, override));
     MOCK_METHOD(bool, isTextEditingStarted, (), (const, override));

--- a/src/notation/view/notationcontextmenumodel.cpp
+++ b/src/notation/view/notationcontextmenumodel.cpp
@@ -27,6 +27,8 @@
 
 #include "view/widgets/editstyle.h"
 
+#include "engraving/dom/gradualtempochange.h"
+
 using namespace mu::notation;
 using namespace muse;
 using namespace muse::uicomponents;
@@ -62,6 +64,10 @@ MenuItemList NotationContextMenuModel::makeItemsByElementType(ElementType elemen
         return makeVerticalBoxItems();
     case ElementType::HBOX:
         return makeHorizontalBoxItems();
+    case ElementType::HAIRPIN_SEGMENT:
+        return makeHairpinItems();
+    case ElementType::GRADUAL_TEMPO_CHANGE_SEGMENT:
+        return makeGradualTempoChangeItems();
     default:
         break;
     }
@@ -276,6 +282,51 @@ MenuItemList NotationContextMenuModel::makeHorizontalBoxItems()
     MenuItemList items = makeElementItems();
     items << makeSeparator();
     items << makeMenu(TranslatableString("notation", "Add"), addMenuItems);
+
+    return items;
+}
+
+MenuItemList NotationContextMenuModel::makeHairpinItems()
+{
+    MenuItemList items = makeElementItems();
+
+    const EngravingItem* hitElement = hitElementContext().element;
+    if (!hitElement || !hitElement->isHairpinSegment() || !isSingleSelection()) {
+        return items;
+    }
+
+    items << makeSeparator();
+
+    const engraving::Hairpin* h = toHairpinSegment(hitElement)->hairpin();
+    ui::UiActionState snapPrevState = { true, h->snapToItemBefore() };
+    MenuItem* snapPrev = makeMenuItem("toggle-snap-to-previous");
+    snapPrev->setState(snapPrevState);
+    items << snapPrev;
+
+    ui::UiActionState snapNextState = { true, h->snapToItemAfter() };
+    MenuItem* snapNext = makeMenuItem("toggle-snap-to-next");
+    snapNext->setState(snapNextState);
+    items << snapNext;
+
+    return items;
+}
+
+MenuItemList NotationContextMenuModel::makeGradualTempoChangeItems()
+{
+    MenuItemList items = makeElementItems();
+
+    const EngravingItem* hitElement = hitElementContext().element;
+    if (!hitElement || !hitElement->isGradualTempoChangeSegment() || !isSingleSelection()) {
+        return items;
+    }
+
+    items << makeSeparator();
+
+    const engraving::GradualTempoChange* gtc = toGradualTempoChangeSegment(hitElement)->tempoChange();
+    ui::UiActionState snapNextState = { true, gtc->snapToItemAfter() };
+    MenuItem* snapNext = makeMenuItem("toggle-snap-to-next");
+    snapNext->setState(snapNextState);
+    items << snapNext;
 
     return items;
 }

--- a/src/notation/view/notationcontextmenumodel.h
+++ b/src/notation/view/notationcontextmenumodel.h
@@ -55,6 +55,8 @@ private:
     muse::uicomponents::MenuItemList makeChangeInstrumentItems();
     muse::uicomponents::MenuItemList makeVerticalBoxItems();
     muse::uicomponents::MenuItemList makeHorizontalBoxItems();
+    muse::uicomponents::MenuItemList makeHairpinItems();
+    muse::uicomponents::MenuItemList makeGradualTempoChangeItems();
 
     bool isSingleSelection() const;
     bool canSelectSimilarInRange() const;


### PR DESCRIPTION
Resolves: #23329 

A couple of extra things to note after discussions with designers:

- When a selection of hairpins or tempo changes contains differing snapping values, using the shortcut should toggle all values to true. This is how it currently works via the inspector (in future we'd like to represent this state visually, perhaps by using a checkbox with indeterminate state instead of a toggle).

- The context menu options should only appear when a single hairpin / tempo change is selected