### PR TITLE
Restore previous selection on arrow keys when nothing in the score is selected

### DIFF
--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -969,6 +969,12 @@ void NotationActionController::move(MoveDirection direction, bool quickly)
         return;
     }
 
+    if (interaction->selection()->isNone()) {
+        interaction->moveSelection(direction, MoveSelectionType::EngravingItem);
+        playSelectedElement(true);
+        return;
+    }
+
     const EngravingItem* selectedElement = interaction->selection()->element();
     bool playChord = false;
 
@@ -986,8 +992,6 @@ void NotationActionController::move(MoveDirection direction, bool quickly)
             }
             interaction->moveSelection(direction, MoveSelectionType::String);
             return;
-        } else if (interaction->selection()->isNone()) {
-            interaction->selectFirstElement(false);
         } else {
             interaction->movePitch(direction, quickly ? PitchMode::OCTAVE : PitchMode::CHROMATIC);
         }
@@ -1035,9 +1039,6 @@ void NotationActionController::move(MoveDirection direction, bool quickly)
         if (selectedElement && selectedElement->isTextBase()) {
             interaction->nudge(direction, quickly);
         } else {
-            if (interaction->selection()->isNone()) {
-                interaction->selectFirstElement(false);
-            }
             interaction->moveSelection(direction, quickly ? MoveSelectionType::Measure : MoveSelectionType::Chord);
             playChord = true;
         }

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -2991,29 +2991,21 @@ void NotationInteraction::moveElementSelection(MoveDirection d)
     }
 
     bool isLeftDirection = MoveDirection::Left == d;
-
-    if (!el) {
-        ChordRest* cr = score()->selection().currentCR();
-        if (cr) {
-            if (cr->isChord()) {
-                if (isLeftDirection) {
-                    el = toChord(cr)->upNote();
-                } else {
-                    el = toChord(cr)->downNote();
-                }
-            } else if (cr->isRest()) {
-                el = cr;
-            }
-            score()->select(el);
-        }
-    }
-
     EngravingItem* toEl = nullptr;
 
     if (el) {
         toEl = isLeftDirection ? score()->prevElement() : score()->nextElement();
     } else {
-        toEl = isLeftDirection ? score()->lastElement() : score()->firstElement();
+        // Nothing currently selected (e.g. because user pressed Esc or clicked on
+        // an empty region of the page). Try to restore previous selection.
+        if (ChordRest* cr = score()->selection().currentCR()) {
+            el = cr->isChord() ? toChord(cr)->upNote() : toEngravingItem(cr);
+        }
+        if (el) {
+            toEl = el; // Restoring previous selection.
+        } else {
+            toEl = isLeftDirection ? score()->lastElement() : score()->firstElement();
+        }
     }
 
     if (!toEl) {


### PR DESCRIPTION
As discussed in #23901 (although the issue is about something slightly different), I find it nonsensical and at times annoying that when accidentally pressing an arrow key when nothing is selected, the selection jumps to the first bar.

Before my changes, the behavior for empty selection was as follows:
- On Up/Down press, the first vertical bar line segment left of bar 1 of the first instrument is selected.
- On Left/Right press, the first note or rest in bar 1 of the first instrument is selected.

I argue that arrow keys should simply be ignored when nothing in the score is selected, and that is what this PR does.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)