### PR TITLE
[Note Entry] Allow [move to previous chord] to use note-entry voice when score selection is of a different voice

### DIFF
--- a/src/engraving/editing/cmd.cpp
+++ b/src/engraving/editing/cmd.cpp
@@ -3094,6 +3094,7 @@ EngravingItem* Score::move(const String& cmd)
         }
     } else if (cmd == u"prev-chord" && cr) {
         // note input cursor
+        bool noteEntryPos = false;
         if (noteEntryMode()) {
             if (m_is.beyondScore()) {
                 m_is.setBeyondScore(false);
@@ -3104,6 +3105,8 @@ EngravingItem* Score::move(const String& cmd)
                 for (; s; s = s->prev1(SegmentType::ChordRest)) {
                     if (s->element(track) || (s->measure() != m && s->rtick().isZero())) {
                         if (s->element(track)) {
+                            el = s->nextChordRest(track, true);
+                            noteEntryPos = true;
                             if (s->element(track)->isRest() && toRest(s->element(track))->isGap()) {
                                 continue;
                             }
@@ -3118,7 +3121,7 @@ EngravingItem* Score::move(const String& cmd)
         // selection "cursor"
         // find previous chordrest, which might be a grace note
         // this may override note input cursor
-        el = prevChordRest(cr);
+        el = noteEntryPos ? el : prevChordRest(cr);
 
         // Skip gap rests if we're not in note entry mode...
         while (!noteEntryMode() && el && el->isRest() && toRest(el)->isGap()) {

--- a/src/engraving/editing/cmd.cpp
+++ b/src/engraving/editing/cmd.cpp
@@ -3103,13 +3103,14 @@ EngravingItem* Score::move(const String& cmd)
                 Segment* s = m_is.segment()->prev1(SegmentType::ChordRest);
                 track_idx_t track = m_is.track();
                 for (; s; s = s->prev1(SegmentType::ChordRest)) {
-                    if (s->element(track) || (s->measure() != m && s->rtick().isZero())) {
-                        if (s->element(track)) {
-                            el = s->nextChordRest(track, true);
-                            noteEntryPos = true;
-                            if (s->element(track)->isRest() && toRest(s->element(track))->isGap()) {
-                                continue;
-                            }
+                    if (s->measure() != m && s->rtick().isZero()) {
+                        break;
+                    }
+                    if (s->element(track)) {
+                        el = s->nextChordRest(track, true);
+                        noteEntryPos = true;
+                        if (s->element(track)->isRest() && toRest(s->element(track))->isGap()) {
+                            continue;
                         }
                         break;
                     }


### PR DESCRIPTION
Keyboard user observation:

Note Entry - Switch to voice two when there isn't a voice two rest but there is in the previous measure
User can't move left to select voice-2 rests. Probably "by design" but I (@worldwideweary) don't like it:
Option: User can use Prev-Element (alt-left) to do so but can't do so in note entry so exit note entry, alt-left a few times, then
Back to note entry again. Either that. or move to the left measure and switch voices and then move forward to the designated area:

https://private-user-images.githubusercontent.com/7139517/363364854-d9faf1da-ed24-4136-babf-00c307922922.webm?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MjUyMjAwNTIsIm5iZiI6MTcyNTIxOTc1MiwicGF0aCI6Ii83MTM5NTE3LzM2MzM2NDg1NC1kOWZhZjFkYS1lZDI0LTQxMzYtYmFiZi0wMGMzMDc5MjI5MjIud2VibT9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDA5MDElMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwOTAxVDE5NDIzMlomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTMwZDNiODM2NWY4YTdiYWU3Y2VlYzczOWFjYmE4NTk2OTE5YzQyOGYwOWViMDEzMmRkYWRkYjU3MTRlYmVlZDUmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.4OHl3SxSn0zI5f9UBEZi6D9GP1CDKAmXjWzFoD-8rLs

Seems kinda lame and imo would be better to allow this:

https://private-user-images.githubusercontent.com/7139517/363365202-7dbdc55b-2a8c-4160-80d4-7dd7bcadf84f.mp4?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MjUyMjAwNTIsIm5iZiI6MTcyNTIxOTc1MiwicGF0aCI6Ii83MTM5NTE3LzM2MzM2NTIwMi03ZGJkYzU1Yi0yYThjLTQxNjAtODBkNC03ZGQ3YmNhZGY4NGYubXA0P1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI0MDkwMSUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNDA5MDFUMTk0MjMyWiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9OWZmYjEzYjBlZDYyODQyZGFiNTE4NTY2ZmVmNjg5MGNlYTkzMTdlODE2YWNiNzU2ZjQ0M2FlZDg4NzM3ZWMxMiZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QmYWN0b3JfaWQ9MCZrZXlfaWQ9MCZyZXBvX2lkPTAifQ.Ha00G2b7iBiI2K3jSNK_Q9bh2ZQAku6ZeOZT6Sxobhc

Port of https://github.com/Jojo-Schmitz/MuseScore/pull/605

