### PR TITLE
Fix #24598: Skip metronome solo state when evaluating hasSolo (4.4.2 port)

### DIFF
--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -1334,6 +1334,9 @@ void PlaybackController::updateSoloMuteStates()
     bool hasSolo = false;
 
     for (const InstrumentTrackId& instrumentTrackId : existingTrackIdSet) {
+        if (instrumentTrackId == notationPlayback()->metronomeTrackId()) {
+            continue;
+        }
         if (m_notation->soloMuteState()->trackSoloMuteState(instrumentTrackId).solo) {
             hasSolo = true;
             break;


### PR DESCRIPTION
Ports: #24622 
Resolves: #24598 