### PR TITLE
EditStyle>FretBoards: fix text clipping by removing hardcoded width

### DIFF
--- a/src/notation/qml/MuseScore/NotationScene/internal/EditStyle/FretboardsPage.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/EditStyle/FretboardsPage.qml
@@ -183,12 +183,10 @@ Rectangle {
                         }
                     }
 
-                    FlatRadioButton {
-                        Layout.preferredWidth: 160
+                    FlatButton {
                         text: qsTrc("notation", "Edit fret number text style")
-                        checked: false
-                        onClicked: function() {
-                            checked = false
+
+                        onClicked: {
                             root.goToTextStylePage("fretboard-diagram-fret-number")
                         }
                     }
@@ -265,12 +263,10 @@ Rectangle {
                 onClicked: fretboardsPage.fretShowFingerings.value = !fretboardsPage.fretShowFingerings.value
             }
 
-            FlatRadioButton {
-                Layout.preferredWidth: 160
+            FlatButton {
                 text: qsTrc("notation", "Edit fingering text style")
-                checked: false
-                onClicked: function() {
-                    checked = false
+
+                onClicked: {
                     root.goToTextStylePage("fretboard-diagram-fingering")
                 }
             }


### PR DESCRIPTION
Resolves: 
<img width="1247" alt="Scherm­afbeelding 2024-08-27 om 22 36 09" src="https://github.com/user-attachments/assets/274c20f7-317a-499e-a52c-8d69079c7cd6">
(before at the right, after at the left; this is Dutch (Nederlands) for example)

(@mike-spa was there a specific reason for using Flat*Radio*Button here?)