### PR TITLE
Fix Kontakt crash because of conflicting QML files (again…)

### DIFF
--- a/SetupConfigure.cmake
+++ b/SetupConfigure.cmake
@@ -73,7 +73,6 @@ endif()
 ###########################################
 if (OS_IS_MAC)
     SET(Mscore_INSTALL_NAME    "Contents/Resources/")
-    SET(Mscore_FRAMEWORKS_NAME "Frameworks/")
     SET(Mscore_SHARE_NAME      "mscore.app/")
 elseif (OS_IS_WIN)
     SET(Mscore_INSTALL_NAME  "")

--- a/buildscripts/packaging/macOS/package.sh
+++ b/buildscripts/packaging/macOS/package.sh
@@ -60,6 +60,10 @@ macdeployqt ${VOLUME}/${APPNAME}.app -verbose=2 -qmldir=.
 echo "otool -L post-macdeployqt"
 otool -L ${VOLUME}/${APPNAME}.app/Contents/MacOS/mscore
 
+# Remove dSYM files
+echo "Remove dSYM files"
+find ${VOLUME}/${APPNAME}.app/Contents -type d -name "*.dSYM" -exec rm -r {} +
+
 echo "Rename ${APPNAME}.app to ${VOLUME}/${LONGER_NAME}.app"
 mv ${VOLUME}/${APPNAME}.app "${VOLUME}/${LONGER_NAME}.app"
 

--- a/buildscripts/packaging/macOS/package.sh
+++ b/buildscripts/packaging/macOS/package.sh
@@ -64,6 +64,14 @@ otool -L ${VOLUME}/${APPNAME}.app/Contents/MacOS/mscore
 echo "Remove dSYM files"
 find ${VOLUME}/${APPNAME}.app/Contents -type d -name "*.dSYM" -exec rm -r {} +
 
+# Rename Resources/qml to Resources/qml_mu. This way, VST3 plugins that also use QML
+# won't find these QML files, to prevent crashes because of conflicts.
+# https://github.com/musescore/MuseScore/issues/21372
+# https://github.com/musescore/MuseScore/issues/24331
+echo "Rename Resources/qml to Resources/qml_mu"
+mv ${VOLUME}/${APPNAME}.app/Contents/Resources/qml ${VOLUME}/${APPNAME}.app/Contents/Resources/qml_mu
+sed -i '' 's:Resources/qml:Resources/qml_mu:g' ${VOLUME}/${APPNAME}.app/Contents/Resources/qt.conf
+
 echo "Rename ${APPNAME}.app to ${VOLUME}/${LONGER_NAME}.app"
 mv ${VOLUME}/${APPNAME}.app "${VOLUME}/${LONGER_NAME}.app"
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/24331

Reapplies a variation of the fix from https://github.com/musescore/MuseScore/pull/22339, which was accidentally undone in https://github.com/musescore/MuseScore/commit/066634ff4dbae99359db0e0643a2313613181a82

The removal of dSYM files doesn't have to do with the fix, but is absolutely safe and should reduce the package size quite a bit.