### PR TITLE
Percussion panel - layout and interaction basics

### DIFF
--- a/src/appshell/qml/NotationPage/NotationPage.qml
+++ b/src/appshell/qml/NotationPage/NotationPage.qml
@@ -437,6 +437,25 @@ DockPage {
             dropDestinations: root.horizontalPanelDropDestinations
 
             navigationSection: root.navigationPanelSec(percussionPanel.location)
+
+            PercussionPanel {
+                navigationSection: percussionPanel.navigationSection
+
+                // TODO: #22050 needed for this
+                /*
+                // contentNavigationPanelOrderStart: percussionPanel.contentNavigationPanelOrderStart
+
+                Component.onCompleted: {
+                    percussionPanel.contextMenuModel = contextMenuModel
+                    percussionPanel.toolbarComponent = toolbarComponent
+                }
+
+                Component.onDestruction: {
+                    percussionPanel.contextMenuModel = null
+                    percussionPanel.toolbarComponent = null
+                }
+                */
+            }
         }
     ]
 

--- a/src/notation/CMakeLists.txt
+++ b/src/notation/CMakeLists.txt
@@ -159,6 +159,13 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/view/editgridsizedialogmodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/editgridsizedialogmodel.h
 
+    ${CMAKE_CURRENT_LIST_DIR}/view/percussionpanel/percussionpanelmodel.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/view/percussionpanel/percussionpanelmodel.h
+    ${CMAKE_CURRENT_LIST_DIR}/view/percussionpanel/percussionpanelpadlistmodel.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/view/percussionpanel/percussionpanelpadlistmodel.h
+    ${CMAKE_CURRENT_LIST_DIR}/view/percussionpanel/percussionpanelpadmodel.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/view/percussionpanel/percussionpanelpadmodel.h
+
     ${CMAKE_CURRENT_LIST_DIR}/view/pianokeyboard/pianokeyboardtypes.h
     ${CMAKE_CURRENT_LIST_DIR}/view/pianokeyboard/pianokeyboardcontroller.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/pianokeyboard/pianokeyboardcontroller.h

--- a/src/notation/notationmodule.cpp
+++ b/src/notation/notationmodule.cpp
@@ -76,6 +76,8 @@
 #include "view/internal/caposettingsmodel.h"
 #include "view/internal/stringtuningssettingsmodel.h"
 
+#include "view/percussionpanel/percussionpanelmodel.h"
+
 #include "view/styledialog/styleitem.h"
 #include "view/styledialog/notespagemodel.h"
 #include "view/styledialog/restspagemodel.h"
@@ -182,6 +184,9 @@ void NotationModule::registerUiTypes()
     qmlRegisterType<HarpPedalPopupModel>("MuseScore.NotationScene", 1, 0, "HarpPedalPopupModel");
     qmlRegisterType<CapoSettingsModel>("MuseScore.NotationScene", 1, 0, "CapoSettingsModel");
     qmlRegisterType<StringTuningsSettingsModel>("MuseScore.NotationScene", 1, 0, "StringTuningsSettingsModel");
+
+    qmlRegisterType<PercussionPanelModel>("MuseScore.NotationScene", 1, 0, "PercussionPanelModel");
+    qmlRegisterUncreatableType<PanelMode>("MuseScore.NotationScene", 1, 0, "PanelMode", "Cannot create");
 
     qmlRegisterUncreatableType<StyleItem>("MuseScore.NotationScene", 1, 0, "StyleItem", "Cannot create StyleItem from QML");
     qmlRegisterType<NotesPageModel>("MuseScore.NotationScene", 1, 0, "NotesPageModel");

--- a/src/notation/notationscene.qrc
+++ b/src/notation/notationscene.qrc
@@ -53,5 +53,8 @@
         <file>qml/MuseScore/NotationScene/internal/EditStyle/accidentalImages/octaveOffset-ON.png</file>
         <file>qml/MuseScore/NotationScene/internal/EditStyle/FretboardsPage.qml</file>
         <file>qml/MuseScore/NotationScene/internal/EditStyle/BasicStyleSelectorWithSpinboxAndReset.qml</file>
