### PR TITLE
Percussion panel basics (triggering) - exposed through DevTools

### DIFF
--- a/src/appshell/appshelltypes.h
+++ b/src/appshell/appshelltypes.h
@@ -41,6 +41,7 @@ static const DockName MIXER_PANEL_NAME("mixerPanel");
 static const DockName PIANO_KEYBOARD_PANEL_NAME("pianoKeyboardPanel");
 static const DockName TIMELINE_PANEL_NAME("timelinePanel");
 static const DockName DRUMSET_PANEL_NAME("drumsetPanel");
+static const DockName PERCUSSION_PANEL_NAME("percussionPanel");
 
 // Toolbars:
 static const DockName NOTATION_TOOLBAR_NAME("notationToolBar");

--- a/src/appshell/internal/applicationuiactions.cpp
+++ b/src/appshell/internal/applicationuiactions.cpp
@@ -187,6 +187,14 @@ const UiActionList ApplicationUiActions::m_actions = {
              TranslatableString("action", "Show/hide piano keyboard"),
              Checkable::Yes
              ),
+    // still in development
+    // UiAction("toggle-percussion-panel",
+    //          mu::context::UiCtxNotationOpened,
+    //          mu::context::CTX_ANY,
+    //          TranslatableString("action", "Percussion"),
+    //          TranslatableString("action", "Show/hide percussion panel"),
+    //          Checkable::Yes
+    //          ),
     UiAction("toggle-scorecmp-tool",
              mu::context::UiCtxNotationOpened,
              mu::context::CTX_NOTATION_OPENED,
@@ -324,6 +332,7 @@ const QMap<ActionCode, DockName>& ApplicationUiActions::toggleDockActions()
         { "toggle-timeline", TIMELINE_PANEL_NAME },
         { "toggle-mixer", MIXER_PANEL_NAME },
         { "toggle-piano-keyboard", PIANO_KEYBOARD_PANEL_NAME },
+        { "toggle-percussion-panel", PERCUSSION_PANEL_NAME },
 
         { "toggle-statusbar", NOTATION_STATUSBAR_NAME },
     };

--- a/src/appshell/qml/NotationPage/NotationPage.qml
+++ b/src/appshell/qml/NotationPage/NotationPage.qml
@@ -415,6 +415,28 @@ DockPage {
             DrumsetPanel {
                 navigationSection: timelinePanel.navigationSection
             }
+        },
+
+        DockPanel {
+            id: percussionPanel
+
+            objectName: pageModel.percussionPanelName()
+            title: qsTrc("appshell", "Percussion")
+
+            height: 200
+            minimumHeight: root.horizontalPanelMinHeight
+            maximumHeight: root.horizontalPanelMaxHeight
+
+            groupName: root.horizontalPanelsGroup
+
+            //! NOTE: hidden by default
+            visible: false
+
+            location: Location.Bottom
+
+            dropDestinations: root.horizontalPanelDropDestinations
+
+            navigationSection: root.navigationPanelSec(percussionPanel.location)
         }
     ]
 

--- a/src/appshell/view/appmenumodel.cpp
+++ b/src/appshell/view/appmenumodel.cpp
@@ -199,6 +199,7 @@ MenuItem* AppMenuModel::makeViewMenu()
         makeMenuItem("toggle-timeline"),
         makeMenuItem("toggle-mixer"),
         makeMenuItem("toggle-piano-keyboard"),
+        // makeMenuItem("toggle-percussion-panel"), // still in development
         makeMenuItem("playback-setup"),
         //makeMenuItem("toggle-scorecmp-tool"), // not implemented
         makeSeparator(),

--- a/src/appshell/view/notationpagemodel.h
+++ b/src/appshell/view/notationpagemodel.h
@@ -30,6 +30,7 @@
 #include "actions/iactionsdispatcher.h"
 #include "context/iglobalcontext.h"
 #include "iappshellconfiguration.h"
+#include "notation/inotationconfiguration.h"
 #include "braille/ibrailleconfiguration.h"
 #include "dockwindow/idockwindowprovider.h"
 
@@ -41,6 +42,7 @@ class NotationPageModel : public QObject, public muse::async::Asyncable, public 
     INJECT(muse::actions::IActionsDispatcher, dispatcher)
     INJECT(context::IGlobalContext, globalContext)
     INJECT(IAppShellConfiguration, configuration)
