### PR TITLE
Fix #24596: Adding "c. " text support  within Tempo text

### DIFF
--- a/src/engraving/dom/tempotext.cpp
+++ b/src/engraving/dom/tempotext.cpp
@@ -267,6 +267,7 @@ void TempoText::updateTempo()
     s.replace(u"≈", u"=");
     s.replace(u"~", u"=");
     s.replace(u"ca.", u"");
+    s.replace(u"c.", u"");
     s.replace(u"approx.", u"");
     std::string su8 = s.toStdString();
     for (const TempoPattern& pa : tp) {


### PR DESCRIPTION
Resolves: #24596 

This change allows the use of "c. " within the tempo text 

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
