### PR TITLE
[4.4.2] Fix crash (infinite recursion) or corruption when changing length of measure after frame

### DIFF
--- a/src/engraving/dom/durationtype.cpp
+++ b/src/engraving/dom/durationtype.cpp
@@ -595,8 +595,15 @@ void populateRhythmicList(std::vector<TDuration>* dList, const Fraction& l, bool
         // no single TDuration fits so must split anyway
     }
 
+    // Prevent infinite recursion if there is no splitting point other than the start and end ticks
+    IF_ASSERT_FAILED(rtickStart.ticks() < rtickSplit && rtickSplit < rtickEnd.ticks()) {
+        std::vector<TDuration> dList2 = toDurationList(l, maxDots > 0, maxDots, false);
+        dList->insert(dList->end(), dList2.begin(), dList2.end());
+        return;
+    }
+
     // Split on the strongest beat or subbeat crossed
-    Fraction leftSplit   = Fraction::fromTicks(rtickSplit) - rtickStart;
+    Fraction leftSplit = Fraction::fromTicks(rtickSplit) - rtickStart;
     Fraction rightSplit = l - leftSplit;
 
     // Recurse to see if we need to split further before adding to list

--- a/src/engraving/dom/durationtype.cpp
+++ b/src/engraving/dom/durationtype.cpp
@@ -511,7 +511,7 @@ std::vector<TDuration> toRhythmicDurationList(const Fraction& l, bool isRest, Fr
     dList.reserve(8);
 
     if (msr->isAnacrusis()) {
-        rtickStart = Fraction::fromTicks(nominal.ticksPerMeasure()) - rtickStart;
+        rtickStart += msr->anacrusisOffset();
     } else if (isRest && l == msr->ticks()) {
         TDuration d = TDuration(DurationType::V_MEASURE);
         dList.push_back(d);
@@ -519,9 +519,9 @@ std::vector<TDuration> toRhythmicDurationList(const Fraction& l, bool isRest, Fr
     }
 
     if (nominal.isCompound()) {
-        splitCompoundBeatsForList(&dList, l, isRest, rtickStart + msr->anacrusisOffset(), nominal, maxDots);
+        splitCompoundBeatsForList(&dList, l, isRest, rtickStart, nominal, maxDots);
     } else {
-        populateRhythmicList(&dList, l, isRest, rtickStart + msr->anacrusisOffset(), nominal, maxDots);
+        populateRhythmicList(&dList, l, isRest, rtickStart, nominal, maxDots);
     }
 
     return dList;

--- a/src/engraving/dom/measure.cpp
+++ b/src/engraving/dom/measure.cpp
@@ -1801,8 +1801,12 @@ void Measure::adjustToLen(Fraction nf, bool appendRestsIfNecessary)
                 rest->undoChangeProperty(Pid::DURATION_TYPE_WITH_DOTS, DurationTypeWithDots(DurationType::V_MEASURE));
             } else {          // if measure value did change, represent with rests actual measure value
                 // convert the measure duration in a list of values (no dots for rests)
-                std::vector<TDuration> durList = toRhythmicDurationList(nf * stretch, true, tick(),
-                                                                        score()->sigmap()->timesig(tick().ticks()).nominal(), this, 0);
+                std::vector<TDuration> durList = toRhythmicDurationList(nf * stretch,
+                                                                        /*isRest=*/ true,
+                                                                        /*rtickStart=*/ Fraction(0, 1),
+                                                                        /*nominal=*/ score()->sigmap()->timesig(tick().ticks()).nominal(),
+                                                                        /*measure=*/ this,
+                                                                        /*maxDots=*/ 0);
 
                 // set the existing rest to the first value of the duration list
                 TDuration firstDur = durList[0];


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/24298
Resolves: https://github.com/musescore/MuseScore/issues/24583

Ports: #24562 