### PR TITLE
Change inappropriate toggles to checkboxes

### DIFF
--- a/src/inspector/view/qml/MuseScore/Inspector/notation/lines/internal/GradualTempoChangePositionSettingsTab.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/lines/internal/GradualTempoChangePositionSettingsTab.qml
@@ -63,7 +63,7 @@ FocusableItem {
             text: qsTrc("inspector", "Alignment with adjacent tempo text")
         }
 
-        PropertyToggle {
+        PropertyCheckBox {
             id: snapAfter
             text: qsTrc("inspector", "Snap to next")
             propertyItem: root.model ? root.model.snapAfter : null

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/lines/internal/HairpinPositionSettingsTab.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/lines/internal/HairpinPositionSettingsTab.qml
@@ -63,7 +63,7 @@ FocusableItem {
             text: qsTrc("inspector", "Alignment with adjacent dynamics")
         }
 
-        PropertyToggle {
+        PropertyCheckBox {
             id: snapBefore
             text: qsTrc("inspector", "Snap to previous")
             propertyItem: root.model ? root.model.snapBefore : null
@@ -72,7 +72,7 @@ FocusableItem {
             navigation.row: voicesAndPositionSection.navigationRowEnd + 1
         }
 
-        PropertyToggle {
+        PropertyCheckBox {
             id: snapAfter
             text: qsTrc("inspector", "Snap to next")
             propertyItem: root.model ? root.model.snapAfter : null


### PR DESCRIPTION
Resolves: #23545

Changed the snapping behaviour toggle in hairpin and tempo line properties to a checkbox. This is because checkboxes have the ability to show an indeterminate state when multiple items with different states are selected.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
