### PR TITLE
NotationSwitchListModel: fix crash when using "Close other tabs"

### DIFF
--- a/src/notation/view/notationswitchlistmodel.cpp
+++ b/src/notation/view/notationswitchlistmodel.cpp
@@ -269,7 +269,10 @@ void NotationSwitchListModel::closeOtherNotations(int index)
     INotationPtr notationToKeepOpen = m_notations[index];
     context()->setCurrentNotation(notationToKeepOpen);
 
-    for (INotationPtr notation : m_notations) {
+    // Copy the list to avoid modifying it while iterating
+    QList<INotationPtr> notations = m_notations;
+
+    for (INotationPtr notation : notations) {
         if (!isMasterNotation(notation) && notation != notationToKeepOpen) {
             currentMasterNotation()->setExcerptIsOpen(notation, false);
         }


### PR DESCRIPTION
We were modifying a list while looping over it

Resolves: #23489 