### PR TITLE
[4.4.2] Revert "fix: anacrusis has wrong tempo if not explicitly set (#23656)"

### DIFF
--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -419,7 +419,6 @@ void Score::setUpTempoMap()
         sigmap()->clear();
         sigmap()->add(0, SigEvent(fm->ticks(),  fm->timesig(), 0));
     }
-    std::vector<Measure*> anacrusisMeasures;
 
     auto tempoPrimo = std::optional<BeatsPerSecond> {};
 
@@ -435,14 +434,6 @@ void Score::setUpTempoMap()
         m->moveTicks(diff);
         if (m->mmRest()) {
             m->mmRest()->moveTicks(diff);
-        }
-        // TODO: Better to use Measure::isAnacrusis() here
-        // but since it requires irregular() return true it's not working as expected
-        // if user didn't checked "Exclude from measure count" in measure properties,
-        // but reduces the real measure length.
-        // So we use the following workaround:
-        if (m->ticks() < m->timesig()) {
-            anacrusisMeasures.push_back(m);
         }
 
         rebuildTempoAndTimeSigMaps(m, tempoPrimo);
@@ -488,9 +479,6 @@ void Score::setUpTempoMap()
     }
 
     masterScore()->updateRepeatListTempo();
-    if (!anacrusisMeasures.empty()) {
-        fixAnacrusisTempo(anacrusisMeasures);
-    }
     m_needSetUpTempoMap = false;
 }
 
@@ -620,34 +608,6 @@ void Score::rebuildTempoAndTimeSigMaps(Measure* measure, std::optional<BeatsPerS
 
         if (pm && (!mTicks.identical(pm->ticks()) || !m->timesig().identical(pm->timesig()))) {
             sigmap()->add(m->tick().ticks(), SigEvent(mTicks, m->timesig(), m->no()));
-        }
-    }
-}
-
-void Score::fixAnacrusisTempo(const std::vector<Measure*>& measures) const
-{
-    auto getTempoTextIfExist = [](const Measure* m) -> TempoText* {
-        for (const Segment& s : m->segments()) {
-            if (s.isChordRestType()) {
-                for (EngravingItem* e : s.annotations()) {
-                    if (e->isTempoText()) {
-                        return toTempoText(e);
-                    }
-                }
-            }
-        }
-        return nullptr;
-    };
-
-    for (Measure* measure : measures) {
-        if (getTempoTextIfExist(measure)) {
-            continue;
-        }
-        Measure* nextMeasure = measure->nextMeasure();
-        if (nextMeasure) {
-            if (TempoText* tt = getTempoTextIfExist(nextMeasure); tt) {
-                tempomap()->setTempo(measure->tick().ticks(), tt->tempo());
-            }
         }
     }
 }

--- a/src/engraving/dom/score.h
+++ b/src/engraving/dom/score.h
@@ -1056,7 +1056,6 @@ private:
     void resetTempo();
     void resetTempoRange(const Fraction& tick1, const Fraction& tick2);
     void rebuildTempoAndTimeSigMaps(Measure* m, std::optional<BeatsPerSecond>& tempoPrimo);
-    void fixAnacrusisTempo(const std::vector<Measure*>& measures) const;
 
     void deleteOrShortenOutSpannersFromRange(const Fraction& t1, const Fraction& t2, track_idx_t trackStart, track_idx_t trackEnd,
                                              const SelectionFilter& filter);


### PR DESCRIPTION
This reverts commit 34b99aaac628b41a2cd9f3a294f8c47a9adce69a. I think we don't really need that on the 4.4 branch, especially since it is not working not entirely correctly. For the master branch, I'll create a separate PR with a fix instead of a revert.

Resolves: https://github.com/musescore/MuseScore/issues/24570