### PR TITLE
Fix MSVC compiler warnings

### DIFF
--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -3932,7 +3932,7 @@ void Score::cmdCreateTuplet(ChordRest* ocr, Tuplet* tuplet)
 //   cmdExchangeVoice
 //---------------------------------------------------------
 
-void Score::cmdExchangeVoice(int s, int d)
+void Score::cmdExchangeVoice(voice_idx_t s, voice_idx_t d)
 {
     if (!selection().isRange()) {
         MScore::setError(MsError::NO_STAFF_SELECTED);

--- a/src/engraving/dom/score.h
+++ b/src/engraving/dom/score.h
@@ -955,7 +955,7 @@ public:
     void cmdSlashFill();
     void cmdSlashRhythm();
     void cmdResequenceRehearsalMarks();
-    void cmdExchangeVoice(int, int);
+    void cmdExchangeVoice(voice_idx_t, voice_idx_t);
     void cmdRemoveEmptyTrailingMeasures();
     void cmdRealizeChordSymbols(bool lit = true, Voicing v = Voicing(-1), HDuration durationType = HDuration(-1));
 

--- a/src/engraving/rendering/dev/chordlayout.cpp
+++ b/src/engraving/rendering/dev/chordlayout.cpp
@@ -1539,10 +1539,6 @@ void ChordLayout::layoutChords1(LayoutContext& ctx, Segment* segment, staff_idx_
     std::vector<Note*> downStemNotes;
     int upVoices       = 0;
     int downVoices     = 0;
-    // Fret width plus white background box for TAB
-    const double fretBackground = ctx.conf().styleS(Sid::tabFretPadding).val() * staff->spatium(tick);
-    // double nominalWidth = !isTab ? ctx.conf().noteHeadWidth() * staff->staffMag(tick)
-    //                       : (ctx.conf().fretWidth(staffType) + 2 * fretBackground) * staff->staffMag(tick);
     double nominalWidth = ctx.conf().noteHeadWidth() * staff->staffMag(tick);
     double maxUpWidth   = 0.0;
     double maxDownWidth = 0.0;


### PR DESCRIPTION
* reg.: 'fretBackground': local variable is initialized but not referenced (C4189)
* reg.: 'argument': conversion from 'size_t' to 'int', possible loss of data (C4267)