### PR TITLE
Export text from text lines with line hidden

### DIFF
--- a/src/importexport/musicxml/tests/data/testTextLines.mscx
+++ b/src/importexport/musicxml/tests/data/testTextLines.mscx
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="3.01">
+<museScore version="4.40">
+  <programVersion>4.4.0</programVersion>
+  <programRevision></programRevision>
   <Score>
     <Division>480</Division>
     <Style>
@@ -19,14 +21,14 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
+    <Part id="1">
       <Staff id="1">
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
         </Staff>
       <trackName>Flute</trackName>
-      <Instrument>
+      <Instrument id="flute">
         <longName>Flute</longName>
         <shortName>Fl.</shortName>
         <trackName>Flute</trackName>
@@ -82,14 +84,14 @@
           </Channel>
         </Instrument>
       </Part>
-    <Part>
+    <Part id="2">
       <Staff id="2">
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
         </Staff>
       <trackName>B♭ Clarinet</trackName>
-      <Instrument>
+      <Instrument id="bb-clarinet">
         <longName>B♭ Clarinet</longName>
         <shortName>B♭ Cl.</shortName>
         <trackName>B♭ Clarinet</trackName>
@@ -150,6 +152,7 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
+        <boxAutoSize>0</boxAutoSize>
         <Text>
           <style>title</style>
           <text>testlines</text>
@@ -165,6 +168,7 @@
           <Spanner type="HairPin">
             <HairPin>
               <subtype>0</subtype>
+              <direction>down</direction>
               </HairPin>
             <next>
               <location>
@@ -173,7 +177,7 @@
               </next>
             </Spanner>
           <Spanner type="TextLine">
-            <TextLine system="0">
+            <TextLine>
               <endHookType>1</endHookType>
               <beginText>Staff/1</beginText>
               </TextLine>
@@ -344,7 +348,8 @@
       <Measure>
         <voice>
           <KeySig>
-            <accidental>2</accidental>
+            <concertKey>0</concertKey>
+            <actualKey>2</actualKey>
             </KeySig>
           <TimeSig>
             <sigN>4</sigN>
@@ -377,6 +382,7 @@
           <Spanner type="HairPin">
             <HairPin>
               <subtype>1</subtype>
+              <direction>down</direction>
               </HairPin>
             <next>
               <location>
@@ -385,7 +391,7 @@
               </next>
             </Spanner>
           <Spanner type="TextLine">
-            <TextLine system="0">
+            <TextLine>
               <endHookType>1</endHookType>
               <beginText>Staff/2</beginText>
               </TextLine>
@@ -433,6 +439,17 @@
                 </location>
               </prev>
             </Spanner>
+          <Spanner type="HairPin">
+            <HairPin>
+              <subtype>2</subtype>
+              <lineVisible>0</lineVisible>
+              </HairPin>
+            <next>
+              <location>
+                <measures>2</measures>
+                </location>
+              </next>
+            </Spanner>
           <Chord>
             <durationType>whole</durationType>
             <Note>
@@ -457,6 +474,17 @@
         </Measure>
       <Measure>
         <voice>
+          <Dynamic>
+            <subtype>f</subtype>
+            <velocity>96</velocity>
+            </Dynamic>
+          <Spanner type="HairPin">
+            <prev>
+              <location>
+                <measures>-2</measures>
+                </location>
+              </prev>
+            </Spanner>
           <Chord>
             <durationType>whole</durationType>
             <Note>

--- a/src/importexport/musicxml/tests/data/testTextLines_ref.xml
+++ b/src/importexport/musicxml/tests/data/testTextLines_ref.xml
@@ -220,7 +220,7 @@
       <attributes>
         <divisions>1</divisions>
         <key>
-          <fifths>2</fifths>
+          <fifths>0</fifths>
           </key>
         <time>
           <beats>4</beats>
@@ -302,6 +302,11 @@
         </direction>
       </measure>
     <measure number="5">
+      <direction placement="below">
+        <direction-type>
+          <words font-family="Edwin" font-size="10" font-style="italic">cresc.</words>
+          </direction-type>
+        </direction>
       <note>
         <pitch>
           <step>F</step>
@@ -311,6 +316,7 @@
         <duration>4</duration>
         <voice>1</voice>
         <type>whole</type>
+        <accidental>sharp</accidental>
         </note>
       </measure>
     <measure number="6">
@@ -325,6 +331,14 @@
         </note>
       </measure>
     <measure number="7">
+      <direction placement="below">
+        <direction-type>
+          <dynamics>
+            <f/>
+            </dynamics>
+          </direction-type>
+        <sound dynamics="106.67"/>
+        </direction>
       <note>
         <pitch>
           <step>F</step>
@@ -334,6 +348,7 @@
         <duration>4</duration>
         <voice>1</voice>
         <type>whole</type>
+        <accidental>sharp</accidental>
         </note>
       <barline location="right">
         <bar-style>light-heavy</bar-style>


### PR DESCRIPTION
Resolves: #21390
"cresc." and "dim." marks weren't being exported at all if their line was set to invisible.  This PR exports start and end text to XML when the line is hidden.