### PR TITLE
Remove pointless 'this' argument to Segment member functions

### DIFF
--- a/src/engraving/dom/measure.cpp
+++ b/src/engraving/dom/measure.cpp
@@ -3057,7 +3057,7 @@ EngravingItem* Measure::nextElementStaff(staff_idx_t staff)
     }
     Segment* seg = toSegment(e);
     Segment* nextSegment = seg ? seg->next() : first();
-    EngravingItem* next = seg->firstElementOfSegment(nextSegment, staff);
+    EngravingItem* next = nextSegment->firstElementOfSegment(staff);
     if (next) {
         return next;
     }

--- a/src/engraving/dom/navigate.cpp
+++ b/src/engraving/dom/navigate.cpp
@@ -762,7 +762,7 @@ EngravingItem* Score::nextElement()
             if (seg) {
                 Segment* nextSegment = seg->next1();
                 while (nextSegment) {
-                    EngravingItem* nextEl = nextSegment->firstElementOfSegment(nextSegment, staffId);
+                    EngravingItem* nextEl = nextSegment->firstElementOfSegment(staffId);
                     if (nextEl) {
                         return nextEl;
                     }
@@ -925,12 +925,12 @@ EngravingItem* Score::prevElement()
             } else {
                 Segment* startSeg = sp->startSegment();
                 if (!startSeg->annotations().empty()) {
-                    EngravingItem* last = startSeg->lastAnnotation(startSeg, staffId);
+                    EngravingItem* last = startSeg->lastAnnotation(staffId);
                     if (last) {
                         return last;
                     }
                 }
-                EngravingItem* el = startSeg->lastElementOfSegment(startSeg, staffId);
+                EngravingItem* el = startSeg->lastElementOfSegment(staffId);
                 if (stEl->type() == ElementType::CHORD || stEl->type() == ElementType::REST
                     || stEl->type() == ElementType::MEASURE_REPEAT || stEl->type() == ElementType::MMREST
                     || stEl->type() == ElementType::NOTE) {

--- a/src/engraving/dom/segment.cpp
+++ b/src/engraving/dom/segment.cpp
@@ -1484,7 +1484,7 @@ RectF Segment::contentRect() const
 //   segment, or a barline if it spanns in the staff
 //---------------------------------------------------------
 
-EngravingItem* Segment::firstElementForNavigation(staff_idx_t staff)
+EngravingItem* Segment::firstElementForNavigation(staff_idx_t staff) const
 {
     if (isChordRestType()) {
         track_idx_t strack = staff * VOICES;
@@ -1508,7 +1508,7 @@ EngravingItem* Segment::firstElementForNavigation(staff_idx_t staff)
 //   segment, or a barline if it spanns in the staff
 //---------------------------------------------------------
 
-EngravingItem* Segment::lastElementForNavigation(staff_idx_t staff)
+EngravingItem* Segment::lastElementForNavigation(staff_idx_t staff) const
 {
     if (segmentType() == SegmentType::ChordRest) {
         for (int voice = static_cast<int>(staff * VOICES + (VOICES - 1)); voice / static_cast<int>(VOICES) == static_cast<int>(staff);
@@ -1539,7 +1539,7 @@ EngravingItem* Segment::lastElementForNavigation(staff_idx_t staff)
 //   Use firstElement, or lastElement instead of this
 //---------------------------------------------------------
 
-EngravingItem* Segment::getElement(staff_idx_t staff)
+EngravingItem* Segment::getElement(staff_idx_t staff) const
 {
     segmentType();
     if (segmentType() == SegmentType::ChordRest) {
@@ -1565,7 +1565,7 @@ EngravingItem* Segment::getElement(staff_idx_t staff)
 //   return next element in _annotations
 //---------------------------------------------------------
 
-EngravingItem* Segment::nextAnnotation(EngravingItem* e)
+EngravingItem* Segment::nextAnnotation(EngravingItem* e) const
 {
     if (m_annotations.empty() || e == m_annotations.back()) {
         return nullptr;
@@ -1587,7 +1587,7 @@ EngravingItem* Segment::nextAnnotation(EngravingItem* e)
 //   return previous element in _annotations
 //---------------------------------------------------------
 
-EngravingItem* Segment::prevAnnotation(EngravingItem* e)
+EngravingItem* Segment::prevAnnotation(EngravingItem* e) const
 {
     if (e == m_annotations.front()) {
         return nullptr;
@@ -1608,9 +1608,9 @@ EngravingItem* Segment::prevAnnotation(EngravingItem* e)
 //   firstAnnotation
 //---------------------------------------------------------
 
-EngravingItem* Segment::firstAnnotation(Segment* s, staff_idx_t activeStaff)
+EngravingItem* Segment::firstAnnotation(staff_idx_t activeStaff) const
 {
-    for (auto i = s->annotations().begin(); i != s->annotations().end(); ++i) {
+    for (auto i = m_annotations.begin(); i != m_annotations.end(); ++i) {
         // TODO: firstVisibleStaff() for system elements? see Spanner::nextSpanner()
         if ((*i)->staffIdx() == activeStaff) {
             return *i;
@@ -1623,15 +1623,15 @@ EngravingItem* Segment::firstAnnotation(Segment* s, staff_idx_t activeStaff)
 //   lastAnnotation
 //---------------------------------------------------------
 
-EngravingItem* Segment::lastAnnotation(Segment* s, staff_idx_t activeStaff)
+EngravingItem* Segment::lastAnnotation(staff_idx_t activeStaff) const
 {
-    for (auto i = --s->annotations().end(); i != s->annotations().begin(); --i) {
+    for (auto i = --m_annotations.end(); i != m_annotations.begin(); --i) {
         // TODO: firstVisibleStaff() for system elements? see Spanner::nextSpanner()
         if ((*i)->staffIdx() == activeStaff) {
             return *i;
         }
     }
-    auto i = s->annotations().begin();
+    auto i = m_annotations.begin();
     if ((*i)->staffIdx() == activeStaff) {
         return *i;
     }
@@ -1647,10 +1647,10 @@ EngravingItem* Segment::lastAnnotation(Segment* s, staff_idx_t activeStaff)
 //   spans into the active staff
 //--------------------------------------------------------
 
-EngravingItem* Segment::firstInNextSegments(staff_idx_t activeStaff)
+EngravingItem* Segment::firstInNextSegments(staff_idx_t activeStaff) const
 {
     EngravingItem* re = 0;
-    Segment* seg = this;
+    const Segment* seg = this;
     while (!re) {
         seg = seg->next1MMenabled();
         if (!seg) {   //end of staff, or score
@@ -1676,12 +1676,12 @@ EngravingItem* Segment::firstInNextSegments(staff_idx_t activeStaff)
 
 //---------------------------------------------------------
 //   firstElementOfSegment
-//   returns the first non null element in the given segment
+//   returns the first non null element
 //---------------------------------------------------------
 
-EngravingItem* Segment::firstElementOfSegment(Segment* s, staff_idx_t activeStaff)
+EngravingItem* Segment::firstElementOfSegment(staff_idx_t activeStaff) const
 {
-    for (auto i: s->elist()) {
+    for (auto i: m_elist) {
         if (i && i->staffIdx() == activeStaff) {
             if (i->type() == ElementType::CHORD) {
                 Chord* chord = toChord(i);
@@ -1703,21 +1703,21 @@ EngravingItem* Segment::firstElementOfSegment(Segment* s, staff_idx_t activeStaf
 
 //---------------------------------------------------------
 //   nextElementOfSegment
-//   returns the next element in the given segment
+//   returns the next element after the given element
 //---------------------------------------------------------
 
-EngravingItem* Segment::nextElementOfSegment(Segment* s, EngravingItem* e, staff_idx_t activeStaff)
+EngravingItem* Segment::nextElementOfSegment(EngravingItem* e, staff_idx_t activeStaff) const
 {
     for (size_t track = 0; track < score()->nstaves() * VOICES - 1; ++track) {
-        if (s->element(track) == 0) {
+        if (element(track) == 0) {
             continue;
         }
-        EngravingItem* el = s->element(track);
+        EngravingItem* el = element(track);
         if (el == e) {
-            EngravingItem* next = s->element(track + 1);
+            EngravingItem* next = element(track + 1);
             while (track < score()->nstaves() * VOICES - 1
                    && (!next || next->staffIdx() != activeStaff)) {
-                next = s->element(++track);
+                next = element(++track);
             }
             if (!next || next->staffIdx() != activeStaff) {
                 return nullptr;
@@ -1737,10 +1737,10 @@ EngravingItem* Segment::nextElementOfSegment(Segment* s, EngravingItem* e, staff
             if (i != notes.begin()) {
                 return *(i - 1);
             } else {
-                EngravingItem* nextEl = s->element(++track);
+                EngravingItem* nextEl = element(++track);
                 while (track < score()->nstaves() * VOICES - 1
                        && (!nextEl || nextEl->staffIdx() != activeStaff)) {
-                    nextEl = s->element(++track);
+                    nextEl = element(++track);
                 }
                 if (!nextEl || nextEl->staffIdx() != activeStaff) {
                     return nullptr;
@@ -1757,21 +1757,21 @@ EngravingItem* Segment::nextElementOfSegment(Segment* s, EngravingItem* e, staff
 
 //---------------------------------------------------------
 //   prevElementOfSegment
-//   returns the previous element in the given segment
+//   returns the previous element before the given element
 //---------------------------------------------------------
 
-EngravingItem* Segment::prevElementOfSegment(Segment* s, EngravingItem* e, staff_idx_t activeStaff)
+EngravingItem* Segment::prevElementOfSegment(EngravingItem* e, staff_idx_t activeStaff) const
 {
     for (int track = static_cast<int>(score()->nstaves() * VOICES) - 1; track > 0; --track) {
-        if (s->element(track) == 0) {
+        if (element(track) == 0) {
             continue;
         }
-        EngravingItem* el = s->element(track);
+        EngravingItem* el = element(track);
         if (el == e) {
-            EngravingItem* prev = s->element(track - 1);
+            EngravingItem* prev = element(track - 1);
             while (track > 0
                    && (!prev || prev->staffIdx() != activeStaff)) {
-                prev = s->element(--track);
+                prev = element(--track);
             }
             if (!prev) {
                 return nullptr;
@@ -1806,10 +1806,10 @@ EngravingItem* Segment::prevElementOfSegment(Segment* s, EngravingItem* e, staff
             if (i != --notes.end()) {
                 return *(i + 1);
             } else {
-                EngravingItem* prevEl = s->element(--track);
+                EngravingItem* prevEl = element(--track);
                 while (track > 0
                        && (!prevEl || prevEl->staffIdx() != activeStaff)) {
-                    prevEl = s->element(--track);
+                    prevEl = element(--track);
                 }
                 if (!prevEl) {
                     return nullptr;
@@ -1829,12 +1829,12 @@ EngravingItem* Segment::prevElementOfSegment(Segment* s, EngravingItem* e, staff
 
 //---------------------------------------------------------
 //   lastElementOfSegment
-//   returns the last element in the given segment
+//   returns the last element
 //---------------------------------------------------------
 
-EngravingItem* Segment::lastElementOfSegment(Segment* s, staff_idx_t activeStaff)
+EngravingItem* Segment::lastElementOfSegment(staff_idx_t activeStaff) const
 {
-    const std::vector<EngravingItem*>& elements = s->elist();
+    const std::vector<EngravingItem*>& elements = m_elist;
     for (auto it = elements.rbegin(); it != elements.rend(); ++it) {
         EngravingItem* item = *it;
         if (item && item->staffIdx() == activeStaff) {
@@ -1860,7 +1860,7 @@ EngravingItem* Segment::lastElementOfSegment(Segment* s, staff_idx_t activeStaff
 //   firstSpanner
 //---------------------------------------------------------
 
-Spanner* Segment::firstSpanner(staff_idx_t activeStaff)
+Spanner* Segment::firstSpanner(staff_idx_t activeStaff) const
 {
     std::multimap<int, Spanner*> mmap = score()->spanner();
     auto range = mmap.equal_range(tick().ticks());
@@ -1889,7 +1889,7 @@ Spanner* Segment::firstSpanner(staff_idx_t activeStaff)
 //   lastSpanner
 //---------------------------------------------------------
 
-Spanner* Segment::lastSpanner(staff_idx_t activeStaff)
+Spanner* Segment::lastSpanner(staff_idx_t activeStaff) const
 {
     std::multimap<int, Spanner*> mmap = score()->spanner();
     auto range = mmap.equal_range(tick().ticks());
@@ -1921,17 +1921,17 @@ Spanner* Segment::lastSpanner(staff_idx_t activeStaff)
 //   notChordRestType
 //---------------------------------------------------------
 
-bool Segment::notChordRestType(Segment* s)
+bool Segment::notChordRestType() const
 {
-    if (s->segmentType() == SegmentType::KeySig
-        || s->segmentType() == SegmentType::TimeSig
-        || s->segmentType() == SegmentType::Clef
-        || s->segmentType() == SegmentType::HeaderClef
-        || s->segmentType() == SegmentType::BeginBarLine
-        || s->segmentType() == SegmentType::EndBarLine
-        || s->segmentType() == SegmentType::BarLine
-        || s->segmentType() == SegmentType::KeySigAnnounce
-        || s->segmentType() == SegmentType::TimeSigAnnounce) {
+    if (segmentType() == SegmentType::KeySig
+        || segmentType() == SegmentType::TimeSig
+        || segmentType() == SegmentType::Clef
+        || segmentType() == SegmentType::HeaderClef
+        || segmentType() == SegmentType::BeginBarLine
+        || segmentType() == SegmentType::EndBarLine
+        || segmentType() == SegmentType::BarLine
+        || segmentType() == SegmentType::KeySigAnnounce
+        || segmentType() == SegmentType::TimeSigAnnounce) {
         return true;
     } else {
         return false;
@@ -1990,7 +1990,7 @@ EngravingItem* Segment::nextElement(staff_idx_t activeStaff)
         }
         Segment* nextSegment = this->next1MMenabled();
         while (nextSegment) {
-            EngravingItem* nextEl = nextSegment->firstElementOfSegment(nextSegment, activeStaff);
+            EngravingItem* nextEl = nextSegment->firstElementOfSegment(activeStaff);
             if (nextEl) {
                 return nextEl;
             }
@@ -2000,7 +2000,7 @@ EngravingItem* Segment::nextElement(staff_idx_t activeStaff)
     }
     case ElementType::SEGMENT: {
         if (!m_annotations.empty()) {
-            EngravingItem* next = firstAnnotation(this, activeStaff);
+            EngravingItem* next = firstAnnotation(activeStaff);
             if (next) {
                 return next;
             }
@@ -2012,7 +2012,7 @@ EngravingItem* Segment::nextElement(staff_idx_t activeStaff)
 
         Segment* nextSegment = this->next1MMenabled();
         while (nextSegment) {
-            EngravingItem* nextEl = nextSegment->firstElementOfSegment(nextSegment, activeStaff);
+            EngravingItem* nextEl = nextSegment->firstElementOfSegment(activeStaff);
             if (nextEl) {
                 return nextEl;
             }
@@ -2038,12 +2038,12 @@ EngravingItem* Segment::nextElement(staff_idx_t activeStaff)
         }
         Segment* seg = toSegment(p);
         // next in _elist
-        EngravingItem* nextEl = nextElementOfSegment(seg, el, activeStaff);
+        EngravingItem* nextEl = seg->nextElementOfSegment(el, activeStaff);
         if (nextEl) {
             return nextEl;
         }
         if (!m_annotations.empty()) {
-            EngravingItem* next = firstAnnotation(seg, activeStaff);
+            EngravingItem* next = seg->firstAnnotation(activeStaff);
             if (next) {
                 if (next->isStaffText()) {
                     if (SoundFlag* soundFlag = toStaffText(next)->soundFlag()) {
@@ -2079,7 +2079,7 @@ EngravingItem* Segment::nextElement(staff_idx_t activeStaff)
         }
 
         while (nextSegment) {
-            nextEl = nextSegment->firstElementOfSegment(nextSegment, activeStaff);
+            nextEl = nextSegment->firstElementOfSegment(activeStaff);
             if (nextEl) {
                 return nextEl;
             }
@@ -2143,8 +2143,8 @@ EngravingItem* Segment::prevElement(staff_idx_t activeStaff)
         if (prev) {
             return prev;
         }
-        if (notChordRestType(this)) {
-            EngravingItem* lastEl = lastElementOfSegment(this, activeStaff);
+        if (notChordRestType()) {
+            EngravingItem* lastEl = lastElementOfSegment(activeStaff);
             if (lastEl) {
                 return lastEl;
             }
@@ -2204,7 +2204,7 @@ EngravingItem* Segment::prevElement(staff_idx_t activeStaff)
             }
         }
 
-        EngravingItem* prev = seg->prevElementOfSegment(seg, el, activeStaff);
+        EngravingItem* prev = seg->prevElementOfSegment(el, activeStaff);
         if (prev) {
             if (prev->type() == ElementType::CHORD || prev->type() == ElementType::REST
                 || prev->type() == ElementType::MMREST || prev->type() == ElementType::MEASURE_REPEAT) {
@@ -2245,17 +2245,17 @@ EngravingItem* Segment::prevElement(staff_idx_t activeStaff)
             }
         }
 
-        prev = lastElementOfSegment(prevSeg, activeStaff);
+        prev = prevSeg->lastElementOfSegment(activeStaff);
         while (!prev && prevSeg) {
             prevSeg = prevSeg->prev1MMenabled();
-            prev = lastElementOfSegment(prevSeg, activeStaff);
+            prev = prevSeg->lastElementOfSegment(activeStaff);
         }
         if (!prevSeg) {
             return score()->firstElement();
         }
 
-        if (notChordRestType(prevSeg)) {
-            EngravingItem* lastEl = lastElementOfSegment(prevSeg, activeStaff);
+        if (prevSeg->notChordRestType()) {
+            EngravingItem* lastEl = prevSeg->lastElementOfSegment(activeStaff);
             if (lastEl) {
                 return lastEl;
             }
@@ -2264,7 +2264,7 @@ EngravingItem* Segment::prevElement(staff_idx_t activeStaff)
         if (s1) {
             return s1->spannerSegments().front();
         } else if (!prevSeg->annotations().empty()) {
-            EngravingItem* next = lastAnnotation(prevSeg, activeStaff);
+            EngravingItem* next = prevSeg->lastAnnotation(activeStaff);
             if (next) {
                 return next;
             }
@@ -2312,10 +2312,10 @@ EngravingItem* Segment::firstElement(staff_idx_t staffIdx) const
 //   spans into the active staff
 //--------------------------------------------------------
 
-EngravingItem* Segment::lastInPrevSegments(staff_idx_t activeStaff)
+EngravingItem* Segment::lastInPrevSegments(staff_idx_t activeStaff) const
 {
     EngravingItem* re = 0;
-    Segment* seg = this;
+    const Segment* seg = this;
 
     while (!re) {
         seg = seg->prev1MMenabled();
@@ -2323,7 +2323,7 @@ EngravingItem* Segment::lastInPrevSegments(staff_idx_t activeStaff)
             break;
         }
 
-        re = seg->lastElementOfSegment(seg, activeStaff);
+        re = seg->lastElementOfSegment(activeStaff);
     }
 
     if (re) {

--- a/src/engraving/dom/segment.h
+++ b/src/engraving/dom/segment.h
@@ -86,7 +86,7 @@ class Segment final : public EngravingItem
     DECLARE_CLASSOF(ElementType::SEGMENT)
 
 protected:
-    EngravingItem* getElement(staff_idx_t staff);       //??
+    EngravingItem* getElement(staff_idx_t staff) const;       //??
 
 public:
 
@@ -224,21 +224,21 @@ public:
     AccessibleItemPtr createAccessible() override;
 #endif
 
-    EngravingItem* firstInNextSegments(staff_idx_t activeStaff);   //<
-    EngravingItem* lastInPrevSegments(staff_idx_t activeStaff);     //<
-    EngravingItem* firstElementForNavigation(staff_idx_t staff);                //<  These methods are used for navigation
-    EngravingItem* lastElementForNavigation(staff_idx_t staff);                 //<  for next-element and prev-element
-    EngravingItem* firstElementOfSegment(Segment* s, staff_idx_t activeStaff);
-    EngravingItem* nextElementOfSegment(Segment* s, EngravingItem* e, staff_idx_t activeStaff);
-    EngravingItem* prevElementOfSegment(Segment* s, EngravingItem* e, staff_idx_t activeStaff);
-    EngravingItem* lastElementOfSegment(Segment* s, staff_idx_t activeStaff);
-    EngravingItem* nextAnnotation(EngravingItem* e);
-    EngravingItem* prevAnnotation(EngravingItem* e);
-    EngravingItem* firstAnnotation(Segment* s, staff_idx_t activeStaff);
-    EngravingItem* lastAnnotation(Segment* s, staff_idx_t activeStaff);
-    Spanner* firstSpanner(staff_idx_t activeStaff);
-    Spanner* lastSpanner(staff_idx_t activeStaff);
-    bool notChordRestType(Segment* s);
+    EngravingItem* firstInNextSegments(staff_idx_t activeStaff) const;   //<
+    EngravingItem* lastInPrevSegments(staff_idx_t activeStaff) const;     //<
+    EngravingItem* firstElementForNavigation(staff_idx_t staff) const;          //<  These methods are used for navigation
+    EngravingItem* lastElementForNavigation(staff_idx_t staff) const;           //<  for next-element and prev-element
+    EngravingItem* firstElementOfSegment(staff_idx_t activeStaff) const;
+    EngravingItem* nextElementOfSegment(EngravingItem* e, staff_idx_t activeStaff) const;
+    EngravingItem* prevElementOfSegment(EngravingItem* e, staff_idx_t activeStaff) const;
+    EngravingItem* lastElementOfSegment(staff_idx_t activeStaff) const;
+    EngravingItem* nextAnnotation(EngravingItem* e) const;
+    EngravingItem* prevAnnotation(EngravingItem* e) const;
+    EngravingItem* firstAnnotation(staff_idx_t activeStaff) const;
+    EngravingItem* lastAnnotation(staff_idx_t activeStaff) const;
+    Spanner* firstSpanner(staff_idx_t activeStaff) const;
+    Spanner* lastSpanner(staff_idx_t activeStaff) const;
+    bool notChordRestType() const;
     using EngravingItem::nextElement;
     EngravingItem* nextElement(staff_idx_t activeStaff);
     using EngravingItem::prevElement;

--- a/src/engraving/rendering/dev/tlayout.cpp
+++ b/src/engraving/rendering/dev/tlayout.cpp
@@ -2611,7 +2611,7 @@ void TLayout::layoutFretDiagram(const FretDiagram* item, FretDiagram::LayoutData
     double noteheadWidth = 0;
     if (pSeg->isChordRestType()) {
         staff_idx_t idx = item->staff()->idx();
-        for (EngravingItem* e = pSeg->firstElementOfSegment(pSeg, idx); e; e = pSeg->nextElementOfSegment(pSeg, e, idx)) {
+        for (EngravingItem* e = pSeg->firstElementOfSegment(idx); e; e = pSeg->nextElementOfSegment(e, idx)) {
             if (e->isRest()) {
                 const Rest* r = toRest(e);
                 LD_CONDITION(r->ldata()->sym.has_value());

--- a/src/engraving/rendering/stable/tlayout.cpp
+++ b/src/engraving/rendering/stable/tlayout.cpp
@@ -2506,7 +2506,7 @@ void TLayout::layoutFretDiagram(const FretDiagram* item, FretDiagram::LayoutData
     double noteheadWidth = 0;
     if (pSeg->isChordRestType()) {
         staff_idx_t idx = item->staff()->idx();
-        for (EngravingItem* e = pSeg->firstElementOfSegment(pSeg, idx); e; e = pSeg->nextElementOfSegment(pSeg, e, idx)) {
+        for (EngravingItem* e = pSeg->firstElementOfSegment(idx); e; e = pSeg->nextElementOfSegment(e, idx)) {
             if (e->isRest()) {
                 const Rest* r = toRest(e);
                 LD_CONDITION(r->ldata()->sym.has_value());


### PR DESCRIPTION
Replace:

```C++
seg->myFunc(seg);
```

With simply:

```C++
seg->myFunc();
```

And add `const` in a few places where it can be applied.

The functions likely have other issues beyond the scope of this PR.