### PR TITLE
Fix undoing then reapplying range selections and restoring clefs/key sigs/time sigs in effect after applying them to range

### DIFF
--- a/src/engraving/dom/select.cpp
+++ b/src/engraving/dom/select.cpp
@@ -610,9 +610,12 @@ void Selection::updateSelectedElements()
             return;
         }
 
-        if (s2 && s2 == s2->measure()->first() && !(s2->measure()->prevMeasure() && s2->measure()->prevMeasure()->coveringMMRestOrThis())) {
+        if (s2 && s2 == s2->measure()->first()) {
             // we want the last segment of the previous measure (unless it's part of a MMrest)
-            s2 = s2->prev1();
+            Measure* prevMeasure = s2->measure()->prevMeasure();
+            if (!(prevMeasure && prevMeasure != prevMeasure->coveringMMRestOrThis())) {
+                s2 = s2->prev1();
+            }
         }
 
         setRange(s1, s2, staffStart, staffEnd);

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -1847,22 +1847,22 @@ bool NotationInteraction::applyPaletteElement(mu::engraving::EngravingItem* elem
                     }
                 }
                 if (m2 || e2) {
-                    // restore original clef/keysig/timesig
+                    // restore clef/keysig/timesig that was in effect at end of selection
                     mu::engraving::Staff* staff = score->staff(i);
-                    mu::engraving::Fraction tick1 = sel.startSegment()->tick();
+                    mu::engraving::Fraction tick2 = sel.endSegment()->tick();
                     mu::engraving::EngravingItem* oelement = nullptr;
                     switch (element->type()) {
                     case mu::engraving::ElementType::CLEF:
                     {
                         mu::engraving::Clef* oclef = engraving::Factory::createClef(score->dummy()->segment());
-                        oclef->setClefType(staff->clef(tick1));
+                        oclef->setClefType(staff->clef(tick2));
                         oelement = oclef;
                         break;
                     }
                     case mu::engraving::ElementType::KEYSIG:
                     {
                         mu::engraving::KeySig* okeysig = engraving::Factory::createKeySig(score->dummy()->segment());
-                        okeysig->setKeySigEvent(staff->keySigEvent(tick1));
+                        okeysig->setKeySigEvent(staff->keySigEvent(tick2));
                         Key ck = okeysig->concertKey();
                         okeysig->setKey(ck);
                         oelement = okeysig;
@@ -1871,7 +1871,7 @@ bool NotationInteraction::applyPaletteElement(mu::engraving::EngravingItem* elem
                     case mu::engraving::ElementType::TIMESIG:
                     {
                         mu::engraving::TimeSig* otimesig = engraving::Factory::createTimeSig(score->dummy()->segment());
-                        otimesig->setFrom(staff->timeSig(tick1));
+                        otimesig->setFrom(staff->timeSig(tick2));
                         oelement = otimesig;
                         break;
                     }


### PR DESCRIPTION
Resolves: #17718

`updateSelectedElements` should go to the previous segment from end of selection if the previous measure is not a MM rest. It seems this check was broken since commit f369233, which is now fixed. This caused the restored key sig etc to be shifted one bar after when undoing and reapplying it. 

Now the behavior when applying an element for the first time and the behavior when undoing and reapplying is the same.


https://github.com/user-attachments/assets/7f0439b9-cb26-4875-b1c6-46a1c78acc38





Resolves: #23936

Instead of restoring the clef/key sig/time sig that was in effect in the beginning of the selection, it restores what is in effect at the end of the selection. This also means if there's a clef/key sig/time sig at the end of the selection, it will not be overwritten. 

https://github.com/user-attachments/assets/7d09a8e4-60b7-4c86-8cbc-135390e12937

For the last scenario (applying a key signature to a range which already contains a key signature), it feels weird to add a duplicate key signature at the end. The behavior I would expect is to remove all key signatures within the selection because I want the whole selection to be in the key signature I apply. Implementing this would need to take into account if the key signature is local or if it's added in part scores etc, so maybe for simplicity we should just not add the duplicate key signature, or keep the current behavior. 


<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
