### PR TITLE
Fix #24074: Misplaced delegates in instruments panel

### DIFF
--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/InstrumentsPanel.qml
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/InstrumentsPanel.qml
@@ -246,8 +246,8 @@ Item {
 
                             InstrumentsTreeItemDelegate {
                                 treeView: instrumentsTreeView
-
                                 item: treeItemDelegateLoader.item
+                                originalParent: treeItemDelegateLoader
 
                                 sideMargin: contentColumn.sideMargin
                                 popupAnchorItem: root

--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/InstrumentsTreeItemDelegate.qml
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/InstrumentsTreeItemDelegate.qml
@@ -29,6 +29,8 @@ import MuseScore.InstrumentsScene 1.0
 FocusableControl {
     id: root
 
+    required property var originalParent
+
     property var item: null
     property var treeView: undefined
     property var index: styleData.index
@@ -442,6 +444,19 @@ FocusableControl {
                     horizontalCenter: undefined
                 }
             }
+        },
+
+        //! NOTE: Workaround for a bug in Qt 6.2.4 - see PR #24106 comment
+        // https://bugreports.qt.io/browse/QTBUG-99436
+        State {
+            when: !prv.dragged
+            name: "DROPPED"
+
+            ParentChange {
+                target: root
+                parent: root.originalParent
+            }
         }
+
     ]
 }


### PR DESCRIPTION
Resolves: #24074

Caused by [QTBUG-99436](https://bugreports.qt.io/browse/QTBUG-99436) - a bug relating to `ParentChange`.

Looking at the [fix](https://codereview.qt-project.org/c/qt/qtdeclarative/+/398458/2/src/quick/items/qquickstateoperations.cpp#494) for this bug, it seems that the position of the target (instrument in our case) isn’t being restored properly when rewinding to the orignal parent.

The idea with this workaround is to bypass the problematic rewind logic by introducing a "default/dropped" state which actively changes the parent back to the original.

  Something to note - as discussed in the comments of [QTBUG-99436](https://bugreports.qt.io/browse/QTBUG-99436) - `ParentChange` isn’t always necessary for drag & drop functionality (indeed after this bug came to light, it [was removed](https://codereview.qt-project.org/c/qt/qtdeclarative/+/388166) from Qt’s examples). Unfortunately this isn’t a viable fix for our purposes; it avoids the misplacement issue but we end up with jumpy dragging behaviour as show here:

https://github.com/user-attachments/assets/b318b80c-315d-4df9-a378-739725fd6f76