### PR TITLE
Ignore stuff from 3.x builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ __pycache__/
 .pdm-python
 
 **/_deps/*
+
+# Stuff from 3.x builds
+/share/sound/MuseScore_General*


### PR DESCRIPTION
Quite annoying to have to delete and redownload those 4 files time and time again when switching between 3.x and master, although that's mostly my personal problem ;-)