### PR TITLE
Clear old system before laying out current system

### DIFF
--- a/src/engraving/rendering/dev/systemlayout.cpp
+++ b/src/engraving/rendering/dev/systemlayout.cpp
@@ -284,6 +284,10 @@ System* SystemLayout::collectSystem(LayoutContext& ctx)
             break;
         }
 
+        if (oldSystem && system != oldSystem && muse::contains(ctx.state().systemList(), oldSystem)) {
+            oldSystem->clear();
+        }
+
         if (ctx.state().prevMeasure() && ctx.state().prevMeasure()->isMeasure() && ctx.state().prevMeasure()->system() == system) {
             //
             // now we know that the previous measure is not the last


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/20841

Systems are cleared when they are fetched.  If a measure used to be on a later system and has moved to be on the current system, the later system must also be cleared before the current system's elements are laid out.  This frees spanner segments which will be reused.