### PR TITLE
Consistently use seconds instead of milliseconds throughout playback module

### DIFF
--- a/src/notation/inotationplayback.h
+++ b/src/notation/inotationplayback.h
@@ -51,12 +51,12 @@ public:
     virtual muse::async::Channel<engraving::InstrumentTrackId> trackAdded() const = 0;
     virtual muse::async::Channel<engraving::InstrumentTrackId> trackRemoved() const = 0;
 
-    virtual muse::audio::msecs_t totalPlayTime() const = 0;
-    virtual muse::async::Channel<muse::audio::msecs_t> totalPlayTimeChanged() const = 0;
+    virtual muse::audio::secs_t totalPlayTime() const = 0;
+    virtual muse::async::Channel<muse::audio::secs_t> totalPlayTimeChanged() const = 0;
 
-    virtual float playedTickToSec(muse::midi::tick_t tick) const = 0;
-    virtual muse::midi::tick_t secToPlayedTick(float sec) const = 0;
-    virtual muse::midi::tick_t secToTick(float sec) const = 0;
+    virtual muse::audio::secs_t playedTickToSec(muse::midi::tick_t tick) const = 0;
+    virtual muse::midi::tick_t secToPlayedTick(muse::audio::secs_t sec) const = 0;
+    virtual muse::midi::tick_t secToTick(muse::audio::secs_t sec) const = 0;
 
     virtual muse::RetVal<muse::midi::tick_t> playPositionTickByRawTick(muse::midi::tick_t tick) const = 0;
     virtual muse::RetVal<muse::midi::tick_t> playPositionTickByElement(const EngravingItem* element) const = 0;

--- a/src/notation/internal/notationplayback.cpp
+++ b/src/notation/internal/notationplayback.cpp
@@ -51,7 +51,7 @@ using namespace muse;
 using namespace muse::midi;
 using namespace muse::async;
 
-static constexpr int PLAYBACK_TAIL_SECS = 3;
+static constexpr double PLAYBACK_TAIL_SECS = 3;
 
 NotationPlayback::NotationPlayback(IGetScore* getScore,
                                    muse::async::Notification notationChanged)
@@ -170,10 +170,8 @@ void NotationPlayback::updateTotalPlayTime()
     }
 
     int lastTick = score->repeatList(m_playbackModel.isPlayRepeatsEnabled()).ticks();
-    qreal secs = score->utick2utime(lastTick);
-    secs += PLAYBACK_TAIL_SECS;
-
-    muse::audio::msecs_t newPlayTime = secs * 1000.f;
+    audio::secs_t newPlayTime = score->utick2utime(lastTick);
+    newPlayTime += PLAYBACK_TAIL_SECS;
 
     if (m_totalPlayTime == newPlayTime) {
         return;
@@ -183,22 +181,22 @@ void NotationPlayback::updateTotalPlayTime()
     m_totalPlayTimeChanged.send(m_totalPlayTime);
 }
 
-muse::audio::msecs_t NotationPlayback::totalPlayTime() const
+muse::audio::secs_t NotationPlayback::totalPlayTime() const
 {
     return m_totalPlayTime;
 }
 
-muse::async::Channel<muse::audio::msecs_t> NotationPlayback::totalPlayTimeChanged() const
+muse::async::Channel<muse::audio::secs_t> NotationPlayback::totalPlayTimeChanged() const
 {
     return m_totalPlayTimeChanged;
 }
 
-float NotationPlayback::playedTickToSec(tick_t tick) const
+muse::audio::secs_t NotationPlayback::playedTickToSec(tick_t tick) const
 {
     return score() ? score()->utick2utime(tick) : 0.0;
 }
 
