### PR TITLE
Only layout cross-staff slurs within the updated layout range

### DIFF
--- a/src/engraving/rendering/dev/pagelayout.cpp
+++ b/src/engraving/rendering/dev/pagelayout.cpp
@@ -420,14 +420,18 @@ void PageLayout::collectPage(LayoutContext& ctx)
             continue;
         }
 
-        long int stick = system->firstMeasure()->tick().ticks();
-        long int etick = system->endTick().ticks();
+        Fraction stick = system->firstMeasure()->tick();
+        Fraction etick = system->endTick();
 
         IF_ASSERT_FAILED(stick < etick) {
             continue;
         }
 
-        auto spanners = ctx.dom().spannerMap().findOverlapping(stick, etick);
+        if (stick >= ctx.state().endTick() || etick <= ctx.state().startTick()) {
+            continue;
+        }
+
+        auto spanners = ctx.dom().spannerMap().findOverlapping(stick.ticks(), etick.ticks());
         for (auto interval : spanners) {
             Spanner* sp = interval.value;
             if (!sp->isSlur() || sp->tick() == system->endTick()) {


### PR DESCRIPTION
Resolves: #23889 

The double-slur glitches appear when triggering a relayout (for instance, trigger a layout on the last system of the last page and observe the double slurs appear on the preceding systems of that same page). This PR fixes that.
![image](https://github.com/user-attachments/assets/4bbe8609-a760-4708-baff-7dc1d7ed6bbd)


The reported issue with dynamic placement isn't really an issue as far as I can tell, it's just that the hairpin has some nonsensical manual offset applied to it. That offset probably used to be "canceled" by the layout system by forcing it to attach to the dynamic, hence why it wasn't apparent. Now that all of that logic has been rewritten, it's likely that these manual offsets aren't good/relevant anymore. A simple ctrl+R fixes it.
![image](https://github.com/user-attachments/assets/9eba60e4-0256-4f9e-b37f-e4d0f1ad55fc)
![image](https://github.com/user-attachments/assets/328ac35c-232b-43b8-a2bf-93eb65716137)

