### PR TITLE
Allow user to choose sample rate

### DIFF
--- a/src/appshell/qml/Preferences/internal/CommonAudioApiConfiguration.qml
+++ b/src/appshell/qml/Preferences/internal/CommonAudioApiConfiguration.qml
@@ -99,6 +99,8 @@ Item {
             onValueEdited: function(newIndex, newValue) {
                 apiModel.sampleRateSelected(newValue)
             }
+
+            visible: Qt.platform.os === "linux"
         }
     }
 }

--- a/src/appshell/qml/Preferences/internal/CommonAudioApiConfiguration.qml
+++ b/src/appshell/qml/Preferences/internal/CommonAudioApiConfiguration.qml
@@ -68,7 +68,7 @@ Item {
         ComboBoxWithTitle {
             id: bufferSize
 
-            title: qsTrc("appshell", "Buffer size:")
+            title: qsTrc("appshell/preferences", "Buffer size:")
             columnWidth: root.columnWidth
 
             currentIndex: indexOfValue(apiModel.bufferSize)
@@ -80,6 +80,24 @@ Item {
 
             onValueEdited: function(newIndex, newValue) {
                 apiModel.bufferSizeSelected(newValue)
+            }
+        }
+
+        ComboBoxWithTitle {
+            id: sampleRate
+
+            title: qsTrc("appshell/preferences", "Sample rate:")
+            columnWidth: root.columnWidth
+
+            currentIndex: indexOfValue(apiModel.sampleRate)
+            model: apiModel.sampleRateList
+
+            navigation.name: "SampleRateBox"
+            navigation.panel: root.navigation
+            navigation.row: root.navigationOrderStart + 2
+
+            onValueEdited: function(newIndex, newValue) {
+                apiModel.sampleRateSelected(newValue)
             }
         }
     }

--- a/src/appshell/view/preferences/commonaudioapiconfigurationmodel.cpp
+++ b/src/appshell/view/preferences/commonaudioapiconfigurationmodel.cpp
@@ -43,7 +43,12 @@ void CommonAudioApiConfigurationModel::load()
 
     audioDriver()->outputDeviceChanged().onNotify(this, [this]() {
         emit currentDeviceIdChanged();
+        emit sampleRateChanged();
         emit bufferSizeChanged();
+    });
+
+    audioDriver()->outputDeviceSampleRateChanged().onNotify(this, [this]() {
+        emit sampleRateChanged();
     });
 
     audioDriver()->outputDeviceBufferSizeChanged().onNotify(this, [this]() {
@@ -99,4 +104,26 @@ QList<unsigned int> CommonAudioApiConfigurationModel::bufferSizeList() const
 void CommonAudioApiConfigurationModel::bufferSizeSelected(const QString& bufferSizeStr)
 {
     audioConfiguration()->setDriverBufferSize(bufferSizeStr.toInt());
+}
+
+unsigned int CommonAudioApiConfigurationModel::sampleRate() const
+{
+    return audioDriver()->outputDeviceSampleRate();
+}
+
+QList<unsigned int> CommonAudioApiConfigurationModel::sampleRateList() const
+{
+    QList<unsigned int> result;
+    std::vector<unsigned int> sampleRates = audioDriver()->availableOutputDeviceSampleRates();
+
+    for (unsigned int sampleRate : sampleRates) {
+        result << sampleRate;
+    }
+
+    return result;
+}
+
+void CommonAudioApiConfigurationModel::sampleRateSelected(const QString& sampleRateStr)
+{
+    audioConfiguration()->setSampleRate(sampleRateStr.toInt());
 }

--- a/src/appshell/view/preferences/commonaudioapiconfigurationmodel.h
+++ b/src/appshell/view/preferences/commonaudioapiconfigurationmodel.h
@@ -38,6 +38,9 @@ class CommonAudioApiConfigurationModel : public QObject, public muse::async::Asy
     Q_PROPERTY(QString currentDeviceId READ currentDeviceId NOTIFY currentDeviceIdChanged)
     Q_PROPERTY(QVariantList deviceList READ deviceList NOTIFY deviceListChanged)
 
+    Q_PROPERTY(unsigned int sampleRate READ sampleRate NOTIFY sampleRateChanged)
+    Q_PROPERTY(QList<unsigned int> sampleRateList READ sampleRateList NOTIFY sampleRateListChanged)
+
     Q_PROPERTY(unsigned int bufferSize READ bufferSize NOTIFY bufferSizeChanged)
     Q_PROPERTY(QList<unsigned int> bufferSizeList READ bufferSizeList NOTIFY bufferSizeListChanged)
 
@@ -57,9 +60,16 @@ public:
     QList<unsigned int> bufferSizeList() const;
     Q_INVOKABLE void bufferSizeSelected(const QString& bufferSizeStr);
 
+    unsigned int sampleRate() const;
+    QList<unsigned int> sampleRateList() const;
+    Q_INVOKABLE void sampleRateSelected(const QString& sampleRateStr);
+
 signals:
     void currentDeviceIdChanged();
     void deviceListChanged();
+
+    void sampleRateChanged();
+    void sampleRateListChanged();
 
     void bufferSizeChanged();
     void bufferSizeListChanged();

--- a/src/framework/audio/iaudiodriver.h
+++ b/src/framework/audio/iaudiodriver.h
@@ -79,6 +79,12 @@ public:
 
     virtual std::vector<unsigned int> availableOutputDeviceBufferSizes() const = 0;
 
+    virtual unsigned int outputDeviceSampleRate() const = 0;
+    virtual bool setOutputDeviceSampleRate(unsigned int bufferSize) = 0;
+    virtual async::Notification outputDeviceSampleRateChanged() const = 0;
+
+    virtual std::vector<unsigned int> availableOutputDeviceSampleRates() const = 0;
+
     virtual void resume() = 0;
     virtual void suspend() = 0;
 };

--- a/src/framework/audio/internal/audiooutputdevicecontroller.cpp
+++ b/src/framework/audio/internal/audiooutputdevicecontroller.cpp
@@ -51,6 +51,16 @@ void AudioOutputDeviceController::init()
             }, AudioThread::ID);
         }
     });
