### PR TITLE
Fix #24896: Lyrics getting stuck on odd/even styles

### DIFF
--- a/src/engraving/rendering/score/lyricslayout.cpp
+++ b/src/engraving/rendering/score/lyricslayout.cpp
@@ -126,20 +126,6 @@ void LyricsLayout::layout(Lyrics* item, LayoutContext& ctx)
         }
     }
 
-    bool styleDidChange = false;
-    if (item->isEven() && (item->textStyleType() != TextStyleType::LYRICS_EVEN)) {
-        item->initTextStyleType(TextStyleType::LYRICS_EVEN, /* preserveDifferent */ true);
-        styleDidChange = true;
-    }
-    if (!item->isEven() && (item->textStyleType() != TextStyleType::LYRICS_ODD)) {
-        item->initTextStyleType(TextStyleType::LYRICS_ODD, /* preserveDifferent */ true);
-        styleDidChange = true;
-    }
-
-    if (styleDidChange) {
-        item->styleChanged();
-    }
-
     createOrRemoveLyricsLine(item, ctx);
 
     if (item->isMelisma() || hasNumber) {

--- a/src/importexport/capella/internal/capella.cpp
+++ b/src/importexport/capella/internal/capella.cpp
@@ -808,6 +808,7 @@ static Fraction readCapVoice(Score* score, CapVoice* cvoice, int staffIdx, const
                     l->setSyllabic(LyricsSyllabic::BEGIN);
                 }
                 l->setNo(v.num);
+                l->initTextStyleType(l->isEven() ? TextStyleType::LYRICS_EVEN : TextStyleType::LYRICS_ODD, /*preserveDifferent*/ true);
                 chord->add(l);
             }
 

--- a/src/importexport/mei/internal/meiimporter.cpp
+++ b/src/importexport/mei/internal/meiimporter.cpp
@@ -2213,6 +2213,7 @@ bool MeiImporter::readVerse(pugi::xml_node verseNode, Chord* chord)
 
     lyrics->setXmlText(syllable);
     lyrics->setNo(no);
+    lyrics->initTextStyleType(lyrics->isEven() ? TextStyleType::LYRICS_EVEN : TextStyleType::LYRICS_ODD, /*preserveDifferent*/ true);
     lyrics->setTrack(chord->track());
     chord->add(lyrics);
 

--- a/src/importexport/mei/tests/data/lyric-03.mscx
+++ b/src/importexport/mei/tests/data/lyric-03.mscx
@@ -114,7 +114,7 @@
               <no>1</no>
               <syllabic>begin</syllabic>
               <eid>P_P</eid>
-              <text>Y<sym>lyricsElision</sym><font face="Edwin"/>aun</text>
+              <text>Y<sym>lyricsElision</sym>aun</text>
               </Lyrics>
             <Lyrics>
               <eid>Q_Q</eid>
@@ -480,7 +480,7 @@
               <no>1</no>
               <syllabic>begin</syllabic>
               <eid>XB_XB</eid>
-              <text>Y<sym>lyricsElision</sym><font face="Edwin"/>aun</text>
+              <text>Y<sym>lyricsElision</sym>aun</text>
               </Lyrics>
             <Note>
               <eid>YB_YB</eid>

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -907,6 +907,7 @@ static void addLyric(MusicXmlLogger* logger, const XmlStreamReader* const xmlrea
         delete l;
     } else {
         l->setNo(lyricNo);
+        l->initTextStyleType(l->isEven() ? TextStyleType::LYRICS_EVEN : TextStyleType::LYRICS_ODD, /*preserveDifferent*/ true);
         cr->add(l);
         extendedLyrics.setExtend(lyricNo, cr->track(), cr->tick(), l);
     }

--- a/src/importexport/musicxml/tests/data/testElision.xml
+++ b/src/importexport/musicxml/tests/data/testElision.xml
@@ -124,6 +124,14 @@
           <elision/>
           <text>in</text>
           </lyric>
+        <lyric number="2" default-x="6.5" default-y="-44.42" relative-y="-30">
+          <syllabic>single</syllabic>
+          <text>ce</text>
+          <elision/>
+          <text>e</text>
+          <elision/>
+          <text>in</text>
+          </lyric>
         </note>
       <note default-x="302.17" default-y="-20">
         <pitch>
@@ -135,6 +143,14 @@
         <type>quarter</type>
         <stem>down</stem>
         <lyric number="1" default-x="6.5" default-y="-44.42" relative-y="-30">
+          <syllabic>single</syllabic>
+          <text>ce</text>
+          <elision>‿</elision>
+          <text>e</text>
+          <elision> </elision>
+          <text>in</text>
+          </lyric>
+        <lyric number="2" default-x="6.5" default-y="-44.42" relative-y="-30">
           <syllabic>single</syllabic>
           <text>ce</text>
           <elision>‿</elision>
@@ -160,6 +176,14 @@
           <elision smufl="lyricsElision"/>
           <text>in</text>
           </lyric>
