### PR TITLE
Improved distances and centering of cross-staff beams

### DIFF
--- a/src/engraving/dom/beam.cpp
+++ b/src/engraving/dom/beam.cpp
@@ -220,6 +220,32 @@ const Chord* Beam::findChordWithCustomStemDirection() const
     return nullptr;
 }
 
+const BeamSegment* Beam::topLevelSegmentForElement(const ChordRest* element) const
+{
+    size_t segmentsSize = m_beamSegments.size();
+
+    IF_ASSERT_FAILED(segmentsSize > 0) {
+        return nullptr;
+    }
+
+    const BeamSegment* curSegment = m_beamSegments[0];
+    if (segmentsSize == 1) {
+        return curSegment;
+    }
+
+    for (const BeamSegment* segment : m_beamSegments) {
+        if (segment->level <= curSegment->level) {
+            continue;
+        }
+        Fraction elementTick = element->tick();
+        if (segment->startTick <= elementTick && segment->endTick >= elementTick) {
+            curSegment = segment;
+        }
+    }
+
+    return curSegment;
+}
+
 //---------------------------------------------------------
 //   move
 //---------------------------------------------------------

--- a/src/engraving/dom/beam.h
+++ b/src/engraving/dom/beam.h
@@ -228,6 +228,8 @@ public:
 
     const Chord* findChordWithCustomStemDirection() const;
 
+    const BeamSegment* topLevelSegmentForElement(const ChordRest* element) const;
+
     inline int directionIdx() const { return (m_direction == DirectionV::AUTO || m_direction == DirectionV::DOWN) ? 0 : 1; }
 
 private:

--- a/src/engraving/dom/beambase.h
+++ b/src/engraving/dom/beambase.h
@@ -124,6 +124,8 @@ public:
         const StaffType* tab = nullptr;
         bool isBesideTabStaff = false;
         CrossStaffBeamPosition crossStaffBeamPos = CrossStaffBeamPosition::INVALID;
+        const Chord* limitingChordAbove = nullptr; // <-
+        const Chord* limitingChordBelow = nullptr; // <- For cross-staff spacing and centering
 
         void setAnchors(PointF startA, PointF endA) { startAnchor = startA; endAnchor = endA; }
         bool isValid() const override { return !(beamType == BeamType::INVALID); }

--- a/src/engraving/rendering/dev/beamtremololayout.h
+++ b/src/engraving/rendering/dev/beamtremololayout.h
@@ -62,6 +62,8 @@ public:
     static PointF chordBeamAnchor(const BeamBase::LayoutData* ldata, const ChordRest* chord, ChordBeamAnchorType anchorType);
     static int getMaxSlope(const BeamBase::LayoutData* ldata);
     static void extendStem(const BeamBase::LayoutData* ldata, Chord* chord, double addition);
+    static int minStemLength(const ChordRest* cr, const BeamBase::LayoutData* ldata);
+    static int strokeCount(const BeamBase::LayoutData* ldata, const ChordRest* cr);
 
 private:
 
@@ -93,10 +95,9 @@ private:
     static void add8thSpaceSlant(BeamBase::LayoutData* ldata, PointF& dictatorAnchor, int dictator, int pointer, int beamCount,
                                  int interval, int middleLine, bool Flat);
     static bool noSlope(const Beam* beam);
-    static int strokeCount(const BeamBase::LayoutData* ldata, const ChordRest* cr);
+
     static bool calculateAnchorsCross(const BeamBase* item, BeamBase::LayoutData* ldata, const LayoutConfiguration& conf);
     static bool computeTremoloUp(const BeamBase::LayoutData* ldata);
-    static int minStemLength(const ChordRest* cr, const BeamBase::LayoutData* ldata);
 };
 } // namespace mu::engraving
 #endif

--- a/src/engraving/rendering/dev/systemlayout.cpp
+++ b/src/engraving/rendering/dev/systemlayout.cpp
@@ -2402,7 +2402,10 @@ double SystemLayout::minVertSpaceForCrossStaffBeams(System* system, staff_idx_t 
                     continue;
                 }
                 Beam* beam = toChord(item)->beam();
