### PR TITLE
Option to disable dragging/reordering of palettes

### DIFF
--- a/src/palette/internal/paletteconfiguration.cpp
+++ b/src/palette/internal/paletteconfiguration.cpp
@@ -36,6 +36,7 @@ static const std::string MODULE_NAME("palette");
 static const Settings::Key PALETTE_SCALE(MODULE_NAME, "application/paletteScale");
 static const Settings::Key PALETTE_USE_SINGLE(MODULE_NAME, "application/useSinglePalette");
 static const Settings::Key IS_SINGLE_CLICK_TO_OPEN_PALETTE(MODULE_NAME, "application/singleClickToOpenPalette");
+static const Settings::Key IS_PALETTE_DRAG_ENABLED(MODULE_NAME, "application/paletteDragEnabled");
 
 void PaletteConfiguration::init()
 {
@@ -55,6 +56,13 @@ void PaletteConfiguration::init()
     m_isSingleClickToOpenPalette.val = settings()->value(IS_SINGLE_CLICK_TO_OPEN_PALETTE).toBool();
     settings()->valueChanged(IS_SINGLE_CLICK_TO_OPEN_PALETTE).onReceive(this, [this](const Val& newValue) {
         m_isSingleClickToOpenPalette.set(newValue.toBool());
+    });
+
+    settings()->setDefaultValue(IS_PALETTE_DRAG_ENABLED, Val(true));
+
+    m_isPaletteDragEnabled.val = settings()->value(IS_PALETTE_DRAG_ENABLED).toBool();
+    settings()->valueChanged(IS_PALETTE_DRAG_ENABLED).onReceive(this, [this](const Val& newValue) {
+        m_isPaletteDragEnabled.set(newValue.toBool());
     });
 }
 
@@ -95,6 +103,16 @@ ValCh<bool> PaletteConfiguration::isSingleClickToOpenPalette() const
 void PaletteConfiguration::setIsSingleClickToOpenPalette(bool isSingleClick)
 {
     settings()->setSharedValue(IS_SINGLE_CLICK_TO_OPEN_PALETTE, Val(isSingleClick));
+}
+
+ValCh<bool> PaletteConfiguration::isPaletteDragEnabled() const
+{
+    return m_isPaletteDragEnabled;
+}
+
+void PaletteConfiguration::setIsPaletteDragEnabled(bool enabled)
+{
+    settings()->setSharedValue(IS_PALETTE_DRAG_ENABLED, Val(enabled));
 }
 
 QColor PaletteConfiguration::elementsBackgroundColor() const

--- a/src/palette/internal/paletteconfiguration.h
+++ b/src/palette/internal/paletteconfiguration.h
@@ -49,6 +49,9 @@ public:
     muse::ValCh<bool> isSingleClickToOpenPalette() const override;
     void setIsSingleClickToOpenPalette(bool isSingleClick) override;
 
+    muse::ValCh<bool> isPaletteDragEnabled() const override;
+    void setIsPaletteDragEnabled(bool enabled) override;
+
     QColor elementsBackgroundColor() const override;
     QColor elementsColor() const override;
     QColor gridColor() const override;
@@ -72,6 +75,7 @@ private:
 
     muse::ValCh<bool> m_isSinglePalette;
     muse::ValCh<bool> m_isSingleClickToOpenPalette;
+    muse::ValCh<bool> m_isPaletteDragEnabled;
 
     mutable QHash<QString, muse::ValCh<PaletteConfig> > m_paletteConfigs;
     mutable QHash<QString, muse::ValCh<PaletteCellConfig> > m_paletteCellsConfigs;

--- a/src/palette/internal/paletteprovider.cpp
+++ b/src/palette/internal/paletteprovider.cpp
@@ -614,6 +614,10 @@ void PaletteProvider::init()
     configuration()->isSingleClickToOpenPalette().ch.onReceive(this, [this](bool) {
         emit isSingleClickToOpenPaletteChanged();
     });
