### PR TITLE
fix #23609: Add max fermata time stretch up to 10000%.

### DIFF
--- a/src/inspector/view/qml/MuseScore/Inspector/general/playback/internal/FermataExpandableBlank.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/general/playback/internal/FermataExpandableBlank.qml
@@ -53,7 +53,7 @@ ExpandableBlank {
 
         step: 1
         decimals: 0
-        maxValue: 400
+        maxValue: 10000
         minValue: 0
         measureUnitsSymbol: "%"
     }

--- a/src/inspector/view/qml/MuseScore/Inspector/general/playback/internal/FermataExpandableBlank.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/general/playback/internal/FermataExpandableBlank.qml
@@ -54,7 +54,7 @@ ExpandableBlank {
         step: 1
         decimals: 0
         maxValue: 10000
-        minValue: 0
+        minValue: 100
         measureUnitsSymbol: "%"
     }
 }


### PR DESCRIPTION

Resolves: #23609

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
