### PR TITLE
[CMD: up/down chord] Traverse as list after range selection

### DIFF
--- a/src/engraving/dom/chordrest.cpp
+++ b/src/engraving/dom/chordrest.cpp
@@ -41,6 +41,7 @@
 #include "keysig.h"
 #include "lyrics.h"
 #include "marker.h"
+#include "mcursor.h"
 #include "measure.h"
 #include "navigate.h"
 #include "note.h"
@@ -1326,5 +1327,66 @@ bool ChordRest::hasPrecedingJumpItem() const
     std::vector<Measure*> precedingRepeatMeasures = findPreviousRepeatMeasures(measure);
 
     return !precedingRepeatMeasures.empty();
+}
+
+//----------------------------------------------------------------
+//    getNotesAtPosition - Get all notes corresponding
+//          to the vertical segment of a ChordRest input. Only one
+//          instrument - the ChordRest's instrument - is taken into
+//          account if onlyOne = true, else the entire score -
+//          currently not implemented for pianoview
+//----------------------------------------------------------------
+
+void ChordRest::getNotesAtPosition(std::vector<Note*>& notesAtPosition, bool onlyOne)
+{
+    auto part = staff()->part();
+    auto firstTrackOfPart = onlyOne ? part->startTrack() : 0;
+    auto lastTrackOfPart = onlyOne ? part->endTrack() : score()->ntracks();
+    auto currentPosition = tick();
+
+    MCursor c;
+    c.setScore(score()->masterScore());
+    if (!notesAtPosition.empty()) {
+        notesAtPosition.clear();
+    }
+    for (track_idx_t track = firstTrackOfPart; track < lastTrackOfPart; track++) {
+        c.move(static_cast<int>(track), currentPosition);
+        if (auto e = c.currentElement()) {
+            if (e->isChord()) {
+                auto notes = toChord(e)->notes();
+                for (auto note : notes) {
+                    notesAtPosition.emplace_back(note);
+                }
+            }
+        }
+    }
+}
+
+//----------------------------------------------------------------
+//    getChordRestsAtPosition - same as getNotesAtPosition except
+//          now stores ChordRests to include rests for the purposes
+//          of vertical movement of selection of the same tick
+//----------------------------------------------------------------
+
+void ChordRest::getChordRestsAtPosition(std::vector<ChordRest*>& chordRestsAtPosition, bool onlyOne)
+{
+    auto part = staff()->part();
+    auto firstTrackOfPart = onlyOne ? part->startTrack() : 0;
+    auto lastTrackOfPart = onlyOne ? part->endTrack() : score()->ntracks();
+    auto currentPosition = tick();
+
+    MCursor c;
+    c.setScore(score()->masterScore());
+    if (!chordRestsAtPosition.empty()) {
+        chordRestsAtPosition.clear();
+    }
+    for (track_idx_t track = firstTrackOfPart; track < lastTrackOfPart; track++) {
+        c.move(static_cast<int>(track), currentPosition);
+        if (auto e = c.currentElement()) {
+            if (e->isChord() || e->isRest()) {
+                chordRestsAtPosition.emplace_back(toChordRest(e));
+            }
+        }
+    }
 }
 }

--- a/src/engraving/dom/chordrest.h
+++ b/src/engraving/dom/chordrest.h
@@ -136,6 +136,9 @@ public:
     void removeDeleteBeam(bool beamed);
     void replaceBeam(Beam* newBeam);
 
+    void getNotesAtPosition(std::vector<Note*>&, bool onlyOne = true);
+    void getChordRestsAtPosition(std::vector<ChordRest*>& chordRestsAtPosition, bool onlyOne = true);
+
     const ElementList& el() const { return m_el; }
 
     //! TODO Look like a hack, see using

--- a/src/engraving/dom/mcursor.cpp
+++ b/src/engraving/dom/mcursor.cpp
@@ -182,4 +182,17 @@ void MCursor::addPart(const String& instrument)
     m_score->appendPart(part);
     m_score->insertStaff(staff, 0);
 }
