### PR TITLE
Fix MSVC compiler warnings

### DIFF
--- a/src/engraving/dom/chordline.cpp
+++ b/src/engraving/dom/chordline.cpp
@@ -275,7 +275,7 @@ int ChordLine::subtype() const
     size_t h2 = std::hash<bool> {}(m_straight);
     size_t h3 = std::hash<bool> {}(m_wavy);
 
-    return h1 ^ (h2 << 1) ^ (h3 << 2);
+    return static_cast<int>(h1 ^ (h2 << 1) ^ (h3 << 2));
 }
 
 muse::TranslatableString ChordLine::subtypeUserName() const

--- a/src/engraving/dom/timesig.cpp
+++ b/src/engraving/dom/timesig.cpp
@@ -306,7 +306,7 @@ int TimeSig::subtype() const
     size_t h2 = std::hash<int> {}(denominator());
     size_t h3 = std::hash<TimeSigType> {}(timeSigType());
 
-    return h1 ^ (h2 << 1) ^ (h3 << 2);
+    return static_cast<int>(h1 ^ (h2 << 1) ^ (h3 << 2));
 }
 
 //---------------------------------------------------------


### PR DESCRIPTION
reg.: 'return': conversion from 'size_t' to 'int', possible loss of data (C4267)