### PR TITLE
#12753 : Speed up the opening of palette search box when there is no search text

### DIFF
--- a/src/palette/internal/paletteprovider.cpp
+++ b/src/palette/internal/paletteprovider.cpp
@@ -601,7 +601,6 @@ void PaletteProvider::init()
 
     m_searchFilterModel = new PaletteCellFilterProxyModel(this);
     m_searchFilterModel->setFilterCaseSensitivity(Qt::CaseInsensitive);
-    m_searchFilterModel->setSourceModel(m_masterPaletteModel);
 
     m_visibilityFilterModel = new QSortFilterProxyModel(this);
     m_visibilityFilterModel->setFilterRole(PaletteTreeModel::VisibleRole);
@@ -615,6 +614,22 @@ void PaletteProvider::init()
     configuration()->isSingleClickToOpenPalette().ch.onReceive(this, [this](bool) {
         emit isSingleClickToOpenPaletteChanged();
     });
+}
+
+void PaletteProvider::setFilter(const QString& filter)
+{
+    // Remove the model when there is no search text to return no results
+    // and thus speed up the opening of the palette search text box.
+    // Restore the model as soon as the search text is non-empty.
+    if (!filter.isEmpty()) {
+        m_searchFilterModel->setFilterFixedString(filter);
+        if (!m_searchFilterModel->sourceModel()) {
+            m_searchFilterModel->setSourceModel(m_masterPaletteModel);
+        }
+    } else {
+        m_searchFilterModel->setSourceModel(nullptr);
+        m_searchFilterModel->setFilterFixedString(QString());
+    }
 }
 
 void PaletteProvider::setSearching(bool searching)

--- a/src/palette/internal/paletteprovider.h
+++ b/src/palette/internal/paletteprovider.h
@@ -245,6 +245,7 @@ public:
     Q_INVOKABLE bool loadPalette(const QModelIndex&);
 
     Q_INVOKABLE void setSearching(bool searching);
+    Q_INVOKABLE void setFilter(const QString&);
 
     bool paletteChanged() const { return m_userPaletteModel->paletteTreeChanged(); }
 

--- a/src/palette/qml/MuseScore/Palette/PalettesPanel.qml
+++ b/src/palette/qml/MuseScore/Palette/PalettesPanel.qml
@@ -127,7 +127,7 @@ Item {
             verticalAlignment: Qt.AlignTop
             wrapMode: Text.WordWrap
 
-            visible: !paletteTree.isResultFound
+            visible: !searchHint.visible && !paletteTree.isResultFound
         }
 
         PaletteTree {

--- a/src/palette/qml/MuseScore/Palette/internal/PaletteTree.qml
+++ b/src/palette/qml/MuseScore/Palette/internal/PaletteTree.qml
@@ -83,7 +83,8 @@ StyledListView {
         }
 
         if (paletteModel) {
-            paletteModel.setFilterFixedString(filter)
+            paletteTree.paletteProvider.setFilter(filter)
+            paletteTree.positionViewAtBeginning() // Scroll to top after a search
         }
     }
 


### PR DESCRIPTION
…search text

Resolves: #NNNNN <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

Partially solves #12753 
When you open the palette search box for the first time (i.e. when it is empty), this PR makes the opening of the search box instantaneous.

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [] I created a unit test or vtest to verify the changes I made (if applicable)
