### PR TITLE
Fix crash on delete staves and select tie

### DIFF
--- a/src/engraving/dom/note.cpp
+++ b/src/engraving/dom/note.cpp
@@ -2262,6 +2262,9 @@ void Note::setTrack(track_idx_t val)
             seg->setTrack(val);
         }
     }
+    if (m_tieBack) {
+        m_tieBack->setTrack2(val);
+    }
     for (Spanner* s : m_spannerFor) {
         s->setTrack(val);
     }


### PR DESCRIPTION
Resolves: #24841

When setting track, ensure that Tie also has m_track2 correctly set.
