### PR TITLE
Fix dynamics blocked at barline on drag

### DIFF
--- a/src/engraving/dom/dynamic.cpp
+++ b/src/engraving/dom/dynamic.cpp
@@ -403,6 +403,13 @@ void Dynamic::manageBarlineCollisions()
             break;
         }
     }
+
+    bool isOnTimeTickSegAtBarline = rightBarLineSegment && thisSegment->isTimeTickType()
+                                    && thisSegment->tick() == rightBarLineSegment->tick();
+    if (isOnTimeTickSegAtBarline) {
+        return;
+    }
+
     if (rightBarLineSegment) {
         EngravingItem* e = rightBarLineSegment->elementAt(barLineStaff * VOICES);
         if (e) {

--- a/src/engraving/dom/dynamic.cpp
+++ b/src/engraving/dom/dynamic.cpp
@@ -333,7 +333,7 @@ bool Dynamic::isEditAllowed(EditData& ed) const
 
 void Dynamic::manageBarlineCollisions()
 {
-    if (!_avoidBarLines || score()->nstaves() <= 1 || anchorToEndOfPrevious()) {
+    if (!_avoidBarLines || score()->nstaves() <= 1 || anchorToEndOfPrevious() || !isStyled(Pid::OFFSET)) {
         return;
     }
 
@@ -402,12 +402,6 @@ void Dynamic::manageBarlineCollisions()
             rightBarLineSegment = segment;
             break;
         }
-    }
-
-    bool isOnTimeTickSegAtBarline = rightBarLineSegment && thisSegment->isTimeTickType()
-                                    && thisSegment->tick() == rightBarLineSegment->tick();
-    if (isOnTimeTickSegAtBarline) {
-        return;
     }
 
     if (rightBarLineSegment) {


### PR DESCRIPTION
Resolves: #24349 

This was happening because, while transitioning to the next measure, the dynamic temporarily attaches to a TimeTick segment that coincides with the end-barline, which causes a rebase of the offset and triggers the barline-avoidance logic, effectively preventing the dynamic from moving to the next measure. Solution was to simply check for this case and exclude it from the barline collision checks. 