### PR TITLE
GSoC '24 - Dynamics Popup - Part 1

### DIFF
--- a/src/notation/CMakeLists.txt
+++ b/src/notation/CMakeLists.txt
@@ -170,6 +170,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/view/internal/caposettingsmodel.h
     ${CMAKE_CURRENT_LIST_DIR}/view/internal/stringtuningssettingsmodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/internal/stringtuningssettingsmodel.h
+    ${CMAKE_CURRENT_LIST_DIR}/view/internal/dynamicpopupmodel.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/view/internal/dynamicpopupmodel.h
     ${CMAKE_CURRENT_LIST_DIR}/view/internal/partialtiepopupmodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/internal/partialtiepopupmodel.h
     ${CMAKE_CURRENT_LIST_DIR}/view/selectionfiltermodel.cpp

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -864,12 +864,12 @@ void NotationInteraction::selectAndStartEditIfNeeded(EngravingItem* element)
 {
     if (element->isSpanner() && !toSpanner(element)->segmentsEmpty()) {
         SpannerSegment* frontSeg = toSpanner(element)->frontSegment();
-        select({ frontSeg });
+        doSelect({ frontSeg }, SelectType::SINGLE);
         if (frontSeg->needStartEditingAfterSelecting()) {
             startEditElement(frontSeg, false);
         }
     } else {
-        select({ element });
+        doSelect({ element }, SelectType::SINGLE);
         if (element->needStartEditingAfterSelecting()) {
             startEditElement(element, false);
         }

--- a/src/notation/notationmodule.cpp
+++ b/src/notation/notationmodule.cpp
@@ -74,6 +74,7 @@
 #include "view/internal/harppedalpopupmodel.h"
 #include "view/internal/caposettingsmodel.h"
 #include "view/internal/stringtuningssettingsmodel.h"
+#include "view/internal/dynamicpopupmodel.h"
 #include "view/internal/partialtiepopupmodel.h"
 
 #include "view/percussionpanel/percussionpanelmodel.h"
@@ -183,12 +184,15 @@ void NotationModule::registerUiTypes()
     qmlRegisterType<EditGridSizeDialogModel>("MuseScore.NotationScene", 1, 0, "EditGridSizeDialogModel");
     qmlRegisterType<PianoKeyboardView>("MuseScore.NotationScene", 1, 0, "PianoKeyboardView");
     qmlRegisterType<PianoKeyboardPanelContextMenuModel>("MuseScore.NotationScene", 1, 0, "PianoKeyboardPanelContextMenuModel");
+
     qmlRegisterUncreatableType<AbstractElementPopupModel>("MuseScore.NotationScene", 1, 0, "Notation",
                                                           "Not creatable as it is an enum type");
     qmlRegisterType<HarpPedalPopupModel>("MuseScore.NotationScene", 1, 0, "HarpPedalPopupModel");
     qmlRegisterType<CapoSettingsModel>("MuseScore.NotationScene", 1, 0, "CapoSettingsModel");
     qmlRegisterType<StringTuningsSettingsModel>("MuseScore.NotationScene", 1, 0, "StringTuningsSettingsModel");
+    qmlRegisterType<DynamicPopupModel>("MuseScore.NotationScene", 1, 0, "DynamicPopupModel");
     qmlRegisterType<PartialTiePopupModel>("MuseScore.NotationScene", 1, 0, "PartialTiePopupModel");
+
     qmlRegisterType<PaintedEngravingItem>("MuseScore.NotationScene", 1, 0, "PaintedEngravingItem");
 
     qmlRegisterType<PercussionPanelModel>("MuseScore.NotationScene", 1, 0, "PercussionPanelModel");

--- a/src/notation/notationscene.qrc
+++ b/src/notation/notationscene.qrc
@@ -40,6 +40,7 @@
         <file>qml/MuseScore/NotationScene/internal/HarpPedalPopup.qml</file>
         <file>qml/MuseScore/NotationScene/internal/CapoPopup.qml</file>
         <file>qml/MuseScore/NotationScene/internal/StringTuningsPopup.qml</file>
+        <file>qml/MuseScore/NotationScene/internal/DynamicPopup.qml</file>
         <file>qml/MuseScore/NotationScene/internal/EditStyle/FullBendStyleSelector.qml</file>
         <file>qml/MuseScore/NotationScene/internal/EditStyle/TiePlacementSelector.qml</file>
         <file>qml/MuseScore/NotationScene/internal/EditStyle/StyleToggleWithImage.qml</file>

--- a/src/notation/qml/MuseScore/NotationScene/internal/DynamicPopup.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/DynamicPopup.qml
@@ -1,0 +1,202 @@
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
+
+import Muse.Ui 1.0
+import Muse.UiComponents 1.0
+import MuseScore.NotationScene 1.0
+
+StyledPopupView {
+    id: root
+
+    property NavigationSection notationViewNavigationSection: null
+    property int navigationOrderStart: 0
+    property int navigationOrderEnd: dynamicsNavPanel.order
+
+    property int buttonHeight: 30
+
+    property int currentPage: 0
+
+    margins: 4
+
+    contentWidth: content.width
+    contentHeight: content.height
+
+    showArrow: false
+
+    signal elementRectChanged(var elementRect)
+
+    function updatePosition() {
+        root.x = root.parent.width / 2 - root.contentWidth / 2
+        root.y = root.parent.height
+    }
+
+    RowLayout {
+        id: content
+
+        width: 208
+        spacing: 1
+
+        DynamicPopupModel {
+            id: dynamicModel
+
+            onItemRectChanged: function(rect) {
+                root.elementRectChanged(rect)
+            }
+        }
+
+        Component.onCompleted: {
+            dynamicModel.init()
+        }
+
+        NavigationPanel {
+            id: dynamicsNavPanel
+            name: "DynamicsPopup"
+            direction: NavigationPanel.Vertical
+            section: root.notationViewNavigationSection
+            order: root.navigationOrderStart
+            accessible.name: qsTrc("notation", "Dynamics Popup")
+        }
+
+        FlatButton {
+            id: leftButton
+
+            implicitWidth: 16
+            transparent: true
+
+            contentItem: StyledIconLabel {
+                id: leftArrowLabel
+                iconCode: IconCode.CHEVRON_LEFT
+                font.pixelSize: 16
+            }
+
+            onClicked: {
+                if (currentPage > 0) {
+                    currentPage--
+                } else {
+                    currentPage = dynamicModel.pages.length - 1
+                }
+            }
+        }
+
+        Item {
+            Layout.fillWidth: true
+        }
+
+        Repeater {
+            id: dynamicRepeater
+            model: dynamicModel.pages[currentPage]
+
+            delegate: FlatButton {
+                id: dynamicButton
+
+                implicitWidth: modelData.width
+                implicitHeight: root.buttonHeight
+                transparent: true
+
+                contentItem: modelData.type === DynamicPopupModel.Dynamic ? dynamicComp :
+                                modelData.type === DynamicPopupModel.Crescendo ? crescHairpinComp :
+                                modelData.type === DynamicPopupModel.Decrescendo ? dimHairpinComp : null
+
+                Component {
+                    id: dynamicComp
+
+                    StyledTextLabel {
+                        id: dynamicLabel
+                        text: modelData.text
+                        font.family: dynamicModel.fontFamily
+                        font.pixelSize: 30
+
+                        anchors.centerIn: parent
+                        anchors.horizontalCenterOffset: modelData.offset
+                        anchors.verticalCenterOffset: 5
+                    }
+                }
+
+                Component {
+                    id: crescHairpinComp
+
+                    Canvas {
+                        width: modelData.width
+                        height: root.buttonHeight
+
+                        onPaint: {
+                            var ctx = getContext("2d");
+                            ctx.clearRect(0, 0, width, height);
+
+                            ctx.beginPath();
+                            ctx.moveTo(4, root.buttonHeight / 2);
+                            ctx.lineTo(width - 4, root.buttonHeight / 2 - 4);
+                            ctx.strokeStyle = ui.theme.fontPrimaryColor;
+                            ctx.lineWidth = 1;
+                            ctx.stroke();
+
+                            ctx.beginPath();
+                            ctx.moveTo(4, root.buttonHeight / 2);
+                            ctx.lineTo(width - 4, root.buttonHeight / 2 + 4);
+                            ctx.strokeStyle = ui.theme.fontPrimaryColor;
+                            ctx.lineWidth = 1;
+                            ctx.stroke();
+                        }
+                    }
+                }
+
+                Component {
+                    id: dimHairpinComp
+
+                    Canvas {
+                        width: modelData.width
+                        height: root.buttonHeight
+
+                        onPaint: {
+                            var ctx = getContext("2d");
+                            ctx.clearRect(0, 0, width, height);
+
+                            ctx.beginPath();
+                            ctx.moveTo(width - 4, root.buttonHeight / 2);
+                            ctx.lineTo(4, root.buttonHeight / 2 - 4);
+                            ctx.strokeStyle = ui.theme.fontPrimaryColor;
+                            ctx.lineWidth = 1;
+                            ctx.stroke();
+
+                            ctx.beginPath();
+                            ctx.moveTo(width - 4, root.buttonHeight / 2);
+                            ctx.lineTo(4, root.buttonHeight / 2 + 4);
+                            ctx.strokeStyle = ui.theme.fontPrimaryColor;
+                            ctx.lineWidth = 1;
+                            ctx.stroke();
+                        }
+                    }
+                }
+
+                onClicked: {
+                    modelData.type === DynamicPopupModel.Dynamic ? dynamicModel.addOrChangeDynamic(currentPage, index) : dynamicModel.addHairpinToDynamic(modelData.type);
+                }
+            }
+        }
+
+        Item {
+            Layout.fillWidth: true
+        }
+
+        FlatButton {
+            id: rightButton
+
+            implicitWidth: 16
+            transparent: true
+
+            contentItem: StyledIconLabel {
+                id: rightArrowLabel
+                iconCode: IconCode.CHEVRON_RIGHT
+                font.pixelSize: 16
+            }
+
+            onClicked: {
+                if (currentPage < dynamicModel.pages.length - 1) {
+                    currentPage++
+                } else {
+                    currentPage = 0
+                }
+            }
+        }
+    }
+}

--- a/src/notation/qml/MuseScore/NotationScene/internal/ElementPopupLoader.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/ElementPopupLoader.qml
@@ -53,6 +53,7 @@ Item {
             case Notation.TYPE_CAPO: return capoComp
             case Notation.TYPE_STRING_TUNINGS: return stringTuningsComp
             case Notation.TYPE_SOUND_FLAG: return soundFlagComp
+            case Notation.TYPE_DYNAMIC: return dynamicComp
             case Notation.TYPE_PARTIAL_TIE: return partialTieComp
             }
 
@@ -151,6 +152,12 @@ Item {
     Component {
         id: soundFlagComp
         SoundFlagPopup {
+        }
+    }
+
+    Component {
+        id: dynamicComp
+        DynamicPopup {
         }
     }
 

--- a/src/notation/view/abstractelementpopupmodel.cpp
+++ b/src/notation/view/abstractelementpopupmodel.cpp
@@ -31,6 +31,7 @@ static const QMap<mu::engraving::ElementType, PopupModelType> ELEMENT_POPUP_TYPE
     { mu::engraving::ElementType::CAPO, PopupModelType::TYPE_CAPO },
     { mu::engraving::ElementType::STRING_TUNINGS, PopupModelType::TYPE_STRING_TUNINGS },
     { mu::engraving::ElementType::SOUND_FLAG, PopupModelType::TYPE_SOUND_FLAG },
+    { mu::engraving::ElementType::DYNAMIC, PopupModelType::TYPE_DYNAMIC },
     { mu::engraving::ElementType::TIE_SEGMENT, PopupModelType::TYPE_PARTIAL_TIE },
     { mu::engraving::ElementType::PARTIAL_TIE_SEGMENT, PopupModelType::TYPE_PARTIAL_TIE }
 };
@@ -40,6 +41,7 @@ static const QHash<PopupModelType, mu::engraving::ElementTypeSet> POPUP_DEPENDEN
     { PopupModelType::TYPE_CAPO, { mu::engraving::ElementType::CAPO } },
     { PopupModelType::TYPE_STRING_TUNINGS, { mu::engraving::ElementType::STRING_TUNINGS } },
     { PopupModelType::TYPE_SOUND_FLAG, { mu::engraving::ElementType::SOUND_FLAG, mu::engraving::ElementType::STAFF_TEXT } },
+    { PopupModelType::TYPE_DYNAMIC, { mu::engraving::ElementType::DYNAMIC } },
     { PopupModelType::TYPE_PARTIAL_TIE, { mu::engraving::ElementType::PARTIAL_TIE_SEGMENT, mu::engraving::ElementType::TIE_SEGMENT } },
 };
 

--- a/src/notation/view/abstractelementpopupmodel.h
+++ b/src/notation/view/abstractelementpopupmodel.h
@@ -50,6 +50,7 @@ public:
         TYPE_CAPO,
         TYPE_STRING_TUNINGS,
         TYPE_SOUND_FLAG,
+        TYPE_DYNAMIC,
         TYPE_PARTIAL_TIE
     };
     Q_ENUM(PopupModelType)

