### PR TITLE
#12753: Speed up palette search, open and close (part 2)

### DIFF
--- a/src/palette/internal/paletteprovider.cpp
+++ b/src/palette/internal/paletteprovider.cpp
@@ -618,17 +618,16 @@ void PaletteProvider::init()
 
 void PaletteProvider::setFilter(const QString& filter)
 {
-    // Remove the model when there is no search text to return no results
-    // and thus speed up the opening of the palette search text box.
-    // Restore the model as soon as the search text is non-empty.
+    // Unbind the model when there is no search text so as to return no results
+    // and thus speed up the opening of the palette search. Rebind the model
+    // as soon as the search text is non-empty.
+    // Doing this *trick* also when the search text is non-empty helps
+    // speed up the search in certain other scenarios,
+    // e.g. when deleting search characters (going from fewer to more search results).
+    m_searchFilterModel->setSourceModel(nullptr);
+    m_searchFilterModel->setFilterFixedString(filter);
     if (!filter.isEmpty()) {
-        m_searchFilterModel->setFilterFixedString(filter);
-        if (!m_searchFilterModel->sourceModel()) {
-            m_searchFilterModel->setSourceModel(m_masterPaletteModel);
-        }
-    } else {
-        m_searchFilterModel->setSourceModel(nullptr);
-        m_searchFilterModel->setFilterFixedString(QString());
+        m_searchFilterModel->setSourceModel(m_masterPaletteModel);
     }
 }
 

--- a/src/palette/qml/MuseScore/Palette/internal/PaletteGridView.qml
+++ b/src/palette/qml/MuseScore/Palette/internal/PaletteGridView.qml
@@ -463,6 +463,33 @@ StyledGridView {
         visible: false
     }
 
