### PR TITLE
Fixes menu positioning on Wayland.

### DIFF
--- a/src/framework/uicomponents/view/popupwindow/popupwindow_qquickview.cpp
+++ b/src/framework/uicomponents/view/popupwindow/popupwindow_qquickview.cpp
@@ -75,7 +75,7 @@ void PopupWindow_QQuickView::init(QQmlEngine* engine, bool isDialogMode, bool is
     // popup
     else {
         Qt::WindowFlags flags(
-            Qt::Tool
+            Qt::Popup
             | Qt::FramelessWindowHint            // Without border
             | Qt::NoDropShadowWindowHint         // Without system shadow
             | Qt::BypassWindowManagerHint        // Otherwise, it does not work correctly on Gnome (Linux) when resizing)


### PR DESCRIPTION
Change popup menus from Qt::Tool to Qt::Popup.
Thanks to Kai Uwe Broulik for identifying the problem.

Resolves: #15285

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