-                if (!beam || !beam->cross() || !beam->autoplace() || beam->elements().front() != item) {
+                if (!beam || !beam->autoplace() || beam->elements().front() != item) {
+                    continue;
+                }
+                if (beam->ldata()->crossStaffBeamPos != BeamBase::CrossStaffBeamPosition::BETWEEN) {
                     continue;
                 }
                 const Chord* limitingChordAbove = nullptr;

--- a/src/engraving/rendering/dev/systemlayout.cpp
+++ b/src/engraving/rendering/dev/systemlayout.cpp
@@ -2357,8 +2357,8 @@ void SystemLayout::layout2(System* system, LayoutContext& ctx)
                 }
             }
             dist = std::max(dist, d + minVerticalDistance);
+            dist = std::max(dist, minVertSpaceForCrossStaffBeams(system, si1, si2, ctx));
         }
-        dist = std::max(dist, minVertSpaceForCrossStaffBeams(system, si1, si2, ctx));
         ss->setYOff(yOffset);
         ss->setbbox(system->leftMargin(), y - yOffset, system->width() - system->leftMargin(), h);
         ss->saveLayout();

--- a/src/engraving/rendering/dev/systemlayout.h
+++ b/src/engraving/rendering/dev/systemlayout.h
@@ -83,7 +83,7 @@ private:
     static void addBrackets(System* system, Measure* measure, LayoutContext& ctx);
     static Bracket* createBracket(System* system, LayoutContext& ctx, BracketItem* bi, size_t column, staff_idx_t staffIdx,
                                   std::vector<Bracket*>& bl, Measure* measure);
-    static double minVertSpaceForCrossStaffBeams(System* system, staff_idx_t staffIdx1, staff_idx_t staffIdx2);
+    static double minVertSpaceForCrossStaffBeams(System* system, staff_idx_t staffIdx1, staff_idx_t staffIdx2, LayoutContext& ctx);
 
     static bool elementShouldBeCenteredBetweenStaves(const EngravingItem* item, const System* system);
     static void centerElementBetweenStaves(EngravingItem* element, const System* system);

--- a/src/importexport/mei/tests/data/cross-staff-01.mscx
+++ b/src/importexport/mei/tests/data/cross-staff-01.mscx
@@ -79,8 +79,8 @@
       <Measure>
         <voice>
           <Beam>
-            <l1>48</l1>
-            <l2>48</l2>
+            <l1>51</l1>
+            <l2>51</l2>
             </Beam>
           <Chord>
             <durationType>16th</durationType>
@@ -113,8 +113,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>48</l1>
-            <l2>48</l2>
+            <l1>51</l1>
+            <l2>51</l2>
             </Beam>
           <Chord>
             <staffMove>1</staffMove>
@@ -147,8 +147,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>48</l1>
-            <l2>48</l2>
+            <l1>51</l1>
+            <l2>51</l2>
             </Beam>
           <Chord>
             <durationType>16th</durationType>
@@ -181,8 +181,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>48</l1>
-            <l2>48</l2>
+            <l1>45</l1>
+            <l2>45</l2>
             </Beam>
           <Chord>
             <staffMove>1</staffMove>
@@ -233,8 +233,8 @@
             <sigD>4</sigD>
             </TimeSig>
           <Beam>
-            <l1>-16</l1>
-            <l2>-8</l2>
+            <l1>-13</l1>
+            <l2>-5</l2>
             </Beam>
           <Chord>
             <staffMove>-1</staffMove>
@@ -267,8 +267,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>-16</l1>
-            <l2>-8</l2>
+            <l1>-13</l1>
+            <l2>-5</l2>
             </Beam>
           <Chord>
             <staffMove>-1</staffMove>
@@ -301,8 +301,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>-15</l1>
-            <l2>-9</l2>
+            <l1>-12</l1>
+            <l2>-6</l2>
             </Beam>
           <Chord>
             <staffMove>-1</staffMove>
@@ -332,8 +332,8 @@
             <durationType>16th</durationType>
             </Rest>
           <Beam>
-            <l1>-23</l1>
-            <l2>-21</l2>
+            <l1>-26</l1>
+            <l2>-24</l2>
             </Beam>
           <Chord>
             <staffMove>-1</staffMove>


### PR DESCRIPTION
Resolves: #23553 

The minimum staff distance for cross-staff beams is computed by summing the minimum allowed stem length of the lowest note above and highest note below the beam. My original implementation however didn't take into account that stems from above and from below overlap each other within the height of the beam itself, hence why the resulting space was excessive. 
Additionally, we now measure the distance between first and last beam segment (which for cross-staff beams can be both above and below the beam centerline) and use it to center the beam more precisely.

The action of the fixed-width spacer is now also restored, which allows to fine tune if necessary.