### PR TITLE
ignore note velocity on pre-MU4 import

### DIFF
--- a/src/engraving/rw/read206/read206.cpp
+++ b/src/engraving/rw/read206/read206.cpp
@@ -1000,7 +1000,8 @@ bool Read206::readNoteProperties206(Note* note, XmlReader& e, ReadContext& ctx)
     } else if (tag == "head") {
         read400::TRead::readProperty(note, e, ctx, Pid::HEAD_GROUP);
     } else if (tag == "velocity") {
-        note->setUserVelocity(e.readInt());
+        // TODO: convert to MU4
+        e.skipCurrentElement();
     } else if (tag == "play") {
         note->setPlay(e.readInt());
     } else if (tag == "tuning") {

--- a/src/engraving/rw/read400/tread.cpp
+++ b/src/engraving/rw/read400/tread.cpp
@@ -3132,7 +3132,17 @@ bool TRead::readProperties(Note* n, XmlReader& e, ReadContext& ctx)
     } else if (tag == "head") {
         TRead::readProperty(n, e, ctx, Pid::HEAD_GROUP);
     } else if (tag == "velocity") {
-        n->setUserVelocity(e.readInt());
+        if (n->score()->mscVersion() >= 400) {
+            n->setUserVelocity(e.readInt());
+        } else {
+            // TODO: convert pre-MU4 velocity values to MU4
+            // but doing so is non-trivial,
+            // since MU3 "offset" is based on a percentage of the current dynamic (which is not known at this time)
+            // and MU4 "user" is not raw MIDI velocity like MU3 is
+            // so until a new velocity system is designed for MU4 (or another solution is found),
+            // the best we can do is ignore pre-MU4 velocity values
+            e.skipCurrentElement();
+        }
     } else if (tag == "play") {
         n->setPlay(e.readInt());
     } else if (tag == "tuning") {

--- a/src/importexport/musicxml/tests/data/testChordSymbols_ref.xml
+++ b/src/importexport/musicxml/tests/data/testChordSymbols_ref.xml
@@ -59,7 +59,7 @@
           <degree-type>add</degree-type>
           </degree>
         </harmony>
-      <note dynamics="88.89">
+      <note>
         <pitch>
           <step>E</step>
           <alter>-1</alter>
@@ -75,7 +75,7 @@
           <tied type="start"/>
           </notations>
         </note>
-      <note dynamics="88.89">
+      <note>
         <pitch>
           <step>E</step>
           <alter>-1</alter>
@@ -97,7 +97,7 @@
         <voice>1</voice>
         <type>eighth</type>
         </note>
-      <note dynamics="88.89">
+      <note>
         <pitch>
           <step>A</step>
           <alter>-1</alter>


### PR DESCRIPTION
Resolves: #14768 (partially)
Resolves: https://github.com/musescore/MuseScore/issues/23514

Ignore pre-MU4 note velocities on import, since they can't be converted reasonably, and taking them literally produces nonsense results

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
<!-- - [ ] I created a unit test or vtest to verify the changes I made (if applicable) -->

There was one test affected by the change, so I updated the reference.  Interestingly, it was in the MusicXML section, but it was an MSCX test file with MusicXML export, so it was (correctly) hitting my code here.  The test was producing exactly the wrong results that this PR fixes by ignoring pre-MU4 velocity values, so now it produces the expected results (pre--MU4 velocity ignored).