### PR TITLE
Fix dynamic staff centering for some instruments

### DIFF
--- a/src/engraving/dom/instrument.cpp
+++ b/src/engraving/dom/instrument.cpp
@@ -793,7 +793,11 @@ bool Instrument::isVocalInstrument() const
 bool Instrument::isNormallyMultiStaveInstrument() const
 {
     String instrumentFamily = family();
-    return instrumentFamily == u"keyboards" || instrumentFamily == u"organs" || instrumentFamily == "keyboard-percussion";
+    return instrumentFamily == u"keyboards"
+           || instrumentFamily == u"organs"
+           || instrumentFamily == u"keyboard-percussion"
+           || instrumentFamily == u"harps"
+           || instrumentFamily == u"accordions";
 }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Resolves: #24185

The decision to center dynamics between staves is based on the instrument family. We only center automatically for those instruments which are "naturally" written on multiple staves (as opposed to, say, a string-divisi part). This PR simply adds a couple of more families to the list of `isNormallyMultiStaveInstrument`.