### PR TITLE
Don't create duplicate master nightly builds and prevent it from happening again

### DIFF
--- a/.github/workflows/ci_linux_arm_mu4.yml
+++ b/.github/workflows/ci_linux_arm_mu4.yml
@@ -30,6 +30,11 @@ jobs:
       uses: styfle/cancel-workflow-action@0.12.1
       with:
         access_token: ${{ github.token }}
+    - name: Exit if current release branch configuration is incorrect
+      if: ${{ github.event_name == 'schedule' && github.event.schedule == '0 5 */1 */1 *' && env.CURRENT_RELEASE_BRANCH == '' }}
+      run: |
+        echo "::error::CURRENT_RELEASE_BRANCH is not set"
+        exit 1
     - name: Clone repository (default)
       uses: actions/checkout@v4
       if: ${{ github.event_name != 'schedule' || github.event.schedule == '0 3 */1 */1 *' }}

--- a/.github/workflows/ci_linux_mu4.yml
+++ b/.github/workflows/ci_linux_mu4.yml
@@ -7,7 +7,7 @@ on:
     
   schedule:
     - cron: '0 3 */1 */1 *' # At 03:00 on every day-of-month for master
-    - cron: '0 5 */1 */1 *' # At 05:00 on every day-of-month for current release branch
+    # - cron: '0 5 */1 */1 *' # At 05:00 on every day-of-month for current release branch
   workflow_dispatch:
     inputs:
       build_mode:
@@ -34,6 +34,11 @@ jobs:
       uses: styfle/cancel-workflow-action@0.12.1
       with:
         access_token: ${{ github.token }}
+    - name: Exit if current release branch configuration is incorrect
+      if: ${{ github.event_name == 'schedule' && github.event.schedule == '0 5 */1 */1 *' && env.CURRENT_RELEASE_BRANCH == '' }}
+      run: |
+        echo "::error::CURRENT_RELEASE_BRANCH is not set"
+        exit 1
     - name: Clone repository (default)
       uses: actions/checkout@v4
       if: ${{ github.event_name != 'schedule' || github.event.schedule == '0 3 */1 */1 *' }}

--- a/.github/workflows/ci_macos_mu4.yml
+++ b/.github/workflows/ci_macos_mu4.yml
@@ -7,7 +7,7 @@ on:
     
   schedule:
     - cron: '0 3 */1 */1 *' # At 03:00 on every day-of-month for master
-    - cron: '0 5 */1 */1 *' # At 05:00 on every day-of-month for current release branch
+    # - cron: '0 5 */1 */1 *' # At 05:00 on every day-of-month for current release branch
   workflow_dispatch:
     inputs:
       build_mode:
@@ -35,6 +35,11 @@ jobs:
       uses: styfle/cancel-workflow-action@0.12.1
       with:
         access_token: ${{ github.token }}
+    - name: Exit if current release branch configuration is incorrect
+      if: ${{ github.event_name == 'schedule' && github.event.schedule == '0 5 */1 */1 *' && env.CURRENT_RELEASE_BRANCH == '' }}
+      run: |
+        echo "::error::CURRENT_RELEASE_BRANCH is not set"
+        exit 1
     - name: Clone repository (default)
       uses: actions/checkout@v4
       if: ${{ github.event_name != 'schedule' || github.event.schedule == '0 3 */1 */1 *' }}

--- a/.github/workflows/ci_windows_mu4.yml
+++ b/.github/workflows/ci_windows_mu4.yml
@@ -7,7 +7,7 @@ on:
     
   schedule:
     - cron: '0 3 */1 */1 *' # At 03:00 on every day-of-month for master
-    - cron: '0 5 */1 */1 *' # At 05:00 on every day-of-month for current release branch
+    # - cron: '0 5 */1 */1 *' # At 05:00 on every day-of-month for current release branch
   workflow_dispatch:
     inputs:
       build_mode:
@@ -34,6 +34,11 @@ jobs:
       uses: styfle/cancel-workflow-action@0.12.1
       with:
         access_token: ${{ github.token }}
+    - name: Exit if current release branch configuration is incorrect
+      if: ${{ github.event_name == 'schedule' && github.event.schedule == '0 5 */1 */1 *' && env.CURRENT_RELEASE_BRANCH == '' }}
+      run: |
+        echo "::error::CURRENT_RELEASE_BRANCH is not set"
+        exit 1
     - name: Clone repository (default)
       uses: actions/checkout@v4
       if: ${{ github.event_name != 'schedule' || github.event.schedule == '0 3 */1 */1 *' }}


### PR DESCRIPTION
I discovered that all master nightly builds are duplicated currently. Cause: we removed `CURRENT_RELEASE_BRANCH` but didn't disable the cron; and when passing an empty branch name to `actions/checkout`, it checks out the master branch (in the case of scheduled actions, at least). 
Solution: disable the cron as well, and add a check that checks whether `CURRENT_RELEASE_BRANCH` is set to prevent this situation from arising again.