### PR TITLE
Change the order for focusChanged/accepted/escaped signals for TextInputField

### DIFF
--- a/src/framework/uicomponents/qml/Muse/UiComponents/TextInputField.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/TextInputField.qml
@@ -204,7 +204,6 @@ FocusScope {
                 var isAcceptKey = event.key === Qt.Key_Enter || event.key === Qt.Key_Return
                 var isEscapeKey = event.key === Qt.Key_Escape
                 if (isAcceptKey || isEscapeKey) {
-                    root.focus = false
                     root.textEditingFinished(valueInput.text)
                 }
 
@@ -214,6 +213,10 @@ FocusScope {
 
                 if (isEscapeKey) {
                     root.escaped()
+                }
+
+                if (isAcceptKey || isEscapeKey) {
+                    root.focus = false
                 }
             }
 


### PR DESCRIPTION
Remove focus after accepted or escaped signals to allow submit or reject changes on focus loss

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
