### PR TITLE
SVG Export: Write width and height in mm, not px

### DIFF
--- a/src/importexport/imagesexport/internal/svggenerator.cpp
+++ b/src/importexport/imagesexport/internal/svggenerator.cpp
@@ -248,7 +248,7 @@ protected:
 #define SVG_QUOTE    "\""
 #define SVG_COMMA    ","
 #define SVG_GT       ">"
-#define SVG_PX       "px"
+#define SVG_MM       "mm"
 #define SVG_NONE     "none"
 #define SVG_EVENODD  "evenodd"
 #define SVG_BUTT     "butt"
@@ -1045,8 +1045,8 @@ bool SvgPaintEngine::begin(QPaintDevice*)
     stream() << "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>" << Qt::endl << SVG_BEGIN;
     if (d->viewBox.isValid()) {
         // viewBox has floating point values, size width/height is integer
-        stream() << SVG_WIDTH << d->viewBox.width() << SVG_PX << SVG_QUOTE
-                 << SVG_HEIGHT << d->viewBox.height() << SVG_PX << SVG_QUOTE;
+        stream() << SVG_WIDTH << d->viewBox.width() / mu::engraving::DPMM << SVG_MM << SVG_QUOTE
+                 << SVG_HEIGHT << d->viewBox.height() / mu::engraving::DPMM << SVG_MM << SVG_QUOTE;
 
         stream() << SVG_VIEW_BOX << d->viewBox.left()
                  << SVG_SPACE << d->viewBox.top()


### PR DESCRIPTION
Resolves: #22531

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
