### PR TITLE
Fix translation of some palette cells

### DIFF
--- a/src/palette/internal/palette.cpp
+++ b/src/palette/internal/palette.cpp
@@ -165,7 +165,7 @@ PaletteCellPtr Palette::appendElement(ElementPtr element, const muse::Translatab
 PaletteCellPtr Palette::appendActionIcon(ActionIconType type, ActionCode code, double mag)
 {
     const muse::ui::UiAction& action = actionsRegister()->action(code);
-    QString name = !action.description.isEmpty() ? action.description.qTranslated() : action.title.qTranslatedWithoutMnemonic();
+    const QString name = !action.description.isEmpty() ? action.description.str : action.title.raw().str;
     auto icon = std::make_shared<ActionIcon>(gpaletteScore->dummy());
     icon->setActionType(type);
     icon->setAction(code, static_cast<char16_t>(action.iconCode));

--- a/src/palette/internal/palettecell.cpp
+++ b/src/palette/internal/palettecell.cpp
@@ -112,8 +112,22 @@ const char* PaletteCell::translationContext() const
         return "engraving/bagpipeembellishment";
     case ElementType::CLEF:
         return "engraving/cleftype";
+    case ElementType::DYNAMIC:
+        return "engraving/dynamictype";
+    case ElementType::HAIRPIN:
+        if (!toHairpin(element.get())->beginText().isEmpty()) {
+            // "Dynamic + hairpin"
+            return "palette";
+        }
+        return "engraving/hairpintype";
+    case ElementType::LAYOUT_BREAK:
+        return "engraving/layoutbreaktype";
     case ElementType::NOTEHEAD:
         return "engraving/noteheadgroup";
+    case ElementType::OTTAVA:
+        return "engraving/ottavatype";
+    case ElementType::SPACER:
+        return "engraving/spacertype";
     case ElementType::ACCIDENTAL:
     case ElementType::ARTICULATION:
     case ElementType::BAR_LINE:

--- a/src/palette/internal/palettecreator.cpp
+++ b/src/palette/internal/palettecreator.cpp
@@ -256,22 +256,23 @@ PalettePtr PaletteCreator::newDynamicsPalette(bool defaultPalette)
         sp->appendElement(dynamic, TConv::userName(dynamic->dynamicType()));
     }
 
-    std::pair<HairpinType, const char*> hairpins[] = {
-        { HairpinType::CRESC_LINE,       QT_TRANSLATE_NOOP("palette", "Crescendo line") },
-        { HairpinType::DECRESC_LINE,     QT_TRANSLATE_NOOP("palette", "Diminuendo line") },
-        { HairpinType::CRESC_HAIRPIN,    QT_TRANSLATE_NOOP("palette", "Crescendo hairpin") },
-        { HairpinType::DECRESC_HAIRPIN,  QT_TRANSLATE_NOOP("palette", "Diminuendo hairpin") }
+    static const std::vector<HairpinType> hairpins {
+        HairpinType::CRESC_LINE,
+        HairpinType::DECRESC_LINE,
+        HairpinType::CRESC_HAIRPIN,
+        HairpinType::DECRESC_HAIRPIN,
     };
 
-    qreal w = gpaletteScore->style().spatium() * 8;
-    for (std::pair<HairpinType, const char*> pair : hairpins) {
+    const qreal w = gpaletteScore->style().spatium() * 8;
+
+    for (HairpinType hairpinType : hairpins) {
         auto hairpin = Factory::makeHairpin(gpaletteScore->dummy()->segment());
-        hairpin->setHairpinType(pair.first);
+        hairpin->setHairpinType(hairpinType);
         hairpin->setLen(w);
-        qreal mag = (pair.first == HairpinType::CRESC_LINE || pair.first == HairpinType::DECRESC_LINE) ? 1 : 0.9;
-        const QPointF offset = (pair.first == HairpinType::CRESC_LINE || pair.first == HairpinType::DECRESC_LINE)
+        qreal mag = (hairpinType == HairpinType::CRESC_LINE || hairpinType == HairpinType::DECRESC_LINE) ? 1 : 0.9;
+        const QPointF offset = (hairpinType == HairpinType::CRESC_LINE || hairpinType == HairpinType::DECRESC_LINE)
                                ? QPointF(1, 0.25) : QPointF(0, 0);
-        sp->appendElement(hairpin, pair.second, mag, offset);
+        sp->appendElement(hairpin, hairpin->subtypeUserName(), mag, offset);
     }
 
     return sp;
@@ -393,11 +394,11 @@ PalettePtr PaletteCreator::newRepeatsPalette(bool defaultPalette)
         int measuresCount = 0;
     };
 
-    std::vector<MeasureRepeatInfo> defaultMeasureRepeats {
+    const std::vector<MeasureRepeatInfo> defaultMeasureRepeats {
         { SymId::repeat1Bar, 1 }
     };
 
-    std::vector<MeasureRepeatInfo> masterMeasureRepeats {
+    const std::vector<MeasureRepeatInfo> masterMeasureRepeats {
         { SymId::repeat1Bar, 1 },
         { SymId::repeat2Bars, 2 },
         { SymId::repeat4Bars, 4 }
@@ -1707,7 +1708,7 @@ PalettePtr PaletteCreator::newTimePalette(bool defaultPalette)
         { 9,  8, TimeSigType::CUT_TRIPLE, QT_TRANSLATE_NOOP("engraving/timesig", "Cut triple time (9/8)") }
     };
 
-    for (TS timeSignatureType : defaultPalette ? defaultTimeSignatureList : masterTimeSignatureList) {
+    for (const TS& timeSignatureType : defaultPalette ? defaultTimeSignatureList : masterTimeSignatureList) {
         auto timeSignature = Factory::makeTimeSig(gpaletteScore->dummy()->segment());
         timeSignature->setSig(Fraction(timeSignatureType.numerator, timeSignatureType.denominator), timeSignatureType.type);
         sp->appendElement(timeSignature, timeSignatureType.name);
@@ -1760,7 +1761,7 @@ PalettePtr PaletteCreator::newFretboardDiagramPalette()
         { u"X212O2", u"B7", muse::TranslatableString("palette", "B7") }
     };
 
-    for (FretDiagramInfo fretboardDiagram : fretboardDiagrams) {
+    for (const FretDiagramInfo& fretboardDiagram : fretboardDiagrams) {
         auto fret = FretDiagram::createFromString(gpaletteScore, fretboardDiagram.diagram);
         fret->setHarmony(fretboardDiagram.harmony);
         sp->appendElement(fret, fretboardDiagram.userName);
@@ -1873,7 +1874,7 @@ PalettePtr PaletteCreator::newGuitarPalette(bool defaultPalette)
         { muse::TranslatableString("palette", "normal"),    PlayingTechniqueType::Natural },
     };
 
-    for (PlayTechAnnotationInfo playTechAnnotation : playTechAnnotations) {
+    for (const PlayTechAnnotationInfo& playTechAnnotation : playTechAnnotations) {
         auto pta = makeElement<PlayTechAnnotation>(gpaletteScore);
         pta->setXmlText(playTechAnnotation.xmlText.translated());
         pta->setTechniqueType(playTechAnnotation.playTechType);


### PR DESCRIPTION
For ActionIcons, we were wrongly passing the already-translated name to `appendElement`, which instead needs the untranslated name. (I bet the next thing that's going to happen is that we start seeing undesired `&` characters in the palettes... but let's hope that doesn't happen. This really needs a refactor at some point though.)

For other items, it was forgotten in a commit like 8fd2f00d92cd4d45cbadfcf8f24c4894cedabd69 to update the translation context being used. (Those are namely specified in an entirely different place, which might also need a refactor at some point.)

Resolves: https://github.com/musescore/MuseScore/issues/22960

In case I didn't catch all of them or when it breaks again in the future, this PR might serve as inspiration for contributors who want to fix such issues themselves. 