### PR TITLE
Use next segment in any voice for end of melisma

### DIFF
--- a/src/engraving/rendering/score/lyricslayout.cpp
+++ b/src/engraving/rendering/score/lyricslayout.cpp
@@ -451,8 +451,11 @@ void LyricsLayout::createOrRemoveLyricsLine(Lyrics* item, LayoutContext& ctx)
         EngravingItem* endSegmentElement = endSegment->element(track);
         if (endSegment->tick() == endTick && endSegmentElement && endSegmentElement->type() == ElementType::CHORD) {
             // everything is OK if we have reached a chord at right tick on right track
-            // advance to next CR, or last segment if no next CR
-            endSegment = endSegment->nextCR(track, false);
+            // advance to next CR after duration of note, or last segment if no next CR
+            const Score* score = item->score();
+            const Chord* endChord = toChord(endSegmentElement);
+
+            endSegment = score ? score->tick2segment(endSegment->tick() + endChord->ticks(), true, SegmentType::ChordRest) : nullptr;
         } else {
             // FIXUP - lyrics tick count not valid
             // this happens if edits to score have removed the original end segment

--- a/src/engraving/rendering/score/lyricslayout.cpp
+++ b/src/engraving/rendering/score/lyricslayout.cpp
@@ -452,10 +452,17 @@ void LyricsLayout::createOrRemoveLyricsLine(Lyrics* item, LayoutContext& ctx)
         if (endSegment->tick() == endTick && endSegmentElement && endSegmentElement->type() == ElementType::CHORD) {
             // everything is OK if we have reached a chord at right tick on right track
             // advance to next CR after duration of note, or last segment if no next CR
-            const Score* score = item->score();
+            const Segment* endChordSeg = endSegment;
             const Chord* endChord = toChord(endSegmentElement);
 
-            endSegment = score ? score->tick2segment(endSegment->tick() + endChord->ticks(), true, SegmentType::ChordRest) : nullptr;
+            endSegment = endChordSeg->nextCR(track, false);
+
+            if (!endSegment) {
+                endSegment = endChordSeg;
+                while (endSegment && endSegment->tick() < endChord->tick() + endChord->ticks()) {
+                    endSegment = endSegment->nextCR(muse::nidx, true);
+                }
+            }
         } else {
             // FIXUP - lyrics tick count not valid
             // this happens if edits to score have removed the original end segment


### PR DESCRIPTION
Resolves: #24519 

I think this is the correct solution - we need to end the melisma on the tick of the first chordrest after the final chord of the melisma.  In the case of a melisma on voice 2 and there being no voice 2 chordrest immediately after, use any chordrest segment.
@mike-spa can adjuicate!