### PR TITLE
Fix another anchor crash

### DIFF
--- a/src/engraving/dom/line.cpp
+++ b/src/engraving/dom/line.cpp
@@ -474,6 +474,10 @@ Segment* LineSegment::findSegmentForGrip(Grip grip, PointF pos) const
         sys = foundSystems[0];
     }
 
+    if (!sys) {
+        return nullptr;
+    }
+
     // Restrict searching segment to the correct staff
     pos.setY(sys->staffCanvasYpage(oldStaffIndex));
 


### PR DESCRIPTION
Resolves: #22934 

It is possible during the dragging operations for that System* pointer to be temporarily null, so we must check before using it.