### PR TITLE
Fix typo, follow up to #23473

### DIFF
--- a/share/templates/My_First_Score.mscx
+++ b/share/templates/My_First_Score.mscx
@@ -9,7 +9,7 @@
     <Style>
       <enableVerticalSpread>1</enableVerticalSpread>
       <lastSystemFillLimit>0</lastSystemFillLimit>
-      <Spatium>1.75</Spatium>
+      <spatium>1.75</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/style/style.cpp
+++ b/src/engraving/style/style.cpp
@@ -578,7 +578,7 @@ void MStyle::save(XmlWriter& xml, bool optimize)
         }
     }
 
-    xml.tag("Spatium", value(Sid::spatium).toReal() / DPMM);
+    xml.tag("spatium", value(Sid::spatium).toReal() / DPMM);
     xml.endElement();
 }
 

--- a/src/engraving/tests/barline_data/barlinedelete-ref.mscx
+++ b/src/engraving/tests/barline_data/barlinedelete-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <lastSystemFillLimit>0</lastSystemFillLimit>
       <defaultsVersion>301</defaultsVersion>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/beam_data/Beam-A.mscx
+++ b/src/engraving/tests/beam_data/Beam-A.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/beam_data/Beam-B.mscx
+++ b/src/engraving/tests/beam_data/Beam-B.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/beam_data/Beam-C.mscx
+++ b/src/engraving/tests/beam_data/Beam-C.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/beam_data/Beam-D.mscx
+++ b/src/engraving/tests/beam_data/Beam-D.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/beam_data/Beam-E.mscx
+++ b/src/engraving/tests/beam_data/Beam-E.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/beam_data/Beam-F.mscx
+++ b/src/engraving/tests/beam_data/Beam-F.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/beam_data/Beam-G.mscx
+++ b/src/engraving/tests/beam_data/Beam-G.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/beam_data/beamNoSlope.mscx
+++ b/src/engraving/tests/beam_data/beamNoSlope.mscx
@@ -4,7 +4,7 @@
     <Division>480</Division>
     <Style>
       <beamNoSlope>1</beamNoSlope>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/beam_data/beamPositions.mscx
+++ b/src/engraving/tests/beam_data/beamPositions.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/beam_data/beamStemDir-01-ref.mscx
+++ b/src/engraving/tests/beam_data/beamStemDir-01-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/beam_data/flatBeams-ref.mscx
+++ b/src/engraving/tests/beam_data/flatBeams-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/beam_data/flipBeamStemDir-01-ref.mscx
+++ b/src/engraving/tests/beam_data/flipBeamStemDir-01-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/beam_data/flippedDirection.mscx
+++ b/src/engraving/tests/beam_data/flippedDirection.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/beam_data/wideBeams.mscx
+++ b/src/engraving/tests/beam_data/wideBeams.mscx
@@ -4,7 +4,7 @@
     <Division>480</Division>
     <Style>
       <useWideBeams>1</useWideBeams>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/box_data/undoRemoveVBox1-ref.mscx
+++ b/src/engraving/tests/box_data/undoRemoveVBox1-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/box_data/undoRemoveVBox2-ref.mscx
+++ b/src/engraving/tests/box_data/undoRemoveVBox2-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/breath_data/breath01-ref.mscx
+++ b/src/engraving/tests/breath_data/breath01-ref.mscx
@@ -6,7 +6,7 @@
       <lastSystemFillLimit>0</lastSystemFillLimit>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/breath_data/breath02-ref.mscx
+++ b/src/engraving/tests/breath_data/breath02-ref.mscx
@@ -6,7 +6,7 @@
       <lastSystemFillLimit>0</lastSystemFillLimit>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/chordsymbol_data/add-link-ref.mscx
+++ b/src/engraving/tests/chordsymbol_data/add-link-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/chordsymbol_data/add-part-ref.mscx
+++ b/src/engraving/tests/chordsymbol_data/add-part-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -108,7 +108,7 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
-        <Spatium>1.76389</Spatium>
+        <spatium>1.76389</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/chordsymbol_data/clear-ref.mscx
+++ b/src/engraving/tests/chordsymbol_data/clear-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/chordsymbol_data/extend-ref.mscx
+++ b/src/engraving/tests/chordsymbol_data/extend-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/chordsymbol_data/no-system-ref.mscx
+++ b/src/engraving/tests/chordsymbol_data/no-system-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -206,7 +206,7 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -316,7 +316,7 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/chordsymbol_data/realize-3note-ref.mscx
+++ b/src/engraving/tests/chordsymbol_data/realize-3note-ref.mscx
@@ -10,7 +10,7 @@
       <maxSystemDistance>6</maxSystemDistance>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/chordsymbol_data/realize-4note-ref.mscx
+++ b/src/engraving/tests/chordsymbol_data/realize-4note-ref.mscx
@@ -10,7 +10,7 @@
       <maxSystemDistance>6</maxSystemDistance>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/chordsymbol_data/realize-6note-ref.mscx
+++ b/src/engraving/tests/chordsymbol_data/realize-6note-ref.mscx
@@ -10,7 +10,7 @@
       <maxSystemDistance>6</maxSystemDistance>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/chordsymbol_data/realize-close-ref.mscx
+++ b/src/engraving/tests/chordsymbol_data/realize-close-ref.mscx
@@ -10,7 +10,7 @@
       <maxSystemDistance>6</maxSystemDistance>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/chordsymbol_data/realize-concert-pitch-ref.mscx
+++ b/src/engraving/tests/chordsymbol_data/realize-concert-pitch-ref.mscx
@@ -9,7 +9,7 @@
       <minMeasureWidth>12</minMeasureWidth>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/chordsymbol_data/realize-drop2-ref.mscx
+++ b/src/engraving/tests/chordsymbol_data/realize-drop2-ref.mscx
@@ -10,7 +10,7 @@
       <maxSystemDistance>6</maxSystemDistance>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/chordsymbol_data/realize-duration-ref.mscx
+++ b/src/engraving/tests/chordsymbol_data/realize-duration-ref.mscx
@@ -8,7 +8,7 @@
       <pagePrintableWidth>7.4826</pagePrintableWidth>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/chordsymbol_data/realize-jazz-ref.mscx
+++ b/src/engraving/tests/chordsymbol_data/realize-jazz-ref.mscx
@@ -10,7 +10,7 @@
       <concertPitch>1</concertPitch>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/chordsymbol_data/realize-override-ref.mscx
+++ b/src/engraving/tests/chordsymbol_data/realize-override-ref.mscx
@@ -8,7 +8,7 @@
       <pagePrintableWidth>7.4826</pagePrintableWidth>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/chordsymbol_data/realize-transpose-ref.mscx
+++ b/src/engraving/tests/chordsymbol_data/realize-transpose-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/chordsymbol_data/realize-triplet-ref.mscx
+++ b/src/engraving/tests/chordsymbol_data/realize-triplet-ref.mscx
@@ -8,7 +8,7 @@
       <pagePrintableWidth>7.4826</pagePrintableWidth>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/chordsymbol_data/transpose-part-ref.mscx
+++ b/src/engraving/tests/chordsymbol_data/transpose-part-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -129,7 +129,7 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
-        <Spatium>1.76389</Spatium>
+        <spatium>1.76389</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/chordsymbol_data/transpose-ref.mscx
+++ b/src/engraving/tests/chordsymbol_data/transpose-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/clef_courtesy_data/clef_courtesy01-ref.mscx
+++ b/src/engraving/tests/clef_courtesy_data/clef_courtesy01-ref.mscx
@@ -19,7 +19,7 @@
       <evenFooterR>Version $:version:</evenFooterR>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/clef_courtesy_data/clef_courtesy02-ref.mscx
+++ b/src/engraving/tests/clef_courtesy_data/clef_courtesy02-ref.mscx
@@ -20,7 +20,7 @@
       <evenFooterR>Version $:version:</evenFooterR>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/clef_courtesy_data/clef_courtesy03-ref.mscx
+++ b/src/engraving/tests/clef_courtesy_data/clef_courtesy03-ref.mscx
@@ -19,7 +19,7 @@
       <evenFooterR>Version $:version:</evenFooterR>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/clef_courtesy_data/clef_courtesy04-ref.mscx
+++ b/src/engraving/tests/clef_courtesy_data/clef_courtesy04-ref.mscx
@@ -21,7 +21,7 @@
       <evenFooterR>Version $:version:</evenFooterR>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/clef_data/clef-1-ref.mscx
+++ b/src/engraving/tests/clef_data/clef-1-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.764</Spatium>
+      <spatium>1.764</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/clef_data/clef-2-ref.mscx
+++ b/src/engraving/tests/clef_data/clef-2-ref.mscx
@@ -6,7 +6,7 @@
       <lastSystemFillLimit>0</lastSystemFillLimit>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/clef_data/clef-3-ref.mscx
+++ b/src/engraving/tests/clef_data/clef-3-ref.mscx
@@ -8,7 +8,7 @@
       <pagePrintableWidth>7.4826</pagePrintableWidth>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/compat114_data/accidentals-ref.mscx
+++ b/src/engraving/tests/compat114_data/accidentals-ref.mscx
@@ -6,7 +6,7 @@
       <frameSystemDistance>7</frameSystemDistance>
       <voltaPosAbove x="0" y="-2"/>
       <defaultsVersion>114</defaultsVersion>
-      <Spatium>1.764</Spatium>
+      <spatium>1.764</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/compat114_data/articulations-ref.mscx
+++ b/src/engraving/tests/compat114_data/articulations-ref.mscx
@@ -9,7 +9,7 @@
       <lastSystemFillLimit>0</lastSystemFillLimit>
       <voltaPosAbove x="0" y="-2"/>
       <defaultsVersion>114</defaultsVersion>
-      <Spatium>1.764</Spatium>
+      <spatium>1.764</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/compat114_data/chord_symbol-ref.mscx
+++ b/src/engraving/tests/compat114_data/chord_symbol-ref.mscx
@@ -6,7 +6,7 @@
       <frameSystemDistance>7</frameSystemDistance>
       <voltaPosAbove x="0" y="-2"/>
       <defaultsVersion>114</defaultsVersion>
-      <Spatium>1.764</Spatium>
+      <spatium>1.764</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/compat114_data/clef_missing_first-ref.mscx
+++ b/src/engraving/tests/compat114_data/clef_missing_first-ref.mscx
@@ -6,7 +6,7 @@
       <frameSystemDistance>7</frameSystemDistance>
       <voltaPosAbove x="0" y="-2"/>
       <defaultsVersion>114</defaultsVersion>
-      <Spatium>1.764</Spatium>
+      <spatium>1.764</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/compat114_data/clefs-ref.mscx
+++ b/src/engraving/tests/compat114_data/clefs-ref.mscx
@@ -9,7 +9,7 @@
       <lastSystemFillLimit>0</lastSystemFillLimit>
       <voltaPosAbove x="0" y="-2"/>
       <defaultsVersion>114</defaultsVersion>
-      <Spatium>1.764</Spatium>
+      <spatium>1.764</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/compat114_data/drumset-ref.mscx
+++ b/src/engraving/tests/compat114_data/drumset-ref.mscx
@@ -6,7 +6,7 @@
       <frameSystemDistance>7</frameSystemDistance>
       <voltaPosAbove x="0" y="-2"/>
       <defaultsVersion>114</defaultsVersion>
-      <Spatium>1.764</Spatium>
+      <spatium>1.764</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/compat114_data/fingering-ref.mscx
+++ b/src/engraving/tests/compat114_data/fingering-ref.mscx
@@ -6,7 +6,7 @@
       <frameSystemDistance>7</frameSystemDistance>
       <voltaPosAbove x="0" y="-2"/>
       <defaultsVersion>114</defaultsVersion>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/compat114_data/hairpin-ref.mscx
+++ b/src/engraving/tests/compat114_data/hairpin-ref.mscx
@@ -6,7 +6,7 @@
       <frameSystemDistance>7</frameSystemDistance>
       <voltaPosAbove x="0" y="-2"/>
       <defaultsVersion>114</defaultsVersion>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/compat114_data/hor_frame_and_mmrest-ref.mscx
+++ b/src/engraving/tests/compat114_data/hor_frame_and_mmrest-ref.mscx
@@ -9,7 +9,7 @@
       <createMultiMeasureRests>1</createMultiMeasureRests>
       <voltaPosAbove x="0" y="-2"/>
       <defaultsVersion>114</defaultsVersion>
-      <Spatium>1.764</Spatium>
+      <spatium>1.764</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/compat114_data/keysig-ref.mscx
+++ b/src/engraving/tests/compat114_data/keysig-ref.mscx
@@ -6,7 +6,7 @@
       <frameSystemDistance>7</frameSystemDistance>
       <voltaPosAbove x="0" y="-2"/>
       <defaultsVersion>114</defaultsVersion>
-      <Spatium>1.764</Spatium>
+      <spatium>1.764</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/compat114_data/markers-ref.mscx
+++ b/src/engraving/tests/compat114_data/markers-ref.mscx
@@ -9,7 +9,7 @@
       <lastSystemFillLimit>0</lastSystemFillLimit>
       <voltaPosAbove x="0" y="-2"/>
       <defaultsVersion>114</defaultsVersion>
-      <Spatium>1.764</Spatium>
+      <spatium>1.764</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/compat114_data/noteheads-ref.mscx
+++ b/src/engraving/tests/compat114_data/noteheads-ref.mscx
@@ -6,7 +6,7 @@
       <frameSystemDistance>7</frameSystemDistance>
       <voltaPosAbove x="0" y="-2"/>
       <defaultsVersion>114</defaultsVersion>
-      <Spatium>1.764</Spatium>
+      <spatium>1.764</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/compat114_data/notes-ref.mscx
+++ b/src/engraving/tests/compat114_data/notes-ref.mscx
@@ -6,7 +6,7 @@
       <frameSystemDistance>7</frameSystemDistance>
       <voltaPosAbove x="0" y="-2"/>
       <defaultsVersion>114</defaultsVersion>
-      <Spatium>1.764</Spatium>
+      <spatium>1.764</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/compat114_data/notes_useroffset-ref.mscx
+++ b/src/engraving/tests/compat114_data/notes_useroffset-ref.mscx
@@ -6,7 +6,7 @@
       <frameSystemDistance>7</frameSystemDistance>
       <voltaPosAbove x="0" y="-2"/>
       <defaultsVersion>114</defaultsVersion>
-      <Spatium>1.764</Spatium>
+      <spatium>1.764</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/compat114_data/ottava-ref.mscx
+++ b/src/engraving/tests/compat114_data/ottava-ref.mscx
@@ -6,7 +6,7 @@
       <frameSystemDistance>7</frameSystemDistance>
       <voltaPosAbove x="0" y="-2"/>
       <defaultsVersion>114</defaultsVersion>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/compat114_data/pedal-ref.mscx
+++ b/src/engraving/tests/compat114_data/pedal-ref.mscx
@@ -6,7 +6,7 @@
       <frameSystemDistance>7</frameSystemDistance>
       <voltaPosAbove x="0" y="-2"/>
       <defaultsVersion>114</defaultsVersion>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/compat114_data/slurs-ref.mscx
+++ b/src/engraving/tests/compat114_data/slurs-ref.mscx
@@ -6,7 +6,7 @@
       <frameSystemDistance>7</frameSystemDistance>
       <voltaPosAbove x="0" y="-2"/>
       <defaultsVersion>114</defaultsVersion>
