### PR TITLE
Set thread name on Linux for debugging

### DIFF
--- a/src/framework/global/runtime.cpp
+++ b/src/framework/global/runtime.cpp
@@ -24,7 +24,7 @@
 
 #include "log.h"
 
-#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD) || defined(Q_OS_MACOS)
+#if defined(Q_OS_LINUX) || defined(Q_OS_MACOS)
 #include <pthread.h>
 #endif
 #if defined(Q_OS_FREEBSD)

--- a/src/framework/global/runtime.cpp
+++ b/src/framework/global/runtime.cpp
@@ -27,6 +27,9 @@
 #if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD) || defined(Q_OS_MACOS)
 #include <pthread.h>
 #endif
+#if defined(Q_OS_FREEBSD)
+#include <pthread_np.h> // Needed for pthread_setname_np on FreeBSD
+#endif
 
 static thread_local std::string s_threadName;
 

--- a/src/framework/global/runtime.cpp
+++ b/src/framework/global/runtime.cpp
@@ -22,7 +22,9 @@
 
 #include "runtime.h"
 
-#ifdef Q_OS_LINUX
+#include "log.h"
+
+#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD) || defined(Q_OS_MACOS)
 #include <pthread.h>
 #endif
 
@@ -31,14 +33,17 @@ static thread_local std::string s_threadName;
 void muse::runtime::setThreadName(const std::string& name)
 {
     s_threadName = name;
-#ifdef Q_OS_LINUX
+#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
     // Set thread name through pthreads to aid debuggers that display such names.
     // Thread names are limited to 16 bytes on Linux, including the
     // terminating null.
+    DO_ASSERT(name.length() <= 15);
     std::string truncated_name = name.length() > 15 ? name.substr(0, 15) : name;
     if (pthread_setname_np(pthread_self(), truncated_name.c_str()) > 0) {
-        qWarning() << Q_FUNC_INFO << "Couldn't set thread name through pthreads";
+        LOGW() << "Couldn't set thread name through pthreads";
     }
+#elif defined(Q_OS_MACOS)
+    pthread_setname_np(name.c_str());
 #endif
 }
 


### PR DESCRIPTION
Resolves: N/A

<!-- Add a short description of and motivation for the changes here -->

Set the thread name through system APIs in `muse::runtime::setThreadName` so that debugging tools can get the name. This is only done for Linux for now.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable) – N/A
