### PR TITLE
Fix #23876: Incorrect bitrate calculation

### DIFF
--- a/src/framework/audio/internal/encoders/wavencoder.cpp
+++ b/src/framework/audio/internal/encoders/wavencoder.cpp
@@ -48,7 +48,7 @@ struct WavHeader {
         const uint32_t file_length = headerLength + sampleDataLength;
         const uint32_t overallSize = file_length - 8;
         const uint32_t bytesPerFrame = audioChannelsNumber * bytesPerSample;
-        const uint32_t bytesPerSec = sampleRate * bytesPerSample;
+        const uint32_t bytesPerSec = audioChannelsNumber * sampleRate * bytesPerSample;
 
         stream.write("RIFF", 4); // chunk ID
 


### PR DESCRIPTION
Resolves: #23876
Resolves: https://github.com/musescore/MuseScore/issues/23606

Number of channels needs to be taken into account when calculating bitrate.