### PR TITLE
Items with custom x-offset (as opposed to y-offset) can still be centered

### DIFF
--- a/src/engraving/rendering/dev/systemlayout.cpp
+++ b/src/engraving/rendering/dev/systemlayout.cpp
@@ -2838,7 +2838,7 @@ void SystemLayout::centerElementsBetweenStaves(const System* system)
 
 bool SystemLayout::elementShouldBeCenteredBetweenStaves(const EngravingItem* item, const System* system)
 {
-    if (item->offset() != item->propertyDefault(Pid::OFFSET).value<PointF>()) {
+    if (item->offset().y() != item->propertyDefault(Pid::OFFSET).value<PointF>().y()) {
         // NOTE: because of current limitations of the offset system, we can't center an element that's been manually moved.
         return false;
     }


### PR DESCRIPTION
Resolves: hairpin loose staff-centering as soon as one of their endpoints is manually moved.