### PR TITLE
Fix #23378 - Braille panel crash

### DIFF
--- a/src/braille/internal/braille.cpp
+++ b/src/braille/internal/braille.cpp
@@ -1408,7 +1408,9 @@ void Braille::brailleMeasureItems(BrailleEngravingItemList* beiz, Measure* measu
 
     //Render the barline
     BarLine* bl = lastBarline(measure, staffCount * VOICES);
-    beiz->addEngravingItem(bl, brailleBarline(bl));
+    if (bl) {
+        beiz->addEngravingItem(bl, brailleBarline(bl));
+    }
 
     //Render repeats and jumps that are on the right
     for (EngravingItem* el : measure->el()) {


### PR DESCRIPTION
Resolves: #23378

The crash seems to occur any time a selection is present when clicking "add stave".