### PR TITLE
Fix cross system beam bugs

### DIFF
--- a/src/engraving/rendering/dev/beamlayout.cpp
+++ b/src/engraving/rendering/dev/beamlayout.cpp
@@ -504,7 +504,7 @@ void BeamLayout::breakCrossMeasureBeams(Measure* measure, LayoutContext& ctx)
         std::vector<ChordRest*> nextElements;
 
         for (ChordRest* beamCR : beam->elements()) {
-            if (beamCR->measure() == measure) {
+            if (beamCR->tick() < next->tick()) {
                 mElements.push_back(beamCR);
             } else {
                 nextElements.push_back(beamCR);

--- a/src/engraving/rendering/dev/beamlayout.cpp
+++ b/src/engraving/rendering/dev/beamlayout.cpp
@@ -463,6 +463,32 @@ void BeamLayout::restoreBeams(Measure* m, LayoutContext& ctx)
     }
 }
 
+bool BeamLayout::measureMayHaveBeamsJoinedIntoNext(const Measure* measure)
+{
+    const MeasureBase* next = measure->next();
+    if (!(next && next->isMeasure())) {
+        return false;
+    }
+
+    const Measure* nextMeasure = toMeasure(next);
+    const Segment* firstCrSeg = nextMeasure->findFirstR(SegmentType::ChordRest, Fraction(0, 1));
+    if (!firstCrSeg) {
+        return false;
+    }
+
+    for (const EngravingItem* item : firstCrSeg->elist()) {
+        if (!item) {
+            continue;
+        }
+        BeamMode beamMode = toChordRest(item)->beamMode();
+        if (beamMode == BeamMode::MID || beamMode == BeamMode::BEGIN16 || beamMode == BeamMode::BEGIN32) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 //---------------------------------------------------------
 //   breakCrossMeasureBeams
 //---------------------------------------------------------

--- a/src/engraving/rendering/dev/beamlayout.h
+++ b/src/engraving/rendering/dev/beamlayout.h
@@ -52,6 +52,7 @@ public:
     static bool notTopBeam(ChordRest* cr);
     static void createBeams(LayoutContext& ctx, Measure* measure);
     static void restoreBeams(Measure* m, LayoutContext& ctx);
+    static bool measureMayHaveBeamsJoinedIntoNext(const Measure* measure);
     static void breakCrossMeasureBeams(Measure* measure, LayoutContext& ctx);
     static void layoutNonCrossBeams(Segment* s, LayoutContext& ctx);
     static void verticalAdjustBeamedRests(Rest* rest, Beam* beam, LayoutContext& ctx);


### PR DESCRIPTION
Resolves: #21309 
Resolves: #22952 

Musescore currently supports cross-measure beams but not cross-_system_ beams. If the user sets a beam to join across two measures, but there happens to be a system break in between, the beam is simply split into two separate ones. Proper support for cross-system beams is planned for the future.

For now, this PR resolves two separate issues:
1. An obvious mistake in the way the beams were split at the system break. This could cause chords in the previous system to be assigned to beams in the next and was responsible for the explosions.
2. A "relayout" problem, whereby doing an editing operation in one system could cause a joined beam in the first measure of the _next_ system to be un-joined (see screenshots). The reason is that the relayout stops at that measure so it simply doesn't know that the beam should continue. I've now introduced a check whereby we don't stop layout if the last measure we've touched may have beams joining to the next one. Performance is unaffected.

<img width="536" alt="image" src="https://github.com/user-attachments/assets/bf7e6532-0d7d-420e-96ed-70ddf4aa5f30">
<img width="536" alt="image" src="https://github.com/user-attachments/assets/93be2c88-e20d-4577-9ebd-3f81f5597d52">

