### PR TITLE
GSoC '24 - Dynamics Popup - Part 4

### DIFF
--- a/.github/workflows/check_visual_tests.yml
+++ b/.github/workflows/check_visual_tests.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       do_run: ${{ steps.output_data.outputs.do_run }}
-      reference_sha: ${{ steps.output_data.outputs.reference_sha }}
+      reference_ref: ${{ steps.output_data.outputs.reference_ref }}
       artifact_name: ${{ steps.output_data.outputs.artifact_name }}
     steps:
     - name: Cancel Previous Runs
@@ -18,8 +18,6 @@ jobs:
         access_token: ${{ github.token }}
     - name: Clone repository
       uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
     - name: "Configure workflow"
       run: |
         bash ./buildscripts/ci/tools/make_build_number.sh
@@ -31,29 +29,29 @@ jobs:
       if: github.event_name == 'pull_request'
       env:
         pull_request_title: ${{ github.event.pull_request.title }}
+        REFERENCE_REF: ${{ github.event.pull_request.base.ref }}
       run: |
-        REFERENCE_SHA=$(git merge-base ${{ github.event.pull_request.base.sha }} HEAD)
-        if [ -z "$REFERENCE_SHA" ]; then DO_RUN='false'; else DO_RUN='true'; fi
-        echo "REFERENCE_SHA=$REFERENCE_SHA" >> $GITHUB_ENV
+        if [ -z "$REFERENCE_REF" ]; then DO_RUN='false'; else DO_RUN='true'; fi
+        echo "REFERENCE_REF=$REFERENCE_REF" >> $GITHUB_ENV
         echo "DO_RUN=$DO_RUN" >> $GITHUB_ENV
         echo "PR_INFO= ${{ github.event.pull_request.number }} ${pull_request_title}" >> $GITHUB_ENV
     - name: Get reference commit for push commit
       if: github.event_name == 'push'
       run: |
-        REFERENCE_SHA=${{ github.event.before }}
-        if [[ -z "$REFERENCE_SHA" || "$REFERENCE_SHA" == 0000000000000000000000000000000000000000 ]]; then 
+        REFERENCE_REF=${{ github.event.before }}
+        if [[ -z "$REFERENCE_REF" || "$REFERENCE_REF" == 0000000000000000000000000000000000000000 ]]; then 
           DO_RUN='false' 
         else 
           DO_RUN='true'
         fi
-        echo "REFERENCE_SHA=$REFERENCE_SHA" >> $GITHUB_ENV
+        echo "REFERENCE_REF=$REFERENCE_REF" >> $GITHUB_ENV
         echo "DO_RUN=$DO_RUN" >> $GITHUB_ENV
         echo "PR_INFO=" >> $GITHUB_ENV
     - id: output_data
       name: Output workflow data
       run: |
         echo "do_run=${DO_RUN}" | tee -a $GITHUB_OUTPUT
-        echo "reference_sha=${REFERENCE_SHA}" | tee -a $GITHUB_OUTPUT
+        echo "reference_ref=${REFERENCE_REF}" | tee -a $GITHUB_OUTPUT
         UPLOAD_ARTIFACT_NAME="$(tr '":<>|*?/\\’' '_' <<<"VTests Comparison ${BUILD_NUMBER}${PR_INFO}")"
         echo "artifact_name=$UPLOAD_ARTIFACT_NAME" | tee -a $GITHUB_OUTPUT
 
@@ -102,7 +100,7 @@ jobs:
     - name: Clone repository and checkout reference commit
       uses: actions/checkout@v4
       with:
-        ref: ${{ needs.setup.outputs.reference_sha }}
+        ref: ${{ needs.setup.outputs.reference_ref }}
 
     - name: Get ccache timestamp
       run: echo "CCACHE_TIMESTAMP=$(date -u +"%F-%T")" | tee -a $GITHUB_ENV

--- a/src/engraving/dom/dynamic.cpp
+++ b/src/engraving/dom/dynamic.cpp
@@ -871,3 +871,20 @@ std::vector<PointF> Dynamic::gripsPositions(const EditData&) const
         return {};
     }
 }
+
+//---------------------------------------------------------
+//   adjustedBoundingRect
+//---------------------------------------------------------
+
+RectF Dynamic::adjustedBoundingRect() const
+{
+    RectF r;
+    double m = spatium();
+
+    r = canvasBoundingRect();
+    r.setWidth(width() + m * 2);
+    r.setHeight(m * 4.5);
+    r.translate(-m, -m);
+
+    return r;
+}

