### PR TITLE
Add tooltip delay to Theme API

### DIFF
--- a/src/framework/ui/api/themeapi.cpp
+++ b/src/framework/ui/api/themeapi.cpp
@@ -344,6 +344,11 @@ int ThemeApi::flickableMaxVelocity() const
     return configuration()->flickableMaxVelocity();
 }
 
+int ThemeApi::tooltipDelay() const
+{
+    return configuration()->tooltipDelay();
+}
+
 void ThemeApi::initUiFonts()
 {
     setupUiFonts();

--- a/src/framework/ui/api/themeapi.h
+++ b/src/framework/ui/api/themeapi.h
@@ -88,6 +88,8 @@ class ThemeApi : public api::ApiObject, public async::Asyncable
 
     Q_PROPERTY(int flickableMaxVelocity READ flickableMaxVelocity CONSTANT)
 
+    Q_PROPERTY(int tooltipDelay READ tooltipDelay CONSTANT)
+
 public:
 
     Inject<ui::IUiConfiguration> configuration = { this };
@@ -145,6 +147,8 @@ public:
     qreal itemOpacityDisabled() const;
 
     int flickableMaxVelocity() const;
+
+    int tooltipDelay() const;
 
 signals:
     void themeChanged();

--- a/src/framework/ui/internal/uiconfiguration.cpp
+++ b/src/framework/ui/internal/uiconfiguration.cpp
@@ -55,6 +55,8 @@ static const QString WINDOW_GEOMETRY_KEY("window");
 
 static const int FLICKABLE_MAX_VELOCITY = 1500;
 
+static const int TOOLTIP_DELAY = 500;
+
 void UiConfiguration::init()
 {
     settings()->setDefaultValue(UI_CURRENT_THEME_CODE_KEY, Val(LIGHT_THEME_CODE));
@@ -782,4 +784,9 @@ void UiConfiguration::updateToolConfig(const QString& toolName, ToolConfig& user
 int UiConfiguration::flickableMaxVelocity() const
 {
     return FLICKABLE_MAX_VELOCITY;
+}
+
+int UiConfiguration::tooltipDelay() const
+{
+    return TOOLTIP_DELAY;
 }

--- a/src/framework/ui/internal/uiconfiguration.h
+++ b/src/framework/ui/internal/uiconfiguration.h
@@ -117,6 +117,8 @@ public:
 
     int flickableMaxVelocity() const override;
 
+    int tooltipDelay() const override;
+
 private:
     void initThemes();
     void notifyAboutCurrentThemeChanged();

--- a/src/framework/ui/iuiconfiguration.h
+++ b/src/framework/ui/iuiconfiguration.h
@@ -111,6 +111,8 @@ public:
     virtual async::Notification toolConfigChanged(const QString& toolName) const = 0;
 
     virtual int flickableMaxVelocity() const = 0;
+
+    virtual int tooltipDelay() const = 0;
 };
 }
 

--- a/src/framework/ui/tests/CMakeLists.txt
+++ b/src/framework/ui/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ set(MODULE_TEST muse_ui_tests)
 set(MODULE_TEST_SRC
     ${CMAKE_CURRENT_LIST_DIR}/environment.cpp
     ${CMAKE_CURRENT_LIST_DIR}/mocks/navigationmocks.h
+    ${CMAKE_CURRENT_LIST_DIR}/mocks/uiconfigurationmock.h
     ${CMAKE_CURRENT_LIST_DIR}/mocks/mainwindowmock.h
 
     ${CMAKE_CURRENT_LIST_DIR}/navigationcontroller_tests.cpp

--- a/src/framework/ui/tests/mocks/uiconfigurationmock.h
+++ b/src/framework/ui/tests/mocks/uiconfigurationmock.h
@@ -1,0 +1,104 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2024 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef MUSE_UI_UICONFIGURATIONMOCK_H
+#define MUSE_UI_UICONFIGURATIONMOCK_H
+
+#include <gmock/gmock.h>
+
+#include "ui/iuiconfiguration.h"
+
+namespace muse::ui {
+class UiConfigurationMock : public IUiConfiguration
+{
+public:
+    MOCK_METHOD(ThemeList, themes, (), (const, override));
+
+    MOCK_METHOD(QStringList, possibleFontFamilies, (), (const, override));
+    MOCK_METHOD(QStringList, possibleAccentColors, (), (const, override));
+
+    MOCK_METHOD(bool, isDarkMode, (), (const, override));
+    MOCK_METHOD(void, setIsDarkMode, (bool), (override));
+
+    MOCK_METHOD(bool, isHighContrast, (), (const, override));
+    MOCK_METHOD(void, setIsHighContrast, (bool), (override));
+
+    MOCK_METHOD(const ThemeInfo&, currentTheme, (), (const, override));
+    MOCK_METHOD(async::Notification, currentThemeChanged, (), (const, override));
+    MOCK_METHOD(void, setCurrentTheme, (const ThemeCode&), (override));
+    MOCK_METHOD(void, setCurrentThemeStyleValue, (ThemeStyleKey, const Val&), (override));
+    MOCK_METHOD(void, resetThemes, (), (override));
+
+    MOCK_METHOD(bool, isFollowSystemThemeAvailable, (), (const, override));
+    MOCK_METHOD(ValNt<bool>, isFollowSystemTheme, (), (const, override));
+    MOCK_METHOD(void, setFollowSystemTheme, (bool), (override));
+
+    MOCK_METHOD(std::string, fontFamily, (), (const, override));
+    MOCK_METHOD(void, setFontFamily, (const std::string&), (override));
+    MOCK_METHOD(int, fontSize, (FontSizeType), (const, override));
+    MOCK_METHOD(void, setBodyFontSize, (int), (override));
+    MOCK_METHOD(async::Notification, fontChanged, (), (const, override));
+
+    MOCK_METHOD(std::string, iconsFontFamily, (), (const, override));
+    MOCK_METHOD(int, iconsFontSize, (IconSizeType), (const, override));
+    MOCK_METHOD(async::Notification, iconsFontChanged, (), (const, override));
+
+    MOCK_METHOD(std::string, musicalFontFamily, (), (const, override));
+    MOCK_METHOD(int, musicalFontSize, (), (const, override));
+    MOCK_METHOD(async::Notification, musicalFontChanged, (), (const, override));
+
+    MOCK_METHOD(std::string, defaultFontFamily, (), (const, override));
+    MOCK_METHOD(int, defaultFontSize, (), (const, override));
+
+    MOCK_METHOD(void, resetFonts, (), (override));
+
+    MOCK_METHOD(double, guiScaling, (), (const, override));
+    MOCK_METHOD(double, physicalDpi, (), (const, override));
+    MOCK_METHOD(double, logicalDpi, (), (const, override));
+
+    MOCK_METHOD(void, setPhysicalDotsPerInch, (std::optional<double>), (override));
+
+    MOCK_METHOD(ValNt<QByteArray>, pageState, (const QString&), (const, override));
+    MOCK_METHOD(void, setPageState, (const QString&, const QByteArray&), (override));
+
+    MOCK_METHOD(QByteArray, windowGeometry, (), (const, override));
+    MOCK_METHOD(void, setWindowGeometry, (const QByteArray&), (override));
+    MOCK_METHOD(async::Notification, windowGeometryChanged, (), (const, override));
+
+    MOCK_METHOD(bool, isGlobalMenuAvailable, (), (const, override));
+
+    MOCK_METHOD(void, applyPlatformStyle, (QWindow*), (override));
+
+    MOCK_METHOD(bool, isVisible, (const QString&, bool), (const, override));
+    MOCK_METHOD(void, setIsVisible, (const QString&, bool), (override));
+    MOCK_METHOD(async::Notification, isVisibleChanged, (const QString&), (const, override));
+
+    MOCK_METHOD(ToolConfig, toolConfig, (const QString&, const ToolConfig&), (const, override));
+    MOCK_METHOD(void, setToolConfig, (const QString&, const ToolConfig&), (override));
+    MOCK_METHOD(async::Notification, toolConfigChanged, (const QString&), (const, override));
+
+    MOCK_METHOD(int, flickableMaxVelocity, (), (const, override));
+
+    MOCK_METHOD(int, tooltipDelay, (), (const, override));
+};
+}
+
+#endif // MUSE_UI_UICONFIGURATIONMOCK_H

--- a/src/framework/ui/tests/qmltooltip_tests.cpp
+++ b/src/framework/ui/tests/qmltooltip_tests.cpp
@@ -23,8 +23,12 @@
 
 #include "ui/view/qmltooltip.h"
 
+#include "ui/tests/mocks/uiconfigurationmock.h"
+
 using namespace muse;
 using namespace muse::ui;
+
+using ::testing::Return;
 
 namespace muse::ui {
 class QmlToolTipTests : public ::testing::Test, public QObject
@@ -41,6 +45,12 @@ public:
         QObject::connect(m_tooltip, &QmlToolTip::hideToolTip, this, [this]() {
             m_isToolTipShown = false;
         });
+
+        m_uiConfiguration = std::make_shared<muse::ui::UiConfigurationMock>();
+        m_tooltip->uiConfiguration.set(m_uiConfiguration);
+
+        EXPECT_CALL(*m_uiConfiguration, tooltipDelay())
+        .WillRepeatedly(Return(500));
     }
 
     void TearDown() override
@@ -74,6 +84,7 @@ protected:
     }
 
     QmlToolTip* m_tooltip = nullptr;
+    std::shared_ptr<muse::ui::UiConfigurationMock> m_uiConfiguration;
     bool m_isToolTipShown = false;
 };
 

