### PR TITLE
Allow for custom invisible color

### DIFF
--- a/src/engraving/dom/soundflag.cpp
+++ b/src/engraving/dom/soundflag.cpp
@@ -235,7 +235,7 @@ void SoundFlag::setIconFontSize(double size)
 
 Color SoundFlag::iconBackgroundColor() const
 {
-    Color color = curColor();
+    Color color = curColor(true);
     if (!selected()) {
         color = Color("#CFD5DD");
         color.setAlpha(128);

--- a/src/engraving/iengravingconfiguration.h
+++ b/src/engraving/iengravingconfiguration.h
@@ -54,7 +54,6 @@ public:
 
     virtual Color defaultColor() const = 0;
     virtual Color scoreInversionColor() const = 0;
-    virtual Color invisibleColor() const = 0;
     virtual Color lassoColor() const = 0;
     virtual Color warningColor() const = 0;
     virtual Color warningSelectedColor() const = 0;
@@ -80,6 +79,9 @@ public:
 
     virtual Color formattingColor() const = 0;
     virtual muse::async::Channel<Color> formattingColorChanged() const = 0;
+
+    virtual Color invisibleColor() const = 0;
+    virtual muse::async::Channel<Color> invisibleColorChanged() const = 0;
 
     virtual Color unlinkedColor() const = 0;
     virtual muse::async::Channel<Color> unlinkedColorChanged() const = 0;

--- a/src/engraving/internal/engravingconfiguration.cpp
+++ b/src/engraving/internal/engravingconfiguration.cpp
@@ -48,6 +48,7 @@ static const Settings::Key INVERT_SCORE_COLOR("engraving", "engraving/scoreColor
 static const Settings::Key ALL_VOICES_COLOR("engraving", "engraving/colors/allVoicesColor");
 static const Settings::Key FORMATTING_COLOR("engraving", "engraving/colors/formattingColor");
 static const Settings::Key FRAME_COLOR("engraving", "engraving/colors/frameColor");
+static const Settings::Key INVISIBLE_COLOR("engraving", "engraving/colors/invisibleColor");
 static const Settings::Key UNLINKED_COLOR("engraving", "engraving/colors/unlinkedColor");
 
 static const Settings::Key DYNAMICS_APPLY_TO_ALL_VOICES("engraving", "score/dynamicsApplyToAllVoices");
@@ -118,6 +119,13 @@ void EngravingConfiguration::init()
     settings()->setCanBeManuallyEdited(FORMATTING_COLOR, true);
     settings()->valueChanged(FORMATTING_COLOR).onReceive(nullptr, [this](const Val& val) {
         m_formattingColorChanged.send(Color::fromQColor(val.toQColor()));
+    });
+
+    settings()->setDefaultValue(INVISIBLE_COLOR, Val(Color("#808080").toQColor()));
+    settings()->setDescription(INVISIBLE_COLOR, muse::trc("engraving", "Invisible color"));
+    settings()->setCanBeManuallyEdited(INVISIBLE_COLOR, true);
+    settings()->valueChanged(INVISIBLE_COLOR).onReceive(nullptr, [this](const Val& val) {
+        m_invisibleColorChanged.send(Color::fromQColor(val.toQColor()));
     });
 
     settings()->setDefaultValue(UNLINKED_COLOR, Val(Color(UNLINKED_ITEM_COLOR).toQColor()));
@@ -205,11 +213,6 @@ Color EngravingConfiguration::scoreInversionColor() const
 {
     // slightly dulled white for less strain on the eyes
     return Color(220, 220, 220);
-}
-
-Color EngravingConfiguration::invisibleColor() const
-{
-    return "#808080";
 }
 
 Color EngravingConfiguration::lassoColor() const
@@ -335,6 +338,16 @@ Color EngravingConfiguration::frameColor() const
 muse::async::Channel<Color> EngravingConfiguration::frameColorChanged() const
 {
     return m_frameColorChanged;
+}
+
+Color EngravingConfiguration::invisibleColor() const
+{
+    return Color::fromQColor(settings()->value(INVISIBLE_COLOR).toQColor());
+}
+
+muse::async::Channel<Color> EngravingConfiguration::invisibleColorChanged() const
+{
+    return m_invisibleColorChanged;
 }
 
 Color EngravingConfiguration::unlinkedColor() const

--- a/src/engraving/internal/engravingconfiguration.h
+++ b/src/engraving/internal/engravingconfiguration.h
@@ -60,7 +60,6 @@ public:
 
     Color defaultColor() const override;
     Color scoreInversionColor() const override;
-    Color invisibleColor() const override;
     Color lassoColor() const override;
     Color warningColor() const override;
     Color warningSelectedColor() const override;
@@ -93,6 +92,9 @@ public:
     Color frameColor() const override;
     muse::async::Channel<Color> frameColorChanged() const override;
 
+    Color invisibleColor() const override;
+    muse::async::Channel<Color> invisibleColorChanged() const override;
+
     Color unlinkedColor() const override;
     muse::async::Channel<Color> unlinkedColorChanged() const override;
 
@@ -118,6 +120,7 @@ private:
     muse::async::Notification m_scoreInversionChanged;
     muse::async::Channel<Color> m_formattingColorChanged;
     muse::async::Channel<Color> m_frameColorChanged;
+    muse::async::Channel<Color> m_invisibleColorChanged;
     muse::async::Channel<Color> m_unlinkedColorChanged;
 
     muse::ValNt<DebuggingOptions> m_debuggingOptions;

--- a/src/engraving/rendering/score/tdraw.cpp
+++ b/src/engraving/rendering/score/tdraw.cpp
@@ -2956,7 +2956,7 @@ void TDraw::draw(const SoundFlag* item, Painter* painter)
     f.setPointSizeF(item->spatium() * 2.0);
     painter->setFont(f);
 
-    painter->setPen(!item->selected() ? item->curColor() : Color::WHITE);
+    painter->setPen(!item->selected() ? item->curColor(true) : Color::WHITE);
     painter->drawText(item->ldata()->bbox(), muse::draw::AlignCenter, Char(item->iconCode()));
 }
 

--- a/src/engraving/tests/mocks/engravingconfigurationmock.h
+++ b/src/engraving/tests/mocks/engravingconfigurationmock.h
@@ -44,7 +44,6 @@ public:
 
     MOCK_METHOD(Color, defaultColor, (), (const, override));
     MOCK_METHOD(Color, scoreInversionColor, (), (const, override));
-    MOCK_METHOD(Color, invisibleColor, (), (const, override));
     MOCK_METHOD(Color, lassoColor, (), (const, override));
     MOCK_METHOD(Color, warningColor, (), (const, override));
     MOCK_METHOD(Color, warningSelectedColor, (), (const, override));
@@ -68,14 +67,17 @@ public:
     MOCK_METHOD(void, setScoreInversionEnabled, (bool), (override));
     MOCK_METHOD(muse::async::Notification, scoreInversionChanged, (), (const, override));
 
-    MOCK_METHOD(Color, unlinkedColor, (), (const, override));
-    MOCK_METHOD(muse::async::Channel<Color>, unlinkedColorChanged, (), (const, override));
-
     MOCK_METHOD(Color, formattingColor, (), (const, override));
     MOCK_METHOD(muse::async::Channel<Color>, formattingColorChanged, (), (const, override));
 
     MOCK_METHOD(Color, frameColor, (), (const, override));
     MOCK_METHOD(muse::async::Channel<Color>, frameColorChanged, (), (const, override));
+
+    MOCK_METHOD(Color, invisibleColor, (), (const, override));
+    MOCK_METHOD(muse::async::Channel<Color>, invisibleColorChanged, (), (const, override));
+
+    MOCK_METHOD(Color, unlinkedColor, (), (const, override));
+    MOCK_METHOD(muse::async::Channel<Color>, unlinkedColorChanged, (), (const, override));
 
     MOCK_METHOD(Color, highlightSelectionColor, (engraving::voice_idx_t), (const, override));
 

--- a/src/notation/internal/notationconfiguration.cpp
+++ b/src/notation/internal/notationconfiguration.cpp
@@ -236,6 +236,10 @@ void NotationConfiguration::init()
         m_foregroundChanged.notify();
     });
 
+    engravingConfiguration()->invisibleColorChanged().onReceive(this, [this](const Color&) {
+        m_foregroundChanged.notify();
+    });
+
     engravingConfiguration()->unlinkedColorChanged().onReceive(this, [this](const Color&) {
         m_foregroundChanged.notify();
     });


### PR DESCRIPTION
Resolves: #24054

Note this PR **doesn't** allow for a custom color of _selected_ invisible items, those are currently the selection color at 40% opacity

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
