### PR TITLE
[4.4.3] Fix MSVC compiler warning

### DIFF
--- a/src/framework/audio/internal/worker/mixer.cpp
+++ b/src/framework/audio/internal/worker/mixer.cpp
@@ -38,7 +38,7 @@ Mixer::Mixer(const modularity::ContextPtr& iocCtx)
 {
     ONLY_AUDIO_WORKER_THREAD;
 
-    m_taskScheduler = std::make_unique<TaskScheduler>(configuration()->desiredAudioThreadNumber());
+    m_taskScheduler = std::make_unique<TaskScheduler>(static_cast<thread_pool_size_t>(configuration()->desiredAudioThreadNumber()));
 
     if (!m_taskScheduler->setThreadsPriority(ThreadPriority::High)) {
         LOGE() << "Unable to change audio threads priority";


### PR DESCRIPTION
reg.: conversion from 'size_t' to 'const muse::thread_pool_size_t', possible loss of data (C4267)
Introduced by #24576