+        <file>qml/MuseScore/NotationScene/PercussionPanel.qml</file>
+        <file>qml/MuseScore/NotationScene/internal/PercussionPanelToolBar.qml</file>
+        <file>qml/MuseScore/NotationScene/internal/PercussionPanelPad.qml</file>
     </qresource>
 </RCC>

--- a/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
+++ b/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
@@ -1,0 +1,192 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2024 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import QtQuick 2.15
+import QtQuick.Layouts
+
+import Muse.Ui 1.0
+import Muse.UiComponents 1.0
+import MuseScore.NotationScene 1.0
+
+import "internal"
+
+Item {
+    id: root
+
+    property NavigationSection navigationSection: null
+    property int contentNavigationPanelOrderStart: 1
+
+    anchors.fill: parent
+
+    //TODO: #22050 needed for this
+    /*
+    property Component toolbarComponent: PercussionPanelToolBar {
+        navigation.section: root.navigationSection
+        navigation.order: root.contentNavigationPanelOrderStart
+
+        model: percussionPanelModel
+
+        panelWidth: root.width
+    }
+    */
+
+    Component.onCompleted: {
+        padGrid.model.load()
+    }
+
+    PercussionPanelModel {
+        id: percModel
+    }
+
+    // TODO: Will live inside percussion panel until #22050 is implemented
+    PercussionPanelToolBar {
+        id: toolbar
+
+        anchors.top: parent.top
+
+        width: parent.width
+        height: 36
+
+        navigation.section: root.navigationSection
+        navigation.order: root.contentNavigationPanelOrderStart
+
+        model: percModel
+
+        panelWidth: root.width
+    }
+
+    StyledFlickable {
+        id: flickable
+
+        anchors.top: toolbar.bottom
+        anchors.bottom: parent.bottom
+        anchors.horizontalCenter: parent.horizontalCenter
+
+        width: Math.min(rowLayout.width, parent.width)
+
+        contentWidth: rowLayout.width
+        contentHeight: rowLayout.height
+
+        RowLayout {
+            id: rowLayout
+
+            // side columns being the "delete row" buttons on the left, and the "add row" button on the right
+            readonly property int sideColumnsWidth: addRowButton.width
+
+            height: padGrid.cellHeight * padGrid.numRows
+            spacing: padGrid.spacing / 2
+
+            Column {
+                id: deleteButtonsColumn
+
+                Layout.alignment: Qt.AlignTop
+                Layout.fillHeight: true
+
+                width: rowLayout.sideColumnsWidth
+
+                visible: percModel.currentPanelMode === PanelMode.EDIT_LAYOUT
+
+                Repeater {
+                    model: padGrid.numRows
+
+                    delegate: Item {
+                        id: deleteButtonArea
+
+                        width: parent.width
+                        height: padGrid.cellHeight
+
+                        FlatButton {
+                            id: deleteButton
+
+                            anchors.verticalCenter: parent.verticalCenter
+                            anchors.right: parent.right
+
+                            visible: model.index > 0
+
+                            icon: IconCode.DELETE_TANK
+                            backgroundRadius: deleteButton.width / 2
+
+                            onClicked: {
+                                padGrid.model.deleteRow(model.index)
+                            }
+                        }
+                    }
+                }
+            }
+
+            GridView {
+                id: padGrid
+
+                readonly property int numRows: Math.floor(model.numPads / numColumns)
+                readonly property int numColumns: model.numColumns
+                readonly property int spacing: 20
+
+                Layout.alignment: Qt.AlignTop
+                Layout.fillHeight: true
+
+                width: cellWidth * numColumns
+
+                interactive: false
+
+                cellWidth: 100 + padGrid.spacing
+                cellHeight: 100 + padGrid.spacing
+
+                model: percModel.padListModel
+
+                delegate: Item {
+                    id: padArea
+
+                    width: padGrid.cellWidth
+                    height: padGrid.cellHeight
+
+                    PercussionPanelPad {
+                        anchors.centerIn: parent
+
+                        width: parent.width - padGrid.spacing
+                        height: parent.height - padGrid.spacing
+
+                        padModel: model.padModelRole
+                        panelMode: percModel.currentPanelMode
+                        useNotationPreview: percModel.useNotationPreview
+                    }
+                }
+            }
+
+            FlatButton {
+                id: addRowButton
+
+                // Display to the right of the last pad
+                Layout.alignment: Qt.AlignBottom
+                Layout.bottomMargin: (padGrid.cellHeight / 2) - (height / 2)
+
+                visible: percModel.currentPanelMode === PanelMode.EDIT_LAYOUT
+
+                icon: IconCode.PLUS
+                text: qsTrc("notation", "Add row")
+                orientation: Qt.Horizontal
+                onClicked: {
+                    padGrid.model.addRow()
+                }
+            }
+        }
+    }
+}
+

