### PR TITLE
[4.4.1] fixed parse not ascii args

### DIFF
--- a/src/app/internal/commandlineparser.cpp
+++ b/src/app/internal/commandlineparser.cpp
@@ -36,7 +36,7 @@ static QStringList prepareArguments(int argc, char** argv)
     QStringList args;
 
     for (int i = 0; i < argc; ++i) {
-        QString arg = QString::fromLocal8Bit(argv[i]);
+        QString arg = QString::fromUtf8(argv[i]);
 
 #ifndef NDEBUG
         if (arg.startsWith("-qmljsdebugger")) {


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/23811 https://github.com/musescore/MuseScore/issues/24305