### PR TITLE
Auto-fix scores with broken chordlists (missing 0x)

### DIFF
--- a/src/engraving/dom/chordlist.cpp
+++ b/src/engraving/dom/chordlist.cpp
@@ -1662,7 +1662,7 @@ void ChordList::configureAutoAdjust(double emag, double eadjust, double mmag, do
 //   read
 //---------------------------------------------------------
 
-void ChordList::read(XmlReader& e)
+void ChordList::read(XmlReader& e, int mscVersion)
 {
     int fontIdx = static_cast<int>(fonts.size());
     m_autoAdjust = false;
@@ -1687,6 +1687,9 @@ void ChordList::read(XmlReader& e)
                     if (!code.empty()) {
                         bool ok = true;
                         char32_t val = code.toUInt(&ok, 0);
+                        if (!ok && mscVersion >= 400 && mscVersion < 440) {
+                            val = code.toUInt(&ok, 16);
+                        }
                         if (!ok) {
                             cs.code = 0;
                             cs.value = code;
@@ -1848,10 +1851,10 @@ bool ChordList::read(IODevice* device)
 
     while (e.readNextStartElement()) {
         if (e.name() == "museScore") {
-            // String version = e.attribute(String("version"));
-            // StringList sl = version.split('.');
-            // int _mscVersion = sl[0].toInt() * 100 + sl[1].toInt();
-            read(e);
+            const String version = e.attribute("version");
+            const StringList sl = version.split(u'.');
+            const int mscVersion = sl.size() == 2 ? sl[0].toInt() * 100 + sl[1].toInt() : 0;
+            read(e, mscVersion);
             return true;
         }
     }

--- a/src/engraving/dom/chordlist.h
+++ b/src/engraving/dom/chordlist.h
@@ -305,7 +305,7 @@ private:
 
     friend class compat::ReadChordListHook;
 
-    void read(XmlReader&);
+    void read(XmlReader& xml, int mscVersion);
     void write(XmlWriter& xml) const;
 
     std::map<String, ChordSymbol> m_symbols;

--- a/src/engraving/rw/compat/readchordlisthook.cpp
+++ b/src/engraving/rw/compat/readchordlisthook.cpp
@@ -45,7 +45,7 @@ void ReadChordListHook::read(XmlReader& e)
     }
 
     m_score->chordList()->clear();
-    m_score->chordList()->read(e);
+    m_score->chordList()->read(e, m_score->mscVersion());
     m_score->chordList()->setCustomChordList(true);
 
     m_chordListTag = true;

--- a/src/engraving/rw/mscloader.cpp
+++ b/src/engraving/rw/mscloader.cpp
@@ -230,8 +230,8 @@ Ret MscLoader::readMasterScore(MasterScore* score, XmlReader& e, bool ignoreVers
 {
     while (e.readNextStartElement()) {
         if (e.name() == "museScore") {
-            const String& version = e.attribute("version");
-            StringList sl = version.split('.');
+            const String version = e.attribute("version");
+            const StringList sl = version.split(u'.');
             score->setMscVersion(sl[0].toInt() * 100 + sl[1].toInt());
 
             RetVal<IReaderPtr> reader = makeReader(score->mscVersion(), ignoreVersionError);


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/24650

(To explain the problem a bit more: in 4.0-4.3, there was a bug that caused chordlist files to be written like 
<img width="285" alt="Scherm­afbeelding 2024-09-12 om 00 47 28" src="https://github.com/user-attachments/assets/2a1a34cc-209f-46c0-bcd5-8c8903bd40a8">
instead of
<img width="285" alt="Scherm­afbeelding 2024-09-12 om 00 47 51" src="https://github.com/user-attachments/assets/03f224b0-dd57-4106-9760-25d53b8f284c">
and therefore `code.toUInt(&ok, 0)` couldn't recognise that it should read the value as hexadecimal instead of decimal.)