### PR TITLE
Translations: Initial version of a fallback system for similar languages

### DIFF
--- a/buildscripts/ci/translation/s3_packandsend.py
+++ b/buildscripts/ci/translation/s3_packandsend.py
@@ -75,7 +75,7 @@ translationChanged = False
 
 # read languages.json and store language code and name
 langCode_file = open("share/locale/languages.json", "r+")
-langCodeNameDict = json.load(langCode_file)  # language code --> name
+langCodeNameDict = json.load(langCode_file)  # language code --> props
 langCode_file.close()
 
 detailsJson = outputDir + "details.json"
@@ -92,7 +92,7 @@ else:
 
 
 translationChanged = newDetailsFile
-for lang_code, languageName in langCodeNameDict.items():
+for lang_code, languageProps in langCodeNameDict.items():
     updateMscore = processTsFile("musescore", lang_code, data)
     translationChanged = updateMscore or translationChanged
 
@@ -121,7 +121,7 @@ for lang_code, languageName in langCodeNameDict.items():
         file.close()
 
         data[lang_code]["file_name"] = zipName
-        data[lang_code]["name"] = langCodeNameDict[lang_code]
+        data[lang_code]["name"] = languageProps["name"]
         data[lang_code]["hash"] = str(hash_file.hexdigest())
         data[lang_code]["file_size"] = file_size
 

