### PR TITLE
CI Deploy: Handle differences in openssl output

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -100,7 +100,17 @@ jobs:
   # Dummy build for testing purposes.
   dummy:
     if: ${{ contains(inputs.platforms, 'dummy') }}
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Expose edge cases like different command versions, CRLF line endings, etc.
+        # Use same OS versions as used in real build workflows.
+        os:
+        - ubuntu-20.04 # linux_x64, backend
+        - ubuntu-22.04 # linux_arm32, linux_arm64
+        - macos-latest
+        - windows-2022 # windows_x64, windows_portable
+    runs-on: ${{ matrix.os }}
     steps:
     - name: Clone repository
       uses: actions/checkout@v4
@@ -130,13 +140,13 @@ jobs:
         buildscripts/ci/tools/make_release_channel_env.sh -c "${MUSE_APP_BUILD_MODE}"
         buildscripts/ci/tools/make_revision_env.sh "$(git rev-parse --short=7 HEAD)"
 
-        buildscripts/ci/tools/make_artifact_name_env.sh "MuseScore-Dummy-${BUILD_VERSION}-x86_64.txt"
+        buildscripts/ci/tools/make_artifact_name_env.sh "MuseScore-Dummy-${BUILD_VERSION}-${{ matrix.os }}-${HOSTTYPE}.txt"
         ARTIFACT_NAME="$(<"${ARTIFACTS_DIR}/env/artifact_name.env")"
 
         echo "Hello, world!" >"${ARTIFACTS_DIR}/${ARTIFACT_NAME}"
         buildscripts/ci/tools/checksum.sh
 
-        UPLOAD_ARTIFACT_NAME="$(tr '":<>|*?/\\’' '_' <<<"MU4_${BUILD_NUMBER}_Dummy_${BUILD_BRANCH}")"
+        UPLOAD_ARTIFACT_NAME="$(tr '":<>|*?/\\’' '_' <<<"MU4_${BUILD_NUMBER}_Dummy-${{ matrix.os }}_${BUILD_BRANCH}")"
         echo "UPLOAD_ARTIFACT_NAME=${UPLOAD_ARTIFACT_NAME}" | tee -a "${GITHUB_ENV}"
     - name: Upload artifacts to GitHub
       uses: actions/upload-artifact@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       platforms:
         description: 'Platforms to build:'
-        default: 'linux_arm32 linux_arm64 linux_x64 macos windows_x64 windows_portable' # TODO: backend
+        default: 'backend linux_arm32 linux_arm64 linux_x64 macos windows_x64 windows_portable'
         required: true
       release_type:
         description: 'Release type: alpha,beta,rc,stable, or any label with chars A-Za-z0-9._ for testing'

--- a/.github/workflows/update_learn_playlists.yml
+++ b/.github/workflows/update_learn_playlists.yml
@@ -26,14 +26,15 @@ defaults:
 
 jobs:
   update_playlists:
-    runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         playlist:
           - filename: started_playlist
             id: PLTYuWi2LmaPEhcwZJwFZqoyQ2xXx_maPa
           # - filename: advanced_playlist # old playlist no longer used
           #   id: PL24C760637A625BB6
+    runs-on: ubuntu-latest
     environment:
       name: ${{ inputs.environment }} # can be empty/blank (if so, URL will not be shown)
       url: https://www.youtube.com/playlist?list=${{ matrix.playlist.id }} # show on run page


### PR DESCRIPTION
Example:

- Run https://github.com/shoogle/MuseScore/actions/runs/10533844025
- Release https://github.com/shoogle/MuseScore/releases/tag/v4.5-alpha.5