### PR TITLE
Changes for undo/redo naming phase 1.

### DIFF
--- a/src/appshell/view/appmenumodel.cpp
+++ b/src/appshell/view/appmenumodel.cpp
@@ -144,9 +144,9 @@ void AppMenuModel::setupConnections()
             stack->stackChanged().onNotify(this, [this]() {
                 updateUndoRedoItems();
             });
-        } else {
-            updateUndoRedoItems();
         }
+
+        updateUndoRedoItems();
     });
 }
 

--- a/src/appshell/view/appmenumodel.cpp
+++ b/src/appshell/view/appmenumodel.cpp
@@ -89,14 +89,14 @@ void AppMenuModel::updateUndoRedoItems()
     MenuItem& undoItem = findItem(ActionCode("undo"));
     const TranslatableString undoActionName = stack ? stack->topMostUndoActionName() : TranslatableString();
     undoItem.setTitle(undoActionName.isEmpty()
-                            ? TranslatableString("action", "Undo")
-                            : TranslatableString("action", "Undo '%1'").arg(undoActionName));
+                      ? TranslatableString("action", "Undo")
+                      : TranslatableString("action", "Undo ‘%1’").arg(undoActionName));
 
     MenuItem& redoItem = findItem(ActionCode("redo"));
     const TranslatableString redoActionName = stack ? stack->topMostRedoActionName() : TranslatableString();
     redoItem.setTitle(redoActionName.isEmpty()
-                            ? TranslatableString("action", "Redo")
-                            : TranslatableString("action", "Redo '%1'").arg(redoActionName));
+                      ? TranslatableString("action", "Redo")
+                      : TranslatableString("action", "Redo ‘%1’").arg(redoActionName));
 }
 
 void AppMenuModel::setupConnections()

--- a/src/appshell/view/appmenumodel.h
+++ b/src/appshell/view/appmenumodel.h
@@ -22,6 +22,7 @@
 #ifndef MU_APPSHELL_APPMENUMODEL_H
 #define MU_APPSHELL_APPMENUMODEL_H
 
+#include "context/iglobalcontext.h"
 Q_MOC_INCLUDE(< QWindow >)
 
 #include "uicomponents/view/abstractmenumodel.h"
@@ -60,6 +61,7 @@ public:
     muse::Inject<muse::update::IUpdateConfiguration> updateConfiguration = { this };
     muse::Inject<muse::IGlobalConfiguration> globalConfiguration = { this };
     muse::Inject<project::IProjectConfiguration> projectConfiguration = { this };
+    muse::Inject<mu::context::IGlobalContext> context = { this };
 
 public:
     explicit AppMenuModel(QObject* parent = nullptr);
@@ -68,6 +70,9 @@ public:
     Q_INVOKABLE bool isGlobalMenuAvailable();
 
 private:
+    mu::notation::INotationUndoStackPtr undoStack() const;
+    void updateUndoRedoItems();
+
     void setupConnections();
 
     using muse::uicomponents::AbstractMenuModel::makeMenuItem;

--- a/src/braille/internal/notationbraille.cpp
+++ b/src/braille/internal/notationbraille.cpp
@@ -699,7 +699,7 @@ bool NotationBraille::addTie()
         return false;
     }
 
-    score()->startCmd();
+    score()->startCmd(TranslatableString("undoableAction", "Add tie"));
     Note* note = toNote(currentEngravingItem());
 
     Tie* tie = Factory::createTie(score()->dummy());
@@ -725,7 +725,7 @@ bool NotationBraille::addSlur()
             ChordRest* firstChordRest = toChordRest(note1->parent());
             ChordRest* secondChordRest = toChordRest(note2->parent());
 
-            score()->startCmd();
+            score()->startCmd(TranslatableString("undoableAction", "Add slur"));
 
             Slur* slur = Factory::createSlur(firstChordRest->measure()->system());
             slur->setScore(firstChordRest->score());
@@ -770,7 +770,7 @@ bool NotationBraille::addLongSlur()
             ChordRest* firstChordRest = toChordRest(note1->parent());
             ChordRest* secondChordRest = toChordRest(note2->parent());
 
-            score()->startCmd();
+            score()->startCmd(TranslatableString("undoableAction", "Add long slur"));
 
             Slur* slur = Factory::createSlur(firstChordRest->measure()->system());
             slur->setScore(firstChordRest->score());

--- a/src/engraving/api/v1/qmlpluginapi.cpp
+++ b/src/engraving/api/v1/qmlpluginapi.cpp
@@ -278,7 +278,7 @@ apiv1::Score* PluginAPI::newScore(const QString& /*name*/, const QString& part, 
 
     qApp->processEvents();
     Q_ASSERT(currentScore() == score);
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "New score"));
     return wrap<Score>(score, Ownership::SCORE);
 }
 

--- a/src/engraving/api/v1/score.cpp
+++ b/src/engraving/api/v1/score.cpp
@@ -237,13 +237,17 @@ QQmlListProperty<Staff> Score::staves()
 //   Score::startCmd
 //---------------------------------------------------------
 
-void Score::startCmd()
+void Score::startCmd(const QString& qActionName)
 {
     IF_ASSERT_FAILED(undoStack()) {
         return;
     }
 
-    undoStack()->prepareChanges();
+    muse::TranslatableString actionName = qActionName.isEmpty()
+        ? TranslatableString("undoableAction", "Plugin edit")
+        : TranslatableString::untranslatable(qActionName);
+
+    undoStack()->prepareChanges(actionName);
 }
 
 void Score::endCmd(bool rollback)

--- a/src/engraving/api/v1/score.cpp
+++ b/src/engraving/api/v1/score.cpp
@@ -244,8 +244,8 @@ void Score::startCmd(const QString& qActionName)
     }
 
     muse::TranslatableString actionName = qActionName.isEmpty()
-        ? TranslatableString("undoableAction", "Plugin edit")
-        : TranslatableString::untranslatable(qActionName);
+                                          ? TranslatableString("undoableAction", "Plugin edit")
+                                          : TranslatableString::untranslatable(qActionName);
 
     undoStack()->prepareChanges(actionName);
 }

--- a/src/engraving/api/v1/score.h
+++ b/src/engraving/api/v1/score.h
@@ -225,8 +225,10 @@ public:
      * a corresponding endCmd() call. Should be used at
      * least once by "dock" type plugins in case they
      * modify the score.
+     * \param qActionName - Optional action name that appears in Undo/Redo
+     * menus, palettes, and lists.
      */
-    Q_INVOKABLE void startCmd();
+    Q_INVOKABLE void startCmd(const QString& qActionName = {});
     /**
      * For "dock" type plugins: to be used after score
      * modifications to make them undoable.

--- a/src/engraving/devtools/corruptscoredevtoolsmodel.cpp
+++ b/src/engraving/devtools/corruptscoredevtoolsmodel.cpp
@@ -40,7 +40,7 @@ void CorruptScoreDevToolsModel::corruptOpenScore()
 
     mu::notation::INotationPtr notation = project->masterNotation()->notation();
 
-    notation->undoStack()->prepareChanges();
+    notation->undoStack()->prepareChanges(TranslatableString("undoableAction", "Open corrupt score"));
 
     for (engraving::System* system : notation->elements()->msScore()->systems()) {
         for (engraving::MeasureBase* measureBase : system->measures()) {

--- a/src/engraving/dom/cmd.cpp
+++ b/src/engraving/dom/cmd.cpp
@@ -319,7 +319,7 @@ void CmdState::setUpdateMode(UpdateMode m)
 ///   and starting a user-visible undo.
 //---------------------------------------------------------
 
-void Score::startCmd()
+void Score::startCmd(const TranslatableString& actionName)
 {
     if (undoStack()->locked()) {
         return;
@@ -339,7 +339,7 @@ void Score::startCmd()
         LOGD("Score::startCmd(): cmd already active");
         return;
     }
-    undoStack()->beginMacro(this);
+    undoStack()->beginMacro(this, actionName);
 }
 
 //---------------------------------------------------------
@@ -2790,7 +2790,7 @@ void Score::cmdResetNoteAndRestGroupings()
     staff_idx_t sStaff = selection().staffStart();
     staff_idx_t eStaff = selection().staffEnd();
 
-    startCmd();
+    startCmd(TranslatableString("undoableAction", "Reset note/rest groupings"));
     for (staff_idx_t staff = sStaff; staff < eStaff; staff++) {
         track_idx_t sTrack = staff * VOICES;
         track_idx_t eTrack = sTrack + VOICES;
@@ -2822,7 +2822,7 @@ void Score::cmdResetAllPositions(bool undoable)
     TRACEFUNC;
 
     if (undoable) {
-        startCmd();
+        startCmd(TranslatableString("undoableAction", "Reset all positions"));
     }
     resetAutoplace();
     if (undoable) {

--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -1876,7 +1876,7 @@ void Score::cmdAddTie(bool addToChord)
         return;
     }
 
-    startCmd();
+    startCmd(TranslatableString("undoableAction", "Add tie"));
     Chord* lastAddedChord = 0;
     for (Note* note : noteList) {
         if (note->tieFor()) {
@@ -2010,7 +2010,7 @@ void Score::cmdToggleTie()
         }
     }
 
-    startCmd();
+    startCmd(TranslatableString("undoableAction", "Toggle tie"));
 
     if (canAddTies) {
         for (size_t i = 0; i < notes; ++i) {
@@ -3998,7 +3998,7 @@ void Score::cmdEnterRest(const TDuration& d)
         LOGD("cmdEnterRest: track invalid");
         return;
     }
-    startCmd();
+    startCmd(TranslatableString("undoableAction", "Add rest"));
     enterRest(d);
     endCmd();
 }

--- a/src/engraving/dom/figuredbass.cpp
+++ b/src/engraving/dom/figuredbass.cpp
@@ -750,7 +750,7 @@ void FiguredBass::regenerateText()
         FiguredBassItem* pItem = new FiguredBassItem(this, idx++);
         if (!pItem->parse(str)) {               // if any item fails parsing
             clearItems();
-            score()->startCmd();
+            score()->startCmd(TranslatableString("undoableAction", "Regenerate figured bass text"));
             triggerLayout();
             score()->endCmd();
             delete pItem;
@@ -769,7 +769,7 @@ void FiguredBass::regenerateText()
         undoChangeProperty(Pid::TEXT, normalizedText);
     }
 
-    score()->startCmd();
+    score()->startCmd(TranslatableString("undoableAction", "Update layout"));
     triggerLayout();
     score()->endCmd();
 }

--- a/src/engraving/dom/lyrics.cpp
+++ b/src/engraving/dom/lyrics.cpp
@@ -192,7 +192,7 @@ void Lyrics::paste(EditData& ed, const String& txt)
     }
 
     StringList hyph = sl.at(0).split(u'-');
-    score()->startCmd();
+    score()->startCmd(TranslatableString("undoableAction", "Paste lyrics"));
 
     deleteSelectedText(ed);
 

--- a/src/engraving/dom/score.h
+++ b/src/engraving/dom/score.h
@@ -524,8 +524,8 @@ public:
     muse::Ret repitchNote(const Position& pos, bool replace);
     void regroupNotesAndRests(const Fraction& startTick, const Fraction& endTick, track_idx_t track);
 
-    void startCmd();                    // start undoable command
-    void endCmd(bool rollback = false, bool layoutAllParts = false); // end undoable command
+    void startCmd(const TranslatableString& actionName);                // start undoable command
+    void endCmd(bool rollback = false, bool layoutAllParts = false);    // end undoable command
     void update() { update(true); }
     void lockUpdates(bool locked);
     void undoRedo(bool undo, EditData*);

--- a/src/engraving/dom/textedit.cpp
+++ b/src/engraving/dom/textedit.cpp
@@ -905,7 +905,7 @@ void TextBase::paste(EditData& ed, const String& txt)
     bool symState = false;
     CharFormat format = *static_cast<TextEditData*>(ed.getData(this).get())->cursor()->format();
 
-    score()->startCmd();
+    score()->startCmd(TranslatableString("undoableAction", "Paste text"));
     for (size_t i = 0; i < txt.size(); i++) {
         Char c = txt.at(i);
         if (state == 0) {

--- a/src/engraving/dom/tie.cpp
+++ b/src/engraving/dom/tie.cpp
@@ -124,7 +124,7 @@ void TieSegment::changeAnchor(EditData& ed, EngravingItem* element)
 
         TieSegment* newSegment = toTieSegment(ed.curGrip == Grip::END ? ss.back() : ss.front());
         score()->endCmd();
-        score()->startCmd();
+        score()->startCmd(TranslatableString("undoableAction", "Change tie anchor"));
         ed.view()->changeEditElement(newSegment);
         triggerLayout();
     }

--- a/src/engraving/dom/undo.cpp
+++ b/src/engraving/dom/undo.cpp
@@ -327,7 +327,7 @@ void UndoStack::setLocked(bool val)
 //   beginMacro
 //---------------------------------------------------------
 
-void UndoStack::beginMacro(Score* score)
+void UndoStack::beginMacro(Score* score, const TranslatableString& undoString)
 {
     if (isLocked) {
         return;
@@ -337,7 +337,7 @@ void UndoStack::beginMacro(Score* score)
         LOGW("already active");
         return;
     }
-    curCmd = new UndoMacro(score);
+    curCmd = new UndoMacro(score, undoString);
 }
 
 //---------------------------------------------------------
@@ -574,8 +574,8 @@ void UndoMacro::applySelectionInfo(const SelectionInfo& info, Selection& sel)
     }
 }
 
-UndoMacro::UndoMacro(Score* s)
-    : m_undoInputState(s->inputState()), m_score(s)
+UndoMacro::UndoMacro(Score* s, const TranslatableString& actionName)
+    : m_undoInputState(s->inputState()), m_actionName(actionName), m_score(s)
 {
     fillSelectionInfo(m_undoSelectionInfo, s->selection());
 }
@@ -680,6 +680,11 @@ UndoMacro::ChangesInfo UndoMacro::changesInfo() const
     }
 
     return result;
+}
+
+const TranslatableString& UndoMacro::actionName() const
+{
+    return m_actionName;
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/undo.h
+++ b/src/engraving/dom/undo.h
@@ -163,7 +163,7 @@ public:
         bool isValid() const { return !elements.empty() || staffStart != muse::nidx; }
     };
 
-    UndoMacro(Score* s);
+    UndoMacro(Score* s, const TranslatableString& actionName);
     void undo(EditData*) override;
     void redo(EditData*) override;
     bool empty() const;
@@ -182,6 +182,7 @@ public:
     };
 
     ChangesInfo changesInfo() const;
+    const TranslatableString& actionName() const;
 
     static bool canRecordSelectedElement(const EngravingItem* e);
 
@@ -192,6 +193,7 @@ private:
     InputState m_redoInputState;
     SelectionInfo m_undoSelectionInfo;
     SelectionInfo m_redoSelectionInfo;
+    TranslatableString m_actionName;
 
     Score* m_score = nullptr;
 
@@ -218,7 +220,7 @@ public:
     bool locked() const;
     void setLocked(bool val);
     bool active() const { return curCmd != 0; }
-    void beginMacro(Score*);
+    void beginMacro(Score*, const TranslatableString& actionString);
     void endMacro(bool rollback);
     void push(UndoCommand*, EditData*);        // push & execute
     void push1(UndoCommand*);
@@ -230,6 +232,7 @@ public:
     UndoMacro* current() const { return curCmd; }
     UndoMacro* last() const { return curIdx > 0 ? list[curIdx - 1] : 0; }
     UndoMacro* prev() const { return curIdx > 1 ? list[curIdx - 2] : 0; }
+    UndoMacro* next() const { return canRedo() ? list[curIdx] : 0; }
     void undo(EditData*);
     void redo(EditData*);
     void reopen();

--- a/src/engraving/dom/unrollrepeats.cpp
+++ b/src/engraving/dom/unrollrepeats.cpp
@@ -99,7 +99,7 @@ static void createExcerpts(MasterScore* cs, const std::list<Excerpt*>& excerpts)
         Score* nscore = e->masterScore()->createScore();
         e->setExcerptScore(nscore);
         nscore->style().set(Sid::createMultiMeasureRests, true);
-        cs->startCmd();
+        cs->startCmd(TranslatableString("undoableAction", "Create excerpts"));
         cs->undo(new AddExcerpt(e));
         Excerpt::createExcerpt(e);
 

--- a/src/engraving/rw/write/writer.cpp
+++ b/src/engraving/rw/write/writer.cpp
@@ -89,7 +89,7 @@ void Writer::write(Score* score, XmlWriter& xml, WriteContext& ctx, bool selecti
 
     // if we have multi measure rests and some parts are hidden,
     // then some layout information is missing:
-    // relayout with all parts set visible
+    // relayout with all parts set visible (but rollback at end)
 
     std::list<Part*> hiddenParts;
     bool unhide = false;
@@ -97,7 +97,7 @@ void Writer::write(Score* score, XmlWriter& xml, WriteContext& ctx, bool selecti
         for (Part* part : score->m_parts) {
             if (!part->show()) {
                 if (!unhide) {
-                    score->startCmd();
+                    score->startCmd(TranslatableString("undoableAction", "Unhide parts for save"));
                     unhide = true;
                 }
                 part->undoChangeProperty(Pid::VISIBLE, true);

--- a/src/engraving/tests/barline_tests.cpp
+++ b/src/engraving/tests/barline_tests.cpp
@@ -154,7 +154,7 @@ TEST_F(Engraving_BarlineTests, barline03)
     Score* score = ScoreRW::readScore(BARLINE_DATA_DIR + "barline03.mscx");
     EXPECT_TRUE(score);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving barline tests"));
     score->undo(new ChangeProperty(score->staff(0), Pid::STAFF_BARLINE_SPAN, 1));
     score->undo(new ChangeProperty(score->staff(0), Pid::STAFF_BARLINE_SPAN_FROM, 2));
     score->undo(new ChangeProperty(score->staff(0), Pid::STAFF_BARLINE_SPAN_TO, -2));
@@ -189,7 +189,7 @@ TEST_F(Engraving_BarlineTests, barline04)
 
     score->doLayout();
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving barline tests"));
     // 'go' to 5th measure
     Measure* msr = score->firstMeasure();
     for (int i=0; i < 4; i++) {
@@ -322,7 +322,7 @@ void dropNormalBarline(EngravingItem* e)
     barLine->setBarLineType(BarLineType::NORMAL);
     dropData.dropElement = barLine;
 
-    e->score()->startCmd();
+    e->score()->startCmd(TranslatableString("undoableAction", "Drop normal barline test"));
     e->drop(dropData);
     e->score()->endCmd();
 }
@@ -419,7 +419,7 @@ TEST_F(Engraving_BarlineTests, deleteSkipBarlines)
     Measure* m1 = score->firstMeasure();
     EXPECT_TRUE(m1);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving barline tests"));
     score->cmdSelectAll();
     score->cmdDeleteSelection();
     score->endCmd();

--- a/src/engraving/tests/beam_tests.cpp
+++ b/src/engraving/tests/beam_tests.cpp
@@ -220,7 +220,7 @@ TEST_F(Engraving_BeamTests, flipBeamStemDir)
     Chord* c2 = toChord(cr->beam()->elements()[1]);
 
     score->select(c2);
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving beam tests"));
     score->cmdFlip();
     score->endCmd();
     cr->beam()->setBeamDirection(DirectionV::DOWN);
@@ -253,7 +253,7 @@ TEST_F(Engraving_BeamTests, flipTremoloStemDir)
     EXPECT_TRUE(t->up() && c1->up() && c2->up());
 
     score->select(c1->upNote());
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving beam tests"));
     score->cmdFlip();
     score->endCmd();
 

--- a/src/engraving/tests/box_tests.cpp
+++ b/src/engraving/tests/box_tests.cpp
@@ -59,7 +59,7 @@ TEST_F(Engraving_BoxTests, undoRemoveVBox)
     System* s = score->systems()[0];
     VBox* box = toVBox(s->measure(0));
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving box tests"));
     score->select(box);
     score->cmdDeleteSelection();
     score->endCmd();

--- a/src/engraving/tests/breath_tests.cpp
+++ b/src/engraving/tests/breath_tests.cpp
@@ -53,7 +53,7 @@ TEST_F(Engraving_BreathTests, breath)
     score->doLayout();
 
     // do
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving breath tests"));
     score->cmdSelectAll();
     for (EngravingItem* e : score->selection().elements()) {
         EditData dd(0);

--- a/src/engraving/tests/changevisibility_tests.cpp
+++ b/src/engraving/tests/changevisibility_tests.cpp
@@ -537,7 +537,7 @@ TEST_F(Engraving_ChangeVisibilityTests, CmdToggleVisible)
     // [WHEN] Select the first measure and call cmdToggleVisible()
     m_score->select(measure);
 
-    m_score->startCmd();
+    m_score->startCmd(TranslatableString("undoableAction", "Change visibility tests"));
     m_score->cmdToggleVisible();
     m_score->endCmd();
 
@@ -559,7 +559,7 @@ TEST_F(Engraving_ChangeVisibilityTests, CmdToggleVisible)
     }
 
     // [WHEN] Call cmdToggleVisible() again
-    m_score->startCmd();
+    m_score->startCmd(TranslatableString("undoableAction", "Change visibility tests"));
     m_score->cmdToggleVisible();
     m_score->endCmd();
 
@@ -577,7 +577,7 @@ TEST_F(Engraving_ChangeVisibilityTests, CmdToggleVisible)
         m_score->select(note, SelectType::ADD);
     }
 
-    m_score->startCmd();
+    m_score->startCmd(TranslatableString("undoableAction", "Change visibility tests"));
     m_score->cmdToggleVisible();
     m_score->endCmd();
 
@@ -589,7 +589,7 @@ TEST_F(Engraving_ChangeVisibilityTests, CmdToggleVisible)
     // [WHEN] Select the first measure and call cmdToggleVisible() again
     m_score->select(measure);
 
-    m_score->startCmd();
+    m_score->startCmd(TranslatableString("undoableAction", "Change visibility tests"));
     m_score->cmdToggleVisible();
     m_score->endCmd();
 

--- a/src/engraving/tests/chordsymbol_tests.cpp
+++ b/src/engraving/tests/chordsymbol_tests.cpp
@@ -97,7 +97,7 @@ void Engraving_ChordSymbolTests::realizeSelectionVoiced(MasterScore* score, Voic
             e->setProperty(Pid::HARMONY_VOICING, int(voicing));
         }
     }
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Realize selection voiced"));
     score->cmdRealizeChordSymbols();
     score->endCmd();
 }
@@ -199,7 +199,7 @@ TEST_F(Engraving_ChordSymbolTests, testNoSystem)
 TEST_F(Engraving_ChordSymbolTests, testTranspose)
 {
     MasterScore* score = test_pre(u"transpose");
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving chord symbol tests"));
     score->cmdSelectAll();
     score->transpose(TransposeMode::BY_INTERVAL, TransposeDirection::UP, Key::C, 4, false, true, true);
     score->endCmd();
@@ -209,7 +209,7 @@ TEST_F(Engraving_ChordSymbolTests, testTranspose)
 TEST_F(Engraving_ChordSymbolTests, testTransposePart)
 {
     MasterScore* score = test_pre(u"transpose-part");
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving chord symbol tests"));
     score->cmdSelectAll();
     score->transpose(TransposeMode::BY_INTERVAL, TransposeDirection::UP, Key::C, 4, false, true, true);
     score->endCmd(false, /*layoutAllParts = */ true);
