### PR TITLE
Fix alignment for dynamics or expressions that are not aligned to the baseline

### DIFF
--- a/src/engraving/rendering/dev/alignmentlayout.cpp
+++ b/src/engraving/rendering/dev/alignmentlayout.cpp
@@ -112,11 +112,29 @@ double AlignmentLayout::yOpticalCenter(const EngravingItem* item)
     double curY = item->pos().y();
     switch (item->type()) {
     case ElementType::DYNAMIC:
-        curY -= 0.46 * item->spatium() * toDynamic(item)->dynamicsSize(); // approximated half x-height of dynamic
-        break;
     case ElementType::EXPRESSION:
-        curY -= 0.5 * toExpression(item)->fontMetrics().xHeight();
+    {
+        AlignV vertAlign = toTextBase(item)->align().vertical;
+        double bboxHeight = item->ldata()->bbox().height();
+        switch (vertAlign) {
+        case AlignV::TOP:
+            curY += 0.5 * bboxHeight;
+            break;
+        case AlignV::VCENTER:
+            break;
+        case AlignV::BOTTOM:
+            curY -= 0.5 * bboxHeight;
+            break;
+        case AlignV::BASELINE:
+            if (item->isDynamic()) {
+                curY -= 0.46 * item->spatium() * toDynamic(item)->dynamicsSize(); // approximated half x-height of dynamic
+            } else {
+                curY -= 0.5 * toExpression(item)->fontMetrics().xHeight();
+            }
+            break;
+        }
         break;
+    }
     case ElementType::HAIRPIN_SEGMENT:
     {
         const HairpinSegment* hairpinSeg = toHairpinSegment(item);


### PR DESCRIPTION
Resolves:
![image](https://github.com/user-attachments/assets/3b975b08-2fb7-4e2f-9945-5b5c7cd6dbf8)

My recent alignment code does its calculations on the assumption that the text-based items (i.e. expressions and dynamics) are laid out with the text baseline at y = 0. That may not be the case if the user had manually set it to a different type of alignment (either from style or from property). In such case, the next best thing we can do, given what we don't know exactly where the baseline is, is to center to the bounding box. 