### PR TITLE
[extensions] added compatible with 3.6 for properties declaration

### DIFF
--- a/src/framework/extensions/internal/legacy/extpluginsloader.cpp
+++ b/src/framework/extensions/internal/legacy/extpluginsloader.cpp
@@ -148,6 +148,12 @@ Manifest ExtPluginsLoader::parseManifest(const io::path_t& rootPath, const io::p
     while (current != std::string::npos) {
         String line = content.mid(previous, current - previous).trimmed();
 
+        //! NOTE Needed for compatibility with 3.6
+        //! We can add properties from 4.4 that are not in 3.6
+        if (line.startsWith(u"//4.4 ")) {
+            line = line.mid(6);
+        }
+
         if (line.startsWith(u'/')) { // comment
             // noop
         } else if (line.endsWith(u'{')) {


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/23518

now we can declare plugin properties that are in 4.4 but not in 3.6
Before the property need to add: `//4.4 `
for example

```
import MuseScore 3.0
import QtQuick 2.1

MuseScore {
    id: plugin
    //4.4 title: "Title for MS4.4+ "   
    menuPath: "Plugins.Title for MS 3.6"  
}
```