### PR TITLE
fix(time signatures): adding a time signature does not deselect current measure(s)

### DIFF
--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -1317,11 +1317,11 @@ void Score::cmdAddTimeSig(Measure* firstMeasure, staff_idx_t staffIdx, TimeSig* 
         firstMeasure = firstMeasure->mmRestFirst();
     }
 
-    Fraction newSigFraction   = timeSig->sig();
+    Fraction newTimeSigFraction   = timeSig->sig();
     Fraction tick = firstMeasure->tick();
     TimeSig* localTimeSig  = staff(staffIdx)->timeSig(tick);
     if (local) {
-        Fraction stretch = (newSigFraction / firstMeasure->timesig()).reduced();
+        Fraction stretch = (newTimeSigFraction / firstMeasure->timesig()).reduced();
         timeSig->setStretch(stretch);
     }
 
@@ -1367,7 +1367,7 @@ void Score::cmdAddTimeSig(Measure* firstMeasure, staff_idx_t staffIdx, TimeSig* 
         return std::make_pair(startStaffIdx, endStaffIdx);
     };
 
-    if (originalTimeSig && originalTimeSig->sig() == newSigFraction && originalTimeSig->stretch() == timeSig->stretch()) {
+    if (originalTimeSig && originalTimeSig->sig() == newTimeSigFraction && originalTimeSig->stretch() == timeSig->stretch()) {
         //
         // the measure duration does not change,
         // so its ok to just update the time signatures
@@ -1379,26 +1379,26 @@ void Score::cmdAddTimeSig(Measure* firstMeasure, staff_idx_t staffIdx, TimeSig* 
             Measure* lastMeasure = (lastMeasureTick != Fraction(-1, 1)) ? score->tick2measure(lastMeasureTick) : nullptr;
             for (Measure* currentMeasure = mf; currentMeasure != lastMeasure; currentMeasure = currentMeasure->nextMeasure()) {
                 bool changeActual = currentMeasure->ticks() == currentMeasure->timesig();
-                currentMeasure->undoChangeProperty(Pid::TIMESIG_NOMINAL, newSigFraction);
+                currentMeasure->undoChangeProperty(Pid::TIMESIG_NOMINAL, newTimeSigFraction);
                 if (changeActual) {
-                    currentMeasure->undoChangeProperty(Pid::TIMESIG_ACTUAL, newSigFraction);
+                    currentMeasure->undoChangeProperty(Pid::TIMESIG_ACTUAL, newTimeSigFraction);
                 }
             }
             std::pair<staff_idx_t, staff_idx_t> staffIdxRange = getStaffIdxRange(score);
             for (staff_idx_t si = staffIdxRange.first; si < staffIdxRange.second; ++si) {
-                TimeSig* newSig = toTimeSig(seg->element(si * VOICES));
-                if (!newSig) {
+                TimeSig* newTimeSig = toTimeSig(seg->element(si * VOICES));
+                if (!newTimeSig) {
                     continue;
                 }
-                newSig->undoChangeProperty(Pid::SHOW_COURTESY, timeSig->showCourtesySig());
-                newSig->undoChangeProperty(Pid::TIMESIG, timeSig->sig());
-                newSig->undoChangeProperty(Pid::TIMESIG_TYPE, int(timeSig->timeSigType()));
-                newSig->undoChangeProperty(Pid::NUMERATOR_STRING, timeSig->numeratorString());
-                newSig->undoChangeProperty(Pid::DENOMINATOR_STRING, timeSig->denominatorString());
-                newSig->undoChangeProperty(Pid::TIMESIG_STRETCH, timeSig->stretch());
-                newSig->undoChangeProperty(Pid::GROUP_NODES, timeSig->groups().nodes());
-                newSig->setSelected(false);
-                newSig->setDropTarget(false);
+                newTimeSig->undoChangeProperty(Pid::SHOW_COURTESY, timeSig->showCourtesySig());
+                newTimeSig->undoChangeProperty(Pid::TIMESIG, timeSig->sig());
+                newTimeSig->undoChangeProperty(Pid::TIMESIG_TYPE, int(timeSig->timeSigType()));
+                newTimeSig->undoChangeProperty(Pid::NUMERATOR_STRING, timeSig->numeratorString());
+                newTimeSig->undoChangeProperty(Pid::DENOMINATOR_STRING, timeSig->denominatorString());
+                newTimeSig->undoChangeProperty(Pid::TIMESIG_STRETCH, timeSig->stretch());
+                newTimeSig->undoChangeProperty(Pid::GROUP_NODES, timeSig->groups().nodes());
+                newTimeSig->setSelected(false);
+                newTimeSig->setDropTarget(false);
             }
         }
     } else {
@@ -1410,7 +1410,7 @@ void Score::cmdAddTimeSig(Measure* firstMeasure, staff_idx_t staffIdx, TimeSig* 
         //
         if (mf == mScore->firstMeasure() && mf->nextMeasure() && (mf->ticks() != mf->timesig())) {
             // handle upbeat
-            mf->undoChangeProperty(Pid::TIMESIG_NOMINAL, newSigFraction);
+            mf->undoChangeProperty(Pid::TIMESIG_NOMINAL, newTimeSigFraction);
             Measure* currentMeasure = mf->nextMeasure();
             Segment* segment = currentMeasure->findSegment(SegmentType::TimeSig, currentMeasure->tick());
             mf = segment ? 0 : mf->nextMeasure();
@@ -1420,7 +1420,7 @@ void Score::cmdAddTimeSig(Measure* firstMeasure, staff_idx_t staffIdx, TimeSig* 
                 // but we need to rewrite any staves with local time signatures
                 for (size_t i = 0; i < nstaves(); ++i) {
                     if (staff(i)->timeSig(tick) && staff(i)->timeSig(tick)->isLocal()) {
-                        if (!mScore->rewriteMeasures(mf, newSigFraction, i)) {
+                        if (!mScore->rewriteMeasures(mf, newTimeSigFraction, i)) {
                             undoStack()->current()->unwind();
                             return;
                         }
@@ -1449,37 +1449,37 @@ void Score::cmdAddTimeSig(Measure* firstMeasure, staff_idx_t staffIdx, TimeSig* 
                 if (fm->isMeasureRepeatGroup(si)) {
                     deleteItem(fm->measureRepeatElement(si));
                 }
-                TimeSig* newSig = toTimeSig(seg->element(si * VOICES));
-                if (newSig == 0) {
-                    newSig = Factory::copyTimeSig(*timeSig);
-                    newSig->setScore(score);
-                    newSig->setTrack(si * VOICES);
-                    newSig->setParent(seg);
-                    undoAddElement(newSig);
+                TimeSig* newTimeSig = toTimeSig(seg->element(si * VOICES));
+                if (newTimeSig == 0) {
+                    newTimeSig = Factory::copyTimeSig(*timeSig);
+                    newTimeSig->setScore(score);
+                    newTimeSig->setTrack(si * VOICES);
+                    newTimeSig->setParent(seg);
+                    undoAddElement(newTimeSig);
                     if (score->excerpt()) {
-                        const track_idx_t masterTrack = muse::key(score->excerpt()->tracksMapping(), newSig->track());
+                        const track_idx_t masterTrack = muse::key(score->excerpt()->tracksMapping(), newTimeSig->track());
                         TimeSig* masterTimeSig = masterTimeSigs[masterTrack];
                         if (masterTimeSig) {
-                            undo(new Link(masterTimeSig, newSig));
+                            undo(new Link(masterTimeSig, newTimeSig));
                         }
                     }
                 } else {
-                    newSig->undoChangeProperty(Pid::SHOW_COURTESY, timeSig->showCourtesySig());
-                    newSig->undoChangeProperty(Pid::TIMESIG_TYPE, int(timeSig->timeSigType()));
-                    newSig->undoChangeProperty(Pid::TIMESIG, timeSig->sig());
-                    newSig->undoChangeProperty(Pid::NUMERATOR_STRING, timeSig->numeratorString());
-                    newSig->undoChangeProperty(Pid::DENOMINATOR_STRING, timeSig->denominatorString());
+                    newTimeSig->undoChangeProperty(Pid::SHOW_COURTESY, timeSig->showCourtesySig());
+                    newTimeSig->undoChangeProperty(Pid::TIMESIG_TYPE, int(timeSig->timeSigType()));
+                    newTimeSig->undoChangeProperty(Pid::TIMESIG, timeSig->sig());
+                    newTimeSig->undoChangeProperty(Pid::NUMERATOR_STRING, timeSig->numeratorString());
+                    newTimeSig->undoChangeProperty(Pid::DENOMINATOR_STRING, timeSig->denominatorString());
 
                     // HACK do it twice to accommodate undo
-                    newSig->undoChangeProperty(Pid::TIMESIG_TYPE, int(timeSig->timeSigType()));
-                    newSig->undoChangeProperty(Pid::TIMESIG_STRETCH, timeSig->stretch());
-                    newSig->undoChangeProperty(Pid::GROUP_NODES, timeSig->groups().nodes());
-                    newSig->setSelected(false);
-                    newSig->setDropTarget(false);                 // DEBUG
+                    newTimeSig->undoChangeProperty(Pid::TIMESIG_TYPE, int(timeSig->timeSigType()));
+                    newTimeSig->undoChangeProperty(Pid::TIMESIG_STRETCH, timeSig->stretch());
+                    newTimeSig->undoChangeProperty(Pid::GROUP_NODES, timeSig->groups().nodes());
+                    newTimeSig->setSelected(false);
+                    newTimeSig->setDropTarget(false);                 // DEBUG
                 }
 
                 if (score->isMaster()) {
-                    masterTimeSigs[newSig->track()] = newSig;
+                    masterTimeSigs[newTimeSig->track()] = newTimeSig;
                 }
             }
         }

--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -1415,7 +1415,7 @@ void Score::cmdAddTimeSig(Measure* firstMeasure, staff_idx_t staffIdx, TimeSig* 
             Segment* segment = currentMeasure->findSegment(SegmentType::TimeSig, currentMeasure->tick());
             mf = segment ? 0 : mf->nextMeasure();
         } else {
-            if (sigmap()->timesig(seg->tick().ticks()).nominal().identical(ns)) {
+            if (sigmap()->timesig(seg->tick().ticks()).nominal().identical(newTimeSigFraction)) {
                 // no change to global time signature,
                 // but we need to rewrite any staves with local time signatures
                 for (size_t i = 0; i < nstaves(); ++i) {
@@ -1434,7 +1434,7 @@ void Score::cmdAddTimeSig(Measure* firstMeasure, staff_idx_t staffIdx, TimeSig* 
         // we will only add time signatures if this succeeds
         // this means, however, that the rewrite cannot depend on the time signatures being in place
         if (mf) {
-            if (!mScore->rewriteMeasures(mf, ns, local ? staffIdx : muse::nidx)) {
+            if (!mScore->rewriteMeasures(mf, newTimeSigFraction, local ? staffIdx : muse::nidx)) {
                 undoStack()->current()->unwind();
                 return;
             }
@@ -1446,8 +1446,8 @@ void Score::cmdAddTimeSig(Measure* firstMeasure, staff_idx_t staffIdx, TimeSig* 
             seg = nfm->undoGetSegment(SegmentType::TimeSig, nfm->tick());
             std::pair<staff_idx_t, staff_idx_t> staffIdxRange = getStaffIdxRange(score);
             for (staff_idx_t si = staffIdxRange.first; si < staffIdxRange.second; ++si) {
-                if (fm->isMeasureRepeatGroup(si)) {
-                    deleteItem(fm->measureRepeatElement(si));
+                if (firstMeasure->isMeasureRepeatGroup(si)) {
+                    deleteItem(firstMeasure->measureRepeatElement(si));
                 }
                 TimeSig* newTimeSig = toTimeSig(seg->element(si * VOICES));
                 if (newTimeSig == 0) {

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -4651,7 +4651,7 @@ void NotationInteraction::addTimeSignature(Measure* measure, staff_idx_t staffIn
     startEdit();
     score()->cmdAddTimeSig(measure, staffIndex, timeSignature, true);
     apply();
-    doSelect( { measure }, SelectType::SINGLE, staffIndex);
+    doSelect({ measure }, SelectType::SINGLE, staffIndex);
 }
 
 void NotationInteraction::explodeSelectedStaff()

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -4651,6 +4651,7 @@ void NotationInteraction::addTimeSignature(Measure* measure, staff_idx_t staffIn
     startEdit();
     score()->cmdAddTimeSig(measure, staffIndex, timeSignature, true);
     apply();
+    doSelect( { measure }, SelectType::SINGLE, staffIndex);
 }
 
 void NotationInteraction::explodeSelectedStaff()


### PR DESCRIPTION
Resolves: #9584

<!-- Add a short description of and motivation for the changes here -->
- Change NotationInteraction::addTimeSignature to re-select the current measure after running cmdAddTimeSignature
- More descriptive variable nomenclature
<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [ ] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
