### PR TITLE
Add Campania back

### DIFF
--- a/src/engraving/engravingmodule.cpp
+++ b/src/engraving/engravingmodule.cpp
@@ -207,7 +207,12 @@ void EngravingModule::onInit(const IApplication::RunMode& mode)
         fdb->addFont(FontDataKey(u"FreeSerif", false, true), ":/fonts/FreeSerifItalic.ttf");
         fdb->addFont(FontDataKey(u"FreeSerif", true, true), ":/fonts/FreeSerifBoldItalic.ttf");
         fdb->addFont(FontDataKey(u"FreeSans"), ":/fonts/FreeSans.ttf");
+
+        // Figured Bass
         fdb->addFont(FontDataKey(u"MscoreBC"), ":/fonts/mscore-BC.ttf");
+
+        // Roman Numeral Analysis
+        fdb->addFont(FontDataKey(u"Campania"), ":/fonts/campania/Campania.otf");
 
         // Defaults
         fdb->setDefaultFont(Font::Type::Unknown, FontDataKey(u"Edwin"));

--- a/src/engraving/engravingmodule.cpp
+++ b/src/engraving/engravingmodule.cpp
@@ -207,6 +207,7 @@ void EngravingModule::onInit(const IApplication::RunMode& mode)
         fdb->addFont(FontDataKey(u"FreeSerif", false, true), ":/fonts/FreeSerifItalic.ttf");
         fdb->addFont(FontDataKey(u"FreeSerif", true, true), ":/fonts/FreeSerifBoldItalic.ttf");
         fdb->addFont(FontDataKey(u"FreeSans"), ":/fonts/FreeSans.ttf");
+        fdb->addFont(FontDataKey(u"MScoreTabulature"), ":/fonts/mscoreTab.ttf");
 
         // Figured Bass
         fdb->addFont(FontDataKey(u"MscoreBC"), ":/fonts/mscore-BC.ttf");


### PR DESCRIPTION
Looks like it didn't survive 9a052830095a2e472fe8565ebf504af21b70589c / 00505ec78f61048fdb65c58f0e268a2bb0880b72

Resolves: #24237 
Also fixes the "Renaissance" tablature font (accessible via staff/part properties > advanced style properties…)