-      <Spatium>1.764</Spatium>
+      <spatium>1.764</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/compat114_data/style-ref.mscx
+++ b/src/engraving/tests/compat114_data/style-ref.mscx
@@ -62,7 +62,7 @@
       <oddFooterR>$P</oddFooterR>
       <voltaPosAbove x="0" y="-2"/>
       <defaultsVersion>114</defaultsVersion>
-      <Spatium>1.764</Spatium>
+      <spatium>1.764</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/compat114_data/tamtam-ref.mscx
+++ b/src/engraving/tests/compat114_data/tamtam-ref.mscx
@@ -6,7 +6,7 @@
       <frameSystemDistance>7</frameSystemDistance>
       <voltaPosAbove x="0" y="-2"/>
       <defaultsVersion>114</defaultsVersion>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/compat114_data/text_scaling-ref.mscx
+++ b/src/engraving/tests/compat114_data/text_scaling-ref.mscx
@@ -6,7 +6,7 @@
       <frameSystemDistance>7</frameSystemDistance>
       <voltaPosAbove x="0" y="-2"/>
       <defaultsVersion>114</defaultsVersion>
-      <Spatium>0.764</Spatium>
+      <spatium>0.764</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/compat114_data/textline-ref.mscx
+++ b/src/engraving/tests/compat114_data/textline-ref.mscx
@@ -6,7 +6,7 @@
       <frameSystemDistance>7</frameSystemDistance>
       <voltaPosAbove x="0" y="-2"/>
       <defaultsVersion>114</defaultsVersion>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/compat114_data/textstyles-ref.mscx
+++ b/src/engraving/tests/compat114_data/textstyles-ref.mscx
@@ -17,7 +17,7 @@
       <concertPitch>1</concertPitch>
       <voltaPosAbove x="0" y="-2"/>
       <defaultsVersion>114</defaultsVersion>
-      <Spatium>2</Spatium>
+      <spatium>2</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/compat114_data/title-ref.mscx
+++ b/src/engraving/tests/compat114_data/title-ref.mscx
@@ -6,7 +6,7 @@
       <frameSystemDistance>7</frameSystemDistance>
       <voltaPosAbove x="0" y="-2"/>
       <defaultsVersion>114</defaultsVersion>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/compat114_data/tremolo2notes-ref.mscx
+++ b/src/engraving/tests/compat114_data/tremolo2notes-ref.mscx
@@ -6,7 +6,7 @@
       <frameSystemDistance>7</frameSystemDistance>
       <voltaPosAbove x="0" y="-2"/>
       <defaultsVersion>114</defaultsVersion>
-      <Spatium>1.764</Spatium>
+      <spatium>1.764</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/compat114_data/tuplets-ref.mscx
+++ b/src/engraving/tests/compat114_data/tuplets-ref.mscx
@@ -6,7 +6,7 @@
       <frameSystemDistance>7</frameSystemDistance>
       <voltaPosAbove x="0" y="-2"/>
       <defaultsVersion>114</defaultsVersion>
-      <Spatium>1.764</Spatium>
+      <spatium>1.764</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/compat114_data/tuplets_1-ref.mscx
+++ b/src/engraving/tests/compat114_data/tuplets_1-ref.mscx
@@ -6,7 +6,7 @@
       <frameSystemDistance>7</frameSystemDistance>
       <voltaPosAbove x="0" y="-2"/>
       <defaultsVersion>114</defaultsVersion>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/compat114_data/tuplets_2-ref.mscx
+++ b/src/engraving/tests/compat114_data/tuplets_2-ref.mscx
@@ -6,7 +6,7 @@
       <frameSystemDistance>7</frameSystemDistance>
       <voltaPosAbove x="0" y="-2"/>
       <defaultsVersion>114</defaultsVersion>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/compat206_data/accidentals-ref.mscx
+++ b/src/engraving/tests/compat206_data/accidentals-ref.mscx
@@ -4,7 +4,7 @@
     <Division>480</Division>
     <Style>
       <defaultsVersion>206</defaultsVersion>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/compat206_data/ambitus-ref.mscx
+++ b/src/engraving/tests/compat206_data/ambitus-ref.mscx
@@ -4,7 +4,7 @@
     <Division>480</Division>
     <Style>
       <defaultsVersion>206</defaultsVersion>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/compat206_data/articulations-double-ref.mscx
+++ b/src/engraving/tests/compat206_data/articulations-double-ref.mscx
@@ -14,7 +14,7 @@
       <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <lastSystemFillLimit>0</lastSystemFillLimit>
       <defaultsVersion>206</defaultsVersion>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -1822,7 +1822,7 @@
         <lastSystemFillLimit>0</lastSystemFillLimit>
         <createMultiMeasureRests>1</createMultiMeasureRests>
         <defaultsVersion>206</defaultsVersion>
-        <Spatium>1.76389</Spatium>
+        <spatium>1.76389</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/compat206_data/articulations-ref.mscx
+++ b/src/engraving/tests/compat206_data/articulations-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <lastSystemFillLimit>0</lastSystemFillLimit>
       <defaultsVersion>206</defaultsVersion>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/compat206_data/barlines-ref.mscx
+++ b/src/engraving/tests/compat206_data/barlines-ref.mscx
@@ -12,7 +12,7 @@
       <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <lastSystemFillLimit>0</lastSystemFillLimit>
       <defaultsVersion>206</defaultsVersion>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/compat206_data/breath-ref.mscx
+++ b/src/engraving/tests/compat206_data/breath-ref.mscx
@@ -4,7 +4,7 @@
     <Division>480</Division>
     <Style>
       <defaultsVersion>206</defaultsVersion>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/compat206_data/clefs-ref.mscx
+++ b/src/engraving/tests/compat206_data/clefs-ref.mscx
@@ -4,7 +4,7 @@
     <Division>480</Division>
     <Style>
       <defaultsVersion>206</defaultsVersion>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/compat206_data/drumset-ref.mscx
+++ b/src/engraving/tests/compat206_data/drumset-ref.mscx
@@ -4,7 +4,7 @@
     <Division>480</Division>
     <Style>
       <defaultsVersion>206</defaultsVersion>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/compat206_data/fermata-ref.mscx
+++ b/src/engraving/tests/compat206_data/fermata-ref.mscx
@@ -11,7 +11,7 @@
       <pageOddTopMargin>0.393701</pageOddTopMargin>
       <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <defaultsVersion>206</defaultsVersion>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/compat206_data/frame_text2-ref.mscx
+++ b/src/engraving/tests/compat206_data/frame_text2-ref.mscx
@@ -152,7 +152,7 @@
       <user2FramePadding>0</user2FramePadding>
       <user2FrameWidth>0</user2FrameWidth>
       <defaultsVersion>206</defaultsVersion>
-      <Spatium>1.94</Spatium>
+      <spatium>1.94</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/compat206_data/hairpin-ref.mscx
+++ b/src/engraving/tests/compat206_data/hairpin-ref.mscx
@@ -13,7 +13,7 @@
       <pageOddTopMargin>0.393701</pageOddTopMargin>
       <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <defaultsVersion>206</defaultsVersion>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -609,7 +609,7 @@
         <pageOddBottomMargin>0.787403</pageOddBottomMargin>
         <createMultiMeasureRests>1</createMultiMeasureRests>
         <defaultsVersion>206</defaultsVersion>
-        <Spatium>1.76389</Spatium>
+        <spatium>1.76389</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/compat206_data/instrumentNameAlign-ref.mscx
+++ b/src/engraving/tests/compat206_data/instrumentNameAlign-ref.mscx
@@ -16,7 +16,7 @@
       <longInstrumentFramePadding>0</longInstrumentFramePadding>
       <longInstrumentFrameWidth>0</longInstrumentFrameWidth>
       <defaultsVersion>206</defaultsVersion>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/compat206_data/lidemptytext-ref.mscx
+++ b/src/engraving/tests/compat206_data/lidemptytext-ref.mscx
@@ -7,7 +7,7 @@
       <trillPosAbove x="0" y="0"/>
       <dynamicsFontStyle>0</dynamicsFontStyle>
       <defaultsVersion>206</defaultsVersion>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -234,7 +234,7 @@
         <trillPosAbove x="0" y="0"/>
         <dynamicsFontStyle>0</dynamicsFontStyle>
         <defaultsVersion>206</defaultsVersion>
-        <Spatium>1.76389</Spatium>
+        <spatium>1.76389</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/compat206_data/markers-ref.mscx
+++ b/src/engraving/tests/compat206_data/markers-ref.mscx
@@ -4,7 +4,7 @@
     <Division>480</Division>
     <Style>
       <defaultsVersion>206</defaultsVersion>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/compat206_data/noteheads-ref.mscx
+++ b/src/engraving/tests/compat206_data/noteheads-ref.mscx
@@ -4,7 +4,7 @@
     <Division>480</Division>
     <Style>
       <defaultsVersion>206</defaultsVersion>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/compat206_data/textstyles-ref.mscx
+++ b/src/engraving/tests/compat206_data/textstyles-ref.mscx
@@ -157,7 +157,7 @@
       <instrumentChangeFramePadding>0</instrumentChangeFramePadding>
       <instrumentChangeFrameWidth>0</instrumentChangeFrameWidth>
       <defaultsVersion>206</defaultsVersion>
-      <Spatium>1.85</Spatium>
+      <spatium>1.85</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/compat206_data/tuplets-ref.mscx
+++ b/src/engraving/tests/compat206_data/tuplets-ref.mscx
@@ -4,7 +4,7 @@
     <Division>480</Division>
     <Style>
       <defaultsVersion>206</defaultsVersion>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/compat206_data/userstylesparts-ref.mscx
+++ b/src/engraving/tests/compat206_data/userstylesparts-ref.mscx
@@ -59,7 +59,7 @@
       <user7FramePadding>0</user7FramePadding>
       <user7FrameWidth>0</user7FrameWidth>
       <defaultsVersion>206</defaultsVersion>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -440,7 +440,7 @@
         <user7FramePadding>0</user7FramePadding>
         <user7FrameWidth>0</user7FrameWidth>
         <defaultsVersion>206</defaultsVersion>
-        <Spatium>1.76389</Spatium>
+        <spatium>1.76389</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -675,7 +675,7 @@
         <user7FramePadding>0</user7FramePadding>
         <user7FrameWidth>0</user7FrameWidth>
         <defaultsVersion>206</defaultsVersion>
-        <Spatium>1.76389</Spatium>
+        <spatium>1.76389</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -933,7 +933,7 @@
         <user7FramePadding>0</user7FramePadding>
         <user7FrameWidth>0</user7FrameWidth>
         <defaultsVersion>206</defaultsVersion>
-        <Spatium>1.76389</Spatium>
+        <spatium>1.76389</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/copypaste_data/copypaste01-ref.mscx
+++ b/src/engraving/tests/copypaste_data/copypaste01-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/copypaste_data/copypaste02-ref.mscx
+++ b/src/engraving/tests/copypaste_data/copypaste02-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/copypaste_data/copypaste03-ref.mscx
+++ b/src/engraving/tests/copypaste_data/copypaste03-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/copypaste_data/copypaste04-ref.mscx
+++ b/src/engraving/tests/copypaste_data/copypaste04-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/copypaste_data/copypaste05-ref.mscx
+++ b/src/engraving/tests/copypaste_data/copypaste05-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/copypaste_data/copypaste06-ref.mscx
+++ b/src/engraving/tests/copypaste_data/copypaste06-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/copypaste_data/copypaste08-ref.mscx
+++ b/src/engraving/tests/copypaste_data/copypaste08-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/copypaste_data/copypaste09-ref.mscx
+++ b/src/engraving/tests/copypaste_data/copypaste09-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/copypaste_data/copypaste10-ref.mscx
+++ b/src/engraving/tests/copypaste_data/copypaste10-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/copypaste_data/copypaste11-ref.mscx
+++ b/src/engraving/tests/copypaste_data/copypaste11-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/copypaste_data/copypaste12-ref.mscx
+++ b/src/engraving/tests/copypaste_data/copypaste12-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/copypaste_data/copypaste13-ref.mscx
+++ b/src/engraving/tests/copypaste_data/copypaste13-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/copypaste_data/copypaste17-ref.mscx
+++ b/src/engraving/tests/copypaste_data/copypaste17-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/copypaste_data/copypaste18-ref.mscx
+++ b/src/engraving/tests/copypaste_data/copypaste18-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/copypaste_data/copypaste19-ref.mscx
+++ b/src/engraving/tests/copypaste_data/copypaste19-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/copypaste_data/copypaste20-ref.mscx
+++ b/src/engraving/tests/copypaste_data/copypaste20-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/copypaste_data/copypaste22-ref.mscx
+++ b/src/engraving/tests/copypaste_data/copypaste22-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/copypaste_data/copypaste23-ref.mscx
+++ b/src/engraving/tests/copypaste_data/copypaste23-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/copypaste_data/copypaste24-ref.mscx
+++ b/src/engraving/tests/copypaste_data/copypaste24-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/copypaste_data/copypaste25-ref.mscx
+++ b/src/engraving/tests/copypaste_data/copypaste25-ref.mscx
@@ -9,7 +9,7 @@
       <lastSystemFillLimit>0</lastSystemFillLimit>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/copypaste_data/copypaste26-ref.mscx
+++ b/src/engraving/tests/copypaste_data/copypaste26-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/copypaste_data/copypaste27-ref.mscx
+++ b/src/engraving/tests/copypaste_data/copypaste27-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/copypaste_data/copypaste50-ref.mscx
+++ b/src/engraving/tests/copypaste_data/copypaste50-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/copypaste_data/copypasteNote01-ref.mscx
+++ b/src/engraving/tests/copypaste_data/copypasteNote01-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/copypaste_data/copypasteNote02-ref.mscx
+++ b/src/engraving/tests/copypaste_data/copypasteNote02-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/copypaste_data/copypasteNote03-ref.mscx
+++ b/src/engraving/tests/copypaste_data/copypasteNote03-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/copypaste_data/copypasteNote04-ref.mscx
+++ b/src/engraving/tests/copypaste_data/copypasteNote04-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/copypaste_data/copypasteNote05-ref.mscx
+++ b/src/engraving/tests/copypaste_data/copypasteNote05-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/copypaste_data/copypasteNote06-ref.mscx
+++ b/src/engraving/tests/copypaste_data/copypasteNote06-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/copypaste_data/copypasteNote07-ref.mscx
+++ b/src/engraving/tests/copypaste_data/copypasteNote07-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/copypaste_data/copypasteNote08-ref.mscx
+++ b/src/engraving/tests/copypaste_data/copypasteNote08-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/copypaste_data/copypasteNote09-ref.mscx
+++ b/src/engraving/tests/copypaste_data/copypasteNote09-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/copypaste_data/copypasteNote10-ref.mscx
+++ b/src/engraving/tests/copypaste_data/copypasteNote10-ref.mscx
@@ -7,7 +7,7 @@
       <minEmptyMeasures>1</minEmptyMeasures>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/copypaste_data/copypasteNote11-ref.mscx
+++ b/src/engraving/tests/copypaste_data/copypasteNote11-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/copypaste_data/copypasteNote12-ref.mscx
+++ b/src/engraving/tests/copypaste_data/copypasteNote12-ref.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/copypaste_data/copypasteSplit01-ref.mscx
+++ b/src/engraving/tests/copypaste_data/copypasteSplit01-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/copypaste_data/copypasteSplit02-ref.mscx
+++ b/src/engraving/tests/copypaste_data/copypasteSplit02-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/copypaste_data/copypasteSplit03-ref.mscx
+++ b/src/engraving/tests/copypaste_data/copypasteSplit03-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/copypaste_data/copypasteSplit04-ref.mscx
+++ b/src/engraving/tests/copypaste_data/copypasteSplit04-ref.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/copypaste_data/copypaste_partial_01-ref.mscx
+++ b/src/engraving/tests/copypaste_data/copypaste_partial_01-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/copypaste_data/copypaste_parts-ref.mscx
+++ b/src/engraving/tests/copypaste_data/copypaste_parts-ref.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -843,7 +843,7 @@
       <name>Flute</name>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/copypaste_data/copypaste_tuplet_01-ref.mscx
