### PR TITLE
setUpTempoMap anacrusis: use `m->isAnacrusis`

### DIFF
--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -436,12 +436,7 @@ void Score::setUpTempoMap()
         if (m->mmRest()) {
             m->mmRest()->moveTicks(diff);
         }
-        // TODO: Better to use Measure::isAnacrusis() here
-        // but since it requires irregular() return true it's not working as expected
-        // if user didn't checked "Exclude from measure count" in measure properties,
-        // but reduces the real measure length.
-        // So we use the following workaround:
-        if (m->ticks() < m->timesig()) {
+        if (m->isAnacrusis()) {
             anacrusisMeasures.push_back(m);
         }
 


### PR DESCRIPTION
Initially, I was thinking about relaxing `isAnacrusis` to remove the `irregular` requirement. But then I saw that the 'TODO' comment above it is not completely true: `isAnacrusis()` doesn't require `irregular()` per se; it requires an OR combination of `irregular()` OR some other properties. These other properties must certainly be loose enough to catch all measures that are really an anacrusis, i.e. false negatives are _very_ unlikely. (False positives OTOH seem somewhat likely, but that's for another day.)

Resolves: https://github.com/musescore/MuseScore/issues/24570

Since this turned out to be so simple / low risk, I'm inclined to close https://github.com/musescore/MuseScore/pull/24639 and instead just backport this change to 4.4.2. Thoughts about this?