### PR TITLE
Fix #24791: Only allow image resizing with grips

### DIFF
--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -754,7 +754,7 @@ void NotationViewInputController::handleLeftClick(const ClickContext& ctx)
 
     bool hitElementIsAlreadyBeingEdited = viewInteraction()->isElementEditStarted() && viewInteraction()->editedItem() == ctx.hitElement;
     if (!selection->isRange() && ctx.hitElement && ctx.hitElement->needStartEditingAfterSelecting() && !hitElementIsAlreadyBeingEdited) {
-        if (ctx.hitElement->hasGrips() && selection->elements().size() == 1) {
+        if (ctx.hitElement->hasGrips() && !ctx.hitElement->isImage() && selection->elements().size() == 1) {
             viewInteraction()->startEditGrip(ctx.hitElement, ctx.hitElement->gripsCount() > 4 ? Grip::DRAG : Grip::MIDDLE);
         } else {
             viewInteraction()->startEditElement(ctx.hitElement, false);


### PR DESCRIPTION
Resolves: #24791

Issue has evolved slightly, but images are an exception to the rule outlined in [this commit](https://github.com/musescore/MuseScore/pull/23343/commits/fa28ceb1f2aa57c74881df8ecdb5f056e0f97a45).