### PR TITLE
Add settings for out of range/professional note head colors

### DIFF
--- a/src/engraving/iengravingconfiguration.h
+++ b/src/engraving/iengravingconfiguration.h
@@ -54,11 +54,6 @@ public:
     virtual Color defaultColor() const = 0;
     virtual Color scoreInversionColor() const = 0;
     virtual Color lassoColor() const = 0;
-    virtual Color warningColor() const = 0;
-    virtual Color warningSelectedColor() const = 0;
-    virtual Color criticalColor() const = 0;
-    virtual Color criticalBackgroundColor() const = 0;
-    virtual Color criticalSelectedColor() const = 0;
     virtual Color thumbnailBackgroundColor() const = 0;
     virtual Color noteBackgroundColor() const = 0;
     virtual Color fontPrimaryColor() const = 0;
@@ -80,6 +75,15 @@ public:
 
     virtual Color formattingColor() const = 0;
     virtual muse::async::Channel<Color> formattingColorChanged() const = 0;
+
+    virtual Color warningColor() const = 0;
+    virtual Color warningSelectedColor() const = 0;
+    virtual muse::async::Channel<Color> warningColorChanged() const = 0;
+
+    virtual Color criticalColor() const = 0;
+    virtual Color criticalBackgroundColor() const = 0;
+    virtual Color criticalSelectedColor() const = 0;
+    virtual muse::async::Channel<Color> criticalColorChanged() const = 0;
 
     virtual Color invisibleColor() const = 0;
     virtual muse::async::Channel<Color> invisibleColorChanged() const = 0;

--- a/src/engraving/internal/engravingconfiguration.cpp
+++ b/src/engraving/internal/engravingconfiguration.cpp
@@ -64,6 +64,8 @@ static VoiceColor VOICE_COLORS[VOICES + 1];
 
 static const Color UNLINKED_ITEM_COLOR = "#FF9300";
 
