### PR TITLE
Reimplement ledger lines

### DIFF
--- a/src/engraving/dom/chord.h
+++ b/src/engraving/dom/chord.h
@@ -127,10 +127,9 @@ public:
     bool isUiItem() const { return m_isUiItem; }
     void setIsUiItem(bool val) { m_isUiItem = val; }
 
-    LedgerLine* ledgerLines() { return m_ledgerLines; }
-    const LedgerLine* ledgerLines() const { return m_ledgerLines; }
-    void setLedgerLine(LedgerLine* l) { m_ledgerLines = l; }
-    void addLedgerLines();
+    const std::vector<LedgerLine*>& ledgerLines() const { return m_ledgerLines; }
+    void resizeLedgerLinesTo(size_t newSize);
+    void updateLedgerLines();
 
     double defaultStemLength() const { return m_defaultStemLength; }
     void setDefaultStemLength(double l) { m_defaultStemLength = l; }
@@ -352,7 +351,7 @@ private:
     void processSiblings(std::function<void(EngravingItem*)> func, bool includeTemporarySiblings) const;
 
     std::vector<Note*> m_notes;           // sorted to decreasing line step
-    LedgerLine* m_ledgerLines = nullptr;  // single linked list
+    std::vector<LedgerLine*> m_ledgerLines;
 
     Stem* m_stem = nullptr;
     Hook* m_hook = nullptr;

--- a/src/engraving/dom/ledgerline.cpp
+++ b/src/engraving/dom/ledgerline.cpp
@@ -40,7 +40,6 @@ LedgerLine::LedgerLine(EngravingItem* s)
 {
     setSelectable(false);
     m_len        = 0.;
-    m_next       = 0;
 }
 
 LedgerLine::~LedgerLine()

--- a/src/engraving/dom/ledgerline.h
+++ b/src/engraving/dom/ledgerline.h
@@ -59,8 +59,6 @@ public:
     bool vertical() const { return m_vertical; }
 
     double measureXPos() const;
-    LedgerLine* next() const { return m_next; }
-    void setNext(LedgerLine* l) { m_next = l; }
 
     void spatiumChanged(double /*oldValue*/, double /*newValue*/) override;
 
@@ -72,7 +70,6 @@ public:
 private:
 
     double m_len = 0.0;
-    LedgerLine* m_next = nullptr;
     bool m_vertical = false;
 };
 } // namespace mu::engraving

--- a/src/engraving/dom/scoretree.cpp
+++ b/src/engraving/dom/scoretree.cpp
@@ -403,10 +403,8 @@ EngravingObjectList Chord::scanChildren() const
         children.push_back(m_stemSlash);
     }
 
