### PR TITLE
Fix use-after-free when closing score after using "lasso selection"

### DIFF
--- a/src/engraving/dom/engravingobject.cpp
+++ b/src/engraving/dom/engravingobject.cpp
@@ -137,7 +137,7 @@ EngravingObject::~EngravingObject()
         bool canMoveToDummy = !this->isType(ElementType::ROOT_ITEM)
                               && !this->isType(ElementType::DUMMY)
                               && !this->isType(ElementType::SCORE)
-                              && score()->dummy() != nullptr;
+                              && score()->rootItem() && score()->rootItem()->dummy();
 
         EngravingObjectList children = m_children;
         for (EngravingObject* c : children) {

--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -266,7 +266,10 @@ Score::~Score()
     imageStore.clearUnused();
 
     delete m_shadowNote;
+    m_shadowNote = nullptr;
+
     delete m_rootItem;
+    m_rootItem = nullptr;
 }
 
 muse::async::Channel<LoopBoundaryType, unsigned> Score::loopBoundaryTickChanged() const


### PR DESCRIPTION
- lasso is created in `NotationInteraction::doDragLasso`
- `~Score` is called on the score and deletes the score's RootItem
- `~EngravingObject` is called on the score, and deletes all remaining children of the score
- the lasso is one of those
- when the lasso is deleted, `~EngravingObject` is called on it
- that calls `score()->dummy()`, which uses the rootItem of the score, but that had just been deleted, so ASan reports a use-after-free

Simplest fix: check if the rootItem hasn't been deleted yet before trying to use it. A more advanced fix would be to refactor the situation with the lasso, which could be done on a very large scale or a somewhat smaller scale, but that's not urgent.