### PR TITLE
Fix elements losing staff-centering during editing

### DIFF
--- a/src/engraving/rendering/dev/pagelayout.cpp
+++ b/src/engraving/rendering/dev/pagelayout.cpp
@@ -433,11 +433,7 @@ void PageLayout::collectPage(LayoutContext& ctx)
     }
 
     for (const System* system : page->systems()) {
-        Fraction systemStartTick = system->measures().front()->tick();
-        Fraction systemEndTick = system->measures().back()->endTick();
-        if (systemEndTick > ctx.state().startTick() && systemStartTick <= ctx.state().endTick()) {
-            SystemLayout::centerElementsBetweenStaves(system);
-        }
+        SystemLayout::centerElementsBetweenStaves(system);
     }
 
     page->invalidateBspTree();


### PR DESCRIPTION
Resolves: #23316 

Staff-centering should be computed on _all_ the systems of the page, not just the currently edited system. That's because an editing operation done in the first system can easily affect the staff distances of all the others too (as it should, because the vertical justification re-works the whole page).
