### PR TITLE
fix non-unity builds

### DIFF
--- a/src/notation/internal/notationaccessibility.cpp
+++ b/src/notation/internal/notationaccessibility.cpp
@@ -169,16 +169,16 @@ QString NotationAccessibility::rangeAccessibilityInfo() const
 
     QString start = muse::qtrc("engraving", "Start measure: %1").arg(String::number(startBarbeat.bar));
     if (startBarbeat.displayedBar != startBarbeat.bar) {
-        start += u"; " + muse::qtrc("engraving", "Start displayed measure: %1").arg(startBarbeat.displayedBar);
+        start += "; " + muse::qtrc("engraving", "Start displayed measure: %1").arg(startBarbeat.displayedBar);
     }
-    start += u"; " + muse::qtrc("engraving", "Start beat: %1").arg(startBarbeat.beat);
+    start += "; " + muse::qtrc("engraving", "Start beat: %1").arg(startBarbeat.beat);
 
     EngravingItem::BarBeat endBarbeat = endSegment->barbeat();
     QString end = muse::qtrc("engraving", "End measure: %1").arg(String::number(endBarbeat.bar));
     if (endBarbeat.displayedBar != endBarbeat.bar) {
-        end += u"; " + muse::qtrc("engraving", "End displayed measure: %1").arg(endBarbeat.displayedBar);
+        end += "; " + muse::qtrc("engraving", "End displayed measure: %1").arg(endBarbeat.displayedBar);
     }
-    end += u"; " + muse::qtrc("engraving", "End beat: %1").arg(endBarbeat.beat);
+    end += "; " + muse::qtrc("engraving", "End beat: %1").arg(endBarbeat.beat);
 
     return muse::qtrc("notation", "Range selection; %1; %2")
            .arg(start)

--- a/src/notation/internal/notationconfiguration.cpp
+++ b/src/notation/internal/notationconfiguration.cpp
@@ -33,6 +33,7 @@ using namespace mu;
 using namespace mu::notation;
 using namespace muse;
 using namespace muse::async;
+using namespace muse::draw;
 using namespace muse::ui;
 
 static const std::string module_name("notation");

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -34,6 +34,7 @@
 #include "translation.h"
 
 #include "cloud/clouderrors.h"
+#include "cloud/cloudqmltypes.h"
 #include "engraving/infrastructure/mscio.h"
 #include "engraving/engravingerrors.h"
 


### PR DESCRIPTION
This fixes non-unity builds (`-DMUE_COMPILE_USE_UNITY=OFF`).

These are slower builds, but can be useful because:
 - faster edit-compile-test cycles (especially with the crazy fast `lld` linker `-DCMAKE_CXX_FLAGS="-fuse-ld=lld"`).
 - allows CMake to generate correct `compile_commands.json` which is the best for Intellisense on VS Code.


<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
