### PR TITLE
Fix gcc compiler warnings

### DIFF
--- a/src/engraving/dom/lyrics.cpp
+++ b/src/engraving/dom/lyrics.cpp
@@ -405,7 +405,7 @@ bool Lyrics::setProperty(Pid propertyId, const PropertyValue& v)
             if (Lyrics* l = prevLyrics(this)) {
                 l->setNeedRemoveInvalidSegments();
             }
-            if (Lyrics* l = nextLyrics(this)) {
+            if (nextLyrics(this)) {
                 setNeedRemoveInvalidSegments();
             }
             setPlacement(newVal);

--- a/src/engraving/dom/mscore.cpp
+++ b/src/engraving/dom/mscore.cpp
@@ -125,6 +125,7 @@ std::string MScore::errorToString(MsError err)
     case MsError::CANNOT_CHANGE_LOCAL_TIMESIG_HAS_EXCERPTS: return "CANNOT_CHANGE_LOCAL_TIMESIG_HAS_EXCERPTS";
     case MsError::CORRUPTED_MEASURE: return "CORRUPTED_MEASURE";
     case MsError::CANNOT_REMOVE_KEY_SIG: return "CANNOT_REMOVE_KEY_SIG";
+    case MsError::CANNOT_JOIN_MEASURE_STAFFTYPE_CHANGE: return "CANNOT_JOIN_MEASURE_STAFFTYPE_CHANGE";
     }
 
     return {};

--- a/src/engraving/dom/text.cpp
+++ b/src/engraving/dom/text.cpp
@@ -71,6 +71,7 @@ PropertyValue Text::getProperty(Pid id) const
         if (hasVoiceAssignmentProperties()) {
             return parentItem()->getProperty(id);
         }
+    // fallthrough
     default:
         return TextBase::getProperty(id);
     }


### PR DESCRIPTION
* reg.: unused variable ‘l’ [-Wunused-variable]
* reg.: enumeration value ‘CANNOT_JOIN_MEASURE_STAFFTYPE_CHANGE’ not handled in switch [-Wswitch]
* reg.: this statement may fall through [-Wimplicit-fallthrough=]