### PR TITLE
Correct changing voices in part's linked staves

### DIFF
--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -5188,10 +5188,12 @@ void Score::changeSelectedNotesVoice(voice_idx_t voice)
                 break;
             }
 
-            if (score->excerpt()
-                && muse::key(score->excerpt()->tracksMapping(), chord->staffIdx() * VOICES + chord->voice(),
-                             muse::nidx) == chord->staffIdx() * VOICES + voice) {
-                break;
+            if (score->excerpt()) {
+                const track_idx_t originalTrack = chord->staffIdx() * VOICES + chord->voice();
+                const track_idx_t originalTrackMapped = muse::key(score->excerpt()->tracksMapping(), originalTrack, muse::nidx);
+                if (originalTrackMapped == dstTrack) {
+                    break;
+                }
             }
 
             // set up destination chord

--- a/src/engraving/dom/staff.h
+++ b/src/engraving/dom/staff.h
@@ -261,6 +261,8 @@ public:
 
     Staff* findLinkedInScore(const Score* score) const override;
 
+    std::vector<track_idx_t> getLinkedTracksInStaff(const Staff* linkedStaff, const track_idx_t strack) const;
+
 private:
 
     friend class Factory;

--- a/src/engraving/tests/parts_data/part-visible-tracks-part-ref.mscx
+++ b/src/engraving/tests/parts_data/part-visible-tracks-part-ref.mscx
@@ -1,0 +1,165 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="4.40">
+  <Score>
+    <name>Klarinet in B♭</name>
+    <Tracklist sTrack="0" dstTrack="0"/>
+    <Tracklist sTrack="2" dstTrack="1"/>
+    <Tracklist sTrack="3" dstTrack="2"/>
+    <Tracklist sTrack="5" dstTrack="4"/>
+    <Tracklist sTrack="6" dstTrack="5"/>
+    <Tracklist sTrack="7" dstTrack="6"/>
+    <initialPartId>1</initialPartId>
+    <Division>480</Division>
+    <Style>
+      <pageWidth>8.27</pageWidth>
+      <pageHeight>11.69</pageHeight>
+      <pagePrintableWidth>7.0889</pagePrintableWidth>
+      <pageEvenLeftMargin>0.590551</pageEvenLeftMargin>
+      <pageOddLeftMargin>0.590551</pageOddLeftMargin>
+      <pageEvenTopMargin>0.590551</pageEvenTopMargin>
+      <pageEvenBottomMargin>0.590551</pageEvenBottomMargin>
+      <pageOddTopMargin>0.590551</pageOddTopMargin>
+      <pageOddBottomMargin>0.590551</pageOddBottomMargin>
+      <lyricsDashMaxLength>0.8</lyricsDashMaxLength>
+      <lyricsMelismaPad>0.1</lyricsMelismaPad>
+      <lyricsDashYposRatio>0.6</lyricsDashYposRatio>
+      <clefKeyDistance>1</clefKeyDistance>
+      <barNoteDistance>1.3</barNoteDistance>
+      <accidentalDistance>0.22</accidentalDistance>
+      <hairpinPosAbove x="0" y="-2"/>
+      <hairpinPosBelow x="0" y="2"/>
+      <hairpinLinePosAbove x="0" y="-3"/>
+      <hairpinLinePosBelow x="0" y="4"/>
+      <pedalFontSize>12</pedalFontSize>
+      <fretFretSpacing>0.8</fretFretSpacing>
+      <barreLineWidth>1</barreLineWidth>
+      <createMultiMeasureRests>1</createMultiMeasureRests>
+      <multiMeasureRestMargin>1.2</multiMeasureRestMargin>
+      <arpeggioNoteDistance>0.5</arpeggioNoteDistance>
+      <arpeggioAccidentalDistance>0.5</arpeggioAccidentalDistance>
+      <tiePlacementChord>inside</tiePlacementChord>
+      <dynamicsPosAbove x="0" y="-1.5"/>
+      <dynamicsPosBelow x="0" y="2.5"/>
+      <measureNumberPosBelow x="0" y="1"/>
+      <repeatLeftFontSize>18</repeatLeftFontSize>
+      <systemTextLineFontSize>12</systemTextLineFontSize>
+      <defaultsVersion>410</defaultsVersion>
+      <Spatium>1.74978</Spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <metaTag name="partName">Klarinet in B♭</metaTag>
+    <Part id="1">
+      <Staff id="1">
+        <linkedTo>1</linkedTo>
+        <linkedTo>2</linkedTo>
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        </Staff>
+      <Staff id="2">
+        <linkedTo>1</linkedTo>
+        <linkedTo>2</linkedTo>
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        </Staff>
+      <trackName>Klarinet in B♭</trackName>
+      <Instrument id="bb-clarinet">
+        <longName>Klarinet in B♭</longName>
+        <shortName>Kl. in B♭</shortName>
+        <trackName>Klarinet</trackName>
+        <minPitchP>50</minPitchP>
+        <maxPitchP>94</maxPitchP>
+        <minPitchA>50</minPitchA>
+        <maxPitchA>89</maxPitchA>
+        <transposeDiatonic>-1</transposeDiatonic>
+        <transposeChromatic>-2</transposeChromatic>
+        <instrumentId>wind.reed.clarinet.bflat</instrumentId>
+        <Channel>
+          <program value="71"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <Measure>
+        <voice>
+          <KeySig>
+            <linked>
+              </linked>
+            <concertKey>0</concertKey>
+            </KeySig>
+          <TimeSig>
+            <linked>
+              <indexDiff>-1</indexDiff>
+              </linked>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Chord>
+            <linked>
+              <indexDiff>-2</indexDiff>
+              </linked>
+            <durationType>whole</durationType>
+            <Note>
+              <linked>
+                <indexDiff>-3</indexDiff>
+                </linked>
+              <Accidental>
+                <subtype>accidentalSharp</subtype>
+                </Accidental>
+              <pitch>83</pitch>
+              <tpc>19</tpc>
+              <tpc2>21</tpc2>
+              </Note>
+            </Chord>
+          </voice>
+        </Measure>
+      </Staff>
+    <Staff id="2">
+      <Measure>
+        <voice>
+          <KeySig>
+            <linked>
+              <indexDiff>-4</indexDiff>
+              </linked>
+            <concertKey>0</concertKey>
+            </KeySig>
+          <TimeSig>
+            <linked>
+              <location>
+                <staves>1</staves>
+                </location>
+              </linked>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Chord>
+            <linked>
+              <location>
+                <voices>1</voices>
+                </location>
+              </linked>
+            <durationType>whole</durationType>
+            <Note>
+              <linked>
+                <location>
+                  <voices>1</voices>
+                  </location>
+                <indexDiff>-1</indexDiff>
+                </linked>
+              <Accidental>
+                <subtype>accidentalSharp</subtype>
+                </Accidental>
+              <pitch>71</pitch>
+              <tpc>19</tpc>
+              <tpc2>21</tpc2>
+              </Note>
+            </Chord>
+          </voice>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/src/engraving/tests/parts_data/part-visible-tracks-score-ref.mscx
+++ b/src/engraving/tests/parts_data/part-visible-tracks-score-ref.mscx
@@ -1,0 +1,355 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="4.40">
+  <Score>
+    <Division>480</Division>
+    <Style>
+      <defaultsVersion>410</defaultsVersion>
+      <Spatium>1.74978</Spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="audioComUrl"></metaTag>
+    <metaTag name="composer">Componist / arrangeur</metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="poet"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="sourceRevisionId"></metaTag>
+    <metaTag name="subtitle">Ondertitel</metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle">Naamloze partituur</metaTag>
+    <Order id="orchestral">
+      <name>Orchestral</name>
+      <instrument id="bb-clarinet">
+        <family id="clarinets">Klarinetten</family>
+        </instrument>
+      <section id="woodwind" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>flutes</family>
+        <family>oboes</family>
+        <family>clarinets</family>
+        <family>saxophones</family>
+        <family>bassoons</family>
+        <unsorted group="woodwinds"/>
+        </section>
+      <section id="brass" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>horns</family>
+        <family>trumpets</family>
+        <family>cornets</family>
+        <family>flugelhorns</family>
+        <family>trombones</family>
+        <family>tubas</family>
+        </section>
+      <section id="timpani" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>timpani</family>
+        </section>
+      <section id="percussion" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>keyboard-percussion</family>
+        <family>drums</family>
+        <family>unpitched-metal-percussion</family>
+        <family>unpitched-wooden-percussion</family>
+        <family>other-percussion</family>
+        </section>
+      <family>keyboards</family>
+      <family>harps</family>
+      <family>organs</family>
+      <family>synths</family>
+      <soloists/>
+      <section id="voices" brackets="true" barLineSpan="false" thinBrackets="true">
+        <family>voices</family>
+        <family>voice-groups</family>
+        </section>
+      <section id="strings" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>orchestral-strings</family>
+        </section>
+      <unsorted/>
+      </Order>
+    <Part id="1">
+      <Staff id="1">
+        <linkedTo>2</linkedTo>
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <bracket type="0" span="2" col="0" visible="1"/>
+        <bracket type="2" span="2" col="2" visible="1"/>
+        <barLineSpan>1</barLineSpan>
+        </Staff>
+      <Staff id="2">
+        <linkedTo>1</linkedTo>
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <isStaffVisible>0</isStaffVisible>
+        </Staff>
+      <trackName>Klarinet in B♭</trackName>
+      <Instrument id="bb-clarinet">
+        <longName>Klarinet in B♭</longName>
+        <shortName>Kl. in B♭</shortName>
+        <trackName>Klarinet</trackName>
+        <minPitchP>50</minPitchP>
+        <maxPitchP>94</maxPitchP>
+        <minPitchA>50</minPitchA>
+        <maxPitchA>89</maxPitchA>
+        <transposeDiatonic>-1</transposeDiatonic>
+        <transposeChromatic>-2</transposeChromatic>
+        <instrumentId>wind.reed.clarinet.bflat</instrumentId>
+        <Channel>
+          <program value="71"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <Measure>
+        <voice>
+          <KeySig>
+            <linkedMain/>
+            <concertKey>0</concertKey>
+            </KeySig>
+          <TimeSig>
+            <linkedMain/>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Chord>
+            <linkedMain/>
+            <durationType>whole</durationType>
+            <Note>
+              <linkedMain/>
+              <Accidental>
+                <subtype>accidentalSharp</subtype>
+                </Accidental>
+              <pitch>83</pitch>
+              <tpc>19</tpc>
+              <tpc2>21</tpc2>
+              </Note>
+            </Chord>
+          </voice>
+        <voice>
+          <Chord>
+            <linkedMain/>
+            <durationType>whole</durationType>
+            <Note>
+              <linkedMain/>
+              <Accidental>
+                <subtype>accidentalSharp</subtype>
+                </Accidental>
+              <pitch>71</pitch>
+              <tpc>19</tpc>
+              <tpc2>21</tpc2>
+              </Note>
+            </Chord>
+          </voice>
+        </Measure>
+      </Staff>
+    <Staff id="2">
+      <Measure>
+        <voice>
+          <KeySig>
+            <linked>
+              </linked>
+            <concertKey>0</concertKey>
+            </KeySig>
+          <TimeSig>
+            <linkedMain/>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Chord>
+            <linked>
+              <indexDiff>2</indexDiff>
+              </linked>
+            <durationType>whole</durationType>
+            <Note>
+              <linked>
+                <indexDiff>2</indexDiff>
+                </linked>
+              <pitch>83</pitch>
+              <tpc>19</tpc>
+              <tpc2>21</tpc2>
+              </Note>
+            </Chord>
+          </voice>
+        <voice>
+          <Chord>
+            <linked>
+              </linked>
+            <durationType>whole</durationType>
+            <Note>
+              <linked>
+                </linked>
+              <Accidental>
+                <subtype>accidentalSharp</subtype>
+                </Accidental>
+              <pitch>71</pitch>
+              <tpc>19</tpc>
+              <tpc2>21</tpc2>
+              </Note>
+            </Chord>
+          </voice>
+        </Measure>
+      </Staff>
+    <Score>
+      <name>Klarinet in B♭</name>
+      <Tracklist sTrack="0" dstTrack="0"/>
+      <Tracklist sTrack="2" dstTrack="1"/>
+      <Tracklist sTrack="3" dstTrack="2"/>
+      <Tracklist sTrack="5" dstTrack="4"/>
+      <Tracklist sTrack="6" dstTrack="5"/>
+      <Tracklist sTrack="7" dstTrack="6"/>
+      <initialPartId>1</initialPartId>
+      <Division>480</Division>
+      <Style>
+        <pageWidth>8.27</pageWidth>
+        <pageHeight>11.69</pageHeight>
+        <pagePrintableWidth>7.0889</pagePrintableWidth>
+        <pageEvenLeftMargin>0.590551</pageEvenLeftMargin>
+        <pageOddLeftMargin>0.590551</pageOddLeftMargin>
+        <pageEvenTopMargin>0.590551</pageEvenTopMargin>
+        <pageEvenBottomMargin>0.590551</pageEvenBottomMargin>
+        <pageOddTopMargin>0.590551</pageOddTopMargin>
+        <pageOddBottomMargin>0.590551</pageOddBottomMargin>
+        <lyricsDashMaxLength>0.8</lyricsDashMaxLength>
+        <lyricsMelismaPad>0.1</lyricsMelismaPad>
+        <lyricsDashYposRatio>0.6</lyricsDashYposRatio>
+        <clefKeyDistance>1</clefKeyDistance>
+        <barNoteDistance>1.3</barNoteDistance>
+        <accidentalDistance>0.22</accidentalDistance>
+        <hairpinPosAbove x="0" y="-2"/>
+        <hairpinPosBelow x="0" y="2"/>
+        <hairpinLinePosAbove x="0" y="-3"/>
+        <hairpinLinePosBelow x="0" y="4"/>
+        <pedalFontSize>12</pedalFontSize>
+        <fretFretSpacing>0.8</fretFretSpacing>
+        <barreLineWidth>1</barreLineWidth>
+        <createMultiMeasureRests>1</createMultiMeasureRests>
+        <multiMeasureRestMargin>1.2</multiMeasureRestMargin>
+        <arpeggioNoteDistance>0.5</arpeggioNoteDistance>
+        <arpeggioAccidentalDistance>0.5</arpeggioAccidentalDistance>
+        <tiePlacementChord>inside</tiePlacementChord>
+        <dynamicsPosAbove x="0" y="-1.5"/>
+        <dynamicsPosBelow x="0" y="2.5"/>
+        <measureNumberPosBelow x="0" y="1"/>
+        <repeatLeftFontSize>18</repeatLeftFontSize>
+        <systemTextLineFontSize>12</systemTextLineFontSize>
+        <defaultsVersion>410</defaultsVersion>
+        <Spatium>1.74978</Spatium>
+        </Style>
+      <showInvisible>1</showInvisible>
+      <showUnprintable>1</showUnprintable>
+      <showFrames>1</showFrames>
+      <showMargins>0</showMargins>
+      <metaTag name="partName">Klarinet in B♭</metaTag>
+      <Part id="1">
+        <Staff id="1">
+          <linkedTo>1</linkedTo>
+          <linkedTo>2</linkedTo>
+          <StaffType group="pitched">
+            <name>stdNormal</name>
+            </StaffType>
+          </Staff>
+        <Staff id="2">
+          <linkedTo>1</linkedTo>
+          <linkedTo>2</linkedTo>
+          <StaffType group="pitched">
+            <name>stdNormal</name>
+            </StaffType>
+          </Staff>
+        <trackName>Klarinet in B♭</trackName>
+        <Instrument id="bb-clarinet">
+          <longName>Klarinet in B♭</longName>
+          <shortName>Kl. in B♭</shortName>
+          <trackName>Klarinet</trackName>
+          <minPitchP>50</minPitchP>
+          <maxPitchP>94</maxPitchP>
+          <minPitchA>50</minPitchA>
+          <maxPitchA>89</maxPitchA>
+          <transposeDiatonic>-1</transposeDiatonic>
+          <transposeChromatic>-2</transposeChromatic>
+          <instrumentId>wind.reed.clarinet.bflat</instrumentId>
+          <Channel>
+            <program value="71"/>
+            </Channel>
+          </Instrument>
+        </Part>
+      <Staff id="1">
+        <Measure>
+          <voice>
+            <KeySig>
+              <linked>
+                </linked>
+              <concertKey>0</concertKey>
+              </KeySig>
+            <TimeSig>
+              <linked>
+                </linked>
+              <sigN>4</sigN>
+              <sigD>4</sigD>
+              </TimeSig>
+            <Chord>
+              <linked>
+                </linked>
+              <durationType>whole</durationType>
+              <Note>
+                <linked>
+                  </linked>
+                <Accidental>
+                  <subtype>accidentalSharp</subtype>
+                  </Accidental>
+                <pitch>83</pitch>
+                <tpc>19</tpc>
+                <tpc2>21</tpc2>
+                </Note>
+              </Chord>
+            </voice>
+          </Measure>
+        </Staff>
+      <Staff id="2">
+        <Measure>
+          <voice>
+            <KeySig>
+              <linked>
+                <indexDiff>-4</indexDiff>
+                </linked>
+              <concertKey>0</concertKey>
+              </KeySig>
+            <TimeSig>
+              <linked>
+                <location>
+                  <staves>1</staves>
+                  </location>
+                </linked>
+              <sigN>4</sigN>
+              <sigD>4</sigD>
+              </TimeSig>
+            <Chord>
+              <linked>
+                <location>
+                  <voices>1</voices>
+                  </location>
+                </linked>
+              <durationType>whole</durationType>
+              <Note>
+                <linked>
+                  <location>
+                    <voices>1</voices>
+                    </location>
+                  </linked>
+                <Accidental>
+                  <subtype>accidentalSharp</subtype>
+                  </Accidental>
+                <pitch>71</pitch>
+                <tpc>19</tpc>
+                <tpc2>21</tpc2>
+                </Note>
+              </Chord>
+            </voice>
+          </Measure>
+        </Staff>
+      </Score>
+    </Score>
+  </museScore>

--- a/src/engraving/tests/parts_data/part-visible-tracks.mscx
+++ b/src/engraving/tests/parts_data/part-visible-tracks.mscx
@@ -1,0 +1,334 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="4.40">
+  <programVersion>4.4.0</programVersion>
+  <programRevision></programRevision>
+  <Score>
+    <Division>480</Division>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <open>1</open>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="audioComUrl"></metaTag>
+    <metaTag name="composer">Componist / arrangeur</metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="creationDate">2023-08-26</metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="platform">Linux</metaTag>
+    <metaTag name="poet"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="sourceRevisionId"></metaTag>
+    <metaTag name="subtitle">Ondertitel</metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle">Naamloze partituur</metaTag>
+    <Order id="orchestral">
+      <name>Orchestral</name>
+      <instrument id="bb-clarinet">
+        <family id="clarinets">Klarinetten</family>
+      </instrument>
+      <section id="woodwind" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>flutes</family>
+        <family>oboes</family>
+        <family>clarinets</family>
+        <family>saxophones</family>
+        <family>bassoons</family>
+        <unsorted group="woodwinds"/>
+      </section>
+      <section id="brass" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>horns</family>
+        <family>trumpets</family>
+        <family>cornets</family>
+        <family>flugelhorns</family>
+        <family>trombones</family>
+        <family>tubas</family>
+      </section>
+      <section id="timpani" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>timpani</family>
+      </section>
+      <section id="percussion" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>keyboard-percussion</family>
+        <family>drums</family>
+        <family>unpitched-metal-percussion</family>
+        <family>unpitched-wooden-percussion</family>
+        <family>other-percussion</family>
+      </section>
+      <family>keyboards</family>
+      <family>harps</family>
+      <family>organs</family>
+      <family>synths</family>
+      <soloists/>
+      <section id="voices" brackets="true" barLineSpan="false" thinBrackets="true">
+        <family>voices</family>
+        <family>voice-groups</family>
+      </section>
+      <section id="strings" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>orchestral-strings</family>
+      </section>
+      <unsorted/>
+    </Order>
+    <Part id="1">
+      <Staff id="1">
+        <linkedTo>2</linkedTo>
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+        </StaffType>
+        <bracket type="0" span="2" col="0" visible="1"/>
+        <bracket type="2" span="2" col="2" visible="1"/>
+        <barLineSpan>1</barLineSpan>
+      </Staff>
+      <Staff id="2">
+        <linkedTo>1</linkedTo>
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+        </StaffType>
+        <isStaffVisible>0</isStaffVisible>
+      </Staff>
+      <trackName>Klarinet in B♭</trackName>
+      <Instrument id="bb-clarinet">
+        <longName>Klarinet in B♭</longName>
+        <shortName>Kl. in B♭</shortName>
+        <trackName>Klarinet</trackName>
+        <minPitchP>50</minPitchP>
+        <maxPitchP>94</maxPitchP>
+        <minPitchA>50</minPitchA>
+        <maxPitchA>89</maxPitchA>
+        <transposeDiatonic>-1</transposeDiatonic>
+        <transposeChromatic>-2</transposeChromatic>
+        <instrumentId>wind.reed.clarinet.bflat</instrumentId>
+        <Channel>
+          <program value="71"/>
+          <synti>Fluid</synti>
+        </Channel>
+      </Instrument>
+    </Part>
+    <Staff id="1">
+      <Measure>
+        <voice>
+          <KeySig>
+            <linkedMain/>
+            <concertKey>0</concertKey>
+            <actualKey>2</actualKey>
+          </KeySig>
+          <TimeSig>
+            <linkedMain/>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+          </TimeSig>
+          <Chord>
+            <linkedMain/>
+            <durationType>whole</durationType>
+            <Note>
+              <linkedMain/>
+              <pitch>71</pitch>
+              <tpc>19</tpc>
+              <tpc2>21</tpc2>
+            </Note>
+            <Note>
+              <linkedMain/>
+              <pitch>83</pitch>
+              <tpc>19</tpc>
+              <tpc2>21</tpc2>
+            </Note>
+          </Chord>
+        </voice>
+      </Measure>
+    </Staff>
+    <Staff id="2">
+      <Measure>
+        <voice>
+          <KeySig>
+            <linked>
+              <indexDiff>-5</indexDiff>
+            </linked>
+            <concertKey>0</concertKey>
+            <actualKey>2</actualKey>
+          </KeySig>
+          <TimeSig>
+            <linkedMain/>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+          </TimeSig>
+          <Chord>
+            <linked>
+              <indexDiff>2</indexDiff>
+            </linked>
+            <durationType>whole</durationType>
+            <Note>
+              <linked>
+                <indexDiff>2</indexDiff>
+              </linked>
+              <pitch>71</pitch>
+              <tpc>19</tpc>
+              <tpc2>21</tpc2>
+            </Note>
+            <Note>
+              <linked>
+                <indexDiff>2</indexDiff>
+              </linked>
+              <pitch>83</pitch>
+              <tpc>19</tpc>
+              <tpc2>21</tpc2>
+            </Note>
+          </Chord>
+        </voice>
+      </Measure>
+    </Staff>
+    <Score>
+      <name>Klarinet in B♭</name>
+      <Tracklist sTrack="0" dstTrack="0"/>
+      <Tracklist sTrack="2" dstTrack="1"/>
+      <Tracklist sTrack="3" dstTrack="2"/>
+      <Tracklist sTrack="5" dstTrack="4"/>
+      <Tracklist sTrack="6" dstTrack="5"/>
+      <Tracklist sTrack="7" dstTrack="6"/>
+      <initialPartId>1</initialPartId>
+      <Division>480</Division>
+      <Style>
+        <pageWidth>8.27</pageWidth>
+        <pageHeight>11.69</pageHeight>
+        <pagePrintableWidth>7.0889</pagePrintableWidth>
+        <pageEvenLeftMargin>0.590551</pageEvenLeftMargin>
+        <pageOddLeftMargin>0.590551</pageOddLeftMargin>
+        <pageEvenTopMargin>0.590551</pageEvenTopMargin>
+        <pageEvenBottomMargin>0.590551</pageEvenBottomMargin>
+        <pageOddTopMargin>0.590551</pageOddTopMargin>
+        <pageOddBottomMargin>0.590551</pageOddBottomMargin>
+        <lyricsDashMaxLength>0.8</lyricsDashMaxLength>
+        <lyricsMelismaPad>0.1</lyricsMelismaPad>
+        <lyricsDashYposRatio>0.6</lyricsDashYposRatio>
+        <clefKeyDistance>1</clefKeyDistance>
+        <barNoteDistance>1.3</barNoteDistance>
+        <accidentalDistance>0.22</accidentalDistance>
+        <hairpinPosAbove x="0" y="-2"/>
+        <hairpinPosBelow x="0" y="2"/>
+        <hairpinLinePosAbove x="0" y="-3"/>
+        <hairpinLinePosBelow x="0" y="4"/>
+        <pedalFontSize>12</pedalFontSize>
+        <fretFretSpacing>0.8</fretFretSpacing>
+        <barreLineWidth>1</barreLineWidth>
+        <createMultiMeasureRests>1</createMultiMeasureRests>
+        <multiMeasureRestMargin>1.2</multiMeasureRestMargin>
+        <arpeggioNoteDistance>0.5</arpeggioNoteDistance>
+        <arpeggioAccidentalDistance>0.5</arpeggioAccidentalDistance>
+        <tiePlacementChord>inside</tiePlacementChord>
+        <dynamicsPosAbove x="0" y="-1.5"/>
+        <dynamicsPosBelow x="0" y="2.5"/>
+        <measureNumberPosBelow x="0" y="1"/>
+        <repeatLeftFontSize>18</repeatLeftFontSize>
+        <systemTextLineFontSize>12</systemTextLineFontSize>
+        <defaultsVersion>410</defaultsVersion>
+        <Spatium>1.74978</Spatium>
+      </Style>
+      <showInvisible>1</showInvisible>
+      <showUnprintable>1</showUnprintable>
+      <showFrames>1</showFrames>
+      <showMargins>0</showMargins>
+      <open>1</open>
+      <metaTag name="partName">Klarinet in B♭</metaTag>
+      <Part id="1">
+        <Staff id="1">
+          <linkedTo>1</linkedTo>
+          <linkedTo>2</linkedTo>
+          <StaffType group="pitched">
+            <name>stdNormal</name>
+          </StaffType>
+        </Staff>
+        <Staff id="2">
+          <linkedTo>1</linkedTo>
+          <linkedTo>2</linkedTo>
+          <StaffType group="pitched">
+            <name>stdNormal</name>
+          </StaffType>
+        </Staff>
+        <trackName>Klarinet in B♭</trackName>
+        <Instrument id="bb-clarinet">
+          <longName>Klarinet in B♭</longName>
+          <shortName>Kl. in B♭</shortName>
+          <trackName>Klarinet</trackName>
+          <minPitchP>50</minPitchP>
+          <maxPitchP>94</maxPitchP>
+          <minPitchA>50</minPitchA>
+          <maxPitchA>89</maxPitchA>
+          <transposeDiatonic>-1</transposeDiatonic>
+          <transposeChromatic>-2</transposeChromatic>
+          <instrumentId>wind.reed.clarinet.bflat</instrumentId>
+          <Channel>
+            <program value="71"/>
+            <synti>Fluid</synti>
+          </Channel>
+        </Instrument>
+      </Part>
+      <Staff id="1">
+        <Measure>
+          <voice>
+            <KeySig>
+              <linked>
+                <indexDiff>-3</indexDiff>
+              </linked>
+              <concertKey>0</concertKey>
+              <actualKey>2</actualKey>
+            </KeySig>
+            <TimeSig>
+              <linked>
+                <indexDiff>-3</indexDiff>
+              </linked>
+              <sigN>4</sigN>
+              <sigD>4</sigD>
+            </TimeSig>
+            <Chord>
+              <linked>
+                <indexDiff>-3</indexDiff>
+              </linked>
+              <durationType>whole</durationType>
+              <Note>
+                <linked>
+                  <indexDiff>-3</indexDiff>
+                </linked>
+                <pitch>71</pitch>
+                <tpc>19</tpc>
+                <tpc2>21</tpc2>
+              </Note>
+              <Note>
+                <linked>
+                  <indexDiff>-3</indexDiff>
+                </linked>
+                <pitch>83</pitch>
+                <tpc>19</tpc>
+                <tpc2>21</tpc2>
+              </Note>
+            </Chord>
+          </voice>
+        </Measure>
+      </Staff>
+      <Staff id="2">
+        <Measure>
+          <voice>
+            <KeySig>
+              <linked>
+                <indexDiff>-8</indexDiff>
+              </linked>
+              <concertKey>0</concertKey>
+              <actualKey>2</actualKey>
+            </KeySig>
+            <TimeSig>
+              <linked>
+                <location>
+                  <staves>1</staves>
+                </location>
+              </linked>
+              <sigN>4</sigN>
+              <sigD>4</sigD>
+            </TimeSig>
+            <Rest>
+              <durationType>whole</durationType>
+            </Rest>
+          </voice>
+        </Measure>
+      </Staff>
+    </Score>
+  </Score>
+</museScore>

--- a/src/engraving/tests/parts_tests.cpp
+++ b/src/engraving/tests/parts_tests.cpp
@@ -1270,6 +1270,37 @@ TEST_F(Engraving_PartsTests, partSpanners)
     MScore::useRead302InTestMode = useRead302;
 }
 
