### PR TITLE
Fix crash on deleted ledger line pointer

### DIFF
--- a/src/engraving/rendering/dev/beamlayout.cpp
+++ b/src/engraving/rendering/dev/beamlayout.cpp
@@ -47,6 +47,7 @@
 #include "chordlayout.h"
 #include "beamtremololayout.h"
 #include "tremololayout.h"
+#include "systemlayout.h"
 
 #include "log.h"
 
@@ -1011,6 +1012,7 @@ void BeamLayout::checkCrossPosAndStemConsistency(Beam* beam, LayoutContext& ctx)
     if (inconsistencyFound) {
         BeamLayout::layout(beam, ctx);
     }
+    SystemLayout::layoutSystemElements(beam->system(), ctx);
 }
 
 void BeamLayout::createBeamSegments(Beam* item, const LayoutContext& ctx, const std::vector<ChordRest*>& chordRests)


### PR DESCRIPTION
Resolves: Crash when opening this score with a debug build https://musescore.com/user/1397281/scores/14219449

The new skylines are made from shapes, which have a pointer to an `EngravingItem`.  They are created in `SystemLayout::layoutSystemElements`.  Ledger lines are destroyed and recreated when chords are layed out.  Chord layout is called in `BeamLayout::checkCrossPosAndStemConsistency`, but the skylines aren't updated before a call to `SystemLayout::centerElementsBetweenStaves`.  The pointers in the shapes are stale and refer to a deleted ledger line.  

There doesn't seem to be much of an impact on performance here, but it still feels like overkill to create the skylines from scratch.