### PR TITLE
Implement standalone layout for Lyrics and Sticking

### DIFF
--- a/src/engraving/rendering/single/singledraw.cpp
+++ b/src/engraving/rendering/single/singledraw.cpp
@@ -76,6 +76,7 @@
 #include "dom/layoutbreak.h"
 #include "dom/ledgerline.h"
 #include "dom/letring.h"
+#include "dom/lyrics.h"
 
 #include "dom/marker.h"
 #include "dom/measurenumber.h"
@@ -99,6 +100,7 @@
 #include "dom/score.h"
 #include "dom/shadownote.h"
 #include "dom/slur.h"
+#include "dom/soundflag.h"
 #include "dom/spacer.h"
 #include "dom/stafflines.h"
 #include "dom/staffstate.h"
@@ -107,12 +109,11 @@
 #include "dom/stem.h"
 #include "dom/stemslash.h"
 #include "dom/sticking.h"
-#include "dom/stringtunings.h"
 #include "dom/stretchedbend.h"
+#include "dom/stringtunings.h"
 #include "dom/symbol.h"
 #include "dom/systemdivider.h"
 #include "dom/systemtext.h"
-#include "dom/soundflag.h"
 
 #include "dom/tempotext.h"
 #include "dom/text.h"
@@ -234,6 +235,8 @@ void SingleDraw::drawItem(const EngravingItem* item, Painter* painter)
     case ElementType::LEDGER_LINE:  draw(item_cast<const LedgerLine*>(item), painter);
         break;
     case ElementType::LET_RING_SEGMENT:     draw(item_cast<const LetRingSegment*>(item), painter);
+        break;
+    case ElementType::LYRICS:       draw(item_cast<const Lyrics*>(item), painter);
         break;
 
     case ElementType::MARKER:               draw(item_cast<const Marker*>(item), painter);
@@ -1968,6 +1971,12 @@ void SingleDraw::draw(const LetRingSegment* item, Painter* painter)
 {
     TRACE_DRAW_ITEM;
     drawTextLineBaseSegment(item, painter);
+}
+
+void SingleDraw::draw(const Lyrics* item, muse::draw::Painter* painter)
+{
+    TRACE_DRAW_ITEM;
+    drawTextBase(item, painter);
 }
 
 void SingleDraw::draw(const Marker* item, Painter* painter)

--- a/src/engraving/rendering/single/singledraw.h
+++ b/src/engraving/rendering/single/singledraw.h
@@ -91,6 +91,7 @@ class LetRing;
 class LetRingSegment;
 class SLine;
 class LineSegment;
+class Lyrics;
 
 class Marker;
 class MeasureNumber;
@@ -117,6 +118,7 @@ class Rest;
 class ShadowNote;
 class Slur;
 class SlurSegment;
+class SoundFlag;
 class Spacer;
 class StaffLines;
 class StaffState;
@@ -124,13 +126,12 @@ class StaffText;
 class StaffTypeChange;
 class Stem;
 class StemSlash;
-class StringTunings;
-class StretchedBend;
 class Sticking;
+class StretchedBend;
+class StringTunings;
 class Symbol;
-class SystemText;
 class SystemDivider;
-class SoundFlag;
+class SystemText;
 
 class TabDurationSymbol;
 class TempoText;
@@ -214,6 +215,7 @@ private:
     static void draw(const LayoutBreak* item, muse::draw::Painter* painter);
     static void draw(const LedgerLine* item, muse::draw::Painter* painter);
     static void draw(const LetRingSegment* item, muse::draw::Painter* painter);
+    static void draw(const Lyrics* item, muse::draw::Painter* painter);
 
     static void draw(const Marker* item, muse::draw::Painter* painter);
     static void draw(const MeasureNumber* item, muse::draw::Painter* painter);

--- a/src/engraving/rendering/single/singlelayout.cpp
+++ b/src/engraving/rendering/single/singlelayout.cpp
@@ -59,6 +59,7 @@
 #include "dom/keysig.h"
 #include "dom/letring.h"
 #include "dom/line.h"
+#include "dom/lyrics.h"
 #include "dom/marker.h"
 #include "dom/measurenumber.h"
 #include "dom/measurerepeat.h"
@@ -70,20 +71,21 @@
 #include "dom/playtechannotation.h"
 #include "dom/rehearsalmark.h"
 #include "dom/slur.h"
+#include "dom/soundflag.h"
 #include "dom/stafftext.h"
 #include "dom/stafftypechange.h"
+#include "dom/sticking.h"
 #include "dom/stringtunings.h"
 #include "dom/symbol.h"
 #include "dom/systemtext.h"