+TEST_F(Engraving_PartsTests, partVisibleTracks) {
+    Score* score = ScoreRW::readScore(PARTS_DATA_DIR + u"part-visible-tracks.mscx");
+    EXPECT_TRUE(score);
+
+    Score* part = nullptr;
+    for (Score* s : score->scoreList()) {
+        if (!s->isMaster()) {
+            part = s;
+            break;
+        }
+    }
+    EXPECT_TRUE(part);
+    Measure* m = part->firstMeasure();
+    EXPECT_TRUE(m);
+    Chord* c = m->findChord(Fraction(0, 1), 0);
+    EXPECT_TRUE(c);
+    Note* n = c->downNote();
+    EXPECT_TRUE(n);
+
+    part->startCmd();
+    part->select(n);
+    part->changeSelectedNotesVoice(1);
+    part->endCmd();
+
+    EXPECT_TRUE(ScoreComp::saveCompareScore(part, u"part-visible-tracks-part.mscx",
+                                            PARTS_DATA_DIR + u"part-visible-tracks-part-ref.mscx"));
+    // score->undoRedo(true, 0);
+    EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"part-visible-tracks-score.mscx",
+                                            PARTS_DATA_DIR + u"part-visible-tracks-score-ref.mscx"));
+}
+
 //---------------------------------------------------------
 //   staffStyles
 //---------------------------------------------------------

