### PR TITLE
Fixes for niente dynamic

### DIFF
--- a/src/engraving/dom/hairpin.cpp
+++ b/src/engraving/dom/hairpin.cpp
@@ -490,12 +490,20 @@ Hairpin::Hairpin(Segment* parent)
 
 DynamicType Hairpin::dynamicTypeFrom() const
 {
+    if (m_hairpinType == HairpinType::CRESC_HAIRPIN && hairpinCircledTip()) {
+        return DynamicType::N;
+    }
+
     muse::ByteArray ba = beginText().toAscii();
     return TConv::dynamicType(ba.constChar());
 }
 
 DynamicType Hairpin::dynamicTypeTo() const
 {
+    if (m_hairpinType == HairpinType::DECRESC_HAIRPIN && hairpinCircledTip()) {
+        return DynamicType::N;
+    }
+
     muse::ByteArray ba = endText().toAscii();
     return TConv::dynamicType(ba.constChar());
 }

--- a/src/engraving/playback/playbackcontext.cpp
+++ b/src/engraving/playback/playbackcontext.cpp
@@ -426,7 +426,9 @@ void PlaybackContext::handleSpanners(const ID partId, const Score* score, const 
 
         if (hasNominalLevelTo) {
             const dynamic_level_t dynamicLevelAtEndTick = nominalDynamicLevel(trackIdx, spannerTo + tickPositionOffset);
-            if (dynamicLevelAtEndTick != nominalLevelTo) {
+            const bool hasDynamicAtEndTick = dynamicLevelAtEndTick != mpe::dynamicLevelFromType(mpe::DynamicType::Natural);
+
+            if (hasDynamicAtEndTick && dynamicLevelAtEndTick != nominalLevelTo) {
                 // Fix overlap with the following dynamic by subtracting a small fraction
                 spannerTo -= Fraction::eps().ticks();
             }

--- a/src/engraving/playback/utils/expressionutils.h
+++ b/src/engraving/playback/utils/expressionutils.h
@@ -80,6 +80,7 @@ inline muse::mpe::dynamic_level_t dynamicLevelFromType(const DynamicType type,
 inline bool isOrdinaryDynamicType(const DynamicType type)
 {
     static const std::unordered_set<DynamicType> ORDINARY_DYNAMIC_TYPES = {
+        DynamicType::N,
         DynamicType::PPPPPP,
         DynamicType::PPPPP,
         DynamicType::PPPP,

--- a/src/engraving/tests/playback/playbackcontext_data/dynamics/dynamics_niente.mscx
+++ b/src/engraving/tests/playback/playbackcontext_data/dynamics/dynamics_niente.mscx
@@ -1,0 +1,413 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="4.40">
+  <programVersion>4.5.0</programVersion>
+  <programRevision></programRevision>
+  <LastEID>491</LastEID>
+  <Score>
+    <Division>480</Division>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <open>1</open>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="audioComUrl"></metaTag>
+    <metaTag name="composer">Componist / arrangeur</metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="creationDate">2024-09-08</metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="platform">Apple Macintosh</metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="sourceRevisionId"></metaTag>
+    <metaTag name="subtitle">Ondertitel</metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle">Naamloze partituur</metaTag>
+    <Order id="orchestra">
+      <name>Orchestra</name>
+      <instrument id="violin">
+        <family id="orchestral-strings">Orkest strijkers</family>
+        </instrument>
+      <section id="woodwind" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>flutes</family>
+        <family>oboes</family>
+        <family>clarinets</family>
+        <family>saxophones</family>
+        <family>bassoons</family>
+        <unsorted group="woodwinds"/>
+        </section>
+      <section id="brass" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>horns</family>
+        <family>trumpets</family>
+        <family>cornets</family>
+        <family>flugelhorns</family>
+        <family>trombones</family>
+        <family>tubas</family>
+        <unsorted group="brass"/>
+        </section>
+      <section id="timpani" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>timpani</family>
+        </section>
+      <section id="percussion" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>keyboard-percussion</family>
+        <unsorted group="pitched-percussion"/>
+        <family>drums</family>
+        <family>unpitched-metal-percussion</family>
+        <family>unpitched-wooden-percussion</family>
+        <family>other-percussion</family>
+        <unsorted group="unpitched-percussion"/>
+        </section>
+      <family>keyboards</family>
+      <family>harps</family>
+      <family>organs</family>
+      <family>synths</family>
+      <unsorted/>
+      <soloists/>
+      <section id="voices" brackets="true" barLineSpan="false" thinBrackets="true">
+        <family>voices</family>
+        <family>voice-groups</family>
+        </section>
+      <section id="strings" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>orchestral-strings</family>
+        </section>
+      </Order>
+    <Part id="1">
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        </Staff>
+      <trackName>Viool</trackName>
+      <Instrument id="violin">
+        <longName>Viool</longName>
+        <shortName>Vl.</shortName>
+        <trackName>Viool</trackName>
+        <minPitchP>55</minPitchP>
+        <maxPitchP>103</maxPitchP>
+        <minPitchA>55</minPitchA>
+        <maxPitchA>88</maxPitchA>
+        <instrumentId>strings.violin</instrumentId>
+        <Channel name="arco">
+          <program value="40"/>
+          <synti>Fluid</synti>
+          </Channel>
+        <Channel name="pizzicato">
+          <program value="45"/>
+          <synti>Fluid</synti>
+          </Channel>
+        <Channel name="tremolo">
+          <program value="44"/>
+          <synti>Fluid</synti>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <VBox>
+        <height>10</height>
+        <eid>592705486970</eid>
+        <Text>
+          <eid>597000454149</eid>
+          <style>title</style>
+          <text>Naamloze partituur</text>
+          </Text>
+        <Text>
+          <eid>601295421445</eid>
+          <style>subtitle</style>
+          <text>Ondertitel</text>
+          </Text>
+        <Text>
+          <eid>605590388741</eid>
+          <style>composer</style>
+          <text>Componist / arrangeur</text>
+          </Text>
+        </VBox>
+      <Measure>
+        <voice>
+          <KeySig>
+            <eid>47244640279</eid>
+            <concertKey>0</concertKey>
+            </KeySig>
+          <TimeSig>
+            <eid>38654705689</eid>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Dynamic>
+            <subtype>f</subtype>
+            <velocity>96</velocity>
+            <eid>7344394076196</eid>
+            </Dynamic>
+          <Spanner type="HairPin">
+            <HairPin>
+              <subtype>1</subtype>
+              <eid>2589865279582</eid>
+              </HairPin>
+            <next>
+              <location>
+                <measures>1</measures>
+                </location>
+              </next>
+            </Spanner>
+          <Chord>
+            <eid>2456721293427</eid>
+            <durationType>whole</durationType>
+            <Note>
+              <eid>2452426326036</eid>
+              <Spanner type="Tie">
+                <Tie>
+                  <eid>11166914969631</eid>
+                  </Tie>
+                <next>
+                  <location>
+                    <measures>1</measures>
+                    </location>
+                  </next>
+                </Spanner>
+              <pitch>74</pitch>
+              <tpc>16</tpc>
+              </Note>
+            </Chord>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Dynamic>
+            <subtype>n</subtype>
+            <velocity>49</velocity>
+            <eid>2585570312228</eid>
+            </Dynamic>
+          <Spanner type="HairPin">
+            <prev>
+              <location>
+                <measures>-1</measures>
+                </location>
+              </prev>
+            </Spanner>
+          <Chord>
+            <eid>11154030067827</eid>
+            <durationType>whole</durationType>
+            <Note>
+              <eid>11149735100436</eid>
+              <Spanner type="Tie">
+                <prev>
+                  <location>
+                    <measures>-1</measures>
+                    </location>
+                  </prev>
+                </Spanner>
+              <pitch>74</pitch>
+              <tpc>16</tpc>
+              </Note>
+            </Chord>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Dynamic>
+            <subtype>f</subtype>
+            <velocity>96</velocity>
+            <eid>7348689043492</eid>
+            </Dynamic>
+          <Spanner type="HairPin">
+            <HairPin>
+              <subtype>1</subtype>
+              <hairpinCircledTip>1</hairpinCircledTip>
+              <eid>2589865279582</eid>
+              </HairPin>
+            <next>
+              <location>
+                <measures>1</measures>
+                </location>
+              </next>
+            </Spanner>
+          <Chord>
+            <eid>2456721293427</eid>
+            <durationType>whole</durationType>
+            <Note>
+              <eid>2452426326036</eid>
+              <Spanner type="Tie">
+                <Tie>
+                  <eid>11222749544479</eid>
+                  </Tie>
+                <next>
+                  <location>
+                    <measures>1</measures>
+                    </location>
+                  </next>
+                </Spanner>
+              <pitch>74</pitch>
+              <tpc>16</tpc>
+              </Note>
+            </Chord>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Spanner type="HairPin">
+            <prev>
+              <location>
+                <measures>-1</measures>
+                </location>
+              </prev>
+            </Spanner>
+          <Chord>
+            <eid>11209864642675</eid>
+            <durationType>whole</durationType>
+            <Note>
+              <eid>11205569675284</eid>
+              <Spanner type="Tie">
+                <prev>
+                  <location>
+                    <measures>-1</measures>
+                    </location>
+                  </prev>
+                </Spanner>
+              <pitch>74</pitch>
+              <tpc>16</tpc>
+              </Note>
+            </Chord>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Dynamic>
+            <subtype>n</subtype>
+            <velocity>49</velocity>
+            <eid>2100239007780</eid>
+            </Dynamic>
+          <Spanner type="HairPin">
+            <HairPin>
+              <subtype>0</subtype>
+              <eid>1743756722270</eid>
+              </HairPin>
+            <next>
+              <location>
+                <measures>1</measures>
+                </location>
+              </next>
+            </Spanner>
+          <Chord>
+            <eid>1636382539891</eid>
+            <durationType>whole</durationType>
+            <Note>
+              <eid>1632087572500</eid>
+              <Spanner type="Tie">
+                <Tie>
+                  <eid>1653562408991</eid>
+                  </Tie>
+                <next>
+                  <location>
+                    <measures>1</measures>
+                    </location>
+                  </next>
+                </Spanner>
+              <pitch>74</pitch>
+              <tpc>16</tpc>
+              </Note>
+            </Chord>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Dynamic>
+            <subtype>f</subtype>
+            <velocity>96</velocity>
+            <eid>2104533975076</eid>
+            </Dynamic>
+          <Spanner type="HairPin">
+            <prev>
+              <location>
+                <measures>-1</measures>
+                </location>
+              </prev>
+            </Spanner>
+          <Chord>
+            <eid>1662152343667</eid>
+            <durationType>whole</durationType>
+            <Note>
+              <eid>1657857376276</eid>
+              <Spanner type="Tie">
+                <prev>
+                  <location>
+                    <measures>-1</measures>
+                    </location>
+                  </prev>
+                </Spanner>
+              <pitch>74</pitch>
+              <tpc>16</tpc>
+              </Note>
+            </Chord>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Spanner type="HairPin">
+            <HairPin>
+              <subtype>0</subtype>
+              <hairpinCircledTip>1</hairpinCircledTip>
+              <eid>2070174236766</eid>
+              </HairPin>
+            <next>
+              <location>
+                <measures>1</measures>
+                </location>
+              </next>
+            </Spanner>
+          <Chord>
+            <eid>1692217114739</eid>
+            <durationType>whole</durationType>
+            <Note>
+              <eid>1687922147348</eid>
+              <Spanner type="Tie">
+                <Tie>
+                  <eid>1709396983839</eid>
+                  </Tie>
+                <next>
+                  <location>
+                    <measures>1</measures>
+                    </location>
+                  </next>
+                </Spanner>
+              <pitch>74</pitch>
+              <tpc>16</tpc>
+              </Note>
+            </Chord>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Dynamic>
+            <subtype>f</subtype>
+            <velocity>96</velocity>
+            <eid>2108828942372</eid>
+            </Dynamic>
+          <Spanner type="HairPin">
+            <prev>
+              <location>
+                <measures>-1</measures>
+                </location>
+              </prev>
+            </Spanner>
+          <Chord>
+            <eid>1717986918515</eid>
+            <durationType>whole</durationType>
+            <Note>
+              <eid>1713691951124</eid>
+              <Spanner type="Tie">
+                <prev>
+                  <location>
+                    <measures>-1</measures>
+                    </location>
+                  </prev>
+                </Spanner>
+              <pitch>74</pitch>
+              <tpc>16</tpc>
+              </Note>
+            </Chord>
+          </voice>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/src/engraving/tests/playback/playbackcontext_tests.cpp
+++ b/src/engraving/tests/playback/playbackcontext_tests.cpp
@@ -330,6 +330,64 @@ TEST_F(Engraving_PlaybackContextTests, Dynamics_Overlap)
     }
 }
 
+TEST_F(Engraving_PlaybackContextTests, Dynamics_Niente)
+{
+    // [GIVEN]
+    Score* score = ScoreRW::readScore(PLAYBACK_CONTEXT_TEST_FILES_DIR + "dynamics/dynamics_niente.mscx");
+
+    const std::vector<Part*>& parts = score->parts();
+    ASSERT_FALSE(parts.empty());
+
+    // [GIVEN] Context for parsing dynamics
+    PlaybackContext ctx;
+
+    // [WHEN] Parse dynamics
+    const Part* part = parts.front();
+    ctx.update(part->id(), score);
+
+    // [WHEN] Get the actual dynamics
+    DynamicLevelLayers actualLayers = ctx.dynamicLevelLayers(score);
+
+    // [THEN] The dynamics match the expectation
+    DynamicLevelMap expectedDynamics;
+
+    constexpr mpe::dynamic_level_t f = dynamicLevelFromType(mpe::DynamicType::f);
+    constexpr mpe::dynamic_level_t n = dynamicLevelFromType(mpe::DynamicType::ppppppppp);
+
+    const std::map<int, int> f_to_n_curve = TConv::easingValueCurve(1920, HAIRPIN_STEPS, static_cast<int>(n - f), ChangeMethod::NORMAL);
+    const std::map<int, int> n_to_f_curve = TConv::easingValueCurve(1920, HAIRPIN_STEPS, static_cast<int>(f - n), ChangeMethod::NORMAL);
+
+    // 1st measure: Decresc. al niente with 'n' dynamic
+    for (const auto& pair : f_to_n_curve) {
+        mpe::timestamp_t time = timestampFromTicks(score, pair.first);
+        expectedDynamics.emplace(time, f + static_cast<dynamic_level_t>(pair.second));
+    }
+
+    // 3rd measure: same, now with niente circle
+    for (const auto& pair : f_to_n_curve) {
+        mpe::timestamp_t time = timestampFromTicks(score, 3840 + pair.first);
+        expectedDynamics.emplace(time, f + static_cast<dynamic_level_t>(pair.second));
+    }
+
+    // 5th measure: Cresc. dal niente with 'n' dynamic
+    for (const auto& pair : n_to_f_curve) {
+        mpe::timestamp_t time = timestampFromTicks(score, 7680 + pair.first);
+        expectedDynamics.emplace(time, n + static_cast<dynamic_level_t>(pair.second));
+    }
+
+    // 7th measure: same, now with niente circle
+    for (const auto& pair : n_to_f_curve) {
+        mpe::timestamp_t time = timestampFromTicks(score, 11520 + pair.first);
+        expectedDynamics.emplace(time, n + static_cast<dynamic_level_t>(pair.second));
+    }
+
+    EXPECT_FALSE(actualLayers.empty());
+    for (const auto& layer : actualLayers) {
+        const DynamicLevelMap& actualDynamics = layer.second;
+        EXPECT_EQ(actualDynamics, expectedDynamics);
+    }
+}
+
 TEST_F(Engraving_PlaybackContextTests, PlayTechniques)
 {
     // [GIVEN] Score with playing technique annotations


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/22812

- Niente circle on hairpins is now taken into account
- 'n' is now accepted as a dynamic, so that the 'n' dynamic gets added to the dynamics map while rendering normal dynamics (independent of rendering hairpins). This way, for 'Decresc. al niente', it is still applied after the end of the decresc (which fixes case 1 from https://github.com/musescore/MuseScore/issues/22812#issuecomment-2331772947), _and_ the `if (dynamicLevelAtEndTick != nominalLevelTo) {` case from `handleSpanners` does not get hit (which fixes case 2).
- It turned out that the `if (dynamicLevelAtEndTick != nominalLevelTo) {` case should not be hit at all when there is no explicit dynamic at the end tick of the hairpin; to check that, check that the DynamicType returned by `nominalDynamicLevel` is not Natural. This fixes it also for niente circle hairpins.