### PR TITLE
Fix multiple MIDI out issues

### DIFF
--- a/src/framework/audio/internal/synthesizers/fluidsynth/fluidsequencer.h
+++ b/src/framework/audio/internal/synthesizers/fluidsynth/fluidsequencer.h
@@ -42,6 +42,7 @@ public:
     async::Channel<midi::channel_t, midi::Program> channelAdded() const;
 
     const ChannelMap& channels() const;
+    int lastStaff() const;
 
 private:
     void updateOffStreamEvents(const mpe::PlaybackEventsMap& events, const mpe::PlaybackParamList& params) override;
@@ -69,6 +70,7 @@ private:
 
     mutable ChannelMap m_channels;
     bool m_useDynamicEvents = false;
+    int m_lastStaff = -1;
 };
 }
 

--- a/src/framework/midi/internal/platform/osx/coremidioutport.h
+++ b/src/framework/midi/internal/platform/osx/coremidioutport.h
@@ -56,7 +56,6 @@ public:
 
 private:
     void initCore();
-    void getDestinationProtocolId();
 
     struct Core;
     std::unique_ptr<Core> m_core;


### PR DESCRIPTION
Resolves: #22354
Resolves: #18382

For a long time the midi output was broken in MuseScore 4. Due to inconsistent use of MIDI 2.0 and MIDI 1.0 data values a midi 1.0 note velocity of 64 would be interpreted in Midi 2.0 as very small and substitued by 1. The pull request fixes this by small changes in fluid synth event generation and event interpretation code.
Also handling of Midi event lists on the mac, both output and input was not correct. I fixed it as well. I added some needed utilities and fixed some code in Event type that I noticed was incorrect.
I tested Midi Input and output on the Mac. 

Another change is usability of MIDI output.
Currently the user has no way to assign a port and channel to a staff. As a workaround I suggest using the staff index as the channel number (implemented).
When stopping playback, now also All-Note-Off commands are sent to MIDI output.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x ] I signed the [CLA](https://musescore.org/en/cla)
- [ x] The title of the PR describes the problem it addresses
- [ x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ x] If changes are extensive, there is a sequence of easily reviewable commits
- [ x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [ x] There are no unnecessary changes
- [ x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
