### PR TITLE
Fix #17648: Audio bug on Windows when output device has more than 2 channels (4.4.3 port)

### DIFF
--- a/src/framework/audio/audiomodule.cpp
+++ b/src/framework/audio/audiomodule.cpp
@@ -259,7 +259,7 @@ void AudioModule::setupAudioDriver(const IApplication::RunMode& mode)
 
     if (m_configuration->shouldMeasureInputLag()) {
         requiredSpec.callback = [this](void* /*userdata*/, uint8_t* stream, int byteCount) {
-            auto samplesPerChannel = byteCount / (2 * sizeof(float));
+            auto samplesPerChannel = byteCount / (2 * sizeof(float));  // 2 == m_configuration->audioChannelsCount()
             float* dest = reinterpret_cast<float*>(stream);
             m_audioBuffer->pop(dest, samplesPerChannel);
             measureInputLag(dest, samplesPerChannel * m_audioBuffer->audioChannelCount());
@@ -298,7 +298,7 @@ void AudioModule::setupAudioWorker(const IAudioDriver::Spec& activeSpec)
 
         // Setup audio engine
         m_audioEngine->init(m_audioBuffer, consts);
-        m_audioEngine->setAudioChannelsCount(activeSpec.channels);
+        m_audioEngine->setAudioChannelsCount(m_configuration->audioChannelsCount());
         m_audioEngine->setSampleRate(activeSpec.sampleRate);
         m_audioEngine->setReadBufferSize(activeSpec.samples);
 

--- a/src/framework/audio/internal/audiooutputdevicecontroller.cpp
+++ b/src/framework/audio/internal/audiooutputdevicecontroller.cpp
@@ -100,7 +100,7 @@ void AudioOutputDeviceController::onOutputDeviceChanged()
     IAudioDriver::Spec activeSpec = audioDriver()->activeSpec();
 
     async::Async::call(this, [this, activeSpec]() {
-        audioEngine()->setAudioChannelsCount(activeSpec.channels);
+        // TODO: audioEngine()->setAudioChannelsCount(activeSpec.channels);
         audioEngine()->setSampleRate(activeSpec.sampleRate);
         audioEngine()->setReadBufferSize(activeSpec.samples);
     }, AudioThread::ID);

--- a/src/framework/audio/internal/platform/win/wasapiaudioclient.cpp
+++ b/src/framework/audio/internal/platform/win/wasapiaudioclient.cpp
@@ -560,11 +560,34 @@ void WasapiAudioClient::getSamples(uint32_t framesAvailable)
     uint8_t* data;
 
     uint32_t actualFramesToRead = framesAvailable;
-    uint32_t actualBytesToRead = actualFramesToRead * m_mixFormat->nBlockAlign;
+
+    // WASAPI: "nBlockAlign must be equal to the product of nChannels and wBitsPerSample divided by 8 (bits per byte)"
+    const uint32_t clientFrameSize = m_mixFormat->nBlockAlign;
+
+    // MuseScore assumes only 2 audio channels (same calculation as above to determine frame size)
+    const uint32_t muFrameSize = 2 * m_mixFormat->wBitsPerSample / 8;
 
     check_hresult(m_audioRenderClient->GetBuffer(actualFramesToRead, &data));
-    if (actualBytesToRead > 0) {
-        m_sampleRequestCallback(nullptr, data, actualBytesToRead);
+    if (actualFramesToRead > 0) {
+        // Based on the previous calculations, the only way that clientFrameSize will be larger than muFrameSize is
+        // if the client specifies more than 2 channels. MuseScore doesn't support this (yet), so we use a workaround
+        // where the missing channels are padded with zeroes...
+        if (clientFrameSize > muFrameSize) {
+            const size_t surroundBufferDesiredSize = actualFramesToRead * muFrameSize;
+            if (m_surroundAudioBuffer.size() < surroundBufferDesiredSize) {
+                m_surroundAudioBuffer.resize(surroundBufferDesiredSize, 0);
+            }
+
+            m_sampleRequestCallback(nullptr, m_surroundAudioBuffer.data(), (int)surroundBufferDesiredSize);
+
+            for (uint32_t i = 0; i < actualFramesToRead; ++i) {
+                uint8_t* frameStartPos = data + i * clientFrameSize;
+                std::memcpy(frameStartPos, m_surroundAudioBuffer.data() + i * muFrameSize, muFrameSize);
+                std::memset(frameStartPos + muFrameSize, 0, clientFrameSize - muFrameSize);
+            }
+        } else {
+            m_sampleRequestCallback(nullptr, data, actualFramesToRead * clientFrameSize);
+        }
     }
     check_hresult(m_audioRenderClient->ReleaseBuffer(actualFramesToRead, 0));
 }

--- a/src/framework/audio/internal/platform/win/wasapiaudioclient.h
+++ b/src/framework/audio/internal/platform/win/wasapiaudioclient.h
@@ -71,6 +71,8 @@ private:
     void setState(const DeviceState newState);
     void setStateAndNotify(const DeviceState newState, hresult resultCode);
 
+    std::vector<uint8_t> m_surroundAudioBuffer; //! NOTE: See #17648
+
     hstring m_deviceIdString;
     hstring m_fallbackDeviceIdString;
     uint32_t m_bufferFrames = 0;


### PR DESCRIPTION
Ports: #24913
Resolves: #17648