### PR TITLE
Don't edit slur grip if Grip::NO_GRIP

### DIFF
--- a/src/engraving/dom/slur.cpp
+++ b/src/engraving/dom/slur.cpp
@@ -249,6 +249,10 @@ void SlurSegment::changeAnchor(EditData& ed, EngravingItem* element)
 void SlurSegment::editDrag(EditData& ed)
 {
     Grip g     = ed.curGrip;
+    if (g == Grip::NO_GRIP) {
+        return;
+    }
+
     ups(g).off += ed.delta;
 
     PointF delta;


### PR DESCRIPTION
Resolves: #24726

This check should be done in any case, cause `Grip::NO_GRIP` causes the following line to access an array at index -1. The thing that baffles me is why this never crashed before, given that not much has changes around this code. Anyway, this should solve the crash.