### PR TITLE
fix: anacrusis has wrong tempo if not explicitly set

### DIFF
--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -411,6 +411,7 @@ void Score::setUpTempoMap()
         sigmap()->clear();
         sigmap()->add(0, SigEvent(fm->ticks(),  fm->timesig(), 0));
     }
+    std::vector<Measure*> anacrusisMeasures;
 
     auto tempoPrimo = std::optional<BeatsPerSecond> {};
 
@@ -426,6 +427,14 @@ void Score::setUpTempoMap()
         m->moveTicks(diff);
         if (m->mmRest()) {
             m->mmRest()->moveTicks(diff);
+        }
+        // TODO: Better to use Measure::isAnacrusis() here
+        // but since it requires irregular() return true it's not working as expected
+        // if user didn't checked "Exclude from measure count" in measure properties,
+        // but reduces the real measure length.
+        // So we use the following workaround:
+        if (m->ticks() < m->timesig()) {
+            anacrusisMeasures.push_back(m);
         }
 
         rebuildTempoAndTimeSigMaps(m, tempoPrimo);
@@ -469,6 +478,9 @@ void Score::setUpTempoMap()
     }
 
     masterScore()->updateRepeatListTempo();
+    if (!anacrusisMeasures.empty()) {
+        fixAnacrusisTempo(anacrusisMeasures);
+    }
     m_needSetUpTempoMap = false;
 }
 
@@ -598,6 +610,34 @@ void Score::rebuildTempoAndTimeSigMaps(Measure* measure, std::optional<BeatsPerS
 
         if (pm && (!mTicks.identical(pm->ticks()) || !m->timesig().identical(pm->timesig()))) {
             sigmap()->add(m->tick().ticks(), SigEvent(mTicks, m->timesig(), m->no()));
+        }
+    }
+}
+
+void Score::fixAnacrusisTempo(const std::vector<Measure*>& measures) const
+{
+    auto getTempoTextIfExist = [](const Measure* m) -> TempoText* {
+        for (const Segment& s : m->segments()) {
+            if (s.isChordRestType()) {
+                for (EngravingItem* e : s.annotations()) {
+                    if (e->isTempoText()) {
+                        return toTempoText(e);
+                    }
+                }
+            }
+        }
+        return nullptr;
+    };
+
+    for (Measure* measure : measures) {
+        if (getTempoTextIfExist(measure)) {
+            continue;
+        }
+        Measure* nextMeasure = measure->nextMeasure();
+        if (nextMeasure) {
+            if (TempoText* tt = getTempoTextIfExist(nextMeasure); tt) {
+                tempomap()->setTempo(measure->tick().ticks(), tt->tempo());
+            }
         }
     }
 }

--- a/src/engraving/dom/score.h
+++ b/src/engraving/dom/score.h
@@ -1052,6 +1052,7 @@ private:
     void resetTempo();
     void resetTempoRange(const Fraction& tick1, const Fraction& tick2);
     void rebuildTempoAndTimeSigMaps(Measure* m, std::optional<BeatsPerSecond>& tempoPrimo);
+    void fixAnacrusisTempo(const std::vector<Measure*>& measures) const;
 
     void deleteOrShortenOutSpannersFromRange(const Fraction& t1, const Fraction& t2, track_idx_t trackStart, track_idx_t trackEnd,
                                              const SelectionFilter& filter);


### PR DESCRIPTION
If score has a pick up bar which tempo not explicitly set, the tempo used for the pick up bar is default now, but it should be the same as for the bar followed. Logically. 
Look at the example bellow. The A B C D in the pickup bar played at tempo 120, which is more than twice as fast.
<img width="422" alt="image" src="https://github.com/user-attachments/assets/b8e3abbd-56a0-4980-8409-aab046f6a8a1">

I've made a little check for this kind of situations to set the same tempo for anacrusis as the bar followed. 