-tick_t NotationPlayback::secToPlayedTick(float sec) const
+tick_t NotationPlayback::secToPlayedTick(muse::audio::secs_t sec) const
 {
     if (!score()) {
         return 0;
@@ -207,7 +205,7 @@ tick_t NotationPlayback::secToPlayedTick(float sec) const
     return score()->utime2utick(sec);
 }
 
-tick_t NotationPlayback::secToTick(float sec) const
+tick_t NotationPlayback::secToTick(muse::audio::secs_t sec) const
 {
     if (!score()) {
         return 0;

--- a/src/notation/internal/notationplayback.h
+++ b/src/notation/internal/notationplayback.h
@@ -22,15 +22,12 @@
 #ifndef MU_NOTATION_NOTATIONPLAYBACK_H
 #define MU_NOTATION_NOTATIONPLAYBACK_H
 
-#include <memory>
-
 #include "modularity/ioc.h"
 #include "async/asyncable.h"
 #include "engraving/playback/playbackmodel.h"
 
 #include "../inotationplayback.h"
 #include "igetscore.h"
-#include "inotationundostack.h"
 #include "inotationconfiguration.h"
 
 namespace mu::engraving {
@@ -59,12 +56,12 @@ public:
     muse::async::Channel<engraving::InstrumentTrackId> trackAdded() const override;
     muse::async::Channel<engraving::InstrumentTrackId> trackRemoved() const override;
 
-    muse::audio::msecs_t totalPlayTime() const override;
-    muse::async::Channel<muse::audio::msecs_t> totalPlayTimeChanged() const override;
+    muse::audio::secs_t totalPlayTime() const override;
+    muse::async::Channel<muse::audio::secs_t> totalPlayTimeChanged() const override;
 
-    float playedTickToSec(muse::midi::tick_t tick) const override;
-    muse::midi::tick_t secToPlayedTick(float sec) const override;
-    muse::midi::tick_t secToTick(float sec) const override;
+    muse::audio::secs_t playedTickToSec(muse::midi::tick_t tick) const override;
+    muse::midi::tick_t secToPlayedTick(muse::audio::secs_t sec) const override;
+    muse::midi::tick_t secToTick(muse::audio::secs_t sec) const override;
 
     muse::RetVal<muse::midi::tick_t> playPositionTickByRawTick(muse::midi::tick_t tick) const override;
     muse::RetVal<muse::midi::tick_t> playPositionTickByElement(const EngravingItem* element) const override;
@@ -107,8 +104,8 @@ private:
     LoopBoundaries m_loopBoundaries;
     muse::async::Notification m_loopBoundariesChanged;
 
-    muse::audio::msecs_t m_totalPlayTime = 0;
-    muse::async::Channel<muse::audio::msecs_t> m_totalPlayTimeChanged;
+    muse::audio::secs_t m_totalPlayTime = 0;
+    muse::async::Channel<muse::audio::secs_t> m_totalPlayTimeChanged;
 
     mutable Tempo m_currentTempo;
 

--- a/src/notation/view/abstractnotationpaintview.cpp
+++ b/src/notation/view/abstractnotationpaintview.cpp
@@ -622,7 +622,7 @@ void AbstractNotationPaintView::onNotationSetup()
         onPlayingChanged();
     });
 
-    playbackController()->midiTickPlayed().onReceive(this, [this](uint32_t tick) {
+    playbackController()->currentPlaybackPositionChanged().onReceive(this, [this](audio::secs_t, midi::tick_t tick) {
         movePlaybackCursor(tick);
     });
 

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -227,9 +227,9 @@ void PlaybackController::seek(const audio::secs_t secs)
     currentPlayer()->seek(secs);
 }
 
-Channel<uint32_t> PlaybackController::midiTickPlayed() const
+muse::async::Channel<secs_t, tick_t> PlaybackController::currentPlaybackPositionChanged() const
 {
-    return m_tickPlayed;
+    return m_currentPlaybackPositionChanged;
 }
 
 TrackSequenceId PlaybackController::currentTrackSequenceId() const
@@ -1264,7 +1264,7 @@ void PlaybackController::setupSequencePlayer()
 {
     currentPlayer()->playbackPositionChanged().onReceive(this, [this](const audio::secs_t pos) {
         m_currentTick = notationPlayback()->secToTick(pos);
-        m_tickPlayed.send(m_currentTick);
+        m_currentPlaybackPositionChanged.send(pos, m_currentTick);
 
         updateCurrentTempo();
 

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -28,19 +28,21 @@
 
 #include "audio/audioutils.h"
 #include "audio/devtools/inputlag.h"
+#include "audio/iaudiooutput.h"
+#include "audio/itracks.h"
 
 #include "containers.h"
 #include "defer.h"
 #include "log.h"
 
 using namespace muse;
-using namespace mu::playback;
-using namespace muse::midi;
-using namespace mu::notation;
+using namespace muse::actions;
 using namespace muse::async;
 using namespace muse::audio;
-using namespace muse::actions;
+using namespace muse::midi;
 using namespace mu::engraving;
+using namespace mu::notation;
+using namespace mu::playback;
 
 static const ActionCode PLAY_CODE("play");
 static const ActionCode STOP_CODE("stop");
@@ -558,9 +560,9 @@ void PlaybackController::togglePlay()
     } else if (isPaused()) {
         if (currentPlayer()) {
             secs_t pos = currentPlayer()->playbackPosition();
-            secs_t endSecs = milisecsToSecs(playbackEndMsecs());
+            secs_t endSecs = playbackEndSecs();
             if (pos == endSecs) {
-                secs_t startSecs = milisecsToSecs(playbackStartMsecs());
+                secs_t startSecs = playbackStartSecs();
                 seek(startSecs);
             }
 
@@ -578,7 +580,7 @@ void PlaybackController::play()
     }
 
     if (isLoopEnabled()) {
-        secs_t startSecs = milisecsToSecs(playbackStartMsecs());
+        secs_t startSecs = playbackStartSecs();
         seek(startSecs);
     }
 
@@ -587,10 +589,10 @@ void PlaybackController::play()
 
 void PlaybackController::rewind(const ActionData& args)
 {
-    msecs_t startMsecs = playbackStartMsecs();
-    msecs_t endMsecs = playbackEndMsecs();
-    msecs_t newPosition = !args.empty() ? args.arg<msecs_t>(0) : 0;
-    newPosition = std::clamp(newPosition, startMsecs, endMsecs);
+    secs_t startSecs = playbackStartSecs();
+    secs_t endSecs = playbackEndSecs();
+    secs_t newPosition = !args.empty() ? args.arg<secs_t>(0) : secs_t{ 0 };
+    newPosition = std::clamp(newPosition, startSecs, endSecs);
 
     seek(newPosition);
 }
@@ -622,7 +624,7 @@ void PlaybackController::resume()
     currentPlayer()->resume();
 }
 
-msecs_t PlaybackController::playbackStartMsecs() const
+secs_t PlaybackController::playbackStartSecs() const
 {
     if (!m_notation) {
         return 0;
@@ -635,15 +637,15 @@ msecs_t PlaybackController::playbackStartMsecs() const
         if (!startTick.ret) {
             return 0;
         }
-        return tickToMsecs(startTick.val);
+        return tickToSecs(startTick.val);
     }
 
     return 0;
 }
 
-msecs_t PlaybackController::playbackEndMsecs() const
+secs_t PlaybackController::playbackEndSecs() const
 {
-    return notationPlayback() ? notationPlayback()->totalPlayTime() : 0;
+    return notationPlayback() ? notationPlayback()->totalPlayTime() : secs_t { 0 };
 }
 
 InstrumentTrackIdSet PlaybackController::instrumentTrackIdSetForRangePlayback() const
@@ -797,9 +799,9 @@ void PlaybackController::updateLoop()
         return;
     }
 
-    msecs_t fromMsecs = tickToMsecs(playbackTickFrom.val);
-    msecs_t toMsecs = tickToMsecs(playbackTickTo.val);
-    currentPlayer()->setLoop(fromMsecs, toMsecs);
+    secs_t fromSecs = tickToSecs(playbackTickFrom.val);
+    secs_t toSecs = tickToSecs(playbackTickTo.val);
+    currentPlayer()->setLoop(secsToMilisecs(fromSecs), secsToMilisecs(toSecs));
 
     enableLoop();
 
@@ -1266,7 +1268,7 @@ void PlaybackController::setupSequencePlayer()
 
         updateCurrentTempo();
 
-        secs_t endSecs = milisecsToSecs(playbackEndMsecs());
+        secs_t endSecs = playbackEndSecs();
         if (pos == endSecs) {
             stop();
         }
@@ -1276,10 +1278,10 @@ void PlaybackController::setupSequencePlayer()
         m_isPlayingChanged.notify();
     });
 
-    currentPlayer()->setDuration(notationPlayback()->totalPlayTime());
+    currentPlayer()->setDuration(secsToMilisecs(notationPlayback()->totalPlayTime()));
 
-    notationPlayback()->totalPlayTimeChanged().onReceive(this, [this](const audio::msecs_t totalPlaybackTime) {
-        currentPlayer()->setDuration(totalPlaybackTime);
+    notationPlayback()->totalPlayTimeChanged().onReceive(this, [this](const audio::secs_t totalPlaybackTime) {
+        currentPlayer()->setDuration(secsToMilisecs(totalPlaybackTime));
         m_totalPlayTimeChanged.notify();
     });
 }
@@ -1403,13 +1405,11 @@ Channel<ActionCode> PlaybackController::actionCheckedChanged() const
 
 QTime PlaybackController::totalPlayTime() const
 {
-    QTime result = ZERO_TIME;
-
     if (!notationPlayback()) {
-        return result;
+        return ZERO_TIME;
     }
 
-    return result.addMSecs(notationPlayback()->totalPlayTime());
+    return timeFromSeconds(notationPlayback()->totalPlayTime());
 }
 
 Notification PlaybackController::totalPlayTimeChanged() const
@@ -1432,9 +1432,9 @@ MeasureBeat PlaybackController::currentBeat() const
     return notationPlayback() ? notationPlayback()->beat(m_currentTick) : MeasureBeat();
 }
 
-msecs_t PlaybackController::beatToMilliseconds(int measureIndex, int beatIndex) const
+secs_t PlaybackController::beatToSecs(int measureIndex, int beatIndex) const
 {
-    return notationPlayback() ? tickToMsecs(notationPlayback()->beatToTick(measureIndex, beatIndex)) : 0;
+    return notationPlayback() ? tickToSecs(notationPlayback()->beatToTick(measureIndex, beatIndex)) : secs_t { 0 };
 }
 
 double PlaybackController::tempoMultiplier() const
@@ -1574,12 +1574,6 @@ void PlaybackController::setIsExportingAudio(bool exporting)
 bool PlaybackController::canReceiveAction(const ActionCode&) const
 {
     return m_masterNotation != nullptr && m_masterNotation->hasParts();
-}
-
-msecs_t PlaybackController::tickToMsecs(int tick) const
-{
-    float sec = notationPlayback()->playedTickToSec(tick);
-    return secondsToMilliseconds(sec);
 }
 
 muse::audio::secs_t PlaybackController::tickToSecs(int tick) const

--- a/src/playback/internal/playbackcontroller.h
+++ b/src/playback/internal/playbackcontroller.h
@@ -63,7 +63,7 @@ public:
 
     void reset() override;
 
-    muse::async::Channel<uint32_t> midiTickPlayed() const override;
+    muse::async::Channel<muse::audio::secs_t, muse::midi::tick_t> currentPlaybackPositionChanged() const override;
 
     muse::audio::TrackSequenceId currentTrackSequenceId() const override;
     muse::async::Notification currentTrackSequenceIdChanged() const override;
@@ -212,7 +212,7 @@ private:
     muse::async::Notification m_isPlayingChanged;
     muse::async::Notification m_totalPlayTimeChanged;
     muse::async::Notification m_currentTempoChanged;
-    muse::async::Channel<uint32_t> m_tickPlayed;
+    muse::async::Channel<muse::audio::secs_t, muse::midi::tick_t> m_currentPlaybackPositionChanged;
     muse::async::Channel<muse::actions::ActionCode> m_actionCheckedChanged;
 
     muse::audio::TrackSequenceId m_currentSequenceId = -1;

--- a/src/playback/internal/playbackcontroller.h
+++ b/src/playback/internal/playbackcontroller.h
@@ -22,10 +22,7 @@
 #ifndef MU_PLAYBACK_PLAYBACKCONTROLLER_H
 #define MU_PLAYBACK_PLAYBACKCONTROLLER_H
 
-#include <unordered_map>
-
 #include "modularity/ioc.h"
-#include "types/retval.h"
 #include "async/asyncable.h"
 #include "actions/iactionsdispatcher.h"
 #include "actions/actionable.h"
@@ -35,8 +32,6 @@
 #include "notation/inotationconfiguration.h"
 #include "notation/inotationplayback.h"
 #include "audio/iplayer.h"
-#include "audio/itracks.h"
-#include "audio/iaudiooutput.h"
 #include "audio/iplayback.h"
 #include "audio/audiotypes.h"
 #include "iinteractive.h"
@@ -103,7 +98,7 @@ public:
     muse::async::Notification currentTempoChanged() const override;
 
     notation::MeasureBeat currentBeat() const override;
-    muse::audio::msecs_t beatToMilliseconds(int measureIndex, int beatIndex) const override;
+    muse::audio::secs_t beatToSecs(int measureIndex, int beatIndex) const override;
 
     double tempoMultiplier() const override;
     void setTempoMultiplier(double multiplier) override;
@@ -158,8 +153,8 @@ private:
     void stop();
     void resume();
 
-    muse::audio::msecs_t playbackStartMsecs() const;
-    muse::audio::msecs_t playbackEndMsecs() const;
+    muse::audio::secs_t playbackStartSecs() const;
+    muse::audio::secs_t playbackEndSecs() const;
 
     notation::InstrumentTrackIdSet instrumentTrackIdSetForRangePlayback() const;
 
@@ -207,7 +202,6 @@ private:
     void removeNonExistingTracks();
     void removeTrack(const engraving::InstrumentTrackId& instrumentTrackId);
 
-    muse::audio::msecs_t tickToMsecs(int tick) const;
     muse::audio::secs_t tickToSecs(int tick) const;
 
     notation::INotationPtr m_notation;

--- a/src/playback/iplaybackcontroller.h
+++ b/src/playback/iplaybackcontroller.h
@@ -50,7 +50,7 @@ public:
 
     virtual void reset() = 0;
 
-    virtual muse::async::Channel<uint32_t> midiTickPlayed() const = 0;
+    virtual muse::async::Channel<muse::audio::secs_t, muse::midi::tick_t> currentPlaybackPositionChanged() const = 0;
 
     virtual muse::audio::TrackSequenceId currentTrackSequenceId() const = 0;
     virtual muse::async::Notification currentTrackSequenceIdChanged() const = 0;

--- a/src/playback/iplaybackcontroller.h
+++ b/src/playback/iplaybackcontroller.h
@@ -89,7 +89,7 @@ public:
     virtual muse::async::Notification currentTempoChanged() const = 0;
 
     virtual notation::MeasureBeat currentBeat() const = 0;
-    virtual muse::audio::msecs_t beatToMilliseconds(int measureIndex, int beatIndex) const = 0;
+    virtual muse::audio::secs_t beatToSecs(int measureIndex, int beatIndex) const = 0;
 
     virtual double tempoMultiplier() const = 0;
     virtual void setTempoMultiplier(double multiplier) = 0;

--- a/src/playback/playbacktypes.h
+++ b/src/playback/playbacktypes.h
@@ -66,30 +66,14 @@ inline QList<MixerSectionType> allMixerSectionTypes()
 
 static const QTime ZERO_TIME(0, 0, 0, 0);
 
-inline muse::audio::msecs_t secondsToMilliseconds(float seconds)
+inline QTime timeFromSeconds(muse::audio::secs_t seconds)
 {
-    return seconds * 1000;
+    return ZERO_TIME.addMSecs(muse::audio::secsToMilisecs(seconds));
 }
 
-inline float secondsFromMilliseconds(muse::audio::msecs_t milliseconds)
+inline muse::audio::secs_t timeToSeconds(const QTime& time)
 {
-    return milliseconds / 1000.f;
-}
-
-inline QTime timeFromMilliseconds(muse::audio::msecs_t milliseconds)
-{
-    return ZERO_TIME.addMSecs(milliseconds);
-}
-
-inline QTime timeFromSeconds(float seconds)
-{
-    muse::audio::msecs_t milliseconds = secondsToMilliseconds(seconds);
-    return timeFromMilliseconds(milliseconds);
-}
-
-inline muse::audio::msecs_t timeToMilliseconds(const QTime& time)
-{
-    return ZERO_TIME.msecsTo(time);
+    return muse::audio::milisecsToSecs(ZERO_TIME.msecsTo(time));
 }
 
 enum class SoundProfileType {

--- a/src/playback/tests/mocks/playbackcontrollermock.h
+++ b/src/playback/tests/mocks/playbackcontrollermock.h
@@ -38,7 +38,7 @@ public:
 
     MOCK_METHOD(void, reset, (), (override));
 
-    MOCK_METHOD(muse::async::Channel<uint32_t>, midiTickPlayed, (), (const, override));
+    MOCK_METHOD((muse::async::Channel<muse::audio::secs_t, muse::midi::tick_t>), currentPlaybackPositionChanged, (), (const, override));
 
     MOCK_METHOD(muse::audio::TrackSequenceId, currentTrackSequenceId, (), (const, override));
     MOCK_METHOD(muse::async::Notification, currentTrackSequenceIdChanged, (), (const, override));

--- a/src/playback/tests/mocks/playbackcontrollermock.h
+++ b/src/playback/tests/mocks/playbackcontrollermock.h
@@ -75,7 +75,7 @@ public:
     MOCK_METHOD(muse::async::Notification, currentTempoChanged, (), (const, override));
 
     MOCK_METHOD(notation::MeasureBeat, currentBeat, (), (const, override));
-    MOCK_METHOD(muse::audio::msecs_t, beatToMilliseconds, (int, int), (const, override));
+    MOCK_METHOD(muse::audio::secs_t, beatToSecs, (int, int), (const, override));
 
     MOCK_METHOD(double, tempoMultiplier, (), (const, override));
     MOCK_METHOD(void, setTempoMultiplier, (double), (override));

--- a/src/playback/view/playbacktoolbarmodel.cpp
+++ b/src/playback/view/playbacktoolbarmodel.cpp
@@ -67,8 +67,6 @@ void PlaybackToolBarModel::load()
 
 void PlaybackToolBarModel::setupConnections()
 {
-    context::IPlaybackStatePtr playbackState = globalContext()->playbackState();
-
     playbackController()->isPlayAllowedChanged().onNotify(this, [this]() {
         emit isPlayAllowedChanged();
     });
@@ -77,7 +75,7 @@ void PlaybackToolBarModel::setupConnections()
         onActionsStateChanges({ PLAY_ACTION_CODE });
     });
 
-    playbackState->playbackPositionChanged().onReceive(this, [this](secs_t secs) {
+    playbackController()->currentPlaybackPositionChanged().onReceive(this, [this](secs_t secs, midi::tick_t) {
         updatePlayPosition(secs);
     });
 

--- a/src/playback/view/playbacktoolbarmodel.cpp
+++ b/src/playback/view/playbacktoolbarmodel.cpp
@@ -187,31 +187,31 @@ void PlaybackToolBarModel::setPlayTime(const QDateTime& time)
 
     doSetPlayTime(newTime);
 
-    msecs_t msec = timeToMilliseconds(newTime);
-    rewind(msec);
+    secs_t sec = timeToSeconds(newTime);
+    rewind(sec);
 }
 
 qreal PlaybackToolBarModel::playPosition() const
 {
     QTime totalTime = totalPlayTime();
-    msecs_t totalMsecs = timeToMilliseconds(totalTime);
+    secs_t totalSecs = timeToSeconds(totalTime);
 
-    if (totalMsecs == 0) {
+    if (totalSecs == 0.0) {
         return 0;
     }
 
-    msecs_t msecsDifference = totalMsecs - m_playTime.msecsTo(totalTime);
-    qreal position = static_cast<qreal>(msecsDifference) / static_cast<qreal>(totalMsecs);
+    secs_t currentSecs = timeToSeconds(m_playTime);
+    qreal position = static_cast<qreal>(currentSecs) / static_cast<qreal>(totalSecs);
 
     return position;
 }
 
 void PlaybackToolBarModel::setPlayPosition(qreal position)
 {
-    msecs_t totalPlayTimeMsecs = timeToMilliseconds(totalPlayTime());
-    msecs_t playPositionMsecs = totalPlayTimeMsecs * position;
+    secs_t totalPlayTimeSecs = timeToSeconds(totalPlayTime());
+    secs_t playPositionSecs = totalPlayTimeSecs * position;
 
-    QTime time = timeFromMilliseconds(playPositionMsecs);
+    QTime time = timeFromSeconds(playPositionSecs);
     setPlayTime(QDateTime(QDate::currentDate(), time));
 }
 
@@ -252,15 +252,15 @@ void PlaybackToolBarModel::doSetPlayTime(const QTime& time)
     emit playPositionChanged();
 }
 
-void PlaybackToolBarModel::rewind(msecs_t milliseconds)
+void PlaybackToolBarModel::rewind(secs_t secs)
 {
-    dispatch("rewind", ActionData::make_arg1<msecs_t>(milliseconds));
+    dispatch("rewind", ActionData::make_arg1<secs_t>(secs));
 }
 
 void PlaybackToolBarModel::rewindToBeat(const MeasureBeat& beat)
 {
-    msecs_t msec = playbackController()->beatToMilliseconds(beat.measureIndex, beat.beatIndex);
-    rewind(msec);
+    secs_t secs = playbackController()->beatToSecs(beat.measureIndex, beat.beatIndex);
+    rewind(secs);
 }
 
 int PlaybackToolBarModel::measureNumber() const

--- a/src/playback/view/playbacktoolbarmodel.h
+++ b/src/playback/view/playbacktoolbarmodel.h
@@ -102,7 +102,7 @@ private:
     void updatePlayPosition(muse::audio::secs_t secs);
     void doSetPlayTime(const QTime& time);
 
-    void rewind(muse::audio::msecs_t milliseconds);
+    void rewind(muse::audio::secs_t secs);
     void rewindToBeat(const notation::MeasureBeat& beat);
 
     bool m_isToolbarFloating = false;

--- a/src/stubs/playback/playbackcontrollerstub.cpp
+++ b/src/stubs/playback/playbackcontrollerstub.cpp
@@ -48,9 +48,9 @@ void PlaybackControllerStub::reset()
 {
 }
 
-muse::async::Channel<uint32_t> PlaybackControllerStub::midiTickPlayed() const
+muse::async::Channel<muse::audio::secs_t, muse::midi::tick_t> PlaybackControllerStub::currentPlaybackPositionChanged() const
 {
-    return muse::async::Channel<uint32_t>();
+    return muse::async::Channel<muse::audio::secs_t, muse::midi::tick_t>();
 }
 
 muse::audio::TrackSequenceId PlaybackControllerStub::currentTrackSequenceId() const

--- a/src/stubs/playback/playbackcontrollerstub.cpp
+++ b/src/stubs/playback/playbackcontrollerstub.cpp
@@ -159,7 +159,7 @@ mu::notation::MeasureBeat PlaybackControllerStub::currentBeat() const
     return {};
 }
 
-muse::audio::msecs_t PlaybackControllerStub::beatToMilliseconds(int, int) const
+muse::audio::secs_t PlaybackControllerStub::beatToSecs(int, int) const
 {
     return 0;
 }

--- a/src/stubs/playback/playbackcontrollerstub.h
+++ b/src/stubs/playback/playbackcontrollerstub.h
@@ -36,7 +36,7 @@ public:
 
     void reset() override;
 
-    muse::async::Channel<uint32_t> midiTickPlayed() const override;
+    muse::async::Channel<muse::audio::secs_t, muse::midi::tick_t> currentPlaybackPositionChanged() const override;
 
     muse::audio::TrackSequenceId currentTrackSequenceId() const override;
     muse::async::Notification currentTrackSequenceIdChanged() const override;

--- a/src/stubs/playback/playbackcontrollerstub.h
+++ b/src/stubs/playback/playbackcontrollerstub.h
@@ -71,7 +71,7 @@ public:
     muse::async::Notification currentTempoChanged() const override;
 
     notation::MeasureBeat currentBeat() const override;
-    muse::audio::msecs_t beatToMilliseconds(int measureIndex, int beatIndex) const override;
+    muse::audio::secs_t beatToSecs(int measureIndex, int beatIndex) const override;
 
     double tempoMultiplier() const override;
     void setTempoMultiplier(double multiplier) override;


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/23793

The time input field in the playback toolbar was not working properly, because the amount of milliseconds resulting from the entered time was accidentally interpreted as a number of ticks, because the wrong overload of `seek` was used. This problem is avoided by eliminating the usage of the msecs_t type completely.

Will conflict with #19038; it doesn't really matter which one is merged first. 