+    INJECT(notation::INotationConfiguration, notationConfiguration)
     INJECT(braille::IBrailleConfiguration, brailleConfiguration)
     INJECT(muse::dock::IDockWindowProvider, dockWindowProvider)
 
@@ -69,6 +71,7 @@ public:
     Q_INVOKABLE QString pianoKeyboardPanelName() const;
     Q_INVOKABLE QString timelinePanelName() const;
     Q_INVOKABLE QString drumsetPanelName() const;
+    Q_INVOKABLE QString percussionPanelName() const;
 
     Q_INVOKABLE QString statusBarName() const;
 
@@ -81,7 +84,8 @@ private:
 
     void toggleDock(const QString& name);
 
-    void updateDrumsetPanelVisibility();
+    void updateDrumsetPanelVisibility(); // TODO: Delete when the new percussion panel is finished
+    void updatePercussionPanelVisibility();
 };
 }
 

--- a/src/notation/inotationconfiguration.h
+++ b/src/notation/inotationconfiguration.h
@@ -193,6 +193,13 @@ public:
     virtual muse::ValCh<int> pianoKeyboardNumberOfKeys() const = 0;
     virtual void setPianoKeyboardNumberOfKeys(int number) = 0;
 
+    // TODO: Delete when the new percussion panel is finished
+    virtual bool useNewPercussionPanel() const = 0;
+    virtual void setUseNewPercussionPanel(bool use) = 0;
+
+    virtual bool autoShowPercussionPanel() const = 0;
+    virtual void setAutoShowPercussionPanel(bool autoShow) = 0;
+
     virtual muse::io::path_t styleFileImportPath() const = 0;
     virtual void setStyleFileImportPath(const muse::io::path_t& path) = 0;
 