+static const int LIGHTEN_DARKEN_FACTOR = 135;
+
 void EngravingConfiguration::init()
 {
     static const Color DEFAULT_VOICE_COLORS[VOICES + 1] {
@@ -265,7 +267,8 @@ Color EngravingConfiguration::warningColor() const
 
 Color EngravingConfiguration::warningSelectedColor() const
 {
-    return "#565600";
+    const QColor qColor = warningColor().toQColor();
+    return Color::fromQColor(qColor.darker(LIGHTEN_DARKEN_FACTOR));
 }
 
 Color EngravingConfiguration::criticalColor() const
@@ -280,7 +283,8 @@ Color EngravingConfiguration::criticalBackgroundColor() const
 
 Color EngravingConfiguration::criticalSelectedColor() const
 {
-    return "#8B0000";
+    const QColor qColor = criticalColor().toQColor();
+    return Color::fromQColor(qColor.darker(LIGHTEN_DARKEN_FACTOR));
 }
 
 Color EngravingConfiguration::thumbnailBackgroundColor() const
@@ -337,7 +341,8 @@ muse::async::Channel<voice_idx_t, Color> EngravingConfiguration::selectionColorC
 
 Color EngravingConfiguration::highlightSelectionColor(voice_idx_t voice) const
 {
-    return Color::fromQColor(selectionColor(voice).toQColor().lighter(135));
+    const QColor qColor = selectionColor(voice).toQColor();
+    return Color::fromQColor(qColor.lighter(LIGHTEN_DARKEN_FACTOR));
 }
 
 bool EngravingConfiguration::dynamicsApplyToAllVoices() const

--- a/src/engraving/internal/engravingconfiguration.cpp
+++ b/src/engraving/internal/engravingconfiguration.cpp
@@ -49,6 +49,8 @@ static const Settings::Key FRAME_COLOR("engraving", "engraving/colors/frameColor
 static const Settings::Key SCORE_GREY_COLOR("engraving", "engraving/color/scoreGreyColor");
 static const Settings::Key INVISIBLE_COLOR("engraving", "engraving/colors/invisibleColor");
 static const Settings::Key UNLINKED_COLOR("engraving", "engraving/colors/unlinkedColor");
+static const Settings::Key WARNING_COLOR("engraving", "engraving/colors/warningColor");
+static const Settings::Key CRITICAL_COLOR("engraving", "engraving/colors/criticalColor");
 
 static const Settings::Key DYNAMICS_APPLY_TO_ALL_VOICES("engraving", "score/dynamicsApplyToAllVoices");
 static const Settings::Key FRETBOARD_DIAGRAMS_AUTO_UPDATE("engraving", "score/fretboardDiagramsAutoUpdate");
@@ -140,6 +142,20 @@ void EngravingConfiguration::init()
     settings()->setCanBeManuallyEdited(FORMATTING_COLOR, true);
     settings()->valueChanged(FORMATTING_COLOR).onReceive(nullptr, [this](const Val& val) {
         m_formattingColorChanged.send(Color::fromQColor(val.toQColor()));
+    });
+
+    settings()->setDefaultValue(WARNING_COLOR, Val(Color("#808000").toQColor()));
+    settings()->setDescription(WARNING_COLOR, muse::trc("engraving", "Out of range color (amateur)"));
+    settings()->setCanBeManuallyEdited(WARNING_COLOR, true);
+    settings()->valueChanged(WARNING_COLOR).onReceive(nullptr, [this](const Val& val) {
+        m_warningColorChanged.send(Color::fromQColor(val.toQColor()));
+    });
+
+    settings()->setDefaultValue(CRITICAL_COLOR, Val(Color("#FF0000").toQColor()));
+    settings()->setDescription(CRITICAL_COLOR, muse::trc("engraving", "Out of range color (professional)"));
+    settings()->setCanBeManuallyEdited(CRITICAL_COLOR, true);
+    settings()->valueChanged(CRITICAL_COLOR).onReceive(nullptr, [this](const Val& val) {
+        m_criticalColorChanged.send(Color::fromQColor(val.toQColor()));
     });
 
     settings()->setDefaultValue(INVISIBLE_COLOR, Val(Color("#808080").toQColor()));
@@ -260,33 +276,6 @@ Color EngravingConfiguration::lassoColor() const
     return "#00323200";
 }
 
-Color EngravingConfiguration::warningColor() const
-{
-    return "#808000";
-}
-
-Color EngravingConfiguration::warningSelectedColor() const
-{
-    const QColor qColor = warningColor().toQColor();
-    return Color::fromQColor(qColor.darker(LIGHTEN_DARKEN_FACTOR));
-}
-
-Color EngravingConfiguration::criticalColor() const
-{
-    return Color::RED;
-}
-
-Color EngravingConfiguration::criticalBackgroundColor() const
-{
-    return Color::RED;
-}
-
-Color EngravingConfiguration::criticalSelectedColor() const
-{
-    const QColor qColor = criticalColor().toQColor();
-    return Color::fromQColor(qColor.darker(LIGHTEN_DARKEN_FACTOR));
-}
-
 Color EngravingConfiguration::thumbnailBackgroundColor() const
 {
     return Color::WHITE;
@@ -383,6 +372,43 @@ Color EngravingConfiguration::formattingColor() const
 muse::async::Channel<Color> EngravingConfiguration::formattingColorChanged() const
 {
     return m_formattingColorChanged;
+}
+
+Color EngravingConfiguration::warningColor() const
+{
+    return Color::fromQColor(settings()->value(WARNING_COLOR).toQColor());
+}
+
+muse::async::Channel<Color> EngravingConfiguration::warningColorChanged() const
+{
+    return m_warningColorChanged;
+}
+
+Color EngravingConfiguration::warningSelectedColor() const
+{
+    const QColor qColor = settings()->value(WARNING_COLOR).toQColor();
+    return Color::fromQColor(qColor.darker(LIGHTEN_DARKEN_FACTOR));
+}
+
+Color EngravingConfiguration::criticalColor() const
+{
+    return Color::fromQColor(settings()->value(CRITICAL_COLOR).toQColor());
+}
+
+muse::async::Channel<Color> EngravingConfiguration::criticalColorChanged() const
+{
+    return m_criticalColorChanged;
+}
+
+Color EngravingConfiguration::criticalBackgroundColor() const
+{
+    return Color::RED;
+}
+
+Color EngravingConfiguration::criticalSelectedColor() const
+{
+    const QColor qColor = settings()->value(CRITICAL_COLOR).toQColor();
+    return Color::fromQColor(qColor.darker(LIGHTEN_DARKEN_FACTOR));
 }
 
 Color EngravingConfiguration::frameColor() const

--- a/src/engraving/internal/engravingconfiguration.h
+++ b/src/engraving/internal/engravingconfiguration.h
@@ -63,11 +63,6 @@ public:
     Color defaultColor() const override;
     Color scoreInversionColor() const override;
     Color lassoColor() const override;
-    Color warningColor() const override;
-    Color warningSelectedColor() const override;
-    Color criticalColor() const override;
-    Color criticalBackgroundColor() const override;
-    Color criticalSelectedColor() const override;
     Color thumbnailBackgroundColor() const override;
     Color noteBackgroundColor() const override;
     Color fontPrimaryColor() const override;
@@ -91,6 +86,15 @@ public:
 
     Color formattingColor() const override;
     muse::async::Channel<Color> formattingColorChanged() const override;
+
+    Color warningColor() const override;
+    Color warningSelectedColor() const override;
+    muse::async::Channel<Color> warningColorChanged() const override;
+
+    Color criticalColor() const override;
+    Color criticalBackgroundColor() const override;
+    Color criticalSelectedColor() const override;
+    muse::async::Channel<Color> criticalColorChanged() const override;
 
     Color frameColor() const override;
     muse::async::Channel<Color> frameColorChanged() const override;
@@ -128,6 +132,8 @@ private:
     muse::async::Channel<bool> m_dynamicsApplyToAllVoicesChanged;
     muse::async::Channel<bool> m_fretboardDiagramsAutoUpdateChanged;
     muse::async::Channel<Color> m_formattingColorChanged;
+    muse::async::Channel<Color> m_warningColorChanged;
+    muse::async::Channel<Color> m_criticalColorChanged;
     muse::async::Channel<Color> m_frameColorChanged;
     muse::async::Channel<Color> m_invisibleColorChanged;
     muse::async::Channel<Color> m_unlinkedColorChanged;

--- a/src/engraving/tests/mocks/engravingconfigurationmock.h
+++ b/src/engraving/tests/mocks/engravingconfigurationmock.h
@@ -48,11 +48,6 @@ public:
     MOCK_METHOD(Color, defaultColor, (), (const, override));
     MOCK_METHOD(Color, scoreInversionColor, (), (const, override));
     MOCK_METHOD(Color, lassoColor, (), (const, override));
-    MOCK_METHOD(Color, warningColor, (), (const, override));
-    MOCK_METHOD(Color, warningSelectedColor, (), (const, override));
-    MOCK_METHOD(Color, criticalColor, (), (const, override));
-    MOCK_METHOD(Color, criticalBackgroundColor, (), (const, override));
-    MOCK_METHOD(Color, criticalSelectedColor, (), (const, override));
     MOCK_METHOD(Color, thumbnailBackgroundColor, (), (const, override));
     MOCK_METHOD(Color, noteBackgroundColor, (), (const, override));
     MOCK_METHOD(Color, fontPrimaryColor, (), (const, override));
@@ -74,6 +69,15 @@ public:
 
     MOCK_METHOD(Color, formattingColor, (), (const, override));
     MOCK_METHOD(muse::async::Channel<Color>, formattingColorChanged, (), (const, override));
+
+    MOCK_METHOD(Color, warningColor, (), (const, override));
+    MOCK_METHOD(Color, warningSelectedColor, (), (const, override));
+    MOCK_METHOD(muse::async::Channel<Color>, warningColorChanged, (), (const, override));
+
+    MOCK_METHOD(Color, criticalColor, (), (const, override));
+    MOCK_METHOD(Color, criticalBackgroundColor, (), (const, override));
+    MOCK_METHOD(Color, criticalSelectedColor, (), (const, override));
+    MOCK_METHOD(muse::async::Channel<Color>, criticalColorChanged, (), (const, override));
 
     MOCK_METHOD(Color, frameColor, (), (const, override));
     MOCK_METHOD(muse::async::Channel<Color>, frameColorChanged, (), (const, override));

--- a/src/notationscene/qml/MuseScore/NotationScene/abstractnotationpaintview.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/abstractnotationpaintview.cpp
@@ -762,6 +762,14 @@ void AbstractNotationPaintView::onNotationSetup()
         scheduleRedraw();
     });
 
+    engravingConfiguration()->warningColorChanged().onReceive(this, [this](const Color&) {
+        scheduleRedraw();
+    });
+
+    engravingConfiguration()->criticalColorChanged().onReceive(this, [this](const Color&) {
+        scheduleRedraw();
+    });
+
     engravingConfiguration()->invisibleColorChanged().onReceive(this, [this](const Color&) {
         scheduleRedraw();
     });


### PR DESCRIPTION
Resolves: #24323

Adds a way to change the notehead color for out of range notes (amateur and professional).

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
