### PR TITLE
replace os with pathlib

### DIFF
--- a/share/instruments/generate_tsv.py
+++ b/share/instruments/generate_tsv.py
@@ -12,8 +12,7 @@ if locale.getpreferredencoding().lower() != 'utf-8':
     raise SystemExit(1)
 
 import csv
-import os
-import sys
+from pathlib import Path
 import xml.etree.ElementTree as ET
 
 null='[null]' # value to use in TSV when data is not specified in XML
@@ -51,8 +50,8 @@ def find_text(element, tagName, default='[null]'):
     tag = element.find(tagName)
     return default if tag is None else tag.text
 
-os.chdir(os.path.dirname(os.path.realpath(__file__))) # make all paths relative to this script's directory
-os.makedirs('tsv', exist_ok=True)
+script_dir = Path(__file__).parent
+Path.mkdir(script_dir / 'tsv', exist_ok=True)
 
 # InstrumentsXML
 root = ET.parse('instruments.xml').getroot()

--- a/share/instruments/generate_tsv.py
+++ b/share/instruments/generate_tsv.py
@@ -67,7 +67,7 @@ for genre in root.findall('Genre'):
         'id': id,
         'name': genre.find('name').text,
     }
-create_tsv('tsv/genres.tsv', genres)
+create_tsv(script_dir / 'tsv/genres.tsv', genres)
 
 families = {}
 for family in root.findall('Family'):
@@ -76,7 +76,7 @@ for family in root.findall('Family'):
         'id': id,
         'name': family.find('name').text,
     }
-create_tsv('tsv/families.tsv', families)
+create_tsv(script_dir / 'tsv/families.tsv', families)
 
 articulation_names = {}
 for articulation in root.findall('Articulation'):
@@ -86,7 +86,7 @@ for articulation in root.findall('Articulation'):
         'velocity': articulation.find('velocity').text,
         'gateTime': articulation.find('gateTime').text,
     }
-create_tsv('tsv/articulation_names.tsv', articulation_names)
+create_tsv(script_dir / 'tsv/articulation_names.tsv', articulation_names)
 
 groups = {}
 instruments = {}
@@ -228,8 +228,8 @@ for group in root.findall('InstrumentGroup'):
         if drums:
             drumsets[instrument_id] = drums
 
-create_tsv('tsv/groups.tsv', groups)
-create_tsv('tsv/instruments.tsv', instruments)
-create_tsv('tsv/articulations.tsv', articulations)
-create_tsv('tsv/channels.tsv', channels)
-create_tsv('tsv/drumsets.tsv', drumsets)
+create_tsv(script_dir / 'tsv/groups.tsv', groups)
+create_tsv(script_dir / 'tsv/instruments.tsv', instruments)
+create_tsv(script_dir / 'tsv/articulations.tsv', articulations)
+create_tsv(script_dir / 'tsv/channels.tsv', channels)
+create_tsv(script_dir / 'tsv/drumsets.tsv', drumsets)


### PR DESCRIPTION
Minor update to `generate_tsv.py` removing a doubled import and replacing `os` with the more modern `pathlib`, making the script more readable and elegant.