### PR TITLE
Fix #23063: MusicXML alter element not exported

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/exportxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/exportxml.cpp
@@ -4168,6 +4168,16 @@ static void writePitch(XmlWriter& xml, const Note* const note, const bool useDru
     if (!alter && alter2) {
         xml.tag("alter", alter2);
     }
+
+    // if alter (from tonal pitch class) and alter2 (from note accidental) are empty we check
+    // if the note has a tuning to add the "alter" tag with tuning value / 100
+    if (!alter && !alter2) {
+        double tuning = note->tuning();
+        if (!muse::RealIsNull(tuning)) {
+            xml.tag("alter", tuning / 100);
+        }
+    }
+
     // TODO what if both alter and alter2 are present? For Example: playing with transposing instruments
     xml.tag(useDrumset ? "display-octave" : "octave", octave);
     xml.endElement();


### PR DESCRIPTION
Resolves: #23063

MusicXML alter element not exported

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
