### PR TITLE
Ensure that insivible spanner segments aren't drawn

### DIFF
--- a/src/engraving/dom/engravingitem.cpp
+++ b/src/engraving/dom/engravingitem.cpp
@@ -247,7 +247,7 @@ double EngravingItem::spatium() const
 
 bool EngravingItem::isInteractionAvailable() const
 {
-    if (!visible() && (score()->printing() || !score()->isShowInvisible())) {
+    if (!getProperty(Pid::VISIBLE).toBool() && (score()->printing() || !score()->isShowInvisible())) {
         return false;
     }
 
@@ -622,7 +622,7 @@ Color EngravingItem::color() const
 
 Color EngravingItem::curColor() const
 {
-    return curColor(visible());
+    return curColor(getProperty(Pid::VISIBLE).toBool());
 }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Resolves: #16396 

Using getProperty(Pid::VISIBLE) instead of visible() ensures that spanners segments return the property of the spanner (via the PropertyDelegate method).