### PR TITLE
fix: do not write color attribute on space elements

### DIFF
--- a/src/importexport/mei/internal/meiexporter.cpp
+++ b/src/importexport/mei/internal/meiexporter.cpp
@@ -1341,8 +1341,10 @@ bool MeiExporter::writeRest(const Rest* rest, const Staff* staff)
         if (rest->dots()) {
             meiRest.SetDots(rest->dots());
         }
-        Convert::colorToMEI(rest, meiRest);
-        this->writeBeamTypeAtt(rest, meiRest);
+        if (rest->visible()) {
+            Convert::colorToMEI(rest, meiRest);
+            this->writeBeamTypeAtt(rest, meiRest);
+        }
         this->writeStaffIdentAtt(rest, staff, meiRest);
         // this->writeVerses(rest);
         const char prefix = (rest->visible()) ? 'r' : 's';


### PR DESCRIPTION
Small fix to prevent output of invalid MEI. Previously a colored rest made invisible lead to a `space` element with a forbidden color attribute.

pinging @lpugin 