### PR TITLE
Next stage of Percussion Pad UI (footer, spacers, shortcuts, etc.)

### DIFF
--- a/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
+++ b/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
@@ -158,10 +158,12 @@ Item {
                     height: padGrid.cellHeight
 
                     PercussionPanelPad {
+                        id: pad
+
                         anchors.centerIn: parent
 
-                        width: parent.width - padGrid.spacing
-                        height: parent.height - padGrid.spacing
+                        width: parent.width + pad.totalBorderWidth - padGrid.spacing
+                        height: parent.height + pad.totalBorderWidth - padGrid.spacing
 
                         padModel: model.padModelRole
                         panelMode: percModel.currentPanelMode

--- a/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPad.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPad.qml
@@ -23,6 +23,7 @@ import QtQuick 2.15
 
 import Muse.Ui 1.0
 import Muse.UiComponents 1.0
+import Muse.GraphicalEffects 1.0
 import MuseScore.NotationScene 1.0
 
 Rectangle {
@@ -30,80 +31,100 @@ Rectangle {
 
     property var padModel: null
 
+    property bool isEmptySlot: Boolean(root.padModel) ? root.padModel.isEmptySlot : true
+
     property int panelMode: -1
     property bool useNotationPreview: false
 
+    property alias totalBorderWidth: contentColumn.anchors.margins
+
     radius: root.width / 6
 
-    color: root.useNotationPreview ? "white" : ui.theme.backgroundSecondaryColor
+    color: ui.theme.backgroundPrimaryColor
 
     border.color: root.panelMode === PanelMode.EDIT_LAYOUT ? ui.theme.accentColor : "transparent"
     border.width: 2
 
-    Item {
-        id: contentArea
+    Column {
+        id: contentColumn
 
         anchors.fill: parent
+        anchors.margins: 2 + root.border.width // Defined as 1 in the spec, but causes some aliasing in practice...
 
-        visible: Boolean(root.padModel) ? !root.padModel.isEmptySlot : false
-
-        StyledTextLabel {
-            id: instrumentNameLabel
-
-            visible: !root.useNotationPreview
-
-            anchors.centerIn: parent
-            anchors.margins: 5
-
-            width: parent.width
-
-            wrapMode: Text.WordWrap
-
-            text: Boolean(root.padModel) ? root.padModel.instrumentName : ""
+        // Can't simply use clip as this won't take into account radius...
+        layer.enabled: ui.isEffectsAllowed
+        layer.effect: EffectOpacityMask {
+            maskSource: Rectangle {
+                width: contentColumn.width
+                height: contentColumn.height
+                radius: root.radius - contentColumn.anchors.margins
+            }
         }
 
-        StyledTextLabel {
-            // placeholder component - reflects the current state of the pad/panel
-            id: modeLabel
-
-            anchors.horizontalCenter: parent.horizontalCenter
-            anchors.bottom: parent.bottom
-            anchors.margins: 5
+        Rectangle {
+            id: mainContentArea
 
             width: parent.width
+            height: parent.height - separator.height - footerArea.height
 
-            color: root.useNotationPreview ? "black" : "white"
+            color: root.isEmptySlot ? ui.theme.backgroundSecondaryColor : Utils.colorWithAlpha(ui.theme.accentColor, ui.theme.buttonOpacityNormal)
 
-            wrapMode: Text.WordWrap
+            StyledTextLabel {
+                id: instrumentNameLabel
+
+                visible: !root.useNotationPreview
+
+                anchors.centerIn: parent
+                width: parent.width - root.radius
+
+                wrapMode: Text.WordWrap
+                maximumLineCount: 4
+                font: ui.theme.bodyBoldFont
+
+                text: Boolean(root.padModel) ? root.padModel.instrumentName : ""
+            }
+        }
+
+        Rectangle {
+            id: separator
+
+            width: parent.width
+            height: 1
+
+            color: root.isEmptySlot ? ui.theme.backgroundSecondaryColor : ui.theme.accentColor
+        }
+
+        Rectangle {
+            id: footerArea
+
+            width: parent.width
+            height: 24
+
+            color: ui.theme.backgroundSecondaryColor
+
+            StyledTextLabel {
+                id: shortcutLabel
+
+                anchors.verticalCenter: parent.verticalCenter
+                anchors.left: parent.left
+                anchors.margins: 6
+
+                font: ui.theme.bodyFont
+
+                text: Boolean(root.padModel) ? root.padModel.keyboardShortcut : ""
+            }
+
+            StyledTextLabel {
+                id: midiNoteLabel
+
+                anchors.verticalCenter: parent.verticalCenter
+                anchors.right: parent.right
+                anchors.margins: 6
+
+                font: ui.theme.bodyFont
+
+                text: Boolean(root.padModel) ? root.padModel.midiNote : ""
+            }
         }
     }
-
-    states: [
-        State {
-            name: "WRITE"
-            when: root.panelMode === PanelMode.WRITE
-            PropertyChanges {
-                target: modeLabel
-
-                // See modeLabel - these are all placeholder strings
-                text: "Write mode"
-            }
-        },
-        State {
-            name: "SOUND_PREVIEW"
-            when: root.panelMode === PanelMode.SOUND_PREVIEW
-            PropertyChanges {
-                target: modeLabel
-                text: "Sound preview mode"
-            }
-        },
-        State {
-            name: "EDIT_LAYOUT"
-            when: root.panelMode === PanelMode.EDIT_LAYOUT
-            PropertyChanges {
-                target: modeLabel
-                text: "Edit layout mode"
-            }
-        }
-    ]
 }

--- a/src/notation/view/percussionpanel/percussionpanelpadlistmodel.cpp
+++ b/src/notation/view/percussionpanel/percussionpanelpadlistmodel.cpp
@@ -101,28 +101,33 @@ void PercussionPanelPadListModel::resetLayout()
 
 QList<PercussionPanelPadModel*> PercussionPanelPadListModel::createDefaultItems()
 {
-    QMap<size_t, QString> dummyInstruments;
-    dummyInstruments.insert(2, "Bass Drum (Kit): Mid");
-    dummyInstruments.insert(0, "Bass Drum (Kit): Low");
-    dummyInstruments.insert(8, "Hi-hat (Kit)");
-    dummyInstruments.insert(17, "Splash (Kit)");
-    dummyInstruments.insert(11, "Tom (Kit): High");
-    dummyInstruments.insert(9, "Tom (Kit): Mid");
-    dummyInstruments.insert(12, "Crash (Kit)");
-    dummyInstruments.insert(3, "Snare (Kit)");
-    dummyInstruments.insert(15, "Ride (Kit)");
-    dummyInstruments.insert(5, "Floor Tom (Kit)");
+    QMap<size_t, PadInfo> dummyPads;
+    dummyPads.insert(2, { "Bass Drum (Kit): Mid", "S", "B2" });
+    dummyPads.insert(0, { "This is a pad with a really long text label that truncates.", "A", "F2" });
+    dummyPads.insert(8, { "Hi-hat (Kit)", "J", "G#2" });
+    dummyPads.insert(17, { "Splash (Kit)", "X", "F3" });
+    dummyPads.insert(11, { "Tom (Kit): High", "L", "A#2" });
+    dummyPads.insert(9, { "Tom (Kit): Mid", "K", "F#2" });
+    dummyPads.insert(12, { "Crash (Kit)", ";", "D#3" });
+    dummyPads.insert(3, { "Snare (Kit)", "D", "D3" });
+    dummyPads.insert(15, { "Ride (Kit)", "Z", "E3" });
+    dummyPads.insert(5, { "Floor Tom (Kit)", "F", "D2" });
 
     // Get the largest key and round up to the nearest multiple of 8
-    size_t maxIndex = dummyInstruments.lastKey();
+    size_t maxIndex = dummyPads.lastKey();
     maxIndex = std::ceil(maxIndex / (double)NUM_COLUMNS) * NUM_COLUMNS;
 
     QList<PercussionPanelPadModel*> padModels;
 
     for (size_t i = 0; i < maxIndex; ++i) {
         PercussionPanelPadModel* model = new PercussionPanelPadModel(this);
-        if (!dummyInstruments.value(i).isEmpty()) {
-            model->setInstrumentName(dummyInstruments.value(i));
+        const PadInfo info = dummyPads.value(i);
+        if (info.isValid()) {
+            model->setInstrumentName(info.instrumentName);
+
+            model->setKeyboardShortcut(info.keyboardShortcut);
+            model->setMidiNote(info.midiNote);
+
             model->setIsEmptySlot(false);
         }
         padModels.append(model);

--- a/src/notation/view/percussionpanel/percussionpanelpadlistmodel.h
+++ b/src/notation/view/percussionpanel/percussionpanelpadlistmodel.h
@@ -64,6 +64,21 @@ private:
         PadModelRole = Qt::UserRole + 1,
     };
 
+    //! NOTE: Probably a placeholder struct...
+    struct PadInfo {
+        QString instrumentName;
+
+        QString keyboardShortcut;
+        QString midiNote;
+
+        bool isEmptySlot = true;
+
+        bool isValid() const
+        {
+            return !instrumentName.isEmpty() && !keyboardShortcut.isEmpty() && !midiNote.isEmpty();
+        }
+    };
+
     void movePad(int fromIndex, int toIndex);
 
     QList<PercussionPanelPadModel*> createDefaultItems();

--- a/src/notation/view/percussionpanel/percussionpanelpadmodel.cpp
+++ b/src/notation/view/percussionpanel/percussionpanelpadmodel.cpp
@@ -37,6 +37,26 @@ void PercussionPanelPadModel::setInstrumentName(const QString& instrumentName)
     emit instrumentNameChanged();
 }
 
+void PercussionPanelPadModel::setKeyboardShortcut(const QString& keyboardShortcut)
+{
+    if (m_keyboardShortcut == keyboardShortcut) {
+        return;
+    }
+
+    m_keyboardShortcut = keyboardShortcut;
+    emit keyboardShortcutChanged();
+}
+
+void PercussionPanelPadModel::setMidiNote(const QString& midiNote)
+{
+    if (m_midiNote == midiNote) {
+        return;
+    }
+
+    m_midiNote = midiNote;
+    emit midiNoteChanged();
+}
+
 void PercussionPanelPadModel::setIsEmptySlot(bool isEmptySlot)
 {
     if (m_isEmptySlot == isEmptySlot) {

--- a/src/notation/view/percussionpanel/percussionpanelpadmodel.h
+++ b/src/notation/view/percussionpanel/percussionpanelpadmodel.h
@@ -28,8 +28,12 @@ class PercussionPanelPadModel : public QObject
 {
     Q_OBJECT
 
-    Q_PROPERTY(QString instrumentName READ instrumentName WRITE setInstrumentName NOTIFY instrumentNameChanged)
-    Q_PROPERTY(bool isEmptySlot READ isEmptySlot WRITE setIsEmptySlot NOTIFY isEmptySlotChanged)
+    Q_PROPERTY(QString instrumentName READ instrumentName NOTIFY instrumentNameChanged)
+
+    Q_PROPERTY(QString keyboardShortcut READ keyboardShortcut NOTIFY keyboardShortcutChanged)
+    Q_PROPERTY(QString midiNote READ midiNote NOTIFY midiNoteChanged)
+
+    Q_PROPERTY(bool isEmptySlot READ isEmptySlot NOTIFY isEmptySlotChanged)
 
 public:
     explicit PercussionPanelPadModel(QObject* parent = nullptr);
@@ -37,14 +41,28 @@ public:
     QString instrumentName() const { return m_instrumentName; }
     void setInstrumentName(const QString& instrumentName);
 
+    QString keyboardShortcut() const { return m_keyboardShortcut; }
+    void setKeyboardShortcut(const QString& keyboardShortcut);
+
+    QString midiNote() const { return m_midiNote; }
+    void setMidiNote(const QString& midiNote);
+
     bool isEmptySlot() const { return m_isEmptySlot; }
     void setIsEmptySlot(bool isEmptySlot);
 
 signals:
     void instrumentNameChanged();
+
+    void keyboardShortcutChanged();
+    void midiNoteChanged();
+
     void isEmptySlotChanged();
 
 private:
-    bool m_isEmptySlot = true;
     QString m_instrumentName;
+
+    QString m_keyboardShortcut;
+    QString m_midiNote;
+
+    bool m_isEmptySlot = true;
 };


### PR DESCRIPTION
Continuing to develop the Percussion Panel Pad UI.

- The pads now have a footer detailing the keyboard shortcuts and MIDI notes used to trigger them (still entirely dummy values for now). 
- A gap was added between the "edit layout" border and the pad content.

The current state of the panel is shown below:

<img width="952" alt="Screenshot 2024-10-02 at 13 30 28" src="https://github.com/user-attachments/assets/e0f01ea2-3aa7-406c-bfe6-69233b28cda7">
<img width="1129" alt="Screenshot 2024-10-02 at 13 30 41" src="https://github.com/user-attachments/assets/cc6c9af6-a800-466e-92ac-f79890ca6c2a">
