### PR TITLE
Fix MSVC compiler warnings

### DIFF
--- a/src/engraving/dom/chord.cpp
+++ b/src/engraving/dom/chord.cpp
@@ -1551,7 +1551,7 @@ Chord* Chord::next() const
 
 void Chord::resizeLedgerLinesTo(size_t newSize)
 {
-    int ledgerLineCountDiff = newSize - m_ledgerLines.size();
+    int ledgerLineCountDiff = static_cast<int>(newSize - m_ledgerLines.size());
     if (ledgerLineCountDiff > 0) {
         for (int i = 0; i < ledgerLineCountDiff; ++i) {
             m_ledgerLines.push_back(new LedgerLine(score()->dummy()));

--- a/src/framework/extensions/devtools/apidumpmodel.cpp
+++ b/src/framework/extensions/devtools/apidumpmodel.cpp
@@ -138,20 +138,17 @@ static QString makeCleanType(const QString& type)
 
 static QString sigToString(const IApiRegister::Dump::Sig& sig, IApiRegister::Dump::MethodType type, const QString& prefix = QString())
 {
+    QString str;
     switch (type) {
     case IApiRegister::Dump::MethodType::Property: {
-        QString str;
         if (!prefix.isEmpty()) {
             str += prefix + ".";
         }
         str += sig.name;
         str += " → ";
         str += makeCleanType(sig.retType);
-
-        return str;
     } break;
     case IApiRegister::Dump::MethodType::Method: {
-        QString str;
         if (!prefix.isEmpty()) {
             str += prefix + ".";
         }
@@ -175,10 +172,9 @@ static QString sigToString(const IApiRegister::Dump::Sig& sig, IApiRegister::Dum
             str += " → ";
             str += makeCleanType(sig.retType);
         }
-
-        return str;
     } break;
     }
+    return str;
 }
 
 void ApiDumpModel::load()

--- a/src/framework/global/api/internal/apiregister.cpp
+++ b/src/framework/global/api/internal/apiregister.cpp
@@ -98,7 +98,7 @@ public:
 
     QJSValue newArray(size_t length) override
     {
-        return engine.newArray(length);
+        return engine.newArray(static_cast<uint>(length));
     }
 };
 

--- a/src/framework/global/thirdparty/kors_async/async/internal/abstractinvoker.cpp
+++ b/src/framework/global/thirdparty/kors_async/async/internal/abstractinvoker.cpp
@@ -149,11 +149,11 @@ void AbstractInvoker::removeCallBack(int type, Asyncable* receiver)
 
     {
         std::lock_guard<std::mutex> lock(m_qInvokersMutex);
-        for (auto it = m_qInvokers.begin(); it != m_qInvokers.end(); ++it) {
-            QInvoker* qi = *it;
+        for (auto iter = m_qInvokers.begin(); iter != m_qInvokers.end(); ++iter) {
+            QInvoker* qi = *iter;
             if (qi->call.call == c.call) {
                 qi->invalidate();
-                m_qInvokers.erase(it);
+                m_qInvokers.erase(iter);
                 break;
             }
         }


### PR DESCRIPTION
* reg.: declaration of 'it' hides previous local declaration (C4456)
* reg.: conversion from 'size_t' to 'uint/int', possible loss of data (C4267)
* reg.: not all control paths return a value (C4715)