### PR TITLE
#12753: Bringing back lost lines

### DIFF
--- a/src/palette/qml/MuseScore/Palette/internal/PaletteTree.qml
+++ b/src/palette/qml/MuseScore/Palette/internal/PaletteTree.qml
@@ -305,6 +305,9 @@ StyledListView {
                     customPaletteRootIndex = paletteTree.paletteProvider.customElementsPaletteIndex(control.modelIndex) // TODO: make a property binding? (but that works incorrectly)
                     customPaletteController = paletteTree.paletteProvider.customElementsPaletteController
                 }
+                if (!isOpened) {
+                    paletteTree.expandedPopupIndex = null
+                }
             }
 
             property bool needScrollToBottom: false


### PR DESCRIPTION
Just discovered I had somehow (absolutely no idea how) lost these three lines of code from the MoreElementsPopup component when I extracted it into a single instance Loader.

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
