### PR TITLE
Fix #21133: Fix duplicate notes when adding note to tied chords

### DIFF
--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -595,12 +595,15 @@ Note* Score::addNoteToTiedChord(Chord* chord, const NoteVal& noteVal, bool force
     };
     Note* referenceNote = chord->notes().at(0);
 
-    while (referenceNote->tieBack()) {
+    while (true) {
+        // don't add note if it is already part of tied notes previously
+        if (referenceNote->chord()->findNote(noteVal.pitch)) {
+            return nullptr;
+        }
+        if (!referenceNote->tieBack()) {
+            break;
+        }
         referenceNote = referenceNote->tieBack()->startNote();
-    }
-    // don't add note if it is already exist
-    if (referenceNote->chord()->findNote(noteVal.pitch)) {
-        return nullptr;
     }
 
     Tie* tie = nullptr;


### PR DESCRIPTION
Resolves: #21133

Abort `addNoteToTiedChord` if the same note exists before in tied chords. 

In the two places that calls this method, `addPitch` will call `addNote` instead when `addNoteToTiedChord` fails, and `putNote` already only calls `addNoteToTiedChord` if the bottom note of the chord is not tied backwards, so other behavior shouldn't be affected.

Alt-[num] input and Shift-[letter] input are untouched.

Behavior now:

https://github.com/user-attachments/assets/810a26ab-cffa-4ac4-a520-aae8fcff7c77

It still doesn't check of the existence of the same note after the addition (see screenshot). I'm not sure if that's good or not, and if not what the correct behavior should be:
<img width="821" alt="Screenshot 2024-08-18 at 1 20 39 PM" src="https://github.com/user-attachments/assets/ad8c1b64-4df8-4584-a0d6-65b135ca02c5">



<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
