### PR TITLE
macOS nativeKeycode: handle insert key and other >0xffff keys

### DIFF
--- a/src/framework/shortcuts/internal/platform/macos/macosshortcutsinstancemodel.mm
+++ b/src/framework/shortcuts/internal/platform/macos/macosshortcutsinstancemodel.mm
@@ -199,6 +199,12 @@ static UInt32 nativeKeycode(UCKeyboardLayout* keyboard, Qt::Key keyCode, bool& f
         break;
     }
 
+    if (keyCode < 0 || keyCode > 0xFFFF) {
+        LOGW() << "Unhandled key code: " << keyCode;
+        found = false;
+        return 0;
+    }
+
     UTF16Char keyCodeChar = keyCode;
     UCKeyboardTypeHeader* table = keyboard->keyboardTypeList;
 

--- a/src/framework/shortcuts/internal/platform/macos/macosshortcutsinstancemodel.mm
+++ b/src/framework/shortcuts/internal/platform/macos/macosshortcutsinstancemodel.mm
@@ -50,6 +50,7 @@ static const std::map<UInt32, QString> specialKeysMap = {
     { kVK_F17, "F17" },
     { kVK_F18, "F18" },
     { kVK_F19, "F19" },
+    { kVK_F20, "F20" },
     { kVK_Space, "Space" },
     { kVK_Escape, "Esc" },
     { kVK_Delete, "Backspace" },


### PR DESCRIPTION
These don't fit in a UTF16Char, so overflow occurs; `Key_Insert`, which is `0x01000006`, becomes `0x0006`, which apparently maps to the F key.

Resolves: https://github.com/musescore/MuseScore/issues/24333

Builds on https://github.com/musescore/MuseScore/pull/24368