### PR TITLE
Correct accidentals for cross-staff grace notes

### DIFF
--- a/src/engraving/dom/chord.cpp
+++ b/src/engraving/dom/chord.cpp
@@ -1670,7 +1670,7 @@ static void updatePercussionNotes(Chord* c, const Drumset* drumset)
 //   cmdUpdateNotes
 //---------------------------------------------------------
 
-void Chord::cmdUpdateNotes(AccidentalState* as)
+void Chord::cmdUpdateNotes(AccidentalState* as, staff_idx_t staffIdx)
 {
     // TAB_STAFF is different, as each note has to be fretted
     // in the context of the all of the chords of the whole segment
@@ -1695,43 +1695,52 @@ void Chord::cmdUpdateNotes(AccidentalState* as)
     if (staffGroup == StaffGroup::STANDARD) {
         const std::vector<Chord*> gnb(graceNotesBefore());
         for (Chord* ch : gnb) {
+            if (ch->vStaffIdx() != staffIdx) {
+                continue;
+            }
             std::vector<Note*> notes(ch->notes());        // we need a copy!
             for (Note* note : notes) {
                 note->updateAccidental(as);
             }
             ch->sortNotes();
         }
-        std::vector<Note*> lnotes(notes());      // we need a copy!
-        for (Note* note : lnotes) {
-            if (note->tieBack() && note->tpc() == note->tieBack()->startNote()->tpc()) {
-                // same pitch
-                if (note->accidental() && note->accidental()->role() == AccidentalRole::AUTO) {
-                    // not courtesy
-                    // TODO: remove accidental only if note is not
-                    // on new system
-                    score()->undoRemoveElement(note->accidental());
+        if (vStaffIdx() == staffIdx) {
+            std::vector<Note*> lnotes(notes());      // we need a copy!
+            for (Note* note : lnotes) {
+                if (note->tieBack() && note->tpc() == note->tieBack()->startNote()->tpc()) {
+                    // same pitch
+                    if (note->accidental() && note->accidental()->role() == AccidentalRole::AUTO) {
+                        // not courtesy
+                        // TODO: remove accidental only if note is not
+                        // on new system
+                        score()->undoRemoveElement(note->accidental());
+                    }
+                }
+                note->updateAccidental(as);
+            }
+            for (Articulation* art : m_articulations) {
+                if (!art->isOrnament()) {
+                    continue;
+                }
+                Ornament* ornament = toOrnament(art);
+                ornament->computeNotesAboveAndBelow(as);
+            }
+            for (Spanner* spanner : startingSpanners()) {
+                if (spanner->isTrill()) {
+                    Ornament* ornament = toTrill(spanner)->ornament();
+                    if (ornament) {
+                        ornament->setParent(this);
+                        ornament->computeNotesAboveAndBelow(as);
+                    }
                 }
             }
-            note->updateAccidental(as);
-        }
-        for (Articulation* art : m_articulations) {
-            if (!art->isOrnament()) {
-                continue;
-            }
-            Ornament* ornament = toOrnament(art);
-            ornament->computeNotesAboveAndBelow(as);
-        }
-        for (Spanner* spanner : startingSpanners()) {
-            if (spanner->isTrill()) {
-                Ornament* ornament = toTrill(spanner)->ornament();
-                if (ornament) {
-                    ornament->setParent(this);
-                    ornament->computeNotesAboveAndBelow(as);
-                }
-            }
+            sortNotes();
         }
         const std::vector<Chord*> gna(graceNotesAfter());
         for (Chord* ch : gna) {
+            if (ch->vStaffIdx() != staffIdx) {
+                continue;
+            }
             std::vector<Note*> notes(ch->notes());        // we need a copy!
             for (Note* note : notes) {
                 note->updateAccidental(as);
@@ -1745,9 +1754,8 @@ void Chord::cmdUpdateNotes(AccidentalState* as)
             LOGW("no drumset");
         }
         updatePercussionNotes(this, drumset);
+        sortNotes();
     }
-
-    sortNotes();
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/chord.h
+++ b/src/engraving/dom/chord.h
@@ -212,7 +212,7 @@ public:
     Note* selectedNote() const;
 
     PointF pagePos() const override;        ///< position in page coordinates
-    void cmdUpdateNotes(AccidentalState*);
+    void cmdUpdateNotes(AccidentalState*, staff_idx_t staffIdx);
 
     NoteType noteType() const { return m_noteType; }
     void setNoteType(NoteType t);

--- a/src/engraving/rendering/dev/modifydom.cpp
+++ b/src/engraving/rendering/dev/modifydom.cpp
@@ -42,7 +42,7 @@ void ModifyDom::connectTremolo(Measure* m)
 
 void ModifyDom::cmdUpdateNotes(const Measure* measure, const DomAccessor& dom)
 {
-    for (size_t staffIdx = 0; staffIdx < dom.nstaves(); ++staffIdx) {
+    for (staff_idx_t staffIdx = 0; staffIdx < dom.nstaves(); ++staffIdx) {
         const Staff* staff = dom.staff(staffIdx);
         if (!staff->show()) {
             continue;
@@ -85,8 +85,8 @@ void ModifyDom::cmdUpdateNotes(const Measure* measure, const DomAccessor& dom)
             } else if (segment.isJustType(SegmentType::ChordRest)) {
                 for (track_idx_t t = startTrack; t < endTrack; ++t) {
                     Chord* chord = item_cast<Chord*>(segment.element(t), CastMode::MAYBE_BAD); // maybe Rest
-                    if (chord && chord->vStaffIdx() == staffIdx) {
-                        chord->cmdUpdateNotes(&as);
+                    if (chord) {
+                        chord->cmdUpdateNotes(&as, staffIdx);
                     }
                 }
             }
@@ -97,7 +97,7 @@ void ModifyDom::cmdUpdateNotes(const Measure* measure, const DomAccessor& dom)
 void ModifyDom::createStems(const Measure* measure, LayoutContext& ctx)
 {
     const DomAccessor& dom = ctx.dom();
-    for (size_t staffIdx = 0; staffIdx < dom.nstaves(); ++staffIdx) {
+    for (staff_idx_t staffIdx = 0; staffIdx < dom.nstaves(); ++staffIdx) {
         const Staff* staff = dom.staff(staffIdx);
         if (!staff->show()) {
             continue;
@@ -145,7 +145,7 @@ void ModifyDom::createStems(const Measure* measure, LayoutContext& ctx)
 
 void ModifyDom::setTrackForChordGraceNotes(Measure* measure, const DomAccessor& dom)
 {
-    for (size_t staffIdx = 0; staffIdx < dom.nstaves(); ++staffIdx) {
+    for (staff_idx_t staffIdx = 0; staffIdx < dom.nstaves(); ++staffIdx) {
         track_idx_t startTrack = staffIdx * VOICES;
         track_idx_t endTrack  = startTrack + VOICES;
 

--- a/src/engraving/rendering/stable/measurelayout.cpp
+++ b/src/engraving/rendering/stable/measurelayout.cpp
@@ -948,7 +948,7 @@ void MeasureLayout::layoutChordDrumset(const Staff* staff, const Segment& segmen
 
 void MeasureLayout::cmdUpdateNotes(const Measure* measure, const DomAccessor& dom)
 {
-    for (size_t staffIdx = 0; staffIdx < dom.nstaves(); ++staffIdx) {
+    for (staff_idx_t staffIdx = 0; staffIdx < dom.nstaves(); ++staffIdx) {
         const Staff* staff = dom.staff(staffIdx);
         if (!staff->show()) {
             continue;
@@ -991,7 +991,7 @@ void MeasureLayout::cmdUpdateNotes(const Measure* measure, const DomAccessor& do
                 for (track_idx_t t = track; t < endTrack; ++t) {
                     Chord* chord = item_cast<Chord*>(segment.element(t), CastMode::MAYBE_BAD); // maybe Rest
                     if (chord) {
-                        chord->cmdUpdateNotes(&as);
+                        chord->cmdUpdateNotes(&as, staffIdx);
                     }
                 }
             }
@@ -1002,7 +1002,7 @@ void MeasureLayout::cmdUpdateNotes(const Measure* measure, const DomAccessor& do
 void MeasureLayout::createStems(const Measure* measure, LayoutContext& ctx)
 {
     const DomAccessor& dom = ctx.dom();
-    for (size_t staffIdx = 0; staffIdx < dom.nstaves(); ++staffIdx) {
+    for (staff_idx_t staffIdx = 0; staffIdx < dom.nstaves(); ++staffIdx) {
         const Staff* staff = dom.staff(staffIdx);
         if (!staff->show()) {
             continue;
@@ -1106,7 +1106,7 @@ void MeasureLayout::layoutMeasure(MeasureBase* currentMB, LayoutContext& ctx)
     const DomAccessor& dom = ctx.dom();
     const LayoutConfiguration& conf = ctx.conf();
 
-    for (size_t staffIdx = 0; staffIdx < dom.nstaves(); ++staffIdx) {
+    for (staff_idx_t staffIdx = 0; staffIdx < dom.nstaves(); ++staffIdx) {
         const Staff* staff = dom.staff(staffIdx);
         if (!staff->show()) {
             continue;


### PR DESCRIPTION
Sequel to #21443, cross-staff grace notes in a different staff to the main chord were previously unaccounted for.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
