### PR TITLE
fixed stretched bend crash

### DIFF
--- a/src/engraving/dom/stretchedbend.cpp
+++ b/src/engraving/dom/stretchedbend.cpp
@@ -462,6 +462,10 @@ void StretchedBend::fillStretchedSegments(bool untilNextSegment)
         }
     }
 
+    if (!untilNextSegment) {
+        return;
+    }
+
     /// adjust coordinate to bend of tied back note
     StretchedBend* backTiedBend = backTiedStretchedBend();
     if (backTiedBend) {
@@ -474,6 +478,11 @@ void StretchedBend::fillStretchedSegments(bool untilNextSegment)
             for (EngravingItem* item : tiedBackChord->el()) {
                 if (item->isStretchedBend()) {
                     StretchedBend* bendToAdjust = toStretchedBend(item);
+                    IF_ASSERT_FAILED(!bendToAdjust->m_bendSegmentsStretched.empty()) {
+                        LOGE() << "wrong bend data while adjusting coordinates";
+                        return;
+                    }
+
                     PointF& tiedBendEndPoint = bendToAdjust->m_bendSegmentsStretched.back().dest;
                     tiedBendEndPoint.setX(newX);
                 }


### PR DESCRIPTION
(with --gp-experimental flag)

if untilNextSegment is false, it's wrong to adjust coordinates by X. And it can lead to crash cause the segments of another bend may not be filled (ASSERT added)
It's being adjusted after bend is already layouted for the first time with chord, when fillStretchedSegments is called with untilNextSegment = true.

[crash.gp.zip](https://github.com/user-attachments/files/17033782/crash.gp.zip)
