### PR TITLE
Fix crash when selecting engraving item without staff

### DIFF
--- a/src/appshell/view/notationpagemodel.cpp
+++ b/src/appshell/view/notationpagemodel.cpp
@@ -261,7 +261,7 @@ void NotationPageModel::updatePercussionPanelVisibility()
     } else {
         for (const EngravingItem* e : selection->elements()) {
             const Staff* staff = e->staff();
-            if (!staff->isDrumStaff(e->tick())) {
+            if (!staff || !staff->isDrumStaff(e->tick())) {
                 return;
             }
         }


### PR DESCRIPTION
Fixes a crash I found while working on percussions.

To repro, enable the new percussion panel in DevTools and select an engraving item without a staff - e.g. the title.