### PR TITLE
fix: gp5 voltas import

### DIFF
--- a/src/importexport/guitarpro/internal/importgtp-gp5.cpp
+++ b/src/importexport/guitarpro/internal/importgtp-gp5.cpp
@@ -923,7 +923,7 @@ bool GuitarPro5::read(IODevice* io)
         }
         if (barBits & SCORE_REPEAT_END) {                    // number of repeats
             bar.repeatFlags = bar.repeatFlags | mu::engraving::Repeat::END;
-            bar.repeats = readUInt8();
+            bar.repeats = readUInt8() + 1;
         }
         if (barBits & SCORE_MARKER) {
             bar.marker = readDelphiString();           // new section?

--- a/src/importexport/guitarpro/tests/data/volta.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/volta.gp5-ref.mscx
@@ -922,7 +922,7 @@
           </voice>
         </Measure>
       <Measure>
-        <endRepeat>2</endRepeat>
+        <endRepeat>3</endRepeat>
         <voice>
           <Spanner type="Volta">
             <Volta>


### PR DESCRIPTION
`Measure with the end repeat barline must have a Play count value that is equal to, the total number of times of playback of this measure + 1 or more`
https://musescore.org/en/handbook/4/voltas#change-playback