### PR TITLE
Change linked mmr timesigs when editing

### DIFF
--- a/src/engraving/rendering/score/measurelayout.cpp
+++ b/src/engraving/rendering/score/measurelayout.cpp
@@ -378,9 +378,6 @@ void MeasureLayout::createMMRest(LayoutContext& ctx, Measure* firstMeasure, Meas
                     mmrTimeSig->setParent(mmrSeg);
                     ctx.mutDom().doUndoAddElement(mmrTimeSig);
                 } else {
-                    mmrTimeSig->setSig(underlyingTimeSig->sig(), underlyingTimeSig->timeSigType());
-                    mmrTimeSig->setNumeratorString(underlyingTimeSig->numeratorString());
-                    mmrTimeSig->setDenominatorString(underlyingTimeSig->denominatorString());
                     TLayout::layoutTimeSig(mmrTimeSig, mmrTimeSig->mutldata(), ctx);
                 }
             }

--- a/src/palette/view/widgets/timesignaturepropertiesdialog.cpp
+++ b/src/palette/view/widgets/timesignaturepropertiesdialog.cpp
@@ -211,11 +211,17 @@ void TimeSignaturePropertiesDialog::accept()
 
     notation->undoStack()->prepareChanges();
 
-    m_originTimeSig->undoChangeProperty(Pid::TIMESIG_TYPE, int(m_editedTimeSig->timeSigType()));
-    m_originTimeSig->undoChangeProperty(Pid::SHOW_COURTESY, m_editedTimeSig->showCourtesySig());
-    m_originTimeSig->undoChangeProperty(Pid::NUMERATOR_STRING, m_editedTimeSig->numeratorString());
-    m_originTimeSig->undoChangeProperty(Pid::DENOMINATOR_STRING, m_editedTimeSig->denominatorString());
-    m_originTimeSig->undoChangeProperty(Pid::GROUP_NODES, g.nodes());
+    // Change linked mmr timesigs too
+    for (EngravingObject* obj : m_originTimeSig->linkList()) {
+        TimeSig* timeSig = toTimeSig(obj);
+        if (timeSig == m_originTimeSig || (timeSig->track() == m_originTimeSig->track() && timeSig->score() == m_originTimeSig->score())) {
+            timeSig->undoChangeProperty(Pid::TIMESIG_TYPE, int(m_editedTimeSig->timeSigType()));
+            timeSig->undoChangeProperty(Pid::SHOW_COURTESY, m_editedTimeSig->showCourtesySig());
+            timeSig->undoChangeProperty(Pid::NUMERATOR_STRING, m_editedTimeSig->numeratorString());
+            timeSig->undoChangeProperty(Pid::DENOMINATOR_STRING, m_editedTimeSig->denominatorString());
+            timeSig->undoChangeProperty(Pid::GROUP_NODES, g.nodes());
+        }
+    }
 
     if (m_editedTimeSig->sig() != m_originTimeSig->sig()) {
         notation->interaction()->addTimeSignature(m_originTimeSig->measure(), m_originTimeSig->staffIdx(), m_editedTimeSig);


### PR DESCRIPTION
Resolves: #18620
When changing time signature properties, these properties are not propagated to linked time signatures in the same score.  This included hidden time signatures belonging to hidden multimeasure rest bars, or their hidden underlying couterparts.  
This PR fixes the MMR situation above by also changing time signatures which are linked to the time signature being edited and share the same track and score.