### PR TITLE
Fixed qml warning

### DIFF
--- a/src/palette/qml/MuseScore/Palette/internal/AddPalettesPopup.qml
+++ b/src/palette/qml/MuseScore/Palette/internal/AddPalettesPopup.qml
@@ -37,8 +37,8 @@ StyledPopupView {
 
     property int popupAvailableWidth: 0
 
-    contentHeight: contentColumn.childrenRect.height
-    contentWidth: popupAvailableWidth - 2 * margins
+    contentWidth: contentColumn.width
+    contentHeight: contentColumn.height
 
     property NavigationPanel navigationPanel: NavigationPanel {
         name: "AddPalettesPopup"
@@ -55,7 +55,10 @@ StyledPopupView {
 
     Column {
         id: contentColumn
-        width: parent.width
+
+        width: root.popupAvailableWidth - 2 * root.margins
+        height: childrenRect.height
+
         spacing: 12
 
         StyledTextLabel {

--- a/src/palette/qml/MuseScore/Palette/internal/CreateCustomPalettePopup.qml
+++ b/src/palette/qml/MuseScore/Palette/internal/CreateCustomPalettePopup.qml
@@ -29,8 +29,8 @@ StyledPopupView {
 
     property int popupAvailableWidth: 0
 
-    contentHeight: contentColumn.childrenRect.height
-    contentWidth: popupAvailableWidth - 2 * margins
+    contentWidth: contentColumn.width
+    contentHeight: contentColumn.height
 
     property NavigationPanel navigationPanel: NavigationPanel {
         name: "CreateCustomPalettePopup"
@@ -48,7 +48,10 @@ StyledPopupView {
 
     Column {
         id: contentColumn
-        width: parent.width
+
+        width: root.popupAvailableWidth - 2 * root.margins
+        height: childrenRect.height
+
         spacing: 12
 
         StyledTextLabel {


### PR DESCRIPTION
QML QQuickItem: Binding loop detected for property "implicitWidth"

the solution is the same as in #24102, but for these popups only a warning is displayed