### PR TITLE
Fixed Do solfège noteheads - rollback

### DIFF
--- a/src/engraving/dom/note.cpp
+++ b/src/engraving/dom/note.cpp
@@ -498,40 +498,21 @@ SymId Note::noteHead(int direction, NoteHeadGroup group, NoteHeadType t, int tpc
             group = NoteHeadGroup::HEAD_TI_NAME;
         }
     } else if (scheme == NoteHeadScheme::HEAD_SOLFEGE_FIXED) {
-        if (tpc == Tpc::TPC_C) {
-            group = NoteHeadGroup::HEAD_DO_NAME;
-        } else if (tpc == Tpc::TPC_C_S) {
-            group = NoteHeadGroup::HEAD_DI_NAME;
-        } else if (tpc == Tpc::TPC_D_B) {
-            group = NoteHeadGroup::HEAD_RA_NAME;
-        } else if (tpc == Tpc::TPC_D) {
-            group = NoteHeadGroup::HEAD_RE_NAME;
-        } else if (tpc == Tpc::TPC_D_S) {
-            group = NoteHeadGroup::HEAD_RI_NAME;
-        } else if (tpc == Tpc::TPC_E_B) {
-            group = NoteHeadGroup::HEAD_ME_NAME;
-        } else if (tpc == Tpc::TPC_E) {
-            group = NoteHeadGroup::HEAD_MI_NAME;
-        } else if (tpc == Tpc::TPC_F) {
-            group = NoteHeadGroup::HEAD_FA_NAME;
-        } else if (tpc == Tpc::TPC_F_S) {
-            group = NoteHeadGroup::HEAD_FI_NAME;
-        } else if (tpc == Tpc::TPC_G_B) {
-            group = NoteHeadGroup::HEAD_SE_NAME;
-        } else if (tpc == Tpc::TPC_G) {
-            group = NoteHeadGroup::HEAD_SOL_NAME;
-        } else if (tpc == Tpc::TPC_G_S) {
-            group = NoteHeadGroup::HEAD_SI_NAME;
-        } else if (tpc == Tpc::TPC_A_B) {
-            group = NoteHeadGroup::HEAD_LE_NAME;
-        } else if (tpc == Tpc::TPC_A) {
+        QString stepName = QString(tpc2stepName(tpc));
+        if (stepName == "C") {
+           group = NoteHeadGroup::HEAD_DO_NAME;
+        } else if (stepName == "D") {
+           group = NoteHeadGroup::HEAD_RE_NAME;
+        } else if (stepName == "E") {
+           group = NoteHeadGroup::HEAD_MI_NAME;
+        } else if (stepName == "F") {
+           group = NoteHeadGroup::HEAD_FA_NAME;
+        } else if (stepName == "G") {
+           group = NoteHeadGroup::HEAD_SOL_NAME;
+        } else if (stepName == "A") {
             group = NoteHeadGroup::HEAD_LA_NAME;
-        } else if (tpc == Tpc::TPC_A_S) {
-            group = NoteHeadGroup::HEAD_LI_NAME;
-        } else if (tpc == Tpc::TPC_B_B) {
-            group = NoteHeadGroup::HEAD_TE_NAME;
-        } else if (tpc == Tpc::TPC_B) {
-            group = NoteHeadGroup::HEAD_TI_NAME;
+        } else if (stepName == "B") {
+            group = NoteHeadGroup::HEAD_SI_NAME;
         }
     }
     return noteHeads[direction][int(group)][int(t)];

--- a/src/engraving/dom/note.cpp
+++ b/src/engraving/dom/note.cpp
@@ -498,20 +498,20 @@ SymId Note::noteHead(int direction, NoteHeadGroup group, NoteHeadType t, int tpc
             group = NoteHeadGroup::HEAD_TI_NAME;
         }
     } else if (scheme == NoteHeadScheme::HEAD_SOLFEGE_FIXED) {
-        QString stepName = QString(tpc2stepName(tpc));
-        if (stepName == "C") {
-           group = NoteHeadGroup::HEAD_DO_NAME;
-        } else if (stepName == "D") {
-           group = NoteHeadGroup::HEAD_RE_NAME;
-        } else if (stepName == "E") {
-           group = NoteHeadGroup::HEAD_MI_NAME;
-        } else if (stepName == "F") {
-           group = NoteHeadGroup::HEAD_FA_NAME;
-        } else if (stepName == "G") {
-           group = NoteHeadGroup::HEAD_SOL_NAME;
-        } else if (stepName == "A") {
+       Char stepName = tpc2stepName(tpc);
+        if (stepName == u'C') {
+            group = NoteHeadGroup::HEAD_DO_NAME;
+        } else if (stepName == u'D') {
+			         group = NoteHeadGroup::HEAD_RE_NAME;
+        } else if (stepName == u'E') {
+		         	group = NoteHeadGroup::HEAD_MI_NAME;
+        } else if (stepName == u'F') {
+			         group = NoteHeadGroup::HEAD_FA_NAME;
+        } else if (stepName == u'G') {
+			         group = NoteHeadGroup::HEAD_SOL_NAME;
+        } else if (stepName == u'A') {
             group = NoteHeadGroup::HEAD_LA_NAME;
-        } else if (stepName == "B") {
+        } else if (stepName == u'B') {
             group = NoteHeadGroup::HEAD_SI_NAME;
         }
     }

--- a/src/engraving/dom/note.cpp
+++ b/src/engraving/dom/note.cpp
@@ -502,13 +502,13 @@ SymId Note::noteHead(int direction, NoteHeadGroup group, NoteHeadType t, int tpc
         if (stepName == u'C') {
             group = NoteHeadGroup::HEAD_DO_NAME;
         } else if (stepName == u'D') {
-	    group = NoteHeadGroup::HEAD_RE_NAME;
+            group = NoteHeadGroup::HEAD_RE_NAME;
         } else if (stepName == u'E') {
-	    group = NoteHeadGroup::HEAD_MI_NAME;
+            group = NoteHeadGroup::HEAD_MI_NAME;
         } else if (stepName == u'F') {
-	    group = NoteHeadGroup::HEAD_FA_NAME;
+            group = NoteHeadGroup::HEAD_FA_NAME;
         } else if (stepName == u'G') {
-	    group = NoteHeadGroup::HEAD_SOL_NAME;
+            group = NoteHeadGroup::HEAD_SOL_NAME;
         } else if (stepName == u'A') {
             group = NoteHeadGroup::HEAD_LA_NAME;
         } else if (stepName == u'B') {

--- a/src/engraving/dom/note.cpp
+++ b/src/engraving/dom/note.cpp
@@ -498,17 +498,17 @@ SymId Note::noteHead(int direction, NoteHeadGroup group, NoteHeadType t, int tpc
             group = NoteHeadGroup::HEAD_TI_NAME;
         }
     } else if (scheme == NoteHeadScheme::HEAD_SOLFEGE_FIXED) {
-       Char stepName = tpc2stepName(tpc);
+        Char stepName = tpc2stepName(tpc);
         if (stepName == u'C') {
             group = NoteHeadGroup::HEAD_DO_NAME;
         } else if (stepName == u'D') {
-			         group = NoteHeadGroup::HEAD_RE_NAME;
+	    group = NoteHeadGroup::HEAD_RE_NAME;
         } else if (stepName == u'E') {
-		         	group = NoteHeadGroup::HEAD_MI_NAME;
+	    group = NoteHeadGroup::HEAD_MI_NAME;
         } else if (stepName == u'F') {
-			         group = NoteHeadGroup::HEAD_FA_NAME;
+	    group = NoteHeadGroup::HEAD_FA_NAME;
         } else if (stepName == u'G') {
-			         group = NoteHeadGroup::HEAD_SOL_NAME;
+	    group = NoteHeadGroup::HEAD_SOL_NAME;
         } else if (stepName == u'A') {
             group = NoteHeadGroup::HEAD_LA_NAME;
         } else if (stepName == u'B') {


### PR DESCRIPTION
Fixed do solfège only uses do, re, mi, fa, sol, la and SI
https://github.com/musescore/MuseScore/issues/11120 should be rolled back for Fixed Do Noteheads.

Resolves: #NNNNN <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x ] I signed the [CLA](https://musescore.org/en/cla)
- [x ] The title of the PR describes the problem it addresses
- [ x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [x ] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x ] There are no unnecessary changes
- [x ] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
