### PR TITLE
22354 fix midi out velocity and midi mac

### DIFF
--- a/src/framework/audio/internal/synthesizers/fluidsynth/fluidsequencer.cpp
+++ b/src/framework/audio/internal/synthesizers/fluidsynth/fluidsequencer.cpp
@@ -285,7 +285,7 @@ tuning_t FluidSequencer::noteTuning(const mpe::NoteEvent& noteEvent, const int n
 
 velocity_t FluidSequencer::noteVelocity(const mpe::NoteEvent& noteEvent) const
 {
-    static constexpr midi::velocity_t MAX_SUPPORTED_VELOCITY = 127;
+    static constexpr midi::velocity_t MAX_SUPPORTED_VELOCITY = std::numeric_limits<midi::velocity_t>::max(); // jg: changed
 
     const mpe::ExpressionContext& expressionCtx = noteEvent.expressionCtx();
 

--- a/src/framework/audio/internal/synthesizers/fluidsynth/fluidsequencer.cpp
+++ b/src/framework/audio/internal/synthesizers/fluidsynth/fluidsequencer.cpp
@@ -300,7 +300,7 @@ velocity_t FluidSequencer::noteVelocity(const mpe::NoteEvent& noteEvent) const
     }
 
     dynamic_level_t dynamicLevel = expressionCtx.expressionCurve.maxAmplitudeLevel();
-    return expressionLevel(dynamicLevel);
+    return expressionLevel(dynamicLevel) << 9; // midi::Event::scaleUp(7,16)
 }
 
 int FluidSequencer::expressionLevel(const mpe::dynamic_level_t dynamicLevel) const

