### PR TITLE
Update issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -43,17 +43,20 @@ body:
     validations:
       required: true
   - type: textarea
-    id: screenshot
+    id: evidence
     attributes:
-      label: Screenshots/Screen recordings
-      description: | 
-        Especially for longer or more complicated bugs, screen recordings are highly recommended. 
-
-        If you don't have a screen recording tool installed (OBS, Bandicam, QuickTime, etc.), you can also take a video with your phone.
+      label: Supporting evidence
+      description: |
+        * For crashes: crash logs, system information (OS, CPU, GPU, memory, drive type, etc.)
+        * For playback issues: Is it using MS Basic, MuseSounds or VSTs?
+          * For VSTs in particular: Where did you get the VSTs from? (link)
+        * For engraving: sample score (MuseScore project), screenshots
+        * For UI issues: Screenshots, screen recordings, system information, GPU drivers
+        * For regressions: The last MuseScore version (or even better: commit) that worked well. 
       placeholder: |
-        Click into this text box and paste your video
+        Click into this text box and paste your files or screenshots here.
     validations:
-      required: false
+      required: true
   - type: input
     id: version
     attributes:
@@ -65,11 +68,11 @@ body:
     id: regression
     attributes:
       label: Regression
-      description: Did this work before?
+      description: Did this work before? Older versions of MuseScore Studio can be found [here](https://github.com/musescore/MuseScore/releases).
       options:
         - Choose option...
         - No.
-        - I don't know
+        - I was unable to check
         - Yes, this used to work in MuseScore 3.x and now is broken 
         - Yes, this used to work in a previous version of MuseScore 4.x
     validations: 
@@ -87,17 +90,6 @@ body:
     attributes:
       label: Additional context
       description: Further information which may be relevant to this bug
-      placeholder: Crash log, Screenshots, MuseScore project, build number, etc.
-  - type: markdown
-    attributes:
-      value: |
-        Useful information to include:
-        * For crashes: crash logs, system information (OS, CPU, GPU, memory, drive type, etc.)
-        * For playback issues: Is it using MS Basic, MuseSounds or VSTs?
-          * For VSTs in particular: Where did you get the VSTs from? (link)
-        * For engraving: sample score (MuseScore project), screenshots
-        * For UI issues: Screenshots, screen recordings, system information, GPU drivers
-        * For regressions: The last MuseScore version (or even better: commit) that worked well. 
 
   - type: checkboxes
     id: checklist

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -39,16 +39,17 @@ body:
   - type: textarea
     id: evidence
     attributes:
-      label: Supporting evidence
+      label: Supporting files, videos and screenshots
       description: |
-        * For crashes: crash logs, system information (OS, CPU, GPU, memory, drive type, etc.)
-        * For playback issues: Is it using MS Basic, MuseSounds or VSTs?
-          * For VSTs in particular: Where did you get the VSTs from? (link)
-        * For engraving: sample score (MuseScore project), screenshots
-        * For UI issues: Screenshots, screen recordings, system information, GPU drivers
-        * For regressions: The last MuseScore version (or even better: commit) that worked well. 
+        * For crashes: a short screen recording (ideally 20sec or less) plus crash logs and [diagnostic files](https://github.com/musescore/MuseScore/wiki/Reporting-bugs-and-issues#33-diagnostic-files)
+        * For engraving issues: one or more screenshots showing the problem (and, where possible, the expected outcome)
+        * For playback issues: 
+          * A short screen recording with audio of a minimal reproducible example 
+          * A score containing the problem (please upload as a .zip file)
+          * Examples comparing both MS Basic and Muse Sounds where applicable
+        * For UI/interaction and all other issues: a short screen recording (ideally 20sec or less) and files where applicable (please upload as a .zip file).
       placeholder: |
-        Click into this text box and paste your files or screenshots here.
+        Click into this text box and paste your files, videos and screenshots here.
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -42,7 +42,7 @@ body:
       label: Supporting files, videos and screenshots
       description: |
         * For crashes: a short screen recording (ideally 20sec or less) plus crash logs and [diagnostic files](https://github.com/musescore/MuseScore/wiki/Reporting-bugs-and-issues#33-diagnostic-files)
-        * For engraving issues: one or more screenshots showing the problem (and, where possible, the expected outcome)
+        * For engraving issues: one or more screenshots (or a short screen recording, 20sec or less) showing the problem and, where possible, the expected outcome
         * For playback issues: 
           * A short screen recording with audio of a minimal reproducible example 
           * A score containing the problem (please upload as a .zip file)
@@ -55,8 +55,10 @@ body:
   - type: input
     id: version
     attributes:
-      label: MuseScore Version
-      description: What version of MuseScore are you running? You can copy the info from the Help > About dialog in MuseScore.
+      label: What is the latest version of MuseScore Studio where this issue is present?
+      description: |
+        You can copy the info from the Help > About dialog in MuseScore Studio. 
+        If you can, please also check whether this issue is still present in the _latest_ [nightly build](https://musescore.org/en/nightly-builds).
     validations:
       required: true
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -98,3 +98,21 @@ body:
         * For engraving: sample score (MuseScore project), screenshots
         * For UI issues: Screenshots, screen recordings, system information, GPU drivers
         * For regressions: The last MuseScore version (or even better: commit) that worked well. 
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      description: "Before submitting your bug report, please make sure the following requirements are met:"
+      options:
+        - label: "This report follows the [guidelines](https://github.com/musescore/MuseScore/wiki/Reporting-bugs-and-issues) for reporting bugs and issues"
+          required: true
+        - label: "I have verified that this issue has not been logged before, by searching the [issue tracker](https://github.com/musescore/MuseScore/issues) for similar issues"
+          required: true
+        - label: "I have attached all requested files and information to this report"
+          required: true
+        - label: "I have attempted to identify the root problem as concisely as possible, and have used minimum reproducible examples where possible"
+          required: true
+  - type: markdown
+    attributes:
+      value: If an issue does not meet these requirements, it may be closed without investigation.

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -24,22 +24,16 @@ body:
     validations:
       required: true
   - type: textarea
-    id: desc
+    id: steps
     attributes:
-      label: Bug description
-      description: A more detailed description of the bug
-      placeholder: Context for the bug that didn't fit in the title
-    validations:
-      required: false
-  - type: textarea
-    id: str
-    attributes:
-      label: Steps to reproduce
+      label: Description with steps to reproduce
       description: Please provide step-by-step instructions to reproduce this bug 
       placeholder: |
         1. go to ...
         2. then click on ...
         3. then ...
+        Actual behaviour:
+        Expected behaviour:
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -69,9 +69,9 @@ body:
       options:
         - Choose option...
         - No.
-        - I was unable to check
         - Yes, this used to work in MuseScore 3.x and now is broken 
         - Yes, this used to work in a previous version of MuseScore 4.x
+        - I was unable to check
     validations: 
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -27,7 +27,7 @@ body:
     id: steps
     attributes:
       label: Description with steps to reproduce
-      description: Please provide step-by-step instructions to reproduce this bug 
+      description: Please also describe the actual (current) and expected behaviour 
       placeholder: |
         1. go to ...
         2. then click on ...
@@ -46,8 +46,8 @@ body:
         * For playback issues: 
           * A short screen recording with audio of a minimal reproducible example 
           * A score containing the problem (please upload as a .zip file)
-          * Examples comparing both MS Basic and Muse Sounds where applicable
-        * For UI/interaction and all other issues: a short screen recording (ideally 20sec or less) and files where applicable (please upload as a .zip file).
+          * Examples comparing both MS Basic and Muse Sounds (where applicable)
+        * For UI/interaction and all other issues: a short screen recording (ideally 20sec or less) and files (where applicable; please upload as a .zip file).
       placeholder: |
         Click into this text box and paste your files, videos and screenshots here.
     validations:
@@ -100,7 +100,7 @@ body:
           required: true
         - label: "I have attached all requested files and information to this report"
           required: true
-        - label: "I have attempted to identify the root problem as concisely as possible, and have used minimum reproducible examples where possible"
+        - label: "I have attempted to identify the root problem as concisely as possible, and have used minimal reproducible examples where possible"
           required: true
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -41,3 +41,6 @@ body:
           required: true
         - label: "I have verified that this feature request has not been logged before, by searching the [issue tracker](https://github.com/musescore/MuseScore/issues) for similar requests"
           required: true
+  - type: markdown
+    attributes:
+      value: If a feature request does not meet these requirements, it may be closed without investigation.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -30,3 +30,14 @@ body:
       description: Anything else of note
     validations:
       required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      description: "Before submitting your bug report, please make sure the following requirements are met:"
+      options:
+        - label: "This request follows the [guidelines](https://github.com/musescore/MuseScore/wiki/Reporting-bugs-and-issues) for reporting issues"
+          required: true
+        - label: "I have verified that this feature request has not been logged before, by searching the [issue tracker](https://github.com/musescore/MuseScore/issues) for similar requests"
+          required: true


### PR DESCRIPTION
In one of our bug triage sessions, we (the bug triage team) made an effort to improve the current issue reporting forms, making them easier to use and understand for users, while also encouraging more qualitative issue reports, which will make our work easier. So this should benefit everyone. This PR is the result of that effort.

It can be tried out here: https://github.com/cbjeukendrup/MuseScore/issues/new/choose