### PR TITLE
AppImage: package `libEGL.so.1` as fallback library

### DIFF
--- a/buildscripts/ci/linux/tools/make_appimage.sh
+++ b/buildscripts/ci/linux/tools/make_appimage.sh
@@ -251,19 +251,20 @@ fi
 fallback_libraries=(
   libjack.so.0 # https://github.com/LMMS/lmms/pull/3958
   libOpenGL.so.0 # https://bugreports.qt.io/browse/QTBUG-89754
+  libEGL.so.1 # not installed on GitHub Actions Ubuntu, so maybe missing elsewhere too
 )
 
 # PREVIOUSLY EXTRACTED APPIMAGES
 # These include their own dependencies. We bundle them uncompressed to avoid
 # creating a double layer of compression (AppImage inside AppImage).
 if [[ "${UPDATE_INFORMATION}" ]]; then
-extracted_appimages=(
-  appimageupdatetool
-)
+  extracted_appimages=(
+    appimageupdatetool
+  )
 else
-extracted_appimages=(
-  # none
-)
+  extracted_appimages=(
+    # none
+  )
 fi
 
 for file in "${unwanted_files[@]}"; do

--- a/buildscripts/ci/vtests/generate_pngs.sh
+++ b/buildscripts/ci/vtests/generate_pngs.sh
@@ -21,7 +21,6 @@
 
 trap 'echo Generate PNGs failed; exit 1' ERR
 
-sudo apt-get install libegl1 -y
 export QT_QPA_PLATFORM=offscreen
 
 REF_BIN=./musescore_reference/MuseScore-Studio-vtest.AppImage


### PR DESCRIPTION
GitHub Actions Ubuntu doesn't have it, so perhaps other systems also don't have it. 
I'm not sure though whether we should do this. @shoogle what do you think?