### PR TITLE
Deploy script: add the possibility to reuse artifacts from other workflow runs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,13 +51,44 @@ jobs:
           echo "Tag will not be created."
         fi
 
+  plan_builds:
+    name: Plan builds
+    runs-on: ubuntu-latest
+    outputs:
+      download_linux_arm32_runid: ${{ steps.plan_builds.outputs.download_linux_arm32_runid }}
+      download_linux_arm64_runid: ${{ steps.plan_builds.outputs.download_linux_arm64_runid }}
+      download_linux_x64_runid: ${{ steps.plan_builds.outputs.download_linux_x64_runid }}
+      download_macos_runid: ${{ steps.plan_builds.outputs.download_macos_runid }}
+      download_windows_x64_runid: ${{ steps.plan_builds.outputs.download_windows_x64_runid }}
+      download_windows_portable_runid: ${{ steps.plan_builds.outputs.download_windows_portable_runid }}
+      platforms_to_build: ${{ steps.plan_builds.outputs.platforms_to_build }}
+    steps:
+      - id: plan_builds
+        name: Plan builds
+        env:
+          PLATFORMS: ${{ inputs.platforms }}
+        run: |
+          platform_regex='(linux_arm32|linux_arm64|linux_x64|macos|windows_x64|windows_portable)'
+          int_regex="(0|[1-9][0-9]*)"
+
+          platforms_to_build=()
+          for platform in ${PLATFORMS}; do
+            if [[ "${platform}" =~ "${platform_regex}@${int_regex}" ]]; then
+              echo "download_${BASH_REMATCH[1]}_runid=${BASH_REMATCH[2]}" | tee -a "${GITHUB_OUTPUT}"
+            else
+              platforms_to_build+=("${platform}")
+            fi
+          done
+
+          echo "platforms_to_build=${platforms_to_build[@]}" | tee -a "${GITHUB_OUTPUT}"
+        
   build:
     name: Build
-    needs: get_tag_info
+    needs: [get_tag_info, plan_builds]
     uses: ./.github/workflows/build_all.yml
     secrets: inherit
     with:
-      platforms: ${{ inputs.platforms }}
+      platforms: ${{ needs.plan_builds.outputs.platforms_to_build }}
       build_mode: ${{ inputs.release_type == 'stable' && 'stable' || 'testing' }}
       publish: ${{ inputs.create_tag && 'on' || 'off' }}
       sentry_project: ${{ (inputs.create_tag && inputs.release_type == 'stable') && 'mu4' || 'sandbox' }}
@@ -74,8 +105,11 @@ jobs:
 
   create_release:
     name: 'Create release: ${{ needs.get_tag_info.outputs.tag_name }}'
+    permissions: 
+      actions: read
     needs:
       - get_tag_info # to access outputs
+      - plan_builds # to access outputs
       - update_learn_playlists
     if: ${{ ! failure() && ! cancelled() && inputs.create_tag }} # run even if prior jobs were skipped
     runs-on: ubuntu-latest
@@ -85,10 +119,52 @@ jobs:
     steps:
     - name: Clone repository
       uses: actions/checkout@v4
-    - name: Download and extract artifacts
+    - name: Download and extract built artifacts
       uses: actions/download-artifact@v4
       with:
         path: build.artifacts
+    - name: Download and extract reused linux_arm32 artifacts
+      if: ${{ needs.plan_builds.outputs.download_linux_arm32_runid }}
+      uses: actions/download-artifact@v4
+      with:
+        path: build.artifacts
+        run-id: ${{ needs.plan_builds.outputs.download_linux_arm32_runid }}
+        github-token: ${{ github.token }}
+    - name: Download and extract reused linux_arm64 artifacts
+      if: ${{ needs.plan_builds.outputs.download_linux_arm64_runid }}
+      uses: actions/download-artifact@v4
+      with:
+        path: build.artifacts
+        run-id: ${{ needs.plan_builds.outputs.download_linux_arm64_runid }}
+        github-token: ${{ github.token }}
+    - name: Download and extract reused linux_x64 artifacts
+      if: ${{ needs.plan_builds.outputs.download_linux_x64_runid }}
+      uses: actions/download-artifact@v4
+      with:
+        path: build.artifacts
+        run-id: ${{ needs.plan_builds.outputs.download_linux_x64_runid }}
+        github-token: ${{ github.token }}
+    - name: Download and extract reused macos artifacts
+      if: ${{ needs.plan_builds.outputs.download_macos_runid }}
+      uses: actions/download-artifact@v4
+      with:
+        path: build.artifacts
+        run-id: ${{ needs.plan_builds.outputs.download_macos_runid }}
+        github-token: ${{ github.token }}
+    - name: Download and extract reused windows_x64 artifacts
+      if: ${{ needs.plan_builds.outputs.download_windows_x64_runid }}
+      uses: actions/download-artifact@v4
+      with:
+        path: build.artifacts
+        run-id: ${{ needs.plan_builds.outputs.download_windows_x64_runid }}
+        github-token: ${{ github.token }}
+    - name: Download and extract reused windows_portable artifacts
+      if: ${{ needs.plan_builds.outputs.download_windows_portable_runid }}
+      uses: actions/download-artifact@v4
+      with:
+        path: build.artifacts
+        run-id: ${{ needs.plan_builds.outputs.download_windows_portable_runid }}
+        github-token: ${{ github.token }}
     - name: Collate release binaries
       run: |
         buildscripts/ci/release/collate_release_binaries.sh


### PR DESCRIPTION
This is just an experiment; it's not going to work in practice but I realised that only when I had already written most of this. So this is mostly academic but that's sometimes interesting too. 

The problem: [the big deploy workflow failed](https://github.com/musescore/MuseScore/actions/runs/10507169262) at the very end. But the builds themselves were created successfully. When we re-run the workflow, it would of course be nice if we wouldn't have to wait for those 3.5 hrs long linux_arm builds again, and instead reuse those that had already succeeded.

The solution: for each platform, allow specifying a workflow run id, from which the artifacts would be reused for that platform instead of rebuilding them. (A run id is the part of the url that comes after `actions/runs/`.) 
Example: `linux_arm64@101234567 linux_arm32@102345678 macos@103456789 windows_x64` would mean:
- reuse the `linux_arm64` artifacts from run id 101234567
- reuse the `linux_arm32` artifacts from run id 102345678
- reuse the `macos` artifacts from run id 103456789
- create new builds for `windows_x64

Why it is not going to work: when using the "Deploy" or "Build all" workflows, all artifacts are in one workflow run, with one run id. So if that run id were `104365879`, you'd get `linux_arm64@104365879 linux_arm32@104365879 macos@104365879 windows_x64`. That would result in all artifacts of all platforms being downloaded thrice. I see no way to get the artifacts from a specific workflow that has been used as a "sub workflow".

Of course, I could just drop the per-platform granularity, and create one "reuse from run id" field, but that is less spectacular. But if anyone thinks that would still be useful, let me know and I'll implement that. Otherwise we can just archive this PR.