### PR TITLE
GitHub Actions: Replace github.event.inputs.X with inputs.X

### DIFF
--- a/.github/workflows/build_backend.yml
+++ b/.github/workflows/build_backend.yml
@@ -28,14 +28,14 @@ jobs:
 
     - name: "Configure workflow"
       run: |
-        bash ./buildscripts/ci/tools/make_build_mode_env.sh -e ${{ github.event_name }} -m ${{ github.event.inputs.build_mode }}
+        bash ./buildscripts/ci/tools/make_build_mode_env.sh -e ${{ github.event_name }} -m ${{ inputs.build_mode }}
         BUILD_MODE=$(cat ./build.artifacts/env/build_mode.env)
 
         bash ./buildscripts/ci/tools/make_build_number.sh
         BUILD_NUMBER=$(cat ./build.artifacts/env/build_number.env)
 
         DO_PUBLISH='false'
-        if [ "${{ github.event.inputs.publish }}" = "on" ]; then DO_PUBLISH='true'; fi
+        if [ "${{ inputs.publish }}" = "on" ]; then DO_PUBLISH='true'; fi
         if [ -z "${{ secrets.S3_KEY_CONVERTER }}" ]; then DO_PUBLISH='false'; fi
         if [ -z "${{ secrets.S3_SECRET_CONVERTER }}" ]; then DO_PUBLISH='false'; fi
 

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -61,16 +61,16 @@ jobs:
         pull_request_title: ${{ github.event.pull_request.title }}
         SENTRY_SERVER_MU4_KEY: ${{ secrets.SENTRY_SERVER_MU4_KEY }}
         SENTRY_SERVER_SANDBOX_KEY: ${{ secrets.SENTRY_SERVER_SANDBOX_KEY }}
-        SENTRY_PROJECT: ${{ github.event.inputs.sentry_project }}
+        SENTRY_PROJECT: ${{ inputs.sentry_project }}
       run: |
-        sudo bash ./buildscripts/ci/tools/make_build_mode_env.sh -e ${{ github.event_name }} -m ${{ github.event.inputs.build_mode }}
+        sudo bash ./buildscripts/ci/tools/make_build_mode_env.sh -e ${{ github.event_name }} -m ${{ inputs.build_mode }}
         BUILD_MODE=$(cat ./build.artifacts/env/build_mode.env)
 
         sudo bash ./buildscripts/ci/tools/make_build_number.sh
         BUILD_NUMBER=$(cat ./build.artifacts/env/build_number.env)
 
         DO_PUBLISH='false'
-        if [[ "${{ github.event.inputs.publish }}" == "on" || "$BUILD_MODE" == "nightly" ]]; then 
+        if [[ "${{ inputs.publish }}" == "on" || "$BUILD_MODE" == "nightly" ]]; then
           DO_PUBLISH='true'
           if [ -z "${{ secrets.OSUOSL_SSH_ENCRYPT_SECRET }}" ]; then 
             echo "warning: not set OSUOSL_SSH_ENCRYPT_SECRET, publish disabled" 

--- a/.github/workflows/build_linux_arm.yml
+++ b/.github/workflows/build_linux_arm.yml
@@ -52,16 +52,16 @@ jobs:
         pull_request_title: ${{ github.event.pull_request.title }}
         SENTRY_SERVER_MU4_KEY: ${{ secrets.SENTRY_SERVER_MU4_KEY }}
         SENTRY_SERVER_SANDBOX_KEY: ${{ secrets.SENTRY_SERVER_SANDBOX_KEY }}
-        SENTRY_PROJECT: ${{ github.event.inputs.sentry_project }}
+        SENTRY_PROJECT: ${{ inputs.sentry_project }}
       run: |
