### PR TITLE
Calculate spanner start and end elements before cloning to part

### DIFF
--- a/src/engraving/dom/excerpt.cpp
+++ b/src/engraving/dom/excerpt.cpp
@@ -695,6 +695,13 @@ void Excerpt::cloneSpanner(Spanner* s, Score* score, track_idx_t dstTrack, track
         }
     } else if (ns->isTrill()) {
         ns->computeStartElement();
+    } else {
+        if (!ns->startElement()) {
+            ns->computeStartElement();
+        }
+        if (!ns->endElement()) {
+            ns->computeEndElement();
+        }
     }
 
     if (!ns->startElement() || !ns->endElement()) {
@@ -708,6 +715,7 @@ void Excerpt::cloneSpanner(Spanner* s, Score* score, track_idx_t dstTrack, track
                 toChord(endElement)->removeEndingSpanner(ns);
             }
         }
+        LOGD() << "No start or end element, can't add spanner: " << ns->tick().toString();
         delete ns;
         return;
     }


### PR DESCRIPTION
When opening parts in a musicxml file, some spanners are missing - mainly hairpins.  The hairpins start and end elements are all `TimeTickAnchor`.  These seem to be valid for the first part which allows the spanner to be cloned, but are recreated anyway.  
As we are more flexible with where spanners can be attached, I have recalculated the anchors before double checking the start and end elements aren't null.