### PR TITLE
Prevent crash on dragging note too far

### DIFF
--- a/src/engraving/dom/note.cpp
+++ b/src/engraving/dom/note.cpp
@@ -2664,8 +2664,10 @@ void Note::verticalDrag(EditData& ed)
             accOffs = Accidental::subtype2value(AccidentalType::NONE);
         }
         int nStep = absStep(ned->line + lineOffset, score()->staff(idx)->clef(_tick));
+        nStep = std::max(0, nStep);
         int octave = nStep / 7;
         int newPitch = step2pitch(nStep) + octave * 12 + int(accOffs);
+        newPitch = std::clamp(newPitch, 0, 127);
 
         if (!concertPitch()) {
             newPitch += interval.chromatic;


### PR DESCRIPTION
Resolves: #21999 

This fixes some crashes which happen when quickly dragging notes out of the range of valid pitches.  
I haven't been able to recreate the crash in the attached report, but the problems I have managed to fix are part of the same changes which seem to have caused the issue in the report.