--- a/src/notation/qml/MuseScore/NotationScene/internal/VoicesPopup.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/VoicesPopup.qml
@@ -39,7 +39,7 @@ StyledPopupView {
         spacing: 18
 
         StyledTextLabel {
-            text: qsTrc("notation", "Voices visible on this score")
+            text: qsTrc("notation", "Voices visible on this stave")
         }
 
         ListView {


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/19180
This PR fixes the behaviour when changing the voice of a note on a stave with voices hidden through the 'Voices visible in the score' (N.b, should this not be 'Voices visible on the stave'?) options.
<img width="272" alt="Screenshot 2024-07-22 at 09 55 14" src="https://github.com/user-attachments/assets/74cbc124-0e4f-446d-a609-95d87cb54cc8">

When changing the voice of a note to one which is invisible on the current stave, the note is removed from the current stave and added to all those on which the voice is visible, as you might expect.  

When changing voice, we interpret the users choice as the _real underlying voice_, not the one currently displayed on the stave.  Eg. if the user has a stave configured to only have voice 2 visible, notes will appear as if in voice 1.  We do not allow changing the voice to voice 2 in this instance as it is already in voice 2.  I don't think this is ideal - there is definitely some design jank around this feature which would be great to clear up at some point.  However, this PR is focussed on fixing obviously broken behaviour.