+
+    configuration()->sampleRateChanged().onNotify(this, [this]() {
+        unsigned int sampleRate = configuration()->sampleRate();
+        bool ok = audioDriver()->setOutputDeviceSampleRate(sampleRate);
+        if (ok) {
+            async::Async::call(this, [this, sampleRate](){
+                audioEngine()->setSampleRate(sampleRate);
+            }, AudioThread::ID);
+        }
+    });
 }
 
 void AudioOutputDeviceController::checkConnection()

--- a/src/framework/audio/internal/platform/jack/jackaudiodriver.cpp
+++ b/src/framework/audio/internal/platform/jack/jackaudiodriver.cpp
@@ -289,6 +289,48 @@ std::vector<unsigned int> JackAudioDriver::availableOutputDeviceBufferSizes() co
     return result;
 }
 
+unsigned int JackAudioDriver::outputDeviceSampleRate() const
+{
+    return s_format2.sampleRate;
+}
+
+bool JackAudioDriver::setOutputDeviceSampleRate(unsigned int sampleRate)
+{
+    if (s_format2.sampleRate == sampleRate) {
+        return true;
+    }
+
+    bool reopen = isOpened();
+    close();
+    s_format2.sampleRate = sampleRate;
+
+    bool ok = true;
+    if (reopen) {
+        ok = open(s_format2, &s_format2);
+    }
+
+    if (ok) {
+        m_sampleRateChanged.notify();
+    }
+
+    return ok;
+}
+
+async::Notification JackAudioDriver::outputDeviceSampleRateChanged() const
+{
+    return m_sampleRateChanged;
+}
+
+std::vector<unsigned int> JackAudioDriver::availableOutputDeviceSampleRates() const
+{
+    return {
+        44100,
+        48000,
+        88200,
+        96000,
+    };
+}
+
 void JackAudioDriver::resume()
 {
 }

