### PR TITLE
Fix crash on shift+arrow dynamic with expression

### DIFF
--- a/src/engraving/dom/dynamic.cpp
+++ b/src/engraving/dom/dynamic.cpp
@@ -653,7 +653,7 @@ void Dynamic::moveSnappedItems(Segment* newSeg, Fraction tickDiff) const
                 score()->undoChangeParent(expressionAfter, newSeg, expressionAfter->staffIdx());
             }
             EngravingItem* possibleHairpinAfterExpr = expressionAfter->ldata()->itemSnappedAfter();
-            if (!hairpinAfter && possibleHairpinAfterExpr->isHairpinSegment()) {
+            if (!hairpinAfter && possibleHairpinAfterExpr && possibleHairpinAfterExpr->isHairpinSegment()) {
                 hairpinAfter = toHairpinSegment(possibleHairpinAfterExpr)->hairpin();
             }
         }


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/23482
Fix crash on shift+arrow dynamic with expression