### PR TITLE
Fix compiler warnings about usage of macOS 10.15+ classes/methods

### DIFF
--- a/src/framework/global/internal/platform/macos/macosinteractivehelper.mm
+++ b/src/framework/global/internal/platform/macos/macosinteractivehelper.mm
@@ -49,34 +49,56 @@ Ret MacOSInteractiveHelper::isAppExists(const std::string& appIdentifier)
 
 Ret MacOSInteractiveHelper::canOpenApp(const Uri& uri)
 {
-    NSWorkspace* workspace = [NSWorkspace sharedWorkspace];
-    NSString* nsUri = [NSString stringWithUTF8String:uri.toString().c_str()];
-    NSURL* appURL = [workspace URLForApplicationToOpenURL:[NSURL URLWithString:nsUri]];
-    return appURL != nil;
+    if (__builtin_available(macOS 10.15, *)) {
+        NSString* nsUrlString = [NSString stringWithUTF8String:uri.toString().c_str()];
+        if (nsUrlString == nil) {
+            return make_ret(Ret::Code::InternalError, std::string("Invalid UTF-8 string passed as URI"));
+        }
+
+        NSURL* nsUrl = [NSURL URLWithString:nsUrlString];
+        if (nsUrl == nil) {
+            return make_ret(Ret::Code::InternalError, std::string("Invalid URI"));
+        }
+
+        NSURL* appURL = [[NSWorkspace sharedWorkspace] URLForApplicationToOpenURL:nsUrl];
+        return appURL != nil;
+    } else {
+        return false;
+    }
 }
 
 async::Promise<Ret> MacOSInteractiveHelper::openApp(const Uri& uri)
 {
     return Promise<Ret>([&uri](auto resolve, auto reject) {
-        NSWorkspace* workspace = [NSWorkspace sharedWorkspace];
-        NSString* nsUri = [NSString stringWithUTF8String:uri.toString().c_str()];
-        NSURL* appURL = [NSURL URLWithString: nsUri];
+        if (__builtin_available(macOS 10.15, *)) {
+            NSString* nsUrlString = [NSString stringWithUTF8String:uri.toString().c_str()];
+            if (nsUrlString == nil) {
+                return reject(int(Ret::Code::InternalError), "Invalid UTF-8 string passed as URI");
+            }
 
-        auto configuration = [NSWorkspaceOpenConfiguration configuration];
-        [configuration setPromptsUserIfNeeded:NO];
-        [workspace openURL: appURL
-         configuration: configuration
-         completionHandler: ^(NSRunningApplication*, NSError* error) {
-             if (error) {
-                 std::string errorStr = [[error description] UTF8String];
-                 Ret ret = make_ret(Ret::Code::InternalError, errorStr);
-                 (void)reject(ret.code(), ret.text());
-             } else {
-                 (void)resolve(make_ok());
+            NSURL* nsUrl = [NSURL URLWithString:nsUrlString];
+            if (nsUrl == nil) {
+                return reject(int(Ret::Code::InternalError), "Invalid URI");
+            }
+
+            auto configuration = [NSWorkspaceOpenConfiguration configuration];
+            [configuration setPromptsUserIfNeeded:NO];
+            [[NSWorkspace sharedWorkspace]
+             openURL: nsUrl
+             configuration: configuration
+             completionHandler: ^(NSRunningApplication*, NSError* error) {
+                 if (error) {
+                     std::string errorStr = [[error description] UTF8String];
+                     (void)reject(int(Ret::Code::InternalError), errorStr);
+                 } else {
+                     (void)resolve(make_ok());
+                 }
              }
-         }
-        ];
+            ];
 
-        return Promise<Ret>::Result::unchecked();
+            return Promise<Ret>::Result::unchecked();
+        } else {
+            return reject(int(Ret::Code::NotSupported), "macOS 10.15 or later is required");
+        }
     });
 }

--- a/src/framework/update/internal/musesoundscheckupdateservice.cpp
+++ b/src/framework/update/internal/musesoundscheckupdateservice.cpp
@@ -45,10 +45,6 @@ muse::Ret MuseSoundsCheckUpdateService::needCheckForUpdate() const
 #ifdef Q_OS_WIN
     return true;
 #elif defined(Q_OS_MAC)
-    if (systemInfo()->productVersion() < Version("10.15")) {
-        return false;
-    }
-
     //! NOTE: If there is installed MuseHub, but we can't open it, then we shouldn't check update
     static const std::string MUSEHUB_APP_IDENTIFIER = "com.muse.hub";
     bool isMuseHubExists = interactive()->isAppExists(MUSEHUB_APP_IDENTIFIER);


### PR DESCRIPTION
These warnings were not _really_ a problem because we had a different OS version check elsewhere, but this makes these methods generally correct, so that we cannot run into problems when we use those methods elsewhere in the future. 

Also fixes some `clazy` warnings about potential `nil` pointers where those were not allowed.