+++ b/src/engraving/tests/copypaste_data/copypaste_tuplet_01-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/copypaste_data/copypaste_tuplet_02-ref.mscx
+++ b/src/engraving/tests/copypaste_data/copypaste_tuplet_02-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/copypastesymbollist_data/copypastesymbollist-articulation-ref.mscx
+++ b/src/engraving/tests/copypastesymbollist_data/copypastesymbollist-articulation-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/copypastesymbollist_data/copypastesymbollist-articulation-rest-ref.mscx
+++ b/src/engraving/tests/copypastesymbollist_data/copypastesymbollist-articulation-rest-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/copypastesymbollist_data/copypastesymbollist-chordnames-01-ref.mscx
+++ b/src/engraving/tests/copypastesymbollist_data/copypastesymbollist-chordnames-01-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/copypastesymbollist_data/copypastesymbollist-chordnames-ref.mscx
+++ b/src/engraving/tests/copypastesymbollist_data/copypastesymbollist-chordnames-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/copypastesymbollist_data/copypastesymbollist-lyrics-ref.mscx
+++ b/src/engraving/tests/copypastesymbollist_data/copypastesymbollist-lyrics-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/copypastesymbollist_data/copypastesymbollist-range-01-ref.mscx
+++ b/src/engraving/tests/copypastesymbollist_data/copypastesymbollist-range-01-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/copypastesymbollist_data/copypastesymbollist-range-ref.mscx
+++ b/src/engraving/tests/copypastesymbollist_data/copypastesymbollist-range-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/copypastesymbollist_data/copypastesymbollist-stafftext-ref.mscx
+++ b/src/engraving/tests/copypastesymbollist_data/copypastesymbollist-stafftext-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/copypastesymbollist_data/copypastesymbollist-sticking-ref.mscx
+++ b/src/engraving/tests/copypastesymbollist_data/copypastesymbollist-sticking-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/earlymusic_data/mensurstrich01-ref.mscx
+++ b/src/engraving/tests/earlymusic_data/mensurstrich01-ref.mscx
@@ -4,7 +4,7 @@
     <Division>480</Division>
     <Style>
       <crossMeasureValues>1</crossMeasureValues>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/earlymusic_data/mensurstrich01.mscx
+++ b/src/engraving/tests/earlymusic_data/mensurstrich01.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/exchangevoices_data/exchangevoices-gliss-ref.mscx
+++ b/src/engraving/tests/exchangevoices_data/exchangevoices-gliss-ref.mscx
@@ -6,7 +6,7 @@
       <lastSystemFillLimit>0</lastSystemFillLimit>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/exchangevoices_data/exchangevoices-slurs-ref.mscx
+++ b/src/engraving/tests/exchangevoices_data/exchangevoices-slurs-ref.mscx
@@ -6,7 +6,7 @@
       <lastSystemFillLimit>0</lastSystemFillLimit>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/exchangevoices_data/undoChangeVoice01-ref.mscx
+++ b/src/engraving/tests/exchangevoices_data/undoChangeVoice01-ref.mscx
@@ -6,7 +6,7 @@
       <lastSystemFillLimit>0</lastSystemFillLimit>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -562,7 +562,7 @@
       <Style>
         <lastSystemFillLimit>0</lastSystemFillLimit>
         <createMultiMeasureRests>1</createMultiMeasureRests>
-        <Spatium>1.76389</Spatium>
+        <spatium>1.76389</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/exchangevoices_data/undoChangeVoice02-ref.mscx
+++ b/src/engraving/tests/exchangevoices_data/undoChangeVoice02-ref.mscx
@@ -6,7 +6,7 @@
       <lastSystemFillLimit>0</lastSystemFillLimit>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -546,7 +546,7 @@
       <Style>
         <lastSystemFillLimit>0</lastSystemFillLimit>
         <createMultiMeasureRests>1</createMultiMeasureRests>
-        <Spatium>1.76389</Spatium>
+        <spatium>1.76389</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/expression_data/expression-1-ref.mscx
+++ b/src/engraving/tests/expression_data/expression-1-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/expression_data/expression-2-ref.mscx
+++ b/src/engraving/tests/expression_data/expression-2-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/harpdiagrams_data/textdiagram01-ref.mscx
+++ b/src/engraving/tests/harpdiagrams_data/textdiagram01-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/harpdiagrams_data/textdiagram02.mscx
+++ b/src/engraving/tests/harpdiagrams_data/textdiagram02.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/implode_explode_data/explodeDynamics01-ref.mscx
+++ b/src/engraving/tests/implode_explode_data/explodeDynamics01-ref.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/implode_explode_data/explodeDynamics02-ref.mscx
+++ b/src/engraving/tests/implode_explode_data/explodeDynamics02-ref.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/implode_explode_data/implodeDynamics01-ref.mscx
+++ b/src/engraving/tests/implode_explode_data/implodeDynamics01-ref.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/implode_explode_data/implodeDynamics02-ref.mscx
+++ b/src/engraving/tests/implode_explode_data/implodeDynamics02-ref.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/implode_explode_data/implodeScore.mscx
+++ b/src/engraving/tests/implode_explode_data/implodeScore.mscx
@@ -9,7 +9,7 @@
       <lastSystemFillLimit>0</lastSystemFillLimit>
       <concertPitch>1</concertPitch>
       <minMMRestWidth>0</minMMRestWidth>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/implode_explode_data/implodeScore01-ref.mscx
+++ b/src/engraving/tests/implode_explode_data/implodeScore01-ref.mscx
@@ -9,7 +9,7 @@
       <lastSystemFillLimit>0</lastSystemFillLimit>
       <concertPitch>1</concertPitch>
       <minMMRestWidth>0</minMMRestWidth>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/implode_explode_data/implodeScore02-ref.mscx
+++ b/src/engraving/tests/implode_explode_data/implodeScore02-ref.mscx
@@ -9,7 +9,7 @@
       <lastSystemFillLimit>0</lastSystemFillLimit>
       <concertPitch>1</concertPitch>
       <minMMRestWidth>0</minMMRestWidth>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/implode_explode_data/undoExplode01-ref.mscx
+++ b/src/engraving/tests/implode_explode_data/undoExplode01-ref.mscx
@@ -6,7 +6,7 @@
       <concertPitch>1</concertPitch>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/implode_explode_data/undoExplode02-ref.mscx
+++ b/src/engraving/tests/implode_explode_data/undoExplode02-ref.mscx
@@ -6,7 +6,7 @@
       <concertPitch>1</concertPitch>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/implode_explode_data/undoImplode01-ref.mscx
+++ b/src/engraving/tests/implode_explode_data/undoImplode01-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/implode_explode_data/undoImplode02-ref.mscx
+++ b/src/engraving/tests/implode_explode_data/undoImplode02-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/implode_explode_data/undoImplodeVoice01-ref.mscx
+++ b/src/engraving/tests/implode_explode_data/undoImplodeVoice01-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/implode_explode_data/undoImplodeVoice02-ref.mscx
+++ b/src/engraving/tests/implode_explode_data/undoImplodeVoice02-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/instrumentchange_data/add-ref.mscx
+++ b/src/engraving/tests/instrumentchange_data/add-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/instrumentchange_data/change-ref.mscx
+++ b/src/engraving/tests/instrumentchange_data/change-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/instrumentchange_data/copy-ref.mscx
+++ b/src/engraving/tests/instrumentchange_data/copy-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/instrumentchange_data/delete-ref.mscx
+++ b/src/engraving/tests/instrumentchange_data/delete-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/instrumentchange_data/mixer-ref.mscx
+++ b/src/engraving/tests/instrumentchange_data/mixer-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/join_data/join01-ref.mscx
+++ b/src/engraving/tests/join_data/join01-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/join_data/join02-ref.mscx
+++ b/src/engraving/tests/join_data/join02-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/join_data/join03-ref.mscx
+++ b/src/engraving/tests/join_data/join03-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/join_data/join04-ref.mscx
+++ b/src/engraving/tests/join_data/join04-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/join_data/join05-ref.mscx
+++ b/src/engraving/tests/join_data/join05-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/join_data/join06-ref.mscx
+++ b/src/engraving/tests/join_data/join06-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/join_data/join07-ref.mscx
+++ b/src/engraving/tests/join_data/join07-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/join_data/join09-ref.mscx
+++ b/src/engraving/tests/join_data/join09-ref.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/join_data/join10-ref.mscx
+++ b/src/engraving/tests/join_data/join10-ref.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/keysig_data/concert-pitch-01-ref.mscx
+++ b/src/engraving/tests/keysig_data/concert-pitch-01-ref.mscx
@@ -6,7 +6,7 @@
       <concertPitch>1</concertPitch>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/keysig_data/concert-pitch-02-ref.mscx
+++ b/src/engraving/tests/keysig_data/concert-pitch-02-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/keysig_data/keysig.mscx
+++ b/src/engraving/tests/keysig_data/keysig.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/keysig_data/keysig01-ref.mscx
+++ b/src/engraving/tests/keysig_data/keysig01-ref.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/keysig_data/keysig02-ref.mscx
+++ b/src/engraving/tests/keysig_data/keysig02-ref.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/keysig_data/keysig03-ref.mscx
+++ b/src/engraving/tests/keysig_data/keysig03-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/keysig_data/preferSharpFlat-1-ref.mscx
+++ b/src/engraving/tests/keysig_data/preferSharpFlat-1-ref.mscx
@@ -8,7 +8,7 @@
       <pagePrintableWidth>7.4826</pagePrintableWidth>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/keysig_data/preferSharpFlat-2-ref.mscx
+++ b/src/engraving/tests/keysig_data/preferSharpFlat-2-ref.mscx
@@ -8,7 +8,7 @@
       <pagePrintableWidth>7.4826</pagePrintableWidth>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/measure_data/changeMeasureLen-ref.mscx
+++ b/src/engraving/tests/measure_data/changeMeasureLen-ref.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/measure_data/measure-10-ref.mscx
+++ b/src/engraving/tests/measure_data/measure-10-ref.mscx
@@ -13,7 +13,7 @@
       <keySigNaturals>1</keySigNaturals>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.764</Spatium>
+      <spatium>1.764</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/measure_data/measure-4-ref.mscx
+++ b/src/engraving/tests/measure_data/measure-4-ref.mscx
@@ -13,7 +13,7 @@
       <keySigNaturals>1</keySigNaturals>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.764</Spatium>
+      <spatium>1.764</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/measure_data/measure-5-ref.mscx
+++ b/src/engraving/tests/measure_data/measure-5-ref.mscx
@@ -13,7 +13,7 @@
       <keySigNaturals>1</keySigNaturals>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.764</Spatium>
+      <spatium>1.764</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/measure_data/measure-6-ref.mscx
+++ b/src/engraving/tests/measure_data/measure-6-ref.mscx
@@ -13,7 +13,7 @@
       <keySigNaturals>1</keySigNaturals>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.764</Spatium>
+      <spatium>1.764</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/measure_data/measure-7-ref.mscx
+++ b/src/engraving/tests/measure_data/measure-7-ref.mscx
@@ -13,7 +13,7 @@
       <keySigNaturals>1</keySigNaturals>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.764</Spatium>
+      <spatium>1.764</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/measure_data/measure-8-ref.mscx
+++ b/src/engraving/tests/measure_data/measure-8-ref.mscx
@@ -13,7 +13,7 @@
       <keySigNaturals>1</keySigNaturals>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.764</Spatium>
+      <spatium>1.764</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/measure_data/measure-9-ref.mscx
+++ b/src/engraving/tests/measure_data/measure-9-ref.mscx
@@ -13,7 +13,7 @@
       <keySigNaturals>1</keySigNaturals>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.764</Spatium>
+      <spatium>1.764</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/measure_data/measure-insert_beginning-ref.mscx
+++ b/src/engraving/tests/measure_data/measure-insert_beginning-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/measure_data/measure-insert_bf_clef-2-ref.mscx
+++ b/src/engraving/tests/measure_data/measure-insert_bf_clef-2-ref.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/measure_data/measure-insert_bf_clef-ref.mscx
+++ b/src/engraving/tests/measure_data/measure-insert_bf_clef-ref.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/measure_data/measure-insert_bf_clef.mscx
+++ b/src/engraving/tests/measure_data/measure-insert_bf_clef.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/measure_data/measure-insert_bf_key-2-ref.mscx
+++ b/src/engraving/tests/measure_data/measure-insert_bf_key-2-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/measure_data/measure-insert_bf_key-ref.mscx
+++ b/src/engraving/tests/measure_data/measure-insert_bf_key-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/measure_data/measure-insert_bf_key_undo-ref.mscx
+++ b/src/engraving/tests/measure_data/measure-insert_bf_key_undo-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/measure_data/measureSplit-ref.mscx
+++ b/src/engraving/tests/measure_data/measureSplit-ref.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -1292,7 +1292,7 @@
       <name>Flute</name>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -1995,7 +1995,7 @@
       <name>Oboe</name>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/measure_data/measurenumber-1-ref.mscx
+++ b/src/engraving/tests/measure_data/measurenumber-1-ref.mscx
@@ -6,7 +6,7 @@
       <measureNumberVPlacement>1</measureNumberVPlacement>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/measure_data/measurenumber-2-ref.mscx
+++ b/src/engraving/tests/measure_data/measurenumber-2-ref.mscx
@@ -7,7 +7,7 @@
       <measureNumberHPlacement>1</measureNumberHPlacement>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/measure_data/measurenumber-3-ref.mscx
+++ b/src/engraving/tests/measure_data/measurenumber-3-ref.mscx
@@ -8,7 +8,7 @@
       <measureNumberHPlacement>1</measureNumberHPlacement>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/measure_data/measurenumber-4-ref.mscx
+++ b/src/engraving/tests/measure_data/measurenumber-4-ref.mscx
@@ -9,7 +9,7 @@
       <measureNumberHPlacement>1</measureNumberHPlacement>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/measure_data/measurenumber-5-ref.mscx
+++ b/src/engraving/tests/measure_data/measurenumber-5-ref.mscx
@@ -8,7 +8,7 @@
       <measureNumberHPlacement>1</measureNumberHPlacement>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/measure_data/measurenumber-6-ref.mscx
+++ b/src/engraving/tests/measure_data/measurenumber-6-ref.mscx
@@ -9,7 +9,7 @@
       <measureNumberHPlacement>1</measureNumberHPlacement>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/measure_data/measurenumber-7-ref.mscx
+++ b/src/engraving/tests/measure_data/measurenumber-7-ref.mscx
@@ -10,7 +10,7 @@
       <measureNumberHPlacement>1</measureNumberHPlacement>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/measure_data/mmrest-ref.mscx
+++ b/src/engraving/tests/measure_data/mmrest-ref.mscx
@@ -16,7 +16,7 @@
       <createMultiMeasureRests>1</createMultiMeasureRests>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/measure_data/undoDelInitialVBox_269919-ref.mscx
+++ b/src/engraving/tests/measure_data/undoDelInitialVBox_269919-ref.mscx
@@ -15,7 +15,7 @@
       <lastSystemFillLimit>0</lastSystemFillLimit>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/note_data/grace-ref.mscx
