### PR TITLE
Fix crash on splitting measures

### DIFF
--- a/src/engraving/dom/joinMeasure.cpp
+++ b/src/engraving/dom/joinMeasure.cpp
@@ -103,6 +103,7 @@ void MasterScore::joinMeasure(const Fraction& tick1, const Fraction& tick2)
     options.createEmptyMeasures = true;
     options.moveSignaturesClef = false;
     options.moveStaffTypeChanges = false;
+    options.ignoreBarLines = true;
     insertMeasure(next, options);
 
     for (Score* s : scoreList()) {

--- a/src/engraving/dom/masterscore.cpp
+++ b/src/engraving/dom/masterscore.cpp
@@ -677,7 +677,7 @@ MeasureBase* MasterScore::insertMeasure(MeasureBase* beforeMeasure, const Insert
             score->restoreInitialKeySigAndTimeSig();
         }
 
-        if (pm && !options.moveSignaturesClef) {
+        if (pm && !options.moveSignaturesClef && !options.ignoreBarLines) {
             Segment* pbs = pm->findSegment(SegmentType::EndBarLine, tick);
             if (pbs && pbs->enabled()) {
                 for (size_t staffIdx = 0; staffIdx < score->nstaves(); ++staffIdx) {

--- a/src/engraving/dom/score.h
+++ b/src/engraving/dom/score.h
@@ -872,6 +872,7 @@ public:
         bool needDeselectAll = true;
         bool cloneBoxToAllParts = true;
         bool moveStaffTypeChanges = true;
+        bool ignoreBarLines = false;
     };
 
     MeasureBase* insertMeasure(ElementType type, MeasureBase* beforeMeasure = nullptr,

--- a/src/engraving/dom/splitMeasure.cpp
+++ b/src/engraving/dom/splitMeasure.cpp
@@ -115,6 +115,7 @@ void MasterScore::splitMeasure(const Fraction& tick)
     options.createEmptyMeasures = true;
     options.moveSignaturesClef = false;
     options.moveStaffTypeChanges = false;
+    options.ignoreBarLines = true;
 
     insertMeasure(nm, options);
     Measure* m2 = toMeasure(nm ? nm->prev() : lastMeasure());


### PR DESCRIPTION
Resolves: #22558 

The crash occurs because both the splitMeasure function and the subsequent layout call try to generate the same barlines, so you get only one barline generated but 2 undo calls for it. When splitting measure we should simply ignore barlines as they will get generated anyway during layout.