### PR TITLE
Implement cutout shapes for clefs and dynamics in preparation of new Leland release

### DIFF
--- a/src/engraving/dom/clef.cpp
+++ b/src/engraving/dom/clef.cpp
@@ -479,6 +479,11 @@ void Clef::undoChangeProperty(Pid id, const PropertyValue& v, PropertyFlags ps)
     }
 }
 
+bool Clef::isMidMeasureClef() const
+{
+    return segment() && segment()->rtick().isNotZero();
+}
+
 void Clef::manageExclusionFromParts(bool exclude)
 {
     if (exclude) {

--- a/src/engraving/dom/clef.h
+++ b/src/engraving/dom/clef.h
@@ -146,6 +146,8 @@ public:
     bool isHeader() const { return m_isHeader; }
     void setIsHeader(bool val) { m_isHeader = val; }
 
+    bool isMidMeasureClef() const;
+
     bool canBeExcludedFromOtherParts() const override { return !isHeader(); }
     void manageExclusionFromParts(bool exclude) override;
 

--- a/src/engraving/rendering/dev/horizontalspacing.cpp
+++ b/src/engraving/rendering/dev/horizontalspacing.cpp
@@ -255,13 +255,13 @@ void HorizontalSpacing::spaceRightAlignedSegments(Measure* m, double segmentShap
     // Compute spacing
     for (Segment* raSegment : rightAlignedSegments) {
         // 1) right-align the segment against the following ones
-        double minDistAfter = -DBL_MAX;
+        double minDistAfter = 0.0;
         for (Segment* seg = raSegment->nextActive(); seg; seg = seg->nextActive()) {
             double xDiff = seg->x() - raSegment->x();
             double minDist = minHorizontalCollidingDistance(raSegment, seg, segmentShapeSqueezeFactor);
             minDistAfter = std::max(minDistAfter, minDist - xDiff);
         }
-        if (minDistAfter != -DBL_MAX && raSegment->prevActive()) {
+        if (raSegment->prevActive()) {
             Segment* prevSegment = raSegment->prevActive();
             prevSegment->setWidth(prevSegment->width() - minDistAfter);
             prevSegment->setWidthOffset(prevSegment->widthOffset() - minDistAfter);
@@ -539,6 +539,10 @@ bool HorizontalSpacing::isNeverKernable(const EngravingItem* item)
 
     switch (type) {
     case ElementType::CLEF:
+        if (toClef(item)->isMidMeasureClef()) {
+            return false;
+        }
+    // fall through
     case ElementType::TIMESIG:
     case ElementType::KEYSIG:
     case ElementType::BAR_LINE:

--- a/src/engraving/rendering/dev/tlayout.cpp
+++ b/src/engraving/rendering/dev/tlayout.cpp
@@ -1794,10 +1794,15 @@ void TLayout::layoutClef(const Clef* item, Clef::LayoutData* ldata, const Layout
     }
     // clefs on palette or at start of system/measure are left aligned
     // other clefs are right aligned
-    RectF r(item->symBbox(ldata->symId));
-    double x = item->segment() && item->segment()->rtick().isNotZero() ? -r.right() : 0.0;
+    Shape shape(item->symShapeWithCutouts(ldata->symId));
+    bool isMidMeasureClef = item->isMidMeasureClef();
+    double x = isMidMeasureClef ? -shape.right() : 0.0;
     ldata->setPos(PointF(x, yoff * _spatium + (stepOffset * 0.5 * _spatium)));
-    ldata->setBbox(r);
+    if (item->isMidMeasureClef()) {
+        ldata->setShape(shape);
+    } else {
+        ldata->setBbox(item->symBbox(ldata->symId));
+    }
 }
 
 void TLayout::layoutCapo(const Capo* item, Capo::LayoutData* ldata, const LayoutContext&)


### PR DESCRIPTION
Resolves: #18723 

This PR prepares the logic needed to take advantage of the new shape cutouts that will come with the next release of Leland, namely for clefs and dynamics.

That means that our layout system will be able to see clefs and dynamics like this
<img width="379" alt="image" src="https://github.com/user-attachments/assets/4c6f76ba-bc87-464a-8edc-ecd8806a488f">

which is extremely important in many situations, such as dynamic centering and the horizontal spacing of clef changes.
![image](https://github.com/user-attachments/assets/79f235c1-448c-4c35-aa46-7a0531deada1)

This PR does not actually update Leland, we'll wait for the new release in the Leland repo first (the screenshots are taken with an internal test version).