+++ b/src/engraving/tests/note_data/grace-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/note_data/notelimits-ref.mscx
+++ b/src/engraving/tests/note_data/notelimits-ref.mscx
@@ -6,7 +6,7 @@
       <lastSystemFillLimit>0</lastSystemFillLimit>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/note_data/tpc-ref.mscx
+++ b/src/engraving/tests/note_data/tpc-ref.mscx
@@ -6,7 +6,7 @@
       <concertPitch>1</concertPitch>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/note_data/tpc-transpose-ref.mscx
+++ b/src/engraving/tests/note_data/tpc-transpose-ref.mscx
@@ -6,7 +6,7 @@
       <concertPitch>1</concertPitch>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/note_data/tpc-transpose2-ref.mscx
+++ b/src/engraving/tests/note_data/tpc-transpose2-ref.mscx
@@ -6,7 +6,7 @@
       <concertPitch>1</concertPitch>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/linked-ties-1.mscx
+++ b/src/engraving/tests/parts_data/linked-ties-1.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/linked-ties-parts.mscx
+++ b/src/engraving/tests/parts_data/linked-ties-parts.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -399,7 +399,7 @@
       <name>Flute</name>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-54346-parts.mscx
+++ b/src/engraving/tests/parts_data/part-54346-parts.mscx
@@ -4,7 +4,7 @@
     <Division>480</Division>
     <Style>
       <concertPitch>1</concertPitch>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -275,7 +275,7 @@
       <name>B♭ Trumpet</name>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -453,7 +453,7 @@
       <name>C Trumpet</name>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-54346.mscx
+++ b/src/engraving/tests/parts_data/part-54346.mscx
@@ -4,7 +4,7 @@
     <Division>480</Division>
     <Style>
       <concertPitch>1</concertPitch>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-all-appendmeasures.mscx
+++ b/src/engraving/tests/parts_data/part-all-appendmeasures.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -1081,7 +1081,7 @@
       <name>Alto</name>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -1796,7 +1796,7 @@
       <name>Tenor</name>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-all-insertmeasures.mscx
+++ b/src/engraving/tests/parts_data/part-all-insertmeasures.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -1077,7 +1077,7 @@
       <name>Alto</name>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -1791,7 +1791,7 @@
       <name>Tenor</name>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-all-parts.mscx
+++ b/src/engraving/tests/parts_data/part-all-parts.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -1063,7 +1063,7 @@
       <name>Alto</name>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -1768,7 +1768,7 @@
       <name>Tenor</name>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-all-uappendmeasures.mscx
+++ b/src/engraving/tests/parts_data/part-all-uappendmeasures.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -1063,7 +1063,7 @@
       <name>Alto</name>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -1768,7 +1768,7 @@
       <name>Tenor</name>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-all-uinsertmeasures.mscx
+++ b/src/engraving/tests/parts_data/part-all-uinsertmeasures.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -1063,7 +1063,7 @@
       <name>Alto</name>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -1768,7 +1768,7 @@
       <name>Tenor</name>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-all.mscx
+++ b/src/engraving/tests/parts_data/part-all.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-breath-add.mscx
+++ b/src/engraving/tests/parts_data/part-breath-add.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -776,7 +776,7 @@
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -1221,7 +1221,7 @@
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-breath-del.mscx
+++ b/src/engraving/tests/parts_data/part-breath-del.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -772,7 +772,7 @@
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -1212,7 +1212,7 @@
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-breath-parts.mscx
+++ b/src/engraving/tests/parts_data/part-breath-parts.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -784,7 +784,7 @@
       <name>Alto</name>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -1234,7 +1234,7 @@
       <name>Tenor</name>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-breath-uadd.mscx
+++ b/src/engraving/tests/parts_data/part-breath-uadd.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -772,7 +772,7 @@
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -1212,7 +1212,7 @@
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-breath-udel.mscx
+++ b/src/engraving/tests/parts_data/part-breath-udel.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -776,7 +776,7 @@
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -1221,7 +1221,7 @@
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-breath-uradd.mscx
+++ b/src/engraving/tests/parts_data/part-breath-uradd.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -776,7 +776,7 @@
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -1221,7 +1221,7 @@
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-breath-urdel.mscx
+++ b/src/engraving/tests/parts_data/part-breath-urdel.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -772,7 +772,7 @@
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -1212,7 +1212,7 @@
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-breath.mscx
+++ b/src/engraving/tests/parts_data/part-breath.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-chordline-add.mscx
+++ b/src/engraving/tests/parts_data/part-chordline-add.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -776,7 +776,7 @@
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -1221,7 +1221,7 @@
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-chordline-del.mscx
+++ b/src/engraving/tests/parts_data/part-chordline-del.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -767,7 +767,7 @@
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -1201,7 +1201,7 @@
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-chordline-parts.mscx
+++ b/src/engraving/tests/parts_data/part-chordline-parts.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -770,7 +770,7 @@
       <name>Alto</name>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -1208,7 +1208,7 @@
       <name>Tenor</name>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-chordline-uadd.mscx
+++ b/src/engraving/tests/parts_data/part-chordline-uadd.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -772,7 +772,7 @@
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -1212,7 +1212,7 @@
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-chordline-udel.mscx
+++ b/src/engraving/tests/parts_data/part-chordline-udel.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -771,7 +771,7 @@
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -1210,7 +1210,7 @@
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-chordline-uradd.mscx
+++ b/src/engraving/tests/parts_data/part-chordline-uradd.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -776,7 +776,7 @@
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -1221,7 +1221,7 @@
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-chordline-urdel.mscx
+++ b/src/engraving/tests/parts_data/part-chordline-urdel.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -767,7 +767,7 @@
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -1201,7 +1201,7 @@
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-chordline.mscx
+++ b/src/engraving/tests/parts_data/part-chordline.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-empty-parts.mscx
+++ b/src/engraving/tests/parts_data/part-empty-parts.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -771,7 +771,7 @@
       <name>Alto</name>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -1210,7 +1210,7 @@
       <name>Tenor</name>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-empty.mscx
+++ b/src/engraving/tests/parts_data/part-empty.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-fingering-add.mscx
+++ b/src/engraving/tests/parts_data/part-fingering-add.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -776,7 +776,7 @@
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -1221,7 +1221,7 @@
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-fingering-del.mscx
+++ b/src/engraving/tests/parts_data/part-fingering-del.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -777,7 +777,7 @@
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -1223,7 +1223,7 @@
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-fingering-parts.mscx
+++ b/src/engraving/tests/parts_data/part-fingering-parts.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -781,7 +781,7 @@
       <name>Alto</name>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -1232,7 +1232,7 @@
       <name>Tenor</name>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-fingering-uadd.mscx
+++ b/src/engraving/tests/parts_data/part-fingering-uadd.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -772,7 +772,7 @@
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -1212,7 +1212,7 @@
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-fingering-udel.mscx
+++ b/src/engraving/tests/parts_data/part-fingering-udel.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -782,7 +782,7 @@
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -1234,7 +1234,7 @@
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-fingering-uradd.mscx
+++ b/src/engraving/tests/parts_data/part-fingering-uradd.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -776,7 +776,7 @@
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -1221,7 +1221,7 @@
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-fingering-urdel.mscx
+++ b/src/engraving/tests/parts_data/part-fingering-urdel.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -777,7 +777,7 @@
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -1223,7 +1223,7 @@
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-fingering.mscx
+++ b/src/engraving/tests/parts_data/part-fingering.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-image-add.mscx
+++ b/src/engraving/tests/parts_data/part-image-add.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -777,7 +777,7 @@
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -1223,7 +1223,7 @@
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-image-del.mscx
+++ b/src/engraving/tests/parts_data/part-image-del.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -772,7 +772,7 @@
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -1211,7 +1211,7 @@
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-image-parts.mscx
+++ b/src/engraving/tests/parts_data/part-image-parts.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -782,7 +782,7 @@
       <name>Alto</name>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -1232,7 +1232,7 @@
       <name>Tenor</name>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-image-uadd.mscx
+++ b/src/engraving/tests/parts_data/part-image-uadd.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -772,7 +772,7 @@
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -1212,7 +1212,7 @@
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-image-udel.mscx
+++ b/src/engraving/tests/parts_data/part-image-udel.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -783,7 +783,7 @@
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -1234,7 +1234,7 @@
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-image-uradd.mscx
+++ b/src/engraving/tests/parts_data/part-image-uradd.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -777,7 +777,7 @@
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -1223,7 +1223,7 @@
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-image-urdel.mscx
+++ b/src/engraving/tests/parts_data/part-image-urdel.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -772,7 +772,7 @@
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -1211,7 +1211,7 @@
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-image.mscx
+++ b/src/engraving/tests/parts_data/part-image.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-measure-repeat-add.mscx
+++ b/src/engraving/tests/parts_data/part-measure-repeat-add.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -786,7 +786,7 @@
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -1231,7 +1231,7 @@
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-measure-repeat-del.mscx
+++ b/src/engraving/tests/parts_data/part-measure-repeat-del.mscx
@@ -4,7 +4,7 @@
     <Division>480</Division>
     <Style>
       <defaultsVersion>301</defaultsVersion>
-      <Spatium>1.764</Spatium>
+      <spatium>1.764</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -809,7 +809,7 @@
       <Division>480</Division>
       <Style>
         <defaultsVersion>301</defaultsVersion>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -1257,7 +1257,7 @@
       <Division>480</Division>
       <Style>
         <defaultsVersion>301</defaultsVersion>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-measure-repeat-parts.mscx
+++ b/src/engraving/tests/parts_data/part-measure-repeat-parts.mscx
@@ -4,7 +4,7 @@
     <Division>480</Division>
     <Style>
       <defaultsVersion>301</defaultsVersion>
-      <Spatium>1.764</Spatium>
+      <spatium>1.764</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -813,7 +813,7 @@
       <name>Alto</name>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -1262,7 +1262,7 @@
       <name>Tenor</name>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-measure-repeat-uadd.mscx
+++ b/src/engraving/tests/parts_data/part-measure-repeat-uadd.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -772,7 +772,7 @@
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -1212,7 +1212,7 @@
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-measure-repeat-udel.mscx
+++ b/src/engraving/tests/parts_data/part-measure-repeat-udel.mscx
@@ -4,7 +4,7 @@
     <Division>480</Division>
     <Style>
       <defaultsVersion>301</defaultsVersion>
-      <Spatium>1.764</Spatium>
+      <spatium>1.764</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -815,7 +815,7 @@
       <Division>480</Division>
       <Style>
         <defaultsVersion>301</defaultsVersion>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -1266,7 +1266,7 @@
       <Division>480</Division>
       <Style>
         <defaultsVersion>301</defaultsVersion>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-measure-repeat-uradd.mscx
+++ b/src/engraving/tests/parts_data/part-measure-repeat-uradd.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -786,7 +786,7 @@
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -1231,7 +1231,7 @@
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-measure-repeat-urdel.mscx
+++ b/src/engraving/tests/parts_data/part-measure-repeat-urdel.mscx
@@ -4,7 +4,7 @@
     <Division>480</Division>
     <Style>
       <defaultsVersion>301</defaultsVersion>
-      <Spatium>1.764</Spatium>
+      <spatium>1.764</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -809,7 +809,7 @@
       <Division>480</Division>
       <Style>
         <defaultsVersion>301</defaultsVersion>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -1257,7 +1257,7 @@
       <Division>480</Division>
       <Style>
         <defaultsVersion>301</defaultsVersion>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-measure-repeat.mscx
+++ b/src/engraving/tests/parts_data/part-measure-repeat.mscx
@@ -4,7 +4,7 @@
     <Division>480</Division>
     <Style>
       <defaultsVersion>301</defaultsVersion>
-      <Spatium>1.764</Spatium>
+      <spatium>1.764</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-spanners-parts.mscx
+++ b/src/engraving/tests/parts_data/part-spanners-parts.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -688,7 +688,7 @@
       <name>Flute</name>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -1061,7 +1061,7 @@
       <name>Oboe</name>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-spanners.mscx
+++ b/src/engraving/tests/parts_data/part-spanners.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-stemless-parts.mscx
+++ b/src/engraving/tests/parts_data/part-stemless-parts.mscx
@@ -6,7 +6,7 @@
       <pageWidth>8.27</pageWidth>
       <pageHeight>11.69</pageHeight>
       <pagePrintableWidth>7.4826</pagePrintableWidth>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -482,7 +482,7 @@
       <name>Flute</name>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -768,7 +768,7 @@
       <name>Oboe</name>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-stemless.mscx
+++ b/src/engraving/tests/parts_data/part-stemless.mscx
@@ -6,7 +6,7 @@
       <pageWidth>8.27</pageWidth>
       <pageHeight>11.69</pageHeight>
       <pagePrintableWidth>7.4826</pagePrintableWidth>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-symbol-add.mscx
+++ b/src/engraving/tests/parts_data/part-symbol-add.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -776,7 +776,7 @@
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -1221,7 +1221,7 @@
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-symbol-del.mscx
+++ b/src/engraving/tests/parts_data/part-symbol-del.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -772,7 +772,7 @@
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -1212,7 +1212,7 @@
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-symbol-parts.mscx
+++ b/src/engraving/tests/parts_data/part-symbol-parts.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -775,7 +775,7 @@
       <name>Alto</name>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -1219,7 +1219,7 @@
       <name>Tenor</name>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-symbol-uadd.mscx
+++ b/src/engraving/tests/parts_data/part-symbol-uadd.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -772,7 +772,7 @@
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -1212,7 +1212,7 @@
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-symbol-udel.mscx
+++ b/src/engraving/tests/parts_data/part-symbol-udel.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -776,7 +776,7 @@
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -1221,7 +1221,7 @@
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-symbol-uradd.mscx
+++ b/src/engraving/tests/parts_data/part-symbol-uradd.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -776,7 +776,7 @@
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -1221,7 +1221,7 @@
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-symbol-urdel.mscx
+++ b/src/engraving/tests/parts_data/part-symbol-urdel.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -772,7 +772,7 @@
       <initialPartId>1</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -1212,7 +1212,7 @@
       <initialPartId>2</initialPartId>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-symbol.mscx
+++ b/src/engraving/tests/parts_data/part-symbol.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-visible-tracks-part-ref.mscx
+++ b/src/engraving/tests/parts_data/part-visible-tracks-part-ref.mscx
@@ -44,7 +44,7 @@
       <repeatLeftFontSize>18</repeatLeftFontSize>
       <systemTextLineFontSize>12</systemTextLineFontSize>
       <defaultsVersion>410</defaultsVersion>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-visible-tracks-score-ref.mscx
+++ b/src/engraving/tests/parts_data/part-visible-tracks-score-ref.mscx
@@ -4,7 +4,7 @@
     <Division>480</Division>
     <Style>
       <defaultsVersion>410</defaultsVersion>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -237,7 +237,7 @@
         <repeatLeftFontSize>18</repeatLeftFontSize>
         <systemTextLineFontSize>12</systemTextLineFontSize>
         <defaultsVersion>410</defaultsVersion>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/part-visible-tracks.mscx
+++ b/src/engraving/tests/parts_data/part-visible-tracks.mscx
@@ -221,7 +221,7 @@
         <repeatLeftFontSize>18</repeatLeftFontSize>
         <systemTextLineFontSize>12</systemTextLineFontSize>
         <defaultsVersion>410</defaultsVersion>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
       </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/partExclusion-part-0.mscx
+++ b/src/engraving/tests/parts_data/partExclusion-part-0.mscx
@@ -4,7 +4,7 @@
     <name>Flute</name>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/partExclusion-part-1.mscx
+++ b/src/engraving/tests/parts_data/partExclusion-part-1.mscx
@@ -4,7 +4,7 @@
     <name>Flute</name>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/partPropertyLinking-part-0.mscx
