### PR TITLE
Try what happens when we don't disable ASLR on Windows

### DIFF
--- a/buildscripts/cmake/SetupBuildEnvironment.cmake
+++ b/buildscripts/cmake/SetupBuildEnvironment.cmake
@@ -34,7 +34,6 @@ elseif(CC_IS_MSVC)
     set(CMAKE_C_FLAGS_DEBUG             "/MT /Zi /Ob0 /Od /RTC1")
     set(CMAKE_C_FLAGS_RELEASE           "/MT /O2 /Ob2")
     set(CMAKE_C_FLAGS_RELWITHDEBINFO    "/MT /Zi /O2 /Ob1")
-    set(CMAKE_EXE_LINKER_FLAGS          "/DYNAMICBASE:NO")
 
     add_definitions(-DWIN32)
     add_definitions(-D_WINDOWS)


### PR DESCRIPTION
Address Space Layout Randomization drastically reduces the exploitability of problems like buffer overflows. It is enabled by default, but for a reason unknown to me, we explicitly disable it. Let's see what happens if we simply don't.

Resolves: https://github.com/musescore/MuseScore/pull/23654#issuecomment-2258842795