### PR TITLE
Fix gcc compiler warnings

### DIFF
--- a/src/engraving/dom/dynamic.cpp
+++ b/src/engraving/dom/dynamic.cpp
@@ -729,7 +729,7 @@ void Dynamic::editDrag(EditData& ed)
         Segment* seg = nullptr; // don't prefer any segment while dragging, just snap to the closest
         static constexpr double spacingFactor = 0.5;
         score()->dragPosition(canvasPos(), &si, &seg, spacingFactor, allowTimeAnchor());
-        if (seg && seg != segment() || staffIdx() != si) {
+        if ((seg && seg != segment()) || staffIdx() != si) {
             const PointF oldOffset = offset();
             PointF pos1(canvasPos());
             score()->undoChangeParent(this, seg, staffIdx());

--- a/src/engraving/rendering/dev/tlayout.cpp
+++ b/src/engraving/rendering/dev/tlayout.cpp
@@ -2582,7 +2582,7 @@ void TLayout::layoutFretDiagram(const FretDiagram* item, FretDiagram::LayoutData
         Font fingeringFont = item->fingeringFont();
         FontMetrics fontMetrics(fingeringFont);
         double fontHeight = fontMetrics.capHeight();
-        for (int i = 0; i < item->fingering().size(); ++i) {
+        for (size_t i = 0; i < item->fingering().size(); ++i) {
             int finger = item->fingering()[i];
             if (finger == 0) {
                 continue;

--- a/src/framework/draw/internal/fontfaceft.cpp
+++ b/src/framework/draw/internal/fontfaceft.cpp
@@ -255,10 +255,7 @@ char32_t FontFaceFT::findCharCode(glyph_idx_t idx) const
     char32_t c = findC(idx);
 
     // check
-    {
-        glyph_idx_t i = glyphIndex(c);
-        assert(i == idx);
-    }
+    assert(glyphIndex(c) == idx);
 
     return c;
 }

--- a/src/inspector/view/widgets/fretcanvas.cpp
+++ b/src/inspector/view/widgets/fretcanvas.cpp
@@ -198,7 +198,7 @@ void FretCanvas::draw(QPainter* painter)
         const double padding = 0.2 * _spatium;
         muse::draw::FontMetrics fontMetrics(muse::draw::Font::fromQFont(font, muse::draw::Font::Type::Text));
         double fontHeight = fontMetrics.capHeight();
-        for (int i = 0; i < m_diagram->fingering().size(); ++i) {
+        for (size_t i = 0; i < m_diagram->fingering().size(); ++i) {
             int finger = m_diagram->fingering()[i];
             if (finger == 0) {
                 continue;

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -2379,8 +2379,8 @@ bool NotationInteraction::dragMeasureAnchorElement(const PointF& pos)
         if (m_dropData.ed.modifiers & Qt::ControlModifier) {
             break;
         }
-        // fall through
     }
+    // fall through
     case ElementType::JUMP:
     case ElementType::LAYOUT_BREAK:
     case ElementType::MARKER:
@@ -2389,6 +2389,7 @@ bool NotationInteraction::dragMeasureAnchorElement(const PointF& pos)
     case ElementType::STAFF_LIST:
         // Target all staves
         staffIdx = 0;
+    // fall through
     default: break;
     }
 


### PR DESCRIPTION
* reg.: suggest parentheses around ‘&&’ within ‘||’ [-Wparentheses]
* reg.: comparison of integer expressions of different signedness: ‘int’ and ‘std::vector<int>::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
* reg.: unused variable ‘i’ [-Wunused-variable]
* reg.: this statement may fall through [-Wimplicit-fallthrough=]
