### PR TITLE
Fix that custom ChordList was not written to file anymore after reopening and resaving

### DIFF
--- a/src/engraving/rw/compat/readchordlisthook.cpp
+++ b/src/engraving/rw/compat/readchordlisthook.cpp
@@ -57,6 +57,11 @@ void ReadChordListHook::validate()
         return;
     }
 
+    if (m_chordListTag) {
+        // if we encountered a ChordList tag, everything is fine already
+        return;
+    }
+
     // if we just specified a new chord description file
     // and didn't encounter a ChordList tag
     // then load the chord description file
@@ -65,7 +70,7 @@ void ReadChordListHook::validate()
     ChordList* chordList = m_score->chordList();
 
     String newChordDescriptionFile = style.styleSt(Sid::chordDescriptionFile);
-    if (newChordDescriptionFile != m_oldChordDescriptionFile && !m_chordListTag) {
+    if (newChordDescriptionFile != m_oldChordDescriptionFile) {
         if (!newChordDescriptionFile.startsWith(u"chords_") && style.styleSt(Sid::chordStyle) == "std") {
             // should not normally happen,
             // but treat as "old" (114) score just in case
@@ -81,7 +86,5 @@ void ReadChordListHook::validate()
     }
 
     // make sure we have a chordlist
-    if (!m_chordListTag) {
-        chordList->checkChordList(m_score->configuration()->appDataPath(), style);
-    }
+    chordList->checkChordList(m_score->configuration()->appDataPath(), style);
 }

--- a/src/engraving/rw/mscloader.cpp
+++ b/src/engraving/rw/mscloader.cpp
@@ -99,11 +99,27 @@ Ret MscLoader::loadMscz(MasterScore* masterScore, const MscReader& mscReader, Se
 
     // Read ChordList
     {
+        bool chordListOk = false;
         ByteArray chordListData = mscReader.readChordListFile();
         if (!chordListData.empty()) {
             Buffer buf(&chordListData);
             buf.open(IODevice::ReadOnly);
-            masterScore->chordList()->read(&buf);
+
+            chordListOk = masterScore->chordList()->read(&buf);
+        }
+
+        masterScore->chordList()->setCustomChordList(chordListOk);
+
+        if (!chordListOk) {
+            // See also ReadChordListHook::validate()
+            MStyle& style = masterScore->style();
+            ChordList* chordList = masterScore->chordList();
+
+            bool custom = style.styleSt(Sid::chordStyle) == "custom";
+            chordList->setCustomChordList(custom);
+
+            // Ensure that `checkChordList` loads the default chord list
+            chordList->unload();
         }
     }
 

--- a/src/notation/view/widgets/editstyle.cpp
+++ b/src/notation/view/widgets/editstyle.cpp
@@ -2424,31 +2424,31 @@ void EditStyle::setChordStyle(bool checked)
     if (!checked) {
         return;
     }
-    QVariant val;
-    QString file;
+    String val;
+    String file;
     bool chordsXml;
     if (chordsStandard->isChecked()) {
-        val  = QString("std");
-        file = "chords_std.xml";
+        val  = u"std";
+        file = u"chords_std.xml";
         chordsXml = false;
     } else if (chordsJazz->isChecked()) {
-        val  = QString("jazz");
-        file = "chords_jazz.xml";
+        val  = u"jazz";
+        file = u"chords_jazz.xml";
         chordsXml = false;
     } else {
-        val = QString("custom");
+        val = u"custom";
         chordDescriptionGroup->setEnabled(true);
         file = chordDescriptionFile->text();
         chordsXml = chordsXmlFile->isChecked();
     }
-    if (val != "custom") {
+    if (val != u"custom") {
         chordsXmlFile->setChecked(chordsXml);
         chordDescriptionGroup->setEnabled(false);
         chordDescriptionFile->setText(file);
     }
 
     setStyleValue(StyleId::chordsXmlFile, chordsXml);
-    setStyleQVariantValue(StyleId::chordStyle, val);
+    setStyleValue(StyleId::chordStyle, val);
 
     if (!file.isEmpty()) {
         setStyleValue(StyleId::chordDescriptionFile, file);


### PR DESCRIPTION
To reproduce the problem:
1. Create score
2. In Format > Style > Chord symbols: select custom chord symbols xml file (for example the one from [#16363](https://github.com/musescore/MuseScore/issues/16363#issue-1584492993))
3. Save & close
As expected, this custom chord list is saved inside the MSCZ file.
4. Reopen
5. Re-save (without having to make any change)
As NOT expected, the custom chord list is not saved inside the MSCZ file anymore.

Reason: during re-opening, `chordList->setCustomChordList(true)` was not correctly called