### PR TITLE
Implement Undo/Redo naming and history

### DIFF
--- a/src/appshell/view/appmenumodel.cpp
+++ b/src/appshell/view/appmenumodel.cpp
@@ -81,6 +81,29 @@ bool AppMenuModel::isGlobalMenuAvailable()
     return uiConfiguration()->isGlobalMenuAvailable();
 }
 
+mu::notation::INotationUndoStackPtr AppMenuModel::undoStack() const
+{
+    mu::notation::INotationPtr notation = globalContext()->currentNotation();
+    return notation ? notation->undoStack() : nullptr;
+}
+
+void AppMenuModel::updateUndoRedoItems()
+{
+    auto stack = undoStack();
+
+    MenuItem& undoItem = findItem(ActionCode("undo"));
+    const TranslatableString undoActionName = stack ? stack->topMostUndoActionName() : TranslatableString();
+    undoItem.setTitle(undoActionName.isEmpty()
+                      ? TranslatableString("action", "Undo")
+                      : TranslatableString("action", "Undo ‘%1’").arg(undoActionName));
+
+    MenuItem& redoItem = findItem(ActionCode("redo"));
+    const TranslatableString redoActionName = stack ? stack->topMostRedoActionName() : TranslatableString();
+    redoItem.setTitle(redoActionName.isEmpty()
+                      ? TranslatableString("action", "Redo")
+                      : TranslatableString("action", "Redo ‘%1’").arg(redoActionName));
+}
+
 void AppMenuModel::setupConnections()
 {
     recentFilesController()->recentFilesListChanged().onNotify(this, [this]() {
@@ -118,6 +141,17 @@ void AppMenuModel::setupConnections()
     extensionsProvider()->manifestChanged().onReceive(this, [this](const Manifest&) {
         MenuItem& pluginsItem = findMenu("menu-plugins");
         pluginsItem.setSubitems(makePluginsMenuSubitems());
+    });
+
+    globalContext()->currentNotationChanged().onNotify(this, [this]() {
+        auto stack = undoStack();
+        if (stack) {
+            stack->stackChanged().onNotify(this, [this]() {
+                updateUndoRedoItems();
+            });
+        }
+
+        updateUndoRedoItems();
     });
 }
 
@@ -169,6 +203,7 @@ MenuItem* AppMenuModel::makeEditMenu()
     MenuItemList editItems {
         makeMenuItem("undo"),
         makeMenuItem("redo"),
+        makeMenuItem("undo-history"),
         makeSeparator(),
         makeMenuItem("notation-cut"),
         makeMenuItem("notation-copy"),

--- a/src/appshell/view/appmenumodel.cpp
+++ b/src/appshell/view/appmenumodel.cpp
@@ -81,29 +81,6 @@ bool AppMenuModel::isGlobalMenuAvailable()
     return uiConfiguration()->isGlobalMenuAvailable();
 }
 
-mu::notation::INotationUndoStackPtr AppMenuModel::undoStack() const
-{
-    mu::notation::INotationPtr notation = globalContext()->currentNotation();
-    return notation ? notation->undoStack() : nullptr;
-}
-
-void AppMenuModel::updateUndoRedoItems()
-{
-    auto stack = undoStack();
-
-    MenuItem& undoItem = findItem(ActionCode("undo"));
-    const TranslatableString undoActionName = stack ? stack->topMostUndoActionName() : TranslatableString();
-    undoItem.setTitle(undoActionName.isEmpty()
-                      ? TranslatableString("action", "Undo")
-                      : TranslatableString("action", "Undo ‘%1’").arg(undoActionName));
-
-    MenuItem& redoItem = findItem(ActionCode("redo"));
-    const TranslatableString redoActionName = stack ? stack->topMostRedoActionName() : TranslatableString();
-    redoItem.setTitle(redoActionName.isEmpty()
-                      ? TranslatableString("action", "Redo")
-                      : TranslatableString("action", "Redo ‘%1’").arg(redoActionName));
-}
-
 void AppMenuModel::setupConnections()
 {
     recentFilesController()->recentFilesListChanged().onNotify(this, [this]() {
@@ -221,6 +198,29 @@ MenuItem* AppMenuModel::makeEditMenu()
     };
 
     return makeMenu(TranslatableString("appshell/menu/edit", "&Edit"), editItems, "menu-edit");
+}
+
+mu::notation::INotationUndoStackPtr AppMenuModel::undoStack() const
+{
+    mu::notation::INotationPtr notation = globalContext()->currentNotation();
+    return notation ? notation->undoStack() : nullptr;
+}
+
+void AppMenuModel::updateUndoRedoItems()
+{
+    auto stack = undoStack();
+
+    MenuItem& undoItem = findItem(ActionCode("undo"));
+    const TranslatableString undoActionName = stack ? stack->topMostUndoActionName() : TranslatableString();
+    undoItem.setTitle(undoActionName.isEmpty()
+                      ? TranslatableString("action", "Undo")
+                      : TranslatableString("action", "Undo ‘%1’").arg(undoActionName));
+
+    MenuItem& redoItem = findItem(ActionCode("redo"));
+    const TranslatableString redoActionName = stack ? stack->topMostRedoActionName() : TranslatableString();
+    redoItem.setTitle(redoActionName.isEmpty()
+                      ? TranslatableString("action", "Redo")
+                      : TranslatableString("action", "Redo ‘%1’").arg(redoActionName));
 }
 
 MenuItem* AppMenuModel::makeViewMenu()

--- a/src/appshell/view/appmenumodel.h
+++ b/src/appshell/view/appmenumodel.h
@@ -68,9 +68,6 @@ public:
     Q_INVOKABLE bool isGlobalMenuAvailable();
 
 private:
-    mu::notation::INotationUndoStackPtr undoStack() const;
-    void updateUndoRedoItems();
-
     void setupConnections();
 
     using muse::uicomponents::AbstractMenuModel::makeMenuItem;
@@ -101,6 +98,9 @@ private:
     muse::uicomponents::MenuItemList makeWorkspacesItems();
     muse::uicomponents::MenuItemList makeShowItems();
     muse::uicomponents::MenuItemList makePluginsItems();
+
+    mu::notation::INotationUndoStackPtr undoStack() const;
+    void updateUndoRedoItems();
 };
 }
 

--- a/src/appshell/view/appmenumodel.h
+++ b/src/appshell/view/appmenumodel.h
@@ -22,6 +22,7 @@
 #ifndef MU_APPSHELL_APPMENUMODEL_H
 #define MU_APPSHELL_APPMENUMODEL_H
 
+#include "context/iglobalcontext.h"
 #include "uicomponents/view/abstractmenumodel.h"
 
 #include "modularity/ioc.h"
@@ -58,6 +59,7 @@ public:
     muse::Inject<muse::update::IUpdateConfiguration> updateConfiguration = { this };
     muse::Inject<muse::IGlobalConfiguration> globalConfiguration = { this };
     muse::Inject<project::IProjectConfiguration> projectConfiguration = { this };
+    muse::Inject<mu::context::IGlobalContext> globalContext = { this };
 
 public:
     explicit AppMenuModel(QObject* parent = nullptr);
@@ -66,6 +68,9 @@ public:
     Q_INVOKABLE bool isGlobalMenuAvailable();
 
 private:
+    mu::notation::INotationUndoStackPtr undoStack() const;
+    void updateUndoRedoItems();
+
     void setupConnections();
 
     using muse::uicomponents::AbstractMenuModel::makeMenuItem;

--- a/src/braille/internal/notationbraille.cpp
+++ b/src/braille/internal/notationbraille.cpp
@@ -699,7 +699,7 @@ bool NotationBraille::addTie()
         return false;
     }
 
-    score()->startCmd();
+    score()->startCmd(TranslatableString("undoableAction", "Add tie"));
     Note* note = toNote(currentEngravingItem());
 
     Tie* tie = Factory::createTie(score()->dummy());
@@ -725,7 +725,7 @@ bool NotationBraille::addSlur()
             ChordRest* firstChordRest = toChordRest(note1->parent());
             ChordRest* secondChordRest = toChordRest(note2->parent());
 
-            score()->startCmd();
+            score()->startCmd(TranslatableString("undoableAction", "Add slur"));
 
             Slur* slur = Factory::createSlur(firstChordRest->measure()->system());
             slur->setScore(firstChordRest->score());
@@ -770,7 +770,7 @@ bool NotationBraille::addLongSlur()
             ChordRest* firstChordRest = toChordRest(note1->parent());
             ChordRest* secondChordRest = toChordRest(note2->parent());
 
-            score()->startCmd();
+            score()->startCmd(TranslatableString("undoableAction", "Add long slur"));
 
             Slur* slur = Factory::createSlur(firstChordRest->measure()->system());
             slur->setScore(firstChordRest->score());

--- a/src/engraving/api/v1/qmlpluginapi.cpp
+++ b/src/engraving/api/v1/qmlpluginapi.cpp
@@ -278,7 +278,7 @@ apiv1::Score* PluginAPI::newScore(const QString& /*name*/, const QString& part, 
 
     qApp->processEvents();
     Q_ASSERT(currentScore() == score);
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "New score"));
     return wrap<Score>(score, Ownership::SCORE);
 }
 

--- a/src/engraving/api/v1/score.cpp
+++ b/src/engraving/api/v1/score.cpp
@@ -237,13 +237,17 @@ QQmlListProperty<Staff> Score::staves()
 //   Score::startCmd
 //---------------------------------------------------------
 
-void Score::startCmd()
+void Score::startCmd(const QString& qActionName)
 {
     IF_ASSERT_FAILED(undoStack()) {
         return;
     }
 
-    undoStack()->prepareChanges();
+    muse::TranslatableString actionName = qActionName.isEmpty()
+                                          ? TranslatableString("undoableAction", "Plugin edit")
+                                          : TranslatableString::untranslatable(qActionName);
+
+    undoStack()->prepareChanges(actionName);
 }
 
 void Score::endCmd(bool rollback)

--- a/src/engraving/api/v1/score.h
+++ b/src/engraving/api/v1/score.h
@@ -225,8 +225,10 @@ public:
      * a corresponding endCmd() call. Should be used at
      * least once by "dock" type plugins in case they
      * modify the score.
+     * \param qActionName - Optional action name that appears in Undo/Redo
+     * menus, palettes, and lists.
      */
-    Q_INVOKABLE void startCmd();
+    Q_INVOKABLE void startCmd(const QString& qActionName = {});
     /**
      * For "dock" type plugins: to be used after score
      * modifications to make them undoable.

--- a/src/engraving/api/v1/selection.cpp
+++ b/src/engraving/api/v1/selection.cpp
@@ -136,7 +136,7 @@ bool Selection::selectRange(int startTick, int endTick, int startStaff, int endS
         return false;
     }
 
-    if (segEnd && _select->score()->undoStack()->active()) {
+    if (segEnd && _select->score()->undoStack()->hasActiveCommand()) {
         _select->setRangeTicks(segStart->tick(), segEnd->tick(), startStaff, endStaff);
     } else {
         _select->setRange(segStart, segEnd, startStaff, endStaff);

--- a/src/engraving/devtools/corruptscoredevtoolsmodel.cpp
+++ b/src/engraving/devtools/corruptscoredevtoolsmodel.cpp
@@ -40,7 +40,8 @@ void CorruptScoreDevToolsModel::corruptOpenScore()
 
     mu::notation::INotationPtr notation = project->masterNotation()->notation();
 
-    notation->undoStack()->prepareChanges(TranslatableString("undoableAction", "Open corrupt score"));
+    //: "Corrupt" is used as a verb here, i.e. "Make the current score corrupted" (for testing purposes).
+    notation->undoStack()->prepareChanges(TranslatableString("undoableAction", "Corrupt score"));
 
     for (engraving::System* system : notation->elements()->msScore()->systems()) {
         for (engraving::MeasureBase* measureBase : system->measures()) {

--- a/src/engraving/devtools/corruptscoredevtoolsmodel.cpp
+++ b/src/engraving/devtools/corruptscoredevtoolsmodel.cpp
@@ -40,7 +40,7 @@ void CorruptScoreDevToolsModel::corruptOpenScore()
 
     mu::notation::INotationPtr notation = project->masterNotation()->notation();
 
-    notation->undoStack()->prepareChanges();
+    notation->undoStack()->prepareChanges(TranslatableString("undoableAction", "Open corrupt score"));
 
     for (engraving::System* system : notation->elements()->msScore()->systems()) {
         for (engraving::MeasureBase* measureBase : system->measures()) {

--- a/src/engraving/dom/cmd.cpp
+++ b/src/engraving/dom/cmd.cpp
@@ -2790,7 +2790,6 @@ void Score::cmdResetNoteAndRestGroupings()
     staff_idx_t sStaff = selection().staffStart();
     staff_idx_t eStaff = selection().staffEnd();
 
-    startCmd(TranslatableString("undoableAction", "Reset note/rest groupings"));
     for (staff_idx_t staff = sStaff; staff < eStaff; staff++) {
         track_idx_t sTrack = staff * VOICES;
         track_idx_t eTrack = sTrack + VOICES;
@@ -2800,7 +2799,7 @@ void Score::cmdResetNoteAndRestGroupings()
             }
         }
     }
-    endCmd();
+
     if (noSelection) {
         deselectAll();
     }

--- a/src/engraving/dom/cmd.cpp
+++ b/src/engraving/dom/cmd.cpp
@@ -319,7 +319,7 @@ void CmdState::setUpdateMode(UpdateMode m)
 ///   and starting a user-visible undo.
 //---------------------------------------------------------
 
-void Score::startCmd()
+void Score::startCmd(const TranslatableString& actionName)
 {
     if (undoStack()->locked()) {
         return;
@@ -339,7 +339,7 @@ void Score::startCmd()
         LOGD("Score::startCmd(): cmd already active");
         return;
     }
-    undoStack()->beginMacro(this);
+    undoStack()->beginMacro(this, actionName);
 }
 
 //---------------------------------------------------------
@@ -2790,7 +2790,7 @@ void Score::cmdResetNoteAndRestGroupings()
     staff_idx_t sStaff = selection().staffStart();
     staff_idx_t eStaff = selection().staffEnd();
 
-    startCmd();
+    startCmd(TranslatableString("undoableAction", "Reset note/rest groupings"));
     for (staff_idx_t staff = sStaff; staff < eStaff; staff++) {
         track_idx_t sTrack = staff * VOICES;
         track_idx_t eTrack = sTrack + VOICES;
@@ -2822,7 +2822,7 @@ void Score::cmdResetAllPositions(bool undoable)
     TRACEFUNC;
 
     if (undoable) {
-        startCmd();
+        startCmd(TranslatableString("undoableAction", "Reset all positions"));
     }
     resetAutoplace();
     if (undoable) {

--- a/src/engraving/dom/durationelement.cpp
+++ b/src/engraving/dom/durationelement.cpp
@@ -122,7 +122,7 @@ Fraction DurationElement::actualTicks() const
 void DurationElement::readAddTuplet(Tuplet* t)
 {
     setTuplet(t);
-    if (!score()->undoStack()->active()) {     // HACK, also added in Undo::AddElement()
+    if (!score()->undoStack()->hasActiveCommand()) { // HACK, also added in Undo::AddElement()
         t->add(this);
     }
 }

--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -1421,7 +1421,7 @@ void Score::cmdAddTimeSig(Measure* fm, staff_idx_t staffIdx, TimeSig* ts, bool l
                 for (size_t i = 0; i < nstaves(); ++i) {
                     if (staff(i)->timeSig(tick) && staff(i)->timeSig(tick)->isLocal()) {
                         if (!mScore->rewriteMeasures(mf, ns, i)) {
-                            undoStack()->current()->unwind();
+                            undoStack()->activeCommand()->unwind();
                             return;
                         }
                     }
@@ -1435,7 +1435,7 @@ void Score::cmdAddTimeSig(Measure* fm, staff_idx_t staffIdx, TimeSig* ts, bool l
         // this means, however, that the rewrite cannot depend on the time signatures being in place
         if (mf) {
             if (!mScore->rewriteMeasures(mf, ns, local ? staffIdx : muse::nidx)) {
-                undoStack()->current()->unwind();
+                undoStack()->activeCommand()->unwind();
                 return;
             }
         }
@@ -1527,7 +1527,7 @@ void Score::cmdRemoveTimeSig(TimeSig* ts)
     Fraction ns(pm ? pm->timesig() : Fraction(4, 4));
 
     if (!rScore->rewriteMeasures(rm, ns, muse::nidx)) {
-        undoStack()->current()->unwind();
+        undoStack()->activeCommand()->unwind();
     } else {
         m = tick2measure(tick);           // old m may have been replaced
         // hack: fix measure rest durations for staves with local time signatures
@@ -4932,7 +4932,7 @@ bool Score::undoPropertyChanged(EngravingItem* item, Pid propId, const PropertyV
 
     if ((currentPropValue != propValue) || (currentPropFlags != propFlags)) {
         item->setPropertyFlags(propId, propFlags);
-        undoStack()->push1(new ChangeProperty(item, propId, propValue, propFlags));
+        undoStack()->pushWithoutPerforming(new ChangeProperty(item, propId, propValue, propFlags));
         changed = true;
     }
 
@@ -4946,7 +4946,7 @@ bool Score::undoPropertyChanged(EngravingItem* item, Pid propId, const PropertyV
         switch (propertyPropagate) {
         case PropertyPropagation::PROPAGATE:
             if (linkedItem->getProperty(propId) != currentPropValue) {
-                undoStack()->push(new ChangeProperty(linkedItem, propId, currentPropValue, propFlags), nullptr);
+                undoStack()->pushAndPerform(new ChangeProperty(linkedItem, propId, currentPropValue, propFlags), nullptr);
                 changed = true;
             }
             break;
@@ -4964,7 +4964,7 @@ bool Score::undoPropertyChanged(EngravingItem* item, Pid propId, const PropertyV
 void Score::undoPropertyChanged(EngravingObject* e, Pid t, const PropertyValue& st, PropertyFlags ps)
 {
     if (e->getProperty(t) != st) {
-        undoStack()->push1(new ChangeProperty(e, t, st, ps));
+        undoStack()->pushWithoutPerforming(new ChangeProperty(e, t, st, ps));
     }
 }
 
@@ -5102,7 +5102,7 @@ void Score::undoChangePitch(Note* note, int pitch, int tpc1, int tpc2)
 {
     for (EngravingObject* e : note->linkList()) {
         Note* n = toNote(e);
-        undoStack()->push(new ChangePitch(n, pitch, tpc1, tpc2), 0);
+        undoStack()->pushAndPerform(new ChangePitch(n, pitch, tpc1, tpc2), 0);
     }
 }
 

--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -4002,7 +4002,7 @@ void Score::cmdEnterRest(const TDuration& d)
         LOGD("cmdEnterRest: track invalid");
         return;
     }
-    startCmd(TranslatableString("undoableAction", "Add rest"));
+    startCmd(TranslatableString("undoableAction", "Enter rest"));
     enterRest(d);
     endCmd();
 }

--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -1876,7 +1876,7 @@ void Score::cmdAddTie(bool addToChord)
         return;
     }
 
-    startCmd();
+    startCmd(TranslatableString("undoableAction", "Add tie"));
     Chord* lastAddedChord = 0;
     for (Note* note : noteList) {
         if (note->tieFor()) {
@@ -2010,7 +2010,11 @@ void Score::cmdToggleTie()
         }
     }
 
-    startCmd();
+    const TranslatableString actionName = canAddTies
+                                          ? TranslatableString("undoableAction", "Add tie")
+                                          : TranslatableString("undoableAction", "Remove tie");
+
+    startCmd(actionName);
 
     if (canAddTies) {
         for (size_t i = 0; i < notes; ++i) {
@@ -3998,7 +4002,7 @@ void Score::cmdEnterRest(const TDuration& d)
         LOGD("cmdEnterRest: track invalid");
         return;
     }
-    startCmd();
+    startCmd(TranslatableString("undoableAction", "Add rest"));
     enterRest(d);
     endCmd();
 }

--- a/src/engraving/dom/engravingobject.cpp
+++ b/src/engraving/dom/engravingobject.cpp
@@ -528,7 +528,7 @@ void EngravingObject::undoChangeProperty(Pid id, const PropertyValue& v, Propert
 void EngravingObject::undoPushProperty(Pid id)
 {
     PropertyValue val = getProperty(id);
-    score()->undoStack()->push1(new ChangeProperty(this, id, val));
+    score()->undoStack()->pushWithoutPerforming(new ChangeProperty(this, id, val));
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/figuredbass.cpp
+++ b/src/engraving/dom/figuredbass.cpp
@@ -771,7 +771,7 @@ void FiguredBass::regenerateText()
     }
 
     // TODO: this `startCmd` call is possibly invalid
-    score()->startCmd(TranslatableString("undoableAction", "Update layout"));
+    score()->startCmd(TranslatableString("undoableAction", "Regenerate figured bass text"));
     triggerLayout();
     score()->endCmd();
 }

--- a/src/engraving/dom/figuredbass.cpp
+++ b/src/engraving/dom/figuredbass.cpp
@@ -750,6 +750,7 @@ void FiguredBass::regenerateText()
         FiguredBassItem* pItem = new FiguredBassItem(this, idx++);
         if (!pItem->parse(str)) {               // if any item fails parsing
             clearItems();
+            // TODO: this `startCmd` call is possibly invalid
             score()->startCmd(TranslatableString("undoableAction", "Regenerate figured bass text"));
             triggerLayout();
             score()->endCmd();
@@ -769,6 +770,7 @@ void FiguredBass::regenerateText()
         undoChangeProperty(Pid::TEXT, normalizedText);
     }
 
+    // TODO: this `startCmd` call is possibly invalid
     score()->startCmd(TranslatableString("undoableAction", "Update layout"));
     triggerLayout();
     score()->endCmd();

--- a/src/engraving/dom/figuredbass.cpp
+++ b/src/engraving/dom/figuredbass.cpp
@@ -750,7 +750,7 @@ void FiguredBass::regenerateText()
         FiguredBassItem* pItem = new FiguredBassItem(this, idx++);
         if (!pItem->parse(str)) {               // if any item fails parsing
             clearItems();
-            score()->startCmd();
+            score()->startCmd(TranslatableString("undoableAction", "Regenerate figured bass text"));
             triggerLayout();
             score()->endCmd();
             delete pItem;
@@ -769,7 +769,7 @@ void FiguredBass::regenerateText()
         undoChangeProperty(Pid::TEXT, normalizedText);
     }
 
-    score()->startCmd();
+    score()->startCmd(TranslatableString("undoableAction", "Update layout"));
     triggerLayout();
     score()->endCmd();
 }

--- a/src/engraving/dom/lyrics.cpp
+++ b/src/engraving/dom/lyrics.cpp
@@ -192,7 +192,7 @@ void Lyrics::paste(EditData& ed, const String& txt)
     }
 
     StringList hyph = sl.at(0).split(u'-');
-    score()->startCmd();
+    score()->startCmd(TranslatableString("undoableAction", "Paste lyrics"));
 
     deleteSelectedText(ed);
 

--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -4334,7 +4334,7 @@ void Score::cmdSelectSection()
 
 void Score::undo(UndoCommand* cmd, EditData* ed) const
 {
-    undoStack()->push(cmd, ed);
+    undoStack()->pushAndPerform(cmd, ed);
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/score.h
+++ b/src/engraving/dom/score.h
@@ -524,8 +524,8 @@ public:
     muse::Ret repitchNote(const Position& pos, bool replace);
     void regroupNotesAndRests(const Fraction& startTick, const Fraction& endTick, track_idx_t track);
 
-    void startCmd(const TranslatableString& actionName);                // start undoable command
-    void endCmd(bool rollback = false, bool layoutAllParts = false);    // end undoable command
+    void startCmd(const TranslatableString& actionName);             // start undoable command
+    void endCmd(bool rollback = false, bool layoutAllParts = false); // end undoable command
     void update() { update(true); }
     void lockUpdates(bool locked);
     void undoRedo(bool undo, EditData*);

--- a/src/engraving/dom/score.h
+++ b/src/engraving/dom/score.h
@@ -524,8 +524,8 @@ public:
     muse::Ret repitchNote(const Position& pos, bool replace);
     void regroupNotesAndRests(const Fraction& startTick, const Fraction& endTick, track_idx_t track);
 
-    void startCmd();                    // start undoable command
-    void endCmd(bool rollback = false, bool layoutAllParts = false); // end undoable command
+    void startCmd(const TranslatableString& actionName);                // start undoable command
+    void endCmd(bool rollback = false, bool layoutAllParts = false);    // end undoable command
     void update() { update(true); }
     void lockUpdates(bool locked);
     void undoRedo(bool undo, EditData*);

--- a/src/engraving/dom/slur.cpp
+++ b/src/engraving/dom/slur.cpp
@@ -172,7 +172,7 @@ void SlurSegment::changeAnchor(EditData& ed, EngravingItem* element)
     // save current start/end elements
     for (EngravingObject* e : spanner()->linkList()) {
         Spanner* sp = toSpanner(e);
-        score()->undoStack()->push1(new ChangeStartEndSpanner(sp, sp->startElement(), sp->endElement()));
+        score()->undoStack()->pushWithoutPerforming(new ChangeStartEndSpanner(sp, sp->startElement(), sp->endElement()));
     }
 
     if (ed.curGrip == Grip::START) {

--- a/src/engraving/dom/textedit.cpp
+++ b/src/engraving/dom/textedit.cpp
@@ -907,7 +907,7 @@ void TextBase::paste(EditData& ed, const String& txt)
     bool symState = false;
     CharFormat format = *static_cast<TextEditData*>(ed.getData(this).get())->cursor()->format();
 
-    score()->startCmd();
+    score()->startCmd(TranslatableString("undoableAction", "Paste text"));
     for (size_t i = 0; i < txt.size(); i++) {
         Char c = txt.at(i);
         if (state == 0) {

--- a/src/engraving/dom/textedit.cpp
+++ b/src/engraving/dom/textedit.cpp
@@ -109,10 +109,10 @@ void TextBase::startEdit(EditData& ed)
     ted->e = this;
     ted->cursor()->startEdit();
 
-    assert(!score()->undoStack()->active());        // make sure we are not in a Cmd
+    assert(!score()->undoStack()->hasActiveCommand()); // make sure we are not in a Cmd
 
     ted->oldXmlText = xmlText();
-    ted->startUndoIdx = score()->undoStack()->getCurIdx();
+    ted->startUndoIdx = score()->undoStack()->currentIndex();
 
     const LayoutData* ldata = this->ldata();
     if (!ldata || ldata->layoutInvalid) {
@@ -157,7 +157,7 @@ void TextBase::endEdit(EditData& ed)
 
     //! NOTE: Current index can be less than the start index if the text element is newly added and immediately removed through
     //! undo (the "add element" command will have been popped from the stack before the calling of this method)...
-    const bool textWasEdited = undo->getCurIdx() > ted->startUndoIdx;
+    const bool textWasEdited = undo->currentIndex() > ted->startUndoIdx;
     if (textWasEdited) {
         undo->mergeCommands(ted->startUndoIdx);
         undo->last()->filterChildren(Filter::TextEdit, this);
@@ -204,9 +204,9 @@ void TextBase::endEdit(EditData& ed)
             Filter::Link,
         };
 
-        if (newlyAdded && !undo->current()->hasUnfilteredChildren(filters, this)) {
+        if (newlyAdded && !undo->activeCommand()->hasUnfilteredChildren(filters, this)) {
             for (Filter f : filters) {
-                undo->current()->filterChildren(f, this);
+                undo->activeCommand()->filterChildren(f, this);
             }
 
             ted->setDeleteText(true); // mark this text element for deletion

--- a/src/engraving/dom/tie.cpp
+++ b/src/engraving/dom/tie.cpp
@@ -91,7 +91,7 @@ void TieSegment::changeAnchor(EditData& ed, EngravingItem* element)
 
         TieSegment* newSegment = toTieSegment(ed.curGrip == Grip::END ? ss.back() : ss.front());
         score()->endCmd();
-        score()->startCmd();
+        score()->startCmd(TranslatableString("undoableAction", "Change tie anchor"));
         ed.view()->changeEditElement(newSegment);
         triggerLayout();
     }

--- a/src/engraving/dom/undo.cpp
+++ b/src/engraving/dom/undo.cpp
@@ -327,7 +327,7 @@ void UndoStack::setLocked(bool val)
 //   beginMacro
 //---------------------------------------------------------
 
-void UndoStack::beginMacro(Score* score)
+void UndoStack::beginMacro(Score* score, const TranslatableString& undoString)
 {
     if (isLocked) {
         return;
@@ -337,7 +337,7 @@ void UndoStack::beginMacro(Score* score)
         LOGW("already active");
         return;
     }
-    curCmd = new UndoMacro(score);
+    curCmd = new UndoMacro(score, undoString);
 }
 
 //---------------------------------------------------------
@@ -574,8 +574,8 @@ void UndoMacro::applySelectionInfo(const SelectionInfo& info, Selection& sel)
     }
 }
 
-UndoMacro::UndoMacro(Score* s)
-    : m_undoInputState(s->inputState()), m_score(s)
+UndoMacro::UndoMacro(Score* s, const TranslatableString& actionName)
+    : m_undoInputState(s->inputState()), m_actionName(actionName), m_score(s)
 {
     fillSelectionInfo(m_undoSelectionInfo, s->selection());
 }
@@ -680,6 +680,11 @@ UndoMacro::ChangesInfo UndoMacro::changesInfo() const
     }
 
     return result;
+}
+
+const TranslatableString& UndoMacro::actionName() const
+{
+    return m_actionName;
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/undo.cpp
+++ b/src/engraving/dom/undo.cpp
@@ -282,7 +282,7 @@ void UndoCommand::unwind()
     while (!childList.empty()) {
         UndoCommand* c = muse::takeLast(childList);
         LOG_UNDO() << "unwind: " << c->name();
-        c->undo(0);
+        c->undo(nullptr);
         delete c;
     }
 }
@@ -293,11 +293,11 @@ void UndoCommand::unwind()
 
 UndoStack::UndoStack()
 {
-    curCmd   = 0;
-    curIdx   = 0;
-    cleanState = 0;
-    stateList.push_back(cleanState);
-    nextState = 1;
+    m_activeCommand = nullptr;
+    m_currentIndex = 0;
+    m_cleanState = 0;
+    m_stateList.push_back(m_cleanState);
+    m_nextState = 1;
 }
 
 //---------------------------------------------------------
@@ -307,20 +307,20 @@ UndoStack::UndoStack()
 UndoStack::~UndoStack()
 {
     size_t idx = 0;
-    for (auto c : list) {
-        c->cleanup(idx++ < curIdx);
+    for (auto c : m_macroList) {
+        c->cleanup(idx++ < m_currentIndex);
     }
-    muse::DeleteAll(list);
+    muse::DeleteAll(m_macroList);
 }
 
-bool UndoStack::locked() const
+bool UndoStack::isLocked() const
 {
-    return isLocked;
+    return m_isLocked;
 }
 
-void UndoStack::setLocked(bool val)
+void UndoStack::setLocked(bool locked)
 {
-    isLocked = val;
+    m_isLocked = locked;
 }
 
 //---------------------------------------------------------
@@ -329,24 +329,24 @@ void UndoStack::setLocked(bool val)
 
 void UndoStack::beginMacro(Score* score, const TranslatableString& actionName)
 {
-    if (isLocked) {
+    if (m_isLocked) {
         return;
     }
 
-    if (curCmd) {
+    if (m_activeCommand) {
         LOGW("already active");
         return;
     }
-    curCmd = new UndoMacro(score, actionName);
+    m_activeCommand = new UndoMacro(score, actionName);
 }
 
 //---------------------------------------------------------
 //   push
 //---------------------------------------------------------
 
-void UndoStack::push(UndoCommand* cmd, EditData* ed)
+void UndoStack::pushAndPerform(UndoCommand* cmd, EditData* ed)
 {
-    if (!curCmd) {
+    if (!m_activeCommand) {
         // this can happen for layout() outside of a command (load)
         if (!ScoreLoad::loading()) {
             LOG_UNDO() << "no active command, UndoStack";
@@ -364,7 +364,7 @@ void UndoStack::push(UndoCommand* cmd, EditData* ed)
         LOG_UNDO() << cmd->name();
     }
 #endif
-    curCmd->appendChild(cmd);
+    m_activeCommand->appendChild(cmd);
     cmd->redo(ed);
 }
 
@@ -372,15 +372,15 @@ void UndoStack::push(UndoCommand* cmd, EditData* ed)
 //   push1
 //---------------------------------------------------------
 
-void UndoStack::push1(UndoCommand* cmd)
+void UndoStack::pushWithoutPerforming(UndoCommand* cmd)
 {
-    if (!curCmd) {
+    if (!m_activeCommand) {
         if (!ScoreLoad::loading()) {
             LOGW("no active command, UndoStack %p", this);
         }
         return;
     }
-    curCmd->appendChild(cmd);
+    m_activeCommand->appendChild(cmd);
 }
 
 //---------------------------------------------------------
@@ -389,23 +389,23 @@ void UndoStack::push1(UndoCommand* cmd)
 
 void UndoStack::remove(size_t idx)
 {
-    assert(idx <= curIdx);
-    assert(curIdx != muse::nidx);
+    assert(idx <= m_currentIndex);
+    assert(m_currentIndex != muse::nidx);
     // remove redo stack
-    while (list.size() > curIdx) {
-        UndoCommand* cmd = muse::takeLast(list);
-        stateList.pop_back();
+    while (m_macroList.size() > m_currentIndex) {
+        UndoCommand* cmd = muse::takeLast(m_macroList);
+        m_stateList.pop_back();
         cmd->cleanup(false);      // delete elements for which UndoCommand() holds ownership
         delete cmd;
 //            --curIdx;
     }
-    while (list.size() > idx) {
-        UndoCommand* cmd = muse::takeLast(list);
-        stateList.pop_back();
+    while (m_macroList.size() > idx) {
+        UndoCommand* cmd = muse::takeLast(m_macroList);
+        m_stateList.pop_back();
         cmd->cleanup(true);
         delete cmd;
     }
-    curIdx = idx;
+    m_currentIndex = idx;
 }
 
 //---------------------------------------------------------
@@ -414,16 +414,16 @@ void UndoStack::remove(size_t idx)
 
 void UndoStack::mergeCommands(size_t startIdx)
 {
-    assert(startIdx <= curIdx);
+    assert(startIdx <= m_currentIndex);
 
-    if (startIdx >= list.size()) {
+    if (startIdx >= m_macroList.size()) {
         return;
     }
 
-    UndoMacro* startMacro = list[startIdx];
+    UndoMacro* startMacro = m_macroList[startIdx];
 
-    for (size_t idx = startIdx + 1; idx < curIdx; ++idx) {
-        startMacro->append(std::move(*list[idx]));
+    for (size_t idx = startIdx + 1; idx < m_currentIndex; ++idx) {
+        startMacro->append(std::move(*m_macroList[idx]));
     }
     remove(startIdx + 1);   // TODO: remove from startIdx to curIdx only
 }
@@ -434,14 +434,14 @@ void UndoStack::mergeCommands(size_t startIdx)
 
 void UndoStack::pop()
 {
-    if (!curCmd) {
+    if (!m_activeCommand) {
         if (!ScoreLoad::loading()) {
             LOGW("no active command");
         }
         return;
     }
-    UndoCommand* cmd = curCmd->removeChild();
-    cmd->undo(0);
+    UndoCommand* cmd = m_activeCommand->removeChild();
+    cmd->undo(nullptr);
 }
 
 //---------------------------------------------------------
@@ -450,29 +450,29 @@ void UndoStack::pop()
 
 void UndoStack::endMacro(bool rollback)
 {
-    if (isLocked) {
+    if (m_isLocked) {
         return;
     }
 
-    if (curCmd == 0) {
+    if (m_activeCommand == nullptr) {
         LOGW("not active");
         return;
     }
     if (rollback) {
-        delete curCmd;
+        delete m_activeCommand;
     } else {
         // remove redo stack
-        while (list.size() > curIdx) {
-            UndoCommand* cmd = muse::takeLast(list);
-            stateList.pop_back();
+        while (m_macroList.size() > m_currentIndex) {
+            UndoCommand* cmd = muse::takeLast(m_macroList);
+            m_stateList.pop_back();
             cmd->cleanup(false);        // delete elements for which UndoCommand() holds ownership
             delete cmd;
         }
-        list.push_back(curCmd);
-        stateList.push_back(nextState++);
-        ++curIdx;
+        m_macroList.push_back(m_activeCommand);
+        m_stateList.push_back(m_nextState++);
+        ++m_currentIndex;
     }
-    curCmd = 0;
+    m_activeCommand = nullptr;
 }
 
 //---------------------------------------------------------
@@ -481,17 +481,17 @@ void UndoStack::endMacro(bool rollback)
 
 void UndoStack::reopen()
 {
-    if (isLocked) {
+    if (m_isLocked) {
         return;
     }
 
-    LOG_UNDO() << "curIdx: " << curIdx << ", size: " << list.size();
-    assert(curCmd == 0);
-    assert(curIdx > 0);
-    --curIdx;
-    curCmd = muse::takeAt(list, curIdx);
-    stateList.erase(stateList.begin() + curIdx);
-    for (auto i : curCmd->commands()) {
+    LOG_UNDO() << "curIdx: " << m_currentIndex << ", size: " << m_macroList.size();
+    assert(m_activeCommand == nullptr);
+    assert(m_currentIndex > 0);
+    --m_currentIndex;
+    m_activeCommand = muse::takeAt(m_macroList, m_currentIndex);
+    m_stateList.erase(m_stateList.begin() + m_currentIndex);
+    for (auto i : m_activeCommand->commands()) {
         LOG_UNDO() << "   " << i->name();
     }
 }
@@ -506,15 +506,15 @@ void UndoStack::undo(EditData* ed)
     // Are we currently editing text?
     if (ed && ed->editTextualProperties && ed->element && ed->element->isTextBase()) {
         TextEditData* ted = dynamic_cast<TextEditData*>(ed->getData(ed->element).get());
-        if (ted && ted->startUndoIdx == curIdx) {
+        if (ted && ted->startUndoIdx == m_currentIndex) {
             // No edits to undo, so do nothing
             return;
         }
     }
-    if (curIdx) {
-        --curIdx;
-        assert(curIdx < list.size());
-        list[curIdx]->undo(ed);
+    if (m_currentIndex) {
+        --m_currentIndex;
+        assert(m_currentIndex < m_macroList.size());
+        m_macroList[m_currentIndex]->undo(ed);
     }
 }
 
@@ -526,7 +526,7 @@ void UndoStack::redo(EditData* ed)
 {
     LOG_UNDO() << "called";
     if (canRedo()) {
-        list[curIdx++]->redo(ed);
+        m_macroList[m_currentIndex++]->redo(ed);
     }
 }
 
@@ -717,7 +717,7 @@ void CloneVoice::undo(EditData*)
             EngravingItem* el = seg->element(dTrack);
             if (el && el->isChordRest()) {
                 el->unlink();
-                seg->setElement(dTrack, 0);
+                seg->setElement(dTrack, nullptr);
             }
         }
     }
@@ -756,12 +756,12 @@ void CloneVoice::undo(EditData*)
         }
         // Set rests if first voice in a staff
         if (!(sTrack % VOICES)) {
-            s->setRest(destSeg->tick(), sTrack, ticks, false, 0);
+            s->setRest(destSeg->tick(), sTrack, ticks, false, nullptr);
         }
     } else {
         s->cloneVoice(sTrack, dTrack, sourceSeg, ticks, linked);
         if (!linked && !(dTrack % VOICES)) {
-            s->setRest(destSeg->tick(), dTrack, ticks, false, 0);
+            s->setRest(destSeg->tick(), dTrack, ticks, false, nullptr);
         }
 
         // Remove annotations
@@ -805,7 +805,7 @@ void CloneVoice::redo(EditData*)
             EngravingItem* el = seg->element(dtrack);
             if (el && el->isChordRest()) {
                 el->unlink();
-                seg->setElement(dtrack, 0);
+                seg->setElement(dtrack, nullptr);
             }
         }
     }
@@ -843,7 +843,7 @@ void CloneVoice::redo(EditData*)
         }
         // Set rests if first voice in a staff
         if (!(strack % VOICES)) {
-            s->setRest(destSeg->tick(), strack, ticks, false, 0);
+            s->setRest(destSeg->tick(), strack, ticks, false, nullptr);
         }
     } else {
         s->cloneVoice(strack, dtrack, sourceSeg, ticks, linked, first);
@@ -868,7 +868,7 @@ void AddElement::cleanup(bool undo)
 {
     if (!undo) {
         delete element;
-        element = 0;
+        element = nullptr;
     }
 }
 
@@ -1073,7 +1073,7 @@ void RemoveElement::cleanup(bool undo)
 {
     if (undo) {
         delete element;
-        element = 0;
+        element = nullptr;
     }
 }
 
@@ -1524,7 +1524,7 @@ void ChangeElement::flip(EditData*)
         }
     }
 
-    if (oldElement->explicitParent() == 0) {
+    if (oldElement->explicitParent() == nullptr) {
         newElement->setScore(score);
         score->removeElement(oldElement);
         score->addElement(newElement);
@@ -2284,7 +2284,7 @@ void InsertRemoveMeasures::insertMeasures()
     for (Segment* seg = m->first(); seg; seg = seg->next()) {
         for (track_idx_t track = 0; track < score->ntracks(); ++track) {
             EngravingItem* e = seg->element(track);
-            if (e == 0 || !e->isChord()) {
+            if (!e || !e->isChord()) {
                 continue;
             }
             Chord* chord = toChord(e);
@@ -2947,11 +2947,11 @@ void LinkUnlink::unlink()
     assert(le->contains(e));
     le->remove(e);
     if (le->size() == 1) {
-        le->front()->setLinks(0);
+        le->front()->setLinks(nullptr);
         mustDelete = true;
     }
 
-    e->setLinks(0);
+    e->setLinks(nullptr);
 }
 
 //---------------------------------------------------------
@@ -2961,7 +2961,7 @@ void LinkUnlink::unlink()
 
 Link::Link(EngravingObject* e1, EngravingObject* e2)
 {
-    assert(e1->links() == 0);
+    assert(e1->links() == nullptr);
     le = e2->links();
     if (!le) {
         if (e1->isStaff()) {

--- a/src/engraving/dom/undo.cpp
+++ b/src/engraving/dom/undo.cpp
@@ -327,7 +327,7 @@ void UndoStack::setLocked(bool val)
 //   beginMacro
 //---------------------------------------------------------
 
-void UndoStack::beginMacro(Score* score, const TranslatableString& undoString)
+void UndoStack::beginMacro(Score* score, const TranslatableString& actionName)
 {
     if (isLocked) {
         return;
@@ -337,7 +337,7 @@ void UndoStack::beginMacro(Score* score, const TranslatableString& undoString)
         LOGW("already active");
         return;
     }
-    curCmd = new UndoMacro(score, undoString);
+    curCmd = new UndoMacro(score, actionName);
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/undo.h
+++ b/src/engraving/dom/undo.h
@@ -220,7 +220,7 @@ public:
     bool locked() const;
     void setLocked(bool val);
     bool active() const { return curCmd != 0; }
-    void beginMacro(Score*, const TranslatableString& actionString);
+    void beginMacro(Score*, const TranslatableString& actionName);
     void endMacro(bool rollback);
     void push(UndoCommand*, EditData*);        // push & execute
     void push1(UndoCommand*);

--- a/src/engraving/dom/undo.h
+++ b/src/engraving/dom/undo.h
@@ -163,7 +163,7 @@ public:
         bool isValid() const { return !elements.empty() || staffStart != muse::nidx; }
     };
 
-    UndoMacro(Score* s);
+    UndoMacro(Score* s, const TranslatableString& actionName);
     void undo(EditData*) override;
     void redo(EditData*) override;
     bool empty() const;
@@ -182,6 +182,7 @@ public:
     };
 
     ChangesInfo changesInfo() const;
+    const TranslatableString& actionName() const;
 
     static bool canRecordSelectedElement(const EngravingItem* e);
 
@@ -192,6 +193,7 @@ private:
     InputState m_redoInputState;
     SelectionInfo m_undoSelectionInfo;
     SelectionInfo m_redoSelectionInfo;
+    TranslatableString m_actionName;
 
     Score* m_score = nullptr;
 
@@ -218,7 +220,7 @@ public:
     bool locked() const;
     void setLocked(bool val);
     bool active() const { return curCmd != 0; }
-    void beginMacro(Score*);
+    void beginMacro(Score*, const TranslatableString& actionString);
     void endMacro(bool rollback);
     void push(UndoCommand*, EditData*);        // push & execute
     void push1(UndoCommand*);
@@ -226,10 +228,13 @@ public:
     bool canUndo() const { return curIdx > 0; }
     bool canRedo() const { return curIdx < list.size(); }
     bool isClean() const { return cleanState == stateList[curIdx]; }
+    size_t getSize() const { return list.size(); }
     size_t getCurIdx() const { return curIdx; }
     UndoMacro* current() const { return curCmd; }
     UndoMacro* last() const { return curIdx > 0 ? list[curIdx - 1] : 0; }
     UndoMacro* prev() const { return curIdx > 1 ? list[curIdx - 2] : 0; }
+    UndoMacro* next() const { return canRedo() ? list[curIdx] : 0; }
+    UndoMacro* getAtIndex(size_t idx) const { return idx >= 0 && idx < list.size() ? list[idx] : 0; }
     void undo(EditData*);
     void redo(EditData*);
     void reopen();

--- a/src/engraving/dom/unrollrepeats.cpp
+++ b/src/engraving/dom/unrollrepeats.cpp
@@ -99,7 +99,7 @@ static void createExcerpts(MasterScore* cs, const std::list<Excerpt*>& excerpts)
         Score* nscore = e->masterScore()->createScore();
         e->setExcerptScore(nscore);
         nscore->style().set(Sid::createMultiMeasureRests, true);
-        cs->startCmd();
+        cs->startCmd(TranslatableString("undoableAction", "Create parts"));
         cs->undo(new AddExcerpt(e));
         Excerpt::createExcerpt(e);
 

--- a/src/engraving/rw/read400/readcontext.cpp
+++ b/src/engraving/rw/read400/readcontext.cpp
@@ -169,7 +169,7 @@ void ReadContext::addSpanner(Spanner* s)
 
 bool ReadContext::undoStackActive() const
 {
-    return m_score->undoStack()->active();
+    return m_score->undoStack()->hasActiveCommand();
 }
 
 bool ReadContext::isSameScore(const EngravingObject* obj) const

--- a/src/engraving/rw/read410/readcontext.cpp
+++ b/src/engraving/rw/read410/readcontext.cpp
@@ -170,7 +170,7 @@ void ReadContext::addSpanner(Spanner* s)
 
 bool ReadContext::undoStackActive() const
 {
-    return m_score->undoStack()->active();
+    return m_score->undoStack()->hasActiveCommand();
 }
 
 bool ReadContext::isSameScore(const EngravingObject* obj) const

--- a/src/engraving/rw/write/writer.cpp
+++ b/src/engraving/rw/write/writer.cpp
@@ -89,7 +89,7 @@ void Writer::write(Score* score, XmlWriter& xml, WriteContext& ctx, bool selecti
 
     // if we have multi measure rests and some parts are hidden,
     // then some layout information is missing:
-    // relayout with all parts set visible
+    // relayout with all parts set visible (but rollback at end)
 
     std::list<Part*> hiddenParts;
     bool unhide = false;
@@ -97,7 +97,7 @@ void Writer::write(Score* score, XmlWriter& xml, WriteContext& ctx, bool selecti
         for (Part* part : score->m_parts) {
             if (!part->show()) {
                 if (!unhide) {
-                    score->startCmd();
+                    score->startCmd(TranslatableString("undoableAction", "Unhide instruments for save"));
                     unhide = true;
                 }
                 part->undoChangeProperty(Pid::VISIBLE, true);

--- a/src/engraving/rw/write/writer.cpp
+++ b/src/engraving/rw/write/writer.cpp
@@ -97,7 +97,7 @@ void Writer::write(Score* score, XmlWriter& xml, WriteContext& ctx, bool selecti
         for (Part* part : score->m_parts) {
             if (!part->show()) {
                 if (!unhide) {
-                    score->startCmd(TranslatableString("undoableAction", "Unhide instruments for save"));
+                    score->startCmd(TranslatableString::untranslatable("Unhide instruments for save"));
                     unhide = true;
                 }
                 part->undoChangeProperty(Pid::VISIBLE, true);

--- a/src/engraving/tests/barline_tests.cpp
+++ b/src/engraving/tests/barline_tests.cpp
@@ -154,7 +154,7 @@ TEST_F(Engraving_BarlineTests, barline03)
     Score* score = ScoreRW::readScore(BARLINE_DATA_DIR + "barline03.mscx");
     EXPECT_TRUE(score);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving barline tests"));
     score->undo(new ChangeProperty(score->staff(0), Pid::STAFF_BARLINE_SPAN, 1));
     score->undo(new ChangeProperty(score->staff(0), Pid::STAFF_BARLINE_SPAN_FROM, 2));
     score->undo(new ChangeProperty(score->staff(0), Pid::STAFF_BARLINE_SPAN_TO, -2));
@@ -189,7 +189,7 @@ TEST_F(Engraving_BarlineTests, barline04)
 
     score->doLayout();
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving barline tests"));
     // 'go' to 5th measure
     Measure* msr = score->firstMeasure();
     for (int i=0; i < 4; i++) {
@@ -322,7 +322,7 @@ void dropNormalBarline(EngravingItem* e)
     barLine->setBarLineType(BarLineType::NORMAL);
     dropData.dropElement = barLine;
 
-    e->score()->startCmd();
+    e->score()->startCmd(TranslatableString("undoableAction", "Drop normal barline test"));
     e->drop(dropData);
     e->score()->endCmd();
 }
@@ -419,7 +419,7 @@ TEST_F(Engraving_BarlineTests, deleteSkipBarlines)
     Measure* m1 = score->firstMeasure();
     EXPECT_TRUE(m1);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving barline tests"));
     score->cmdSelectAll();
     score->cmdDeleteSelection();
     score->endCmd();

--- a/src/engraving/tests/barline_tests.cpp
+++ b/src/engraving/tests/barline_tests.cpp
@@ -154,7 +154,7 @@ TEST_F(Engraving_BarlineTests, barline03)
     Score* score = ScoreRW::readScore(BARLINE_DATA_DIR + "barline03.mscx");
     EXPECT_TRUE(score);
 
-    score->startCmd(TranslatableString("undoableAction", "Engraving barline tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving barline tests"));
     score->undo(new ChangeProperty(score->staff(0), Pid::STAFF_BARLINE_SPAN, 1));
     score->undo(new ChangeProperty(score->staff(0), Pid::STAFF_BARLINE_SPAN_FROM, 2));
     score->undo(new ChangeProperty(score->staff(0), Pid::STAFF_BARLINE_SPAN_TO, -2));
@@ -189,7 +189,7 @@ TEST_F(Engraving_BarlineTests, barline04)
 
     score->doLayout();
 
-    score->startCmd(TranslatableString("undoableAction", "Engraving barline tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving barline tests"));
     // 'go' to 5th measure
     Measure* msr = score->firstMeasure();
     for (int i=0; i < 4; i++) {
@@ -322,7 +322,7 @@ void dropNormalBarline(EngravingItem* e)
     barLine->setBarLineType(BarLineType::NORMAL);
     dropData.dropElement = barLine;
 
-    e->score()->startCmd(TranslatableString("undoableAction", "Drop normal barline test"));
+    e->score()->startCmd(TranslatableString::untranslatable("Drop normal barline test"));
     e->drop(dropData);
     e->score()->endCmd();
 }
@@ -419,7 +419,7 @@ TEST_F(Engraving_BarlineTests, deleteSkipBarlines)
     Measure* m1 = score->firstMeasure();
     EXPECT_TRUE(m1);
 
-    score->startCmd(TranslatableString("undoableAction", "Engraving barline tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving barline tests"));
     score->cmdSelectAll();
     score->cmdDeleteSelection();
     score->endCmd();

--- a/src/engraving/tests/beam_tests.cpp
+++ b/src/engraving/tests/beam_tests.cpp
@@ -220,7 +220,7 @@ TEST_F(Engraving_BeamTests, flipBeamStemDir)
     Chord* c2 = toChord(cr->beam()->elements()[1]);
 
     score->select(c2);
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving beam tests"));
     score->cmdFlip();
     score->endCmd();
     cr->beam()->setDirection(DirectionV::DOWN);
@@ -253,7 +253,7 @@ TEST_F(Engraving_BeamTests, flipTremoloStemDir)
     EXPECT_TRUE(t->up() && c1->up() && c2->up());
 
     score->select(c1->upNote());
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving beam tests"));
     score->cmdFlip();
     score->endCmd();
 

--- a/src/engraving/tests/beam_tests.cpp
+++ b/src/engraving/tests/beam_tests.cpp
@@ -220,7 +220,7 @@ TEST_F(Engraving_BeamTests, flipBeamStemDir)
     Chord* c2 = toChord(cr->beam()->elements()[1]);
 
     score->select(c2);
-    score->startCmd(TranslatableString("undoableAction", "Engraving beam tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving beam tests"));
     score->cmdFlip();
     score->endCmd();
     cr->beam()->setDirection(DirectionV::DOWN);
@@ -253,7 +253,7 @@ TEST_F(Engraving_BeamTests, flipTremoloStemDir)
     EXPECT_TRUE(t->up() && c1->up() && c2->up());
 
     score->select(c1->upNote());
-    score->startCmd(TranslatableString("undoableAction", "Engraving beam tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving beam tests"));
     score->cmdFlip();
     score->endCmd();
 

--- a/src/engraving/tests/box_tests.cpp
+++ b/src/engraving/tests/box_tests.cpp
@@ -59,7 +59,7 @@ TEST_F(Engraving_BoxTests, undoRemoveVBox)
     System* s = score->systems()[0];
     VBox* box = toVBox(s->measure(0));
 
-    score->startCmd(TranslatableString("undoableAction", "Engraving box tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving box tests"));
     score->select(box);
     score->cmdDeleteSelection();
     score->endCmd();

--- a/src/engraving/tests/box_tests.cpp
+++ b/src/engraving/tests/box_tests.cpp
@@ -59,7 +59,7 @@ TEST_F(Engraving_BoxTests, undoRemoveVBox)
     System* s = score->systems()[0];
     VBox* box = toVBox(s->measure(0));
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving box tests"));
     score->select(box);
     score->cmdDeleteSelection();
     score->endCmd();

--- a/src/engraving/tests/breath_tests.cpp
+++ b/src/engraving/tests/breath_tests.cpp
@@ -53,7 +53,7 @@ TEST_F(Engraving_BreathTests, breath)
     score->doLayout();
 
     // do
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving breath tests"));
     score->cmdSelectAll();
     for (EngravingItem* e : score->selection().elements()) {
         EditData dd(0);

--- a/src/engraving/tests/breath_tests.cpp
+++ b/src/engraving/tests/breath_tests.cpp
@@ -53,7 +53,7 @@ TEST_F(Engraving_BreathTests, breath)
     score->doLayout();
 
     // do
-    score->startCmd(TranslatableString("undoableAction", "Engraving breath tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving breath tests"));
     score->cmdSelectAll();
     for (EngravingItem* e : score->selection().elements()) {
         EditData dd(0);

--- a/src/engraving/tests/changevisibility_tests.cpp
+++ b/src/engraving/tests/changevisibility_tests.cpp
@@ -537,7 +537,7 @@ TEST_F(Engraving_ChangeVisibilityTests, CmdToggleVisible)
     // [WHEN] Select the first measure and call cmdToggleVisible()
     m_score->select(measure);
 
-    m_score->startCmd();
+    m_score->startCmd(TranslatableString("undoableAction", "Change visibility tests"));
     m_score->cmdToggleVisible();
     m_score->endCmd();
 
@@ -559,7 +559,7 @@ TEST_F(Engraving_ChangeVisibilityTests, CmdToggleVisible)
     }
 
     // [WHEN] Call cmdToggleVisible() again
-    m_score->startCmd();
+    m_score->startCmd(TranslatableString("undoableAction", "Change visibility tests"));
     m_score->cmdToggleVisible();
     m_score->endCmd();
 
@@ -577,7 +577,7 @@ TEST_F(Engraving_ChangeVisibilityTests, CmdToggleVisible)
         m_score->select(note, SelectType::ADD);
     }
 
-    m_score->startCmd();
+    m_score->startCmd(TranslatableString("undoableAction", "Change visibility tests"));
     m_score->cmdToggleVisible();
     m_score->endCmd();
 
@@ -589,7 +589,7 @@ TEST_F(Engraving_ChangeVisibilityTests, CmdToggleVisible)
     // [WHEN] Select the first measure and call cmdToggleVisible() again
     m_score->select(measure);
 
-    m_score->startCmd();
+    m_score->startCmd(TranslatableString("undoableAction", "Change visibility tests"));
     m_score->cmdToggleVisible();
     m_score->endCmd();
 

--- a/src/engraving/tests/changevisibility_tests.cpp
+++ b/src/engraving/tests/changevisibility_tests.cpp
@@ -537,7 +537,7 @@ TEST_F(Engraving_ChangeVisibilityTests, CmdToggleVisible)
     // [WHEN] Select the first measure and call cmdToggleVisible()
     m_score->select(measure);
 
-    m_score->startCmd(TranslatableString("undoableAction", "Change visibility tests"));
+    m_score->startCmd(TranslatableString::untranslatable("Change visibility tests"));
     m_score->cmdToggleVisible();
     m_score->endCmd();
 
@@ -559,7 +559,7 @@ TEST_F(Engraving_ChangeVisibilityTests, CmdToggleVisible)
     }
 
     // [WHEN] Call cmdToggleVisible() again
-    m_score->startCmd(TranslatableString("undoableAction", "Change visibility tests"));
+    m_score->startCmd(TranslatableString::untranslatable("Change visibility tests"));
     m_score->cmdToggleVisible();
     m_score->endCmd();
 
@@ -577,7 +577,7 @@ TEST_F(Engraving_ChangeVisibilityTests, CmdToggleVisible)
         m_score->select(note, SelectType::ADD);
     }
 
-    m_score->startCmd(TranslatableString("undoableAction", "Change visibility tests"));
+    m_score->startCmd(TranslatableString::untranslatable("Change visibility tests"));
     m_score->cmdToggleVisible();
     m_score->endCmd();
 
@@ -589,7 +589,7 @@ TEST_F(Engraving_ChangeVisibilityTests, CmdToggleVisible)
     // [WHEN] Select the first measure and call cmdToggleVisible() again
     m_score->select(measure);
 
-    m_score->startCmd(TranslatableString("undoableAction", "Change visibility tests"));
+    m_score->startCmd(TranslatableString::untranslatable("Change visibility tests"));
     m_score->cmdToggleVisible();
     m_score->endCmd();
 

--- a/src/engraving/tests/chordsymbol_tests.cpp
+++ b/src/engraving/tests/chordsymbol_tests.cpp
@@ -97,7 +97,7 @@ void Engraving_ChordSymbolTests::realizeSelectionVoiced(MasterScore* score, Voic
             e->setProperty(Pid::HARMONY_VOICING, int(voicing));
         }
     }
-    score->startCmd(TranslatableString("undoableAction", "Realize selection voiced"));
+    score->startCmd(TranslatableString::untranslatable("Realize selection voiced"));
     score->cmdRealizeChordSymbols();
     score->endCmd();
 }
@@ -199,7 +199,7 @@ TEST_F(Engraving_ChordSymbolTests, testNoSystem)
 TEST_F(Engraving_ChordSymbolTests, testTranspose)
 {
     MasterScore* score = test_pre(u"transpose");
-    score->startCmd(TranslatableString("undoableAction", "Engraving chord symbol tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving chord symbol tests"));
     score->cmdSelectAll();
     score->transpose(TransposeMode::BY_INTERVAL, TransposeDirection::UP, Key::C, 4, false, true, true);
     score->endCmd();
@@ -209,7 +209,7 @@ TEST_F(Engraving_ChordSymbolTests, testTranspose)
 TEST_F(Engraving_ChordSymbolTests, testTransposePart)
 {
     MasterScore* score = test_pre(u"transpose-part");
-    score->startCmd(TranslatableString("undoableAction", "Engraving chord symbol tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving chord symbol tests"));
     score->cmdSelectAll();
     score->transpose(TransposeMode::BY_INTERVAL, TransposeDirection::UP, Key::C, 4, false, true, true);
     score->endCmd(false, /*layoutAllParts = */ true);
@@ -279,13 +279,13 @@ TEST_F(Engraving_ChordSymbolTests, testRealizeConcertPitch)
 {
     MasterScore* score = test_pre(u"realize-concert-pitch");
     //concert pitch off
-    score->startCmd(TranslatableString("undoableAction", "Engraving chord symbol tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving chord symbol tests"));
     score->cmdConcertPitchChanged(false);
     score->endCmd();
 
     //realize all chord symbols
     selectAllChordSymbols(score);
-    score->startCmd(TranslatableString("undoableAction", "Engraving chord symbol tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving chord symbol tests"));
     score->cmdRealizeChordSymbols();
     score->endCmd();
     test_post(score, u"realize-concert-pitch");
@@ -304,7 +304,7 @@ TEST_F(Engraving_ChordSymbolTests, testRealizeTransposed)
 
     //realize all chord symbols
     selectAllChordSymbols(score);
-    score->startCmd(TranslatableString("undoableAction", "Engraving chord symbol tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving chord symbol tests"));
     score->cmdRealizeChordSymbols();
     score->endCmd();
     test_post(score, u"realize-transpose");
@@ -319,7 +319,7 @@ TEST_F(Engraving_ChordSymbolTests, testRealizeOverrides)
     MasterScore* score = test_pre(u"realize-override");
     //realize all chord symbols
     selectAllChordSymbols(score);
-    score->startCmd(TranslatableString("undoableAction", "Engraving chord symbol tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving chord symbol tests"));
     score->cmdRealizeChordSymbols(true, Voicing::ROOT_ONLY, HDuration::SEGMENT_DURATION);
     score->endCmd();
     test_post(score, u"realize-override");
@@ -333,7 +333,7 @@ TEST_F(Engraving_ChordSymbolTests, testRealizeTriplet)
     MasterScore* score = test_pre(u"realize-triplet");
     //realize all chord symbols
     selectAllChordSymbols(score);
-    score->startCmd(TranslatableString("undoableAction", "Engraving chord symbol tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving chord symbol tests"));
     score->cmdRealizeChordSymbols();
     score->endCmd();
     test_post(score, u"realize-triplet");
@@ -348,7 +348,7 @@ TEST_F(Engraving_ChordSymbolTests, testRealizeDuration)
     MasterScore* score = test_pre(u"realize-duration");
     //realize all chord symbols
     selectAllChordSymbols(score);
-    score->startCmd(TranslatableString("undoableAction", "Engraving chord symbol tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving chord symbol tests"));
     score->cmdRealizeChordSymbols();
     score->endCmd();
     test_post(score, u"realize-duration");
@@ -363,7 +363,7 @@ TEST_F(Engraving_ChordSymbolTests, testRealizeJazz)
     MasterScore* score = test_pre(u"realize-jazz");
     //realize all chord symbols
     selectAllChordSymbols(score);
-    score->startCmd(TranslatableString("undoableAction", "Engraving chord symbol tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving chord symbol tests"));
     score->cmdRealizeChordSymbols();
     score->endCmd();
     test_post(score, u"realize-jazz");

--- a/src/engraving/tests/chordsymbol_tests.cpp
+++ b/src/engraving/tests/chordsymbol_tests.cpp
@@ -97,7 +97,7 @@ void Engraving_ChordSymbolTests::realizeSelectionVoiced(MasterScore* score, Voic
             e->setProperty(Pid::HARMONY_VOICING, int(voicing));
         }
     }
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Realize selection voiced"));
     score->cmdRealizeChordSymbols();
     score->endCmd();
 }
@@ -199,7 +199,7 @@ TEST_F(Engraving_ChordSymbolTests, testNoSystem)
 TEST_F(Engraving_ChordSymbolTests, testTranspose)
 {
     MasterScore* score = test_pre(u"transpose");
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving chord symbol tests"));
     score->cmdSelectAll();
     score->transpose(TransposeMode::BY_INTERVAL, TransposeDirection::UP, Key::C, 4, false, true, true);
     score->endCmd();
@@ -209,7 +209,7 @@ TEST_F(Engraving_ChordSymbolTests, testTranspose)
 TEST_F(Engraving_ChordSymbolTests, testTransposePart)
 {
     MasterScore* score = test_pre(u"transpose-part");
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving chord symbol tests"));
     score->cmdSelectAll();
     score->transpose(TransposeMode::BY_INTERVAL, TransposeDirection::UP, Key::C, 4, false, true, true);
     score->endCmd(false, /*layoutAllParts = */ true);
@@ -279,13 +279,13 @@ TEST_F(Engraving_ChordSymbolTests, testRealizeConcertPitch)
 {
     MasterScore* score = test_pre(u"realize-concert-pitch");
     //concert pitch off
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving chord symbol tests"));
     score->cmdConcertPitchChanged(false);
     score->endCmd();
 
     //realize all chord symbols
     selectAllChordSymbols(score);
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving chord symbol tests"));
     score->cmdRealizeChordSymbols();
     score->endCmd();
     test_post(score, u"realize-concert-pitch");
@@ -304,7 +304,7 @@ TEST_F(Engraving_ChordSymbolTests, testRealizeTransposed)
 
     //realize all chord symbols
     selectAllChordSymbols(score);
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving chord symbol tests"));
     score->cmdRealizeChordSymbols();
     score->endCmd();
     test_post(score, u"realize-transpose");
@@ -319,7 +319,7 @@ TEST_F(Engraving_ChordSymbolTests, testRealizeOverrides)
     MasterScore* score = test_pre(u"realize-override");
     //realize all chord symbols
     selectAllChordSymbols(score);
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving chord symbol tests"));
     score->cmdRealizeChordSymbols(true, Voicing::ROOT_ONLY, HDuration::SEGMENT_DURATION);
     score->endCmd();
     test_post(score, u"realize-override");
@@ -333,7 +333,7 @@ TEST_F(Engraving_ChordSymbolTests, testRealizeTriplet)
     MasterScore* score = test_pre(u"realize-triplet");
     //realize all chord symbols
     selectAllChordSymbols(score);
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving chord symbol tests"));
     score->cmdRealizeChordSymbols();
     score->endCmd();
     test_post(score, u"realize-triplet");
@@ -348,7 +348,7 @@ TEST_F(Engraving_ChordSymbolTests, testRealizeDuration)
     MasterScore* score = test_pre(u"realize-duration");
     //realize all chord symbols
     selectAllChordSymbols(score);
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving chord symbol tests"));
     score->cmdRealizeChordSymbols();
     score->endCmd();
     test_post(score, u"realize-duration");
@@ -363,7 +363,7 @@ TEST_F(Engraving_ChordSymbolTests, testRealizeJazz)
     MasterScore* score = test_pre(u"realize-jazz");
     //realize all chord symbols
     selectAllChordSymbols(score);
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving chord symbol tests"));
     score->cmdRealizeChordSymbols();
     score->endCmd();
     test_post(score, u"realize-jazz");

--- a/src/engraving/tests/clef_courtesy_tests.cpp
+++ b/src/engraving/tests/clef_courtesy_tests.cpp
@@ -55,7 +55,7 @@ static void dropClef(EngravingItem* m, ClefType t)
     EditData dropData(0);
     dropData.pos = m->pagePos();
     dropData.dropElement = clef;
-    m->score()->startCmd(TranslatableString("undoableAction", "Courtesy clef tests"));
+    m->score()->startCmd(TranslatableString::untranslatable("Courtesy clef tests"));
     if (m->isMeasure()) {
         toMeasure(m)->drop(dropData);
     } else {
@@ -108,7 +108,7 @@ TEST_F(Engraving_ClefCourtesyTests, clef_courtesy01)
     EXPECT_TRUE(seg) << "No SegClef in measure 4.";
 
     clef = static_cast<Clef*>(seg->element(0));
-    score->startCmd(TranslatableString("undoableAction", "Courtesy clef tests"));
+    score->startCmd(TranslatableString::untranslatable("Courtesy clef tests"));
     clef->undoChangeProperty(Pid::SHOW_COURTESY, false);
     Clef* otherClef = clef->otherClef();
     if (otherClef) {
@@ -318,7 +318,7 @@ TEST_F(Engraving_ClefCourtesyTests, clef_courtesy04)
     seg = m1->findSegment(SegmentType::HeaderClef, m1->tick());
     EXPECT_TRUE(seg) << "No SegClef in measure 4.";
     clef = toClef(seg->element(0));
-    score->startCmd(TranslatableString("undoableAction", "Courtesy clef tests"));
+    score->startCmd(TranslatableString::untranslatable("Courtesy clef tests"));
     clef->undoChangeProperty(Pid::SHOW_COURTESY, false);
     Clef* otherClef = clef->otherClef();
     if (otherClef) {
@@ -350,7 +350,7 @@ TEST_F(Engraving_ClefCourtesyTests, clef_courtesy04)
     clef = toClef(seg->element(4));
     EXPECT_TRUE(clef) << "No Clef in measure 8, track 4.";
     dropClef(clef, ClefType::G8_VA);
-    score->startCmd(TranslatableString("undoableAction", "Courtesy clef tests"));
+    score->startCmd(TranslatableString::untranslatable("Courtesy clef tests"));
     clef->undoChangeProperty(Pid::SHOW_COURTESY, false);
     otherClef = clef->otherClef();
     if (otherClef) {
@@ -388,7 +388,7 @@ TEST_F(Engraving_ClefCourtesyTests, clef_courtesy04)
     clef = toClef(seg->element(0));
     EXPECT_TRUE(clef) << "No Clef change in measure 8, track 0.";
     EXPECT_GT(clef->ldata()->bbox().width(), 0) << "Clef change in measure 8, track 0, is hidden.";
-    score->startCmd(TranslatableString("undoableAction", "Courtesy clef tests"));
+    score->startCmd(TranslatableString::untranslatable("Courtesy clef tests"));
     clef->undoChangeProperty(Pid::SHOW_COURTESY, false);
     otherClef = clef->otherClef();
     if (otherClef) {

--- a/src/engraving/tests/clef_courtesy_tests.cpp
+++ b/src/engraving/tests/clef_courtesy_tests.cpp
@@ -55,7 +55,7 @@ static void dropClef(EngravingItem* m, ClefType t)
     EditData dropData(0);
     dropData.pos = m->pagePos();
     dropData.dropElement = clef;
-    m->score()->startCmd();
+    m->score()->startCmd(TranslatableString("undoableAction", "Courtesy clef tests"));
     if (m->isMeasure()) {
         toMeasure(m)->drop(dropData);
     } else {
@@ -108,7 +108,7 @@ TEST_F(Engraving_ClefCourtesyTests, clef_courtesy01)
     EXPECT_TRUE(seg) << "No SegClef in measure 4.";
 
     clef = static_cast<Clef*>(seg->element(0));
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Courtesy clef tests"));
     clef->undoChangeProperty(Pid::SHOW_COURTESY, false);
     Clef* otherClef = clef->otherClef();
     if (otherClef) {
@@ -318,7 +318,7 @@ TEST_F(Engraving_ClefCourtesyTests, clef_courtesy04)
     seg = m1->findSegment(SegmentType::HeaderClef, m1->tick());
     EXPECT_TRUE(seg) << "No SegClef in measure 4.";
     clef = toClef(seg->element(0));
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Courtesy clef tests"));
     clef->undoChangeProperty(Pid::SHOW_COURTESY, false);
     Clef* otherClef = clef->otherClef();
     if (otherClef) {
@@ -350,7 +350,7 @@ TEST_F(Engraving_ClefCourtesyTests, clef_courtesy04)
     clef = toClef(seg->element(4));
     EXPECT_TRUE(clef) << "No Clef in measure 8, track 4.";
     dropClef(clef, ClefType::G8_VA);
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Courtesy clef tests"));
     clef->undoChangeProperty(Pid::SHOW_COURTESY, false);
     otherClef = clef->otherClef();
     if (otherClef) {
@@ -388,7 +388,7 @@ TEST_F(Engraving_ClefCourtesyTests, clef_courtesy04)
     clef = toClef(seg->element(0));
     EXPECT_TRUE(clef) << "No Clef change in measure 8, track 0.";
     EXPECT_GT(clef->ldata()->bbox().width(), 0) << "Clef change in measure 8, track 0, is hidden.";
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Courtesy clef tests"));
     clef->undoChangeProperty(Pid::SHOW_COURTESY, false);
     otherClef = clef->otherClef();
     if (otherClef) {

--- a/src/engraving/tests/copypaste_tests.cpp
+++ b/src/engraving/tests/copypaste_tests.cpp
@@ -86,7 +86,7 @@ void Engraving_CopyPasteTests::copypaste(const char* idx)
     EXPECT_TRUE(m4->first()->element(0));
     score->select(m4->first()->element(0));
 
-    score->startCmd(TranslatableString("undoableAction", "Copy/paste tests"));
+    score->startCmd(TranslatableString::untranslatable("Copy/paste tests"));
     QMimeDataAdapter ma(mimeData);
     score->cmdPaste(&ma, 0);
     score->endCmd();
@@ -222,7 +222,7 @@ void Engraving_CopyPasteTests::copypastevoice(const char* idx, int voice)
     //paste to second measure
     score->select(m2->first()->element(0));
 
-    score->startCmd(TranslatableString("undoableAction", "Copy/paste tests"));
+    score->startCmd(TranslatableString::untranslatable("Copy/paste tests"));
     QMimeDataAdapter ma(mimeData);
     score->cmdPaste(&ma, 0);
     score->endCmd();
@@ -259,7 +259,7 @@ TEST_F(Engraving_CopyPasteTests, copypaste2Voice)
     Segment* secondCRSeg = m2->first()->next1(SegmentType::ChordRest);
     score->select(secondCRSeg->element(0));
 
-    score->startCmd(TranslatableString("undoableAction", "Copy/paste tests"));
+    score->startCmd(TranslatableString::untranslatable("Copy/paste tests"));
     QMimeDataAdapter ma(mimeData);
     score->cmdPaste(&ma, 0);
     score->endCmd();
@@ -299,7 +299,7 @@ TEST_F(Engraving_CopyPasteTests, copypaste2Voice5)
     EXPECT_EQ(static_cast<ChordRest*>(dest)->durationType(), DurationType::V_QUARTER);
     score->select(dest);
 
-    score->startCmd(TranslatableString("undoableAction", "Copy/paste tests"));
+    score->startCmd(TranslatableString::untranslatable("Copy/paste tests"));
     QMimeDataAdapter ma(mimeData);
     score->cmdPaste(&ma, 0);
     score->endCmd();
@@ -338,7 +338,7 @@ TEST_F(Engraving_CopyPasteTests, copypaste2Voice6)
     EXPECT_EQ(static_cast<ChordRest*>(dest)->durationType(), DurationType::V_16TH);
     score->select(dest);
 
-    score->startCmd(TranslatableString("undoableAction", "Copy/paste tests"));
+    score->startCmd(TranslatableString::untranslatable("Copy/paste tests"));
     QMimeDataAdapter ma(mimeData);
     score->cmdPaste(&ma, 0);
     score->endCmd();
@@ -374,7 +374,7 @@ TEST_F(Engraving_CopyPasteTests, copypasteOnlySecondVoice)
     score->selectionFilter().setFiltered(SelectionFilterType::FIRST_VOICE, true);
     score->select(m2, SelectType::RANGE);
 
-    score->startCmd(TranslatableString("undoableAction", "Copy/paste tests"));
+    score->startCmd(TranslatableString::untranslatable("Copy/paste tests"));
     QMimeDataAdapter ma(mimeData);
     score->cmdPaste(&ma, 0);
     score->endCmd();
@@ -410,7 +410,7 @@ void Engraving_CopyPasteTests::copypastestaff(const char* idx)
 
     score->select(m2, SelectType::RANGE, 1);
 
-    score->startCmd(TranslatableString("undoableAction", "Copy/paste tests"));
+    score->startCmd(TranslatableString::untranslatable("Copy/paste tests"));
     QMimeDataAdapter ma(mimeData);
     score->cmdPaste(&ma, 0);
     score->endCmd();
@@ -447,7 +447,7 @@ TEST_F(Engraving_CopyPasteTests, copypastePartial)
 
     score->select(m1->first(SegmentType::ChordRest)->element(0));
 
-    score->startCmd(TranslatableString("undoableAction", "Copy/paste tests"));
+    score->startCmd(TranslatableString::untranslatable("Copy/paste tests"));
     QMimeDataAdapter ma(mimeData);
     score->cmdPaste(&ma, 0);
     score->endCmd();
@@ -481,7 +481,7 @@ void Engraving_CopyPasteTests::copypastetuplet(const char* idx)
 
     EngravingItem* dest = m2->first(SegmentType::ChordRest)->element(0);
     score->select(dest);
-    score->startCmd(TranslatableString("undoableAction", "Copy/paste tests"));
+    score->startCmd(TranslatableString::untranslatable("Copy/paste tests"));
     QMimeDataAdapter ma(mimeData);
     score->cmdPaste(&ma, 0);
     score->endCmd();
@@ -518,7 +518,7 @@ void Engraving_CopyPasteTests::copypastenote(const String& idx, Fraction scale)
     mimeData.setData(score->selection().mimeType(), score->selection().mimeData().toQByteArray());
     ChordRest* cr = m1->first(SegmentType::ChordRest)->nextChordRest(0);
     score->select(cr->isChord() ? toChord(cr)->upNote() : static_cast<EngravingItem*>(cr));
-    score->startCmd(TranslatableString("undoableAction", "Copy/paste tests"));
+    score->startCmd(TranslatableString::untranslatable("Copy/paste tests"));
     QMimeDataAdapter ma(&mimeData);
     score->cmdPaste(&ma, 0, scale);
     score->endCmd();
@@ -604,7 +604,7 @@ TEST_F(Engraving_CopyPasteTests, copypasteSplitNoteOverBar)
     mimeData.setData(score->selection().mimeType(), score->selection().mimeData().toQByteArray());
     ChordRest* cr = m1->findChordRest(Fraction(7, 8), 0);
     score->select(cr->isChord() ? toChord(cr)->upNote() : static_cast<EngravingItem*>(cr));
-    score->startCmd(TranslatableString("undoableAction", "Copy/paste tests"));
+    score->startCmd(TranslatableString::untranslatable("Copy/paste tests"));
     QMimeDataAdapter ma(&mimeData);
     score->cmdPaste(&ma, 0);
     score->endCmd();
@@ -638,7 +638,7 @@ TEST_F(Engraving_CopyPasteTests, copypasteSplitTiedNoteOverBar)
     ChordRest* cr = m1->findChordRest(Fraction(6, 8), 0);
     EXPECT_TRUE(cr);
     score->select(cr->isChord() ? toChord(cr)->upNote() : static_cast<EngravingItem*>(cr));
-    score->startCmd(TranslatableString("undoableAction", "Copy/paste tests"));
+    score->startCmd(TranslatableString::untranslatable("Copy/paste tests"));
     QMimeDataAdapter ma(&mimeData);
     score->cmdPaste(&ma, 0);
     score->endCmd();
@@ -666,7 +666,7 @@ TEST_F(Engraving_CopyPasteTests, copypasteSplitNoteOverManyBars)
     ChordRest* cr = m2->findChordRest(Fraction(19, 8), 0);
     EXPECT_TRUE(cr);
     score->select(cr->isChord() ? toChord(cr)->upNote() : static_cast<EngravingItem*>(cr));
-    score->startCmd(TranslatableString("undoableAction", "Copy/paste tests"));
+    score->startCmd(TranslatableString::untranslatable("Copy/paste tests"));
     QMimeDataAdapter ma(&mimeData);
     score->cmdPaste(&ma, 0);
     score->endCmd();
@@ -693,7 +693,7 @@ TEST_F(Engraving_CopyPasteTests, copypasteSplitNoteOverBarDrumStave)
     mimeData.setData(score->selection().mimeType(), score->selection().mimeData().toQByteArray());
     ChordRest* cr = m1->findChordRest(Fraction(7, 8), 0);
     score->select(cr->isChord() ? toChord(cr)->upNote() : static_cast<EngravingItem*>(cr));
-    score->startCmd(TranslatableString("undoableAction", "Copy/paste tests"));
+    score->startCmd(TranslatableString::untranslatable("Copy/paste tests"));
     QMimeDataAdapter ma(&mimeData);
     score->cmdPaste(&ma, 0);
     score->endCmd();
@@ -735,7 +735,7 @@ TEST_F(Engraving_CopyPasteTests, DISABLED_copypastetremolo)
     //paste to second measure
     score->select(m2->first()->element(0));
 
-    score->startCmd(TranslatableString("undoableAction", "Copy/paste tests"));
+    score->startCmd(TranslatableString::untranslatable("Copy/paste tests"));
     QMimeDataAdapter ma(mimeData);
     score->cmdPaste(&ma, 0);
     score->endCmd();
@@ -754,7 +754,7 @@ TEST_F(Engraving_CopyPasteTests, DISABLED_copypastetremolo)
     //paste to third measure
     score->select(m3->first()->element(0));
 
-    score->startCmd(TranslatableString("undoableAction", "Copy/paste tests"));
+    score->startCmd(TranslatableString::untranslatable("Copy/paste tests"));
     score->cmdPaste(&ma, 0);
     score->endCmd();
 
@@ -799,7 +799,7 @@ TEST_F(Engraving_CopyPasteTests, copypasteparts)
     // paste measure 4
     score->select(m4);
 
-    score->startCmd(TranslatableString("undoableAction", "Copy/paste tests"));
+    score->startCmd(TranslatableString::untranslatable("Copy/paste tests"));
     QMimeDataAdapter ma(mimeData);
     score->cmdPaste(&ma, 0);
     score->endCmd();

--- a/src/engraving/tests/copypaste_tests.cpp
+++ b/src/engraving/tests/copypaste_tests.cpp
@@ -86,7 +86,7 @@ void Engraving_CopyPasteTests::copypaste(const char* idx)
     EXPECT_TRUE(m4->first()->element(0));
     score->select(m4->first()->element(0));
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Copy/paste tests"));
     QMimeDataAdapter ma(mimeData);
     score->cmdPaste(&ma, 0);
     score->endCmd();
@@ -222,7 +222,7 @@ void Engraving_CopyPasteTests::copypastevoice(const char* idx, int voice)
     //paste to second measure
     score->select(m2->first()->element(0));
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Copy/paste tests"));
     QMimeDataAdapter ma(mimeData);
     score->cmdPaste(&ma, 0);
     score->endCmd();
@@ -259,7 +259,7 @@ TEST_F(Engraving_CopyPasteTests, copypaste2Voice)
     Segment* secondCRSeg = m2->first()->next1(SegmentType::ChordRest);
     score->select(secondCRSeg->element(0));
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Copy/paste tests"));
     QMimeDataAdapter ma(mimeData);
     score->cmdPaste(&ma, 0);
     score->endCmd();
@@ -299,7 +299,7 @@ TEST_F(Engraving_CopyPasteTests, copypaste2Voice5)
     EXPECT_EQ(static_cast<ChordRest*>(dest)->durationType(), DurationType::V_QUARTER);
     score->select(dest);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Copy/paste tests"));
     QMimeDataAdapter ma(mimeData);
     score->cmdPaste(&ma, 0);
     score->endCmd();
@@ -338,7 +338,7 @@ TEST_F(Engraving_CopyPasteTests, copypaste2Voice6)
     EXPECT_EQ(static_cast<ChordRest*>(dest)->durationType(), DurationType::V_16TH);
     score->select(dest);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Copy/paste tests"));
     QMimeDataAdapter ma(mimeData);
     score->cmdPaste(&ma, 0);
     score->endCmd();
@@ -374,7 +374,7 @@ TEST_F(Engraving_CopyPasteTests, copypasteOnlySecondVoice)
     score->selectionFilter().setFiltered(SelectionFilterType::FIRST_VOICE, true);
     score->select(m2, SelectType::RANGE);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Copy/paste tests"));
     QMimeDataAdapter ma(mimeData);
     score->cmdPaste(&ma, 0);
     score->endCmd();
@@ -410,7 +410,7 @@ void Engraving_CopyPasteTests::copypastestaff(const char* idx)
 
     score->select(m2, SelectType::RANGE, 1);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Copy/paste tests"));
     QMimeDataAdapter ma(mimeData);
     score->cmdPaste(&ma, 0);
     score->endCmd();
@@ -447,7 +447,7 @@ TEST_F(Engraving_CopyPasteTests, copypastePartial)
 
     score->select(m1->first(SegmentType::ChordRest)->element(0));
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Copy/paste tests"));
     QMimeDataAdapter ma(mimeData);
     score->cmdPaste(&ma, 0);
     score->endCmd();
@@ -481,7 +481,7 @@ void Engraving_CopyPasteTests::copypastetuplet(const char* idx)
 
     EngravingItem* dest = m2->first(SegmentType::ChordRest)->element(0);
     score->select(dest);
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Copy/paste tests"));
     QMimeDataAdapter ma(mimeData);
     score->cmdPaste(&ma, 0);
     score->endCmd();
@@ -518,7 +518,7 @@ void Engraving_CopyPasteTests::copypastenote(const String& idx, Fraction scale)
     mimeData.setData(score->selection().mimeType(), score->selection().mimeData().toQByteArray());
     ChordRest* cr = m1->first(SegmentType::ChordRest)->nextChordRest(0);
     score->select(cr->isChord() ? toChord(cr)->upNote() : static_cast<EngravingItem*>(cr));
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Copy/paste tests"));
     QMimeDataAdapter ma(&mimeData);
     score->cmdPaste(&ma, 0, scale);
     score->endCmd();
@@ -604,7 +604,7 @@ TEST_F(Engraving_CopyPasteTests, copypasteSplitNoteOverBar)
     mimeData.setData(score->selection().mimeType(), score->selection().mimeData().toQByteArray());
     ChordRest* cr = m1->findChordRest(Fraction(7, 8), 0);
     score->select(cr->isChord() ? toChord(cr)->upNote() : static_cast<EngravingItem*>(cr));
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Copy/paste tests"));
     QMimeDataAdapter ma(&mimeData);
     score->cmdPaste(&ma, 0);
     score->endCmd();
@@ -638,7 +638,7 @@ TEST_F(Engraving_CopyPasteTests, copypasteSplitTiedNoteOverBar)
     ChordRest* cr = m1->findChordRest(Fraction(6, 8), 0);
     EXPECT_TRUE(cr);
     score->select(cr->isChord() ? toChord(cr)->upNote() : static_cast<EngravingItem*>(cr));
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Copy/paste tests"));
     QMimeDataAdapter ma(&mimeData);
     score->cmdPaste(&ma, 0);
     score->endCmd();
@@ -666,7 +666,7 @@ TEST_F(Engraving_CopyPasteTests, copypasteSplitNoteOverManyBars)
     ChordRest* cr = m2->findChordRest(Fraction(19, 8), 0);
     EXPECT_TRUE(cr);
     score->select(cr->isChord() ? toChord(cr)->upNote() : static_cast<EngravingItem*>(cr));
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Copy/paste tests"));
     QMimeDataAdapter ma(&mimeData);
     score->cmdPaste(&ma, 0);
     score->endCmd();
@@ -693,7 +693,7 @@ TEST_F(Engraving_CopyPasteTests, copypasteSplitNoteOverBarDrumStave)
     mimeData.setData(score->selection().mimeType(), score->selection().mimeData().toQByteArray());
     ChordRest* cr = m1->findChordRest(Fraction(7, 8), 0);
     score->select(cr->isChord() ? toChord(cr)->upNote() : static_cast<EngravingItem*>(cr));
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Copy/paste tests"));
     QMimeDataAdapter ma(&mimeData);
     score->cmdPaste(&ma, 0);
     score->endCmd();
@@ -735,7 +735,7 @@ TEST_F(Engraving_CopyPasteTests, DISABLED_copypastetremolo)
     //paste to second measure
     score->select(m2->first()->element(0));
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Copy/paste tests"));
     QMimeDataAdapter ma(mimeData);
     score->cmdPaste(&ma, 0);
     score->endCmd();
@@ -754,7 +754,7 @@ TEST_F(Engraving_CopyPasteTests, DISABLED_copypastetremolo)
     //paste to third measure
     score->select(m3->first()->element(0));
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Copy/paste tests"));
     score->cmdPaste(&ma, 0);
     score->endCmd();
 
@@ -799,7 +799,7 @@ TEST_F(Engraving_CopyPasteTests, copypasteparts)
     // paste measure 4
     score->select(m4);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Copy/paste tests"));
     QMimeDataAdapter ma(mimeData);
     score->cmdPaste(&ma, 0);
     score->endCmd();

--- a/src/engraving/tests/copypastesymbollist_tests.cpp
+++ b/src/engraving/tests/copypastesymbollist_tests.cpp
@@ -68,7 +68,7 @@ void Engraving_CopyPasteSymbolListTests::copypastecommon(MasterScore* score, con
     }
     score->select(m->first()->element(0));
 
-    score->startCmd(TranslatableString("undoableAction", "Copy/paste symbol tests"));
+    score->startCmd(TranslatableString::untranslatable("Copy/paste symbol tests"));
     if (!mimeData->hasFormat(mimeSymbolListFormat)) {
         LOGD("wrong type mime data");
         return;

--- a/src/engraving/tests/copypastesymbollist_tests.cpp
+++ b/src/engraving/tests/copypastesymbollist_tests.cpp
@@ -68,7 +68,7 @@ void Engraving_CopyPasteSymbolListTests::copypastecommon(MasterScore* score, con
     }
     score->select(m->first()->element(0));
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Copy/paste symbol tests"));
     if (!mimeData->hasFormat(mimeSymbolListFormat)) {
         LOGD("wrong type mime data");
         return;

--- a/src/engraving/tests/durationtype_tests.cpp
+++ b/src/engraving/tests/durationtype_tests.cpp
@@ -58,7 +58,7 @@ TEST_F(Engraving_DurationTypeTests, halfDuration)
     score->inputState().setDuration(DurationType::V_WHOLE);
     score->inputState().setNoteEntryMode(true);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Duration type tests"));
     score->cmdAddPitch(42, false, false);
     Chord* c = score->firstMeasure()->findChord(Fraction(0, 1), 0);
     EXPECT_EQ(c->ticks(), Fraction(1, 1));
@@ -66,7 +66,7 @@ TEST_F(Engraving_DurationTypeTests, halfDuration)
 
     // repeatedly half-duration from V_WHOLE to V_128
     for (int i = 128; i > 1; i /= 2) {
-        score->startCmd();
+        score->startCmd(TranslatableString("undoableAction", "Duration type tests"));
         score->cmdHalfDuration();
         score->endCmd();
         Chord* c2 = score->firstMeasure()->findChord(Fraction(0, 1), 0);
@@ -89,7 +89,7 @@ TEST_F(Engraving_DurationTypeTests, doubleDuration)
     score->inputState().setDuration(DurationType::V_128TH);
     score->inputState().setNoteEntryMode(true);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Duration type tests"));
     score->cmdAddPitch(42, false, false);
     EXPECT_EQ(score->firstMeasure()->findChord(Fraction(0, 1), 0)->ticks(), Fraction(1, 128));
 
@@ -117,7 +117,7 @@ TEST_F(Engraving_DurationTypeTests, decDurationDotted)
     score->inputState().setDuration(DurationType::V_WHOLE);
     score->inputState().setNoteEntryMode(true);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Duration type tests"));
     score->cmdAddPitch(42, false, false);
     Chord* c = score->firstMeasure()->findChord(Fraction(0, 1), 0);
     EXPECT_EQ(c->ticks(), Fraction(1, 1));
@@ -150,7 +150,7 @@ TEST_F(Engraving_DurationTypeTests, incDurationDotted)
     score->inputState().setDuration(DurationType::V_128TH);
     score->inputState().setNoteEntryMode(true);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Duration type tests"));
     score->cmdAddPitch(42, false, false);
     EXPECT_EQ(score->firstMeasure()->findChord(Fraction(0, 1), 0)->ticks(), Fraction(1, 128));
 

--- a/src/engraving/tests/durationtype_tests.cpp
+++ b/src/engraving/tests/durationtype_tests.cpp
@@ -58,7 +58,7 @@ TEST_F(Engraving_DurationTypeTests, halfDuration)
     score->inputState().setDuration(DurationType::V_WHOLE);
     score->inputState().setNoteEntryMode(true);
 
-    score->startCmd(TranslatableString("undoableAction", "Duration type tests"));
+    score->startCmd(TranslatableString::untranslatable("Duration type tests"));
     score->cmdAddPitch(42, false, false);
     Chord* c = score->firstMeasure()->findChord(Fraction(0, 1), 0);
     EXPECT_EQ(c->ticks(), Fraction(1, 1));
@@ -66,7 +66,7 @@ TEST_F(Engraving_DurationTypeTests, halfDuration)
 
     // repeatedly half-duration from V_WHOLE to V_128
     for (int i = 128; i > 1; i /= 2) {
-        score->startCmd(TranslatableString("undoableAction", "Duration type tests"));
+        score->startCmd(TranslatableString::untranslatable("Duration type tests"));
         score->cmdHalfDuration();
         score->endCmd();
         Chord* c2 = score->firstMeasure()->findChord(Fraction(0, 1), 0);
@@ -89,7 +89,7 @@ TEST_F(Engraving_DurationTypeTests, doubleDuration)
     score->inputState().setDuration(DurationType::V_128TH);
     score->inputState().setNoteEntryMode(true);
 
-    score->startCmd(TranslatableString("undoableAction", "Duration type tests"));
+    score->startCmd(TranslatableString::untranslatable("Duration type tests"));
     score->cmdAddPitch(42, false, false);
     EXPECT_EQ(score->firstMeasure()->findChord(Fraction(0, 1), 0)->ticks(), Fraction(1, 128));
 
@@ -117,7 +117,7 @@ TEST_F(Engraving_DurationTypeTests, decDurationDotted)
     score->inputState().setDuration(DurationType::V_WHOLE);
     score->inputState().setNoteEntryMode(true);
 
-    score->startCmd(TranslatableString("undoableAction", "Duration type tests"));
+    score->startCmd(TranslatableString::untranslatable("Duration type tests"));
     score->cmdAddPitch(42, false, false);
     Chord* c = score->firstMeasure()->findChord(Fraction(0, 1), 0);
     EXPECT_EQ(c->ticks(), Fraction(1, 1));
@@ -150,7 +150,7 @@ TEST_F(Engraving_DurationTypeTests, incDurationDotted)
     score->inputState().setDuration(DurationType::V_128TH);
     score->inputState().setNoteEntryMode(true);
 
-    score->startCmd(TranslatableString("undoableAction", "Duration type tests"));
+    score->startCmd(TranslatableString::untranslatable("Duration type tests"));
     score->cmdAddPitch(42, false, false);
     EXPECT_EQ(score->firstMeasure()->findChord(Fraction(0, 1), 0)->ticks(), Fraction(1, 128));
 

--- a/src/engraving/tests/earlymusic_tests.cpp
+++ b/src/engraving/tests/earlymusic_tests.cpp
@@ -69,7 +69,7 @@ TEST_F(Engraving_EarlymusicTests, earlymusic01)
     // set crossMeasureValue flag ON: score should not change
     MStyle newStyle = score->style();
     newStyle.set(Sid::crossMeasureValues, true);
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Early music tests"));
     score->deselectAll();
     score->undo(new ChangeStyle(score, newStyle));
     score->update();

--- a/src/engraving/tests/earlymusic_tests.cpp
+++ b/src/engraving/tests/earlymusic_tests.cpp
@@ -69,7 +69,7 @@ TEST_F(Engraving_EarlymusicTests, earlymusic01)
     // set crossMeasureValue flag ON: score should not change
     MStyle newStyle = score->style();
     newStyle.set(Sid::crossMeasureValues, true);
-    score->startCmd(TranslatableString("undoableAction", "Early music tests"));
+    score->startCmd(TranslatableString::untranslatable("Early music tests"));
     score->deselectAll();
     score->undo(new ChangeStyle(score, newStyle));
     score->update();

--- a/src/engraving/tests/exchangevoices_tests.cpp
+++ b/src/engraving/tests/exchangevoices_tests.cpp
@@ -46,12 +46,12 @@ TEST_F(Engraving_ExchangevoicesTests, slurs)
     score->doLayout();
 
     // select all
-    score->startCmd(TranslatableString("undoableAction", "Exchange select all"));
+    score->startCmd(TranslatableString::untranslatable("Exchange select all"));
     score->cmdSelectAll();
     score->endCmd();
 
     // do
-    score->startCmd(TranslatableString("undoableAction", "Exchange voices tests"));
+    score->startCmd(TranslatableString::untranslatable("Exchange voices tests"));
     score->cmdExchangeVoice(0, 1);
     score->endCmd();
 
@@ -66,12 +66,12 @@ TEST_F(Engraving_ExchangevoicesTests, glissandi)
     score->doLayout();
 
     // select all
-    score->startCmd(TranslatableString("undoableAction", "Exchange voices select all"));
+    score->startCmd(TranslatableString::untranslatable("Exchange voices select all"));
     score->cmdSelectAll();
     score->endCmd();
 
     // do
-    score->startCmd(TranslatableString("undoableAction", "Exchange voices tests"));
+    score->startCmd(TranslatableString::untranslatable("Exchange voices tests"));
     score->cmdExchangeVoice(0, 1);
     score->endCmd();
 
@@ -102,7 +102,7 @@ TEST_F(Engraving_ExchangevoicesTests, undoChangeVoice)
         }
     }
     // change voice
-    score->startCmd(TranslatableString("undoableAction", "Exchange voices tests"));
+    score->startCmd(TranslatableString::untranslatable("Exchange voices tests"));
     score->changeSelectedElementsVoice(1);
     score->endCmd(false, /*layoutAllParts = */ true);
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, writeFile1, reference1));

--- a/src/engraving/tests/exchangevoices_tests.cpp
+++ b/src/engraving/tests/exchangevoices_tests.cpp
@@ -46,12 +46,12 @@ TEST_F(Engraving_ExchangevoicesTests, slurs)
     score->doLayout();
 
     // select all
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Exchange select all"));
     score->cmdSelectAll();
     score->endCmd();
 
     // do
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Exchange voices tests"));
     score->cmdExchangeVoice(0, 1);
     score->endCmd();
 
@@ -66,12 +66,12 @@ TEST_F(Engraving_ExchangevoicesTests, glissandi)
     score->doLayout();
 
     // select all
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Exchange voices select all"));
     score->cmdSelectAll();
     score->endCmd();
 
     // do
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Exchange voices tests"));
     score->cmdExchangeVoice(0, 1);
     score->endCmd();
 
@@ -102,7 +102,7 @@ TEST_F(Engraving_ExchangevoicesTests, undoChangeVoice)
         }
     }
     // change voice
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Exchange voices tests"));
     score->changeSelectedElementsVoice(1);
     score->endCmd(false, /*layoutAllParts = */ true);
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, writeFile1, reference1));

--- a/src/engraving/tests/harpdiagram_tests.cpp
+++ b/src/engraving/tests/harpdiagram_tests.cpp
@@ -107,7 +107,7 @@ TEST_F(Engraving_HarpDiagramTests, textdiagrams)
             PedalPosition::NATURAL, PedalPosition::NATURAL };
     diagram1->setIsDiagram(false);
 
-    score->startCmd(TranslatableString("undoableAction", "Harp diagram tests"));
+    score->startCmd(TranslatableString::untranslatable("Harp diagram tests"));
     EditData dd1(0);
     dd1.dropElement = diagram1;
     EngravingItem* e1 = s1->firstElementForNavigation(0);
@@ -125,7 +125,7 @@ TEST_F(Engraving_HarpDiagramTests, textdiagrams)
     HarpPedalDiagram* diagram2 = Factory::createHarpPedalDiagram(s2);
     diagram2->setIsDiagram(false);
 
-    score->startCmd(TranslatableString("undoableAction", "Harp diagram tests"));
+    score->startCmd(TranslatableString::untranslatable("Harp diagram tests"));
     EditData dd2(0);
     dd2.dropElement = diagram2;
     EngravingItem* e2 = s2->firstElementForNavigation(0);
@@ -142,7 +142,7 @@ TEST_F(Engraving_HarpDiagramTests, textdiagrams)
     HarpPedalDiagram* diagram3 = Factory::createHarpPedalDiagram(s3);
     diagram3->setIsDiagram(false);
 
-    score->startCmd(TranslatableString("undoableAction", "Harp diagram tests"));
+    score->startCmd(TranslatableString::untranslatable("Harp diagram tests"));
     EditData dd3(0);
     dd3.dropElement = diagram3;
     EngravingItem* e3 = s3->firstElementForNavigation(0);
@@ -157,7 +157,7 @@ TEST_F(Engraving_HarpDiagramTests, textdiagrams)
     HarpPedalDiagram* diagram4 = Factory::createHarpPedalDiagram(s4);
     diagram4->setIsDiagram(false);
 
-    score->startCmd(TranslatableString("undoableAction", "Harp diagram tests"));
+    score->startCmd(TranslatableString::untranslatable("Harp diagram tests"));
     EditData dd4(0);
     dd4.dropElement = diagram4;
     EngravingItem* e4 = s4->firstElementForNavigation(0);
@@ -197,7 +197,7 @@ TEST_F(Engraving_HarpDiagramTests, textdiagrams2)
     HarpPedalDiagram* diagram2 = Factory::createHarpPedalDiagram(s2);
     diagram2->setIsDiagram(false);
 
-    score->startCmd(TranslatableString("undoableAction", "Harp diagram tests"));
+    score->startCmd(TranslatableString::untranslatable("Harp diagram tests"));
     EditData dd(0);
     dd.dropElement = diagram2;
     EngravingItem* e = s2->firstElementForNavigation(0);
@@ -215,7 +215,7 @@ TEST_F(Engraving_HarpDiagramTests, textdiagrams2)
     EXPECT_EQ(diagram1->xmlText(), expText);
 
     // Test undo
-    score->startCmd(TranslatableString("undoableAction", "Harp diagram tests"));
+    score->startCmd(TranslatableString::untranslatable("Harp diagram tests"));
     score->undoRedo(true, &dd);
     score->endCmd();
 

--- a/src/engraving/tests/harpdiagram_tests.cpp
+++ b/src/engraving/tests/harpdiagram_tests.cpp
@@ -107,7 +107,7 @@ TEST_F(Engraving_HarpDiagramTests, textdiagrams)
             PedalPosition::NATURAL, PedalPosition::NATURAL };
     diagram1->setIsDiagram(false);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Harp diagram tests"));
     EditData dd1(0);
     dd1.dropElement = diagram1;
     EngravingItem* e1 = s1->firstElementForNavigation(0);
@@ -125,7 +125,7 @@ TEST_F(Engraving_HarpDiagramTests, textdiagrams)
     HarpPedalDiagram* diagram2 = Factory::createHarpPedalDiagram(s2);
     diagram2->setIsDiagram(false);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Harp diagram tests"));
     EditData dd2(0);
     dd2.dropElement = diagram2;
     EngravingItem* e2 = s2->firstElementForNavigation(0);
@@ -142,7 +142,7 @@ TEST_F(Engraving_HarpDiagramTests, textdiagrams)
     HarpPedalDiagram* diagram3 = Factory::createHarpPedalDiagram(s3);
     diagram3->setIsDiagram(false);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Harp diagram tests"));
     EditData dd3(0);
     dd3.dropElement = diagram3;
     EngravingItem* e3 = s3->firstElementForNavigation(0);
@@ -157,7 +157,7 @@ TEST_F(Engraving_HarpDiagramTests, textdiagrams)
     HarpPedalDiagram* diagram4 = Factory::createHarpPedalDiagram(s4);
     diagram4->setIsDiagram(false);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Harp diagram tests"));
     EditData dd4(0);
     dd4.dropElement = diagram4;
     EngravingItem* e4 = s4->firstElementForNavigation(0);
@@ -197,7 +197,7 @@ TEST_F(Engraving_HarpDiagramTests, textdiagrams2)
     HarpPedalDiagram* diagram2 = Factory::createHarpPedalDiagram(s2);
     diagram2->setIsDiagram(false);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Harp diagram tests"));
     EditData dd(0);
     dd.dropElement = diagram2;
     EngravingItem* e = s2->firstElementForNavigation(0);
@@ -215,7 +215,7 @@ TEST_F(Engraving_HarpDiagramTests, textdiagrams2)
     EXPECT_EQ(diagram1->xmlText(), expText);
 
     // Test undo
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Harp diagram tests"));
     score->undoRedo(true, &dd);
     score->endCmd();
 

--- a/src/engraving/tests/implodeexplode_tests.cpp
+++ b/src/engraving/tests/implodeexplode_tests.cpp
@@ -53,12 +53,12 @@ void Engraving_ImplodeExplodeTests::testUndoExplode(String fileName)
     score->doLayout();
 
     // select all
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Implode/explode select all"));
     score->cmdSelectAll();
     score->endCmd();
 
     // do
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Implode/explode tests"));
     score->cmdExplode();
     score->endCmd();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, writeFile1, reference1));
@@ -84,12 +84,12 @@ void Engraving_ImplodeExplodeTests::testUndoImplode(String filename)
     score->doLayout();
 
     // select all
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Implode/explode select all"));
     score->cmdSelectAll();
     score->endCmd();
 
     // do
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Implode/explode tests"));
     score->cmdImplode();
     score->endCmd();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, writeFile1, reference1));

--- a/src/engraving/tests/implodeexplode_tests.cpp
+++ b/src/engraving/tests/implodeexplode_tests.cpp
@@ -53,12 +53,12 @@ void Engraving_ImplodeExplodeTests::testUndoExplode(String fileName)
     score->doLayout();
 
     // select all
-    score->startCmd(TranslatableString("undoableAction", "Implode/explode select all"));
+    score->startCmd(TranslatableString::untranslatable("Implode/explode select all"));
     score->cmdSelectAll();
     score->endCmd();
 
     // do
-    score->startCmd(TranslatableString("undoableAction", "Implode/explode tests"));
+    score->startCmd(TranslatableString::untranslatable("Implode/explode tests"));
     score->cmdExplode();
     score->endCmd();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, writeFile1, reference1));
@@ -84,12 +84,12 @@ void Engraving_ImplodeExplodeTests::testUndoImplode(String filename)
     score->doLayout();
 
     // select all
-    score->startCmd(TranslatableString("undoableAction", "Implode/explode select all"));
+    score->startCmd(TranslatableString::untranslatable("Implode/explode select all"));
     score->cmdSelectAll();
     score->endCmd();
 
     // do
-    score->startCmd(TranslatableString("undoableAction", "Implode/explode tests"));
+    score->startCmd(TranslatableString::untranslatable("Implode/explode tests"));
     score->cmdImplode();
     score->endCmd();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, writeFile1, reference1));

--- a/src/engraving/tests/instrumentchange_tests.cpp
+++ b/src/engraving/tests/instrumentchange_tests.cpp
@@ -74,7 +74,7 @@ TEST_F(Engraving_InstrumentChangeTests, testAdd)
     ic->setParent(s);
     ic->setTrack(0);
     ic->setXmlText("Instrument");
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Instrument change tests"));
     score->undoAddElement(ic);
     score->endCmd();
     test_post(score, u"add");
@@ -99,7 +99,7 @@ TEST_F(Engraving_InstrumentChangeTests, testChange)
     InstrumentChange* ic = toInstrumentChange(s->annotations()[0]);
     Instrument* ni       = score->staff(1)->part()->instrument();
     ic->setInstrument(new Instrument(*ni));
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Instrument change tests"));
     ic->setXmlText("Instrument Oboe");
     score->undo(new ChangeInstrument(ic, ic->instrument()));
     score->endCmd();
@@ -121,7 +121,7 @@ TEST_F(Engraving_InstrumentChangeTests, testMixer)
     mp->name = "Viola";
     mp->prog = 41;
     mp->synti = "Fluid";
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Instrument change tests"));
     ic->setXmlText("Mixer Viola");
     score->undo(new ChangePatch(score, c, mp));
     score->endCmd();

--- a/src/engraving/tests/instrumentchange_tests.cpp
+++ b/src/engraving/tests/instrumentchange_tests.cpp
@@ -74,7 +74,7 @@ TEST_F(Engraving_InstrumentChangeTests, testAdd)
     ic->setParent(s);
     ic->setTrack(0);
     ic->setXmlText("Instrument");
-    score->startCmd(TranslatableString("undoableAction", "Instrument change tests"));
+    score->startCmd(TranslatableString::untranslatable("Instrument change tests"));
     score->undoAddElement(ic);
     score->endCmd();
     test_post(score, u"add");
@@ -99,7 +99,7 @@ TEST_F(Engraving_InstrumentChangeTests, testChange)
     InstrumentChange* ic = toInstrumentChange(s->annotations()[0]);
     Instrument* ni       = score->staff(1)->part()->instrument();
     ic->setInstrument(new Instrument(*ni));
-    score->startCmd(TranslatableString("undoableAction", "Instrument change tests"));
+    score->startCmd(TranslatableString::untranslatable("Instrument change tests"));
     ic->setXmlText("Instrument Oboe");
     score->undo(new ChangeInstrument(ic, ic->instrument()));
     score->endCmd();
@@ -121,7 +121,7 @@ TEST_F(Engraving_InstrumentChangeTests, testMixer)
     mp->name = "Viola";
     mp->prog = 41;
     mp->synti = "Fluid";
-    score->startCmd(TranslatableString("undoableAction", "Instrument change tests"));
+    score->startCmd(TranslatableString::untranslatable("Instrument change tests"));
     ic->setXmlText("Mixer Viola");
     score->undo(new ChangePatch(score, c, mp));
     score->endCmd();

--- a/src/engraving/tests/join_tests.cpp
+++ b/src/engraving/tests/join_tests.cpp
@@ -61,7 +61,7 @@ void Engraving_JoinTests::join(const char* p1, const char* p2, int index)
 
     EXPECT_NE(m1, m2);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving join tests"));
     score->cmdJoinMeasure(m1, m2);
     score->endCmd();
 

--- a/src/engraving/tests/join_tests.cpp
+++ b/src/engraving/tests/join_tests.cpp
@@ -61,7 +61,7 @@ void Engraving_JoinTests::join(const char* p1, const char* p2, int index)
 
     EXPECT_NE(m1, m2);
 
-    score->startCmd(TranslatableString("undoableAction", "Engraving join tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving join tests"));
     score->cmdJoinMeasure(m1, m2);
     score->endCmd();
 

--- a/src/engraving/tests/keysig_tests.cpp
+++ b/src/engraving/tests/keysig_tests.cpp
@@ -64,7 +64,7 @@ TEST_F(Engraving_KeySigTests, keysig)
     // add a key signature (D major) in measure 2
     KeySigEvent ke2;
     ke2.setConcertKey(Key::D);
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Key signature tests"));
     score->undoChangeKeySig(score->staff(0), m2->tick(), ke2);
     score->endCmd();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, writeFile1, reference1));
@@ -72,7 +72,7 @@ TEST_F(Engraving_KeySigTests, keysig)
     // change key signature in measure 2 to E flat major
     KeySigEvent ke_3;
     ke_3.setConcertKey(Key(-3));
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Key signature tests"));
     score->undoChangeKeySig(score->staff(0), m2->tick(), ke_3);
     score->endCmd();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, writeFile2, reference2));
@@ -83,7 +83,7 @@ TEST_F(Engraving_KeySigTests, keysig)
         s = s->next();
     }
     EngravingItem* e = s->element(0);
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Key signature tests"));
     score->undoRemoveElement(e);
     score->endCmd();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, writeFile3, reference3));
@@ -158,7 +158,7 @@ TEST_F(Engraving_KeySigTests, preferSharpFlat)
     MasterScore* score2 = ScoreRW::readScore(KEYSIG_DATA_DIR + u"preferSharpFlat-2.mscx");
     EXPECT_TRUE(score2);
     score2->cmdSelectAll();
-    score2->startCmd();
+    score2->startCmd(TranslatableString("undoableAction", "Key signature tests"));
     // transpose augmented unison up
     score2->transpose(TransposeMode::BY_INTERVAL, TransposeDirection::UP, Key::C, 1, true, true, true);
     score2->endCmd();

--- a/src/engraving/tests/keysig_tests.cpp
+++ b/src/engraving/tests/keysig_tests.cpp
@@ -64,7 +64,7 @@ TEST_F(Engraving_KeySigTests, keysig)
     // add a key signature (D major) in measure 2
     KeySigEvent ke2;
     ke2.setConcertKey(Key::D);
-    score->startCmd(TranslatableString("undoableAction", "Key signature tests"));
+    score->startCmd(TranslatableString::untranslatable("Key signature tests"));
     score->undoChangeKeySig(score->staff(0), m2->tick(), ke2);
     score->endCmd();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, writeFile1, reference1));
@@ -72,7 +72,7 @@ TEST_F(Engraving_KeySigTests, keysig)
     // change key signature in measure 2 to E flat major
     KeySigEvent ke_3;
     ke_3.setConcertKey(Key(-3));
-    score->startCmd(TranslatableString("undoableAction", "Key signature tests"));
+    score->startCmd(TranslatableString::untranslatable("Key signature tests"));
     score->undoChangeKeySig(score->staff(0), m2->tick(), ke_3);
     score->endCmd();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, writeFile2, reference2));
@@ -83,7 +83,7 @@ TEST_F(Engraving_KeySigTests, keysig)
         s = s->next();
     }
     EngravingItem* e = s->element(0);
-    score->startCmd(TranslatableString("undoableAction", "Key signature tests"));
+    score->startCmd(TranslatableString::untranslatable("Key signature tests"));
     score->undoRemoveElement(e);
     score->endCmd();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, writeFile3, reference3));
@@ -158,7 +158,7 @@ TEST_F(Engraving_KeySigTests, preferSharpFlat)
     MasterScore* score2 = ScoreRW::readScore(KEYSIG_DATA_DIR + u"preferSharpFlat-2.mscx");
     EXPECT_TRUE(score2);
     score2->cmdSelectAll();
-    score2->startCmd(TranslatableString("undoableAction", "Key signature tests"));
+    score2->startCmd(TranslatableString::untranslatable("Key signature tests"));
     // transpose augmented unison up
     score2->transpose(TransposeMode::BY_INTERVAL, TransposeDirection::UP, Key::C, 1, true, true, true);
     score2->endCmd();

--- a/src/engraving/tests/links_tests.cpp
+++ b/src/engraving/tests/links_tests.cpp
@@ -98,7 +98,7 @@ TEST_F(Engraving_LinksTests, test3LinkedSameScore_99796)
     EXPECT_TRUE(e->links() == nullptr);
 
     // add a linked staff
-    score->startCmd(TranslatableString("undoableAction", "Engraving links tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving links tests"));
     Staff* oStaff = score->staff(0);
     Staff* staff  = Factory::createStaff(oStaff->part());
     staff->setPart(oStaff->part());
@@ -129,7 +129,7 @@ TEST_F(Engraving_LinksTests, test3LinkedSameScore_99796)
     EXPECT_TRUE(e->links()->size() == 3);
 
     // delete staff
-    score->startCmd(TranslatableString("undoableAction", "Engraving links tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving links tests"));
     score->cmdRemoveStaff(0);
     score->endCmd();
 
@@ -202,7 +202,7 @@ TEST_F(Engraving_LinksTests, test3LinkedParts_99796)
     EXPECT_TRUE(e->links() == nullptr);
 
     // create parts
-    score->startCmd(TranslatableString("undoableAction", "Engraving links tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving links tests"));
     std::vector<Part*> parts;
     parts.push_back(score->parts().at(0));
     Score* nscore = score->createScore();
@@ -216,7 +216,7 @@ TEST_F(Engraving_LinksTests, test3LinkedParts_99796)
     score->endCmd();
 
     // add a linked staff
-    score->startCmd(TranslatableString("undoableAction", "Engraving links tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving links tests"));
     Staff* oStaff = score->staff(0);
     Staff* staff  = Factory::createStaff(oStaff->part());
     staff->setPart(oStaff->part());
@@ -234,7 +234,7 @@ TEST_F(Engraving_LinksTests, test3LinkedParts_99796)
     EXPECT_TRUE(e->links()->size() == 3);
 
     // delete part
-    score->startCmd(TranslatableString("undoableAction", "Engraving links tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving links tests"));
     score->deleteExcerpt(&ex);
     score->undo(new RemoveExcerpt(&ex));
 
@@ -283,7 +283,7 @@ TEST_F(Engraving_LinksTests, DISABLED_test4LinkedParts_94911)
     EXPECT_TRUE(e->links() == nullptr);
 
     // add a linked staff
-    score->startCmd(TranslatableString("undoableAction", "Engraving links tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving links tests"));
     Staff* oStaff = score->staff(0);
     Staff* staff  = Factory::createStaff(oStaff->part());
     staff->setPart(oStaff->part());
@@ -301,7 +301,7 @@ TEST_F(Engraving_LinksTests, DISABLED_test4LinkedParts_94911)
     EXPECT_TRUE(e->links()->size() == 2);
 
     // create parts
-    score->startCmd(TranslatableString("undoableAction", "Engraving links tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving links tests"));
     std::vector<Part*> parts;
     parts.push_back(score->parts().at(0));
     Score* nscore = score->createScore();
@@ -328,7 +328,7 @@ TEST_F(Engraving_LinksTests, DISABLED_test4LinkedParts_94911)
     EXPECT_TRUE(score->excerpts().size() == 1);
 
     // delete second staff
-    score->startCmd(TranslatableString("undoableAction", "Engraving links tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving links tests"));
     score->cmdRemoveStaff(1);
     for (Excerpt* excerpt : score->excerpts()) {
         std::vector<Staff*> sl = nscore->staves();
@@ -406,7 +406,7 @@ TEST_F(Engraving_LinksTests, test5LinkedParts_94911)
     EXPECT_TRUE(e->links() == nullptr);
 
     // create parts//
-    score->startCmd(TranslatableString("undoableAction", "Engraving links tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving links tests"));
     std::vector<Part*> parts;
     parts.push_back(score->parts().at(0));
     Score* nscore = score->createScore();
@@ -426,7 +426,7 @@ TEST_F(Engraving_LinksTests, test5LinkedParts_94911)
     EXPECT_TRUE(e->links()->size() == 2);
 
     // add a linked staff
-    score->startCmd(TranslatableString("undoableAction", "Engraving links tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving links tests"));
     Staff* oStaff = score->staff(0);
     Staff* staff  = Factory::createStaff(oStaff->part());
     staff->setPart(oStaff->part());

--- a/src/engraving/tests/links_tests.cpp
+++ b/src/engraving/tests/links_tests.cpp
@@ -98,7 +98,7 @@ TEST_F(Engraving_LinksTests, test3LinkedSameScore_99796)
     EXPECT_TRUE(e->links() == nullptr);
 
     // add a linked staff
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving links tests"));
     Staff* oStaff = score->staff(0);
     Staff* staff  = Factory::createStaff(oStaff->part());
     staff->setPart(oStaff->part());
@@ -129,7 +129,7 @@ TEST_F(Engraving_LinksTests, test3LinkedSameScore_99796)
     EXPECT_TRUE(e->links()->size() == 3);
 
     // delete staff
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving links tests"));
     score->cmdRemoveStaff(0);
     score->endCmd();
 
@@ -202,7 +202,7 @@ TEST_F(Engraving_LinksTests, test3LinkedParts_99796)
     EXPECT_TRUE(e->links() == nullptr);
 
     // create parts
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving links tests"));
     std::vector<Part*> parts;
     parts.push_back(score->parts().at(0));
     Score* nscore = score->createScore();
@@ -216,7 +216,7 @@ TEST_F(Engraving_LinksTests, test3LinkedParts_99796)
     score->endCmd();
 
     // add a linked staff
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving links tests"));
     Staff* oStaff = score->staff(0);
     Staff* staff  = Factory::createStaff(oStaff->part());
     staff->setPart(oStaff->part());
@@ -234,7 +234,7 @@ TEST_F(Engraving_LinksTests, test3LinkedParts_99796)
     EXPECT_TRUE(e->links()->size() == 3);
 
     // delete part
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving links tests"));
     score->deleteExcerpt(&ex);
     score->undo(new RemoveExcerpt(&ex));
 
@@ -283,7 +283,7 @@ TEST_F(Engraving_LinksTests, DISABLED_test4LinkedParts_94911)
     EXPECT_TRUE(e->links() == nullptr);
 
     // add a linked staff
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving links tests"));
     Staff* oStaff = score->staff(0);
     Staff* staff  = Factory::createStaff(oStaff->part());
     staff->setPart(oStaff->part());
@@ -301,7 +301,7 @@ TEST_F(Engraving_LinksTests, DISABLED_test4LinkedParts_94911)
     EXPECT_TRUE(e->links()->size() == 2);
 
     // create parts
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving links tests"));
     std::vector<Part*> parts;
     parts.push_back(score->parts().at(0));
     Score* nscore = score->createScore();
@@ -328,7 +328,7 @@ TEST_F(Engraving_LinksTests, DISABLED_test4LinkedParts_94911)
     EXPECT_TRUE(score->excerpts().size() == 1);
 
     // delete second staff
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving links tests"));
     score->cmdRemoveStaff(1);
     for (Excerpt* excerpt : score->excerpts()) {
         std::vector<Staff*> sl = nscore->staves();
@@ -406,7 +406,7 @@ TEST_F(Engraving_LinksTests, test5LinkedParts_94911)
     EXPECT_TRUE(e->links() == nullptr);
 
     // create parts//
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving links tests"));
     std::vector<Part*> parts;
     parts.push_back(score->parts().at(0));
     Score* nscore = score->createScore();
@@ -426,7 +426,7 @@ TEST_F(Engraving_LinksTests, test5LinkedParts_94911)
     EXPECT_TRUE(e->links()->size() == 2);
 
     // add a linked staff
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving links tests"));
     Staff* oStaff = score->staff(0);
     Staff* staff  = Factory::createStaff(oStaff->part());
     staff->setPart(oStaff->part());

--- a/src/engraving/tests/measure_tests.cpp
+++ b/src/engraving/tests/measure_tests.cpp
@@ -49,7 +49,7 @@ TEST_F(Engraving_MeasureTests, DISABLED_insertMeasureMiddle) //TODO: verify prog
     MasterScore* score = ScoreRW::readScore(MEASURE_DATA_DIR + u"measure-1.mscx");
     EXPECT_TRUE(score);
 
-    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving measure tests"));
     Measure* m = score->firstMeasure()->nextMeasure();
     score->insertMeasure(m);
     score->endCmd();
@@ -63,7 +63,7 @@ TEST_F(Engraving_MeasureTests, DISABLED_insertMeasureBegin) // TODO: verify prog
     MasterScore* score = ScoreRW::readScore(MEASURE_DATA_DIR + u"measure-1.mscx");
     EXPECT_TRUE(score);
 
-    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving measure tests"));
     Measure* m = score->firstMeasure();
     score->insertMeasure(m);
     score->endCmd();
@@ -77,7 +77,7 @@ TEST_F(Engraving_MeasureTests, DISABLED_insertMeasureEnd) // TODO: verify progra
     MasterScore* score = ScoreRW::readScore(MEASURE_DATA_DIR + "measure-1.mscx");
     EXPECT_TRUE(score);
 
-    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving measure tests"));
     score->insertMeasure(0);
     score->endCmd();
 
@@ -90,7 +90,7 @@ TEST_F(Engraving_MeasureTests, insertAtBeginning)
     MasterScore* score = ScoreRW::readScore(MEASURE_DATA_DIR + u"measure-insert_beginning.mscx");
     EXPECT_TRUE(score);
     Measure* m = score->firstMeasure();
-    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving measure tests"));
     score->insertMeasure(m);
     score->endCmd();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"measure-insert_beginning.mscx",
@@ -106,7 +106,7 @@ TEST_F(Engraving_MeasureTests, insertBfClefChange)
     // 4th measure
     Measure* m = score->firstMeasure()->nextMeasure();
     m = m->nextMeasure()->nextMeasure();
-    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving measure tests"));
     score->insertMeasure(m);
     score->endCmd();
 
@@ -117,7 +117,7 @@ TEST_F(Engraving_MeasureTests, insertBfClefChange)
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"measure-insert_bf_clef_undo.mscx", MEASURE_DATA_DIR + u"measure-insert_bf_clef.mscx"));
 
     m = score->firstMeasure()->nextMeasure()->nextMeasure()->nextMeasure()->nextMeasure()->nextMeasure();
-    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving measure tests"));
     score->insertMeasure(m);
     score->endCmd();
 
@@ -138,7 +138,7 @@ TEST_F(Engraving_MeasureTests, insertBfKeyChange)
     // 4th measure
     Measure* m = score->firstMeasure()->nextMeasure();
     m = m->nextMeasure()->nextMeasure();
-    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving measure tests"));
     score->insertMeasure(m);
     score->endCmd();
 
@@ -152,7 +152,7 @@ TEST_F(Engraving_MeasureTests, insertBfKeyChange)
                                             MEASURE_DATA_DIR + u"measure-insert_bf_key_undo-ref.mscx"));
 
     m = score->firstMeasure()->nextMeasure()->nextMeasure()->nextMeasure()->nextMeasure()->nextMeasure();
-    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving measure tests"));
     score->insertMeasure(m);
     score->endCmd();
     EXPECT_TRUE(score->checkKeys());
@@ -181,7 +181,7 @@ TEST_F(Engraving_MeasureTests, spanner_a)
     EXPECT_TRUE(score);
 
     Measure* m = score->firstMeasure()->nextMeasure();
-    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving measure tests"));
     score->insertMeasure(m);
     score->endCmd();
 
@@ -203,7 +203,7 @@ TEST_F(Engraving_MeasureTests, spanner_b)
     EXPECT_TRUE(score);
 
     Measure* m = score->firstMeasure();
-    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving measure tests"));
     score->insertMeasure(m);
     score->endCmd();
 
@@ -224,7 +224,7 @@ TEST_F(Engraving_MeasureTests, spanner_A)
     EXPECT_TRUE(score);
 
     score->select(score->firstMeasure());
-    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving measure tests"));
     score->cmdTimeDelete();
     score->endCmd();
     score->doLayout();
@@ -248,7 +248,7 @@ TEST_F(Engraving_MeasureTests, spanner_B)
 
     Measure* m = score->firstMeasure()->nextMeasure();
     score->select(m);
-    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving measure tests"));
     score->cmdTimeDelete();
     score->endCmd();
 
@@ -271,7 +271,7 @@ TEST_F(Engraving_MeasureTests, spanner_C)
 
     Measure* m = score->firstMeasure()->nextMeasure();
     score->select(m);
-    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving measure tests"));
     score->cmdTimeDelete();
     score->endCmd();
 
@@ -294,7 +294,7 @@ TEST_F(Engraving_MeasureTests, spanner_D)
 
     Measure* m = score->firstMeasure()->nextMeasure();
     score->select(m);
-    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving measure tests"));
     score->cmdTimeDelete();
     score->endCmd();
 
@@ -313,7 +313,7 @@ TEST_F(Engraving_MeasureTests, deleteLast)
 
     Measure* m = score->lastMeasure();
     score->select(m);
-    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving measure tests"));
     score->cmdTimeDelete();
     score->endCmd();
 
@@ -333,7 +333,7 @@ TEST_F(Engraving_MeasureTests, gap)
     EngravingItem* tst = 0;
 
     //Select and delete third quarter rest in first Measure (voice 2)
-    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving measure tests"));
     Measure* m  = score->firstMeasure();
     Segment* s  = m->undoGetSegment(SegmentType::ChordRest, Fraction::fromTicks(960));
     EngravingItem* el = s->element(1);
@@ -349,7 +349,7 @@ TEST_F(Engraving_MeasureTests, gap)
     /*&& toRest(tst)->durationType() == DurationType::V_QUARTER*/
 
     //Select and delete second quarter rest in third Measure (voice 4)
-    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving measure tests"));
     m  = m->nextMeasure()->nextMeasure();
     s  = m->undoGetSegment(SegmentType::ChordRest, Fraction::fromTicks(4320));
     el = s->element(3);
@@ -365,7 +365,7 @@ TEST_F(Engraving_MeasureTests, gap)
     /*&& toRest(tst)->durationType() == DurationType::V_QUARTER*/
 
     //Select and delete first quarter rest in third Measure (voice 4)
-    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving measure tests"));
     s  = m->undoGetSegment(SegmentType::ChordRest, Fraction::fromTicks(3840));
     el = s->element(3);
     score->select(el);
@@ -450,14 +450,14 @@ TEST_F(Engraving_MeasureTests, undoDelInitialVBox_269919)
     EXPECT_TRUE(score);
 
     // 1. delete initial VBox
-    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving measure tests"));
     MeasureBase* initialVBox = score->measure(0);
     score->select(initialVBox);
     score->cmdDeleteSelection();
     score->endCmd();
 
     // 2. change duration of first chordrest
-    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving measure tests"));
     Measure* m = score->firstMeasure();
     ChordRest* cr = m->findChordRest(Fraction(0, 1), 0);
     Fraction quarter(4, 1);
@@ -485,7 +485,7 @@ TEST_F(Engraving_MeasureTests, mmrest)
     MasterScore* score = ScoreRW::readScore(MEASURE_DATA_DIR + u"mmrest.mscx");
     EXPECT_TRUE(score);
 
-    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving measure tests"));
     score->undoChangeStyleVal(Sid::createMultiMeasureRests, true);
     score->setLayoutAll();
     score->endCmd();
@@ -514,14 +514,14 @@ TEST_F(Engraving_MeasureTests, measureNumbers)
     delete mn;
 
     // Place measure numbers below
-    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving measure tests"));
     score->undoChangeStyleVal(Sid::measureNumberVPlacement, PlacementV::BELOW);
     score->setLayoutAll();
     score->endCmd();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"measurenumber-1.mscx", MEASURE_DATA_DIR + u"measurenumber-1-ref.mscx"));
 
     // center measure numbers
-    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving measure tests"));
     score->undoChangeStyleVal(Sid::measureNumberHPlacement, PlacementH::CENTER);
     score->setLayoutAll();
     score->endCmd();
@@ -534,7 +534,7 @@ TEST_F(Engraving_MeasureTests, measureNumbers)
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"measurenumber-3.mscx", MEASURE_DATA_DIR + u"measurenumber-3-ref.mscx"));
 
     // every 5 measures (default interval)
-    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving measure tests"));
     // to know whether measure numbers are shown at regular intervals or on every system,
     // musescore simply checks if measure numbers are shown at system or not.
     score->undoChangeStyleVal(Sid::measureNumberSystem, false);
@@ -545,21 +545,21 @@ TEST_F(Engraving_MeasureTests, measureNumbers)
     // do not show first measure number. This should shift all measure numbers,
     // because they are still placed at regular intervals.
     // Instead of being at 1-6-11-16-21, etc. They should be at 5-10-15-20-25, etc.
-    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving measure tests"));
     score->undoChangeStyleVal(Sid::showMeasureNumberOne, false);
     score->setLayoutAll();
     score->endCmd();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"measurenumber-5.mscx", MEASURE_DATA_DIR + u"measurenumber-5-ref.mscx"));
 
     // show at every measure (except fist)
-    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving measure tests"));
     score->undoChangeStyleVal(Sid::measureNumberInterval, 1);
     score->setLayoutAll();
     score->endCmd();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"measurenumber-6.mscx", MEASURE_DATA_DIR + u"measurenumber-6-ref.mscx"));
 
     // Disable measure numbers
-    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving measure tests"));
     // to know whether measure numbers are shown at regular intervals or on every system,
     // musescore simply checks if measure numbers are shown at system or not.
     score->undoChangeStyleVal(Sid::showMeasureNumber, false);
@@ -576,7 +576,7 @@ TEST_F(Engraving_MeasureTests, changeMeasureLen) {
 
     Measure* m = score->firstMeasure()->nextMeasure();
 
-    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving measure tests"));
 
     m->adjustToLen(Fraction(2, 4));
 
@@ -592,7 +592,7 @@ TEST_F(Engraving_MeasureTests, measureSplit) {
     EXPECT_TRUE(score);
 
     TestUtils::createParts(score, 2);
-    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving measure tests"));
 
     Measure* m = score->firstMeasure()->nextMeasure();
     EXPECT_TRUE(m);

--- a/src/engraving/tests/measure_tests.cpp
+++ b/src/engraving/tests/measure_tests.cpp
@@ -49,7 +49,7 @@ TEST_F(Engraving_MeasureTests, DISABLED_insertMeasureMiddle) //TODO: verify prog
     MasterScore* score = ScoreRW::readScore(MEASURE_DATA_DIR + u"measure-1.mscx");
     EXPECT_TRUE(score);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
     Measure* m = score->firstMeasure()->nextMeasure();
     score->insertMeasure(m);
     score->endCmd();
@@ -63,7 +63,7 @@ TEST_F(Engraving_MeasureTests, DISABLED_insertMeasureBegin) // TODO: verify prog
     MasterScore* score = ScoreRW::readScore(MEASURE_DATA_DIR + u"measure-1.mscx");
     EXPECT_TRUE(score);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
     Measure* m = score->firstMeasure();
     score->insertMeasure(m);
     score->endCmd();
@@ -77,7 +77,7 @@ TEST_F(Engraving_MeasureTests, DISABLED_insertMeasureEnd) // TODO: verify progra
     MasterScore* score = ScoreRW::readScore(MEASURE_DATA_DIR + "measure-1.mscx");
     EXPECT_TRUE(score);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
     score->insertMeasure(0);
     score->endCmd();
 
@@ -90,7 +90,7 @@ TEST_F(Engraving_MeasureTests, insertAtBeginning)
     MasterScore* score = ScoreRW::readScore(MEASURE_DATA_DIR + u"measure-insert_beginning.mscx");
     EXPECT_TRUE(score);
     Measure* m = score->firstMeasure();
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
     score->insertMeasure(m);
     score->endCmd();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"measure-insert_beginning.mscx",
@@ -106,7 +106,7 @@ TEST_F(Engraving_MeasureTests, insertBfClefChange)
     // 4th measure
     Measure* m = score->firstMeasure()->nextMeasure();
     m = m->nextMeasure()->nextMeasure();
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
     score->insertMeasure(m);
     score->endCmd();
 
@@ -117,7 +117,7 @@ TEST_F(Engraving_MeasureTests, insertBfClefChange)
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"measure-insert_bf_clef_undo.mscx", MEASURE_DATA_DIR + u"measure-insert_bf_clef.mscx"));
 
     m = score->firstMeasure()->nextMeasure()->nextMeasure()->nextMeasure()->nextMeasure()->nextMeasure();
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
     score->insertMeasure(m);
     score->endCmd();
 
@@ -138,7 +138,7 @@ TEST_F(Engraving_MeasureTests, insertBfKeyChange)
     // 4th measure
     Measure* m = score->firstMeasure()->nextMeasure();
     m = m->nextMeasure()->nextMeasure();
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
     score->insertMeasure(m);
     score->endCmd();
 
@@ -152,7 +152,7 @@ TEST_F(Engraving_MeasureTests, insertBfKeyChange)
                                             MEASURE_DATA_DIR + u"measure-insert_bf_key_undo-ref.mscx"));
 
     m = score->firstMeasure()->nextMeasure()->nextMeasure()->nextMeasure()->nextMeasure()->nextMeasure();
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
     score->insertMeasure(m);
     score->endCmd();
     EXPECT_TRUE(score->checkKeys());
@@ -181,7 +181,7 @@ TEST_F(Engraving_MeasureTests, spanner_a)
     EXPECT_TRUE(score);
 
     Measure* m = score->firstMeasure()->nextMeasure();
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
     score->insertMeasure(m);
     score->endCmd();
 
@@ -203,7 +203,7 @@ TEST_F(Engraving_MeasureTests, spanner_b)
     EXPECT_TRUE(score);
 
     Measure* m = score->firstMeasure();
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
     score->insertMeasure(m);
     score->endCmd();
 
@@ -224,7 +224,7 @@ TEST_F(Engraving_MeasureTests, spanner_A)
     EXPECT_TRUE(score);
 
     score->select(score->firstMeasure());
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
     score->cmdTimeDelete();
     score->endCmd();
     score->doLayout();
@@ -248,7 +248,7 @@ TEST_F(Engraving_MeasureTests, spanner_B)
 
     Measure* m = score->firstMeasure()->nextMeasure();
     score->select(m);
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
     score->cmdTimeDelete();
     score->endCmd();
 
@@ -271,7 +271,7 @@ TEST_F(Engraving_MeasureTests, spanner_C)
 
     Measure* m = score->firstMeasure()->nextMeasure();
     score->select(m);
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
     score->cmdTimeDelete();
     score->endCmd();
 
@@ -294,7 +294,7 @@ TEST_F(Engraving_MeasureTests, spanner_D)
 
     Measure* m = score->firstMeasure()->nextMeasure();
     score->select(m);
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
     score->cmdTimeDelete();
     score->endCmd();
 
@@ -313,7 +313,7 @@ TEST_F(Engraving_MeasureTests, deleteLast)
 
     Measure* m = score->lastMeasure();
     score->select(m);
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
     score->cmdTimeDelete();
     score->endCmd();
 
@@ -333,7 +333,7 @@ TEST_F(Engraving_MeasureTests, gap)
     EngravingItem* tst = 0;
 
     //Select and delete third quarter rest in first Measure (voice 2)
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
     Measure* m  = score->firstMeasure();
     Segment* s  = m->undoGetSegment(SegmentType::ChordRest, Fraction::fromTicks(960));
     EngravingItem* el = s->element(1);
@@ -349,7 +349,7 @@ TEST_F(Engraving_MeasureTests, gap)
     /*&& toRest(tst)->durationType() == DurationType::V_QUARTER*/
 
     //Select and delete second quarter rest in third Measure (voice 4)
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
     m  = m->nextMeasure()->nextMeasure();
     s  = m->undoGetSegment(SegmentType::ChordRest, Fraction::fromTicks(4320));
     el = s->element(3);
@@ -365,7 +365,7 @@ TEST_F(Engraving_MeasureTests, gap)
     /*&& toRest(tst)->durationType() == DurationType::V_QUARTER*/
 
     //Select and delete first quarter rest in third Measure (voice 4)
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
     s  = m->undoGetSegment(SegmentType::ChordRest, Fraction::fromTicks(3840));
     el = s->element(3);
     score->select(el);
@@ -450,14 +450,14 @@ TEST_F(Engraving_MeasureTests, undoDelInitialVBox_269919)
     EXPECT_TRUE(score);
 
     // 1. delete initial VBox
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
     MeasureBase* initialVBox = score->measure(0);
     score->select(initialVBox);
     score->cmdDeleteSelection();
     score->endCmd();
 
     // 2. change duration of first chordrest
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
     Measure* m = score->firstMeasure();
     ChordRest* cr = m->findChordRest(Fraction(0, 1), 0);
     Fraction quarter(4, 1);
@@ -485,7 +485,7 @@ TEST_F(Engraving_MeasureTests, mmrest)
     MasterScore* score = ScoreRW::readScore(MEASURE_DATA_DIR + u"mmrest.mscx");
     EXPECT_TRUE(score);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
     score->undoChangeStyleVal(Sid::createMultiMeasureRests, true);
     score->setLayoutAll();
     score->endCmd();
@@ -514,14 +514,14 @@ TEST_F(Engraving_MeasureTests, measureNumbers)
     delete mn;
 
     // Place measure numbers below
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
     score->undoChangeStyleVal(Sid::measureNumberVPlacement, PlacementV::BELOW);
     score->setLayoutAll();
     score->endCmd();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"measurenumber-1.mscx", MEASURE_DATA_DIR + u"measurenumber-1-ref.mscx"));
 
     // center measure numbers
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
     score->undoChangeStyleVal(Sid::measureNumberHPlacement, PlacementH::CENTER);
     score->setLayoutAll();
     score->endCmd();
@@ -534,7 +534,7 @@ TEST_F(Engraving_MeasureTests, measureNumbers)
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"measurenumber-3.mscx", MEASURE_DATA_DIR + u"measurenumber-3-ref.mscx"));
 
     // every 5 measures (default interval)
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
     // to know whether measure numbers are shown at regular intervals or on every system,
     // musescore simply checks if measure numbers are shown at system or not.
     score->undoChangeStyleVal(Sid::measureNumberSystem, false);
@@ -545,21 +545,21 @@ TEST_F(Engraving_MeasureTests, measureNumbers)
     // do not show first measure number. This should shift all measure numbers,
     // because they are still placed at regular intervals.
     // Instead of being at 1-6-11-16-21, etc. They should be at 5-10-15-20-25, etc.
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
     score->undoChangeStyleVal(Sid::showMeasureNumberOne, false);
     score->setLayoutAll();
     score->endCmd();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"measurenumber-5.mscx", MEASURE_DATA_DIR + u"measurenumber-5-ref.mscx"));
 
     // show at every measure (except fist)
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
     score->undoChangeStyleVal(Sid::measureNumberInterval, 1);
     score->setLayoutAll();
     score->endCmd();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"measurenumber-6.mscx", MEASURE_DATA_DIR + u"measurenumber-6-ref.mscx"));
 
     // Disable measure numbers
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
     // to know whether measure numbers are shown at regular intervals or on every system,
     // musescore simply checks if measure numbers are shown at system or not.
     score->undoChangeStyleVal(Sid::showMeasureNumber, false);
@@ -576,7 +576,7 @@ TEST_F(Engraving_MeasureTests, changeMeasureLen) {
 
     Measure* m = score->firstMeasure()->nextMeasure();
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
 
     m->adjustToLen(Fraction(2, 4));
 
@@ -592,7 +592,7 @@ TEST_F(Engraving_MeasureTests, measureSplit) {
     EXPECT_TRUE(score);
 
     TestUtils::createParts(score, 2);
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving measure tests"));
 
     Measure* m = score->firstMeasure()->nextMeasure();
     EXPECT_TRUE(m);

--- a/src/engraving/tests/note_tests.cpp
+++ b/src/engraving/tests/note_tests.cpp
@@ -312,7 +312,7 @@ TEST_F(Engraving_NoteTests, grace)
 //      delete n;
 
     // tremolo
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving note tests"));
     TremoloSingleChord* tr = Factory::createTremoloSingleChord(gc);
     tr->setTremoloType(TremoloType::R16);
     tr->setParent(gc);
@@ -324,7 +324,7 @@ TEST_F(Engraving_NoteTests, grace)
 //      delete c;
 
     // articulation
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving note tests"));
     Articulation* ar = Factory::createArticulation(gc);
     ar->setSymId(SymId::articAccentAbove);
     ar->setParent(gc);
@@ -375,19 +375,19 @@ TEST_F(Engraving_NoteTests, tpcTranspose)
 {
     MasterScore* score = ScoreRW::readScore(NOTE_DATA_DIR + u"tpc-transpose.mscx");
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving note tests"));
     Measure* m = score->firstMeasure();
     score->select(m, SelectType::SINGLE, 0);
     score->changeAccidental(AccidentalType::FLAT);
     score->endCmd();
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving note tests"));
     m = m->nextMeasure();
     score->select(m, SelectType::SINGLE, 0);
     score->upDown(false, UpDownMode::CHROMATIC);
     score->endCmd();
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving note tests"));
     score->cmdConcertPitchChanged(true);
     score->endCmd();
 
@@ -410,7 +410,7 @@ TEST_F(Engraving_NoteTests, tpcTranspose2)
     int octave = 5 * 7;
     score->cmdAddPitch(octave + 3, false, false);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving note tests"));
     score->cmdConcertPitchChanged(true);
     score->endCmd();
 
@@ -447,7 +447,7 @@ TEST_F(Engraving_NoteTests, noteLimits)
     score->cmdAddPitch(42, false, false);
     for (int i = 0; i < 20; i++) {
         std::vector<Note*> nl = score->selection().noteList();
-        score->startCmd();
+        score->startCmd(TranslatableString("undoableAction", "Engraving note tests"));
         score->addInterval(-8, nl);
         score->endCmd();
     }
@@ -456,7 +456,7 @@ TEST_F(Engraving_NoteTests, noteLimits)
     score->cmdAddPitch(42, false, false);
     for (int i = 0; i < 20; i++) {
         std::vector<Note*> nl = score->selection().noteList();
-        score->startCmd();
+        score->startCmd(TranslatableString("undoableAction", "Engraving note tests"));
         score->addInterval(8, nl);
         score->endCmd();
     }

--- a/src/engraving/tests/note_tests.cpp
+++ b/src/engraving/tests/note_tests.cpp
@@ -312,7 +312,7 @@ TEST_F(Engraving_NoteTests, grace)
 //      delete n;
 
     // tremolo
-    score->startCmd(TranslatableString("undoableAction", "Engraving note tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving note tests"));
     TremoloSingleChord* tr = Factory::createTremoloSingleChord(gc);
     tr->setTremoloType(TremoloType::R16);
     tr->setParent(gc);
@@ -324,7 +324,7 @@ TEST_F(Engraving_NoteTests, grace)
 //      delete c;
 
     // articulation
-    score->startCmd(TranslatableString("undoableAction", "Engraving note tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving note tests"));
     Articulation* ar = Factory::createArticulation(gc);
     ar->setSymId(SymId::articAccentAbove);
     ar->setParent(gc);
@@ -375,19 +375,19 @@ TEST_F(Engraving_NoteTests, tpcTranspose)
 {
     MasterScore* score = ScoreRW::readScore(NOTE_DATA_DIR + u"tpc-transpose.mscx");
 
-    score->startCmd(TranslatableString("undoableAction", "Engraving note tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving note tests"));
     Measure* m = score->firstMeasure();
     score->select(m, SelectType::SINGLE, 0);
     score->changeAccidental(AccidentalType::FLAT);
     score->endCmd();
 
-    score->startCmd(TranslatableString("undoableAction", "Engraving note tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving note tests"));
     m = m->nextMeasure();
     score->select(m, SelectType::SINGLE, 0);
     score->upDown(false, UpDownMode::CHROMATIC);
     score->endCmd();
 
-    score->startCmd(TranslatableString("undoableAction", "Engraving note tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving note tests"));
     score->cmdConcertPitchChanged(true);
     score->endCmd();
 
@@ -410,7 +410,7 @@ TEST_F(Engraving_NoteTests, tpcTranspose2)
     int octave = 5 * 7;
     score->cmdAddPitch(octave + 3, false, false);
 
-    score->startCmd(TranslatableString("undoableAction", "Engraving note tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving note tests"));
     score->cmdConcertPitchChanged(true);
     score->endCmd();
 
@@ -447,7 +447,7 @@ TEST_F(Engraving_NoteTests, noteLimits)
     score->cmdAddPitch(42, false, false);
     for (int i = 0; i < 20; i++) {
         std::vector<Note*> nl = score->selection().noteList();
-        score->startCmd(TranslatableString("undoableAction", "Engraving note tests"));
+        score->startCmd(TranslatableString::untranslatable("Engraving note tests"));
         score->addInterval(-8, nl);
         score->endCmd();
     }
@@ -456,7 +456,7 @@ TEST_F(Engraving_NoteTests, noteLimits)
     score->cmdAddPitch(42, false, false);
     for (int i = 0; i < 20; i++) {
         std::vector<Note*> nl = score->selection().noteList();
-        score->startCmd(TranslatableString("undoableAction", "Engraving note tests"));
+        score->startCmd(TranslatableString::untranslatable("Engraving note tests"));
         score->addInterval(8, nl);
         score->endCmd();
     }

--- a/src/engraving/tests/parts_tests.cpp
+++ b/src/engraving/tests/parts_tests.cpp
@@ -71,7 +71,7 @@ public:
 
 void Engraving_PartsTests::createLinkedStaff(MasterScore* masterScore)
 {
-    masterScore->startCmd();
+    masterScore->startCmd(TranslatableString("undoableAction", "Engraving parts tests"));
     Staff* sourceStaff = masterScore->staff(0);
     EXPECT_TRUE(sourceStaff);
     Staff* linkedStaff = Factory::createStaff(sourceStaff->part());
@@ -189,7 +189,7 @@ TEST_F(Engraving_PartsTests, appendMeasure)
 
     TestUtils::createParts(score, 2);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving parts tests"));
     score->insertMeasure(0);
     score->endCmd();
 
@@ -212,7 +212,7 @@ TEST_F(Engraving_PartsTests, insertMeasure)
 
     TestUtils::createParts(score, 2);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving parts tests"));
     Measure* m = score->firstMeasure();
     score->insertMeasure(m);
     score->endCmd();
@@ -340,7 +340,7 @@ MasterScore* Engraving_PartsTests::doAddBreath()
     b->setSymId(SymId::breathMarkComma);
     dd.dropElement = b;
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving parts tests"));
     note->drop(dd);
     score->endCmd();          // does layout
 
@@ -401,7 +401,7 @@ MasterScore* Engraving_PartsTests::doRemoveBreath()
     Breath* b    = toBreath(s->element(0));
 
     score->select(b);
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving parts tests"));
     score->cmdDeleteSelection();
     score->setLayoutAll();
     score->endCmd();
@@ -472,7 +472,7 @@ MasterScore* Engraving_PartsTests::doAddFingering()
     b->setXmlText("3");
     dd.dropElement = b;
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving parts tests"));
     note->drop(dd);
     score->endCmd();          // does layout
     return score;
@@ -536,7 +536,7 @@ MasterScore* Engraving_PartsTests::doRemoveFingering()
     }
     score->select(fingering);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving parts tests"));
     score->cmdDeleteSelection();
     score->setLayoutAll();
     score->endCmd();
@@ -606,7 +606,7 @@ MasterScore* Engraving_PartsTests::doAddSymbol()
     b->setSym(SymId::gClef);
     dd.dropElement = b;
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving parts tests"));
     note->drop(dd);
     score->endCmd();          // does layout
     return score;
@@ -670,7 +670,7 @@ MasterScore* Engraving_PartsTests::doRemoveSymbol()
     }
     score->select(se);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving parts tests"));
     score->cmdDeleteSelection();
     score->setLayoutAll();
     score->endCmd();
@@ -740,7 +740,7 @@ MasterScore* Engraving_PartsTests::doAddChordline()
     b->setChordLineType(ChordLineType::FALL);
     dd.dropElement = b;
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving parts tests"));
     note->drop(dd);
     score->endCmd();          // does layout
     return score;
@@ -804,7 +804,7 @@ MasterScore* Engraving_PartsTests::doRemoveChordline()
     }
     score->select(se);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving parts tests"));
     score->cmdDeleteSelection();
     score->setLayoutAll();
     score->endCmd();
@@ -867,7 +867,7 @@ MasterScore* Engraving_PartsTests::doAddMeasureRepeat()
 
     Measure* m = score->firstMeasure()->nextMeasure();
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving parts tests"));
     score->cmdAddMeasureRepeat(m, 4, 0); // test with 4-measure repeat in first staff
     score->setLayoutAll();
     score->endCmd();
@@ -928,7 +928,7 @@ MasterScore* Engraving_PartsTests::doRemoveMeasureRepeat()
     MeasureRepeat* mr = m->measureRepeatElement(0);
     score->select(mr);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving parts tests"));
     score->cmdDeleteSelection();
     score->setLayoutAll();
     score->endCmd();
@@ -999,7 +999,7 @@ MasterScore* Engraving_PartsTests::doAddImage()
     b->load(PARTS_DATA_DIR + u"schnee.png");
     dd.dropElement = b;
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving parts tests"));
     note->drop(dd);
     score->endCmd();          // does layout
     return score;
@@ -1063,7 +1063,7 @@ MasterScore* Engraving_PartsTests::doRemoveImage()
     }
     score->select(fingering);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving parts tests"));
     score->cmdDeleteSelection();
     score->setLayoutAll();
     score->endCmd();
@@ -1251,7 +1251,7 @@ TEST_F(Engraving_PartsTests, partVisibleTracks) {
     Note* n = c->downNote();
     EXPECT_TRUE(n);
 
-    part->startCmd();
+    part->startCmd(TranslatableString("undoableAction", "Engraving parts tests"));
     part->select(n);
     part->changeSelectedElementsVoice(1);
     part->endCmd();

--- a/src/engraving/tests/parts_tests.cpp
+++ b/src/engraving/tests/parts_tests.cpp
@@ -71,7 +71,7 @@ public:
 
 void Engraving_PartsTests::createLinkedStaff(MasterScore* masterScore)
 {
-    masterScore->startCmd(TranslatableString("undoableAction", "Engraving parts tests"));
+    masterScore->startCmd(TranslatableString::untranslatable("Engraving parts tests"));
     Staff* sourceStaff = masterScore->staff(0);
     EXPECT_TRUE(sourceStaff);
     Staff* linkedStaff = Factory::createStaff(sourceStaff->part());
@@ -189,7 +189,7 @@ TEST_F(Engraving_PartsTests, appendMeasure)
 
     TestUtils::createParts(score, 2);
 
-    score->startCmd(TranslatableString("undoableAction", "Engraving parts tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving parts tests"));
     score->insertMeasure(0);
     score->endCmd();
 
@@ -212,7 +212,7 @@ TEST_F(Engraving_PartsTests, insertMeasure)
 
     TestUtils::createParts(score, 2);
 
-    score->startCmd(TranslatableString("undoableAction", "Engraving parts tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving parts tests"));
     Measure* m = score->firstMeasure();
     score->insertMeasure(m);
     score->endCmd();
@@ -340,7 +340,7 @@ MasterScore* Engraving_PartsTests::doAddBreath()
     b->setSymId(SymId::breathMarkComma);
     dd.dropElement = b;
 
-    score->startCmd(TranslatableString("undoableAction", "Engraving parts tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving parts tests"));
     note->drop(dd);
     score->endCmd();          // does layout
 
@@ -401,7 +401,7 @@ MasterScore* Engraving_PartsTests::doRemoveBreath()
     Breath* b    = toBreath(s->element(0));
 
     score->select(b);
-    score->startCmd(TranslatableString("undoableAction", "Engraving parts tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving parts tests"));
     score->cmdDeleteSelection();
     score->setLayoutAll();
     score->endCmd();
@@ -472,7 +472,7 @@ MasterScore* Engraving_PartsTests::doAddFingering()
     b->setXmlText("3");
     dd.dropElement = b;
 
-    score->startCmd(TranslatableString("undoableAction", "Engraving parts tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving parts tests"));
     note->drop(dd);
     score->endCmd();          // does layout
     return score;
@@ -536,7 +536,7 @@ MasterScore* Engraving_PartsTests::doRemoveFingering()
     }
     score->select(fingering);
 
-    score->startCmd(TranslatableString("undoableAction", "Engraving parts tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving parts tests"));
     score->cmdDeleteSelection();
     score->setLayoutAll();
     score->endCmd();
@@ -606,7 +606,7 @@ MasterScore* Engraving_PartsTests::doAddSymbol()
     b->setSym(SymId::gClef);
     dd.dropElement = b;
 
-    score->startCmd(TranslatableString("undoableAction", "Engraving parts tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving parts tests"));
     note->drop(dd);
     score->endCmd();          // does layout
     return score;
@@ -670,7 +670,7 @@ MasterScore* Engraving_PartsTests::doRemoveSymbol()
     }
     score->select(se);
 
-    score->startCmd(TranslatableString("undoableAction", "Engraving parts tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving parts tests"));
     score->cmdDeleteSelection();
     score->setLayoutAll();
     score->endCmd();
@@ -740,7 +740,7 @@ MasterScore* Engraving_PartsTests::doAddChordline()
     b->setChordLineType(ChordLineType::FALL);
     dd.dropElement = b;
 
-    score->startCmd(TranslatableString("undoableAction", "Engraving parts tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving parts tests"));
     note->drop(dd);
     score->endCmd();          // does layout
     return score;
@@ -804,7 +804,7 @@ MasterScore* Engraving_PartsTests::doRemoveChordline()
     }
     score->select(se);
 
-    score->startCmd(TranslatableString("undoableAction", "Engraving parts tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving parts tests"));
     score->cmdDeleteSelection();
     score->setLayoutAll();
     score->endCmd();
@@ -867,7 +867,7 @@ MasterScore* Engraving_PartsTests::doAddMeasureRepeat()
 
     Measure* m = score->firstMeasure()->nextMeasure();
 
-    score->startCmd(TranslatableString("undoableAction", "Engraving parts tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving parts tests"));
     score->cmdAddMeasureRepeat(m, 4, 0); // test with 4-measure repeat in first staff
     score->setLayoutAll();
     score->endCmd();
@@ -928,7 +928,7 @@ MasterScore* Engraving_PartsTests::doRemoveMeasureRepeat()
     MeasureRepeat* mr = m->measureRepeatElement(0);
     score->select(mr);
 
-    score->startCmd(TranslatableString("undoableAction", "Engraving parts tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving parts tests"));
     score->cmdDeleteSelection();
     score->setLayoutAll();
     score->endCmd();
@@ -999,7 +999,7 @@ MasterScore* Engraving_PartsTests::doAddImage()
     b->load(PARTS_DATA_DIR + u"schnee.png");
     dd.dropElement = b;
 
-    score->startCmd(TranslatableString("undoableAction", "Engraving parts tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving parts tests"));
     note->drop(dd);
     score->endCmd();          // does layout
     return score;
@@ -1063,7 +1063,7 @@ MasterScore* Engraving_PartsTests::doRemoveImage()
     }
     score->select(fingering);
 
-    score->startCmd(TranslatableString("undoableAction", "Engraving parts tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving parts tests"));
     score->cmdDeleteSelection();
     score->setLayoutAll();
     score->endCmd();
@@ -1251,7 +1251,7 @@ TEST_F(Engraving_PartsTests, partVisibleTracks) {
     Note* n = c->downNote();
     EXPECT_TRUE(n);
 
-    part->startCmd(TranslatableString("undoableAction", "Engraving parts tests"));
+    part->startCmd(TranslatableString::untranslatable("Engraving parts tests"));
     part->select(n);
     part->changeSelectedElementsVoice(1);
     part->endCmd();

--- a/src/engraving/tests/readwriteundoreset_tests.cpp
+++ b/src/engraving/tests/readwriteundoreset_tests.cpp
@@ -83,7 +83,7 @@ TEST_F(Engraving_ReadWriteUndoResetTests, testMMRestLinksRecreateMMRest)
 
     // Regenerate MM rests from scratch:
     // 1) turn MM rests off
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Read/write/undo/reset tests"));
     score->undoChangeStyleVal(Sid::createMultiMeasureRests, false);
     score->endCmd();
 
@@ -93,7 +93,7 @@ TEST_F(Engraving_ReadWriteUndoResetTests, testMMRestLinksRecreateMMRest)
     score = ScoreRW::readScore(writeFile, true);
 
     // 3) turn MM rests back on
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Read/write/undo/reset tests"));
     score->undoChangeStyleVal(Sid::createMultiMeasureRests, true);
     score->endCmd();
 

--- a/src/engraving/tests/readwriteundoreset_tests.cpp
+++ b/src/engraving/tests/readwriteundoreset_tests.cpp
@@ -83,7 +83,7 @@ TEST_F(Engraving_ReadWriteUndoResetTests, testMMRestLinksRecreateMMRest)
 
     // Regenerate MM rests from scratch:
     // 1) turn MM rests off
-    score->startCmd(TranslatableString("undoableAction", "Read/write/undo/reset tests"));
+    score->startCmd(TranslatableString::untranslatable("Read/write/undo/reset tests"));
     score->undoChangeStyleVal(Sid::createMultiMeasureRests, false);
     score->endCmd();
 
@@ -93,7 +93,7 @@ TEST_F(Engraving_ReadWriteUndoResetTests, testMMRestLinksRecreateMMRest)
     score = ScoreRW::readScore(writeFile, true);
 
     // 3) turn MM rests back on
-    score->startCmd(TranslatableString("undoableAction", "Read/write/undo/reset tests"));
+    score->startCmd(TranslatableString::untranslatable("Read/write/undo/reset tests"));
     score->undoChangeStyleVal(Sid::createMultiMeasureRests, true);
     score->endCmd();
 

--- a/src/engraving/tests/remove_tests.cpp
+++ b/src/engraving/tests/remove_tests.cpp
@@ -94,7 +94,7 @@ TEST_F(Engraving_RemoveTests, removeStaff)
     EXPECT_TRUE(score);
 
     // Remove the second staff and see what happens
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving remove tests"));
     score->cmdRemoveStaff(1);
     score->endCmd(false, /*layoutAllParts = */ true);
 

--- a/src/engraving/tests/remove_tests.cpp
+++ b/src/engraving/tests/remove_tests.cpp
@@ -94,7 +94,7 @@ TEST_F(Engraving_RemoveTests, removeStaff)
     EXPECT_TRUE(score);
 
     // Remove the second staff and see what happens
-    score->startCmd(TranslatableString("undoableAction", "Engraving remove tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving remove tests"));
     score->cmdRemoveStaff(1);
     score->endCmd(false, /*layoutAllParts = */ true);
 

--- a/src/engraving/tests/rhythmicgrouping_tests.cpp
+++ b/src/engraving/tests/rhythmicgrouping_tests.cpp
@@ -49,7 +49,7 @@ void Engraving_RhythmicGroupingTests::group(const char* p1, const char* p2, size
         score->cmdResetNoteAndRestGroupings();
     } else {
         assert(staves < score->nstaves());
-        score->startCmd();
+        score->startCmd(TranslatableString("undoableAction", "Rhythmic grouping tests"));
         for (size_t track = 0; track < staves * VOICES; track++) {
             score->regroupNotesAndRests(score->firstSegment(SegmentType::All)->tick(),
                                         score->lastSegment()->tick(), static_cast<int>(track));

--- a/src/engraving/tests/rhythmicgrouping_tests.cpp
+++ b/src/engraving/tests/rhythmicgrouping_tests.cpp
@@ -44,21 +44,23 @@ void Engraving_RhythmicGroupingTests::group(const char* p1, const char* p2, size
     MasterScore* score = ScoreRW::readScore(RHYTHMICGRP_DATA_DIR + String::fromUtf8(p1));
     EXPECT_TRUE(score);
 
+    score->startCmd(TranslatableString("undoableAction", "Regroup notes and rests"));
     if (!staves) {
         score->cmdSelectAll();
         score->cmdResetNoteAndRestGroupings();
     } else {
         assert(staves < score->nstaves());
-        score->startCmd(TranslatableString("undoableAction", "Rhythmic grouping tests"));
         for (size_t track = 0; track < staves * VOICES; track++) {
             score->regroupNotesAndRests(score->firstSegment(SegmentType::All)->tick(),
                                         score->lastSegment()->tick(), static_cast<int>(track));
         }
-        score->endCmd();
     }
 
+    score->endCmd();
     score->doLayout();
+
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, String::fromUtf8(p1), RHYTHMICGRP_DATA_DIR + String::fromUtf8(p2)));
+
     delete score;
 }
 

--- a/src/engraving/tests/rhythmicgrouping_tests.cpp
+++ b/src/engraving/tests/rhythmicgrouping_tests.cpp
@@ -44,7 +44,7 @@ void Engraving_RhythmicGroupingTests::group(const char* p1, const char* p2, size
     MasterScore* score = ScoreRW::readScore(RHYTHMICGRP_DATA_DIR + String::fromUtf8(p1));
     EXPECT_TRUE(score);
 
-    score->startCmd(TranslatableString("undoableAction", "Regroup notes and rests"));
+    score->startCmd(TranslatableString::untranslatable("Regroup notes and rests"));
     if (!staves) {
         score->cmdSelectAll();
         score->cmdResetNoteAndRestGroupings();

--- a/src/engraving/tests/selectionrangedelete_tests.cpp
+++ b/src/engraving/tests/selectionrangedelete_tests.cpp
@@ -46,7 +46,7 @@ public:
 
 void Engraving_SelectionRangeDeleteTests::verifyDelete(MasterScore* score, size_t spanners)
 {
-    score->startCmd(TranslatableString("undoableAction", "Selection range delete tests"));
+    score->startCmd(TranslatableString::untranslatable("Selection range delete tests"));
     score->cmdDeleteSelection();
     score->endCmd();
 
@@ -57,7 +57,7 @@ void Engraving_SelectionRangeDeleteTests::verifyDelete(MasterScore* score, size_
 
 void Engraving_SelectionRangeDeleteTests::verifyNoDelete(MasterScore* score, size_t spanners)
 {
-    score->startCmd(TranslatableString("undoableAction", "Selection range delete tests"));
+    score->startCmd(TranslatableString::untranslatable("Selection range delete tests"));
     score->cmdDeleteSelection();
     score->endCmd();
 
@@ -160,7 +160,7 @@ void Engraving_SelectionRangeDeleteTests::deleteVoice(int voice, String idx)
     score->selectionFilter().setFiltered(voiceFilterType, false);
     score->select(m1, SelectType::RANGE);
 
-    score->startCmd(TranslatableString("undoableAction", "Selection range delete tests"));
+    score->startCmd(TranslatableString::untranslatable("Selection range delete tests"));
     score->cmdDeleteSelection();
     score->endCmd();
 
@@ -192,7 +192,7 @@ TEST_F(Engraving_SelectionRangeDeleteTests, deleteSkipAnnotations)
     SelectionFilterType annotationFilterType = SelectionFilterType((int)SelectionFilterType::CHORD_SYMBOL);
     score->selectionFilter().setFiltered(annotationFilterType, false);
 
-    score->startCmd(TranslatableString("undoableAction", "Selection range delete tests"));
+    score->startCmd(TranslatableString::untranslatable("Selection range delete tests"));
     score->cmdSelectAll();
     score->cmdDeleteSelection();
     score->endCmd();

--- a/src/engraving/tests/selectionrangedelete_tests.cpp
+++ b/src/engraving/tests/selectionrangedelete_tests.cpp
@@ -46,7 +46,7 @@ public:
 
 void Engraving_SelectionRangeDeleteTests::verifyDelete(MasterScore* score, size_t spanners)
 {
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Selection range delete tests"));
     score->cmdDeleteSelection();
     score->endCmd();
 
@@ -57,7 +57,7 @@ void Engraving_SelectionRangeDeleteTests::verifyDelete(MasterScore* score, size_
 
 void Engraving_SelectionRangeDeleteTests::verifyNoDelete(MasterScore* score, size_t spanners)
 {
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Selection range delete tests"));
     score->cmdDeleteSelection();
     score->endCmd();
 
@@ -160,7 +160,7 @@ void Engraving_SelectionRangeDeleteTests::deleteVoice(int voice, String idx)
     score->selectionFilter().setFiltered(voiceFilterType, false);
     score->select(m1, SelectType::RANGE);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Selection range delete tests"));
     score->cmdDeleteSelection();
     score->endCmd();
 
@@ -192,7 +192,7 @@ TEST_F(Engraving_SelectionRangeDeleteTests, deleteSkipAnnotations)
     SelectionFilterType annotationFilterType = SelectionFilterType((int)SelectionFilterType::CHORD_SYMBOL);
     score->selectionFilter().setFiltered(annotationFilterType, false);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Selection range delete tests"));
     score->cmdSelectAll();
     score->cmdDeleteSelection();
     score->endCmd();

--- a/src/engraving/tests/spanners_tests.cpp
+++ b/src/engraving/tests/spanners_tests.cpp
@@ -377,7 +377,7 @@ TEST_F(Engraving_SpannersTests, spanners09)
     EXPECT_TRUE(msr);
     msr = msr->nextMeasure();
     EXPECT_TRUE(msr);
-    score->startCmd(TranslatableString("undoableAction", "Engraving spanners tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving spanners tests"));
     score->select(msr);
     score->cmdTimeDelete();
     score->endCmd();
@@ -410,7 +410,7 @@ TEST_F(Engraving_SpannersTests, spanners10)
     EXPECT_TRUE(msr);
     msr = msr->nextMeasure();
     EXPECT_TRUE(msr);
-    score->startCmd(TranslatableString("undoableAction", "Engraving spanners tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving spanners tests"));
     score->select(msr);
     score->cmdTimeDelete();
     score->endCmd();
@@ -443,7 +443,7 @@ TEST_F(Engraving_SpannersTests, spanners11)
     EXPECT_TRUE(msr);
     msr = msr->nextMeasure();
     EXPECT_TRUE(msr);
-    score->startCmd(TranslatableString("undoableAction", "Engraving spanners tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving spanners tests"));
     score->select(msr);
     score->cmdTimeDelete();
     score->endCmd();
@@ -476,7 +476,7 @@ TEST_F(Engraving_SpannersTests, spanners12)
     EXPECT_TRUE(msr);
     msr = msr->nextMeasure();
     EXPECT_TRUE(msr);
-    score->startCmd(TranslatableString("undoableAction", "Engraving spanners tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving spanners tests"));
     score->select(msr);
     score->cmdTimeDelete();
     score->endCmd();
@@ -511,7 +511,7 @@ TEST_F(Engraving_SpannersTests, DISABLED_spanners13)
     brk->setLayoutBreakType(LayoutBreakType::LINE);
     dropData.pos      = msr->pagePos();
     dropData.dropElement  = brk;
-    score->startCmd(TranslatableString("undoableAction", "Engraving spanners tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving spanners tests"));
     msr->drop(dropData);
     score->endCmd();
     // VERIFY SEGMENTS IN SYSTEMS AND THEN SCORE

--- a/src/engraving/tests/spanners_tests.cpp
+++ b/src/engraving/tests/spanners_tests.cpp
@@ -377,7 +377,7 @@ TEST_F(Engraving_SpannersTests, spanners09)
     EXPECT_TRUE(msr);
     msr = msr->nextMeasure();
     EXPECT_TRUE(msr);
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving spanners tests"));
     score->select(msr);
     score->cmdTimeDelete();
     score->endCmd();
@@ -410,7 +410,7 @@ TEST_F(Engraving_SpannersTests, spanners10)
     EXPECT_TRUE(msr);
     msr = msr->nextMeasure();
     EXPECT_TRUE(msr);
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving spanners tests"));
     score->select(msr);
     score->cmdTimeDelete();
     score->endCmd();
@@ -443,7 +443,7 @@ TEST_F(Engraving_SpannersTests, spanners11)
     EXPECT_TRUE(msr);
     msr = msr->nextMeasure();
     EXPECT_TRUE(msr);
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving spanners tests"));
     score->select(msr);
     score->cmdTimeDelete();
     score->endCmd();
@@ -476,7 +476,7 @@ TEST_F(Engraving_SpannersTests, spanners12)
     EXPECT_TRUE(msr);
     msr = msr->nextMeasure();
     EXPECT_TRUE(msr);
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving spanners tests"));
     score->select(msr);
     score->cmdTimeDelete();
     score->endCmd();
@@ -511,7 +511,7 @@ TEST_F(Engraving_SpannersTests, DISABLED_spanners13)
     brk->setLayoutBreakType(LayoutBreakType::LINE);
     dropData.pos      = msr->pagePos();
     dropData.dropElement  = brk;
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving spanners tests"));
     msr->drop(dropData);
     score->endCmd();
     // VERIFY SEGMENTS IN SYSTEMS AND THEN SCORE

--- a/src/engraving/tests/split_tests.cpp
+++ b/src/engraving/tests/split_tests.cpp
@@ -52,7 +52,7 @@ void Engraving_SplitTests::split(const char* f1, const char* ref, int index)
     }
     ChordRest* cr = toChordRest(s->element(0));
 
-    score->startCmd(TranslatableString("undoableAction", "Engraving split tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving split tests"));
     score->cmdSplitMeasure(cr);
     score->endCmd();
 

--- a/src/engraving/tests/split_tests.cpp
+++ b/src/engraving/tests/split_tests.cpp
@@ -52,7 +52,7 @@ void Engraving_SplitTests::split(const char* f1, const char* ref, int index)
     }
     ChordRest* cr = toChordRest(s->element(0));
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving split tests"));
     score->cmdSplitMeasure(cr);
     score->endCmd();
 

--- a/src/engraving/tests/splitstaff_tests.cpp
+++ b/src/engraving/tests/splitstaff_tests.cpp
@@ -43,7 +43,7 @@ void Engraving_SplitStaffTests::splitstaff(int idx, int staffIdx)
     MasterScore* score = ScoreRW::readScore(SPLITSTAFF_DATA_DIR + String(u"splitstaff0%1.mscx").arg(idx));
     EXPECT_TRUE(score);
 
-    score->startCmd(TranslatableString("undoableAction", "Engraving split staff tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving split staff tests"));
     score->splitStaff(staffIdx, 60);
     score->endCmd();
 

--- a/src/engraving/tests/splitstaff_tests.cpp
+++ b/src/engraving/tests/splitstaff_tests.cpp
@@ -43,7 +43,7 @@ void Engraving_SplitStaffTests::splitstaff(int idx, int staffIdx)
     MasterScore* score = ScoreRW::readScore(SPLITSTAFF_DATA_DIR + String(u"splitstaff0%1.mscx").arg(idx));
     EXPECT_TRUE(score);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving split staff tests"));
     score->splitStaff(staffIdx, 60);
     score->endCmd();
 

--- a/src/engraving/tests/staffmove_tests.cpp
+++ b/src/engraving/tests/staffmove_tests.cpp
@@ -59,12 +59,12 @@ TEST_F(Engraving_StaffMoveTests, hiddenStaff)
     Staff* staff = score->staff(0);
 
     // Move chord
-    score->startCmd(TranslatableString("undoableAction", "Engraving staff move tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving staff move tests"));
     score->moveUp(c1);
     score->endCmd();
 
     // Hide staff
-    score->startCmd(TranslatableString("undoableAction", "Engraving staff move tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving staff move tests"));
     score->undo(new mu::engraving::ChangeStaff(staff, false, staff->defaultClefType(), staff->userDist(), staff->hideWhenEmpty(),
                                                staff->showIfEmpty(), staff->cutaway(), staff->hideSystemBarLine(),
                                                staff->mergeMatchingRests(),
@@ -75,7 +75,7 @@ TEST_F(Engraving_StaffMoveTests, hiddenStaff)
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"hiddenStaff1.mscx", STAFF_MOVE_DIR + u"hiddenStaff-ref.mscx"));
 
     // Unhide staff
-    score->startCmd(TranslatableString("undoableAction", "Engraving staff move tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving staff move tests"));
     score->undo(new mu::engraving::ChangeStaff(staff, true, staff->defaultClefType(), staff->userDist(), staff->hideWhenEmpty(),
                                                staff->showIfEmpty(), staff->cutaway(), staff->hideSystemBarLine(),
                                                staff->mergeMatchingRests(),
@@ -83,7 +83,7 @@ TEST_F(Engraving_StaffMoveTests, hiddenStaff)
     score->endCmd();
 
     // Move chord back
-    score->startCmd(TranslatableString("undoableAction", "Engraving staff move tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving staff move tests"));
     score->moveDown(c1);
     score->endCmd();
 
@@ -104,19 +104,19 @@ TEST_F(Engraving_StaffMoveTests, linkedStaff)
     Chord* c2 = toChord(s->element(8));
     EXPECT_TRUE(c2);
 
-    score->startCmd(TranslatableString("undoableAction", "Engraving staff move tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving staff move tests"));
     score->moveDown(c1);
     score->endCmd();
 
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"linkedStaff1.mscx", STAFF_MOVE_DIR + u"linkedStaff-ref.mscx"));
 
     // Try to move linked chord - should be no change
-    score->startCmd(TranslatableString("undoableAction", "Engraving staff move tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving staff move tests"));
     score->moveUp(c2);
     score->endCmd();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"linkedStaff2.mscx", STAFF_MOVE_DIR + u"linkedStaff-ref.mscx"));
 
-    score->startCmd(TranslatableString("undoableAction", "Engraving staff move tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving staff move tests"));
     score->moveUp(c1);
     score->endCmd();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"linkedStaff3.mscx", STAFF_MOVE_DIR + u"linkedStaff.mscx"));

--- a/src/engraving/tests/staffmove_tests.cpp
+++ b/src/engraving/tests/staffmove_tests.cpp
@@ -59,12 +59,12 @@ TEST_F(Engraving_StaffMoveTests, hiddenStaff)
     Staff* staff = score->staff(0);
 
     // Move chord
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving staff move tests"));
     score->moveUp(c1);
     score->endCmd();
 
     // Hide staff
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving staff move tests"));
     score->undo(new mu::engraving::ChangeStaff(staff, false, staff->defaultClefType(), staff->userDist(), staff->hideWhenEmpty(),
                                                staff->showIfEmpty(), staff->cutaway(), staff->hideSystemBarLine(),
                                                staff->mergeMatchingRests(),
@@ -75,7 +75,7 @@ TEST_F(Engraving_StaffMoveTests, hiddenStaff)
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"hiddenStaff1.mscx", STAFF_MOVE_DIR + u"hiddenStaff-ref.mscx"));
 
     // Unhide staff
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving staff move tests"));
     score->undo(new mu::engraving::ChangeStaff(staff, true, staff->defaultClefType(), staff->userDist(), staff->hideWhenEmpty(),
                                                staff->showIfEmpty(), staff->cutaway(), staff->hideSystemBarLine(),
                                                staff->mergeMatchingRests(),
@@ -83,7 +83,7 @@ TEST_F(Engraving_StaffMoveTests, hiddenStaff)
     score->endCmd();
 
     // Move chord back
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving staff move tests"));
     score->moveDown(c1);
     score->endCmd();
 
@@ -104,19 +104,19 @@ TEST_F(Engraving_StaffMoveTests, linkedStaff)
     Chord* c2 = toChord(s->element(8));
     EXPECT_TRUE(c2);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving staff move tests"));
     score->moveDown(c1);
     score->endCmd();
 
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"linkedStaff1.mscx", STAFF_MOVE_DIR + u"linkedStaff-ref.mscx"));
 
     // Try to move linked chord - should be no change
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving staff move tests"));
     score->moveUp(c2);
     score->endCmd();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"linkedStaff2.mscx", STAFF_MOVE_DIR + u"linkedStaff-ref.mscx"));
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving staff move tests"));
     score->moveUp(c1);
     score->endCmd();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"linkedStaff3.mscx", STAFF_MOVE_DIR + u"linkedStaff.mscx"));

--- a/src/engraving/tests/textbase_tests.cpp
+++ b/src/engraving/tests/textbase_tests.cpp
@@ -140,11 +140,11 @@ TEST_F(Engraving_TextBaseTests, undoChangeFontStyleProperty)
     StaffText* staffText = addStaffText(score);
     staffText->setXmlText(u"normal <b>bold</b> <u>underline</u> <i>italic</i>");
     score->renderer()->layoutItem(staffText);
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving text base tests"));
     staffText->undoChangeProperty(Pid::FONT_STYLE, PropertyValue::fromValue(0), PropertyFlags::UNSTYLED);
     score->endCmd();
     EXPECT_EQ(staffText->xmlText(), u"normal <b>bold</b> <u>underline</u> <i>italic</i>");
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving text base tests"));
     staffText->undoChangeProperty(Pid::FONT_STYLE, PropertyValue::fromValue(static_cast<int>(FontStyle::Bold)),
                                   PropertyFlags::UNSTYLED);
     score->endCmd();
@@ -154,19 +154,19 @@ TEST_F(Engraving_TextBaseTests, undoChangeFontStyleProperty)
     EXPECT_EQ(staffText->xmlText(), u"normal <b>bold</b> <u>underline</u> <i>italic</i>");
     score->undoStack()->redo(&ed);
     EXPECT_EQ(staffText->xmlText(), u"<b>normal bold <u>underline</u> <i>italic</i></b>");
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving text base tests"));
     staffText->undoChangeProperty(Pid::FONT_STYLE, PropertyValue::fromValue(
                                       static_cast<int>(FontStyle::Italic + FontStyle::Bold)), PropertyFlags::UNSTYLED);
     score->endCmd();
     EXPECT_EQ(staffText->xmlText(), u"<b><i>normal bold <u>underline</u> italic</i></b>");
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving text base tests"));
     staffText->undoChangeProperty(Pid::FONT_STYLE,
                                   PropertyValue::fromValue(
                                       static_cast<int>(FontStyle::Italic + FontStyle::Bold + FontStyle::Underline)),
                                   PropertyFlags::UNSTYLED);
     score->endCmd();
     EXPECT_EQ(staffText->xmlText(), u"<b><i><u>normal bold underline italic</u></i></b>");
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving text base tests"));
     staffText->undoChangeProperty(Pid::FONT_STYLE, PropertyValue::fromValue(0), PropertyFlags::UNSTYLED);
     score->endCmd();
     EXPECT_EQ(staffText->xmlText(), u"normal bold underline italic");

--- a/src/engraving/tests/textbase_tests.cpp
+++ b/src/engraving/tests/textbase_tests.cpp
@@ -140,11 +140,11 @@ TEST_F(Engraving_TextBaseTests, undoChangeFontStyleProperty)
     StaffText* staffText = addStaffText(score);
     staffText->setXmlText(u"normal <b>bold</b> <u>underline</u> <i>italic</i>");
     score->renderer()->layoutItem(staffText);
-    score->startCmd(TranslatableString("undoableAction", "Engraving text base tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving text base tests"));
     staffText->undoChangeProperty(Pid::FONT_STYLE, PropertyValue::fromValue(0), PropertyFlags::UNSTYLED);
     score->endCmd();
     EXPECT_EQ(staffText->xmlText(), u"normal <b>bold</b> <u>underline</u> <i>italic</i>");
-    score->startCmd(TranslatableString("undoableAction", "Engraving text base tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving text base tests"));
     staffText->undoChangeProperty(Pid::FONT_STYLE, PropertyValue::fromValue(static_cast<int>(FontStyle::Bold)),
                                   PropertyFlags::UNSTYLED);
     score->endCmd();
@@ -154,19 +154,19 @@ TEST_F(Engraving_TextBaseTests, undoChangeFontStyleProperty)
     EXPECT_EQ(staffText->xmlText(), u"normal <b>bold</b> <u>underline</u> <i>italic</i>");
     score->undoStack()->redo(&ed);
     EXPECT_EQ(staffText->xmlText(), u"<b>normal bold <u>underline</u> <i>italic</i></b>");
-    score->startCmd(TranslatableString("undoableAction", "Engraving text base tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving text base tests"));
     staffText->undoChangeProperty(Pid::FONT_STYLE, PropertyValue::fromValue(
                                       static_cast<int>(FontStyle::Italic + FontStyle::Bold)), PropertyFlags::UNSTYLED);
     score->endCmd();
     EXPECT_EQ(staffText->xmlText(), u"<b><i>normal bold <u>underline</u> italic</i></b>");
-    score->startCmd(TranslatableString("undoableAction", "Engraving text base tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving text base tests"));
     staffText->undoChangeProperty(Pid::FONT_STYLE,
                                   PropertyValue::fromValue(
                                       static_cast<int>(FontStyle::Italic + FontStyle::Bold + FontStyle::Underline)),
                                   PropertyFlags::UNSTYLED);
     score->endCmd();
     EXPECT_EQ(staffText->xmlText(), u"<b><i><u>normal bold underline italic</u></i></b>");
-    score->startCmd(TranslatableString("undoableAction", "Engraving text base tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving text base tests"));
     staffText->undoChangeProperty(Pid::FONT_STYLE, PropertyValue::fromValue(0), PropertyFlags::UNSTYLED);
     score->endCmd();
     EXPECT_EQ(staffText->xmlText(), u"normal bold underline italic");

--- a/src/engraving/tests/timesig_tests.cpp
+++ b/src/engraving/tests/timesig_tests.cpp
@@ -53,7 +53,7 @@ TEST_F(Engraving_TimesigTests, timesig01)
     TimeSig* ts = Factory::createTimeSig(score->dummy()->segment());
     ts->setSig(Fraction(3, 4), TimeSigType::NORMAL);
 
-    score->startCmd(TranslatableString("undoableAction", "Engraving time signature tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving time signature tests"));
     int staffIdx = 0;
     bool local   = false;
     score->cmdAddTimeSig(m, staffIdx, ts, local);
@@ -77,7 +77,7 @@ TEST_F(Engraving_TimesigTests, timesig02)
     TimeSig* ts = Factory::createTimeSig(score->dummy()->segment());
     ts->setSig(Fraction(3, 4), TimeSigType::NORMAL);
 
-    score->startCmd(TranslatableString("undoableAction", "Engraving time signature tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving time signature tests"));
     score->cmdAddTimeSig(m, 0, ts, false);
     score->doLayout();
     score->endCmd();
@@ -168,7 +168,7 @@ TEST_F(Engraving_TimesigTests, timesig06)
     TimeSig* ts = Factory::createTimeSig(score->dummy()->segment());
     ts->setSig(Fraction(5, 4), TimeSigType::NORMAL);
 
-    score->startCmd(TranslatableString("undoableAction", "Engraving time signature tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving time signature tests"));
     score->cmdAddTimeSig(m, 0, ts, false);
     score->doLayout();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"timesig-06.mscx", TIMESIG_DATA_DIR + u"timesig-06-ref.mscx"));
@@ -194,7 +194,7 @@ TEST_F(Engraving_TimesigTests, timesig07)
     TimeSig* ts = Factory::createTimeSig(score->dummy()->segment());
     ts->setSig(Fraction(3, 4), TimeSigType::NORMAL);
 
-    score->startCmd(TranslatableString("undoableAction", "Engraving time signature tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving time signature tests"));
     score->cmdAddTimeSig(m, 0, ts, false);
     score->doLayout();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"timesig-07.mscx", TIMESIG_DATA_DIR + u"timesig-07-ref.mscx"));
@@ -239,7 +239,7 @@ TEST_F(Engraving_TimesigTests, DISABLED_timesig09)
     TimeSig* ts = Factory::createTimeSig(score->dummy()->segment());
     ts->setSig(Fraction(9, 8), TimeSigType::NORMAL);
 
-    score->startCmd(TranslatableString("undoableAction", "Engraving time signature tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving time signature tests"));
     score->cmdAddTimeSig(m, 0, ts, false);
     score->doLayout();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"timesig-09-1.mscx", TIMESIG_DATA_DIR + u"timesig-09-ref.mscx"));
@@ -266,7 +266,7 @@ TEST_F(Engraving_TimesigTests, timesig10)
     TimeSig* ts1 = Factory::createTimeSig(score->dummy()->segment());
     ts1->setSig(Fraction(2, 2), TimeSigType::ALLA_BREVE);
 
-    score->startCmd(TranslatableString("undoableAction", "Engraving time signature tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving time signature tests"));
     score->cmdAddTimeSig(m1, 0, ts1, false);
 
     Measure* m2 = m1->nextMeasure();

--- a/src/engraving/tests/timesig_tests.cpp
+++ b/src/engraving/tests/timesig_tests.cpp
@@ -53,7 +53,7 @@ TEST_F(Engraving_TimesigTests, timesig01)
     TimeSig* ts = Factory::createTimeSig(score->dummy()->segment());
     ts->setSig(Fraction(3, 4), TimeSigType::NORMAL);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving time signature tests"));
     int staffIdx = 0;
     bool local   = false;
     score->cmdAddTimeSig(m, staffIdx, ts, local);
@@ -77,7 +77,7 @@ TEST_F(Engraving_TimesigTests, timesig02)
     TimeSig* ts = Factory::createTimeSig(score->dummy()->segment());
     ts->setSig(Fraction(3, 4), TimeSigType::NORMAL);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving time signature tests"));
     score->cmdAddTimeSig(m, 0, ts, false);
     score->doLayout();
     score->endCmd();
@@ -168,7 +168,7 @@ TEST_F(Engraving_TimesigTests, timesig06)
     TimeSig* ts = Factory::createTimeSig(score->dummy()->segment());
     ts->setSig(Fraction(5, 4), TimeSigType::NORMAL);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving time signature tests"));
     score->cmdAddTimeSig(m, 0, ts, false);
     score->doLayout();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"timesig-06.mscx", TIMESIG_DATA_DIR + u"timesig-06-ref.mscx"));
@@ -194,7 +194,7 @@ TEST_F(Engraving_TimesigTests, timesig07)
     TimeSig* ts = Factory::createTimeSig(score->dummy()->segment());
     ts->setSig(Fraction(3, 4), TimeSigType::NORMAL);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving time signature tests"));
     score->cmdAddTimeSig(m, 0, ts, false);
     score->doLayout();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"timesig-07.mscx", TIMESIG_DATA_DIR + u"timesig-07-ref.mscx"));
@@ -239,7 +239,7 @@ TEST_F(Engraving_TimesigTests, DISABLED_timesig09)
     TimeSig* ts = Factory::createTimeSig(score->dummy()->segment());
     ts->setSig(Fraction(9, 8), TimeSigType::NORMAL);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving time signature tests"));
     score->cmdAddTimeSig(m, 0, ts, false);
     score->doLayout();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"timesig-09-1.mscx", TIMESIG_DATA_DIR + u"timesig-09-ref.mscx"));
@@ -266,7 +266,7 @@ TEST_F(Engraving_TimesigTests, timesig10)
     TimeSig* ts1 = Factory::createTimeSig(score->dummy()->segment());
     ts1->setSig(Fraction(2, 2), TimeSigType::ALLA_BREVE);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving time signature tests"));
     score->cmdAddTimeSig(m1, 0, ts1, false);
 
     Measure* m2 = m1->nextMeasure();

--- a/src/engraving/tests/tools_tests.cpp
+++ b/src/engraving/tests/tools_tests.cpp
@@ -52,12 +52,12 @@ TEST_F(Engraving_ToolsTests, undoAddLineBreaks)
     score->doLayout();
 
     // select all
-    score->startCmd(TranslatableString("undoableAction", "Engraving tools tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving tools tests"));
     score->cmdSelectAll();
     score->endCmd();
 
     // do
-    score->startCmd(TranslatableString("undoableAction", "Engraving tools tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving tools tests"));
     score->addRemoveBreaks(4, false);
     score->endCmd();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, writeFile1, reference1));
@@ -85,7 +85,7 @@ TEST_F(Engraving_ToolsTests, undoSlashFill)
     score->selection().setRange(s, score->lastSegment(), 0, 2);
 
     // do
-    score->startCmd(TranslatableString("undoableAction", "Engraving tools tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving tools tests"));
     score->cmdSlashFill();
     score->endCmd();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, writeFile1, reference1));
@@ -110,12 +110,12 @@ TEST_F(Engraving_ToolsTests, undoSlashRhythm)
     score->doLayout();
 
     // select all
-    score->startCmd(TranslatableString("undoableAction", "Engraving tools tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving tools tests"));
     score->cmdSelectAll();
     score->endCmd();
 
     // do
-    score->startCmd(TranslatableString("undoableAction", "Engraving tools tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving tools tests"));
     score->cmdSlashRhythm();
     score->endCmd();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, writeFile1, reference1));
@@ -140,7 +140,7 @@ TEST_F(Engraving_ToolsTests, undoResequenceAlpha)
     score->doLayout();
 
     // do
-    score->startCmd(TranslatableString("undoableAction", "Engraving tools tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving tools tests"));
     score->cmdResequenceRehearsalMarks();
     score->endCmd();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, writeFile1, reference1));
@@ -165,7 +165,7 @@ TEST_F(Engraving_ToolsTests, undoResequenceNumeric)
     score->doLayout();
 
     // do
-    score->startCmd(TranslatableString("undoableAction", "Engraving tools tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving tools tests"));
     score->cmdResequenceRehearsalMarks();
     score->endCmd();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, writeFile1, reference1));
@@ -190,7 +190,7 @@ TEST_F(Engraving_ToolsTests, undoResequenceMeasure)
     score->doLayout();
 
     // do
-    score->startCmd(TranslatableString("undoableAction", "Engraving tools tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving tools tests"));
     score->cmdResequenceRehearsalMarks();
     score->endCmd();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, writeFile1, reference1));
@@ -215,7 +215,7 @@ TEST_F(Engraving_ToolsTests, undoResequencePart)
     score->doLayout();
 
     // do
-    score->startCmd(TranslatableString("undoableAction", "Engraving tools tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving tools tests"));
     score->cmdResequenceRehearsalMarks();
     score->endCmd();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, writeFile1, reference1));
@@ -236,7 +236,7 @@ void Engraving_ToolsTests::changeEnharmonic(bool both)
     score->doLayout();
     score->cmdSelectAll();
     for (int i = 1; i < 6; ++i) {
-        score->startCmd(TranslatableString("undoableAction", "Engraving tools tests"));
+        score->startCmd(TranslatableString::untranslatable("Engraving tools tests"));
         score->changeEnharmonicSpelling(both);
         score->endCmd();
         String prefix = u"change-enharmonic-" + mode + u"-0" + (u'0' + i);

--- a/src/engraving/tests/tools_tests.cpp
+++ b/src/engraving/tests/tools_tests.cpp
@@ -52,12 +52,12 @@ TEST_F(Engraving_ToolsTests, undoAddLineBreaks)
     score->doLayout();
 
     // select all
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving tools tests"));
     score->cmdSelectAll();
     score->endCmd();
 
     // do
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving tools tests"));
     score->addRemoveBreaks(4, false);
     score->endCmd();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, writeFile1, reference1));
@@ -85,7 +85,7 @@ TEST_F(Engraving_ToolsTests, undoSlashFill)
     score->selection().setRange(s, score->lastSegment(), 0, 2);
 
     // do
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving tools tests"));
     score->cmdSlashFill();
     score->endCmd();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, writeFile1, reference1));
@@ -110,12 +110,12 @@ TEST_F(Engraving_ToolsTests, undoSlashRhythm)
     score->doLayout();
 
     // select all
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving tools tests"));
     score->cmdSelectAll();
     score->endCmd();
 
     // do
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving tools tests"));
     score->cmdSlashRhythm();
     score->endCmd();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, writeFile1, reference1));
@@ -140,7 +140,7 @@ TEST_F(Engraving_ToolsTests, undoResequenceAlpha)
     score->doLayout();
 
     // do
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving tools tests"));
     score->cmdResequenceRehearsalMarks();
     score->endCmd();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, writeFile1, reference1));
@@ -165,7 +165,7 @@ TEST_F(Engraving_ToolsTests, undoResequenceNumeric)
     score->doLayout();
 
     // do
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving tools tests"));
     score->cmdResequenceRehearsalMarks();
     score->endCmd();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, writeFile1, reference1));
@@ -190,7 +190,7 @@ TEST_F(Engraving_ToolsTests, undoResequenceMeasure)
     score->doLayout();
 
     // do
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving tools tests"));
     score->cmdResequenceRehearsalMarks();
     score->endCmd();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, writeFile1, reference1));
@@ -215,7 +215,7 @@ TEST_F(Engraving_ToolsTests, undoResequencePart)
     score->doLayout();
 
     // do
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving tools tests"));
     score->cmdResequenceRehearsalMarks();
     score->endCmd();
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, writeFile1, reference1));
@@ -236,7 +236,7 @@ void Engraving_ToolsTests::changeEnharmonic(bool both)
     score->doLayout();
     score->cmdSelectAll();
     for (int i = 1; i < 6; ++i) {
-        score->startCmd();
+        score->startCmd(TranslatableString("undoableAction", "Engraving tools tests"));
         score->changeEnharmonicSpelling(both);
         score->endCmd();
         String prefix = u"change-enharmonic-" + mode + u"-0" + (u'0' + i);

--- a/src/engraving/tests/transpose_tests.cpp
+++ b/src/engraving/tests/transpose_tests.cpp
@@ -51,7 +51,7 @@ TEST_F(Engraving_TransposeTests, undoTranspose)
     score->cmdSelectAll();
 
     // transpose major second up
-    score->startCmd(TranslatableString("undoableAction", "Engraving transpose tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving transpose tests"));
     score->transpose(TransposeMode::BY_INTERVAL, TransposeDirection::UP, Key::C, 4,
                      true, true, true);
     score->endCmd();
@@ -80,7 +80,7 @@ TEST_F(Engraving_TransposeTests, undoDiatonicTranspose)
     score->cmdSelectAll();
 
     // transpose diatonic fourth down
-    score->startCmd(TranslatableString("undoableAction", "Engraving transpose tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving transpose tests"));
     score->transpose(TransposeMode::DIATONICALLY, TransposeDirection::DOWN, Key::C, 3,
                      true, false, false);
     score->endCmd();

--- a/src/engraving/tests/transpose_tests.cpp
+++ b/src/engraving/tests/transpose_tests.cpp
@@ -51,7 +51,7 @@ TEST_F(Engraving_TransposeTests, undoTranspose)
     score->cmdSelectAll();
 
     // transpose major second up
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving transpose tests"));
     score->transpose(TransposeMode::BY_INTERVAL, TransposeDirection::UP, Key::C, 4,
                      true, true, true);
     score->endCmd();
@@ -80,7 +80,7 @@ TEST_F(Engraving_TransposeTests, undoDiatonicTranspose)
     score->cmdSelectAll();
 
     // transpose diatonic fourth down
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving transpose tests"));
     score->transpose(TransposeMode::DIATONICALLY, TransposeDirection::DOWN, Key::C, 3,
                      true, false, false);
     score->endCmd();

--- a/src/engraving/tests/tuplet_tests.cpp
+++ b/src/engraving/tests/tuplet_tests.cpp
@@ -88,7 +88,7 @@ bool Engraving_TupletTests::createTuplet(int n, ChordRest* cr)
     if (ot) {
         tuplet->setTuplet(ot);
     }
-    cr->score()->startCmd();
+    cr->score()->startCmd(TranslatableString("undoableAction", "Engraving tuplet tests"));
     cr->score()->cmdCreateTuplet(cr, tuplet);
     cr->score()->endCmd();
     return true;
@@ -127,7 +127,7 @@ void Engraving_TupletTests::split(const char16_t* p1, const char16_t* p2)
     TimeSig* ts        = Factory::createTimeSig(score->dummy()->segment());
     ts->setSig(Fraction(3, 4), TimeSigType::NORMAL);
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Engraving tuplet tests"));
     EditData dd(0);
     dd.dropElement = ts;
     dd.modifiers = {};

--- a/src/engraving/tests/tuplet_tests.cpp
+++ b/src/engraving/tests/tuplet_tests.cpp
@@ -88,7 +88,7 @@ bool Engraving_TupletTests::createTuplet(int n, ChordRest* cr)
     if (ot) {
         tuplet->setTuplet(ot);
     }
-    cr->score()->startCmd(TranslatableString("undoableAction", "Engraving tuplet tests"));
+    cr->score()->startCmd(TranslatableString::untranslatable("Engraving tuplet tests"));
     cr->score()->cmdCreateTuplet(cr, tuplet);
     cr->score()->endCmd();
     return true;
@@ -127,7 +127,7 @@ void Engraving_TupletTests::split(const char16_t* p1, const char16_t* p2)
     TimeSig* ts        = Factory::createTimeSig(score->dummy()->segment());
     ts->setSig(Fraction(3, 4), TimeSigType::NORMAL);
 
-    score->startCmd(TranslatableString("undoableAction", "Engraving tuplet tests"));
+    score->startCmd(TranslatableString::untranslatable("Engraving tuplet tests"));
     EditData dd(0);
     dd.dropElement = ts;
     dd.modifiers = {};

--- a/src/engraving/types/typesconv.h
+++ b/src/engraving/types/typesconv.h
@@ -26,10 +26,6 @@
 #include "types/string.h"
 #include "types.h"
 
-namespace mu {
-class TranslatableString;
-}
-
 namespace mu::engraving {
 class TConv
 {

--- a/src/inspector/models/abstractinspectormodel.cpp
+++ b/src/inspector/models/abstractinspectormodel.cpp
@@ -355,7 +355,7 @@ void AbstractInspectorModel::setPropertyValue(const QList<engraving::EngravingIt
         return;
     }
 
-    beginCommand();
+    beginCommand(TranslatableString("undoableAction", "Set property value"));
 
     for (mu::engraving::EngravingItem* item : items) {
         IF_ASSERT_FAILED(item) {
@@ -437,7 +437,7 @@ bool AbstractInspectorModel::updateStyleValue(const mu::engraving::Sid& sid, con
 {
     PropertyValue newVal = PropertyValue::fromQVariant(newValue, mu::engraving::MStyle::valueType(sid));
     if (style() && style()->styleValue(sid) != newVal) {
-        beginCommand();
+        beginCommand(TranslatableString("undoableAction", "Update style value"));
         style()->setStyleValue(sid, newVal);
         endCommand();
         return true;
@@ -685,10 +685,10 @@ INotationUndoStackPtr AbstractInspectorModel::undoStack() const
     return currentNotation() ? currentNotation()->undoStack() : nullptr;
 }
 
-void AbstractInspectorModel::beginCommand()
+void AbstractInspectorModel::beginCommand(const muse::TranslatableString& actionName)
 {
     if (undoStack()) {
-        undoStack()->prepareChanges();
+        undoStack()->prepareChanges(actionName);
     }
 
     //! NOTE prevents unnecessary updating of properties

--- a/src/inspector/models/abstractinspectormodel.cpp
+++ b/src/inspector/models/abstractinspectormodel.cpp
@@ -355,7 +355,7 @@ void AbstractInspectorModel::setPropertyValue(const QList<engraving::EngravingIt
         return;
     }
 
-    beginCommand(TranslatableString("undoableAction", "Set property value"));
+    beginCommand(TranslatableString("undoableAction", "Edit element property"));
 
     for (mu::engraving::EngravingItem* item : items) {
         IF_ASSERT_FAILED(item) {
@@ -437,7 +437,7 @@ bool AbstractInspectorModel::updateStyleValue(const mu::engraving::Sid& sid, con
 {
     PropertyValue newVal = PropertyValue::fromQVariant(newValue, mu::engraving::MStyle::valueType(sid));
     if (style() && style()->styleValue(sid) != newVal) {
-        beginCommand(TranslatableString("undoableAction", "Update style value"));
+        beginCommand(TranslatableString("undoableAction", "Edit style"));
         style()->setStyleValue(sid, newVal);
         endCommand();
         return true;

--- a/src/inspector/models/abstractinspectormodel.h
+++ b/src/inspector/models/abstractinspectormodel.h
@@ -204,7 +204,7 @@ protected:
     QVariant styleValue(const mu::engraving::Sid& sid) const;
 
     notation::INotationUndoStackPtr undoStack() const;
-    void beginCommand();
+    void beginCommand(const muse::TranslatableString& actionName);
     void endCommand();
 
     void updateNotation();

--- a/src/inspector/models/general/generalsettingsmodel.cpp
+++ b/src/inspector/models/general/generalsettingsmodel.cpp
@@ -139,8 +139,8 @@ void GeneralSettingsModel::onCurrentNotationChanged()
 void GeneralSettingsModel::onVisibleChanged(bool visible)
 {
     const muse::TranslatableString actionName = visible
-                                                ? TranslatableString("undoableAction", "Show item(s)")
-                                                : TranslatableString("undoableAction", "Hide item(s)");
+                                                ? TranslatableString("undoableAction", "Make element(s) visible")
+                                                : TranslatableString("undoableAction", "Make element(s) invisible");
 
     beginCommand(actionName);
 

--- a/src/inspector/models/general/generalsettingsmodel.cpp
+++ b/src/inspector/models/general/generalsettingsmodel.cpp
@@ -138,7 +138,11 @@ void GeneralSettingsModel::onCurrentNotationChanged()
 
 void GeneralSettingsModel::onVisibleChanged(bool visible)
 {
-    beginCommand();
+    const muse::TranslatableString actionName = visible
+                                                ? TranslatableString("undoableAction", "Show item(s)")
+                                                : TranslatableString("undoableAction", "Hide item(s)");
+
+    beginCommand(actionName);
 
     Score* score = currentNotation()->elements()->msScore();
 

--- a/src/inspector/models/inspectormodelwithvoiceandpositionoptions.cpp
+++ b/src/inspector/models/inspectormodelwithvoiceandpositionoptions.cpp
@@ -160,7 +160,7 @@ void InspectorModelWithVoiceAndPositionOptions::changeVoice(int voice)
         return;
     }
 
-    beginCommand();
+    beginCommand(TranslatableString("undoableAction", "Change voice"));
 
     for (EngravingItem* item : m_elementList) {
         IF_ASSERT_FAILED(item) {

--- a/src/inspector/models/notation/barlines/barlinesettingsmodel.cpp
+++ b/src/inspector/models/notation/barlines/barlinesettingsmodel.cpp
@@ -148,7 +148,7 @@ void BarlineSettingsModel::applySpanPreset(const int presetType)
 
 void BarlineSettingsModel::setSpanIntervalAsStaffDefault()
 {
-    undoStack()->prepareChanges(muse::TranslatableString("undoableAction", "Set span interval as staff default"));
+    undoStack()->prepareChanges(muse::TranslatableString("undoableAction", "Set barline span interval as staff default"));
 
     std::vector<mu::engraving::EngravingItem*> staves;
 

--- a/src/inspector/models/notation/barlines/barlinesettingsmodel.cpp
+++ b/src/inspector/models/notation/barlines/barlinesettingsmodel.cpp
@@ -148,7 +148,7 @@ void BarlineSettingsModel::applySpanPreset(const int presetType)
 
 void BarlineSettingsModel::setSpanIntervalAsStaffDefault()
 {
-    undoStack()->prepareChanges();
+    undoStack()->prepareChanges(muse::TranslatableString("undoableAction", "Set span interval as staff default"));
 
     std::vector<mu::engraving::EngravingItem*> staves;
 

--- a/src/inspector/models/notation/bends/bendsettingsmodel.cpp
+++ b/src/inspector/models/notation/bends/bendsettingsmodel.cpp
@@ -274,7 +274,7 @@ void BendSettingsModel::setBendCurve(const QVariantList& newBendCurve)
 
     bool pitchChanged = endTimePoint.pitch != m_bendCurve.at(END_POINT_INDEX).pitch;
 
-    beginCommand();
+    beginCommand(muse::TranslatableString("undoableAction", "Set bend curve"));
 
     if (pitchChanged) {
         int bendAmount = curvePitchToBendAmount(endTimePoint.pitch);

--- a/src/inspector/models/notation/bends/bendsettingsmodel.cpp
+++ b/src/inspector/models/notation/bends/bendsettingsmodel.cpp
@@ -274,7 +274,7 @@ void BendSettingsModel::setBendCurve(const QVariantList& newBendCurve)
 
     bool pitchChanged = endTimePoint.pitch != m_bendCurve.at(END_POINT_INDEX).pitch;
 
-    beginCommand(muse::TranslatableString("undoableAction", "Set bend curve"));
+    beginCommand(muse::TranslatableString("undoableAction", "Edit bend curve"));
 
     if (pitchChanged) {
         int bendAmount = curvePitchToBendAmount(endTimePoint.pitch);

--- a/src/inspector/models/notation/notes/stems/stemsettingsmodel.cpp
+++ b/src/inspector/models/notation/notes/stems/stemsettingsmodel.cpp
@@ -111,7 +111,7 @@ void StemSettingsModel::setUseStraightNoteFlags(bool use)
 
 void StemSettingsModel::onStemDirectionChanged(DirectionV newDirection)
 {
-    beginCommand();
+    beginCommand(muse::TranslatableString("undoableAction", "Change stem direction"));
 
     for (EngravingItem* element : m_elementList) {
         Stem* stem = toStem(element);

--- a/src/inspector/models/notation/ornaments/ornamentsettingsmodel.cpp
+++ b/src/inspector/models/notation/ornaments/ornamentsettingsmodel.cpp
@@ -245,7 +245,7 @@ void OrnamentSettingsModel::setIntervalStep(Pid id, engraving::IntervalStep step
         return;
     }
 
-    beginCommand();
+    beginCommand(muse::TranslatableString("undoableAction", "Set ornament interval step"));
 
     for (mu::engraving::EngravingItem* item : m_elementList) {
         IF_ASSERT_FAILED(item) {
@@ -277,7 +277,7 @@ void OrnamentSettingsModel::setIntervalType(Pid id, engraving::IntervalType type
         return;
     }
 
-    beginCommand();
+    beginCommand(muse::TranslatableString("undoableAction", "Set ornament interval type"));
 
     for (mu::engraving::EngravingItem* item : m_elementList) {
         IF_ASSERT_FAILED(item) {

--- a/src/inspector/view/widgets/fretcanvas.cpp
+++ b/src/inspector/view/widgets/fretcanvas.cpp
@@ -269,7 +269,7 @@ void FretCanvas::mousePressEvent(QMouseEvent* ev)
         return;
     }
 
-    globalContext()->currentNotation()->undoStack()->prepareChanges();
+    globalContext()->currentNotation()->undoStack()->prepareChanges(muse::TranslatableString("undoableAction", "Edit fretboard"));
 
     // Click above the fret diagram, so change the open/closed string marker
     if (fret == 0) {
@@ -378,7 +378,7 @@ void FretCanvas::setFretDiagram(QVariant fd)
 
 void FretCanvas::clear()
 {
-    globalContext()->currentNotation()->undoStack()->prepareChanges();
+    globalContext()->currentNotation()->undoStack()->prepareChanges(muse::TranslatableString("undoableAction", "Clear fretboard"));
     m_diagram->undoFretClear();
     globalContext()->currentNotation()->undoStack()->commitChanges();
     update();

--- a/src/inspector/view/widgets/fretcanvas.cpp
+++ b/src/inspector/view/widgets/fretcanvas.cpp
@@ -269,7 +269,7 @@ void FretCanvas::mousePressEvent(QMouseEvent* ev)
         return;
     }
 
-    globalContext()->currentNotation()->undoStack()->prepareChanges(muse::TranslatableString("undoableAction", "Edit fretboard"));
+    globalContext()->currentNotation()->undoStack()->prepareChanges(muse::TranslatableString("undoableAction", "Edit fretboard diagram"));
 
     // Click above the fret diagram, so change the open/closed string marker
     if (fret == 0) {
@@ -378,7 +378,7 @@ void FretCanvas::setFretDiagram(QVariant fd)
 
 void FretCanvas::clear()
 {
-    globalContext()->currentNotation()->undoStack()->prepareChanges(muse::TranslatableString("undoableAction", "Clear fretboard"));
+    globalContext()->currentNotation()->undoStack()->prepareChanges(muse::TranslatableString("undoableAction", "Clear fretboard diagram"));
     m_diagram->undoFretClear();
     globalContext()->currentNotation()->undoStack()->commitChanges();
     update();

--- a/src/notation/CMakeLists.txt
+++ b/src/notation/CMakeLists.txt
@@ -146,8 +146,10 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/view/continuouspanel.h
     ${CMAKE_CURRENT_LIST_DIR}/view/abstractelementpopupmodel.h
     ${CMAKE_CURRENT_LIST_DIR}/view/abstractelementpopupmodel.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/view/internal/undoredomodel.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/view/internal/undoredomodel.h
+    ${CMAKE_CURRENT_LIST_DIR}/view/internal/undoredotoolbarmodel.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/view/internal/undoredotoolbarmodel.h
+    ${CMAKE_CURRENT_LIST_DIR}/view/internal/undoredohistorymodel.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/view/internal/undoredohistorymodel.h
     ${CMAKE_CURRENT_LIST_DIR}/view/internal/harppedalpopupmodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/internal/harppedalpopupmodel.h
     ${CMAKE_CURRENT_LIST_DIR}/view/internal/caposettingsmodel.cpp

--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -114,7 +114,7 @@ public:
     virtual bool applyPaletteElement(mu::engraving::EngravingItem* element, Qt::KeyboardModifiers modifiers = {}) = 0;
     virtual void undo() = 0;
     virtual void redo() = 0;
-    virtual void undoHistory(size_t moveToIdx) = 0;
+    virtual void undoRedoToIdx(size_t idx) = 0;
 
     // Change selection
     virtual bool moveSelectionAvailable(MoveSelectionType type) const = 0;

--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -290,8 +290,7 @@ public:
     virtual void transposeDiatonicAlterations(mu::engraving::TransposeDirection) = 0;
     virtual void toggleAutoplace(bool all) = 0;
     virtual void getLocation() = 0;
-    //virtual void execute(void (mu::engraving::Score::*)(), const muse::TranslatableString& actionName = {}) = 0;
-    virtual void execute(void (mu::engraving::Score::*)()) = 0;
+    virtual void execute(void (mu::engraving::Score::*)(), const muse::TranslatableString& actionName) = 0;
 
     struct ShowItemRequest {
         const EngravingItem* item = nullptr;

--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -114,6 +114,7 @@ public:
     virtual bool applyPaletteElement(mu::engraving::EngravingItem* element, Qt::KeyboardModifiers modifiers = {}) = 0;
     virtual void undo() = 0;
     virtual void redo() = 0;
+    virtual void undoHistory(size_t moveToIdx) = 0;
 
     // Change selection
     virtual bool moveSelectionAvailable(MoveSelectionType type) const = 0;
@@ -289,6 +290,7 @@ public:
     virtual void transposeDiatonicAlterations(mu::engraving::TransposeDirection) = 0;
     virtual void toggleAutoplace(bool all) = 0;
     virtual void getLocation() = 0;
+    //virtual void execute(void (mu::engraving::Score::*)(), const muse::TranslatableString& actionName = {}) = 0;
     virtual void execute(void (mu::engraving::Score::*)()) = 0;
 
     struct ShowItemRequest {

--- a/src/notation/internal/excerptnotation.cpp
+++ b/src/notation/internal/excerptnotation.cpp
@@ -141,7 +141,8 @@ void ExcerptNotation::undoSetName(const QString& name)
         return;
     }
 
-    undoStack()->prepareChanges(muse::TranslatableString("undoableAction", "Undo set part name"));
+    //: Means: "edit the name of a part score"
+    undoStack()->prepareChanges(muse::TranslatableString("undoableAction", "Rename part"));
 
     score()->undo(new engraving::ChangeExcerptTitle(m_excerpt, name));
 

--- a/src/notation/internal/excerptnotation.cpp
+++ b/src/notation/internal/excerptnotation.cpp
@@ -141,7 +141,7 @@ void ExcerptNotation::undoSetName(const QString& name)
         return;
     }
 
-    undoStack()->prepareChanges();
+    undoStack()->prepareChanges(muse::TranslatableString("undoableAction", "Undo set part name"));
 
     score()->undo(new engraving::ChangeExcerptTitle(m_excerpt, name));
 

--- a/src/notation/internal/inotationundostack.h
+++ b/src/notation/internal/inotationundostack.h
@@ -47,7 +47,9 @@ public:
     virtual void redo(mu::engraving::EditData*) = 0;
     virtual muse::async::Notification redoNotification() const = 0;
 
-    virtual void prepareChanges() = 0;
+    virtual void undoRedoToIdx(size_t, mu::engraving::EditData*) = 0;
+
+    virtual void prepareChanges(const muse::TranslatableString&) = 0;
     virtual void rollbackChanges() = 0;
     virtual void commitChanges() = 0;
 
@@ -56,6 +58,12 @@ public:
     virtual void lock() = 0;
     virtual void unlock() = 0;
     virtual bool isLocked() const = 0;
+
+    virtual const muse::TranslatableString topMostUndoActionName() const = 0;
+    virtual const muse::TranslatableString topMostRedoActionName() const = 0;
+    virtual size_t undoRedoActionCount() const = 0;
+    virtual size_t undoRedoActionCurrentIdx() const = 0;
+    virtual const muse::TranslatableString undoRedoActionNameAtIdx(size_t) const = 0;
 
     virtual muse::async::Notification stackChanged() const = 0;
     virtual muse::async::Channel<ChangesRange> changesChannel() const = 0;

--- a/src/notation/internal/inotationundostack.h
+++ b/src/notation/internal/inotationundostack.h
@@ -41,11 +41,9 @@ public:
 
     virtual bool canUndo() const = 0;
     virtual void undo(mu::engraving::EditData*) = 0;
-    virtual muse::async::Notification undoNotification() const = 0;
 
     virtual bool canRedo() const = 0;
     virtual void redo(mu::engraving::EditData*) = 0;
-    virtual muse::async::Notification redoNotification() const = 0;
 
     virtual void undoRedoToIdx(size_t, mu::engraving::EditData*) = 0;
 
@@ -67,6 +65,7 @@ public:
 
     virtual muse::async::Notification stackChanged() const = 0;
     virtual muse::async::Channel<ChangesRange> changesChannel() const = 0;
+    virtual muse::async::Notification undoRedoNotification() const = 0;
 };
 
 using INotationUndoStackPtr = std::shared_ptr<INotationUndoStack>;

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -523,7 +523,7 @@ void MasterNotation::setExcerpts(const ExcerptNotationList& excerpts)
         return;
     }
 
-    undoStack()->prepareChanges();
+    undoStack()->prepareChanges(TranslatableString("undoableAction", "Parts dialog"));
 
     // Delete old excerpts (that are not included in the new list)
     for (IExcerptNotationPtr excerptNotation : m_excerpts) {
@@ -566,7 +566,7 @@ void MasterNotation::resetExcerpt(IExcerptNotationPtr excerptNotation)
 
     TRACEFUNC;
 
-    undoStack()->prepareChanges();
+    undoStack()->prepareChanges(TranslatableString("undoableAction", "Reset part"));
 
     mu::engraving::Excerpt* oldExcerpt = get_impl(excerptNotation)->excerpt();
     masterScore()->deleteExcerpt(oldExcerpt);

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -523,7 +523,7 @@ void MasterNotation::setExcerpts(const ExcerptNotationList& excerpts)
         return;
     }
 
-    undoStack()->prepareChanges(TranslatableString("undoableAction", "Parts dialog"));
+    undoStack()->prepareChanges(TranslatableString("undoableAction", "Add/remove parts"));
 
     // Delete old excerpts (that are not included in the new list)
     for (IExcerptNotationPtr excerptNotation : m_excerpts) {

--- a/src/notation/internal/masternotationparts.cpp
+++ b/src/notation/internal/masternotationparts.cpp
@@ -48,9 +48,9 @@ void MasterNotationParts::setExcerpts(ExcerptNotationList excerpts)
     m_excerpts = excerpts;
 }
 
-void MasterNotationParts::startGlobalEdit()
+void MasterNotationParts::startGlobalEdit(const muse::TranslatableString& actionName)
 {
-    NotationParts::startEdit();
+    NotationParts::startEdit(actionName);
     undoStack()->lock();
 }
 
@@ -67,7 +67,7 @@ void MasterNotationParts::setParts(const PartInstrumentList& partList, const Sco
     mu::engraving::KeyList keyList = score()->keyList();
 
     endInteractionWithScore();
-    startGlobalEdit();
+    startGlobalEdit(TranslatableString("undoableAction", "Add or remove instruments"));
 
     doSetScoreOrder(order);
     removeMissingParts(partList);
@@ -103,7 +103,7 @@ void MasterNotationParts::removeParts(const IDList& partsIds)
 {
     TRACEFUNC;
 
-    startGlobalEdit();
+    startGlobalEdit(TranslatableString("undoableAction", "Remove instruments"));
 
     NotationParts::removeParts(partsIds);
 
@@ -118,7 +118,7 @@ void MasterNotationParts::removeStaves(const IDList& stavesIds)
 {
     TRACEFUNC;
 
-    startGlobalEdit();
+    startGlobalEdit(TranslatableString("undoableAction", "Remove staves"));
 
     NotationParts::removeStaves(stavesIds);
 
@@ -137,7 +137,7 @@ bool MasterNotationParts::appendStaff(Staff* staff, const ID& destinationPartId)
         return false;
     }
 
-    startGlobalEdit();
+    startGlobalEdit(TranslatableString("undoableAction", "Append staff"));
 
     //! NOTE: will be generated later after adding to the score
     staff->setId(mu::engraving::INVALID_ID);
@@ -165,7 +165,7 @@ bool MasterNotationParts::appendLinkedStaff(Staff* staff, const muse::ID& source
         return false;
     }
 
-    startGlobalEdit();
+    startGlobalEdit(TranslatableString("undoableAction", "Append linked staff"));
 
     //! NOTE: will be generated later after adding to the score
     staff->setId(mu::engraving::INVALID_ID);
@@ -188,7 +188,7 @@ void MasterNotationParts::replaceInstrument(const InstrumentKey& instrumentKey, 
 {
     TRACEFUNC;
 
-    startGlobalEdit();
+    startGlobalEdit(TranslatableString("undoableAction", "Replace instrument"));
 
     Part* part = partModifiable(instrumentKey.partId);
     bool isMainInstrument = part && isMainInstrumentForPart(instrumentKey, part);
@@ -223,7 +223,7 @@ void MasterNotationParts::replaceDrumset(const InstrumentKey& instrumentKey, con
 {
     TRACEFUNC;
 
-    startGlobalEdit();
+    startGlobalEdit(TranslatableString("undoableAction", "Replace drumset"));
 
     NotationParts::replaceDrumset(instrumentKey, newDrumset, undoable);
 

--- a/src/notation/internal/masternotationparts.cpp
+++ b/src/notation/internal/masternotationparts.cpp
@@ -67,7 +67,7 @@ void MasterNotationParts::setParts(const PartInstrumentList& partList, const Sco
     mu::engraving::KeyList keyList = score()->keyList();
 
     endInteractionWithScore();
-    startGlobalEdit(TranslatableString("undoableAction", "Add or remove instruments"));
+    startGlobalEdit(TranslatableString("undoableAction", "Add/remove instruments"));
 
     doSetScoreOrder(order);
     removeMissingParts(partList);
@@ -137,7 +137,7 @@ bool MasterNotationParts::appendStaff(Staff* staff, const ID& destinationPartId)
         return false;
     }
 
-    startGlobalEdit(TranslatableString("undoableAction", "Append staff"));
+    startGlobalEdit(TranslatableString("undoableAction", "Add staff"));
 
     //! NOTE: will be generated later after adding to the score
     staff->setId(mu::engraving::INVALID_ID);
@@ -165,7 +165,7 @@ bool MasterNotationParts::appendLinkedStaff(Staff* staff, const muse::ID& source
         return false;
     }
 
-    startGlobalEdit(TranslatableString("undoableAction", "Append linked staff"));
+    startGlobalEdit(TranslatableString("undoableAction", "Add linked staff"));
 
     //! NOTE: will be generated later after adding to the score
     staff->setId(mu::engraving::INVALID_ID);
@@ -223,7 +223,7 @@ void MasterNotationParts::replaceDrumset(const InstrumentKey& instrumentKey, con
 {
     TRACEFUNC;
 
-    startGlobalEdit(TranslatableString("undoableAction", "Replace drumset"));
+    startGlobalEdit(TranslatableString("undoableAction", "Edit drumset"));
 
     NotationParts::replaceDrumset(instrumentKey, newDrumset, undoable);
 

--- a/src/notation/internal/masternotationparts.h
+++ b/src/notation/internal/masternotationparts.h
@@ -46,7 +46,7 @@ public:
     void replaceDrumset(const InstrumentKey& instrumentKey, const Drumset& newDrumset, bool undoable = true) override;
 
 private:
-    void startGlobalEdit();
+    void startGlobalEdit(const muse::TranslatableString& actionName);
     void endGlobalEdit();
 
     void onPartsRemoved(const std::vector<Part*>& parts) override;

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -2103,7 +2103,7 @@ void NotationActionController::openUndoRedoHistory()
 
     RetVal<Val> result = interactive()->open("musescore://notation/undohistory");
     if (result.ret) {
-        interaction->undoHistory(static_cast<size_t>(result.val.toInt()));
+        interaction->undoRedoToIdx(static_cast<size_t>(result.val.toInt()));
     }
 }
 

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -446,10 +446,13 @@ void NotationActionController::init()
     registerAction("toggle-insert-mode", [this]() { toggleNoteInputInsert(); }, &NotationActionController::isNotEditingElement);
 
     registerAction("get-location", &Interaction::getLocation, &Controller::isNotationPage);
-    registerAction("toggle-mmrest", &Interaction::execute, &mu::engraving::Score::cmdToggleMmrest);
-    registerAction("toggle-hide-empty", &Interaction::execute, &mu::engraving::Score::cmdToggleHideEmpty);
+    registerAction("toggle-mmrest", &Interaction::execute, &mu::engraving::Score::cmdToggleMmrest,
+                   TranslatableString("undoableAction", "Toggle multimeasure rests"));
+    registerAction("toggle-hide-empty", &Interaction::execute, &mu::engraving::Score::cmdToggleHideEmpty,
+                   TranslatableString("undoableAction", "Toggle empty staves"));
 
-    registerAction("mirror-note", &Interaction::execute, &mu::engraving::Score::cmdMirrorNoteHead);
+    registerAction("mirror-note", &Interaction::execute, &mu::engraving::Score::cmdMirrorNoteHead,
+                   TranslatableString("undoableAction", "Mirror notehead"));
 
     registerAction("clef-violin", [this]() { insertClef(mu::engraving::ClefType::G); });
     registerAction("clef-bass", [this]() { insertClef(mu::engraving::ClefType::F); });
@@ -463,9 +466,12 @@ void NotationActionController::init()
                    PlayMode::PlayNote);
     registerAction("pitch-down-diatonic-alterations", &Interaction::transposeDiatonicAlterations, mu::engraving::TransposeDirection::DOWN,
                    PlayMode::PlayNote);
-    registerAction("full-measure-rest", &Interaction::execute, &mu::engraving::Score::cmdFullMeasureRest);
-    registerAction("set-visible", &Interaction::execute, &mu::engraving::Score::cmdSetVisible);
-    registerAction("unset-visible", &Interaction::execute, &mu::engraving::Score::cmdUnsetVisible);
+    registerAction("full-measure-rest", &Interaction::execute, &mu::engraving::Score::cmdFullMeasureRest,
+                   TranslatableString("undoableAction", "Enter full-measure rest"));
+    registerAction("set-visible", &Interaction::execute, &mu::engraving::Score::cmdSetVisible,
+                   TranslatableString("undoableAction", "Make element(s) visible"));
+    registerAction("unset-visible", &Interaction::execute, &mu::engraving::Score::cmdUnsetVisible,
+                   TranslatableString("undoableAction", "Make element(s) invisible"));
     registerAction("toggle-autoplace", &Interaction::toggleAutoplace, false);
     registerAction("autoplace-enabled", &Interaction::toggleAutoplace, true);
 
@@ -499,8 +505,6 @@ void NotationActionController::init()
     registerTabPadNoteAction("pad-note-512-TAB", Pad::NOTE512);
     registerTabPadNoteAction("pad-note-1024-TAB", Pad::NOTE1024);
     registerAction("rest-TAB", &Interaction::putRestToSelection);
-
-    registerAction("edit-strings", &Interaction::changeEnharmonicSpelling, true);
 
     registerAction("standard-bend", [this]() { addGuitarBend(GuitarBendType::BEND); });
     registerAction("pre-bend",  [this]() { addGuitarBend(GuitarBendType::PRE_BEND); });

--- a/src/notation/internal/notationactioncontroller.h
+++ b/src/notation/internal/notationactioncontroller.h
@@ -211,6 +211,9 @@ private:
 
     bool canUndo() const;
     bool canRedo() const;
+    bool canUndoOrRedo() const;
+    void openUndoRedoHistory();
+
     bool isNotationPage() const;
     bool isStandardStaff() const;
     bool isTablatureStaff() const;

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -232,11 +232,11 @@ void NotationInteraction::onScoreInited()
     });
 }
 
-void NotationInteraction::startEdit()
+void NotationInteraction::startEdit(const muse::TranslatableString& actionName)
 {
     m_notifyAboutDropChanged = false;
 
-    m_undoStack->prepareChanges();
+    m_undoStack->prepareChanges(actionName);
 }
 
 void NotationInteraction::apply()
@@ -443,7 +443,7 @@ RectF NotationInteraction::shadowNoteRect() const
 
 void NotationInteraction::toggleVisible()
 {
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Toggle visible"));
     score()->cmdToggleVisible();
     apply();
 }
@@ -986,7 +986,7 @@ void NotationInteraction::startDrag(const std::vector<EngravingItem*>& elems,
         }
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Drag item"));
 
     qreal scaling = m_notation->viewState()->matrix().m11();
     qreal proximity = configuration()->selectionProximity() * 0.5f / scaling;
@@ -1399,7 +1399,7 @@ bool NotationInteraction::drop(const PointF& pos, Qt::KeyboardModifiers modifier
     bool systemStavesOnly = false;
     bool applyUserOffset = false;
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Drop position"));
     score()->addRefresh(m_dropData.ed.dropElement->canvasBoundingRect());
     ElementType et = m_dropData.ed.dropElement->type();
     switch (et) {
@@ -1645,7 +1645,7 @@ bool NotationInteraction::applyPaletteElement(mu::engraving::EngravingItem* elem
         return false;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Apply palette element"));
 
     const bool isMeasureAnchoredElement = element->type() == ElementType::MARKER
                                           || element->type() == ElementType::JUMP
@@ -2144,7 +2144,7 @@ void NotationInteraction::applyLineNoteToNote(Score* score, Note* note1, Note* n
 //! NOTE Copied from ScoreView::cmdAddSlur
 void NotationInteraction::doAddSlur(const mu::engraving::Slur* slurTemplate)
 {
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Add slur"));
     m_notifyAboutDropChanged = true;
 
     mu::engraving::ChordRest* firstChordRest = nullptr;
@@ -2869,7 +2869,7 @@ static ChordRest* asChordRest(EngravingItem* e)
 
 void NotationInteraction::moveChordRestToStaff(MoveDirection dir)
 {
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Move chord/rest to staff"));
 
     for (EngravingItem* e: score()->selection().uniqueElements()) {
         ChordRest* cr = asChordRest(e);
@@ -2899,7 +2899,7 @@ void NotationInteraction::swapChordRest(MoveDirection direction)
     } else {
         crl.append(cr);
     }
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Swap chord/rest"));
     for (ChordRest* cr1 : crl) {
         if (cr1->type() == ElementType::REST) {
             Measure* m = toRest(cr1)->measure();
@@ -2949,7 +2949,7 @@ void NotationInteraction::toggleSnapToPrevious()
     }
 
     // Do toggle...
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Toggle snap to previous"));
     for (Hairpin* h : hairpins) {
         if (h->snapToItemBefore() == newSnapValue) {
             continue;
@@ -2990,7 +2990,7 @@ void NotationInteraction::toggleSnapToNext()
     }
 
     // Do toggle...
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Toggle snap to next"));
     for (Hairpin* h : hairpins) {
         if (h->snapToItemAfter() == newSnapValue) {
             continue;
@@ -3093,7 +3093,7 @@ void NotationInteraction::movePitch(MoveDirection d, PitchMode mode)
         return;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Change pitch"));
 
     if (score()->selection().element() && score()->selection().element()->isRest()) {
         score()->cmdMoveRest(toRest(score()->selection().element()), toDirection(d));
@@ -3110,7 +3110,7 @@ void NotationInteraction::moveLyrics(MoveDirection d)
     IF_ASSERT_FAILED(el && el->isLyrics()) {
         return;
     }
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Move lyrics"));
     score()->cmdMoveLyrics(toLyrics(el), toDirection(d));
     apply();
 }
@@ -3122,7 +3122,7 @@ void NotationInteraction::nudge(MoveDirection d, bool quickly)
         return;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Nudge"));
 
     qreal step = quickly ? mu::engraving::MScore::nudgeStep10 : mu::engraving::MScore::nudgeStep;
     step = step * el->spatium();
@@ -3221,7 +3221,7 @@ void NotationInteraction::editText(QInputMethodEvent* event)
     }
 
     if (!event->commitString().isEmpty()) {
-        score()->startCmd();
+        score()->startCmd(TranslatableString("undoableAction", "Edit text"));
         text->insertText(m_editData, event->commitString());
         score()->endCmd();
         preeditString.clear();
@@ -3386,6 +3386,11 @@ void NotationInteraction::undo()
 void NotationInteraction::redo()
 {
     m_undoStack->redo(&m_editData);
+}
+
+void NotationInteraction::undoHistory(size_t moveToIdx)
+{
+    m_undoStack->undoRedoToIdx(moveToIdx, &m_editData);
 }
 
 muse::async::Notification NotationInteraction::textEditingStarted() const
@@ -3624,7 +3629,7 @@ void NotationInteraction::editElement(QKeyEvent* event)
         }
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Keystroke edit"));
 
     if (needStartEditGrip(event)) {
         m_editData.curGrip = m_editData.element->defaultGrip();
@@ -3724,7 +3729,7 @@ void NotationInteraction::splitSelectedMeasure()
 
     ChordRest* chordRest = dynamic_cast<ChordRest*>(selectedElement);
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Split selected measure"));
     score()->cmdSplitMeasure(chordRest);
     apply();
 
@@ -3739,7 +3744,7 @@ void NotationInteraction::joinSelectedMeasures()
 
     INotationSelectionRange::MeasureRange measureRange = m_selection->range()->measureRange();
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Join selected measures"));
     score()->cmdJoinMeasure(measureRange.startMeasure, measureRange.endMeasure);
     apply();
 
@@ -3884,6 +3889,18 @@ void NotationInteraction::addBoxes(BoxType boxType, int count, int beforeBoxInde
         return ElementType::INVALID;
     };
 
+    auto boxTypeDescription = [](BoxType boxType) -> TranslatableString {
+        switch (boxType) {
+        case BoxType::Horizontal: return TranslatableString("undoableAction", "Add horizontal frame");
+        case BoxType::Vertical: return TranslatableString("undoableAction", "Add vertical frame");
+        case BoxType::Text: return TranslatableString("undoableAction", "Add text frame");
+        case BoxType::Measure: return TranslatableString("undoableAction", "Add %1 measure(s)");
+        case BoxType::Unknown: return {};
+        }
+
+        return {};
+    };
+
     mu::engraving::ElementType elementType = boxTypeToElementType(boxType);
     if (elementType == mu::engraving::ElementType::INVALID) {
         return;
@@ -3891,7 +3908,7 @@ void NotationInteraction::addBoxes(BoxType boxType, int count, int beforeBoxInde
 
     mu::engraving::MeasureBase* beforeBox = beforeBoxIndex >= 0 ? score()->measure(beforeBoxIndex) : nullptr;
 
-    startEdit();
+    startEdit(boxTypeDescription(boxType).arg(count));
 
     mu::engraving::Score::InsertMeasureOptions options;
     options.createEmptyMeasures = false;
@@ -3947,7 +3964,7 @@ Ret NotationInteraction::repeatSelection()
     if (score()->noteEntryMode() && selection.isSingle()) {
         EngravingItem* el = selection.element();
         if (el && el->type() == ElementType::NOTE && !score()->inputState().endOfScore()) {
-            startEdit();
+            startEdit(TranslatableString("undoableAction", "Repeat selection"));
             Chord* c = toNote(el)->chord();
             for (Note* note : c->notes()) {
                 mu::engraving::NoteVal nval = note->noteVal();
@@ -3981,7 +3998,7 @@ Ret NotationInteraction::repeatSelection()
     if (endSegment && endSegment->element(dStaff * mu::engraving::VOICES)) {
         EngravingItem* e = endSegment->element(dStaff * mu::engraving::VOICES);
         if (e) {
-            startEdit();
+            startEdit(TranslatableString("undoableAction", "Repeat selection"));
             ChordRest* cr = toChordRest(e);
             score()->pasteStaff(xml, cr->segment(), cr->staffIdx());
             apply();
@@ -4001,7 +4018,7 @@ void NotationInteraction::copyLyrics()
 
 void NotationInteraction::pasteSelection(const Fraction& scale)
 {
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Paste selection"));
 
     if (isTextEditingStarted()) {
         const QMimeData* mimeData = QApplication::clipboard()->mimeData();
@@ -4098,7 +4115,7 @@ void NotationInteraction::deleteSelection()
         return;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Delete selection"));
 
     if (isTextEditingStarted()) {
         mu::engraving::TextBase* textBase = toTextBase(m_editData.element);
@@ -4124,21 +4141,21 @@ void NotationInteraction::flipSelection()
         return;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Flip selection"));
     score()->cmdFlip();
     apply();
 }
 
 void NotationInteraction::addTieToSelection()
 {
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Add tie to selection"));
     score()->cmdToggleTie();
     apply();
 }
 
 void NotationInteraction::addTiedNoteToChord()
 {
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Add tied note to chord"));
     score()->cmdAddTie(true);
     apply();
 }
@@ -4149,7 +4166,7 @@ void NotationInteraction::addSlurToSelection()
         return;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Add slur to selection"));
     doAddSlur();
     apply();
 }
@@ -4160,7 +4177,7 @@ void NotationInteraction::addOttavaToSelection(OttavaType type)
         return;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Add ottava to selection"));
     score()->cmdAddOttava(type);
     apply();
 }
@@ -4171,7 +4188,7 @@ void NotationInteraction::addHairpinsToSelection(HairpinType type)
         return;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Add hairpins to selection"));
     std::vector<mu::engraving::Hairpin*> hairpins = score()->addHairpins(type);
     apply();
 
@@ -4190,7 +4207,7 @@ void NotationInteraction::addAccidentalToSelection(AccidentalType type)
 
     mu::engraving::EditData editData(&m_scoreCallbacks);
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Add accidental to selection"));
     score()->toggleAccidental(type, editData);
     apply();
 }
@@ -4219,7 +4236,7 @@ void NotationInteraction::putRest(Duration duration)
         return;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Put rest"));
     score()->cmdEnterRest(duration);
     apply();
 }
@@ -4230,7 +4247,7 @@ void NotationInteraction::addBracketsToSelection(BracketsType type)
         return;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Add brackets to selection"));
 
     switch (type) {
     case BracketsType::Brackets:
@@ -4279,7 +4296,7 @@ void NotationInteraction::changeSelectedNotesArticulation(SymbolId articulationS
         }
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Update articulations"));
     for (Chord* chord: chords) {
         chord->updateArticulations({ articulationSymbolId }, updateMode);
     }
@@ -4315,7 +4332,7 @@ void NotationInteraction::addGraceNotesToSelectedNotes(GraceNoteType type)
         break;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Add grace notes"));
     score()->cmdAddGrace(type, mu::engraving::Constants::DIVISION / denominator);
     apply();
 }
@@ -4342,7 +4359,7 @@ void NotationInteraction::addTupletToSelectedChordRests(const TupletOptions& opt
         return;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Add tuplet to selected"));
 
     for (ChordRest* chordRest : score()->getSelectedChordRests()) {
         if (!chordRest->isGrace() && !(chordRest->isChord() && toChord(chordRest)->isTrillCueNote())) {
@@ -4363,7 +4380,7 @@ void NotationInteraction::addBeamToSelectedChordRests(BeamMode mode)
         return;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Add beam to selected"));
     score()->cmdSetBeamMode(mode);
     apply();
 }
@@ -4374,7 +4391,7 @@ void NotationInteraction::increaseDecreaseDuration(int steps, bool stepByDots)
         return;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Modify duration"));
     score()->cmdIncDecDuration(steps, stepByDots);
     apply();
 }
@@ -4386,7 +4403,7 @@ bool NotationInteraction::toggleLayoutBreakAvailable() const
 
 void NotationInteraction::toggleLayoutBreak(LayoutBreakType breakType)
 {
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Toggle layout break"));
     score()->cmdToggleLayoutBreak(breakType);
     apply();
 }
@@ -4396,14 +4413,14 @@ void NotationInteraction::setBreaksSpawnInterval(BreaksSpawnIntervalType interva
     interval = intervalType == BreaksSpawnIntervalType::MeasuresInterval ? interval : 0;
     bool afterEachSystem = intervalType == BreaksSpawnIntervalType::AfterEachSystem;
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Break spawn interval"));
     score()->addRemoveBreaks(interval, afterEachSystem);
     apply();
 }
 
 bool NotationInteraction::transpose(const TransposeOptions& options)
 {
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Transposition"));
 
     bool ok = score()->transpose(options.mode, options.direction, options.key, options.interval,
                                  options.needTransposeKeys, options.needTransposeChordNames, options.needTransposeDoubleSharpsFlats);
@@ -4427,7 +4444,7 @@ void NotationInteraction::swapVoices(voice_idx_t voiceIndex1, voice_idx_t voiceI
         return;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Swap voices"));
     score()->cmdExchangeVoice(voiceIndex1, voiceIndex2);
     apply();
 }
@@ -4458,14 +4475,14 @@ void NotationInteraction::addIntervalToSelectedNotes(int interval)
         return;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Add interval to selected notes"));
     score()->addInterval(interval, notes);
     apply();
 }
 
 void NotationInteraction::addFret(int fretIndex)
 {
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Add fret"));
     score()->cmdAddFret(fretIndex);
     apply();
 }
@@ -4480,7 +4497,7 @@ void NotationInteraction::changeSelectedElementsVoice(voice_idx_t voiceIndex)
         return;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Change voice"));
     score()->changeSelectedElementsVoice(voiceIndex);
     apply();
 }
@@ -4491,7 +4508,7 @@ void NotationInteraction::changeSelectedElementsVoiceAssignment(VoiceAssignment 
         return;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Change voice assignment"));
     score()->changeSelectedElementsVoiceAssignment(voiceAssignment);
     apply();
 }
@@ -4502,7 +4519,7 @@ void NotationInteraction::addAnchoredLineToSelectedNotes()
         return;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Add anchored line"));
     score()->addNoteLine();
     apply();
 }
@@ -4572,7 +4589,7 @@ void NotationInteraction::addText(TextStyleType type, EngravingItem* item)
         m_noteInput->endNoteInput();
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Add text"));
     mu::engraving::TextBase* text = score()->addText(type, item);
 
     if (!text) {
@@ -4632,7 +4649,7 @@ void NotationInteraction::addImageToItem(const muse::io::path_t& imagePath, Engr
         return;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Add image to item"));
     score()->undoAddElement(image);
     apply();
 }
@@ -4651,7 +4668,7 @@ Ret NotationInteraction::canAddFiguredBass() const
 
 void NotationInteraction::addFiguredBass()
 {
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Add figured bass"));
     mu::engraving::FiguredBass* figuredBass = score()->addFiguredBass();
 
     if (figuredBass) {
@@ -4665,7 +4682,7 @@ void NotationInteraction::addFiguredBass()
 
 void NotationInteraction::addStretch(qreal value)
 {
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Add stretch"));
     score()->cmdAddStretch(value);
     apply();
 }
@@ -4688,7 +4705,7 @@ Measure* NotationInteraction::selectedMeasure() const
 
 void NotationInteraction::addTimeSignature(Measure* measure, staff_idx_t staffIndex, TimeSignature* timeSignature)
 {
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Add time signature"));
     score()->cmdAddTimeSig(measure, staffIndex, timeSignature, true);
     apply();
 }
@@ -4699,7 +4716,7 @@ void NotationInteraction::explodeSelectedStaff()
         return;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Explode staff"));
     score()->cmdExplode();
     apply();
 }
@@ -4710,7 +4727,7 @@ void NotationInteraction::implodeSelectedStaff()
         return;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Implode staff"));
     score()->cmdImplode();
     apply();
 }
@@ -4721,7 +4738,7 @@ void NotationInteraction::realizeSelectedChordSymbols(bool literal, Voicing voic
         return;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Realize chord symbols"));
     score()->cmdRealizeChordSymbols(literal, voicing, durationType);
     apply();
 }
@@ -4758,10 +4775,15 @@ void NotationInteraction::removeSelectedMeasures()
         }
     }
 
+    IF_ASSERT_FAILED(firstMeasure && lastMeasure) {
+        return;
+    }
+
     doSelect({ firstMeasure }, SelectType::REPLACE);
     doSelect({ lastMeasure }, SelectType::RANGE);
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction",
+                                 "Delete %1 measure(s)").arg(1 + lastMeasure->measureIndex() - firstMeasure->measureIndex()));
     score()->cmdTimeDelete();
     apply();
 }
@@ -4772,14 +4794,14 @@ void NotationInteraction::removeSelectedRange()
         return;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Delete selection"));
     score()->cmdTimeDelete();
     apply();
 }
 
 void NotationInteraction::removeEmptyTrailingMeasures()
 {
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Delete trailing measures"));
     score()->cmdRemoveEmptyTrailingMeasures();
     apply();
 }
@@ -4790,7 +4812,7 @@ void NotationInteraction::fillSelectionWithSlashes()
         return;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Fill selection with slashes"));
     score()->cmdSlashFill();
     apply();
 }
@@ -4801,56 +4823,56 @@ void NotationInteraction::replaceSelectedNotesWithSlashes()
         return;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Replace notes with slashes"));
     score()->cmdSlashRhythm();
     apply();
 }
 
 void NotationInteraction::changeEnharmonicSpelling(bool both)
 {
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Change enharmonic spelling"));
     score()->changeEnharmonicSpelling(both);
     apply();
 }
 
 void NotationInteraction::spellPitches()
 {
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Spell pitches"));
     score()->spell();
     apply();
 }
 
 void NotationInteraction::regroupNotesAndRests()
 {
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Regroup notes and rests"));
     score()->cmdResetNoteAndRestGroupings();
     apply();
 }
 
 void NotationInteraction::resequenceRehearsalMarks()
 {
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Resequence rehearsal marks"));
     score()->cmdResequenceRehearsalMarks();
     apply();
 }
 
 void NotationInteraction::resetStretch()
 {
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Reset stretch"));
     score()->resetUserStretch();
     apply();
 }
 
 void NotationInteraction::resetTextStyleOverrides()
 {
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Reset text style overrides"));
     score()->cmdResetTextStyleOverrides();
     apply();
 }
 
 void NotationInteraction::resetBeamMode()
 {
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Reset beaming mode"));
     score()->cmdResetBeamMode();
     apply();
 }
@@ -4867,7 +4889,7 @@ void NotationInteraction::resetShapesAndPosition()
         }
     };
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Reset shapes and position"));
 
     DEFER {
         apply();
@@ -4887,7 +4909,7 @@ void NotationInteraction::resetToDefaultLayout()
 {
     TRACEFUNC;
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Reset to default layout"));
     score()->cmdResetToDefaultLayout();
     apply();
 }
@@ -4911,7 +4933,7 @@ void NotationInteraction::setScoreConfig(const ScoreConfig& config)
         return;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Set score configuration"));
     score()->setShowInvisible(config.isShowInvisibleElements);
     score()->setShowUnprintable(config.isShowUnprintableElements);
     score()->setShowFrames(config.isShowFrames);
@@ -5073,7 +5095,7 @@ void NotationInteraction::navigateToLyrics(bool back, bool moveOnly, bool end)
         newLyrics = true;
     }
 
-    score()->startCmd();
+    score()->startCmd(TranslatableString("undoableAction", "Navigate to lyrics"));
     if (fromLyrics && !moveOnly) {
         switch (nextLyrics->syllabic()) {
         // as we arrived at nextLyrics by a [Space], it can be the beginning
@@ -5191,7 +5213,7 @@ void NotationInteraction::navigateToNextSyllable()
         segment = segment->prev1(mu::engraving::SegmentType::ChordRest);
     }
 
-    score()->startCmd();
+    score()->startCmd(TranslatableString("undoableAction", "Navigate to next syllable"));
     ChordRest* cr = toChordRest(nextSegment->element(toLyricTrack));
     mu::engraving::Lyrics* toLyrics = cr->lyrics(verse, placement);
 
@@ -5317,7 +5339,7 @@ void NotationInteraction::navigateToLyricsVerse(MoveDirection direction)
         lyrics->setFontStyle(fStyle);
         lyrics->setPropertyFlags(mu::engraving::Pid::FONT_STYLE, fFlags);
 
-        score()->startCmd();
+        score()->startCmd(TranslatableString("undoableAction", "Navigate to verse"));
         score()->undoAddElement(lyrics);
         score()->endCmd();
     }
@@ -5408,7 +5430,7 @@ void NotationInteraction::navigateToNearHarmony(MoveDirection direction, bool ne
         }
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Navigate to near harmony"));
 
     if (needAddSegment) {
         score()->undoAddElement(segment);
@@ -5462,7 +5484,7 @@ void NotationInteraction::navigateToHarmonyInNearMeasure(MoveDirection direction
     if (!nextHarmony) {
         nextHarmony = createHarmony(segment, track, harmony->harmonyType());
 
-        startEdit();
+        startEdit(TranslatableString("undoableAction", "Navigate to near harmony in measure"));
         score()->undoAddElement(nextHarmony);
         apply();
     }
@@ -5499,7 +5521,7 @@ void NotationInteraction::navigateToHarmony(const Fraction& ticks)
         segment = segment->next1(mu::engraving::SegmentType::ChordRest);
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Navigate to harmony"));
 
     if (!segment || segment->tick() > newTick) {      // no ChordRest segment at this tick
         segment = Factory::createSegment(measure, mu::engraving::SegmentType::ChordRest, newTick - measure->tick());
@@ -5555,7 +5577,7 @@ void NotationInteraction::navigateToNearFiguredBass(MoveDirection direction)
     // add a (new) FB element, using chord duration as default duration
     mu::engraving::FiguredBass* fbNew = mu::engraving::FiguredBass::addFiguredBassToSegment(nextSegm, track, Fraction(0, 1), &bNew);
     if (bNew) {
-        startEdit();
+        startEdit(TranslatableString("undoableAction", "Navigate to near figured bass"));
         score()->undoAddElement(fbNew);
         apply();
     }
@@ -5599,7 +5621,7 @@ void NotationInteraction::navigateToFiguredBassInNearMeasure(MoveDirection direc
     // add a (new) FB element, using chord duration as default duration
     mu::engraving::FiguredBass* fbNew = mu::engraving::FiguredBass::addFiguredBassToSegment(nextSegm, fb->track(), Fraction(0, 1), &bNew);
     if (bNew) {
-        startEdit();
+        startEdit(TranslatableString("undoableAction", "Navigate to figured bass in near measure"));
         score()->undoAddElement(fbNew);
         apply();
     }
@@ -5650,7 +5672,7 @@ void NotationInteraction::navigateToFiguredBass(const Fraction& ticks)
         needAddSegment = true;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Navigate to figured bass"));
 
     if (needAddSegment) {
         score()->undoAddElement(nextSegm);
@@ -5836,14 +5858,14 @@ void NotationInteraction::addMelisma()
     // if still at melisma initial chord and there is a valid next chord (if not,
     // there will be no melisma anyway), set a temporary melisma duration
     if (fromLyrics == lyrics && nextSegment) {
-        score()->startCmd();
+        score()->startCmd(TranslatableString("undoableAction", "Add melisma"));
         lyrics->undoChangeProperty(mu::engraving::Pid::LYRIC_TICKS, mu::engraving::Lyrics::TEMP_MELISMA_TICKS);
         score()->setLayoutAll();
         score()->endCmd();
     }
 
     if (nextSegment == 0) {
-        score()->startCmd();
+        score()->startCmd(TranslatableString("undoableAction", "Add melisma"));
         if (fromLyrics) {
             switch (fromLyrics->syllabic()) {
             case mu::engraving::LyricsSyllabic::SINGLE:
@@ -5868,7 +5890,7 @@ void NotationInteraction::addMelisma()
 
     // if a place for a new lyrics has been found, create a lyrics there
 
-    score()->startCmd();
+    score()->startCmd(TranslatableString("undoableAction", "Create lyric for melisma"));
     ChordRest* cr = toChordRest(nextSegment->element(track));
     mu::engraving::Lyrics* toLyrics = cr->lyrics(verse, placement);
     bool newLyrics = (toLyrics == 0);
@@ -5933,7 +5955,7 @@ void NotationInteraction::addLyricsVerse()
 
     endEditText();
 
-    score()->startCmd();
+    score()->startCmd(TranslatableString("undoableAction", "Add verse"));
     int newVerse = oldLyrics->no() + 1;
 
     mu::engraving::Lyrics* lyrics = Factory::createLyrics(oldLyrics->chordRest());
@@ -5981,7 +6003,7 @@ void NotationInteraction::addGuitarBend(GuitarBendType bendType)
         return;
     }
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Add guitar bend"));
 
     Note* startNote = nullptr;
     Note* endNote = nullptr;
@@ -6091,7 +6113,7 @@ void NotationInteraction::toggleFontStyle(mu::engraving::FontStyle style)
     }
     mu::engraving::TextBase* text = toTextBase(m_editData.element);
     int currentStyle = text->getProperty(mu::engraving::Pid::FONT_STYLE).toInt();
-    score()->startCmd();
+    score()->startCmd(TranslatableString("undoableAction", "Toggle font style"));
     text->undoChangeProperty(mu::engraving::Pid::FONT_STYLE, PropertyValue::fromValue(
                                  currentStyle ^ static_cast<int>(style)), mu::engraving::PropertyFlags::UNSTYLED);
     score()->endCmd();
@@ -6107,7 +6129,7 @@ void NotationInteraction::toggleVerticalAlignment(VerticalAlignment align)
     mu::engraving::TextBase* text = toTextBase(m_editData.element);
     int ialign = static_cast<int>(align);
     int currentAlign = text->getProperty(mu::engraving::Pid::TEXT_SCRIPT_ALIGN).toInt();
-    score()->startCmd();
+    score()->startCmd(TranslatableString("undoableAction", "Toggle vertical alignment"));
     text->undoChangeProperty(mu::engraving::Pid::TEXT_SCRIPT_ALIGN, PropertyValue::fromValue(
                                  (currentAlign == ialign) ? static_cast<int>(VerticalAlignment::AlignNormal) : ialign),
                              mu::engraving::PropertyFlags::UNSTYLED);
@@ -6146,26 +6168,26 @@ void NotationInteraction::toggleSuperScript()
 }
 
 template<typename P>
-void NotationInteraction::execute(void (mu::engraving::Score::* function)(P), P param)
+void NotationInteraction::execute(void (mu::engraving::Score::* function)(P), P param, const TranslatableString& actionName)
 {
-    startEdit();
+    startEdit(actionName);
     (score()->*function)(param);
     apply();
 }
 
 void NotationInteraction::toggleArticulation(mu::engraving::SymId symId)
 {
-    execute(&mu::engraving::Score::toggleArticulation, symId);
+    execute(&mu::engraving::Score::toggleArticulation, symId, TranslatableString("undoableAction", "Toggle articulation"));
 }
 
 void NotationInteraction::toggleOrnament(mu::engraving::SymId symId)
 {
-    execute(&mu::engraving::Score::toggleOrnament, symId);
+    execute(&mu::engraving::Score::toggleOrnament, symId, TranslatableString("undoableAction", "Toggle ornament"));
 }
 
 void NotationInteraction::toggleAutoplace(bool all)
 {
-    execute(&mu::engraving::Score::cmdToggleAutoplace, all);
+    execute(&mu::engraving::Score::cmdToggleAutoplace, all, TranslatableString("undoableAction", "Toggle autoplace"));
 }
 
 bool NotationInteraction::canInsertClef(ClefType type) const
@@ -6176,22 +6198,23 @@ bool NotationInteraction::canInsertClef(ClefType type) const
 
 void NotationInteraction::insertClef(ClefType type)
 {
-    execute(&mu::engraving::Score::cmdInsertClef, type);
+    execute(&mu::engraving::Score::cmdInsertClef, type, TranslatableString("undoableAction", "Insert clef"));
 }
 
 void NotationInteraction::changeAccidental(mu::engraving::AccidentalType accidental)
 {
-    execute(&mu::engraving::Score::changeAccidental, accidental);
+    execute(&mu::engraving::Score::changeAccidental, accidental, TranslatableString("undoableAction", "Insert accidental"));
 }
 
 void NotationInteraction::transposeSemitone(int steps)
 {
-    execute(&mu::engraving::Score::transposeSemitone, steps);
+    execute(&mu::engraving::Score::transposeSemitone, steps, TranslatableString("undoableAction", "Transpose semitone"));
 }
 
 void NotationInteraction::transposeDiatonicAlterations(mu::engraving::TransposeDirection direction)
 {
-    execute(&mu::engraving::Score::transposeDiatonicAlterations, direction);
+    execute(&mu::engraving::Score::transposeDiatonicAlterations, direction,
+            TranslatableString("undoableAction", "Transpose diatonic alterations"));
 }
 
 void NotationInteraction::getLocation()
@@ -6218,7 +6241,7 @@ void NotationInteraction::getLocation()
 
 void NotationInteraction::execute(void (mu::engraving::Score::* function)())
 {
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Execute action"));
     (score()->*function)();
     apply();
 }

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -986,7 +986,7 @@ void NotationInteraction::startDrag(const std::vector<EngravingItem*>& elems,
         }
     }
 
-    startEdit(TranslatableString("undoableAction", "Drag item"));
+    startEdit(TranslatableString("undoableAction", "Drag element"));
 
     qreal scaling = m_notation->viewState()->matrix().m11();
     qreal proximity = configuration()->selectionProximity() * 0.5f / scaling;
@@ -1399,7 +1399,7 @@ bool NotationInteraction::drop(const PointF& pos, Qt::KeyboardModifiers modifier
     bool systemStavesOnly = false;
     bool applyUserOffset = false;
 
-    startEdit(TranslatableString("undoableAction", "Drop position"));
+    startEdit(TranslatableString("undoableAction", "Drop element"));
     score()->addRefresh(m_dropData.ed.dropElement->canvasBoundingRect());
     ElementType et = m_dropData.ed.dropElement->type();
     switch (et) {
@@ -2899,7 +2899,7 @@ void NotationInteraction::swapChordRest(MoveDirection direction)
     } else {
         crl.append(cr);
     }
-    startEdit(TranslatableString("undoableAction", "Swap chord/rest"));
+    startEdit(TranslatableString("undoableAction", "Move chord/rest"));
     for (ChordRest* cr1 : crl) {
         if (cr1->type() == ElementType::REST) {
             Measure* m = toRest(cr1)->measure();
@@ -3122,7 +3122,7 @@ void NotationInteraction::nudge(MoveDirection d, bool quickly)
         return;
     }
 
-    startEdit(TranslatableString("undoableAction", "Nudge"));
+    startEdit(TranslatableString("undoableAction", "Nudge element"));
 
     qreal step = quickly ? mu::engraving::MScore::nudgeStep10 : mu::engraving::MScore::nudgeStep;
     step = step * el->spatium();
@@ -3629,6 +3629,7 @@ void NotationInteraction::editElement(QKeyEvent* event)
         }
     }
 
+    //: Means: an editing operation triggered by a keystroke
     startEdit(TranslatableString("undoableAction", "Keystroke edit"));
 
     if (needStartEditGrip(event)) {
@@ -3729,7 +3730,7 @@ void NotationInteraction::splitSelectedMeasure()
 
     ChordRest* chordRest = dynamic_cast<ChordRest*>(selectedElement);
 
-    startEdit(TranslatableString("undoableAction", "Split selected measure"));
+    startEdit(TranslatableString("undoableAction", "Split measure"));
     score()->cmdSplitMeasure(chordRest);
     apply();
 
@@ -3744,7 +3745,7 @@ void NotationInteraction::joinSelectedMeasures()
 
     INotationSelectionRange::MeasureRange measureRange = m_selection->range()->measureRange();
 
-    startEdit(TranslatableString("undoableAction", "Join selected measures"));
+    startEdit(TranslatableString("undoableAction", "Join measures"));
     score()->cmdJoinMeasure(measureRange.startMeasure, measureRange.endMeasure);
     apply();
 
@@ -3889,26 +3890,26 @@ void NotationInteraction::addBoxes(BoxType boxType, int count, int beforeBoxInde
         return ElementType::INVALID;
     };
 
-    auto boxTypeDescription = [](BoxType boxType) -> TranslatableString {
-        switch (boxType) {
-        case BoxType::Horizontal: return TranslatableString("undoableAction", "Add horizontal frame");
-        case BoxType::Vertical: return TranslatableString("undoableAction", "Add vertical frame");
-        case BoxType::Text: return TranslatableString("undoableAction", "Add text frame");
-        case BoxType::Measure: return TranslatableString("undoableAction", "Add %1 measure(s)");
-        case BoxType::Unknown: return {};
-        }
-
-        return {};
-    };
-
     mu::engraving::ElementType elementType = boxTypeToElementType(boxType);
     if (elementType == mu::engraving::ElementType::INVALID) {
         return;
     }
 
-    mu::engraving::MeasureBase* beforeBox = beforeBoxIndex >= 0 ? score()->measure(beforeBoxIndex) : nullptr;
+    auto boxTypeDescription = [count](BoxType boxType) -> TranslatableString {
+        switch (boxType) {
+        case BoxType::Horizontal: return TranslatableString("undoableAction", "Add horizontal frame");
+        case BoxType::Vertical: return TranslatableString("undoableAction", "Add vertical frame");
+        case BoxType::Text: return TranslatableString("undoableAction", "Add text frame");
+        case BoxType::Measure: return TranslatableString("undoableAction", "Add %n measure(s)", nullptr, count);
+        case BoxType::Unknown: break;
+        }
 
-    startEdit(boxTypeDescription(boxType).arg(count));
+        return {};
+    };
+
+    startEdit(boxTypeDescription(boxType));
+
+    mu::engraving::MeasureBase* beforeBox = beforeBoxIndex >= 0 ? score()->measure(beforeBoxIndex) : nullptr;
 
     mu::engraving::Score::InsertMeasureOptions options;
     options.createEmptyMeasures = false;
@@ -4018,7 +4019,7 @@ void NotationInteraction::copyLyrics()
 
 void NotationInteraction::pasteSelection(const Fraction& scale)
 {
-    startEdit(TranslatableString("undoableAction", "Paste selection"));
+    startEdit(TranslatableString("undoableAction", "Paste"));
 
     if (isTextEditingStarted()) {
         const QMimeData* mimeData = QApplication::clipboard()->mimeData();
@@ -4115,7 +4116,7 @@ void NotationInteraction::deleteSelection()
         return;
     }
 
-    startEdit(TranslatableString("undoableAction", "Delete selection"));
+    startEdit(TranslatableString("undoableAction", "Delete"));
 
     if (isTextEditingStarted()) {
         mu::engraving::TextBase* textBase = toTextBase(m_editData.element);
@@ -4141,7 +4142,7 @@ void NotationInteraction::flipSelection()
         return;
     }
 
-    startEdit(TranslatableString("undoableAction", "Flip selection"));
+    startEdit(TranslatableString("undoableAction", "Flip direction"));
     score()->cmdFlip();
     apply();
 }
@@ -4178,7 +4179,7 @@ void NotationInteraction::addOttavaToSelection(OttavaType type)
         return;
     }
 
-    startEdit(TranslatableString("undoableAction", "Add ottava to selection"));
+    startEdit(TranslatableString("undoableAction", "Add ottava"));
     score()->cmdAddOttava(type);
     apply();
 }
@@ -4189,7 +4190,7 @@ void NotationInteraction::addHairpinsToSelection(HairpinType type)
         return;
     }
 
-    startEdit(TranslatableString("undoableAction", "Add hairpins to selection"));
+    startEdit(TranslatableString("undoableAction", "Add hairpin"));
     std::vector<mu::engraving::Hairpin*> hairpins = score()->addHairpins(type);
     apply();
 
@@ -4208,7 +4209,7 @@ void NotationInteraction::addAccidentalToSelection(AccidentalType type)
 
     mu::engraving::EditData editData(&m_scoreCallbacks);
 
-    startEdit(TranslatableString("undoableAction", "Add accidental to selection"));
+    startEdit(TranslatableString("undoableAction", "Add accidental"));
     score()->toggleAccidental(type, editData);
     apply();
 }
@@ -4249,21 +4250,23 @@ void NotationInteraction::addBracketsToSelection(BracketsType type)
         return;
     }
 
-    startEdit(TranslatableString("undoableAction", "Add brackets to selection"));
-
     switch (type) {
     case BracketsType::Brackets:
+        startEdit(TranslatableString("undoableAction", "Add brackets"));
         score()->cmdAddBracket();
+        apply();
         break;
     case BracketsType::Braces:
+        startEdit(TranslatableString("undoableAction", "Add braces"));
         score()->cmdAddBraces();
+        apply();
         break;
     case BracketsType::Parentheses:
+        startEdit(TranslatableString("undoableAction", "Add parentheses"));
         score()->cmdAddParentheses();
+        apply();
         break;
     }
-
-    apply();
 }
 
 void NotationInteraction::changeSelectedNotesArticulation(SymbolId articulationSymbolId)
@@ -4298,7 +4301,7 @@ void NotationInteraction::changeSelectedNotesArticulation(SymbolId articulationS
         }
     }
 
-    startEdit(TranslatableString("undoableAction", "Update articulations"));
+    startEdit(TranslatableString("undoableAction", "Toggle articulation"));
     for (Chord* chord: chords) {
         chord->updateArticulations({ articulationSymbolId }, updateMode);
     }
@@ -4334,7 +4337,7 @@ void NotationInteraction::addGraceNotesToSelectedNotes(GraceNoteType type)
         break;
     }
 
-    startEdit(TranslatableString("undoableAction", "Add grace notes"));
+    startEdit(TranslatableString("undoableAction", "Add grace note"));
     score()->cmdAddGrace(type, mu::engraving::Constants::DIVISION / denominator);
     apply();
 }
@@ -4361,7 +4364,7 @@ void NotationInteraction::addTupletToSelectedChordRests(const TupletOptions& opt
         return;
     }
 
-    startEdit(TranslatableString("undoableAction", "Add tuplet to selected"));
+    startEdit(TranslatableString("undoableAction", "Add tuplet"));
 
     for (ChordRest* chordRest : score()->getSelectedChordRests()) {
         if (!chordRest->isGrace() && !(chordRest->isChord() && toChord(chordRest)->isTrillCueNote())) {
@@ -4382,7 +4385,7 @@ void NotationInteraction::addBeamToSelectedChordRests(BeamMode mode)
         return;
     }
 
-    startEdit(TranslatableString("undoableAction", "Add beam to selected"));
+    startEdit(TranslatableString("undoableAction", "Set beam type"));
     score()->cmdSetBeamMode(mode);
     apply();
 }
@@ -4393,7 +4396,9 @@ void NotationInteraction::increaseDecreaseDuration(int steps, bool stepByDots)
         return;
     }
 
-    startEdit(TranslatableString("undoableAction", "Modify duration"));
+    startEdit(steps >= 0
+              ? TranslatableString("undoableAction", "Increase duration")
+              : TranslatableString("undoableAction", "Decrease duration"));
     score()->cmdIncDecDuration(steps, stepByDots);
     apply();
 }
@@ -4415,7 +4420,7 @@ void NotationInteraction::setBreaksSpawnInterval(BreaksSpawnIntervalType interva
     interval = intervalType == BreaksSpawnIntervalType::MeasuresInterval ? interval : 0;
     bool afterEachSystem = intervalType == BreaksSpawnIntervalType::AfterEachSystem;
 
-    startEdit(TranslatableString("undoableAction", "Break spawn interval"));
+    startEdit(TranslatableString("undoableAction", "Add/remove system breaks"));
     score()->addRemoveBreaks(interval, afterEachSystem);
     apply();
 }
@@ -4477,14 +4482,14 @@ void NotationInteraction::addIntervalToSelectedNotes(int interval)
         return;
     }
 
-    startEdit(TranslatableString("undoableAction", "Add interval to selected notes"));
+    startEdit(TranslatableString("undoableAction", "Add interval"));
     score()->addInterval(interval, notes);
     apply();
 }
 
 void NotationInteraction::addFret(int fretIndex)
 {
-    startEdit(TranslatableString("undoableAction", "Add fret"));
+    startEdit(TranslatableString("undoableAction", "Enter note at fret %1").arg(fretIndex));
     score()->cmdAddFret(fretIndex);
     apply();
 }
@@ -4521,7 +4526,7 @@ void NotationInteraction::addAnchoredLineToSelectedNotes()
         return;
     }
 
-    startEdit(TranslatableString("undoableAction", "Add anchored line"));
+    startEdit(TranslatableString("undoableAction", "Add note anchored line"));
     score()->addNoteLine();
     apply();
 }
@@ -4651,7 +4656,7 @@ void NotationInteraction::addImageToItem(const muse::io::path_t& imagePath, Engr
         return;
     }
 
-    startEdit(TranslatableString("undoableAction", "Add image to item"));
+    startEdit(TranslatableString("undoableAction", "Add image"));
     score()->undoAddElement(image);
     apply();
 }
@@ -4684,7 +4689,9 @@ void NotationInteraction::addFiguredBass()
 
 void NotationInteraction::addStretch(qreal value)
 {
-    startEdit(TranslatableString("undoableAction", "Add stretch"));
+    startEdit(value >= 0
+              ? TranslatableString("undoableAction", "Increase layout stretch")
+              : TranslatableString("undoableAction", "Decrease layout stretch"));
     score()->cmdAddStretch(value);
     apply();
 }
@@ -4718,7 +4725,7 @@ void NotationInteraction::explodeSelectedStaff()
         return;
     }
 
-    startEdit(TranslatableString("undoableAction", "Explode staff"));
+    startEdit(TranslatableString("undoableAction", "Explode"));
     score()->cmdExplode();
     apply();
 }
@@ -4729,7 +4736,7 @@ void NotationInteraction::implodeSelectedStaff()
         return;
     }
 
-    startEdit(TranslatableString("undoableAction", "Implode staff"));
+    startEdit(TranslatableString("undoableAction", "Implode"));
     score()->cmdImplode();
     apply();
 }
@@ -4784,8 +4791,9 @@ void NotationInteraction::removeSelectedMeasures()
     doSelect({ firstMeasure }, SelectType::REPLACE);
     doSelect({ lastMeasure }, SelectType::RANGE);
 
-    startEdit(TranslatableString("undoableAction",
-                                 "Delete %1 measure(s)").arg(1 + lastMeasure->measureIndex() - firstMeasure->measureIndex()));
+    int numDeletedMeasures = 1 + lastMeasure->measureIndex() - firstMeasure->measureIndex();
+
+    startEdit(TranslatableString("undoableAction", "Delete %1 measure(s)", nullptr, numDeletedMeasures));
     score()->cmdTimeDelete();
     apply();
 }
@@ -4796,14 +4804,14 @@ void NotationInteraction::removeSelectedRange()
         return;
     }
 
-    startEdit(TranslatableString("undoableAction", "Delete selection"));
+    startEdit(TranslatableString("undoableAction", "Delete range"));
     score()->cmdTimeDelete();
     apply();
 }
 
 void NotationInteraction::removeEmptyTrailingMeasures()
 {
-    startEdit(TranslatableString("undoableAction", "Delete trailing measures"));
+    startEdit(TranslatableString("undoableAction", "Remove empty trailing measures"));
     score()->cmdRemoveEmptyTrailingMeasures();
     apply();
 }
@@ -4814,7 +4822,7 @@ void NotationInteraction::fillSelectionWithSlashes()
         return;
     }
 
-    startEdit(TranslatableString("undoableAction", "Fill selection with slashes"));
+    startEdit(TranslatableString("undoableAction", "Fill with slashes"));
     score()->cmdSlashFill();
     apply();
 }
@@ -4825,7 +4833,7 @@ void NotationInteraction::replaceSelectedNotesWithSlashes()
         return;
     }
 
-    startEdit(TranslatableString("undoableAction", "Replace notes with slashes"));
+    startEdit(TranslatableString("undoableAction", "Toggle rhythmic slash notation"));
     score()->cmdSlashRhythm();
     apply();
 }
@@ -4839,14 +4847,14 @@ void NotationInteraction::changeEnharmonicSpelling(bool both)
 
 void NotationInteraction::spellPitches()
 {
-    startEdit(TranslatableString("undoableAction", "Spell pitches"));
+    startEdit(TranslatableString("undoableAction", "Respell pitches"));
     score()->spell();
     apply();
 }
 
 void NotationInteraction::regroupNotesAndRests()
 {
-    startEdit(TranslatableString("undoableAction", "Regroup notes and rests"));
+    startEdit(TranslatableString("undoableAction", "Regroup rhythms"));
     score()->cmdResetNoteAndRestGroupings();
     apply();
 }
@@ -4860,7 +4868,7 @@ void NotationInteraction::resequenceRehearsalMarks()
 
 void NotationInteraction::resetStretch()
 {
-    startEdit(TranslatableString("undoableAction", "Reset stretch"));
+    startEdit(TranslatableString("undoableAction", "Reset layout stretch"));
     score()->resetUserStretch();
     apply();
 }
@@ -4874,7 +4882,7 @@ void NotationInteraction::resetTextStyleOverrides()
 
 void NotationInteraction::resetBeamMode()
 {
-    startEdit(TranslatableString("undoableAction", "Reset beaming mode"));
+    startEdit(TranslatableString("undoableAction", "Reset beams"));
     score()->cmdResetBeamMode();
     apply();
 }
@@ -4891,7 +4899,7 @@ void NotationInteraction::resetShapesAndPosition()
         }
     };
 
-    startEdit(TranslatableString("undoableAction", "Reset shapes and position"));
+    startEdit(TranslatableString("undoableAction", "Reset shapes and positions"));
 
     DEFER {
         apply();
@@ -4935,7 +4943,9 @@ void NotationInteraction::setScoreConfig(const ScoreConfig& config)
         return;
     }
 
-    startEdit(TranslatableString("undoableAction", "Set score configuration"));
+    // TODO: refactor together with `NotationActionController::toggleScoreConfig`
+    // to be able to give a more precise name
+    startEdit(TranslatableString("undoableAction", "Set score view settings"));
     score()->setShowInvisible(config.isShowInvisibleElements);
     score()->setShowUnprintable(config.isShowUnprintableElements);
     score()->setShowFrames(config.isShowFrames);
@@ -5432,7 +5442,7 @@ void NotationInteraction::navigateToNearHarmony(MoveDirection direction, bool ne
         }
     }
 
-    startEdit(TranslatableString("undoableAction", "Navigate to near harmony"));
+    startEdit(TranslatableString("undoableAction", "Navigate to next chord symbol"));
 
     if (needAddSegment) {
         score()->undoAddElement(segment);
@@ -5486,7 +5496,7 @@ void NotationInteraction::navigateToHarmonyInNearMeasure(MoveDirection direction
     if (!nextHarmony) {
         nextHarmony = createHarmony(segment, track, harmony->harmonyType());
 
-        startEdit(TranslatableString("undoableAction", "Navigate to near harmony in measure"));
+        startEdit(TranslatableString("undoableAction", "Navigate to next chord symbol"));
         score()->undoAddElement(nextHarmony);
         apply();
     }
@@ -5523,7 +5533,7 @@ void NotationInteraction::navigateToHarmony(const Fraction& ticks)
         segment = segment->next1(mu::engraving::SegmentType::ChordRest);
     }
 
-    startEdit(TranslatableString("undoableAction", "Navigate to harmony"));
+    startEdit(TranslatableString("undoableAction", "Navigate to chord symbol"));
 
     if (!segment || segment->tick() > newTick) {      // no ChordRest segment at this tick
         segment = Factory::createSegment(measure, mu::engraving::SegmentType::ChordRest, newTick - measure->tick());
@@ -5579,7 +5589,7 @@ void NotationInteraction::navigateToNearFiguredBass(MoveDirection direction)
     // add a (new) FB element, using chord duration as default duration
     mu::engraving::FiguredBass* fbNew = mu::engraving::FiguredBass::addFiguredBassToSegment(nextSegm, track, Fraction(0, 1), &bNew);
     if (bNew) {
-        startEdit(TranslatableString("undoableAction", "Navigate to near figured bass"));
+        startEdit(TranslatableString("undoableAction", "Navigate to next figured bass"));
         score()->undoAddElement(fbNew);
         apply();
     }
@@ -5623,7 +5633,7 @@ void NotationInteraction::navigateToFiguredBassInNearMeasure(MoveDirection direc
     // add a (new) FB element, using chord duration as default duration
     mu::engraving::FiguredBass* fbNew = mu::engraving::FiguredBass::addFiguredBassToSegment(nextSegm, fb->track(), Fraction(0, 1), &bNew);
     if (bNew) {
-        startEdit(TranslatableString("undoableAction", "Navigate to figured bass in near measure"));
+        startEdit(TranslatableString("undoableAction", "Navigate to next figured bass"));
         score()->undoAddElement(fbNew);
         apply();
     }
@@ -5860,14 +5870,14 @@ void NotationInteraction::addMelisma()
     // if still at melisma initial chord and there is a valid next chord (if not,
     // there will be no melisma anyway), set a temporary melisma duration
     if (fromLyrics == lyrics && nextSegment) {
-        score()->startCmd(TranslatableString("undoableAction", "Add melisma"));
+        score()->startCmd(TranslatableString("undoableAction", "Enter lyrics extension line"));
         lyrics->undoChangeProperty(mu::engraving::Pid::LYRIC_TICKS, mu::engraving::Lyrics::TEMP_MELISMA_TICKS);
         score()->setLayoutAll();
         score()->endCmd();
     }
 
     if (nextSegment == 0) {
-        score()->startCmd(TranslatableString("undoableAction", "Add melisma"));
+        score()->startCmd(TranslatableString("undoableAction", "Enter lyrics extension line"));
         if (fromLyrics) {
             switch (fromLyrics->syllabic()) {
             case mu::engraving::LyricsSyllabic::SINGLE:
@@ -5892,7 +5902,7 @@ void NotationInteraction::addMelisma()
 
     // if a place for a new lyrics has been found, create a lyrics there
 
-    score()->startCmd(TranslatableString("undoableAction", "Create lyric for melisma"));
+    score()->startCmd(TranslatableString("undoableAction", "Enter lyrics extension line"));
     ChordRest* cr = toChordRest(nextSegment->element(track));
     mu::engraving::Lyrics* toLyrics = cr->lyrics(verse, placement);
     bool newLyrics = (toLyrics == 0);
@@ -5957,7 +5967,7 @@ void NotationInteraction::addLyricsVerse()
 
     endEditText();
 
-    score()->startCmd(TranslatableString("undoableAction", "Add verse"));
+    score()->startCmd(TranslatableString("undoableAction", "Add lyrics verse"));
     int newVerse = oldLyrics->no() + 1;
 
     mu::engraving::Lyrics* lyrics = Factory::createLyrics(oldLyrics->chordRest());
@@ -6005,7 +6015,7 @@ void NotationInteraction::addGuitarBend(GuitarBendType bendType)
         return;
     }
 
-    startEdit(TranslatableString("undoableAction", "Add guitar bend"));
+    startEdit(TranslatableString("undoableAction", "Enter guitar bend"));
 
     Note* startNote = nullptr;
     Note* endNote = nullptr;
@@ -6115,7 +6125,7 @@ void NotationInteraction::toggleFontStyle(mu::engraving::FontStyle style)
     }
     mu::engraving::TextBase* text = toTextBase(m_editData.element);
     int currentStyle = text->getProperty(mu::engraving::Pid::FONT_STYLE).toInt();
-    score()->startCmd(TranslatableString("undoableAction", "Toggle font style"));
+    score()->startCmd(TranslatableString("undoableAction", "Format text"));
     text->undoChangeProperty(mu::engraving::Pid::FONT_STYLE, PropertyValue::fromValue(
                                  currentStyle ^ static_cast<int>(style)), mu::engraving::PropertyFlags::UNSTYLED);
     score()->endCmd();
@@ -6131,7 +6141,19 @@ void NotationInteraction::toggleVerticalAlignment(VerticalAlignment align)
     mu::engraving::TextBase* text = toTextBase(m_editData.element);
     int ialign = static_cast<int>(align);
     int currentAlign = text->getProperty(mu::engraving::Pid::TEXT_SCRIPT_ALIGN).toInt();
-    score()->startCmd(TranslatableString("undoableAction", "Toggle vertical alignment"));
+
+    TranslatableString actionName = [align]() {
+        switch (align) {
+        case VerticalAlignment::AlignSubScript:
+            return TranslatableString("undoableAction", "Toggle subscript");
+        case VerticalAlignment::AlignSuperScript:
+            return TranslatableString("undoableAction", "Toggle superscript");
+        default:
+            return TranslatableString("undoableAction", "Toggle subscript/superscript");
+        }
+    }();
+
+    score()->startCmd(actionName);
     text->undoChangeProperty(mu::engraving::Pid::TEXT_SCRIPT_ALIGN, PropertyValue::fromValue(
                                  (currentAlign == ialign) ? static_cast<int>(VerticalAlignment::AlignNormal) : ialign),
                              mu::engraving::PropertyFlags::UNSTYLED);
@@ -6189,7 +6211,7 @@ void NotationInteraction::toggleOrnament(mu::engraving::SymId symId)
 
 void NotationInteraction::toggleAutoplace(bool all)
 {
-    execute(&mu::engraving::Score::cmdToggleAutoplace, all, TranslatableString("undoableAction", "Toggle autoplace"));
+    execute(&mu::engraving::Score::cmdToggleAutoplace, all, TranslatableString("undoableAction", "Toggle automatic placement"));
 }
 
 bool NotationInteraction::canInsertClef(ClefType type) const
@@ -6200,12 +6222,12 @@ bool NotationInteraction::canInsertClef(ClefType type) const
 
 void NotationInteraction::insertClef(ClefType type)
 {
-    execute(&mu::engraving::Score::cmdInsertClef, type, TranslatableString("undoableAction", "Insert clef"));
+    execute(&mu::engraving::Score::cmdInsertClef, type, TranslatableString("undoableAction", "Add clef"));
 }
 
 void NotationInteraction::changeAccidental(mu::engraving::AccidentalType accidental)
 {
-    execute(&mu::engraving::Score::changeAccidental, accidental, TranslatableString("undoableAction", "Insert accidental"));
+    execute(&mu::engraving::Score::changeAccidental, accidental, TranslatableString("undoableAction", "Add accidental"));
 }
 
 void NotationInteraction::transposeSemitone(int steps)
@@ -6216,7 +6238,7 @@ void NotationInteraction::transposeSemitone(int steps)
 void NotationInteraction::transposeDiatonicAlterations(mu::engraving::TransposeDirection direction)
 {
     execute(&mu::engraving::Score::transposeDiatonicAlterations, direction,
-            TranslatableString("undoableAction", "Transpose diatonic alterations"));
+            TranslatableString("undoableAction", "Transpose diatonically"));
 }
 
 void NotationInteraction::getLocation()
@@ -6241,9 +6263,9 @@ void NotationInteraction::getLocation()
     }
 }
 
-void NotationInteraction::execute(void (mu::engraving::Score::* function)())
+void NotationInteraction::execute(void (mu::engraving::Score::* function)(), const TranslatableString& actionName)
 {
-    startEdit(TranslatableString("undoableAction", "Execute action"));
+    startEdit(actionName);
     (score()->*function)();
     apply();
 }

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -192,11 +192,7 @@ NotationInteraction::NotationInteraction(Notation* notation, INotationUndoStackP
         }
     });
 
-    m_undoStack->undoNotification().onNotify(this, [this]() {
-        endEditElement();
-    });
-
-    m_undoStack->redoNotification().onNotify(this, [this]() {
+    m_undoStack->undoRedoNotification().onNotify(this, [this]() {
         endEditElement();
     });
 

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -3388,9 +3388,9 @@ void NotationInteraction::redo()
     m_undoStack->redo(&m_editData);
 }
 
-void NotationInteraction::undoHistory(size_t moveToIdx)
+void NotationInteraction::undoRedoToIdx(size_t idx)
 {
-    m_undoStack->undoRedoToIdx(moveToIdx, &m_editData);
+    m_undoStack->undoRedoToIdx(idx, &m_editData);
 }
 
 muse::async::Notification NotationInteraction::textEditingStarted() const

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -4148,16 +4148,18 @@ void NotationInteraction::flipSelection()
 
 void NotationInteraction::addTieToSelection()
 {
-    startEdit(TranslatableString("undoableAction", "Add tie to selection"));
+    // Calls `startEdit` internally
     score()->cmdToggleTie();
-    apply();
+
+    notifyAboutNotationChanged();
 }
 
 void NotationInteraction::addTiedNoteToChord()
 {
-    startEdit(TranslatableString("undoableAction", "Add tied note to chord"));
+    // Calls `startEdit` internally
     score()->cmdAddTie(true);
-    apply();
+
+    notifyAboutNotationChanged();
 }
 
 void NotationInteraction::addSlurToSelection()
@@ -4166,9 +4168,8 @@ void NotationInteraction::addSlurToSelection()
         return;
     }
 
-    startEdit(TranslatableString("undoableAction", "Add slur to selection"));
+    // Calls `startEdit` internally
     doAddSlur();
-    apply();
 }
 
 void NotationInteraction::addOttavaToSelection(OttavaType type)
@@ -4236,9 +4237,10 @@ void NotationInteraction::putRest(Duration duration)
         return;
     }
 
-    startEdit(TranslatableString("undoableAction", "Put rest"));
+    // Calls `startEdit` internally
     score()->cmdEnterRest(duration);
-    apply();
+
+    notifyAboutNotationChanged();
 }
 
 void NotationInteraction::addBracketsToSelection(BracketsType type)

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -121,7 +121,7 @@ public:
     bool applyPaletteElement(mu::engraving::EngravingItem* element, Qt::KeyboardModifiers modifiers = {}) override;
     void undo() override;
     void redo() override;
-    void undoHistory(size_t moveToIdx) override;
+    void undoRedoToIdx(size_t idx) override;
 
     // Change selection
     bool moveSelectionAvailable(MoveSelectionType type) const override;

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -291,8 +291,7 @@ public:
     void transposeSemitone(int) override;
     void transposeDiatonicAlterations(mu::engraving::TransposeDirection) override;
     void getLocation() override;
-//    void execute(void (mu::engraving::Score::*)(), const muse::TranslatableString& actionName) override;
-    void execute(void (mu::engraving::Score::*)()) override;
+    void execute(void (mu::engraving::Score::*)(), const muse::TranslatableString& actionName) override;
 
     void showItem(const mu::engraving::EngravingItem* item, int staffIndex = -1) override;
     muse::async::Channel<ShowItemRequest> showItemRequested() const override;

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -121,6 +121,7 @@ public:
     bool applyPaletteElement(mu::engraving::EngravingItem* element, Qt::KeyboardModifiers modifiers = {}) override;
     void undo() override;
     void redo() override;
+    void undoHistory(size_t moveToIdx) override;
 
     // Change selection
     bool moveSelectionAvailable(MoveSelectionType type) const override;
@@ -290,6 +291,7 @@ public:
     void transposeSemitone(int) override;
     void transposeDiatonicAlterations(mu::engraving::TransposeDirection) override;
     void getLocation() override;
+//    void execute(void (mu::engraving::Score::*)(), const muse::TranslatableString& actionName) override;
     void execute(void (mu::engraving::Score::*)()) override;
 
     void showItem(const mu::engraving::EngravingItem* item, int staffIndex = -1) override;
@@ -301,7 +303,7 @@ private:
     mu::engraving::Score* score() const;
     void onScoreInited();
 
-    void startEdit();
+    void startEdit(const muse::TranslatableString& actionName);
     void apply();
     void rollback();
 
@@ -394,7 +396,7 @@ private:
     bool elementsSelected(const std::set<ElementType>& elementsTypes) const;
 
     template<typename P>
-    void execute(void (mu::engraving::Score::* function)(P), P param);
+    void execute(void (mu::engraving::Score::* function)(P), P param, const muse::TranslatableString& actionName);
 
     struct HitMeasureData
     {

--- a/src/notation/internal/notationmidiinput.cpp
+++ b/src/notation/internal/notationmidiinput.cpp
@@ -177,7 +177,7 @@ Note* NotationMidiInput::addNoteToScore(const muse::midi::Event& e)
         m_undoStack->commitChanges();
     };
 
-    m_undoStack->prepareChanges(muse::TranslatableString("undoableAction", "Add note"));
+    m_undoStack->prepareChanges(muse::TranslatableString("undoableAction", "Enter note"));
 
     if (e.opcode() == muse::midi::Event::Opcode::NoteOff) {
         if (isRealtime()) {

--- a/src/notation/internal/notationmidiinput.cpp
+++ b/src/notation/internal/notationmidiinput.cpp
@@ -177,7 +177,7 @@ Note* NotationMidiInput::addNoteToScore(const muse::midi::Event& e)
         m_undoStack->commitChanges();
     };
 
-    m_undoStack->prepareChanges();
+    m_undoStack->prepareChanges(muse::TranslatableString("undoableAction", "Add note"));
 
     if (e.opcode() == muse::midi::Event::Opcode::NoteOff) {
         if (isRealtime()) {
@@ -305,7 +305,7 @@ void NotationMidiInput::doRealtimeAdvance()
     playbackController()->playMetronome(is.tick().ticks());
 
     QTimer::singleShot(100, Qt::PreciseTimer, [this]() {
-        m_undoStack->prepareChanges();
+        m_undoStack->prepareChanges(muse::TranslatableString("undoableAction", "Realtime advance"));
         m_getScore->score()->realtimeAdvance(configuration()->midiUseWrittenPitch().val);
         m_undoStack->commitChanges();
     });

--- a/src/notation/internal/notationnoteinput.cpp
+++ b/src/notation/internal/notationnoteinput.cpp
@@ -337,7 +337,7 @@ void NotationNoteInput::addNote(NoteName noteName, NoteAddingMode addingMode)
 
     mu::engraving::EditData editData(m_scoreCallbacks);
 
-    startEdit(TranslatableString("undoableAction", "Add note"));
+    startEdit(TranslatableString("undoableAction", "Enter note"));
     int inote = static_cast<int>(noteName);
     bool addToUpOnCurrentChord = addingMode == NoteAddingMode::CurrentChord;
     bool insertNewChord = addingMode == NoteAddingMode::InsertChord;
@@ -369,7 +369,7 @@ Ret NotationNoteInput::putNote(const PointF& pos, bool replace, bool insert)
 {
     TRACEFUNC;
 
-    startEdit(TranslatableString("undoableAction", "Put note"));
+    startEdit(TranslatableString("undoableAction", "Enter note"));
     Ret ret = score()->putNote(pos, replace, insert);
     apply();
 
@@ -388,7 +388,7 @@ void NotationNoteInput::removeNote(const PointF& pos)
     mu::engraving::InputState& inputState = score()->inputState();
     bool restMode = inputState.rest();
 
-    startEdit(TranslatableString("undoableAction", "Remove note"));
+    startEdit(TranslatableString("undoableAction", "Delete note"));
     inputState.setRest(!restMode);
     score()->putNote(pos, false, false);
     inputState.setRest(restMode);

--- a/src/notation/internal/notationnoteinput.cpp
+++ b/src/notation/internal/notationnoteinput.cpp
@@ -602,9 +602,8 @@ void NotationNoteInput::addTie()
 {
     TRACEFUNC;
 
-    startEdit(TranslatableString("undoableAction", "Add tie"));
+    // Calls `startEdit` internally
     score()->cmdAddTie();
-    apply();
 
     notifyAboutStateChanged();
 

--- a/src/notation/internal/notationnoteinput.cpp
+++ b/src/notation/internal/notationnoteinput.cpp
@@ -337,7 +337,7 @@ void NotationNoteInput::addNote(NoteName noteName, NoteAddingMode addingMode)
 
     mu::engraving::EditData editData(m_scoreCallbacks);
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Add note"));
     int inote = static_cast<int>(noteName);
     bool addToUpOnCurrentChord = addingMode == NoteAddingMode::CurrentChord;
     bool insertNewChord = addingMode == NoteAddingMode::InsertChord;
@@ -356,7 +356,7 @@ void NotationNoteInput::padNote(const Pad& pad)
 
     mu::engraving::EditData editData(m_scoreCallbacks);
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Pad note"));
     score()->padToggle(pad, editData);
     apply();
 
@@ -369,7 +369,7 @@ Ret NotationNoteInput::putNote(const PointF& pos, bool replace, bool insert)
 {
     TRACEFUNC;
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Put note"));
     Ret ret = score()->putNote(pos, replace, insert);
     apply();
 
@@ -388,7 +388,7 @@ void NotationNoteInput::removeNote(const PointF& pos)
     mu::engraving::InputState& inputState = score()->inputState();
     bool restMode = inputState.rest();
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Remove note"));
     inputState.setRest(!restMode);
     score()->putNote(pos, false, false);
     inputState.setRest(restMode);
@@ -486,7 +486,7 @@ void NotationNoteInput::addTuplet(const TupletOptions& options)
 
     const mu::engraving::InputState& inputState = score()->inputState();
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Add tuplet"));
     score()->expandVoice();
     mu::engraving::ChordRest* chordRest = inputState.cr();
     if (chordRest) {
@@ -602,7 +602,7 @@ void NotationNoteInput::addTie()
 {
     TRACEFUNC;
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Add tie"));
     score()->cmdAddTie();
     apply();
 
@@ -631,9 +631,9 @@ mu::engraving::Score* NotationNoteInput::score() const
     return m_getScore->score();
 }
 
-void NotationNoteInput::startEdit()
+void NotationNoteInput::startEdit(const muse::TranslatableString& actionName)
 {
-    m_undoStack->prepareChanges();
+    m_undoStack->prepareChanges(actionName);
 }
 
 void NotationNoteInput::apply()
@@ -686,7 +686,7 @@ void NotationNoteInput::doubleNoteInputDuration()
 
     mu::engraving::EditData editData(m_scoreCallbacks);
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Double note input duration"));
     score()->cmdPadNoteIncreaseTAB(editData);
     apply();
 
@@ -701,7 +701,7 @@ void NotationNoteInput::halveNoteInputDuration()
 
     mu::engraving::EditData editData(m_scoreCallbacks);
 
-    startEdit();
+    startEdit(TranslatableString("undoableAction", "Halve note input duration"));
     score()->cmdPadNoteDecreaseTAB(editData);
     apply();
 

--- a/src/notation/internal/notationnoteinput.h
+++ b/src/notation/internal/notationnoteinput.h
@@ -88,7 +88,7 @@ private:
 
     EngravingItem* resolveNoteInputStartPosition() const;
 
-    void startEdit();
+    void startEdit(const muse::TranslatableString& actionName);
     void apply();
 
     void updateInputState();

--- a/src/notation/internal/notationparts.cpp
+++ b/src/notation/internal/notationparts.cpp
@@ -255,7 +255,7 @@ void NotationParts::setParts(const PartInstrumentList& parts, const ScoreOrder& 
     TRACEFUNC;
 
     endInteractionWithScore();
-    startEdit(TranslatableString("undoableAction", "Add or remove instruments"));
+    startEdit(TranslatableString("undoableAction", "Add/remove instruments"));
 
     doSetScoreOrder(order);
     removeMissingParts(parts);
@@ -325,12 +325,12 @@ void NotationParts::setPartSharpFlat(const ID& partId, const SharpFlat& sharpFla
 
     auto calcActionName = [](const SharpFlat& sharpFlat) -> TranslatableString {
         switch (sharpFlat) {
-        case SharpFlat::NONE: return TranslatableString("undoableAction", "Set sharp/flat no preference");
+        case SharpFlat::NONE: return TranslatableString("undoableAction", "Set sharps/flats no preference");
         case SharpFlat::FLATS: return TranslatableString("undoableAction", "Set prefer flats");
         case SharpFlat::SHARPS: return TranslatableString("undoableAction", "Set prefer sharps");
-        case SharpFlat::AUTO: return TranslatableString("undoableAction", "Set sharp/flat automatic");
+        case SharpFlat::AUTO: return TranslatableString("undoableAction", "Set sharps/flats automatic");
         }
-        return TranslatableString("undoableAction", "Set sharp/flat preference");
+        return TranslatableString("undoableAction", "Set sharps/flats preference");
     };
 
     startEdit(calcActionName(sharpFlat));
@@ -398,7 +398,7 @@ void NotationParts::setInstrumentAbbreviature(const InstrumentKey& instrumentKey
         return;
     }
 
-    startEdit(TranslatableString("undoableAction", "Set abbreviated name"));
+    startEdit(TranslatableString("undoableAction", "Set abbreviated instrument name"));
 
     score()->undo(new mu::engraving::ChangeInstrumentShort(instrumentKey.tick, part, { StaffName(abbreviature, 0) }));
 
@@ -505,7 +505,7 @@ void NotationParts::setStaffConfig(const ID& staffId, const StaffConfig& config)
         return;
     }
 
-    startEdit(TranslatableString("undoableAction", "Set staff properties"));
+    startEdit(TranslatableString("undoableAction", "Edit staff properties"));
 
     doSetStaffConfig(staff, config);
 
@@ -527,7 +527,7 @@ bool NotationParts::appendStaff(Staff* staff, const ID& destinationPartId)
         return false;
     }
 
-    startEdit(TranslatableString("undoableAction", "Append staff"));
+    startEdit(TranslatableString("undoableAction", "Add staff"));
     doAppendStaff(staff, destinationPart);
     apply();
 
@@ -550,7 +550,7 @@ bool NotationParts::appendLinkedStaff(Staff* staff, const muse::ID& sourceStaffI
         return false;
     }
 
-    startEdit(TranslatableString("undoableAction", "Append linked staff"));
+    startEdit(TranslatableString("undoableAction", "Add linked staff"));
 
     doAppendStaff(staff, destinationPart);
 
@@ -573,7 +573,7 @@ void NotationParts::insertPart(Part* part, size_t index)
         return;
     }
 
-    startEdit(TranslatableString("undoableAction", "Insert instrument"));
+    startEdit(TranslatableString("undoableAction", "Add instrument"));
 
     doInsertPart(part, index);
 
@@ -660,7 +660,7 @@ void NotationParts::replaceDrumset(const InstrumentKey& instrumentKey, const Dru
     }
 
     if (undoable) {
-        startEdit(TranslatableString("undoableAction", "Replace drumset"));
+        startEdit(TranslatableString("undoableAction", "Edit drumset"));
         score()->undo(new mu::engraving::ChangeDrumset(instrument, &newDrumset, part));
         apply();
     } else {
@@ -719,7 +719,7 @@ void NotationParts::removeParts(const IDList& partsIds)
     }
 
     endInteractionWithScore();
-    startEdit(TranslatableString("undoableAction", "Delete instrument(s)"));
+    startEdit(TranslatableString("undoableAction", "Remove instruments"));
 
     doRemoveParts(partsToRemove);
 
@@ -895,7 +895,7 @@ void NotationParts::moveParts(const IDList& sourcePartsIds, const ID& destinatio
     }
 
     endInteractionWithScore();
-    startEdit(TranslatableString("undoableAction", "Move instrument(s)"));
+    startEdit(TranslatableString("undoableAction", "Move instruments"));
 
     sortParts(parts);
     setBracketsAndBarlines();

--- a/src/notation/internal/notationparts.cpp
+++ b/src/notation/internal/notationparts.cpp
@@ -77,11 +77,7 @@ static QString formatInstrumentTitleOnScore(const QString& instrumentName, const
 NotationParts::NotationParts(IGetScore* getScore, INotationInteractionPtr interaction, INotationUndoStackPtr undoStack)
     : m_getScore(getScore), m_undoStack(undoStack), m_interaction(interaction)
 {
-    m_undoStack->undoNotification().onNotify(this, [this]() {
-        m_partChangedNotifier.changed();
-    });
-
-    m_undoStack->redoNotification().onNotify(this, [this]() {
+    m_undoStack->undoRedoNotification().onNotify(this, [this]() {
         m_partChangedNotifier.changed();
     });
 }

--- a/src/notation/internal/notationparts.h
+++ b/src/notation/internal/notationparts.h
@@ -83,7 +83,7 @@ protected:
 
     Part* partModifiable(const muse::ID& partId) const;
 
-    void startEdit();
+    void startEdit(const muse::TranslatableString& actionName);
     void apply();
     void rollback();
 

--- a/src/notation/internal/notationstyle.cpp
+++ b/src/notation/internal/notationstyle.cpp
@@ -104,7 +104,7 @@ Notification NotationStyle::styleChanged() const
 
 bool NotationStyle::loadStyle(const muse::io::path_t& path, bool allowAnyVersion)
 {
-    m_undoStack->prepareChanges();
+    m_undoStack->prepareChanges(TranslatableString("undoableAction", "Load style"));
     bool result = score()->loadStyle(path.toQString(), allowAnyVersion);
     m_undoStack->commitChanges();
 

--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -583,6 +583,13 @@ const UiActionList NotationUiActions::m_actions = {
              TranslatableString("action", "Redo"),
              IconCode::Code::REDO
              ),
+    UiAction("undo-history",
+             mu::context::UiCtxProjectOpened,
+             mu::context::CTX_ANY,
+             TranslatableString("action", "Undo/redo history…"),
+             TranslatableString("action", "Undo/redo history…"),
+             IconCode::Code::NONE
+             ),
     UiAction("voice-x12",
              mu::context::UiCtxProjectOpened,
              mu::context::CTX_NOTATION_OPENED,

--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -1729,8 +1729,8 @@ const UiActionList NotationUiActions::m_actions = {
     UiAction("add-lyric-verse",
              mu::context::UiCtxProjectOpened,
              mu::context::CTX_NOTATION_OPENED,
-             TranslatableString("action", "Add lyric verse"),
-             TranslatableString("action", "Add lyric verse")
+             TranslatableString("action", "Add lyrics verse"),
+             TranslatableString("action", "Add lyrics verse")
              ),
     UiAction("text-b",
              mu::context::UiCtxProjectOpened,

--- a/src/notation/internal/notationundostack.cpp
+++ b/src/notation/internal/notationundostack.cpp
@@ -97,12 +97,12 @@ void NotationUndoStack::undoRedoToIdx(size_t idx, mu::engraving::EditData* editD
         return;
     }
 
-    if ((stack->getCurIdx() > idx)) {
-        while ((stack->getCurIdx() > idx) && canUndo()) {
+    if (stack->currentIndex() > idx) {
+        while (stack->currentIndex() > idx && canUndo()) {
             undo(editData);
         }
     } else {
-        while ((stack->getCurIdx() <= idx) && canRedo()) {
+        while (stack->currentIndex() <= idx && canRedo()) {
             redo(editData);
         }
     }
@@ -178,7 +178,7 @@ void NotationUndoStack::unlock()
 
 bool NotationUndoStack::isLocked() const
 {
-    return undoStack()->locked();
+    return undoStack()->isLocked();
 }
 
 const muse::TranslatableString NotationUndoStack::topMostUndoActionName() const
@@ -213,7 +213,7 @@ size_t NotationUndoStack::undoRedoActionCount() const
         return muse::nidx;
     }
 
-    return undoStack()->getSize();
+    return undoStack()->size();
 }
 
 size_t NotationUndoStack::undoRedoActionCurrentIdx() const
@@ -222,7 +222,7 @@ size_t NotationUndoStack::undoRedoActionCurrentIdx() const
         return muse::nidx;
     }
 
-    return undoStack()->getCurIdx();
+    return undoStack()->currentIndex();
 }
 
 const muse::TranslatableString NotationUndoStack::undoRedoActionNameAtIdx(size_t idx) const
@@ -231,7 +231,7 @@ const muse::TranslatableString NotationUndoStack::undoRedoActionNameAtIdx(size_t
         return {};
     }
 
-    if (auto action = undoStack()->getAtIndex(idx)) {
+    if (auto action = undoStack()->atIndex(idx)) {
         return action->actionName();
     }
 

--- a/src/notation/internal/notationundostack.h
+++ b/src/notation/internal/notationundostack.h
@@ -41,11 +41,9 @@ public:
 
     bool canUndo() const override;
     void undo(mu::engraving::EditData*) override;
-    muse::async::Notification undoNotification() const override;
 
     bool canRedo() const override;
     void redo(mu::engraving::EditData*) override;
-    muse::async::Notification redoNotification() const override;
 
     void undoRedoToIdx(size_t idx, mu::engraving::EditData* editData) override;
 
@@ -67,12 +65,12 @@ public:
 
     muse::async::Notification stackChanged() const override;
     muse::async::Channel<ChangesRange> changesChannel() const override;
+    muse::async::Notification undoRedoNotification() const override;
 
 private:
     void notifyAboutNotationChanged();
     void notifyAboutStateChanged();
-    void notifyAboutUndo();
-    void notifyAboutRedo();
+    void notifyAboutUndoRedo();
 
     mu::engraving::Score* score() const;
     mu::engraving::MasterScore* masterScore() const;
@@ -82,8 +80,7 @@ private:
 
     muse::async::Notification m_notationChanged;
     muse::async::Notification m_stackStateChanged;
-    muse::async::Notification m_undoNotification;
-    muse::async::Notification m_redoNotification;
+    muse::async::Notification m_undoRedoNotification;
 };
 }
 

--- a/src/notation/internal/notationundostack.h
+++ b/src/notation/internal/notationundostack.h
@@ -47,7 +47,9 @@ public:
     void redo(mu::engraving::EditData*) override;
     muse::async::Notification redoNotification() const override;
 
-    void prepareChanges() override;
+    void undoRedoToIdx(size_t idx, mu::engraving::EditData* editData) override;
+
+    void prepareChanges(const muse::TranslatableString& actionName) override;
     void rollbackChanges() override;
     void commitChanges() override;
 
@@ -56,6 +58,12 @@ public:
     void lock() override;
     void unlock() override;
     bool isLocked() const override;
+
+    const muse::TranslatableString topMostUndoActionName() const override;
+    const muse::TranslatableString topMostRedoActionName() const override;
+    size_t undoRedoActionCount() const override;
+    size_t undoRedoActionCurrentIdx() const override;
+    const muse::TranslatableString undoRedoActionNameAtIdx(size_t idx) const override;
 
     muse::async::Notification stackChanged() const override;
     muse::async::Channel<ChangesRange> changesChannel() const override;

--- a/src/notation/notationmodule.cpp
+++ b/src/notation/notationmodule.cpp
@@ -28,7 +28,6 @@
 #include "ui/iuiactionsregister.h"
 #include "project/inotationwritersregister.h"
 
-#include "internal/notation.h"
 #include "internal/notationactioncontroller.h"
 #include "internal/notationconfiguration.h"
 #include "internal/midiinputoutputcontroller.h"
@@ -45,7 +44,8 @@
 #include "view/noteinputbarmodel.h"
 #include "view/noteinputbarcustomisemodel.h"
 #include "view/noteinputbarcustomiseitem.h"
-#include "view/internal/undoredomodel.h"
+#include "view/internal/undoredotoolbarmodel.h"
+#include "view/internal/undoredohistorymodel.h"
 #include "view/notationtoolbarmodel.h"
 #include "view/notationnavigator.h"
 #include "view/selectionfiltermodel.h"
@@ -55,7 +55,6 @@
 #include "view/pianokeyboard/pianokeyboardpanelcontextmenumodel.h"
 
 #include "ui/iinteractiveuriregister.h"
-#include "ui/uitypes.h"
 #include "view/widgets/editstyle.h"
 #include "view/widgets/measureproperties.h"
 #include "view/widgets/editstaff.h"
@@ -71,7 +70,6 @@
 #include "view/widgets/realizeharmonydialog.h"
 #include "view/notationcontextmenumodel.h"
 #include "view/abstractelementpopupmodel.h"
-#include "view/internal/undoredomodel.h"
 #include "view/internal/harppedalpopupmodel.h"
 #include "view/internal/caposettingsmodel.h"
 #include "view/internal/stringtuningssettingsmodel.h"
@@ -174,7 +172,8 @@ void NotationModule::registerUiTypes()
     qmlRegisterType<NoteInputBarCustomiseModel>("MuseScore.NotationScene", 1, 0, "NoteInputBarCustomiseModel");
     qmlRegisterType<NotationToolBarModel>("MuseScore.NotationScene", 1, 0, "NotationToolBarModel");
     qmlRegisterType<NotationNavigator>("MuseScore.NotationScene", 1, 0, "NotationNavigator");
-    qmlRegisterType<UndoRedoModel>("MuseScore.NotationScene", 1, 0, "UndoRedoModel");
+    qmlRegisterType<UndoRedoToolbarModel>("MuseScore.NotationScene", 1, 0, "UndoRedoToolbarModel");
+    qmlRegisterType<UndoRedoHistoryModel>("MuseScore.NotationScene", 1, 0, "UndoRedoHistoryModel");
     qmlRegisterType<TimelineView>("MuseScore.NotationScene", 1, 0, "TimelineView");
     qmlRegisterType<SelectionFilterModel>("MuseScore.NotationScene", 1, 0, "SelectionFilterModel");
     qmlRegisterType<EditGridSizeDialogModel>("MuseScore.NotationScene", 1, 0, "EditGridSizeDialogModel");

--- a/src/notation/notationmodule.cpp
+++ b/src/notation/notationmodule.cpp
@@ -149,6 +149,7 @@ void NotationModule::resolveImports()
         ir->registerWidgetUri<StaffTextPropertiesDialog>(Uri("musescore://notation/stafftextproperties"));
         ir->registerWidgetUri<RealizeHarmonyDialog>(Uri("musescore://notation/realizechordsymbols"));
 
+        ir->registerQmlUri(Uri("musescore://notation/undohistory"), "MuseScore/NotationScene/UndoHistoryDialog.qml");
         ir->registerQmlUri(Uri("musescore://notation/parts"), "MuseScore/NotationScene/PartsDialog.qml");
         ir->registerQmlUri(Uri("musescore://notation/selectmeasurescount"), "MuseScore/NotationScene/SelectMeasuresCountDialog.qml");
         ir->registerQmlUri(Uri("musescore://notation/editgridsize"), "MuseScore/NotationScene/EditGridSizeDialog.qml");

--- a/src/notation/notationscene.qrc
+++ b/src/notation/notationscene.qrc
@@ -53,6 +53,7 @@
         <file>qml/MuseScore/NotationScene/internal/EditStyle/accidentalImages/octaveOffset-ON.png</file>
         <file>qml/MuseScore/NotationScene/internal/EditStyle/FretboardsPage.qml</file>
         <file>qml/MuseScore/NotationScene/internal/EditStyle/BasicStyleSelectorWithSpinboxAndReset.qml</file>
+        <file>qml/MuseScore/NotationScene/UndoHistoryDialog.qml</file>
         <file>qml/MuseScore/NotationScene/PercussionPanel.qml</file>
         <file>qml/MuseScore/NotationScene/internal/PercussionPanelToolBar.qml</file>
         <file>qml/MuseScore/NotationScene/internal/PercussionPanelPad.qml</file>

--- a/src/notation/qml/MuseScore/NotationScene/UndoHistoryDialog.qml
+++ b/src/notation/qml/MuseScore/NotationScene/UndoHistoryDialog.qml
@@ -39,20 +39,19 @@ StyledDialogView {
     resizable: true
 
     Component.onCompleted: {
-        model.load()
         populateList()
     }
 
-    UndoRedoModel {
-        id: model
+    UndoRedoHistoryModel {
+        id: undoRedoHistoryModel
     }
 
     property int selectedIndex: {
-        var val = model.undoRedoActionCount() - model.undoRedoActionCurrentIdx()
+        var val = undoRedoHistoryModel.undoRedoActionCount() - undoRedoHistoryModel.undoRedoActionCurrentIdx()
         if (val < 0) {
             return 0
-        } else if ((val > 0) && (val >= model.undoRedoActionCount())) {
-            return model.undoRedoActionCount() - 1
+        } else if ((val > 0) && (val >= undoRedoHistoryModel.undoRedoActionCount())) {
+            return undoRedoHistoryModel.undoRedoActionCount() - 1
         }
         return val
     }
@@ -60,13 +59,13 @@ StyledDialogView {
     function populateList() {
         listView.model.clear() // Clear the existing model
 
-        for (var i = model.undoRedoActionCount() - 1; i >= 0; i--) {
-            listView.model.append({ text: model.undoRedoActionNameAtIdx(i) }) // Add each action name
+        for (var i = undoRedoHistoryModel.undoRedoActionCount() - 1; i >= 0; i--) {
+            listView.model.append({ text: undoRedoHistoryModel.undoRedoActionNameAtIdx(i) }) // Add each action name
         }
     }
 
     function actionIndex() {
-        return model.undoRedoActionCount() - selectedIndex - 1
+        return undoRedoHistoryModel.undoRedoActionCount() - selectedIndex - 1
     }
 
     ColumnLayout {

--- a/src/notation/qml/MuseScore/NotationScene/UndoHistoryDialog.qml
+++ b/src/notation/qml/MuseScore/NotationScene/UndoHistoryDialog.qml
@@ -1,0 +1,189 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
+
+import Muse.Ui 1.0
+import Muse.UiComponents 1.0
+import MuseScore.NotationScene 1.0
+
+StyledDialogView {
+    id: root
+    
+    title: qsTrc("notation", "Undo/redo history")
+
+    contentWidth: content.implicitWidth
+    contentHeight: content.implicitHeight
+    margins: 16
+
+    Component.onCompleted: {
+        model.load()
+        populateList()
+    }
+
+    UndoRedoModel {
+        id: model
+    }
+
+    modal: true
+
+    property int selectedIndex: (() => {
+        var val = model.undoRedoActionCount() - model.undoRedoActionCurrentIdx()
+        if (val < 0) {
+            return 0
+        } else if ((val > 0) && (val >= model.undoRedoActionCount())) {
+            return model.undoRedoActionCount() - 1
+        }
+        return val
+    })()
+
+    function populateList() {
+        listView.model.clear() // Clear the existing model
+
+        for (var i = model.undoRedoActionCount() - 1; i >= 0; i--) {
+            listView.model.append({ text: model.undoRedoActionNameAtIdx(i) }) // Add each action name
+        }
+    }
+
+    function actionIndex() {
+        return model.undoRedoActionCount() - selectedIndex - 1
+    }
+
+    ColumnLayout {
+        id: content
+        anchors.fill: parent
+        spacing: 20
+
+
+        RowLayout {
+            Layout.fillHeight: true
+            Layout.fillWidth: true
+            spacing: 24
+
+            ColumnLayout {
+                id: contentColumn
+
+                Layout.fillHeight: true
+                Layout.preferredWidth: root.width * 0.45
+
+                spacing: 20
+
+                property NavigationPanel navigationPanel: NavigationPanel {
+                    name: "UndoRedoItemsView"
+                    section: root.navigationSection
+                    direction: NavigationPanel.Vertical
+                    order: 1
+                    accessible.name: qsTrc("notation", "Undo/redo items")
+                }
+
+                StyledListView {
+                    id: listView
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: 300
+
+                    model: ListModel {}
+
+                    delegate: ListItemBlank {
+                        navigation.panel: contentColumn.navigationPanel
+                        navigation.order: index
+
+                        StyledTextLabel {
+                            text: model.text
+
+                            anchors.fill: parent
+                            anchors.centerIn: parent
+                            font: Qt.font(Object.assign({}, ui.theme.bodyBoldFont, {}))
+                            horizontalAlignment: Text.AlignLeft
+                            verticalAlignment: Text.AlignVCenter
+                        }
+
+                        onClicked: {
+                            root.selectedIndex = index // Store selected index
+                        }
+
+                        onDoubleClicked: {
+                            root.ret = { errcode: 0, value: actionIndex() }
+                            root.hide()
+                        }
+
+                        isSelected: {
+                            root.selectedIndex === index // Highlight selected item
+                        }
+
+                    }
+
+
+                    clip: true
+                }
+
+                RowLayout {
+                    Layout.fillHeight: true
+                    Layout.fillWidth: true
+                    spacing: 24
+
+                    ColumnLayout {
+                        id: listColumn
+
+                        Layout.fillHeight: true
+                        Layout.preferredWidth: root.width * 0.45
+
+                        spacing: 20
+                    }
+                }
+            }
+        }
+
+        ButtonBox {
+            Layout.fillWidth: true
+            Layout.alignment: Qt.AlignRight | Qt.AlignBottom
+
+            navigationPanel.section: root.navigationSection
+            navigationPanel.order: 2
+
+            // Cancel button
+            FlatButton {
+                text: qsTrc("global", "Cancel")
+                buttonRole: ButtonBoxModel.RejectRole
+                buttonId: ButtonBoxModel.Cancel
+                enabled: true
+
+                onClicked: {
+                    root.reject()
+                }
+            }
+
+            // Ok button
+            FlatButton {
+                text: qsTrc("global", "OK")
+                buttonRole: ButtonBoxModel.AcceptRole
+                buttonId: ButtonBoxModel.Ok
+                enabled: true
+                accentButton: true
+
+                onClicked: {
+                    root.ret = { errcode: 0, value: actionIndex() }
+                    root.hide()
+                }
+            }
+        }
+    }
+}

--- a/src/notation/qml/MuseScore/NotationScene/UndoRedoToolBar.qml
+++ b/src/notation/qml/MuseScore/NotationScene/UndoRedoToolBar.qml
@@ -42,7 +42,7 @@ Item {
         accessible.name: qsTrc("notation", "Undo redo toolbar")
     }
 
-    UndoRedoModel {
+    UndoRedoToolbarModel {
         id: model
     }
 

--- a/src/notation/tests/mocks/notationinteractionmock.h
+++ b/src/notation/tests/mocks/notationinteractionmock.h
@@ -250,7 +250,7 @@ public:
     MOCK_METHOD(void, transposeDiatonicAlterations, (mu::engraving::TransposeDirection), (override));
     MOCK_METHOD(void, toggleAutoplace, (bool), (override));
     MOCK_METHOD(void, getLocation, (), (override));
-    MOCK_METHOD(void, execute, (void (mu::engraving::Score::*)()), (override));
+    MOCK_METHOD(void, execute, (void (mu::engraving::Score::*)(), const muse::TranslatableString&), (override));
 
     MOCK_METHOD(void, showItem, (const mu::engraving::EngravingItem*, int), (override));
     MOCK_METHOD(muse::async::Channel<ShowItemRequest>, showItemRequested, (), (const, override));

--- a/src/notation/tests/mocks/notationinteractionmock.h
+++ b/src/notation/tests/mocks/notationinteractionmock.h
@@ -82,7 +82,7 @@ public:
     MOCK_METHOD(bool, applyPaletteElement, (mu::engraving::EngravingItem*, Qt::KeyboardModifiers), (override));
     MOCK_METHOD(void, undo, (), (override));
     MOCK_METHOD(void, redo, (), (override));
-    MOCK_METHOD(void, undoHistory, (size_t moveToIdx), (override));
+    MOCK_METHOD(void, undoRedoToIdx, (size_t idx), (override));
 
     MOCK_METHOD(bool, moveSelectionAvailable, (MoveSelectionType), (const, override));
     MOCK_METHOD(void, moveSelection, (MoveDirection, MoveSelectionType), (override));

--- a/src/notation/tests/mocks/notationinteractionmock.h
+++ b/src/notation/tests/mocks/notationinteractionmock.h
@@ -82,6 +82,7 @@ public:
     MOCK_METHOD(bool, applyPaletteElement, (mu::engraving::EngravingItem*, Qt::KeyboardModifiers), (override));
     MOCK_METHOD(void, undo, (), (override));
     MOCK_METHOD(void, redo, (), (override));
+    MOCK_METHOD(void, undoHistory, (size_t moveToIdx), (override));
 
     MOCK_METHOD(bool, moveSelectionAvailable, (MoveSelectionType), (const, override));
     MOCK_METHOD(void, moveSelection, (MoveDirection, MoveSelectionType), (override));

--- a/src/notation/view/abstractelementpopupmodel.cpp
+++ b/src/notation/view/abstractelementpopupmodel.cpp
@@ -79,16 +79,16 @@ INotationUndoStackPtr AbstractElementPopupModel::undoStack() const
     return currentNotation() ? currentNotation()->undoStack() : nullptr;
 }
 
-void AbstractElementPopupModel::beginCommand()
+void AbstractElementPopupModel::beginCommand(const muse::TranslatableString& actionName)
 {
     if (undoStack()) {
-        undoStack()->prepareChanges();
+        undoStack()->prepareChanges(actionName);
     }
 }
 
-void AbstractElementPopupModel::beginMultiCommands()
+void AbstractElementPopupModel::beginMultiCommands(const muse::TranslatableString& actionName)
 {
-    beginCommand();
+    beginCommand(actionName);
 
     if (undoStack()) {
         undoStack()->lock();
@@ -136,7 +136,7 @@ void AbstractElementPopupModel::changeItemProperty(mu::engraving::Pid id, const 
         flags = mu::engraving::PropertyFlags::UNSTYLED;
     }
 
-    beginCommand();
+    beginCommand(muse::TranslatableString("undoableAction", "Change item property"));
     m_item->undoChangeProperty(id, value, flags);
     endCommand();
     updateNotation();
@@ -148,7 +148,7 @@ void AbstractElementPopupModel::changeItemProperty(mu::engraving::Pid id, const 
         return;
     }
 
-    beginCommand();
+    beginCommand(muse::TranslatableString("undoableAction", "Change item property"));
     m_item->undoChangeProperty(id, value, flags);
     endCommand();
     updateNotation();

--- a/src/notation/view/abstractelementpopupmodel.cpp
+++ b/src/notation/view/abstractelementpopupmodel.cpp
@@ -136,7 +136,7 @@ void AbstractElementPopupModel::changeItemProperty(mu::engraving::Pid id, const 
         flags = mu::engraving::PropertyFlags::UNSTYLED;
     }
 
-    beginCommand(muse::TranslatableString("undoableAction", "Change item property"));
+    beginCommand(muse::TranslatableString("undoableAction", "Edit element property"));
     m_item->undoChangeProperty(id, value, flags);
     endCommand();
     updateNotation();
@@ -148,7 +148,7 @@ void AbstractElementPopupModel::changeItemProperty(mu::engraving::Pid id, const 
         return;
     }
 
-    beginCommand(muse::TranslatableString("undoableAction", "Change item property"));
+    beginCommand(muse::TranslatableString("undoableAction", "Edit element property"));
     m_item->undoChangeProperty(id, value, flags);
     endCommand();
     updateNotation();

--- a/src/notation/view/abstractelementpopupmodel.h
+++ b/src/notation/view/abstractelementpopupmodel.h
@@ -73,8 +73,8 @@ protected:
     muse::RectF fromLogical(muse::RectF rect) const;
 
     notation::INotationUndoStackPtr undoStack() const;
-    void beginCommand();
-    void beginMultiCommands();
+    void beginCommand(const muse::TranslatableString& actionName);
+    void beginMultiCommands(const muse::TranslatableString& actionName);
     void endCommand();
     void endMultiCommands();
     void updateNotation();

--- a/src/notation/view/internal/harppedalpopupmodel.cpp
+++ b/src/notation/view/internal/harppedalpopupmodel.cpp
@@ -176,7 +176,7 @@ void HarpPedalPopupModel::setDiagramPedalState(QVector<Position> pedalState)
         return;
     }
 
-    beginCommand(muse::TranslatableString("undoableAction", "Set harp diagram"));
+    beginCommand(muse::TranslatableString("undoableAction", "Edit harp pedal diagram"));
     setPopupPedalState(stdPedalState);
     toHarpPedalDiagram(m_item)->undoChangePedalState(getPopupPedalState());
     updateNotation();

--- a/src/notation/view/internal/harppedalpopupmodel.cpp
+++ b/src/notation/view/internal/harppedalpopupmodel.cpp
@@ -176,7 +176,7 @@ void HarpPedalPopupModel::setDiagramPedalState(QVector<Position> pedalState)
         return;
     }
 
-    beginCommand();
+    beginCommand(muse::TranslatableString("undoableAction", "Set harp diagram"));
     setPopupPedalState(stdPedalState);
     toHarpPedalDiagram(m_item)->undoChangePedalState(getPopupPedalState());
     updateNotation();

--- a/src/notation/view/internal/stringtuningssettingsmodel.cpp
+++ b/src/notation/view/internal/stringtuningssettingsmodel.cpp
@@ -139,7 +139,7 @@ bool StringTuningsSettingsModel::setStringValue(int stringIndex, const QString& 
     bool useFlat = _stringValue.contains(u'♭');
     item->setUseFlat(useFlat);
 
-    beginMultiCommands();
+    beginMultiCommands(TranslatableString("undoableAction", "Set string tuning"));
 
     updateCurrentPreset();
     saveStrings();
@@ -229,7 +229,7 @@ void StringTuningsSettingsModel::setCurrentPreset(const QString& preset)
 {
     bool isCurrentCustom = currentPreset() == customPreset();
 
-    beginMultiCommands();
+    beginMultiCommands(TranslatableString("undoableAction", "Set current string preset"));
 
     changeItemProperty(mu::engraving::Pid::STRINGTUNINGS_PRESET, String::fromQString(preset));
     emit currentPresetChanged();
@@ -282,7 +282,7 @@ void StringTuningsSettingsModel::setCurrentNumberOfStrings(int number)
         return;
     }
 
-    beginMultiCommands();
+    beginMultiCommands(TranslatableString("undoableAction", "Set number of strings"));
 
     changeItemProperty(mu::engraving::Pid::STRINGTUNINGS_STRINGS_COUNT, number);
 
@@ -353,7 +353,7 @@ void StringTuningsSettingsModel::saveStrings()
         stringList[i].useFlat = item->useFlat();
     }
 
-    beginCommand();
+    beginCommand(TranslatableString("undoableAction", "Save strings"));
 
     StringData newStringData(originStringData->frets(), stringList);
     stringTunings->undoStringData(newStringData);

--- a/src/notation/view/internal/stringtuningssettingsmodel.cpp
+++ b/src/notation/view/internal/stringtuningssettingsmodel.cpp
@@ -229,7 +229,7 @@ void StringTuningsSettingsModel::setCurrentPreset(const QString& preset)
 {
     bool isCurrentCustom = currentPreset() == customPreset();
 
-    beginMultiCommands(TranslatableString("undoableAction", "Set current string preset"));
+    beginMultiCommands(TranslatableString("undoableAction", "Load string tunings preset"));
 
     changeItemProperty(mu::engraving::Pid::STRINGTUNINGS_PRESET, String::fromQString(preset));
     emit currentPresetChanged();
@@ -353,7 +353,7 @@ void StringTuningsSettingsModel::saveStrings()
         stringList[i].useFlat = item->useFlat();
     }
 
-    beginCommand(TranslatableString("undoableAction", "Save strings"));
+    beginCommand(TranslatableString("undoableAction", "Edit strings"));
 
     StringData newStringData(originStringData->frets(), stringList);
     stringTunings->undoStringData(newStringData);

--- a/src/notation/view/internal/undoredohistorymodel.cpp
+++ b/src/notation/view/internal/undoredohistorymodel.cpp
@@ -1,0 +1,64 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2024 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "undoredohistorymodel.h"
+
+using namespace mu::notation;
+using namespace muse;
+
+UndoRedoHistoryModel::UndoRedoHistoryModel(QObject* parent)
+    : QObject(parent), Injectable(iocCtxForQmlObject(this))
+{
+}
+
+size_t UndoRedoHistoryModel::undoRedoActionCount() const
+{
+    if (auto stack = undoStack()) {
+        return stack->undoRedoActionCount();
+    }
+
+    return 0;
+}
+
+size_t UndoRedoHistoryModel::undoRedoActionCurrentIdx() const
+{
+    if (auto stack = undoStack()) {
+        return stack->undoRedoActionCurrentIdx();
+    }
+
+    return muse::nidx;
+}
+
+const QString UndoRedoHistoryModel::undoRedoActionNameAtIdx(size_t idx) const
+{
+    if (auto stack = undoStack()) {
+        return stack->undoRedoActionNameAtIdx(idx).qTranslated();
+    }
+
+    return {};
+}
+
+INotationUndoStackPtr UndoRedoHistoryModel::undoStack() const
+{
+    INotationPtr notation = context()->currentNotation();
+    return notation ? notation->undoStack() : nullptr;
+}

--- a/src/notation/view/internal/undoredohistorymodel.h
+++ b/src/notation/view/internal/undoredohistorymodel.h
@@ -5,7 +5,7 @@
  * MuseScore Studio
  * Music Composition & Notation
  *
- * Copyright (C) 2021 MuseScore Limited
+ * Copyright (C) 2024 MuseScore Limited
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -19,57 +19,33 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef MU_NOTATION_UNDOREDOMODEL_H
-#define MU_NOTATION_UNDOREDOMODEL_H
+#pragma once
 
 #include <QObject>
 
 #include "async/asyncable.h"
 #include "context/iglobalcontext.h"
 #include "modularity/ioc.h"
-#include "ui/iuiactionsregister.h"
 
 namespace muse::uicomponents {
 class MenuItem;
 }
 
 namespace mu::notation {
-class UndoRedoModel : public QObject, public muse::Injectable, public muse::async::Asyncable
+class UndoRedoHistoryModel : public QObject, public muse::Injectable, public muse::async::Asyncable
 {
     Q_OBJECT
 
-    Q_PROPERTY(muse::uicomponents::MenuItem * undoItem READ undoItem NOTIFY itemsChanged)
-    Q_PROPERTY(muse::uicomponents::MenuItem * redoItem READ redoItem NOTIFY itemsChanged)
-
     muse::Inject<context::IGlobalContext> context = { this };
-    muse::Inject<muse::ui::IUiActionsRegister> actionsRegister = { this };
 
 public:
-    explicit UndoRedoModel(QObject* parent = nullptr);
-
-    Q_INVOKABLE void load();
-
-    muse::uicomponents::MenuItem* undoItem() const;
-    muse::uicomponents::MenuItem* redoItem() const;
-
-    Q_INVOKABLE void undo();
-    Q_INVOKABLE void redo();
+    explicit UndoRedoHistoryModel(QObject* parent = nullptr);
 
     Q_INVOKABLE size_t undoRedoActionCount() const;
     Q_INVOKABLE size_t undoRedoActionCurrentIdx() const;
     Q_INVOKABLE const QString undoRedoActionNameAtIdx(size_t idx) const;
 
-signals:
-    void itemsChanged();
-
 private:
     INotationUndoStackPtr undoStack() const;
-
-    void updateItems();
-
-    muse::uicomponents::MenuItem* m_undoItem = nullptr;
-    muse::uicomponents::MenuItem* m_redoItem = nullptr;
 };
 }
-
-#endif // MU_NOTATION_UNDOREDOMODEL_H

--- a/src/notation/view/internal/undoredomodel.cpp
+++ b/src/notation/view/internal/undoredomodel.cpp
@@ -78,15 +78,23 @@ void UndoRedoModel::updateItems()
     auto stack = undoStack();
 
     if (m_undoItem) {
+        const TranslatableString undoActionName = stack ? stack->topMostUndoActionName() : TranslatableString();
         ui::UiActionState state;
         state.enabled = stack ? stack->canUndo() : false;
         m_undoItem->setState(state);
+        m_undoItem->setTitle(undoActionName.isEmpty()
+                             ? TranslatableString("action", "Undo")
+                             : TranslatableString("action", "Undo ‘%1’").arg(undoActionName));
     }
 
     if (m_redoItem) {
+        const TranslatableString redoActionName = stack ? stack->topMostRedoActionName() : TranslatableString();
         ui::UiActionState state;
         state.enabled = stack ? stack->canRedo() : false;
         m_redoItem->setState(state);
+        m_redoItem->setTitle(redoActionName.isEmpty()
+                             ? TranslatableString("action", "Redo")
+                             : TranslatableString("action", "Redo ‘%1’").arg(redoActionName));
     }
 }
 
@@ -102,6 +110,33 @@ void UndoRedoModel::undo()
     if (undoStack()) {
         undoStack()->undo(nullptr);
     }
+}
+
+size_t UndoRedoModel::undoRedoActionCount() const
+{
+    if (auto stack = undoStack()) {
+        return stack->undoRedoActionCount();
+    }
+
+    return 0;
+}
+
+size_t UndoRedoModel::undoRedoActionCurrentIdx() const
+{
+    if (auto stack = undoStack()) {
+        return stack->undoRedoActionCurrentIdx();
+    }
+
+    return muse::nidx;
+}
+
+const QString UndoRedoModel::undoRedoActionNameAtIdx(size_t idx) const
+{
+    if (auto stack = undoStack()) {
+        return stack->undoRedoActionNameAtIdx(idx).qTranslated();
+    }
+
+    return {};
 }
 
 INotationUndoStackPtr UndoRedoModel::undoStack() const

--- a/src/notation/view/internal/undoredomodel.h
+++ b/src/notation/view/internal/undoredomodel.h
@@ -55,6 +55,10 @@ public:
     Q_INVOKABLE void undo();
     Q_INVOKABLE void redo();
 
+    Q_INVOKABLE size_t undoRedoActionCount() const;
+    Q_INVOKABLE size_t undoRedoActionCurrentIdx() const;
+    Q_INVOKABLE const QString undoRedoActionNameAtIdx(size_t idx) const;
+
 signals:
     void itemsChanged();
 

--- a/src/notation/view/internal/undoredotoolbarmodel.cpp
+++ b/src/notation/view/internal/undoredotoolbarmodel.cpp
@@ -5,7 +5,7 @@
  * MuseScore Studio
  * Music Composition & Notation
  *
- * Copyright (C) 2021 MuseScore Limited
+ * Copyright (C) 2024 MuseScore Limited
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -20,7 +20,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include "undoredomodel.h"
+#include "undoredotoolbarmodel.h"
 
 #include "uicomponents/view/menuitem.h"
 
@@ -28,12 +28,12 @@ using namespace mu::notation;
 using namespace muse;
 using namespace muse::uicomponents;
 
-UndoRedoModel::UndoRedoModel(QObject* parent)
+UndoRedoToolbarModel::UndoRedoToolbarModel(QObject* parent)
     : QObject(parent), Injectable(iocCtxForQmlObject(this))
 {
 }
 
-void UndoRedoModel::load()
+void UndoRedoToolbarModel::load()
 {
     context()->currentNotationChanged().onNotify(this, [this]() {
         updateItems();
@@ -63,17 +63,17 @@ void UndoRedoModel::load()
     emit itemsChanged();
 }
 
-MenuItem* UndoRedoModel::undoItem() const
+MenuItem* UndoRedoToolbarModel::undoItem() const
 {
     return m_undoItem;
 }
 
-MenuItem* UndoRedoModel::redoItem() const
+MenuItem* UndoRedoToolbarModel::redoItem() const
 {
     return m_redoItem;
 }
 
-void UndoRedoModel::updateItems()
+void UndoRedoToolbarModel::updateItems()
 {
     auto stack = undoStack();
 
@@ -98,48 +98,21 @@ void UndoRedoModel::updateItems()
     }
 }
 
-void UndoRedoModel::redo()
+void UndoRedoToolbarModel::redo()
 {
     if (undoStack()) {
         undoStack()->redo(nullptr);
     }
 }
 
-void UndoRedoModel::undo()
+void UndoRedoToolbarModel::undo()
 {
     if (undoStack()) {
         undoStack()->undo(nullptr);
     }
 }
 
-size_t UndoRedoModel::undoRedoActionCount() const
-{
-    if (auto stack = undoStack()) {
-        return stack->undoRedoActionCount();
-    }
-
-    return 0;
-}
-
-size_t UndoRedoModel::undoRedoActionCurrentIdx() const
-{
-    if (auto stack = undoStack()) {
-        return stack->undoRedoActionCurrentIdx();
-    }
-
-    return muse::nidx;
-}
-
-const QString UndoRedoModel::undoRedoActionNameAtIdx(size_t idx) const
-{
-    if (auto stack = undoStack()) {
-        return stack->undoRedoActionNameAtIdx(idx).qTranslated();
-    }
-
-    return {};
-}
-
-INotationUndoStackPtr UndoRedoModel::undoStack() const
+INotationUndoStackPtr UndoRedoToolbarModel::undoStack() const
 {
     INotationPtr notation = context()->currentNotation();
     return notation ? notation->undoStack() : nullptr;

--- a/src/notation/view/internal/undoredotoolbarmodel.h
+++ b/src/notation/view/internal/undoredotoolbarmodel.h
@@ -1,0 +1,68 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2024 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <QObject>
+
+#include "async/asyncable.h"
+#include "context/iglobalcontext.h"
+#include "modularity/ioc.h"
+#include "ui/iuiactionsregister.h"
+
+namespace muse::uicomponents {
+class MenuItem;
+}
+
+namespace mu::notation {
+class UndoRedoToolbarModel : public QObject, public muse::Injectable, public muse::async::Asyncable
+{
+    Q_OBJECT
+
+    Q_PROPERTY(muse::uicomponents::MenuItem * undoItem READ undoItem NOTIFY itemsChanged)
+    Q_PROPERTY(muse::uicomponents::MenuItem * redoItem READ redoItem NOTIFY itemsChanged)
+
+    muse::Inject<context::IGlobalContext> context = { this };
+    muse::Inject<muse::ui::IUiActionsRegister> actionsRegister = { this };
+
+public:
+    explicit UndoRedoToolbarModel(QObject* parent = nullptr);
+
+    Q_INVOKABLE void load();
+
+    muse::uicomponents::MenuItem* undoItem() const;
+    muse::uicomponents::MenuItem* redoItem() const;
+
+    Q_INVOKABLE void undo();
+    Q_INVOKABLE void redo();
+
+signals:
+    void itemsChanged();
+
+private:
+    INotationUndoStackPtr undoStack() const;
+
+    void updateItems();
+
+    muse::uicomponents::MenuItem* m_undoItem = nullptr;
+    muse::uicomponents::MenuItem* m_redoItem = nullptr;
+};
+}

--- a/src/notation/view/percussionpanel/percussionpanelmodel.cpp
+++ b/src/notation/view/percussionpanel/percussionpanelmodel.cpp
@@ -196,7 +196,7 @@ void PercussionPanelModel::writePitch(int pitch)
         undoStack->commitChanges();
     };
 
-    undoStack->prepareChanges(muse::TranslatableString("undoableAction", "Write pitch"));
+    undoStack->prepareChanges(muse::TranslatableString("undoableAction", "Enter percussion note"));
 
     interaction()->noteInput()->startNoteInput();
 

--- a/src/notation/view/percussionpanel/percussionpanelmodel.cpp
+++ b/src/notation/view/percussionpanel/percussionpanelmodel.cpp
@@ -196,7 +196,7 @@ void PercussionPanelModel::writePitch(int pitch)
         undoStack->commitChanges();
     };
 
-    undoStack->prepareChanges();
+    undoStack->prepareChanges(muse::TranslatableString("undoableAction", "Write pitch"));
 
     interaction()->noteInput()->startNoteInput();
 

--- a/src/notation/view/widgets/editstaff.cpp
+++ b/src/notation/view/widgets/editstaff.cpp
@@ -313,7 +313,7 @@ void EditStaff::bboxClicked(QAbstractButton* button)
 
 void EditStaff::apply()
 {
-    size_t index = m_staff->score()->undoStack()->getCurIdx();
+    size_t index = m_staff->score()->undoStack()->currentIndex();
     applyStaffProperties();
     applyPartProperties();
     m_staff->score()->undoStack()->mergeCommands(index);

--- a/src/notation/view/widgets/editstyle.cpp
+++ b/src/notation/view/widgets/editstyle.cpp
@@ -1205,7 +1205,7 @@ void EditStyle::showEvent(QShowEvent* ev)
 {
     setValues();
     pageList->setFocus();
-    globalContext()->currentNotation()->undoStack()->prepareChanges(muse::TranslatableString("undoableAction", "Set style properties"));
+    globalContext()->currentNotation()->undoStack()->prepareChanges(muse::TranslatableString("undoableAction", "Edit style"));
     buttonApplyToAllParts->setEnabled(globalContext()->currentNotation()->style()->canApplyToAllParts());
     QWidget::showEvent(ev);
 }

--- a/src/notation/view/widgets/editstyle.cpp
+++ b/src/notation/view/widgets/editstyle.cpp
@@ -1205,7 +1205,7 @@ void EditStyle::showEvent(QShowEvent* ev)
 {
     setValues();
     pageList->setFocus();
-    globalContext()->currentNotation()->undoStack()->prepareChanges();
+    globalContext()->currentNotation()->undoStack()->prepareChanges(muse::TranslatableString("undoableAction", "Set style properties"));
     buttonApplyToAllParts->setEnabled(globalContext()->currentNotation()->style()->canApplyToAllParts());
     QWidget::showEvent(ev);
 }

--- a/src/notation/view/widgets/measureproperties.cpp
+++ b/src/notation/view/widgets/measureproperties.cpp
@@ -313,7 +313,7 @@ void MeasurePropertiesDialog::apply()
 
     mu::engraving::Score* score = m_measure->score();
 
-    m_notation->undoStack()->prepareChanges(muse::TranslatableString("undoableAction", "Set measure properties"));
+    m_notation->undoStack()->prepareChanges(muse::TranslatableString("undoableAction", "Edit measure properties"));
     bool propertiesChanged = false;
     for (size_t staffIdx = 0; staffIdx < score->nstaves(); ++staffIdx) {
         bool v = visible(static_cast<int>(staffIdx));

--- a/src/notation/view/widgets/measureproperties.cpp
+++ b/src/notation/view/widgets/measureproperties.cpp
@@ -313,7 +313,7 @@ void MeasurePropertiesDialog::apply()
 
     mu::engraving::Score* score = m_measure->score();
 
-    m_notation->undoStack()->prepareChanges();
+    m_notation->undoStack()->prepareChanges(muse::TranslatableString("undoableAction", "Set measure properties"));
     bool propertiesChanged = false;
     for (size_t staffIdx = 0; staffIdx < score->nstaves(); ++staffIdx) {
         bool v = visible(static_cast<int>(staffIdx));

--- a/src/notation/view/widgets/pagesettings.cpp
+++ b/src/notation/view/widgets/pagesettings.cpp
@@ -98,7 +98,7 @@ PageSettings::PageSettings(QWidget* parent)
 
 void PageSettings::showEvent(QShowEvent* event)
 {
-    globalContext()->currentNotation()->undoStack()->prepareChanges(muse::TranslatableString("undoableAction", "Save page settings"));
+    globalContext()->currentNotation()->undoStack()->prepareChanges(muse::TranslatableString("undoableAction", "Edit page settings"));
     updateValues();
     QWidget::showEvent(event);
 }

--- a/src/notation/view/widgets/pagesettings.cpp
+++ b/src/notation/view/widgets/pagesettings.cpp
@@ -98,7 +98,7 @@ PageSettings::PageSettings(QWidget* parent)
 
 void PageSettings::showEvent(QShowEvent* event)
 {
-    globalContext()->currentNotation()->undoStack()->prepareChanges();
+    globalContext()->currentNotation()->undoStack()->prepareChanges(muse::TranslatableString("undoableAction", "Save page settings"));
     updateValues();
     QWidget::showEvent(event);
 }

--- a/src/notation/view/widgets/stafftextpropertiesdialog.cpp
+++ b/src/notation/view/widgets/stafftextpropertiesdialog.cpp
@@ -141,7 +141,7 @@ void StaffTextPropertiesDialog::saveValues()
     StaffTextBase* nt = toStaffTextBase(m_staffText->clone());
     nt->setScore(score);
 
-    stack->prepareChanges();
+    stack->prepareChanges(muse::TranslatableString("undoableAction", "Save text properties"));
     score->undoChangeElement(m_originStaffText, nt);
     score->masterScore()->updateChannel();
     score->updateSwing();

--- a/src/notation/view/widgets/stafftextpropertiesdialog.cpp
+++ b/src/notation/view/widgets/stafftextpropertiesdialog.cpp
@@ -141,7 +141,7 @@ void StaffTextPropertiesDialog::saveValues()
     StaffTextBase* nt = toStaffTextBase(m_staffText->clone());
     nt->setScore(score);
 
-    stack->prepareChanges(muse::TranslatableString("undoableAction", "Save text properties"));
+    stack->prepareChanges(muse::TranslatableString("undoableAction", "Edit staff text properties"));
     score->undoChangeElement(m_originStaffText, nt);
     score->masterScore()->updateChannel();
     score->updateSwing();

--- a/src/notation/view/widgets/timeline.cpp
+++ b/src/notation/view/widgets/timeline.cpp
@@ -3031,7 +3031,7 @@ void Timeline::toggleShow(int staff)
 
     QList<Part*> parts = getParts();
     if (parts.size() > staff && staff >= 0) {
-        m_notation->undoStack()->prepareChanges();
+        m_notation->undoStack()->prepareChanges(muse::TranslatableString("undoableAction", "Toggle show timeline"));
         parts.at(staff)->setShow(!parts.at(staff)->show());
         parts.at(staff)->undoChangeProperty(Pid::VISIBLE, parts.at(staff)->show());
         m_notation->undoStack()->commitChanges();

--- a/src/notation/view/widgets/timeline.cpp
+++ b/src/notation/view/widgets/timeline.cpp
@@ -30,6 +30,7 @@
 #include <QTextDocument>
 
 #include "translation.h"
+#include "types/translatablestring.h"
 
 #include "engraving/dom/barline.h"
 #include "engraving/dom/jump.h"
@@ -3030,13 +3031,21 @@ void Timeline::toggleShow(int staff)
     }
 
     QList<Part*> parts = getParts();
-    if (parts.size() > staff && staff >= 0) {
-        m_notation->undoStack()->prepareChanges(muse::TranslatableString("undoableAction", "Toggle show timeline"));
-        parts.at(staff)->setShow(!parts.at(staff)->show());
-        parts.at(staff)->undoChangeProperty(Pid::VISIBLE, parts.at(staff)->show());
-        m_notation->undoStack()->commitChanges();
-        m_notation->notationChanged().notify();
+    if (staff < 0 || staff >= parts.size()) {
+        return;
     }
+
+    Part* part = parts.at(staff);
+
+    bool newShow = !part->show();
+    TranslatableString actionName = newShow
+                                    ? TranslatableString("undoableAction", "Show instrument")
+                                    : TranslatableString("undoableAction", "Hide instrument");
+
+    m_notation->undoStack()->prepareChanges(actionName);
+    part->undoChangeProperty(Pid::VISIBLE, newShow);
+    m_notation->undoStack()->commitChanges();
+    m_notation->notationChanged().notify();
 }
 
 //---------------------------------------------------------

--- a/src/palette/view/widgets/timesignaturepropertiesdialog.cpp
+++ b/src/palette/view/widgets/timesignaturepropertiesdialog.cpp
@@ -209,7 +209,7 @@ void TimeSignaturePropertiesDialog::accept()
     Groups g = groups->groups();
     m_editedTimeSig->setGroups(g);
 
-    notation->undoStack()->prepareChanges(TranslatableString("undoableAction", "Set time signature properties"));
+    notation->undoStack()->prepareChanges(TranslatableString("undoableAction", "Edit time signature properties"));
 
     // Change linked mmr timesigs too
     for (EngravingObject* obj : m_originTimeSig->linkList()) {

--- a/src/palette/view/widgets/timesignaturepropertiesdialog.cpp
+++ b/src/palette/view/widgets/timesignaturepropertiesdialog.cpp
@@ -209,7 +209,7 @@ void TimeSignaturePropertiesDialog::accept()
     Groups g = groups->groups();
     m_editedTimeSig->setGroups(g);
 
-    notation->undoStack()->prepareChanges();
+    notation->undoStack()->prepareChanges(TranslatableString("undoableAction", "Set time signature properties"));
 
     // Change linked mmr timesigs too
     for (EngravingObject* obj : m_originTimeSig->linkList()) {

--- a/src/playback/view/internal/soundflag/soundflagsettingsmodel.cpp
+++ b/src/playback/view/internal/soundflag/soundflagsettingsmodel.cpp
@@ -180,7 +180,7 @@ void SoundFlagSettingsModel::togglePreset(const QString& presetCode)
 
     SoundFlag* soundFlag = toSoundFlag(m_item);
 
-    beginCommand(TranslatableString("undoableAction", "Toggle preset"));
+    beginCommand(TranslatableString("undoableAction", "Toggle sound flag preset"));
     soundFlag->undoChangeSoundFlag(StringList(newPresetCodes), soundFlag->playingTechnique());
     bool needUpdateNotation = updateStaffText();
     endCommand();
@@ -207,7 +207,7 @@ void SoundFlagSettingsModel::togglePlayingTechnique(const QString& playingTechni
 
     SoundFlag* soundFlag = toSoundFlag(m_item);
 
-    beginCommand(TranslatableString("undoableAction", "Toggle playing technique"));
+    beginCommand(TranslatableString("undoableAction", "Toggle sound flag playing technique"));
     soundFlag->undoChangeSoundFlag(soundFlag->soundPresets(), muse::String(playingTechniqueCode));
     bool needUpdateNotation = updateStaffText();
     endCommand();
@@ -330,7 +330,7 @@ void SoundFlagSettingsModel::handleContextMenuItem(const QString& menuId)
     }
 
     if (menuId == RESET_MENU_ID) {
-        beginCommand(TranslatableString("undoableAction", "Reset sound settings"));
+        beginCommand(TranslatableString("undoableAction", "Reset sound flag"));
 
         const SoundFlag::PresetCodes oldPresetCodes = soundFlag->soundPresets();
         const SoundFlag::PresetCodes newPresetCodes = { defaultPresetCode() };
@@ -356,7 +356,7 @@ void SoundFlagSettingsModel::handleContextMenuItem(const QString& menuId)
         playbackConfiguration()->setSoundPresetsMultiSelectionEnabled(!playbackConfiguration()->soundPresetsMultiSelectionEnabled());
         emit contextMenuModelChanged();
     } else if (menuId == APPLY_TO_ALL_STAVES_MENU_ID) {
-        beginCommand(TranslatableString("undoableAction", "Apply sound settings to all"));
+        beginCommand(TranslatableString("undoableAction", "Toggle ‘Apply sound flag to all staves’"));
         soundFlag->undoChangeProperty(Pid::APPLY_TO_ALL_STAVES, !soundFlag->applyToAllStaves());
         endCommand();
 

--- a/src/playback/view/internal/soundflag/soundflagsettingsmodel.cpp
+++ b/src/playback/view/internal/soundflag/soundflagsettingsmodel.cpp
@@ -180,7 +180,7 @@ void SoundFlagSettingsModel::togglePreset(const QString& presetCode)
 
     SoundFlag* soundFlag = toSoundFlag(m_item);
 
-    beginCommand();
+    beginCommand(TranslatableString("undoableAction", "Toggle preset"));
     soundFlag->undoChangeSoundFlag(StringList(newPresetCodes), soundFlag->playingTechnique());
     bool needUpdateNotation = updateStaffText();
     endCommand();
@@ -207,7 +207,7 @@ void SoundFlagSettingsModel::togglePlayingTechnique(const QString& playingTechni
 
     SoundFlag* soundFlag = toSoundFlag(m_item);
 
-    beginCommand();
+    beginCommand(TranslatableString("undoableAction", "Toggle playing technique"));
     soundFlag->undoChangeSoundFlag(soundFlag->soundPresets(), muse::String(playingTechniqueCode));
     bool needUpdateNotation = updateStaffText();
     endCommand();
@@ -330,7 +330,7 @@ void SoundFlagSettingsModel::handleContextMenuItem(const QString& menuId)
     }
 
     if (menuId == RESET_MENU_ID) {
-        beginCommand();
+        beginCommand(TranslatableString("undoableAction", "Reset sound settings"));
 
         const SoundFlag::PresetCodes oldPresetCodes = soundFlag->soundPresets();
         const SoundFlag::PresetCodes newPresetCodes = { defaultPresetCode() };
@@ -356,7 +356,7 @@ void SoundFlagSettingsModel::handleContextMenuItem(const QString& menuId)
         playbackConfiguration()->setSoundPresetsMultiSelectionEnabled(!playbackConfiguration()->soundPresetsMultiSelectionEnabled());
         emit contextMenuModelChanged();
     } else if (menuId == APPLY_TO_ALL_STAVES_MENU_ID) {
-        beginCommand();
+        beginCommand(TranslatableString("undoableAction", "Apply sound settings to all"));
         soundFlag->undoChangeProperty(Pid::APPLY_TO_ALL_STAVES, !soundFlag->applyToAllStaves());
         endCommand();
 

--- a/src/project/internal/notationproject.cpp
+++ b/src/project/internal/notationproject.cpp
@@ -1089,7 +1089,7 @@ void NotationProject::setMetaInfo(const ProjectMeta& meta, bool undoable)
     MasterScore* score = m_masterNotation->masterScore();
 
     if (undoable) {
-        m_masterNotation->notation()->undoStack()->prepareChanges();
+        m_masterNotation->notation()->undoStack()->prepareChanges(TranslatableString("undoableAction", "Set project properties"));
         score->undo(new mu::engraving::ChangeMetaTags(score, tags));
         m_masterNotation->notation()->undoStack()->commitChanges();
         m_masterNotation->notation()->notationChanged().notify();

--- a/src/project/internal/notationproject.cpp
+++ b/src/project/internal/notationproject.cpp
@@ -1089,7 +1089,7 @@ void NotationProject::setMetaInfo(const ProjectMeta& meta, bool undoable)
     MasterScore* score = m_masterNotation->masterScore();
 
     if (undoable) {
-        m_masterNotation->notation()->undoStack()->prepareChanges(TranslatableString("undoableAction", "Set project properties"));
+        m_masterNotation->notation()->undoStack()->prepareChanges(TranslatableString("undoableAction", "Edit project properties"));
         score->undo(new mu::engraving::ChangeMetaTags(score, tags));
         m_masterNotation->notation()->undoStack()->commitChanges();
         m_masterNotation->notation()->notationChanged().notify();

--- a/src/project/internal/projectmigrator.cpp
+++ b/src/project/internal/projectmigrator.cpp
@@ -154,7 +154,7 @@ Ret ProjectMigrator::migrateProject(engraving::EngravingProjectPtr project, cons
         return make_ret(Ret::Code::InternalError);
     }
 
-    score->startCmd();
+    score->startCmd(TranslatableString("undoableAction", "Migrate project"));
 
     bool ok = true;
     if (opt.isApplyLeland) {


### PR DESCRIPTION
Resolves: #24509 Resolves: #20573 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

- Adds a name for every call to `UndoStack::beginMacro` and displays these names in the menu and palettes.
- Adds `Undo/Redo History` to the Edit Menu and a dialog box to allow cycling through the history. This dialog box copies the simple single-list approach used by Dorico rather than the more complex dialog box used by Finale. Anyone who knows how to use the Dorico undo history should know immediately how to use this.

This PR incorporates the changes in #24543. I made a slight modification in `UndoRedoModel::load` to remove code duplication. Please review that part carefully, @cbjeukendrup.

The PR replaces #24587, and that PR is now closed.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
