### PR TITLE
Another attempt at fixing the popup memory leak

### DIFF
--- a/src/framework/uicomponents/view/popupview.cpp
+++ b/src/framework/uicomponents/view/popupview.cpp
@@ -132,7 +132,7 @@ void PopupView::init()
         return;
     }
 
-    m_window = new PopupWindow_QQuickView(muse::iocCtxForQmlEngine(engine));
+    m_window = new PopupWindow_QQuickView(muse::iocCtxForQmlEngine(engine), this);
     m_window->init(engine, isDialog(), frameless());
     m_window->setOnHidden([this]() { onHidden(); });
     m_window->setContent(m_component, m_contentItem);

--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/InstrumentSettingsPopup.qml
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/InstrumentSettingsPopup.qml
@@ -114,7 +114,8 @@ StyledPopupView {
 
             onClicked: {
                 root.close()
-                Qt.callLater(settingsModel.replaceInstrument)
+
+                settingsModel.replaceInstrument()
             }
         }
 
@@ -130,7 +131,8 @@ StyledPopupView {
 
             onClicked: {
                 root.close()
-                Qt.callLater(settingsModel.resetAllFormatting)
+
+                settingsModel.resetAllFormatting()
             }
         }
     }

--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/InstrumentsTreeItemDelegate.qml
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/InstrumentsTreeItemDelegate.qml
@@ -71,30 +71,6 @@ FocusableControl {
                 root.dropped()
             }
         }
-
-        property var openedPopup: null
-        property bool isPopupOpened: Boolean(openedPopup) && openedPopup.isOpened
-
-        function openPopup(popup, item) {
-            if (Boolean(popup)) {
-                openedPopup = popup
-                popup.load(item)
-                root.popupOpened(popup.x, popup.y, popup.height)
-                popup.open()
-            }
-        }
-
-        function closeOpenedPopup() {
-            if (isPopupOpened) {
-                openedPopup.close()
-                resetOpenedPopup()
-            }
-        }
-
-        function resetOpenedPopup() {
-            root.popupClosed()
-            openedPopup = null
-        }
     }
 
     anchors.verticalCenter: parent ? parent.verticalCenter : undefined
@@ -154,11 +130,40 @@ FocusableControl {
     Loader {
         id: popupLoader
 
-        function createPopup(comp, btn) {
+        property alias openedPopup: popupLoader.item
+        property bool isPopupOpened: Boolean(openedPopup) && openedPopup.isOpened
+
+        function openPopup(comp, btn, item) {
             popupLoader.sourceComponent = comp
-            popupLoader.item.parent = btn
-            popupLoader.item.needActiveFirstItem = btn.navigation.highlight
-            return popupLoader.item
+            if (!openedPopup) {
+                return
+            }
+
+            openedPopup.parent = btn
+            openedPopup.needActiveFirstItem = btn.navigation.highlight
+
+            openedPopup.load(item)
+
+            openedPopup.opened.connect(function() {
+                root.popupOpened(popup.x, popup.y, popup.height)
+            })
+
+            openedPopup.closed.connect(function() {
+                root.popupClosed()
+
+                Qt.callLater(function() {
+                    openedPopup = null
+                    popupLoader.sourceComponent = null
+                })
+            })
+
+            openedPopup.open()
+        }
+
+        function closeOpenedPopup() {
+            if (isPopupOpened) {
+                openedPopup.close()
+            }
         }
     }
 
@@ -167,11 +172,6 @@ FocusableControl {
 
         InstrumentSettingsPopup {
             anchorItem: popupAnchorItem
-
-            onClosed: {
-                prv.resetOpenedPopup()
-                popupLoader.sourceComponent = null
-            }
         }
     }
 
@@ -180,11 +180,6 @@ FocusableControl {
 
         StaffSettingsPopup {
             anchorItem: popupAnchorItem
-
-            onClosed: {
-                prv.resetOpenedPopup()
-                popupLoader.sourceComponent = null
-            }
         }
     }
 
@@ -294,29 +289,26 @@ FocusableControl {
             icon: IconCode.SETTINGS_COG
 
             onClicked: {
-                if (prv.isPopupOpened) {
-                    prv.closeOpenedPopup()
+                if (popupLoader.isPopupOpened) {
+                    popupLoader.closeOpenedPopup()
                     return
                 }
 
-                var popup = null
-                var item = {}
+                let comp = null
+                let item = {}
 
                 if (root.type === InstrumentsTreeItemType.PART) {
-
-                    popup = popupLoader.createPopup(instrumentSettingsComp, this)
+                    comp = instrumentSettingsComp
 
                     item["partId"] = model.itemRole.id
                     item["instrumentId"] = model.itemRole.instrumentId()
-
                 } else if (root.type === InstrumentsTreeItemType.STAFF) {
-
-                    popup = popupLoader.createPopup(staffSettingsComp, this)
+                    comp = staffSettingsComp
 
                     item["id"] = model.itemRole.id
                 }
 
-                prv.openPopup(popup, item)
+                popupLoader.openPopup(comp, this, item)
             }
 
             Behavior on opacity {


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/22885

Essentially just reapplying https://github.com/musescore/MuseScore/commit/2fa36e3371700c49c37ac1a19b1eb47872c772c7.

However, this time I attempted to do it without re-causing https://github.com/musescore/MuseScore/issues/22640, and for me on macOS it seems to work.
I also couldn't reproduce https://github.com/musescore/MuseScore/issues/22641 again, but I didn't do anything special for that, so that's a bit more scary. 

It turns out that the memory leak issue is a sort of blocker for #18436. That PR crashes because the popup window stays alive even after the popup has been closed, and thus the popup content and model stay alive too, and the latter causes crashes because it contains pointers to deleted items. That can be patched in other ways, but fixing the memory leak problem would be the cleanest way. That was the main motivation for re-trying this right now.