@@ -279,13 +279,13 @@ TEST_F(Engraving_ChordSymbolTests, testRealizeConcertPitch)
 {
     MasterScore* score = test_pre(u"realize-concert-pitch");
     //concert pitch off
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving chord symbol tests"));
     score->cmdConcertPitchChanged(false);
     score->endCmd();
 
     //realize all chord symbols
     selectAllChordSymbols(score);
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving chord symbol tests"));
     score->cmdRealizeChordSymbols();
     score->endCmd();
     test_post(score, u"realize-concert-pitch");
@@ -304,7 +304,7 @@ TEST_F(Engraving_ChordSymbolTests, testRealizeTransposed)
 
     //realize all chord symbols
     selectAllChordSymbols(score);
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving chord symbol tests"));
     score->cmdRealizeChordSymbols();
     score->endCmd();
     test_post(score, u"realize-transpose");
@@ -319,7 +319,7 @@ TEST_F(Engraving_ChordSymbolTests, testRealizeOverrides)
     MasterScore* score = test_pre(u"realize-override");
     //realize all chord symbols
     selectAllChordSymbols(score);
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving chord symbol tests"));
     score->cmdRealizeChordSymbols(true, Voicing::ROOT_ONLY, HDuration::SEGMENT_DURATION);
     score->endCmd();
     test_post(score, u"realize-override");
@@ -333,7 +333,7 @@ TEST_F(Engraving_ChordSymbolTests, testRealizeTriplet)
     MasterScore* score = test_pre(u"realize-triplet");
     //realize all chord symbols
     selectAllChordSymbols(score);
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving chord symbol tests"));
     score->cmdRealizeChordSymbols();
     score->endCmd();
     test_post(score, u"realize-triplet");
@@ -348,7 +348,7 @@ TEST_F(Engraving_ChordSymbolTests, testRealizeDuration)
     MasterScore* score = test_pre(u"realize-duration");
     //realize all chord symbols
     selectAllChordSymbols(score);
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving chord symbol tests"));
     score->cmdRealizeChordSymbols();
     score->endCmd();
     test_post(score, u"realize-duration");
@@ -363,7 +363,7 @@ TEST_F(Engraving_ChordSymbolTests, testRealizeJazz)
     MasterScore* score = test_pre(u"realize-jazz");
     //realize all chord symbols
     selectAllChordSymbols(score);
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving chord symbol tests"));
     score->cmdRealizeChordSymbols();
     score->endCmd();
     test_post(score, u"realize-jazz");

--- a/src/engraving/tests/clef_courtesy_tests.cpp
+++ b/src/engraving/tests/clef_courtesy_tests.cpp
@@ -55,7 +55,7 @@ static void dropClef(EngravingItem* m, ClefType t)
     EditData dropData(0);
     dropData.pos = m->pagePos();
     dropData.dropElement = clef;
-    m->score()->startCmd();
+    m->score()->startCmd(TranslatableString("undoableAction", "Courtesy clef tests"));
     if (m->isMeasure()) {
         toMeasure(m)->drop(dropData);
     } else {
@@ -108,7 +108,7 @@ TEST_F(Engraving_ClefCourtesyTests, clef_courtesy01)
     EXPECT_TRUE(seg) << "No SegClef in measure 4.";
 
     clef = static_cast<Clef*>(seg->element(0));
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Courtesy clef tests"));
     clef->undoChangeProperty(Pid::SHOW_COURTESY, false);
     Clef* otherClef = clef->otherClef();
     if (otherClef) {
@@ -318,7 +318,7 @@ TEST_F(Engraving_ClefCourtesyTests, clef_courtesy04)
     seg = m1->findSegment(SegmentType::HeaderClef, m1->tick());
     EXPECT_TRUE(seg) << "No SegClef in measure 4.";
     clef = toClef(seg->element(0));
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Courtesy clef tests"));
     clef->undoChangeProperty(Pid::SHOW_COURTESY, false);
     Clef* otherClef = clef->otherClef();
     if (otherClef) {
@@ -350,7 +350,7 @@ TEST_F(Engraving_ClefCourtesyTests, clef_courtesy04)
     clef = toClef(seg->element(4));
     EXPECT_TRUE(clef) << "No Clef in measure 8, track 4.";
     dropClef(clef, ClefType::G8_VA);
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Courtesy clef tests"));
     clef->undoChangeProperty(Pid::SHOW_COURTESY, false);
     otherClef = clef->otherClef();
     if (otherClef) {
@@ -388,7 +388,7 @@ TEST_F(Engraving_ClefCourtesyTests, clef_courtesy04)
     clef = toClef(seg->element(0));
     EXPECT_TRUE(clef) << "No Clef change in measure 8, track 0.";
     EXPECT_GT(clef->ldata()->bbox().width(), 0) << "Clef change in measure 8, track 0, is hidden.";
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Courtesy clef tests"));
     clef->undoChangeProperty(Pid::SHOW_COURTESY, false);
     otherClef = clef->otherClef();
     if (otherClef) {

--- a/src/engraving/tests/copypaste_tests.cpp
+++ b/src/engraving/tests/copypaste_tests.cpp
@@ -88,7 +88,7 @@ void Engraving_CopyPasteTests::copypaste(const char* idx)
     EXPECT_TRUE(m4->first()->element(0));
     score->select(m4->first()->element(0));
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Copy/paste tests"));
     QMimeDataAdapter ma(mimeData);
     score->cmdPaste(&ma, 0);
     score->endCmd();
@@ -225,7 +225,7 @@ void Engraving_CopyPasteTests::copypastevoice(const char* idx, int voice)
     //paste to second measure
     score->select(m2->first()->element(0));
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Copy/paste tests"));
     QMimeDataAdapter ma(mimeData);
     score->cmdPaste(&ma, 0);
     score->endCmd();
@@ -263,7 +263,7 @@ TEST_F(Engraving_CopyPasteTests, copypaste2Voice)
     Segment* secondCRSeg = m2->first()->next1(SegmentType::ChordRest);
     score->select(secondCRSeg->element(0));
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Copy/paste tests"));
     QMimeDataAdapter ma(mimeData);
     score->cmdPaste(&ma, 0);
     score->endCmd();
@@ -304,7 +304,7 @@ TEST_F(Engraving_CopyPasteTests, copypaste2Voice5)
     EXPECT_EQ(static_cast<ChordRest*>(dest)->durationType(), DurationType::V_QUARTER);
     score->select(dest);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Copy/paste tests"));
     QMimeDataAdapter ma(mimeData);
     score->cmdPaste(&ma, 0);
     score->endCmd();
@@ -344,7 +344,7 @@ TEST_F(Engraving_CopyPasteTests, copypaste2Voice6)
     EXPECT_EQ(static_cast<ChordRest*>(dest)->durationType(), DurationType::V_16TH);
     score->select(dest);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Copy/paste tests"));
     QMimeDataAdapter ma(mimeData);
     score->cmdPaste(&ma, 0);
     score->endCmd();
@@ -381,7 +381,7 @@ TEST_F(Engraving_CopyPasteTests, copypasteOnlySecondVoice)
     score->selectionFilter().setFiltered(SelectionFilterType::FIRST_VOICE, true);
     score->select(m2, SelectType::RANGE);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Copy/paste tests"));
     QMimeDataAdapter ma(mimeData);
     score->cmdPaste(&ma, 0);
     score->endCmd();
@@ -418,7 +418,7 @@ void Engraving_CopyPasteTests::copypastestaff(const char* idx)
 
     score->select(m2, SelectType::RANGE, 1);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Copy/paste tests"));
     QMimeDataAdapter ma(mimeData);
     score->cmdPaste(&ma, 0);
     score->endCmd();
@@ -456,7 +456,7 @@ TEST_F(Engraving_CopyPasteTests, copypastePartial)
 
     score->select(m1->first(SegmentType::ChordRest)->element(0));
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Copy/paste tests"));
     QMimeDataAdapter ma(mimeData);
     score->cmdPaste(&ma, 0);
     score->endCmd();
@@ -491,7 +491,7 @@ void Engraving_CopyPasteTests::copypastetuplet(const char* idx)
 
     EngravingItem* dest = m2->first(SegmentType::ChordRest)->element(0);
     score->select(dest);
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Copy/paste tests"));
     QMimeDataAdapter ma(mimeData);
     score->cmdPaste(&ma, 0);
     score->endCmd();
@@ -528,7 +528,7 @@ void Engraving_CopyPasteTests::copypastenote(const String& idx, Fraction scale)
     mimeData.setData(score->selection().mimeType(), score->selection().mimeData().toQByteArray());
     ChordRest* cr = m1->first(SegmentType::ChordRest)->nextChordRest(0);
     score->select(cr->isChord() ? toChord(cr)->upNote() : static_cast<EngravingItem*>(cr));
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Copy/paste tests"));
     QMimeDataAdapter ma(&mimeData);
     score->cmdPaste(&ma, 0, scale);
     score->endCmd();
@@ -614,7 +614,7 @@ TEST_F(Engraving_CopyPasteTests, copypasteSplitNoteOverBar)
     mimeData.setData(score->selection().mimeType(), score->selection().mimeData().toQByteArray());
     ChordRest* cr = m1->findChordRest(Fraction(7, 8), 0);
     score->select(cr->isChord() ? toChord(cr)->upNote() : static_cast<EngravingItem*>(cr));
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Copy/paste tests"));
     QMimeDataAdapter ma(&mimeData);
     score->cmdPaste(&ma, 0);
     score->endCmd();
@@ -648,7 +648,7 @@ TEST_F(Engraving_CopyPasteTests, copypasteSplitTiedNoteOverBar)
     ChordRest* cr = m1->findChordRest(Fraction(6, 8), 0);
     EXPECT_TRUE(cr);
     score->select(cr->isChord() ? toChord(cr)->upNote() : static_cast<EngravingItem*>(cr));
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Copy/paste tests"));
     QMimeDataAdapter ma(&mimeData);
     score->cmdPaste(&ma, 0);
     score->endCmd();
@@ -676,7 +676,7 @@ TEST_F(Engraving_CopyPasteTests, copypasteSplitNoteOverManyBars)
     ChordRest* cr = m2->findChordRest(Fraction(19, 8), 0);
     EXPECT_TRUE(cr);
     score->select(cr->isChord() ? toChord(cr)->upNote() : static_cast<EngravingItem*>(cr));
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Copy/paste tests"));
     QMimeDataAdapter ma(&mimeData);
     score->cmdPaste(&ma, 0);
     score->endCmd();
@@ -703,7 +703,7 @@ TEST_F(Engraving_CopyPasteTests, copypasteSplitNoteOverBarDrumStave)
     mimeData.setData(score->selection().mimeType(), score->selection().mimeData().toQByteArray());
     ChordRest* cr = m1->findChordRest(Fraction(7, 8), 0);
     score->select(cr->isChord() ? toChord(cr)->upNote() : static_cast<EngravingItem*>(cr));
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Copy/paste tests"));
     QMimeDataAdapter ma(&mimeData);
     score->cmdPaste(&ma, 0);
     score->endCmd();
@@ -746,7 +746,7 @@ TEST_F(Engraving_CopyPasteTests, DISABLED_copypastetremolo)
     //paste to second measure
     score->select(m2->first()->element(0));
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Copy/paste tests"));
     QMimeDataAdapter ma(mimeData);
     score->cmdPaste(&ma, 0);
     score->endCmd();
@@ -766,7 +766,7 @@ TEST_F(Engraving_CopyPasteTests, DISABLED_copypastetremolo)
     //paste to third measure
     score->select(m3->first()->element(0));
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Copy/paste tests"));
     score->cmdPaste(&ma, 0);
     score->endCmd();
 

--- a/src/engraving/tests/copypastesymbollist_tests.cpp
+++ b/src/engraving/tests/copypastesymbollist_tests.cpp
@@ -71,7 +71,7 @@ void Engraving_CopyPasteSymbolListTests::copypastecommon(MasterScore* score, con
     }
     score->select(m->first()->element(0));
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Copy/paste symbol tests"));
     const QMimeData* ms = QApplication::clipboard()->mimeData();
     if (!ms->hasFormat(mimeSymbolListFormat)) {
         LOGD("wrong type mime data");

--- a/src/engraving/tests/durationtype_tests.cpp
+++ b/src/engraving/tests/durationtype_tests.cpp
@@ -58,7 +58,7 @@ TEST_F(Engraving_DurationTypeTests, halfDuration)
     score->inputState().setDuration(DurationType::V_WHOLE);
     score->inputState().setNoteEntryMode(true);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Duration type tests"));
     score->cmdAddPitch(42, false, false);
     Chord* c = score->firstMeasure()->findChord(Fraction(0, 1), 0);
     EXPECT_EQ(c->ticks(), Fraction(1, 1));
@@ -66,7 +66,7 @@ TEST_F(Engraving_DurationTypeTests, halfDuration)
 
     // repeatedly half-duration from V_WHOLE to V_128
     for (int i = 128; i > 1; i /= 2) {
-        score->startCmd();
+        score->startCmd(TranslatableString("undoableAction", "Duration type tests"));
         score->cmdHalfDuration();
         score->endCmd();
         Chord* c2 = score->firstMeasure()->findChord(Fraction(0, 1), 0);
@@ -89,7 +89,7 @@ TEST_F(Engraving_DurationTypeTests, doubleDuration)
     score->inputState().setDuration(DurationType::V_128TH);
     score->inputState().setNoteEntryMode(true);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Duration type tests"));
     score->cmdAddPitch(42, false, false);
     EXPECT_EQ(score->firstMeasure()->findChord(Fraction(0, 1), 0)->ticks(), Fraction(1, 128));
 
@@ -117,7 +117,7 @@ TEST_F(Engraving_DurationTypeTests, decDurationDotted)
     score->inputState().setDuration(DurationType::V_WHOLE);
     score->inputState().setNoteEntryMode(true);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Duration type tests"));
     score->cmdAddPitch(42, false, false);
     Chord* c = score->firstMeasure()->findChord(Fraction(0, 1), 0);
     EXPECT_EQ(c->ticks(), Fraction(1, 1));
@@ -150,7 +150,7 @@ TEST_F(Engraving_DurationTypeTests, incDurationDotted)
     score->inputState().setDuration(DurationType::V_128TH);
     score->inputState().setNoteEntryMode(true);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Duration type tests"));
     score->cmdAddPitch(42, false, false);
     EXPECT_EQ(score->firstMeasure()->findChord(Fraction(0, 1), 0)->ticks(), Fraction(1, 128));
 

--- a/src/engraving/tests/earlymusic_tests.cpp
+++ b/src/engraving/tests/earlymusic_tests.cpp
@@ -69,7 +69,7 @@ TEST_F(Engraving_EarlymusicTests, earlymusic01)
     // set crossMeasureValue flag ON: score should not change
     MStyle newStyle = score->style();
     newStyle.set(Sid::crossMeasureValues, true);
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Early music tests"));
     score->deselectAll();
     score->undo(new ChangeStyle(score, newStyle));
     score->update();

--- a/src/engraving/tests/exchangevoices_tests.cpp
+++ b/src/engraving/tests/exchangevoices_tests.cpp
@@ -46,12 +46,12 @@ TEST_F(Engraving_ExchangevoicesTests, slurs)
     score->doLayout();
 
     // select all
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Exchange select all"));
     score->cmdSelectAll();
     score->endCmd();
 
     // do
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Exchange voices tests"));
     score->cmdExchangeVoice(0, 1);
     score->endCmd();
 
@@ -66,12 +66,12 @@ TEST_F(Engraving_ExchangevoicesTests, glissandi)
     score->doLayout();
 
     // select all
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Exchange voices select all"));
     score->cmdSelectAll();
     score->endCmd();
 
     // do
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Exchange voices tests"));
     score->cmdExchangeVoice(0, 1);
     score->endCmd();
 
@@ -102,7 +102,7 @@ TEST_F(Engraving_ExchangevoicesTests, undoChangeVoice)
         }
     }
     // change voice
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Exchange voices tests"));
     score->changeSelectedElementsVoice(1);
     score->endCmd(false, /*layoutAllParts = */ true);
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, writeFile1, reference1));

--- a/src/engraving/tests/harpdiagram_tests.cpp
+++ b/src/engraving/tests/harpdiagram_tests.cpp
@@ -107,7 +107,7 @@ TEST_F(Engraving_HarpDiagramTests, textdiagrams)
             PedalPosition::NATURAL, PedalPosition::NATURAL };
     diagram1->setIsDiagram(false);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Harp diagram tests"));
     EditData dd1(0);
     dd1.dropElement = diagram1;
     EngravingItem* e1 = s1->firstElementForNavigation(0);
@@ -125,7 +125,7 @@ TEST_F(Engraving_HarpDiagramTests, textdiagrams)
     HarpPedalDiagram* diagram2 = Factory::createHarpPedalDiagram(s2);
     diagram2->setIsDiagram(false);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Harp diagram tests"));
     EditData dd2(0);
     dd2.dropElement = diagram2;
     EngravingItem* e2 = s2->firstElementForNavigation(0);
@@ -142,7 +142,7 @@ TEST_F(Engraving_HarpDiagramTests, textdiagrams)
     HarpPedalDiagram* diagram3 = Factory::createHarpPedalDiagram(s3);
     diagram3->setIsDiagram(false);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Harp diagram tests"));
     EditData dd3(0);
     dd3.dropElement = diagram3;
     EngravingItem* e3 = s3->firstElementForNavigation(0);
@@ -157,7 +157,7 @@ TEST_F(Engraving_HarpDiagramTests, textdiagrams)
     HarpPedalDiagram* diagram4 = Factory::createHarpPedalDiagram(s4);
     diagram4->setIsDiagram(false);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Harp diagram tests"));
     EditData dd4(0);
     dd4.dropElement = diagram4;
     EngravingItem* e4 = s4->firstElementForNavigation(0);
@@ -197,7 +197,7 @@ TEST_F(Engraving_HarpDiagramTests, textdiagrams2)
     HarpPedalDiagram* diagram2 = Factory::createHarpPedalDiagram(s2);
     diagram2->setIsDiagram(false);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Harp diagram tests"));
     EditData dd(0);
     dd.dropElement = diagram2;
     EngravingItem* e = s2->firstElementForNavigation(0);
@@ -215,7 +215,7 @@ TEST_F(Engraving_HarpDiagramTests, textdiagrams2)
     EXPECT_EQ(diagram1->xmlText(), expText);
 
     // Test undo
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Harp diagram tests"));
     score->undoRedo(true, &dd);
     score->endCmd();
 

--- a/src/engraving/tests/implodeexplode_tests.cpp
+++ b/src/engraving/tests/implodeexplode_tests.cpp
@@ -53,12 +53,12 @@ void Engraving_ImplodeExplodeTests::testUndoExplode(String fileName)
     score->doLayout();
 
     // select all
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Implode/explode select all"));
     score->cmdSelectAll();
     score->endCmd();
 
     // do
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Implode/explode tests"));
     score->cmdExplode();
     score->endCmd();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, writeFile1, reference1));
@@ -84,12 +84,12 @@ void Engraving_ImplodeExplodeTests::testUndoImplode(String filename)
     score->doLayout();
 
     // select all
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Implode/explode select all"));
     score->cmdSelectAll();
     score->endCmd();
 
     // do
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Implode/explode tests"));
     score->cmdImplode();
     score->endCmd();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, writeFile1, reference1));