-    LedgerLine* ledgerLines = m_ledgerLines;
-    while (ledgerLines) {
-        children.push_back(ledgerLines);
-        ledgerLines = ledgerLines->next();
+    for (LedgerLine* ledg : m_ledgerLines) {
+        children.push_back(ledg);
     }
 
     for (EngravingObject* child : ChordRest::scanChildren()) {

--- a/src/engraving/rendering/dev/accidentalslayout.cpp
+++ b/src/engraving/rendering/dev/accidentalslayout.cpp
@@ -261,10 +261,8 @@ void AccidentalsLayout::createChordsShape(AccidentalsLayoutContext& ctx)
 
     for (const Chord* chord : ctx.chords) {
         PointF chordPos = keepAccidentalsCloseToChord(chord) ? PointF() : chord->pos();
-        const LedgerLine* ledger = chord->ledgerLines();
-        while (ledger) {
+        for (const LedgerLine* ledger : chord->ledgerLines()) {
             ctx.chordsShape.add(ledger->shape().translate(ledger->pos() + chordPos));
-            ledger = ledger->next();
         }
         for (const Note* note : chord->notes()) {
             SymId noteSym = note->ldata()->cachedNoteheadSym;

--- a/src/engraving/rendering/dev/slurtielayout.cpp
+++ b/src/engraving/rendering/dev/slurtielayout.cpp
@@ -1649,7 +1649,7 @@ void SlurTieLayout::adjustX(TieSegment* tieSegment, SlurTiePos& sPos, Grip start
 void SlurTieLayout::adjustXforLedgerLines(TieSegment* tieSegment, bool start, Chord* chord, Note* note,
                                           const PointF& chordSystemPos, double padding, double& resultingX)
 {
-    if (tieSegment->tie()->isInside() || !chord->ledgerLines()) {
+    if (tieSegment->tie()->isInside() || chord->ledgerLines().empty()) {
         return;
     }
 
@@ -1660,7 +1660,7 @@ void SlurTieLayout::adjustXforLedgerLines(TieSegment* tieSegment, bool start, Ch
 
     bool ledgersAbove = false;
     bool ledgersBelow = false;
-    for (LedgerLine* ledger = chord->ledgerLines(); ledger; ledger = ledger->next()) {
+    for (LedgerLine* ledger : chord->ledgerLines()) {
         if (ledger->y() < 0.0) {
             ledgersAbove = true;
         } else {
@@ -1697,7 +1697,7 @@ void SlurTieLayout::adjustYforLedgerLines(TieSegment* tieSegment, SlurTiePos& sP
     }
 
     Chord* chord = note->chord();
-    if (!chord->ledgerLines()) {
+    if (chord->ledgerLines().empty()) {
         return;
     }
     PointF chordSystemPos = chord->pos() + chord->segment()->pos() + chord->segment()->measure()->pos();
@@ -1706,7 +1706,7 @@ void SlurTieLayout::adjustYforLedgerLines(TieSegment* tieSegment, SlurTiePos& sP
     int upSign = tie->up() ? -1 : 1;
     double margin = 0.4 * spatium;
 
-    for (LedgerLine* ledger = chord->ledgerLines(); ledger; ledger = ledger->next()) {
+    for (LedgerLine* ledger : chord->ledgerLines()) {
         PointF ledgerPos = ledger->pos() + chordSystemPos;
         double yDiff = upSign * (ledgerPos.y() - tiePoint.y());
         bool collision = yDiff > 0 && yDiff < margin;

--- a/src/engraving/rendering/stable/chordlayout.cpp
+++ b/src/engraving/rendering/stable/chordlayout.cpp
@@ -417,7 +417,7 @@ void ChordLayout::layoutTablature(Chord* item, LayoutContext& ctx)
         double extraLen    = 0;
         double llX         = stemX - (headWidth + extraLen) * 0.5;
         for (int i = 0; i < ledgerLines; i++) {
-            LedgerLine* ldgLin = new LedgerLine(ctx.mutDom().dummyParent());
+            LedgerLine* ldgLin = item->ledgerLines()[i];
             ldgLin->setParent(item);
             ldgLin->setTrack(item->track());
             ldgLin->setVisible(item->visible());

--- a/src/engraving/rendering/stable/chordlayout.cpp
+++ b/src/engraving/rendering/stable/chordlayout.cpp
@@ -101,12 +101,6 @@ void ChordLayout::layoutPitched(Chord* item, LayoutContext& ctx)
 
     double chordX           = (item->noteType() == NoteType::NORMAL) ? item->ldata()->pos().x() : 0.0;
 
-    while (item->ledgerLines()) {
-        LedgerLine* l = item->ledgerLines()->next();
-        delete item->ledgerLines();
-        item->setLedgerLine(l);
-    }
-
     double lll    = 0.0;           // space to leave at left of chord
     double rrr    = 0.0;           // space to leave at right of chord
     double lhead  = 0.0;           // amount of notehead to left of chord origin
@@ -169,7 +163,7 @@ void ChordLayout::layoutPitched(Chord* item, LayoutContext& ctx)
     //  create ledger lines
     //-----------------------------------------
 
-    item->addLedgerLines();
+    item->updateLedgerLines();
 
     // If item has an arpeggio: mark chords which are part of the arpeggio
     if (item->arpeggio()) {
@@ -335,12 +329,6 @@ void ChordLayout::layoutTablature(Chord* item, LayoutContext& ctx)
         layoutTablature(c, ctx);
     }
 
-    while (item->ledgerLines()) {
-        LedgerLine* l = item->ledgerLines()->next();
-        delete item->ledgerLines();
-        item->setLedgerLine(l);
-    }
-
     double lll         = 0.0;                    // space to leave at left of chord
     double rrr         = 0.0;                    // space to leave at right of chord
     Note* upnote       = item->upNote();
@@ -425,9 +413,7 @@ void ChordLayout::layoutTablature(Chord* item, LayoutContext& ctx)
 
     // create ledger lines, if required (in some historic styles)
     if (ledgerLines > 0) {
-// there seems to be no need for widening 'ledger lines' beyond fret mark widths; more 'on the field'
-// tests and usage will show if this depends on the metrics of the specific fonts used or not.
-//            double extraLen    = style().styleS(Sid::ledgerLineLength).val() * _spatium;
+        item->resizeLedgerLinesTo(ledgerLines);
         double extraLen    = 0;
         double llX         = stemX - (headWidth + extraLen) * 0.5;
         for (int i = 0; i < ledgerLines; i++) {
@@ -437,8 +423,6 @@ void ChordLayout::layoutTablature(Chord* item, LayoutContext& ctx)
             ldgLin->setVisible(item->visible());
             ldgLin->setLen(headWidth + extraLen);
             ldgLin->setPos(llX, llY);
-            ldgLin->setNext(item->ledgerLines());
-            item->setLedgerLine(ldgLin);
             TLayout::layoutLedgerLine(ldgLin, ctx);
             llY += lineDist / ledgerLines;
         }
@@ -3499,8 +3483,9 @@ void ChordLayout::layoutNote2(Note* item, LayoutContext& ctx)
             e->mutldata()->setMag(item->mag());
             Shape noteShape = item->shape();
             noteShape.remove_if([e](ShapeElement& s) { return s.item() == e || s.item()->isBend(); });
-            LedgerLine* ledger = item->line() < -1 || item->line() > item->staff()->lines(item->tick())
-                                 ? item->chord()->ledgerLines() : nullptr;
+            LedgerLine* ledger = (item->line() < -1 || item->line() > item->staff()->lines(item->tick()))
+                                 && !item->chord()->ledgerLines().empty()
+                                 ? item->chord()->ledgerLines().front() : nullptr;
             if (ledger) {
                 noteShape.add(ledger->shape().translate(ledger->pos() - item->pos()));
             }
@@ -3729,7 +3714,7 @@ void ChordLayout::fillShape(const Chord* item, ChordRest::LayoutData* ldata, con
 
     shape.add(chordRestShape(item, conf));      // add lyrics
 
-    for (const LedgerLine* l = item->ledgerLines(); l; l = l->next()) {
+    for (const LedgerLine* l : item->ledgerLines()) {
         shape.add(l->shape().translate(l->pos()));
     }
 

--- a/src/engraving/rendering/stable/slurtielayout.cpp
+++ b/src/engraving/rendering/stable/slurtielayout.cpp
@@ -1766,7 +1766,7 @@ void SlurTieLayout::adjustX(TieSegment* tieSegment, SlurTiePos& sPos, Grip start
 void SlurTieLayout::adjustXforLedgerLines(TieSegment* tieSegment, bool start, Chord* chord, Note* note,
                                           const PointF& chordSystemPos, double padding, double& resultingX)
 {
-    if (tieSegment->tie()->isInside() || !chord->ledgerLines()) {
+    if (tieSegment->tie()->isInside() || chord->ledgerLines().empty()) {
         return;
     }
 
@@ -1777,7 +1777,7 @@ void SlurTieLayout::adjustXforLedgerLines(TieSegment* tieSegment, bool start, Ch
 
     bool ledgersAbove = false;
     bool ledgersBelow = false;
-    for (LedgerLine* ledger = chord->ledgerLines(); ledger; ledger = ledger->next()) {
+    for (LedgerLine* ledger : chord->ledgerLines()) {
         if (ledger->y() < 0.0) {
             ledgersAbove = true;
         } else {
@@ -1812,7 +1812,7 @@ void SlurTieLayout::adjustYforLedgerLines(TieSegment* tieSegment, SlurTiePos& sP
     }
 
     Chord* chord = note->chord();
-    if (!chord->ledgerLines()) {
+    if (chord->ledgerLines().empty()) {
         return;
     }
     PointF chordSystemPos = chord->pos() + chord->segment()->pos() + chord->segment()->measure()->pos();
@@ -1821,7 +1821,7 @@ void SlurTieLayout::adjustYforLedgerLines(TieSegment* tieSegment, SlurTiePos& sP
     int upSign = tie->up() ? -1 : 1;
     double margin = 0.4 * spatium;
 
-    for (LedgerLine* ledger = chord->ledgerLines(); ledger; ledger = ledger->next()) {
+    for (LedgerLine* ledger : chord->ledgerLines()) {
         PointF ledgerPos = ledger->pos() + chordSystemPos;
         double yDiff = upSign * (ledgerPos.y() - tiePoint.y());
         bool collision = yDiff > 0 && yDiff < margin;


### PR DESCRIPTION
Resolves: a crash which happens in a specific file under specific conditions @oktophonie. The crash is due to a read-after-free so it doesn't always crash. It can be reliably reproduced only by using the adress sanitizer, which shows that this is yet another instance of our well known invalid ledger lines problem. Hopefully this is the end of that @cbjeukendrup @miiizen.

**To summarize**

Two things are bad about the current way we do ledger lines.

a) They are implemented as a linked list, with the Chord holding the pointer to the first LedgerLine of the list and each LedgerLine holding a pointer to the next. This makes zero sense: it makes the list slower to traverse, it wastes memory, and it makes the code uglier for no reason. I've now reimplemented it with the Chord holding a vector of LedgerLines* instead.

b) They are deleted and recreated at every single layout. This is a waste of resources, as we keep deleting and reallocating things in the heap for no reason, but most importanly has been the source of countless (meaning that I've literally lost count) memory bugs as anything that holds pointers to these LedgerLines (especially Shapes and now Skylines too) get invalidated. Now ledger lines are deleted / created only if necessary, i.e. only if the total number of ledger lines needed by the chord has changed. This should be, hopefully, the end of those memory bugs.