+
+    configuration()->isPaletteDragEnabled().ch.onReceive(this, [this](bool) {
+        emit isPaletteDragEnabledChanged();
+    });
 }
 
 void PaletteProvider::setFilter(const QString& filter)
@@ -652,6 +656,11 @@ bool PaletteProvider::isSinglePalette() const
 bool PaletteProvider::isSingleClickToOpenPalette() const
 {
     return configuration()->isSingleClickToOpenPalette().val;
+}
+
+bool PaletteProvider::isPaletteDragEnabled() const
+{
+    return configuration()->isPaletteDragEnabled().val;
 }
 
 QAbstractItemModel* PaletteProvider::mainPaletteModel()

--- a/src/palette/internal/paletteprovider.h
+++ b/src/palette/internal/paletteprovider.h
@@ -215,6 +215,7 @@ class PaletteProvider : public QObject, public IPaletteProvider, public muse::as
 
     Q_PROPERTY(bool isSinglePalette READ isSinglePalette NOTIFY isSinglePaletteChanged)
     Q_PROPERTY(bool isSingleClickToOpenPalette READ isSingleClickToOpenPalette NOTIFY isSingleClickToOpenPaletteChanged)
+    Q_PROPERTY(bool isPaletteDragEnabled READ isPaletteDragEnabled NOTIFY isPaletteDragEnabledChanged)
 
 public:
     void init() override;
@@ -262,6 +263,7 @@ public:
 
     bool isSinglePalette() const;
     bool isSingleClickToOpenPalette() const;
+    bool isPaletteDragEnabled() const;
 
 signals:
     void userPaletteChanged();
@@ -269,6 +271,7 @@ signals:
 
     void isSinglePaletteChanged();
     void isSingleClickToOpenPaletteChanged();
+    void isPaletteDragEnabledChanged();
 
 private slots:
     void notifyAboutUserPaletteChanged()

--- a/src/palette/ipaletteconfiguration.h
+++ b/src/palette/ipaletteconfiguration.h
@@ -49,6 +49,9 @@ public:
     virtual muse::ValCh<bool> isSingleClickToOpenPalette() const = 0;
     virtual void setIsSingleClickToOpenPalette(bool isSingleClick) = 0;
 
+    virtual muse::ValCh<bool> isPaletteDragEnabled() const = 0;
+    virtual void setIsPaletteDragEnabled(bool enabled) = 0;
+
     virtual QColor elementsBackgroundColor() const = 0;
     virtual QColor elementsColor() const = 0;
     virtual QColor gridColor() const = 0;

