### PR TITLE
Fix crash when pressing delete key twice in note input mode in non-first voices

### DIFF
--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -4488,12 +4488,10 @@ ChordRest* Score::findCR(Fraction tick, track_idx_t track) const
     }
     EngravingItem* el = s->element(track);
     if (el && el->isRest() && toRest(el)->isGap()) {
-        s = nullptr;
+        return nullptr;
     }
-    if (s) {
-        return toChordRest(s->element(track));
-    }
-    return nullptr;
+
+    return toChordRest(el);
 }
 
 //---------------------------------------------------------


### PR DESCRIPTION
The changes in `findCR` are purely cosmetic. The problem however was that `cmdDeleteSelection` did not handle the case that `findCR` returns nullptr.

Resolves: https://github.com/musescore/MuseScore/issues/23585