### PR TITLE
Fix crash on hidden stave grace notes

### DIFF
--- a/src/engraving/rendering/score/tlayout.cpp
+++ b/src/engraving/rendering/score/tlayout.cpp
@@ -2947,7 +2947,7 @@ void TLayout::layoutGraceNotesGroup(GraceNotesGroup* item, LayoutContext& ctx)
         double offset;
         offset = -std::max(HorizontalSpacing::minHorizontalDistance(graceShape, groupShape, grace->spatium()), 0.0);
         // Adjust spacing for cross-beam situations
-        if (i < item->size() - 1) {
+        if (i < item->size() - 1 && grace->stem()) {
             Chord* prevGrace = item->at(i + 1);
             if (prevGrace->up() != grace->up()) {
                 double crossCorrection = grace->notes().front()->headWidth() - grace->stem()->width();


### PR DESCRIPTION
Resolves: #24862 

This fix is intended for the patch release. We can do a better fix later where this layout call is avoided completely as it's on a hidden staff.
