### PR TITLE
Add elements written after the end of the score to the final tick

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -934,6 +934,7 @@ static void addElemOffset(EngravingItem* el, track_idx_t track, const String& pl
     if (!measure) {
         return;
     }
+    Fraction elTick = tick;
 
     if (!placement.empty()) {
         if (el->hasVoiceApplicationProperties()) {
@@ -944,9 +945,13 @@ static void addElemOffset(EngravingItem* el, track_idx_t track, const String& pl
             el->setPropertyFlags(Pid::PLACEMENT, PropertyFlags::UNSTYLED);
         }
     }
+    const Fraction& endTick = measure->score()->endTick();
+    if (elTick > endTick) {
+        elTick = endTick;
+    }
 
     el->setTrack(el->isTempoText() ? 0 : track);      // TempoText must be in track 0
-    Segment* s = measure->getSegment(SegmentType::ChordRest, tick);
+    Segment* s = measure->getSegment(SegmentType::ChordRest, elTick);
     if (el->systemFlag()) {
         Score* score = measure->score();
         Staff* st = score->staff(track2staff(track));
@@ -954,7 +959,7 @@ static void addElemOffset(EngravingItem* el, track_idx_t track, const String& pl
             score->addSystemObjectStaff(st);
         }
         bool found = false;
-        for (EngravingItem* existingEl : muse::values(_pass2.systemElements(), tick.ticks())) {
+        for (EngravingItem* existingEl : muse::values(_pass2.systemElements(), elTick.ticks())) {
             if (el->type() == existingEl->type()) {
                 found = true;
                 break;
@@ -962,7 +967,7 @@ static void addElemOffset(EngravingItem* el, track_idx_t track, const String& pl
         }
         if (!found) {
             el->setParent(s);
-            _pass2.addSystemElement(el, tick);
+            _pass2.addSystemElement(el, elTick);
         }
     } else {
         s->add(el);

--- a/src/importexport/musicxml/tests/data/testSystemObjectStaves.xml
+++ b/src/importexport/musicxml/tests/data/testSystemObjectStaves.xml
@@ -412,6 +412,12 @@
         <voice>5</voice>
         <staff>2</staff>
         </note>
+        <direction placement="above">
+        <direction-type>
+          <rehearsal default-y="20" enclosure="oval" font-size="5.7" font-style="italic" relative-x="-6">m</rehearsal>
+        </direction-type>
+        <offset>10</offset>
+      </direction>
       <barline location="right">
         <bar-style>light-heavy</bar-style>
         </barline>

--- a/src/importexport/musicxml/tests/data/testSystemObjectStaves_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testSystemObjectStaves_ref.mscx
@@ -405,6 +405,10 @@
             <durationType>measure</durationType>
             <duration>1/1</duration>
             </Rest>
+          <RehearsalMark>
+            <linkedMain/>
+            <text><b></b><font size="5.7"/><i>m</i></text>
+            </RehearsalMark>
           <BarLine>
             <subtype>end</subtype>
             </BarLine>
@@ -577,6 +581,14 @@
             <durationType>measure</durationType>
             <duration>1/1</duration>
             </Rest>
+          <RehearsalMark>
+            <linked>
+              <location>
+                <staves>-3</staves>
+                </location>
+              </linked>
+            <text><b></b><font size="5.7"/><i>m</i></text>
+            </RehearsalMark>
           <BarLine>
             <subtype>end</subtype>
             </BarLine>


### PR DESCRIPTION
Fixes a crash occuring when elements have an `offset` value which places the element after the end of a score.  In this case, we add the element to the final tick of the score.
