### PR TITLE
Fix #18269: Don't prevent kerning when slurs are on the stem side of chords

### DIFF
--- a/src/engraving/dom/chord.cpp
+++ b/src/engraving/dom/chord.cpp
@@ -3209,10 +3209,10 @@ void Chord::computeKerningExceptions()
             m_allowKerningBelow = false;
         }
     }
-    if (m_startEndSlurs.startUp || m_startEndSlurs.endUp) {
+    if ((m_startEndSlurs.startUp || m_startEndSlurs.endUp) && !ldata()->up) {
         m_allowKerningAbove = false;
     }
-    if (m_startEndSlurs.startDown || m_startEndSlurs.endDown) {
+    if ((m_startEndSlurs.startDown || m_startEndSlurs.endDown) && ldata()->up) {
         m_allowKerningBelow = false;
     }
 }


### PR DESCRIPTION
Resolves: #18269

As described in the issue, kerning should only be prevented when the slur is on the note-side of the chord. This PR adds this check using `ldata()->up`, which should be fine since it's computed in `ChordLayout::computeUp()` which is called before `Chord::computeKerningExceptions()`.

Before: 
<img width="574" alt="Screenshot 2024-07-23 at 2 03 16 AM" src="https://github.com/user-attachments/assets/a8ea0d65-5cc5-42c8-b7b3-cda29f12f0b3">

After:
<img width="521" alt="Screenshot 2024-07-24 at 9 33 06 PM" src="https://github.com/user-attachments/assets/dd5efbcc-38cc-42a1-99b5-8c6afccb176c">

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