+++ b/src/engraving/tests/parts_data/partPropertyLinking-part-0.mscx
@@ -4,7 +4,7 @@
     <name>Flute</name>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/partPropertyLinking-part-1.mscx
+++ b/src/engraving/tests/parts_data/partPropertyLinking-part-1.mscx
@@ -4,7 +4,7 @@
     <name>Flute</name>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/partStyle-score-ref.mscx
+++ b/src/engraving/tests/parts_data/partStyle-score-ref.mscx
@@ -12,7 +12,7 @@
       <titleFontSpatiumDependent>1</titleFontSpatiumDependent>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.364</Spatium>
+      <spatium>1.364</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -313,7 +313,7 @@
       <name>Flute</name>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -511,7 +511,7 @@
       <name>Oboe</name>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/partStyle-score-reload-ref.mscx
+++ b/src/engraving/tests/parts_data/partStyle-score-reload-ref.mscx
@@ -11,7 +11,7 @@
       <titleFontSpatiumDependent>1</titleFontSpatiumDependent>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.364</Spatium>
+      <spatium>1.364</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -316,7 +316,7 @@
         <titleFontFace>Arial</titleFontFace>
         <titleFontSize>48</titleFontSize>
         <titleFontSpatiumDependent>1</titleFontSpatiumDependent>
-        <Spatium>1.76389</Spatium>
+        <spatium>1.76389</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -511,7 +511,7 @@
         <titleFontFace>Arial</titleFontFace>
         <titleFontSize>48</titleFontSize>
         <titleFontSpatiumDependent>1</titleFontSpatiumDependent>
-        <Spatium>1.76389</Spatium>
+        <spatium>1.76389</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/parts_data/voices-ref.mscx
+++ b/src/engraving/tests/parts_data/voices-ref.mscx
@@ -6,7 +6,7 @@
       <lastSystemFillLimit>0</lastSystemFillLimit>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -1069,7 +1069,7 @@
       <name>Piano</name>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -1814,7 +1814,7 @@
       <name>Trombone</name>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>
@@ -2313,7 +2313,7 @@
       <name>Trombone</name>
       <Division>480</Division>
       <Style>
-        <Spatium>1.74978</Spatium>
+        <spatium>1.74978</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/readwriteundoreset_data/barlines.mscx
+++ b/src/engraving/tests/readwriteundoreset_data/barlines.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/readwriteundoreset_data/mmrestBarlineTextLinks-disable-mmrest-ref.mscx
+++ b/src/engraving/tests/readwriteundoreset_data/mmrestBarlineTextLinks-disable-mmrest-ref.mscx
@@ -6,7 +6,7 @@
       <pageWidth>8.27</pageWidth>
       <pageHeight>11.69</pageHeight>
       <pagePrintableWidth>7.4826</pagePrintableWidth>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/readwriteundoreset_data/mmrestBarlineTextLinks-recreate-mmrest-ref.mscx
+++ b/src/engraving/tests/readwriteundoreset_data/mmrestBarlineTextLinks-recreate-mmrest-ref.mscx
@@ -7,7 +7,7 @@
       <pageHeight>11.69</pageHeight>
       <pagePrintableWidth>7.4826</pagePrintableWidth>
       <createMultiMeasureRests>1</createMultiMeasureRests>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/readwriteundoreset_data/mmrestBarlineTextLinks.mscx
+++ b/src/engraving/tests/readwriteundoreset_data/mmrestBarlineTextLinks.mscx
@@ -7,7 +7,7 @@
       <pageHeight>11.69</pageHeight>
       <pagePrintableWidth>7.4826</pagePrintableWidth>
       <createMultiMeasureRests>1</createMultiMeasureRests>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/readwriteundoreset_data/slurs.mscx
+++ b/src/engraving/tests/readwriteundoreset_data/slurs.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/rhythmicGrouping_data/group8ths4-4-ref.mscx
+++ b/src/engraving/tests/rhythmicGrouping_data/group8ths4-4-ref.mscx
@@ -6,7 +6,7 @@
       <lastSystemFillLimit>0</lastSystemFillLimit>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/rhythmicGrouping_data/group8thsCompound-ref.mscx
+++ b/src/engraving/tests/rhythmicGrouping_data/group8thsCompound-ref.mscx
@@ -6,7 +6,7 @@
       <lastSystemFillLimit>0</lastSystemFillLimit>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/rhythmicGrouping_data/group8thsSimple-ref.mscx
+++ b/src/engraving/tests/rhythmicGrouping_data/group8thsSimple-ref.mscx
@@ -6,7 +6,7 @@
       <lastSystemFillLimit>0</lastSystemFillLimit>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/rhythmicGrouping_data/groupArticulationsTies-ref.mscx
+++ b/src/engraving/tests/rhythmicGrouping_data/groupArticulationsTies-ref.mscx
@@ -6,7 +6,7 @@
       <lastSystemFillLimit>0</lastSystemFillLimit>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/rhythmicGrouping_data/groupConflicts-ref.mscx
+++ b/src/engraving/tests/rhythmicGrouping_data/groupConflicts-ref.mscx
@@ -6,7 +6,7 @@
       <lastSystemFillLimit>0</lastSystemFillLimit>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/rhythmicGrouping_data/groupShortenNotes-ref.mscx
+++ b/src/engraving/tests/rhythmicGrouping_data/groupShortenNotes-ref.mscx
@@ -6,7 +6,7 @@
       <lastSystemFillLimit>0</lastSystemFillLimit>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/rhythmicGrouping_data/groupSubbeats-ref.mscx
+++ b/src/engraving/tests/rhythmicGrouping_data/groupSubbeats-ref.mscx
@@ -6,7 +6,7 @@
       <lastSystemFillLimit>0</lastSystemFillLimit>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/rhythmicGrouping_data/groupVoices-ref.mscx
+++ b/src/engraving/tests/rhythmicGrouping_data/groupVoices-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/selectionrangedelete_data/selectionrangedelete03-ref.mscx
+++ b/src/engraving/tests/selectionrangedelete_data/selectionrangedelete03-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/selectionrangedelete_data/selectionrangedelete04-ref.mscx
+++ b/src/engraving/tests/selectionrangedelete_data/selectionrangedelete04-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/selectionrangedelete_data/selectionrangedelete05-ref.mscx
+++ b/src/engraving/tests/selectionrangedelete_data/selectionrangedelete05-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/selectionrangedelete_data/selectionrangedelete06_partialnestedtuplets-ref.mscx
+++ b/src/engraving/tests/selectionrangedelete_data/selectionrangedelete06_partialnestedtuplets-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/spanners_data/glissando-cloning01-ref.mscx
+++ b/src/engraving/tests/spanners_data/glissando-cloning01-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/spanners_data/glissando-cloning03-ref.mscx
+++ b/src/engraving/tests/spanners_data/glissando-cloning03-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/spanners_data/glissando-cloning04-ref.mscx
+++ b/src/engraving/tests/spanners_data/glissando-cloning04-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -139,7 +139,7 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
-        <Spatium>1.76389</Spatium>
+        <spatium>1.76389</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/spanners_data/glissando-crossstaff01-ref.mscx
+++ b/src/engraving/tests/spanners_data/glissando-crossstaff01-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/spanners_data/glissando-graces01-ref.mscx
+++ b/src/engraving/tests/spanners_data/glissando-graces01-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/spanners_data/glissando01-ref.mscx
+++ b/src/engraving/tests/spanners_data/glissando01-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/spanners_data/linecolor01-ref.mscx
+++ b/src/engraving/tests/spanners_data/linecolor01-ref.mscx
@@ -8,7 +8,7 @@
       <pagePrintableWidth>7.4826</pagePrintableWidth>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/spanners_data/lyricsline02-ref.mscx
+++ b/src/engraving/tests/spanners_data/lyricsline02-ref.mscx
@@ -7,7 +7,7 @@
       <clefLeftMargin>0.64</clefLeftMargin>
       <clefKeyRightMargin>1.75</clefKeyRightMargin>
       <minMMRestWidth>0</minMMRestWidth>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/spanners_data/lyricsline02.mscx
+++ b/src/engraving/tests/spanners_data/lyricsline02.mscx
@@ -7,7 +7,7 @@
       <clefLeftMargin>0.64</clefLeftMargin>
       <clefKeyRightMargin>1.75</clefKeyRightMargin>
       <minMMRestWidth>0</minMMRestWidth>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/spanners_data/lyricsline03-ref.mscx
+++ b/src/engraving/tests/spanners_data/lyricsline03-ref.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/spanners_data/lyricsline03.mscx
+++ b/src/engraving/tests/spanners_data/lyricsline03.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/spanners_data/lyricsline04-ref.mscx
+++ b/src/engraving/tests/spanners_data/lyricsline04-ref.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/spanners_data/lyricsline04.mscx
+++ b/src/engraving/tests/spanners_data/lyricsline04.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/spanners_data/lyricsline05-ref.mscx
+++ b/src/engraving/tests/spanners_data/lyricsline05-ref.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/spanners_data/lyricsline05.mscx
+++ b/src/engraving/tests/spanners_data/lyricsline05.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/spanners_data/smallstaff01-ref.mscx
+++ b/src/engraving/tests/spanners_data/smallstaff01-ref.mscx
@@ -8,7 +8,7 @@
       <pagePrintableWidth>7.4826</pagePrintableWidth>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/split_data/split01-ref.mscx
+++ b/src/engraving/tests/split_data/split01-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/split_data/split02-ref.mscx
+++ b/src/engraving/tests/split_data/split02-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/split_data/split03-ref.mscx
+++ b/src/engraving/tests/split_data/split03-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/split_data/split04-ref.mscx
+++ b/src/engraving/tests/split_data/split04-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/split_data/split05-ref.mscx
+++ b/src/engraving/tests/split_data/split05-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/split_data/split06-ref.mscx
+++ b/src/engraving/tests/split_data/split06-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/split_data/split07-ref.mscx
+++ b/src/engraving/tests/split_data/split07-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/split_data/split08-ref.mscx
+++ b/src/engraving/tests/split_data/split08-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/split_data/split184061-keep-tie-before-break-voice-4-ref.mscx
+++ b/src/engraving/tests/split_data/split184061-keep-tie-before-break-voice-4-ref.mscx
@@ -22,7 +22,7 @@
       <dynamicsFontStyle>0</dynamicsFontStyle>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/split_data/split184061-keep-tie-ref.mscx
+++ b/src/engraving/tests/split_data/split184061-keep-tie-ref.mscx
@@ -33,7 +33,7 @@
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
       <figuredBassFontFace>FreeSerif</figuredBassFontFace>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/split_data/split184061-no-tie-ref.mscx
+++ b/src/engraving/tests/split_data/split184061-no-tie-ref.mscx
@@ -33,7 +33,7 @@
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
       <figuredBassFontFace>FreeSerif</figuredBassFontFace>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/split_data/split184061-other-inst-only-one-tie-ref.mscx
+++ b/src/engraving/tests/split_data/split184061-other-inst-only-one-tie-ref.mscx
@@ -22,7 +22,7 @@
       <dynamicsFontStyle>0</dynamicsFontStyle>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/split_data/split295207-ref.mscx
+++ b/src/engraving/tests/split_data/split295207-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/splitstaff_data/splitstaff01-ref.mscx
+++ b/src/engraving/tests/splitstaff_data/splitstaff01-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/splitstaff_data/splitstaff02-ref.mscx
+++ b/src/engraving/tests/splitstaff_data/splitstaff02-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/splitstaff_data/splitstaff03-ref.mscx
+++ b/src/engraving/tests/splitstaff_data/splitstaff03-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/splitstaff_data/splitstaff04-ref.mscx
+++ b/src/engraving/tests/splitstaff_data/splitstaff04-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/splitstaff_data/splitstaff05-ref.mscx
+++ b/src/engraving/tests/splitstaff_data/splitstaff05-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/splitstaff_data/splitstaff06-ref.mscx
+++ b/src/engraving/tests/splitstaff_data/splitstaff06-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/staffmove_data/hiddenStaff-ref.mscx
+++ b/src/engraving/tests/staffmove_data/hiddenStaff-ref.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/staffmove_data/hiddenStaff.mscx
+++ b/src/engraving/tests/staffmove_data/hiddenStaff.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/staffmove_data/linkedStaff-ref.mscx
+++ b/src/engraving/tests/staffmove_data/linkedStaff-ref.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/staffmove_data/linkedStaff.mscx
+++ b/src/engraving/tests/staffmove_data/linkedStaff.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/textbase_data/createDynamic-ref.mscx
+++ b/src/engraving/tests/textbase_data/createDynamic-ref.mscx
@@ -4,7 +4,7 @@
     <Division>480</Division>
     <Style>
       <defaultsVersion>301</defaultsVersion>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/textbase_data/dynamicAddTextAfter-ref.mscx
+++ b/src/engraving/tests/textbase_data/dynamicAddTextAfter-ref.mscx
@@ -4,7 +4,7 @@
     <Division>480</Division>
     <Style>
       <defaultsVersion>301</defaultsVersion>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/textbase_data/dynamicAddTextBefore-ref.mscx
+++ b/src/engraving/tests/textbase_data/dynamicAddTextBefore-ref.mscx
@@ -4,7 +4,7 @@
     <Division>480</Division>
     <Style>
       <defaultsVersion>301</defaultsVersion>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/textbase_data/dynamicAddTextNoItalic-ref.mscx
+++ b/src/engraving/tests/textbase_data/dynamicAddTextNoItalic-ref.mscx
@@ -4,7 +4,7 @@
     <Division>480</Division>
     <Style>
       <defaultsVersion>301</defaultsVersion>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/timesig_data/timesig-02-ref.mscx
+++ b/src/engraving/tests/timesig_data/timesig-02-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/timesig_data/timesig-03-ref.mscx
+++ b/src/engraving/tests/timesig_data/timesig-03-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/timesig_data/timesig-04-ref.mscx
+++ b/src/engraving/tests/timesig_data/timesig-04-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/timesig_data/timesig-05-ref.mscx
+++ b/src/engraving/tests/timesig_data/timesig-05-ref.mscx
@@ -8,7 +8,7 @@
       <pagePrintableWidth>7.4826</pagePrintableWidth>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/timesig_data/timesig-06-ref.mscx
+++ b/src/engraving/tests/timesig_data/timesig-06-ref.mscx
@@ -8,7 +8,7 @@
       <pagePrintableWidth>7.4826</pagePrintableWidth>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/timesig_data/timesig-07-ref.mscx
+++ b/src/engraving/tests/timesig_data/timesig-07-ref.mscx
@@ -8,7 +8,7 @@
       <pagePrintableWidth>7.4826</pagePrintableWidth>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/timesig_data/timesig-10-ref.mscx
+++ b/src/engraving/tests/timesig_data/timesig-10-ref.mscx
@@ -8,7 +8,7 @@
       <pagePrintableWidth>7.4826</pagePrintableWidth>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/timesig_data/timesig01-ref.mscx
+++ b/src/engraving/tests/timesig_data/timesig01-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/tools_data/change-enharmonic-both-01-ref.mscx
+++ b/src/engraving/tests/tools_data/change-enharmonic-both-01-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageWidth>8.27</pageWidth>
       <pageHeight>11.69</pageHeight>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/tools_data/change-enharmonic-both-02-ref.mscx
+++ b/src/engraving/tests/tools_data/change-enharmonic-both-02-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageWidth>8.27</pageWidth>
       <pageHeight>11.69</pageHeight>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/tools_data/change-enharmonic-both-03-ref.mscx
