### PR TITLE
Don't fill shape for rests that are not drawn

### DIFF
--- a/src/engraving/rendering/dev/chordlayout.cpp
+++ b/src/engraving/rendering/dev/chordlayout.cpp
@@ -3524,7 +3524,7 @@ void ChordLayout::fillShape(const Rest* item, Rest::LayoutData* ldata)
 {
     Shape shape(Shape::Type::Composite);
 
-    if (!item->isGap()) {
+    if (!item->isGap() && !item->shouldNotBeDrawn()) {
         shape.add(chordRestShape(item));
         shape.add(item->symBbox(ldata->sym), item);
         for (const NoteDot* dot : item->dotList()) {


### PR DESCRIPTION
Resolves: #19204 

This issue is likely unrelated to #19850. In this case, it is just a matter of not creating shapes (and adding them to skylines) for rests that aren't drawn.
<img width="350" alt="image" src="https://github.com/user-attachments/assets/6e12a859-4fa5-4827-b554-756d5dee934c">
