### PR TITLE
Text fixes: missing colons in Style -> Beams

### DIFF
--- a/src/notation/qml/MuseScore/NotationScene/internal/EditStyle/BeamsPage.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/EditStyle/BeamsPage.qml
@@ -77,7 +77,7 @@ StyleDialogPage {
     }
 
     ItemWithTitle {
-        title: qsTrc("notation", "Beam thickness")
+        title: qsTrc("notation", "Beam thickness:")
 
         IncrementalPropertyControl {
             width: 106
@@ -97,7 +97,7 @@ StyleDialogPage {
     }
 
     ItemWithTitle {
-        title: qsTrc("notation", "Broken beam minimum length")
+        title: qsTrc("notation", "Broken beam minimum length:")
 
         IncrementalPropertyControl {
             width: 106


### PR DESCRIPTION
Text fixes: missing colons in Style -> Beams
There should be colons at the end, like in similar options with "sp". I'm think that these "frames with sp" should be on the right, after the text. That's only my opinion, of course.

Greetings,
Gootector

Resolves: #NNNNN <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
