### PR TITLE
Correct style definition for harp pedal text diagram

### DIFF
--- a/src/engraving/style/styledef.cpp
+++ b/src/engraving/style/styledef.cpp
@@ -891,7 +891,7 @@ const std::array<StyleDef::StyleValue, size_t(Sid::STYLES)> StyleDef::styleValue
     styleDef(harpPedalTextDiagramFrameWidth,             0.1),
     styleDef(harpPedalTextDiagramFrameRound,             0),
     styleDef(harpPedalTextDiagramFrameFgColor,           PropertyValue::fromValue(Color::BLACK)),
-    styleDef(harpPedalTextDiagramFrameFgColor,           PropertyValue::fromValue(Color::transparent)),
+    styleDef(harpPedalTextDiagramFrameBgColor,           PropertyValue::fromValue(Color::transparent)),
     styleDef(harpPedalTextDiagramOffset,                 PointF()),
     styleDef(harpPedalTextDiagramPlacement,              PlacementV::BELOW),
     styleDef(harpPedalTextDiagramPosAbove,               PointF(.0, -1.5)),


### PR DESCRIPTION
Fix: frame fill color style for harp text diagrams being lost after save/reload.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
