### PR TITLE
Fix disappearing fret diagram fingering

### DIFF
--- a/src/inspector/view/widgets/fretcanvas.cpp
+++ b/src/inspector/view/widgets/fretcanvas.cpp
@@ -208,6 +208,8 @@ void FretCanvas::draw(QPainter* painter)
             double xOff = -0.5 * width;
             double fingerX = (m_diagram->strings() - i - 1) * stringDist + xOff;
             double fingerY = (m_diagram->frets() * fretDist) + fontHeight + padding;
+            painter->setPen(pen);
+            painter->setFont(font);
             painter->drawText(QPointF(fingerX, fingerY), fingerS);
         }
     }


### PR DESCRIPTION
Resolves: #24367 
This PR makes sure the `painter`'s font and pen was set.  These weren't always being updated after drawing the 'hover' dot, leading to text disappearing or appearing at the wrong size.