### PR TITLE
Create slur segments on layout

### DIFF
--- a/src/engraving/rendering/score/slurtielayout.h
+++ b/src/engraving/rendering/score/slurtielayout.h
@@ -58,6 +58,7 @@ public:
     static void computeBezier(TieSegment* tieSeg, PointF shoulderOffset = PointF());
     static void computeBezier(SlurSegment* slurSeg, PointF shoulderOffset = PointF());
     static double noteOpticalCenterForTie(const Note* note, bool up);
+    static void createSlurSegments(Slur* item, LayoutContext& ctx);
 
 private:
 

--- a/src/engraving/rendering/score/tlayout.cpp
+++ b/src/engraving/rendering/score/tlayout.cpp
@@ -5039,8 +5039,7 @@ void TLayout::layoutLine(SLine* item, LayoutContext& ctx)
 
 void TLayout::layoutSlur(Slur* item, LayoutContext& ctx)
 {
-    UNUSED(item)
-    UNUSED(ctx)
+    SlurTieLayout::createSlurSegments(item, ctx);
 }
 
 void TLayout::layoutSpacer(Spacer* item, LayoutContext&)


### PR DESCRIPTION
Resolves: #24803 

When editing a slur, new segments weren't being created in time for `changeEditElement` in `SlurSegment::changeAnchor` to select them.  This is due to (mostly) redundant code being removed from `TLayout::layoutSlur` [here](https://github.com/musescore/MuseScore/issues/21057).  
I've created a much slimmed down function which only creates slur segments and sets their type at this stage.