### PR TITLE
[4.4.2] AppImage: deploy `libopengl.so.0` as a fallback library

### DIFF
--- a/buildscripts/ci/linux/setup.sh
+++ b/buildscripts/ci/linux/setup.sh
@@ -106,6 +106,7 @@ apt_packages_runtime=(
   libxcb-xinerama0
   libxcb-xkb-dev
   libxkbcommon-dev
+  libopengl-dev
   libvulkan-dev
   )
 

--- a/buildscripts/ci/linux/tools/make_appimage.sh
+++ b/buildscripts/ci/linux/tools/make_appimage.sh
@@ -243,6 +243,7 @@ additional_libraries=(
 # Report new additions at https://github.com/linuxdeploy/linuxdeploy/issues
 fallback_libraries=(
   libjack.so.0 # https://github.com/LMMS/lmms/pull/3958
+  libopengl.so.0 # https://bugreports.qt.io/browse/QTBUG-89754
 
   # https://github.com/musescore/MuseScore/issues/24068#issuecomment-2297823192
   libwayland-client.so.0


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/24228