### PR TITLE
Disallow Ctrl+Shift+dragging Frames to prevent crashes

### DIFF
--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -1160,6 +1160,9 @@ bool NotationInteraction::dragCopyAllowed(const EngravingItem* element) const
     case ElementType::MEASURE:
     case ElementType::NOTE:
     case ElementType::VBOX:
+    case ElementType::HBOX:
+    case ElementType::TBOX:
+    case ElementType::FBOX:
     // TODO: Bends can't be copy-dragged until corresponding SingleLayout::layout and SingleDraw::draw methods have been implemented
     case ElementType::GUITAR_BEND:
     case ElementType::GUITAR_BEND_SEGMENT:


### PR DESCRIPTION
SingleLayout and SingleDraw are not implemented for these types. In release builds, TLayout is used as a fallback, but that assumes that the Frame has a `system` which is not the case when Ctrl+Shift+dragging. Isn't questionable how useful that would be anyway for frames, so let's disable it for now.

Resolves: https://github.com/musescore/MuseScore/issues/23318