+    StyledMenuLoader {
+        id: contextMenu
+
+        property var modelIndex: null
+        property bool canEdit: true
+
+        property var items: [
+            { id: "delete", title: qsTrc("palette", "Delete"), icon: IconCode.DELETE_TANK, enabled: contextMenu.canEdit },
+            { id: "properties", title: qsTrc("palette", "Properties…"), enabled: contextMenu.canEdit }
+        ]
+
+        onHandleMenuItem: function(itemId) {
+            switch(itemId) {
+            case "delete":
+                paletteView.paletteController.remove(contextMenu.modelIndex)
+                break
+            case "properties":
+                Qt.callLater(paletteView.paletteController.editCellProperties, contextMenu.modelIndex)
+                break
+            }
+        }
+
+        onClosed: function(force) {
+            contextMenu.parent = paletteView
+        }
+    }
+
     model: DelegateModel {
         id: paletteCellDelegateModel
         //         model: paletteView.visible ? paletteView.paletteModel : null // TODO: use this optimization? TODO: apply it manually where appropriate (Custom palette breaks)
@@ -605,30 +632,8 @@ StyledGridView {
             function showCellMenu() {
                 contextMenu.modelIndex = modelIndex
                 contextMenu.canEdit = paletteView.paletteController.canEdit(paletteView.paletteRootIndex)
+                contextMenu.parent = paletteCell
                 contextMenu.toggleOpened(contextMenu.items, mouseArea.mouseX, mouseArea.mouseY)
-            }
-
-            StyledMenuLoader {
-                id: contextMenu
-
-                property var modelIndex: null
-                property bool canEdit: true
-
-                property var items: [
-                    { id: "delete", title: qsTrc("palette", "Delete"), icon: IconCode.DELETE_TANK, enabled: contextMenu.canEdit },
-                    { id: "properties", title: qsTrc("palette", "Properties…"), enabled: contextMenu.canEdit }
-                ]
-
-                onHandleMenuItem: function(itemId) {
-                    switch(itemId) {
-                    case "delete":
-                        paletteView.paletteController.remove(contextMenu.modelIndex)
-                        break
-                    case "properties":
-                        Qt.callLater(paletteView.paletteController.editCellProperties, contextMenu.modelIndex)
-                        break
-                    }
-                }
             }
 
             /* TODO?

--- a/src/palette/qml/MuseScore/Palette/internal/PaletteGridView.qml
+++ b/src/palette/qml/MuseScore/Palette/internal/PaletteGridView.qml
@@ -490,6 +490,21 @@ StyledGridView {
         }
     }
 
+    MouseArea {
+        id: rightClickArea
+        anchors.fill: parent
+        acceptedButtons: Qt.RightButton
+        onClicked: function(mouseEvent) {
+            var paletteCell = paletteView.itemAt(mouseEvent.x, mouseEvent.y)
+            if (Boolean(paletteCell)) {
+                contextMenu.modelIndex = paletteCell.modelIndex
+                contextMenu.canEdit = paletteView.paletteController.canEdit(paletteView.paletteRootIndex)
+                contextMenu.parent = paletteCell
+                contextMenu.toggleOpened(contextMenu.items, mouseEvent.x, mouseEvent.y)
+            }
+        }
+    }
+
     model: DelegateModel {
         id: paletteCellDelegateModel
         //         model: paletteView.visible ? paletteView.paletteModel : null // TODO: use this optimization? TODO: apply it manually where appropriate (Custom palette breaks)
@@ -568,13 +583,6 @@ StyledGridView {
                 removeSelectedCells()
             }
 
-            MouseArea {
-                id: rightClickArea
-                anchors.fill: parent
-                acceptedButtons: Qt.RightButton
-                onClicked: showCellMenu(true)
-            }
-
             Drag.active: mouseArea.drag.active
             Drag.dragType: Drag.Automatic
             Drag.supportedActions: Qt.CopyAction | (model.editable ? Qt.MoveAction : 0)
@@ -627,13 +635,6 @@ StyledGridView {
                     Drag.hotSpot.y = paletteCell.mouseArea.mouseY
                     dragDropReorderTimer.restart();
                 })
-            }
-
-            function showCellMenu() {
-                contextMenu.modelIndex = modelIndex
-                contextMenu.canEdit = paletteView.paletteController.canEdit(paletteView.paletteRootIndex)
-                contextMenu.parent = paletteCell
-                contextMenu.toggleOpened(contextMenu.items, mouseArea.mouseX, mouseArea.mouseY)
             }
 
             /* TODO?

--- a/src/palette/qml/MuseScore/Palette/internal/PaletteTree.qml
+++ b/src/palette/qml/MuseScore/Palette/internal/PaletteTree.qml
@@ -82,9 +82,11 @@ StyledListView {
             expandedPopupIndex = null
         }
 
-        if (paletteModel) {
-            paletteTree.paletteProvider.setFilter(filter)
-            paletteTree.positionViewAtBeginning() // Scroll to top after a search
+        if (paletteProvider) {
+            paletteProvider.setFilter(filter)
+            if (paletteTree) {
+                paletteTree.positionViewAtBeginning()   // Scroll to the top after a search
+            }
         }
     }
 

--- a/src/palette/qml/MuseScore/Palette/internal/PaletteTree.qml
+++ b/src/palette/qml/MuseScore/Palette/internal/PaletteTree.qml
@@ -84,9 +84,7 @@ StyledListView {
 
         if (paletteProvider) {
             paletteProvider.setFilter(filter)
-            if (paletteTree) {
-                paletteTree.positionViewAtBeginning()   // Scroll to the top after a search
-            }
+            paletteTree.positionViewAtBeginning()   // Scroll to the top after a search
         }
     }
 

--- a/src/palette/qml/MuseScore/Palette/internal/PaletteTree.qml
+++ b/src/palette/qml/MuseScore/Palette/internal/PaletteTree.qml
@@ -272,6 +272,104 @@ StyledListView {
         }
     }
 
+    Loader {
+        id: palettePopup
+        active: false
+
+        property var control: null
+        property var model: null
+        property alias isOpened: palettePopup.active
+
+        sourceComponent: MoreElementsPopup {
+            id: moreElementsPopup
+
+            property var control: palettePopup.control
+            property var model: palettePopup.model
+
+            maxHeight: Math.min(0.75 * paletteTree.height, 500)
+
+            // TODO: change settings to "hidden" model?
+            cellSize: control.cellSize
+            drawGrid: control.drawGrid
+
+            paletteName: model.display
+            paletteIsCustom: model.custom
+            paletteEditingEnabled: model.editable
+
+            onIsOpenedChanged: {
+                // build pool model on first popup appearance
+                if (visible && !poolPalette) {
+                    poolPalette = paletteTree.paletteProvider.poolPaletteModel(control.modelIndex);
+                    poolPaletteRootIndex = paletteTree.paletteProvider.poolPaletteIndex(control.modelIndex, poolPalette);
+                    poolPaletteController = paletteTree.paletteProvider.poolPaletteController(poolPalette, control.modelIndex);
+
+                    customPalette = paletteTree.paletteProvider.customElementsPaletteModel
+                    customPaletteRootIndex = paletteTree.paletteProvider.customElementsPaletteIndex(control.modelIndex) // TODO: make a property binding? (but that works incorrectly)
+                    customPaletteController = paletteTree.paletteProvider.customElementsPaletteController
+                }
+            }
+
+            property bool needScrollToBottom: false
+
+            onOpened: {
+                scrollToPopupBottom();
+                needScrollToBottom = false;
+                enablePaletteAnimations = true;
+            }
+
+            onClosed: {
+                enablePaletteAnimations = false;
+                palettePopup.active = false;
+            }
+
+            function scrollToPopupBottom() {
+                //! FIXME Not worked as should
+//                        const popupBottom = implicitHeight + y + control.y + 14; // 14 for DropShadow in StyledPopup: depends on blur radius and vertical offset
+//                        paletteTree.ensureYVisible(popupBottom);
+            }
+
+            onContentHeightChanged: {
+                if (visible && (needScrollToBottom || atYEnd))
+                    scrollToPopupBottom();
+            }
+
+            onAddElementsRequested: function(mimeDataList) {
+                const parentIndex = control.modelIndex;
+                var idx = paletteTree.paletteModel.rowCount(parentIndex);
+
+                for (var i = 0; i < mimeDataList.length; i++) {
+                    const mimeData = mimeDataList[i];
+
+                    if (paletteTree.paletteController.insert(parentIndex, idx, mimeData, Qt.MoveAction)) {
+                        idx++;
+                    }
+                }
+            }
+        }
+
+        function close() {
+            if (palettePopup.active) {
+                palettePopup.item.close();
+            }
+        }
+
+        function toggleOpened(model, control, parent) {
+            if (palettePopup.active) {
+                palettePopup.close();
+                return;
+            }
+
+            palettePopup.parent = parent;
+            palettePopup.model = model;
+            palettePopup.control = control;
+
+            palettePopup.active = true;
+            palettePopup.item.setParentItem(parent);
+
+            palettePopup.item.toggleOpened();
+        }
+    }
+
     model: DelegateModel {
         id: paletteTreeDelegateModel
         model: paletteTree.paletteModel
@@ -397,10 +495,7 @@ StyledListView {
             function togglePopup(btn) {
                 const expand = !popupExpanded;
                 paletteTree.expandedPopupIndex = expand ? modelIndex : null;
-                if (btn) {
-                    palettePopup.parent = btn
-                }
-                palettePopup.toggleOpened()
+                palettePopup.toggleOpened(model, control, btn)
             }
 
             property size cellSize: model.gridSize
@@ -620,70 +715,6 @@ StyledListView {
 
                         enableAnimations: paletteTree.enableAnimations
                         externalDropBlocked: paletteTree.expandedPopupIndex && !control.popupExpanded // FIXME: find another way to prevent drops go under a popup
-                    }
-                }
-
-                MoreElementsPopup {
-                    id: palettePopup
-
-                    maxHeight: Math.min(0.75 * paletteTree.height, 500)
-
-                    // TODO: change settings to "hidden" model?
-                    cellSize: control.cellSize
-                    drawGrid: control.drawGrid
-
-                    paletteName: model.display
-                    paletteIsCustom: model.custom
-                    paletteEditingEnabled: model.editable
-
-                    onIsOpenedChanged: {
-                        // build pool model on first popup appearance
-                        if (visible && !poolPalette) {
-                            poolPalette = paletteTree.paletteProvider.poolPaletteModel(control.modelIndex);
-                            poolPaletteRootIndex = paletteTree.paletteProvider.poolPaletteIndex(control.modelIndex, poolPalette);
-                            poolPaletteController = paletteTree.paletteProvider.poolPaletteController(poolPalette, control.modelIndex);
-
-                            customPalette = paletteTree.paletteProvider.customElementsPaletteModel
-                            customPaletteRootIndex = paletteTree.paletteProvider.customElementsPaletteIndex(control.modelIndex) // TODO: make a property binding? (but that works incorrectly)
-                            customPaletteController = paletteTree.paletteProvider.customElementsPaletteController
-                        }
-                        if (!isOpened) {
-                            paletteTree.expandedPopupIndex = null
-                        }
-                    }
-
-                    property bool needScrollToBottom: false
-
-                    onOpened: {
-                        scrollToPopupBottom();
-                        needScrollToBottom = false;
-                        enablePaletteAnimations = true;
-                    }
-
-                    onClosed: enablePaletteAnimations = false
-
-                    function scrollToPopupBottom() {
-                        //! FIXME Not worked as should
-//                        const popupBottom = implicitHeight + y + control.y + 14; // 14 for DropShadow in StyledPopup: depends on blur radius and vertical offset
-//                        paletteTree.ensureYVisible(popupBottom);
-                    }
-
-                    onContentHeightChanged: {
-                        if (visible && (needScrollToBottom || atYEnd))
-                            scrollToPopupBottom();
-                    }
-
-                    onAddElementsRequested: function(mimeDataList) {
-                        const parentIndex = control.modelIndex;
-                        var idx = paletteTree.paletteModel.rowCount(parentIndex);
-
-                        for (var i = 0; i < mimeDataList.length; i++) {
-                            const mimeData = mimeDataList[i];
-
-                            if (paletteTree.paletteController.insert(parentIndex, idx, mimeData, Qt.MoveAction)) {
-                                idx++;
-                            }
-                        }
                     }
                 }
             }


### PR DESCRIPTION
Resolves: #12753

The individual commit messages should be self-explanatory. The single instance Loader (More Elements popup) commit seems to have the greatest impact on speeding things up.

QA: This PR needs very thorough testing of palette actions to ensure nothing has been broken.

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)