--- a/src/framework/audio/internal/synthesizers/fluidsynth/fluidsynth.cpp
+++ b/src/framework/audio/internal/synthesizers/fluidsynth/fluidsynth.cpp
@@ -167,7 +167,8 @@ bool FluidSynth::handleEvent(const midi::Event& event)
     int ret = FLUID_OK;
     switch (event.opcode()) {
     case Event::Opcode::NoteOn: {
-        ret = fluid_synth_noteon(m_fluid->synth, event.channel(), event.note(), event.velocity());
+        // fluid_synth_noteon expects 0...127
+        ret = fluid_synth_noteon(m_fluid->synth, event.channel(), event.note(), event.velocity7());
         m_tuning.add(event.note(), event.pitchTuningCents());
     } break;
     case Event::Opcode::NoteOff: {
@@ -176,16 +177,16 @@ bool FluidSynth::handleEvent(const midi::Event& event)
     } break;
     case Event::Opcode::ControlChange: {
         if (event.index() == muse::midi::EXPRESSION_CONTROLLER) {
-            ret = setExpressionLevel(event.data());
+            ret = setExpressionLevel(event.data7());
         } else {
-            ret = setControllerValue(event.channel(), event.index(), event.data());
+            ret = setControllerValue(event.channel(), event.index(), event.data7());
         }
     } break;
     case Event::Opcode::ProgramChange: {
         fluid_synth_program_change(m_fluid->synth, event.channel(), event.program());
     } break;
     case Event::Opcode::PitchBend: {
-        ret = setPitchBend(event.channel(), event.data());
+        ret = setPitchBend(event.channel(), event.pitchBend14());
     } break;
     default: {
         LOGD() << "not supported event type: " << event.opcodeString();

--- a/src/framework/audio/internal/synthesizers/fluidsynth/fluidsynth.cpp
+++ b/src/framework/audio/internal/synthesizers/fluidsynth/fluidsynth.cpp
@@ -169,20 +169,20 @@ void FluidSynth::allNotesOff()
         // - We could send all events at once.
         // Does i directly relate to midi channels? -> lastChannelIndex, otherwise use 16.
         int upperBound = min(lastChannelIdx, 16);
-        for (int i = 0; i<upperBound; i++) {
+        for (int i = 0; i < upperBound; i++) {
             muse::midi::Event e(muse::midi::Event::Opcode::ControlChange, muse::midi::Event::MessageType::ChannelVoice20);
             e.setChannel(i);
             e.setIndex(123); // CC#123 = All notes off
             port->sendEvent(e);
         }
-        for (int i = 0; i<upperBound; i++) {
+        for (int i = 0; i < upperBound; i++) {
             muse::midi::Event e(muse::midi::Event::Opcode::ControlChange, muse::midi::Event::MessageType::ChannelVoice20);
             e.setChannel(i);
             e.setIndex(midi::SUSTAIN_PEDAL_CONTROLLER);
             e.setData(0);
             port->sendEvent(e);
         }
-        for (int i = 0; i<upperBound; i++) {
+        for (int i = 0; i < upperBound; i++) {
             muse::midi::Event e(muse::midi::Event::Opcode::PitchBend, muse::midi::Event::MessageType::ChannelVoice20);
             e.setChannel(i);
             e.setData(0x80000000);

--- a/src/framework/midi/internal/platform/osx/coremidiinport.cpp
+++ b/src/framework/midi/internal/platform/osx/coremidiinport.cpp
@@ -256,7 +256,7 @@ void CoreMidiInPort::initCore()
             for (UInt32 index = 0; index < packetList->numPackets; index++) {
                 auto len = packet->length;
                 int pos = 0;
-                const Byte * pointer = static_cast<const Byte*>(&(packet->data[0]));
+                const Byte* pointer = static_cast<const Byte*>(&(packet->data[0]));
                 while (pos < len) {
                     Byte status = pointer[pos] >> 4;
                     if (status < 8 || status >= 15) {

--- a/src/framework/midi/internal/platform/osx/coremidiinport.cpp
+++ b/src/framework/midi/internal/platform/osx/coremidiinport.cpp
@@ -198,22 +198,26 @@ void CoreMidiInPort::initCore()
             // Document Version 1.1.2
             // Draft Date 2023-10-27
             // Published 2023-11-10
-            const uint32_t message_type_to_size_in_byte[] =  { 1,  // 0x0
-                                                               1,  // 0x1
-                                                               1,  // 0x2
-                                                               2,  // 0x3
-                                                               2,  // 0x4
-                                                               4,  // 0x5
-                                                               1,  // 0x6
-                                                               1,  // 0x7
-                                                               2,  // 0x8
-                                                               2,  // 0x9
-                                                               2,  // 0xA
-                                                               3,  // 0xB
-                                                               3,  // 0xC
-                                                               4,  // 0xD
-                                                               4,  // 0xE
-                                                               4 };// 0xF
+            // Section 2.1.4
+            const uint32_t message_type_to_size_in_words[] = {
+                1,  // 0x0 Utility
+                1,  // 0x1 SystemRealTime
+                1,  // 0x2 ChannelVoice10
+                2,  // 0x3 SystemExclusiveData
+                2,  // 0x4 ChannelVoice20
+                4,  // 0x5 Data
+                1,  // 0x6 Reserved
+                1,  // 0x7 Reserved
+                2,  // 0x8 Reserved
+                2,  // 0x9 Reserved
+                2,  // 0xA Reserved
+                3,  // 0xB Reserved
+                3,  // 0xC Reserved
+                4,  // 0xD Reserved
+                4,  // 0xE Reserved
+                4   // 0xF Reserved
+            };
+
             const MIDIEventPacket* packet = eventList->packet;
             for (UInt32 index = 0; index < eventList->numPackets; index++) {
                 LOGD() << "midi packet size " << packet->wordCount << " bytes";
@@ -221,11 +225,14 @@ void CoreMidiInPort::initCore()
                 uint32_t pos = 0;
                 while (pos < packet->wordCount) {
                     uint32_t most_significant_4_bit = packet->words[pos] >> 28;
-                    uint32_t message_size = message_type_to_size_in_byte[most_significant_4_bit];
+                    assert(most_significant_4_bit < 6);
 
-                    LOGD() << "midi message size " << message_size << " bytes";
+                    uint32_t message_size = message_type_to_size_in_words[most_significant_4_bit];
+
+                    LOGW() << "midi message size " << message_size << " words";
                     Event e = Event::fromRawData(&packet->words[pos], message_size);
                     if (e) {
+                        LOGW() << "Received midi message:" << e.to_string();
                         m_eventReceived.send((tick_t)packet->timeStamp, e);
                     }
                     pos += message_size;
@@ -241,18 +248,30 @@ void CoreMidiInPort::initCore()
         {
             const MIDIPacket* packet = packetList->packet;
             for (UInt32 index = 0; index < packetList->numPackets; index++) {
-                if (packet->length != 0 && packet->length <= 4) {
-                    uint32_t message(0);
-                    memcpy(&message, packet->data, std::min(sizeof(message), sizeof(char) * packet->length));
-
-                    auto e = Event::fromMIDI10Package(message).toMIDI20();
+                auto len = packet->length;
+                int pos = 0;
+                const Byte * pointer = static_cast<const Byte*>(&(packet->data[0]));
+                while (pos < len) {
+                    Byte status = pointer[pos] >> 4;
+                    if (status < 8 || status >= 15) {
+                        LOGW() << "unhandled status byte:" << status;
+                        return;
+                    }
+                    Event::Opcode opcode = static_cast<Event::Opcode>(status);
+                    int msgLen = Event::midi10ByteCountForOpcode(opcode);
+                    if (msgLen == 0) {
+                        LOGW() << "unhandled opcode:" << status;
+                        return;
+                    }
+                    Event e = Event::fromMIDI10BytePackage(pointer + pos, msgLen);
+                    LOGW() << "Received midi 1.0 message:" << e.to_string();
+                    e = e.toMIDI20();
                     if (e) {
+                        LOGW() << "Converted to midi 2.0 midi message:" << e.to_string();
                         m_eventReceived.send((tick_t)packet->timeStamp, e);
                     }
-                } else if (packet->length > 4) {
-                    LOGW() << "unsupported midi message size " << packet->length << " bytes";
+                    pos += msgLen;
                 }
-
                 packet = MIDIPacketNext(packet);
             }
         };

--- a/src/framework/midi/internal/platform/osx/coremidioutport.cpp
+++ b/src/framework/midi/internal/platform/osx/coremidioutport.cpp
@@ -289,18 +289,6 @@ bool CoreMidiOutPort::supportsMIDI20Output() const
     return false;
 }
 
-static ByteCount packetListSize(const std::vector<Event>& events)
-{
-    if (events.empty()) {
-        return 0;
-    }
-
-    // TODO: should be dynamic per type of event
-    constexpr size_t eventSize = sizeof(Event().to_MIDI10Package());
-
-    return offsetof(MIDIPacketList, packet) + events.size() * (offsetof(MIDIPacket, data) + eventSize);
-}
-
 Ret CoreMidiOutPort::sendEvent(const Event& e)
 {
     if (!isConnected()) {

--- a/src/framework/midi/midievent.h
+++ b/src/framework/midi/midievent.h
@@ -1046,7 +1046,7 @@ struct Event {
 
     uint32_t pitchBend14() const
     {
-        assert(messageType().isChannelVoice() && opcode() == Opcode::PitchBend);
+        assert(isChannelVoice() && opcode() == Opcode::PitchBend);
         return data14();
     }
 

--- a/src/framework/midi/midievent.h
+++ b/src/framework/midi/midievent.h
@@ -140,28 +140,28 @@ struct Event {
         return 0;
     }
 
-    static Event fromMIDI10BytePackage(const unsigned char *pointer, int length)
+    static Event fromMIDI10BytePackage(const unsigned char* pointer, int length)
     {
         Event e;
         uint32_t val = 0;
         assert(length <= 3);
-        for (int i=0; i<length; i++) {
+        for (int i=0; i < length; i++) {
             uint32_t byteVal = static_cast<uint32_t>(pointer[i]);
-            val |= byteVal << ((2-i)*8);
+            val |= byteVal << ((2 - i) * 8);
         }
         e.m_data[0]=val;
         e.setMessageType(MessageType::ChannelVoice10);
         return e;
     }
 
-    int to_MIDI10BytesPackage(unsigned char *pointer) const
+    int to_MIDI10BytesPackage(unsigned char* pointer) const
     {
         if (messageType() == MessageType::ChannelVoice10) {
             auto val = m_data[0];
             int c = Event::midi10ByteCountForOpcode(opcode());
-            assert(c<=3);
-            for (int i=0; i<c; i++) {
-                auto byteVal = (val>>((2-i)*8)) & 0xff;
+            assert(c <= 3);
+            for (int i=0; i < c; i++) {
+                auto byteVal = (val >> ((2 - i) * 8)) & 0xff;
                 pointer[i]=static_cast<unsigned char>(byteVal);
             }
             return c;
@@ -1017,7 +1017,8 @@ struct Event {
         return static_cast<uint8_t>(val);
     }
 
-    void setVelocity7(uint8_t value) {
+    void setVelocity7(uint8_t value)
+    {
         if (isChannelVoice20()) {
             uint16_t scaled = scaleUp(value, 7, 16);
             setVelocity(scaled);
@@ -1030,7 +1031,7 @@ struct Event {
     {
         uint32_t val = data();
         if (messageType() == MessageType::ChannelVoice20) {
-            return scaleDown(val,32,7);
+            return scaleDown(val, 32, 7);
         }
         return val;
     }
@@ -1039,7 +1040,7 @@ struct Event {
     {
         uint32_t val = data();
         if (messageType() == MessageType::ChannelVoice20) {
-            return scaleDown(val,32,14);
+            return scaleDown(val, 32, 14);
         }
         return val;
     }

--- a/src/framework/midi/midievent.h
+++ b/src/framework/midi/midievent.h
@@ -978,6 +978,60 @@ struct Event {
         return str;
     }
 
+    uint8_t velocity7() const
+    {
+        uint16_t val = velocity();
+        if (isChannelVoice20()) {
+            return static_cast<uint8_t>(scaleDown(val >> 16, 16, 7));
+        }
+        return static_cast<uint8_t>(val);
+    }
+
+    void setVelocity7(uint8_t value) {
+        if (isChannelVoice20()) {
+            uint16_t scaled = scaleUp(value, 7, 16);
+            setVelocity(scaled);
+            return;
+        }
+        setVelocity(value);
+    }
+
+    uint8_t data7() const
+    {
+        uint32_t val = data();
+        if (messageType() == MessageType::ChannelVoice20) {
+            return scaleDown(val,32,7);
+        }
+        return val;
+    }
+
+    uint32_t pitchBend14() const
+    {
+        uint32_t val = data();
+        switch (messageType()) {
+        case MessageType::ChannelVoice10: {
+            return val;
+        }
+        case MessageType::ChannelVoice20: {
+            return scaleDown(val,32,14);
+        }
+        default: assert(false);
+        }
+        return 0;
+    }
+
+    int midi20WordCount() const
+    {
+        switch (messageType()) {
+        case MessageType::Utility: return 1;
+        case MessageType::SystemRealTime: return 1;
+        case MessageType::ChannelVoice10: return 1;
+        case MessageType::SystemExclusiveData: return 2;
+        case MessageType::ChannelVoice20: return 2;
+        case MessageType::Data: return 4;
+        }
+    }
+
 private:
     //!Note Temporarily disabled until the end of the investigation, looks like we're not supporting some 'custom' messages from MU3
     //! v.pereverzev@wsmgroup.ru

--- a/src/framework/midi/midievent.h
+++ b/src/framework/midi/midievent.h
@@ -1012,7 +1012,7 @@ struct Event {
     {
         uint16_t val = velocity();
         if (isChannelVoice20()) {
-            return static_cast<uint8_t>(scaleDown(val >> 16, 16, 7));
+            return static_cast<uint8_t>(scaleDown(val, 16, 7));
         }
         return static_cast<uint8_t>(val);
     }

--- a/src/framework/midi/midievent.h
+++ b/src/framework/midi/midievent.h
@@ -1032,6 +1032,34 @@ struct Event {
         }
     }
 
+    int midi10ByteCount() const
+    {
+        assert(messageType() == MessageType::ChannelVoice10);
+        switch (opcode()) {
+        case Opcode::RegisteredPerNoteController:
+        case Opcode::AssignablePerNoteController:
+        case Opcode::RelativeRegisteredController:
+        case Opcode::RelativeAssignableController:
+        case Opcode::PerNotePitchBend:
+        case Opcode::PerNoteManagement:
+            //D2.8 cannot be translated to Midi 1.0
+            assert(false);
+        case Opcode::RegisteredController:
+        case Opcode::AssignableController:
+            // Already translated to a sequence of CCs.
+            assert(false);
+        case Opcode::NoteOff:
+        case Opcode::NoteOn:
+        case Opcode::PolyPressure:
+        case Opcode::ControlChange:
+        case Opcode::PitchBend:
+            return 3;
+        case Opcode::ProgramChange:
+        case Opcode::ChannelPressure:
+            return 2;
+        }
+    }
+
 private:
     //!Note Temporarily disabled until the end of the investigation, looks like we're not supporting some 'custom' messages from MU3
     //! v.pereverzev@wsmgroup.ru


### PR DESCRIPTION
Resolves: #22354
For a long time the midi output was broken in MuseScore 4. Due to inconsistent use of MIDI 2.0 and MIDI 1.0 data values a midi 1.0 note velocity of 64 would be interpreted in Midi 2.0 as very small and substitued by 1.
The pull request fixes this by small changes in fluid synth event generation and event interpretation code.

Also handling of Midi event lists on the mac, both output and input was not correct. I fixed it as well.
I added some needed utilities and fixed some code in Event type that I noticed was incorrect.

I tested Midi Input and output on the Mac.
I am not sure if the code follows the CodeGuidelines.

- [x ] I signed the [CLA](https://musescore.org/en/cla)
- [ x] The title of the PR describes the problem it addresses
- [ x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ x] If changes are extensive, there is a sequence of easily reviewable commits
- [ ] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [ x] There are no unnecessary changes
- [x ] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
