### PR TITLE
Remove unnecessary debug log from Score::tick2Segment

### DIFF
--- a/src/engraving/dom/utils.cpp
+++ b/src/engraving/dom/utils.cpp
@@ -169,7 +169,7 @@ Segment* Score::tick2segment(const Fraction& t, bool first, SegmentType st, bool
     }
 
     if (m == 0) {
-        LOGD("no measure for tick %d", tick.toString());
+        LOGD("no measure for tick %s", tick.toString());
         return 0;
     }
     for (Segment* segment   = m->first(st); segment;) {

--- a/src/engraving/dom/utils.cpp
+++ b/src/engraving/dom/utils.cpp
@@ -169,7 +169,7 @@ Segment* Score::tick2segment(const Fraction& t, bool first, SegmentType st, bool
     }
 
     if (m == 0) {
-        LOGD("no measure for tick %d", tick.ticks());
+        LOGD("no measure for tick %d", tick.toString());
         return 0;
     }
     for (Segment* segment   = m->first(st); segment;) {
@@ -186,7 +186,6 @@ Segment* Score::tick2segment(const Fraction& t, bool first, SegmentType st, bool
         }
         segment = nsegment;
     }
-    LOGD("no segment for tick %d (start search at %d (measure %d))", tick.ticks(), t.ticks(), m->tick().ticks());
     return 0;
 }
 

--- a/src/engraving/dom/utils.cpp
+++ b/src/engraving/dom/utils.cpp
@@ -169,7 +169,7 @@ Segment* Score::tick2segment(const Fraction& t, bool first, SegmentType st, bool
     }
 
     if (m == 0) {
-        LOGD("no measure for tick %s", tick.toString());
+        LOGD() << "no measure for tick" << tick.ticks();
         return 0;
     }
     for (Segment* segment   = m->first(st); segment;) {

--- a/src/engraving/dom/utils.cpp
+++ b/src/engraving/dom/utils.cpp
@@ -169,7 +169,7 @@ Segment* Score::tick2segment(const Fraction& t, bool first, SegmentType st, bool
     }
 
     if (m == 0) {
-        LOGD() << "no measure for tick" << tick.ticks();
+        LOGD() << "no measure for tick " << tick.ticks();
         return 0;
     }
     for (Segment* segment   = m->first(st); segment;) {


### PR DESCRIPTION
It is perfectly fine for this method to return a null result, it just means that there is no segment of the specified type in the specified location (which is in many cases exactly the information we want). This debug log is unnecessary and litters our console with hundreds of unnecessary messages.
