### PR TITLE
Fix #18764: Disallow kerning of noteheads over dots in the same voice

### DIFF
--- a/src/engraving/rendering/dev/horizontalspacing.cpp
+++ b/src/engraving/rendering/dev/horizontalspacing.cpp
@@ -522,6 +522,7 @@ bool HorizontalSpacing::isSameVoiceKerningLimited(const EngravingItem* item)
 
     switch (type) {
     case ElementType::NOTE:
+    case ElementType::NOTEDOT:
     case ElementType::REST:
     case ElementType::STEM:
     case ElementType::CHORDLINE:


### PR DESCRIPTION
Resolves: #18764

Added `computeNoteDotKerningType` as another special case in deciding kerning. Dots are still allowed to kern with other objects after it, like other notes and grace notes. I'm not sure if this should be allowed since to me it creates a similar visual clutter as trill cue notes did before, but perhaps this needs more consideration.

Before: 
<img width="877" alt="Screenshot 2024-07-28 at 6 32 12 PM" src="https://github.com/user-attachments/assets/ad326084-d124-4b1e-8515-7e488340ba29">

After:
<img width="939" alt="Screenshot 2024-07-28 at 6 32 16 PM" src="https://github.com/user-attachments/assets/6f848a46-9be5-4ef6-87d0-8c655e973643">

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
