### PR TITLE
Fix cross-staff slur glitch

### DIFF
--- a/src/engraving/rendering/dev/pagelayout.cpp
+++ b/src/engraving/rendering/dev/pagelayout.cpp
@@ -423,7 +423,7 @@ void PageLayout::collectPage(LayoutContext& ctx)
         auto spanners = ctx.dom().spannerMap().findOverlapping(stick, etick);
         for (auto interval : spanners) {
             Spanner* sp = interval.value;
-            if (!sp->isSlur()) {
+            if (!sp->isSlur() || sp->tick() == system->endTick()) {
                 continue;
             }
             if (toSlur(sp)->isCrossStaff()) {


### PR DESCRIPTION
Resolves this:
![image](https://github.com/user-attachments/assets/c3f8ada2-8f0f-4874-a4c2-2fd5f9335b78)

