### PR TITLE
Dynamic voicing and position improvements

### DIFF
--- a/src/engraving/dom/engravingitem.cpp
+++ b/src/engraving/dom/engravingitem.cpp
@@ -1340,18 +1340,18 @@ void EngravingItem::setPlacementBasedOnVoiceAssignment(DirectionV styledDirectio
             // Put above the staff only in case of multiple voices at this tick (similar to stem directions)
             const Measure* measure = score()->tick2measure(tick());
             Fraction startTick = Fraction(-1, 1);
-            Fraction endTick = Fraction(-1, 1);
+            Fraction length = Fraction(-1, 1);
             if (isSpanner()) {
                 startTick = tick();
-                endTick = toSpanner(this)->tick2();
+                length = toSpanner(this)->ticks();
             } else if (const Segment* segment = toSegment(findAncestor(ElementType::SEGMENT))) {
                 startTick = segment->tick();
-                endTick = startTick + segment->ticks();
+                length = segment->ticks();
             } else if (measure) {
                 startTick = measure->tick();
-                endTick = measure->endTick();
+                length = measure->ticks();
             }
-            if (measure && measure->hasVoices(staffIdx(), startTick, endTick)) {
+            if (measure && measure->hasVoices(staffIdx(), startTick, length)) {
                 newPlacement = PlacementV::ABOVE;
             } else {
                 newPlacement = PlacementV::BELOW;

--- a/src/engraving/dom/engravingitem.cpp
+++ b/src/engraving/dom/engravingitem.cpp
@@ -1288,13 +1288,13 @@ bool EngravingItem::appliesToAllVoicesInInstrument() const
            && getProperty(Pid::VOICE_ASSIGNMENT).value<VoiceAssignment>() == VoiceAssignment::ALL_VOICE_IN_INSTRUMENT;
 }
 
-void EngravingItem::setInitialTrackAndVoiceAssignment(track_idx_t track)
+void EngravingItem::setInitialTrackAndVoiceApplication(track_idx_t track, bool ctrlModifier)
 {
     IF_ASSERT_FAILED(track != muse::nidx) {
         return;
     }
 
-    if (configuration()->dynamicsApplyToAllVoices()) {
+    if (configuration()->dynamicsApplyToAllVoices() && !ctrlModifier) {
         setTrack(trackZeroVoice(track));
         setProperty(Pid::VOICE_ASSIGNMENT, VoiceAssignment::ALL_VOICE_IN_INSTRUMENT);
     } else {

--- a/src/engraving/dom/engravingitem.cpp
+++ b/src/engraving/dom/engravingitem.cpp
@@ -1288,13 +1288,13 @@ bool EngravingItem::appliesToAllVoicesInInstrument() const
            && getProperty(Pid::VOICE_ASSIGNMENT).value<VoiceAssignment>() == VoiceAssignment::ALL_VOICE_IN_INSTRUMENT;
 }
 
-void EngravingItem::setInitialTrackAndVoiceAssignment(track_idx_t track, bool ctrlModifier)
+void EngravingItem::setInitialTrackAndVoiceAssignment(track_idx_t track, bool curVoiceOnlyOverride)
 {
     IF_ASSERT_FAILED(track != muse::nidx) {
         return;
     }
 
-    if (configuration()->dynamicsApplyToAllVoices() && !ctrlModifier) {
+    if (configuration()->dynamicsApplyToAllVoices() && !curVoiceOnlyOverride) {
         setTrack(trackZeroVoice(track));
         setProperty(Pid::VOICE_ASSIGNMENT, VoiceAssignment::ALL_VOICE_IN_INSTRUMENT);
     } else {

--- a/src/engraving/dom/engravingitem.cpp
+++ b/src/engraving/dom/engravingitem.cpp
@@ -1288,7 +1288,7 @@ bool EngravingItem::appliesToAllVoicesInInstrument() const
            && getProperty(Pid::VOICE_ASSIGNMENT).value<VoiceAssignment>() == VoiceAssignment::ALL_VOICE_IN_INSTRUMENT;
 }
 
-void EngravingItem::setInitialTrackAndVoiceApplication(track_idx_t track, bool ctrlModifier)
+void EngravingItem::setInitialTrackAndVoiceAssignment(track_idx_t track, bool ctrlModifier)
 {
     IF_ASSERT_FAILED(track != muse::nidx) {
         return;

--- a/src/engraving/dom/engravingitem.h
+++ b/src/engraving/dom/engravingitem.h
@@ -682,9 +682,9 @@ public:
 
     virtual bool hasVoiceAssignmentProperties() const { return false; }
     bool appliesToAllVoicesInInstrument() const;
-    void setInitialTrackAndVoiceApplication(track_idx_t track, bool ctrlModifier);
-    void checkVoiceApplicationCompatibleWithTrack();
-    void setPlacementBasedOnVoiceApplication(DirectionV styledDirection);
+    void setInitialTrackAndVoiceAssignment(track_idx_t track, bool ctrlModifier);
+    void checkVoiceAssignmentCompatibleWithTrack();
+    void setPlacementBasedOnVoiceAssignment(DirectionV styledDirection);
 
     void setOffsetChanged(bool val, bool absolute = true, const PointF& diff = PointF());
     //! ---------------------

--- a/src/engraving/dom/engravingitem.h
+++ b/src/engraving/dom/engravingitem.h
@@ -682,7 +682,7 @@ public:
 
     virtual bool hasVoiceAssignmentProperties() const { return false; }
     bool appliesToAllVoicesInInstrument() const;
-    void setInitialTrackAndVoiceAssignment(track_idx_t track, bool ctrlModifier);
+    void setInitialTrackAndVoiceAssignment(track_idx_t track, bool curVoiceOnlyOverride);
     void checkVoiceAssignmentCompatibleWithTrack();
     void setPlacementBasedOnVoiceAssignment(DirectionV styledDirection);
 

--- a/src/engraving/dom/engravingitem.h
+++ b/src/engraving/dom/engravingitem.h
@@ -682,9 +682,9 @@ public:
 
     virtual bool hasVoiceAssignmentProperties() const { return false; }
     bool appliesToAllVoicesInInstrument() const;
-    void setInitialTrackAndVoiceAssignment(track_idx_t track);
-    void checkVoiceAssignmentCompatibleWithTrack();
-    void setPlacementBasedOnVoiceAssignment(DirectionV styledDirection);
+    void setInitialTrackAndVoiceApplication(track_idx_t track, bool ctrlModifier);
+    void checkVoiceApplicationCompatibleWithTrack();
+    void setPlacementBasedOnVoiceApplication(DirectionV styledDirection);
 
     void setOffsetChanged(bool val, bool absolute = true, const PointF& diff = PointF());
     //! ---------------------

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -2053,7 +2053,7 @@ void NotationInteraction::applyDropPaletteElement(mu::engraving::Score* score, m
         }
 
         if (el && el->hasVoiceAssignmentProperties()) {
-            // If target has voice application properties, dropped element takes those and discards the default
+            // If target has voice assignment properties, dropped element takes those and discards the default
             if (!target->hasVoiceAssignmentProperties()) {
                 el->setInitialTrackAndVoiceAssignment(target->track(), modifiers & ControlModifier);
             }

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -1742,8 +1742,8 @@ bool NotationInteraction::applyPaletteElement(mu::engraving::EngravingItem* elem
                 staff_idx_t targetStaff = firstStaffOnly ? 0 : cr1->staffIdx();
                 score->cmdAddSpanner(spanner, targetStaff, startSegment, endSegment, modifiers & Qt::ControlModifier);
             }
-            if (spanner->hasVoiceApplicationProperties()) {
-                spanner->setInitialTrackAndVoiceApplication(cr1->track(), modifiers & ControlModifier);
+            if (spanner->hasVoiceAssignmentProperties()) {
+                spanner->setInitialTrackAndVoiceAssignment(cr1->track(), modifiers & ControlModifier);
             } else if (spanner->isVoiceSpecific()) {
                 spanner->setTrack(cr1->track());
             }
@@ -1910,8 +1910,8 @@ bool NotationInteraction::applyPaletteElement(mu::engraving::EngravingItem* elem
                 spanner->setScore(score);
                 spanner->styleChanged();
                 score->cmdAddSpanner(spanner, i, startSegment, endSegment, modifiers & Qt::ControlModifier);
-                if (spanner->hasVoiceApplicationProperties()) {
-                    spanner->setInitialTrackAndVoiceApplication(staff2track(i), modifiers & ControlModifier);
+                if (spanner->hasVoiceAssignmentProperties()) {
+                    spanner->setInitialTrackAndVoiceAssignment(staff2track(i), modifiers & ControlModifier);
                 }
                 selectAndStartEditIfNeeded(spanner);
             }
@@ -2052,10 +2052,10 @@ void NotationInteraction::applyDropPaletteElement(mu::engraving::Score* score, m
             }
         }
 
-        if (el && el->hasVoiceApplicationProperties()) {
+        if (el && el->hasVoiceAssignmentProperties()) {
             // If target has voice application properties, dropped element takes those and discards the default
-            if (!target->hasVoiceApplicationProperties()) {
-                el->setInitialTrackAndVoiceApplication(target->track(), modifiers & ControlModifier);
+            if (!target->hasVoiceAssignmentProperties()) {
+                el->setInitialTrackAndVoiceAssignment(target->track(), modifiers & ControlModifier);
             }
         }
 

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -1742,8 +1742,8 @@ bool NotationInteraction::applyPaletteElement(mu::engraving::EngravingItem* elem
                 staff_idx_t targetStaff = firstStaffOnly ? 0 : cr1->staffIdx();
                 score->cmdAddSpanner(spanner, targetStaff, startSegment, endSegment, modifiers & Qt::ControlModifier);
             }
-            if (spanner->hasVoiceAssignmentProperties()) {
-                spanner->setInitialTrackAndVoiceAssignment(cr1->track());
+            if (spanner->hasVoiceApplicationProperties()) {
+                spanner->setInitialTrackAndVoiceApplication(cr1->track(), modifiers & ControlModifier);
             } else if (spanner->isVoiceSpecific()) {
                 spanner->setTrack(cr1->track());
             }
@@ -1910,8 +1910,8 @@ bool NotationInteraction::applyPaletteElement(mu::engraving::EngravingItem* elem
                 spanner->setScore(score);
                 spanner->styleChanged();
                 score->cmdAddSpanner(spanner, i, startSegment, endSegment, modifiers & Qt::ControlModifier);
-                if (spanner->hasVoiceAssignmentProperties()) {
-                    spanner->setInitialTrackAndVoiceAssignment(staff2track(i));
+                if (spanner->hasVoiceApplicationProperties()) {
+                    spanner->setInitialTrackAndVoiceApplication(staff2track(i), modifiers & ControlModifier);
                 }
                 selectAndStartEditIfNeeded(spanner);
             }
@@ -2052,10 +2052,10 @@ void NotationInteraction::applyDropPaletteElement(mu::engraving::Score* score, m
             }
         }
 
-        if (el && el->hasVoiceAssignmentProperties()) {
-            // If target has voice assignment properties, dropped element takes those and discards the default
-            if (!target->hasVoiceAssignmentProperties()) {
-                el->setInitialTrackAndVoiceAssignment(el->track());
+        if (el && el->hasVoiceApplicationProperties()) {
+            // If target has voice application properties, dropped element takes those and discards the default
+            if (!target->hasVoiceApplicationProperties()) {
+                el->setInitialTrackAndVoiceApplication(target->track(), modifiers & ControlModifier);
             }
         }
 


### PR DESCRIPTION
Resolves: #23321 

1. Dynamics in voice-0 will go above the staff only if the measure has multiple voices.
2. If the general preference is set to "Apply to all voice", entering a dynamic with ctrl modifier overrides the preference and applies the element only to the selected voice.