--- a/src/framework/audio/internal/platform/jack/jackaudiodriver.h
+++ b/src/framework/audio/internal/platform/jack/jackaudiodriver.h
@@ -60,6 +60,12 @@ public:
 
     std::vector<unsigned int> availableOutputDeviceBufferSizes() const override;
 
+    unsigned int outputDeviceSampleRate() const override;
+    bool setOutputDeviceSampleRate(unsigned int bufferSize) override;
+    async::Notification outputDeviceSampleRateChanged() const override;
+
+    std::vector<unsigned int> availableOutputDeviceSampleRates() const override;
+
     void resume() override;
     void suspend() override;
 

--- a/src/framework/audio/internal/platform/lin/linuxaudiodriver.cpp
+++ b/src/framework/audio/internal/platform/lin/linuxaudiodriver.cpp
@@ -304,6 +304,51 @@ std::vector<unsigned int> LinuxAudioDriver::availableOutputDeviceBufferSizes() c
     return result;
 }
 
+unsigned int LinuxAudioDriver::outputDeviceSampleRate() const
+{
+    return s_format.sampleRate;
+}
+
+bool LinuxAudioDriver::setOutputDeviceSampleRate(unsigned int sampleRate)
+{
+    if (s_format.sampleRate == sampleRate) {
+        return true;
+    }
+
+    bool reopen = isOpened();
+    close();
+    s_format.sampleRate = sampleRate;
+
+    bool ok = true;
+    if (reopen) {
+        ok = open(s_format, &s_format);
+    }
+
+    if (ok) {
+        m_sampleRateChanged.notify();
+    }
+
+    return ok;
+}
+
+async::Notification LinuxAudioDriver::outputDeviceSampleRateChanged() const
+{
+    return m_sampleRateChanged;
+}
+
+std::vector<unsigned int> LinuxAudioDriver::availableOutputDeviceSampleRates() const
+{
+    // ALSA API is not of any help to get sample rates supported by the driver.
+    // (snd_pcm_hw_params_get_rate_[min|max] will return 1 to 384000 Hz)
+    // So just returning a sensible hard-coded list.
+    return {
+        44100,
+        48000,
+        88200,
+        96000,
+    };
+}
+
 void LinuxAudioDriver::resume()
 {
 }

--- a/src/framework/audio/internal/platform/lin/linuxaudiodriver.h
+++ b/src/framework/audio/internal/platform/lin/linuxaudiodriver.h
@@ -57,6 +57,12 @@ public:
 
     std::vector<unsigned int> availableOutputDeviceBufferSizes() const override;
 
+    unsigned int outputDeviceSampleRate() const override;
+    bool setOutputDeviceSampleRate(unsigned int sampleRate) override;
+    async::Notification outputDeviceSampleRateChanged() const override;
+
+    std::vector<unsigned int> availableOutputDeviceSampleRates() const override;
+
     void resume() override;
     void suspend() override;
 

--- a/src/framework/audio/internal/platform/osx/osxaudiodriver.h
+++ b/src/framework/audio/internal/platform/osx/osxaudiodriver.h
@@ -70,6 +70,12 @@ public:
 
     std::vector<unsigned int> availableOutputDeviceBufferSizes() const override;
 
+    unsigned int outputDeviceSampleRate() const override;
+    bool setOutputDeviceSampleRate(unsigned int sampleRate) override;
+    async::Notification outputDeviceSampleRateChanged() const override;
+
+    std::vector<unsigned int> availableOutputDeviceSampleRates() const override;
+
 private:
     static void OnFillBuffer(void* context, OpaqueAudioQueue* queue, AudioQueueBuffer* buffer);
     static void logError(const std::string message, OSStatus error);

