### PR TITLE
Improve Mu1 import

### DIFF
--- a/src/engraving/rw/read206/read206.cpp
+++ b/src/engraving/rw/read206/read206.cpp
@@ -3022,19 +3022,10 @@ static void readMeasure206(Measure* m, int staffIdx, XmlReader& e, ReadContext& 
 
 static void readBox(Box* b, XmlReader& e, ReadContext& ctx)
 {
-    b->setLeftMargin(0.0);
-    b->setRightMargin(0.0);
-    b->setTopMargin(0.0);
-    b->setBottomMargin(0.0);
-    b->setTopGap(Millimetre(0.0));
-    b->setBottomGap(Millimetre(0.0));
-    b->setAutoSizeEnabled(false);
-    b->setPropertyFlags(Pid::TOP_GAP, PropertyFlags::UNSTYLED);
-    b->setPropertyFlags(Pid::BOTTOM_GAP, PropertyFlags::UNSTYLED);
+    b->setAutoSizeEnabled(false);      // didn't exist in Mu2
 
     b->setBoxHeight(Spatium(0));       // override default set in constructor
     b->setBoxWidth(Spatium(0));
-    bool keepMargins = false;          // whether original margins have to be kept when reading old file
 
     while (e.readNextStartElement()) {
         const AsciiStringView tag(e.name());
@@ -3042,12 +3033,10 @@ static void readBox(Box* b, XmlReader& e, ReadContext& ctx)
             HBox* hb = Factory::createHBox(b->score()->dummy()->system());
             read400::TRead::read(hb, e, ctx);
             b->add(hb);
-            keepMargins = true;           // in old file, box nesting used outer box margins
         } else if (tag == "VBox") {
             VBox* vb = Factory::createVBox(b->score()->dummy()->system());
             read400::TRead::read(vb, e, ctx);
             b->add(vb);
-            keepMargins = true;           // in old file, box nesting used outer box margins
         } else if (tag == "Text") {
             Text* t;
             if (b->isTBox()) {
@@ -3065,16 +3054,6 @@ static void readBox(Box* b, XmlReader& e, ReadContext& ctx)
         } else if (!read400::TRead::readBoxProperties(b, e, ctx)) {
             e.unknown();
         }
-    }
-
-    // with .msc versions prior to 1.17, box margins were only used when nesting another box inside this box:
-    // for backward compatibility set them to 0 in all other cases
-
-    if (ctx.mscVersion() <= 114 && (b->isHBox() || b->isVBox()) && !keepMargins) {
-        b->setLeftMargin(0.0);
-        b->setRightMargin(0.0);
-        b->setTopMargin(0.0);
-        b->setBottomMargin(0.0);
     }
 }
 

--- a/src/engraving/tests/compat114_data/clefs-ref.mscx
+++ b/src/engraving/tests/compat114_data/clefs-ref.mscx
@@ -65,10 +65,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <leftMargin>5</leftMargin>
-        <rightMargin>5</rightMargin>
-        <topMargin>5</topMargin>
-        <bottomMargin>5</bottomMargin>
         <boxAutoSize>0</boxAutoSize>
         <Text>
           <style>title</style>

--- a/src/engraving/tests/compat114_data/fingering-ref.mscx
+++ b/src/engraving/tests/compat114_data/fingering-ref.mscx
@@ -73,10 +73,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <leftMargin>5</leftMargin>
-        <rightMargin>5</rightMargin>
-        <topMargin>5</topMargin>
-        <bottomMargin>5</bottomMargin>
         <boxAutoSize>0</boxAutoSize>
         <Text>
           <style>title</style>

--- a/src/engraving/tests/compat114_data/hairpin-ref.mscx
+++ b/src/engraving/tests/compat114_data/hairpin-ref.mscx
@@ -69,10 +69,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <leftMargin>5</leftMargin>
-        <rightMargin>5</rightMargin>
-        <topMargin>5</topMargin>
-        <bottomMargin>5</bottomMargin>
         <boxAutoSize>0</boxAutoSize>
         <Text>
           <style>title</style>

--- a/src/engraving/tests/compat114_data/hor_frame_and_mmrest-ref.mscx
+++ b/src/engraving/tests/compat114_data/hor_frame_and_mmrest-ref.mscx
@@ -65,10 +65,6 @@
     <Staff id="1">
       <HBox>
         <width>5</width>
-        <leftMargin>5</leftMargin>
-        <rightMargin>5</rightMargin>
-        <topMargin>5</topMargin>
-        <bottomMargin>5</bottomMargin>
         <boxAutoSize>0</boxAutoSize>
         </HBox>
       <Measure>

--- a/src/engraving/tests/compat114_data/keysig-ref.mscx
+++ b/src/engraving/tests/compat114_data/keysig-ref.mscx
@@ -64,10 +64,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <leftMargin>5</leftMargin>
-        <rightMargin>5</rightMargin>
-        <topMargin>5</topMargin>
-        <bottomMargin>5</bottomMargin>
         <boxAutoSize>0</boxAutoSize>
         <Text>
           <style>title</style>

--- a/src/engraving/tests/compat114_data/notes-ref.mscx
+++ b/src/engraving/tests/compat114_data/notes-ref.mscx
@@ -64,10 +64,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <leftMargin>5</leftMargin>
-        <rightMargin>5</rightMargin>
-        <topMargin>5</topMargin>
-        <bottomMargin>5</bottomMargin>
         <boxAutoSize>0</boxAutoSize>
         <Text>
           <style>title</style>

--- a/src/engraving/tests/compat114_data/textstyles-ref.mscx
+++ b/src/engraving/tests/compat114_data/textstyles-ref.mscx
@@ -69,10 +69,6 @@
     <Staff id="1">
       <VBox>
         <height>6.36254</height>
-        <leftMargin>5</leftMargin>
-        <rightMargin>5</rightMargin>
-        <topMargin>5</topMargin>
-        <bottomMargin>5</bottomMargin>
         <boxAutoSize>0</boxAutoSize>
         <Text>
           <style>title</style>

--- a/src/engraving/tests/compat114_data/title-ref.mscx
+++ b/src/engraving/tests/compat114_data/title-ref.mscx
@@ -69,10 +69,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <leftMargin>5</leftMargin>
-        <rightMargin>5</rightMargin>
-        <topMargin>5</topMargin>
-        <bottomMargin>5</bottomMargin>
         <boxAutoSize>0</boxAutoSize>
         <Text>
           <style>title</style>

--- a/src/engraving/tests/compat114_data/tuplets-ref.mscx
+++ b/src/engraving/tests/compat114_data/tuplets-ref.mscx
@@ -62,10 +62,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <leftMargin>5</leftMargin>
-        <rightMargin>5</rightMargin>
-        <topMargin>5</topMargin>
-        <bottomMargin>5</bottomMargin>
         <boxAutoSize>0</boxAutoSize>
         <Text>
           <style>title</style>

--- a/src/engraving/tests/compat114_data/tuplets_1-ref.mscx
+++ b/src/engraving/tests/compat114_data/tuplets_1-ref.mscx
@@ -62,10 +62,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <leftMargin>5</leftMargin>
-        <rightMargin>5</rightMargin>
-        <topMargin>5</topMargin>
-        <bottomMargin>5</bottomMargin>
         <boxAutoSize>0</boxAutoSize>
         <Text>
           <style>title</style>

--- a/src/engraving/tests/compat114_data/tuplets_2-ref.mscx
+++ b/src/engraving/tests/compat114_data/tuplets_2-ref.mscx
@@ -62,10 +62,6 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <leftMargin>5</leftMargin>
-        <rightMargin>5</rightMargin>
-        <topMargin>5</topMargin>
-        <bottomMargin>5</bottomMargin>
         <boxAutoSize>0</boxAutoSize>
         <Text>
           <style>title</style>

--- a/src/engraving/tests/compat206_data/frame_text2-ref.mscx
+++ b/src/engraving/tests/compat206_data/frame_text2-ref.mscx
@@ -189,7 +189,6 @@
     <Staff id="1">
       <VBox>
         <height>25.5926</height>
-        <bottomGap>0</bottomGap>
         <topMargin>3</topMargin>
         <boxAutoSize>0</boxAutoSize>
         <Text>
@@ -205,7 +204,6 @@
       <VBox>
         <height>47.762</height>
         <topGap>10</topGap>
-        <bottomGap>0</bottomGap>
         <boxAutoSize>0</boxAutoSize>
         <Text>
           <style>frame</style>

--- a/vtest/scores/mmrest-6.mscx
+++ b/vtest/scores/mmrest-6.mscx
@@ -1,27 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="2.07">
-  <programVersion>2.1.0</programVersion>
-  <programRevision>3543170</programRevision>
+<museScore version="3.02">
+  <programVersion>3.6.2</programVersion>
+  <programRevision>3224f34</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>
     <currentLayer>0</currentLayer>
-    <Synthesizer>
-      </Synthesizer>
     <Division>480</Division>
     <Style>
+      <pageWidth>3.93701</pageWidth>
+      <pageHeight>1.96851</pageHeight>
+      <pagePrintableWidth>3.77953</pagePrintableWidth>
+      <pageEvenLeftMargin>0.0787403</pageEvenLeftMargin>
+      <pageOddLeftMargin>0.0787403</pageOddLeftMargin>
+      <pageEvenTopMargin>0</pageEvenTopMargin>
+      <pageEvenBottomMargin>0</pageEvenBottomMargin>
+      <pageOddTopMargin>0</pageOddTopMargin>
+      <pageOddBottomMargin>0</pageOddBottomMargin>
+      <pageTwosided>0</pageTwosided>
+      <harmonyPlay>0</harmonyPlay>
       <showMeasureNumber>0</showMeasureNumber>
       <createMultiMeasureRests>1</createMultiMeasureRests>
       <showFooter>0</showFooter>
-      <page-layout>
-        <page-height>283.465</page-height>
-        <page-width>566.929</page-width>
-        <page-margins type="both">
-          <left-margin>11.3386</left-margin>
-          <right-margin>11.3386</right-margin>
-          <top-margin>0</top-margin>
-          <bottom-margin>0</bottom-margin>
-          </page-margins>
-        </page-layout>
       <Spatium>1.764</Spatium>
       </Style>
     <showInvisible>1</showInvisible>
@@ -36,24 +35,16 @@
     <metaTag name="movementNumber"></metaTag>
     <metaTag name="movementTitle"></metaTag>
     <metaTag name="platform">X11</metaTag>
+    <metaTag name="poet"></metaTag>
     <metaTag name="source"></metaTag>
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <PageList>
-      <Page>
-        <System>
-          </System>
-        <System>
-          </System>
-        </Page>
-      </PageList>
     <Part>
       <Staff id="1">
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
-        <bracket type="-1" span="0"/>
         </Staff>
       <trackName>Piano</trackName>
       <Instrument>
@@ -66,6 +57,7 @@ p, li { white-space: pre-wrap; }
         <maxPitchP>108</maxPitchP>
         <minPitchA>21</minPitchA>
         <maxPitchA>108</maxPitchA>
+        <instrumentId>keyboard.piano</instrumentId>
         <Articulation>
           <velocity>100</velocity>
           <gateTime>70</gateTime>
@@ -91,102 +83,105 @@ p, li { white-space: pre-wrap; }
     <Staff id="1">
       <VBox>
         <height>7.1335</height>
+        <boxAutoSize>0</boxAutoSize>
         <Text>
-          <style>title</style>
+          <style>Title</style>
           <text>vbox</text>
           </Text>
         </VBox>
-      <Measure number="1">
-        <Clef>
-          <concertClefType>G</concertClefType>
-          <transposingClefType>G</transposingClefType>
-          </Clef>
-        <TimeSig>
-          <sigN>4</sigN>
-          <sigD>4</sigD>
-          <showCourtesySig>1</showCourtesySig>
-          </TimeSig>
-        <Rest>
-          <durationType>measure</durationType>
-          <duration z="4" n="4"/>
-          </Rest>
+      <Measure>
+        <voice>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          </voice>
         </Measure>
-      <Measure number="1" len="16/4">
+      <Measure len="16/4">
         <multiMeasureRest>4</multiMeasureRest>
-        <TimeSig>
-          <sigN>4</sigN>
-          <sigD>4</sigD>
-          <showCourtesySig>1</showCourtesySig>
-          </TimeSig>
-        <Rest>
-          <durationType>measure</durationType>
-          <duration z="16" n="4"/>
-          </Rest>
-        <Clef>
-          <concertClefType>F</concertClefType>
-          <transposingClefType>F</transposingClefType>
-          </Clef>
-        <BarLine>
-          <subtype>normal</subtype>
-          <span>1</span>
-          </BarLine>
+        <voice>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>16/4</duration>
+            </Rest>
+          <Clef>
+            <concertClefType>F</concertClefType>
+            <transposingClefType>F</transposingClefType>
+            </Clef>
+          <BarLine>
+            </BarLine>
+          </voice>
         </Measure>
-      <tick>1920</tick>
-      <Measure number="2">
-        <Rest>
-          <durationType>measure</durationType>
-          <duration z="4" n="4"/>
-          </Rest>
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          </voice>
         </Measure>
-      <Measure number="3">
-        <Rest>
-          <durationType>measure</durationType>
-          <duration z="4" n="4"/>
-          </Rest>
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          </voice>
         </Measure>
-      <Measure number="4">
-        <Rest>
-          <durationType>measure</durationType>
-          <duration z="4" n="4"/>
-          </Rest>
-        <Clef>
-          <concertClefType>F</concertClefType>
-          <transposingClefType>F</transposingClefType>
-          </Clef>
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          <Clef>
+            <concertClefType>F</concertClefType>
+            <transposingClefType>F</transposingClefType>
+            </Clef>
+          </voice>
         </Measure>
-      <Measure number="5">
-        <Chord>
-          <durationType>quarter</durationType>
-          <Note>
-            <pitch>48</pitch>
-            <tpc>14</tpc>
-            </Note>
-          </Chord>
-        <Chord>
-          <durationType>quarter</durationType>
-          <Note>
-            <pitch>48</pitch>
-            <tpc>14</tpc>
-            </Note>
-          </Chord>
-        <Chord>
-          <durationType>quarter</durationType>
-          <Note>
-            <pitch>48</pitch>
-            <tpc>14</tpc>
-            </Note>
-          </Chord>
-        <Chord>
-          <durationType>quarter</durationType>
-          <Note>
-            <pitch>48</pitch>
-            <tpc>14</tpc>
-            </Note>
-          </Chord>
-        <BarLine>
-          <subtype>end</subtype>
-          <span>1</span>
-          </BarLine>
+      <Measure>
+        <voice>
+          <Chord>
+            <durationType>quarter</durationType>
+            <Note>
+              <pitch>48</pitch>
+              <tpc>14</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>quarter</durationType>
+            <Note>
+              <pitch>48</pitch>
+              <tpc>14</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>quarter</durationType>
+            <Note>
+              <pitch>48</pitch>
+              <tpc>14</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>quarter</durationType>
+            <Note>
+              <pitch>48</pitch>
+              <tpc>14</tpc>
+              </Note>
+            </Chord>
+          <BarLine>
+            <subtype>end</subtype>
+            </BarLine>
+          </voice>
         </Measure>
       </Staff>
     </Score>


### PR DESCRIPTION
### Issue type

Import/Export issue

### Description with steps to reproduce

here esp. the vertical and horizontal frames and their margins, by syncing read114.cpp's readBox() with what read206.cpp's readBox() does.
Examples, Mu4 (and Mu3):
![Screenshot 2024-07-18 190249](https://github.com/user-attachments/assets/072d7da9-03f7-4a31-8a79-ca4547499653)

Mu1 (and Mu2 and with this PR):
![image](https://github.com/user-attachments/assets/7c11393d-8b42-499b-84b2-9b1b4ba744c4)

Highly annoying to have to reset these 4 setting to default on every single score, I really should have done this PR back in 2019 when I switched to Mu3 and migrated loads of my old M1 and Mu2 scores. All done now, so too late for me ... (except for some 400 scores on the back burner, awaiting a properly working album feature)

### Supporting files, videos and screenshots

n/a

### What is the latest version of MuseScore Studio where this issue is present?

all Mu4 and Mu3

### Regression

no

### Operating system

all

### Additional context

### Checklist

- [X] This report follows the [guidelines](https://github.com/musescore/MuseScore/wiki/Reporting-bugs-and-issues) for reporting bugs and issues
- [X] I have verified that this issue has not been logged before, by searching the [issue tracker](https://github.com/musescore/MuseScore/issues) for similar issues
- [X] I have attached all requested files and information to this report
- [X] I have attempted to identify the root problem as concisely as possible, and have used minimal reproducible examples where possible