### PR TITLE
Fix compiler warnings about PolygonX constructors

### DIFF
--- a/src/framework/draw/types/geometry.h
+++ b/src/framework/draw/types/geometry.h
@@ -446,10 +446,15 @@ class PolygonX : public std::vector<PointX<T> >
 {
 public:
 
-    inline PolygonX<T>() = default;
-    inline PolygonX<T>(const std::vector<PointX<T> >& v) : std::vector<PointX<T> >(v) {
+    inline PolygonX() = default;
+    inline PolygonX(const std::vector<PointX<T> >& v)
+        : std::vector<PointX<T> >(v)
+    {
     }
-    inline PolygonX<T>(size_t size) : std::vector<PointX<T> >(size) {
+
+    inline PolygonX(size_t size)
+        : std::vector<PointX<T> >(size)
+    {
     }
 
     inline PolygonX<T>& operator<<(const PointX<T>& p)


### PR DESCRIPTION
g++ 14.1.1 has a `-Wtemplate-id-cdtor` warning that complains _constantly_ about the PolygonX constructors in `geometry.h`, which are incorrectly specified.

```text
.../src/framework/draw/types/geometry.h:449:23: warning: template-id not allowed for constructor in C++20 [-Wtemplate-id-cdtor]
  449 |     inline PolygonX<T>() = default;
      |                       ^
.../src/framework/draw/types/geometry.h:449:23: note: remove the ‘< >’
.../src/framework/draw/types/geometry.h:450:23: warning: template-id not allowed for constructor in C++20 [-Wtemplate-id-cdtor]
  450 |     inline PolygonX<T>(const std::vector<PointX<T> >& v) : std::vector<PointX<T> >(v) {
      |                       ^
.../src/framework/draw/types/geometry.h:450:23: note: remove the ‘< >’
.../src/framework/draw/types/geometry.h:452:24: warning: template-id not allowed for constructor in C++20 [-Wtemplate-id-cdtor]
  452 |     inline PolygonX<T>(size_t size) : std::vector<PointX<T> >(size) {
      |                        ^~~~~~
```


<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
