### PR TITLE
Add / del key signatures in part apply to all staves in score

### DIFF
--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -3567,6 +3567,25 @@ void Score::cmdDeleteSelection()
             for (EngravingObject* se : links) {
                 deletedElements.insert(se);
             }
+
+            // when deleting "global key signature" in part,
+            // make sure all key signatures in score will be deleted too
+            // (part score doesn't need to contain all staves)
+            if (e->isKeySig() && !score()->isMaster() && toSegment(e->explicitParent())->empty()) {
+                for (EngravingObject* linkedSig : links) {
+                    Score* score = linkedSig->score();
+                    if (score->isMaster()) {
+                        Segment* keySeg = toSegment(linkedSig->explicitParent());
+                        for (staff_idx_t i = 0; i < score->nstaves(); ++i) {
+                            track_idx_t track = i * VOICES;
+                            if (EngravingItem* sig = keySeg->element(track)) {
+                                score->deleteItem(sig);
+                            }
+                        }
+                        break;
+                    }
+                }
+            }
         }
     }
 

--- a/src/engraving/dom/measure.cpp
+++ b/src/engraving/dom/measure.cpp
@@ -1508,7 +1508,7 @@ EngravingItem* Measure::drop(EditData& data)
             score()->undoChangeKeySig(staff, tick(), k);
         } else {
             // apply to all staves:
-            for (Staff* s : score()->staves()) {
+            for (Staff* s : score()->masterScore()->staves()) {
                 score()->undoChangeKeySig(s, tick(), k);
             }
         }


### PR DESCRIPTION
Resolves: #23934 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
Both cases have same root - there are no all staves in part score

### adding in part (first commit)
it should act from master score (as master score contains all parts)
(it may look weired, `undoChangeKeySig` is called from part score, but in fact, there is no difference, if it is called from any score; and exactly same [code is alredy used on other place](https://github.com/musescore/MuseScore/blob/6d843753e8e22347be32ffaaabfd0388c43d2a78/src/engraving/dom/keysig.cpp#L96), so I used it here too)

### deleting in part (second commit)
this is a bit tricky. when deleting, it just deletes selected elements, so we need to consider, whether selected key signature(s) in part are "global" key signature (so all signatures in score should be removed):
- If all signatures in part are deleted, we guess, it is intended to be "global" signature, so we delete also all signatures in score

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