--- a/src/engraving/tests/instrumentchange_tests.cpp
+++ b/src/engraving/tests/instrumentchange_tests.cpp
@@ -74,7 +74,7 @@ TEST_F(Engraving_InstrumentChangeTests, testAdd)
     ic->setParent(s);
     ic->setTrack(0);
     ic->setXmlText("Instrument");
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Instrument change tests"));
     score->undoAddElement(ic);
     score->endCmd();
     test_post(score, u"add");
@@ -99,7 +99,7 @@ TEST_F(Engraving_InstrumentChangeTests, testChange)
     InstrumentChange* ic = toInstrumentChange(s->annotations()[0]);
     Instrument* ni       = score->staff(1)->part()->instrument();
     ic->setInstrument(new Instrument(*ni));
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Instrument change tests"));
     ic->setXmlText("Instrument Oboe");
     score->undo(new ChangeInstrument(ic, ic->instrument()));
     score->endCmd();
@@ -121,7 +121,7 @@ TEST_F(Engraving_InstrumentChangeTests, testMixer)
     mp->name = "Viola";
     mp->prog = 41;
     mp->synti = "Fluid";
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Instrument change tests"));
     ic->setXmlText("Mixer Viola");
     score->undo(new ChangePatch(score, c, mp));
     score->endCmd();

--- a/src/engraving/tests/join_tests.cpp
+++ b/src/engraving/tests/join_tests.cpp
@@ -61,7 +61,7 @@ void Engraving_JoinTests::join(const char* p1, const char* p2, int index)
 
     EXPECT_NE(m1, m2);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving join tests"));
     score->cmdJoinMeasure(m1, m2);
     score->endCmd();
 

--- a/src/engraving/tests/keysig_tests.cpp
+++ b/src/engraving/tests/keysig_tests.cpp
@@ -64,7 +64,7 @@ TEST_F(Engraving_KeySigTests, keysig)
     // add a key signature (D major) in measure 2
     KeySigEvent ke2;
     ke2.setConcertKey(Key::D);
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Key signature tests"));
     score->undoChangeKeySig(score->staff(0), m2->tick(), ke2);
     score->endCmd();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, writeFile1, reference1));
@@ -72,7 +72,7 @@ TEST_F(Engraving_KeySigTests, keysig)
     // change key signature in measure 2 to E flat major
     KeySigEvent ke_3;
     ke_3.setConcertKey(Key(-3));
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Key signature tests"));
     score->undoChangeKeySig(score->staff(0), m2->tick(), ke_3);
     score->endCmd();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, writeFile2, reference2));
@@ -83,7 +83,7 @@ TEST_F(Engraving_KeySigTests, keysig)
         s = s->next();
     }
     EngravingItem* e = s->element(0);
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Key signature tests"));
     score->undoRemoveElement(e);
     score->endCmd();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, writeFile3, reference3));
@@ -158,7 +158,7 @@ TEST_F(Engraving_KeySigTests, preferSharpFlat)
     MasterScore* score2 = ScoreRW::readScore(KEYSIG_DATA_DIR + u"preferSharpFlat-2.mscx");
     EXPECT_TRUE(score2);
     score2->cmdSelectAll();
-    score2->startCmd();
+    score2->startCmd(TranslatableString("undoableAction", "Key signature tests"));
     // transpose augmented unison up
     score2->transpose(TransposeMode::BY_INTERVAL, TransposeDirection::UP, Key::C, 1, true, true, true);
     score2->endCmd();

--- a/src/engraving/tests/links_tests.cpp
+++ b/src/engraving/tests/links_tests.cpp
@@ -93,7 +93,7 @@ TEST_F(Engraving_LinksTests, test3LinkedSameScore_99796)
     EXPECT_TRUE(e->links() == nullptr);
 
     // add a linked staff
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving links tests"));
     Staff* oStaff = score->staff(0);
     Staff* staff  = Factory::createStaff(oStaff->part());
     staff->setPart(oStaff->part());
@@ -124,7 +124,7 @@ TEST_F(Engraving_LinksTests, test3LinkedSameScore_99796)
     EXPECT_TRUE(e->links()->size() == 3);
 
     // delete staff
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving links tests"));
     score->cmdRemoveStaff(0);
     score->endCmd();
 
@@ -197,7 +197,7 @@ TEST_F(Engraving_LinksTests, test3LinkedParts_99796)
     EXPECT_TRUE(e->links() == nullptr);
 
     // create parts
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving links tests"));
     std::vector<Part*> parts;
     parts.push_back(score->parts().at(0));
     Score* nscore = score->createScore();
@@ -211,7 +211,7 @@ TEST_F(Engraving_LinksTests, test3LinkedParts_99796)
     score->endCmd();
 
     // add a linked staff
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving links tests"));
     Staff* oStaff = score->staff(0);
     Staff* staff  = Factory::createStaff(oStaff->part());
     staff->setPart(oStaff->part());
@@ -229,7 +229,7 @@ TEST_F(Engraving_LinksTests, test3LinkedParts_99796)
     EXPECT_TRUE(e->links()->size() == 3);
 
     // delete part
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving links tests"));
     score->deleteExcerpt(&ex);
     score->undo(new RemoveExcerpt(&ex));
 
@@ -278,7 +278,7 @@ TEST_F(Engraving_LinksTests, DISABLED_test4LinkedParts_94911)
     EXPECT_TRUE(e->links() == nullptr);
 
     // add a linked staff
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving links tests"));
     Staff* oStaff = score->staff(0);
     Staff* staff  = Factory::createStaff(oStaff->part());
     staff->setPart(oStaff->part());
@@ -296,7 +296,7 @@ TEST_F(Engraving_LinksTests, DISABLED_test4LinkedParts_94911)
     EXPECT_TRUE(e->links()->size() == 2);
 
     // create parts
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving links tests"));
     std::vector<Part*> parts;
     parts.push_back(score->parts().at(0));
     Score* nscore = score->createScore();
@@ -323,7 +323,7 @@ TEST_F(Engraving_LinksTests, DISABLED_test4LinkedParts_94911)
     EXPECT_TRUE(score->excerpts().size() == 1);
 
     // delete second staff
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving links tests"));
     score->cmdRemoveStaff(1);
     for (Excerpt* excerpt : score->excerpts()) {
         std::vector<Staff*> sl = nscore->staves();
@@ -401,7 +401,7 @@ TEST_F(Engraving_LinksTests, test5LinkedParts_94911)
     EXPECT_TRUE(e->links() == nullptr);
 
     // create parts//
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving links tests"));
     std::vector<Part*> parts;
     parts.push_back(score->parts().at(0));
     Score* nscore = score->createScore();
@@ -421,7 +421,7 @@ TEST_F(Engraving_LinksTests, test5LinkedParts_94911)
     EXPECT_TRUE(e->links()->size() == 2);
 
     // add a linked staff
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving links tests"));
     Staff* oStaff = score->staff(0);
     Staff* staff  = Factory::createStaff(oStaff->part());
     staff->setPart(oStaff->part());

--- a/src/engraving/tests/measure_tests.cpp
+++ b/src/engraving/tests/measure_tests.cpp
@@ -85,7 +85,7 @@ TEST_F(Engraving_MeasureTests, DISABLED_insertMeasureMiddle) //TODO: verify prog
     MasterScore* score = ScoreRW::readScore(MEASURE_DATA_DIR + u"measure-1.mscx");
     EXPECT_TRUE(score);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
     Measure* m = score->firstMeasure()->nextMeasure();
     score->insertMeasure(m);
     score->endCmd();
@@ -99,7 +99,7 @@ TEST_F(Engraving_MeasureTests, DISABLED_insertMeasureBegin) // TODO: verify prog
     MasterScore* score = ScoreRW::readScore(MEASURE_DATA_DIR + u"measure-1.mscx");
     EXPECT_TRUE(score);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
     Measure* m = score->firstMeasure();
     score->insertMeasure(m);
     score->endCmd();
@@ -113,7 +113,7 @@ TEST_F(Engraving_MeasureTests, DISABLED_insertMeasureEnd) // TODO: verify progra
     MasterScore* score = ScoreRW::readScore(MEASURE_DATA_DIR + "measure-1.mscx");
     EXPECT_TRUE(score);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
     score->insertMeasure(0);
     score->endCmd();
 
@@ -126,7 +126,7 @@ TEST_F(Engraving_MeasureTests, insertAtBeginning)
     MasterScore* score = ScoreRW::readScore(MEASURE_DATA_DIR + u"measure-insert_beginning.mscx");
     EXPECT_TRUE(score);
     Measure* m = score->firstMeasure();
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
     score->insertMeasure(m);
     score->endCmd();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"measure-insert_beginning.mscx",
@@ -142,7 +142,7 @@ TEST_F(Engraving_MeasureTests, insertBfClefChange)
     // 4th measure
     Measure* m = score->firstMeasure()->nextMeasure();
     m = m->nextMeasure()->nextMeasure();
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
     score->insertMeasure(m);
     score->endCmd();
 
@@ -153,7 +153,7 @@ TEST_F(Engraving_MeasureTests, insertBfClefChange)
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"measure-insert_bf_clef_undo.mscx", MEASURE_DATA_DIR + u"measure-insert_bf_clef.mscx"));
 
     m = score->firstMeasure()->nextMeasure()->nextMeasure()->nextMeasure()->nextMeasure()->nextMeasure();
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
     score->insertMeasure(m);
     score->endCmd();
 
@@ -174,7 +174,7 @@ TEST_F(Engraving_MeasureTests, insertBfKeyChange)
     // 4th measure
     Measure* m = score->firstMeasure()->nextMeasure();
     m = m->nextMeasure()->nextMeasure();
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
     score->insertMeasure(m);
     score->endCmd();
 
@@ -188,7 +188,7 @@ TEST_F(Engraving_MeasureTests, insertBfKeyChange)
                                             MEASURE_DATA_DIR + u"measure-insert_bf_key_undo-ref.mscx"));
 
     m = score->firstMeasure()->nextMeasure()->nextMeasure()->nextMeasure()->nextMeasure()->nextMeasure();
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
     score->insertMeasure(m);
     score->endCmd();
     EXPECT_TRUE(score->checkKeys());
@@ -217,7 +217,7 @@ TEST_F(Engraving_MeasureTests, spanner_a)
     EXPECT_TRUE(score);
 
     Measure* m = score->firstMeasure()->nextMeasure();
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
     score->insertMeasure(m);
     score->endCmd();
 
@@ -239,7 +239,7 @@ TEST_F(Engraving_MeasureTests, spanner_b)
     EXPECT_TRUE(score);
 
     Measure* m = score->firstMeasure();
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
     score->insertMeasure(m);
     score->endCmd();
 
@@ -260,7 +260,7 @@ TEST_F(Engraving_MeasureTests, spanner_A)
     EXPECT_TRUE(score);
 
     score->select(score->firstMeasure());
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
     score->cmdTimeDelete();
     score->endCmd();
     score->doLayout();
@@ -284,7 +284,7 @@ TEST_F(Engraving_MeasureTests, spanner_B)
 
     Measure* m = score->firstMeasure()->nextMeasure();
     score->select(m);
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
     score->cmdTimeDelete();
     score->endCmd();
 
@@ -307,7 +307,7 @@ TEST_F(Engraving_MeasureTests, spanner_C)
 
     Measure* m = score->firstMeasure()->nextMeasure();
     score->select(m);
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
     score->cmdTimeDelete();
     score->endCmd();
 
@@ -330,7 +330,7 @@ TEST_F(Engraving_MeasureTests, spanner_D)
 
     Measure* m = score->firstMeasure()->nextMeasure();
     score->select(m);
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
     score->cmdTimeDelete();
     score->endCmd();
 
@@ -349,7 +349,7 @@ TEST_F(Engraving_MeasureTests, deleteLast)
 
     Measure* m = score->lastMeasure();
     score->select(m);
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
     score->cmdTimeDelete();
     score->endCmd();
 
@@ -369,7 +369,7 @@ TEST_F(Engraving_MeasureTests, gap)
     EngravingItem* tst = 0;
 
     //Select and delete third quarter rest in first Measure (voice 2)
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
     Measure* m  = score->firstMeasure();
     Segment* s  = m->undoGetSegment(SegmentType::ChordRest, Fraction::fromTicks(960));
     EngravingItem* el = s->element(1);
@@ -385,7 +385,7 @@ TEST_F(Engraving_MeasureTests, gap)
     /*&& toRest(tst)->durationType() == DurationType::V_QUARTER*/
 
     //Select and delete second quarter rest in third Measure (voice 4)
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
     m  = m->nextMeasure()->nextMeasure();
     s  = m->undoGetSegment(SegmentType::ChordRest, Fraction::fromTicks(4320));
     el = s->element(3);
@@ -401,7 +401,7 @@ TEST_F(Engraving_MeasureTests, gap)
     /*&& toRest(tst)->durationType() == DurationType::V_QUARTER*/
 
     //Select and delete first quarter rest in third Measure (voice 4)
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
     s  = m->undoGetSegment(SegmentType::ChordRest, Fraction::fromTicks(3840));
     el = s->element(3);
     score->select(el);
@@ -486,14 +486,14 @@ TEST_F(Engraving_MeasureTests, undoDelInitialVBox_269919)
     EXPECT_TRUE(score);
 
     // 1. delete initial VBox
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
     MeasureBase* initialVBox = score->measure(0);
     score->select(initialVBox);
     score->cmdDeleteSelection();
     score->endCmd();
 
     // 2. change duration of first chordrest
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
     Measure* m = score->firstMeasure();
     ChordRest* cr = m->findChordRest(Fraction(0, 1), 0);
     Fraction quarter(4, 1);
@@ -521,7 +521,7 @@ TEST_F(Engraving_MeasureTests, mmrest)
     MasterScore* score = ScoreRW::readScore(MEASURE_DATA_DIR + u"mmrest.mscx");
     EXPECT_TRUE(score);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
     score->undoChangeStyleVal(Sid::createMultiMeasureRests, true);
     score->setLayoutAll();
     score->endCmd();
@@ -550,14 +550,14 @@ TEST_F(Engraving_MeasureTests, measureNumbers)
     delete mn;
 
     // Place measure numbers below
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
     score->undoChangeStyleVal(Sid::measureNumberVPlacement, PlacementV::BELOW);
     score->setLayoutAll();
     score->endCmd();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"measurenumber-1.mscx", MEASURE_DATA_DIR + u"measurenumber-1-ref.mscx"));
 
     // center measure numbers
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
     score->undoChangeStyleVal(Sid::measureNumberHPlacement, PlacementH::CENTER);
     score->setLayoutAll();
     score->endCmd();
@@ -570,7 +570,7 @@ TEST_F(Engraving_MeasureTests, measureNumbers)
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"measurenumber-3.mscx", MEASURE_DATA_DIR + u"measurenumber-3-ref.mscx"));
 
     // every 5 measures (default interval)
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
     // to know whether measure numbers are shown at regular intervals or on every system,
     // musescore simply checks if measure numbers are shown at system or not.
     score->undoChangeStyleVal(Sid::measureNumberSystem, false);
