### PR TITLE
GSoC '24 - Dynamics Popup - Part 3

### DIFF
--- a/src/app/configs/data/shortcuts.xml
+++ b/src/app/configs/data/shortcuts.xml
@@ -363,6 +363,10 @@
     <seq>X</seq>
     </SC>
   <SC>
+    <key>flip-horizontally</key>
+    <seq>Alt+X</seq>
+    </SC>
+  <SC>
     <key>pitch-up</key>
     <seq>Up</seq>
     </SC>

--- a/src/app/configs/data/shortcuts.xml
+++ b/src/app/configs/data/shortcuts.xml
@@ -539,6 +539,10 @@
     <seq>S</seq>
     </SC>
   <SC>
+    <key>add-dynamic</key>
+    <seq>Ctrl+D</seq>
+    </SC>
+  <SC>
     <key>add-hairpin</key>
     <seq>Shift+,</seq>
     </SC>
@@ -742,10 +746,6 @@
   <SC>
     <key>staff-text</key>
     <seq>Ctrl+T</seq>
-    </SC>
-  <SC>
-    <key>dynamics</key>
-    <seq>Ctrl+D</seq>
     </SC>
   <SC>
     <key>expression-text</key>

--- a/src/app/configs/data/shortcuts_azerty.xml
+++ b/src/app/configs/data/shortcuts_azerty.xml
@@ -548,6 +548,10 @@
     <seq>S</seq>
     </SC>
   <SC>
+    <key>add-dynamic</key>
+    <seq>Ctrl+D</seq>
+    </SC>
+  <SC>
     <key>add-hairpin</key>
     <seq>Shift+,</seq>
     </SC>
@@ -768,10 +772,6 @@
   <SC>
     <key>staff-text</key>
     <seq>Ctrl+T</seq>
-    </SC>
-  <SC>
-    <key>dynamics</key>
-    <seq>Ctrl+D</seq>
     </SC>
   <SC>
     <key>expression-text</key>

--- a/src/app/configs/data/shortcuts_azerty.xml
+++ b/src/app/configs/data/shortcuts_azerty.xml
@@ -372,6 +372,10 @@
     <seq>X</seq>
     </SC>
   <SC>
+    <key>flip-horizontally</key>
+    <seq>Alt+X</seq>
+    </SC>
+  <SC>
     <key>pitch-up</key>
     <seq>Up</seq>
     </SC>

--- a/src/app/configs/data/shortcuts_mac.xml
+++ b/src/app/configs/data/shortcuts_mac.xml
@@ -363,6 +363,10 @@
     <seq>X</seq>
     </SC>
   <SC>
+    <key>flip-horizontally</key>
+    <seq>Alt+X</seq>
+    </SC>
+  <SC>
     <key>pitch-up</key>
     <seq>Up</seq>
     </SC>

--- a/src/app/configs/data/shortcuts_mac.xml
+++ b/src/app/configs/data/shortcuts_mac.xml
@@ -539,6 +539,10 @@
     <seq>S</seq>
     </SC>
   <SC>
+    <key>add-dynamic</key>
+    <seq>Ctrl+D</seq>
+    </SC>
+  <SC>
     <key>add-hairpin</key>
     <seq>Shift+,</seq>
     </SC>
@@ -742,10 +746,6 @@
   <SC>
     <key>staff-text</key>
     <seq>Ctrl+T</seq>
-    </SC>
-  <SC>
-    <key>dynamics</key>
-    <seq>Ctrl+D</seq>
     </SC>
   <SC>
     <key>expression-text</key>

--- a/src/appshell/view/appmenumodel.cpp
+++ b/src/appshell/view/appmenumodel.cpp
@@ -643,7 +643,7 @@ MenuItemList AppMenuModel::makeTextItems()
         makeSeparator(),
         makeMenuItem("system-text"),
         makeMenuItem("staff-text"),
-        makeMenuItem("dynamics"),
+        makeMenuItem("add-dynamic"),
         makeMenuItem("expression-text"),
         makeMenuItem("rehearsalmark-text"),
         makeMenuItem("instrument-change-text"),

--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -2459,6 +2459,38 @@ void Score::cmdFlip()
     }
 }
 
