### PR TITLE
Fix #23063: (import) MusicXML alter element not exported

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/importmxmlnotepitch.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlnotepitch.cpp
@@ -129,6 +129,7 @@ void MxmlNotePitch::pitch(muse::XmlStreamReader& e)
     // defaults
     m_step = -1;
     m_alter = 0;
+    m_tuning = 0.0;
     m_octave = -1;
 
     while (e.readNextStartElement()) {
@@ -143,6 +144,11 @@ void MxmlNotePitch::pitch(muse::XmlStreamReader& e)
                 if (ok2 && (std::abs(altervalue) < 2.0) && (m_accType == AccidentalType::NONE)) {
                     // try to see if a microtonal accidental is needed
                     m_accType = microtonalGuess(altervalue);
+
+                    // If it's not a microtonal accidental we will use tuning
+                    if (m_accType == AccidentalType::NONE) {
+                        m_tuning = 100 * altervalue;
+                    }
                 }
                 m_alter = 0;
             }

--- a/src/importexport/musicxml/internal/musicxml/importmxmlnotepitch.h
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlnotepitch.h
@@ -48,6 +48,7 @@ public:
     Accidental* acc() const { return m_acc; }
     AccidentalType accType() const { return m_accType; }
     int alter() const { return m_alter; }
+    double tuning() const { return m_tuning; }
     int displayOctave() const { return m_displayOctave; }
     int displayStep() const { return m_displayStep; }
     void displayStepOctave(muse::XmlStreamReader& e);
@@ -59,6 +60,7 @@ private:
     Accidental* m_acc = nullptr;                             // created based on accidental element
     AccidentalType m_accType = AccidentalType::NONE;         // set by pitch() based on alter value (can be microtonal)
     int m_alter = 0;
+    double m_tuning = 0.0;
     int m_displayStep = -1;                                  // invalid
     int m_displayOctave = -1;                                // invalid
     int m_octave = -1;

--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -267,7 +267,7 @@ static int MusicXMLStepAltOct2Pitch(int step, int alter, int octave)
  Note that n's staff and track have not been set yet
  */
 
-static void xmlSetPitch(Note* n, int step, int alter, int octave, const int octaveShift, const Instrument* const instr)
+static void xmlSetPitch(Note* n, int step, int alter, double tuning, int octave, const int octaveShift, const Instrument* const instr)
 {
     //LOGD("xmlSetPitch(n=%p, step=%d, alter=%d, octave=%d, octaveShift=%d)",
     //       n, step, alter, octave, octaveShift);
@@ -289,6 +289,7 @@ static void xmlSetPitch(Note* n, int step, int alter, int octave, const int octa
     int tpc2 = step2tpc(step, AccidentalVal(alter));
     int tpc1 = mu::engraving::transposeTpc(tpc2, intval, true);
     n->setPitch(pitch, tpc1, tpc2);
+    n->setTuning(tuning);
     //LOGD("  pitch=%d tpc1=%d tpc2=%d", n->pitch(), n->tpc1(), n->tpc2());
 }
 
@@ -6401,10 +6402,10 @@ static void setPitch(Note* note, const MusicXMLInstruments& instruments, const S
             note->setTpc(pitch2tpc(unpitched, Key::C, Prefer::NEAREST));             // TODO: necessary ?
         } else {
             //LOGD("disp step %d oct %d", displayStep, displayOctave);
-            xmlSetPitch(note, mnp.displayStep(), 0, mnp.displayOctave(), 0, instrument);
+            xmlSetPitch(note, mnp.displayStep(), 0, 0.0, mnp.displayOctave(), 0, instrument);
         }
     } else {
-        xmlSetPitch(note, mnp.step(), mnp.alter(), mnp.octave(), octaveShift, instrument);
+        xmlSetPitch(note, mnp.step(), mnp.alter(), mnp.tuning(), mnp.octave(), octaveShift, instrument);
     }
 }
 


### PR DESCRIPTION
Resolves: #23063

Imports a MusicXML exported with alter elements 

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