--- a/src/framework/audio/internal/platform/osx/osxaudiodriver.mm
+++ b/src/framework/audio/internal/platform/osx/osxaudiodriver.mm
@@ -365,6 +365,52 @@ std::vector<unsigned int> OSXAudioDriver::availableOutputDeviceBufferSizes() con
     return result;
 }
 
+unsigned int OSXAudioDriver::outputDeviceSampleRate() const
+{
+    if (!isOpened()) {
+        return 0;
+    }
+
+    return m_data->format.sampleRate;
+}
+
+bool OSXAudioDriver::setOutputDeviceSampleRate(unsigned int sampleRate)
+{
+    if (m_data->format.sampleRate == sampleRate) {
+        return true;
+    }
+
+    bool reopen = isOpened();
+    close();
+    m_data->format.sampleRate = sampleRate;
+
+    bool ok = true;
+    if (reopen) {
+        ok = open(m_data->format, &m_data->format);
+    }
+
+    if (ok) {
+        m_sampleRateChanged.notify();
+    }
+
+    return ok;
+}
+
+async::Notification OSXAudioDriver::outputDeviceSampleRateChanged() const
+{
+    return m_sampleRateChanged;
+}
+
+std::vector<unsigned int> OSXAudioDriver::availableOutputDeviceSampleRates() const
+{
+    return {
+        44100,
+        48000,
+        88200,
+        96000,
+    };
+}
+
 bool OSXAudioDriver::audioQueueSetDeviceName(const AudioDeviceID& deviceId)
 {
     if (deviceId.empty() || deviceId == DEFAULT_DEVICE_ID) {

--- a/src/framework/audio/internal/platform/win/wasapiaudiodriver.cpp
+++ b/src/framework/audio/internal/platform/win/wasapiaudiodriver.cpp
@@ -282,6 +282,44 @@ std::vector<unsigned int> WasapiAudioDriver::availableOutputDeviceBufferSizes() 
     return result;
 }
 
+unsigned int WasapiAudioDriver::outputDeviceSampleRate() const
+{
+    return m_activeSpec.sampleRate;
+}
+
+bool WasapiAudioDriver::setOutputDeviceSampleRate(unsigned int sampleRate)
+{
+    bool result = true;
+
+    if (isOpened()) {
+        close();
+
+        m_activeSpec.sampleRate = sampleRate;
+        result = open(m_activeSpec, &m_activeSpec);
+    } else {
+        m_desiredSpec.sampleRate = sampleRate;
+    }
+
+    m_outputDeviceSampleRateChanged.notify();
+
+    return result;
+}
+
+async::Notification WasapiAudioDriver::outputDeviceSampleRateChanged() const
+{
+    return m_outputDeviceSampleRateChanged;
+}
+
+std::vector<unsigned int> WasapiAudioDriver::availableOutputDeviceSampleRates() const
+{
+    return {
+        44100,
+        48000,
+        88200,
+        96000,
+    };
+}
+
 void WasapiAudioDriver::resume()
 {
 }

--- a/src/framework/audio/internal/platform/win/wasapiaudiodriver.h
+++ b/src/framework/audio/internal/platform/win/wasapiaudiodriver.h
@@ -47,10 +47,17 @@ public:
     async::Notification outputDeviceChanged() const override;
     AudioDeviceList availableOutputDevices() const override;
     async::Notification availableOutputDevicesChanged() const override;
+
     unsigned int outputDeviceBufferSize() const override;
     bool setOutputDeviceBufferSize(unsigned int bufferSize) override;
     async::Notification outputDeviceBufferSizeChanged() const override;
     std::vector<unsigned int> availableOutputDeviceBufferSizes() const override;
+
+    unsigned int outputDeviceSampleRate() const override;
+    bool setOutputDeviceSampleRate(unsigned int sampleRate) override;
+    async::Notification outputDeviceSampleRateChanged() const override;
+    std::vector<unsigned int> availableOutputDeviceSampleRates() const override;
+
     void resume() override;
     void suspend() override;
 
@@ -71,6 +78,7 @@ private:
     async::Notification m_outputDeviceChanged;
     async::Notification m_availableOutputDevicesChanged;
     async::Notification m_outputDeviceBufferSizeChanged;
+    async::Notification m_outputDeviceSampleRateChanged;
 
     Spec m_desiredSpec;
     Spec m_activeSpec;

--- a/src/framework/audio/internal/worker/audioengine.cpp
+++ b/src/framework/audio/internal/worker/audioengine.cpp
@@ -88,7 +88,7 @@ sample_rate_t AudioEngine::sampleRate() const
     return m_sampleRate;
 }
 
