### PR TITLE
Fix MSVC compiler warnings

### DIFF
--- a/src/framework/audio/internal/worker/mixer.cpp
+++ b/src/framework/audio/internal/worker/mixer.cpp
@@ -38,7 +38,7 @@ Mixer::Mixer(const modularity::ContextPtr& iocCtx)
 {
     ONLY_AUDIO_WORKER_THREAD;
 
-    m_taskScheduler = std::make_unique<TaskScheduler>(configuration()->desiredAudioThreadNumber());
+    m_taskScheduler = std::make_unique<TaskScheduler>(static_cast<thread_pool_size_t>(configuration()->desiredAudioThreadNumber()));
 
     if (!m_taskScheduler->setThreadsPriority(ThreadPriority::High)) {
         LOGE() << "Unable to change audio threads priority";

--- a/src/importexport/mei/internal/meiconverter.cpp
+++ b/src/importexport/mei/internal/meiconverter.cpp
@@ -3386,7 +3386,7 @@ void Convert::layerIdentToMEI(const engraving::EngravingItem* item, libmei::Elem
     if (item->hasVoiceAssignmentProperties()
         && (item->getProperty(engraving::Pid::VOICE_ASSIGNMENT).value<engraving::VoiceAssignment>()
             == engraving::VoiceAssignment::CURRENT_VOICE_ONLY)) {
-        layerAtt->SetLayer(item->voice() + 1);
+        layerAtt->SetLayer(static_cast<int>(item->voice()) + 1);
     }
 }
 
@@ -3399,7 +3399,7 @@ void Convert::staffIdentToMEI(const engraving::EngravingItem* item, libmei::Elem
     }
 
     libmei::xsdPositiveInteger_List staffList;
-    staffList.push_back(item->staff()->idx() + 1);
+    staffList.push_back(static_cast<int>(item->staff()->idx()) + 1);
     // TODO: add staff number if centered between staves
     staffAtt->SetStaff(staffList);
 }

--- a/src/importexport/musicxml/internal/musicxml/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmusicxmlpass2.cpp
@@ -2244,8 +2244,8 @@ void MusicXmlParserPass2::part()
                 matchingNote->setTieBack(unendedTie);
             } else {
                 // try other voices in the stave
-                const Part* part = startChord->part();
-                for (track_idx_t track = part->startTrack(); track < part->endTrack() + VOICES; track++) {
+                const Part* p = startChord->part();
+                for (track_idx_t track = p->startTrack(); track < p->endTrack() + VOICES; track++) {
                     nextEl = nextSeg ? nextSeg->element(track) : nullptr;
                     nextChord = nextEl && nextEl->isChord() ? toChord(nextEl) : nullptr;
                     if (nextChord && nextChord->vStaffIdx() != startChord->vStaffIdx()) {


### PR DESCRIPTION
* reg.: conversion from 'size_t' to 'xxx', possible loss of data (C4267)
* reg.: declaration of 'part' hides previous local declaration (C4456)