+
+//---------------------------------------------------------
+//   currentElement
+//   returns the element @ cursor position if
+//   a valid track & tick were set
+//---------------------------------------------------------
+
+EngravingItem* MCursor::currentElement() const
+{
+    auto measure = m_score->tick2measure(m_tick);
+    auto seg = measure->getSegment(SegmentType::ChordRest, m_tick);
+    return seg && seg->element(m_track) ? seg->element(m_track) : nullptr;
+}
 }

--- a/src/engraving/dom/mcursor.h
+++ b/src/engraving/dom/mcursor.h
@@ -23,6 +23,7 @@
 #ifndef MU_ENGRAVING_MCURSOR_H
 #define MU_ENGRAVING_MCURSOR_H
 
+#include "engravingitem.h"
 #include "types/string.h"
 #include "../types/types.h"
 
@@ -54,6 +55,8 @@ public:
     MasterScore* score() const { return m_score; }
     void setScore(MasterScore* s) { m_score = s; }
     void setTimeSig(Fraction f) { m_sig = f; }
+
+    EngravingItem* currentElement() const;
 
 private:
 

--- a/src/engraving/dom/navigate.cpp
+++ b/src/engraving/dom/navigate.cpp
@@ -393,6 +393,87 @@ Note* Score::downAltCtrl(Note* note) const
 }
 
 //---------------------------------------------------------
+//   moveAlt - Updated upAlt/downAlt to let tick (beat) take
+//      precedence - facilitate up/down traveling in a
+//      vertical time domain
+//
+//    element: Note() or Rest()
+//    return: Note() or Rest()
+//
+//    return next higher/lower pitched note in chord
+//    or top/bottom of next/previous track's chord if at wit's end
+//---------------------------------------------------------
+
+EngravingItem* Score::moveAlt(EngravingItem* element, DirectionV direction)
+{
+    EngravingItem* result = nullptr;
+    ChordRest* cr = nullptr;
+    auto originalTrack = element->track();
+    bool moveUp = (direction == DirectionV::UP);
+    bool isNote = element->isNote();
+    bool isRest = element->isRest();
+
+    if (isNote) {
+        cr = toChordRest(element->parent());
+        auto note = toNote(element);
+        auto chord = note->chord();
+        const std::vector<Note*>& notes = chord->notes();
+        auto it = std::find(notes.begin(), notes.end(), note);
+        // Traverse notes within same ChordRest until at extremum
+        auto condition = moveUp ? notes.end() : notes.begin();
+        if (moveUp) {
+            ++it;
+        }
+        if (it != condition) {
+            if (!moveUp) {
+                --it;
+            }
+            result = *it;
+        }
+    } else if (isRest) {
+        cr = toChordRest(element);
+    }
+
+    if (!result) {
+        // Traverse same-beat tracks
+        std::vector<ChordRest*> chordRestsOfBeat;
+        if (!cr) {
+            return nullptr;
+        }
+
+        cr->getChordRestsAtPosition(chordRestsOfBeat, false);
+        if (moveUp) {
+            std::reverse(chordRestsOfBeat.begin(), chordRestsOfBeat.end());
+        }
+
+        for (auto it : chordRestsOfBeat) {
+            auto targetCR = it;
+            auto targetTrack = targetCR->track();
+            if (moveUp && (targetTrack >= originalTrack)) {
+                continue;
+            } else if (!moveUp && (targetTrack <= originalTrack)) {
+                continue;
+            }
+            if (targetCR) {
+                result = targetCR;
+            }
+            break;
+        }
+
+        if (result && (result->track() == originalTrack)) {
+            result = element;
+        }
+    }
+
+    if (result && result->isChord()) {
+        auto chord = toChord(result);
+        result = moveUp ? chord->downNote() : chord->upNote();
+    }
+
+    return result;
+}
+
+//---------------------------------------------------------
 //   firstElement
 //---------------------------------------------------------
 

--- a/src/engraving/dom/navigate.cpp
+++ b/src/engraving/dom/navigate.cpp
@@ -40,6 +40,8 @@
 #include "staff.h"
 #include "tapping.h"
 