--- a/src/notation/view/internal/dynamicpopupmodel.cpp
+++ b/src/notation/view/internal/dynamicpopupmodel.cpp
@@ -1,0 +1,184 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2024 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "dynamicpopupmodel.h"
+
+#include "engraving/dom/dynamic.h"
+#include "engraving/dom/factory.h"
+#include "engraving/types/symnames.h"
+
+#include "log.h"
+
+using namespace mu::notation;
+using namespace mu::engraving;
+
+static const QList<QList<DynamicPopupModel::PageItem> > DYN_POPUP_PAGES = {
+    {   // Page 1
+        { DynamicType::PP,     30, 1.5, DynamicPopupModel::Dynamic },
+        { DynamicType::P,      21, 1.0, DynamicPopupModel::Dynamic },
+        { DynamicType::MP,     29, 0.5, DynamicPopupModel::Dynamic },
+        { DynamicType::MF,     30, 0.5, DynamicPopupModel::Dynamic },
+        { DynamicType::F,      23, 2.5, DynamicPopupModel::Dynamic },
+        { DynamicType::FF,     30, 2.5, DynamicPopupModel::Dynamic },
+    },
+    {   // Page 2
+        { DynamicType::FFF,    38, 2.5, DynamicPopupModel::Dynamic },
+        { DynamicType::FFFF,   45, 2.5, DynamicPopupModel::Dynamic },
+        { DynamicType::FFFFF,  53, 2.5, DynamicPopupModel::Dynamic },
+    },
+    {   // Page 3
+        { DynamicType::FP,     30, 2.5, DynamicPopupModel::Dynamic },
+        { DynamicType::PF,     32, 2.0, DynamicPopupModel::Dynamic },
+        { DynamicType::SF,     25, 0.5, DynamicPopupModel::Dynamic },
+        { DynamicType::SFZ,    29, 0.5, DynamicPopupModel::Dynamic },
+        { DynamicType::SFF,    33, 0.5, DynamicPopupModel::Dynamic },
+    },
+    {   // Page 4
+        { DynamicType::SFFZ,   37, 0.5, DynamicPopupModel::Dynamic },
+        { DynamicType::SFP,    33, 0.5, DynamicPopupModel::Dynamic },
+        { DynamicType::RFZ,    30, 0.5, DynamicPopupModel::Dynamic },
+        { DynamicType::RF,     26, 0.5, DynamicPopupModel::Dynamic },
+        { DynamicType::FZ,     26, 2.5, DynamicPopupModel::Dynamic },
+    },
+    {   // Page 5
+        { DynamicType::PPPPPP, 74, 2.0, DynamicPopupModel::Dynamic },
+        { DynamicType::FFFFFF, 60, 2.5, DynamicPopupModel::Dynamic },
+    },
+    {   // Page 6
+        { DynamicType::PPPPP,  64, 2.0, DynamicPopupModel::Dynamic },
+        { DynamicType::PPPP,   52, 2.0, DynamicPopupModel::Dynamic },
+        { DynamicType::PPP,    44, 2.0, DynamicPopupModel::Dynamic },
+    },
+    {   // Page 7 - Hairpins
+        { DynamicType::OTHER,  62, 0.0, DynamicPopupModel::Crescendo },
+        { DynamicType::OTHER,  62, 0.0, DynamicPopupModel::Decrescendo },
+    },
+};
+
+DynamicPopupModel::DynamicPopupModel(QObject* parent)
+    : AbstractElementPopupModel(PopupModelType::TYPE_DYNAMIC, parent)
+{
+}
+
+QString DynamicPopupModel::fontFamily() const
+{
+    IF_ASSERT_FAILED(m_item) {
+        return QString();
+    }
+
+    return QString::fromStdString(m_item->score()->engravingFont()->family());
+}
+
+QVariantList DynamicPopupModel::pages() const
+{
+    return m_pages;
+}
+
+QString DynamicPopupModel::xmlTextToQString(const std::string& text, IEngravingFontPtr engravingFont) const
+{
+    const std::string startTag = "<sym>";
+    const std::string endTag = "</sym>";
+
+    String str;
+    size_t pos = 0;
+
+    while (true) {
+        size_t startPos = text.find(startTag, pos);
+        if (startPos == std::string::npos) {
+            break;
+        }
+        size_t symNameStart = startPos + startTag.length();
+        size_t endPos = text.find(endTag, symNameStart);
+        if (endPos == std::string::npos) {
+            break;
+        }
+        SymId id = SymNames::symIdByName(text.substr(symNameStart, endPos - symNameStart));
+        str += engravingFont->toString(id);
+        pos = endPos + endTag.length();
+    }
+
+    return str.toQString();
+}
+
+void DynamicPopupModel::init()
+{
+    AbstractElementPopupModel::init();
+
+    m_pages.clear();
+
+    if (!m_item) {
+        return;
+    }
+
+    IEngravingFontPtr engravingFont = m_item->score()->engravingFont();
+
+    for (const QList<DynamicPopupModel::PageItem>& page : DYN_POPUP_PAGES) {
+        QVariantList variantPage;
+        for (const DynamicPopupModel::PageItem& item : page) {
+            QVariantMap variantMap {
+                { "text", xmlTextToQString(Dynamic::dynamicText(item.dynType).toStdString(), engravingFont) },
+                { "width", item.width },
+                { "offset", item.offset },
+                { "type", item.itemType }
+            };
+            variantPage.append(variantMap);
+        }
+        m_pages.append(QVariant::fromValue(variantPage));
+    }
+
+    emit pagesChanged();
+}
+
+void DynamicPopupModel::addOrChangeDynamic(int page, int index)
+{
+    IF_ASSERT_FAILED(m_item && m_item->isDynamic()) {
+        return;
+    }
+
+    beginCommand(TranslatableString::untranslatable("Add dynamic"));
+    m_item->undoChangeProperty(Pid::TEXT, Dynamic::dynamicText(DYN_POPUP_PAGES[page][index].dynType));
+    m_item->undoChangeProperty(Pid::DYNAMIC_TYPE, DYN_POPUP_PAGES[page][index].dynType);
+    endCommand();
+
+    updateNotation();
+}
+
+void DynamicPopupModel::addHairpinToDynamic(ItemType itemType)
+{
+    IF_ASSERT_FAILED(m_item && m_item->isDynamic()) {
+        return;
+    }
+
+    beginCommand(TranslatableString("undoableAction", "Add hairpin"));
+
+    Hairpin* pin = Factory::createHairpin(m_item->score()->dummy()->segment());
+    if (itemType == ItemType::Crescendo) {
+        pin->setHairpinType(HairpinType::CRESC_HAIRPIN);
+    } else if (itemType == ItemType::Decrescendo) {
+        pin->setHairpinType(HairpinType::DECRESC_HAIRPIN);
+    }
+
+    m_item->score()->addHairpinToDynamic(pin, toDynamic(m_item));
+
+    endCommand();
+    updateNotation();
+}