+void Score::cmdFlipHorizontally()
+{
+    const std::vector<EngravingItem*>& el = selection().elements();
+    if (el.empty()) {
+        MScore::setError(MsError::NO_FLIPPABLE_SELECTED);
+        return;
+    }
+
+    std::set<const EngravingItem*> alreadyFlippedElements;
+    auto flipOnce = [&alreadyFlippedElements](const EngravingItem* element, std::function<void()> flipFunction) -> void {
+        if (alreadyFlippedElements.insert(element).second) {
+            flipFunction();
+        }
+    };
+
+    for (EngravingItem* e : el) {
+        if (e->isHairpinSegment()) {
+            e = toHairpinSegment(e)->hairpin();
+        }
+        if (e->isHairpin()) {
+            Hairpin* h = toHairpin(e);
+            flipOnce(h, [h] {
+                if (h->hairpinType() == HairpinType::CRESC_HAIRPIN) {
+                    h->undoChangeProperty(Pid::HAIRPIN_TYPE, int(HairpinType::DECRESC_HAIRPIN));
+                } else if (h->hairpinType() == HairpinType::DECRESC_HAIRPIN) {
+                    h->undoChangeProperty(Pid::HAIRPIN_TYPE, int(HairpinType::CRESC_HAIRPIN));
+                }
+            });
+        }
+    }
+}
+
 //---------------------------------------------------------
 //   deleteItem
 //---------------------------------------------------------

--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -763,6 +763,15 @@ TextBase* Score::addText(TextStyleType type, EngravingItem* destinationElement)
         chordRest->undoAddAnnotation(textBox);
         break;
     }
+    case TextStyleType::DYNAMICS: {
+        ChordRest* chordRest = chordOrRest(destinationElement);
+        if (!chordRest) {
+            break;
+        }
+        textBox = Factory::createDynamic(dummy()->segment());
+        chordRest->undoAddAnnotation(textBox);
+        break;
+    }
     case TextStyleType::EXPRESSION: {
         ChordRest* chordRest = chordOrRest(destinationElement);
         if (!chordRest) {
@@ -953,15 +962,6 @@ TextBase* Score::addText(TextStyleType type, EngravingItem* destinationElement)
 
         textBox = tempoText;
         undoAddElement(textBox);
-        break;
-    }
-    case TextStyleType::DYNAMICS: {
-        ChordRest* chordRest = chordOrRest(destinationElement);
-        if (!chordRest) {
-            break;
-        }
-        textBox = Factory::createDynamic(dummy()->segment());
-        chordRest->undoAddAnnotation(textBox);
         break;
     }
     case TextStyleType::HARP_PEDAL_DIAGRAM:

--- a/src/engraving/dom/hairpin.cpp
+++ b/src/engraving/dom/hairpin.cpp
@@ -520,6 +520,36 @@ DynamicType Hairpin::dynamicTypeTo() const
     return TConv::dynamicType(ba.constChar());
 }
 
+const Dynamic* Hairpin::dynamicSnappedBefore() const
+{
+    const LineSegment* seg = frontSegment();
+    if (!seg) {
+        return nullptr;
+    }
+
+    const EngravingItem* item = seg->ldata()->itemSnappedBefore();
+    if (!item || !item->isDynamic()) {
+        return nullptr;
+    }
+
+    return toDynamic(item);
+}
+
+const Dynamic* Hairpin::dynamicSnappedAfter() const
+{
+    const LineSegment* seg = backSegment();
+    if (!seg) {
+        return nullptr;
+    }
+
+    const EngravingItem* item = seg->ldata()->itemSnappedAfter();
+    if (!item || !item->isDynamic()) {
+        return nullptr;
+    }
+
+    return toDynamic(item);
+}
+
 //---------------------------------------------------------
 //   setHairpinType
 //---------------------------------------------------------

--- a/src/engraving/dom/hairpin.h
+++ b/src/engraving/dom/hairpin.h
@@ -115,6 +115,9 @@ public:
     DynamicType dynamicTypeFrom() const;
     DynamicType dynamicTypeTo() const;
 
+    const Dynamic* dynamicSnappedBefore() const;
+    const Dynamic* dynamicSnappedAfter() const;
+
     HairpinType hairpinType() const { return m_hairpinType; }
     void setHairpinType(HairpinType val);
 