+        <lyric number="2" default-x="6.5" default-y="-44.42" relative-y="-30">
+          <syllabic>single</syllabic>
+          <text>ce</text>
+          <elision smufl="lyricsElisionNarrow"/>
+          <text>e</text>
+          <elision smufl="lyricsElision"/>
+          <text>in</text>
+          </lyric>
         </note>
       <note default-x="746.08" default-y="-20">
         <pitch>
@@ -171,6 +195,14 @@
         <type>quarter</type>
         <stem>down</stem>
         <lyric number="1" default-x="6.5" default-y="-44.42" relative-y="-30">
+          <syllabic>single</syllabic>
+          <text>ce</text>
+          <elision smufl="lyricsElisionWide"/>
+          <text>e</text>
+          <elision>‿</elision>
+          <text>in</text>
+          </lyric>
+        <lyric number="2" default-x="6.5" default-y="-44.42" relative-y="-30">
           <syllabic>single</syllabic>
           <text>ce</text>
           <elision smufl="lyricsElisionWide"/>

--- a/src/importexport/musicxml/tests/data/testElision_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testElision_ref.mscx
@@ -152,47 +152,48 @@
               <eid>K_K</eid>
               <text>ce<sym>lyricsElision</sym>e<sym>lyricsElision</sym>in</text>
               </Lyrics>
-            <StemDirection>down</StemDirection>
-            <Note>
+            <Lyrics>
+              <no>1</no>
               <eid>L_L</eid>
-              <pitch>71</pitch>
-              <tpc>19</tpc>
-              </Note>
-            </Chord>
-          <Chord>
-            <eid>M_M</eid>
-            <durationType>quarter</durationType>
-            <Lyrics>
-              <eid>N_N</eid>
-              <text>ce‿e in</text>
-              </Lyrics>
-            <StemDirection>down</StemDirection>
-            <Note>
-              <eid>O_O</eid>
-              <pitch>71</pitch>
-              <tpc>19</tpc>
-              </Note>
-            </Chord>
-          <Chord>
-            <eid>P_P</eid>
-            <durationType>quarter</durationType>
-            <Lyrics>
-              <eid>Q_Q</eid>
               <text>ce<sym>lyricsElision</sym>e<sym>lyricsElision</sym>in</text>
               </Lyrics>
             <StemDirection>down</StemDirection>
             <Note>
-              <eid>R_R</eid>
+              <eid>M_M</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>S_S</eid>
+            <eid>N_N</eid>
             <durationType>quarter</durationType>
             <Lyrics>
+              <eid>O_O</eid>
+              <text>ce‿e in</text>
+              </Lyrics>
+            <Lyrics>
+              <no>1</no>
+              <eid>P_P</eid>
+              <text>ce‿e in</text>
+              </Lyrics>
+            <StemDirection>down</StemDirection>
+            <Note>
+              <eid>Q_Q</eid>
+              <pitch>71</pitch>
+              <tpc>19</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <eid>R_R</eid>
+            <durationType>quarter</durationType>
+            <Lyrics>
+              <eid>S_S</eid>
+              <text>ce<sym>lyricsElision</sym>e<sym>lyricsElision</sym>in</text>
+              </Lyrics>
+            <Lyrics>
+              <no>1</no>
               <eid>T_T</eid>
-              <text>ce<sym>lyricsElision</sym>e‿in</text>
+              <text>ce<sym>lyricsElision</sym>e<sym>lyricsElision</sym>in</text>
               </Lyrics>
             <StemDirection>down</StemDirection>
             <Note>
@@ -201,9 +202,28 @@
               <tpc>19</tpc>
               </Note>
             </Chord>
+          <Chord>
+            <eid>V_V</eid>
+            <durationType>quarter</durationType>
+            <Lyrics>
+              <eid>W_W</eid>
+              <text>ce<sym>lyricsElision</sym>e‿in</text>
+              </Lyrics>
+            <Lyrics>
+              <no>1</no>
+              <eid>X_X</eid>
+              <text>ce<sym>lyricsElision</sym>e‿in</text>
+              </Lyrics>
+            <StemDirection>down</StemDirection>
+            <Note>
+              <eid>Y_Y</eid>
+              <pitch>71</pitch>
+              <tpc>19</tpc>
+              </Note>
+            </Chord>
           <BarLine>
             <subtype>end</subtype>
-            <eid>V_V</eid>
+            <eid>Z_Z</eid>
             </BarLine>
           </voice>
         </Measure>

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -6128,6 +6128,7 @@ void NotationInteraction::navigateToLyrics(bool back, bool moveOnly, bool end)
     mu::engraving::PropertyFlags pFlags = lyrics->propertyFlags(mu::engraving::Pid::PLACEMENT);
     mu::engraving::FontStyle fStyle = lyrics->fontStyle();
     mu::engraving::PropertyFlags fFlags = lyrics->propertyFlags(mu::engraving::Pid::FONT_STYLE);