--- a/src/notation/view/internal/dynamicpopupmodel.h
+++ b/src/notation/view/internal/dynamicpopupmodel.h
@@ -1,0 +1,72 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2024 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QList>
+#include <QObject>
+#include <QVariantList>
+
+#include "view/abstractelementpopupmodel.h"
+
+namespace mu::notation {
+class DynamicPopupModel : public AbstractElementPopupModel
+{
+    Q_OBJECT
+
+    Q_PROPERTY(QString fontFamily READ fontFamily CONSTANT)
+    Q_PROPERTY(QVariantList pages READ pages NOTIFY pagesChanged)
+
+public:
+    explicit DynamicPopupModel(QObject* parent = nullptr);
+
+    enum ItemType {
+        Dynamic,
+        Crescendo,
+        Decrescendo
+    };
+    Q_ENUM(ItemType)
+
+    struct PageItem {
+        engraving::DynamicType dynType;
+        double width;
+        double offset;
+        ItemType itemType;
+    };
+
+    Q_INVOKABLE void init() override;
+    Q_INVOKABLE void addOrChangeDynamic(int page, int index);
+    Q_INVOKABLE void addHairpinToDynamic(ItemType itemType);
+
+    QString fontFamily() const;
+    QVariantList pages() const;
+
+signals:
+    void pagesChanged();
+
+private:
+    // Represents different pages of the popup, each containing dynamic/hairpin symbols as strings, width, offset and ItemType
+    QVariantList m_pages;
+
+    QString xmlTextToQString(const std::string& text, engraving::IEngravingFontPtr engravingFont) const;
+};
+} // namespace mu::notation


### PR DESCRIPTION
This is the first part of the main pull request: [GSoC '24 - Dynamics Popup](https://github.com/musescore/MuseScore/pull/23038), which adds a dynamic popup with the functionality to change dynamics and add hairpins through the popup.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
