### PR TITLE
[4.4.0] Keyboard Navigation: Skip timeTick anchors for Alt+Right next-element

### DIFF
--- a/src/engraving/dom/navigate.cpp
+++ b/src/engraving/dom/navigate.cpp
@@ -763,6 +763,9 @@ EngravingItem* Score::nextElement()
                 Segment* nextSegment = seg->next1();
                 while (nextSegment) {
                     if (nextSegment->isTimeTickType()) {
+                        if (EngravingItem* annotation = nextSegment->firstAnnotation(staffId)) {
+                            return annotation;
+                        }
                         if (Spanner* spanner = nextSegment->firstSpanner(staffId)) {
                             return spanner->spannerSegments().front();
                         }
@@ -927,25 +930,28 @@ EngravingItem* Score::prevElement()
                 return prevSp->spannerSegments().front();
             } else {
                 Segment* startSeg = sp->startSegment();
+                if (EngravingItem* annotation = startSeg->lastAnnotation(staffId)) {
+                    return annotation;
+                }
                 if (startSeg->isTimeTickType()) {
                     startSeg = startSeg->prev1MMenabled();
                     for (; startSeg && startSeg->isTimeTickType(); startSeg = startSeg->prev1MMenabled()) {
                         if (Spanner* spanner = startSeg->lastSpanner(staffId)) {
                             return spanner->spannerSegments().front();
                         }
+                        if (EngravingItem* annotation = startSeg->lastAnnotation(staffId)) {
+                            return annotation;
+                        }
                     }
                     if (!startSeg) {
                         break;
                     }
-                    // Also check for spanners on first non-timeTick segment encountered.
+                    // Also check first non-timeTick segment encountered.
                     if (Spanner* spanner = startSeg->lastSpanner(staffId)) {
                         return spanner->spannerSegments().front();
                     }
-                }
-                if (!startSeg->annotations().empty()) {
-                    EngravingItem* last = startSeg->lastAnnotation(staffId);
-                    if (last) {
-                        return last;
+                    if (EngravingItem* annotation = startSeg->lastAnnotation(staffId)) {
+                        return annotation;
                     }
                 }
                 EngravingItem* el = startSeg->lastElementOfSegment(staffId);

--- a/src/engraving/dom/segment.cpp
+++ b/src/engraving/dom/segment.cpp
@@ -2058,7 +2058,12 @@ EngravingItem* Segment::nextElement(staff_idx_t activeStaff)
         if (s) {
             return s->spannerSegments().front();
         }
-        Segment* nextSegment =  seg->next1MMenabled();
+        Segment* nextSegment = seg->next1MMenabled();
+        for (; nextSegment && nextSegment->isTimeTickType(); nextSegment = nextSegment->next1MMenabled()) {
+            if (Spanner* spanner = nextSegment->firstSpanner(activeStaff)) {
+                return spanner->spannerSegments().front();
+            }
+        }
         if (!nextSegment) {
             MeasureBase* mb = measure()->next();
             return mb && mb->isBox() ? mb : score()->lastElement();
@@ -2226,6 +2231,11 @@ EngravingItem* Segment::prevElement(staff_idx_t activeStaff)
             }
         }
         Segment* prevSeg = seg->prev1MMenabled();
+        for (; prevSeg && prevSeg->isTimeTickType(); prevSeg = prevSeg->prev1MMenabled()) {
+            if (Spanner* spanner = prevSeg->lastSpanner(activeStaff)) {
+                return spanner->spannerSegments().front();
+            }
+        }
         if (!prevSeg) {
             MeasureBase* mb = measure()->prev();
             return mb && mb->isBox() ? mb : score()->firstElement();

--- a/src/engraving/dom/segment.cpp
+++ b/src/engraving/dom/segment.cpp
@@ -1625,15 +1625,15 @@ EngravingItem* Segment::firstAnnotation(staff_idx_t activeStaff) const
 
 EngravingItem* Segment::lastAnnotation(staff_idx_t activeStaff) const
 {
-    for (auto i = --m_annotations.end(); i != m_annotations.begin(); --i) {
+    for (auto i = m_annotations.rbegin(); i != m_annotations.rend(); ++i) {
         // TODO: firstVisibleStaff() for system elements? see Spanner::nextSpanner()
-        if ((*i)->staffIdx() == activeStaff) {
-            return *i;
+        EngravingItem* e = *i;
+        IF_ASSERT_FAILED(e) {
+            continue;
         }
-    }
-    auto i = m_annotations.begin();
-    if ((*i)->staffIdx() == activeStaff) {
-        return *i;
+        if (e->staffIdx() == activeStaff) {
+            return e;
+        }
     }
     return nullptr;
 }
@@ -2060,6 +2060,9 @@ EngravingItem* Segment::nextElement(staff_idx_t activeStaff)
         }
         Segment* nextSegment = seg->next1MMenabled();
         for (; nextSegment && nextSegment->isTimeTickType(); nextSegment = nextSegment->next1MMenabled()) {
+            if (EngravingItem* annotation = nextSegment->firstAnnotation(activeStaff)) {
+                return annotation;
+            }
             if (Spanner* spanner = nextSegment->firstSpanner(activeStaff)) {
                 return spanner->spannerSegments().front();
             }
@@ -2234,6 +2237,9 @@ EngravingItem* Segment::prevElement(staff_idx_t activeStaff)
         for (; prevSeg && prevSeg->isTimeTickType(); prevSeg = prevSeg->prev1MMenabled()) {
             if (Spanner* spanner = prevSeg->lastSpanner(activeStaff)) {
                 return spanner->spannerSegments().front();
+            }
+            if (EngravingItem* annotation = prevSeg->lastAnnotation(activeStaff)) {
+                return annotation;
             }
         }
         if (!prevSeg) {


### PR DESCRIPTION
Backport PR #24090 to the 4.4.0 branch.

Fix #23348