--- a/src/framework/ui/view/qmltooltip.cpp
+++ b/src/framework/ui/view/qmltooltip.cpp
@@ -23,8 +23,6 @@
 
 #include <QGuiApplication>
 
-static constexpr int INTERVAL = 500;
-
 using namespace muse::ui;
 
 QmlToolTip::QmlToolTip(QObject* parent, const modularity::ContextPtr& iocCtx)
@@ -60,7 +58,7 @@ void QmlToolTip::show(QQuickItem* item, const QString& title, const QString& des
     }
 
     if (toolTipNotOpened || openTimerStarted) {
-        m_openTimer.start(INTERVAL);
+        m_openTimer.start(uiConfiguration()->tooltipDelay());
     } else {
         doShow();
     }
@@ -79,7 +77,7 @@ void QmlToolTip::hide(QQuickItem* item, bool force)
         return;
     }
 
-    m_closeTimer.start(INTERVAL);
+    m_closeTimer.start(uiConfiguration()->tooltipDelay());
 }
 
 void QmlToolTip::init()

--- a/src/framework/ui/view/qmltooltip.h
+++ b/src/framework/ui/view/qmltooltip.h
@@ -30,6 +30,7 @@
 
 #include "modularity/ioc.h"
 #include "ui/iinteractiveprovider.h"
+#include "ui/iuiconfiguration.h"
 
 namespace muse::ui {
 class QmlToolTip : public QObject, public Injectable, public async::Asyncable
@@ -37,6 +38,7 @@ class QmlToolTip : public QObject, public Injectable, public async::Asyncable
     Q_OBJECT
 
     Inject<IInteractiveProvider> interactiveProvider = { this };
+    Inject<IUiConfiguration> uiConfiguration = { this };
 
 public:
     explicit QmlToolTip(QObject* parent, const modularity::ContextPtr& iocCtx);


### PR DESCRIPTION
Add tooltip delay to Theme API to make it available to different tooltip implementations

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
