### PR TITLE
Fix disappearing beams in continuous view

### DIFF
--- a/src/engraving/rendering/score/slurtielayout.cpp
+++ b/src/engraving/rendering/score/slurtielayout.cpp
@@ -2288,7 +2288,9 @@ bool SlurTieLayout::isDirectionMixture(const Chord* c1, const Chord* c2, LayoutC
         }
         Chord* c = toChord(e);
         const Measure* m = c->measure();
-        if (!c->staff()->isDrumStaff(c->tick()) && c1->measure()->system() != m->system()) {
+        const System* c1Sys = c1->measure()->system();
+        const System* cSys = m->system();
+        if (!c->staff()->isDrumStaff(c->tick()) && c1Sys && cSys && c1Sys != cSys) {
             // This chord is on a different system and may not have been laid out yet
             for (Note* note : c->notes()) {
                 note->updateLine();     // because chord direction is based on note lines


### PR DESCRIPTION
Resolves: #24550 

In horizontal view, each measure is added to the system then laid out one at a time.  In the following situation, the slur is laid out which involves calculating it's direction.  This means we need to lay out beams under the slur to find stem direction.  The beam is in the following measure out of layout range so will not get laid out fully.  This means there are garbage values left after calculating beam position which are drawn.  
This code should not have been called anyway, as the chords are on the same system.  This PR accounts for the measures not being added to the system yet.