### PR TITLE
Returned fontengine=freetype for Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .idea
 .vscode/
 /builds
+build
 /build_overrides.cmake
 build.release
 build.debug

--- a/src/app/configs/qt_win.conf
+++ b/src/app/configs/qt_win.conf
@@ -2,5 +2,4 @@
 Prefix=./
 
 [Platforms]
-#For Qt6, semi-bold looks like bold
-#WindowsArguments = fontengine=freetype
+WindowsArguments = fontengine=freetype


### PR DESCRIPTION
This is a rollback of the solution to the problem: [[Qt6 migration] Palette names are bold and other font differences on Windows ](https://github.com/musescore/MuseScore/issues/23430)

But this should eliminate these problems that arose after this solution: 
* #23692
* #23689
* #23655