### PR TITLE
Set ledger line mag value equal to its parent chord

### DIFF
--- a/src/engraving/rendering/dev/tlayout.cpp
+++ b/src/engraving/rendering/dev/tlayout.cpp
@@ -3891,7 +3891,9 @@ void TLayout::layoutLayoutBreak(const LayoutBreak* item, LayoutBreak::LayoutData
 
 static void _layoutLedgerLine(const LedgerLine* item, const LayoutContext& ctx, LedgerLine::LayoutData* ldata)
 {
-    ldata->lineWidth = ctx.conf().styleMM(Sid::ledgerLineWidth) * item->chord()->mag();
+    double chordMag = item->chord()->mag();
+    ldata->setMag(chordMag);
+    ldata->lineWidth = ctx.conf().styleMM(Sid::ledgerLineWidth) * chordMag;
     if (item->staff()) {
         const_cast<LedgerLine*>(item)->setColor(item->staff()->staffType(item->tick())->color());
     }


### PR DESCRIPTION
The mag value wasn't being set for ledger lines, which was causing small discrepancies in the scaling of padding values such as: 
![image](https://github.com/user-attachments/assets/1e13b94b-6991-49ee-9a61-ce725fafe9a3)
