### PR TITLE
Set correct tempo for metronome marking #14678

### DIFF
--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -426,12 +426,14 @@ void MasterNotation::applyOptions(mu::engraving::MasterScore* score, const Score
         mu::engraving::Fraction ts(scoreOptions.timesigNumerator, scoreOptions.timesigDenominator);
 
         QString text("<sym>metNoteQuarterUp</sym> = %1");
-        double bpm = scoreOptions.tempo.valueBpm;
+        const double bpm = scoreOptions.tempo.valueBpm;
+        double tempo = bpm; // initial value for tempo, which internally is always expressed in quarter notes
 
         bool withDot = scoreOptions.tempo.withDot;
         switch (scoreOptions.tempo.duration) {
         case DurationType::V_WHOLE:
             text = "<sym>metNoteWhole</sym> = %1";
+            tempo *= 4.0;
             break;
         case DurationType::V_HALF:
             if (withDot) {
@@ -439,6 +441,7 @@ void MasterNotation::applyOptions(mu::engraving::MasterScore* score, const Score
             } else {
                 text = "<sym>metNoteHalfUp</sym> = %1";
             }
+            tempo *= 2.0;
             break;
         case DurationType::V_QUARTER:
             if (withDot) {
@@ -453,6 +456,7 @@ void MasterNotation::applyOptions(mu::engraving::MasterScore* score, const Score
             } else {
                 text = "<sym>metNote8thUp</sym> = %1";
             }
+            tempo *= 0.5;
             break;
         case DurationType::V_16TH:
             if (withDot) {
@@ -460,17 +464,21 @@ void MasterNotation::applyOptions(mu::engraving::MasterScore* score, const Score
             } else {
                 text = "<sym>metNote16thUp</sym> = %1";
             }
+            tempo *= 0.25;
             break;
         default:
             break;
+        }
+
+        if (withDot) {
+            tempo *= 1.5;
         }
 
         mu::engraving::Segment* seg = score->firstMeasure()->first(mu::engraving::SegmentType::ChordRest);
         mu::engraving::TempoText* tt = new mu::engraving::TempoText(seg);
         tt->setXmlText(text.arg(bpm));
 
-        double tempo = scoreOptions.tempo.valueBpm;
-        tempo /= 60; // bpm -> bps
+        tempo /= 60; // qpm -> qps
 
         tt->setTempo(tempo);
         tt->setFollowText(true);


### PR DESCRIPTION
Resolves: #14678 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

When creating a new document, the tempo was not changed to match the metronome marking. Instead, the tempo always was the tempo for quarter notes. (See #14678.) This change corrects that.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
