### PR TITLE
Cloud: don't mark MS3 scores as imported when opening them

### DIFF
--- a/src/project/internal/notationproject.cpp
+++ b/src/project/internal/notationproject.cpp
@@ -127,7 +127,7 @@ Ret NotationProject::load(const muse::io::path_t& path, const muse::io::path_t& 
         return ret;
     }
 
-    bool treatAsImported = m_masterNotation->mscVersion() < 400;
+    bool treatAsImported = m_masterNotation->mscVersion() < 400 && !isCloudProject();
 
     listenIfNeedSaveChanges();
     setNeedSave(treatAsImported);


### PR DESCRIPTION
When opening MS3 or older scores from the local file system, we mark them as imported. This way, when the user tries to save the score, they are prompted to select a new save location. This should prevent accidentally overwriting an MS3 score with the resulting MS4 score, because some users might later regret migrating to MS4 and going back is not possible.

But let's not do that for cloud scores, because according to https://github.com/musescore/MuseScore/issues/18821 that's janky. (And I believe MuseScore.com has a versioning feature anyway, so if you want to revert to the MS3 version, you can just use that feature. But I'm not sure about that.)

Resolves: https://github.com/musescore/MuseScore/issues/18821

Confession: this is _completely_ untested