### PR TITLE
fixed #17006: Freeze/crash when editing Title or Arranger fields (when Text cursor indicator is turned on, Windows only)

### DIFF
--- a/src/engraving/accessibility/accessibleitem.cpp
+++ b/src/engraving/accessibility/accessibleitem.cpp
@@ -252,8 +252,8 @@ void AccessibleItem::accessibleSelection(int selectionIndex, int* startOffset, i
         *startOffset = selectionRange.startPosition;
         *endOffset = selectionRange.endPosition;
     } else {
-        *startOffset = 0;
-        *endOffset = 0;
+        *startOffset = -1;
+        *endOffset = -1;
     }
 }
 
@@ -303,15 +303,21 @@ QString AccessibleItem::accessibleText(int startOffset, int endOffset) const
     return text;
 }
 
-QString AccessibleItem::accessibleTextBeforeOffset(int, TextBoundaryType, int*, int*) const
+QString AccessibleItem::accessibleTextBeforeOffset(int, TextBoundaryType, int* startOffset, int* endOffset) const
 {
     NOT_IMPLEMENTED;
+
+    *startOffset = -1;
+    *endOffset = -1;
     return QString();
 }
 
-QString AccessibleItem::accessibleTextAfterOffset(int, TextBoundaryType, int*, int*) const
+QString AccessibleItem::accessibleTextAfterOffset(int, TextBoundaryType, int* startOffset, int* endOffset) const
 {
     NOT_IMPLEMENTED;
+
+    *startOffset = -1;
+    *endOffset = -1;
     return QString();
 }
 

--- a/src/framework/accessibility/internal/accessibleiteminterface.cpp
+++ b/src/framework/accessibility/internal/accessibleiteminterface.cpp
@@ -391,8 +391,8 @@ QString AccessibleItemInterface::attributes(int, int* startOffset, int* endOffse
 {
     NOT_IMPLEMENTED;
 
-    *startOffset = 0;
-    *endOffset = 0;
+    *startOffset = -1;
+    *endOffset = -1;
     return QString();
 }
 

--- a/src/framework/ui/view/qmlaccessible.cpp
+++ b/src/framework/ui/view/qmlaccessible.cpp
@@ -154,8 +154,8 @@ void AccessibleItem::accessibleSelection(int selectionIndex, int* startOffset, i
         *startOffset = m_selectionStart;
         *endOffset = m_selectionEnd;
     } else {
-        *startOffset = 0;
-        *endOffset = 0;
+        *startOffset = -1;
+        *endOffset = -1;
     }
 }
 


### PR DESCRIPTION
Resolves: #17006
