### PR TITLE
Fix A key with Danish keyboard layout on macOS

### DIFF
--- a/src/framework/shortcuts/internal/platform/macos/macosshortcutsinstancemodel.mm
+++ b/src/framework/shortcuts/internal/platform/macos/macosshortcutsinstancemodel.mm
@@ -109,8 +109,10 @@ static UCKeyboardLayout* keyboardLayout()
     return (UCKeyboardLayout*)CFDataGetBytePtr(uchr);
 }
 
-static UInt32 nativeKeycode(UCKeyboardLayout* keyboard, Qt::Key keyCode)
+static UInt32 nativeKeycode(UCKeyboardLayout* keyboard, Qt::Key keyCode, bool& found)
 {
+    found = true;
+
     switch (keyCode) {
     case Qt::Key_Return:
         return kVK_Return;
@@ -234,10 +236,11 @@ static UInt32 nativeKeycode(UCKeyboardLayout* keyboard, Qt::Key keyCode)
         }
     }
 
+    found = false;
     return 0;
 }
 
-UInt32 nativeModifiers(Qt::KeyboardModifiers modifiers)
+static UInt32 nativeModifiers(Qt::KeyboardModifiers modifiers)
 {
     UInt32 result = 0;
     if (modifiers & Qt::ShiftModifier) {
@@ -259,7 +262,7 @@ UInt32 nativeModifiers(Qt::KeyboardModifiers modifiers)
     return result;
 }
 
-QString keyCodeToString(UCKeyboardLayout* keyboard, UInt32 keyNativeCode)
+static QString keyCodeToString(UCKeyboardLayout* keyboard, UInt32 keyNativeCode)
 {
     if (muse::contains(specialKeysMap, keyNativeCode)) {
         return specialKeysMap.at(keyNativeCode);
@@ -297,7 +300,7 @@ QString keyCodeToString(UCKeyboardLayout* keyboard, UInt32 keyNativeCode)
     return "";
 }
 
-QString keyModifiersToString(UInt32 keyNativeModifiers)
+static QString keyModifiersToString(UInt32 keyNativeModifiers)
 {
     static const QMap<int, QString> qtModifiers = {
         { shiftKey, "Shift" },
@@ -326,7 +329,7 @@ QString keyModifiersToString(UInt32 keyNativeModifiers)
     return result;
 }
 
-QString translateToCurrentKeyboardLayout(const QKeySequence& sequence)
+static QString translateToCurrentKeyboardLayout(const QKeySequence& sequence)
 {
     const QKeyCombination keyCombination = sequence[0];
 
@@ -338,7 +341,12 @@ QString translateToCurrentKeyboardLayout(const QKeySequence& sequence)
         return {};
     }
 
-    UInt32 keyNativeCode = nativeKeycode(keyboard, qKey);
+    bool found = false;
+    UInt32 keyNativeCode = nativeKeycode(keyboard, qKey, found);
+    if (!found) {
+        LOGW() << "Key " << qKey << " not found in the keyboard layout";
+        return {};
+    }
 
     Qt::KeyboardModifiers modifiers = keyCombination.keyboardModifiers();
     UInt32 keyNativeModifiers = nativeModifiers(modifiers);
@@ -369,6 +377,10 @@ void MacOSShortcutsInstanceModel::doLoadShortcuts()
             QString sequence = QString::fromStdString(seq);
 
             QString seqStr = translateToCurrentKeyboardLayout(QKeySequence::fromString(sequence, QKeySequence::PortableText));
+            if (seqStr.isEmpty()) {
+                LOGW() << "Failed to translate sequence " << sequence;
+                continue;
+            }
 
             // RULE: If a sequence is used for several shortcuts but the values for autoRepeat vary depending on
             // the context, then we should force autoRepeat to false for all shortcuts sharing the sequence in


### PR DESCRIPTION
The Danish keyboard layout does not have a `backtick` key. We do have shortcuts that use this key. For these shortcuts, `nativeKeycode` returned 0, but 0 is also the code of the `a` key. So the `a` key would get bound to the wrong shortcut.

Resolves: https://github.com/musescore/MuseScore/issues/20866

I noticed that this issue can be reproduced with an international physical keyboard by simply setting the Danish keyboard layout via System Settings (System preferences).