### PR TITLE
Fix #17397: Fully export instrument changes to MusicXML

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
@@ -7800,7 +7800,7 @@ void ExportMusicXml::writeInstrumentChange(const InstrumentChange* instrChange)
 
     m_xml.startElement("sound");
     m_xml.startElement("instrument-change");
-    scoreInstrument(m_xml, static_cast<int>(partNr) + 1, instNr + 1, instr->trackName(), instrChange->instrument());
+    scoreInstrument(m_xml, static_cast<int>(partNr) + 1, instNr + 1, instr->trackName(), instr);
     m_xml.endElement();
     m_xml.endElement();
 }

--- a/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
@@ -7777,26 +7777,23 @@ void ExportMusicXml::writeInstrumentChange(const InstrumentChange* instrChange)
     const Part* part = instrChange->part();
     const size_t partNr = muse::indexOf(m_score->parts(), part);
     const int instNr = muse::value(m_instrMap, instr, -1);
-    static const std::wregex acc(L"[♭♯]");
+    const String longName = instr->nameAsPlainText();
+    const String shortName = instr->abbreviatureAsPlainText();
 
     m_xml.startElement("print");
-    m_xml.tag("part-name", instr->nameAsPlainText().replace(u"♭", u"b").replace(u"♯", u"#"));
-    if (instr->nameAsPlainText().contains(acc)) {
+    if (!longName.isEmpty()) {
         m_xml.startElement("part-name-display");
-        writeDisplayName(m_xml, instr->nameAsPlainText());
+        writeDisplayName(m_xml, longName);
         m_xml.endElement();
     }
-    if (!instr->abbreviatureAsPlainText().isEmpty()) {
-        m_xml.tag("part-abbreviation", instr->abbreviatureAsPlainText().replace(u"♭", u"b").replace(u"♯", u"#"));
-        if (instr->abbreviatureAsPlainText().contains(acc)) {
-            m_xml.startElement("part-abbreviation-display");
-            writeDisplayName(m_xml, instr->abbreviatureAsPlainText());
-            m_xml.endElement();
-        }
+    if (!shortName.isEmpty()) {
+        m_xml.startElement("part-abbreviation-display");
+        writeDisplayName(m_xml, shortName);
+        m_xml.endElement();
     }
     m_xml.endElement();
 
-    writeInstrumentDetails(instrChange->instrument(), m_score->style().styleB(Sid::concertPitch));
+    writeInstrumentDetails(instr, m_score->style().styleB(Sid::concertPitch));
 
     m_xml.startElement("sound");
     m_xml.startElement("instrument-change");

--- a/src/importexport/musicxml/tests/data/testChangeTranspose-no-diatonic_ref.xml
+++ b/src/importexport/musicxml/tests/data/testChangeTranspose-no-diatonic_ref.xml
@@ -101,8 +101,12 @@
           </key>
         </attributes>
       <print>
-        <part-name>A Clarinet</part-name>
-        <part-abbreviation>A Cl.</part-abbreviation>
+        <part-name-display>
+          <display-text>A Clarinet</display-text>
+          </part-name-display>
+        <part-abbreviation-display>
+          <display-text>A Cl.</display-text>
+          </part-abbreviation-display>
         </print>
       <attributes>
         <transpose>

--- a/src/importexport/musicxml/tests/data/testChangeTranspose-no-diatonic_ref.xml
+++ b/src/importexport/musicxml/tests/data/testChangeTranspose-no-diatonic_ref.xml
@@ -100,12 +100,23 @@
           <fifths>2</fifths>
           </key>
         </attributes>
+      <print>
+        <part-name>A Clarinet</part-name>
+        <part-abbreviation>A Cl.</part-abbreviation>
+        </print>
       <attributes>
         <transpose>
           <diatonic>-1</diatonic>
           <chromatic>-2</chromatic>
           </transpose>
         </attributes>
+      <sound>
+        <instrument-change>
+          <score-instrument id="P1-I2">
+            <instrument-name>B♭ Clarinet</instrument-name>
+            </score-instrument>
+          </instrument-change>
+        </sound>
       <direction placement="above">
         <direction-type>
           <words font-weight="bold" font-size="12">To B♭ Clarinet</words>

--- a/src/importexport/musicxml/tests/data/testChangeTranspose.xml
+++ b/src/importexport/musicxml/tests/data/testChangeTranspose.xml
@@ -101,8 +101,12 @@
           </key>
         </attributes>
       <print>
-        <part-name>A Clarinet</part-name>
-        <part-abbreviation>A Cl.</part-abbreviation>
+        <part-name-display>
+          <display-text>A Clarinet</display-text>
+          </part-name-display>
+        <part-abbreviation-display>
+          <display-text>A Cl.</display-text>
+          </part-abbreviation-display>
         </print>
       <attributes>
         <transpose>

--- a/src/importexport/musicxml/tests/data/testChangeTranspose.xml
+++ b/src/importexport/musicxml/tests/data/testChangeTranspose.xml
@@ -100,12 +100,23 @@
           <fifths>2</fifths>
           </key>
         </attributes>
+      <print>
+        <part-name>A Clarinet</part-name>
+        <part-abbreviation>A Cl.</part-abbreviation>
+        </print>
       <attributes>
         <transpose>
           <diatonic>-1</diatonic>
           <chromatic>-2</chromatic>
           </transpose>
         </attributes>
+      <sound>
+        <instrument-change>
+          <score-instrument id="P1-I2">
+            <instrument-name>B♭ Clarinet</instrument-name>
+            </score-instrument>
+          </instrument-change>
+        </sound>
       <direction placement="above">
         <direction-type>
           <words font-weight="bold" font-size="12">To B♭ Clarinet</words>

--- a/src/importexport/musicxml/tests/data/testInstrumentChangeMIDIportExport_ref.xml
+++ b/src/importexport/musicxml/tests/data/testInstrumentChangeMIDIportExport_ref.xml
@@ -1061,8 +1061,12 @@
       </measure>
     <measure number="2">
       <print>
-        <part-name>Voice</part-name>
-        <part-abbreviation>Vo.</part-abbreviation>
+        <part-name-display>
+          <display-text>Voice</display-text>
+          </part-name-display>
+        <part-abbreviation-display>
+          <display-text>Vo.</display-text>
+          </part-abbreviation-display>
         </print>
       <sound>
         <instrument-change>

--- a/src/importexport/musicxml/tests/data/testInstrumentChangeMIDIportExport_ref.xml
+++ b/src/importexport/musicxml/tests/data/testInstrumentChangeMIDIportExport_ref.xml
@@ -1060,6 +1060,17 @@
         </note>
       </measure>
     <measure number="2">
+      <print>
+        <part-name>Voice</part-name>
+        <part-abbreviation>Vo.</part-abbreviation>
+        </print>
+      <sound>
+        <instrument-change>
+          <score-instrument id="P15-I2">
+            <instrument-name>Voice</instrument-name>
+            </score-instrument>
+          </instrument-change>
+        </sound>
       <direction placement="above">
         <direction-type>
           <words font-weight="bold" font-size="12">Voice</words>

--- a/src/importexport/musicxml/tests/data/testMultiInstrumentPart1.xml
+++ b/src/importexport/musicxml/tests/data/testMultiInstrumentPart1.xml
@@ -84,8 +84,12 @@
       </measure>
     <measure number="3">
       <print>
-        <part-name>Piano</part-name>
-        <part-abbreviation>Pno.</part-abbreviation>
+        <part-name-display>
+          <display-text>Piano</display-text>
+          </part-name-display>
+        <part-abbreviation-display>
+          <display-text>Pno.</display-text>
+          </part-abbreviation-display>
         </print>
       <sound>
         <instrument-change>

--- a/src/importexport/musicxml/tests/data/testMultiInstrumentPart1.xml
+++ b/src/importexport/musicxml/tests/data/testMultiInstrumentPart1.xml
@@ -83,6 +83,17 @@
         </note>
       </measure>
     <measure number="3">
+      <print>
+        <part-name>Piano</part-name>
+        <part-abbreviation>Pno.</part-abbreviation>
+        </print>
+      <sound>
+        <instrument-change>
+          <score-instrument id="P1-I2">
+            <instrument-name>Flute</instrument-name>
+            </score-instrument>
+          </instrument-change>
+        </sound>
       <direction placement="above">
         <direction-type>
           <words font-weight="bold" font-size="12">Flute</words>

--- a/src/importexport/musicxml/tests/data/testMultiInstrumentPart2.xml
+++ b/src/importexport/musicxml/tests/data/testMultiInstrumentPart2.xml
@@ -107,6 +107,17 @@
         </note>
       </measure>
     <measure number="3">
+      <print>
+        <part-name>Piano</part-name>
+        <part-abbreviation>Pno.</part-abbreviation>
+        </print>
+      <sound>
+        <instrument-change>
+          <score-instrument id="P1-I2">
+            <instrument-name>Flute</instrument-name>
+            </score-instrument>
+          </instrument-change>
+        </sound>
       <direction placement="above">
         <direction-type>
           <words font-weight="bold" font-size="12">Flute</words>
@@ -246,6 +257,17 @@
         </note>
       </measure>
     <measure number="7">
+      <print>
+        <part-name>Voice</part-name>
+        <part-abbreviation>Vo.</part-abbreviation>
+        </print>
+      <sound>
+        <instrument-change>
+          <score-instrument id="P2-I2">
+            <instrument-name>C Trumpet</instrument-name>
+            </score-instrument>
+          </instrument-change>
+        </sound>
       <direction placement="above">
         <direction-type>
           <words font-weight="bold" font-size="12">Trumpet</words>

--- a/src/importexport/musicxml/tests/data/testMultiInstrumentPart2.xml
+++ b/src/importexport/musicxml/tests/data/testMultiInstrumentPart2.xml
@@ -108,8 +108,12 @@
       </measure>
     <measure number="3">
       <print>
-        <part-name>Piano</part-name>
-        <part-abbreviation>Pno.</part-abbreviation>
+        <part-name-display>
+          <display-text>Piano</display-text>
+          </part-name-display>
+        <part-abbreviation-display>
+          <display-text>Pno.</display-text>
+          </part-abbreviation-display>
         </print>
       <sound>
         <instrument-change>
@@ -258,8 +262,12 @@
       </measure>
     <measure number="7">
       <print>
-        <part-name>Voice</part-name>
-        <part-abbreviation>Vo.</part-abbreviation>
+        <part-name-display>
+          <display-text>Voice</display-text>
+          </part-name-display>
+        <part-abbreviation-display>
+          <display-text>Vo.</display-text>
+          </part-abbreviation-display>
         </print>
       <sound>
         <instrument-change>

--- a/src/importexport/musicxml/tests/data/testMultiInstrumentPart3_ref.xml
+++ b/src/importexport/musicxml/tests/data/testMultiInstrumentPart3_ref.xml
@@ -169,13 +169,11 @@
           </key>
         </attributes>
       <print>
-        <part-name>Bb Clarinet</part-name>
         <part-name-display>
           <display-text>B</display-text>
           <accidental-text>flat</accidental-text>
           <display-text> Clarinet</display-text>
           </part-name-display>
-        <part-abbreviation>Bb Cl.</part-abbreviation>
         <part-abbreviation-display>
           <display-text>B</display-text>
           <accidental-text>flat</accidental-text>

--- a/src/importexport/musicxml/tests/data/testMultiInstrumentPart3_ref.xml
+++ b/src/importexport/musicxml/tests/data/testMultiInstrumentPart3_ref.xml
@@ -168,12 +168,33 @@
           <fifths>-3</fifths>
           </key>
         </attributes>
+      <print>
+        <part-name>Bb Clarinet</part-name>
+        <part-name-display>
+          <display-text>B</display-text>
+          <accidental-text>flat</accidental-text>
+          <display-text> Clarinet</display-text>
+          </part-name-display>
+        <part-abbreviation>Bb Cl.</part-abbreviation>
+        <part-abbreviation-display>
+          <display-text>B</display-text>
+          <accidental-text>flat</accidental-text>
+          <display-text> Cl.</display-text>
+          </part-abbreviation-display>
+        </print>
       <attributes>
         <transpose>
           <diatonic>-1</diatonic>
           <chromatic>-2</chromatic>
           </transpose>
         </attributes>
+      <sound>
+        <instrument-change>
+          <score-instrument id="P1-I2">
+            <instrument-name>B♭ Clarinet</instrument-name>
+            </score-instrument>
+          </instrument-change>
+        </sound>
       <direction placement="above">
         <direction-type>
           <words font-weight="bold" font-size="12">B♭ Clarinet</words>


### PR DESCRIPTION
This PR adds full export of instrument changes to MusicXML support.

Closes #17397.

NB: Import currently doesn't change the instrument name yet, so this has to be adjested for fully working round-trips of import and export.