### PR TITLE
Fix #24985: Ensure newly added instruments are muted in excerpts

### DIFF
--- a/src/playback/internal/playbackcontroller.h
+++ b/src/playback/internal/playbackcontroller.h
@@ -203,6 +203,8 @@ private:
     void removeNonExistingTracks();
     void removeTrack(const engraving::InstrumentTrackId& instrumentTrackId);
 
+    void onTrackNewlyAdded(const engraving::InstrumentTrackId& instrumentTrackId);
+
     muse::audio::secs_t playedTickToSecs(int tick) const;
 
     notation::INotationPtr m_notation;

--- a/src/project/internal/projectaudiosettings.cpp
+++ b/src/project/internal/projectaudiosettings.cpp
@@ -123,6 +123,11 @@ void ProjectAudioSettings::clearTrackInputParams()
     m_settingsChanged.notify();
 }
 
+bool ProjectAudioSettings::trackHasExistingOutputParams(const InstrumentTrackId& partId) const
+{
+    return muse::contains(m_trackOutputParamsMap, partId);
+}
+
 const AudioOutputParams& ProjectAudioSettings::trackOutputParams(const InstrumentTrackId& partId) const
 {
     auto search = m_trackOutputParamsMap.find(partId);

--- a/src/project/internal/projectaudiosettings.h
+++ b/src/project/internal/projectaudiosettings.h
@@ -49,6 +49,7 @@ public:
     void setTrackInputParams(const engraving::InstrumentTrackId& partId, const muse::audio::AudioInputParams& params) override;
     void clearTrackInputParams() override;
 
+    bool trackHasExistingOutputParams(const engraving::InstrumentTrackId& partId) const override;
     const muse::audio::AudioOutputParams& trackOutputParams(const engraving::InstrumentTrackId& partId) const override;
     void setTrackOutputParams(const engraving::InstrumentTrackId& partId, const muse::audio::AudioOutputParams& params) override;
 

--- a/src/project/iprojectaudiosettings.h
+++ b/src/project/iprojectaudiosettings.h
@@ -50,6 +50,7 @@ public:
     virtual void setTrackInputParams(const engraving::InstrumentTrackId& trackId, const muse::audio::AudioInputParams& params) = 0;
     virtual void clearTrackInputParams() = 0;
 
+    virtual bool trackHasExistingOutputParams(const engraving::InstrumentTrackId& trackId) const = 0;
     virtual const muse::audio::AudioOutputParams& trackOutputParams(const engraving::InstrumentTrackId& trackId) const = 0;
     virtual void setTrackOutputParams(const engraving::InstrumentTrackId& trackId, const muse::audio::AudioOutputParams& params) = 0;
 


### PR DESCRIPTION
Resolves: #24985

Bug introduced with #20758

Usually `PlaybackController` is only concerned with the current notation, but in this case we need to iterate through each excerpt and mute the newly added instrument.