### PR TITLE
Fix guitar bends changing horizontal spacing in continuous view

### DIFF
--- a/src/engraving/rendering/score/scorehorizontalviewlayout.cpp
+++ b/src/engraving/rendering/score/scorehorizontalviewlayout.cpp
@@ -309,6 +309,7 @@ void ScoreHorizontalViewLayout::collectLinearSystem(LayoutContext& ctx)
                     MeasureLayout::stretchMeasureInPracticeMode(m, ww, ctx);
                 } else {
                     MeasureLayout::createEndBarLines(m, false, ctx);
+                    MeasureLayout::computePreSpacingItems(m, ctx);
                     MeasureLayout::computeWidth(m, ctx, minTicks, maxTicks, 1);
                     ww = m->width();
                     MeasureLayout::layoutMeasureElements(m, ctx);


### PR DESCRIPTION
Resolves: #24073
Resolves: https://github.com/musescore/MuseScore/issues/24212

The function `MeasureLayout::computePreSpacingItems` wasn't being called in continous view. As a result, the `lineAttachPoints` (which are used by notes to create enough horizontal space for things like ties, glissandos and guitar bends) kept being added at every layout call but were never cleared. This could also result in a big performance drop (which can be seen in the video of related issue as the editing operation becomes laggy), so fixing this may also make the editing in continuous view smoother in general.