--- a/src/palette/qml/MuseScore/Palette/internal/PaletteTree.qml
+++ b/src/palette/qml/MuseScore/Palette/internal/PaletteTree.qml
@@ -519,7 +519,7 @@ StyledListView {
 
             width: ListView.view.width
 
-            Drag.active: paletteHeaderDragArea.drag.active
+            Drag.active: paletteProvider.isPaletteDragEnabled && paletteHeaderDragArea.drag.active
             Drag.dragType: Drag.Automatic
             Drag.supportedActions: Qt.MoveAction
             Drag.proposedAction: Qt.MoveAction

--- a/src/palette/view/palettespanelcontextmenumodel.cpp
+++ b/src/palette/view/palettespanelcontextmenumodel.cpp
@@ -35,6 +35,7 @@ using namespace muse::uicomponents;
 
 static const ActionCode TOGGLE_SINGLE_CLICK_CODE("toggle-single-click-to-open-palette");
 static const ActionCode TOGGLE_SINGLE_PALETTE_CODE("toggle-single-palette");
+static const ActionCode TOGGLE_PALETTE_DRAG("toggle-palette-drag");
 static const ActionCode EXPAND_ALL_CODE("expand-all-palettes");
 static const ActionCode COLLAPSE_ALL_CODE("collapse-all-palettes");
 
@@ -48,6 +49,7 @@ void PalettesPanelContextMenuModel::load()
     MenuItemList items {
         createIsSingleClickToOpenPaletteItem(),
         createIsSinglePaletteItem(),
+        createIsDragEnabledItem(),
         makeSeparator(),
         createExpandCollapseAllItem(false),
         createExpandCollapseAllItem(true),
@@ -116,6 +118,38 @@ MenuItem* PalettesPanelContextMenuModel::createIsSinglePaletteItem()
     dispatcher()->reg(this, TOGGLE_SINGLE_PALETTE_CODE, [this, item]() {
         bool newValue = !item->state().checked;
         configuration()->setIsSinglePalette(newValue);
+    });
+
+    return item;
+}
+
+MenuItem* PalettesPanelContextMenuModel::createIsDragEnabledItem()
+{
+    MenuItem* item = new MenuItem(this);
+    item->setId(QString::fromStdString(TOGGLE_PALETTE_DRAG));
+
+    UiAction action;
+    action.title = TranslatableString("palette", "Allow reordering palettes");
+    action.code = TOGGLE_PALETTE_DRAG;
+    action.checkable = Checkable::Yes;
+    item->setAction(action);
+
+    ValCh<bool> checked = configuration()->isPaletteDragEnabled();
+
+    UiActionState state;
+    state.enabled = true;
+    state.checked = checked.val;
+    item->setState(state);
+
+    checked.ch.onReceive(item, [item](bool newValue) {
+        UiActionState state = item->state();
+        state.checked = newValue;
+        item->setState(state);
+    });
+
+    dispatcher()->reg(this, TOGGLE_PALETTE_DRAG, [this, item]() {
+        bool newValue = !item->state().checked;
+        configuration()->setIsPaletteDragEnabled(newValue);
     });
 
     return item;

--- a/src/palette/view/palettespanelcontextmenumodel.h
+++ b/src/palette/view/palettespanelcontextmenumodel.h
@@ -48,6 +48,7 @@ signals:
 private:
     muse::uicomponents::MenuItem* createIsSingleClickToOpenPaletteItem();
     muse::uicomponents::MenuItem* createIsSinglePaletteItem();
+    muse::uicomponents::MenuItem* createIsDragEnabledItem();
     muse::uicomponents::MenuItem* createExpandCollapseAllItem(bool expand);
 };
 }

--- a/src/stubs/palette/paletteconfigurationstub.cpp
+++ b/src/stubs/palette/paletteconfigurationstub.cpp
@@ -56,6 +56,15 @@ void PaletteConfigurationStub::setIsSingleClickToOpenPalette(bool)
 {
 }
 
+ValCh<bool> PaletteConfigurationStub::isPaletteDragEnabled() const
+{
+    return ValCh<bool>();
+}
+
+void PaletteConfigurationStub::setIsPaletteDragEnabled(bool)
+{
+}
+
 QColor PaletteConfigurationStub::elementsBackgroundColor() const
 {
     return QColor();

--- a/src/stubs/palette/paletteconfigurationstub.h
+++ b/src/stubs/palette/paletteconfigurationstub.h
@@ -39,6 +39,9 @@ public:
     muse::ValCh<bool> isSingleClickToOpenPalette() const override;
     void setIsSingleClickToOpenPalette(bool isSingleClick) override;
 
+    muse::ValCh<bool> isPaletteDragEnabled() const override;
+    void setIsPaletteDragEnabled(bool isSingleClick) override;
+
     QColor elementsBackgroundColor() const override;
     QColor elementsColor() const override;
     QColor gridColor() const override;


### PR DESCRIPTION
This PR allows disabling the ability of dragging palettes, to avoid unwanted reordering of them. It adds a checkable option to the palette context menu:
![image](https://github.com/user-attachments/assets/542d899c-4fe7-42db-b57b-75fa539fc790)

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
