### PR TITLE
Fix MainToolbar, and AppMenuBar in Qt 6.5+

### DIFF
--- a/src/appshell/qml/MainToolBar.qml
+++ b/src/appshell/qml/MainToolBar.qml
@@ -70,8 +70,8 @@ Item {
 
         model: toolBarModel
 
-        width: contentItem.childrenRect.width
-        height: contentItem.childrenRect.height
+        width: Math.max(1, contentItem.childrenRect.width)
+        height: Math.max(1, contentItem.childrenRect.height)
 
         delegate: PageTabButton {
             id: radioButtonDelegate

--- a/src/appshell/qml/platform/AppMenuBar.qml
+++ b/src/appshell/qml/platform/AppMenuBar.qml
@@ -28,7 +28,7 @@ import MuseScore.AppShell 1.0
 ListView {
     id: root
 
-    height: contentItem.childrenRect.height
+    height: Math.max(1,contentItem.childrenRect.height)
     width: contentWidth
 
     property alias appWindow: appMenuModel.appWindow


### PR DESCRIPTION
The problem was that a ListView lazily creates delegates as needed to actually display them. If the size of the ListView is 0, then it doesn't need to display anything, so it may not create any of the delegates. If it doesn't create any delegates, then we can't make it size itself to fit its contents. By setting a minimum size of 1, we force the ListView to create a delegate that we can then use to determine the ListView's actual size.

Resolves: #24097

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
