### PR TITLE
Fix crash with piano keyboard versus instruments dialog

### DIFF
--- a/src/notation/inotationnoteinput.h
+++ b/src/notation/inotationnoteinput.h
@@ -23,8 +23,9 @@
 #define MU_NOTATION_INOTATIONNOTEINPUT_H
 
 #include "async/notification.h"
+#include "types/ret.h"
+
 #include "notationtypes.h"
-#include "types/retval.h"
 
 namespace mu::notation {
 class INotationNoteInput
@@ -37,7 +38,7 @@ public:
     virtual NoteInputState state() const = 0;
 
     virtual void startNoteInput() = 0;
-    virtual void endNoteInput() = 0;
+    virtual void endNoteInput(bool resetState = false) = 0;
     virtual void toggleNoteInputMethod(NoteInputMethod method) = 0;
     virtual void addNote(NoteName noteName, NoteAddingMode addingMode) = 0;
     virtual void padNote(const Pad& pad)  = 0;
@@ -61,8 +62,6 @@ public:
     virtual void setDrumNote(int note) = 0;
     virtual void setCurrentVoice(voice_idx_t voiceIndex) = 0;
     virtual void setCurrentTrack(track_idx_t trackIndex) = 0;
-
-    virtual void resetInputPosition() = 0;
 
     virtual muse::RectF cursorRect() const = 0;
 

--- a/src/notation/internal/notationmidiinput.cpp
+++ b/src/notation/internal/notationmidiinput.cpp
@@ -169,6 +169,10 @@ Note* NotationMidiInput::addNoteToScore(const muse::midi::Event& e)
         return nullptr;
     }
 
+    if (!is.cr()) { // invalid state
+        return nullptr;
+    }
+
     DEFER {
         m_undoStack->commitChanges();
     };

--- a/src/notation/internal/notationnoteinput.cpp
+++ b/src/notation/internal/notationnoteinput.cpp
@@ -293,7 +293,7 @@ EngravingItem* NotationNoteInput::resolveNoteInputStartPosition() const
     return el;
 }
 
-void NotationNoteInput::endNoteInput()
+void NotationNoteInput::endNoteInput(bool resetState)
 {
     TRACEFUNC;
 
@@ -310,6 +310,12 @@ void NotationNoteInput::endNoteInput()
             el.front()->setSelected(false);
         }
         is.setSlur(0);
+    }
+
+    if (resetState) {
+        is.setTrack(muse::nidx);
+        is.setString(-1);
+        is.setSegment(nullptr);
     }
 
     notifyAboutNoteInputEnded();
@@ -463,17 +469,6 @@ void NotationNoteInput::setCurrentTrack(track_idx_t trackIndex)
     TRACEFUNC;
 
     score()->inputState().setTrack(trackIndex);
-    notifyAboutStateChanged();
-}
-
-void NotationNoteInput::resetInputPosition()
-{
-    mu::engraving::InputState& inputState = score()->inputState();
-
-    inputState.setTrack(muse::nidx);
-    inputState.setString(-1);
-    inputState.setSegment(nullptr);
-
     notifyAboutStateChanged();
 }
 

--- a/src/notation/internal/notationnoteinput.h
+++ b/src/notation/internal/notationnoteinput.h
@@ -52,7 +52,7 @@ public:
     NoteInputState state() const override;
 
     void startNoteInput() override;
-    void endNoteInput() override;
+    void endNoteInput(bool resetState = false) override;
     void toggleNoteInputMethod(NoteInputMethod method) override;
     void addNote(NoteName noteName, NoteAddingMode addingMode) override;
     void padNote(const Pad& pad) override;
@@ -75,8 +75,6 @@ public:
     void setDrumNote(int note) override;
     void setCurrentVoice(voice_idx_t voiceIndex) override;
     void setCurrentTrack(track_idx_t trackIndex) override;
-
-    void resetInputPosition() override;
 
     muse::RectF cursorRect() const override;
 

--- a/src/notation/internal/notationparts.cpp
+++ b/src/notation/internal/notationparts.cpp
@@ -1136,7 +1136,7 @@ void NotationParts::setBracketsAndBarlines()
 void NotationParts::endInteractionWithScore()
 {
     m_interaction->clearSelection();
-    m_interaction->noteInput()->resetInputPosition();
+    m_interaction->noteInput()->endNoteInput(/*resetState=*/ true);
 }
 
 void NotationParts::notifyAboutPartChanged(const Part* part) const


### PR DESCRIPTION
Resolves: #23704

First commit adds sanity check to prevent similar crashes in the future, if note input is in an invalid state. Second commit prevents such a state from happening.