### PR TITLE
[4.4.2] Windows: also deploy other TLS backends

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -382,7 +382,9 @@ if (OS_IS_WIN)
             DESTINATION bin/platforms)
 
     install(FILES
+            ${QT_INSTALL_PLUGINS}/tls/qcertonlybackend.dll
             ${QT_INSTALL_PLUGINS}/tls/qopensslbackend.dll
+            ${QT_INSTALL_PLUGINS}/tls/qschannelbackend.dll
             DESTINATION bin/tls)
 
     install(DIRECTORY


### PR DESCRIPTION
The OpenSSL one doesn't seem to work with Qt 6 for some people

Resolves: https://github.com/musescore/MuseScore/issues/24511

Ports: https://github.com/musescore/MuseScore/pull/24527