-#include "dom/soundflag.h"
 #include "dom/tempotext.h"
 #include "dom/text.h"
 #include "dom/textline.h"
 #include "dom/textlinebase.h"
 #include "dom/timesig.h"
+#include "dom/tremolobar.h"
 #include "dom/tremolosinglechord.h"
 #include "dom/tremolotwochord.h"
-#include "dom/tremolobar.h"
 #include "dom/trill.h"
 #include "dom/vibrato.h"
 #include "dom/volta.h"
@@ -168,6 +170,8 @@ void SingleLayout::layoutItem(EngravingItem* item)
         break;
     case ElementType::LET_RING:     layout(toLetRing(item), ctx);
         break;
+    case ElementType::LYRICS:       layout(toLyrics(item), ctx);
+        break;
     case ElementType::MARKER:       layout(toMarker(item), ctx);
         break;
     case ElementType::MEASURE_NUMBER: layout(toMeasureNumber(item), ctx);
@@ -195,6 +199,8 @@ void SingleLayout::layoutItem(EngravingItem* item)
     case ElementType::STAFF_TEXT:   layout(toStaffText(item), ctx);
         break;
     case ElementType::STAFFTYPE_CHANGE: layout(toStaffTypeChange(item), ctx);
+        break;
+    case ElementType::STICKING:     layout(toSticking(item), ctx);
         break;
     case ElementType::STRING_TUNINGS: layout(toStringTunings(item), ctx);
         break;
@@ -1266,6 +1272,11 @@ void SingleLayout::layout(LetRingSegment* item, const Context& ctx)
     layoutTextLineBaseSegment(item, ctx);
 }
 
+void SingleLayout::layout(Lyrics* item, const Context& ctx)
+{
+    layoutTextBase(static_cast<TextBase*>(item), ctx, item->mutldata());
+}
+
 void SingleLayout::layout(NoteHead* item, const Context& ctx)
 {
     layout(static_cast<Symbol*>(item), ctx);
@@ -1484,6 +1495,11 @@ void SingleLayout::layout(Stem* item, const Context& ctx)
 {
     LayoutContext tctx(ctx.dontUseScore());
     TLayout::layoutStem(item, item->mutldata(), tctx.conf());
+}
+
+void SingleLayout::layout(Sticking* item, const Context& ctx)
+{
+    layoutTextBase(static_cast<TextBase*>(item), ctx, item->mutldata());
 }
 
 void SingleLayout::layout(TempoText* item, const Context& ctx)

--- a/src/engraving/rendering/single/singlelayout.h
+++ b/src/engraving/rendering/single/singlelayout.h
@@ -79,6 +79,7 @@ class LetRing;
 class LetRingSegment;
 class SLine;
 class LineSegment;
+class Lyrics;
 
 class Marker;
 class MeasureNumber;
@@ -99,13 +100,14 @@ class PlayTechAnnotation;
 class RehearsalMark;
 
 class Slur;
+class SoundFlag;
 class Spacer;
 class StaffText;
 class StaffTypeChange;
+class Sticking;
 class StringTunings;
 class Symbol;
 class SystemText;
-class SoundFlag;
 
 class TempoText;
 class Text;
@@ -194,6 +196,7 @@ public:
 
     static void layout(LayoutBreak* item, const Context& ctx);
     static void layout(LetRing* item, const Context& ctx);
+    static void layout(Lyrics* item, const Context& ctx);
 
     static void layout(NoteHead* item, const Context& ctx);
 
@@ -211,14 +214,15 @@ public:
     static void layout(RehearsalMark* item, const Context& ctx);
 
     static void layout(Slur* item, const Context& ctx);
+    static void layout(SoundFlag* item, const Context& ctx);
     static void layout(Spacer* item, const Context&);
     static void layout(StaffText* item, const Context& ctx);
     static void layout(StaffTypeChange* item, const Context& ctx);
+    static void layout(Stem* item, const Context& ctx);
+    static void layout(Sticking* item, const Context& ctx);
     static void layout(StringTunings* item, const Context& ctx);
     static void layout(Symbol* item, const Context& ctx);
     static void layout(SystemText* item, const Context& ctx);
-    static void layout(SoundFlag* item, const Context& ctx);
-    static void layout(Stem* item, const Context& ctx);
 
     static void layout(TempoText* item, const Context& ctx);
     static void layout(TextLine* item, const Context& ctx);


### PR DESCRIPTION
To prevent a crash when Ctrl+Shift+dragging these items, or when these are in an existing palette

Resolves: https://github.com/musescore/MuseScore/issues/24208

(`SingleDraw::draw(Sticking* …)` appeared to exist already)