### PR TITLE
Fix #24019: Ensure proper conversion of `TremoloBar` line widths (4.4.0 port)

### DIFF
--- a/src/engraving/rendering/dev/tdraw.cpp
+++ b/src/engraving/rendering/dev/tdraw.cpp
@@ -3126,7 +3126,8 @@ void TDraw::draw(const TremoloBar* item, Painter* painter)
 {
     TRACE_DRAW_ITEM;
     const TremoloBar::LayoutData* ldata = item->ldata();
-    Pen pen(item->curColor(), item->lineWidth().val(), PenStyle::SolidLine, PenCapStyle::RoundCap, PenJoinStyle::RoundJoin);
+    const double lw = item->absoluteFromSpatium(item->lineWidth());
+    Pen pen(item->curColor(), lw, PenStyle::SolidLine, PenCapStyle::RoundCap, PenJoinStyle::RoundJoin);
     painter->setPen(pen);
     painter->drawPolyline(ldata->polygon);
 }

--- a/src/engraving/rendering/dev/tlayout.cpp
+++ b/src/engraving/rendering/dev/tlayout.cpp
@@ -6305,7 +6305,7 @@ void TLayout::layoutTremoloBar(const TremoloBar* item, TremoloBar::LayoutData* l
     }
     ldata->polygon = polygon;
 
-    double w = item->lineWidth().val();
+    const double w = item->absoluteFromSpatium(item->lineWidth());
     ldata->setBbox(ldata->polygon.boundingRect().adjusted(-w, -w, w, w));
 }
 

--- a/src/engraving/rendering/single/singledraw.cpp
+++ b/src/engraving/rendering/single/singledraw.cpp
@@ -2439,7 +2439,8 @@ void SingleDraw::draw(const TremoloBar* item, Painter* painter)
 {
     TRACE_DRAW_ITEM;
     const TremoloBar::LayoutData* ldata = item->ldata();
-    Pen pen(item->curColor(), item->lineWidth().val(), PenStyle::SolidLine, PenCapStyle::RoundCap, PenJoinStyle::RoundJoin);
+    const double lw = item->absoluteFromSpatium(item->lineWidth());
+    Pen pen(item->curColor(), lw, PenStyle::SolidLine, PenCapStyle::RoundCap, PenJoinStyle::RoundJoin);
     painter->setPen(pen);
     painter->drawPolyline(ldata->polygon);
 }

--- a/src/engraving/rendering/single/singlelayout.cpp
+++ b/src/engraving/rendering/single/singlelayout.cpp
@@ -1638,7 +1638,7 @@ void SingleLayout::layout(TremoloBar* item, const Context&)
     }
     ldata->polygon = polygon;
 
-    double w = item->lineWidth().val();
+    const double w = item->absoluteFromSpatium(item->lineWidth());
     ldata->setBbox(ldata->polygon.boundingRect().adjusted(-w, -w, w, w));
 }
 

--- a/src/engraving/rendering/stable/tdraw.cpp
+++ b/src/engraving/rendering/stable/tdraw.cpp
@@ -3026,7 +3026,8 @@ void TDraw::draw(const TremoloBar* item, Painter* painter)
 {
     TRACE_DRAW_ITEM;
     const TremoloBar::LayoutData* ldata = item->ldata();
-    Pen pen(item->curColor(), item->lineWidth().val(), PenStyle::SolidLine, PenCapStyle::RoundCap, PenJoinStyle::RoundJoin);
+    const double lw = item->absoluteFromSpatium(item->lineWidth());
+    Pen pen(item->curColor(), lw, PenStyle::SolidLine, PenCapStyle::RoundCap, PenJoinStyle::RoundJoin);
     painter->setPen(pen);
     painter->drawPolyline(ldata->polygon);
 }

--- a/src/engraving/rendering/stable/tlayout.cpp
+++ b/src/engraving/rendering/stable/tlayout.cpp
@@ -6073,7 +6073,7 @@ void TLayout::layoutTremoloBar(const TremoloBar* item, TremoloBar::LayoutData* l
     }
     ldata->polygon = polygon;
 
-    double w = item->lineWidth().val();
+    const double w = item->absoluteFromSpatium(item->lineWidth());
     ldata->setBbox(ldata->polygon.boundingRect().adjusted(-w, -w, w, w));
 }
 


### PR DESCRIPTION
Resolves: #24019
Ports: #24030