### PR TITLE
fixed #22362: Revert to factory settings doesn't clear AppData>MuseScore4Development folder

### DIFF
--- a/src/framework/global/settings.cpp
+++ b/src/framework/global/settings.cpp
@@ -219,7 +219,7 @@ QString Settings::dataPath() const
 #ifdef WIN_PORTABLE
     return QDir::cleanPath(QString("%1/../../../Data/settings").arg(QCoreApplication::applicationDirPath()));
 #else
-    return QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+    return QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation);
 #endif
 }
 


### PR DESCRIPTION
Resolves: #22362
as it was before 7568f73b16e8dd6eddc42268c9bf688559a5dfec and currently in `GlobalConfiguration::resolveUserAppDataPath`