### PR TITLE
Fix crash accessing uninitialized properties

### DIFF
--- a/src/engraving/dom/property.h
+++ b/src/engraving/dom/property.h
@@ -44,7 +44,7 @@ namespace mu::engraving {
 //---------------------------------------------------------
 
 #define M_PROPERTY(a, b, c)                                      \
-    a _##b;                                                \
+    a _##b { };                                                \
 public:                                                     \
     const a& b() const { return _##b; }                  \
     void c(const a& val) { _##b = val; }                  \


### PR DESCRIPTION
When MuseScore is built with GCC 13.3.0 with optimizations, statements like

    return lineVisible() ? Sid::pedalEndText : Sid::pedalRosetteEndText;

in `Pedal::getPropertyStyle` are optimized to

    return Sid::pedalRosetteEndText - _lineVisible

However constructors like `Pedal::Pedal` call `EngravingObject::initElementStyle` when such properties are not initialized yet, and when `initElementStyle` calls `getPropertyStyle` it receives a bogus result and may crash when it calls `setProperty` with a wrong `PropertyValue`.

On my machine this causes MuseScore to crash during startup about 40% of the times. This change fixes the crash by adding default initialiazers.

Resolves: #20878

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
