### PR TITLE
[4.4.2] Fix huge brackets/braces sometimes appearing when deleting instruments

### DIFF
--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -2715,13 +2715,13 @@ void Score::adjustBracketsDel(size_t sidx, size_t eidx)
                 continue;
             }
             const bool startsOutsideDeletedRange = (staffIdx < sidx);
-            const bool endsOutsideDeletedRange = ((staffIdx + span) > eidx);
+            const bool endsOutsideDeletedRange = ((staffIdx + span) >= eidx);
             if (startsOutsideDeletedRange && endsOutsideDeletedRange) {
                 // Shorten the bracket by the number of staves deleted
                 bi->undoChangeProperty(Pid::BRACKET_SPAN, int(span - (eidx - sidx)));
             } else if (startsOutsideDeletedRange) {
                 // Shorten the bracket by the number of staves deleted that were spanned by it
-                bi->undoChangeProperty(Pid::BRACKET_SPAN, int(staffIdx - sidx));
+                bi->undoChangeProperty(Pid::BRACKET_SPAN, int(sidx - staffIdx));
             } else if (endsOutsideDeletedRange) {
                 if (eidx < m_staves.size()) {
                     // Move the bracket past the end of the deleted range,


### PR DESCRIPTION
- `staffIdx + span` is the (exclusive) end index of the bracket, `eidx` the (exclusive) end index of the deleted range of staves. If a bracket ended _before_ its inclusive end index, then a strict comparison would be correct. But since the bracket actually ends _after_ its inclusive end index, a non-strict comparison is necessary.
- in the `else if (startsOutsideDeletedRange)` case, the specified new span would be negative. That's now fixed. (However, since the other fix, this  case will never occur anymore in practice, because this method is only ever called with a difference of 1 between sidx and eidx.)

Resolves: https://github.com/musescore/MuseScore/issues/24468

Ports: https://github.com/musescore/MuseScore/pull/24489