### PR TITLE
fluid_wrong_note_duration

### DIFF
--- a/src/framework/audio/internal/abstracteventsequencer.h
+++ b/src/framework/audio/internal/abstracteventsequencer.h
@@ -163,11 +163,12 @@ public:
             return result;
         }
 
+        // Empty sequence means to continue the previous sequence
+        result.emplace(m_playbackPosition, EventSequence());
+
         if (m_currentMainSequenceIt == m_mainStreamEvents.cend()) {
             return result;
         }
-
-        result.emplace(m_playbackPosition, EventSequence());
 
         m_playbackPosition += nextMsecs;
 
@@ -227,7 +228,7 @@ protected:
     void handleMainStream(EventSequenceMap& result)
     {
         while (m_currentMainSequenceIt != m_mainStreamEvents.end()
-               && m_currentMainSequenceIt->first < m_playbackPosition) {
+               && m_currentMainSequenceIt->first <= m_playbackPosition) {
             EventSequence& sequence = result[m_currentMainSequenceIt->first];
             sequence.insert(m_currentMainSequenceIt->second.cbegin(),
                             m_currentMainSequenceIt->second.cend());
@@ -242,7 +243,7 @@ protected:
         }
 
         while (m_currentDynamicsIt != m_dynamicEvents.end()
-               && m_currentDynamicsIt->first < m_playbackPosition) {
+               && m_currentDynamicsIt->first <= m_playbackPosition) {
             EventSequence& sequence = result[m_currentDynamicsIt->first];
             sequence.insert(m_currentDynamicsIt->second.cbegin(),
                             m_currentDynamicsIt->second.cend());


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/23812

Caused by https://github.com/musescore/MuseScore/pull/22791/commits/db138b7614234bcfa8565a6996c7f082e86df686