--- a/src/engraving/dom/score.h
+++ b/src/engraving/dom/score.h
@@ -378,6 +378,7 @@ public:
     void cmdAddMeasureRepeat(Measure*, int numMeasures, staff_idx_t staffIdx);
     bool makeMeasureRepeatGroup(Measure*, int numMeasures, staff_idx_t staffIdx);
     void cmdFlip();
+    void cmdFlipHorizontally();
     void resetUserStretch();
     void cmdResetToDefaultLayout();
     void cmdResetBeamMode();

--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -185,6 +185,7 @@ public:
     virtual void swapSelection() = 0;
     virtual void deleteSelection() = 0;
     virtual void flipSelection() = 0;
+    virtual void flipSelectionHorizontally() = 0;
     virtual void addTieToSelection() = 0;
     virtual void addTiedNoteToChord() = 0;
     virtual void addLaissezVibToSelection() = 0;
@@ -205,7 +206,7 @@ public:
 
     virtual void increaseDecreaseDuration(int steps, bool stepByDots) = 0;
 
-    virtual void flipHairpinsType(engraving::Dynamic* selDyn) = 0;
+    virtual void autoFlipHairpinsType(engraving::Dynamic* selDyn) = 0;
 
     virtual void toggleDynamicPopup() = 0;
     virtual bool toggleLayoutBreakAvailable() const = 0;

--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -205,6 +205,9 @@ public:
 
     virtual void increaseDecreaseDuration(int steps, bool stepByDots) = 0;
 
+    virtual void flipHairpinsType(engraving::Dynamic* selDyn) = 0;
+
+    virtual void toggleDynamicPopup() = 0;
     virtual bool toggleLayoutBreakAvailable() const = 0;
     virtual void toggleLayoutBreak(LayoutBreakType breakType) = 0;
     virtual void moveMeasureToPrevSystem() = 0;

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -322,6 +322,7 @@ void NotationActionController::init()
 
     registerAction("add-8va", &Interaction::addOttavaToSelection, OttavaType::OTTAVA_8VA);
     registerAction("add-8vb", &Interaction::addOttavaToSelection, OttavaType::OTTAVA_8VB);
+    registerAction("add-dynamic", &Interaction::toggleDynamicPopup, &Controller::noteOrRestSelected);
     registerAction("add-hairpin", &Interaction::addHairpinsToSelection, HairpinType::CRESC_HAIRPIN, &Controller::noteOrRestSelected);
     registerAction("add-hairpin-reverse", &Interaction::addHairpinsToSelection, HairpinType::DECRESC_HAIRPIN,
                    &Controller::noteOrRestSelected);
@@ -338,7 +339,6 @@ void NotationActionController::init()
 
     registerAction("system-text", [this]() { addText(TextStyleType::SYSTEM); });
     registerAction("staff-text", [this]() { addText(TextStyleType::STAFF); });
-    registerAction("dynamics", [this]() { addText(TextStyleType::DYNAMICS); });
     registerAction("expression-text", [this]() { addText(TextStyleType::EXPRESSION); });
     registerAction("rehearsalmark-text", [this]() { addText(TextStyleType::REHEARSAL_MARK); });
     registerAction("instrument-change-text", [this]() { addText(TextStyleType::INSTRUMENT_CHANGE); });

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -223,6 +223,7 @@ void NotationActionController::init()
     registerAction("notation-delete", &Interaction::deleteSelection, &Controller::hasSelection);
 
     registerAction("flip", &Interaction::flipSelection, &Controller::hasSelection);
