### PR TITLE
Fix #24678: Remember which tab was last open within a session

### DIFF
--- a/src/appshell/iappshellconfiguration.h
+++ b/src/appshell/iappshellconfiguration.h
@@ -66,6 +66,9 @@ public:
     virtual bool needShowSplashScreen() const = 0;
     virtual void setNeedShowSplashScreen(bool show) = 0;
 
+    virtual const QString& preferencesDialogLastOpenedPageId() const = 0;
+    virtual void setPreferencesDialogLastOpenedPageId(const QString& lastOpenedPageId) = 0;
+
     virtual void startEditSettings() = 0;
     virtual void applySettings() = 0;
     virtual void rollbackSettings() = 0;

--- a/src/appshell/internal/appshellconfiguration.cpp
+++ b/src/appshell/internal/appshellconfiguration.cpp
@@ -188,6 +188,16 @@ void AppShellConfiguration::setNeedShowSplashScreen(bool show)
     settings()->setSharedValue(SPLASH_SCREEN_VISIBLE_KEY, Val(show));
 }
 
+const QString& AppShellConfiguration::preferencesDialogLastOpenedPageId() const
+{
+    return m_preferencesDialogCurrentPageId;
+}
+
+void AppShellConfiguration::setPreferencesDialogLastOpenedPageId(const QString& lastOpenedPageId)
+{
+    m_preferencesDialogCurrentPageId = lastOpenedPageId;
+}
+
 void AppShellConfiguration::startEditSettings()
 {
     settings()->beginTransaction();

--- a/src/appshell/internal/appshellconfiguration.h
+++ b/src/appshell/internal/appshellconfiguration.h
@@ -85,6 +85,9 @@ public:
     bool needShowSplashScreen() const override;
     void setNeedShowSplashScreen(bool show) override;
 
+    const QString& preferencesDialogLastOpenedPageId() const override;
+    void setPreferencesDialogLastOpenedPageId(const QString& lastOpenedPageId) override;
+
     void startEditSettings() override;
     void applySettings() override;
     void rollbackSettings() override;
@@ -106,6 +109,8 @@ private:
     muse::Ret writeSessionState(const QByteArray& data);
 
     muse::io::paths_t parseSessionProjectsPaths(const QByteArray& json) const;
+
+    QString m_preferencesDialogCurrentPageId;
 };
 }
 

--- a/src/appshell/view/preferences/preferencesmodel.cpp
+++ b/src/appshell/view/preferences/preferencesmodel.cpp
@@ -143,7 +143,12 @@ void PreferencesModel::load(const QString& currentPageId)
     if (!currentPageId.isEmpty()) {
         setCurrentPageId(currentPageId);
     } else {
-        setCurrentPageId("general");
+        const QString& lastOpenedPageId = configuration()->preferencesDialogLastOpenedPageId();
+        if (lastOpenedPageId.isEmpty()) {
+            setCurrentPageId("general");
+        } else {
+            setCurrentPageId(lastOpenedPageId);
+        }
     }
 
     m_rootItem = new PreferencePageItem();
@@ -275,6 +280,7 @@ void PreferencesModel::setCurrentPageId(QString currentPageId)
     }
 
     m_currentPageId = currentPageId;
+    configuration()->setPreferencesDialogLastOpenedPageId(currentPageId);
     emit currentPageIdChanged(m_currentPageId);
 }
 


### PR DESCRIPTION
Resolves: #24678

This change remembers the tab you where within the Preferences window when opening the window again within the same session.

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
