### PR TITLE
[4.4.3] Fix GH#24553: MusicXML: A title like "Jazz Piece No. 5" get interpreted as a subtitle

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass1.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass1.cpp
@@ -788,7 +788,7 @@ static void inferFromTitle(String& title, String& inferredSubtitle, String& infe
     StringList subtitleLines;
     StringList creditLines;
     StringList titleLines = title.split(std::regex("\\n"));
-    for (size_t i = titleLines.size(); i > 0; --i) {
+    for (size_t i = titleLines.size(); i > 1; --i) {
         String line = titleLines[i - 1];
         if (isLikelyCreditText(line, true)) {
             creditLines.insert(0, line);

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass1.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass1.cpp
@@ -788,7 +788,11 @@ static void inferFromTitle(String& title, String& inferredSubtitle, String& infe
     StringList subtitleLines;
     StringList creditLines;
     StringList titleLines = title.split(std::regex("\\n"));
-    for (size_t i = titleLines.size(); i > 1; --i) {
+    size_t nrOfTitleLines = titleLines.size();
+    if (nrOfTitleLines == 1) {
+        return;
+    }
+    for (size_t i = nrOfTitleLines; i > 0; --i) {
         String line = titleLines[i - 1];
         if (isLikelyCreditText(line, true)) {
             creditLines.insert(0, line);


### PR DESCRIPTION
Resolves: #24553
Same as #24555