### PR TITLE
Fix #22729: Prevent crash when pressing undo for newly added, unedited, empty text

### DIFF
--- a/src/engraving/dom/textedit.cpp
+++ b/src/engraving/dom/textedit.cpp
@@ -152,25 +152,30 @@ void TextBase::endEdit(EditData& ed)
     // one property change
 
     using Filter = UndoCommand::Filter;
-    const bool textWasEdited = (undo->getCurIdx() != ted->startUndoIdx);
 
+    //! NOTE: Current index can be less than the start index if the text element is newly added and immediately removed through
+    //! undo (the "add element" command will have been popped from the stack before the calling of this method)...
+    const bool textWasEdited = undo->getCurIdx() > ted->startUndoIdx;
     if (textWasEdited) {
         undo->mergeCommands(ted->startUndoIdx);
         undo->last()->filterChildren(Filter::TextEdit, this);
     } else {
         // No text changes in "undo" part of undo stack,
         // hence nothing to merge and filter.
-        undo->cleanRedoStack();     // prevent text editing commands from remaining in undo stack
+        undo->cleanRedoStack(); // prevent text editing commands from remaining in undo stack
+
+        // already removed, no further processing required...
+        if (!ed.element) {
+            return;
+        }
     }
 
-    bool newlyAdded = false;
-
-    if (ted->oldXmlText.isEmpty()) {
+    const bool newlyAdded = ted->oldXmlText.isEmpty();
+    if (newlyAdded) {
         UndoCommand* ucmd = textWasEdited ? undo->prev() : undo->last();
         if (ucmd && ucmd->hasFilteredChildren(Filter::AddElement, this)) {
             // We have just added this element to a score.
             // Combine undo records of text creation with text editing.
-            newlyAdded = true;
             undo->mergeCommands(ted->startUndoIdx - 1);
         }
     }
@@ -202,7 +207,7 @@ void TextBase::endEdit(EditData& ed)
                 undo->current()->filterChildren(f, this);
             }
 
-            ted->setDeleteText(true);       // mark this text element for deletion
+            ted->setDeleteText(true); // mark this text element for deletion
         }
 
         commitText();
@@ -217,16 +222,18 @@ void TextBase::endEdit(EditData& ed)
     }
 
     if (textWasEdited) {
-        setXmlText(ted->oldXmlText);                        // reset text to value before editing
+        setXmlText(ted->oldXmlText); // reset text to value before editing
         undo->reopen();
         resetFormatting();
-        undoChangeProperty(Pid::TEXT, actualXmlText);       // change property to set text to actual value again
-                                                            // this also changes text of linked elements
+
+        // change property to set text to actual value again - this also changes text of linked elements
+        undoChangeProperty(Pid::TEXT, actualXmlText);
+
         renderer()->layoutText1(this);
-        triggerLayout();                                    // force relayout even if text did not change
-    } else {
-        triggerLayout();
     }
+
+    triggerLayout(); // force relayout even if text did not change
+
     if (isLyrics()) {
         // we must adjust previous lyrics before the call to commitText(), in order to make the adjustments
         // part of the same undo command. there is logic above that will skip this call if the text is empty

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -3295,8 +3295,8 @@ bool NotationInteraction::handleKeyPress(QKeyEvent* event)
 
 void NotationInteraction::endEditText()
 {
-    EngravingItem* element = m_editData.element;
-    IF_ASSERT_FAILED(element) {
+    EngravingItem** element = &m_editData.element;
+    IF_ASSERT_FAILED(*element) {
         return;
     }
 
@@ -3306,7 +3306,9 @@ void NotationInteraction::endEditText()
 
     doEndEditElement();
 
-    notifyAboutTextEditingEnded(toTextBase(element));
+    if (*element) {
+        notifyAboutTextEditingEnded(toTextBase(*element));
+    }
     notifyAboutTextEditingChanged();
     notifyAboutSelectionChangedIfNeed();
 }


### PR DESCRIPTION
Resolves: #22729

Also contains some small codestyle changes/refactoring.