### PR TITLE
Disable 'Play' toggle for TextLines

### DIFF
--- a/src/engraving/dom/noteline.cpp
+++ b/src/engraving/dom/noteline.cpp
@@ -167,6 +167,8 @@ PropertyValue NoteLine::propertyDefault(Pid propertyId) const
 PropertyValue NoteLine::getProperty(Pid propertyId) const
 {
     switch (propertyId) {
+    case Pid::PLAY:
+        return PropertyValue();
     case Pid::PLACEMENT:
         return PlacementV::ABOVE;
     case Pid::NOTELINE_PLACEMENT:
@@ -179,6 +181,8 @@ PropertyValue NoteLine::getProperty(Pid propertyId) const
 bool NoteLine::setProperty(Pid propertyId, const PropertyValue& val)
 {
     switch (propertyId) {
+    case Pid::PLAY:
+        break;
     case Pid::NOTELINE_PLACEMENT:
         setLineEndPlacement(val.value<NoteLineEndPlacement>());
         break;

--- a/src/engraving/dom/textline.cpp
+++ b/src/engraving/dom/textline.cpp
@@ -244,7 +244,7 @@ Sid TextLine::getPropertyStyle(Pid pid) const
 //   propertyDefault
 //---------------------------------------------------------
 
-engraving::PropertyValue TextLine::propertyDefault(Pid propertyId) const
+PropertyValue TextLine::propertyDefault(Pid propertyId) const
 {
     switch (propertyId) {
     case Pid::PLACEMENT:
@@ -293,6 +293,8 @@ bool TextLine::allowTimeAnchor() const
 bool TextLine::setProperty(Pid id, const engraving::PropertyValue& v)
 {
     switch (id) {
+    case Pid::PLAY:
+        break;
     case Pid::PLACEMENT:
         setPlacement(v.value<PlacementV>());
         break;
@@ -301,6 +303,21 @@ bool TextLine::setProperty(Pid id, const engraving::PropertyValue& v)
     }
     triggerLayout();
     return true;
+}
+
+//---------------------------------------------------------
+//   getProperty
+//---------------------------------------------------------
+
+PropertyValue TextLine::getProperty(Pid id) const
+{
+    switch (id) {
+    case Pid::PLAY:
+        return PropertyValue();
+    default:
+        break;
+    }
+    return TextLineBase::getProperty(id);
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/textline.h
+++ b/src/engraving/dom/textline.h
@@ -79,7 +79,8 @@ public:
     bool allowTimeAnchor() const override;
 
     PropertyValue propertyDefault(Pid) const override;
-    bool setProperty(Pid propertyId, const PropertyValue&) override;
+    bool setProperty(Pid id, const PropertyValue&) override;
+    PropertyValue getProperty(Pid id) const override;
 };
 } // namespace mu::engraving
 #endif


### PR DESCRIPTION
Since TextLines don't affect playback, best to disable this property for them

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