--- a/src/notation/internal/notationconfiguration.cpp
+++ b/src/notation/internal/notationconfiguration.cpp
@@ -90,6 +90,9 @@ static const Settings::Key NEED_TO_SHOW_ADD_GUITAR_BEND_ERROR_MESSAGE_KEY(module
 
 static const Settings::Key PIANO_KEYBOARD_NUMBER_OF_KEYS(module_name,  "pianoKeyboard/numberOfKeys");
 
+static const Settings::Key USE_NEW_PERCUSSION_PANEL_KEY(module_name,  "ui/useNewPercussionPanel");
+static const Settings::Key AUTO_SHOW_PERCUSSION_PANEL_KEY(module_name,  "ui/autoShowPercussionPanel");
+
 static const Settings::Key STYLE_FILE_IMPORT_PATH_KEY(module_name, "import/style/styleFile");
 
 static constexpr int DEFAULT_GRID_SIZE_SPATIUM = 2;
@@ -216,6 +219,9 @@ void NotationConfiguration::init()
     settings()->valueChanged(PIANO_KEYBOARD_NUMBER_OF_KEYS).onReceive(this, [this](const Val& val) {
         m_pianoKeyboardNumberOfKeys.set(val.toInt());
     });
+
+    settings()->setDefaultValue(USE_NEW_PERCUSSION_PANEL_KEY, Val(false));
+    settings()->setDefaultValue(AUTO_SHOW_PERCUSSION_PANEL_KEY, Val(true));
 
     settings()->setDefaultValue(ANCHOR_COLOR, Val(QColor("#C31989")));
     settings()->setDescription(ANCHOR_COLOR, muse::qtrc("notation", "Anchor color").toStdString());
@@ -886,6 +892,26 @@ void NotationConfiguration::setNeedToShowMScoreError(const std::string& errorKey
 ValCh<int> NotationConfiguration::pianoKeyboardNumberOfKeys() const
 {
     return m_pianoKeyboardNumberOfKeys;
+}
+
+bool NotationConfiguration::useNewPercussionPanel() const
+{
+    return settings()->value(USE_NEW_PERCUSSION_PANEL_KEY).toBool();
+}
+
+void NotationConfiguration::setUseNewPercussionPanel(bool use)
+{
+    settings()->setSharedValue(USE_NEW_PERCUSSION_PANEL_KEY, Val(use));
+}
+
+bool NotationConfiguration::autoShowPercussionPanel() const
+{
+    return settings()->value(AUTO_SHOW_PERCUSSION_PANEL_KEY).toBool();
+}
+
+void NotationConfiguration::setAutoShowPercussionPanel(bool autoShow)
+{
+    settings()->setSharedValue(AUTO_SHOW_PERCUSSION_PANEL_KEY, Val(autoShow));
 }
 
 void NotationConfiguration::setPianoKeyboardNumberOfKeys(int number)

--- a/src/notation/internal/notationconfiguration.h
+++ b/src/notation/internal/notationconfiguration.h
@@ -198,6 +198,12 @@ public:
     muse::ValCh<int> pianoKeyboardNumberOfKeys() const override;
     void setPianoKeyboardNumberOfKeys(int number) override;
 
+    bool useNewPercussionPanel() const override;
+    void setUseNewPercussionPanel(bool use) override;
+
+    bool autoShowPercussionPanel() const override;
+    void setAutoShowPercussionPanel(bool autoShow) override;
+
     muse::io::path_t styleFileImportPath() const override;
     void setStyleFileImportPath(const muse::io::path_t& path) override;
 

--- a/src/notation/tests/mocks/notationconfigurationmock.h
+++ b/src/notation/tests/mocks/notationconfigurationmock.h
@@ -183,6 +183,12 @@ public:
     MOCK_METHOD(muse::ValCh<int>, pianoKeyboardNumberOfKeys, (), (const, override));
     MOCK_METHOD(void, setPianoKeyboardNumberOfKeys, (int), (override));
 
+    MOCK_METHOD(bool, useNewPercussionPanel, (), (const, override));
+    MOCK_METHOD(void, setUseNewPercussionPanel, (bool), (override));
+
+    MOCK_METHOD(bool, autoShowPercussionPanel, (), (const, override));
+    MOCK_METHOD(void, setAutoShowPercussionPanel, (bool), (override));
+
     MOCK_METHOD(muse::io::path_t, styleFileImportPath, (), (const, override));
     MOCK_METHOD(void, setStyleFileImportPath, (const muse::io::path_t&), (override));
 

--- a/src/stubs/notation/notationconfigurationstub.cpp
+++ b/src/stubs/notation/notationconfigurationstub.cpp
@@ -465,6 +465,24 @@ void NotationConfigurationStub::setPianoKeyboardNumberOfKeys(int)
 {
 }
 
+bool NotationConfigurationStub::useNewPercussionPanel() const
+{
+    return false
+}
+
+void NotationConfigurationStub::setUseNewPercussionPanel(bool)
+{
+}
+
+bool NotationConfigurationStub::autoShowPercussionPanel() const
+{
+    return true;
+}
+
+void NotationConfigurationStub::setAutoShowPercussionPanel(bool)
+{
+}
+
 muse::io::path_t NotationConfigurationStub::styleFileImportPath() const
 {
     return muse::io::path_t();

--- a/src/stubs/notation/notationconfigurationstub.h
+++ b/src/stubs/notation/notationconfigurationstub.h
@@ -171,6 +171,12 @@ public:
     ValCh<int> pianoKeyboardNumberOfKeys() const override;
     void setPianoKeyboardNumberOfKeys(int number)  override;
 
+    bool useNewPercussionPanel() const override;
+    void setUseNewPercussionPanel(bool use) override;
+
+    bool autoShowPercussionPanel() const override;
+    void setAutoShowPercussionPanel(bool autoShow) override;
+
     muse::io::path_t styleFileImportPath() const override;
     void setStyleFileImportPath(const muse::io::path_t& path)  override;
 };


### PR DESCRIPTION
The first step of many towards the new percussion panel!

Two new settings can be found in DevTools:
<img width="404" alt="Screenshot 2024-08-16 at 09 22 42" src="https://github.com/user-attachments/assets/89876d6f-9ae6-4a37-91e0-55d6b8dce11f">
`useNewPercussionPanel` allows switching between the old "drumset" panel and the new percussion panel, `autoShowPercussionPanel` dictates whether the panel is automatically shown when a drum staff is selected (this will eventually become a preference).

This PR also contains logic for show/hiding the panel through the "View" menu, though we won't expose this until the panel is in a usable state.