### PR TITLE
BeamBase, Beam and TremoloTwoChord refactor

### DIFF
--- a/src/engraving/dom/beam.cpp
+++ b/src/engraving/dom/beam.cpp
@@ -77,10 +77,6 @@ Beam::Beam(const Beam& b)
     for (const BeamSegment* bs : b.m_beamSegments) {
         m_beamSegments.push_back(new BeamSegment(*bs));
     }
-    m_direction       = b.m_direction;
-    m_up              = b.m_up;
-    m_userModified[0] = b.m_userModified[0];
-    m_userModified[1] = b.m_userModified[1];
     m_growLeft           = b.m_growLeft;
     m_growRight           = b.m_growRight;
     m_beamDist        = b.m_beamDist;
@@ -322,7 +318,7 @@ void Beam::calcBeamBreaks(const ChordRest* cr, const ChordRest* prevCr, int leve
 void Beam::spatiumChanged(double oldValue, double newValue)
 {
     int idx = directionIdx();
-    if (m_userModified[idx]) {
+    if (userModified()) {
         double diff = newValue / oldValue;
         for (BeamFragment* f : m_fragments) {
             f->py1[idx] = f->py1[idx] * diff;
@@ -431,14 +427,14 @@ std::vector<PointF> Beam::gripsPositions(const EditData& ed) const
 
 void Beam::setBeamDirection(DirectionV d)
 {
-    if (m_direction == d || m_cross) {
+    if (direction() == d || m_cross) {
         return;
     }
 
-    m_direction = d;
+    setDirection(d);
 
     if (d != DirectionV::AUTO) {
-        m_up = d == DirectionV::UP;
+        setUp(d == DirectionV::UP);
     }
 
     for (ChordRest* e : elements()) {
@@ -575,7 +571,7 @@ void Beam::setBeamPos(const PairF& bp)
     }
     BeamFragment* f = m_fragments.back();
     int idx = directionIdx();
-    m_userModified[idx] = true;
+    setUserModified(true);
     setGenerated(false);
 
     double _spatium = spatium();
@@ -594,7 +590,7 @@ void Beam::setNoSlope(bool b)
     // Make flat if usermodified
     if (m_noSlope) {
         int idx = directionIdx();
-        if (m_userModified[idx]) {
+        if (userModified()) {
             BeamFragment* f = m_fragments.back();
             f->py1[idx] = f->py2[idx] = (f->py1[idx] + f->py2[idx]) * 0.5;
         }
@@ -615,36 +611,14 @@ void Beam::computeAndSetSlope()
 }
 
 //---------------------------------------------------------
-//   userModified
-//---------------------------------------------------------
-
-bool Beam::userModified() const
-{
-    int idx = directionIdx();
-    return m_userModified[idx];
-}
-
-//---------------------------------------------------------
-//   setUserModified
-//---------------------------------------------------------
-
-void Beam::setUserModified(bool val)
-{
-    int idx = directionIdx();
-    m_userModified[idx] = val;
-}
-
-//---------------------------------------------------------
 //   getProperty
 //---------------------------------------------------------
 
 PropertyValue Beam::getProperty(Pid propertyId) const
 {
     switch (propertyId) {
-    case Pid::STEM_DIRECTION: return beamDirection();
     case Pid::GROW_LEFT:      return growLeft();
     case Pid::GROW_RIGHT:     return growRight();
-    case Pid::USER_MODIFIED:  return userModified();
     case Pid::BEAM_POS:       return PropertyValue::fromValue(beamPos());
     case Pid::BEAM_NO_SLOPE:  return noSlope();
     case Pid::POSITION_LINKED_TO_MASTER:
@@ -668,17 +642,11 @@ PropertyValue Beam::getProperty(Pid propertyId) const
 bool Beam::setProperty(Pid propertyId, const PropertyValue& v)
 {
     switch (propertyId) {
-    case Pid::STEM_DIRECTION:
-        setBeamDirection(v.value<DirectionV>());
-        break;
     case Pid::GROW_LEFT:
         setGrowLeft(v.toDouble());
         break;
     case Pid::GROW_RIGHT:
         setGrowRight(v.toDouble());
-        break;
-    case Pid::USER_MODIFIED:
-        setUserModified(v.toBool());
         break;
     case Pid::BEAM_POS:
         if (userModified()) {
@@ -717,11 +685,8 @@ bool Beam::setProperty(Pid propertyId, const PropertyValue& v)
 PropertyValue Beam::propertyDefault(Pid id) const
 {
     switch (id) {
-//            case Pid::SUB_STYLE:      return int(TextStyleName::BEAM);
-    case Pid::STEM_DIRECTION: return DirectionV::AUTO;
     case Pid::GROW_LEFT:      return 1.0;
     case Pid::GROW_RIGHT:     return 1.0;
-    case Pid::USER_MODIFIED:  return false;
     case Pid::BEAM_POS:       return PropertyValue::fromValue(beamPos());
     default:                  return BeamBase::propertyDefault(id);
     }

--- a/src/engraving/dom/beam.cpp
+++ b/src/engraving/dom/beam.cpp
@@ -244,7 +244,7 @@ const BeamSegment* Beam::topLevelSegmentForElement(const ChordRest* element) con
 void Beam::move(const PointF& offset)
 {
     EngravingItem::move(offset);
-    for (BeamSegment* bs : beamSegments()) {
+    for (BeamSegment* bs : m_beamSegments) {
         bs->line.translate(offset);
     }
 }
@@ -404,8 +404,8 @@ std::vector<PointF> Beam::gripsPositions(const EditData& ed) const
     }
 
     int y = pagePos().y();
-    double beamStartX = startAnchor().x() + (system() ? system()->x() : 0);
-    double beamEndX = endAnchor().x() + (system() ? system()->x() : 0);
+    double beamStartX = m_startAnchor.x() + (system() ? system()->x() : 0);
+    double beamEndX = m_endAnchor.x() + (system() ? system()->x() : 0);
     double middleX = (beamStartX + beamEndX) / 2;
     double middleY = (f->py1[idx] + y + f->py2[idx] + y) / 2;
 
@@ -420,13 +420,13 @@ std::vector<PointF> Beam::gripsPositions(const EditData& ed) const
 //   setBeamDirection
 //---------------------------------------------------------
 
-void Beam::setBeamDirection(DirectionV d)
+void Beam::setDirection(DirectionV d)
 {
     if (direction() == d || m_cross) {
         return;
     }
 
-    setDirection(d);
+    doSetDirection(d);
 
     if (d != DirectionV::AUTO) {
         setUp(d == DirectionV::UP);
@@ -594,8 +594,8 @@ void Beam::setNoSlope(bool b)
 
 void Beam::computeAndSetSlope()
 {
-    double xDiff = endAnchor().x() - startAnchor().x();
-    double yDiff = endAnchor().y() - startAnchor().y();
+    double xDiff = m_endAnchor.x() - m_startAnchor.x();
+    double yDiff = m_endAnchor.y() - m_startAnchor.y();
     if (std::abs(xDiff) < 0.5 * spatium()) {
         // Temporary safeguard: a beam this short is invalid, and exists only as a temporary state,
         // so don't try to compute the slope as it will be wrong. Needs a better solution in future.
@@ -694,12 +694,12 @@ PropertyValue Beam::propertyDefault(Pid id) const
 
 void Beam::addSkyline(Skyline& sk)
 {
-    if (beamSegments().empty() || !addToSkyline()) {
+    if (m_beamSegments.empty() || !addToSkyline()) {
         return;
     }
 
     // Only add the outer segment, no need to add the inner one
-    sk.add(beamSegments().front()->shape());
+    sk.add(m_beamSegments.front()->shape());
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/beam.cpp
+++ b/src/engraving/dom/beam.cpp
@@ -23,13 +23,10 @@
 #include "beam.h"
 
 #include <cmath>
-#include <set>
 #include <algorithm>
 
 #include "containers.h"
 #include "realfn.h"
-
-#include "draw/types/brush.h"
 
 #include "actionicon.h"
 #include "chord.h"

--- a/src/engraving/dom/beam.cpp
+++ b/src/engraving/dom/beam.cpp
@@ -404,8 +404,8 @@ std::vector<PointF> Beam::gripsPositions(const EditData& ed) const
     }
 
     int y = pagePos().y();
-    double beamStartX = m_startAnchor.x() + (system() ? system()->x() : 0);
-    double beamEndX = m_endAnchor.x() + (system() ? system()->x() : 0);
+    double beamStartX = startAnchor().x() + (system() ? system()->x() : 0);
+    double beamEndX = endAnchor().x() + (system() ? system()->x() : 0);
     double middleX = (beamStartX + beamEndX) / 2;
     double middleY = (f->py1[idx] + y + f->py2[idx] + y) / 2;
 

--- a/src/engraving/dom/beam.cpp
+++ b/src/engraving/dom/beam.cpp
@@ -74,9 +74,6 @@ Beam::Beam(const Beam& b)
 {
     m_elements     = b.m_elements;
     m_id           = b.m_id;
-    for (const BeamSegment* bs : b.m_beamSegments) {
-        m_beamSegments.push_back(new BeamSegment(*bs));
-    }
     m_growLeft           = b.m_growLeft;
     m_growRight           = b.m_growRight;
     m_beamDist        = b.m_beamDist;
@@ -218,18 +215,19 @@ const Chord* Beam::findChordWithCustomStemDirection() const
 
 const BeamSegment* Beam::topLevelSegmentForElement(const ChordRest* element) const
 {
-    size_t segmentsSize = m_beamSegments.size();
+    const std::vector<BeamSegment*>& segments = beamSegments();
+    size_t segmentsSize = segments.size();
 
     IF_ASSERT_FAILED(segmentsSize > 0) {
         return nullptr;
     }
 
-    const BeamSegment* curSegment = m_beamSegments[0];
+    const BeamSegment* curSegment = segments[0];
     if (segmentsSize == 1) {
         return curSegment;
     }
 
-    for (const BeamSegment* segment : m_beamSegments) {
+    for (const BeamSegment* segment : segments) {
         if (segment->level <= curSegment->level) {
             continue;
         }
@@ -249,7 +247,7 @@ const BeamSegment* Beam::topLevelSegmentForElement(const ChordRest* element) con
 void Beam::move(const PointF& offset)
 {
     EngravingItem::move(offset);
-    for (BeamSegment* bs : m_beamSegments) {
+    for (BeamSegment* bs : beamSegments()) {
         bs->line.translate(offset);
     }
 }
@@ -699,12 +697,12 @@ PropertyValue Beam::propertyDefault(Pid id) const
 
 void Beam::addSkyline(Skyline& sk)
 {
-    if (m_beamSegments.empty() || !addToSkyline()) {
+    if (beamSegments().empty() || !addToSkyline()) {
         return;
     }
 
     // Only add the outer segment, no need to add the inner one
-    sk.add(m_beamSegments.front()->shape());
+    sk.add(beamSegments().front()->shape());
 }
 
 //---------------------------------------------------------
@@ -853,8 +851,7 @@ void Beam::clearBeamSegments()
         chordRest->setBeamlet(nullptr);
     }
 
-    muse::DeleteAll(m_beamSegments);
-    m_beamSegments.clear();
+    BeamBase::clearBeamSegments();
 }
 
 //-------------------------------------------------------

--- a/src/engraving/dom/beam.h
+++ b/src/engraving/dom/beam.h
@@ -130,8 +130,7 @@ public:
     void setId(int i) const { m_id = i; }
     int id() const { return m_id; }
 
-    void setBeamDirection(DirectionV d);
-    DirectionV beamDirection() const { return m_direction; }
+    void setBeamDirection(DirectionV d) override;
 
     void calcBeamBreaks(const ChordRest* chord, const ChordRest* prevChord, int level, bool& isBroken32, bool& isBroken64) const;
 
@@ -144,9 +143,6 @@ public:
     double growRight() const { return m_growRight; }
     void setGrowLeft(double val) { m_growLeft = val; }
     void setGrowRight(double val) { m_growRight = val; }
-
-    bool userModified() const;
-    void setUserModified(bool val);
 
     PairF beamPos() const;
     void setBeamPos(const PairF& bp);
@@ -230,8 +226,6 @@ public:
 
     const BeamSegment* topLevelSegmentForElement(const ChordRest* element) const;
 
-    inline int directionIdx() const { return (m_direction == DirectionV::AUTO || m_direction == DirectionV::DOWN) ? 0 : 1; }
-
 private:
 
     friend class Factory;
@@ -248,9 +242,7 @@ private:
 
     std::vector<ChordRest*> m_elements;          // must be sorted by tick
     std::vector<BeamSegment*> m_beamSegments;
-    DirectionV m_direction = DirectionV::AUTO;
 
-    bool m_userModified[2]{ false };    // 0: auto/down  1: up
     bool m_isGrace = false;
     bool m_cross = false;
     bool m_fullCross = false;

--- a/src/engraving/dom/beam.h
+++ b/src/engraving/dom/beam.h
@@ -23,8 +23,6 @@
 #ifndef MU_ENGRAVING_BEAM_H
 #define MU_ENGRAVING_BEAM_H
 
-#include <memory>
-
 #include "beambase.h"
 #include "engravingitem.h"
 #include "property.h"
@@ -39,26 +37,10 @@ class Beam;
 enum class ActionIconType;
 enum class SpannerSegmentType;
 
-//---------------------------------------------------------
-//   BeamFragment
-//    position of primary beam
-//    idx 0 - DirectionV::AUTO or DirectionV::DOWN
-//        1 - DirectionV::UP
-//---------------------------------------------------------
-
-struct BeamFragment {
-    double py1[2];
-    double py2[2];
-};
-
 struct TremAnchor {
     ChordRest* chord1 = nullptr;
     double y1 = 0.;
     double y2 = 0.;
-};
-
-enum class ChordBeamAnchorType {
-    Start, End, Middle
 };
 
 //---------------------------------------------------------

--- a/src/engraving/dom/beam.h
+++ b/src/engraving/dom/beam.h
@@ -94,7 +94,7 @@ public:
     void setId(int i) const { m_id = i; }
     int id() const { return m_id; }
 
-    void setBeamDirection(DirectionV d) override;
+    void setDirection(DirectionV d) override;
 
     void calcBeamBreaks(const ChordRest* chord, const ChordRest* prevChord, int level, bool& isBroken32, bool& isBroken64) const;
 

--- a/src/engraving/dom/beam.h
+++ b/src/engraving/dom/beam.h
@@ -124,13 +124,6 @@ public:
     void computeAndSetSlope();
     void setSlope(double val) { m_slope = val; }
 
-    const PointF& startAnchor() const { return m_startAnchor; }
-    PointF& startAnchor() { return m_startAnchor; }
-    void setStartAnchor(const PointF& p) { m_startAnchor = p; }
-    const PointF& endAnchor() const { return m_endAnchor; }
-    PointF& endAnchor() { return m_endAnchor; }
-    void setEndAnchor(const PointF& p) { m_endAnchor = p; }
-
     PropertyValue getProperty(Pid propertyId) const override;
     bool setProperty(Pid propertyId, const PropertyValue&) override;
     PropertyValue propertyDefault(Pid id) const override;
@@ -213,8 +206,6 @@ private:
     double m_beamDist = 0.0;
     int m_beamSpacing = 3;              // how far apart beams are spaced in quarter spaces
     double m_beamWidth = 0.0;           // how wide each beam is
-    PointF m_startAnchor;
-    PointF m_endAnchor;
 
     // for tabs
     bool m_isBesideTabStaff = false;

--- a/src/engraving/dom/beam.h
+++ b/src/engraving/dom/beam.h
@@ -51,24 +51,6 @@ struct BeamFragment {
     double py2[2];
 };
 
-class BeamSegment
-{
-    OBJECT_ALLOCATOR(engraving, BeamSegment)
-public:
-    LineF line;
-    int level = 0;
-    bool above = false; // above level 0 or below? (meaningless for level 0)
-    Fraction startTick;
-    Fraction endTick;
-    bool isBeamlet = false;
-    bool isBefore = false;
-
-    Shape shape() const;
-    EngravingItem* parentElement = nullptr;
-
-    BeamSegment(EngravingItem* b);
-};
-
 struct TremAnchor {
     ChordRest* chord1 = nullptr;
     double y1 = 0.;
@@ -210,9 +192,7 @@ public:
     std::vector<BeamFragment*>& beamFragments() { return m_fragments; }
     void addBeamFragment(BeamFragment* f) { m_fragments.push_back(f); }
 
-    const std::vector<BeamSegment*>& beamSegments() const { return m_beamSegments; }
-    std::vector<BeamSegment*>& beamSegments() { return m_beamSegments; }
-    void clearBeamSegments();
+    void clearBeamSegments() override;
 
     const StaffType* tab() const { return m_tab; }
     void setTab(const StaffType* t) { m_tab = t; }
@@ -241,7 +221,6 @@ private:
     void removeChordRest(ChordRest* a);
 
     std::vector<ChordRest*> m_elements;          // must be sorted by tick
-    std::vector<BeamSegment*> m_beamSegments;
 
     bool m_isGrace = false;
     bool m_cross = false;

--- a/src/engraving/dom/beambase.cpp
+++ b/src/engraving/dom/beambase.cpp
@@ -32,6 +32,10 @@ BeamBase::BeamBase(const BeamBase& b)
     : EngravingItem(b)
 {
     _crossStaffMove = b._crossStaffMove;
+    m_direction       = b.m_direction;
+    m_up              = b.m_up;
+    m_userModified[0] = b.m_userModified[0];
+    m_userModified[1] = b.m_userModified[1];
 }
 
 void BeamBase::undoChangeProperty(Pid id, const PropertyValue& v, PropertyFlags ps)
@@ -51,6 +55,10 @@ PropertyValue BeamBase::getProperty(Pid propertyId) const
     switch (propertyId) {
     case Pid::BEAM_CROSS_STAFF_MOVE:
         return crossStaffMove();
+    case Pid::STEM_DIRECTION:
+        return direction();
+    case Pid::USER_MODIFIED:
+        return userModified();
     default:
         return EngravingItem::getProperty(propertyId);
     }
@@ -61,6 +69,12 @@ bool BeamBase::setProperty(Pid propertyId, const PropertyValue& v)
     switch (propertyId) {
     case Pid::BEAM_CROSS_STAFF_MOVE:
         setCrossStaffMove(v.toInt());
+        break;
+    case Pid::STEM_DIRECTION:
+        setBeamDirection(v.value<DirectionV>());
+        break;
+    case Pid::USER_MODIFIED:
+        setUserModified(v.toBool());
         break;
     default:
         if (!EngravingItem::setProperty(propertyId, v)) {
@@ -79,6 +93,10 @@ PropertyValue BeamBase::propertyDefault(Pid propertyId) const
     switch (propertyId) {
     case Pid::BEAM_CROSS_STAFF_MOVE:
         return 0;
+    case Pid::STEM_DIRECTION:
+        return DirectionV::AUTO;
+    case Pid::USER_MODIFIED:
+        return false;
     default:
         return EngravingItem::propertyDefault(propertyId);
     }
@@ -99,4 +117,16 @@ bool BeamBase::acceptCrossStaffMove(int move) const
 {
     int newCrossStaffIdx = defaultCrossStaffIdx() + move;
     return newCrossStaffIdx >= minCRMove() && newCrossStaffIdx <= maxCRMove() + 1;
+}
+
+bool BeamBase::userModified() const
+{
+    int idx = directionIdx();
+    return m_userModified[idx];
+}
+
+void BeamBase::setUserModified(bool val)
+{
+    int idx = directionIdx();
+    m_userModified[idx] = val;
 }

--- a/src/engraving/dom/beambase.cpp
+++ b/src/engraving/dom/beambase.cpp
@@ -74,7 +74,7 @@ bool BeamBase::setProperty(Pid propertyId, const PropertyValue& v)
         setCrossStaffMove(v.toInt());
         break;
     case Pid::STEM_DIRECTION:
-        setBeamDirection(v.value<DirectionV>());
+        setDirection(v.value<DirectionV>());
         break;
     case Pid::USER_MODIFIED:
         setUserModified(v.toBool());

--- a/src/engraving/dom/beambase.cpp
+++ b/src/engraving/dom/beambase.cpp
@@ -31,6 +31,9 @@ BeamBase::BeamBase(const ElementType& type, EngravingItem* parent, ElementFlags 
 BeamBase::BeamBase(const BeamBase& b)
     : EngravingItem(b)
 {
+    for (const BeamSegment* bs : b.m_beamSegments) {
+        m_beamSegments.push_back(new BeamSegment(*bs));
+    }
     _crossStaffMove = b._crossStaffMove;
     m_direction       = b.m_direction;
     m_up              = b.m_up;
@@ -129,4 +132,10 @@ void BeamBase::setUserModified(bool val)
 {
     int idx = directionIdx();
     m_userModified[idx] = val;
+}
+
+void BeamBase::clearBeamSegments()
+{
+    muse::DeleteAll(m_beamSegments);
+    m_beamSegments.clear();
 }

--- a/src/engraving/dom/beambase.h
+++ b/src/engraving/dom/beambase.h
@@ -57,6 +57,15 @@ public:
     bool up() const { return m_up; }
     void setUp(bool v) { m_up = v; }
 
+    bool userModified() const;
+    void setUserModified(bool val);
+
+    DirectionV direction() const { return m_direction; }
+    void setDirection(DirectionV val) { m_direction = val; }
+    virtual void setBeamDirection(DirectionV v) = 0;
+
+    inline int directionIdx() const { return (m_direction == DirectionV::AUTO || m_direction == DirectionV::DOWN) ? 0 : 1; }
+
     void undoChangeProperty(Pid id, const PropertyValue& v, PropertyFlags ps = PropertyFlags::NOSTYLE) override;
 
     struct NotePosition {
@@ -136,7 +145,10 @@ protected:
     BeamBase(const ElementType& type, EngravingItem* parent, ElementFlags flags = ElementFlag::NOTHING);
     BeamBase(const BeamBase&);
 
+private:
     bool m_up = true;
+    bool m_userModified[2]{ false };    // 0: auto/down  1: up
+    DirectionV m_direction = DirectionV::AUTO;
 };
 }
 

--- a/src/engraving/dom/beambase.h
+++ b/src/engraving/dom/beambase.h
@@ -95,8 +95,8 @@ public:
     void setUserModified(bool val);
 
     DirectionV direction() const { return m_direction; }
-    void setDirection(DirectionV val) { m_direction = val; }
-    virtual void setBeamDirection(DirectionV v) = 0;
+    void doSetDirection(DirectionV val) { m_direction = val; }
+    virtual void setDirection(DirectionV v) = 0;
 
     inline int directionIdx() const { return (m_direction == DirectionV::AUTO || m_direction == DirectionV::DOWN) ? 0 : 1; }
 
@@ -189,14 +189,14 @@ public:
 protected:
     BeamBase(const ElementType& type, EngravingItem* parent, ElementFlags flags = ElementFlag::NOTHING);
     BeamBase(const BeamBase&);
+    std::vector<BeamSegment*> m_beamSegments;
+    PointF m_startAnchor;
+    PointF m_endAnchor;
 
 private:
     bool m_up = true;
     bool m_userModified[2]{ false };    // 0: auto/down  1: up
     DirectionV m_direction = DirectionV::AUTO;
-    std::vector<BeamSegment*> m_beamSegments;
-    PointF m_startAnchor;
-    PointF m_endAnchor;
 };
 }
 

--- a/src/engraving/dom/beambase.h
+++ b/src/engraving/dom/beambase.h
@@ -34,6 +34,22 @@ enum class BeamType {
     TREMOLO
 };
 
+//---------------------------------------------------------
+//   BeamFragment
+//    position of primary beam
+//    idx 0 - DirectionV::AUTO or DirectionV::DOWN
+//        1 - DirectionV::UP
+//---------------------------------------------------------
+
+struct BeamFragment {
+    double py1[2];
+    double py2[2];
+};
+
+enum class ChordBeamAnchorType {
+    Start, End, Middle
+};
+
 class BeamSegment
 {
     OBJECT_ALLOCATOR(engraving, BeamSegment)

--- a/src/engraving/dom/beambase.h
+++ b/src/engraving/dom/beambase.h
@@ -34,6 +34,24 @@ enum class BeamType {
     TREMOLO
 };
 
+class BeamSegment
+{
+    OBJECT_ALLOCATOR(engraving, BeamSegment)
+public:
+    LineF line;
+    int level = 0;
+    bool above = false; // above level 0 or below? (meaningless for level 0)
+    Fraction startTick;
+    Fraction endTick;
+    bool isBeamlet = false;
+    bool isBefore = false;
+
+    Shape shape() const;
+    EngravingItem* parentElement = nullptr;
+
+    BeamSegment(EngravingItem* b);
+};
+
 class BeamBase : public EngravingItem
 {
     OBJECT_ALLOCATOR(engraving, BeamBase)
@@ -65,6 +83,10 @@ public:
     virtual void setBeamDirection(DirectionV v) = 0;
 
     inline int directionIdx() const { return (m_direction == DirectionV::AUTO || m_direction == DirectionV::DOWN) ? 0 : 1; }
+
+    const std::vector<BeamSegment*>& beamSegments() const { return m_beamSegments; }
+    std::vector<BeamSegment*>& beamSegments() { return m_beamSegments; }
+    virtual void clearBeamSegments();
 
     void undoChangeProperty(Pid id, const PropertyValue& v, PropertyFlags ps = PropertyFlags::NOSTYLE) override;
 
@@ -149,6 +171,7 @@ private:
     bool m_up = true;
     bool m_userModified[2]{ false };    // 0: auto/down  1: up
     DirectionV m_direction = DirectionV::AUTO;
+    std::vector<BeamSegment*> m_beamSegments;
 };
 }
 

--- a/src/engraving/dom/beambase.h
+++ b/src/engraving/dom/beambase.h
@@ -104,6 +104,13 @@ public:
     std::vector<BeamSegment*>& beamSegments() { return m_beamSegments; }
     virtual void clearBeamSegments();
 
+    const PointF& startAnchor() const { return m_startAnchor; }
+    PointF& startAnchor() { return m_startAnchor; }
+    void setStartAnchor(const PointF& p) { m_startAnchor = p; }
+    const PointF& endAnchor() const { return m_endAnchor; }
+    PointF& endAnchor() { return m_endAnchor; }
+    void setEndAnchor(const PointF& p) { m_endAnchor = p; }
+
     void undoChangeProperty(Pid id, const PropertyValue& v, PropertyFlags ps = PropertyFlags::NOSTYLE) override;
 
     struct NotePosition {
@@ -188,6 +195,8 @@ private:
     bool m_userModified[2]{ false };    // 0: auto/down  1: up
     DirectionV m_direction = DirectionV::AUTO;
     std::vector<BeamSegment*> m_beamSegments;
+    PointF m_startAnchor;
+    PointF m_endAnchor;
 };
 }
 

--- a/src/engraving/dom/tremolotwochord.cpp
+++ b/src/engraving/dom/tremolotwochord.cpp
@@ -351,8 +351,8 @@ std::vector<PointF> TremoloTwoChord::gripsPositions(const EditData&) const
     }
 
     int y = pagePos().y();
-    double beamStartX = m_startAnchor.x() + m_chord1->pageX();
-    double beamEndX = m_endAnchor.x() + m_chord1->pageX(); // intentional--chord1 is start x
+    double beamStartX = startAnchor().x() + m_chord1->pageX();
+    double beamEndX = endAnchor().x() + m_chord1->pageX(); // intentional--chord1 is start x
     double middleX = (beamStartX + beamEndX) / 2;
     double middleY = (m_beamFragment.py1[idx] + y + m_beamFragment.py2[idx] + y) / 2;
 

--- a/src/engraving/dom/tremolotwochord.cpp
+++ b/src/engraving/dom/tremolotwochord.cpp
@@ -30,7 +30,6 @@
 
 #include "rendering/score/beamtremololayout.h"
 
-#include "beam.h"
 #include "chord.h"
 #include "stem.h"
 #include "system.h"

--- a/src/engraving/dom/tremolotwochord.cpp
+++ b/src/engraving/dom/tremolotwochord.cpp
@@ -208,14 +208,14 @@ PointF TremoloTwoChord::pagePos() const
 
 void TremoloTwoChord::setBeamDirection(DirectionV d)
 {
-    if (m_direction == d) {
+    if (direction() == d) {
         return;
     }
 
-    m_direction = d;
+    setDirection(d);
 
     if (d != DirectionV::AUTO) {
-        m_up = d == DirectionV::UP;
+        setUp(d == DirectionV::UP);
     }
     if (twoNotes()) {
         if (m_chord1) {
@@ -286,7 +286,7 @@ Fraction TremoloTwoChord::tremoloLen() const
 void TremoloTwoChord::setBeamPos(const PairF& bp)
 {
     int idx = directionIdx();
-    m_userModified[idx] = true;
+    setUserModified(true);
     setGenerated(false);
 
     double _spatium = spatium();
@@ -303,26 +303,6 @@ PairF TremoloTwoChord::beamPos() const
     int idx = directionIdx();
     double _spatium = spatium();
     return PairF(m_beamFragment.py1[idx] / _spatium, m_beamFragment.py2[idx] / _spatium);
-}
-
-//---------------------------------------------------------
-//   userModified
-//---------------------------------------------------------
-
-bool TremoloTwoChord::userModified() const
-{
-    int idx = directionIdx();
-    return m_userModified[idx];
-}
-
-//---------------------------------------------------------
-//   setUserModified
-//---------------------------------------------------------
-
-void TremoloTwoChord::setUserModified(bool val)
-{
-    int idx = directionIdx();
-    m_userModified[idx] = val;
 }
 
 //---------------------------------------------------------
@@ -465,12 +445,10 @@ PropertyValue TremoloTwoChord::getProperty(Pid propertyId) const
         return int(m_style);
     case Pid::PLAY:
         return m_playTremolo;
-    case Pid::USER_MODIFIED:
-        return userModified();
     default:
         break;
     }
-    return EngravingItem::getProperty(propertyId);
+    return BeamBase::getProperty(propertyId);
 }
 
 //---------------------------------------------------------
@@ -488,12 +466,6 @@ bool TremoloTwoChord::setProperty(Pid propertyId, const PropertyValue& val)
             setTremoloStyle(TremoloStyle(val.toInt()));
         }
         break;
-    case Pid::STEM_DIRECTION:
-        setBeamDirection(val.value<DirectionV>());
-        break;
-    case Pid::USER_MODIFIED:
-        setUserModified(val.toBool());
-        break;
     case Pid::BEAM_POS:
         if (userModified()) {
             setBeamPos(val.value<PairF>());
@@ -503,7 +475,7 @@ bool TremoloTwoChord::setProperty(Pid propertyId, const PropertyValue& val)
         setPlayTremolo(val.toBool());
         break;
     default:
-        return EngravingItem::setProperty(propertyId, val);
+        return BeamBase::setProperty(propertyId, val);
     }
     triggerLayout();
     return true;
@@ -520,10 +492,8 @@ PropertyValue TremoloTwoChord::propertyDefault(Pid propertyId) const
         return style().styleI(Sid::tremoloStyle);
     case Pid::PLAY:
         return true;
-    case Pid::USER_MODIFIED:
-        return false;
     default:
-        return EngravingItem::propertyDefault(propertyId);
+        return BeamBase::propertyDefault(propertyId);
     }
 }
 

--- a/src/engraving/dom/tremolotwochord.cpp
+++ b/src/engraving/dom/tremolotwochord.cpp
@@ -120,7 +120,7 @@ PointF TremoloTwoChord::chordBeamAnchor(const ChordRest* chord, ChordBeamAnchorT
 
 RectF TremoloTwoChord::drag(EditData& ed)
 {
-    int idx = (m_direction == DirectionV::AUTO || m_direction == DirectionV::DOWN) ? 0 : 1;
+    int idx = directionIdx();
     double dy = ed.pos.y() - ed.lastPos.y();
 
     double y1 = m_beamFragment.py1[idx];
@@ -244,21 +244,6 @@ bool TremoloTwoChord::crossStaffBeamBetween() const
            || ((m_chord1->staffMove() < m_chord2->staffMove()) && !m_chord1->up() && m_chord2->up());
 }
 
-void TremoloTwoChord::setUserModified(DirectionV d, bool val)
-{
-    switch (d) {
-    case DirectionV::AUTO:
-        m_userModified[0] = val;
-        break;
-    case DirectionV::DOWN:
-        m_userModified[0] = val;
-        break;
-    case DirectionV::UP:
-        m_userModified[1] = val;
-        break;
-    }
-}
-
 TDuration TremoloTwoChord::durationType() const
 {
     return m_durationType;
@@ -300,7 +285,7 @@ Fraction TremoloTwoChord::tremoloLen() const
 
 void TremoloTwoChord::setBeamPos(const PairF& bp)
 {
-    int idx = (m_direction == DirectionV::AUTO || m_direction == DirectionV::DOWN) ? 0 : 1;
+    int idx = directionIdx();
     m_userModified[idx] = true;
     setGenerated(false);
 
@@ -315,7 +300,7 @@ void TremoloTwoChord::setBeamPos(const PairF& bp)
 
 PairF TremoloTwoChord::beamPos() const
 {
-    int idx = (m_direction == DirectionV::AUTO || m_direction == DirectionV::DOWN) ? 0 : 1;
+    int idx = directionIdx();
     double _spatium = spatium();
     return PairF(m_beamFragment.py1[idx] / _spatium, m_beamFragment.py2[idx] / _spatium);
 }
@@ -326,7 +311,7 @@ PairF TremoloTwoChord::beamPos() const
 
 bool TremoloTwoChord::userModified() const
 {
-    int idx = (m_direction == DirectionV::AUTO || m_direction == DirectionV::DOWN) ? 0 : 1;
+    int idx = directionIdx();
     return m_userModified[idx];
 }
 
@@ -336,7 +321,7 @@ bool TremoloTwoChord::userModified() const
 
 void TremoloTwoChord::setUserModified(bool val)
 {
-    int idx = (m_direction == DirectionV::AUTO || m_direction == DirectionV::DOWN) ? 0 : 1;
+    int idx = directionIdx();
     m_userModified[idx] = val;
 }
 
@@ -380,7 +365,7 @@ Grip TremoloTwoChord::defaultGrip() const
 
 std::vector<PointF> TremoloTwoChord::gripsPositions(const EditData&) const
 {
-    int idx = (m_direction == DirectionV::AUTO || m_direction == DirectionV::DOWN) ? 0 : 1;
+    int idx = directionIdx();
 
     if (!twoNotes()) {
         return std::vector<PointF>();
@@ -414,7 +399,7 @@ void TremoloTwoChord::endEdit(EditData& ed)
 
 void TremoloTwoChord::editDrag(EditData& ed)
 {
-    int idx = (m_direction == DirectionV::AUTO || m_direction == DirectionV::DOWN) ? 0 : 1;
+    int idx = directionIdx();
     double dy = ed.delta.y();
     double y1 = m_beamFragment.py1[idx];
     double y2 = m_beamFragment.py2[idx];
@@ -480,6 +465,8 @@ PropertyValue TremoloTwoChord::getProperty(Pid propertyId) const
         return int(m_style);
     case Pid::PLAY:
         return m_playTremolo;
+    case Pid::USER_MODIFIED:
+        return userModified();
     default:
         break;
     }
@@ -533,6 +520,8 @@ PropertyValue TremoloTwoChord::propertyDefault(Pid propertyId) const
         return style().styleI(Sid::tremoloStyle);
     case Pid::PLAY:
         return true;
+    case Pid::USER_MODIFIED:
+        return false;
     default:
         return EngravingItem::propertyDefault(propertyId);
     }

--- a/src/engraving/dom/tremolotwochord.cpp
+++ b/src/engraving/dom/tremolotwochord.cpp
@@ -515,7 +515,7 @@ void TremoloTwoChord::clearBeamSegments()
     BeamSegment* chord2Segment = m_chord2 ? m_chord2->beamlet() : nullptr;
 
     if (chord1Segment || chord2Segment) {
-        for (BeamSegment* segment : m_beamSegments) {
+        for (BeamSegment* segment : beamSegments()) {
             if (chord1Segment && chord1Segment == segment) {
                 m_chord1->setBeamlet(nullptr);
             } else if (chord2Segment && chord2Segment == segment) {
@@ -524,8 +524,7 @@ void TremoloTwoChord::clearBeamSegments()
         }
     }
 
-    muse::DeleteAll(m_beamSegments);
-    m_beamSegments.clear();
+    BeamBase::clearBeamSegments();
 }
 
 int TremoloTwoChord::maxCRMove() const

--- a/src/engraving/dom/tremolotwochord.cpp
+++ b/src/engraving/dom/tremolotwochord.cpp
@@ -205,13 +205,13 @@ PointF TremoloTwoChord::pagePos() const
 //   setBeamDirection
 //---------------------------------------------------------
 
-void TremoloTwoChord::setBeamDirection(DirectionV d)
+void TremoloTwoChord::setDirection(DirectionV d)
 {
     if (direction() == d) {
         return;
     }
 
-    setDirection(d);
+    doSetDirection(d);
 
     if (d != DirectionV::AUTO) {
         setUp(d == DirectionV::UP);
@@ -351,8 +351,8 @@ std::vector<PointF> TremoloTwoChord::gripsPositions(const EditData&) const
     }
 
     int y = pagePos().y();
-    double beamStartX = startAnchor().x() + m_chord1->pageX();
-    double beamEndX = endAnchor().x() + m_chord1->pageX(); // intentional--chord1 is start x
+    double beamStartX = m_startAnchor.x() + m_chord1->pageX();
+    double beamEndX = m_endAnchor.x() + m_chord1->pageX(); // intentional--chord1 is start x
     double middleX = (beamStartX + beamEndX) / 2;
     double middleY = (m_beamFragment.py1[idx] + y + m_beamFragment.py2[idx] + y) / 2;
 
@@ -514,7 +514,7 @@ void TremoloTwoChord::clearBeamSegments()
     BeamSegment* chord2Segment = m_chord2 ? m_chord2->beamlet() : nullptr;
 
     if (chord1Segment || chord2Segment) {
-        for (BeamSegment* segment : beamSegments()) {
+        for (BeamSegment* segment : m_beamSegments) {
             if (chord1Segment && chord1Segment == segment) {
                 m_chord1->setBeamlet(nullptr);
             } else if (chord2Segment && chord2Segment == segment) {

--- a/src/engraving/dom/tremolotwochord.h
+++ b/src/engraving/dom/tremolotwochord.h
@@ -128,9 +128,7 @@ public:
     PointF& endAnchor() { return m_endAnchor; }
     void setEndAnchor(const PointF& p) { m_endAnchor = p; }
 
-    const std::vector<BeamSegment*>& beamSegments() const { return m_beamSegments; }
-    std::vector<BeamSegment*>& beamSegments() { return m_beamSegments; }
-    void clearBeamSegments();
+    void clearBeamSegments() override;
 
     int maxCRMove() const override;
     int minCRMove() const override;
@@ -154,7 +152,6 @@ private:
     Chord* m_chord1 = nullptr;
     Chord* m_chord2 = nullptr;
     TDuration m_durationType;
-    std::vector<BeamSegment*> m_beamSegments;
     bool m_playTremolo = true;
 
     PointF m_startAnchor;

--- a/src/engraving/dom/tremolotwochord.h
+++ b/src/engraving/dom/tremolotwochord.h
@@ -64,8 +64,6 @@ public:
     double chordMag() const;
     RectF drag(EditData&) override;
 
-    void layout2();
-
     Chord* chord1() const { return m_chord1; }
     void setChord1(Chord* ch) { m_chord1 = ch; }
     Chord* chord2() const { return m_chord2; }
@@ -121,13 +119,6 @@ public:
     void endEdit(EditData&) override;
     void editDrag(EditData&) override;
 
-    const PointF& startAnchor() const { return m_startAnchor; }
-    PointF& startAnchor() { return m_startAnchor; }
-    void setStartAnchor(const PointF& p) { m_startAnchor = p; }
-    const PointF& endAnchor() const { return m_endAnchor; }
-    PointF& endAnchor() { return m_endAnchor; }
-    void setEndAnchor(const PointF& p) { m_endAnchor = p; }
-
     void clearBeamSegments() override;
 
     int maxCRMove() const override;
@@ -153,9 +144,6 @@ private:
     Chord* m_chord2 = nullptr;
     TDuration m_durationType;
     bool m_playTremolo = true;
-
-    PointF m_startAnchor;
-    PointF m_endAnchor;
 
     int m_lines = 0;         // derived from _subtype
     TremoloStyle m_style = TremoloStyle::DEFAULT;

--- a/src/engraving/dom/tremolotwochord.h
+++ b/src/engraving/dom/tremolotwochord.h
@@ -61,8 +61,6 @@ public:
     DirectionV direction() const { return m_direction; }
     void setDirection(DirectionV val) { m_direction = val; }
 
-    void setUserModified(DirectionV d, bool val);
-
     double minHeight() const;
     void reset() override;
 
@@ -144,6 +142,8 @@ public:
 
     int maxCRMove() const override;
     int minCRMove() const override;
+
+    inline int directionIdx() const { return (m_direction == DirectionV::AUTO || m_direction == DirectionV::DOWN) ? 0 : 1; }
 
     //! NOTE for palettes
     muse::draw::PainterPath basePath(double stretch = 0) const;

--- a/src/engraving/dom/tremolotwochord.h
+++ b/src/engraving/dom/tremolotwochord.h
@@ -94,7 +94,7 @@ public:
 
     TremoloStyle tremoloStyle() const { return m_style; }
     void setTremoloStyle(TremoloStyle v) { m_style = v; }
-    void setBeamDirection(DirectionV v) override;
+    void setDirection(DirectionV v) override;
     void setBeamFragment(const BeamFragment& bf) { m_beamFragment = bf; }
     const BeamFragment& beamFragment() const { return m_beamFragment; }
     BeamFragment& beamFragment() { return m_beamFragment; }

--- a/src/engraving/dom/tremolotwochord.h
+++ b/src/engraving/dom/tremolotwochord.h
@@ -80,11 +80,7 @@ public:
     void setDurationType(TDuration d);
 
     Fraction tremoloLen() const;
-    bool isBuzzRoll() const { return m_tremoloType == TremoloType::BUZZ_ROLL; }
-    bool twoNotes() const { return m_tremoloType >= TremoloType::C8; }    // is it a two note tremolo?
     int lines() const { return m_lines; }
-
-    bool placeMidStem() const;
 
     bool crossStaffBeamBetween() const;
 
@@ -108,7 +104,6 @@ public:
     bool setProperty(Pid propertyId, const PropertyValue&) override;
     PropertyValue propertyDefault(Pid propertyId) const override;
 
-    // only need grips for two-note trems
     bool needStartEditingAfterSelecting() const override;
     int gripsCount() const override;
     Grip initialEditModeGrip() const override;
@@ -139,7 +134,7 @@ private:
 
     void setBeamPos(const PairF& bp);
 
-    TremoloType m_tremoloType = TremoloType::R8;
+    TremoloType m_tremoloType = TremoloType::INVALID_TREMOLO;
     Chord* m_chord1 = nullptr;
     Chord* m_chord2 = nullptr;
     TDuration m_durationType;

--- a/src/engraving/dom/tremolotwochord.h
+++ b/src/engraving/dom/tremolotwochord.h
@@ -23,8 +23,6 @@
 #ifndef MU_ENGRAVING_TREMOLOTWOCHORD_H
 #define MU_ENGRAVING_TREMOLOTWOCHORD_H
 
-#include <memory>
-
 #include "beambase.h"
 #include "engravingitem.h"
 
@@ -58,9 +56,6 @@ public:
     void setTremoloType(TremoloType t);
     TremoloType tremoloType() const { return m_tremoloType; }
 
-    DirectionV direction() const { return m_direction; }
-    void setDirection(DirectionV val) { m_direction = val; }
-
     double minHeight() const;
     void reset() override;
 
@@ -86,9 +81,6 @@ public:
     TDuration durationType() const;
     void setDurationType(TDuration d);
 
-    bool userModified() const;
-    void setUserModified(bool val);
-
     Fraction tremoloLen() const;
     bool isBuzzRoll() const { return m_tremoloType == TremoloType::BUZZ_ROLL; }
     bool twoNotes() const { return m_tremoloType >= TremoloType::C8; }    // is it a two note tremolo?
@@ -104,7 +96,7 @@ public:
 
     TremoloStyle tremoloStyle() const { return m_style; }
     void setTremoloStyle(TremoloStyle v) { m_style = v; }
-    void setBeamDirection(DirectionV v);
+    void setBeamDirection(DirectionV v) override;
     void setBeamFragment(const BeamFragment& bf) { m_beamFragment = bf; }
     const BeamFragment& beamFragment() const { return m_beamFragment; }
     BeamFragment& beamFragment() { return m_beamFragment; }
@@ -143,8 +135,6 @@ public:
     int maxCRMove() const override;
     int minCRMove() const override;
 
-    inline int directionIdx() const { return (m_direction == DirectionV::AUTO || m_direction == DirectionV::DOWN) ? 0 : 1; }
-
     //! NOTE for palettes
     muse::draw::PainterPath basePath(double stretch = 0) const;
     const muse::draw::PainterPath& path() const { return m_path; }
@@ -164,8 +154,6 @@ private:
     Chord* m_chord1 = nullptr;
     Chord* m_chord2 = nullptr;
     TDuration m_durationType;
-    bool m_userModified[2]{ false };                // 0: auto/down  1: up
-    DirectionV m_direction = DirectionV::AUTO;
     std::vector<BeamSegment*> m_beamSegments;
     bool m_playTremolo = true;
 

--- a/src/engraving/rendering/score/beamlayout.cpp
+++ b/src/engraving/rendering/score/beamlayout.cpp
@@ -1489,7 +1489,6 @@ void BeamLayout::setTremAnchors(Beam* item, const LayoutContext& ctx)
             // there is an inset tremolo here!
             // figure out up / down
             bool tremUp = t->up();
-            //int fragmentIndex = (m_direction == DirectionV::AUTO || m_direction == DirectionV::DOWN) ? 0 : 1;
             if (item->userModified()) {
                 tremUp = c->up();
             } else if (item->cross() && t->chord1()->staffMove() == t->chord2()->staffMove()) {

--- a/src/engraving/rendering/score/beamlayout.cpp
+++ b/src/engraving/rendering/score/beamlayout.cpp
@@ -155,8 +155,8 @@ void BeamLayout::layout1(Beam* item, LayoutContext& ctx)
     }
 
     if (item->staff()->isDrumStaff(Fraction(0, 1))) {
-        if (item->beamDirection() != DirectionV::AUTO) {
-            item->setUp(item->beamDirection() == DirectionV::UP);
+        if (item->direction() != DirectionV::AUTO) {
+            item->setUp(item->direction() == DirectionV::UP);
         } else if (item->isGrace()) {
             item->setUp(true);
         } else {
@@ -224,8 +224,8 @@ void BeamLayout::layout1(Beam* item, LayoutContext& ctx)
     Measure* measure = firstNote->measure();
     bool hasMultipleVoices = measure->hasVoices(firstNote->staffIdx(), item->tick(), item->ticks());
     if (computeUpForMovedCross(item)) {
-    } else if (item->beamDirection() != DirectionV::AUTO) {
-        item->setUp(item->beamDirection() == DirectionV::UP);
+    } else if (item->direction() != DirectionV::AUTO) {
+        item->setUp(item->direction() == DirectionV::UP);
     } else if (item->maxCRMove() > 0) {
         item->setUp(false);
     } else if (item->minCRMove() < 0) {
@@ -265,7 +265,7 @@ void BeamLayout::layout1(Beam* item, LayoutContext& ctx)
     if (item->minCRMove() == item->maxCRMove() && item->minCRMove() != 0) {
         isEntirelyMoved = true;
         item->setStaffIdx(staffIdx);
-        if (item->beamDirection() == DirectionV::AUTO) {
+        if (item->direction() == DirectionV::AUTO) {
             item->setUp(item->maxCRMove() > 0);
         }
     } else if (item->elements().size()) {

--- a/src/engraving/rendering/score/tremololayout.cpp
+++ b/src/engraving/rendering/score/tremololayout.cpp
@@ -187,7 +187,7 @@ void TremoloLayout::layoutTwoNotesTremolo(TremoloTwoChord* item, const LayoutCon
     if (item->chord1()->beam() && item->chord1()->beam() == item->chord2()->beam()) {
         Beam* beam = item->chord1()->beam();
         item->setUp(beam->up());
-        item->setDirection(beam->direction());
+        item->doSetDirection(beam->direction());
         // stem stuff is already taken care of by the beams
     } else if (!item->userModified()) {
         // user modified trems will be dealt with later

--- a/src/engraving/rendering/score/tremololayout.cpp
+++ b/src/engraving/rendering/score/tremololayout.cpp
@@ -187,7 +187,7 @@ void TremoloLayout::layoutTwoNotesTremolo(TremoloTwoChord* item, const LayoutCon
     if (item->chord1()->beam() && item->chord1()->beam() == item->chord2()->beam()) {
         Beam* beam = item->chord1()->beam();
         item->setUp(beam->up());
-        item->setDirection(beam->beamDirection());
+        item->setDirection(beam->direction());
         // stem stuff is already taken care of by the beams
     } else if (!item->userModified()) {
         // user modified trems will be dealt with later

--- a/src/engraving/rendering/score/tremololayout.cpp
+++ b/src/engraving/rendering/score/tremololayout.cpp
@@ -233,7 +233,7 @@ void TremoloLayout::layoutTwoNotesTremolo(TremoloTwoChord* item, const LayoutCon
     // deal with manual adjustments here and return
     PropertyValue val = item->getProperty(Pid::PLACEMENT);
     if (item->userModified()) {
-        int idx = (item->direction() == DirectionV::AUTO || item->direction() == DirectionV::DOWN) ? 0 : 1;
+        int idx = item->directionIdx();
         double startY = item->beamFragment().py1[idx];
         double endY = item->beamFragment().py2[idx];
         if (ctx.conf().styleB(Sid::snapCustomBeamsToGrid)) {
@@ -280,7 +280,7 @@ void TremoloLayout::layoutTwoNotesTremolo(TremoloTwoChord* item, const LayoutCon
     item->setStartAnchor(item->ldata()->startAnchor);
     item->setEndAnchor(item->ldata()->endAnchor);
 
-    int idx = (item->direction() == DirectionV::AUTO || item->direction() == DirectionV::DOWN) ? 0 : 1;
+    int idx = item->directionIdx();
     item->beamFragment().py1[idx] = item->startAnchor().y() - item->pagePos().y();
     item->beamFragment().py2[idx] = item->endAnchor().y() - item->pagePos().y();
     createBeamSegments(item, ctx);

--- a/src/engraving/rendering/score/tremololayout.cpp
+++ b/src/engraving/rendering/score/tremololayout.cpp
@@ -55,18 +55,6 @@ void TremoloLayout::layout(TremoloTwoChord* item, const LayoutContext& ctx)
     } else {
         // center tremolo above note
         x = anchor1->x() + anchor1->headWidth() * 0.5;
-        if (!item->twoNotes()) {
-            bool hasMirroredNote = false;
-            for (Note* n : item->chord1()->notes()) {
-                if (n->ldata()->mirror.value()) {
-                    hasMirroredNote = true;
-                    break;
-                }
-            }
-            if (hasMirroredNote) {
-                x = item->chord1()->stemPosX();
-            }
-        }
         y = anchor1->y();
         h = (ctx.conf().styleMM(Sid::tremoloNoteSidePadding).val() + item->ldata()->bbox().height()) * item->chord1()->intrinsicMag();
     }
@@ -326,10 +314,6 @@ void TremoloLayout::createBeamSegments(TremoloTwoChord* item, const LayoutContex
     const bool defaultStyle = (!item->customStyleApplicable()) || (item->tremoloStyle() == TremoloStyle::DEFAULT);
 
     item->clearBeamSegments();
-
-    if (!item->twoNotes()) {
-        return;
-    }
 
     bool _isGrace = item->chord1()->isGrace();
     const PointF pagePos = item->pagePos();

--- a/src/engraving/rendering/score/tremololayout.h
+++ b/src/engraving/rendering/score/tremololayout.h
@@ -45,6 +45,7 @@ public:
 private:
     static void layoutOneNoteTremolo(TremoloSingleChord* item, const LayoutContext& ctx, double x, double y, double h, double spatium);
     static void layoutTwoNotesTremolo(TremoloTwoChord* item, const LayoutContext& ctx, double x, double y, double h, double spatium);
+    static void calcIsUp(TremoloTwoChord* item);
 };
 }
 

--- a/src/engraving/rendering/score/tremololayout.h
+++ b/src/engraving/rendering/score/tremololayout.h
@@ -45,7 +45,6 @@ public:
 private:
     static void layoutOneNoteTremolo(TremoloSingleChord* item, const LayoutContext& ctx, double x, double y, double h, double spatium);
     static void layoutTwoNotesTremolo(TremoloTwoChord* item, const LayoutContext& ctx, double x, double y, double h, double spatium);
-    static void calcIsUp(TremoloTwoChord* item);
 };
 }
 

--- a/src/engraving/rw/read400/tread.cpp
+++ b/src/engraving/rw/read400/tread.cpp
@@ -1567,7 +1567,7 @@ void TRead::read(Beam* b, XmlReader& e, ReadContext& ctx)
             b->setGrowRight(e.readDouble());
         } else if (tag == "Fragment") {
             BeamFragment* f = new BeamFragment;
-            int idx = (b->beamDirection() == DirectionV::AUTO || b->beamDirection() == DirectionV::DOWN) ? 0 : 1;
+            int idx = (b->direction() == DirectionV::AUTO || b->direction() == DirectionV::DOWN) ? 0 : 1;
             b->setUserModified(true);
             double _spatium = b->spatium();
             while (e.readNextStartElement()) {

--- a/src/engraving/rw/read400/tread.cpp
+++ b/src/engraving/rw/read400/tread.cpp
@@ -4153,8 +4153,8 @@ void TRead::read(TremoloCompat& t, XmlReader& e, ReadContext& ctx)
         } else if (tag == "Fragment") {
             if (t.two) {
                 BeamFragment f = BeamFragment();
-                int idx = (t.two->direction() == DirectionV::AUTO || t.two->direction() == DirectionV::DOWN) ? 0 : 1;
-                t.two->setUserModified(t.two->direction(), true);
+                int idx = t.two->directionIdx();
+                t.two->setUserModified(true);
                 double _spatium = t.two->spatium();
                 while (e.readNextStartElement()) {
                     const AsciiStringView tag1(e.name());

--- a/src/engraving/rw/read410/tread.cpp
+++ b/src/engraving/rw/read410/tread.cpp
@@ -1758,7 +1758,7 @@ void TRead::read(Beam* b, XmlReader& e, ReadContext& ctx)
             b->setGrowRight(e.readDouble());
         } else if (tag == "Fragment") {
             BeamFragment* f = new BeamFragment;
-            int idx = (b->beamDirection() == DirectionV::AUTO || b->beamDirection() == DirectionV::DOWN) ? 0 : 1;
+            int idx = b->directionIdx();
             b->setUserModified(true);
             double _spatium = b->spatium();
             while (e.readNextStartElement()) {
@@ -4563,8 +4563,8 @@ void TRead::read(compat::TremoloCompat* tc, XmlReader& e, ReadContext& ctx)
         } else if (tag == "Fragment") {
             if (tc->two) {
                 BeamFragment f = BeamFragment();
-                int idx = (tc->two->direction() == DirectionV::AUTO || tc->two->direction() == DirectionV::DOWN) ? 0 : 1;
-                tc->two->setUserModified(tc->two->direction(), true);
+                int idx = tc->two->directionIdx();
+                tc->two->setUserModified(true);
                 double _spatium = tc->two->spatium();
                 while (e.readNextStartElement()) {
                     const AsciiStringView tag1(e.name());

--- a/src/engraving/rw/write/twrite.cpp
+++ b/src/engraving/rw/write/twrite.cpp
@@ -3024,7 +3024,7 @@ void TWrite::write(const TremoloTwoChord* item, XmlWriter& xml, WriteContext& ct
     writeItemProperties(item, xml, ctx);
 
     // write manual adjustments to file
-    int idx = (item->direction() == DirectionV::AUTO || item->direction() == DirectionV::DOWN) ? 0 : 1;
+    int idx = item->directionIdx();
     if (item->userModified()) {
         double _spatium = item->spatium();
 

--- a/src/engraving/tests/beam_tests.cpp
+++ b/src/engraving/tests/beam_tests.cpp
@@ -193,7 +193,7 @@ TEST_F(Engraving_BeamTests, beamStemDir)
     Measure* m1 = score->firstMeasure();
     ChordRest* cr = toChordRest(m1->findSegment(SegmentType::ChordRest, m1->tick())->element(0));
 
-    cr->beam()->setBeamDirection(DirectionV::UP);
+    cr->beam()->setDirection(DirectionV::UP);
 
     score->update();
     score->doLayout();
@@ -223,7 +223,7 @@ TEST_F(Engraving_BeamTests, flipBeamStemDir)
     score->startCmd();
     score->cmdFlip();
     score->endCmd();
-    cr->beam()->setBeamDirection(DirectionV::DOWN);
+    cr->beam()->setDirection(DirectionV::DOWN);
 
     score->update();
     score->doLayout();

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -2279,7 +2279,7 @@ static void handleBeamAndStemDir(ChordRest* cr, const BeamMode bm, const Directi
         // create a new beam
         beam = Factory::createBeam(cr->score()->dummy()->system());
         beam->setTrack(cr->track());
-        beam->setBeamDirection(sd);
+        beam->setDirection(sd);
     }
     // add ChordRest to beam
     if (beam) {


### PR DESCRIPTION
I spotted a lot of duplicated code between `Beam` and `TremoloTwoChord`.  I've unified this in `BeamBase`.  This is mostly completely straightforward, with the exception of `clearBeamSegments` and `setBeamDirection` which need overriden methods to deal with the different numbers of chords expected on each beam.  

It also looks like there's some leftover dead code from when two note and one note tremolos were a single class.  I haven't tackled that in this PR, but we can slim the `TremoloTwoChord` class down even further in future.