### PR TITLE
Decrease flag to notehead padding

### DIFF
--- a/src/engraving/rendering/paddingtable.cpp
+++ b/src/engraving/rendering/paddingtable.cpp
@@ -73,7 +73,7 @@ void PaddingTable::createTable(const MStyle& style)
     table[ElementType::LEDGER_LINE][ElementType::TIMESIG]
         = std::max(table[ElementType::NOTE][ElementType::TIMESIG] - ledgerLength / 2, ledgerPad);
 
-    table[ElementType::HOOK][ElementType::NOTE] = 0.5 * spatium;
+    table[ElementType::HOOK][ElementType::NOTE] = 0.35 * spatium;
     table[ElementType::HOOK][ElementType::LEDGER_LINE]
         = std::max(table[ElementType::HOOK][ElementType::NOTE] - ledgerLength, ledgerPad);
     table[ElementType::HOOK][ElementType::ACCIDENTAL] = 0.35 * spatium;

--- a/src/importexport/musicxml/tests/data/testLayout.xml
+++ b/src/importexport/musicxml/tests/data/testLayout.xml
@@ -78,12 +78,12 @@
       </score-part>
     </part-list>
   <part id="P1">
-    <measure number="1" width="235.38">
+    <measure number="1" width="234.07">
       <print>
         <system-layout>
           <system-margins>
             <left-margin>50</left-margin>
-            <right-margin>743.65</right-margin>
+            <right-margin>744.96</right-margin>
             </system-margins>
           <top-system-distance>169.98</top-system-distance>
           </system-layout>
@@ -110,7 +110,7 @@
           <line>4</line>
           </clef>
         </attributes>
-      <note default-x="134.93" default-y="-10">
+      <note default-x="134.27" default-y="-10">
         <rest measure="yes"/>
         <duration>4</duration>
         <voice>1</voice>
@@ -155,7 +155,7 @@
         <stem>up</stem>
         <staff>2</staff>
         </note>
-      <note default-x="128.51" default-y="-110">
+      <note default-x="127.2" default-y="-110">
         <pitch>
           <step>G</step>
           <octave>4</octave>
@@ -166,7 +166,7 @@
         <stem>down</stem>
         <staff>2</staff>
         </note>
-      <note default-x="158.9" default-y="-135">
+      <note default-x="157.59" default-y="-135">
         <pitch>
           <step>B</step>
           <octave>3</octave>
@@ -183,7 +183,7 @@
           </direction-type>
         <staff>2</staff>
         </direction>
-      <note default-x="189.29" default-y="-125">
+      <note default-x="187.98" default-y="-125">
         <pitch>
           <step>D</step>
           <octave>3</octave>


### PR DESCRIPTION
The current value of 0.5 sp is perhaps a bit too generous, especially for notation with plenty of grace notes:
![image](https://github.com/user-attachments/assets/d14d1353-7f14-449f-9fea-10f608ac1519). 