--- a/src/engraving/dom/dynamic.h
+++ b/src/engraving/dom/dynamic.h
@@ -140,6 +140,8 @@ public:
 
     void findAdjacentHairpins();
 
+    RectF adjustedBoundingRect() const;
+
 private:
 
     M_PROPERTY(bool, avoidBarLines, setAvoidBarLines)

--- a/src/engraving/dom/engravingitem.cpp
+++ b/src/engraving/dom/engravingitem.cpp
@@ -612,6 +612,10 @@ Color EngravingItem::curColor(bool isVisible, Color normalColor) const
         return configuration()->highlightSelectionColor(track() == muse::nidx ? 0 : voice());
     }
 
+    if (flag(ElementFlag::IS_PREVIEW)) {
+        return configuration()->formattingColor();
+    }
+
     bool marked = false;
     if (isNote()) {
         marked = toNote(this)->mark();

--- a/src/engraving/dom/engravingitem.h
+++ b/src/engraving/dom/engravingitem.h
@@ -121,7 +121,9 @@ enum class ElementFlag {
     ENABLED                = 0x04000000,      // used for segments
     EMPTY                  = 0x08000000,
     WRITTEN                = 0x10000000,
-    END_OF_MEASURE_CHANGE         = 0x20000000
+    END_OF_MEASURE_CHANGE  = 0x20000000,
+
+    IS_PREVIEW             = 0x40000000,      // used for hover preview in dynamics popup
 };
 
 typedef muse::Flags<ElementFlag> ElementFlags;

--- a/src/engraving/dom/textbase.cpp
+++ b/src/engraving/dom/textbase.cpp
@@ -1892,10 +1892,9 @@ void TextBase::createBlocks(LayoutData* ldata) const
                     SymId id = SymNames::symIdByName(sym);
                     if (id != SymId::noSym) {
                         CharFormat fmt = *cursor.format(); // save format
-
-                        //char32_t code = score()->scoreFont()->symCode(id);
-                        char32_t code = id
-                                        == SymId::space ? static_cast<char32_t>(' ') : score()->engravingFonts()->fallbackFont()->symCode(id);
+                        char32_t code = id == SymId::space
+                                        ? static_cast<char32_t>(' ')
+                                        : score()->engravingFonts()->fallbackFont()->symCode(id);
                         cursor.format()->setFontFamily(u"ScoreText");
                         insert(&cursor, code, ldata);
                         cursor.setFormat(fmt); // restore format
@@ -3602,8 +3601,14 @@ void TextBase::drawEditMode(Painter* p, EditData& ed, double currentViewScaling)
     p->setPen(Pen(configuration()->frameColor(), 2.0 / currentViewScaling)); // 2 pixel pen size
     p->setBrush(BrushStyle::NoBrush);
 
-    double m = spatium();
-    RectF r = canvasBoundingRect().adjusted(-m, -m, m, m);
+    RectF r;
+
+    if (ed.element->isDynamic()) {
+        r = toDynamic(ed.element)->adjustedBoundingRect();
+    } else {
+        double m = spatium();
+        r = canvasBoundingRect().adjusted(-m, -m, m, m);
+    }
 
     p->drawRect(r);
     pen = Pen(configuration()->defaultColor(), 0.0);

--- a/src/notation/qml/MuseScore/NotationScene/internal/DynamicPopup.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/DynamicPopup.qml
@@ -29,7 +29,7 @@ StyledPopupView {
 
     function updatePosition() {
         root.x = root.parent.width / 2 - root.contentWidth / 2
-        root.y = root.parent.height
+        root.y = root.parent.height - root.padding + root.margins
     }
 
     RowLayout {

--- a/src/notation/qml/MuseScore/NotationScene/internal/DynamicPopup.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/DynamicPopup.qml
@@ -226,6 +226,12 @@ StyledPopupView {
                     }
                 }
 
+                mouseArea.onContainsMouseChanged: {
+                    if (modelData.type === DynamicPopupModel.Dynamic) {
+                        mouseArea.containsMouse ? dynamicModel.showPreview(currentPage, index) : dynamicModel.hidePreview()
+                    }
+                }
+
                 onClicked: {
                     modelData.type === DynamicPopupModel.Dynamic ? dynamicModel.addOrChangeDynamic(currentPage, index) : dynamicModel.addHairpinToDynamic(modelData.type);
                 }

--- a/src/notation/view/abstractelementpopupmodel.cpp
+++ b/src/notation/view/abstractelementpopupmodel.cpp
@@ -21,8 +21,12 @@
  */
 
 #include "abstractelementpopupmodel.h"
+
 #include "internal/partialtiepopupmodel.h"
 #include "internal/shadownotepopupmodel.h"
+
+#include "engraving/dom/dynamic.h"
+
 #include "log.h"
 
 using namespace mu::notation;
@@ -236,7 +240,16 @@ const mu::engraving::ElementTypeSet& AbstractElementPopupModel::dependentElement
 
 void AbstractElementPopupModel::updateItemRect()
 {
-    const QRectF rect = m_item ? fromLogical(m_item->canvasBoundingRect()).toQRectF() : QRectF();
+    QRectF rect;
+    if (!m_item) {
+        rect = QRectF();
+    } else {
+        if (m_item->isDynamic()) {
+            rect = fromLogical(toDynamic(m_item)->adjustedBoundingRect()).toQRectF();
+        } else {
+            rect = fromLogical(m_item->canvasBoundingRect()).toQRectF();
+        }
+    }
 
     if (m_itemRect != rect) {
         m_itemRect = rect;

--- a/src/notation/view/abstractelementpopupmodel.cpp
+++ b/src/notation/view/abstractelementpopupmodel.cpp
@@ -57,7 +57,7 @@ PopupModelType AbstractElementPopupModel::modelType() const
     return m_modelType;
 }
 
-QRect AbstractElementPopupModel::itemRect() const
+QRectF AbstractElementPopupModel::itemRect() const
 {
     return m_itemRect;
 }
@@ -236,7 +236,7 @@ const mu::engraving::ElementTypeSet& AbstractElementPopupModel::dependentElement
 
 void AbstractElementPopupModel::updateItemRect()
 {
-    const QRect rect = m_item ? fromLogical(m_item->canvasBoundingRect()).toQRect() : QRect();
+    const QRectF rect = m_item ? fromLogical(m_item->canvasBoundingRect()).toQRectF() : QRectF();
 
     if (m_itemRect != rect) {
         m_itemRect = rect;

--- a/src/notation/view/abstractelementpopupmodel.h
+++ b/src/notation/view/abstractelementpopupmodel.h
@@ -37,7 +37,7 @@ class AbstractElementPopupModel : public QObject, public muse::Injectable, publi
     Q_OBJECT
 
     Q_PROPERTY(PopupModelType modelType READ modelType CONSTANT)
-    Q_PROPERTY(QRect itemRect READ itemRect NOTIFY itemRectChanged)
+    Q_PROPERTY(QRectF itemRect READ itemRect NOTIFY itemRectChanged)
 
 public:
     muse::Inject<muse::actions::IActionsDispatcher> dispatcher = { this };
@@ -59,7 +59,7 @@ public:
     AbstractElementPopupModel(PopupModelType modelType, QObject* parent = nullptr);
 
     PopupModelType modelType() const;
-    QRect itemRect() const;
+    QRectF itemRect() const;
 
     static bool supportsPopup(const mu::engraving::EngravingItem* element);
     static PopupModelType modelTypeFromElement(const mu::engraving::ElementType& elementType);
@@ -68,7 +68,7 @@ public:
 
 signals:
     void dataChanged();
-    void itemRectChanged(QRect rect);
+    void itemRectChanged(QRectF rect);
 
 protected:
     virtual void updateItemRect();
@@ -89,7 +89,7 @@ protected:
     void changeItemProperty(mu::engraving::Pid id, const PropertyValue& value, engraving::PropertyFlags flags);
 
     EngravingItem* m_item = nullptr;
-    QRect m_itemRect;
+    QRectF m_itemRect;
 
 private:
     INotationSelectionPtr selection() const;

--- a/src/notation/view/internal/dynamicpopupmodel.h
+++ b/src/notation/view/internal/dynamicpopupmodel.h
@@ -57,6 +57,9 @@ public:
     Q_INVOKABLE void addOrChangeDynamic(int page, int index);
     Q_INVOKABLE void addHairpinToDynamic(ItemType itemType);
 
+    Q_INVOKABLE void showPreview(int page, int index);
+    Q_INVOKABLE void hidePreview();
+
     QString fontFamily() const;
     QVariantList pages() const;
 

--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -30,6 +30,7 @@
 #include "log.h"
 #include "commonscene/commonscenetypes.h"
 #include "abstractelementpopupmodel.h"
+#include "engraving/dom/dynamic.h"
 
 #include "engraving/dom/drumset.h"
 #include "engraving/dom/shadownote.h"
@@ -146,7 +147,11 @@ void NotationViewInputController::onNotationChanged()
         m_view->hideElementPopup();
 
         if (AbstractElementPopupModel::supportsPopup(selectedItem)) {
-            m_view->showElementPopup(type, selectedItem->canvasBoundingRect());
+            if (selectedItem->isDynamic()) {
+                m_view->showElementPopup(type, toDynamic(selectedItem)->adjustedBoundingRect());
+            } else {
+                m_view->showElementPopup(type, selectedItem->canvasBoundingRect());
+            }
         }
     });
 }
@@ -1375,7 +1380,11 @@ void NotationViewInputController::togglePopupForItemIfSupports(const EngravingIt
     ElementType type = item->type();
 
     if (AbstractElementPopupModel::supportsPopup(item)) {
-        m_view->toggleElementPopup(type, item->canvasBoundingRect());
+        if (item->isDynamic()) {
+            m_view->toggleElementPopup(type, toDynamic(item)->adjustedBoundingRect());
+        } else {
+            m_view->toggleElementPopup(type, item->canvasBoundingRect());
+        }
     }
 }
 

--- a/src/playback/view/internal/soundflag/soundflagsettingsmodel.cpp
+++ b/src/playback/view/internal/soundflag/soundflagsettingsmodel.cpp
@@ -99,8 +99,8 @@ void SoundFlagSettingsModel::init()
 {
     TRACEFUNC;
 
-    connect(this, &SoundFlagSettingsModel::itemRectChanged, this, [this](const QRect&) {
-        QRect rect = iconRect();
+    connect(this, &SoundFlagSettingsModel::itemRectChanged, this, [this](const QRectF&) {
+        QRectF rect = iconRect();
         if (rect.isValid()) {
             emit iconRectChanged(rect);
         }
@@ -439,9 +439,9 @@ void SoundFlagSettingsModel::setTitle(const QString& title)
     emit titleChanged();
 }
 
-QRect SoundFlagSettingsModel::iconRect() const
+QRectF SoundFlagSettingsModel::iconRect() const
 {
-    return m_item ? fromLogical(m_item->canvasBoundingRect()).toQRect() : QRect();
+    return m_item ? fromLogical(m_item->canvasBoundingRect()).toQRectF() : QRectF();
 }
 
 QVariantList SoundFlagSettingsModel::availablePresets() const

--- a/src/playback/view/internal/soundflag/soundflagsettingsmodel.h
+++ b/src/playback/view/internal/soundflag/soundflagsettingsmodel.h
@@ -42,7 +42,7 @@ class SoundFlagSettingsModel : public notation::AbstractElementPopupModel
 
     Q_PROPERTY(QString title READ title WRITE setTitle NOTIFY titleChanged FINAL)
 
-    Q_PROPERTY(QRect iconRect READ iconRect NOTIFY iconRectChanged FINAL)
+    Q_PROPERTY(QRectF iconRect READ iconRect NOTIFY iconRectChanged FINAL)
 
     Q_PROPERTY(QVariantList availablePresets READ availablePresets NOTIFY availablePresetsChanged FINAL)
     Q_PROPERTY(QStringList selectedPresetCodes READ selectedPresetCodes NOTIFY selectedPresetCodesChanged FINAL)
@@ -70,7 +70,7 @@ public:
     QString title() const;
     void setTitle(const QString& title);
 
-    QRect iconRect() const;
+    QRectF iconRect() const;
 
     QVariantList availablePresets() const;
     QStringList selectedPresetCodes() const;
@@ -81,7 +81,7 @@ public:
 signals:
     void initedChanged();
 
-    void iconRectChanged(const QRect& rect);
+    void iconRectChanged(const QRectF& rect);
 
     void titleChanged();
 


### PR DESCRIPTION
This is the fourth part of the main pull request: https://github.com/musescore/MuseScore/pull/23038, which adds the preview of dynamic on hovering.

PR for part 1: https://github.com/musescore/MuseScore/pull/24125
PR for part 2: https://github.com/musescore/MuseScore/pull/24147
PR for part 3: https://github.com/musescore/MuseScore/pull/24152

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
