### PR TITLE
Fix #24742: Lost cursor style when moving to next syllable, verse, etc.

### DIFF
--- a/src/engraving/dom/textedit.cpp
+++ b/src/engraving/dom/textedit.cpp
@@ -118,7 +118,9 @@ void TextBase::startEdit(EditData& ed)
     if (!ldata || ldata->layoutInvalid) {
         renderer()->layoutItem(this);
     }
-    if (!ted->cursor()->set(ed.startMove)) {
+
+    //! NOTE: startMove will be null if we didn't use the mouse (e.g. we added a lyric with the spacebar)
+    if (!ed.startMove.isNull() && !ted->cursor()->set(ed.startMove)) {
         resetFormatting();
     }
     double _spatium = spatium();

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -139,7 +139,7 @@ static qreal nudgeDistance(const mu::engraving::EditData& editData, qreal raster
 
 static PointF bindCursorPosToText(const PointF& cursorPos, const EngravingItem* text)
 {
-    if (!text || !text->isTextBase()) {
+    if (cursorPos.isNull() || !text || !text->isTextBase()) {
         return PointF();
     }
 
@@ -5020,7 +5020,11 @@ void NotationInteraction::navigateToLyrics(bool back, bool moveOnly, bool end)
         nextLyrics->setTrack(track);
         cr = toChordRest(nextSegment->element(track));
         nextLyrics->setParent(cr);
+
         nextLyrics->setNo(verse);
+        const mu::engraving::TextStyleType styleType(nextLyrics->isEven() ? TextStyleType::LYRICS_EVEN : TextStyleType::LYRICS_ODD);
+        nextLyrics->setTextStyleType(styleType);
+
         nextLyrics->setPlacement(placement);
         nextLyrics->setPropertyFlags(mu::engraving::Pid::PLACEMENT, pFlags);
         nextLyrics->setSyllabic(mu::engraving::LyricsSyllabic::SINGLE);
@@ -5177,7 +5181,11 @@ void NotationInteraction::navigateToNextSyllable()
         toLyrics = Factory::createLyrics(cr);
         toLyrics->setTrack(track);
         toLyrics->setParent(cr);
+
         toLyrics->setNo(verse);
+        const mu::engraving::TextStyleType styleType(toLyrics->isEven() ? TextStyleType::LYRICS_EVEN : TextStyleType::LYRICS_ODD);
+        toLyrics->setTextStyleType(styleType);
+
         toLyrics->setPlacement(placement);
         toLyrics->setPropertyFlags(mu::engraving::Pid::PLACEMENT, pFlags);
         toLyrics->setSyllabic(mu::engraving::LyricsSyllabic::END);
@@ -5259,7 +5267,11 @@ void NotationInteraction::navigateToLyricsVerse(MoveDirection direction)
         lyrics = Factory::createLyrics(cr);
         lyrics->setTrack(track);
         lyrics->setParent(cr);
+
         lyrics->setNo(verse);
+        const mu::engraving::TextStyleType styleType(lyrics->isEven() ? TextStyleType::LYRICS_EVEN : TextStyleType::LYRICS_ODD);
+        lyrics->setTextStyleType(styleType);
+
         lyrics->setPlacement(placement);
         lyrics->setPropertyFlags(mu::engraving::Pid::PLACEMENT, pFlags);
         lyrics->setFontStyle(fStyle);
@@ -5824,7 +5836,11 @@ void NotationInteraction::addMelisma()
         toLyrics = Factory::createLyrics(cr);
         toLyrics->setTrack(track);
         toLyrics->setParent(cr);
+
         toLyrics->setNo(verse);
+        const mu::engraving::TextStyleType styleType(toLyrics->isEven() ? TextStyleType::LYRICS_EVEN : TextStyleType::LYRICS_ODD);
+        toLyrics->setTextStyleType(styleType);
+
         toLyrics->setPlacement(placement);
         toLyrics->setPropertyFlags(mu::engraving::Pid::PLACEMENT, pFlags);
         toLyrics->setSyllabic(mu::engraving::LyricsSyllabic::SINGLE);
@@ -5885,7 +5901,11 @@ void NotationInteraction::addLyricsVerse()
     lyrics->setParent(oldLyrics->chordRest());
     lyrics->setPlacement(oldLyrics->placement());
     lyrics->setPropertyFlags(mu::engraving::Pid::PLACEMENT, oldLyrics->propertyFlags(mu::engraving::Pid::PLACEMENT));
+
     lyrics->setNo(newVerse);
+    const mu::engraving::TextStyleType styleType(lyrics->isEven() ? TextStyleType::LYRICS_EVEN : TextStyleType::LYRICS_ODD);
+    lyrics->setTextStyleType(styleType);
+
     lyrics->setFontStyle(fStyle);
     lyrics->setPropertyFlags(mu::engraving::Pid::FONT_STYLE, fFlags);
 


### PR DESCRIPTION
Resolves: #24742

The underlying problem here is that we're calling `TextCursor::set` when we really shouldn't. This method is used to set the cursor based on a point (set by the mouse) which we don't have when we're adding lyrics with the keyboard. This initially became a problem with #22209 (after this we call `updateCursorFormat` every time `set` is called), and the problem evolved with #23627 (changes to font metrics caused an early return inside set, leading to a `resetFormatting` call).

The first part of this fix is a change to `bindCursorPosToText` as this was spitting out garbage values when `cursorPos` was null. After this we can check whether `startMove` is null and avoid unwanted calls to `TextCursor::set`. 

After making these changes everything is fine for syllables, melisma, etc. - but I discovered that verses were still broken. This is for an entirely different reason - these were broken in #23868 when some `setIsEven` calls were removed. The problem here is that `styleDidChange` will evaluate to true in `LyricsLayout::layout` due to a mismatch between `isEven` and the `TextStyleType`.