### PR TITLE
Fix pedals randomly not joining

### DIFF
--- a/src/engraving/dom/pedal.cpp
+++ b/src/engraving/dom/pedal.cpp
@@ -183,10 +183,11 @@ engraving::PropertyValue Pedal::propertyDefault(Pid propertyId) const
 
 Pedal* Pedal::findNextInStaff() const
 {
-    auto spanners = score()->spannerMap().findOverlapping(tick2().ticks(), score()->endTick().ticks());
+    Fraction endTick = tick2();
+    auto spanners = score()->spannerMap().findOverlapping(endTick.ticks(), score()->endTick().ticks());
     for (auto element : spanners) {
         Spanner* spanner = element.value;
-        if (spanner->isPedal() && spanner != this && spanner->staffIdx() == staffIdx()) {
+        if (spanner->isPedal() && spanner != this && spanner->staffIdx() == staffIdx() && spanner->tick() == endTick) {
             return toPedal(spanner);
         }
     }
@@ -243,9 +244,8 @@ PointF Pedal::linePos(Grip grip, System** sys) const
     }
 
     Pedal* nextPedal = findNextInStaff();
-    bool hasNextRightAfter = nextPedal && nextPedal->tick() == tick2();
 
-    if (endHookType() == HookType::HOOK_45 && hasNextRightAfter) {
+    if (nextPedal && endHookType() == HookType::HOOK_45) {
         *sys = endSeg->measure()->system();
         double x = endSeg->x() + endSeg->measure()->x();
         EngravingItem* item = endElement();
@@ -272,7 +272,7 @@ PointF Pedal::linePos(Grip grip, System** sys) const
         x -= symWidth(SymId::keyboardPedalUp);
     }
 
-    x -= (endSeg->isChordRestType() && hasNextRightAfter ? 1.25 : 0.75) * spatium();
+    x -= (endSeg->isChordRestType() && nextPedal ? 1.25 : 0.75) * spatium();
 
     return PointF(x, 0.0);
 }


### PR DESCRIPTION
Resolves: #24290 

The issue is caused by the same problem which I've described [here](https://github.com/musescore/MuseScore/pull/23550). In this case, findNextInStaff assumed the result of findOverlapping to be ordered, meaning that the first pedal found would be the correct one. Unfortunaly, the ordering seems to be unreliable. There is in this case a simple solution, that is checking that the endTick of the current pedal matches the start tick of the next one directly inside findNextInStaff.