### PR TITLE
Fix cross-staff fingering layout and tidy up code

### DIFF
--- a/src/engraving/rendering/score/pagelayout.cpp
+++ b/src/engraving/rendering/score/pagelayout.cpp
@@ -355,31 +355,6 @@ void PageLayout::collectPage(LayoutContext& ctx)
                                     ChordLayout::computeUp(c2, ctx);
                                 }
                             }
-                            // Fingering and articulations on top of cross-staff beams must be laid out here
-                            if (c->beam() && (c->beam()->cross() || c->staffMove() != 0)) {
-                                ChordLayout::layoutArticulations(c, ctx);
-                                ChordLayout::layoutArticulations2(c, ctx, true);
-
-                                for (Note* note : c->notes()) {
-                                    for (EngravingItem* e : note->el()) {
-                                        if (!e || !e->isFingering()) {
-                                            continue;
-                                        }
-                                        Fingering* fingering = toFingering(e);
-                                        if (fingering->isOnCrossBeamSide()) {
-                                            TLayout::layoutFingering(fingering, fingering->mutldata());
-                                            if (fingering->addToSkyline()) {
-                                                const Note* n = fingering->note();
-                                                const RectF r
-                                                    = fingering->ldata()->bbox().translated(
-                                                          fingering->pos() + n->pos() + n->chord()->pos() + segment->pos()
-                                                          + segment->measure()->pos());
-                                                s->staff(fingering->note()->chord()->vStaffIdx())->skyline().add(r, fingering);
-                                            }
-                                        }
-                                    }
-                                }
-                            }
                         }
                     } else if (e2->isBarLine()) {
                         TLayout::layoutBarLine2(toBarLine(e2), ctx);
@@ -413,8 +388,17 @@ void PageLayout::collectPage(LayoutContext& ctx)
         page->mutldata()->setBbox(0.0, 0.0, ctx.conf().loWidth(), height + ctx.state().page()->bm());
     }
 
-    // HACK: we relayout here cross-staff slurs because only now the information
-    // about staff distances is fully available.
+    layoutCrossStaffElements(ctx, page);
+
+    for (const System* system : page->systems()) {
+        SystemLayout::centerElementsBetweenStaves(system);
+    }
+
+    page->invalidateBspTree();
+}
+
+void PageLayout::layoutCrossStaffElements(LayoutContext& ctx, Page* page)
+{
     for (System* system : page->systems()) {
         if (!system->firstMeasure()) {
             continue;
@@ -431,23 +415,74 @@ void PageLayout::collectPage(LayoutContext& ctx)
             continue;
         }
 
-        auto spanners = ctx.dom().spannerMap().findOverlapping(stick.ticks(), etick.ticks());
-        for (auto interval : spanners) {
-            Spanner* sp = interval.value;
-            if (!sp->isSlur() || sp->tick() == system->endTick()) {
+        layoutCrossStaffSlurs(ctx, system);
+
+        layoutArticAndFingeringOnCrossStaffBeams(ctx, system);
+    }
+}
+
+void PageLayout::layoutCrossStaffSlurs(LayoutContext& ctx, System* system)
+{
+    Fraction stick = system->firstMeasure()->tick();
+    Fraction etick = system->endTick();
+
+    auto spanners = ctx.dom().spannerMap().findOverlapping(stick.ticks(), etick.ticks());
+    for (auto interval : spanners) {
+        Spanner* sp = interval.value;
+        if (!sp->isSlur() || sp->tick() == system->endTick()) {
+            continue;
+        }
+        if (toSlur(sp)->isCrossStaff()) {
+            SlurTieLayout::layoutSystem(toSlur(sp), system, ctx);
+        }
+    }
+}
+
+void PageLayout::layoutArticAndFingeringOnCrossStaffBeams(LayoutContext& ctx, System* system)
+{
+    for (const MeasureBase* mb : system->measures()) {
+        if (!mb->isMeasure()) {
+            continue;
+        }
+        for (const Segment& segment : toMeasure(mb)->segments()) {
+            if (!segment.isChordRestType()) {
                 continue;
             }
-            if (toSlur(sp)->isCrossStaff()) {
-                SlurTieLayout::layoutSystem(toSlur(sp), system, ctx);
+            for (EngravingItem* item : segment.elist()) {
+                if (!item || !item->isChord()) {
+                    continue;
+                }
+
+                Chord* c = toChord(item);
+                bool hasCrossBeam = c->beam() && (c->beam()->cross() || c->staffMove() != 0);
+                if (!hasCrossBeam) {
+                    continue;
+                }
+
+                ChordLayout::layoutArticulations(c, ctx);
+                ChordLayout::layoutArticulations2(c, ctx, true);
+
+                for (Note* note : c->notes()) {
+                    for (EngravingItem* e : note->el()) {
+                        if (!e || !e->isFingering()) {
+                            continue;
+                        }
+                        Fingering* fingering = toFingering(e);
+                        if (fingering->isOnCrossBeamSide()) {
+                            TLayout::layoutFingering(fingering, fingering->mutldata());
+                            if (fingering->addToSkyline()) {
+                                const Note* n = fingering->note();
+                                const RectF r = fingering->ldata()->bbox().translated(
+                                    fingering->pos() + n->pos() + n->chord()->pos() + segment.pos()
+                                    + segment.measure()->pos());
+                                system->staff(fingering->note()->chord()->vStaffIdx())->skyline().add(r, fingering);
+                            }
+                        }
+                    }
+                }
             }
         }
     }
-
-    for (const System* system : page->systems()) {
-        SystemLayout::centerElementsBetweenStaves(system);
-    }
-
-    page->invalidateBspTree();
 }
 
 //---------------------------------------------------------

--- a/src/engraving/rendering/score/pagelayout.h
+++ b/src/engraving/rendering/score/pagelayout.h
@@ -41,6 +41,10 @@ private:
     static void layoutPage(LayoutContext& ctx, Page* page, double restHeight, double footerPadding);
     static void checkDivider(LayoutContext& ctx, bool left, System* s, double yOffset, bool remove = false);
     static void distributeStaves(LayoutContext& ctx, Page* page, double footerPadding);
+
+    static void layoutCrossStaffElements(LayoutContext& ctx, Page* page);
+    static void layoutCrossStaffSlurs(LayoutContext& ctx, System* system);
+    static void layoutArticAndFingeringOnCrossStaffBeams(LayoutContext& ctx, System* system);
 };
 }
 


### PR DESCRIPTION
Resolves: #24718

Fingerings on cross-staff beams are laid out at the very end, because they need to know staff distances and cross-staff beams positions. The problem is that they should only be laid out if they are within the current layout range, otherwise they get laid out multiple times and get stacked on themselves. 
![image](https://github.com/user-attachments/assets/a84f1d95-674a-44d8-bf24-44adcd62e526)

Given that cross-staff slursare also laid out at the same time and with the same logic, I've taken the opportunity to tidy up and reuse some code.