+    mu::engraving::TextStyleType styleType = lyrics->textStyleType();
 
     mu::engraving::Segment* nextSegment = segment;
     if (back) {
@@ -6198,11 +6199,8 @@ void NotationInteraction::navigateToLyrics(bool back, bool moveOnly, bool end)
         nextLyrics->setTrack(track);
         cr = toChordRest(nextSegment->element(track));
         nextLyrics->setParent(cr);
-
         nextLyrics->setNo(verse);
-        const mu::engraving::TextStyleType styleType(nextLyrics->isEven() ? TextStyleType::LYRICS_EVEN : TextStyleType::LYRICS_ODD);
         nextLyrics->setTextStyleType(styleType);
-
         nextLyrics->setPlacement(placement);
         nextLyrics->setPropertyFlags(mu::engraving::Pid::PLACEMENT, pFlags);
         nextLyrics->setSyllabic(mu::engraving::LyricsSyllabic::SINGLE);
@@ -6289,6 +6287,7 @@ void NotationInteraction::navigateToNextSyllable()
     PropertyFlags pFlags = lyrics->propertyFlags(Pid::PLACEMENT);
     FontStyle fStyle = lyrics->fontStyle();
     PropertyFlags fFlags = lyrics->propertyFlags(Pid::FONT_STYLE);
+    mu::engraving::TextStyleType styleType = lyrics->textStyleType();
 
     // search next chord
     Segment* nextSegment = segment;
@@ -6378,11 +6377,8 @@ void NotationInteraction::navigateToNextSyllable()
             Lyrics* toLyrics = Factory::createLyrics(initialCR);
             toLyrics->setTrack(track);
             toLyrics->setParent(initialCR);
-
             toLyrics->setNo(verse);
-            const TextStyleType styleType(toLyrics->isEven() ? TextStyleType::LYRICS_EVEN : TextStyleType::LYRICS_ODD);
             toLyrics->setTextStyleType(styleType);
-
             toLyrics->setPlacement(placement);
             toLyrics->setPropertyFlags(Pid::PLACEMENT, pFlags);
             toLyrics->setSyllabic(LyricsSyllabic::END);
@@ -6473,7 +6469,6 @@ void NotationInteraction::navigateToNextSyllable()
         toLyrics->setParent(toLyricsChord);
 
         toLyrics->setNo(verse);
-        const TextStyleType styleType(toLyrics->isEven() ? TextStyleType::LYRICS_EVEN : TextStyleType::LYRICS_ODD);
         toLyrics->setTextStyleType(styleType);
 
         toLyrics->setPlacement(placement);
@@ -6553,6 +6548,7 @@ void NotationInteraction::navigateToLyricsVerse(MoveDirection direction)
     mu::engraving::PropertyFlags pFlags = lyrics->propertyFlags(mu::engraving::Pid::PLACEMENT);
     mu::engraving::FontStyle fStyle = lyrics->fontStyle();
     mu::engraving::PropertyFlags fFlags = lyrics->propertyFlags(mu::engraving::Pid::FONT_STYLE);
+    mu::engraving::TextStyleType styleType = lyrics->textStyleType();
 
     if (direction == MoveDirection::Up) {
         if (verse == 0) {
@@ -6573,11 +6569,8 @@ void NotationInteraction::navigateToLyricsVerse(MoveDirection direction)
         lyrics = Factory::createLyrics(cr);
         lyrics->setTrack(track);
         lyrics->setParent(cr);
-
         lyrics->setNo(verse);
-        const mu::engraving::TextStyleType styleType(lyrics->isEven() ? TextStyleType::LYRICS_EVEN : TextStyleType::LYRICS_ODD);
         lyrics->setTextStyleType(styleType);
-
         lyrics->setPlacement(placement);
         lyrics->setPropertyFlags(mu::engraving::Pid::PLACEMENT, pFlags);
         lyrics->setFontStyle(fStyle);


### PR DESCRIPTION
Resolves: #24896

The main change in this PR is to remove some very old logic from `LyricsLayout`. This logic has evolved over time, but it seems to be based on the assumption that lyric styles should _always_ be set according to odd/even status - which is precisely the problem in the attached issue. The same assumption was made in #24792 - so I've included some additional tweaks to ensure the style of the "from" lyric is carried over into the next syllable, melisma, etc.

MXML, MEI, and Capella import appear to be relying on this removed logic, so new proactive calls to `initTextStyleType` have been added where necessary. In doing so - another issue was uncovered which is that the `preserveDifferent` flag fails to consider individually formatted text fragments. The new `hadCustomFragments` logic aims to address this.

Note that this fix could be taken a step further. Instead of skipping face, size, and style when a customised fragment is found, we could try the following:
1. Before calling `setTextStyle` type, iterate over every fragment
2. For each fragment, collect every `Pid` that matches the old default (face, size, or style)
3. Call `setTextStyleType`
4. Go through each fragment again, and use `styleValue` to set new defaults for the `Pids` we collected

I decided against this for simplicity's sake - `TextBase` is already incredibly bloated...