--- a/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPad.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPad.qml
@@ -1,0 +1,109 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2024 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import QtQuick 2.15
+
+import Muse.Ui 1.0
+import Muse.UiComponents 1.0
+import MuseScore.NotationScene 1.0
+
+Rectangle {
+    id: root
+
+    property var padModel: null
+
+    property int panelMode: -1
+    property bool useNotationPreview: false
+
+    radius: root.width / 6
+
+    color: root.useNotationPreview ? "white" : ui.theme.backgroundSecondaryColor
+
+    border.color: root.panelMode === PanelMode.EDIT_LAYOUT ? ui.theme.accentColor : "transparent"
+    border.width: 2
+
+    Item {
+        id: contentArea
+
+        anchors.fill: parent
+
+        visible: Boolean(root.padModel) ? !root.padModel.isEmptySlot : false
+
+        StyledTextLabel {
+            id: instrumentNameLabel
+
+            visible: !root.useNotationPreview
+
+            anchors.centerIn: parent
+            anchors.margins: 5
+
+            width: parent.width
+
+            wrapMode: Text.WordWrap
+
+            text: Boolean(root.padModel) ? root.padModel.instrumentName : ""
+        }
+
+        StyledTextLabel {
+            // placeholder component - reflects the current state of the pad/panel
+            id: modeLabel
+
+            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.bottom: parent.bottom
+            anchors.margins: 5
+
+            width: parent.width
+
+            color: root.useNotationPreview ? "black" : "white"
+
+            wrapMode: Text.WordWrap
+        }
+    }
+
+    states: [
+        State {
+            name: "WRITE"
+            when: root.panelMode === PanelMode.WRITE
+            PropertyChanges {
+                target: modeLabel
+
+                // See modeLabel - these are all placeholder strings
+                text: "Write mode"
+            }
+        },
+        State {
+            name: "SOUND_PREVIEW"
+            when: root.panelMode === PanelMode.SOUND_PREVIEW
+            PropertyChanges {
+                target: modeLabel
+                text: "Sound preview mode"
+            }
+        },
+        State {
+            name: "EDIT_LAYOUT"
+            when: root.panelMode === PanelMode.EDIT_LAYOUT
+            PropertyChanges {
+                target: modeLabel
+                text: "Edit layout mode"
+            }
+        }
+    ]
+}