-        sudo bash ./buildscripts/ci/tools/make_build_mode_env.sh -e ${{ github.event_name }} -m ${{ github.event.inputs.build_mode }}
+        sudo bash ./buildscripts/ci/tools/make_build_mode_env.sh -e ${{ github.event_name }} -m ${{ inputs.build_mode }}
         BUILD_MODE=$(cat ./build.artifacts/env/build_mode.env)
 
         sudo bash ./buildscripts/ci/tools/make_build_number.sh
         BUILD_NUMBER=$(cat ./build.artifacts/env/build_number.env)
 
         DO_PUBLISH='false'
-        if [[ "${{ github.event.inputs.publish }}" == "on" || "$BUILD_MODE" == "nightly" ]]; then 
+        if [[ "${{ inputs.publish }}" == "on" || "$BUILD_MODE" == "nightly" ]]; then
           DO_PUBLISH='true'
           if [ -z "${{ secrets.OSUOSL_SSH_ENCRYPT_SECRET }}" ]; then 
             echo "warning: not set OSUOSL_SSH_ENCRYPT_SECRET, publish disabled" 
@@ -192,14 +192,14 @@ jobs:
       env:
         pull_request_title: ${{ github.event.pull_request.title }}
       run: |
-        sudo bash ./buildscripts/ci/tools/make_build_mode_env.sh -e ${{ github.event_name }} -m ${{ github.event.inputs.build_mode }}
+        sudo bash ./buildscripts/ci/tools/make_build_mode_env.sh -e ${{ github.event_name }} -m ${{ inputs.build_mode }}
         BUILD_MODE=$(cat ./build.artifacts/env/build_mode.env)
 
         sudo bash ./buildscripts/ci/tools/make_build_number.sh
         BUILD_NUMBER=$(cat ./build.artifacts/env/build_number.env)
 
         DO_PUBLISH='false'
-        if [[ "${{ github.event.inputs.publish }}" == "on" || "$BUILD_MODE" == "nightly" ]]; then 
+        if [[ "${{ inputs.publish }}" == "on" || "$BUILD_MODE" == "nightly" ]]; then
           DO_PUBLISH='true'
           if [ -z "${{ secrets.OSUOSL_SSH_ENCRYPT_SECRET }}" ]; then 
             echo "warning: not set OSUOSL_SSH_ENCRYPT_SECRET, publish disabled" 
@@ -222,7 +222,7 @@ jobs:
         fi
 
         DO_UPLOAD_SYMBOLS='false'
-        SENTRY_PROJECT=${{ github.event.inputs.sentry_project }}
+        SENTRY_PROJECT=${{ inputs.sentry_project }}
         SENTRY_URL=""
         if [ "$SENTRY_PROJECT" == "editor" ] && [ ${{ secrets.SENTRY_SERVER_MU3_KEY }} != 0 ]; then 
           DO_UPLOAD_SYMBOLS='true'

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -62,16 +62,16 @@ jobs:
         pull_request_title: ${{ github.event.pull_request.title }}
         SENTRY_SERVER_MU4_KEY: ${{ secrets.SENTRY_SERVER_MU4_KEY }}
         SENTRY_SERVER_SANDBOX_KEY: ${{ secrets.SENTRY_SERVER_SANDBOX_KEY }}
-        SENTRY_PROJECT: ${{ github.event.inputs.sentry_project }}
+        SENTRY_PROJECT: ${{ inputs.sentry_project }}
       run: |
-        bash ./buildscripts/ci/tools/make_build_mode_env.sh -e ${{ github.event_name }} -m ${{ github.event.inputs.build_mode }}
+        bash ./buildscripts/ci/tools/make_build_mode_env.sh -e ${{ github.event_name }} -m ${{ inputs.build_mode }}
         BUILD_MODE=$(cat ./build.artifacts/env/build_mode.env)
 
         bash ./buildscripts/ci/tools/make_build_number.sh
         BUILD_NUMBER=$(cat ./build.artifacts/env/build_number.env)
 
         DO_PUBLISH='false'