+++ b/src/engraving/tests/tools_data/change-enharmonic-both-03-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageWidth>8.27</pageWidth>
       <pageHeight>11.69</pageHeight>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/tools_data/change-enharmonic-both-04-ref.mscx
+++ b/src/engraving/tests/tools_data/change-enharmonic-both-04-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageWidth>8.27</pageWidth>
       <pageHeight>11.69</pageHeight>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/tools_data/change-enharmonic-both-05-ref.mscx
+++ b/src/engraving/tests/tools_data/change-enharmonic-both-05-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageWidth>8.27</pageWidth>
       <pageHeight>11.69</pageHeight>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/tools_data/change-enharmonic-current-01-ref.mscx
+++ b/src/engraving/tests/tools_data/change-enharmonic-current-01-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageWidth>8.27</pageWidth>
       <pageHeight>11.69</pageHeight>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/tools_data/change-enharmonic-current-02-ref.mscx
+++ b/src/engraving/tests/tools_data/change-enharmonic-current-02-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageWidth>8.27</pageWidth>
       <pageHeight>11.69</pageHeight>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/tools_data/change-enharmonic-current-03-ref.mscx
+++ b/src/engraving/tests/tools_data/change-enharmonic-current-03-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageWidth>8.27</pageWidth>
       <pageHeight>11.69</pageHeight>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/tools_data/change-enharmonic-current-04-ref.mscx
+++ b/src/engraving/tests/tools_data/change-enharmonic-current-04-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageWidth>8.27</pageWidth>
       <pageHeight>11.69</pageHeight>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/tools_data/change-enharmonic-current-05-ref.mscx
+++ b/src/engraving/tests/tools_data/change-enharmonic-current-05-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageWidth>8.27</pageWidth>
       <pageHeight>11.69</pageHeight>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/tools_data/undoAddLineBreaks01-ref.mscx
+++ b/src/engraving/tests/tools_data/undoAddLineBreaks01-ref.mscx
@@ -7,7 +7,7 @@
       <createMultiMeasureRests>1</createMultiMeasureRests>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/tools_data/undoAddLineBreaks02-ref.mscx
+++ b/src/engraving/tests/tools_data/undoAddLineBreaks02-ref.mscx
@@ -7,7 +7,7 @@
       <createMultiMeasureRests>1</createMultiMeasureRests>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/tools_data/undoResequenceAlpha01-ref.mscx
+++ b/src/engraving/tests/tools_data/undoResequenceAlpha01-ref.mscx
@@ -7,7 +7,7 @@
       <showMeasureNumber>0</showMeasureNumber>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/tools_data/undoResequenceAlpha02-ref.mscx
+++ b/src/engraving/tests/tools_data/undoResequenceAlpha02-ref.mscx
@@ -7,7 +7,7 @@
       <showMeasureNumber>0</showMeasureNumber>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/tools_data/undoResequenceMeasure01-ref.mscx
+++ b/src/engraving/tests/tools_data/undoResequenceMeasure01-ref.mscx
@@ -7,7 +7,7 @@
       <showMeasureNumber>0</showMeasureNumber>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/tools_data/undoResequenceMeasure02-ref.mscx
+++ b/src/engraving/tests/tools_data/undoResequenceMeasure02-ref.mscx
@@ -7,7 +7,7 @@
       <showMeasureNumber>0</showMeasureNumber>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/tools_data/undoResequenceNumeric01-ref.mscx
+++ b/src/engraving/tests/tools_data/undoResequenceNumeric01-ref.mscx
@@ -7,7 +7,7 @@
       <showMeasureNumber>0</showMeasureNumber>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/tools_data/undoResequenceNumeric02-ref.mscx
+++ b/src/engraving/tests/tools_data/undoResequenceNumeric02-ref.mscx
@@ -7,7 +7,7 @@
       <showMeasureNumber>0</showMeasureNumber>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/tools_data/undoResequencePart01-ref.mscx
+++ b/src/engraving/tests/tools_data/undoResequencePart01-ref.mscx
@@ -7,7 +7,7 @@
       <showMeasureNumber>0</showMeasureNumber>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -310,7 +310,7 @@
         <lastSystemFillLimit>0.03</lastSystemFillLimit>
         <showMeasureNumber>0</showMeasureNumber>
         <createMultiMeasureRests>1</createMultiMeasureRests>
-        <Spatium>1.76389</Spatium>
+        <spatium>1.76389</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/tools_data/undoResequencePart02-ref.mscx
+++ b/src/engraving/tests/tools_data/undoResequencePart02-ref.mscx
@@ -7,7 +7,7 @@
       <showMeasureNumber>0</showMeasureNumber>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -310,7 +310,7 @@
         <lastSystemFillLimit>0.03</lastSystemFillLimit>
         <showMeasureNumber>0</showMeasureNumber>
         <createMultiMeasureRests>1</createMultiMeasureRests>
-        <Spatium>1.76389</Spatium>
+        <spatium>1.76389</spatium>
         </Style>
       <showInvisible>1</showInvisible>
       <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/tools_data/undoSlashFill01-ref.mscx
+++ b/src/engraving/tests/tools_data/undoSlashFill01-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/tools_data/undoSlashFill02-ref.mscx
+++ b/src/engraving/tests/tools_data/undoSlashFill02-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/tools_data/undoSlashRhythm01-ref.mscx
+++ b/src/engraving/tests/tools_data/undoSlashRhythm01-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/tools_data/undoSlashRhythm02-ref.mscx
+++ b/src/engraving/tests/tools_data/undoSlashRhythm02-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/tools_data/undoSlashRhythm02-test.mscx
+++ b/src/engraving/tests/tools_data/undoSlashRhythm02-test.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/transpose_data/undoDiatonicTranspose01-ref.mscx
+++ b/src/engraving/tests/transpose_data/undoDiatonicTranspose01-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/transpose_data/undoDiatonicTranspose02-ref.mscx
+++ b/src/engraving/tests/transpose_data/undoDiatonicTranspose02-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/transpose_data/undoTranspose01-ref.mscx
+++ b/src/engraving/tests/transpose_data/undoTranspose01-ref.mscx
@@ -12,7 +12,7 @@
       <beamMinLen>1.25</beamMinLen>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.764</Spatium>
+      <spatium>1.764</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/transpose_data/undoTranspose02-ref.mscx
+++ b/src/engraving/tests/transpose_data/undoTranspose02-ref.mscx
@@ -12,7 +12,7 @@
       <beamMinLen>1.25</beamMinLen>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.764</Spatium>
+      <spatium>1.764</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/tuplet_data/nestedTuplets_addStaff-ref.mscx
+++ b/src/engraving/tests/tuplet_data/nestedTuplets_addStaff-ref.mscx
@@ -16,7 +16,7 @@
       <tupletOutOfStaff>0</tupletOutOfStaff>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/tuplet_data/save-load.mscx
+++ b/src/engraving/tests/tuplet_data/save-load.mscx
@@ -6,7 +6,7 @@
       <pageWidth>8.27</pageWidth>
       <pageHeight>11.69</pageHeight>
       <pagePrintableWidth>7.4826</pagePrintableWidth>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/tuplet_data/split1-ref.mscx
+++ b/src/engraving/tests/tuplet_data/split1-ref.mscx
@@ -12,7 +12,7 @@
       <minMMRestWidth>0</minMMRestWidth>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/tuplet_data/split2-ref.mscx
+++ b/src/engraving/tests/tuplet_data/split2-ref.mscx
@@ -12,7 +12,7 @@
       <minMMRestWidth>0</minMMRestWidth>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/tuplet_data/split3-ref.mscx
+++ b/src/engraving/tests/tuplet_data/split3-ref.mscx
@@ -12,7 +12,7 @@
       <minMMRestWidth>0</minMMRestWidth>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/tuplet_data/split4-ref.mscx
+++ b/src/engraving/tests/tuplet_data/split4-ref.mscx
@@ -12,7 +12,7 @@
       <minMMRestWidth>0</minMMRestWidth>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/engraving/tests/tuplet_data/tuplet1-ref.mscx
+++ b/src/engraving/tests/tuplet_data/tuplet1-ref.mscx
@@ -5,7 +5,7 @@
     <Style>
       <pageNumberFontSize>9</pageNumberFontSize>
       <pageNumberFontStyle>0</pageNumberFontStyle>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/capella/tests/data/test1.cap-ref.mscx
+++ b/src/importexport/capella/tests/data/test1.cap-ref.mscx
@@ -7,7 +7,7 @@
       <maxSystemDistance>12</maxSystemDistance>
       <measureSpacing>1</measureSpacing>
       <smallStaffMag>0.666667</smallStaffMag>
-      <Spatium>1.8</Spatium>
+      <spatium>1.8</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/capella/tests/data/test1.capx-ref.mscx
+++ b/src/importexport/capella/tests/data/test1.capx-ref.mscx
@@ -7,7 +7,7 @@
       <maxSystemDistance>12</maxSystemDistance>
       <measureSpacing>1</measureSpacing>
       <smallStaffMag>0.681818</smallStaffMag>
-      <Spatium>1.76</Spatium>
+      <spatium>1.76</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/capella/tests/data/test2.cap-ref.mscx
+++ b/src/importexport/capella/tests/data/test2.cap-ref.mscx
@@ -7,7 +7,7 @@
       <maxSystemDistance>12</maxSystemDistance>
       <measureSpacing>1</measureSpacing>
       <smallStaffMag>0.666667</smallStaffMag>
-      <Spatium>1.8</Spatium>
+      <spatium>1.8</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/capella/tests/data/test2.capx-ref.mscx
+++ b/src/importexport/capella/tests/data/test2.capx-ref.mscx
@@ -7,7 +7,7 @@
       <maxSystemDistance>12</maxSystemDistance>
       <measureSpacing>1</measureSpacing>
       <smallStaffMag>0.681818</smallStaffMag>
-      <Spatium>1.76</Spatium>
+      <spatium>1.76</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/capella/tests/data/test3.cap-ref.mscx
+++ b/src/importexport/capella/tests/data/test3.cap-ref.mscx
@@ -7,7 +7,7 @@
       <maxSystemDistance>12</maxSystemDistance>
       <measureSpacing>1</measureSpacing>
       <smallStaffMag>0.666667</smallStaffMag>
-      <Spatium>1.8</Spatium>
+      <spatium>1.8</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/capella/tests/data/test3.capx-ref.mscx
+++ b/src/importexport/capella/tests/data/test3.capx-ref.mscx
@@ -7,7 +7,7 @@
       <maxSystemDistance>12</maxSystemDistance>
       <measureSpacing>1</measureSpacing>
       <smallStaffMag>0.681818</smallStaffMag>
-      <Spatium>1.76</Spatium>
+      <spatium>1.76</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/capella/tests/data/test4.cap-ref.mscx
+++ b/src/importexport/capella/tests/data/test4.cap-ref.mscx
@@ -7,7 +7,7 @@
       <maxSystemDistance>12</maxSystemDistance>
       <measureSpacing>1</measureSpacing>
       <smallStaffMag>0.666667</smallStaffMag>
-      <Spatium>1.8</Spatium>
+      <spatium>1.8</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/capella/tests/data/test4.capx-ref.mscx
+++ b/src/importexport/capella/tests/data/test4.capx-ref.mscx
@@ -7,7 +7,7 @@
       <maxSystemDistance>12</maxSystemDistance>
       <measureSpacing>1</measureSpacing>
       <smallStaffMag>0.681818</smallStaffMag>
-      <Spatium>1.76</Spatium>
+      <spatium>1.76</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/capella/tests/data/test5.cap-ref.mscx
+++ b/src/importexport/capella/tests/data/test5.cap-ref.mscx
@@ -7,7 +7,7 @@
       <maxSystemDistance>12</maxSystemDistance>
       <measureSpacing>1</measureSpacing>
       <smallStaffMag>0.666667</smallStaffMag>
-      <Spatium>1.8</Spatium>
+      <spatium>1.8</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/capella/tests/data/test5.capx-ref.mscx
+++ b/src/importexport/capella/tests/data/test5.capx-ref.mscx
@@ -7,7 +7,7 @@
       <maxSystemDistance>12</maxSystemDistance>
       <measureSpacing>1</measureSpacing>
       <smallStaffMag>0.681818</smallStaffMag>
-      <Spatium>1.76</Spatium>
+      <spatium>1.76</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/capella/tests/data/test6.cap-ref.mscx
+++ b/src/importexport/capella/tests/data/test6.cap-ref.mscx
@@ -7,7 +7,7 @@
       <maxSystemDistance>12</maxSystemDistance>
       <measureSpacing>1</measureSpacing>
       <smallStaffMag>0.666667</smallStaffMag>
-      <Spatium>1.8</Spatium>
+      <spatium>1.8</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/capella/tests/data/test6.capx-ref.mscx
+++ b/src/importexport/capella/tests/data/test6.capx-ref.mscx
@@ -7,7 +7,7 @@
       <maxSystemDistance>12</maxSystemDistance>
       <measureSpacing>1</measureSpacing>
       <smallStaffMag>0.681818</smallStaffMag>
-      <Spatium>1.76</Spatium>
+      <spatium>1.76</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/capella/tests/data/test7.cap-ref.mscx
+++ b/src/importexport/capella/tests/data/test7.cap-ref.mscx
@@ -7,7 +7,7 @@
       <maxSystemDistance>12</maxSystemDistance>
       <measureSpacing>1</measureSpacing>
       <smallStaffMag>0.666667</smallStaffMag>
-      <Spatium>1.8</Spatium>
+      <spatium>1.8</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/capella/tests/data/test7.capx-ref.mscx
+++ b/src/importexport/capella/tests/data/test7.capx-ref.mscx
@@ -7,7 +7,7 @@
       <maxSystemDistance>12</maxSystemDistance>
       <measureSpacing>1</measureSpacing>
       <smallStaffMag>0.681818</smallStaffMag>
-      <Spatium>1.76</Spatium>
+      <spatium>1.76</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/capella/tests/data/test8.cap-ref.mscx
+++ b/src/importexport/capella/tests/data/test8.cap-ref.mscx
@@ -7,7 +7,7 @@
       <maxSystemDistance>12</maxSystemDistance>
       <measureSpacing>1</measureSpacing>
       <smallStaffMag>0.666667</smallStaffMag>
-      <Spatium>1.8</Spatium>
+      <spatium>1.8</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/capella/tests/data/testBarline.capx-ref.mscx
+++ b/src/importexport/capella/tests/data/testBarline.capx-ref.mscx
@@ -7,7 +7,7 @@
       <maxSystemDistance>12</maxSystemDistance>
       <measureSpacing>1</measureSpacing>
       <smallStaffMag>0.62766</smallStaffMag>
-      <Spatium>1.88</Spatium>
+      <spatium>1.88</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/capella/tests/data/testEmptyStaff1.capx-ref.mscx
+++ b/src/importexport/capella/tests/data/testEmptyStaff1.capx-ref.mscx
@@ -7,7 +7,7 @@
       <maxSystemDistance>12</maxSystemDistance>
       <measureSpacing>1</measureSpacing>
       <smallStaffMag>0.681818</smallStaffMag>
-      <Spatium>1.76</Spatium>
+      <spatium>1.76</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/capella/tests/data/testEmptyStaff2.capx-ref.mscx
+++ b/src/importexport/capella/tests/data/testEmptyStaff2.capx-ref.mscx
@@ -7,7 +7,7 @@
       <maxSystemDistance>12</maxSystemDistance>
       <measureSpacing>1</measureSpacing>
       <smallStaffMag>0.681818</smallStaffMag>
