### PR TITLE
Handle Qt 6.7 changes to QKeyMapper::possibleKeys, with backwards compatibility

### DIFF
--- a/src/appshell/view/navigableappmenumodel.cpp
+++ b/src/appshell/view/navigableappmenumodel.cpp
@@ -33,23 +33,36 @@ using namespace mu::appshell;
 using namespace muse::ui;
 using namespace muse::uicomponents;
 
+QSet<int> convertToSet(QList<int> keys)
+{
+    return QSet<int>(keys.cbegin(), keys.cend());
+}
+
+QSet<int> convertToSet(QList<QKeyCombination> keys)
+{
+    QSet<int> keyset;
+    for (const auto& key : keys) {
+        keyset << key.toCombined();
+    }
+    return keyset;
+}
+
 QSet<int> possibleKeys(QKeyEvent* keyEvent)
 {
     QKeyEvent* correctedKeyEvent = keyEvent;
     //! NOTE: correct work only with alt modifier
     correctedKeyEvent->setModifiers(Qt::AltModifier);
 
-    QList<int> keys = QKeyMapper::possibleKeys(correctedKeyEvent);
-
-    return QSet<int>(keys.cbegin(), keys.cend());
+    auto keys = QKeyMapper::possibleKeys(correctedKeyEvent);
+    return convertToSet(keys);
 }
 
 QSet<int> possibleKeys(const QChar& keySymbol)
 {
     QKeyEvent fakeKey(QKeyEvent::KeyRelease, Qt::Key_unknown, Qt::AltModifier, keySymbol);
-    QList<int> keys = QKeyMapper::possibleKeys(&fakeKey);
+    auto keys = QKeyMapper::possibleKeys(&fakeKey);
 
-    return QSet<int>(keys.cbegin(), keys.cend());
+    return convertToSet(keys);
 }
 
 NavigableAppMenuModel::NavigableAppMenuModel(QObject* parent)


### PR DESCRIPTION
Resolves: #23980

Qt 6.7 changes the return type of private `QKeyMapper::possibleKeys` from `QList<int>` to `QList<QKeyCombination>`. A QKeyCombination can easily be transformed into an `int` by calling its `.toCombined()` method.

Since MuseScore really _wants_ a `QSet<int>`, the return value must be transformed regardless. So, to avoid ugly ifdefs, I use `auto` for the variable that accepts the return from `possibleKeys()` (which will be either `QList<int>` or `QList<QKeyCombination>`), then call a newly-added function `convertToSet()` which has two overloads: one takes a `QList<QKeyCombination>`, the other a `QList<int>`, and both return `QSet<int>`. The correct one will be called based on what the current version of Qt returns from `QKeyMapper::possibleKeys()`.

This makes the code buildable with Qt 6.7, without affecting its compatibility with earlier versions.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
