### PR TITLE
Don't massively duplicate QML_IMPORT_PATH dirs

### DIFF
--- a/buildscripts/cmake/DeclareModuleSetup.cmake
+++ b/buildscripts/cmake/DeclareModuleSetup.cmake
@@ -65,6 +65,17 @@ macro(declare_module name)
 endmacro()
 
 
+macro(add_qml_import_path input_var)
+  if (NOT ${${input_var}} STREQUAL "")
+      set(QML_IMPORT_PATH "$CACHE{QML_IMPORT_PATH}")
+      list(APPEND QML_IMPORT_PATH ${${input_var}})
+      list(REMOVE_DUPLICATES QML_IMPORT_PATH)
+      set(QML_IMPORT_PATH "${QML_IMPORT_PATH}" CACHE STRING
+          "QtCreator extra import paths for QML modules" FORCE)
+  endif()
+endmacro()
+
+
 macro(setup_module)
 
     if (MODULE_IS_STUB)
@@ -90,13 +101,8 @@ macro(setup_module)
         QT6_WRAP_UI(ui_headers ${MODULE_UI} )
     endif()
 
-    if (NOT ${MODULE_QML_IMPORT} STREQUAL "")
-        set(QML_IMPORT_PATH "${QML_IMPORT_PATH};${MODULE_QML_IMPORT}" CACHE STRING "QtCreator extra import paths for QML modules" FORCE)
-    endif()
-
-    if (NOT ${MODULE_QMLAPI_IMPORT} STREQUAL "")
-        set(QML_IMPORT_PATH "${QML_IMPORT_PATH};${MODULE_QMLAPI_IMPORT}" CACHE STRING "QtCreator extra import paths for QML modules" FORCE)
-    endif()
+    add_qml_import_path(MODULE_QML_IMPORT)
+    add_qml_import_path(MODULE_QMLAPI_IMPORT)
 
     if (CC_IS_EMSCRIPTEN)
         add_library(${MODULE} OBJECT)


### PR DESCRIPTION
`setup_module` was unconditionally appending paths to the `QML_IMPORT_PATH` cache variable with every call, so after a few configure passes you could have a cache variable with >100 paths in it, when there should only be ~25 unique ones.

Use `list(APPEND)` and `list(REMOVE_DUPLICATES)` to keep them unique.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