--- a/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelToolBar.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelToolBar.qml
@@ -1,0 +1,151 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2024 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import QtQuick 2.15
+
+import Muse.Ui 1.0
+import Muse.UiComponents 1.0
+
+import MuseScore.NotationScene 1.0
+
+Item {
+    id: root
+
+    required property var model
+    required property int panelWidth
+
+    property alias navigation: navPanel
+
+    QtObject {
+        id: prv
+        // The central buttons are placed centrally relative to the panel, not the toolbar area
+        readonly property int tabAreaLength: root.panelWidth - root.width
+        readonly property int centerX: (root.panelWidth / 2) - prv.tabAreaLength
+
+        readonly property int spacing: 4
+    }
+
+    NavigationPanel {
+        id: navPanel
+        name: "PercussionPanelToolBar"
+        enabled: root.enabled && root.visible
+    }
+
+    Row {
+        id: centralButtonsRow
+
+        anchors.verticalCenter: parent.verticalCenter
+        x: prv.centerX - (centralButtonsRow.width / 2)
+
+        visible: model.currentPanelMode !== PanelMode.EDIT_LAYOUT
+
+        FlatButton {
+            icon: IconCode.EDIT
+            text: qsTrc("notation", "Write")
+            orientation: Qt.Horizontal
+            accentButton: model.currentPanelMode === PanelMode.WRITE
+
+            navigation.panel: navPanel
+            navigation.row: 0
+
+            onClicked: {
+                root.model.currentPanelMode = PanelMode.WRITE
+            }
+        }
+
+        FlatButton {
+            icon: IconCode.PLAY
+            text: qsTrc("notation", "Preview")
+            orientation: Qt.Horizontal
+            accentButton: model.currentPanelMode === PanelMode.SOUND_PREVIEW
+
+            navigation.panel: navPanel
+            navigation.row: 0
+
+            onClicked: {
+                root.model.currentPanelMode = PanelMode.SOUND_PREVIEW
+            }
+        }
+    }
+
+    FlatButton {
+        id: finishEditingButton
+
+        anchors.verticalCenter: parent.verticalCenter
+        x: prv.centerX - (finishEditingButton.width / 2)
+
+        visible: model.currentPanelMode === PanelMode.EDIT_LAYOUT
+        text: qsTrc("notation", "Finish editing")
+        orientation: Qt.Horizontal
+        accentButton: true
+
+        navigation.panel: navPanel
+        navigation.row: 0
+
+        onClicked: {
+            root.model.finishEditing()
+        }
+    }
+
+    Row {
+        id: rightSideButtonsRow
+
+        anchors.verticalCenter: parent.verticalCenter
+        anchors.right: parent.right
+        anchors.rightMargin: prv.spacing
+
+        spacing: prv.spacing
+
+        FlatButton {
+            icon: IconCode.SPLIT_VIEW_HORIZONTAL
+            text: qsTrc("notation", "Layout")
+            orientation: Qt.Horizontal
+
+            navigation.panel: navPanel
+            navigation.row: 0
+
+            onClicked: {
+                menuLoader.toggleOpened(root.model.layoutMenuItems)
+            }
+
+            StyledMenuLoader {
+                id: menuLoader
+
+                onHandleMenuItem: function(itemId) {
+                    root.model.handleMenuItem(itemId)
+                }
+            }
+        }
+
+        FlatButton {
+            enabled: model.currentPanelMode !== PanelMode.EDIT_LAYOUT
+            text: qsTrc("notation", "Customize kit")
+            orientation: Qt.Horizontal
+
+            navigation.panel: navPanel
+            navigation.row: 0
+
+            onClicked: {
+                api.launcher.open("muse://devtools/interactive/sample")
+            }
+        }
+    }
+}

--- a/src/notation/qml/MuseScore/NotationScene/qmldir
+++ b/src/notation/qml/MuseScore/NotationScene/qmldir
@@ -11,3 +11,4 @@ UndoRedoToolBar 1.0 UndoRedoToolBar.qml
 Timeline 1.0 Timeline.qml
 SelectionFilterPanel 1.0 SelectionFilterPanel.qml
 PianoKeyboardPanel 1.0 PianoKeyboardPanel.qml
+PercussionPanel 1.0 PercussionPanel.qml

