### PR TITLE
Fix skyline conflicts on staff centering

### DIFF
--- a/src/engraving/infrastructure/shape.cpp
+++ b/src/engraving/infrastructure/shape.cpp
@@ -291,8 +291,8 @@ double Shape::left() const
 {
     double dist = DBL_MAX;
     for (const ShapeElement& r : m_elements) {
-        if (!RealIsNull(r.height()) && !(r.item() && r.item()->isTextBase()) && r.left() < dist) {
-            // if (r.left() < dist)
+        // TURBO-HACK: the only purpose of this is to ignore fingering for spacing the first CR segment after the header.
+        if (!RealIsNull(r.height()) && !(r.item() && r.item()->isFingering()) && r.left() < dist) {
             dist = r.left();
         }
     }

--- a/src/engraving/rendering/score/systemlayout.h
+++ b/src/engraving/rendering/score/systemlayout.h
@@ -36,6 +36,7 @@ class System;
 class Measure;
 class Bracket;
 class BracketItem;
+class SkylineLine;
 }
 
 namespace mu::engraving::rendering::score {
@@ -86,6 +87,7 @@ private:
     static double minVertSpaceForCrossStaffBeams(System* system, staff_idx_t staffIdx1, staff_idx_t staffIdx2, LayoutContext& ctx);
 
     static bool elementShouldBeCenteredBetweenStaves(const EngravingItem* item, const System* system);
+    static bool elementHasAnotherStackedOutside(const EngravingItem* element, const Shape& elementShape, const SkylineLine& skylineLine);
     static void centerElementBetweenStaves(EngravingItem* element, const System* system);
 };
 }


### PR DESCRIPTION
Resolves: #24225 

If there is any element stacked to the outside of the element we want to center (for example, a harp pedal diagram outside of a dyanmic, like in the related issue) we don't try to center it, as it can only produce wrong results. In this case, the harp pedal diagram should _also_ be centered between staves. That will be done in a separate PR.
