### PR TITLE
Fix crash when reordering and deleting staves, caused by brackets

### DIFF
--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -2725,15 +2725,10 @@ void Score::adjustBracketsDel(size_t sidx, size_t eidx)
             } else if (endsOutsideDeletedRange) {
                 if (eidx < m_staves.size()) {
                     // Move the bracket past the end of the deleted range,
-                    // and shorten it by the number of staves deleted that were spanned by it
+                    // and shorten it by the number of staves deleted that were spanned by it.
+                    // That is, add a new bracket; the old one will be removed when removing the staves.
 
-                    // Store these properties, because `bi` will be deleted after the call to RemoveBracket
-                    size_t column = bi->column();
-                    BracketType type = bi->bracketType();
-
-                    undo(new RemoveBracket(staff, column, type, span));
-
-                    undoAddBracket(m_staves.at(eidx), column, type, int(span - (eidx - staffIdx)));
+                    undoAddBracket(m_staves.at(eidx), bi->column(), bi->bracketType(), int(span - (eidx - staffIdx)));
                 }
             }
         }

--- a/src/notation/internal/notationparts.cpp
+++ b/src/notation/internal/notationparts.cpp
@@ -200,12 +200,30 @@ std::vector<Staff*> NotationParts::staves(const IDList& stavesIds) const
     }
 
     for (Staff* staff : score()->staves()) {
-        if (std::find(stavesIds.cbegin(), stavesIds.cend(), staff->id()) != stavesIds.cend()) {
+        if (muse::contains(stavesIds, staff->id())) {
             staves.push_back(staff);
         }
     }
 
     return staves;
+}
+
+std::vector<staff_idx_t> NotationParts::staffIndices(const muse::IDList& stavesIds) const
+{
+    std::vector<staff_idx_t> staffIndices;
+
+    if (stavesIds.empty()) {
+        return staffIndices;
+    }
+
+    const auto& staves = score()->staves();
+    for (staff_idx_t staffIdx = 0; staffIdx < staves.size(); ++staffIdx) {
+        if (muse::contains(stavesIds, staves.at(staffIdx)->id())) {
+            staffIndices.push_back(staffIdx);
+        }
+    }
+
+    return staffIndices;
 }
 
 std::vector<Part*> NotationParts::parts(const IDList& partsIds) const
@@ -797,24 +815,21 @@ void NotationParts::removeStaves(const IDList& stavesIds)
 {
     TRACEFUNC;
 
-    std::vector<Staff*> stavesToRemove = staves(stavesIds);
-    if (stavesToRemove.empty()) {
-        return;
-    }
+    std::vector<staff_idx_t> staffIndicesToRemove = staffIndices(stavesIds);
 
     endInteractionWithScore();
     startEdit();
 
-    for (Staff* staff: stavesToRemove) {
-        score()->cmdRemoveStaff(staff->idx());
+    for (staff_idx_t staffIdx: staffIndicesToRemove) {
+        score()->cmdRemoveStaff(staffIdx);
     }
 
     setBracketsAndBarlines();
 
     apply();
 
-    for (const Staff* staff : stavesToRemove) {
-        notifyAboutStaffRemoved(staff);
+    for (staff_idx_t staffIdx: staffIndicesToRemove) {
+        notifyAboutStaffRemoved(score()->staff(staffIdx));
     }
 }
 

--- a/src/notation/internal/notationparts.cpp
+++ b/src/notation/internal/notationparts.cpp
@@ -806,27 +806,7 @@ void NotationParts::removeStaves(const IDList& stavesIds)
     startEdit();
 
     for (Staff* staff: stavesToRemove) {
-        class BracketData
-        {
-        public:
-            size_t column;
-            size_t span;
-
-            BracketData(size_t c, size_t s)
-                : column(c), span(s) {}
-        };
-
-        std::vector<BracketData> newBrackets;
-        staff_idx_t staffIdx = score()->staffIdx(staff);
-        for (BracketItem* bi : staff->brackets()) {
-            if ((bi->bracketType() == BracketType::BRACE) && (bi->bracketSpan() > 1)) {
-                newBrackets.push_back(BracketData(bi->column(), bi->bracketSpan() - 1));
-            }
-        }
         score()->cmdRemoveStaff(staff->idx());
-        for (BracketData bd : newBrackets) {
-            score()->undoAddBracket(score()->staff(staffIdx), bd.column, BracketType::BRACE, bd.span);
-        }
     }
 
     setBracketsAndBarlines();

--- a/src/notation/internal/notationparts.h
+++ b/src/notation/internal/notationparts.h
@@ -101,6 +101,7 @@ private:
     Staff* staffModifiable(const muse::ID& staffId) const;
 
     std::vector<Staff*> staves(const muse::IDList& stavesIds) const;
+    std::vector<engraving::staff_idx_t> staffIndices(const muse::IDList& stavesIds) const;
     std::vector<Part*> parts(const muse::IDList& partsIds) const;
 
     mu::engraving::InstrumentChange* findInstrumentChange(const Part* part, const Fraction& tick) const;


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/24207

See the commit messages for details. 

The removed code was introduced in https://github.com/musescore/MuseScore/pull/10526, so it would be good to check if there are no regressions w.r.t. the issues that that PR was solving back then. 