### PR TITLE
Add support for measure-distance

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -422,6 +422,7 @@ private:
     void wavyLineStartStop(const ChordRest* cr, Notations& notations, Ornaments& ornaments, TrillHash& trillStart, TrillHash& trillStop);
     void print(const Measure* const m, const int partNr, const int firstStaffOfPart, const int nrStavesInPart,
                const MeasurePrintContext& mpc);
+    void measureLayout(const double distance);
     void findAndExportClef(const Measure* const m, const int staves, const track_idx_t strack, const track_idx_t etrack);
     void exportDefaultClef(const Part* const part, const Measure* const m);
     void writeElement(EngravingItem* el, const Measure* m, staff_idx_t sstaff, bool useDrumset);
@@ -7211,11 +7212,31 @@ void ExportMusicXml::print(const Measure* const m, const int partNr, const int f
                 m_xml.endElement();
             }
 
+            // Measure layout elements.
+            if (m->prev() && m->prev()->isHBox()) {
+                measureLayout(m->prev()->width());
+            }
+
             m_xml.endElement();
         } else if (!newSystemOrPage.empty()) {
             m_xml.tagRaw(String(u"print%1").arg(newSystemOrPage));
         }
+    } else if (m->prev() && m->prev()->isHBox()) {
+        m_xml.startElement("print");
+        measureLayout(m->prev()->width());
+        m_xml.endElement();
     }
