### PR TITLE
Fix crash on select ornament accidental

### DIFF
--- a/src/inspector/models/notation/accidentals/accidentalsettingsmodel.cpp
+++ b/src/inspector/models/notation/accidentals/accidentalsettingsmodel.cpp
@@ -126,7 +126,7 @@ void AccidentalSettingsModel::updateIsStackingOrderAvailableAndEnabled()
     setIsStackingOrderEnabled(m_elementList.size() == 1);
 
     for (EngravingItem* item : m_elementList) {
-        if (!item->isAccidental()) {
+        if (!item->isAccidental() || !toAccidental(item)->note()) {
             continue;
         }
         setIsStackingOrderEnabled(item->addToSkyline());


### PR DESCRIPTION
Resolves: #23860 

Its parent is an Ornament in this case, not a Note.
