### PR TITLE
Fix hairpin layout error

### DIFF
--- a/src/engraving/dom/hairpin.cpp
+++ b/src/engraving/dom/hairpin.cpp
@@ -730,7 +730,7 @@ PointF Hairpin::linePos(Grip grip, System** system) const
 
     if (!start) {
         Fraction curTick = segment->tick();
-        Segment* prevSeg = segment->prev1(SegmentType::BarLineType);
+        Segment* prevSeg = segment->prev1(SegmentType::EndBarLine);
         if (prevSeg && prevSeg->tick() == curTick) {
             segment = prevSeg;
         }


### PR DESCRIPTION
Resolves: #24450 

Regression was caused by 607cdf14df99a8918c3c1204d75fab5cdb959a60. Without this change, the hairpin would try to take as reference the begin barline of the next system, rather than the end barline of this.