### PR TITLE
Fix crash on pasting bends

### DIFF
--- a/src/engraving/dom/note.cpp
+++ b/src/engraving/dom/note.cpp
@@ -1861,6 +1861,13 @@ EngravingItem* Note::drop(EditData& data)
         delete e;
         break;
 
+    case ElementType::GUITAR_BEND:
+    {
+        GuitarBend* newGuitarBend = score()->addGuitarBend(toGuitarBend(e)->type(), this);
+        delete e;
+        return newGuitarBend;
+    }
+
     case ElementType::BAGPIPE_EMBELLISHMENT:
     {
         BagpipeEmbellishment* b = toBagpipeEmbellishment(e);


### PR DESCRIPTION
Resolves: #22935 

The issue has become different, in the sense that current master doesn't crash anymore with the described steps, but instead the bends will just not get pasted (this is probably due to all the major changes done to Spanners since the anchors project). 

About this solution: bends are a very specific note-to-note item, so it's not very clear what should happen if you take a bend and copy-paste it to a location that doesn't match the original: you can have different notes, different intervals, different durations, no available end note, etc. The only sensible solution I could think of is that, on paste, we don't even try to copy the original bend and adapt it to context, but we just trigger the command to create a new bend of the same type of the copied one. This ensures the exact same result as when inserting a bend from palette: for example, if there is no available end note (first case of the linked issue) a suitable one will be created. I think it works nicely.
