### PR TITLE
 Make sure gap rests correspond to the `<location>` gap duration (#2)

### DIFF
--- a/src/engraving/dom/check.cpp
+++ b/src/engraving/dom/check.cpp
@@ -272,19 +272,6 @@ void Measure::fillGap(const Fraction& pos, const Fraction& len, track_idx_t trac
          stretch.numerator(), stretch.denominator(),
          track);
 
-    if (useGapRests) {
-        // fill this gap with a single gap rest, where the duration does not need to correspond to a valid DurationType
-        TDuration d;
-        d.setVal(len.ticks());
-        Rest* rest = Factory::createRest(score()->dummy()->segment());
-        rest->setTicks(len);
-        rest->setDurationType(d);
-        rest->setTrack(track);
-        rest->setGap(useGapRests);
-        score()->undoAddCR(rest, this, (pos / stretch) + tick());
-        return;
-    }
-
     // break the gap into shorter durations if necessary
     std::vector<TDuration> durationList = toRhythmicDurationList(len, true, pos, score()->sigmap()->timesig(tick()).nominal(), this, 0);
 

--- a/src/importexport/mei/internal/meiexporter.cpp
+++ b/src/importexport/mei/internal/meiexporter.cpp
@@ -1353,7 +1353,7 @@ bool MeiExporter::writeRest(const Rest* rest, const Staff* staff)
         this->writeBeamAndTupletEnd(closingBeam, closingTuplet, closingBeamInTuplet);
 
         // Change invisible rests to space by simply adjusting the element name
-        if (!rest->visible()) {
+        if (!rest->visible() || rest->isGap()) {
             restNode.set_name("space");
         }
     }


### PR DESCRIPTION
Clean replacement for https://github.com/musescore/MuseScore/pull/22931