-        if [[ "${{ github.event.inputs.publish }}" == "on" || "$BUILD_MODE" == "nightly" ]]; then 
+        if [[ "${{ inputs.publish }}" == "on" || "$BUILD_MODE" == "nightly" ]]; then
           DO_PUBLISH='true'
           if [ -z "${{ secrets.OSUOSL_SSH_ENCRYPT_SECRET }}" ]; then 
             echo "warning: not set OSUOSL_SSH_ENCRYPT_SECRET, publish disabled" 

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -59,16 +59,16 @@ jobs:
         pull_request_title: ${{ github.event.pull_request.title }}
         SENTRY_SERVER_MU4_KEY: ${{ secrets.SENTRY_SERVER_MU4_KEY }}
         SENTRY_SERVER_SANDBOX_KEY: ${{ secrets.SENTRY_SERVER_SANDBOX_KEY }}
-        SENTRY_PROJECT: ${{ github.event.inputs.sentry_project }}
+        SENTRY_PROJECT: ${{ inputs.sentry_project }}
       run: |
-        bash ./buildscripts/ci/tools/make_build_mode_env.sh -e ${{ github.event_name }} -m ${{ github.event.inputs.build_mode }}
+        bash ./buildscripts/ci/tools/make_build_mode_env.sh -e ${{ github.event_name }} -m ${{ inputs.build_mode }}
         BUILD_MODE=$(cat ./build.artifacts/env/build_mode.env)
 
         bash ./buildscripts/ci/tools/make_build_number.sh
         BUILD_NUMBER=$(cat ./build.artifacts/env/build_number.env)
 
         DO_PUBLISH='false'
-        if [[ "${{ github.event.inputs.publish }}" == "on" || "$BUILD_MODE" == "nightly" ]]; then 
+        if [[ "${{ inputs.publish }}" == "on" || "$BUILD_MODE" == "nightly" ]]; then
           DO_PUBLISH='true'
           if [ -z "${{ secrets.OSUOSL_SSH_ENCRYPT_SECRET }}" ]; then 
             echo "warning: not set OSUOSL_SSH_ENCRYPT_SECRET, publish disabled" 
@@ -248,7 +248,7 @@ jobs:
       env:
         pull_request_title: ${{ github.event.pull_request.title }}
       run: |
-        bash ./buildscripts/ci/tools/make_build_mode_env.sh -e ${{ github.event_name }} -m ${{ github.event.inputs.build_mode }}
+        bash ./buildscripts/ci/tools/make_build_mode_env.sh -e ${{ github.event_name }} -m ${{ inputs.build_mode }}
         BUILD_MODE=$(cat ./build.artifacts/env/build_mode.env)
 
         bash ./buildscripts/ci/tools/make_build_number.sh
@@ -263,7 +263,7 @@ jobs:
         fi
 
         DO_PUBLISH='false'
-        if [[ "${{ github.event.inputs.publish }}" == "on" || "$BUILD_MODE" == "nightly" ]]; then 
+        if [[ "${{ inputs.publish }}" == "on" || "$BUILD_MODE" == "nightly" ]]; then
           DO_PUBLISH='true'
           if [ -z "${{ secrets.OSUOSL_SSH_ENCRYPT_SECRET }}" ]; then 
             echo "warning: not set OSUOSL_SSH_ENCRYPT_SECRET, publish disabled" 

--- a/.github/workflows/translate_lupdate.yml
+++ b/.github/workflows/translate_lupdate.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Configure workflow
         run: |
           LUPDATE_ARGS=''
-          if [[ "${{ github.event_name }}" == "schedule" || "${{ github.event.inputs.cleanup_obsolete }}" == "true" ]]; then
+          if [[ "${{ github.event_name }}" == "schedule" || "${{ inputs.cleanup_obsolete }}" == "true" ]]; then
             LUPDATE_ARGS='-no-obsolete'
           fi
 

--- a/.github/workflows/translate_tx_pull_to_s3.yml
+++ b/.github/workflows/translate_tx_pull_to_s3.yml
@@ -49,10 +49,10 @@ jobs:
             DO_CREATE_PR="${{ github.event.schedule == '0 12 * * Sun'}}"
             DO_PUSH_TO_S3='true'
           else