--- a/share/locale/languages.json
+++ b/share/locale/languages.json
@@ -1,72 +1,216 @@
 {
-    "af": "Afrikaans",
-    "ar": "العربية",
-    "ar_DZ": "\u200e(العربية (الجزائر",
-    "ar_EG": "\u200e(العربية (مصر",
-    "ar_SD": "\u200e(العربية (السودان" ,
-    "ast": "Asturianu",
-    "be": "Беларуская мова",
-    "bg": "български",
-    "br": "Brezhoneg",
-    "ca": "Català",
-    "ca@valencia": "Valencià",
-    "cs": "Čeština",
-    "cy": "Cymraeg",
-    "da": "Dansk",
-    "de": "Deutsch",
-    "el": "ελληνικά",
-    "en_GB": "English (GB)",
-    "en_US": "English (US)",
-    "eo": "Esperanto",
-    "es": "Español",
-    "et": "Eesti",
-    "eu": "Euskara",
-    "fa": "فارس",
-    "fi": "Suomi",
-    "fil": "Filipino",
-    "fo": "Føroyskt",
-    "fr": "Français",
-    "ga": "Gaeilge",
-    "gd": "Gàidhlig",
-    "gl": "Galego",
-    "he": "עברית",
-    "hi_IN": "हिन्दी",
-    "hr": "Hrvatski",
-    "hu": "Magyar",
-    "hy": "Հայերեն",
-    "id": "Bahasa Indonesia",
-    "ig": "Ásụ̀sụ̀ Ị̀gbò",
-    "it": "Italiano",
-    "ja": "日本語",
-    "ka": "ქართული",
-    "kab": "ⵜⴰⵇⴱⴰⵢⵍⵉⵜ",
-    "ko": "한국어",
-    "lt": "Lietuvių",
-    "lv": "Latviešu",
-    "ml": "മലയാളം",
-    "mn_MN": "Монгол хэл",
-    "mt": "Malti",
-    "nb": "Norsk (Bokmål)",
-    "nl": "Nederlands",
-    "nn": "Norsk (Nynorsk)",
-    "pl": "Polski",
-    "pt": "Português",
-    "pt_BR": "Português brasileiro",
-    "ro": "Română",
-    "ru": "Русский",
-    "scn": "Sicilianu",
-    "sk": "Slovenčina",
-    "sl": "Slovenščina",
-    "sr": "Srpski",
-    "sr_RS" : "Српски",
-    "sv": "Svenska (modern)",
-    "sv_SE": "Svenska (traditionell)",
-    "th": "ภาษาไทย",
-    "tr": "Türkçe",
-    "uk": "Українська",
-    "uz@Latn": "O'zbek tili",
-    "vi": "Tiếng Việt",
-    "zh_CN": "简体中文",
-    "zh_HK": "繁體中文 (香港)",
-    "zh_TW": "繁體中文 (台灣)"
+    "af": {
+        "name": "Afrikaans"
+    },
+    "ar": {
+        "name": "العربية"
+    },
+    "ar_DZ": {
+        "name": "\u200e(العربية (الجزائر",
+        "fallbackLanguages": ["ar"]
+    },
+    "ar_EG": {
+        "name": "\u200e(العربية (مصر",
+        "fallbackLanguages": ["ar"]
+    },
+    "ar_SD": {
+        "name": "\u200e(العربية (السودان",
+        "fallbackLanguages": ["ar"]
+    },
+    "ast": {
+        "name": "Asturianu"
+    },
+    "be": {
+        "name": "Беларуская мова"
+    },
+    "bg": {
+        "name": "български"
+    },
+    "br": {
+        "name": "Brezhoneg"
+    },
+    "ca": {
+        "name": "Català"
+    },
+    "ca@valencia": {
+        "name": "Valencià"
+    },
+    "cs": {
+        "name": "Čeština"
+    },
+    "cy": {
+        "name": "Cymraeg"
+    },
+    "da": {
+        "name": "Dansk"
+    },
+    "de": {
+        "name": "Deutsch"
+    },
+    "el": {
+        "name": "ελληνικά"
+    },
+    "en_GB": {
+        "name": "English (GB)",
+        "fallbackLanguages": ["en_US"]
+    },
+    "en_US": {
+        "name": "English (US)"
+    },
+    "eo": {
+        "name": "Esperanto"
+    },
+    "es": {
+        "name": "Español"
+    },
+    "et": {
+        "name": "Eesti"
+    },
+    "eu": {
+        "name": "Euskara"
+    },
+    "fa": {
+        "name": "فارس"
+    },
+    "fi": {
+        "name": "Suomi"
+    },
+    "fil": {
+        "name": "Filipino"
+    },
+    "fo": {
+        "name": "Føroyskt"
+    },
+    "fr": {
+        "name": "Français"
+    },
+    "ga": {
+        "name": "Gaeilge"
+    },
+    "gd": {
+        "name": "Gàidhlig"
+    },
+    "gl": {
+        "name": "Galego"
+    },
+    "he": {
+        "name": "עברית"
+    },
+    "hi_IN": {
+        "name": "हिन्दी"
+    },
+    "hr": {
+        "name": "Hrvatski"
+    },
+    "hu": {
+        "name": "Magyar"
+    },
+    "hy": {
+        "name": "Հայերեն"
+    },
+    "id": {
+        "name": "Bahasa Indonesia"
+    },
+    "ig": {
+        "name": "Ásụ̀sụ̀ Ị̀gbò"
+    },
+    "it": {
+        "name": "Italiano"
+    },
+    "ja": {
+        "name": "日本語"
+    },
+    "ka": {
+        "name": "ქართული"
+    },
+    "kab": {
+        "name": "ⵜⴰⵇⴱⴰⵢⵍⵉⵜ"
+    },
+    "ko": {
+        "name": "한국어"
+    },
+    "lt": {
+        "name": "Lietuvių"
+    },
+    "lv": {
+        "name": "Latviešu"
+    },
+    "ml": {
+        "name": "മലയാളം"
+    },
+    "mn_MN": {
+        "name": "Монгол хэл"
+    },
+    "mt": {
+        "name": "Malti"
+    },
+    "nb": {
+        "name": "Norsk (Bokmål)"
+    },
+    "nl": {
+        "name": "Nederlands"
+    },
+    "nn": {
+        "name": "Norsk (Nynorsk)"
+    },
+    "pl": {
+        "name": "Polski"
+    },
+    "pt": {
+        "name": "Português"
+    },
+    "pt_BR": {
+        "name": "Português brasileiro"
+    },
+    "ro": {
+        "name": "Română"
+    },
+    "ru": {
+        "name": "Русский"
+    },
+    "scn": {
+        "name": "Sicilianu"
+    },
+    "sk": {
+        "name": "Slovenčina"
+    },
+    "sl": {
+        "name": "Slovenščina"
+    },
+    "sr": {
+        "name": "Srpski"
+    },
+    "sr_RS": {
+        "name": "Српски"
+    },
+    "sv": {
+        "name": "Svenska (modern)"
+    },
+    "sv_SE": {
+        "name": "Svenska (traditionell)"
+    },
+    "th": {
+        "name": "ภาษาไทย"
+    },
+    "tr": {
+        "name": "Türkçe"
+    },
+    "uk": {
+        "name": "Українська"
+    },
+    "uz@Latn": {
+        "name": "O'zbek tili"
+    },
+    "vi": {
+        "name": "Tiếng Việt"
+    },
+    "zh_CN": {
+        "name": "简体中文"
+    },
+    "zh_HK": {
+        "name": "繁體中文 (香港)"
+    },
+    "zh_TW": {
+        "name": "繁體中文 (台灣)"
+    }
 }

