### PR TITLE
Fixed crash when closing user score

### DIFF
--- a/src/engraving/dom/ambitus.cpp
+++ b/src/engraving/dom/ambitus.cpp
@@ -72,8 +72,13 @@ Ambitus::Ambitus(const Ambitus& a)
     m_direction = a.m_direction;
     m_hasLine = a.m_hasLine;
     m_lineWidth = a.m_lineWidth;
+
     m_topAccidental = a.m_topAccidental->clone();
+    m_topAccidental->setParent(this);
+
     m_bottomAccidental = a.m_bottomAccidental->clone();
+    m_bottomAccidental->setParent(this);
+
     m_topPitch = a.m_topPitch;
     m_topTpc = a.m_topTpc;
     m_bottomPitch = a.m_bottomPitch;


### PR DESCRIPTION
Another case leading to a crash when closing the score 

1. open the score from https://musescore.org/en/node/368111
2. open Tenor part
3. hide and unhide the Tenor instrument in Instrument panel
4. close the score without save
5. crash