### PR TITLE
Fix #24723: Honor --score-transpose flag in CLI

### DIFF
--- a/src/converter/internal/compat/backendapi.cpp
+++ b/src/converter/internal/compat/backendapi.cpp
@@ -621,7 +621,7 @@ Ret BackendApi::doExportScoreTranspose(const INotationPtr notation, BackendJsonW
     jsonWriter.addKey("mscz");
 
     std::string fileNumber = std::to_string(QRandomGenerator::global()->generate() % 1000000);
-    std::string fileName = score->name().toStdString() + "_transposed." + fileNumber + ".mscx";
+    std::string fileName = score->name().toStdString() + "_transposed." + fileNumber + ".mscz";
 
     RetVal<QByteArray> scoreJson = scorePartJson(score, fileName);
     if (!scoreJson.ret) {
@@ -724,6 +724,8 @@ RetVal<TransposeOptions> BackendApi::parseTransposeOptions(const std::string& op
         }
     }
 
+    options.interval = transposeInterval;
+    options.key = targetKey;
     options.needTransposeKeys = optionsObj["transposeKeySignatures"].toBool();
     options.needTransposeChordNames = optionsObj["transposeChordNames"].toBool();
     options.needTransposeDoubleSharpsFlats = optionsObj["useDoubleSharpsFlats"].toBool();
@@ -746,6 +748,8 @@ Ret BackendApi::applyTranspose(const INotationPtr notation, const std::string& o
     if (!interaction) {
         return make_ret(Ret::Code::InternalError);
     }
+
+    interaction->selectAll();
 
     bool ok = interaction->transpose(options.val);
     if (!ok) {


### PR DESCRIPTION
Resolves: #24723

While investigating #24723 three problems were identified and addressed in this PR:

* A temporary "filename" with `.mscx` extension that should be `.mscz` (but immaterial)
* `BackendApi::parseTransposeOptions` was not setting `options.interval` and `options.key` before returning
* ~~Since `4.0`,~~ [Score::transpose](https://github.com/musescore/MuseScore/blob/c16c3a79e5758e3eabee2709d39b823d12ac92a6/src/engraving/dom/transpose.cpp#L281) only applies to a selected range. In the GUI, this is accommodated by [selecting all](https://github.com/musescore/MuseScore/blob/c16c3a79e5758e3eabee2709d39b823d12ac92a6/src/notation/view/widgets/transposedialog.cpp#L46-L49) when the `TransposeDialog` is opened without a selection. Because the CLI will never have a selection, treat it like opening the `TransposeDialog` with no selection and replicate the behavior of selecting all. 

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