-      <Spatium>1.76</Spatium>
+      <spatium>1.76</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/capella/tests/data/testPianoG4G5.capx-ref.mscx
+++ b/src/importexport/capella/tests/data/testPianoG4G5.capx-ref.mscx
@@ -7,7 +7,7 @@
       <maxSystemDistance>12</maxSystemDistance>
       <measureSpacing>1</measureSpacing>
       <smallStaffMag>0.681818</smallStaffMag>
-      <Spatium>1.76</Spatium>
+      <spatium>1.76</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/capella/tests/data/testScaleC4C5.capx-ref.mscx
+++ b/src/importexport/capella/tests/data/testScaleC4C5.capx-ref.mscx
@@ -7,7 +7,7 @@
       <maxSystemDistance>12</maxSystemDistance>
       <measureSpacing>1</measureSpacing>
       <smallStaffMag>0.681818</smallStaffMag>
-      <Spatium>1.76</Spatium>
+      <spatium>1.76</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/capella/tests/data/testSlurTie.capx-ref.mscx
+++ b/src/importexport/capella/tests/data/testSlurTie.capx-ref.mscx
@@ -7,7 +7,7 @@
       <maxSystemDistance>12</maxSystemDistance>
       <measureSpacing>1</measureSpacing>
       <smallStaffMag>0.681818</smallStaffMag>
-      <Spatium>1.76</Spatium>
+      <spatium>1.76</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/capella/tests/data/testText1.capx-ref.mscx
+++ b/src/importexport/capella/tests/data/testText1.capx-ref.mscx
@@ -7,7 +7,7 @@
       <maxSystemDistance>12</maxSystemDistance>
       <measureSpacing>1</measureSpacing>
       <smallStaffMag>0.681818</smallStaffMag>
-      <Spatium>1.76</Spatium>
+      <spatium>1.76</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/capella/tests/data/testTuplet1.capx-ref.mscx
+++ b/src/importexport/capella/tests/data/testTuplet1.capx-ref.mscx
@@ -7,7 +7,7 @@
       <maxSystemDistance>12</maxSystemDistance>
       <measureSpacing>1</measureSpacing>
       <smallStaffMag>0.681818</smallStaffMag>
-      <Spatium>1.76</Spatium>
+      <spatium>1.76</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/capella/tests/data/testTuplet2.cap-ref.mscx
+++ b/src/importexport/capella/tests/data/testTuplet2.cap-ref.mscx
@@ -7,7 +7,7 @@
       <maxSystemDistance>12</maxSystemDistance>
       <measureSpacing>1</measureSpacing>
       <smallStaffMag>0.666667</smallStaffMag>
-      <Spatium>1.8</Spatium>
+      <spatium>1.8</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/capella/tests/data/testTuplet2.capx-ref.mscx
+++ b/src/importexport/capella/tests/data/testTuplet2.capx-ref.mscx
@@ -7,7 +7,7 @@
       <maxSystemDistance>12</maxSystemDistance>
       <measureSpacing>1</measureSpacing>
       <smallStaffMag>0.666667</smallStaffMag>
-      <Spatium>1.8</Spatium>
+      <spatium>1.8</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/capella/tests/data/testVolta1.capx-ref.mscx
+++ b/src/importexport/capella/tests/data/testVolta1.capx-ref.mscx
@@ -7,7 +7,7 @@
       <maxSystemDistance>12</maxSystemDistance>
       <measureSpacing>1</measureSpacing>
       <smallStaffMag>0.681818</smallStaffMag>
-      <Spatium>1.76</Spatium>
+      <spatium>1.76</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/accid-01.mscx
+++ b/src/importexport/mei/tests/data/accid-01.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/accid-02.mscx
+++ b/src/importexport/mei/tests/data/accid-02.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/arpeg-01.mscx
+++ b/src/importexport/mei/tests/data/arpeg-01.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/artic-01.mscx
+++ b/src/importexport/mei/tests/data/artic-01.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/beam-01.mscx
+++ b/src/importexport/mei/tests/data/beam-01.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/beam-02.mscx
+++ b/src/importexport/mei/tests/data/beam-02.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/beam-03.mscx
+++ b/src/importexport/mei/tests/data/beam-03.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/breaks-01.mscx
+++ b/src/importexport/mei/tests/data/breaks-01.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/breath-01.mscx
+++ b/src/importexport/mei/tests/data/breath-01.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/btrem-01.mscx
+++ b/src/importexport/mei/tests/data/btrem-01.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/chord-label-01.mscx
+++ b/src/importexport/mei/tests/data/chord-label-01.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/clef-01.mscx
+++ b/src/importexport/mei/tests/data/clef-01.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/color-01.mscx
+++ b/src/importexport/mei/tests/data/color-01.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/cross-staff-01.mscx
+++ b/src/importexport/mei/tests/data/cross-staff-01.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/dir-01.mscx
+++ b/src/importexport/mei/tests/data/dir-01.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/dynamic-01.mscx
+++ b/src/importexport/mei/tests/data/dynamic-01.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/ending-01.mscx
+++ b/src/importexport/mei/tests/data/ending-01.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/fermata-01.mscx
+++ b/src/importexport/mei/tests/data/fermata-01.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/fig-bass-01.mscx
+++ b/src/importexport/mei/tests/data/fig-bass-01.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/gracenote-01.mscx
+++ b/src/importexport/mei/tests/data/gracenote-01.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/gracenote-02.mscx
+++ b/src/importexport/mei/tests/data/gracenote-02.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/hairpin-01.mscx
+++ b/src/importexport/mei/tests/data/hairpin-01.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/jump-01.mscx
+++ b/src/importexport/mei/tests/data/jump-01.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/jump-02.mscx
+++ b/src/importexport/mei/tests/data/jump-02.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/key-signature-01.mscx
+++ b/src/importexport/mei/tests/data/key-signature-01.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/label-01.mscx
+++ b/src/importexport/mei/tests/data/label-01.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/laissez-vibrer-01.mscx
+++ b/src/importexport/mei/tests/data/laissez-vibrer-01.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/lyric-01.mscx
+++ b/src/importexport/mei/tests/data/lyric-01.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/lyric-02.mscx
+++ b/src/importexport/mei/tests/data/lyric-02.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/lyric-03.mscx
+++ b/src/importexport/mei/tests/data/lyric-03.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/lyric-04.mscx
+++ b/src/importexport/mei/tests/data/lyric-04.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/measure-01.mscx
+++ b/src/importexport/mei/tests/data/measure-01.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/measure-02.mscx
+++ b/src/importexport/mei/tests/data/measure-02.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/measure-repeat-01.mscx
+++ b/src/importexport/mei/tests/data/measure-repeat-01.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/metadata-01.mscx
+++ b/src/importexport/mei/tests/data/metadata-01.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/mordent-01.mscx
+++ b/src/importexport/mei/tests/data/mordent-01.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/octave-01.mscx
+++ b/src/importexport/mei/tests/data/octave-01.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/ornam-01.mscx
+++ b/src/importexport/mei/tests/data/ornam-01.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/page-head-01.mscx
+++ b/src/importexport/mei/tests/data/page-head-01.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/page-head-02.mscx
+++ b/src/importexport/mei/tests/data/page-head-02.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/pedal-01.mscx
+++ b/src/importexport/mei/tests/data/pedal-01.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/reh-01.mscx
+++ b/src/importexport/mei/tests/data/reh-01.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/roman-numeral-01.mscx
+++ b/src/importexport/mei/tests/data/roman-numeral-01.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/score-01.mscx
+++ b/src/importexport/mei/tests/data/score-01.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/score-02.mscx
+++ b/src/importexport/mei/tests/data/score-02.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/slur-01.mscx
+++ b/src/importexport/mei/tests/data/slur-01.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/slur-02.mscx
+++ b/src/importexport/mei/tests/data/slur-02.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/stem-01.mscx
+++ b/src/importexport/mei/tests/data/stem-01.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/tempo-01.mscx
+++ b/src/importexport/mei/tests/data/tempo-01.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/tie-01.mscx
+++ b/src/importexport/mei/tests/data/tie-01.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/time-signature-01.mscx
+++ b/src/importexport/mei/tests/data/time-signature-01.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/time-signature-02.mscx
+++ b/src/importexport/mei/tests/data/time-signature-02.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/transpose-01.mscx
+++ b/src/importexport/mei/tests/data/transpose-01.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/tuplet-01.mscx
+++ b/src/importexport/mei/tests/data/tuplet-01.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/tuplet-02.mscx
+++ b/src/importexport/mei/tests/data/tuplet-02.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/mei/tests/data/tuplet-03.mscx
+++ b/src/importexport/mei/tests/data/tuplet-03.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/importTie1_ref.mscx
+++ b/src/importexport/musicxml/tests/data/importTie1_ref.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/importTie2_ref.mscx
+++ b/src/importexport/musicxml/tests/data/importTie2_ref.mscx
@@ -124,7 +124,7 @@
       <user11FontSize>10.25</user11FontSize>
       <user12FontFace>Times New Roman</user12FontFace>
       <user12FontSize>10.25</user12FontSize>
-      <Spatium>1.80798</Spatium>
+      <spatium>1.80798</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/importTie3_ref.mscx
+++ b/src/importexport/musicxml/tests/data/importTie3_ref.mscx
@@ -79,7 +79,7 @@
       <user10FontFace>Times New Roman</user10FontFace>
       <user11FontFace>Times New Roman</user11FontFace>
       <user12FontFace>Times New Roman</user12FontFace>
-      <Spatium>1.75</Spatium>
+      <spatium>1.75</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/importTie4_ref.mscx
+++ b/src/importexport/musicxml/tests/data/importTie4_ref.mscx
@@ -125,7 +125,7 @@
       <user11FontSize>22</user11FontSize>
       <user12FontFace>Palatino,serif</user12FontFace>
       <user12FontSize>22</user12FontSize>
-      <Spatium>1.75</Spatium>
+      <spatium>1.75</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testArpCrossVoice_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testArpCrossVoice_ref.mscx
@@ -35,7 +35,7 @@
       <footerFontSize>10</footerFontSize>
       <copyrightFontSize>10</copyrightFontSize>
       <pageNumberFontSize>10</pageNumberFontSize>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testArpOnRest_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testArpOnRest_ref.mscx
@@ -35,7 +35,7 @@
       <footerFontSize>10</footerFontSize>
       <copyrightFontSize>10</copyrightFontSize>
       <pageNumberFontSize>10</pageNumberFontSize>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testBackupRoundingError_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testBackupRoundingError_ref.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testBarlineLoc_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testBarlineLoc_ref.mscx
@@ -35,7 +35,7 @@
       <footerFontSize>10</footerFontSize>
       <copyrightFontSize>10</copyrightFontSize>
       <pageNumberFontSize>10</pageNumberFontSize>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testBeamModes_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testBeamModes_ref.mscx
@@ -34,7 +34,7 @@
       <footerFontSize>10</footerFontSize>
       <copyrightFontSize>10</copyrightFontSize>
       <pageNumberFontSize>10</pageNumberFontSize>
-      <Spatium>1.75</Spatium>
+      <spatium>1.75</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testBracketTypes_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testBracketTypes_ref.mscx
@@ -34,7 +34,7 @@
       <footerFontSize>10</footerFontSize>
       <copyrightFontSize>10</copyrightFontSize>
       <pageNumberFontSize>10</pageNumberFontSize>
-      <Spatium>1.75</Spatium>
+      <spatium>1.75</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testBuzzRoll_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testBuzzRoll_ref.mscx
@@ -27,7 +27,7 @@
       <slurMidWidth>0.21875</slurMidWidth>
       <tieEndWidth>0.0625</tieEndWidth>
       <tieMidWidth>0.21875</tieMidWidth>
-      <Spatium>1.75</Spatium>
+      <spatium>1.75</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testChordSymbols2_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testChordSymbols2_ref.mscx
@@ -27,7 +27,7 @@
       <slurMidWidth>0.21875</slurMidWidth>
       <tieEndWidth>0.0625</tieEndWidth>
       <tieMidWidth>0.21875</tieMidWidth>
-      <Spatium>1.75</Spatium>
+      <spatium>1.75</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testCodaHBox_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testCodaHBox_ref.mscx
@@ -35,7 +35,7 @@
       <footerFontSize>10</footerFontSize>
       <copyrightFontSize>10</copyrightFontSize>
       <pageNumberFontSize>10</pageNumberFontSize>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testCopyrightScale_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testCopyrightScale_ref.mscx
@@ -35,7 +35,7 @@
       <footerFontSize>1</footerFontSize>
       <copyrightFontSize>10</copyrightFontSize>
       <pageNumberFontSize>10</pageNumberFontSize>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testCueGraceNotes_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testCueGraceNotes_ref.mscx
@@ -34,7 +34,7 @@
       <footerFontSize>10</footerFontSize>
       <copyrightFontSize>10</copyrightFontSize>
       <pageNumberFontSize>10</pageNumberFontSize>
-      <Spatium>1.75</Spatium>
+      <spatium>1.75</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testCueNotes3_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testCueNotes3_ref.mscx
@@ -35,7 +35,7 @@
       <footerFontSize>10</footerFontSize>
       <copyrightFontSize>10</copyrightFontSize>
       <pageNumberFontSize>10</pageNumberFontSize>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testDSalCodaMisplaced_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testDSalCodaMisplaced_ref.mscx
@@ -34,7 +34,7 @@
       <footerFontSize>10</footerFontSize>
       <copyrightFontSize>10</copyrightFontSize>
       <pageNumberFontSize>10</pageNumberFontSize>
-      <Spatium>1.75</Spatium>
+      <spatium>1.75</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testDSalCoda_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testDSalCoda_ref.mscx
@@ -34,7 +34,7 @@
       <footerFontSize>10</footerFontSize>
       <copyrightFontSize>10</copyrightFontSize>
       <pageNumberFontSize>10</pageNumberFontSize>
-      <Spatium>1.75</Spatium>
+      <spatium>1.75</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testDoletOttavas_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testDoletOttavas_ref.mscx
@@ -78,7 +78,7 @@
       <user10FontFace>Times New Roman</user10FontFace>
       <user11FontFace>Times New Roman</user11FontFace>
       <user12FontFace>Times New Roman</user12FontFace>
-      <Spatium>1.75</Spatium>
+      <spatium>1.75</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testDuplicateInstrChange_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testDuplicateInstrChange_ref.mscx
@@ -35,7 +35,7 @@
       <footerFontSize>10</footerFontSize>
       <copyrightFontSize>10</copyrightFontSize>
       <pageNumberFontSize>10</pageNumberFontSize>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testDurationLargeError_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testDurationLargeError_ref.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testDurationRoundingError_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testDurationRoundingError_ref.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testElision_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testElision_ref.mscx
@@ -35,7 +35,7 @@
       <footerFontSize>10</footerFontSize>
       <copyrightFontSize>10</copyrightFontSize>
       <pageNumberFontSize>10</pageNumberFontSize>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testExcessHiddenStaves_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testExcessHiddenStaves_ref.mscx
@@ -36,7 +36,7 @@
       <footerFontSize>10</footerFontSize>
       <copyrightFontSize>10</copyrightFontSize>
       <pageNumberFontSize>10</pageNumberFontSize>
-      <Spatium>1.75</Spatium>
+      <spatium>1.75</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testFinaleDynamics_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testFinaleDynamics_ref.mscx
@@ -35,7 +35,7 @@
       <footerFontSize>10</footerFontSize>
       <copyrightFontSize>10</copyrightFontSize>
       <pageNumberFontSize>10</pageNumberFontSize>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testFinaleInstr2_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testFinaleInstr2_ref.mscx
