### PR TITLE
Fix #24312: Don't dismiss existing selections when cycling stacked elements

### DIFF
--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -645,6 +645,7 @@ void NotationViewInputController::mousePressEvent(QMouseEvent* event)
         if (numHitElements > 1 && (keyState & Qt::ControlModifier)) {
             size_t currTop = numHitElements - 1;
             EngravingItem* e = hitElements[currTop];
+            std::set<EngravingItem*> selectedAtPosition;
             bool found = false;
 
             // e is the topmost element in stacking order,
@@ -658,13 +659,17 @@ void NotationViewInputController::mousePressEvent(QMouseEvent* event)
                     }
                 } else if (hitElements[currTop]->selected()) {
                     found = true;
+                    selectedAtPosition.emplace(hitElements[currTop]);
                     e = nullptr;
                 }
                 currTop = (currTop + 1) % numHitElements;
             }
 
             if (e && !e->selected()) {
-                viewInteraction()->select({ e }, SelectType::SINGLE, hitStaffIndex);
+                for (EngravingItem* selectedElem : selectedAtPosition) {
+                    selectedElem->score()->deselect(selectedElem);
+                }
+                viewInteraction()->select({ e }, SelectType::ADD, hitStaffIndex);
             }
         } else {
             viewInteraction()->select({ hitElement }, selectType, hitStaffIndex);


### PR DESCRIPTION
Resolves: #24312

Quick rundown - in #21438 we implemented the ability to cycle through stacked elements with ctrl-click. The problem is, `SelectType::SINGLE` dismisses the entire selection before selecting the desired element.

Since titles, subtitles, etc. overlap with a vertical frame, ctrl-clicking them will run our new "cycle" logic, thus dismissing any previously selected elements. This problem isn't limited to text and frames though, as shown here (my previous selection of rests gets dismissed when ctrl-clicking stacked notes):

https://github.com/user-attachments/assets/05d5d3c1-c36f-4d6f-913f-927db9c1c511

The idea with this PR is to instead use `SelectType::ADD` when ctrl-clicking stacked elements, and explicitly deselect elements at the stacked position in order to cycle through them.