### PR TITLE
Fix #23144: Don't enable arrange section unless element has `Page` ancestor

### DIFF
--- a/src/inspector/models/abstractinspectormodel.cpp
+++ b/src/inspector/models/abstractinspectormodel.cpp
@@ -610,7 +610,12 @@ void AbstractInspectorModel::loadPropertyItem(PropertyItem* propertyItem, Conver
 void AbstractInspectorModel::loadPropertyItem(PropertyItem* propertyItem, const QList<EngravingItem*>& elements,
                                               ConvertPropertyValueFunc convertElementPropertyValueFunc)
 {
-    if (!propertyItem || elements.isEmpty()) {
+    if (!propertyItem) {
+        return;
+    }
+
+    if (elements.isEmpty()) {
+        propertyItem->setIsEnabled(false);
         return;
     }
 

--- a/src/inspector/models/general/appearance/appearancesettingsmodel.cpp
+++ b/src/inspector/models/general/appearance/appearancesettingsmodel.cpp
@@ -75,8 +75,15 @@ void AppearanceSettingsModel::requestElements()
         ElementType::HOOK,
     };
 
-    QSet<EngravingItem*> elementsForOffsetProperty;
+    QSet<EngravingItem*> elementsForArrangeProperty;
+    for (EngravingItem* element : m_elementList) {
+        if (element->findAncestor(ElementType::PAGE)) {
+            elementsForArrangeProperty.insert(element);
+        }
+    }
+    m_elementsForArrangeProperty = elementsForArrangeProperty.values();
 
+    QSet<EngravingItem*> elementsForOffsetProperty;
     for (EngravingItem* element : m_elementList) {
         if (!muse::contains(applyOffsetToChordTypes, element->type())) {
             elementsForOffsetProperty.insert(element);
@@ -88,7 +95,6 @@ void AppearanceSettingsModel::requestElements()
             elementsForOffsetProperty.insert(parent);
         }
     }
-
     m_elementsForOffsetProperty = elementsForOffsetProperty.values();
 }
 
@@ -142,7 +148,7 @@ void AppearanceSettingsModel::loadProperties(const PropertyIdSet& propertyIdSet)
     }
 
     if (muse::contains(propertyIdSet, Pid::Z)) {
-        loadPropertyItem(m_arrangeOrder);
+        loadPropertyItem(m_arrangeOrder, m_elementsForArrangeProperty);
     }
 
     if (muse::contains(propertyIdSet, Pid::OFFSET)) {
@@ -154,7 +160,7 @@ void AppearanceSettingsModel::loadProperties(const PropertyIdSet& propertyIdSet)
 
 Page* AppearanceSettingsModel::page() const
 {
-    return toPage(m_elementList.first()->findAncestor(ElementType::PAGE));
+    return toPage(m_elementsForArrangeProperty.first()->findAncestor(ElementType::PAGE));
 }
 
 std::vector<EngravingItem*> AppearanceSettingsModel::allElementsInPage() const
@@ -164,8 +170,8 @@ std::vector<EngravingItem*> AppearanceSettingsModel::allElementsInPage() const
 
 std::vector<EngravingItem*> AppearanceSettingsModel::allOverlappingElements() const
 {
-    RectF bbox = m_elementList.first()->abbox();
-    for (EngravingItem* element : m_elementList) {
+    RectF bbox = m_elementsForArrangeProperty.first()->abbox();
+    for (EngravingItem* element : m_elementsForArrangeProperty) {
         bbox |= element->abbox();
     }
     if (bbox.width() == 0 || bbox.height() == 0) {
@@ -180,7 +186,7 @@ void AppearanceSettingsModel::pushBackwardsInOrder()
     std::vector<EngravingItem*> elements = allOverlappingElements();
     std::sort(elements.begin(), elements.end(), elementLessThan);
 
-    int minZ = (*std::min_element(m_elementList.begin(), m_elementList.end(), elementLessThan))->z();
+    int minZ = (*std::min_element(m_elementsForArrangeProperty.begin(), m_elementsForArrangeProperty.end(), elementLessThan))->z();
     int i;
     for (i = 0; i < static_cast<int>(elements.size()); i++) {
         if (elements[i]->z() == minZ) {
@@ -197,7 +203,7 @@ void AppearanceSettingsModel::pushForwardsInOrder()
     std::vector<EngravingItem*> elements = allOverlappingElements();
     std::sort(elements.begin(), elements.end(), elementLessThan);
 
-    int maxZ = (*std::max_element(m_elementList.begin(), m_elementList.end(), elementLessThan))->z();
+    int maxZ = (*std::max_element(m_elementsForArrangeProperty.begin(), m_elementsForArrangeProperty.end(), elementLessThan))->z();
     int elementsCount = static_cast<int>(elements.size());
     int i;
     for (i = elementsCount - 1; i > 0; i--) {
@@ -215,7 +221,7 @@ void AppearanceSettingsModel::pushToBackInOrder()
     std::vector<EngravingItem*> elements = allElementsInPage();
     EngravingItem* minElement = *std::min_element(elements.begin(), elements.end(), elementLessThan);
 
-    if (m_elementList.contains(minElement)) {
+    if (m_elementsForArrangeProperty.contains(minElement)) {
         m_arrangeOrder->setValue(minElement->z());
     } else {
         m_arrangeOrder->setValue(minElement->z() - REARRANGE_ORDER_STEP);
@@ -227,7 +233,7 @@ void AppearanceSettingsModel::pushToFrontInOrder()
     std::vector<EngravingItem*> elements = allElementsInPage();
     EngravingItem* maxElement = *std::max_element(elements.begin(), elements.end(), elementLessThan);
 
-    if (m_elementList.contains(maxElement)) {
+    if (m_elementsForArrangeProperty.contains(maxElement)) {
         m_arrangeOrder->setValue(maxElement->z());
     } else {
         m_arrangeOrder->setValue(maxElement->z() + REARRANGE_ORDER_STEP);

--- a/src/inspector/models/general/appearance/appearancesettingsmodel.h
+++ b/src/inspector/models/general/appearance/appearancesettingsmodel.h
@@ -97,6 +97,7 @@ private:
     bool m_isVerticalOffsetAvailable = true;
 
     QList<engraving::EngravingItem*> m_elementsForOffsetProperty;
+    QList<engraving::EngravingItem*> m_elementsForArrangeProperty;
 };
 }
 

--- a/src/inspector/view/qml/MuseScore/Inspector/general/appearance/internal/ArrangeSection.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/general/appearance/internal/ArrangeSection.qml
@@ -71,7 +71,7 @@ Column {
                 navigation.row: root.resetButtonNavigationRow
                 navigation.accessible.name: qsTrc("inspector", "Reset stacking order to default")
 
-                enabled: root.arrangeOrderProperty.isModified
+                enabled: root.arrangeOrderProperty.isEnabled && root.arrangeOrderProperty.isModified
 
                 onClicked: {
                     root.arrangeOrderProperty.resetToDefault()
@@ -93,6 +93,8 @@ Column {
                 navigation.panel: root.navigationPanel
                 navigation.row: root.navigationRowStart + 1
 
+                enabled: root.arrangeOrderProperty.isEnabled
+
                 text: qsTrc("inspector", "Forwards")
 
                 onClicked: {
@@ -109,6 +111,8 @@ Column {
                 navigation.name: "To front"
                 navigation.panel: root.navigationPanel
                 navigation.row: forwardsButton.navigation.row + 1
+
+                enabled: root.arrangeOrderProperty.isEnabled
 
                 text: qsTrc("inspector", "To front")
 
@@ -132,6 +136,8 @@ Column {
                 navigation.panel: root.navigationPanel
                 navigation.row: toFrontButton.navigation.row + 1
 
+                enabled: root.arrangeOrderProperty.isEnabled
+
                 text: qsTrc("inspector", "Backwards")
 
                 onClicked: {
@@ -148,6 +154,8 @@ Column {
                 navigation.name: "To back"
                 navigation.panel: root.navigationPanel
                 navigation.row: backwardsButton.navigation.row + 1
+
+                enabled: root.arrangeOrderProperty.isEnabled
 
                 text: qsTrc("inspector", "To back")
 


### PR DESCRIPTION
Resolves: #23144

The “arrange/stacking” system (to front, to back, etc.) requires the selected item to have a `Page` ancestor. Brackets, however, can exist on multiple pages simultaneously and thus do not have one (we use the dummy element instead).

This PR disables the arrange section for items that do not have a page ancestor, making the crash unreachable. This may be something to revisit if the implementation of brackets or stacking changes.