### PR TITLE
[NO MERGE] Report pressed keys

### DIFF
--- a/src/framework/ui/internal/navigationcontroller.cpp
+++ b/src/framework/ui/internal/navigationcontroller.cpp
@@ -27,6 +27,7 @@
 #include <QApplication>
 #include <QWindow>
 #include <QTextStream>
+#include <QKeyEvent>
 
 #include "global/defer.h"
 
@@ -381,6 +382,14 @@ bool NavigationController::eventFilter(QObject* watched, QEvent* event)
 {
     if (event->type() == QEvent::MouseButtonPress) {
         resetIfNeed(watched);
+    } else if (event->type() == QEvent::ShortcutOverride) {
+        auto keyEvent = static_cast<QKeyEvent*>(event);
+        QKeySequence sequence(keyEvent->keyCombination());
+        LOGI() << QString("Keys: '%1'  Native: '%2'  Text: '%3'").arg(
+            sequence.toString(QKeySequence::PortableText), // default
+            sequence.toString(QKeySequence::NativeText),
+            keyEvent->text()
+                ).toStdString();
     }
 
     return QObject::eventFilter(watched, event);


### PR DESCRIPTION
Following discussions in [PR #24958](https://github.com/musescore/MuseScore/pull/24958#pullrequestreview-2338087337), it would be useful to know how Qt is reporting keypresses on each platform. (Perhaps we should add a keylogger to the Diagnostic menu?)

For now, this PR just prints keys on the console. Download the artifact and run it on the command line to see how Qt reports keys on your system. On Windows it might be necessary to run it in Qt Creator or another debugger/IDE to see the console output.

### Results with UK QWERTY PC keyboard on Windows

On this keyboard, `+` is entered with <kbd>Shift</kbd>&nbsp;<kbd>=</kbd>, thus combinations involving <kbd>Shift</kbd>&nbsp;<kbd>=</kbd> are _conceptually_ using <kbd>+</kbd>.

On this platform, [Qt's portable key names](https://doc.qt.io/qt-6/qkeysequence.html#SequenceFormat-enum) are equivalent to the native key names (at least in English).

Physical keys pressed | Conceptual keys | Qt portable/native keys | Qt text
---:|---:|---:|---:
<kbd>=</kbd> | <kbd>=</kbd> | `=` | `=`
<kbd>Alt</kbd>&nbsp;<kbd>=</kbd> | <kbd>Alt</kbd>&nbsp;<kbd>=</kbd> | `Alt+=` | `=`
<kbd>Ctrl</kbd>&nbsp;<kbd>=</kbd> | <kbd>Ctrl</kbd>&nbsp;<kbd>=</kbd> | `Ctrl+=` | `=`
<kbd>Ctrl</kbd>&nbsp;<kbd>Alt</kbd>&nbsp;<kbd>=</kbd> | <kbd>Ctrl</kbd>&nbsp;<kbd>Alt</kbd>&nbsp;<kbd>=</kbd> | ⚠️ Main window: `Alt+=`<br>Dialogs: `Ctrl+Alt+=` | `=`
<kbd>Shift</kbd>&nbsp;<kbd>=</kbd> | <kbd>+</kbd> | `Shift++` | `+`
<kbd>Alt</kbd>&nbsp;<kbd>Shift</kbd>&nbsp;<kbd>=</kbd> | <kbd>Alt</kbd>&nbsp;<kbd>+</kbd> | `Alt+Shift++` | `+`
<kbd>Ctrl</kbd>&nbsp;<kbd>Shift</kbd>&nbsp;<kbd>=</kbd> | <kbd>Ctrl</kbd>&nbsp;<kbd>+</kbd> | `Ctrl+Shift++` | ⚠️ `=`
<kbd>Ctrl</kbd>&nbsp;<kbd>Alt</kbd>&nbsp;<kbd>Shift</kbd>&nbsp;<kbd>=</kbd> | <kbd>Ctrl</kbd>&nbsp;<kbd>Alt</kbd>&nbsp;<kbd>+</kbd> | `Ctrl+Alt+Shift++` | ⚠️ `=`

<details>
<summary><b>Markdown</b></summary>

```Markdown
Physical keys pressed | Conceptual keys | Qt portable/native keys | Qt text
---:|---:|---:|---:
<kbd>Ctrl</kbd>&nbsp;<kbd>Alt</kbd>&nbsp;<kbd>=</kbd> | <kbd>Ctrl</kbd>&nbsp;<kbd>Alt</kbd>&nbsp;<kbd>=</kbd> | ⚠️ Main window: `Alt+=`<br>Dialogs: `Ctrl+Alt+=` | `=`
```
</details>

Reasonable people can disagree over whether it's better to show physical or conceptual keys in **Preferences > Shortcuts**. The real question is, which of those things (physical or conceptual) can we reliably determine based on the information Qt is reporting?

With this particular OS (Windows), keyboard layout (UK QWERTY PC), and key (<kbd>=</kbd>), it seems that dropping <kbd>Shift</kbd> from Qt's reported keys does give a reasonable approximation of the _conceptual_ keys (but we know that's [not the case for all keys](https://github.com/musescore/MuseScore/issues/24864)).

There doesn't seem to be a straightforward way to determine the _physical_ keys pressed. It might be possible using [native methods](https://doc.qt.io/qt-6/qkeyevent.html#nativeModifiers) as demonstrated [here](https://stackoverflow.com/a/11283320). However, the output of these methods is platform-specific.