### PR TITLE
Work around Opus 1.4+ build failure on armv7l

### DIFF
--- a/buildscripts/cmake/SetupBuildEnvironment.cmake
+++ b/buildscripts/cmake/SetupBuildEnvironment.cmake
@@ -10,6 +10,10 @@ set(CMAKE_UNITY_BUILD_BATCH_SIZE 12)
 if (CC_IS_GCC)
     message(STATUS "Using Compiler GCC ${CMAKE_CXX_COMPILER_VERSION}")
 
+    if (ARCH_IS_ARMV7L)
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mfpu=neon")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mfpu=neon")
+    endif()
     set(CMAKE_CXX_FLAGS_DEBUG   "-g")
     set(CMAKE_CXX_FLAGS_RELEASE "-O2")
 
@@ -65,6 +69,10 @@ elseif(CC_IS_MINGW)
 elseif(CC_IS_CLANG)
     message(STATUS "Using Compiler CLANG ${CMAKE_CXX_COMPILER_VERSION}")
 
+    if (ARCH_IS_ARMV7L)
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mfpu=neon")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mfpu=neon")
+    endif()
     set(CMAKE_CXX_FLAGS_DEBUG   "-g")
     set(CMAKE_CXX_FLAGS_RELEASE "-O2")
 

--- a/buildscripts/cmake/SetupBuildEnvironment.cmake
+++ b/buildscripts/cmake/SetupBuildEnvironment.cmake
@@ -10,10 +10,6 @@ set(CMAKE_UNITY_BUILD_BATCH_SIZE 12)
 if (CC_IS_GCC)
     message(STATUS "Using Compiler GCC ${CMAKE_CXX_COMPILER_VERSION}")
 
-    if (ARCH_IS_ARMV7L)
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mfpu=neon")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mfpu=neon")
-    endif()
     set(CMAKE_CXX_FLAGS_DEBUG   "-g")
     set(CMAKE_CXX_FLAGS_RELEASE "-O2")
 
@@ -69,10 +65,6 @@ elseif(CC_IS_MINGW)
 elseif(CC_IS_CLANG)
     message(STATUS "Using Compiler CLANG ${CMAKE_CXX_COMPILER_VERSION}")
 
-    if (ARCH_IS_ARMV7L)
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mfpu=neon")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mfpu=neon")
-    endif()
     set(CMAKE_CXX_FLAGS_DEBUG   "-g")
     set(CMAKE_CXX_FLAGS_RELEASE "-O2")
 

--- a/src/framework/audio/thirdparty/opusenc/cmake/SetupOpus.cmake
+++ b/src/framework/audio/thirdparty/opusenc/cmake/SetupOpus.cmake
@@ -41,6 +41,11 @@ endif ()
 set(OPUS_LIB_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../opus/opus-1.4)
 add_subdirectory(${OPUS_LIB_DIR} opus)
 
+include(GetPlatformInfo)
+if (ARCH_IS_ARMV7L)
+    target_compile_options(opus PUBLIC -mfpu=neon)
+endif()
+
 set(OPUS_INCLUDE_DIRS ${OPUS_LIB_DIR}/include)
 set(OPUS_LIBRARIES opus)
 

--- a/src/framework/audio/thirdparty/opusenc/cmake/SetupOpus.cmake
+++ b/src/framework/audio/thirdparty/opusenc/cmake/SetupOpus.cmake
@@ -38,11 +38,6 @@ if (MUE_COMPILE_USE_SYSTEM_OPUS)
     message(WARNING "Set MUE_COMPILE_USE_SYSTEM_OPUS=ON, but system opus not found, built-in will be used")
 endif ()
 
-include(GetPlatformInfo)
-if (ARCH_IS_ARMV7L)
-    target_compile_options(opus PRIVATE -mfpu=neon)
-endif()
-
 set(OPUS_LIB_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../opus/opus-1.4)
 add_subdirectory(${OPUS_LIB_DIR} opus)
 

--- a/src/framework/audio/thirdparty/opusenc/cmake/SetupOpus.cmake
+++ b/src/framework/audio/thirdparty/opusenc/cmake/SetupOpus.cmake
@@ -40,8 +40,7 @@ endif ()
 
 include(GetPlatformInfo)
 if (ARCH_IS_ARMV7L)
-    # Temporary workaround for https://github.com/musescore/MuseScore/issues/24015
-    set(OPUS_FIXED_POINT ON CACHE BOOL "compile as fixed-point (for machines without a fast enough FPU)." FORCE)
+    target_compile_options(opus PRIVATE -mfpu=neon)
 endif()
 
 set(OPUS_LIB_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../opus/opus-1.4)

--- a/src/framework/audio/thirdparty/opusenc/cmake/SetupOpus.cmake
+++ b/src/framework/audio/thirdparty/opusenc/cmake/SetupOpus.cmake
@@ -38,6 +38,12 @@ if (MUE_COMPILE_USE_SYSTEM_OPUS)
     message(WARNING "Set MUE_COMPILE_USE_SYSTEM_OPUS=ON, but system opus not found, built-in will be used")
 endif ()
 
+include(GetPlatformInfo)
+if (ARCH_IS_ARMV7L)
+    # Temporary workaround for https://github.com/musescore/MuseScore/issues/24015
+    set(OPUS_FIXED_POINT ON CACHE BOOL "compile as fixed-point (for machines without a fast enough FPU)." FORCE)
+endif()
+
 set(OPUS_LIB_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../opus/opus-1.4)
 add_subdirectory(${OPUS_LIB_DIR} opus)
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/24015

We'll see if it works at https://github.com/cbjeukendrup/MuseScore/actions/runs/10372975091/job/28716972470

I wonder though how this affects performance/functionality/quality. Anyway, it should only affect Opus export on Linux armv7l only, so _if_ it has negative effects, those are limited to this specific area.

@theofficialgman FYI :)