### PR TITLE
fixed extra parenthesis on harmonic notes for tab notation

### DIFF
--- a/src/engraving/rendering/score/chordlayout.cpp
+++ b/src/engraving/rendering/score/chordlayout.cpp
@@ -3180,6 +3180,11 @@ void ChordLayout::layoutNote2(Note* item, LayoutContext& ctx)
     ShowTiedFret showTiedFret = item->style().value(Sid::tabShowTiedFret).value<ShowTiedFret>();
     bool useParens = isTabStaff && !item->fixed() && item->tieBack()
                      && (showTiedFret != ShowTiedFret::TIE_AND_FRET || item->isContinuationOfBend()) && !item->shouldHideFret();
+
+    if (item->harmonic() && item->displayFret() != Note::DisplayFretOption::NaturalHarmonic) {
+        useParens = false;
+    }
+
     if (useParens) {
         double widthWithoutParens = item->tabHeadWidth(staffType);
         item->setHeadHasParentheses(true, /* addToLinked= */ false, /* generated= */ true);


### PR DESCRIPTION
notes which are imported from guitar pro as "harmonic" shouldn't have extra brackets
(see `void setHarmonic(bool val) { m_harmonic = val; }`)

this fix is needed until harmonics are implemented in musescore

<img width="136" alt="Screenshot 2024-08-25 at 22 59 15" src="https://github.com/user-attachments/assets/4be13759-9f0e-4be0-a767-16577dff112b">

[tied-harmonic-notes.zip](https://github.com/user-attachments/files/16745005/tied-harmonic-notes.zip)
