### PR TITLE
Don't skip gap rests when entering notes (#17931 & #21355) 

### DIFF
--- a/src/engraving/dom/cmd.cpp
+++ b/src/engraving/dom/cmd.cpp
@@ -2956,7 +2956,9 @@ EngravingItem* Score::move(const String& cmd)
         // find next chordrest, which might be a grace note
         // this may override note input cursor
         el = nextChordRest(cr);
-        while (el && el->isRest() && toRest(el)->isGap()) {
+
+        // Skip gap rests if we're not in note entry mode...
+        while (!noteEntryMode() && el && el->isRest() && toRest(el)->isGap()) {
             el = nextChordRest(toChordRest(el));
         }
         if (el && noteEntryMode()) {
@@ -2998,7 +3000,9 @@ EngravingItem* Score::move(const String& cmd)
         // find previous chordrest, which might be a grace note
         // this may override note input cursor
         el = prevChordRest(cr);
-        while (el && el->isRest() && toRest(el)->isGap()) {
+
+        // Skip gap rests if we're not in note entry mode...
+        while (!noteEntryMode() && el && el->isRest() && toRest(el)->isGap()) {
             el = prevChordRest(toChordRest(el));
         }
         if (el && noteEntryMode()) {

--- a/src/engraving/dom/input.cpp
+++ b/src/engraving/dom/input.cpp
@@ -319,16 +319,11 @@ Segment* InputState::nextInputPos() const
 {
     Measure* m = m_segment->measure();
     Segment* s = m_segment->next1(SegmentType::ChordRest);
-    for (; s; s = s->next1(SegmentType::ChordRest)) {
-        if (s->element(m_track)) {
-            if (s->element(m_track)->isRest() && toRest(s->element(m_track))->isGap()) {
-                m = s->measure();
-            } else {
-                return s;
-            }
-        } else if (s->measure() != m) {
+    while (s) {
+        if (s->element(m_track) || s->measure() != m) {
             return s;
         }
+        s = s->next1(SegmentType::ChordRest);
     }
     return 0;
 }

--- a/src/notation/internal/notationnoteinput.cpp
+++ b/src/notation/internal/notationnoteinput.cpp
@@ -455,12 +455,6 @@ void NotationNoteInput::setCurrentVoice(voice_idx_t voiceIndex)
 
     mu::engraving::InputState& inputState = score()->inputState();
     inputState.setVoice(voiceIndex);
-
-    if (inputState.segment()) {
-        mu::engraving::Segment* segment = inputState.segment()->measure()->first(mu::engraving::SegmentType::ChordRest);
-        inputState.setSegment(segment);
-    }
-
     notifyAboutStateChanged();
 }
 


### PR DESCRIPTION
Resolves: #17931
Resolves: #21355

Also improves input cursor logic when switching voices (first point in [this comment](https://github.com/musescore/MuseScore/pull/23911#issuecomment-2269583163)).