### PR TITLE
Fix assertion failure when clicking "Style" in lyrics context menu

### DIFF
--- a/src/notation/view/widgets/editstyle.cpp
+++ b/src/notation/view/widgets/editstyle.cpp
@@ -1608,7 +1608,7 @@ QString EditStyle::subPageCodeForElement(const EngravingItem* element)
         return QString();
     }
 
-    if (element->isTextBase()) {
+    if (pageCodeForElement(element) == "text-styles" && element->isTextBase()) {
         switch (toTextBase(element)->textStyleType()) {
         case TextStyleType::TITLE:
             return "title";


### PR DESCRIPTION
For lyrics, the page code is "lyrics", so trying to set the sub page code to something causes the assertion in `EditStyle::setCurrentSubPageCode` to fail.