+}
+
+//---------------------------------------------------------
+//  measureLayout
+//---------------------------------------------------------
+
+void ExportMusicXml::measureLayout(const double distance)
+{
+    m_xml.startElement("measure-layout");
+    m_xml.tag("measure-distance", String::number(getTenthsFromDots(distance), 2));
+    m_xml.endElement();
 }
 
 //---------------------------------------------------------

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass1.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass1.cpp
@@ -1820,7 +1820,7 @@ void MusicXMLParserPass1::defaults()
         } else if (m_e.name() == "staff-layout") {
             while (m_e.readNextStartElement()) {
                 if (m_e.name() == "staff-distance") {
-                    Spatium val(m_e.readText().toDouble() / 10.0);
+                    const Spatium val(m_e.readText().toDouble() / 10.0);
                     if (isImportLayout) {
                         m_score->style().set(Sid::staffDistance, val);
                     }

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.h
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.h
@@ -349,6 +349,7 @@ private:
     void measChordNote(/*, const MxmlPhase2Note note, ChordRest& currChord */);
     void measChordFlush(/*, ChordRest& currChord */);
     void measure(const String& partId, const Fraction time);
+    void measureLayout(Measure* measure);
     void setMeasureRepeats(const staff_idx_t scoreRelStaff, Measure* measure);
     void attributes(const String& partId, Measure* measure, const Fraction& tick);
     void measureStyle(Measure* measure);

--- a/src/importexport/musicxml/tests/data/testBackupRoundingError_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testBackupRoundingError_ref.mscx
@@ -101,6 +101,9 @@
           <text>MuseScore testfile</text>
           </Text>
         </VBox>
+      <HBox>
+        <width>7</width>
+        </HBox>
       <Measure>
         <voice>
           <Clef>
@@ -197,7 +200,7 @@
             </Chord>
           <Beam>
             <StemDirection>up</StemDirection>
-            <l1>-24</l1>
+            <l1>-26</l1>
             <l2>-36</l2>
             </Beam>
           <Chord>

--- a/src/importexport/musicxml/tests/data/testBreaksSystem_no_ref.xml
+++ b/src/importexport/musicxml/tests/data/testBreaksSystem_no_ref.xml
@@ -71,6 +71,11 @@
         </note>
       </measure>
     <measure number="2">
+      <print>
+        <measure-layout>
+          <measure-distance>50</measure-distance>
+          </measure-layout>
+        </print>
       <direction placement="above" system="only-top">
         <direction-type>
           <words>After system break in horizontal frame</words>
@@ -83,6 +88,11 @@
         </note>
       </measure>
     <measure number="1">
+      <print>
+        <measure-layout>
+          <measure-distance>50</measure-distance>
+          </measure-layout>
+        </print>
       <attributes>
         <divisions>1</divisions>
         </attributes>
@@ -98,6 +108,11 @@
         </note>
       </measure>
     <measure number="2">
+      <print>
+        <measure-layout>
+          <measure-distance>50</measure-distance>
+          </measure-layout>
+        </print>
       <direction placement="above" system="only-top">
         <direction-type>
           <words>After page break in horizontal frame</words>
@@ -139,6 +154,11 @@
         </note>
       </measure>
     <measure number="5">
+      <print>
+        <measure-layout>
+          <measure-distance>50</measure-distance>
+          </measure-layout>
+        </print>
       <direction placement="above" system="only-top">
         <direction-type>
           <words>After system break in hframe</words>

--- a/src/importexport/musicxml/tests/data/testBuzzRoll_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testBuzzRoll_ref.mscx
@@ -118,6 +118,9 @@
           <text>James M</text>
           </Text>
         </VBox>
+      <HBox>
+        <width>5</width>
+        </HBox>
       <Measure>
         <voice>
           <Clef>

--- a/src/importexport/musicxml/tests/data/testChordSymbols2_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testChordSymbols2_ref.mscx
@@ -118,6 +118,9 @@
           <text>James M</text>
           </Text>
         </VBox>
+      <HBox>
+        <width>5</width>
+        </HBox>
       <Measure>
         <voice>
           <Clef>

--- a/src/importexport/musicxml/tests/data/testDCalCoda.xml
+++ b/src/importexport/musicxml/tests/data/testDCalCoda.xml
@@ -100,6 +100,11 @@
         </note>
       </measure>
     <measure number="5">
+      <print>
+        <measure-layout>
+          <measure-distance>100</measure-distance>
+          </measure-layout>
+        </print>
       <direction placement="above">
         <direction-type>
           <coda/>

--- a/src/importexport/musicxml/tests/data/testInferCodaII_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testInferCodaII_ref.mscx
@@ -169,6 +169,9 @@
           <text>James M</text>
           </Text>
         </VBox>
+      <HBox>
+        <width>5</width>
+        </HBox>
       <Measure>
         <voice>
           <Clef>

--- a/src/importexport/musicxml/tests/data/testInferSegnoII_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testInferSegnoII_ref.mscx
@@ -169,6 +169,9 @@
           <text>James M</text>
           </Text>
         </VBox>
+      <HBox>
+        <width>5</width>
+        </HBox>
       <Measure>
         <voice>
           <Clef>

--- a/src/importexport/musicxml/tests/data/testInferredCrescLines2_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testInferredCrescLines2_ref.mscx
@@ -177,6 +177,9 @@
           <text>James M</text>
           </Text>
         </VBox>
+      <HBox>
+        <width>5</width>
+        </HBox>
       <Measure>
         <voice>
           <Clef>

--- a/src/importexport/musicxml/tests/data/testInferredCrescLines_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testInferredCrescLines_ref.mscx
@@ -177,6 +177,9 @@
           <text>James M</text>
           </Text>
         </VBox>
+      <HBox>
+        <width>5</width>
+        </HBox>
       <Measure>
         <voice>
           <Clef>

--- a/src/importexport/musicxml/tests/data/testSibMetronomeMarks_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testSibMetronomeMarks_ref.mscx
@@ -161,6 +161,9 @@
       <VBox>
         <height>10</height>
         </VBox>
+      <HBox>
+        <width>5</width>
+        </HBox>
       <Measure>
         <voice>
           <Clef>

--- a/src/importexport/musicxml/tests/data/testSibOttavas_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testSibOttavas_ref.mscx
@@ -161,6 +161,9 @@
       <VBox>
         <height>10</height>
         </VBox>
+      <HBox>
+        <width>5</width>
+        </HBox>
       <Measure>
         <voice>
           <Clef>

--- a/src/importexport/musicxml/tests/data/testSibRitLine_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testSibRitLine_ref.mscx
@@ -110,6 +110,9 @@
       <VBox>
         <height>10</height>
         </VBox>
+      <HBox>
+        <width>5</width>
+        </HBox>
       <Measure>
         <voice>
           <Clef>


### PR DESCRIPTION
This PR adds support for the `measure-distance` element (`HBox`) to the MusicXML import and export.