### PR TITLE
fix #23809 - note change by up / down key respect double and triple accidentals (if present)

### DIFF
--- a/src/engraving/dom/cmd.cpp
+++ b/src/engraving/dom/cmd.cpp
@@ -1819,17 +1819,23 @@ void Score::changeCRlen(ChordRest* cr, const Fraction& dstF, bool fillWithRest)
 
 static void upDownChromatic(bool up, int pitch, Note* n, Key key, int tpc1, int tpc2, int& newPitch, int& newTpc1, int& newTpc2)
 {
+    bool concertPitch = n->concertPitch();
+    AccidentalVal noteAccVal = tpc2alter(concertPitch ? tpc1 : tpc2);
+    AccidentalVal accState = AccidentalVal::NATURAL;
+    if (Measure* m = n->findMeasure()) {
+        accState = m->findAccidental(n);
+    }
     if (up && pitch < 127) {
         newPitch = pitch + 1;
-        if (n->concertPitch()) {
-            if (tpc1 > Tpc::TPC_A + int(key)) {
+        if (concertPitch) {
+            if (tpc1 > Tpc::TPC_A + int(key) && noteAccVal >= accState) {
                 newTpc1 = tpc1 - 5;           // up semitone diatonic
             } else {
                 newTpc1 = tpc1 + 7;           // up semitone chromatic
             }
             newTpc2 = n->transposeTpc(newTpc1);
         } else {
-            if (tpc2 > Tpc::TPC_A + int(key)) {
+            if (tpc2 > Tpc::TPC_A + int(key) && noteAccVal >= accState) {
                 newTpc2 = tpc2 - 5;           // up semitone diatonic
             } else {
                 newTpc2 = tpc2 + 7;           // up semitone chromatic
@@ -1838,15 +1844,15 @@ static void upDownChromatic(bool up, int pitch, Note* n, Key key, int tpc1, int 
         }
     } else if (!up && pitch > 0) {
         newPitch = pitch - 1;
-        if (n->concertPitch()) {
-            if (tpc1 > Tpc::TPC_C + int(key)) {
+        if (concertPitch) {
+            if (tpc1 > Tpc::TPC_C + int(key) || noteAccVal > accState) {
                 newTpc1 = tpc1 - 7;           // down semitone chromatic
             } else {
                 newTpc1 = tpc1 + 5;           // down semitone diatonic
             }
             newTpc2 = n->transposeTpc(newTpc1);
         } else {
-            if (tpc2 > Tpc::TPC_C + int(key)) {
+            if (tpc2 > Tpc::TPC_C + int(key) || noteAccVal > accState) {
                 newTpc2 = tpc2 - 7;           // down semitone chromatic
             } else {
                 newTpc2 = tpc2 + 5;           // down semitone diatonic


### PR DESCRIPTION


Resolves: #23809 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
if note with double or triple accidentals is present in score (or souch key signature), user should be able to achieve souch note by up / down arrow keys


https://github.com/user-attachments/assets/40580a33-a830-4b0d-9ac9-f188c91f6531


<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
