### PR TITLE
Text fix: "Custom suffix:" (missing colon)

### DIFF
--- a/src/notation/qml/MuseScore/NotationScene/internal/EditStyle/FretboardsPage.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/EditStyle/FretboardsPage.qml
@@ -164,7 +164,7 @@ Rectangle {
                                 }
                                 StyledTextLabel {
                                     horizontalAlignment: Text.AlignLeft
-                                    text: qsTrc("notation", "Custom suffix")
+                                    text: qsTrc("notation", "Custom suffix:")
                                 }
                                 TextInputField {
                                     enabled: fretboardsPage.fretUseCustomSuffix.value === true


### PR DESCRIPTION
Text fix: "Custom suffix:" (missing colon)
In Style -> Fretboard diagrams -> "Custom suffix:". There should be a colon at the end, like in Style -> Measure numbers -> "Interval:".

Greetings,
Gootector

Resolves: #NNNNN <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
