### PR TITLE
Fix freeze on add title text

### DIFF
--- a/src/engraving/dom/undo.cpp
+++ b/src/engraving/dom/undo.cpp
@@ -2231,11 +2231,10 @@ void InsertRemoveMeasures::insertMeasures()
     score->setLayoutAll();
 
     // move subsequent StaffTypeChanges
-    if (moveStc) {
+    Fraction tickStart = fm->tick();
+    Fraction tickEnd = lm->endTick();
+    if (moveStc && tickEnd > tickStart) {
         for (Staff* staff : score->staves()) {
-            Fraction tickStart = fm->tick();
-            Fraction tickEnd = lm->endTick();
-
             // loop backwards until the insert point
             auto stRange = staff->staffTypeRange(score->lastMeasure()->tick());
             int moveTick = stRange.first;


### PR DESCRIPTION
Resolves: #24795 

The problem is two-fold. First: the program was getting stuck on a loop because, after adding a new VBox, it was trying to move the staff type changes by a given tick difference, but the VBox has zero tick so the loop was never progressing. Second: the VBox shouldn't be actually added because one is already there. The reason it was being added is that there is an empty part that _doesn't_ have the title VBox, and adding it to the part was also creating it in the score. 
