### PR TITLE
Fix #24026: Ensure correct key signature accidentals after clef change

### DIFF
--- a/src/engraving/rendering/score/tlayout.cpp
+++ b/src/engraving/rendering/score/tlayout.cpp
@@ -3656,7 +3656,7 @@ void TLayout::layoutKeySig(const KeySig* item, KeySig::LayoutData* ldata, const 
         Clef* c = nullptr;
         if (item->segment()) {
             for (Segment* seg = item->segment()->prev1(); !c && seg && seg->tick() == item->tick(); seg = seg->prev1()) {
-                if (seg->isClefType() || seg->isHeaderClefType()) {
+                if (seg->enabled() && (seg->isClefType() || seg->isHeaderClefType())) {
                     c = toClef(seg->element(item->track()));
                 }
             }


### PR DESCRIPTION
Resolves: [#24026](https://github.com/musescore/MuseScore/issues/24026)

Reproduction steps:
- Create a score with a single instrument (single-staff, non-transposing, G-clef), use default settings for everything.
- Note the bar number of the first bar of the second system (using the default style and layout this is bar 12, I will use this as the target bar for remaining steps).
- Add notes to the first system until this bar moves to the right, i.e. until the second system starts with bar 11 or earlier.
- Select bar 12 and add a key signature change, e.g. to G Major.
- Add a clef change to any earlier bar, e.g. to F-clef.

**Expected**: The key signature accidental(s) at bar 12 change to reflect the new clef; in this case, the single sharp moves from the first line (F in G-clef) to the second line (F in F-clef).

**Actual**: The key signature accidental(s) at bar 12 remain unchanged.

**Analysis**: When a bar is first in a system, it receives a system header, which includes a header clef segment; see `addSystemHeader()` in `measurelayout.cpp`. If it later moves so that it is no longer first in the system, these header segments are disabled, see `removeSystemHeader()` in same. Note that these header segments are only disabled, not removed (as the name of the function suggests). Also note that these disabled header segments are not updated on e.g. a preceding clef change.

In `layoutKeySig()` in `tlayout.cpp`, we check if there is a preceding clef or header clef segment at the same tick as the key signature segment; if so, we use it as the target clef. However, we do not check if the segment is enabled. This means that the disabled header clef segments in bars that used to be at the start of a system are still considered valid. In this case, the bar with the key signature change also contains a disabled header clef segment for the original G-clef, and as such the key signature is printed as if it were in G-clef.

The fix is to skip disabled (header) clef segments in `layoutKeySig()`.

Notes:
- This is my first PR for MuseScore, let me know if I missed anything.
- I'm not sure if this warrants a vtest since it's somewhat of a corner case.
- Out of curiosity, why are header segments merely disabled instead of actually removed?

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
