### PR TITLE
Hide anchors on EngravingItem::endEdit

### DIFF
--- a/src/engraving/dom/engravingitem.cpp
+++ b/src/engraving/dom/engravingitem.cpp
@@ -2372,6 +2372,7 @@ void EngravingItem::endEditDrag(EditData& ed)
 
 void EngravingItem::endEdit(EditData&)
 {
+    score()->hideAnchors();
 }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Resolves: #24327 

Ensures that the anchor visualization gets hidden when clicking away from an item.
