### PR TITLE
Show AppMenuBar in Qt 6.5+

### DIFF
--- a/src/appshell/qml/platform/AppMenuBar.qml
+++ b/src/appshell/qml/platform/AppMenuBar.qml
@@ -28,7 +28,7 @@ import MuseScore.AppShell 1.0
 ListView {
     id: root
 
-    height: contentItem.childrenRect.height
+    height: 10
     width: contentWidth
 
     property alias appWindow: appMenuModel.appWindow
@@ -73,6 +73,7 @@ ListView {
 
     Component.onCompleted: {
         appMenuModel.load()
+        root.height = root.contentItem.childrenRect.height
     }
 
     QtObject {


### PR DESCRIPTION
In Qt 6.5+, AppMenuBar's Component.onCompleted doesn't run until the component has a non-zero height. This solves the chicken-and-egg problem by assigning an initial height, and then replacing it with the height of its contents in the onCompleted handler.

I'm not a Qt expert, so I have no idea whether this is the best, most correct solution to this problem, but it is *a* solution.

Partial fix for : # 24097

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
