### PR TITLE
Make text of textlines follow voice assignment colour

### DIFF
--- a/src/engraving/dom/spanner.cpp
+++ b/src/engraving/dom/spanner.cpp
@@ -281,10 +281,10 @@ void SpannerSegment::undoChangeProperty(Pid pid, const PropertyValue& val, Prope
 
 void SpannerSegment::setSelected(bool f)
 {
-    for (SpannerSegment* ss : m_spanner->spannerSegments()) {
-        ss->EngravingItem::setSelected(f);
+    EngravingItem::setSelected(f);
+    if (spanner()->selected() != f) {
+        spanner()->setSelected(f);
     }
-    m_spanner->setSelected(f);
 }
 
 //---------------------------------------------------------
@@ -1155,10 +1155,13 @@ Measure* Spanner::endMeasure() const
 
 void Spanner::setSelected(bool f)
 {
-    for (SpannerSegment* ss : spannerSegments()) {
-        ss->EngravingItem::setSelected(f);
-    }
     EngravingItem::setSelected(f);
+
+    for (SpannerSegment* ss : spannerSegments()) {
+        if (ss->selected() != f) {
+            ss->setSelected(f);
+        }
+    }
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/text.cpp
+++ b/src/engraving/dom/text.cpp
@@ -64,10 +64,31 @@ engraving::PropertyValue Text::propertyDefault(Pid id) const
     }
 }
 
+PropertyValue Text::getProperty(Pid id) const
+{
+    switch (id) {
+    case Pid::VOICE_ASSIGNMENT:
+        if (hasVoiceAssignmentProperties()) {
+            return parentItem()->getProperty(id);
+        }
+    default:
+        return TextBase::getProperty(id);
+    }
+}
+
 String Text::readXmlText(XmlReader& xml, Score* score)
 {
     Text t(score->dummy());
     rw::RWRegister::reader()->readItem(&t, xml);
     return t.xmlText();
+}
+
+bool Text::hasVoiceAssignmentProperties() const
+{
+    const EngravingItem* parent = parentItem();
+    if (parent && parent->isTextLineBaseSegment()) {
+        return parent->hasVoiceAssignmentProperties();
+    }
+    return false;
 }
 }

--- a/src/engraving/dom/text.h
+++ b/src/engraving/dom/text.h
@@ -40,10 +40,14 @@ public:
     Text* clone() const override { return new Text(*this); }
 
     PropertyValue propertyDefault(Pid id) const override;
+    PropertyValue getProperty(Pid id) const override;
 
     static String readXmlText(XmlReader& r, Score* score);
 
     void setLayoutToParentWidth(bool v) { m_layoutToParentWidth = v; }
+
+    bool hasVoiceAssignmentProperties() const override;
+    VoiceAssignment voiceAssignment() const;
 
 private:
     friend class Factory;


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/23937

Text items get their voice assignment property from their parent if their parent is a text line segment.