+#include "notation/notationtypes.h"
+
 using namespace mu;
 
 namespace mu::engraving {
@@ -404,12 +406,12 @@ Note* Score::downAltCtrl(Note* note) const
 //    or top/bottom of next/previous track's chord if at wit's end
 //---------------------------------------------------------
 
-EngravingItem* Score::moveAlt(EngravingItem* element, DirectionV direction)
+EngravingItem* Score::moveAlt(EngravingItem* element, notation::MoveDirection direction)
 {
     EngravingItem* result = nullptr;
     ChordRest* cr = nullptr;
     auto originalTrack = element->track();
-    bool moveUp = (direction == DirectionV::UP);
+    bool moveUp = (direction == notation::MoveDirection::Up);
     bool isNote = element->isNote();
     bool isRest = element->isRest();
 

--- a/src/engraving/dom/score.h
+++ b/src/engraving/dom/score.h
@@ -983,6 +983,7 @@ public:
     Note* upAltCtrl(Note*) const;
     EngravingItem* downAlt(EngravingItem*);
     Note* downAltCtrl(Note*) const;
+    EngravingItem* moveAlt(EngravingItem*, DirectionV);
 
     EngravingItem* firstElement(bool frame = true);
     EngravingItem* lastElement(bool frame = true);

--- a/src/engraving/dom/score.h
+++ b/src/engraving/dom/score.h
@@ -104,6 +104,10 @@ namespace mu::engraving::compat {
 class WriteScoreHook;
 }
 
+namespace mu::notation {
+enum class MoveDirection : unsigned char;
+}
+
 namespace mu::engraving {
 class Articulation;
 class Audio;
@@ -983,7 +987,7 @@ public:
     Note* upAltCtrl(Note*) const;
     EngravingItem* downAlt(EngravingItem*);
     Note* downAltCtrl(Note*) const;
-    EngravingItem* moveAlt(EngravingItem*, DirectionV);
+    EngravingItem* moveAlt(EngravingItem*, notation::MoveDirection);
 
     EngravingItem* firstElement(bool frame = true);
     EngravingItem* lastElement(bool frame = true);

--- a/src/engraving/editing/cmd.cpp
+++ b/src/engraving/editing/cmd.cpp
@@ -2356,8 +2356,8 @@ EngravingItem* Score::move(const String& cmd)
         // to catch up with the cursor and not move the selection by 2 positions
         cr = selection().cr();
         if (cr && (cr->isGrace() || cmd == u"next-chord" || cmd == u"prev-chord")) {
-        } else {
-            cr = inputState().cr();
+        } else if (ChordRest* is = inputState().cr()) {
+            cr = is;
         }
     } else if (selection().activeCR()) {
         cr = selection().activeCR();
@@ -2516,8 +2516,11 @@ EngravingItem* Score::move(const String& cmd)
         // selection "cursor"
         // find previous chordrest, which might be a grace note
         // this may override note input cursor
-        el = prevChordRest(cr);
-
+        if (ChordRest* pcr = prevChordRest(cr)) {
+            if (prevChordRest(cr)->isGrace()) {
+                el = pcr;
+            }
+        }
         // Skip gap rests if we're not in note entry mode...
         while (!noteEntryMode() && el && el->isRest() && toRest(el)->isGap()) {
             el = prevChordRest(toChordRest(el));

--- a/src/instrumentsscene/internal/selectinstrumentscenario.cpp
+++ b/src/instrumentsscene/internal/selectinstrumentscenario.cpp
@@ -47,7 +47,7 @@ muse::async::Promise<InstrumentTemplate> SelectInstrumentsScenario::selectInstru
     return async::make_promise<InstrumentTemplate>([this, params](auto resolve, auto reject) {
         Promise<PartInstrumentListScoreOrder> selectedInstruments = selectInstruments(params);
         selectedInstruments.onResolve(this, [resolve](const PartInstrumentListScoreOrder& selectedInstruments) {
-            const InstrumentTemplate& tpl = selectedInstruments.instruments.first().instrumentTemplate;
+            const InstrumentTemplate& tpl = selectedInstruments.instruments.front().instrumentTemplate;
             (void)resolve(tpl);
         });
         selectedInstruments.onReject(this, [reject](int code, const std::string& msg) {
@@ -94,7 +94,7 @@ muse::async::Promise<PartInstrumentListScoreOrder> SelectInstrumentsScenario::se
                 String instrumentId = String::fromStdString(map["instrumentId"].toString());
                 pi.instrumentTemplate = instrumentsRepository()->instrumentTemplate(instrumentId);
 
-                result.instruments << pi;
+                result.instruments.push_back(pi);
             }
 
             ValMap order = content["scoreOrder"].toMap();

--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/staffsettingsmodel.cpp
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/staffsettingsmodel.cpp
@@ -117,7 +117,7 @@ QVariantList StaffSettingsModel::allStaffTypes() const
         if (isTypeAllowed(type)) {
             QVariantMap obj;
 
-            obj["text"] = staffTypeToString(type.type());
+            obj["text"] = staffTypeToString(type.type()).toQString();
             obj["value"] = static_cast<int>(type.type());
 
             result << obj;

--- a/src/notation/internal/masternotationparts.cpp
+++ b/src/notation/internal/masternotationparts.cpp
@@ -87,7 +87,7 @@ void MasterNotationParts::setParts(const PartInstrumentList& partList, const Sco
             PartInstrument pi;
             pi.isExistingPart = true;
             pi.partId = part->id();
-            excerptPartList << pi;
+            excerptPartList.push_back(pi);
         }
 
         impl->sortParts(excerptPartList);

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -862,24 +862,78 @@ void NotationInteraction::moveChordNoteSelection(MoveDirection d)
         return;
     }
 
-    EngravingItem* current = selection()->element();
-    if (!current || !(current->isNote() || current->isRest())) {
+    auto removeDuplicates = [](std::vector<EngravingItem*>& elements) {
+        std::sort(elements.begin(), elements.end());
+        auto it = std::unique(elements.begin(), elements.end());
+        elements.erase(it, elements.end());
+    };
+
+    auto& _score = *score();
+    auto& selection = _score.selection();
+    EngravingItem* currentSingle = selection.element();
+    EngravingItem* oldSingle = currentSingle;
+    bool isRange = selection.isRange();
+    std::vector<EngravingItem*> notes;
+    DirectionV dir = d == MoveDirection::Up ? DirectionV::UP : DirectionV::DOWN;
+
+    // Single traverse:
+    if (currentSingle && (currentSingle->isNote() || currentSingle->isRest())) {
+        EngravingItem* newSingle = _score.moveAlt(currentSingle, dir);
+        if (newSingle == currentSingle) {
+            return;
+        }
+        while (newSingle && newSingle->isRest() && toRest(newSingle)->isGap()) {
+            newSingle = _score.moveAlt(newSingle, dir);
+            if (newSingle == oldSingle) {
+                break;
+            }
+        }
+        if (newSingle) {
+            select({ newSingle }, SelectType::SINGLE, newSingle->staffIdx());
+            showItem(newSingle);
+        }
         return;
     }
-
-    EngravingItem* chordElem;
-    if (d == MoveDirection::Up) {
-        chordElem = score()->upAlt(current);
-    } else {
-        chordElem = score()->downAlt(current);
+    // Range/List traverse:
+    else {
+        for (auto item : selection.elements()) {
+            if (item->isNote()) {
+                auto selectedNote = toNote(item);
+                if (isRange) {
+                    auto newSelection = (d == MoveDirection::Down)
+                                        ? selectedNote->chord()->downNote()
+                                        : selectedNote->chord()->upNote();
+                    notes.emplace_back(newSelection);
+                } else { // List
+                    auto newSelection = _score.moveAlt(selectedNote, dir);
+                    bool keepSelection = !newSelection;
+                    if (newSelection) {
+                        if (newSelection->isNote()) {
+                            auto newNote = toNote(newSelection);
+                            bool sameChord = (newNote->chord() == selectedNote->chord());
+                            if (!sameChord) {
+                                keepSelection = true;
+                            }
+                        } else if (newSelection->isRest()) {
+                            keepSelection = true;
+                        }
+                    }
+                    notes.emplace_back(keepSelection ? selectedNote : newSelection);
+                }
+            }
+            removeDuplicates(notes);
+        }
     }
 
-    if (chordElem == current) {
+    if (!notes.empty()) {
+        selection.clear();
+        for (auto& note : notes) {
+            select({ note }, SelectType::ADD, note->staffIdx());
+            showItem(note);
+        }
+        // score.update();
         return;
     }
-
-    select({ chordElem }, SelectType::SINGLE, chordElem->staffIdx());
-    showItem(chordElem);
 }
 
 void NotationInteraction::moveSegmentSelection(MoveDirection d)

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -874,16 +874,15 @@ void NotationInteraction::moveChordNoteSelection(MoveDirection d)
     EngravingItem* oldSingle = currentSingle;
     bool isRange = selection.isRange();
     std::vector<EngravingItem*> notes;
-    DirectionV dir = d == MoveDirection::Up ? DirectionV::UP : DirectionV::DOWN;
 
     // Single traverse:
     if (currentSingle && (currentSingle->isNote() || currentSingle->isRest())) {
-        EngravingItem* newSingle = _score.moveAlt(currentSingle, dir);
+        EngravingItem* newSingle = _score.moveAlt(currentSingle, d);
         if (newSingle == currentSingle) {
             return;
         }
         while (newSingle && newSingle->isRest() && toRest(newSingle)->isGap()) {
-            newSingle = _score.moveAlt(newSingle, dir);
+            newSingle = _score.moveAlt(newSingle, d);
             if (newSingle == oldSingle) {
                 break;
             }
@@ -905,7 +904,7 @@ void NotationInteraction::moveChordNoteSelection(MoveDirection d)
                                         : selectedNote->chord()->upNote();
                     notes.emplace_back(newSelection);
                 } else { // List
-                    auto newSelection = _score.moveAlt(selectedNote, dir);
+                    auto newSelection = _score.moveAlt(selectedNote, d);
                     bool keepSelection = !newSelection;
                     if (newSelection) {
                         if (newSelection->isNote()) {

--- a/src/notation/internal/notationparts.cpp
+++ b/src/notation/internal/notationparts.cpp
@@ -903,7 +903,7 @@ void NotationParts::removeParts(const IDList& partsIds)
         PartInstrument pi;
         pi.isExistingPart = true;
         pi.partId = part->id();
-        parts << pi;
+        parts.push_back(pi);
     }
 
     sortParts(parts);

--- a/src/notation/notationtypes.h
+++ b/src/notation/notationtypes.h
@@ -21,9 +21,6 @@
  */
 #pragma once
 
-#include <QPixmap>
-#include <QDate>
-
 #include "translation.h"
 
 #include "types/id.h"
@@ -154,7 +151,7 @@ using Pid = mu::engraving::Pid;
 using VoiceAssignment = mu::engraving::VoiceAssignment;
 using MeasureBeat = mu::engraving::MeasureBeat;
 
-static const muse::String COMMON_GENRE_ID("common");
+static const muse::String COMMON_GENRE_ID(u"common");
 
 enum class DragMode : unsigned char
 {
@@ -298,57 +295,57 @@ inline bool isMainInstrumentForPart(const InstrumentKey& instrumentKey, const Pa
     return instrumentKey.instrumentId == part->instrumentId() && instrumentKey.tick == Part::MAIN_INSTRUMENT_TICK;
 }
 
-inline QString formatInstrumentTitle(const QString& instrumentName, const InstrumentTrait& trait)
+inline muse::String formatInstrumentTitle(const muse::String& instrumentName, const InstrumentTrait& trait)
 {
     // Comments for translators start with //:
     switch (trait.type) {
     case TraitType::Tuning:
         //: %1=tuning ("D"), %2=name ("Tin Whistle"). Example: "D Tin Whistle"
-        return muse::qtrc("notation", "%1 %2", "Tuned instrument displayed in the UI")
+        return muse::mtrc("notation", "%1 %2", "Tuned instrument displayed in the UI")
                .arg(trait.name, instrumentName);
     case TraitType::Transposition:
         //: %1=name ("Horn"), %2=transposition ("C alto"). Example: "Horn in C alto"
-        return muse::qtrc("notation", "%1 in %2", "Transposing instrument displayed in the UI")
+        return muse::mtrc("notation", "%1 in %2", "Transposing instrument displayed in the UI")
                .arg(instrumentName, trait.name);
     case TraitType::Course:
         //: %1=name ("Tenor Lute"), %2=course/strings ("7-course"). Example: "Tenor Lute (7-course)"
-        return muse::qtrc("notation", "%1 (%2)", "String instrument displayed in the UI")
+        return muse::mtrc("notation", "%1 (%2)", "String instrument displayed in the UI")
                .arg(instrumentName, trait.name);
     case TraitType::Unknown:
+    default:
         return instrumentName; // Example: "Flute"
     }
-    Q_UNREACHABLE();
 }
 
-inline QString formatInstrumentTitle(const QString& instrumentName, const InstrumentTrait& trait, int instrumentNumber)
+inline muse::String formatInstrumentTitle(const muse::String& instrumentName, const InstrumentTrait& trait, int instrumentNumber)
 {
     if (instrumentNumber == 0) {
         // Only one instance of this instrument in the score
         return formatInstrumentTitle(instrumentName, trait);
     }
 
-    QString number = QString::number(instrumentNumber);
+    muse::String number = muse::String::number(instrumentNumber);
 
     // Comments for translators start with //:
     switch (trait.type) {
     case TraitType::Tuning:
         //: %1=tuning ("D"), %2=name ("Tin Whistle"), %3=number ("2"). Example: "D Tin Whistle 2"
-        return muse::qtrc("notation", "%1 %2 %3", "One of several tuned instruments displayed in the UI")
+        return muse::mtrc("notation", "%1 %2 %3", "One of several tuned instruments displayed in the UI")
                .arg(trait.name, instrumentName, number);
     case TraitType::Transposition:
         //: %1=name ("Horn"), %2=transposition ("C alto"), %3=number ("2"). Example: "Horn in C alto 2"
-        return muse::qtrc("notation", "%1 in %2 %3", "One of several transposing instruments displayed in the UI")
+        return muse::mtrc("notation", "%1 in %2 %3", "One of several transposing instruments displayed in the UI")
                .arg(instrumentName, trait.name, number);
     case TraitType::Course:
         //: %1=name ("Tenor Lute"), %2=course/strings ("7-course"), %3=number ("2"). Example: "Tenor Lute (7-course) 2"
-        return muse::qtrc("notation", "%1 (%2) %3", "One of several string instruments displayed in the UI")
+        return muse::mtrc("notation", "%1 (%2) %3", "One of several string instruments displayed in the UI")
                .arg(instrumentName, trait.name, number);
     case TraitType::Unknown:
+    default:
         //: %1=name ("Flute"), %2=number ("2"). Example: "Flute 2"
-        return muse::qtrc("notation", "%1 %2", "One of several instruments displayed in the UI")
+        return muse::mtrc("notation", "%1 %2", "One of several instruments displayed in the UI")
                .arg(instrumentName, number);
     }
-    Q_UNREACHABLE();
 }
 
 struct PartInstrument
@@ -360,7 +357,7 @@ struct PartInstrument
     bool isSoloist = false;
 };
 
-using PartInstrumentList = QList<PartInstrument>;
+using PartInstrumentList = std::list<PartInstrument>;
 
 struct PartInstrumentListScoreOrder
 {
@@ -510,10 +507,10 @@ struct ScoreConfig
     }
 };
 
-inline QString staffTypeToString(StaffTypeId type)
+inline muse::String staffTypeToString(StaffTypeId type)
 {
     const StaffType* preset = StaffType::preset(type);
-    return preset ? preset->staffTypeName().toQString() : QString();
+    return preset ? preset->staffTypeName() : muse::String();
 }
 
 enum class BracketsType : unsigned char
@@ -545,7 +542,7 @@ struct ScoreCreateOptions
 inline const ScoreOrder& customOrder()
 {
     static ScoreOrder order;
-    order.id = "custom";
+    order.id = u"custom";
     order.name = muse::TranslatableString("engraving/scoreorder", "Custom");
 
     return order;

--- a/src/project/qml/MuseScore/Project/internal/NewScore/newscoremodel.cpp
+++ b/src/project/qml/MuseScore/Project/internal/NewScore/newscoremodel.cpp
@@ -116,7 +116,7 @@ ProjectCreateOptions NewScoreModel::parseOptions(const QVariantMap& info) const
         pi.isExistingPart = objMap["isExistingPart"].toBool();
         pi.isSoloist = objMap["isSoloist"].toBool();
 
-        scoreOptions.parts << pi;
+        scoreOptions.parts.push_back(pi);
     }
 
     QVariantMap orderMap = info["scoreOrder"].toMap();


### PR DESCRIPTION
The commands [up/down chord] work only with a single selection of a note/rest, moving through a chord, and then moves to the next voice above/below. 

At the moment, it won't work while in a list selection of multiple notes, nor will it do anything while having a range selection. 

**Posited feature:** allow a range selection to convert to a list selection, where [up] takes the list selection to the top of that chord and [down] takes to the bottom note. It will work on multiple chords at once in the range. 

- Let a list-selection do likewise of moving up/down but only within selected chords. That is, when a list-selection is active, "bottom out" or "top out" on the chord that is initially selected as a designed limitation, and not move on to a chord/rest above/below it. 

- Finally, regular single element selection should function exactly the same way as usual.

This will allow for something akin to the "Chord Levels Selector" Plugin but built in through traversal. And, in addition with @XiaoMigros' changes (in already) a list selection will still have a valid selection after deletion or [add interval] - so it kind of takes on a new charm that Mu4.4 and before just didn't have


An example doing inversions on a range of chords:
1) Range selection
2) bottom-chord: selects bottom of voice 1 and 2
3) octave shift and then use bottom-chord some more to reach to bottom and continue
4) then finally delete. 

[demonstration.webm](https://github.com/user-attachments/assets/b1f36f98-f22b-40a4-8621-730ee15453ab)


Nifty. The only thing it doesn't really do that the Chord Level Selector plugin does is the "select all but particular voice", but whatever. 

Update: Had to make use of some other personal changes to get this to work here, which is to allow to "stay" within the beat when using up/down the chord when going beyond the current chord. It's also an enhancement in my opinion, but you can test that ---

The old 3.6.2 way forces into a voice that isn't related to the beat: 

[2 olderUpDown.webm](https://github.com/user-attachments/assets/3eca1245-307b-4175-b38b-7943a53f269e)

With this change the beat takes precedence (the vertical space)

[1newerUpDown.webm](https://github.com/user-attachments/assets/560f99b2-07d9-4f9a-bcf7-7368a4c8ccbe)


And with the ability to keep the list selection after deleting/adding intervals (was backported earlier), you can do something like this:

[enh3.webm](https://github.com/user-attachments/assets/4d26a6c9-4b62-454d-98bd-19c8d0d3d7f4)

Port of https://github.com/Jojo-Schmitz/MuseScore/pull/607 to fix https://github.com/Jojo-Schmitz/MuseScore/issues/606

---

Fix regression from the above and also allow for [prev measure/system] in note-entry even when input state has no ChordRest

Resolves: (https://github.com/Jojo-Schmitz/MuseScore/issues/604 regression and enabling previous measure/previous system when input track doesn't contain a correspondent chordrest

That should do it. Unfortunately that means your "up-port" (is that the word?) would also need to be updated 

Verification: 

1) Traversal through grace notes is verified:

[1.webm](https://github.com/user-attachments/assets/f0dce062-d9dd-45ae-a742-772e52f12678)


2) Reason for issue is verified:

[2.webm](https://github.com/user-attachments/assets/c5b292f0-63a7-4acf-86b2-dcf8e3c8f8a7)


3) Update: allow previous measure and previous system (switches to voice one, but initially wasn't working at all when in that input state of not having any existing chordrest in 3.6.2 etc):

[3.webm](https://github.com/user-attachments/assets/22065f80-5db9-49bd-8289-4ff7ee31d638)

Port of https://github.com/Jojo-Schmitz/MuseScore/pull/666 to fix https://github.com/Jojo-Schmitz/MuseScore/issues/604
