### PR TITLE
Fix nested tuplet crash

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -1062,6 +1062,11 @@ static void handleTupletStop(Tuplet*& tuplet, const int normalNotes)
     tuplet->setBaseLen(td);
     Fraction f(normalNotes, td.fraction().denominator());
     f.reduce();
+    if (!f.isValid()) {
+        LOGD("MusicXML::import: tuplet stop but note values too small");
+        tuplet = nullptr;
+        return;
+    }
     tuplet->setTicks(f);
     // TODO determine usefulness of following check
     int totalDuration = 0;


### PR DESCRIPTION
Resolves: A niche crash on quadruply nested tuplets with the top tuplet having a ratio of <1.  This still produces corrupt scores as most XML nested tuplets produce.