### PR TITLE
Ensure that the Ornament item inside the trill always has score and parent properly set

### DIFF
--- a/src/engraving/dom/spanner.h
+++ b/src/engraving/dom/spanner.h
@@ -212,7 +212,7 @@ public:
     PropertyValue propertyDefault(Pid propertyId) const override;
     virtual void undoChangeProperty(Pid id, const PropertyValue&, PropertyFlags ps) override;
 
-    void computeStartElement();
+    virtual void computeStartElement();
     void computeEndElement();
 
     static Note* endElementFromSpanner(Spanner* sp, EngravingItem* newStart);

--- a/src/engraving/dom/trill.cpp
+++ b/src/engraving/dom/trill.cpp
@@ -230,6 +230,22 @@ void Trill::setTrack(track_idx_t n)
     }
 }
 
+void Trill::setScore(Score* s)
+{
+    Spanner::setScore(s);
+    if (m_ornament) {
+        m_ornament->setScore(s);
+    }
+}
+
+void Trill::computeStartElement()
+{
+    Spanner::computeStartElement();
+    if (startElement() && startElement()->isChord() && m_ornament) {
+        m_ornament->setParent(startElement());
+    }
+}
+
 void Trill::setTrillType(TrillType tt)
 {
     m_trillType = tt;

--- a/src/engraving/dom/trill.h
+++ b/src/engraving/dom/trill.h
@@ -92,6 +92,8 @@ public:
     void remove(EngravingItem*) override;
 
     void setTrack(track_idx_t n) override;
+    void setScore(Score* s) override;
+    void computeStartElement() override;
 
     void setTrillType(TrillType tt);
     TrillType trillType() const { return m_trillType; }


### PR DESCRIPTION
Resolves: #22368 

The Trill item (which we use to represent the _tr~~~_ line) has to be a Spanner, because it is a line that spans a given duration so it needs all the properties of the Spanner. But it also needs the all properties of the Ornament items (intervals, cue notes, etc). Inheriting from both classes would be a mess, so the only solution is for Trill to wrap the Ornament by storing an Ornament object inside. The flip side is that the Trill now has to take care of keeping the Ornament properties synced.

The bug occurred because some small (and completely irrelevant) inconsistencies in the Ornament item were causing spurious "location" tags to appear, and those messed up all the re-linking of the upon reopening the file. I'll file a separate ~~rant~~ issue detailing why I think "location" tags are an extremely bad solution and we should change it.