### PR TITLE
Use the item-snapping logic to detect dragging groups

### DIFF
--- a/src/engraving/rendering/score/tlayout.h
+++ b/src/engraving/rendering/score/tlayout.h
@@ -376,6 +376,8 @@ private:
 
     static Shape textLineBaseSegmentShape(const TextLineBaseSegment* item);
     static void layoutDynamicToEndOfPrevious(const Dynamic* item, Dynamic::LayoutData* ldata, const LayoutConfiguration& conf);
+
+    static void manageHairpinSnapping(HairpinSegment* item, LayoutContext& ctx);
 };
 }
 


### PR DESCRIPTION
Resolves: #24263

@oktophonie @avvvvve I'm reasonably confident that this change is all good and safe (in fact it also makes the code simpler). But this is always finicky territory, so do keep an eye out when testing that this doesn't inadvertently change/break any other case of dragging interactions.