### PR TITLE
Read ActionIcon: decide ActionIconType based on <action> tag

### DIFF
--- a/src/engraving/rw/write/twrite.cpp
+++ b/src/engraving/rw/write/twrite.cpp
@@ -528,9 +528,7 @@ void TWrite::write(const ActionIcon* item, XmlWriter& xml, WriteContext&)
 {
     xml.startElement(item);
     xml.tag("subtype", int(item->actionType()));
-    if (!item->actionCode().empty()) {
-        xml.tag("action", String::fromStdString(item->actionCode()));
-    }
+    xml.tag("action", String::fromStdString(item->actionCode()));
     xml.endElement();
 }
 


### PR DESCRIPTION
The integer value from the <subtype> tag is unreliable, because in 4aacacfbef871118e3343448af74e5ab3f50089c a new value was inserted into the enum, without handling compatibility with palettes from previous MuseScore versions. See https://github.com/musescore/MuseScore/issues/24060#issuecomment-2299665318 for the full explanation.

Resolves: https://github.com/musescore/MuseScore/issues/24060