### PR TITLE
EditStyle>ChordSymbols: disambiguate multiple kinds of "standard"

### DIFF
--- a/src/notation/view/widgets/editstyle.ui
+++ b/src/notation/view/widgets/editstyle.ui
@@ -12887,7 +12887,7 @@ first note of the system</string>
                         <string notr="true">A, B♭, B, C, C♯, …</string>
                        </property>
                        <property name="text">
-                        <string>Standard</string>
+                        <string comment="chord symbol spelling">Standard</string>
                        </property>
                        <property name="checked">
                         <bool>true</bool>
@@ -12959,7 +12959,7 @@ first note of the system</string>
                      <item>
                       <widget class="QRadioButton" name="chordsStandard">
                        <property name="text">
-                        <string>Standard</string>
+                        <string comment="chord symbol style">Standard</string>
                        </property>
                        <property name="checked">
                         <bool>true</bool>


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/24193