### PR TITLE
[4.4.2] Don't layout lyrics line on hidden staff

### DIFF
--- a/src/engraving/rendering/dev/systemlayout.cpp
+++ b/src/engraving/rendering/dev/systemlayout.cpp
@@ -1193,6 +1193,9 @@ void SystemLayout::layoutSystemElements(System* system, LayoutContext& ctx)
     bool dashOnFirstNoteSyllable = ctx.conf().style().styleB(Sid::lyricsShowDashIfSyllableOnFirstNote);
     std::set<Spanner*> unmanagedSpanners = ctx.dom().unmanagedSpanners();
     for (Spanner* sp : unmanagedSpanners) {
+        if (!sp->systemFlag() && sp->staff() && !sp->staff()->show()) {
+            continue;
+        }
         bool dashOnFirst = dashOnFirstNoteSyllable && !toLyricsLine(sp)->isEndMelisma();
         if (sp->tick() >= etick || sp->tick2() < stick || (sp->tick2() == stick && !dashOnFirst)) {
             continue;


### PR DESCRIPTION
because the corresponding Lyric has not been laid out either, apparently (its shape is sometimes empty)

Resolves: https://github.com/musescore/MuseScore/issues/24431

Ports: https://github.com/musescore/MuseScore/pull/24486