### PR TITLE
Fix theoretical data race in Inject class

### DIFF
--- a/src/framework/global/thirdparty/kors_async/async/internal/abstractinvoker.cpp
+++ b/src/framework/global/thirdparty/kors_async/async/internal/abstractinvoker.cpp
@@ -39,6 +39,8 @@ AbstractInvoker::~AbstractInvoker()
     for (QInvoker* qi : m_qInvokers) {
         qi->invalidate();
     }
+
+    m_qInvokers.clear();
 }
 
 void AbstractInvoker::invoke(int type)
@@ -147,9 +149,11 @@ void AbstractInvoker::removeCallBack(int type, Asyncable* receiver)
 
     {
         std::lock_guard<std::mutex> lock(m_qInvokersMutex);
-        for (QInvoker* qi : m_qInvokers) {
+        for (auto it = m_qInvokers.begin(); it != m_qInvokers.end(); ++it) {
+            QInvoker* qi = *it;
             if (qi->call.call == c.call) {
                 qi->invalidate();
+                m_qInvokers.erase(it);
                 break;
             }
         }

--- a/src/framework/global/thirdparty/kors_modularity/modularity/ioc.cpp
+++ b/src/framework/global/thirdparty/kors_modularity/modularity/ioc.cpp
@@ -23,7 +23,7 @@ SOFTWARE.
 */
 #include "ioc.h"
 
-std::mutex kors::modularity::StaticMutex::mutex;
+std::shared_mutex kors::modularity::StaticMutex::mutex;
 
 static std::map<kors::modularity::IoCID, kors::modularity::ModulesIoC*> s_map;
 


### PR DESCRIPTION
Includes #14790, so should wait on that PR

While concurrent reads don't need protection, and concurrent writes were protected by a mutex, the reads were not protected from the writes, because they didn't have a mutex. That is solved by this PR.

This problem was found using Thread Sanitizer. It is questionable though whether we should try to fix it, because it is unlikely to be a serious problem in practice, and the fix adds some overhead.