### PR TITLE
Fix GH#13762: Lyrics verses should have even/odd text style set

### DIFF
--- a/src/engraving/dom/lyrics.h
+++ b/src/engraving/dom/lyrics.h
@@ -65,7 +65,8 @@ public:
     TranslatableString subtypeUserName() const override;
     void setNo(int n) { m_no = n; }
     int no() const { return m_no; }
-    bool isEven() const { return m_no % 2; }
+    // m_no is 0-based, so 1, 3, 5... are even here, the lowest bit is set, while 0, 2, 4... are odd here
+    bool isEven() const { return m_no & 1; }
     void setSyllabic(LyricsSyllabic s) { m_syllabic = s; }
     LyricsSyllabic syllabic() const { return m_syllabic; }
     void add(EngravingItem*) override;


### PR DESCRIPTION
Resolves: #13762, this time for real, unlike #13771

Lyrics verse numbers are 0-based, so 1, 3, 5... are even here, the lowest bit is set, while 0, 2, 4... are odd here...
Mu3 uses the same code as this PR, and there it works properly. But indeed Mu3 had the same mistake once.