### PR TITLE
Fix crash in Tuplet::addMissingElements

### DIFF
--- a/src/engraving/dom/tuplet.cpp
+++ b/src/engraving/dom/tuplet.cpp
@@ -766,13 +766,17 @@ void Tuplet::addMissingElements()
     if (voice() == 0) {
         return;         // nothing to do for tuplets in voice 1
     }
+
     Fraction missingElementsDuration = ticks() * ratio() - elementsDuration();
     if (missingElementsDuration.isZero()) {
         return;
     }
+
     // first, fill in any holes in the middle of the tuplet
     Fraction expectedTick = elements().front()->tick();
-    for (DurationElement* de : elements()) {
+
+    const std::vector<DurationElement*> elementsCopy = elements(); // mofified during loop
+    for (const DurationElement* de : elementsCopy) {
         if (!de) {
             continue;
         }
@@ -784,6 +788,7 @@ void Tuplet::addMissingElements()
         }
         expectedTick += de->actualTicks();
     }
+
     // calculate the tick where we would expect a tuplet of this duration to start
     // TODO: check:
     expectedTick = elements().front()->tick() - Fraction::fromTicks(elements().front()->tick().ticks() % ticks().ticks());


### PR DESCRIPTION
Container being modified during loop

Resolves: https://github.com/musescore/MuseScore/issues/24195