### PR TITLE
Add half-open articulation

### DIFF
--- a/src/engraving/types/symnames.cpp
+++ b/src/engraving/types/symnames.cpp
@@ -5504,7 +5504,7 @@ const std::array<muse::TranslatableString, size_t(SymId::lastSym) + 1> SymNames:
     muse::TranslatableString::untranslatable("Soft gum beater, right"),
     muse::TranslatableString::untranslatable("Soft gum beater, up"),
     muse::TranslatableString::untranslatable("Half-open"),
-    muse::TranslatableString::untranslatable("Half-open 2 (Weinberg)"),
+    muse::TranslatableString("engraving/sym", "Half-open 2 (Weinberg)"),
     muse::TranslatableString::untranslatable("Handbell"),
     muse::TranslatableString::untranslatable("Hi-hat"),
     muse::TranslatableString::untranslatable("Hi-hat cymbals on stand"),

--- a/src/palette/internal/palettecreator.cpp
+++ b/src/palette/internal/palettecreator.cpp
@@ -753,6 +753,7 @@ PalettePtr PaletteCreator::newArticulationsPalette(bool defaultPalette)
         SymId::stringsUpBow,
         SymId::stringsDownBow,
         SymId::pluckedSnapPizzicatoAbove,
+        SymId::pictHalfOpen2,
         // SymId::stringsThumbPosition,
         // SymId::luteFingeringRHThumb,
         // SymId::luteFingeringRHFirst,


### PR DESCRIPTION
Resolves: #21317

The articulation has been added to 'Articulations->more' using the smufl symbol `pictHalfOpen2`.