--- a/src/notation/view/percussionpanel/percussionpanelmodel.cpp
+++ b/src/notation/view/percussionpanel/percussionpanelmodel.cpp
@@ -1,0 +1,132 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2024 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "percussionpanelmodel.h"
+#include "types/translatablestring.h"
+#include "ui/view/iconcodes.h"
+
+static const QString INSTRUMENT_NAMES_CODE("percussion-instrument-names");
+static const QString NOTATION_PREVIEW_CODE("percussion-notation-preview");
+static const QString EDIT_LAYOUT_CODE("percussion-edit-layout");
+static const QString RESET_LAYOUT_CODE("percussion-reset-layout");
+
+using namespace muse;
+using namespace ui;
+
+PercussionPanelModel::PercussionPanelModel(QObject* parent)
+    : QObject(parent)
+{
+    m_padListModel = new PercussionPanelPadListModel(this);
+}
+
+PanelMode::Mode PercussionPanelModel::currentPanelMode() const
+{
+    return m_currentPanelMode;
+}
+
+void PercussionPanelModel::setCurrentPanelMode(const PanelMode::Mode& panelMode)
+{
+    if (m_currentPanelMode == panelMode) {
+        return;
+    }
+
+    // After editing, return to the last non-edit mode...
+    if (panelMode != PanelMode::Mode::EDIT_LAYOUT && m_panelModeToRestore != panelMode) {
+        m_panelModeToRestore = panelMode;
+    }
+
+    m_currentPanelMode = panelMode;
+    emit currentPanelModeChanged(m_currentPanelMode);
+}
+
+bool PercussionPanelModel::useNotationPreview() const
+{
+    return m_useNotationPreview;
+}
+
+void PercussionPanelModel::setUseNotationPreview(bool useNotationPreview)
+{
+    if (m_useNotationPreview == useNotationPreview) {
+        return;
+    }
+
+    m_useNotationPreview = useNotationPreview;
+    emit useNotationPreviewChanged(m_useNotationPreview);
+}
+
+PercussionPanelPadListModel* PercussionPanelModel::padListModel() const
+{
+    return m_padListModel;
+}
+
+QList<QVariantMap> PercussionPanelModel::layoutMenuItems() const
+{
+    const TranslatableString instrumentNamesTitle("notation", "Instrument names");
+    // Using IconCode for this instead of "checked" because we want the tick to display on the left
+    const int instrumentNamesIcon = static_cast<int>(m_useNotationPreview ? IconCode::Code::NONE : IconCode::Code::TICK_RIGHT_ANGLE);
+
+    const TranslatableString notationPreviewTitle("notation", "Notation preview");
+    // Using IconCode for this instead of "checked" because we want the tick to display on the left
+    const int notationPreviewIcon = static_cast<int>(m_useNotationPreview ? IconCode::Code::TICK_RIGHT_ANGLE : IconCode::Code::NONE);
+
+    const TranslatableString editLayoutTitle("notation", "Edit layout");
+    const int editLayoutIcon = static_cast<int>(IconCode::Code::CONFIGURE);
+
+    const TranslatableString resetLayoutTitle("notation", "Reset layout");
+    const int resetLayoutIcon = static_cast<int>(IconCode::Code::UNDO);
+
+    QList<QVariantMap> menuItems = {
+        { { "id", INSTRUMENT_NAMES_CODE },
+            { "title", instrumentNamesTitle.qTranslated() }, { "icon", instrumentNamesIcon }, { "enabled", true } },
+
+        { { "id", NOTATION_PREVIEW_CODE },
+            { "title", notationPreviewTitle.qTranslated() }, { "icon", notationPreviewIcon }, { "enabled", true } },
+
+        { }, // separator
+
+        { { "id", EDIT_LAYOUT_CODE },
+            { "title", editLayoutTitle.qTranslated() }, { "icon", editLayoutIcon }, { "enabled", true } },
+
+        { { "id", RESET_LAYOUT_CODE },
+            { "title", resetLayoutTitle.qTranslated() }, { "icon", resetLayoutIcon }, { "enabled", true } },
+    };
+
+    return menuItems;
+}
+
+void PercussionPanelModel::handleMenuItem(const QString& itemId)
+{
+    if (itemId == INSTRUMENT_NAMES_CODE) {
+        setUseNotationPreview(false);
+    } else if (itemId == NOTATION_PREVIEW_CODE) {
+        setUseNotationPreview(true);
+    } else if (itemId == EDIT_LAYOUT_CODE) {
+        setCurrentPanelMode(PanelMode::Mode::EDIT_LAYOUT);
+    } else if (itemId == RESET_LAYOUT_CODE) {
+        m_padListModel->resetLayout();
+    }
+}
+
+void PercussionPanelModel::finishEditing()
+{
+    setCurrentPanelMode(m_panelModeToRestore);
+}

