### PR TITLE
If the measure in part has only one voice, promote gap rests to real rests

### DIFF
--- a/src/engraving/dom/excerpt.cpp
+++ b/src/engraving/dom/excerpt.cpp
@@ -1617,6 +1617,9 @@ void Excerpt::cloneStaff2(Staff* srcStaff, Staff* dstStaff, const Fraction& star
                 score->removeElement(&seg);
             }
         }
+        if (!nm->hasVoices(dstStaffIdx, nm->tick(), nm->ticks())) {
+            promoteGapRestsToRealRests(nm, dstStaffIdx);
+        }
     }
 
     for (auto i : oscore->spanner()) {
@@ -1668,6 +1671,23 @@ void Excerpt::cloneStaff2(Staff* srcStaff, Staff* dstStaff, const Fraction& star
         }
 
         score->transposeKeys(dstStaffIdx, dstStaffIdx + 1, startTick, endTick, !scoreConcertPitch);
+    }
+}
+
+void Excerpt::promoteGapRestsToRealRests(const Measure* measure, staff_idx_t staffIdx)
+{
+    track_idx_t startTrack = staff2track(staffIdx);
+    track_idx_t endTrack = startTrack + VOICES;
+    for (const Segment& seg : measure->segments()) {
+        if (!seg.isChordRestType()) {
+            continue;
+        }
+        for (track_idx_t track = startTrack; track < endTrack; ++track) {
+            EngravingItem* item = seg.element(track);
+            if (item && item->isRest() && toRest(item)->isGap()) {
+                toRest(item)->setGap(false);
+            }
+        }
     }
 }
 

--- a/src/engraving/dom/excerpt.h
+++ b/src/engraving/dom/excerpt.h
@@ -31,6 +31,7 @@
 
 namespace mu::engraving {
 class MasterScore;
+class Measure;
 class Part;
 class Score;
 class Staff;
@@ -96,6 +97,8 @@ public:
 
 private:
     friend class MasterScore;
+
+    static void promoteGapRestsToRealRests(const Measure* measure, staff_idx_t staffIdx);
 
     void setInited(bool inited);
     void writeNameToMetaTags();


### PR DESCRIPTION
Resolves: #19182 

The issue isn't that the rest is missing in the part. The rest is there, but is marked as a "gap" rest (as it is in the score), and is therefore not shown. When cloning staves to part, we should check if the resulting measures are single-voiced (which may happen due to voice-selections), and in that case we should "promote" the gap rests to a real rest.