--- a/src/framework/languages/CMakeLists.txt
+++ b/src/framework/languages/CMakeLists.txt
@@ -36,3 +36,6 @@ set(MODULE_SRC
 
 setup_module()
 
+if (MUSE_MODULE_LANGUAGES_TESTS)
+    add_subdirectory(tests)
+endif()

--- a/src/framework/languages/internal/languagesservice.h
+++ b/src/framework/languages/internal/languagesservice.h
@@ -63,6 +63,7 @@ private:
     void setCurrentLanguage(const QString& languageCode);
     QString effectiveLanguageCode(QString languageCode) const;
     Ret loadLanguage(Language& lang);
+    Ret doLoadLanguage(Language& lang);
 
     void th_update(const QString& languageCode, Progress progress);
     bool canUpdate(const QString& languageCode);

--- a/src/framework/languages/languagestypes.h
+++ b/src/framework/languages/languagestypes.h
@@ -38,6 +38,8 @@ struct Language
 {
     QString code;
     QString name;
+    QStringList fallbackLanguages;
+
     Qt::LayoutDirection direction = Qt::LeftToRight;
 
     LanguageFilesMap files;

--- a/src/framework/languages/tests/CMakeLists.txt
+++ b/src/framework/languages/tests/CMakeLists.txt
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: GPL-3.0-only
+# MuseScore-CLA-applies
+#
+# MuseScore
+# Music Composition & Notation
+#
+# Copyright (C) 2024 MuseScore BVBA and others
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+set(MODULE_TEST muse_languages_test)
+
+set(MODULE_TEST_SRC
+    ${CMAKE_CURRENT_LIST_DIR}/languagesjson_tests.cpp
+    )
+
+set(MODULE_TEST_LINK muse_languages)
+
+set(MODULE_TEST_DATA_ROOT ${CMAKE_CURRENT_LIST_DIR})
+
+include(SetupGTest)

--- a/src/framework/languages/tests/languagesjson_tests.cpp
+++ b/src/framework/languages/tests/languagesjson_tests.cpp
@@ -1,0 +1,89 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <gtest/gtest.h>
+
+#include "io/ifilesystem.h"
+#include "io/path.h"
+#include "modularity/ioc.h"
+#include "serialization/json.h"
+#include "types/retval.h"
+
+using namespace muse;
+
+class Languages_Json : public ::testing::Test, public Injectable
+{
+public:
+    Inject<io::IFileSystem> fileSystem = { this };
+};
+
+TEST_F(Languages_Json, Correctness)
+{
+    io::path_t filePath(muse_languages_test_DATA_ROOT "/../../../../share/locale/languages.json");
+
+    RetVal<ByteArray> data = fileSystem()->readFile(filePath);
+    ASSERT_TRUE(data.ret);
+
+    std::string err;
+    JsonDocument json = JsonDocument::fromJson(data.val, &err);
+    ASSERT_TRUE(err.empty());
+
+    ASSERT_TRUE(json.isObject());
+
+    JsonObject rootObject = json.rootObject();
+
+    std::vector languageCodes = rootObject.keys();
+
+    for (const std::string& languageCode : languageCodes) {
+        SCOPED_TRACE("languageCode = " + languageCode);
+
+        JsonValue languageVal = rootObject.value(languageCode);
+        ASSERT_TRUE(languageVal.isObject());
+
+        JsonObject languageObject = languageVal.toObject();
+
+        EXPECT_TRUE(!languageObject.value("name").toStdString().empty());
+
+        if (!languageObject.contains("fallbackLanguages")) {
+            continue;
+        }
+
+        JsonValue fallbacksVal = languageObject.value("fallbackLanguages");
+        ASSERT_TRUE(fallbacksVal.isArray());
+
+        JsonArray fallbacksArray = languageObject.value("fallbackLanguages").toArray();
+
+        for (size_t i = 0; i < fallbacksArray.size(); ++i) {
+            SCOPED_TRACE("fallbacksArray[" + std::to_string(i) + "]");
+
+            std::string fallback = fallbacksArray.at(i).toStdString();
+
+            EXPECT_TRUE(!fallback.empty());
+
+            // Fallback must not be the language itself
+            EXPECT_NE(fallback, languageCode);
+
+            // Fallback must be known language
+            EXPECT_TRUE(muse::contains(languageCodes, fallback));
+        }
+    }
+}


### PR DESCRIPTION
Over the past decade, the idea of implementing a fallback system for similar languages has been proposed several times, among others by @Jojo-Schmitz. 

The problem this would solve is particularly apparently with the different variants of Arabic. In specific variants, some translations are apparently slightly different from the "main" Arabic, so therefore they are listed as a separate language on Transifex. But there are not many translators for these specific variants, so most strings are untranslated and fall back to English. 

A better solution would probably be to fall back to the "main" Arabic, rather than English. Multiple ways of achieving this have been discussed, like writing scripts that automatically populate translations on Transifex, or process the resulting .ts files. But last week I suddenly realised that there is a _much_ simpler way: just load the fallback languages as `QTranslators` and install them in the right order. When looking up a translation, Qt looks through all installed translators in reverse order, and takes the translation from the first translator that it encounters that has a translation.

Out of enthusiasm, I implemented that in this PR. The only thing that's left is updating the "Language update" functionality: when updating a language, it is desirable that its fallback languages are updated too.