--- a/src/notation/view/percussionpanel/percussionpanelmodel.h
+++ b/src/notation/view/percussionpanel/percussionpanelmodel.h
@@ -1,0 +1,81 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2024 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QObject>
+
+#include "percussionpanelpadlistmodel.h"
+
+class PanelMode
+{
+    Q_GADGET
+public:
+    enum Mode
+    {
+        WRITE,
+        SOUND_PREVIEW, //! NOTE: Not to be confused with "notation preview"
+        EDIT_LAYOUT
+    };
+    Q_ENUM(Mode)
+};
+
+class PercussionPanelModel : public QObject
+{
+    Q_OBJECT
+
+    Q_PROPERTY(PanelMode::Mode currentPanelMode READ currentPanelMode WRITE setCurrentPanelMode NOTIFY currentPanelModeChanged)
+    Q_PROPERTY(bool useNotationPreview READ useNotationPreview WRITE setUseNotationPreview NOTIFY useNotationPreviewChanged)
+
+    Q_PROPERTY(PercussionPanelPadListModel * padListModel READ padListModel NOTIFY padListModelChanged)
+
+    Q_PROPERTY(QList<QVariantMap> layoutMenuItems READ layoutMenuItems CONSTANT)
+
+public:
+    explicit PercussionPanelModel(QObject* parent = nullptr);
+
+    PanelMode::Mode currentPanelMode() const;
+    void setCurrentPanelMode(const PanelMode::Mode& panelMode);
+
+    bool useNotationPreview() const;
+    void setUseNotationPreview(bool useNotationPreview);
+
+    PercussionPanelPadListModel* padListModel() const;
+
+    QList<QVariantMap> layoutMenuItems() const;
+    Q_INVOKABLE void handleMenuItem(const QString& itemId);
+
+    Q_INVOKABLE void finishEditing();
+
+signals:
+    void currentPanelModeChanged(const PanelMode::Mode& panelMode);
+    void useNotationPreviewChanged(bool useNotationPreview);
+
+    void padListModelChanged();
+
+private:
+    PanelMode::Mode m_currentPanelMode = PanelMode::Mode::WRITE;
+    PanelMode::Mode m_panelModeToRestore = PanelMode::Mode::WRITE;
+    bool m_useNotationPreview = false;
+
+    PercussionPanelPadListModel* m_padListModel = nullptr;
+};

