### PR TITLE
Fix inferring measure rests & read the measure attribute

### DIFF
--- a/src/importexport/musicxml/tests/data/testArpOnRest_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testArpOnRest_ref.mscx
@@ -147,7 +147,8 @@
             <sigD>4</sigD>
             </TimeSig>
           <Rest>
-            <durationType>whole</durationType>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
             </Rest>
           <BarLine>
             <subtype>end</subtype>

--- a/src/importexport/musicxml/tests/data/testImportDrums_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testImportDrums_ref.mscx
@@ -370,14 +370,16 @@
       <Measure>
         <voice>
           <Rest>
-            <durationType>whole</durationType>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
         <voice>
           <Rest>
-            <durationType>whole</durationType>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
             </Rest>
           <BarLine>
             <subtype>end</subtype>

--- a/src/importexport/musicxml/tests/data/testIncompleteTuplet_ref.xml
+++ b/src/importexport/musicxml/tests/data/testIncompleteTuplet_ref.xml
@@ -54,20 +54,18 @@
           </clef>
         </attributes>
       <note>
-        <rest/>
+        <rest measure="yes"/>
         <duration>36</duration>
         <voice>1</voice>
-        <type>whole</type>
         <staff>1</staff>
         </note>
       <backup>
         <duration>36</duration>
         </backup>
       <note>
-        <rest/>
+        <rest measure="yes"/>
         <duration>36</duration>
         <voice>5</voice>
-        <type>whole</type>
         <staff>2</staff>
         </note>
       </measure>
@@ -243,10 +241,9 @@
         <duration>36</duration>
         </backup>
       <note>
-        <rest/>
+        <rest measure="yes"/>
         <duration>36</duration>
         <voice>5</voice>
-        <type>whole</type>
         <staff>2</staff>
         </note>
       <barline location="right">

--- a/src/importexport/musicxml/tests/data/testNoteAttributes1.xml
+++ b/src/importexport/musicxml/tests/data/testNoteAttributes1.xml
@@ -169,10 +169,9 @@
       </measure>
     <measure number="3">
       <note>
-        <rest/>
+        <rest measure="yes"/>
         <duration>4</duration>
         <voice>1</voice>
-        <type>whole</type>
         <notations>
           <fermata type="upright"/>
           </notations>

--- a/src/importexport/musicxml/tests/data/testNotesRests1.xml
+++ b/src/importexport/musicxml/tests/data/testNotesRests1.xml
@@ -232,10 +232,9 @@
       </measure>
     <measure number="3">
       <note>
-        <rest/>
+        <rest measure="yes"/>
         <duration>64</duration>
         <voice>1</voice>
-        <type>whole</type>
         </note>
       <backup>
         <duration>64</duration>

--- a/src/importexport/musicxml/tests/data/testRestNotations_ref.xml
+++ b/src/importexport/musicxml/tests/data/testRestNotations_ref.xml
@@ -49,26 +49,23 @@
           </clef>
         </attributes>
       <note>
-        <rest/>
+        <rest measure="yes"/>
         <duration>4</duration>
         <voice>1</voice>
-        <type>whole</type>
         </note>
       </measure>
     <measure number="2">
       <note>
-        <rest/>
+        <rest measure="yes"/>
         <duration>4</duration>
         <voice>1</voice>
-        <type>whole</type>
         </note>
       </measure>
     <measure number="3">
       <note>
-        <rest/>
+        <rest measure="yes"/>
         <duration>4</duration>
         <voice>1</voice>
-        <type>whole</type>
         </note>
       </measure>
     <measure number="4">
@@ -87,10 +84,9 @@
       </measure>
     <measure number="5">
       <note>
-        <rest/>
+        <rest measure="yes"/>
         <duration>4</duration>
         <voice>1</voice>
-        <type>whole</type>
         </note>
       <barline location="right">
         <bar-style>light-heavy</bar-style>


### PR DESCRIPTION
Resolves: #25012 
This PR fixes inference of measure rests for Finale files.  Previously, rests the same length as their measure weren't inferred as measure rests if the measure was in 4/4.

I've also added the ability to read the `measure` attribute of the [rest tag](https://www.w3.org/2021/06/musicxml40/musicxml-reference/elements/rest/) which is the preferred way of signifying this.