@@ -581,21 +581,21 @@ TEST_F(Engraving_MeasureTests, measureNumbers)
     // do not show first measure number. This should shift all measure numbers,
     // because they are still placed at regular intervals.
     // Instead of being at 1-6-11-16-21, etc. They should be at 5-10-15-20-25, etc.
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
     score->undoChangeStyleVal(Sid::showMeasureNumberOne, false);
     score->setLayoutAll();
     score->endCmd();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"measurenumber-5.mscx", MEASURE_DATA_DIR + u"measurenumber-5-ref.mscx"));
 
     // show at every measure (except fist)
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
     score->undoChangeStyleVal(Sid::measureNumberInterval, 1);
     score->setLayoutAll();
     score->endCmd();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"measurenumber-6.mscx", MEASURE_DATA_DIR + u"measurenumber-6-ref.mscx"));
 
     // Disable measure numbers
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
     // to know whether measure numbers are shown at regular intervals or on every system,
     // musescore simply checks if measure numbers are shown at system or not.
     score->undoChangeStyleVal(Sid::showMeasureNumber, false);
@@ -612,7 +612,7 @@ TEST_F(Engraving_MeasureTests, changeMeasureLen) {
 
     Measure* m = score->firstMeasure()->nextMeasure();
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
 
     m->adjustToLen(Fraction(2, 4));
 
@@ -628,7 +628,7 @@ TEST_F(Engraving_MeasureTests, measureSplit) {
     EXPECT_TRUE(score);
 
     createParts(score);
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
 
     Measure* m = score->firstMeasure()->nextMeasure();
     EXPECT_TRUE(m);

--- a/src/engraving/tests/note_tests.cpp
+++ b/src/engraving/tests/note_tests.cpp
@@ -312,7 +312,7 @@ TEST_F(Engraving_NoteTests, grace)
 //      delete n;
 
     // tremolo
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving note tests"));
     TremoloSingleChord* tr = Factory::createTremoloSingleChord(gc);
     tr->setTremoloType(TremoloType::R16);
     tr->setParent(gc);
@@ -324,7 +324,7 @@ TEST_F(Engraving_NoteTests, grace)
 //      delete c;
 
     // articulation
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving note tests"));
     Articulation* ar = Factory::createArticulation(gc);
     ar->setSymId(SymId::articAccentAbove);
     ar->setParent(gc);
@@ -375,19 +375,19 @@ TEST_F(Engraving_NoteTests, tpcTranspose)
 {
     MasterScore* score = ScoreRW::readScore(NOTE_DATA_DIR + u"tpc-transpose.mscx");
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving note tests"));
     Measure* m = score->firstMeasure();
     score->select(m, SelectType::SINGLE, 0);
     score->changeAccidental(AccidentalType::FLAT);
     score->endCmd();
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving note tests"));
     m = m->nextMeasure();
     score->select(m, SelectType::SINGLE, 0);
     score->upDown(false, UpDownMode::CHROMATIC);
     score->endCmd();
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving note tests"));
     score->cmdConcertPitchChanged(true);
     score->endCmd();
 
@@ -410,7 +410,7 @@ TEST_F(Engraving_NoteTests, tpcTranspose2)
     int octave = 5 * 7;
     score->cmdAddPitch(octave + 3, false, false);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving note tests"));
     score->cmdConcertPitchChanged(true);
     score->endCmd();
 
@@ -447,7 +447,7 @@ TEST_F(Engraving_NoteTests, noteLimits)
     score->cmdAddPitch(42, false, false);
     for (int i = 0; i < 20; i++) {
         std::vector<Note*> nl = score->selection().noteList();
-        score->startCmd();
+        score->startCmd(TranslatableString("undoableAction", "Engraving note tests"));
         score->addInterval(-8, nl);
         score->endCmd();
     }
@@ -456,7 +456,7 @@ TEST_F(Engraving_NoteTests, noteLimits)
     score->cmdAddPitch(42, false, false);
     for (int i = 0; i < 20; i++) {
         std::vector<Note*> nl = score->selection().noteList();
-        score->startCmd();
+        score->startCmd(TranslatableString("undoableAction", "Engraving note tests"));
         score->addInterval(8, nl);
         score->endCmd();
     }

--- a/src/engraving/tests/parts_tests.cpp
+++ b/src/engraving/tests/parts_tests.cpp
@@ -135,7 +135,7 @@ void Engraving_PartsTests::createParts(MasterScore* masterScore)
 
 void Engraving_PartsTests::createLinkedStaff(MasterScore* masterScore)
 {
-    masterScore->startCmd();
+    masterScore->startCmd(TranslatableString("undoableAction", "Engraving parts tests"));
     Staff* sourceStaff = masterScore->staff(0);
     EXPECT_TRUE(sourceStaff);
     Staff* linkedStaff = Factory::createStaff(sourceStaff->part());
@@ -253,7 +253,7 @@ TEST_F(Engraving_PartsTests, appendMeasure)
 
     createParts(score);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving parts tests"));
     score->insertMeasure(0);
     score->endCmd();
 
@@ -276,7 +276,7 @@ TEST_F(Engraving_PartsTests, insertMeasure)
 
     createParts(score);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving parts tests"));
     Measure* m = score->firstMeasure();
     score->insertMeasure(m);
     score->endCmd();
@@ -404,7 +404,7 @@ MasterScore* Engraving_PartsTests::doAddBreath()
     b->setSymId(SymId::breathMarkComma);
     dd.dropElement = b;
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving parts tests"));
     note->drop(dd);
     score->endCmd();          // does layout
 
@@ -465,7 +465,7 @@ MasterScore* Engraving_PartsTests::doRemoveBreath()
     Breath* b    = toBreath(s->element(0));
 
     score->select(b);
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving parts tests"));
     score->cmdDeleteSelection();
     score->setLayoutAll();
     score->endCmd();
@@ -536,7 +536,7 @@ MasterScore* Engraving_PartsTests::doAddFingering()
     b->setXmlText("3");
     dd.dropElement = b;
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving parts tests"));
     note->drop(dd);
     score->endCmd();          // does layout
     return score;
@@ -600,7 +600,7 @@ MasterScore* Engraving_PartsTests::doRemoveFingering()
     }
     score->select(fingering);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving parts tests"));
     score->cmdDeleteSelection();
     score->setLayoutAll();
     score->endCmd();
@@ -670,7 +670,7 @@ MasterScore* Engraving_PartsTests::doAddSymbol()
     b->setSym(SymId::gClef);
     dd.dropElement = b;
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving parts tests"));
     note->drop(dd);
     score->endCmd();          // does layout
     return score;
@@ -734,7 +734,7 @@ MasterScore* Engraving_PartsTests::doRemoveSymbol()
     }
     score->select(se);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving parts tests"));
     score->cmdDeleteSelection();
     score->setLayoutAll();
     score->endCmd();
@@ -804,7 +804,7 @@ MasterScore* Engraving_PartsTests::doAddChordline()
     b->setChordLineType(ChordLineType::FALL);
     dd.dropElement = b;
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving parts tests"));
     note->drop(dd);
     score->endCmd();          // does layout
     return score;
@@ -868,7 +868,7 @@ MasterScore* Engraving_PartsTests::doRemoveChordline()
     }
     score->select(se);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving parts tests"));
     score->cmdDeleteSelection();
     score->setLayoutAll();
     score->endCmd();
@@ -931,7 +931,7 @@ MasterScore* Engraving_PartsTests::doAddMeasureRepeat()
 
     Measure* m = score->firstMeasure()->nextMeasure();
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving parts tests"));
     score->cmdAddMeasureRepeat(m, 4, 0); // test with 4-measure repeat in first staff
     score->setLayoutAll();
     score->endCmd();
@@ -992,7 +992,7 @@ MasterScore* Engraving_PartsTests::doRemoveMeasureRepeat()
     MeasureRepeat* mr = m->measureRepeatElement(0);
     score->select(mr);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving parts tests"));
     score->cmdDeleteSelection();
     score->setLayoutAll();
     score->endCmd();
@@ -1063,7 +1063,7 @@ MasterScore* Engraving_PartsTests::doAddImage()
     b->load(PARTS_DATA_DIR + u"schnee.png");
     dd.dropElement = b;
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving parts tests"));
     note->drop(dd);
     score->endCmd();          // does layout
     return score;
@@ -1127,7 +1127,7 @@ MasterScore* Engraving_PartsTests::doRemoveImage()
     }
     score->select(fingering);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving parts tests"));
     score->cmdDeleteSelection();
     score->setLayoutAll();
     score->endCmd();
@@ -1315,7 +1315,7 @@ TEST_F(Engraving_PartsTests, partVisibleTracks) {
     Note* n = c->downNote();
     EXPECT_TRUE(n);
 
-    part->startCmd();
+    part->startCmd(TranslatableString("undoableAction", "Engraving parts tests"));
     part->select(n);
     part->changeSelectedElementsVoice(1);
     part->endCmd();

--- a/src/engraving/tests/readwriteundoreset_tests.cpp
+++ b/src/engraving/tests/readwriteundoreset_tests.cpp
@@ -83,7 +83,7 @@ TEST_F(Engraving_ReadWriteUndoResetTests, testMMRestLinksRecreateMMRest)
 
     // Regenerate MM rests from scratch:
     // 1) turn MM rests off
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Read/write/undo/reset tests"));
     score->undoChangeStyleVal(Sid::createMultiMeasureRests, false);
     score->endCmd();
 
@@ -93,7 +93,7 @@ TEST_F(Engraving_ReadWriteUndoResetTests, testMMRestLinksRecreateMMRest)
     score = ScoreRW::readScore(writeFile, true);
 
     // 3) turn MM rests back on
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Read/write/undo/reset tests"));
     score->undoChangeStyleVal(Sid::createMultiMeasureRests, true);
     score->endCmd();
 

--- a/src/engraving/tests/remove_tests.cpp
+++ b/src/engraving/tests/remove_tests.cpp
@@ -94,7 +94,7 @@ TEST_F(Engraving_RemoveTests, removeStaff)
     EXPECT_TRUE(score);
 
     // Remove the second staff and see what happens
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving remove tests"));
     score->cmdRemoveStaff(1);
     score->endCmd(false, /*layoutAllParts = */ true);
 

--- a/src/engraving/tests/rhythmicgrouping_tests.cpp
+++ b/src/engraving/tests/rhythmicgrouping_tests.cpp
@@ -49,7 +49,7 @@ void Engraving_RhythmicGroupingTests::group(const char* p1, const char* p2, size
         score->cmdResetNoteAndRestGroupings();
     } else {
         assert(staves < score->nstaves());
-        score->startCmd();
+        score->startCmd(TranslatableString("undoableAction", "Rhythmic grouping tests"));
         for (size_t track = 0; track < staves * VOICES; track++) {
             score->regroupNotesAndRests(score->firstSegment(SegmentType::All)->tick(),
                                         score->lastSegment()->tick(), static_cast<int>(track));

--- a/src/engraving/tests/selectionrangedelete_tests.cpp
+++ b/src/engraving/tests/selectionrangedelete_tests.cpp
@@ -46,7 +46,7 @@ public:
 
 void Engraving_SelectionRangeDeleteTests::verifyDelete(MasterScore* score, size_t spanners)
 {
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Selection range delete tests"));
     score->cmdDeleteSelection();
     score->endCmd();
 
@@ -57,7 +57,7 @@ void Engraving_SelectionRangeDeleteTests::verifyDelete(MasterScore* score, size_
 
 void Engraving_SelectionRangeDeleteTests::verifyNoDelete(MasterScore* score, size_t spanners)
 {
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Selection range delete tests"));
     score->cmdDeleteSelection();
     score->endCmd();
 
@@ -160,7 +160,7 @@ void Engraving_SelectionRangeDeleteTests::deleteVoice(int voice, String idx)
     score->selectionFilter().setFiltered(voiceFilterType, false);
     score->select(m1, SelectType::RANGE);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Selection range delete tests"));
     score->cmdDeleteSelection();
     score->endCmd();
 
@@ -192,7 +192,7 @@ TEST_F(Engraving_SelectionRangeDeleteTests, deleteSkipAnnotations)
     SelectionFilterType annotationFilterType = SelectionFilterType((int)SelectionFilterType::CHORD_SYMBOL);
     score->selectionFilter().setFiltered(annotationFilterType, false);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Selection range delete tests"));
     score->cmdSelectAll();
     score->cmdDeleteSelection();
     score->endCmd();

--- a/src/engraving/tests/spanners_tests.cpp
+++ b/src/engraving/tests/spanners_tests.cpp
@@ -377,7 +377,7 @@ TEST_F(Engraving_SpannersTests, spanners09)
     EXPECT_TRUE(msr);
     msr = msr->nextMeasure();
     EXPECT_TRUE(msr);
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving spanners tests"));
     score->select(msr);
     score->cmdTimeDelete();
     score->endCmd();
@@ -410,7 +410,7 @@ TEST_F(Engraving_SpannersTests, spanners10)
     EXPECT_TRUE(msr);
     msr = msr->nextMeasure();
     EXPECT_TRUE(msr);
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving spanners tests"));
     score->select(msr);
     score->cmdTimeDelete();
     score->endCmd();
@@ -443,7 +443,7 @@ TEST_F(Engraving_SpannersTests, spanners11)
     EXPECT_TRUE(msr);
     msr = msr->nextMeasure();
     EXPECT_TRUE(msr);
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving spanners tests"));
     score->select(msr);
     score->cmdTimeDelete();
     score->endCmd();
@@ -476,7 +476,7 @@ TEST_F(Engraving_SpannersTests, spanners12)
     EXPECT_TRUE(msr);
     msr = msr->nextMeasure();
     EXPECT_TRUE(msr);
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving spanners tests"));
     score->select(msr);
     score->cmdTimeDelete();
     score->endCmd();
@@ -511,7 +511,7 @@ TEST_F(Engraving_SpannersTests, DISABLED_spanners13)
     brk->setLayoutBreakType(LayoutBreakType::LINE);
     dropData.pos      = msr->pagePos();
     dropData.dropElement  = brk;
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving spanners tests"));
     msr->drop(dropData);
     score->endCmd();
     // VERIFY SEGMENTS IN SYSTEMS AND THEN SCORE

--- a/src/engraving/tests/split_tests.cpp
+++ b/src/engraving/tests/split_tests.cpp
@@ -52,7 +52,7 @@ void Engraving_SplitTests::split(const char* f1, const char* ref, int index)
     }
     ChordRest* cr = toChordRest(s->element(0));
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving split tests"));
     score->cmdSplitMeasure(cr);
     score->endCmd();
 

--- a/src/engraving/tests/splitstaff_tests.cpp
+++ b/src/engraving/tests/splitstaff_tests.cpp
@@ -43,7 +43,7 @@ void Engraving_SplitStaffTests::splitstaff(int idx, int staffIdx)
     MasterScore* score = ScoreRW::readScore(SPLITSTAFF_DATA_DIR + String(u"splitstaff0%1.mscx").arg(idx));
     EXPECT_TRUE(score);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving split staff tests"));
     score->splitStaff(staffIdx, 60);
     score->endCmd();
 

--- a/src/engraving/tests/staffmove_tests.cpp
+++ b/src/engraving/tests/staffmove_tests.cpp
@@ -103,7 +103,7 @@ TEST_F(Engraving_StaffMoveTests, linkedStaff)
     EXPECT_TRUE(c1);
     Chord* c2 = toChord(s->element(8));
     EXPECT_TRUE(c2);
-    
+
     score->startCmd(TranslatableString("undoableAction", "Engraving staff move tests"));
     score->moveDown(c1);
     score->endCmd();

--- a/src/engraving/tests/staffmove_tests.cpp
+++ b/src/engraving/tests/staffmove_tests.cpp
@@ -59,12 +59,12 @@ TEST_F(Engraving_StaffMoveTests, hiddenStaff)
     Staff* staff = score->staff(0);
 
     // Move chord
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving staff move tests"));
     score->moveUp(c1);
     score->endCmd();
 
     // Hide staff
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving staff move tests"));
     score->undo(new mu::engraving::ChangeStaff(staff, false, staff->defaultClefType(), staff->userDist(), staff->hideWhenEmpty(),
                                                staff->showIfEmpty(), staff->cutaway(), staff->hideSystemBarLine(),
                                                staff->mergeMatchingRests(),
@@ -75,7 +75,7 @@ TEST_F(Engraving_StaffMoveTests, hiddenStaff)
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"hiddenStaff1.mscx", STAFF_MOVE_DIR + u"hiddenStaff-ref.mscx"));
 
     // Unhide staff
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving staff move tests"));
     score->undo(new mu::engraving::ChangeStaff(staff, true, staff->defaultClefType(), staff->userDist(), staff->hideWhenEmpty(),
                                                staff->showIfEmpty(), staff->cutaway(), staff->hideSystemBarLine(),
                                                staff->mergeMatchingRests(),
@@ -83,7 +83,7 @@ TEST_F(Engraving_StaffMoveTests, hiddenStaff)
     score->endCmd();
 
     // Move chord back
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving staff move tests"));
     score->moveDown(c1);
     score->endCmd();
 
@@ -103,20 +103,20 @@ TEST_F(Engraving_StaffMoveTests, linkedStaff)
     EXPECT_TRUE(c1);
     Chord* c2 = toChord(s->element(8));
     EXPECT_TRUE(c2);
-
-    score->startCmd();
+    
+    score->startCmd(TranslatableString("undoableAction", "Engraving staff move tests"));
     score->moveDown(c1);
     score->endCmd();
 
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"linkedStaff1.mscx", STAFF_MOVE_DIR + u"linkedStaff-ref.mscx"));
 
     // Try to move linked chord - should be no change
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving staff move tests"));
     score->moveUp(c2);
     score->endCmd();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"linkedStaff2.mscx", STAFF_MOVE_DIR + u"linkedStaff-ref.mscx"));
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving staff move tests"));
     score->moveUp(c1);
     score->endCmd();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"linkedStaff3.mscx", STAFF_MOVE_DIR + u"linkedStaff.mscx"));

--- a/src/engraving/tests/textbase_tests.cpp
+++ b/src/engraving/tests/textbase_tests.cpp
@@ -140,11 +140,11 @@ TEST_F(Engraving_TextBaseTests, undoChangeFontStyleProperty)
     StaffText* staffText = addStaffText(score);
     staffText->setXmlText(u"normal <b>bold</b> <u>underline</u> <i>italic</i>");
     score->renderer()->layoutItem(staffText);
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving text base tests"));
     staffText->undoChangeProperty(Pid::FONT_STYLE, PropertyValue::fromValue(0), PropertyFlags::UNSTYLED);
     score->endCmd();
     EXPECT_EQ(staffText->xmlText(), u"normal <b>bold</b> <u>underline</u> <i>italic</i>");
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving text base tests"));
     staffText->undoChangeProperty(Pid::FONT_STYLE, PropertyValue::fromValue(static_cast<int>(FontStyle::Bold)),
                                   PropertyFlags::UNSTYLED);
     score->endCmd();
@@ -154,19 +154,19 @@ TEST_F(Engraving_TextBaseTests, undoChangeFontStyleProperty)
     EXPECT_EQ(staffText->xmlText(), u"normal <b>bold</b> <u>underline</u> <i>italic</i>");
     score->undoStack()->redo(&ed);
     EXPECT_EQ(staffText->xmlText(), u"<b>normal bold <u>underline</u> <i>italic</i></b>");
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving text base tests"));
     staffText->undoChangeProperty(Pid::FONT_STYLE, PropertyValue::fromValue(
                                       static_cast<int>(FontStyle::Italic + FontStyle::Bold)), PropertyFlags::UNSTYLED);
     score->endCmd();
     EXPECT_EQ(staffText->xmlText(), u"<b><i>normal bold <u>underline</u> italic</i></b>");
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving text base tests"));
     staffText->undoChangeProperty(Pid::FONT_STYLE,
                                   PropertyValue::fromValue(
                                       static_cast<int>(FontStyle::Italic + FontStyle::Bold + FontStyle::Underline)),
                                   PropertyFlags::UNSTYLED);
     score->endCmd();
     EXPECT_EQ(staffText->xmlText(), u"<b><i><u>normal bold underline italic</u></i></b>");
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving text base tests"));
     staffText->undoChangeProperty(Pid::FONT_STYLE, PropertyValue::fromValue(0), PropertyFlags::UNSTYLED);
     score->endCmd();
     EXPECT_EQ(staffText->xmlText(), u"normal bold underline italic");

--- a/src/engraving/tests/timesig_tests.cpp
+++ b/src/engraving/tests/timesig_tests.cpp
@@ -53,7 +53,7 @@ TEST_F(Engraving_TimesigTests, timesig01)
     TimeSig* ts = Factory::createTimeSig(score->dummy()->segment());
     ts->setSig(Fraction(3, 4), TimeSigType::NORMAL);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving time signature tests"));
     int staffIdx = 0;
     bool local   = false;
     score->cmdAddTimeSig(m, staffIdx, ts, local);
@@ -77,7 +77,7 @@ TEST_F(Engraving_TimesigTests, timesig02)
     TimeSig* ts = Factory::createTimeSig(score->dummy()->segment());
     ts->setSig(Fraction(3, 4), TimeSigType::NORMAL);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving time signature tests"));
     score->cmdAddTimeSig(m, 0, ts, false);
     score->doLayout();
     score->endCmd();
@@ -168,7 +168,7 @@ TEST_F(Engraving_TimesigTests, timesig06)
     TimeSig* ts = Factory::createTimeSig(score->dummy()->segment());
     ts->setSig(Fraction(5, 4), TimeSigType::NORMAL);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving time signature tests"));
     score->cmdAddTimeSig(m, 0, ts, false);
     score->doLayout();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"timesig-06.mscx", TIMESIG_DATA_DIR + u"timesig-06-ref.mscx"));
