### PR TITLE
CI: Add deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,130 @@
+name: Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      platforms:
+        description: 'Platforms to build:'
+        default: 'linux_arm32 linux_arm64 linux_x64 macos windows_x64 windows_portable' # TODO: backend
+        required: true
+      release_type:
+        description: 'Release type: alpha,beta,rc,stable, or any label with chars A-Za-z0-9._ for testing'
+        default: 'test'
+        required: true
+      create_tag:
+        description: 'Create tag & release: (if enabled, release type must be alpha,beta,rc,stable)'
+        type: boolean
+        default: false
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+
+  get_tag_info:
+    name: Get tag info
+    runs-on: ubuntu-latest
+    outputs:
+      tag_name: ${{ steps.make_tag_info.outputs.TAG_NAME }}
+      release_name: ${{ steps.make_tag_info.outputs.RELEASE_NAME }}
+    steps:
+    - name: Clone repo with history
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0 # entire history for all branches and tags
+    - id: make_tag_info
+      name: Make tag info
+      env:
+        RELEASE_TYPE: ${{ inputs.release_type }}
+        CREATE_TAG: ${{ inputs.create_tag }}
+      run: |
+        git tag --list | tail -n 20
+        echo ==========
+        buildscripts/ci/release/make_tag_name.sh | tee -a "${GITHUB_OUTPUT}"
+        echo ==========
+        echo "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA}"
+        echo ==========
+        if [[ "${CREATE_TAG}" == 'true' ]]; then
+          echo "Tag will be created."
+        else
+          echo "Tag will not be created."
+        fi
+
+  build:
+    name: Build
+    needs: get_tag_info
+    uses: ./.github/workflows/build_all.yml
+    with:
+      platforms: ${{ inputs.platforms }}
+      build_mode: ${{ inputs.release_type == 'stable' && 'stable' || 'testing' }}
+      publish: ${{ inputs.create_tag && 'on' || 'off' }}
+      sentry_project: ${{ (inputs.create_tag && inputs.release_type == 'stable') && 'mu4' || 'sandbox' }}
+
+  update_learn_playlists:
+    name: 'Update Home→Learn playlists'
+    if: ${{ github.repository == 'musescore/MuseScore' }}
+    needs: build
+    uses: ./.github/workflows/update_learn_playlists.yml
+    with:
+      mode: ${{ inputs.create_tag && 'stable' || 'testing' }}
+      environment: production # requires approval
+
+  create_release:
+    name: 'Create release: ${{ needs.get_tag_info.outputs.tag_name }}'
+    needs:
+      - get_tag_info # to access outputs
+      - update_learn_playlists
+    if: ${{ ! failure() && ! cancelled() && inputs.create_tag }} # run even if prior jobs were skipped
+    runs-on: ubuntu-latest
+    environment:
+      name: production # requires approval
+      url: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ needs.get_tag_info.outputs.tag_name }}
+    steps:
+    - name: Clone repository
+      uses: actions/checkout@v4
+    - name: Download and extract artifacts
+      uses: actions/download-artifact@v4
+      with:
+        path: build.artifacts
+    - name: Collate release binaries
+      run: |
+        buildscripts/ci/release/collate_release_binaries.sh
+    - name: Create tag # do this as late as possible so we're not left with a useless tag if something fails
+      env:
+        TAG_NAME: ${{ needs.get_tag_info.outputs.tag_name }}
+      run: |
+        int="(0|[1-9][0-9]*)"
+        version="${int}\.${int}(\.${int})?"
+        label="(alpha|beta|rc)(\.${int})?"
+        pattern="^v${version}(-${label})?$"
+
+        if [[ ! "${TAG_NAME}" =~ ${pattern} ]]; then
+          echo >&2 "Error: TAG_NAME '${TAG_NAME}' doesn't match required regex: ${pattern}"
+          exit 1
+        fi
+
+        git tag "${TAG_NAME}" "${GITHUB_SHA}"
+        git push origin "${TAG_NAME}"
+    - name: Create draft release
+      uses: softprops/action-gh-release@v2
+      with: # https://github.com/softprops/action-gh-release?tab=readme-ov-file#inputs
+        draft: true
+        prerelease: ${{ inputs.release_type != 'stable' }}
+        files: release/*
+        name: ${{ needs.get_tag_info.outputs.release_name }}
+        tag_name: ${{ needs.get_tag_info.outputs.tag_name }}
+        fail_on_unmatched_files: true
+        generate_release_notes: false
+
+  notify_users:
+    name: Notify users
+    needs:
+      - get_tag_info # to access outputs
+      - create_release
+    if: ${{ github.repository == 'musescore/MuseScore' && ! failure() && ! cancelled() && needs.create_release.result == 'success' }}
+    uses: ./.github/workflows/update_release_info.yml
+    with:
+      mode: ${{ inputs.release_type == 'stable' && 'stable' || 'testing' }}
+      tag: ${{ needs.get_tag_info.outputs.tag_name }}
+      environment: production # requires approval

--- a/.github/workflows/update_learn_playlists.yml
+++ b/.github/workflows/update_learn_playlists.yml
@@ -5,56 +5,56 @@ on:
     inputs:
       mode:
         description: 'Mode: stable, testing'
-        required: true
         default: 'testing'
+        required: true
+  workflow_call:
+    inputs:
+      mode:
+        description: 'Mode: stable, testing'
+        default: 'testing'
+        type: string
+        required: true
+      environment:
+        description: "Environment: use 'production' to prompt for approval"
+        default: ''
+        type: string
+        required: false
 
 defaults:
   run:
     shell: bash
 
 jobs:
-  update-get-started-playlist:
-    runs-on: ubuntu-20.04
+  update_playlists:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        playlist:
+          - filename: started_playlist
+            id: PLTYuWi2LmaPEhcwZJwFZqoyQ2xXx_maPa
+          # - filename: advanced_playlist # old playlist no longer used
+          #   id: PL24C760637A625BB6
+    environment:
+      name: ${{ inputs.environment }} # can be empty/blank (if so, URL will not be shown)
+      url: https://www.youtube.com/playlist?list=${{ matrix.playlist.id }} # show on run page
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
 
-      - name: Update info about the get started playlist in s3
+      - name: Update playlist info on s3
         run: |
-          S3_URL="s3://extensions.musescore.org/4.0/learn/started_playlist.json"
-          if [ ${{ inputs.mode }} == "testing" ]; then
-            S3_URL="s3://extensions.musescore.org/4.0/learn/started_playlist.test.json"
+          if [ '${{ inputs.mode }}' == 'stable' ]; then
+            S3_URL='s3://extensions.musescore.org/4.0/learn/${{ matrix.playlist.filename }}.json'
+          else
+            S3_URL='s3://extensions.musescore.org/4.0/learn/${{ matrix.playlist.filename }}.test.json'
           fi
 
           sudo bash ./buildscripts/ci/learn/make_playlists_info_file.sh \
-            --youtube_api_key ${{ secrets.YOUTUBE_API_KEY }} \
-            --youtube_playlist_id 'PLTYuWi2LmaPEhcwZJwFZqoyQ2xXx_maPa'
+            --youtube_api_key '${{ secrets.YOUTUBE_API_KEY }}' \
+            --youtube_playlist_id '${{ matrix.playlist.id }}'
 
           sudo bash ./buildscripts/ci/learn/push_file_to_s3.sh \
-            --s3_key ${{ secrets.S3_KEY }} \
-            --s3_secret ${{ secrets.S3_SECRET }} \
-            --s3_url ${S3_URL} \
-            --file_name "playlist.json"
-
-  update-advanced-playlist:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v4
-
-      - name: Update info about the advanced playlist in s3
-        run: |
-          S3_URL="s3://extensions.musescore.org/4.0/learn/advanced_playlist.json"
-          if [ ${{ inputs.mode }} == "testing" ]; then
-            S3_URL="s3://extensions.musescore.org/4.0/learn/advanced_playlist.test.json"
-          fi
-
-          sudo bash ./buildscripts/ci/learn/make_playlists_info_file.sh \
-            --youtube_api_key ${{ secrets.YOUTUBE_API_KEY }} \
-            --youtube_playlist_id 'PL24C760637A625BB6'
-
-          sudo bash ./buildscripts/ci/learn/push_file_to_s3.sh \
-            --s3_key ${{ secrets.S3_KEY }} \
-            --s3_secret ${{ secrets.S3_SECRET }} \
-            --s3_url ${S3_URL} \
-            --file_name "playlist.json"
+            --s3_key '${{ secrets.S3_KEY }}' \
+            --s3_secret '${{ secrets.S3_SECRET }}' \
+            --s3_url "${S3_URL}" \
+            --file_name 'playlist.json'

--- a/.github/workflows/update_release_info.yml
+++ b/.github/workflows/update_release_info.yml
@@ -5,10 +5,26 @@ on:
     inputs:
       mode:
         description: 'Mode: stable, testing(alpha, beta, rc)'
-        required: true
         default: 'testing'
+        required: true
       tag:
         description: 'Release tag (latest stable by default)'
+        required: false
+  workflow_call:
+    inputs:
+      mode:
+        description: 'Mode: stable, testing(alpha, beta, rc)'
+        default: 'testing'
+        type: string
+        required: true
+      tag:
+        description: 'Release tag (latest stable by default)'
+        type: string
+        required: false
+      environment:
+        description: "Environment: use 'production' to prompt for approval"
+        default: ''
+        type: string
         required: false
 
 defaults:
@@ -18,11 +34,15 @@ defaults:
 jobs:
   update-release-info:
     runs-on: ubuntu-20.04
+    environment:
+      name: ${{ inputs.environment }} # can be empty/blank (if so, URL will not be shown)
+      url: ${{ github.server_url }}/${{ github.repository }}/releases/${{ inputs.tag && format('tag/{0}', inputs.tag) || 'latest' }} # show on run page
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
 
       - name: Update info about the release in musescore-updates
+        if: ${{ false }}
         run: |
           S3_URL="s3://musescore-updates/feed/latest.xml"
           S3_ALL_URL="s3://musescore-updates/feed/all.xml"

--- a/buildscripts/ci/release/collate_release_binaries.sh
+++ b/buildscripts/ci/release/collate_release_binaries.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-only
+# MuseScore-Studio-CLA-applies
+#
+# MuseScore Studio
+# Music Composition & Notation
+#
+# Copyright (C) 2024 MuseScore Limited
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+o="$(basename "$0")" # script name
+
+((${BASH_VERSION%%.*} >= 4)) || { echo >&2 "$o: Error: Please upgrade Bash."; exit 1; }
+
+set -euo pipefail # exit on error, error on unset variable, preserve errors in pipelines
+
+ARTIFACTS_DIR=build.artifacts
+RELEASE_DIR=release
+CHECKSUMS_FILE=checksums.sha256.txt
+
+mkdir "${RELEASE_DIR}" # error if it already exists (need it to be empty)
+
+# Move artifacts into release directory.
+for path in "${ARTIFACTS_DIR}/"*"/env/artifact_name.env"; do
+    artifact_dir="$(dirname "$(dirname "${path}")")"
+    artifact_name="$(<"${path}")"
+    artifact_path="${artifact_dir}/${artifact_name}"
+
+    mv -v "${artifact_path}" "${RELEASE_DIR}/"
+    if [[ -f "${artifact_path}.zsync" ]]; then
+        mv -v "${artifact_path}.zsync" "${RELEASE_DIR}/"
+    fi
+done
+
+declare -A old_checksums new_checksums # associative arrays (i.e. maps / dictionaries)
+
+# Read old checksums calculated during the build.
+echo >&2
+echo >&2 "Old checksums (openssl sha256):"
+for path in "${ARTIFACTS_DIR}/"*"/checksum.txt"; do
+    while read -r line; do
+        printf '%s\n' "${line}" >&2
+        if [[ ! "${line}" =~ ^SHA256\(.*\)=\ [0-9a-f]{64}$ ]]; then
+            echo >&2 "$o: Error: openssl line is badly formed: ${line}"
+            exit 1
+        fi
+        checksum="${line##*)= }"
+        filename="${line%)= *}"
+        filename="${filename#SHA256(}"
+        filename="$(basename "${filename}")"
+        old_checksums["${filename}"]="${checksum}"
+    done <"${path}"
+done
+
+# Calculate new checksums to be uploaded with the release.
+echo >&2
+cd "${RELEASE_DIR}/"
+echo >&2 "New checksums (sha256sum):"
+sha256sum * | tee "${CHECKSUMS_FILE}" >&2
+echo >&2
+
+# Read new checksums.
+while read -r line; do
+    # sha256sum prepends filenames with space ( ) if opened in text mode
+    # or asterisk (*) if opened in binary mode.
+    if [[ ! "${line}" =~ ^[0-9a-f]{64}\ [\ *][^/]+$ ]]; then
+        echo >&2 "$o: Error: sha256sum line is badly formed: ${line}"
+        exit 1
+    fi
+    checksum="${line%% *}"
+    filename="${line#* ?}"
+    new_checksums["${filename}"]="${checksum}"
+done <"${CHECKSUMS_FILE}"
+
+# Compare old and new checksums.
+# Loop over old ones because there's no old checksum for .zsync files.
+status=0
+for filename in "${!old_checksums[@]}"; do
+    old_checksum="${old_checksums["${filename}"]}"
+    new_checksum="${new_checksums["${filename}"]}"
+    if [[ "${old_checksum}" != "${new_checksum}" ]]; then
+        echo >&2 "$o: Error: Checksum mismatch: ${filename}"
+        status=1
+    fi
+done
+
+if ((status == 0)); then
+    echo >&2 "All checksums match!"
+fi
+
+exit ${status}

--- a/buildscripts/ci/release/make_tag_name.sh
+++ b/buildscripts/ci/release/make_tag_name.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-only
+# MuseScore-Studio-CLA-applies
+#
+# MuseScore Studio
+# Music Composition & Notation
+#
+# Copyright (C) 2024 MuseScore Limited
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+o="$(basename "$0")" # script name
+
+((${BASH_VERSION%%.*} >= 4)) || { echo >&2 "$o: Error: Please upgrade Bash."; exit 1; }
+
+set -euo pipefail # exit on error, error on unset variable, preserve errors in pipelines
+
+function tag_exists()
+{
+    local tags="$(git tag --list -- "$@")"
+    if [[ "${tags}" ]]; then
+        # printf '%s\n' "${tags}"
+        return 0
+    fi
+    return 1
+}
+
+function version_exists()
+{
+    local version="$1" label="${2-}" # label is optional
+    local suffix="${label:+-${label}}" # prepend hyphen if label not empty
+    version="${version%.0}" # strip patch number if it's zero
+    version="${version%.0}" # strip minor number if it's zero
+    tag_exists "v${version}${suffix}" "v${version}.0${suffix}" "v${version}.0.0${suffix}"
+}
+
+if [[ "${CREATE_TAG}" == 'true' ]]; then
+    types="alpha|beta|rc|stable"
+    if [[ ! "${RELEASE_TYPE}" =~ ^(${types})$ ]]; then
+        echo >&2 "$o: Error: Creating tag with RELEASE_TYPE '${RELEASE_TYPE}'."
+        echo >&2 "Allowed release types for tags are: ${types//|/, }."
+        exit 1
+    fi
+else
+    pattern="^[A-Za-z][A-Za-z0-9._]*[A-Za-z0-9]$"
+    if [[ ! "${RELEASE_TYPE}" =~ ${pattern} ]]; then
+        echo >&2 "$o: Error: Invalid RELEASE_TYPE '${RELEASE_TYPE}'."
+        echo >&2 "Allowed characters are ASCII letters, numbers, dot '.' and underscore '_'."
+        echo >&2 "It must start with a letter and end with a letter or number."
+        echo >&2 "Regex: ${pattern}"
+        exit 1
+    fi
+fi
+
+VERSION="$(cmake -P version.cmake | sed -n "s|^-- MUSE_APP_VERSION ||p")"
+int="(0|[1-9][0-9]*)"
+
+if [[ ! "${VERSION}" =~ ^${int}\.${int}\.${int}$ ]]; then
+    echo >&2 "$o: Badly formed version from version.cmake: ${VERSION}"
+    exit 1
+elif version_exists "${VERSION}"; then
+    if [[ "${RELEASE_TYPE}" == 'stable' ]]; then
+        echo >&2 "$o: Error: Stable tag already exists for version ${VERSION}."
+    else
+        echo >&2 "$o: Error: Creating pre-release for v${VERSION}, which already has a stable tag."
+    fi
+    echo >&2 "You need to bump the version numbers in version.cmake (e.g. increase PATCH by 1)."
+    exit 1
+elif [[ "${RELEASE_TYPE}" =~ ^(beta|alpha)$ ]] && version_exists "${VERSION}" 'rc*'; then
+    echo >&2 "$o: Error: Release type is '${RELEASE_TYPE}' but v${VERSION} already has a Release Candidate tag."
+    echo >&2 "Please change the release type to 'rc' or bump the version numbers in version.cmake."
+    exit 1
+elif [[ "${RELEASE_TYPE}" == 'alpha' ]] && version_exists "${VERSION}" 'beta*'; then
+    echo >&2 "$o: Error: Release type is '${RELEASE_TYPE}' but v${VERSION} already has a Beta tag."
+    echo >&2 "Please change the release type to 'beta' or 'rc', or bump the version numbers in version.cmake."
+    exit 1
+fi
+
+MAJOR="${VERSION%%.*}"
+MINOR="${VERSION#*.}"
+MINOR="${MINOR%%.*}"
+PATCH="${VERSION#*.*.}"
+
+if ((PATCH > 0)); then
+    older_version="${MAJOR}.${MINOR}.$((PATCH - 1))"
+elif ((MINOR > 0)); then
+    older_version="${MAJOR}.$((MINOR - 1)).0"
+elif ((MAJOR > 0)); then
+    older_version="$((MAJOR - 1)).0.0"
+else
+    echo >&2 "$o: Error: Can't release version '0.0.0'. Please check version.cmake."
+    exit 1
+fi
+
+if ! version_exists "${older_version}"; then
+    # Assume VERSION isn't the very first release.
+    echo >&2 "$o: Error: Version is ${VERSION} but no tag exists for ${older_version}."
+    echo >&2 "You need to reduce the version numbers in version.cmake to avoid skipping releases."
+    exit 1
+fi
+
+RELEASE_TYPE_COUNT=1
+
+if [[ "${RELEASE_TYPE}" == 'stable' ]]; then
+    VERSION_LABEL=""
+else
+    label="${RELEASE_TYPE}"
+    if version_exists "${VERSION}" "${label}" || version_exists "${VERSION}" "${label}.1"; then
+        while true; do
+            label="${RELEASE_TYPE}.$((++RELEASE_TYPE_COUNT))"
+            version_exists "${VERSION}" "${label}" || break
+        done
+    fi
+    VERSION_LABEL="${label}"
+fi
+
+if ((PATCH == 0)); then
+    PRETTY_VERSION="${MAJOR}.${MINOR}"          # e.g. '4.0'
+else
+    PRETTY_VERSION="${MAJOR}.${MINOR}.${PATCH}" # e.g. '4.0.1'
+fi
+
+TAG_NAME="v${PRETTY_VERSION}"                   # e.g. 'v4.0'
+
+if [[ "${VERSION_LABEL}" ]]; then
+    TAG_NAME="${TAG_NAME}-${VERSION_LABEL}"     # e.g. 'v4.0-rc.2'
+fi
+
+if tag_exists "${TAG_NAME}"; then
+    echo >&2 "$o: Error: '${TAG_NAME}' tag already exists."
+    echo >&2 "This shouldn't happen. Check for bugs in the script code."
+    exit 1
+fi
+
+case "${RELEASE_TYPE}" in
+stable) PRETTY_RELEASE_TYPE="Release";;
+rc)     PRETTY_RELEASE_TYPE="Release Candidate";;
+beta)   PRETTY_RELEASE_TYPE="Beta";;
+alpha)  PRETTY_RELEASE_TYPE="Alpha";;
+*)      PRETTY_RELEASE_TYPE="${RELEASE_TYPE}";;
+esac
+
+RELEASE_LABEL="${PRETTY_RELEASE_TYPE}"
+
+if ((RELEASE_TYPE_COUNT > 1)); then
+    RELEASE_LABEL="${RELEASE_LABEL} ${RELEASE_TYPE_COUNT}"
+fi
+
+echo "TAG_NAME=${TAG_NAME}"
+echo "RELEASE_NAME=MuseScore Studio ${PRETTY_VERSION} ${RELEASE_LABEL}"


### PR DESCRIPTION
Fix #23067. Follows on from PR #24113.

After the `build` job is complete, each subsequent job is paused until it receives manual approval. For this to work, an admin must visit https://github.com/musescore/MuseScore/settings/environments and create an environment called `production`. It should have one protection rule: `Required reviewers: MuseScore Editor Team` (or list the specific users who can approve it).

Note: Only one of the listed people / team members needs to approve a job for it to proceed.

The `update_learn_playlists` and `notify_users` jobs haven't been properly tested since this can only be done on the official repo. The other jobs have been tested. Here's an [example run](https://github.com/shoogle/MuseScore/actions/runs/10502280481) on my fork, and the [release](https://github.com/shoogle/MuseScore/releases/tag/v4.5-alpha.2) it created.