-            if [[ "${{ github.event.inputs.create_pull_request }}" == "true" ]]; then
+            if [[ "${{ inputs.create_pull_request }}" == "true" ]]; then
               DO_CREATE_PR='true'
             fi
-            if [[ "${{ github.event.inputs.push_to_s3 }}" == "true" ]]; then
+            if [[ "${{ inputs.push_to_s3 }}" == "true" ]]; then
               DO_PUSH_TO_S3='true'
             fi
           fi

--- a/.github/workflows/translate_tx_push.yml
+++ b/.github/workflows/translate_tx_push.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Check preconditions
         env:
           GITHUB_REF: ${{ github.ref }}
-          RETYPED_BRANCH_NAME: ${{ github.event.inputs.retyped_branch_name }}
+          RETYPED_BRANCH_NAME: ${{ inputs.retyped_branch_name }}
         run: |
           if [ "${GITHUB_REF}" != "refs/heads/${RETYPED_BRANCH_NAME}" ]; then
             echo "::error::Retyped branch name does not match actual branch name. Please make sure you have selected the correct branch."

--- a/.github/workflows/update_learn_playlists.yml
+++ b/.github/workflows/update_learn_playlists.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Update info about the get started playlist in s3
         run: |
           S3_URL="s3://extensions.musescore.org/4.0/learn/started_playlist.json"
-          if [ ${{ github.event.inputs.mode }} == "testing" ]; then
+          if [ ${{ inputs.mode }} == "testing" ]; then
             S3_URL="s3://extensions.musescore.org/4.0/learn/started_playlist.test.json"
           fi
 
@@ -45,7 +45,7 @@ jobs:
       - name: Update info about the advanced playlist in s3
         run: |
           S3_URL="s3://extensions.musescore.org/4.0/learn/advanced_playlist.json"
-          if [ ${{ github.event.inputs.mode }} == "testing" ]; then
+          if [ ${{ inputs.mode }} == "testing" ]; then
             S3_URL="s3://extensions.musescore.org/4.0/learn/advanced_playlist.test.json"
           fi
 

--- a/.github/workflows/update_release_info.yml
+++ b/.github/workflows/update_release_info.yml
@@ -27,7 +27,7 @@ jobs:
           S3_URL="s3://musescore-updates/feed/latest.xml"
           S3_ALL_URL="s3://musescore-updates/feed/all.xml"
           
-          if [ ${{ github.event.inputs.mode }} == "testing" ]; then
+          if [ ${{ inputs.mode }} == "testing" ]; then
             S3_URL="s3://musescore-updates/feed/latest.test.xml"
             S3_ALL_URL="s3://musescore-updates/feed/all.test.xml"
           fi
@@ -35,7 +35,7 @@ jobs:
           sudo bash ./buildscripts/ci/release/make_release_info_file.sh \
             --token ${{ secrets.GITHUB_TOKEN }} \
             --repo ${{ github.repository }} \
-            --release_tag ${{ github.event.inputs.tag }}
+            --release_tag ${{ inputs.tag }}
 
           sudo bash ./buildscripts/ci/release/push_file_to_s3.sh \
             --s3_key ${{ secrets.S3_KEY_UPDATE }} \

--- a/.github/workflows/update_release_info_clear.yml
+++ b/.github/workflows/update_release_info_clear.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Clear info about the latest release in musescore-updates
         run: |
           S3_URL="s3://musescore-updates/feed/latest.xml"
-          if [ ${{ github.event.inputs.mode }} == "testing" ]; then
+          if [ ${{ inputs.mode }} == "testing" ]; then
             S3_URL="s3://musescore-updates/feed/latest.test.xml"
           fi
 


### PR DESCRIPTION
See https://github.blog/changelog/2022-06-10-github-actions-inputs-unified-across-manual-and-reusable-workflows/

This is necessary to enable a combined workflow that will call the other workflows via [`workflow_call`](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onworkflow_call).

Preparation for #23067. I'm splitting it across several PRs for easier review.