### PR TITLE
gp-import: fixed arpeggio direction for gp5

### DIFF
--- a/src/importexport/guitarpro/internal/importgtp-gp5.cpp
+++ b/src/importexport/guitarpro/internal/importgtp-gp5.cpp
@@ -151,12 +151,12 @@ int GuitarPro5::readBeatEffects(int track, Segment* segment)
         Arpeggio* a = Factory::createArpeggio(score->dummy()->chord());
         // representation is different in guitar pro 5 - the up/down order below is correct
         if (strokeup > 0) {
-            a->setArpeggioType(ArpeggioType::UP_STRAIGHT);
+            a->setArpeggioType(ArpeggioType::DOWN_STRAIGHT);
             if (strokeup < 7) {
                 a->setStretch(1.0 / std::pow(2, 6 - strokeup));
             }
         } else if (strokedown > 0) {
-            a->setArpeggioType(ArpeggioType::DOWN_STRAIGHT);
+            a->setArpeggioType(ArpeggioType::UP_STRAIGHT);
             if (strokedown < 7) {
                 a->setStretch(1.0 / std::pow(2, 6 - strokedown));
             }


### PR DESCRIPTION
the direction of arpeggio in gp5 is reversed, as the comment says.
Probably didn't pay attention before

`// representation is different in guitar pro 5 - the up/down order below is correct`