### PR TITLE
[techdebt] Clean up UndoRedoModel

### DIFF
--- a/src/notation/view/internal/undoredomodel.cpp
+++ b/src/notation/view/internal/undoredomodel.cpp
@@ -25,53 +25,69 @@
 #include "uicomponents/view/menuitem.h"
 
 using namespace mu::notation;
+using namespace muse;
 using namespace muse::uicomponents;
 
 UndoRedoModel::UndoRedoModel(QObject* parent)
-    : QObject(parent), muse::Injectable(muse::iocCtxForQmlObject(this))
+    : QObject(parent), Injectable(iocCtxForQmlObject(this))
 {
-}
-
-QVariant UndoRedoModel::makeUndoItem()
-{
-    MenuItem* item = new MenuItem(actionsRegister()->action("undo"), this);
-
-    muse::ui::UiActionState state;
-    state.enabled = undoStack() ? undoStack()->canUndo() : false;
-    item->setState(state);
-
-    return QVariant::fromValue(item);
-}
-
-QVariant UndoRedoModel::makeRedoItem()
-{
-    MenuItem* item = new MenuItem(actionsRegister()->action("redo"), this);
-
-    muse::ui::UiActionState state;
-    state.enabled = undoStack() ? undoStack()->canRedo() : false;
-    item->setState(state);
-
-    return QVariant::fromValue(item);
 }
 
 void UndoRedoModel::load()
 {
     context()->currentNotationChanged().onNotify(this, [this]() {
-        if (!undoStack()) {
-            emit stackChanged();
-            return;
+        updateItems();
+
+        auto stack = undoStack();
+        if (stack) {
+            stack->stackChanged().onNotify(this, [this]() {
+                updateItems();
+            });
         }
+    });
 
-        undoStack()->stackChanged().onNotify(this, [this]() {
-            emit stackChanged();
+    auto stack = undoStack();
+    if (stack) {
+        stack->stackChanged().onNotify(this, [this]() {
+            updateItems();
         });
-    });
+    }
 
-    context()->currentProjectChanged().onNotify(this, [this]() {
-        emit stackChanged();
-    });
+    m_undoItem = new MenuItem(actionsRegister()->action("undo"), this);
+    m_redoItem = new MenuItem(actionsRegister()->action("redo"), this);
 
-    emit stackChanged();
+    updateItems();
+
+    // Only to let QML know that `m_undoItem` and `m_redoItem` have been initialised;
+    // changes to their properties will be communicated via those MenuItems' own signals.
+    emit itemsChanged();
+}
+
+MenuItem* UndoRedoModel::undoItem() const
+{
+    return m_undoItem;
+}
+
+MenuItem* UndoRedoModel::redoItem() const
+{
+    return m_redoItem;
+}
+
+void UndoRedoModel::updateItems()
+{
+    auto stack = undoStack();
+
+    if (m_undoItem) {
+        ui::UiActionState state;
+        state.enabled = stack ? stack->canUndo() : false;
+        m_undoItem->setState(state);
+    }
+
+    if (m_redoItem) {
+        ui::UiActionState state;
+        state.enabled = stack ? stack->canRedo() : false;
+        m_redoItem->setState(state);
+    }
 }
 
 void UndoRedoModel::redo()

--- a/src/notation/view/internal/undoredomodel.h
+++ b/src/notation/view/internal/undoredomodel.h
@@ -24,18 +24,22 @@
 
 #include <QObject>
 
-#include "context/iglobalcontext.h"
-#include "ui/iuiactionsregister.h"
-#include "modularity/ioc.h"
 #include "async/asyncable.h"
+#include "context/iglobalcontext.h"
+#include "modularity/ioc.h"
+#include "ui/iuiactionsregister.h"
+
+namespace muse::uicomponents {
+class MenuItem;
+}
 
 namespace mu::notation {
 class UndoRedoModel : public QObject, public muse::Injectable, public muse::async::Asyncable
 {
     Q_OBJECT
 
-    Q_PROPERTY(QVariant undoItem READ makeUndoItem NOTIFY stackChanged)
-    Q_PROPERTY(QVariant redoItem READ makeRedoItem NOTIFY stackChanged)
+    Q_PROPERTY(muse::uicomponents::MenuItem * undoItem READ undoItem NOTIFY itemsChanged)
+    Q_PROPERTY(muse::uicomponents::MenuItem * redoItem READ redoItem NOTIFY itemsChanged)
 
     muse::Inject<context::IGlobalContext> context = { this };
     muse::Inject<muse::ui::IUiActionsRegister> actionsRegister = { this };
@@ -43,18 +47,24 @@ class UndoRedoModel : public QObject, public muse::Injectable, public muse::asyn
 public:
     explicit UndoRedoModel(QObject* parent = nullptr);
 
-    QVariant makeUndoItem();
-    QVariant makeRedoItem();
-
     Q_INVOKABLE void load();
+
+    muse::uicomponents::MenuItem* undoItem() const;
+    muse::uicomponents::MenuItem* redoItem() const;
+
     Q_INVOKABLE void undo();
     Q_INVOKABLE void redo();
 
 signals:
-    void stackChanged();
+    void itemsChanged();
 
 private:
     INotationUndoStackPtr undoStack() const;
+
+    void updateItems();
+
+    muse::uicomponents::MenuItem* m_undoItem = nullptr;
+    muse::uicomponents::MenuItem* m_redoItem = nullptr;
 };
 }
 


### PR DESCRIPTION
It turned out that UndoRedoModel creates new MenuItems at every `stackChanged` signal, which means at every action that is done, undone, or redone. This probably stems from the time that `MenuItem` did not exist yet and this class used QVariantMaps. It is bad for memory usage, although on the other hand not catastrophic. Anyway, let's clean it up, it's easy enough. 