### PR TITLE
Don't autoplace hairpins against their own snapped elements

### DIFF
--- a/src/engraving/rendering/dev/autoplace.cpp
+++ b/src/engraving/rendering/dev/autoplace.cpp
@@ -206,13 +206,21 @@ void Autoplace::autoplaceSpannerSegment(const SpannerSegment* item, EngravingIte
         } else {
             ldata->setIsSkipDraw(false);
         }
+        const System* system = item->system();
+        const Skyline& staffSkyline = system->staff(stfIdx)->skyline();
+        const SkylineLine& skyline = above ? staffSkyline.north() : staffSkyline.south();
+        SkylineLine filteredSkyline = skyline.getFilteredCopy([item](const ShapeElement& shapeEl){
+            const EngravingItem* el = shapeEl.item();
+            return el && (el == item->ldata()->itemSnappedBefore() || el == item->ldata()->itemSnappedAfter());
+        });
+
         if (above) {
-            double d = item->system()->topDistance(stfIdx, sl);
+            double d = sl.minDistance(filteredSkyline);
             if (d > -md) {
                 yd = -(d + md);
             }
         } else {
-            double d = item->system()->bottomDistance(stfIdx, sl);
+            double d =  filteredSkyline.minDistance(sl);
             if (d > -md) {
                 yd = d + md;
             }


### PR DESCRIPTION
Resolves: #23594 

The issue is caused by the autoplace logic of the hairpin, which tries to avoid the end dynamic by placing the hairpin below it, except the dynamic will be subsequently aligned to the hairpin itself, which brings them all down.

With the new skyline system it is now easy to filter elements out. Basically, we are just avoiding that the hairpin autoplaces itself against its own snapped elements.