--- a/src/notation/view/percussionpanel/percussionpanelpadlistmodel.cpp
+++ b/src/notation/view/percussionpanel/percussionpanelpadlistmodel.cpp
@@ -1,0 +1,138 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2024 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "percussionpanelpadlistmodel.h"
+
+PercussionPanelPadListModel::PercussionPanelPadListModel(QObject* parent)
+    : QAbstractListModel(parent)
+{
+}
+
+QVariant PercussionPanelPadListModel::data(const QModelIndex& index, int role) const
+{
+    if (index.row() < 0 || index.row() >= m_padModels.count()) {
+        return QVariant();
+    }
+
+    PercussionPanelPadModel* item = m_padModels.at(index.row());
+
+    switch (role) {
+    case PadModelRole: return QVariant::fromValue(item);
+    default: break;
+    }
+
+    return QVariant();
+}
+
+QHash<int, QByteArray> PercussionPanelPadListModel::roleNames() const
+{
+    static const QHash<int, QByteArray> roles = {
+        { PadModelRole, "padModelRole" },
+    };
+    return roles;
+}
+
+void PercussionPanelPadListModel::load()
+{
+    m_padModels = createDefaultItems();
+    emit layoutChanged();
+    emit numPadsChanged();
+}
+
+void PercussionPanelPadListModel::addRow()
+{
+    for (size_t i = 0; i < NUM_COLUMNS; ++i) {
+        m_padModels.append(new PercussionPanelPadModel(QObject::parent()));
+    }
+    emit layoutChanged();
+    emit numPadsChanged();
+}
+
+void PercussionPanelPadListModel::deleteRow(int row)
+{
+    m_padModels.remove(row * NUM_COLUMNS, NUM_COLUMNS);
+    emit layoutChanged();
+    emit numPadsChanged();
+}
+
+void PercussionPanelPadListModel::startDrag(int startIndex)
+{
+    m_dragStartIndex = startIndex;
+}
+
+void PercussionPanelPadListModel::endDrag(int endIndex)
+{
+    movePad(m_dragStartIndex, endIndex);
+    m_dragStartIndex = -1;
+}
+
+bool PercussionPanelPadListModel::isDragActive() const
+{
+    return m_dragStartIndex > -1;
+}
+
+void PercussionPanelPadListModel::resetLayout()
+{
+    beginResetModel();
+    m_padModels = createDefaultItems();
+    endResetModel();
+
+    emit numPadsChanged();
+}
+
+QList<PercussionPanelPadModel*> PercussionPanelPadListModel::createDefaultItems()
+{
+    QMap<size_t, QString> dummyInstruments;
+    dummyInstruments.insert(2, "Bass Drum (Kit): Mid");
+    dummyInstruments.insert(0, "Bass Drum (Kit): Low");
+    dummyInstruments.insert(8, "Hi-hat (Kit)");
+    dummyInstruments.insert(17, "Splash (Kit)");
+    dummyInstruments.insert(11, "Tom (Kit): High");
+    dummyInstruments.insert(9, "Tom (Kit): Mid");
+    dummyInstruments.insert(12, "Crash (Kit)");
+    dummyInstruments.insert(3, "Snare (Kit)");
+    dummyInstruments.insert(15, "Ride (Kit)");
+    dummyInstruments.insert(5, "Floor Tom (Kit)");
+
+    // Get the largest key and round up to the nearest multiple of 8
+    size_t maxIndex = dummyInstruments.lastKey();
+    maxIndex = std::ceil(maxIndex / (double)NUM_COLUMNS) * NUM_COLUMNS;
+
+    QList<PercussionPanelPadModel*> padModels;
+
+    for (size_t i = 0; i < maxIndex; ++i) {
+        PercussionPanelPadModel* model = new PercussionPanelPadModel(this);
+        if (!dummyInstruments.value(i).isEmpty()) {
+            model->setInstrumentName(dummyInstruments.value(i));
+            model->setIsEmptySlot(false);
+        }
+        padModels.append(model);
+    }
+
+    return padModels;
+}
+
+void PercussionPanelPadListModel::movePad(int fromIndex, int toIndex)
+{
+    m_padModels.swapItemsAt(fromIndex, toIndex);
+    emit layoutChanged();
+}

