### PR TITLE
Fix mnemonics in Format menu

### DIFF
--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -1422,13 +1422,13 @@ const UiActionList NotationUiActions::m_actions = {
     UiAction("reset",
              mu::context::UiCtxNotationOpened,
              mu::context::CTX_ANY,
-             TranslatableString("action", "Reset shapes and &positions"),
+             TranslatableString("action", "Reset s&hapes and positions"),
              TranslatableString("action", "Reset shapes and positions")
              ),
     UiAction("reset-to-default-layout",
              mu::context::UiCtxNotationOpened,
              mu::context::CTX_ANY,
-             TranslatableString("action", "Reset entire score to default layout"),
+             TranslatableString("action", "Reset entire score to &default layout"),
              TranslatableString("action", "Reset entire score to default layout")
              ),
     UiAction("zoomin",


### PR DESCRIPTION
Resolves: #23705 

Fix mnemonic letter for "Reset shapes and position"  and "Reset entire score to default layout" in Format Menu.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