+    registerAction("flip-horizontally", &Interaction::flipSelectionHorizontally, &Controller::hasSelection);
     registerAction("tie", &Controller::addTie);
     registerAction("chord-tie", &Controller::chordTie);
     registerAction("lv", &Controller::addLaissezVib);

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -5282,16 +5282,10 @@ void NotationInteraction::autoFlipHairpinsType(Dynamic* selDyn)
 
 void NotationInteraction::toggleDynamicPopup()
 {
-    if (selection()->isNone()) {
-        return;
-    }
-
-    // If multiple selected selection()->element() returns null
-    if (!selection()->element()) {
-        return;
-    }
-
     EngravingItem* el = selection()->element();
+    if (!el) {
+        return;
+    }
 
     if (el->isHairpinSegment()) {
         HairpinSegment* hairpinSeg = toHairpinSegment(el);
@@ -5311,9 +5305,10 @@ void NotationInteraction::toggleDynamicPopup()
         };
 
         switch (m_editData.curGrip) {
-        case Grip::START: {
+        case Grip::START:
             if (EngravingItem* startDynOrExp = hairpinSeg->findElementToSnapBefore()) {
-                select({ startDynOrExp }); // If there is already a dynamic select it instead of opening an empty popup
+                // If there is already a dynamic, select it instead of opening an empty popup
+                select({ startDynOrExp });
                 if (startDynOrExp->isDynamic()) {
                     startEditElement(startDynOrExp, false);
                     autoFlipHairpinsType(toDynamic(startDynOrExp));
@@ -5321,12 +5316,11 @@ void NotationInteraction::toggleDynamicPopup()
             } else {
                 addDynamic(hairpin->tick(), hairpin->track(), hairpin->voiceAssignment());
             }
-        }
-            return;
-        case Grip::END: {
-            EngravingItem* endDynOrExp = hairpinSeg->findElementToSnapAfter();
-            if (endDynOrExp != nullptr) {
-                select({ endDynOrExp }); // If there is already a dynamic select it instead of opening an empty popup
+            break;
+        case Grip::END:
+            if (EngravingItem* endDynOrExp = hairpinSeg->findElementToSnapAfter()) {
+                // If there is already a dynamic, select it instead of opening an empty popup
+                select({ endDynOrExp });
                 if (endDynOrExp->isDynamic()) {
                     startEditElement(endDynOrExp, false);
                     autoFlipHairpinsType(toDynamic(endDynOrExp));
@@ -5334,14 +5328,14 @@ void NotationInteraction::toggleDynamicPopup()
             } else {
                 addDynamic(hairpin->tick2(), hairpin->track2(), hairpin->voiceAssignment());
             }
-        }
-            return;
+            break;
         default:
-            return;
+            break;
         }
-    } else {
-        addTextToItem(TextStyleType::DYNAMICS, el);
+        return;
     }
+
+    addTextToItem(TextStyleType::DYNAMICS, el);
 }
 
 bool NotationInteraction::toggleLayoutBreakAvailable() const

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -4340,8 +4340,22 @@ void NotationInteraction::editElement(QKeyEvent* event)
 
     m_editData.modifiers = keyboardModifier(event->modifiers());
 
+    bool isHairpinStartEndGrip = m_editData.element->isHairpinSegment() && m_editData.isStartEndGrip();
+
     if (isDragStarted()) {
-        return; // ignore all key strokes while dragging
+        if (isHairpinStartEndGrip && (m_editData.modifiers & ShiftModifier)) {
+            HairpinSegment* seg = toHairpinSegment(m_editData.element);
+            HairpinType type = seg->hairpin()->hairpinType();
+
+            startEdit(TranslatableString("undoableAction", "Change hairpin type"));
+            if (type == HairpinType::CRESC_HAIRPIN) {
+                seg->hairpin()->setHairpinType(HairpinType::DECRESC_HAIRPIN);
+            } else if (type == HairpinType::DECRESC_HAIRPIN) {
+                seg->hairpin()->setHairpinType(HairpinType::CRESC_HAIRPIN);
+            }
+            apply();
+        }
+        return; // ignore all key strokes while dragging except for the shift key functionality on hairpin grips to change type
     }
 
     m_editData.key = event->key();

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -4340,22 +4340,8 @@ void NotationInteraction::editElement(QKeyEvent* event)
 
     m_editData.modifiers = keyboardModifier(event->modifiers());
 
-    bool isHairpinStartEndGrip = m_editData.element->isHairpinSegment() && m_editData.isStartEndGrip();
-
     if (isDragStarted()) {
-        if (isHairpinStartEndGrip && (m_editData.modifiers & ShiftModifier)) {
-            HairpinSegment* seg = toHairpinSegment(m_editData.element);
-            HairpinType type = seg->hairpin()->hairpinType();
-
-            startEdit(TranslatableString("undoableAction", "Change hairpin type"));
-            if (type == HairpinType::CRESC_HAIRPIN) {
-                seg->hairpin()->setHairpinType(HairpinType::DECRESC_HAIRPIN);
-            } else if (type == HairpinType::DECRESC_HAIRPIN) {
-                seg->hairpin()->setHairpinType(HairpinType::CRESC_HAIRPIN);
-            }
-            apply();
-        }
-        return; // ignore all key strokes while dragging except for the shift key functionality on hairpin grips to change type
+        return; // ignore all key strokes while dragging
     }
 
     m_editData.key = event->key();
@@ -4907,6 +4893,17 @@ void NotationInteraction::flipSelection()
     apply();
 }
 
+void NotationInteraction::flipSelectionHorizontally()
+{
+    if (selection()->isNone()) {
+        return;
+    }
+
+    startEdit(TranslatableString("undoableAction", "Flip horizontally"));
+    score()->cmdFlipHorizontally();
+    apply();
+}
+
 void NotationInteraction::addTieToSelection()
 {
     // Calls `startEdit` internally
@@ -5240,7 +5237,7 @@ void NotationInteraction::increaseDecreaseDuration(int steps, bool stepByDots)
     apply();
 }
 
-void NotationInteraction::flipHairpinsType(Dynamic* selDyn)
+void NotationInteraction::autoFlipHairpinsType(Dynamic* selDyn)
 {
     if (!selDyn) {
         return;
@@ -5306,7 +5303,7 @@ void NotationInteraction::toggleDynamicPopup()
                 select({ startDynOrExp }); // If there is already a dynamic select it instead of opening an empty popup
                 if (startDynOrExp->isDynamic()) {
                     startEditElement(startDynOrExp, false);
-                    flipHairpinsType(toDynamic(startDynOrExp));
+                    autoFlipHairpinsType(toDynamic(startDynOrExp));
                 }
             } else {
                 addTextToItem(TextStyleType::DYNAMICS, hairpinSeg->spanner()->startCR());
@@ -5319,7 +5316,7 @@ void NotationInteraction::toggleDynamicPopup()
                 select({ endDynOrExp }); // If there is already a dynamic select it instead of opening an empty popup
                 if (endDynOrExp->isDynamic()) {
                     startEditElement(endDynOrExp, false);
-                    flipHairpinsType(toDynamic(endDynOrExp));
+                    autoFlipHairpinsType(toDynamic(endDynOrExp));
                 }
             } else {
                 addTextToItem(TextStyleType::DYNAMICS, hairpinSeg->spanner()->endCR());

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -5254,11 +5254,11 @@ void NotationInteraction::flipHairpinsType(Dynamic* selDyn)
 
     startEdit(TranslatableString("undoableAction", "Change hairpin type"));
 
-    if (selDyn->leftHairpin()) {
-        Hairpin* leftHp = selDyn->leftHairpin();
+    if (Hairpin* leftHp = selDyn->leftHairpin()) {
         const Dynamic* startDyn = leftHp->dynamicSnappedBefore();
-
-        if (!(startDyn->dynamicType() == DynamicType::OTHER || startDyn->dynamicType() >= DynamicType::FP) && !leftHp->isLineType()) {
+        if (startDyn
+            && !(startDyn->dynamicType() == DynamicType::OTHER || startDyn->dynamicType() >= DynamicType::FP)
+            && !leftHp->isLineType()) {
             if (int(startDyn->dynamicType()) > int(selDyn->dynamicType())) {
                 leftHp->undoChangeProperty(Pid::HAIRPIN_TYPE, int(HairpinType::DECRESC_HAIRPIN));
             } else {
@@ -5267,11 +5267,11 @@ void NotationInteraction::flipHairpinsType(Dynamic* selDyn)
         }
     }
 
-    if (selDyn->rightHairpin()) {
-        Hairpin* rightHp = selDyn->rightHairpin();
+    if (Hairpin* rightHp = selDyn->rightHairpin()) {
         const Dynamic* endDyn = rightHp->dynamicSnappedAfter();
-
-        if (!(endDyn->dynamicType() == DynamicType::OTHER || endDyn->dynamicType() >= DynamicType::FP) && !rightHp->isLineType()) {
+        if (endDyn
+            && !(endDyn->dynamicType() == DynamicType::OTHER || endDyn->dynamicType() >= DynamicType::FP)
+            && !rightHp->isLineType()) {
             if (int(endDyn->dynamicType()) > int(selDyn->dynamicType())) {
                 rightHp->undoChangeProperty(Pid::HAIRPIN_TYPE, int(HairpinType::CRESC_HAIRPIN));
             } else {

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -209,6 +209,9 @@ public:
 
     void increaseDecreaseDuration(int steps, bool stepByDots) override;
 
+    void flipHairpinsType(engraving::Dynamic* selDyn) override;
+
+    void toggleDynamicPopup() override;
     bool toggleLayoutBreakAvailable() const override;
     void toggleLayoutBreak(LayoutBreakType breakType) override;
     void moveMeasureToPrevSystem() override;

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -189,6 +189,7 @@ public:
     void swapSelection() override;
     void deleteSelection() override;
     void flipSelection() override;
+    void flipSelectionHorizontally() override;
     void addTieToSelection() override;
     void addLaissezVibToSelection() override;
     void addTiedNoteToChord() override;
@@ -209,7 +210,7 @@ public:
 
     void increaseDecreaseDuration(int steps, bool stepByDots) override;
 
-    void flipHairpinsType(engraving::Dynamic* selDyn) override;
+    void autoFlipHairpinsType(engraving::Dynamic* selDyn) override;
 
     void toggleDynamicPopup() override;
     bool toggleLayoutBreakAvailable() const override;

--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -1219,6 +1219,12 @@ const UiActionList NotationUiActions::m_actions = {
              TranslatableString("action", "Ottava 8va &bassa"),
              TranslatableString("action", "Add ottava 8va bassa")
              ),
+    UiAction("add-dynamic",
+             mu::context::UiCtxProjectOpened,
+             mu::context::CTX_ANY,
+             TranslatableString("action", "&Dynamic"),
+             TranslatableString("action", "Add dynamic")
+             ),
     UiAction("add-hairpin",
              mu::context::UiCtxProjectOpened,
              mu::context::CTX_ANY,
@@ -1295,12 +1301,6 @@ const UiActionList NotationUiActions::m_actions = {
              mu::context::CTX_ANY,
              TranslatableString("action", "St&aff text"),
              TranslatableString("action", "Add text: staff text")
-             ),
-    UiAction("dynamics",
-             mu::context::UiCtxProjectOpened,
-             mu::context::CTX_ANY,
-             TranslatableString("action", "&Dynamic"),
-             TranslatableString("action", "Add text: dynamic")
              ),
     UiAction("expression-text",
              mu::context::UiCtxProjectOpened,

--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -1643,6 +1643,11 @@ const UiActionList NotationUiActions::m_actions = {
              TranslatableString("action", "Flip direction"),
              IconCode::Code::NOTE_FLIP
              ),
+    UiAction("flip-horizontally",
+             mu::context::UiCtxProjectOpened,
+             mu::context::CTX_ANY,
+             TranslatableString("action", "Flip horizontally"),
+             TranslatableString("action", "Flip horizontally")),
     UiAction(TOGGLE_CONCERT_PITCH_CODE,
              mu::context::UiCtxProjectOpened,
              mu::context::CTX_NOTATION_OPENED,

--- a/src/notation/tests/mocks/notationinteractionmock.h
+++ b/src/notation/tests/mocks/notationinteractionmock.h
@@ -148,6 +148,7 @@ public:
     MOCK_METHOD(void, swapSelection, (), (override));
     MOCK_METHOD(void, deleteSelection, (), (override));
     MOCK_METHOD(void, flipSelection, (), (override));
+    MOCK_METHOD(void, flipSelectionHorizontally, (), (override));
     MOCK_METHOD(void, addTieToSelection, (), (override));
     MOCK_METHOD(void, addLaissezVibToSelection, (), (override));
     MOCK_METHOD(void, addTiedNoteToChord, (), (override));
@@ -168,7 +169,7 @@ public:
 
     MOCK_METHOD(void, increaseDecreaseDuration, (int, bool), (override));
 
-    MOCK_METHOD(void, flipHairpinsType, (engraving::Dynamic * selDyn), (override));
+    MOCK_METHOD(void, autoFlipHairpinsType, (engraving::Dynamic * selDyn), (override));
 
     MOCK_METHOD(void, toggleDynamicPopup, (), (override));
     MOCK_METHOD(bool, toggleLayoutBreakAvailable, (), (const, override));

--- a/src/notation/tests/mocks/notationinteractionmock.h
+++ b/src/notation/tests/mocks/notationinteractionmock.h
@@ -168,6 +168,9 @@ public:
 
     MOCK_METHOD(void, increaseDecreaseDuration, (int, bool), (override));
 
+    MOCK_METHOD(void, flipHairpinsType, (engraving::Dynamic * selDyn), (override));
+
+    MOCK_METHOD(void, toggleDynamicPopup, (), (override));
     MOCK_METHOD(bool, toggleLayoutBreakAvailable, (), (const, override));
     MOCK_METHOD(void, toggleLayoutBreak, (LayoutBreakType), (override));
     MOCK_METHOD(void, moveMeasureToPrevSystem, (), (override));

--- a/src/notation/view/internal/dynamicpopupmodel.cpp
+++ b/src/notation/view/internal/dynamicpopupmodel.cpp
@@ -161,6 +161,16 @@ void DynamicPopupModel::addOrChangeDynamic(int page, int index)
     m_item->undoChangeProperty(Pid::DYNAMIC_TYPE, DYN_POPUP_PAGES[page][index].dynType);
     endCommand();
 
+    INotationInteractionPtr interaction = currentNotation()->interaction();
+
+    interaction->flipHairpinsType(toDynamic(m_item));
+
+    // Hide the bounding box which appears when called using Ctrl+D shortcut
+    if (interaction->isTextEditingStarted()) {
+        interaction->endEditText();
+        interaction->startEditGrip(m_item, Grip::DRAG);
+    }
+
     updateNotation();
 }
 

--- a/src/notation/view/internal/dynamicpopupmodel.cpp
+++ b/src/notation/view/internal/dynamicpopupmodel.cpp
@@ -163,7 +163,7 @@ void DynamicPopupModel::addOrChangeDynamic(int page, int index)
 
     INotationInteractionPtr interaction = currentNotation()->interaction();
 
-    interaction->flipHairpinsType(toDynamic(m_item));
+    interaction->autoFlipHairpinsType(toDynamic(m_item));
 
     // Hide the bounding box which appears when called using Ctrl+D shortcut
     if (interaction->isTextEditingStarted()) {

--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -982,6 +982,11 @@ void NotationViewInputController::mouseReleaseEvent(QMouseEvent* event)
 
     if (interaction->isDragStarted()) {
         interaction->endDrag();
+        // When dragging of hairpin ends on a note or rest, open dynamic popup
+        // Check for note or rest happens in Score::addText which is called through addTextToItem in toggleDynamicPopup
+        if (interaction->selection()->element()->isHairpinSegment()) {
+            interaction->toggleDynamicPopup();
+        }
     }
 
     if (interaction->isOutgoingDragStarted()) {

--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -981,10 +981,16 @@ void NotationViewInputController::mouseReleaseEvent(QMouseEvent* event)
     m_isCanvasDragged = false;
 
     if (interaction->isDragStarted()) {
+        bool isDraggingHairpinSegmentGrip
+            = interaction->isGripEditStarted()
+              && interaction->selection()->element()
+              && interaction->selection()->element()->isHairpinSegment();
+
         interaction->endDrag();
+
         // When dragging of hairpin ends on a note or rest, open dynamic popup
         // Check for note or rest happens in Score::addText which is called through addTextToItem in toggleDynamicPopup
-        if (interaction->selection()->element()->isHairpinSegment()) {
+        if (isDraggingHairpinSegmentGrip) {
             interaction->toggleDynamicPopup();
         }
     }

--- a/src/notation/view/noteinputbarmodel.cpp
+++ b/src/notation/view/noteinputbarmodel.cpp
@@ -664,7 +664,7 @@ MenuItemList NoteInputBarModel::makeTextItems()
         makeSeparator(),
         makeMenuItem("system-text"),
         makeMenuItem("staff-text"),
-        makeMenuItem("dynamics"),
+        makeMenuItem("add-dynamic"),
         makeMenuItem("expression-text"),
         makeMenuItem("rehearsalmark-text"),
         makeMenuItem("instrument-change-text"),


### PR DESCRIPTION
This is the third part of the main pull request: https://github.com/musescore/MuseScore/pull/23038, which adds functionality to add dynamic using shortcut, opening of popup when hairpin ends on a note or rest and the automatic switching of hairpin type.

PR for part 1: https://github.com/musescore/MuseScore/pull/24125
PR for part 2: https://github.com/musescore/MuseScore/pull/24147

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
