### PR TITLE
Update automatic issue assignment

### DIFF
--- a/.github/issue_assign_by_label_config.yml
+++ b/.github/issue_assign_by_label_config.yml
@@ -1,5 +1,3 @@
-corruption:
-- cbjeukendrup
 crash:
 - RomanPudashkin
 - DmitryArefiev
@@ -12,10 +10,6 @@ VST:
 - matthewreadbass
 playback:
 - RomanPudashkin
-UI:
-- Eism
-accessibility:
-- Eism
 cloud:
 - shoogle
 - cbjeukendrup


### PR DESCRIPTION
- There were times that corruption issues were often investigated by me, but nowadays they are probably best handled by the engraving team. So corruption issues are no longer auto-assigned.
- UI and accessibility issues were automatically assigned to Elnur, but he is working mostly on Audacity nowadays. So UI and accessibility issues are also no longer auto-assigned. 

Since every issue is looked at anyway during our triage sessions, these automatic assignments is not really necessary anymore. 