@@ -194,7 +194,7 @@ TEST_F(Engraving_TimesigTests, timesig07)
     TimeSig* ts = Factory::createTimeSig(score->dummy()->segment());
     ts->setSig(Fraction(3, 4), TimeSigType::NORMAL);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving time signature tests"));
     score->cmdAddTimeSig(m, 0, ts, false);
     score->doLayout();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"timesig-07.mscx", TIMESIG_DATA_DIR + u"timesig-07-ref.mscx"));
@@ -239,7 +239,7 @@ TEST_F(Engraving_TimesigTests, DISABLED_timesig09)
     TimeSig* ts = Factory::createTimeSig(score->dummy()->segment());
     ts->setSig(Fraction(9, 8), TimeSigType::NORMAL);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving time signature tests"));
     score->cmdAddTimeSig(m, 0, ts, false);
     score->doLayout();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"timesig-09-1.mscx", TIMESIG_DATA_DIR + u"timesig-09-ref.mscx"));
@@ -266,7 +266,7 @@ TEST_F(Engraving_TimesigTests, timesig10)
     TimeSig* ts1 = Factory::createTimeSig(score->dummy()->segment());
     ts1->setSig(Fraction(2, 2), TimeSigType::ALLA_BREVE);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving time signature tests"));
     score->cmdAddTimeSig(m1, 0, ts1, false);
 
     Measure* m2 = m1->nextMeasure();

--- a/src/engraving/tests/tools_tests.cpp
+++ b/src/engraving/tests/tools_tests.cpp
@@ -52,12 +52,12 @@ TEST_F(Engraving_ToolsTests, undoAddLineBreaks)
     score->doLayout();
 
     // select all
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving tools tests"));
     score->cmdSelectAll();
     score->endCmd();
 
     // do
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving tools tests"));
     score->addRemoveBreaks(4, false);
     score->endCmd();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, writeFile1, reference1));
@@ -85,7 +85,7 @@ TEST_F(Engraving_ToolsTests, undoSlashFill)
     score->selection().setRange(s, score->lastSegment(), 0, 2);
 
     // do
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving tools tests"));
     score->cmdSlashFill();
     score->endCmd();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, writeFile1, reference1));
@@ -110,12 +110,12 @@ TEST_F(Engraving_ToolsTests, undoSlashRhythm)
     score->doLayout();
 
     // select all
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving tools tests"));
     score->cmdSelectAll();
     score->endCmd();
 
     // do
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving tools tests"));
     score->cmdSlashRhythm();
     score->endCmd();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, writeFile1, reference1));
@@ -140,7 +140,7 @@ TEST_F(Engraving_ToolsTests, undoResequenceAlpha)
     score->doLayout();
 
     // do
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving tools tests"));
     score->cmdResequenceRehearsalMarks();
     score->endCmd();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, writeFile1, reference1));
@@ -165,7 +165,7 @@ TEST_F(Engraving_ToolsTests, undoResequenceNumeric)
     score->doLayout();
 
     // do
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving tools tests"));
     score->cmdResequenceRehearsalMarks();
     score->endCmd();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, writeFile1, reference1));
@@ -190,7 +190,7 @@ TEST_F(Engraving_ToolsTests, undoResequenceMeasure)
     score->doLayout();
 
     // do
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving tools tests"));
     score->cmdResequenceRehearsalMarks();
     score->endCmd();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, writeFile1, reference1));
@@ -215,7 +215,7 @@ TEST_F(Engraving_ToolsTests, undoResequencePart)
     score->doLayout();
 
     // do
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving tools tests"));
     score->cmdResequenceRehearsalMarks();
     score->endCmd();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, writeFile1, reference1));
