### PR TITLE
Implemented Initial letter Navigation in Dropdowns

### DIFF
--- a/src/framework/uicomponents/view/dropdownview.cpp
+++ b/src/framework/uicomponents/view/dropdownview.cpp
@@ -86,6 +86,11 @@ int DropdownView::focusItemY() const
     return m_focusItemY;
 }
 
+void DropdownView::requestHighlight(bool isHighlight)
+{
+    navigationController()->setIsHighlight(isHighlight);
+}
+
 void DropdownView::setFocusItemY(int newFocusItemY)
 {
     if (m_focusItemY == newFocusItemY) {

--- a/src/framework/uicomponents/view/dropdownview.cpp
+++ b/src/framework/uicomponents/view/dropdownview.cpp
@@ -100,3 +100,4 @@ void DropdownView::setFocusItemY(int newFocusItemY)
     m_focusItemY = newFocusItemY;
     emit focusItemYChanged();
 }
+

--- a/src/framework/uicomponents/view/dropdownview.h
+++ b/src/framework/uicomponents/view/dropdownview.h
@@ -41,6 +41,8 @@ public:
     int focusItemY() const;
     void setFocusItemY(int newFocusItemY);
 
+    Q_INVOKABLE void requestHighlight(bool isHighlight);
+
 signals:
     void focusItemYChanged();
 

--- a/src/framework/uicomponents/view/dropdownview.h
+++ b/src/framework/uicomponents/view/dropdownview.h
@@ -54,3 +54,4 @@ private:
 }
 
 #endif // MUSE_UICOMPONENTS_DROPDOWNVIEW_H
+


### PR DESCRIPTION
Resolves: #16508  for Dropdowns

Key points - 

Single Key Press: When you press a letter like S, the dropdown should highlight the next item that comes lexicographically after S, such as "Sans Serif Collection."

Multiple Key Presses in Quick Succession: If you press S followed by E quickly, it should highlight the first item after "Se," like "Segoe Fluent Icons." Similarly, S then G highlights "Showcard Gothic."

Repeated Key Presses: If the same key is pressed repeatedly (e.g., S followed by S), the selection cycles through items that begin with S.


- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