-void AudioEngine::setSampleRate(unsigned int sampleRate)
+void AudioEngine::setSampleRate(sample_rate_t sampleRate)
 {
     ONLY_AUDIO_WORKER_THREAD;
 

--- a/src/framework/audio/internal/worker/audioengine.h
+++ b/src/framework/audio/internal/worker/audioengine.h
@@ -53,7 +53,7 @@ public:
 
     sample_rate_t sampleRate() const override;
 
-    void setSampleRate(unsigned int sampleRate);
+    void setSampleRate(sample_rate_t sampleRate) override;
     void setReadBufferSize(uint16_t readBufferSize) override;
     void setAudioChannelsCount(const audioch_t count);
 

--- a/src/framework/audio/internal/worker/iaudioengine.h
+++ b/src/framework/audio/internal/worker/iaudioengine.h
@@ -38,6 +38,7 @@ public:
 
     virtual sample_rate_t sampleRate() const = 0;
 
+    virtual void setSampleRate(sample_rate_t sampleRate) = 0;
     virtual void setReadBufferSize(uint16_t readBufferSize) = 0;
 
     virtual RenderMode mode() const = 0;

--- a/src/framework/stubs/audio/audiodriverstub.cpp
+++ b/src/framework/stubs/audio/audiodriverstub.cpp
@@ -97,6 +97,26 @@ std::vector<unsigned int> AudioDriverStub::availableOutputDeviceBufferSizes() co
     return {};
 }
 
+unsigned int AudioDriverStub::outputDeviceSampleRate() const
+{
+    return 0;
+}
+
+bool AudioDriverStub::setOutputDeviceSampleRate(unsigned int)
+{
+    return false;
+}
+
+async::Notification AudioDriverStub::outputDeviceSampleRateChanged() const
+{
+    return async::Notification();
+}
+
+std::vector<unsigned int> AudioDriverStub::availableOutputDeviceSampleRates() const
+{
+    return {};
+}
+
 void AudioDriverStub::resume()
 {
 }

--- a/src/framework/stubs/audio/audiodriverstub.h
+++ b/src/framework/stubs/audio/audiodriverstub.h
@@ -49,6 +49,12 @@ public:
 
     std::vector<unsigned int> availableOutputDeviceBufferSizes() const override;
 
+    unsigned int outputDeviceSampleRate() const override;
+    bool setOutputDeviceSampleRate(unsigned int bufferSize) override;
+    async::Notification outputDeviceSampleRateChanged() const override;
+
+    std::vector<unsigned int> availableOutputDeviceSampleRates() const override;
+
     void resume() override;
     void suspend() override;
 };


### PR DESCRIPTION
Following [comment](https://github.com/musescore/MuseScore/issues/18701#issuecomment-2243402697) of @MarcSabatella. It makes really simple for users to fix by themselves the issue #18701.

Only implemented on Linux Alsa.
I can write the code for other platforms, but will be unable to test.

![image](https://github.com/user-attachments/assets/28f0f997-8952-4506-a908-5a8544b934ed)


<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
