### PR TITLE
gp-import: fixed origin offset for bends midi

### DIFF
--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -2021,7 +2021,7 @@ void GPConverter::addBend(const GPNote* gpnote, Note* note)
 
     PitchValues pitchValues;
 
-    pitchValues.push_back(PitchValue(gpTimeToMuTime(0), gpBend->originValue));
+    pitchValues.push_back(PitchValue(gpTimeToMuTime(gpBend->originOffset), gpBend->originValue));
     PitchValue lastPoint = pitchValues.back();
 
     if (bendHasMiddleValue) {


### PR DESCRIPTION
this two bends from guitar pro had same pitch start in export midi

<img width="321" alt="Screenshot 2024-08-28 at 14 10 27" src="https://github.com/user-attachments/assets/57b7ca54-2412-45eb-b43b-7bff00d67d5b">
<img width="310" alt="Screenshot 2024-08-28 at 14 11 36" src="https://github.com/user-attachments/assets/6fe87c7c-3204-4f90-bb9a-f7e37ef6d8a9">

[bends-pitches.zip](https://github.com/user-attachments/files/16783628/bends-pitches.zip)