@@ -236,7 +236,7 @@ void Engraving_ToolsTests::changeEnharmonic(bool both)
     score->doLayout();
     score->cmdSelectAll();
     for (int i = 1; i < 6; ++i) {
-        score->startCmd();
+        score->startCmd(TranslatableString("undoableAction", "Engraving tools tests"));
         score->changeEnharmonicSpelling(both);
         score->endCmd();
         String prefix = u"change-enharmonic-" + mode + u"-0" + (u'0' + i);

--- a/src/engraving/tests/transpose_tests.cpp
+++ b/src/engraving/tests/transpose_tests.cpp
@@ -51,7 +51,7 @@ TEST_F(Engraving_TransposeTests, undoTranspose)
     score->cmdSelectAll();
 
     // transpose major second up
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving transpose tests"));
     score->transpose(TransposeMode::BY_INTERVAL, TransposeDirection::UP, Key::C, 4,
                      true, true, true);
     score->endCmd();
@@ -80,7 +80,7 @@ TEST_F(Engraving_TransposeTests, undoDiatonicTranspose)
     score->cmdSelectAll();
 
     // transpose diatonic fourth down
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving transpose tests"));
     score->transpose(TransposeMode::DIATONICALLY, TransposeDirection::DOWN, Key::C, 3,
                      true, false, false);
     score->endCmd();

--- a/src/engraving/tests/tuplet_tests.cpp
+++ b/src/engraving/tests/tuplet_tests.cpp
@@ -88,7 +88,7 @@ bool Engraving_TupletTests::createTuplet(int n, ChordRest* cr)
     if (ot) {
         tuplet->setTuplet(ot);
     }
-    cr->score()->startCmd();
+    cr->score()->startCmd(TranslatableString("undoableAction", "Engraving tuplet tests"));
     cr->score()->cmdCreateTuplet(cr, tuplet);
     cr->score()->endCmd();
     return true;
@@ -127,7 +127,7 @@ void Engraving_TupletTests::split(const char16_t* p1, const char16_t* p2)
     TimeSig* ts        = Factory::createTimeSig(score->dummy()->segment());
     ts->setSig(Fraction(3, 4), TimeSigType::NORMAL);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving tuplet tests"));
     EditData dd(0);
     dd.dropElement = ts;
     dd.modifiers = {};

--- a/src/inspector/models/abstractinspectormodel.cpp
+++ b/src/inspector/models/abstractinspectormodel.cpp
@@ -356,7 +356,7 @@ void AbstractInspectorModel::setPropertyValue(const QList<engraving::EngravingIt
         return;
     }
 
-    beginCommand();
+    beginCommand(TranslatableString("undoableAction", "Set property value"));
 
     for (mu::engraving::EngravingItem* item : items) {
         IF_ASSERT_FAILED(item) {
@@ -438,7 +438,7 @@ bool AbstractInspectorModel::updateStyleValue(const mu::engraving::Sid& sid, con
 {
     PropertyValue newVal = PropertyValue::fromQVariant(newValue, mu::engraving::MStyle::valueType(sid));
     if (style() && style()->styleValue(sid) != newVal) {
-        beginCommand();
+        beginCommand(TranslatableString("undoableAction", "Update style value"));
         style()->setStyleValue(sid, newVal);
         endCommand();
         return true;
@@ -686,10 +686,10 @@ INotationUndoStackPtr AbstractInspectorModel::undoStack() const
     return currentNotation() ? currentNotation()->undoStack() : nullptr;
 }
 
-void AbstractInspectorModel::beginCommand()
+void AbstractInspectorModel::beginCommand(const muse::TranslatableString& actionName)
 {
     if (undoStack()) {
-        undoStack()->prepareChanges();
+        undoStack()->prepareChanges(actionName);
     }
 
     //! NOTE prevents unnecessary updating of properties

--- a/src/inspector/models/abstractinspectormodel.h
+++ b/src/inspector/models/abstractinspectormodel.h
@@ -204,7 +204,7 @@ protected:
     QVariant styleValue(const mu::engraving::Sid& sid) const;
 
     notation::INotationUndoStackPtr undoStack() const;
-    void beginCommand();
+    void beginCommand(const muse::TranslatableString& actionName);
     void endCommand();
 
     void updateNotation();

--- a/src/inspector/models/general/generalsettingsmodel.cpp
+++ b/src/inspector/models/general/generalsettingsmodel.cpp
@@ -138,7 +138,7 @@ void GeneralSettingsModel::onCurrentNotationChanged()
 
 void GeneralSettingsModel::onVisibleChanged(bool visible)
 {
-    beginCommand();
+    beginCommand(muse::TranslatableString("undoableAction", "Toggle item(s) visible"));
 
     Score* score = currentNotation()->elements()->msScore();
 

--- a/src/inspector/models/inspectormodelwithvoiceandpositionoptions.cpp
+++ b/src/inspector/models/inspectormodelwithvoiceandpositionoptions.cpp
@@ -160,7 +160,7 @@ void InspectorModelWithVoiceAndPositionOptions::changeVoice(int voice)
         return;
     }
 
-    beginCommand();
+    beginCommand(TranslatableString("undoableAction", "Change voice"));
 
     for (EngravingItem* item : m_elementList) {
         IF_ASSERT_FAILED(item) {

--- a/src/inspector/models/notation/barlines/barlinesettingsmodel.cpp
+++ b/src/inspector/models/notation/barlines/barlinesettingsmodel.cpp
@@ -148,7 +148,7 @@ void BarlineSettingsModel::applySpanPreset(const int presetType)
 
 void BarlineSettingsModel::setSpanIntervalAsStaffDefault()
 {
-    undoStack()->prepareChanges();
+    undoStack()->prepareChanges(muse::TranslatableString("undoableAction", "Set span interval as staff default"));
 
     std::vector<mu::engraving::EngravingItem*> staves;
 

--- a/src/inspector/models/notation/bends/bendsettingsmodel.cpp
+++ b/src/inspector/models/notation/bends/bendsettingsmodel.cpp
@@ -274,7 +274,7 @@ void BendSettingsModel::setBendCurve(const QVariantList& newBendCurve)
 
     bool pitchChanged = endTimePoint.pitch != m_bendCurve.at(END_POINT_INDEX).pitch;
 
-    beginCommand();
+    beginCommand(muse::TranslatableString("undoableAction", "Set bend curve"));
 
     if (pitchChanged) {
         int bendAmount = curvePitchToBendAmount(endTimePoint.pitch);

--- a/src/inspector/models/notation/notes/stems/stemsettingsmodel.cpp
+++ b/src/inspector/models/notation/notes/stems/stemsettingsmodel.cpp
@@ -111,7 +111,7 @@ void StemSettingsModel::setUseStraightNoteFlags(bool use)
 
 void StemSettingsModel::onStemDirectionChanged(DirectionV newDirection)
 {
-    beginCommand();
+    beginCommand(muse::TranslatableString("undoableAction", "Change stem direction"));
 
     for (EngravingItem* element : m_elementList) {
         Stem* stem = toStem(element);

--- a/src/inspector/models/notation/ornaments/ornamentsettingsmodel.cpp
+++ b/src/inspector/models/notation/ornaments/ornamentsettingsmodel.cpp
@@ -245,7 +245,7 @@ void OrnamentSettingsModel::setIntervalStep(Pid id, engraving::IntervalStep step
         return;
     }
 
-    beginCommand();
+    beginCommand(muse::TranslatableString("undoableAction", "Set ornament interval step"));
 
     for (mu::engraving::EngravingItem* item : m_elementList) {
         IF_ASSERT_FAILED(item) {
@@ -277,7 +277,7 @@ void OrnamentSettingsModel::setIntervalType(Pid id, engraving::IntervalType type
         return;
     }
 
-    beginCommand();
+    beginCommand(muse::TranslatableString("undoableAction", "Set ornament interval type"));
 
     for (mu::engraving::EngravingItem* item : m_elementList) {
         IF_ASSERT_FAILED(item) {

--- a/src/inspector/view/widgets/fretcanvas.cpp
+++ b/src/inspector/view/widgets/fretcanvas.cpp
@@ -267,7 +267,7 @@ void FretCanvas::mousePressEvent(QMouseEvent* ev)
         return;
     }
 
-    globalContext()->currentNotation()->undoStack()->prepareChanges();
+    globalContext()->currentNotation()->undoStack()->prepareChanges(muse::TranslatableString("undoableAction", "Edit fretboard"));
 
     // Click above the fret diagram, so change the open/closed string marker
     if (fret == 0) {
@@ -376,7 +376,7 @@ void FretCanvas::setFretDiagram(QVariant fd)
 
 void FretCanvas::clear()
 {
-    globalContext()->currentNotation()->undoStack()->prepareChanges();
+    globalContext()->currentNotation()->undoStack()->prepareChanges(muse::TranslatableString("undoableAction", "Clear fretboard"));
     m_diagram->undoFretClear();
     globalContext()->currentNotation()->undoStack()->commitChanges();
     update();

--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -289,6 +289,7 @@ public:
     virtual void transposeDiatonicAlterations(mu::engraving::TransposeDirection) = 0;
     virtual void toggleAutoplace(bool all) = 0;
     virtual void getLocation() = 0;
+    //virtual void execute(void (mu::engraving::Score::*)(), const muse::TranslatableString& actionName = {}) = 0;
     virtual void execute(void (mu::engraving::Score::*)()) = 0;
 
     struct ShowItemRequest {

--- a/src/notation/internal/excerptnotation.cpp
+++ b/src/notation/internal/excerptnotation.cpp
@@ -141,7 +141,7 @@ void ExcerptNotation::undoSetName(const QString& name)
         return;
     }
 
-    undoStack()->prepareChanges();
+    undoStack()->prepareChanges(TranslatableString("undoableAction", "Undo set excerpt name"));
 
     score()->undo(new engraving::ChangeExcerptTitle(m_excerpt, name));
 

--- a/src/notation/internal/inotationundostack.h
+++ b/src/notation/internal/inotationundostack.h
@@ -47,7 +47,7 @@ public:
     virtual void redo(mu::engraving::EditData*) = 0;
     virtual muse::async::Notification redoNotification() const = 0;
 
-    virtual void prepareChanges() = 0;
+    virtual void prepareChanges(const muse::TranslatableString& actionName) = 0;
     virtual void rollbackChanges() = 0;
     virtual void commitChanges() = 0;
 
@@ -56,6 +56,9 @@ public:
     virtual void lock() = 0;
     virtual void unlock() = 0;
     virtual bool isLocked() const = 0;
+
+    virtual muse::TranslatableString topMostUndoActionName() const = 0;
+    virtual muse::TranslatableString topMostRedoActionName() const = 0;
 
     virtual muse::async::Notification stackChanged() const = 0;
     virtual muse::async::Channel<ChangesRange> changesChannel() const = 0;

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -521,7 +521,7 @@ void MasterNotation::setExcerpts(const ExcerptNotationList& excerpts)
         return;
     }
 
-    undoStack()->prepareChanges();
+    undoStack()->prepareChanges(TranslatableString("undoableAction", "Set excerpts"));
 
     // Delete old excerpts (that are not included in the new list)
     for (IExcerptNotationPtr excerptNotation : m_excerpts) {
@@ -564,7 +564,7 @@ void MasterNotation::resetExcerpt(IExcerptNotationPtr excerptNotation)
 
     TRACEFUNC;
 
-    undoStack()->prepareChanges();
+    undoStack()->prepareChanges(TranslatableString("undoableAction", "Reset excerpt"));
 
     mu::engraving::Excerpt* oldExcerpt = get_impl(excerptNotation)->excerpt();
     masterScore()->deleteExcerpt(oldExcerpt);

--- a/src/notation/internal/masternotationparts.cpp
+++ b/src/notation/internal/masternotationparts.cpp
@@ -48,9 +48,9 @@ void MasterNotationParts::setExcerpts(ExcerptNotationList excerpts)
     m_excerpts = excerpts;
 }
 
-void MasterNotationParts::startGlobalEdit()
+void MasterNotationParts::startGlobalEdit(const muse::TranslatableString& actionName)
 {
-    NotationParts::startEdit();
+    NotationParts::startEdit(actionName);
     undoStack()->lock();
 }
 
@@ -67,7 +67,7 @@ void MasterNotationParts::setParts(const PartInstrumentList& partList, const Sco
     mu::engraving::KeyList keyList = score()->keyList();
 
     endInteractionWithScore();
-    startGlobalEdit();
+    startGlobalEdit(TranslatableString("undoableAction", "Set parts"));
 
     doSetScoreOrder(order);
     removeMissingParts(partList);
@@ -103,7 +103,7 @@ void MasterNotationParts::removeParts(const IDList& partsIds)
 {
     TRACEFUNC;
 
-    startGlobalEdit();
+    startGlobalEdit(TranslatableString("undoableAction", "Remove parts"));
 
     NotationParts::removeParts(partsIds);
 
@@ -118,7 +118,7 @@ void MasterNotationParts::removeStaves(const IDList& stavesIds)
 {
     TRACEFUNC;
 
-    startGlobalEdit();
+    startGlobalEdit(TranslatableString("undoableAction", "Remove staves"));
 
     NotationParts::removeStaves(stavesIds);
 
@@ -137,7 +137,7 @@ bool MasterNotationParts::appendStaff(Staff* staff, const ID& destinationPartId)
         return false;
     }
 
-    startGlobalEdit();
+    startGlobalEdit(TranslatableString("undoableAction", "Append staff"));
 
     //! NOTE: will be generated later after adding to the score
     staff->setId(mu::engraving::INVALID_ID);
@@ -165,7 +165,7 @@ bool MasterNotationParts::appendLinkedStaff(Staff* staff, const muse::ID& source
         return false;
     }
 
-    startGlobalEdit();
+    startGlobalEdit(TranslatableString("undoableAction", "Append linked staff"));
 
     //! NOTE: will be generated later after adding to the score
     staff->setId(mu::engraving::INVALID_ID);
@@ -188,7 +188,7 @@ void MasterNotationParts::replaceInstrument(const InstrumentKey& instrumentKey, 
 {
     TRACEFUNC;
 
-    startGlobalEdit();
+    startGlobalEdit(TranslatableString("undoableAction", "Replace instrument"));
 
     Part* part = partModifiable(instrumentKey.partId);
     bool isMainInstrument = part && isMainInstrumentForPart(instrumentKey, part);
@@ -223,7 +223,7 @@ void MasterNotationParts::replaceDrumset(const InstrumentKey& instrumentKey, con
 {
     TRACEFUNC;
 
-    startGlobalEdit();
+    startGlobalEdit(TranslatableString("undoableAction", "Replace drumset"));
 
     NotationParts::replaceDrumset(instrumentKey, newDrumset, undoable);
 

--- a/src/notation/internal/masternotationparts.h
+++ b/src/notation/internal/masternotationparts.h
@@ -46,7 +46,7 @@ public:
     void replaceDrumset(const InstrumentKey& instrumentKey, const Drumset& newDrumset, bool undoable = true) override;
 
 private:
-    void startGlobalEdit();
+    void startGlobalEdit(const muse::TranslatableString& actionName);
     void endGlobalEdit();
 
     void onPartsRemoved(const std::vector<Part*>& parts) override;

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -1967,7 +1967,7 @@ void NotationActionController::toggleConcertPitch()
         return;
     }
 
-    currentNotationUndoStack()->prepareChanges();
+    currentNotationUndoStack()->prepareChanges(TranslatableString("undoableAction", "Toggle concert pitch"));
     bool enabled = style->styleValue(StyleId::concertPitch).toBool();
     style->setStyleValue(StyleId::concertPitch, !enabled);
     currentNotationUndoStack()->commitChanges();

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -231,11 +231,11 @@ void NotationInteraction::onScoreInited()
     });
 }
 
-void NotationInteraction::startEdit()
+void NotationInteraction::startEdit(const muse::TranslatableString& actionName)
 {
     m_notifyAboutDropChanged = false;
 
-    m_undoStack->prepareChanges();
+    m_undoStack->prepareChanges(actionName);
 }
 
 void NotationInteraction::apply()
@@ -442,7 +442,7 @@ RectF NotationInteraction::shadowNoteRect() const
 
 void NotationInteraction::toggleVisible()
 {
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Toggle visible"));
     score()->cmdToggleVisible();
     apply();
 }
@@ -985,7 +985,7 @@ void NotationInteraction::startDrag(const std::vector<EngravingItem*>& elems,
         }
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Drag item"));
 
     qreal scaling = m_notation->viewState()->matrix().m11();
     qreal proximity = configuration()->selectionProximity() * 0.5f / scaling;
@@ -1398,7 +1398,7 @@ bool NotationInteraction::drop(const PointF& pos, Qt::KeyboardModifiers modifier
     bool systemStavesOnly = false;
     bool applyUserOffset = false;
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Drop position"));
     score()->addRefresh(m_dropData.ed.dropElement->canvasBoundingRect());
     ElementType et = m_dropData.ed.dropElement->type();
     switch (et) {
@@ -1644,7 +1644,7 @@ bool NotationInteraction::applyPaletteElement(mu::engraving::EngravingItem* elem
         return false;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Apply palette element"));
 
     if (sel.isList()) {
         ChordRest* cr1 = sel.firstChordRest();
@@ -2112,7 +2112,7 @@ void NotationInteraction::applyLineNoteToNote(Score* score, Note* note1, Note* n
 //! NOTE Copied from ScoreView::cmdAddSlur
 void NotationInteraction::doAddSlur(const mu::engraving::Slur* slurTemplate)
 {
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Add slur"));
     m_notifyAboutDropChanged = true;
 
     mu::engraving::ChordRest* firstChordRest = nullptr;
@@ -2837,7 +2837,7 @@ static ChordRest* asChordRest(EngravingItem* e)
 
 void NotationInteraction::moveChordRestToStaff(MoveDirection dir)
 {
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Move chord/rest to staff"));
 
     for (EngravingItem* e: score()->selection().uniqueElements()) {
         ChordRest* cr = asChordRest(e);
@@ -2867,7 +2867,7 @@ void NotationInteraction::swapChordRest(MoveDirection direction)
     } else {
         crl.append(cr);
     }
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Swap chord/rest"));
     for (ChordRest* cr1 : crl) {
         if (cr1->type() == ElementType::REST) {
             Measure* m = toRest(cr1)->measure();
@@ -2917,7 +2917,7 @@ void NotationInteraction::toggleSnapToPrevious()
     }
 
     // Do toggle...
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Toggle snap to previous"));
     for (Hairpin* h : hairpins) {
         if (h->snapToItemBefore() == newSnapValue) {
             continue;
@@ -2958,7 +2958,7 @@ void NotationInteraction::toggleSnapToNext()
     }
 
     // Do toggle...
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Toggle snap to next"));
     for (Hairpin* h : hairpins) {
         if (h->snapToItemAfter() == newSnapValue) {
             continue;
@@ -3069,7 +3069,7 @@ void NotationInteraction::movePitch(MoveDirection d, PitchMode mode)
         return;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Move pitch"));
 
     if (score()->selection().element() && score()->selection().element()->isRest()) {
         score()->cmdMoveRest(toRest(score()->selection().element()), toDirection(d));
@@ -3086,7 +3086,7 @@ void NotationInteraction::moveLyrics(MoveDirection d)
     IF_ASSERT_FAILED(el && el->isLyrics()) {
         return;
     }
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Move lyrics"));
     score()->cmdMoveLyrics(toLyrics(el), toDirection(d));
     apply();
 }
@@ -3098,7 +3098,7 @@ void NotationInteraction::nudge(MoveDirection d, bool quickly)
         return;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Nudge"));
 
     qreal step = quickly ? mu::engraving::MScore::nudgeStep10 : mu::engraving::MScore::nudgeStep;
     step = step * el->spatium();
@@ -3197,7 +3197,7 @@ void NotationInteraction::editText(QInputMethodEvent* event)
     }
 
     if (!event->commitString().isEmpty()) {
-        score()->startCmd();
+        score()->startCmd(TranslatableString("undoableAction", "Edit text"));
         text->insertText(m_editData, event->commitString());
         score()->endCmd();
         preeditString.clear();
@@ -3600,7 +3600,7 @@ void NotationInteraction::editElement(QKeyEvent* event)
         }
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Keystroke edit"));
 
     if (needStartEditGrip(event)) {
         m_editData.curGrip = m_editData.element->defaultGrip();
@@ -3705,7 +3705,7 @@ void NotationInteraction::splitSelectedMeasure()
 
     ChordRest* chordRest = dynamic_cast<ChordRest*>(selectedElement);
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Split selected measure"));
     score()->cmdSplitMeasure(chordRest);
     apply();
 
@@ -3720,7 +3720,7 @@ void NotationInteraction::joinSelectedMeasures()
 
     INotationSelectionRange::MeasureRange measureRange = m_selection->range()->measureRange();
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Join selected measures"));
     score()->cmdJoinMeasure(measureRange.startMeasure, measureRange.endMeasure);
     apply();
 
@@ -3865,6 +3865,18 @@ void NotationInteraction::addBoxes(BoxType boxType, int count, int beforeBoxInde
         return ElementType::INVALID;
     };
 
+    auto boxTypeDescription = [](BoxType boxType) -> TranslatableString {
+        switch (boxType) {
+        case BoxType::Horizontal: return TranslatableString("undoableAction", "Add horizontal frame");
+        case BoxType::Vertical: return TranslatableString("undoableAction", "Add vertical frame");
+        case BoxType::Text: return TranslatableString("undoableAction", "Add text frame");
+        case BoxType::Measure: return TranslatableString("undoableAction", "Add %1 measure(s)");
+        case BoxType::Unknown: return {};
+        }
+
+        return {};
+    };
+
     mu::engraving::ElementType elementType = boxTypeToElementType(boxType);
     if (elementType == mu::engraving::ElementType::INVALID) {
         return;
@@ -3872,7 +3884,7 @@ void NotationInteraction::addBoxes(BoxType boxType, int count, int beforeBoxInde
 
     mu::engraving::MeasureBase* beforeBox = beforeBoxIndex >= 0 ? score()->measure(beforeBoxIndex) : nullptr;
 
-    startEdit();
+    startEdit(boxTypeDescription(boxType).arg(count));
 
     mu::engraving::Score::InsertMeasureOptions options;
     options.createEmptyMeasures = false;
@@ -3928,7 +3940,7 @@ Ret NotationInteraction::repeatSelection()
     if (score()->noteEntryMode() && selection.isSingle()) {
         EngravingItem* el = selection.element();
         if (el && el->type() == ElementType::NOTE && !score()->inputState().endOfScore()) {
-            startEdit();
+            startEdit(TranslatableString("undoableAction", "Repeat selection"));
             Chord* c = toNote(el)->chord();
             for (Note* note : c->notes()) {
                 mu::engraving::NoteVal nval = note->noteVal();
@@ -3962,7 +3974,7 @@ Ret NotationInteraction::repeatSelection()
     if (endSegment && endSegment->element(dStaff * mu::engraving::VOICES)) {
         EngravingItem* e = endSegment->element(dStaff * mu::engraving::VOICES);
         if (e) {
-            startEdit();
+            startEdit(TranslatableString("undoableAction", "Repeat selection"));
             ChordRest* cr = toChordRest(e);
             score()->pasteStaff(xml, cr->segment(), cr->staffIdx());
             apply();
@@ -3982,7 +3994,7 @@ void NotationInteraction::copyLyrics()
 
 void NotationInteraction::pasteSelection(const Fraction& scale)
 {
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Paste selection"));
 
     if (isTextEditingStarted()) {
         const QMimeData* mimeData = QApplication::clipboard()->mimeData();
@@ -4079,7 +4091,7 @@ void NotationInteraction::deleteSelection()
         return;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Delete selection"));
 
     if (isTextEditingStarted()) {
         mu::engraving::TextBase* textBase = toTextBase(m_editData.element);
@@ -4105,21 +4117,21 @@ void NotationInteraction::flipSelection()
         return;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Flip selection"));
     score()->cmdFlip();
     apply();
 }
 
 void NotationInteraction::addTieToSelection()
 {
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Add tie to selection"));
     score()->cmdToggleTie();
     apply();
 }
 
 void NotationInteraction::addTiedNoteToChord()
 {
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Add tied note to chord"));
     score()->cmdAddTie(true);
     apply();
 }
@@ -4130,7 +4142,7 @@ void NotationInteraction::addSlurToSelection()
         return;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Add slur to selection"));
     doAddSlur();
     apply();
 }
@@ -4141,7 +4153,7 @@ void NotationInteraction::addOttavaToSelection(OttavaType type)
         return;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Add ottava to selection"));
     score()->cmdAddOttava(type);
     apply();
 }
@@ -4152,7 +4164,7 @@ void NotationInteraction::addHairpinsToSelection(HairpinType type)
         return;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Add hairpins to selection"));
     std::vector<mu::engraving::Hairpin*> hairpins = score()->addHairpins(type);
     apply();
 
@@ -4171,7 +4183,7 @@ void NotationInteraction::addAccidentalToSelection(AccidentalType type)
 
     mu::engraving::EditData editData(&m_scoreCallbacks);
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Add accidental to selection"));
     score()->toggleAccidental(type, editData);
     apply();
 }
@@ -4195,7 +4207,7 @@ void NotationInteraction::putRest(Duration duration)
         return;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Put rest"));
     score()->cmdEnterRest(duration);
     apply();
 }
@@ -4206,7 +4218,7 @@ void NotationInteraction::addBracketsToSelection(BracketsType type)
         return;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Add brackets to selection"));
 
     switch (type) {
     case BracketsType::Brackets:
@@ -4255,7 +4267,7 @@ void NotationInteraction::changeSelectedNotesArticulation(SymbolId articulationS
         }
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Update articulations"));
     for (Chord* chord: chords) {
         chord->updateArticulations({ articulationSymbolId }, updateMode);
     }
@@ -4291,7 +4303,7 @@ void NotationInteraction::addGraceNotesToSelectedNotes(GraceNoteType type)
         break;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Add grace notes"));
     score()->cmdAddGrace(type, mu::engraving::Constants::DIVISION / denominator);
     apply();
 }
@@ -4318,7 +4330,7 @@ void NotationInteraction::addTupletToSelectedChordRests(const TupletOptions& opt
         return;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Add tuplet to selected"));
 
     for (ChordRest* chordRest : score()->getSelectedChordRests()) {
         if (!chordRest->isGrace() && !(chordRest->isChord() && toChord(chordRest)->isTrillCueNote())) {
@@ -4339,7 +4351,7 @@ void NotationInteraction::addBeamToSelectedChordRests(BeamMode mode)
         return;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Add beam to selected"));
     score()->cmdSetBeamMode(mode);
     apply();
 }
@@ -4350,7 +4362,7 @@ void NotationInteraction::increaseDecreaseDuration(int steps, bool stepByDots)
         return;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Modify duration"));
     score()->cmdIncDecDuration(steps, stepByDots);
     apply();
 }
@@ -4362,7 +4374,7 @@ bool NotationInteraction::toggleLayoutBreakAvailable() const
 
 void NotationInteraction::toggleLayoutBreak(LayoutBreakType breakType)
 {
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Toggle layout break"));
     score()->cmdToggleLayoutBreak(breakType);
     apply();
 }
@@ -4372,14 +4384,14 @@ void NotationInteraction::setBreaksSpawnInterval(BreaksSpawnIntervalType interva
     interval = intervalType == BreaksSpawnIntervalType::MeasuresInterval ? interval : 0;
     bool afterEachSystem = intervalType == BreaksSpawnIntervalType::AfterEachSystem;
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Break spawn interval"));
     score()->addRemoveBreaks(interval, afterEachSystem);
     apply();
 }
 
 bool NotationInteraction::transpose(const TransposeOptions& options)
 {
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Transposition"));
 
     bool ok = score()->transpose(options.mode, options.direction, options.key, options.interval,
                                  options.needTransposeKeys, options.needTransposeChordNames, options.needTransposeDoubleSharpsFlats);
@@ -4403,7 +4415,7 @@ void NotationInteraction::swapVoices(voice_idx_t voiceIndex1, voice_idx_t voiceI
         return;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Swap voices"));
     score()->cmdExchangeVoice(voiceIndex1, voiceIndex2);
     apply();
 }
@@ -4434,14 +4446,14 @@ void NotationInteraction::addIntervalToSelectedNotes(int interval)
         return;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Add interval to selected notes"));
     score()->addInterval(interval, notes);
     apply();
 }
 
 void NotationInteraction::addFret(int fretIndex)
 {
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Add fret"));
     score()->cmdAddFret(fretIndex);
     apply();
 }
@@ -4456,7 +4468,7 @@ void NotationInteraction::changeSelectedElementsVoice(voice_idx_t voiceIndex)
         return;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Change voice"));
     score()->changeSelectedElementsVoice(voiceIndex);
     apply();
 }
@@ -4467,7 +4479,7 @@ void NotationInteraction::changeSelectedElementsVoiceAssignment(VoiceAssignment 
         return;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Change voice assignment"));
     score()->changeSelectedElementsVoiceAssignment(voiceAssignment);
     apply();
 }
@@ -4478,7 +4490,7 @@ void NotationInteraction::addAnchoredLineToSelectedNotes()
         return;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Add anchored line"));
     score()->addNoteLine();
     apply();
 }
@@ -4548,7 +4560,7 @@ void NotationInteraction::addText(TextStyleType type, EngravingItem* item)
         m_noteInput->endNoteInput();
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Add text"));
     mu::engraving::TextBase* text = score()->addText(type, item);
 
     if (!text) {
@@ -4608,7 +4620,7 @@ void NotationInteraction::addImageToItem(const muse::io::path_t& imagePath, Engr
         return;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Add image to item"));
     score()->undoAddElement(image);
     apply();
 }
@@ -4627,7 +4639,7 @@ Ret NotationInteraction::canAddFiguredBass() const
 
 void NotationInteraction::addFiguredBass()
 {
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Add figured bass"));
     mu::engraving::FiguredBass* figuredBass = score()->addFiguredBass();
 
     if (figuredBass) {
@@ -4641,14 +4653,14 @@ void NotationInteraction::addFiguredBass()
 
 void NotationInteraction::addStretch(qreal value)
 {
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Add stretch"));
     score()->cmdAddStretch(value);
     apply();
 }
 
 void NotationInteraction::addTimeSignature(Measure* measure, staff_idx_t staffIndex, TimeSignature* timeSignature)
 {
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Add time signature"));
     score()->cmdAddTimeSig(measure, staffIndex, timeSignature, true);
     apply();
 }
@@ -4659,7 +4671,7 @@ void NotationInteraction::explodeSelectedStaff()
         return;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Explode staff"));
     score()->cmdExplode();
     apply();
 }
@@ -4670,7 +4682,7 @@ void NotationInteraction::implodeSelectedStaff()
         return;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Implode staff"));
     score()->cmdImplode();
     apply();
 }
@@ -4681,7 +4693,7 @@ void NotationInteraction::realizeSelectedChordSymbols(bool literal, Voicing voic
         return;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Realize chord symbols"));
     score()->cmdRealizeChordSymbols(literal, voicing, durationType);
     apply();
 }
@@ -4718,10 +4730,14 @@ void NotationInteraction::removeSelectedMeasures()
         }
     }
 
+    IF_ASSERT_FAILED(firstMeasure && lastMeasure) {
+        return;
+    }
+
     doSelect({ firstMeasure }, SelectType::REPLACE);
     doSelect({ lastMeasure }, SelectType::RANGE);
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Delete %1 measure(s)").arg(1 + lastMeasure->measureIndex() - firstMeasure->measureIndex()));
     score()->cmdTimeDelete();
     apply();
 }
@@ -4732,14 +4748,14 @@ void NotationInteraction::removeSelectedRange()
         return;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Delete selection"));
     score()->cmdTimeDelete();
     apply();
 }
 
 void NotationInteraction::removeEmptyTrailingMeasures()
 {
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Delete trailing measures"));
     score()->cmdRemoveEmptyTrailingMeasures();
     apply();
 }
@@ -4750,7 +4766,7 @@ void NotationInteraction::fillSelectionWithSlashes()
         return;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Fill selection with slashes"));
     score()->cmdSlashFill();
     apply();
 }
@@ -4761,56 +4777,56 @@ void NotationInteraction::replaceSelectedNotesWithSlashes()
         return;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Replace notes with slashes"));
     score()->cmdSlashRhythm();
     apply();
 }
 
 void NotationInteraction::changeEnharmonicSpelling(bool both)
 {
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Change enharmonic spelling"));
     score()->changeEnharmonicSpelling(both);
     apply();
 }
 
 void NotationInteraction::spellPitches()
 {
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Spell pitches"));
     score()->spell();
     apply();
 }
 
 void NotationInteraction::regroupNotesAndRests()
 {
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Regroup notes and rests"));
     score()->cmdResetNoteAndRestGroupings();
     apply();
 }
 
 void NotationInteraction::resequenceRehearsalMarks()
 {
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Resequence rehearsal marks"));
     score()->cmdResequenceRehearsalMarks();
     apply();
 }
 
 void NotationInteraction::resetStretch()
 {
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Reset stretch"));
     score()->resetUserStretch();
     apply();
 }
 
 void NotationInteraction::resetTextStyleOverrides()
 {
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Reset text style overrides"));
     score()->cmdResetTextStyleOverrides();
     apply();
 }
 
 void NotationInteraction::resetBeamMode()
 {
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Reset beaming mode"));
     score()->cmdResetBeamMode();
     apply();
 }
@@ -4827,7 +4843,7 @@ void NotationInteraction::resetShapesAndPosition()
         }
     };
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Reset shapes and position"));
 
     DEFER {
         apply();
@@ -4847,7 +4863,7 @@ void NotationInteraction::resetToDefaultLayout()
 {
     TRACEFUNC;
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Reset to default layout"));
     score()->cmdResetToDefaultLayout();
     apply();
 }
@@ -4871,7 +4887,7 @@ void NotationInteraction::setScoreConfig(const ScoreConfig& config)
         return;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Set score configuration"));
     score()->setShowInvisible(config.isShowInvisibleElements);
     score()->setShowUnprintable(config.isShowUnprintableElements);
     score()->setShowFrames(config.isShowFrames);
@@ -5029,7 +5045,7 @@ void NotationInteraction::navigateToLyrics(bool back, bool moveOnly, bool end)
         newLyrics = true;
     }
 
-    score()->startCmd();
+    score()->startCmd(TranslatableString("undoableAction", "Navigate to lyrics"));
     if (fromLyrics && !moveOnly) {
         switch (nextLyrics->syllabic()) {
         // as we arrived at nextLyrics by a [Space], it can be the beginning
@@ -5147,7 +5163,7 @@ void NotationInteraction::navigateToNextSyllable()
         segment = segment->prev1(mu::engraving::SegmentType::ChordRest);
     }
 
-    score()->startCmd();
+    score()->startCmd(TranslatableString("undoableAction", "Navigate to next syllable"));
     ChordRest* cr = toChordRest(nextSegment->element(toLyricTrack));
     mu::engraving::Lyrics* toLyrics = cr->lyrics(verse, placement);
 
@@ -5265,7 +5281,7 @@ void NotationInteraction::navigateToLyricsVerse(MoveDirection direction)
         lyrics->setFontStyle(fStyle);
         lyrics->setPropertyFlags(mu::engraving::Pid::FONT_STYLE, fFlags);
 
-        score()->startCmd();
+        score()->startCmd(TranslatableString("undoableAction", "Navigate to verse"));
         score()->undoAddElement(lyrics);
         score()->endCmd();
     }
@@ -5356,7 +5372,7 @@ void NotationInteraction::navigateToNearHarmony(MoveDirection direction, bool ne
         }
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Navigate to near harmony"));
 
     if (needAddSegment) {
         score()->undoAddElement(segment);
@@ -5410,7 +5426,7 @@ void NotationInteraction::navigateToHarmonyInNearMeasure(MoveDirection direction
     if (!nextHarmony) {
         nextHarmony = createHarmony(segment, track, harmony->harmonyType());
 
-        startEdit();
+        startEdit(TranslatableString("undoableAction", "Navigate to near harmony in measure"));
         score()->undoAddElement(nextHarmony);
         apply();
     }
@@ -5447,7 +5463,7 @@ void NotationInteraction::navigateToHarmony(const Fraction& ticks)
         segment = segment->next1(mu::engraving::SegmentType::ChordRest);
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Navigate to harmony"));
 
     if (!segment || segment->tick() > newTick) {      // no ChordRest segment at this tick
         segment = Factory::createSegment(measure, mu::engraving::SegmentType::ChordRest, newTick - measure->tick());
@@ -5503,7 +5519,7 @@ void NotationInteraction::navigateToNearFiguredBass(MoveDirection direction)
     // add a (new) FB element, using chord duration as default duration
     mu::engraving::FiguredBass* fbNew = mu::engraving::FiguredBass::addFiguredBassToSegment(nextSegm, track, Fraction(0, 1), &bNew);
     if (bNew) {
-        startEdit();
+        startEdit(TranslatableString("undoableAction", "Navigate to near figured bass"));
         score()->undoAddElement(fbNew);
         apply();
     }
@@ -5547,7 +5563,7 @@ void NotationInteraction::navigateToFiguredBassInNearMeasure(MoveDirection direc
     // add a (new) FB element, using chord duration as default duration
     mu::engraving::FiguredBass* fbNew = mu::engraving::FiguredBass::addFiguredBassToSegment(nextSegm, fb->track(), Fraction(0, 1), &bNew);
     if (bNew) {
-        startEdit();
+        startEdit(TranslatableString("undoableAction", "Navigate to figured bass in near measure"));
         score()->undoAddElement(fbNew);
         apply();
     }
@@ -5598,7 +5614,7 @@ void NotationInteraction::navigateToFiguredBass(const Fraction& ticks)
         needAddSegment = true;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Navigate to figured bass"));
 
     if (needAddSegment) {
         score()->undoAddElement(nextSegm);
@@ -5784,14 +5800,14 @@ void NotationInteraction::addMelisma()
     // if still at melisma initial chord and there is a valid next chord (if not,
     // there will be no melisma anyway), set a temporary melisma duration
     if (fromLyrics == lyrics && nextSegment) {
-        score()->startCmd();
+        score()->startCmd(TranslatableString("undoableAction", "Add melisma"));
         lyrics->undoChangeProperty(mu::engraving::Pid::LYRIC_TICKS, mu::engraving::Lyrics::TEMP_MELISMA_TICKS);
         score()->setLayoutAll();
         score()->endCmd();
     }
 
     if (nextSegment == 0) {
-        score()->startCmd();
+        score()->startCmd(TranslatableString("undoableAction", "Add melisma"));
         if (fromLyrics) {
             switch (fromLyrics->syllabic()) {
             case mu::engraving::LyricsSyllabic::SINGLE:
@@ -5816,7 +5832,7 @@ void NotationInteraction::addMelisma()
 
     // if a place for a new lyrics has been found, create a lyrics there
 
-    score()->startCmd();
+    score()->startCmd(TranslatableString("undoableAction", "Create lyric for melisma"));
     ChordRest* cr = toChordRest(nextSegment->element(track));
     mu::engraving::Lyrics* toLyrics = cr->lyrics(verse, placement);
     bool newLyrics = (toLyrics == 0);
@@ -5877,7 +5893,7 @@ void NotationInteraction::addLyricsVerse()
 
     endEditText();
 
-    score()->startCmd();
+    score()->startCmd(TranslatableString("undoableAction", "Add verse"));
     int newVerse = oldLyrics->no() + 1;
 
     mu::engraving::Lyrics* lyrics = Factory::createLyrics(oldLyrics->chordRest());
@@ -5921,7 +5937,7 @@ void NotationInteraction::addGuitarBend(GuitarBendType bendType)
         return;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Add guitar bend"));
 
     Note* startNote = nullptr;
     Note* endNote = nullptr;
@@ -6031,7 +6047,7 @@ void NotationInteraction::toggleFontStyle(mu::engraving::FontStyle style)
     }
     mu::engraving::TextBase* text = toTextBase(m_editData.element);
     int currentStyle = text->getProperty(mu::engraving::Pid::FONT_STYLE).toInt();
-    score()->startCmd();
+    score()->startCmd(TranslatableString("undoableAction", "Toggle font style"));
     text->undoChangeProperty(mu::engraving::Pid::FONT_STYLE, PropertyValue::fromValue(
                                  currentStyle ^ static_cast<int>(style)), mu::engraving::PropertyFlags::UNSTYLED);
     score()->endCmd();
@@ -6047,7 +6063,7 @@ void NotationInteraction::toggleVerticalAlignment(VerticalAlignment align)
     mu::engraving::TextBase* text = toTextBase(m_editData.element);
     int ialign = static_cast<int>(align);
     int currentAlign = text->getProperty(mu::engraving::Pid::TEXT_SCRIPT_ALIGN).toInt();
-    score()->startCmd();
+    score()->startCmd(TranslatableString("undoableAction", "Toggle vertical alignment"));
     text->undoChangeProperty(mu::engraving::Pid::TEXT_SCRIPT_ALIGN, PropertyValue::fromValue(
                                  (currentAlign == ialign) ? static_cast<int>(VerticalAlignment::AlignNormal) : ialign),
                              mu::engraving::PropertyFlags::UNSTYLED);
@@ -6086,26 +6102,26 @@ void NotationInteraction::toggleSuperScript()
 }
 
 template<typename P>
-void NotationInteraction::execute(void (mu::engraving::Score::* function)(P), P param)
+void NotationInteraction::execute(void (mu::engraving::Score::* function)(P), P param, const TranslatableString& actionName)
 {
-    startEdit();
+    startEdit(actionName);
     (score()->*function)(param);
     apply();
 }
 
 void NotationInteraction::toggleArticulation(mu::engraving::SymId symId)
 {
-    execute(&mu::engraving::Score::toggleArticulation, symId);
+    execute(&mu::engraving::Score::toggleArticulation, symId, TranslatableString("undoableAction", "Toggle articulation"));
 }
 
 void NotationInteraction::toggleOrnament(mu::engraving::SymId symId)
 {
-    execute(&mu::engraving::Score::toggleOrnament, symId);
+    execute(&mu::engraving::Score::toggleOrnament, symId, TranslatableString("undoableAction", "Toggle ornament"));
 }
 
 void NotationInteraction::toggleAutoplace(bool all)
 {
-    execute(&mu::engraving::Score::cmdToggleAutoplace, all);
+    execute(&mu::engraving::Score::cmdToggleAutoplace, all, TranslatableString("undoableAction", "Toggle autoplace"));
 }
 
 bool NotationInteraction::canInsertClef(ClefType type) const
@@ -6116,22 +6132,22 @@ bool NotationInteraction::canInsertClef(ClefType type) const
 
 void NotationInteraction::insertClef(ClefType type)
 {
-    execute(&mu::engraving::Score::cmdInsertClef, type);
+    execute(&mu::engraving::Score::cmdInsertClef, type, TranslatableString("undoableAction", "Insert clef"));
 }
 
 void NotationInteraction::changeAccidental(mu::engraving::AccidentalType accidental)
 {
-    execute(&mu::engraving::Score::changeAccidental, accidental);
+    execute(&mu::engraving::Score::changeAccidental, accidental, TranslatableString("undoableAction", "Insert accidental"));
 }
 
 void NotationInteraction::transposeSemitone(int steps)
 {
-    execute(&mu::engraving::Score::transposeSemitone, steps);
+    execute(&mu::engraving::Score::transposeSemitone, steps, TranslatableString("undoableAction", "Transpose semitone"));
 }
 
 void NotationInteraction::transposeDiatonicAlterations(mu::engraving::TransposeDirection direction)
 {
-    execute(&mu::engraving::Score::transposeDiatonicAlterations, direction);
+    execute(&mu::engraving::Score::transposeDiatonicAlterations, direction, TranslatableString("undoableAction", "Transpose diatonic alterations"));
 }
 
 void NotationInteraction::getLocation()
@@ -6158,7 +6174,7 @@ void NotationInteraction::getLocation()
 
 void NotationInteraction::execute(void (mu::engraving::Score::* function)())
 {
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Execute action"));
     (score()->*function)();
     apply();
 }

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -4737,7 +4737,8 @@ void NotationInteraction::removeSelectedMeasures()
     doSelect({ firstMeasure }, SelectType::REPLACE);
     doSelect({ lastMeasure }, SelectType::RANGE);
 
-    startEdit(TranslatableString("undoableAction", "Delete %1 measure(s)").arg(1 + lastMeasure->measureIndex() - firstMeasure->measureIndex()));
+    startEdit(TranslatableString("undoableAction",
+                                 "Delete %1 measure(s)").arg(1 + lastMeasure->measureIndex() - firstMeasure->measureIndex()));
     score()->cmdTimeDelete();
     apply();
 }
@@ -6147,7 +6148,8 @@ void NotationInteraction::transposeSemitone(int steps)
 
 void NotationInteraction::transposeDiatonicAlterations(mu::engraving::TransposeDirection direction)
 {
-    execute(&mu::engraving::Score::transposeDiatonicAlterations, direction, TranslatableString("undoableAction", "Transpose diatonic alterations"));
+    execute(&mu::engraving::Score::transposeDiatonicAlterations, direction,
+            TranslatableString("undoableAction", "Transpose diatonic alterations"));
 }
 
 void NotationInteraction::getLocation()

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -290,6 +290,7 @@ public:
     void transposeSemitone(int) override;
     void transposeDiatonicAlterations(mu::engraving::TransposeDirection) override;
     void getLocation() override;
+//    void execute(void (mu::engraving::Score::*)(), const muse::TranslatableString& actionName) override;
     void execute(void (mu::engraving::Score::*)()) override;
 
     void showItem(const mu::engraving::EngravingItem* item, int staffIndex = -1) override;
@@ -301,7 +302,7 @@ private:
     mu::engraving::Score* score() const;
     void onScoreInited();
 
-    void startEdit();
+    void startEdit(const muse::TranslatableString& actionName);
     void apply();
     void rollback();
 
@@ -394,7 +395,7 @@ private:
     bool elementsSelected(const std::set<ElementType>& elementsTypes) const;
 
     template<typename P>
-    void execute(void (mu::engraving::Score::* function)(P), P param);
+    void execute(void (mu::engraving::Score::* function)(P), P param, const muse::TranslatableString& actionName);
 
     struct HitMeasureData
     {

--- a/src/notation/internal/notationmidiinput.cpp
+++ b/src/notation/internal/notationmidiinput.cpp
@@ -177,7 +177,7 @@ Note* NotationMidiInput::addNoteToScore(const muse::midi::Event& e)
         m_undoStack->commitChanges();
     };
 
-    m_undoStack->prepareChanges();
+    m_undoStack->prepareChanges(muse::TranslatableString("undoableAction", "Add note"));
 
     if (e.opcode() == muse::midi::Event::Opcode::NoteOff) {
         if (isRealtime()) {
@@ -305,7 +305,7 @@ void NotationMidiInput::doRealtimeAdvance()
     playbackController()->playMetronome(is.tick().ticks());
 
     QTimer::singleShot(100, Qt::PreciseTimer, [this]() {
-        m_undoStack->prepareChanges();
+        m_undoStack->prepareChanges(TranslatableString("undoableAction", "Realtime advance"));
         m_getScore->score()->realtimeAdvance();
         m_undoStack->commitChanges();
     });

--- a/src/notation/internal/notationmidiinput.cpp
+++ b/src/notation/internal/notationmidiinput.cpp
@@ -305,7 +305,7 @@ void NotationMidiInput::doRealtimeAdvance()
     playbackController()->playMetronome(is.tick().ticks());
 
     QTimer::singleShot(100, Qt::PreciseTimer, [this]() {
-        m_undoStack->prepareChanges(TranslatableString("undoableAction", "Realtime advance"));
+        m_undoStack->prepareChanges(muse::TranslatableString("undoableAction", "Realtime advance"));
         m_getScore->score()->realtimeAdvance();
         m_undoStack->commitChanges();
     });

--- a/src/notation/internal/notationnoteinput.cpp
+++ b/src/notation/internal/notationnoteinput.cpp
@@ -337,7 +337,7 @@ void NotationNoteInput::addNote(NoteName noteName, NoteAddingMode addingMode)
 
     mu::engraving::EditData editData(m_scoreCallbacks);
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Add note"));
     int inote = static_cast<int>(noteName);
     bool addToUpOnCurrentChord = addingMode == NoteAddingMode::CurrentChord;
     bool insertNewChord = addingMode == NoteAddingMode::InsertChord;
@@ -356,7 +356,7 @@ void NotationNoteInput::padNote(const Pad& pad)
 
     mu::engraving::EditData editData(m_scoreCallbacks);
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Pad note"));
     score()->padToggle(pad, editData);
     apply();
 
@@ -369,7 +369,7 @@ Ret NotationNoteInput::putNote(const PointF& pos, bool replace, bool insert)
 {
     TRACEFUNC;
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Put note"));
     Ret ret = score()->putNote(pos, replace, insert);
     apply();
 
@@ -388,7 +388,7 @@ void NotationNoteInput::removeNote(const PointF& pos)
     mu::engraving::InputState& inputState = score()->inputState();
     bool restMode = inputState.rest();
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Remove note"));
     inputState.setRest(!restMode);
     score()->putNote(pos, false, false);
     inputState.setRest(restMode);
@@ -472,7 +472,7 @@ void NotationNoteInput::addTuplet(const TupletOptions& options)
 
     const mu::engraving::InputState& inputState = score()->inputState();
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Add tuplet"));
     score()->expandVoice();
     mu::engraving::ChordRest* chordRest = inputState.cr();
     if (chordRest) {
@@ -588,7 +588,7 @@ void NotationNoteInput::addTie()
 {
     TRACEFUNC;
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Add tie"));
     score()->cmdAddTie();
     apply();
 
@@ -617,9 +617,9 @@ mu::engraving::Score* NotationNoteInput::score() const
     return m_getScore->score();
 }
 
-void NotationNoteInput::startEdit()
+void NotationNoteInput::startEdit(const muse::TranslatableString& actionName)
 {
-    m_undoStack->prepareChanges();
+    m_undoStack->prepareChanges(actionName);
 }
 
 void NotationNoteInput::apply()
@@ -672,7 +672,7 @@ void NotationNoteInput::doubleNoteInputDuration()
 
     mu::engraving::EditData editData(m_scoreCallbacks);
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Double note input duration"));
     score()->cmdPadNoteIncreaseTAB(editData);
     apply();
 
@@ -687,7 +687,7 @@ void NotationNoteInput::halveNoteInputDuration()
 
     mu::engraving::EditData editData(m_scoreCallbacks);
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Halve note input duration"));
     score()->cmdPadNoteDecreaseTAB(editData);
     apply();
 

--- a/src/notation/internal/notationnoteinput.h
+++ b/src/notation/internal/notationnoteinput.h
@@ -88,7 +88,7 @@ private:
 
     EngravingItem* resolveNoteInputStartPosition() const;
 
-    void startEdit();
+    void startEdit(const muse::TranslatableString& actionName);
     void apply();
 
     void updateInputState();

--- a/src/notation/internal/notationparts.cpp
+++ b/src/notation/internal/notationparts.cpp
@@ -320,7 +320,7 @@ void NotationParts::setPartSharpFlat(const ID& partId, const SharpFlat& sharpFla
     }
 
     auto calcActionName = [](const SharpFlat& sharpFlat) -> TranslatableString {
-        switch(sharpFlat) {
+        switch (sharpFlat) {
         case SharpFlat::NONE: return TranslatableString("undoableAction", "Set sharp/flat no preference");
         case SharpFlat::FLATS: return TranslatableString("undoableAction", "Set prefer flats");
         case SharpFlat::SHARPS: return TranslatableString("undoableAction", "Set prefer sharps");

--- a/src/notation/internal/notationparts.h
+++ b/src/notation/internal/notationparts.h
@@ -83,7 +83,7 @@ protected:
 
     Part* partModifiable(const muse::ID& partId) const;
 
-    void startEdit();
+    void startEdit(const muse::TranslatableString& actionName);
     void apply();
     void rollback();
 

--- a/src/notation/internal/notationstyle.cpp
+++ b/src/notation/internal/notationstyle.cpp
@@ -104,7 +104,7 @@ Notification NotationStyle::styleChanged() const
 
 bool NotationStyle::loadStyle(const muse::io::path_t& path, bool allowAnyVersion)
 {
-    m_undoStack->prepareChanges();
+    m_undoStack->prepareChanges(TranslatableString("undoableAction", "Load style"));
     bool result = score()->loadStyle(path.toQString(), allowAnyVersion);
     m_undoStack->commitChanges();
 

--- a/src/notation/internal/notationundostack.cpp
+++ b/src/notation/internal/notationundostack.cpp
@@ -168,8 +168,9 @@ muse::TranslatableString NotationUndoStack::topMostUndoActionName() const
         return {};
     }
 
-    if (auto current = undoStack()->last())
+    if (auto current = undoStack()->last()) {
         return current->actionName();
+    }
 
     return {};
 }
@@ -180,8 +181,9 @@ muse::TranslatableString NotationUndoStack::topMostRedoActionName() const
         return {};
     }
 
-    if (auto current = undoStack()->next())
+    if (auto current = undoStack()->next()) {
         return current->actionName();
+    }
 
     return {};
 }

--- a/src/notation/internal/notationundostack.cpp
+++ b/src/notation/internal/notationundostack.cpp
@@ -89,7 +89,7 @@ Notification NotationUndoStack::redoNotification() const
     return m_redoNotification;
 }
 
-void NotationUndoStack::prepareChanges()
+void NotationUndoStack::prepareChanges(const muse::TranslatableString& actionName)
 {
     IF_ASSERT_FAILED(score()) {
         return;
@@ -99,7 +99,7 @@ void NotationUndoStack::prepareChanges()
         return;
     }
 
-    score()->startCmd();
+    score()->startCmd(actionName);
 }
 
 void NotationUndoStack::rollbackChanges()
@@ -160,6 +160,30 @@ void NotationUndoStack::unlock()
 bool NotationUndoStack::isLocked() const
 {
     return undoStack()->locked();
+}
+
+muse::TranslatableString NotationUndoStack::topMostUndoActionName() const
+{
+    IF_ASSERT_FAILED(undoStack()) {
+        return {};
+    }
+
+    if (auto current = undoStack()->last())
+        return current->actionName();
+
+    return {};
+}
+
+muse::TranslatableString NotationUndoStack::topMostRedoActionName() const
+{
+    IF_ASSERT_FAILED(undoStack()) {
+        return {};
+    }
+
+    if (auto current = undoStack()->next())
+        return current->actionName();
+
+    return {};
 }
 
 muse::async::Notification NotationUndoStack::stackChanged() const

--- a/src/notation/internal/notationundostack.h
+++ b/src/notation/internal/notationundostack.h
@@ -47,7 +47,7 @@ public:
     void redo(mu::engraving::EditData*) override;
     muse::async::Notification redoNotification() const override;
 
-    void prepareChanges() override;
+    void prepareChanges(const muse::TranslatableString& actionName) override;
     void rollbackChanges() override;
     void commitChanges() override;
 
@@ -56,6 +56,9 @@ public:
     void lock() override;
     void unlock() override;
     bool isLocked() const override;
+
+    muse::TranslatableString topMostUndoActionName() const override;
+    muse::TranslatableString topMostRedoActionName() const override;
 
     muse::async::Notification stackChanged() const override;
     muse::async::Channel<ChangesRange> changesChannel() const override;

--- a/src/notation/view/abstractelementpopupmodel.cpp
+++ b/src/notation/view/abstractelementpopupmodel.cpp
@@ -79,16 +79,16 @@ INotationUndoStackPtr AbstractElementPopupModel::undoStack() const
     return currentNotation() ? currentNotation()->undoStack() : nullptr;
 }
 
-void AbstractElementPopupModel::beginCommand()
+void AbstractElementPopupModel::beginCommand(const muse::TranslatableString& actionName)
 {
     if (undoStack()) {
-        undoStack()->prepareChanges();
+        undoStack()->prepareChanges(actionName);
     }
 }
 
-void AbstractElementPopupModel::beginMultiCommands()
+void AbstractElementPopupModel::beginMultiCommands(const muse::TranslatableString& actionName)
 {
-    beginCommand();
+    beginCommand(actionName);
 
     if (undoStack()) {
         undoStack()->lock();
@@ -136,7 +136,7 @@ void AbstractElementPopupModel::changeItemProperty(mu::engraving::Pid id, const 
         flags = mu::engraving::PropertyFlags::UNSTYLED;
     }
 
-    beginCommand();
+    beginCommand(muse::TranslatableString("undoableAction", "Change item property"));
     m_item->undoChangeProperty(id, value, flags);
     endCommand();
     updateNotation();
@@ -148,7 +148,7 @@ void AbstractElementPopupModel::changeItemProperty(mu::engraving::Pid id, const 
         return;
     }
 
-    beginCommand();
+    beginCommand(muse::TranslatableString("undoableAction", "Change item property"));
     m_item->undoChangeProperty(id, value, flags);
     endCommand();
     updateNotation();

--- a/src/notation/view/abstractelementpopupmodel.h
+++ b/src/notation/view/abstractelementpopupmodel.h
@@ -73,8 +73,8 @@ protected:
     muse::RectF fromLogical(muse::RectF rect) const;
 
     notation::INotationUndoStackPtr undoStack() const;
-    void beginCommand();
-    void beginMultiCommands();
+    void beginCommand(const muse::TranslatableString& actionName);
+    void beginMultiCommands(const muse::TranslatableString& actionName);
     void endCommand();
     void endMultiCommands();
     void updateNotation();

--- a/src/notation/view/internal/harppedalpopupmodel.cpp
+++ b/src/notation/view/internal/harppedalpopupmodel.cpp
@@ -176,7 +176,7 @@ void HarpPedalPopupModel::setDiagramPedalState(QVector<Position> pedalState)
         return;
     }
 
-    beginCommand();
+    beginCommand(muse::TranslatableString("undoableAction", "Set harp diagram"));
     setPopupPedalState(stdPedalState);
     toHarpPedalDiagram(m_item)->undoChangePedalState(getPopupPedalState());
     updateNotation();

--- a/src/notation/view/internal/stringtuningssettingsmodel.cpp
+++ b/src/notation/view/internal/stringtuningssettingsmodel.cpp
@@ -139,7 +139,7 @@ bool StringTuningsSettingsModel::setStringValue(int stringIndex, const QString& 
     bool useFlat = _stringValue.contains(u'♭');
     item->setUseFlat(useFlat);
 
-    beginMultiCommands();
+    beginMultiCommands(TranslatableString("undoableAction", "Set string tuning"));
 
     updateCurrentPreset();
     saveStrings();
@@ -229,7 +229,7 @@ void StringTuningsSettingsModel::setCurrentPreset(const QString& preset)
 {
     bool isCurrentCustom = currentPreset() == customPreset();
 
-    beginMultiCommands();
+    beginMultiCommands(TranslatableString("undoableAction", "Set current string preset"));
 
     changeItemProperty(mu::engraving::Pid::STRINGTUNINGS_PRESET, String::fromQString(preset));
     emit currentPresetChanged();
@@ -282,7 +282,7 @@ void StringTuningsSettingsModel::setCurrentNumberOfStrings(int number)
         return;
     }
 
-    beginMultiCommands();
+    beginMultiCommands(TranslatableString("undoableAction", "Set number of strings"));
 
     changeItemProperty(mu::engraving::Pid::STRINGTUNINGS_STRINGS_COUNT, number);
 
@@ -353,7 +353,7 @@ void StringTuningsSettingsModel::saveStrings()
         stringList[i].useFlat = item->useFlat();
     }
 
-    beginCommand();
+    beginCommand(TranslatableString("undoableAction", "Save strings"));
 
     StringData newStringData(originStringData->frets(), stringList);
     stringTunings->undoStringData(newStringData);

--- a/src/notation/view/internal/undoredomodel.cpp
+++ b/src/notation/view/internal/undoredomodel.cpp
@@ -74,15 +74,14 @@ void UndoRedoModel::updateItems()
 {
     auto stack = undoStack();
 
-
     if (m_undoItem) {
         const TranslatableString undoActionName = stack ? stack->topMostUndoActionName() : TranslatableString();
         ui::UiActionState state;
         state.enabled = stack ? stack->canUndo() : false;
         m_undoItem->setState(state);
         m_undoItem->setTitle(undoActionName.isEmpty()
-            ? TranslatableString("action", "Undo")
-            : TranslatableString("action", "Undo '%1'").arg(undoActionName));
+                             ? TranslatableString("action", "Undo")
+                             : TranslatableString("action", "Undo ‘%1’").arg(undoActionName));
     }
 
     if (m_redoItem) {
@@ -91,8 +90,8 @@ void UndoRedoModel::updateItems()
         state.enabled = stack ? stack->canRedo() : false;
         m_redoItem->setState(state);
         m_redoItem->setTitle(redoActionName.isEmpty()
-             ? TranslatableString("action", "Redo")
-             : TranslatableString("action", "Redo '%1'").arg(redoActionName));
+                             ? TranslatableString("action", "Redo")
+                             : TranslatableString("action", "Redo ‘%1’").arg(redoActionName));
     }
 }
 

--- a/src/notation/view/internal/undoredomodel.cpp
+++ b/src/notation/view/internal/undoredomodel.cpp
@@ -36,13 +36,13 @@ UndoRedoModel::UndoRedoModel(QObject* parent)
 void UndoRedoModel::load()
 {
     context()->currentNotationChanged().onNotify(this, [this]() {
+        updateItems();
+
         auto stack = undoStack();
         if (stack) {
             stack->stackChanged().onNotify(this, [this]() {
                 updateItems();
             });
-        } else {
-            updateItems();
         }
     });
 

--- a/src/notation/view/internal/undoredomodel.h
+++ b/src/notation/view/internal/undoredomodel.h
@@ -24,18 +24,22 @@
 
 #include <QObject>
 
-#include "context/iglobalcontext.h"
-#include "ui/iuiactionsregister.h"
-#include "modularity/ioc.h"
 #include "async/asyncable.h"
+#include "context/iglobalcontext.h"
+#include "modularity/ioc.h"
+#include "ui/iuiactionsregister.h"
+
+namespace muse::uicomponents {
+class MenuItem;
+}
 
 namespace mu::notation {
 class UndoRedoModel : public QObject, public muse::Injectable, public muse::async::Asyncable
 {
     Q_OBJECT
 
-    Q_PROPERTY(QVariant undoItem READ makeUndoItem NOTIFY stackChanged)
-    Q_PROPERTY(QVariant redoItem READ makeRedoItem NOTIFY stackChanged)
+    Q_PROPERTY(muse::uicomponents::MenuItem * undoItem READ undoItem NOTIFY itemsChanged)
+    Q_PROPERTY(muse::uicomponents::MenuItem * redoItem READ redoItem NOTIFY itemsChanged)
 
     muse::Inject<context::IGlobalContext> context = { this };
     muse::Inject<muse::ui::IUiActionsRegister> actionsRegister = { this };
@@ -43,18 +47,24 @@ class UndoRedoModel : public QObject, public muse::Injectable, public muse::asyn
 public:
     explicit UndoRedoModel(QObject* parent = nullptr);
 
-    QVariant makeUndoItem();
-    QVariant makeRedoItem();
-
     Q_INVOKABLE void load();
+
+    muse::uicomponents::MenuItem* undoItem() const;
+    muse::uicomponents::MenuItem* redoItem() const;
+
     Q_INVOKABLE void undo();
     Q_INVOKABLE void redo();
 
 signals:
-    void stackChanged();
+    void itemsChanged();
 
 private:
     INotationUndoStackPtr undoStack() const;
+
+    void updateItems();
+
+    muse::uicomponents::MenuItem* m_undoItem = nullptr;
+    muse::uicomponents::MenuItem* m_redoItem = nullptr;
 };
 }
 

--- a/src/notation/view/widgets/editstyle.cpp
+++ b/src/notation/view/widgets/editstyle.cpp
@@ -1205,7 +1205,7 @@ void EditStyle::showEvent(QShowEvent* ev)
 {
     setValues();
     pageList->setFocus();
-    globalContext()->currentNotation()->undoStack()->prepareChanges();
+    globalContext()->currentNotation()->undoStack()->prepareChanges(muse::TranslatableString("undoableAction", "Set style properties"));
     buttonApplyToAllParts->setEnabled(globalContext()->currentNotation()->style()->canApplyToAllParts());
     QWidget::showEvent(ev);
 }

--- a/src/notation/view/widgets/measureproperties.cpp
+++ b/src/notation/view/widgets/measureproperties.cpp
@@ -321,7 +321,7 @@ void MeasurePropertiesDialog::apply()
 
     mu::engraving::Score* score = m_measure->score();
 
-    m_notation->undoStack()->prepareChanges();
+    m_notation->undoStack()->prepareChanges(TranslatableString("undoableAction", "Set measure properties"));
     bool propertiesChanged = false;
     for (size_t staffIdx = 0; staffIdx < score->nstaves(); ++staffIdx) {
         bool v = visible(static_cast<int>(staffIdx));

--- a/src/notation/view/widgets/pagesettings.cpp
+++ b/src/notation/view/widgets/pagesettings.cpp
@@ -98,7 +98,7 @@ PageSettings::PageSettings(QWidget* parent)
 
 void PageSettings::showEvent(QShowEvent* event)
 {
-    globalContext()->currentNotation()->undoStack()->prepareChanges();
+    globalContext()->currentNotation()->undoStack()->prepareChanges(muse::TranslatableString("undoableAction", "Save page settings"));
     updateValues();
     QWidget::showEvent(event);
 }

--- a/src/notation/view/widgets/stafftextpropertiesdialog.cpp
+++ b/src/notation/view/widgets/stafftextpropertiesdialog.cpp
@@ -141,7 +141,7 @@ void StaffTextPropertiesDialog::saveValues()
     StaffTextBase* nt = toStaffTextBase(m_staffText->clone());
     nt->setScore(score);
 
-    stack->prepareChanges();
+    stack->prepareChanges(muse::TranslatableString("undoableAction", "Save text properties"));
     score->undoChangeElement(m_originStaffText, nt);
     score->masterScore()->updateChannel();
     score->updateSwing();

--- a/src/notation/view/widgets/timeline.cpp
+++ b/src/notation/view/widgets/timeline.cpp
@@ -3034,7 +3034,7 @@ void Timeline::toggleShow(int staff)
 
     QList<Part*> parts = getParts();
     if (parts.size() > staff && staff >= 0) {
-        m_notation->undoStack()->prepareChanges();
+        m_notation->undoStack()->prepareChanges(muse::TranslatableString("undoableAction", "Toggle show timeline"));
         parts.at(staff)->setShow(!parts.at(staff)->show());
         parts.at(staff)->undoChangeProperty(Pid::VISIBLE, parts.at(staff)->show());
         m_notation->undoStack()->commitChanges();

--- a/src/palette/view/widgets/timesignaturepropertiesdialog.cpp
+++ b/src/palette/view/widgets/timesignaturepropertiesdialog.cpp
@@ -209,7 +209,7 @@ void TimeSignaturePropertiesDialog::accept()
     Groups g = groups->groups();
     m_editedTimeSig->setGroups(g);
 
-    notation->undoStack()->prepareChanges();
+    notation->undoStack()->prepareChanges(TranslatableString("undoableAction", "Set time signature properties"));
 
     // Change linked mmr timesigs too
     for (EngravingObject* obj : m_originTimeSig->linkList()) {

--- a/src/playback/view/internal/soundflag/soundflagsettingsmodel.cpp
+++ b/src/playback/view/internal/soundflag/soundflagsettingsmodel.cpp
@@ -180,7 +180,7 @@ void SoundFlagSettingsModel::togglePreset(const QString& presetCode)
 
     SoundFlag* soundFlag = toSoundFlag(m_item);
 
-    beginCommand();
+    beginCommand(TranslatableString("undoableAction", "Toggle preset"));
     soundFlag->undoChangeSoundFlag(StringList(newPresetCodes), soundFlag->playingTechnique());
     bool needUpdateNotation = updateStaffText();
     endCommand();
@@ -207,7 +207,7 @@ void SoundFlagSettingsModel::togglePlayingTechnique(const QString& playingTechni
 
     SoundFlag* soundFlag = toSoundFlag(m_item);
 
-    beginCommand();
+    beginCommand(TranslatableString("undoableAction", "Toggle playing technique"));
     soundFlag->undoChangeSoundFlag(soundFlag->soundPresets(), muse::String(playingTechniqueCode));
     bool needUpdateNotation = updateStaffText();
     endCommand();
@@ -330,7 +330,7 @@ void SoundFlagSettingsModel::handleContextMenuItem(const QString& menuId)
     }
 
     if (menuId == RESET_MENU_ID) {
-        beginCommand();
+        beginCommand(TranslatableString("undoableAction", "Reset sound settings"));
 
         const SoundFlag::PresetCodes oldPresetCodes = soundFlag->soundPresets();
         const SoundFlag::PresetCodes newPresetCodes = { defaultPresetCode() };
@@ -356,7 +356,7 @@ void SoundFlagSettingsModel::handleContextMenuItem(const QString& menuId)
         playbackConfiguration()->setSoundPresetsMultiSelectionEnabled(!playbackConfiguration()->soundPresetsMultiSelectionEnabled());
         emit contextMenuModelChanged();
     } else if (menuId == APPLY_TO_ALL_STAVES_MENU_ID) {
-        beginCommand();
+        beginCommand(TranslatableString("undoableAction", "Apply sound settings to all"));
         soundFlag->undoChangeProperty(Pid::APPLY_TO_ALL_STAVES, !soundFlag->applyToAllStaves());
         endCommand();
 

--- a/src/project/internal/notationproject.cpp
+++ b/src/project/internal/notationproject.cpp
@@ -1014,7 +1014,7 @@ void NotationProject::setMetaInfo(const ProjectMeta& meta, bool undoable)
     MasterScore* score = m_masterNotation->masterScore();
 
     if (undoable) {
-        m_masterNotation->notation()->undoStack()->prepareChanges();
+        m_masterNotation->notation()->undoStack()->prepareChanges(TranslatableString("undoableAction", "Set project properties"));
         score->undo(new mu::engraving::ChangeMetaTags(score, tags));
         m_masterNotation->notation()->undoStack()->commitChanges();
         m_masterNotation->notation()->notationChanged().notify();

--- a/src/project/internal/projectmigrator.cpp
+++ b/src/project/internal/projectmigrator.cpp
@@ -154,7 +154,7 @@ Ret ProjectMigrator::migrateProject(engraving::EngravingProjectPtr project, cons
         return make_ret(Ret::Code::InternalError);
     }
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Migrate project"));
 
     bool ok = true;
     if (opt.isApplyLeland) {


### PR DESCRIPTION
Adds a name for every call to `UndoStack::beginMacro` and displays these names in the menu and palettes.

Implements phase 1 of #24509. Phase 2 will be a Undo/Redo history dialog box.

<!-- Add a short description of and motivation for the changes here -->

These changes display text that shows what each undo/redo step is undoing or redoing.

This PR incorporates the changes in #24543. I made a slight modification in `UndoRedoModel::load` to remove code duplication. Please review that part carefully, @cbjeukendrup.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
