### PR TITLE
Fix dragging image

### DIFF
--- a/src/engraving/dom/image.cpp
+++ b/src/engraving/dom/image.cpp
@@ -323,6 +323,13 @@ void Image::startEditDrag(EditData& data)
 
 void Image::editDrag(EditData& ed)
 {
+    if (ed.curGrip == Grip::MIDDLE) {
+        setOffset(offset() + ed.evtDelta);
+        setOffsetChanged(true);
+        renderer()->layoutItem(this);
+        return;
+    }
+
     double ratio = m_size.width() / m_size.height();
     double dx = ed.delta.x();
     double dy = ed.delta.y();
@@ -339,7 +346,7 @@ void Image::editDrag(EditData& ed)
         if (m_lockAspectRatio) {
             m_size.setHeight(m_size.width() / ratio);
         }
-    } else {
+    } else if (ed.curGrip == Grip::END) {
         m_size.setHeight(m_size.height() + dy);
         if (m_lockAspectRatio) {
             m_size.setWidth(m_size.height() * ratio);


### PR DESCRIPTION
Resolves: #24353 

This PR corrects the image's `editDrag` function to behave like other items with 3 grips.  