### PR TITLE
Allow popup tooltips to pop Up

### DIFF
--- a/src/framework/uicomponents/view/popupview.h
+++ b/src/framework/uicomponents/view/popupview.h
@@ -65,6 +65,7 @@ class PopupView : public QObject, public QQmlParserStatus, public Injectable, pu
 
     Q_PROPERTY(bool showArrow READ showArrow WRITE setShowArrow NOTIFY showArrowChanged)
     Q_PROPERTY(int padding READ padding WRITE setPadding NOTIFY paddingChanged)
+    Q_PROPERTY(Placement placement READ placement WRITE setPlacement NOTIFY placementChanged)
 
     Q_PROPERTY(QQuickItem * anchorItem READ anchorItem WRITE setAnchorItem NOTIFY anchorItemChanged)
     Q_PROPERTY(bool opensUpward READ opensUpward NOTIFY opensUpwardChanged)
@@ -114,6 +115,12 @@ public:
     Q_DECLARE_FLAGS(ClosePolicies, ClosePolicy)
     Q_FLAG(ClosePolicies)
 
+    enum Placement {
+        Below,
+        Above
+    };
+    Q_ENUM(Placement)
+
     QQuickItem* parentItem() const;
 
     QQuickItem* contentItem() const;
@@ -140,6 +147,7 @@ public:
 
     OpenPolicies openPolicies() const;
     ClosePolicies closePolicies() const;
+    Placement placement() const;
 
     bool activateParentOnClose() const;
 
@@ -175,6 +183,7 @@ public slots:
     void setLocalY(qreal y);
     void setOpenPolicies(muse::uicomponents::PopupView::OpenPolicies openPolicies);
     void setClosePolicies(muse::uicomponents::PopupView::ClosePolicies closePolicies);
+    void setPlacement(muse::uicomponents::PopupView::Placement newPlacement);
     void setNavigationParentControl(ui::INavigationControl* parentNavigationControl);
     void setObjectId(QString objectId);
     void setTitle(QString title);
@@ -202,6 +211,7 @@ signals:
     void yChanged(qreal y);
     void openPoliciesChanged(muse::uicomponents::PopupView::OpenPolicies openPolicies);
     void closePoliciesChanged(muse::uicomponents::PopupView::ClosePolicies closePolicies);
+    void placementChanged(muse::uicomponents::PopupView::Placement placement);
     void navigationParentControlChanged(ui::INavigationControl* navigationParentControl);
     void objectIdChanged(QString objectId);
     void titleChanged(QString title);
@@ -280,6 +290,8 @@ protected:
     bool m_isContentReady = false;
 
     ClosePolicies m_closePolicies = { ClosePolicy::CloseOnPressOutsideParent };
+
+    Placement m_placement = { Placement::Below };
 
     bool m_activateParentOnClose = true;
     ui::INavigationControl* m_navigationParentControl = nullptr;


### PR DESCRIPTION
Add `Placement` property to PopupView allowing to set preferred popup placement: above or below the target

Let me know if there is a better name for the property

Example:
```placement: PopupView.Below``` **[default]**
![image](https://github.com/user-attachments/assets/e0586218-ea37-4fbe-abc7-56a4a6eb8275)


```placement: PopupView.Above```

![image](https://github.com/user-attachments/assets/9b8a1e72-876d-4800-b638-d3a9955203f2)

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