--- a/src/notation/view/percussionpanel/percussionpanelpadlistmodel.h
+++ b/src/notation/view/percussionpanel/percussionpanelpadlistmodel.h
@@ -1,0 +1,73 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2024 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QAbstractListModel>
+
+#include "percussionpanelpadmodel.h"
+
+static constexpr int NUM_COLUMNS(8);
+
+class PercussionPanelPadListModel : public QAbstractListModel
+{
+    Q_OBJECT
+
+    Q_PROPERTY(int numColumns READ numColumns CONSTANT)
+    Q_PROPERTY(int numPads READ numPads NOTIFY numPadsChanged CONSTANT)
+
+public:
+    explicit PercussionPanelPadListModel(QObject* parent = nullptr);
+
+    int rowCount(const QModelIndex&) const override { return m_padModels.count(); }
+    QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
+    QHash<int, QByteArray> roleNames() const override;
+
+    Q_INVOKABLE void load();
+
+    Q_INVOKABLE void addRow();
+    Q_INVOKABLE void deleteRow(int row);
+
+    Q_INVOKABLE void startDrag(int startIndex);
+    Q_INVOKABLE void endDrag(int endIndex);
+    Q_INVOKABLE bool isDragActive() const;
+
+    int numColumns() const { return NUM_COLUMNS; }
+    int numPads() const { return m_padModels.count(); }
+
+    void resetLayout();
+
+signals:
+    void numPadsChanged();
+
+private:
+    enum Roles {
+        PadModelRole = Qt::UserRole + 1,
+    };
+
+    void movePad(int fromIndex, int toIndex);
+
+    QList<PercussionPanelPadModel*> createDefaultItems();
+    QList<PercussionPanelPadModel*> m_padModels;
+
+    int m_dragStartIndex = -1;
+};

--- a/src/notation/view/percussionpanel/percussionpanelpadmodel.cpp
+++ b/src/notation/view/percussionpanel/percussionpanelpadmodel.cpp
@@ -1,0 +1,48 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2024 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "percussionpanelpadmodel.h"
+
+PercussionPanelPadModel::PercussionPanelPadModel(QObject* parent)
+    : QObject(parent)
+{
+}
+
+void PercussionPanelPadModel::setInstrumentName(const QString& instrumentName)
+{
+    if (m_instrumentName == instrumentName) {
+        return;
+    }
+
+    m_instrumentName = instrumentName;
+    emit instrumentNameChanged();
+}
+
+void PercussionPanelPadModel::setIsEmptySlot(bool isEmptySlot)
+{
+    if (m_isEmptySlot == isEmptySlot) {
+        return;
+    }
+
+    m_isEmptySlot = isEmptySlot;
+    emit isEmptySlotChanged();
+}

--- a/src/notation/view/percussionpanel/percussionpanelpadmodel.h
+++ b/src/notation/view/percussionpanel/percussionpanelpadmodel.h
@@ -1,0 +1,50 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2024 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QObject>
+
+class PercussionPanelPadModel : public QObject
+{
+    Q_OBJECT
+
+    Q_PROPERTY(QString instrumentName READ instrumentName WRITE setInstrumentName NOTIFY instrumentNameChanged)
+    Q_PROPERTY(bool isEmptySlot READ isEmptySlot WRITE setIsEmptySlot NOTIFY isEmptySlotChanged)
+
+public:
+    explicit PercussionPanelPadModel(QObject* parent = nullptr);
+
+    QString instrumentName() const { return m_instrumentName; }
+    void setInstrumentName(const QString& instrumentName);
+
+    bool isEmptySlot() const { return m_isEmptySlot; }
+    void setIsEmptySlot(bool isEmptySlot);
+
+signals:
+    void instrumentNameChanged();
+    void isEmptySlotChanged();
+
+private:
+    bool m_isEmptySlot = true;
+    QString m_instrumentName;
+};


### PR DESCRIPTION
Some things to note: 

- There is no interaction with the score yet (hence why an example/placeholder kit is used). This PR focuses purely on the panel layout and UX basics.

-   The “toolbar” (Write, Preview, etc.) is placed within the percussion panel area in this PR. This is expected as we first need to merge [#22050](https://github.com/musescore/MuseScore/pull/22050) to place these controls in the `DockFrame`.

To summarise the interactions/responsibilities of the new components: `PercussionPanelPadModel` will maintain all data relevant to single pad (currently this only consists of the instrument name), `PercussionPanelPadListModel` will handle the initialisation of pads in the grid (and any layout editing), and the `PercussionPanelModel` handles panel modes (and eventually score interactions).
