### PR TITLE
Fix corruption on Measure::fillGap

### DIFF
--- a/src/braille/tests/data/testVoices_Example_11.1.1.4_MBC2015_ref.brf
+++ b/src/braille/tests/data/testVoices_Example_11.1.1.4_MBC2015_ref.brf
@@ -5,5 +5,5 @@ composer ,composer
 #a ,piano
 #b ,piano
 
-a >/l<<#c4 .::$<>x.DJIHI .o'+<K 
-  >#l<<#c4 ^J_IHGFG<>u"? ^t'-<K 
+a >/l<<#c4 .::$<>x.DJIHI  .o'+<K 
+  >#l<<#c4 ^J_IHGFG<>vv"? ^t'-<K 

--- a/src/engraving/dom/check.cpp
+++ b/src/engraving/dom/check.cpp
@@ -273,7 +273,7 @@ void Measure::fillGap(const Fraction& pos, const Fraction& len, track_idx_t trac
          track);
 
     // break the gap into shorter durations if necessary
-    std::vector<TDuration> durationList = toRhythmicDurationList(len, true, pos, score()->sigmap()->timesig(tick()).nominal(), this, 0);
+    std::vector<TDuration> durationList = toRhythmicDurationList(len, true, pos, timesig(), this, 0);
 
     Fraction curTick = pos;
     for (TDuration d : durationList) {


### PR DESCRIPTION
Resolves: #24387 

The corruption is related to gap rests but gap rests are not the problem. Rather, the problem is that Measure::fillGap gets called during the reading of the file, when Score::sigmap() hasn't been generated yet, which means it will return a defult time signature of 4/4, as opposed to the actual time signature of 6/8 in the example score. That results in wrong gap rests being generated and therefore corruption.

It seems that using Measure::timesig() instead is more reliable (and simpler too).