### PR TITLE
Fix Cubase XML chord symbol import

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass1.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass1.cpp
@@ -1702,9 +1702,9 @@ void MusicXMLParserPass1::defaults()
         if (m_e.name() == "scaling") {
             while (m_e.readNextStartElement()) {
                 if (m_e.name() == "millimeters") {
-                    millimeter = m_e.readText().toDouble();
+                    millimeter = m_e.readDouble();
                 } else if (m_e.name() == "tenths") {
-                    tenths = m_e.readText().toDouble();
+                    tenths = m_e.readDouble();
                 } else {
                     skipLogCurrElem();
                 }
@@ -1727,7 +1727,7 @@ void MusicXMLParserPass1::defaults()
                 if (m_e.name() == "system-margins") {
                     m_e.skipCurrentElement();            // skip but don't log
                 } else if (m_e.name() == "system-distance") {
-                    const Spatium val(m_e.readText().toDouble() / 10.0);
+                    const Spatium val(m_e.readDouble() / 10.0);
                     if (isImportLayout) {
                         m_score->style().set(Sid::minSystemDistance, val);
                         //LOGD("system distance %f", val.val());
@@ -1761,7 +1761,7 @@ void MusicXMLParserPass1::defaults()
         } else if (m_e.name() == "staff-layout") {
             while (m_e.readNextStartElement()) {
                 if (m_e.name() == "staff-distance") {
-                    const Spatium val(m_e.readText().toDouble() / 10.0);
+                    const Spatium val(m_e.readDouble() / 10.0);
                     if (isImportLayout) {
                         m_score->style().set(Sid::staffDistance, val);
                     }
@@ -1773,12 +1773,12 @@ void MusicXMLParserPass1::defaults()
             while (m_e.readNextStartElement()) {
                 const String type = m_e.attribute("type");
                 if (m_e.name() == "line-width") {
-                    const double val = m_e.readText().toDouble();
+                    const double val = m_e.readDouble();
                     if (isImportLayout) {
                         setStyle(type, val);
                     }
                 } else if (m_e.name() == "note-size") {
-                    const double val = m_e.readText().toDouble();
+                    const double val = m_e.readDouble();
                     if (isImportLayout) {
                         setStyle(type, val);
                     }
@@ -1903,13 +1903,13 @@ void MusicXMLParserPass1::pageLayout(PageFormat& pf, const double conversion)
             double lm = 0.0, rm = 0.0, tm = 0.0, bm = 0.0;
             while (m_e.readNextStartElement()) {
                 if (m_e.name() == "left-margin") {
-                    lm = m_e.readText().toDouble() * conversion;
+                    lm = m_e.readDouble() * conversion;
                 } else if (m_e.name() == "right-margin") {
-                    rm = m_e.readText().toDouble() * conversion;
+                    rm = m_e.readDouble() * conversion;
                 } else if (m_e.name() == "top-margin") {
-                    tm = m_e.readText().toDouble() * conversion;
+                    tm = m_e.readDouble() * conversion;
                 } else if (m_e.name() == "bottom-margin") {
-                    bm = m_e.readText().toDouble() * conversion;
+                    bm = m_e.readDouble() * conversion;
                 } else {
                     skipLogCurrElem();
                 }
@@ -1928,12 +1928,12 @@ void MusicXMLParserPass1::pageLayout(PageFormat& pf, const double conversion)
                 pf.evenBottomMargin = bm;
             }
         } else if (m_e.name() == "page-height") {
-            const double val = m_e.readText().toDouble();
+            const double val = m_e.readDouble();
             size.setHeight(val * conversion);
             // set pageHeight and pageWidth for use by doCredits()
             m_pageSize.setHeight(static_cast<int>(val + 0.5));
         } else if (m_e.name() == "page-width") {
-            const double val = m_e.readText().toDouble();
+            const double val = m_e.readDouble();
             size.setWidth(val * conversion);
             // set pageHeight and pageWidth for use by doCredits()
             m_pageSize.setWidth(static_cast<int>(val + 0.5));
@@ -2304,7 +2304,7 @@ void MusicXMLParserPass1::midiInstrument(const String& partId)
         if (m_e.name() == "midi-bank") {
             skipLogCurrElem();
         } else if (m_e.name() == "midi-channel") {
-            int channel = m_e.readText().toInt();
+            int channel = m_e.readInt();
             if (channel < 1) {
                 m_logger->logError(String(u"incorrect midi-channel: %1").arg(channel), &m_e);
                 channel = 1;
@@ -2316,7 +2316,7 @@ void MusicXMLParserPass1::midiInstrument(const String& partId)
                 m_instruments[partId][instrId].midiChannel = channel - 1;
             }
         } else if (m_e.name() == "midi-program") {
-            int program = m_e.readText().toInt();
+            int program = m_e.readInt();
             // Bug fix for Cubase 6.5.5 which generates <midi-program>0</midi-program>
             // Check program number range
             if (program < 1) {
@@ -2331,10 +2331,10 @@ void MusicXMLParserPass1::midiInstrument(const String& partId)
             }
         } else if (m_e.name() == "midi-unpitched") {
             if (muse::contains(m_instruments.at(partId), instrId)) {
-                m_instruments[partId][instrId].unpitched = m_e.readText().toInt() - 1;
+                m_instruments[partId][instrId].unpitched = m_e.readInt() - 1;
             }
         } else if (m_e.name() == "volume") {
-            double vol = m_e.readText().toDouble();
+            double vol = m_e.readDouble();
             if (vol >= 0 && vol <= 100) {
                 if (muse::contains(m_instruments.at(partId), instrId)) {
                     m_instruments[partId][instrId].midiVolume = static_cast<int>((vol / 100) * 127);
@@ -2343,7 +2343,7 @@ void MusicXMLParserPass1::midiInstrument(const String& partId)
                 m_logger->logError(String(u"incorrect midi-volume: %1").arg(vol), &m_e);
             }
         } else if (m_e.name() == "pan") {
-            double pan = m_e.readText().toDouble();
+            double pan = m_e.readDouble();
             if (pan >= -90 && pan <= 90) {
                 if (muse::contains(m_instruments.at(partId), instrId)) {
                     m_instruments[partId][instrId].midiPan = static_cast<int>(((pan + 90) / 180) * 127);
@@ -2672,7 +2672,7 @@ void MusicXMLParserPass1::attributes(const String& partId, const Fraction cTime)
             }
             m_e.skipCurrentElement();
         } else if (m_e.name() == "staves") {
-            staves = m_e.readText().toInt();
+            staves = m_e.readInt();
         } else if (m_e.name() == "time") {
             time(cTime);
         } else if (m_e.name() == "transpose") {
@@ -2840,7 +2840,7 @@ void MusicXMLParserPass1::transpose(const String& partId, const Fraction& tick)
 {
     Interval interval;
     while (m_e.readNextStartElement()) {
-        int i = m_e.readText().toInt();
+        int i = m_e.readInt();
         if (m_e.name() == "diatonic") {
             interval.diatonic = i;
         } else if (m_e.name() == "chromatic") {
@@ -2873,7 +2873,7 @@ void MusicXMLParserPass1::transpose(const String& partId, const Fraction& tick)
 
 void MusicXMLParserPass1::divisions()
 {
-    m_divs = m_e.readText().toInt();
+    m_divs = m_e.readInt();
     if (!(m_divs > 0)) {
         m_logger->logError(u"illegal divisions", &m_e);
     }
@@ -3686,7 +3686,7 @@ void MusicXMLParserPass1::duration(Fraction& dura, muse::XmlStreamReader& e)
     m_logger->logDebugTrace(u"MusicXMLParserPass1::duration", &e);
 
     dura.set(0, 0);    // invalid unless set correctly
-    int intDura = e.readText().toInt();
+    int intDura = e.readInt();
     dura = calcTicks(intDura);
 }
 

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -2831,7 +2831,7 @@ void MusicXMLParserPass2::measureLayout(Measure* measure)
 {
     while (m_e.readNextStartElement()) {
         if (m_e.name() == "measure-distance") {
-            const Spatium val(m_e.readText().toDouble() / 10.0);
+            const Spatium val(m_e.readDouble() / 10.0);
             if (!measure->prev()->isHBox()) {
                 MeasureBase* gap = m_score->insertBox(ElementType::HBOX, measure);
                 toHBox(gap)->setBoxWidth(val);
@@ -2955,7 +2955,7 @@ void MusicXMLParserPass2::staffDetails(const String& partId, Measure* measure)
     while (m_e.readNextStartElement()) {
         if (m_e.name() == "staff-lines") {
             // save staff lines for later
-            staffLines = m_e.readText().toInt();
+            staffLines = m_e.readInt();
             // for a TAB staff also resize the string table and init with zeroes
             if (t) {
                 if (0 < staffLines) {
@@ -2967,7 +2967,7 @@ void MusicXMLParserPass2::staffDetails(const String& partId, Measure* measure)
         } else if (m_e.name() == "staff-tuning") {
             staffTuning(t);
         } else if (m_e.name() == "staff-size") {
-            const double val = m_e.readText().toDouble() / 100;
+            const double val = m_e.readDouble() / 100;
             m_score->staff(staffIdx)->setProperty(Pid::MAG, val);
         } else {
             skipLogCurrElem();
@@ -3020,9 +3020,9 @@ void MusicXMLParserPass2::staffTuning(StringData* t)
     int octave = 0;
     while (m_e.readNextStartElement()) {
         if (m_e.name() == "tuning-alter") {
-            alter = m_e.readText().toInt();
+            alter = m_e.readInt();
         } else if (m_e.name() == "tuning-octave") {
-            octave = m_e.readText().toInt();
+            octave = m_e.readInt();
         } else if (m_e.name() == "tuning-step") {
             String strStep = m_e.readText();
             int pos = static_cast<int>(String(u"CDEFGAB").indexOf(strStep));
@@ -3078,7 +3078,7 @@ void MusicXMLParserPass2::measureStyle(Measure* measure)
 
     while (m_e.readNextStartElement()) {
         if (m_e.name() == "multiple-rest") {
-            int multipleRest = m_e.readText().toInt();
+            int multipleRest = m_e.readInt();
             if (multipleRest > 1) {
                 m_multiMeasureRestCount = multipleRest;
                 m_score->style().set(Sid::createMultiMeasureRests, true);
@@ -3090,7 +3090,7 @@ void MusicXMLParserPass2::measureStyle(Measure* measure)
             String startStop = m_e.attribute("type");
             // note: possible "slashes" attribute is either redundant with numMeasures or not supported by MuseScore, so ignored either way
             if (startStop == u"start") {
-                int numMeasures = m_e.readText().toInt();
+                int numMeasures = m_e.readInt();
                 for (int i = startStaff; i <= endStaff; i++) {
                     m_measureRepeatNumMeasures[i] = numMeasures;
                     m_measureRepeatCount[i] = numMeasures;   // measure repeat(s) haven't actually started yet in current measure, so this is a lie,
@@ -3234,7 +3234,7 @@ void MusicXMLParserDirection::direction(const String& partId,
         if (m_e.name() == "direction-type") {
             directionType(starts, stops);
         } else if (m_e.name() == "offset") {
-            m_offset = m_pass1.calcTicks(m_e.readText().toInt(), m_pass2.divs(), &m_e);
+            m_offset = m_pass1.calcTicks(m_e.readInt(), m_pass2.divs(), &m_e);
             preventNegativeTick(tick, m_offset, m_logger);
         } else if (m_e.name() == "sound") {
             sound();
@@ -5596,7 +5596,7 @@ void MusicXMLParserPass2::key(const String& partId, Measure* measure, const Frac
 
     while (m_e.readNextStartElement()) {
         if (m_e.name() == "fifths") {
-            Key tKey = Key(m_e.readText().toInt());
+            Key tKey = Key(m_e.readInt());
             Key cKey = tKey;
             Interval v = m_pass1.getPart(partId)->instrument()->transpose();
             if (!v.isZero() && !m_score->style().styleB(Sid::concertPitch)) {
@@ -5689,9 +5689,9 @@ void MusicXMLParserPass2::clef(const String& partId, Measure* measure, const Fra
         if (m_e.name() == "sign") {
             c = m_e.readText();
         } else if (m_e.name() == "line") {
-            line = m_e.readText().toInt();
+            line = m_e.readInt();
         } else if (m_e.name() == "clef-octave-change") {
-            i = m_e.readText().toInt();
+            i = m_e.readInt();
             if (i && !(c == "F" || c == "G" || c == "C")) {
                 LOGD("clef-octave-change only implemented for F and G key");          // TODO
             }
@@ -5925,7 +5925,7 @@ void MusicXMLParserPass2::time(const String& partId, Measure* measure, const Fra
 
 void MusicXMLParserPass2::divisions()
 {
-    m_divs = m_e.readText().toInt();
+    m_divs = m_e.readInt();
     if (!(m_divs > 0)) {
         m_logger->logError(u"illegal divisions", &m_e);
     }
@@ -7196,14 +7196,14 @@ FretDiagram* MusicXMLParserPass2::frame()
     while (m_e.readNextStartElement()) {
         if (m_e.name() == "first-fret") {
             bool ok {};
-            int val = m_e.readText().toInt(&ok);
+            int val = m_e.readInt(&ok);
             if (ok && val > 0) {
                 fd->setFretOffset(val - 1);
             } else {
                 m_logger->logError(String(u"FretDiagram::readMusicXML: illegal first-fret %1").arg(val), &m_e);
             }
         } else if (m_e.name() == "frame-frets") {
-            int val = m_e.readText().toInt();
+            int val = m_e.readInt();
             if (val > 0) {
                 fd->setProperty(Pid::FRET_FRETS, val);
                 fd->setPropertyFlags(Pid::FRET_FRETS, PropertyFlags::UNSTYLED);
@@ -7216,9 +7216,9 @@ FretDiagram* MusicXMLParserPass2::frame()
             int actualString = -1;
             while (m_e.readNextStartElement()) {
                 if (m_e.name() == "fret") {
-                    fret = m_e.readText().toInt();
+                    fret = m_e.readInt();
                 } else if (m_e.name() == "string") {
-                    string = m_e.readText().toInt();
+                    string = m_e.readInt();
                     actualString = fd->strings() - string;
                 } else if (m_e.name() == "barre") {
                     // Keep barres to be added later
@@ -7250,7 +7250,7 @@ FretDiagram* MusicXMLParserPass2::frame()
                 m_logger->logError(String(u"FretDiagram::readMusicXML: illegal frame-note string %1").arg(string), &m_e);
             }
         } else if (m_e.name() == "frame-strings") {
-            int val = m_e.readText().toInt();
+            int val = m_e.readInt();
             if (val > 0) {
                 fd->setStrings(val);
                 for (int i = 0; i < val; ++i) {
@@ -7326,7 +7326,7 @@ void MusicXMLParserPass2::harmony(const String& partId, Measure* measure, const 
                 } else if (m_e.name() == "root-alter") {
                     // attributes: print-object, print-style
                     //             location (left-right)
-                    alter = m_e.readText().toInt();
+                    alter = m_e.readInt();
                 } else {
                     skipLogCurrElem();
                 }
@@ -7368,7 +7368,7 @@ void MusicXMLParserPass2::harmony(const String& partId, Measure* measure, const 
                 } else if (m_e.name() == "bass-alter") {
                     // attributes: print-object, print-style
                     //             location (left-right)
-                    alter = m_e.readText().toInt();
+                    alter = m_e.readInt();
                 } else {
                     skipLogCurrElem();
                 }
@@ -7380,9 +7380,9 @@ void MusicXMLParserPass2::harmony(const String& partId, Measure* measure, const 
             String degreeType;
             while (m_e.readNextStartElement()) {
                 if (m_e.name() == "degree-value") {
-                    degreeValue = m_e.readText().toInt();
+                    degreeValue = m_e.readInt();
                 } else if (m_e.name() == "degree-alter") {
-                    degreeAlter = m_e.readText().toInt();
+                    degreeAlter = m_e.readInt();
                 } else if (m_e.name() == "degree-type") {
                     degreeType = m_e.readText();
                 } else {
@@ -7408,7 +7408,7 @@ void MusicXMLParserPass2::harmony(const String& partId, Measure* measure, const 
         } else if (m_e.name() == "level") {
             skipLogCurrElem();
         } else if (m_e.name() == "offset") {
-            offset = m_pass1.calcTicks(m_e.readText().toInt(), m_divs, &m_e);
+            offset = m_pass1.calcTicks(m_e.readInt(), m_divs, &m_e);
             preventNegativeTick(sTime, offset, m_logger);
         } else if (m_e.name() == "staff") {
             size_t nstaves = m_pass1.getPart(partId)->nstaves();
@@ -7983,7 +7983,7 @@ void MusicXMLParserNotations::ornaments()
         } else if (m_e.name() == "tremolo") {
             m_hasTremolo = true;
             m_tremoloType = m_e.attribute("type");
-            m_tremoloNr = m_e.readText().toInt();
+            m_tremoloNr = m_e.readInt();
             m_tremoloSmufl = m_e.attribute("smufl");
         } else if (m_e.name() == "inverted-mordent"
                    || m_e.name() == "mordent") {

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -7326,7 +7326,8 @@ void MusicXMLParserPass2::harmony(const String& partId, Measure* measure, const 
                 } else if (m_e.name() == "root-alter") {
                     // attributes: print-object, print-style
                     //             location (left-right)
-                    alter = m_e.readInt();
+                    // Cubase exports this value with a trailing newline
+                    alter = m_e.readText().simplified().toInt();
                 } else {
                     skipLogCurrElem();
                 }


### PR DESCRIPTION
Resolves: #24865

Also changes `.readText().toInt/Double` to `.readInt` and `.readDouble` for readability.
