### PR TITLE
Fix showing ledger lines in percussion input panel

### DIFF
--- a/src/engraving/rendering/single/singlelayout.cpp
+++ b/src/engraving/rendering/single/singlelayout.cpp
@@ -778,6 +778,7 @@ void SingleLayout::layout(Chord* item, const Context& ctx)
     ChordLayout::computeUp(item, tctx);
     ChordLayout::layout(item, tctx);
     ChordLayout::layoutStem(item, tctx);
+    ChordLayout::layoutLedgerLines({ item });
 }
 
 void SingleLayout::layout(ChordLine* item, const Context& ctx)


### PR DESCRIPTION
Regression caused probably by 3a859a602165886e954ba12ca4b5a2a332f3d2cd

This shows a slight issue: of course we don't want to duplicate a lot of layout code in SingleLayout, so we reuse the "normal" layout code; but that means we need to be careful when modifying that normal code, because otherwise we might break palette layout.

Resolves: https://github.com/musescore/MuseScore/issues/23104