### PR TITLE
Update MDL percussion URLs in migration dialogs

### DIFF
--- a/src/project/qml/MuseScore/Project/internal/Migration/MigrationContentFor362.qml
+++ b/src/project/qml/MuseScore/Project/internal/Migration/MigrationContentFor362.qml
@@ -83,7 +83,7 @@ ColumnLayout {
     CheckBox {
         id: percussionOption
         text: qsTrc("project/migration", "Use our new notation and sound mapping for <a href=\"%1\">MDL percussion</a>")
-              .arg("https://musescore.org/en/handbook/4") // TODO: Replace with link to page about MDL migration.
+              .arg("https://musescore.org/node/367337") // non-'/en' URL should redirect to translated version, if available
         checked: root.isRemapPercussion
 
         navigation.panel: root.navigationPanel

--- a/src/project/qml/MuseScore/Project/internal/Migration/MigrationContentForPre362.qml
+++ b/src/project/qml/MuseScore/Project/internal/Migration/MigrationContentForPre362.qml
@@ -136,7 +136,7 @@ ColumnLayout {
         CheckBox {
             id: percussionOption
             text: qsTrc("project/migration", "Our new notation and sound mapping for <a href=\"%1\">MDL percussion</a>")
-                  .arg("https://musescore.org/en/handbook/4") // TODO: Replace with link to page about MDL migration.
+                  .arg("https://musescore.org/node/367337") // non-'/en' URL should redirect to translated version, if available
             checked: root.isRemapPercussion
 
             navigation.panel: root.navigationPanel


### PR DESCRIPTION
Tested by changing preferred page language in my browser settings to:

- Chinese
- Italian
- English
- French
- German
- Cornish (because we don't have any translations for this, so it showed the 2nd preferred language instead)