@@ -125,7 +125,7 @@
       <user11FontSize>8.8</user11FontSize>
       <user12FontFace>Times</user12FontFace>
       <user12FontSize>8.8</user12FontSize>
-      <Spatium>1.69333</Spatium>
+      <spatium>1.69333</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testFinaleInstr_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testFinaleInstr_ref.mscx
@@ -125,7 +125,7 @@
       <user11FontSize>7.4</user11FontSize>
       <user12FontFace>Times</user12FontFace>
       <user12FontSize>7.4</user12FontSize>
-      <Spatium>1.31233</Spatium>
+      <spatium>1.31233</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testGlissFall_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testGlissFall_ref.mscx
@@ -35,7 +35,7 @@
       <footerFontSize>10</footerFontSize>
       <copyrightFontSize>10</copyrightFontSize>
       <pageNumberFontSize>10</pageNumberFontSize>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testImportDrums2_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testImportDrums2_ref.mscx
@@ -27,7 +27,7 @@
       <slurMidWidth>0.21875</slurMidWidth>
       <tieEndWidth>0.0625</tieEndWidth>
       <tieMidWidth>0.21875</tieMidWidth>
-      <Spatium>1.75</Spatium>
+      <spatium>1.75</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testImportDrums_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testImportDrums_ref.mscx
@@ -16,7 +16,7 @@
       <staffDistance>5.5</staffDistance>
       <minSystemDistance>9.25</minSystemDistance>
       <romanNumeralFontFace>Edwin</romanNumeralFontFace>
-      <Spatium>2.11667</Spatium>
+      <spatium>2.11667</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testInferCodaII_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testInferCodaII_ref.mscx
@@ -78,7 +78,7 @@
       <user10FontFace>Times New Roman</user10FontFace>
       <user11FontFace>Times New Roman</user11FontFace>
       <user12FontFace>Times New Roman</user12FontFace>
-      <Spatium>1.75</Spatium>
+      <spatium>1.75</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testInferFraction_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testInferFraction_ref.mscx
@@ -35,7 +35,7 @@
       <footerFontSize>10</footerFontSize>
       <copyrightFontSize>10</copyrightFontSize>
       <pageNumberFontSize>10</pageNumberFontSize>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testInferSegnoII_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testInferSegnoII_ref.mscx
@@ -78,7 +78,7 @@
       <user10FontFace>Times New Roman</user10FontFace>
       <user11FontFace>Times New Roman</user11FontFace>
       <user12FontFace>Times New Roman</user12FontFace>
-      <Spatium>1.75</Spatium>
+      <spatium>1.75</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testInferredCredits1_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testInferredCredits1_ref.mscx
@@ -34,7 +34,7 @@
       <footerFontSize>10</footerFontSize>
       <copyrightFontSize>10</copyrightFontSize>
       <pageNumberFontSize>10</pageNumberFontSize>
-      <Spatium>1.75</Spatium>
+      <spatium>1.75</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testInferredCredits2_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testInferredCredits2_ref.mscx
@@ -34,7 +34,7 @@
       <footerFontSize>10</footerFontSize>
       <copyrightFontSize>10</copyrightFontSize>
       <pageNumberFontSize>10</pageNumberFontSize>
-      <Spatium>1.75</Spatium>
+      <spatium>1.75</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testInferredCrescLines2_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testInferredCrescLines2_ref.mscx
@@ -79,7 +79,7 @@
       <user10FontFace>Times New Roman</user10FontFace>
       <user11FontFace>Times New Roman</user11FontFace>
       <user12FontFace>Times New Roman</user12FontFace>
-      <Spatium>1.75</Spatium>
+      <spatium>1.75</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testInferredCrescLines_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testInferredCrescLines_ref.mscx
@@ -79,7 +79,7 @@
       <user10FontFace>Times New Roman</user10FontFace>
       <user11FontFace>Times New Roman</user11FontFace>
       <user12FontFace>Times New Roman</user12FontFace>
-      <Spatium>1.75</Spatium>
+      <spatium>1.75</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testInferredDynamicRange_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testInferredDynamicRange_ref.mscx
@@ -35,7 +35,7 @@
       <footerFontSize>10</footerFontSize>
       <copyrightFontSize>10</copyrightFontSize>
       <pageNumberFontSize>10</pageNumberFontSize>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testInferredDynamicsExpression_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testInferredDynamicsExpression_ref.mscx
@@ -35,7 +35,7 @@
       <footerFontSize>10</footerFontSize>
       <copyrightFontSize>10</copyrightFontSize>
       <pageNumberFontSize>10</pageNumberFontSize>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testInferredFingerings_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testInferredFingerings_ref.mscx
@@ -34,7 +34,7 @@
       <footerFontSize>10</footerFontSize>
       <copyrightFontSize>10</copyrightFontSize>
       <pageNumberFontSize>10</pageNumberFontSize>
-      <Spatium>1.75</Spatium>
+      <spatium>1.75</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testInferredRights_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testInferredRights_ref.mscx
@@ -35,7 +35,7 @@
       <footerFontSize>10</footerFontSize>
       <copyrightFontSize>10</copyrightFontSize>
       <pageNumberFontSize>10</pageNumberFontSize>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testInferredTechnique_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testInferredTechnique_ref.mscx
@@ -35,7 +35,7 @@
       <footerFontSize>10</footerFontSize>
       <copyrightFontSize>10</copyrightFontSize>
       <pageNumberFontSize>10</pageNumberFontSize>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testInferredTempoText2_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testInferredTempoText2_ref.mscx
@@ -35,7 +35,7 @@
       <footerFontSize>10</footerFontSize>
       <copyrightFontSize>10</copyrightFontSize>
       <pageNumberFontSize>10</pageNumberFontSize>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testInferredTempoText_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testInferredTempoText_ref.mscx
@@ -78,7 +78,7 @@
       <user10FontFace>Times New Roman</user10FontFace>
       <user11FontFace>Times New Roman</user11FontFace>
       <user12FontFace>Times New Roman</user12FontFace>
-      <Spatium>1.75</Spatium>
+      <spatium>1.75</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testInstrImport_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testInstrImport_ref.mscx
@@ -16,7 +16,7 @@
       <staffDistance>7.25</staffDistance>
       <minSystemDistance>9.25</minSystemDistance>
       <romanNumeralFontFace>Edwin</romanNumeralFontFace>
-      <Spatium>1.05833</Spatium>
+      <spatium>1.05833</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testLyricBracket_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testLyricBracket_ref.mscx
@@ -34,7 +34,7 @@
       <footerFontSize>10</footerFontSize>
       <copyrightFontSize>10</copyrightFontSize>
       <pageNumberFontSize>10</pageNumberFontSize>
-      <Spatium>1.75</Spatium>
+      <spatium>1.75</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testLyricExtension2_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testLyricExtension2_ref.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testLyricExtensions_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testLyricExtensions_ref.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testLyricPos_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testLyricPos_ref.mscx
@@ -35,7 +35,7 @@
       <footerFontSize>10</footerFontSize>
       <copyrightFontSize>10</copyrightFontSize>
       <pageNumberFontSize>10</pageNumberFontSize>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testMeasureStyleSlash_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testMeasureStyleSlash_ref.mscx
@@ -37,7 +37,7 @@
       <footerFontSize>10</footerFontSize>
       <copyrightFontSize>10</copyrightFontSize>
       <pageNumberFontSize>10</pageNumberFontSize>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testNamedNoteheads_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testNamedNoteheads_ref.mscx
@@ -35,7 +35,7 @@
       <footerFontSize>10</footerFontSize>
       <copyrightFontSize>10</copyrightFontSize>
       <pageNumberFontSize>10</pageNumberFontSize>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testNegativeOffset_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testNegativeOffset_ref.mscx
@@ -34,7 +34,7 @@
       <footerFontSize>10</footerFontSize>
       <copyrightFontSize>10</copyrightFontSize>
       <pageNumberFontSize>10</pageNumberFontSize>
-      <Spatium>1.75</Spatium>
+      <spatium>1.75</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testNoteAttributes2_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testNoteAttributes2_ref.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testPartNames_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testPartNames_ref.mscx
@@ -35,7 +35,7 @@
       <footerFontSize>10</footerFontSize>
       <copyrightFontSize>10</copyrightFontSize>
       <pageNumberFontSize>10</pageNumberFontSize>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testPedalChangesBroken_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testPedalChangesBroken_ref.mscx
@@ -34,7 +34,7 @@
       <footerFontSize>10</footerFontSize>
       <copyrightFontSize>10</copyrightFontSize>
       <pageNumberFontSize>10</pageNumberFontSize>
-      <Spatium>1.75</Spatium>
+      <spatium>1.75</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testPlacementDefaults_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testPlacementDefaults_ref.mscx
@@ -34,7 +34,7 @@
       <footerFontSize>10</footerFontSize>
       <copyrightFontSize>10</copyrightFontSize>
       <pageNumberFontSize>10</pageNumberFontSize>
-      <Spatium>1.75</Spatium>
+      <spatium>1.75</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testSecondVoiceMelismata_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testSecondVoiceMelismata_ref.mscx
@@ -34,7 +34,7 @@
       <footerFontSize>10</footerFontSize>
       <copyrightFontSize>10</copyrightFontSize>
       <pageNumberFontSize>10</pageNumberFontSize>
-      <Spatium>1.75</Spatium>
+      <spatium>1.75</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testSibMetronomeMarks_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testSibMetronomeMarks_ref.mscx
@@ -78,7 +78,7 @@
       <user10FontFace>Times New Roman</user10FontFace>
       <user11FontFace>Times New Roman</user11FontFace>
       <user12FontFace>Times New Roman</user12FontFace>
-      <Spatium>1.75</Spatium>
+      <spatium>1.75</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testSibOttavas_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testSibOttavas_ref.mscx
@@ -134,7 +134,7 @@
       <user11FontSize>11.9365</user11FontSize>
       <user12FontFace>Quicksand</user12FontFace>
       <user12FontSize>11.9365</user12FontSize>
-      <Spatium>1.75101</Spatium>
+      <spatium>1.75101</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testSibRitLine_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testSibRitLine_ref.mscx
@@ -27,7 +27,7 @@
       <slurMidWidth>0.21875</slurMidWidth>
       <tieEndWidth>0.0625</tieEndWidth>
       <tieMidWidth>0.21875</tieMidWidth>
-      <Spatium>1.75</Spatium>
+      <spatium>1.75</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testStaffEmptiness_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testStaffEmptiness_ref.mscx
@@ -34,7 +34,7 @@
       <footerFontSize>10</footerFontSize>
       <copyrightFontSize>10</copyrightFontSize>
       <pageNumberFontSize>10</pageNumberFontSize>
-      <Spatium>1.75</Spatium>
+      <spatium>1.75</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testStickingLyrics_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testStickingLyrics_ref.mscx
@@ -27,7 +27,7 @@
       <slurMidWidth>0.21875</slurMidWidth>
       <tieEndWidth>0.0625</tieEndWidth>
       <tieMidWidth>0.21875</tieMidWidth>
-      <Spatium>1.75</Spatium>
+      <spatium>1.75</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testSticking_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testSticking_ref.mscx
@@ -35,7 +35,7 @@
       <footerFontSize>10</footerFontSize>
       <copyrightFontSize>10</copyrightFontSize>
       <pageNumberFontSize>10</pageNumberFontSize>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testSystemBrackets3_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testSystemBrackets3_ref.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testSystemObjectStaves_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testSystemObjectStaves_ref.mscx
@@ -35,7 +35,7 @@
       <footerFontSize>10</footerFontSize>
       <copyrightFontSize>10</copyrightFontSize>
       <pageNumberFontSize>10</pageNumberFontSize>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testTempoLineFermata_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testTempoLineFermata_ref.mscx
@@ -35,7 +35,7 @@
       <footerFontSize>10</footerFontSize>
       <copyrightFontSize>10</copyrightFontSize>
       <pageNumberFontSize>10</pageNumberFontSize>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testTempoTextSpace1_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testTempoTextSpace1_ref.mscx
@@ -34,7 +34,7 @@
       <footerFontSize>10</footerFontSize>
       <copyrightFontSize>10</copyrightFontSize>
       <pageNumberFontSize>10</pageNumberFontSize>
-      <Spatium>1.75</Spatium>
+      <spatium>1.75</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testTempoTextSpace2_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testTempoTextSpace2_ref.mscx
@@ -34,7 +34,7 @@
       <footerFontSize>10</footerFontSize>
       <copyrightFontSize>10</copyrightFontSize>
       <pageNumberFontSize>10</pageNumberFontSize>
-      <Spatium>1.75</Spatium>
+      <spatium>1.75</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testTextLines.mscx
+++ b/src/importexport/musicxml/tests/data/testTextLines.mscx
@@ -5,7 +5,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.76389</Spatium>
+      <spatium>1.76389</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testTextOrder_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testTextOrder_ref.mscx
@@ -34,7 +34,7 @@
       <footerFontSize>10</footerFontSize>
       <copyrightFontSize>10</copyrightFontSize>
       <pageNumberFontSize>10</pageNumberFontSize>
-      <Spatium>1.75</Spatium>
+      <spatium>1.75</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testTextQuirkInference_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testTextQuirkInference_ref.mscx
@@ -34,7 +34,7 @@
       <footerFontSize>10</footerFontSize>
       <copyrightFontSize>10</copyrightFontSize>
       <pageNumberFontSize>10</pageNumberFontSize>
-      <Spatium>1.75</Spatium>
+      <spatium>1.75</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testTimeTick_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testTimeTick_ref.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testTitleSwapMu_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testTitleSwapMu_ref.mscx
@@ -118,7 +118,7 @@
       <user11FontSize>11.9365</user11FontSize>
       <user12FontFace>Plantin MT Std</user12FontFace>
       <user12FontSize>11.9365</user12FontSize>
-      <Spatium>1.2192</Spatium>
+      <spatium>1.2192</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testTitleSwapSib_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testTitleSwapSib_ref.mscx
@@ -118,7 +118,7 @@
       <user11FontSize>11.9365</user11FontSize>
       <user12FontFace>Plantin MT Std</user12FontFace>
       <user12FontSize>11.9365</user12FontSize>
-      <Spatium>1.2192</Spatium>
+      <spatium>1.2192</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testTupletTie_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testTupletTie_ref.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testUnnecessaryBarlines_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testUnnecessaryBarlines_ref.mscx
@@ -3,7 +3,7 @@
   <Score>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testUnterminatedTies_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testUnterminatedTies_ref.mscx
@@ -34,7 +34,7 @@
       <footerFontSize>10</footerFontSize>
       <copyrightFontSize>10</copyrightFontSize>
       <pageNumberFontSize>10</pageNumberFontSize>
-      <Spatium>1.75</Spatium>
+      <spatium>1.75</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testVoltaHiding_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testVoltaHiding_ref.mscx
@@ -35,7 +35,7 @@
       <footerFontSize>10</footerFontSize>
       <copyrightFontSize>10</copyrightFontSize>
       <pageNumberFontSize>10</pageNumberFontSize>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/src/importexport/musicxml/tests/data/testWedgeOffset_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testWedgeOffset_ref.mscx
@@ -34,7 +34,7 @@
       <footerFontSize>10</footerFontSize>
       <copyrightFontSize>10</copyrightFontSize>
       <pageNumberFontSize>10</pageNumberFontSize>
-      <Spatium>1.75</Spatium>
+      <spatium>1.75</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>


### PR DESCRIPTION
We changed the style tag "Spatium" into "spatium" in #23473, but still write "Spatium" hard coded into the style files, this PR fixes that. On reading we already read both, so no extra action needed.