### PR TITLE
Fix accidental spacing issues when the parent chord isn't positioned relative to a segment

### DIFF
--- a/src/engraving/rendering/dev/accidentalslayout.cpp
+++ b/src/engraving/rendering/dev/accidentalslayout.cpp
@@ -260,9 +260,10 @@ void AccidentalsLayout::createChordsShape(AccidentalsLayoutContext& ctx)
     ctx.chordsShape.clear();
 
     for (const Chord* chord : ctx.chords) {
+        PointF chordPos = chord->isTrillCueNote() ? PointF() : chord->pos();
         const LedgerLine* ledger = chord->ledgerLines();
         while (ledger) {
-            ctx.chordsShape.add(ledger->shape().translate(ledger->pos() + chord->pos()));
+            ctx.chordsShape.add(ledger->shape().translate(ledger->pos() + chordPos));
             ledger = ledger->next();
         }
         for (const Note* note : chord->notes()) {
@@ -270,11 +271,11 @@ void AccidentalsLayout::createChordsShape(AccidentalsLayoutContext& ctx)
             if (noteSym == SymId::noSym) {
                 noteSym = note->noteHead();
             }
-            ctx.chordsShape.add(note->symShapeWithCutouts(noteSym).translate(note->pos() + chord->pos()));
+            ctx.chordsShape.add(note->symShapeWithCutouts(noteSym).translate(note->pos() + chordPos));
         }
         const Stem* stem = chord->stem();
         if (stem && stem->addToSkyline()) {
-            ctx.chordsShape.add(stem->shape().translate(stem->pos() + chord->pos()));
+            ctx.chordsShape.add(stem->shape().translate(stem->pos() + chordPos));
         }
     }
 }
@@ -1090,7 +1091,7 @@ void AccidentalsLayout::setXposRelativeToSegment(Accidental* accidental, double 
     if (note) {
         x -= note->pos().x();
     }
-    if (chord) {
+    if (chord && !chord->isTrillCueNote()) {
         x -= chord->pos().x();
     }
     accidental->mutldata()->setPosX(x);

--- a/src/engraving/rendering/dev/accidentalslayout.cpp
+++ b/src/engraving/rendering/dev/accidentalslayout.cpp
@@ -260,7 +260,7 @@ void AccidentalsLayout::createChordsShape(AccidentalsLayoutContext& ctx)
     ctx.chordsShape.clear();
 
     for (const Chord* chord : ctx.chords) {
-        PointF chordPos = chord->isTrillCueNote() ? PointF() : chord->pos();
+        PointF chordPos = keepAccidentalsCloseToChord(chord) ? PointF() : chord->pos();
         const LedgerLine* ledger = chord->ledgerLines();
         while (ledger) {
             ctx.chordsShape.add(ledger->shape().translate(ledger->pos() + chordPos));
@@ -1091,7 +1091,7 @@ void AccidentalsLayout::setXposRelativeToSegment(Accidental* accidental, double 
     if (note) {
         x -= note->pos().x();
     }
-    if (chord && !chord->isTrillCueNote()) {
+    if (chord && !keepAccidentalsCloseToChord(chord)) {
         x -= chord->pos().x();
     }
     accidental->mutldata()->setPosX(x);
@@ -1123,6 +1123,11 @@ void AccidentalsLayout::sortTopDown(std::vector<Accidental*>& accidentals)
         }
         return line1 < line2;
     });
+}
+
+bool AccidentalsLayout::keepAccidentalsCloseToChord(const Chord* chord)
+{
+    return chord->isTrillCueNote() || chord->isGraceAfter();
 }
 
 double AccidentalsLayout::verticalPadding(const Accidental* acc1, const Accidental* acc2, const AccidentalsLayoutContext& ctx)

--- a/src/engraving/rendering/dev/accidentalslayout.h
+++ b/src/engraving/rendering/dev/accidentalslayout.h
@@ -172,6 +172,8 @@ private:
     static double xPosRelativeToSegment(const Accidental* accidental);
 
     static void sortTopDown(std::vector<Accidental*>& accidentals);
+
+    static bool keepAccidentalsCloseToChord(const Chord* chord);
 };
 }
 


### PR DESCRIPTION
Resolves: #23023
Resolves: https://github.com/musescore/MuseScore/issues/23467
The new accidental layout system treats all positions relative to the segment, but trill cue notes (and grace notes after, thanks @miiizen) don't really belong to a segment so they need a special case. (By the way, I could reproduce the issue without the second trill and the tie, just write a trill with a cue note and accidental and you'll see the spacing jumping at every relayout).

