### PR TITLE
Fix unreliable ordering of spanners during system layout

### DIFF
--- a/src/engraving/rendering/dev/systemlayout.cpp
+++ b/src/engraving/rendering/dev/systemlayout.cpp
@@ -918,6 +918,9 @@ void SystemLayout::layoutSystemElements(System* system, LayoutContext& ctx)
     Fraction stick = useRange ? ctx.state().startTick() : system->measures().front()->tick();
     Fraction etick = useRange ? ctx.state().endTick() : system->measures().back()->endTick();
     auto spanners = ctx.dom().spannerMap().findOverlapping(stick.ticks(), etick.ticks());
+    std::sort(spanners.begin(), spanners.end(), [](const auto& sp1, const auto& sp2) {
+        return sp1.value->tick() < sp2.value->tick();
+    });
 
     // ties
     if (ctx.conf().isLinearMode()) {


### PR DESCRIPTION
Resolves: #23549 

SpannerMap is an std::multimap from ticks to Spanner*, so it is guaranteed to be ordered by tick. However, it seems that SpannerMap::findOverlapping, which we use to find the spanners contained in a given range, does not guarantee that the output is ordered in the same way. From what I can see, the output is almost always correctly ordered, but apparently under the wrong conditions (see the linked issue) it may lose the original order. In that score, deleting an unrelated measure in the next page my cause it to be reordered again.

Having the spanners correctly ordered was probably irrelevant before, but is now fundamental for the new snapping/alignment business, so I'm just doing an std::sort to reorder it. Performance shouldn't be affected because, as said, the ordering is almost always correct already.

Couple of thoughts:
- Do we really need to use an external library (intervaltree) just for this findOverlapping operation?
- At some point we need to seriously look into how we store/represent spanners. I think there are better ways (especially now as we have TimeTickAnchors) to store our spanners which are simpler and more efficient than a multimap.


