### PR TITLE
Fix #24598: Skip metronome solo state when evaluating hasSolo

### DIFF
--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -1334,6 +1334,9 @@ void PlaybackController::updateSoloMuteStates()
     bool hasSolo = false;
 
     for (const InstrumentTrackId& instrumentTrackId : existingTrackIdSet) {
+        if (instrumentTrackId == notationPlayback()->metronomeTrackId()) {
+            continue;
+        }
         if (m_notation->soloMuteState()->trackSoloMuteState(instrumentTrackId).solo) {
             hasSolo = true;
             break;


### PR DESCRIPTION
Resolves: #24598

Adds a forgotten piece of logic from #19433. We skip over the metronome in the "main" `updateSoloMuteStates` loop and we should do the same here.