### PR TITLE
#24704 ensure xml parse can cope with comments after empty notes

### DIFF
--- a/src/framework/global/serialization/xmlstreamreader.cpp
+++ b/src/framework/global/serialization/xmlstreamreader.cpp
@@ -157,7 +157,7 @@ static std::pair<XMLNode*, XmlStreamReader::TokenType> resolveNode(XMLNode* curr
         }
 
         XMLNode* sibling = currentNode->NextSibling();
-        if (!sibling || sibling->ToElement() || sibling->ToText()) {
+        if (!sibling || sibling->ToElement() || sibling->ToText() || sibling->ToComment()) {
             return { currentNode, XmlStreamReader::TokenType::EndElement };
         }
     }
@@ -474,11 +474,11 @@ double XmlStreamReader::readDouble(bool* ok)
 
 int64_t XmlStreamReader::lineNumber() const
 {
-    if (!m_xml->doc.Error() && m_xml->node) {
-        return m_xml->node->GetLineNum();
+    int64_t lineNum = m_xml->doc.ErrorLineNum();
+    if (lineNum == 0 && m_xml->node) {
+        lineNum = m_xml->node->GetLineNum();
     }
-
-    return m_xml->doc.ErrorLineNum();
+    return lineNum;
 }
 
 int64_t XmlStreamReader::columnNumber() const

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass1.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass1.cpp
@@ -1286,6 +1286,9 @@ Err MusicXmlParserPass1::parse()
 
     if (!found) {
         m_logger->logError(u"this is not a MusicXML score-partwise file, node <score-partwise> not found", &m_e);
+        if (!m_e.errorString().isEmpty()) {
+            m_errors += errorStringWithLocation(m_e.lineNumber(), m_e.columnNumber(), m_e.errorString()) + '\n';
+        }
         return Err::FileBadFormat;
     }
 

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -3061,7 +3061,7 @@ void MusicXmlParserPass2::staffDetails(const String& partId, Measure* measure)
 
     staff_idx_t staffIdx = m_score->staffIdx(part) + n;
 
-    StringData* t = new StringData;
+    StringData stringData;
     String visible = m_e.attribute("print-object");
     String spacing = m_e.attribute("print-spacing");
     if (visible == "no") {
@@ -3095,15 +3095,13 @@ void MusicXmlParserPass2::staffDetails(const String& partId, Measure* measure)
             // save staff lines for later
             staffLines = m_e.readInt();
             // for a TAB staff also resize the string table and init with zeroes
-            if (t) {
-                if (0 < staffLines) {
-                    t->stringList() = std::vector<instrString>(staffLines);
-                } else {
-                    m_logger->logError(String(u"illegal staff-lines %1").arg(staffLines), &m_e);
-                }
+            if (0 < staffLines) {
+                stringData.stringList() = std::vector<instrString>(staffLines);
+            } else {
+                m_logger->logError(String(u"illegal staff-lines %1").arg(staffLines), &m_e);
             }
         } else if (m_e.name() == "staff-tuning") {
-            staffTuning(t);
+            staffTuning(&stringData);
         } else if (m_e.name() == "staff-size") {
             const double val = m_e.readDouble() / 100;
             m_score->staff(staffIdx)->setProperty(Pid::MAG, val);
@@ -3116,20 +3114,18 @@ void MusicXmlParserPass2::staffDetails(const String& partId, Measure* measure)
         setStaffLines(m_score, staffIdx, staffLines);
     }
 
-    if (t) {
-        Instrument* i = part->instrument();
-        if (m_score->staff(staffIdx)->isTabStaff(Fraction(0, 1))) {
-            if (i->stringData()->frets() == 0) {
-                t->setFrets(25);
-            } else {
-                t->setFrets(i->stringData()->frets());
-            }
-        }
-        if (t->strings() > 0) {
-            i->setStringData(*t);
+    Instrument* i = part->instrument();
+    if (m_score->staff(staffIdx)->isTabStaff(Fraction(0, 1))) {
+        if (i->stringData()->frets() == 0) {
+            stringData.setFrets(25);
         } else {
-            m_logger->logError(u"trying to change string data (not supported)", &m_e);
+            stringData.setFrets(i->stringData()->frets());
         }
+        if (stringData.strings() > 0) {
+            i->setStringData(stringData);
+        }
+    } else if (stringData.strings() > 0) {
+        m_logger->logError(u"trying to change string data for non-TAB staff (not supported)", &m_e);
     }
 }
 


### PR DESCRIPTION
Resolves: #24704

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
