### PR TITLE
Fix data race in AbstractInvoker

### DIFF
--- a/src/framework/global/thirdparty/kors_async/async/internal/abstractinvoker.cpp
+++ b/src/framework/global/thirdparty/kors_async/async/internal/abstractinvoker.cpp
@@ -39,6 +39,8 @@ AbstractInvoker::~AbstractInvoker()
     for (QInvoker* qi : m_qInvokers) {
         qi->invalidate();
     }
+
+    m_qInvokers.clear();
 }
 
 void AbstractInvoker::invoke(int type)
@@ -147,9 +149,11 @@ void AbstractInvoker::removeCallBack(int type, Asyncable* receiver)
 
     {
         std::lock_guard<std::mutex> lock(m_qInvokersMutex);
-        for (QInvoker* qi : m_qInvokers) {
+        for (auto it = m_qInvokers.begin(); it != m_qInvokers.end(); ++it) {
+            QInvoker* qi = *it;
             if (qi->call.call == c.call) {
                 qi->invalidate();
+                m_qInvokers.erase(it);
                 break;
             }
         }

--- a/src/framework/global/thirdparty/kors_async/async/internal/abstractinvoker.h
+++ b/src/framework/global/thirdparty/kors_async/async/internal/abstractinvoker.h
@@ -27,9 +27,9 @@ SOFTWARE.
 #include <memory>
 #include <vector>
 #include <list>
-#include <iostream>
 #include <map>
 #include <mutex>
+#include <shared_mutex>
 #include <thread>
 #include <functional>
 
@@ -106,6 +106,11 @@ protected:
     virtual void deleteCall(int type, void* call) = 0;
     virtual void doInvoke(int type, void* call, const NotifyData& data) = 0;
 
+    void addCallBack(int type, Asyncable* receiver, void* call, Asyncable::AsyncMode mode = Asyncable::AsyncMode::AsyncSetRepeat);
+    void removeCallBack(int type, Asyncable* receiver);
+    void removeAllCallBacks();
+
+private:
     struct CallBack {
         std::thread::id threadID;
         int type = 0;
@@ -166,15 +171,14 @@ protected:
 
     void invokeCallback(int type, const CallBack& c, const NotifyData& data);
 
-    void addCallBack(int type, Asyncable* receiver, void* call, Asyncable::AsyncMode mode = Asyncable::AsyncMode::AsyncSetRepeat);
-    void removeCallBack(int type, Asyncable* receiver);
-    void removeAllCallBacks();
+    void doRemoveCallBack(int type, Asyncable* receiver);
 
     void addQInvoker(QInvoker* qi);
     void removeQInvoker(QInvoker* qi);
 
     bool containsReceiver(Asyncable* receiver) const;
 
+    mutable std::shared_mutex m_callbacksMutex;
     std::map<int /*type*/, CallBacks > m_callbacks;
 
     std::mutex m_qInvokersMutex;

--- a/src/framework/global/thirdparty/kors_modularity/modularity/ioc.cpp
+++ b/src/framework/global/thirdparty/kors_modularity/modularity/ioc.cpp
@@ -23,7 +23,7 @@ SOFTWARE.
 */
 #include "ioc.h"
 
-std::mutex kors::modularity::StaticMutex::mutex;
+std::shared_mutex kors::modularity::StaticMutex::mutex;
 
 static std::map<kors::modularity::IoCID, kors::modularity::ModulesIoC*> s_map;
 


### PR DESCRIPTION
Includes #23805

This data race was reproducible in Address Sanitizer builds, when you opened and closed the Mixer extremely often and quickly during playback. It is also reported by Thread Sanitizer.

This fix has the risk of introducing deadlocks or performance issues. Before we merge this, we should convince ourselves more that this solution is indeed desirable. I am in contact with Igor to discuss the details, and when we reach a conclusion I will probably post that here. 

Like with #23805, it is questionable whether this fix is worth it, even regardless of its correctness and efficiency. The data race that it solves was quite difficult to reproduce (that is, reproduce in such way that the effects were noticeable in the form of an ASan error, and not even a real crash). 