### PR TITLE
#21553: Palette context menu placement and dismissal when open not vi…

### DIFF
--- a/src/palette/qml/MuseScore/Palette/internal/TreePaletteHeader.qml
+++ b/src/palette/qml/MuseScore/Palette/internal/TreePaletteHeader.qml
@@ -132,7 +132,17 @@ Item {
         acceptedButtons: Qt.RightButton
 
         onClicked: {
-            menuButton.toggleMenu(this, mouseX, mouseY)
+            contextMenuLoader.show(Qt.point(mouseX, mouseY))
+        }
+
+        ContextMenuLoader {
+            id: contextMenuLoader
+
+            items: menuButton.menuModel
+
+            onHandleMenuItem: function(itemId) {
+                menuButton.menuItemClicked(itemId)
+            }
         }
     }
 
@@ -168,6 +178,10 @@ Item {
         ]
 
         onHandleMenuItem: function(itemId) {
+            menuItemClicked(itemId)
+        }
+
+        function menuItemClicked(itemId) {
             switch(itemId) {
             case "hide": root.hidePaletteRequested(); break
             case "new": root.insertNewPaletteRequested(); break


### PR DESCRIPTION
Resolves: #21553

- [X ] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
