### PR TITLE
Fix drag of multiple hairpins

### DIFF
--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -724,7 +724,7 @@ void NotationViewInputController::handleLeftClick(const ClickContext& ctx)
 
     bool hitElementIsAlreadyBeingEdited = viewInteraction()->isElementEditStarted() && viewInteraction()->editedItem() == ctx.hitElement;
     if (!selection->isRange() && ctx.hitElement && ctx.hitElement->needStartEditingAfterSelecting() && !hitElementIsAlreadyBeingEdited) {
-        if (ctx.hitElement->hasGrips()) {
+        if (ctx.hitElement->hasGrips() && selection->elements().size() == 1) {
             viewInteraction()->startEditGrip(ctx.hitElement, ctx.hitElement->gripsCount() > 4 ? Grip::DRAG : Grip::MIDDLE);
         } else {
             viewInteraction()->startEditElement(ctx.hitElement, false);


### PR DESCRIPTION
Resolves: #24104

This resolves the linked issues in the smallest way possible. It should bring back the same behaviour as we had pre-4.4. 

I should also point out that Musescore is currently very limited when it comes to multi-item editing. Our notation-interaction codebase wasn't built for multi-editing, as most of the functions work on an underlying assumption that there is only one item at a time being edited. The limited multi-editing capabilities we have now are the result of several workarounds. This is something that  will need some dedicated work (definitely not patch releaseable), and some design input too @avvvvve.