### PR TITLE
undoChangeElement fixes

### DIFF
--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -4412,7 +4412,16 @@ void Score::cmdTimeDelete()
     }
 
     if (!isMaster() && masterScore()) {
-        masterScore()->doTimeDelete(startSegment, endSegment);
+        Measure* masterStartMeas = masterScore()->tick2measure(startSegment->tick());
+        Measure* masterEndMeas = masterScore()->tick2measure(endSegment->tick());
+        if (endSegment->isEndBarLineType()) {
+            Measure* prevEndMeasure = masterEndMeas->prevMeasure();
+            masterEndMeas = prevEndMeasure ? prevEndMeasure : masterEndMeas;
+        }
+        Segment* masterStartSeg
+            = masterStartMeas ? masterStartMeas->findSegment(startSegment->segmentType(), startSegment->tick()) : startSegment;
+        Segment* masterEndSeg = masterEndMeas ? masterEndMeas->findSegment(endSegment->segmentType(), endSegment->tick()) : endSegment;
+        masterScore()->doTimeDelete(masterStartSeg, masterEndSeg);
     } else {
         doTimeDelete(startSegment, endSegment);
     }

--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -5074,8 +5074,6 @@ void Score::undoChangeElement(EngravingItem* oldElement, EngravingItem* newEleme
 {
     if (!oldElement) {
         undoAddElement(newElement);
-    } else if (oldElement->isSpanner()) {
-        undo(new ChangeElement(oldElement, newElement));
     } else {
         const std::list<EngravingObject*> links = oldElement->linkList();
         for (EngravingObject* obj : links) {
@@ -5084,7 +5082,8 @@ void Score::undoChangeElement(EngravingItem* oldElement, EngravingItem* newEleme
                 undo(new ChangeElement(oldElement, newElement));
             } else {
                 if (item->score()) {
-                    item->score()->undo(new ChangeElement(item, newElement->linkedClone()));
+                    EngravingItem* newClone = newElement->clone();
+                    item->score()->undo(new ChangeElement(item, newClone));
                 }
             }
         }

--- a/src/engraving/dom/spanner.cpp
+++ b/src/engraving/dom/spanner.cpp
@@ -780,6 +780,8 @@ void Spanner::doComputeStartElement()
         break;
 
     case Anchor::CHORD:
+        m_startElement = startCR();
+        break;
     case Anchor::NOTE:
         break;
     }
@@ -837,7 +839,9 @@ void Spanner::doComputeEndElement()
         break;
 
     case Anchor::NOTE:
+        break;
     case Anchor::CHORD:
+        m_endElement = endCR();
         break;
     }
 }

--- a/src/engraving/dom/undo.cpp
+++ b/src/engraving/dom/undo.cpp
@@ -1504,6 +1504,11 @@ void ChangeElement::flip(EditData*)
         oldElement->unlink();
     }
 
+    newElement->setTrack(oldElement->track());
+    if (newElement->isSpanner()) {
+        toSpanner(newElement)->setTrack2(toSpanner(oldElement)->track2());
+    }
+
     Score* score = oldElement->score();
     if (!score->selection().isRange()) {
         if (oldElement->selected()) {
@@ -1515,6 +1520,7 @@ void ChangeElement::flip(EditData*)
     }
 
     if (oldElement->explicitParent() == 0) {
+        newElement->setScore(score);
         score->removeElement(oldElement);
         score->addElement(newElement);
     } else {

--- a/src/importexport/guitarpro/internal/importgtp-gp4.cpp
+++ b/src/importexport/guitarpro/internal/importgtp-gp4.cpp
@@ -1040,6 +1040,7 @@ bool GuitarPro4::read(IODevice* io)
                         slur->setTrack2(track);
                         slur->setTick(cr->tick());
                         slur->setTick2(cr->tick());
+                        slur->setStartElement(cr);
                         slurs[staffIdx] = slur;
                         score->addElement(slur);
                     } else if (slurs[staffIdx] && !hasSlur) {
@@ -1048,6 +1049,7 @@ bool GuitarPro4::read(IODevice* io)
                         slurs[staffIdx] = 0;
                         s->setTick2(cr->tick());
                         s->setTrack2(cr->track());
+                        s->setEndElement(cr);
                         if (cr->isChord()) {
                             lastSlurAdd = true;
                             slurSwap = false;

--- a/src/importexport/musedata/internal/musedata.h
+++ b/src/importexport/musedata/internal/musedata.h
@@ -26,6 +26,7 @@
 #include "engraving/types/fraction.h"
 
 namespace mu::engraving {
+class EngravingItem;
 class Staff;
 class Part;
 class Score;
@@ -60,8 +61,8 @@ class MuseData
     void readBackup(QStringView s);
     engraving::Measure* createMeasure();
     int countStaves(const QStringList& sl);
-    void openSlur(int idx, const engraving::Fraction& tick, engraving::Staff* staff, int voice);
-    void closeSlur(int idx, const engraving::Fraction& tick, engraving::Staff* staff, int voice);
+    void openSlur(int idx, const engraving::Fraction& tick, engraving::Staff* staff, int voice, mu::engraving::EngravingItem* startChord);
+    void closeSlur(int idx, const engraving::Fraction& tick, engraving::Staff* staff, int voice, engraving::EngravingItem* endChord);
     QString diacritical(QStringView);
 
 public:


### PR DESCRIPTION
Resolves: #23862 
This PR fixes the above issue and removes a [hack](https://github.com/musescore/MuseScore/pull/21101) in the `undoChangeElement`.  The correct solution for the slurs exception is to set `track` and `track2` properly.  

While checking for unwanted side effects, I noticed that while `cmdTimeDelete` always calls `doTimeDelete` on the master score, the segments it passes in could be from a part.  This leads to the following situation (the slur should be shortened, not deleted):

https://github.com/user-attachments/assets/39f4730e-43c1-44f3-a11d-55ae844fea30

Then finally - another score/part inconsistency.  When cloning a spanner in `undoChangeElement`, the end anchors need to be recalculated.  This now happens in `doComputeStart/endElement`.  Without this, a cloned spanner ends up being attached to a chord in a different open part and deleted twice leading to a crash on closing the score.