### PR TITLE
Refactor and fix nightly builds

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -1,4 +1,5 @@
-name: 'Build: All'
+name: "Build: All"
+run-name: "Build: All - ${{ inputs.build_mode }}"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/build_backend.yml
+++ b/.github/workflows/build_backend.yml
@@ -30,6 +30,7 @@ on:
 jobs:
   backend:
     runs-on: ubuntu-20.04
+    if: github.event_name != 'schedule' || github.repository == 'musescore/MuseScore'
     steps:
     - name: Cancel Previous Runs
       uses: styfle/cancel-workflow-action@0.12.1

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -2,9 +2,6 @@ name: 'Build: Linux'
 
 on:
   pull_request:
-  schedule:
-    - cron: '0 3 */1 */1 *' # At 03:00 on every day-of-month for master
-    - cron: '0 5 */1 */1 *' # At 05:00 on every day-of-month for current release branch
   workflow_dispatch:
     inputs:
       build_mode:
@@ -37,32 +34,17 @@ on:
         type: string
         required: false
 
-env:
-  CURRENT_RELEASE_BRANCH: 4.4.3
-
 jobs:
   linux_x64:
     runs-on: ubuntu-20.04
-    if: github.event_name != 'schedule' || github.repository == 'musescore/MuseScore'
     steps:
     - name: Cancel Previous Runs
       uses: styfle/cancel-workflow-action@0.12.1
       with:
         access_token: ${{ github.token }}
-    - name: Exit if current release branch configuration is incorrect
-      if: ${{ github.event_name == 'schedule' && github.event.schedule == '0 5 */1 */1 *' && env.CURRENT_RELEASE_BRANCH == '' }}
-      run: |
-        echo "::error::CURRENT_RELEASE_BRANCH is empty"
-        exit 1
-    - name: Clone repository (default)
+    - name: Clone repository
       uses: actions/checkout@v4
-      if: ${{ github.event_name != 'schedule' || github.event.schedule == '0 3 */1 */1 *' }}
-    - name: Clone repository (${{ env.CURRENT_RELEASE_BRANCH }})
-      uses: actions/checkout@v4
-      if: ${{ github.event_name == 'schedule' && github.event.schedule == '0 5 */1 */1 *' }}
-      with:
-        ref: ${{ env.CURRENT_RELEASE_BRANCH }}
-    - name: "Configure workflow"
+    - name: Configure workflow
       env:
         pull_request_title: ${{ github.event.pull_request.title }}
         SENTRY_SERVER_MU4_KEY: ${{ secrets.SENTRY_SERVER_MU4_KEY }}
@@ -113,7 +95,7 @@ jobs:
         fi
 
         DO_PUBLISH='false'
-        if [[ "${{ inputs.publish }}" == "on" || ("${{ github.event_name }}" == "schedule" && $BUILD_MODE == 'nightly') ]]; then
+        if [ "${{ inputs.publish }}" == "on" ]; then
           DO_PUBLISH='true'
           if [ -z "${{ secrets.OSUOSL_SSH_ENCRYPT_SECRET }}" ]; then
             echo "::warning::OSUOSL_SSH_ENCRYPT_SECRET is empty; not publishing to OSUOSL"
@@ -122,8 +104,9 @@ jobs:
         fi
 
         ADD_INFO="_${GITHUB_REF#refs/heads/}"
-        if [ "${{ github.event_name }}" == "schedule" ] && [ "${{ github.event.schedule }}" == "0 5 */1 */1 *" ]; then ADD_INFO="_${{ env.CURRENT_RELEASE_BRANCH }}"; fi
-        if [ "${{ github.event_name }}" == "pull_request" ]; then ADD_INFO="_${{ github.event.pull_request.number }}_${pull_request_title}"; fi
+        if [ "${{ github.event_name }}" == "pull_request" ]; then
+          ADD_INFO="_${{ github.event.pull_request.number }}_${pull_request_title}"
+        fi
         UPLOAD_ARTIFACT_NAME="$(tr '":<>|*?/\\’' '_' <<<"MU4_${BUILD_NUMBER}_Lin${ADD_INFO}")"
 
         echo "github.repository: ${{ github.repository }}"

--- a/.github/workflows/build_linux_arm.yml
+++ b/.github/workflows/build_linux_arm.yml
@@ -135,25 +135,29 @@ jobs:
         echo "DO_PUBLISH=$DO_PUBLISH" | tee -a $GITHUB_ENV
         echo "UPLOAD_ARTIFACT_NAME=$UPLOAD_ARTIFACT_NAME" | tee -a $GITHUB_ENV
 
-    - name: Generate _en.ts files
-      env:
-        LUPDATE_ARGS: ""
-        POSTPROCESS_ARGS: ${{ env.DO_PLACEHOLDER_TRANSLATIONS == 'true' && '--generate-placeholder-translations' || '' }}
-      run: |
-        bash ./buildscripts/ci/translation/run_lupdate.sh
+    # - name: Generate _en.ts files
+    #   env:
+    #     LUPDATE_ARGS: ""
+    #     POSTPROCESS_ARGS: ${{ env.DO_PLACEHOLDER_TRANSLATIONS == 'true' && '--generate-placeholder-translations' || '' }}
+    #   run: |
+    #     bash ./buildscripts/ci/translation/run_lupdate.sh
     - name: Update .ts files
       if: env.DO_UPDATE_TS == 'true'
       run: |
         bash ./buildscripts/ci/translation/tx_install.sh -t ${{ secrets.TRANSIFEX_API_TOKEN }} -s linux
         bash ./buildscripts/ci/translation/tx_pull.sh
 
-    - name: Setup, Generate, Update, Build the AppImage
+    - name: Setup, Generate _en.ts files, Build AppImage, Package, Checksum
+      env: # For lupdate
+        LUPDATE_ARGS: ""
+        POSTPROCESS_ARGS: ${{ env.DO_PLACEHOLDER_TRANSLATIONS == 'true' && '--generate-placeholder-translations' || '' }}
       run: |
         C_URL=${SENTRY_URL}; if [ -z "$C_URL" ]; then C_URL="''"; fi
 
         sudo docker run -i -v "${PWD}:/MuseScore" -v /usr/bin/qemu-arm-static:/usr/bin/qemu-arm-static "arm32v7/ubuntu:jammy" /bin/bash -c "\
           cd /MuseScore && \
           bash /MuseScore/buildscripts/ci/linux/setup-arm.sh --arch armv7l && \
+          bash /MuseScore/buildscripts/ci/translation/run_lupdate.sh && \
           bash /MuseScore/buildscripts/ci/linux/build.sh -n ${{ env.BUILD_NUMBER }} --crash_log_url $C_URL --arch armv7l && \
           bash /MuseScore/buildscripts/ci/linux/package.sh --arch armv7l && \
           bash /MuseScore/buildscripts/ci/tools/checksum.sh \
@@ -257,25 +261,29 @@ jobs:
         echo "DO_PUBLISH=$DO_PUBLISH" | tee -a "${GITHUB_ENV}"
         echo "UPLOAD_ARTIFACT_NAME=$UPLOAD_ARTIFACT_NAME" | tee -a "${GITHUB_ENV}"
 
-    - name: Generate _en.ts files
-      env:
-        LUPDATE_ARGS: ""
-        POSTPROCESS_ARGS: ${{ env.DO_PLACEHOLDER_TRANSLATIONS == 'true' && '--generate-placeholder-translations' || '' }}
-      run: |
-        bash ./buildscripts/ci/translation/run_lupdate.sh
+    # - name: Generate _en.ts files
+    #   env:
+    #     LUPDATE_ARGS: ""
+    #     POSTPROCESS_ARGS: ${{ env.DO_PLACEHOLDER_TRANSLATIONS == 'true' && '--generate-placeholder-translations' || '' }}
+    #   run: |
+    #     bash ./buildscripts/ci/translation/run_lupdate.sh
     - name: Update .ts files
       if: env.DO_UPDATE_TS == 'true'
       run: |
         bash ./buildscripts/ci/translation/tx_install.sh -t ${{ secrets.TRANSIFEX_API_TOKEN }} -s linux
         bash ./buildscripts/ci/translation/tx_pull.sh
 
-    - name: Setup, Generate, Update, Build the AppImage
+    - name: Setup, Generate _en.ts files, Build AppImage, Package, Checksum
+      env: # For lupdate
+        LUPDATE_ARGS: ""
+        POSTPROCESS_ARGS: ${{ env.DO_PLACEHOLDER_TRANSLATIONS == 'true' && '--generate-placeholder-translations' || '' }}
       run: |
         C_URL=${SENTRY_URL}; if [ -z "$C_URL" ]; then C_URL="''"; fi
 
         sudo docker run -i -v "${PWD}:/MuseScore" -v /usr/bin/qemu-aarch64-static:/usr/bin/qemu-aarch64-static "arm64v8/ubuntu:jammy" /bin/bash -c "\
           cd /MuseScore && \
           bash /MuseScore/buildscripts/ci/linux/setup-arm.sh --arch aarch64 && \
+          bash /MuseScore/buildscripts/ci/translation/run_lupdate.sh && \
           bash /MuseScore/buildscripts/ci/linux/build.sh -n ${{ env.BUILD_NUMBER }} --crash_log_url $C_URL --arch aarch64 && \
           bash /MuseScore/buildscripts/ci/linux/package.sh --arch aarch64 && \
           bash /MuseScore/buildscripts/ci/tools/checksum.sh \

--- a/.github/workflows/build_linux_arm.yml
+++ b/.github/workflows/build_linux_arm.yml
@@ -2,9 +2,6 @@ name: 'Build: Linux ARM'
 
 on:
   # pull_request:
-  schedule:
-    - cron: '0 3 */1 */1 *' # At 03:00 on every day-of-month for master
-    # - cron: '0 3 */1 */1 *' # At 05:00 on every day-of-month for current release branch
   workflow_dispatch:
     inputs:
       platforms:
@@ -46,39 +43,23 @@ on:
         type: string
         required: false
 
-#env:
-#  CURRENT_RELEASE_BRANCH: 4.4.3
-
 jobs:
 
   linux_arm32:
-    if: |
-      (github.event_name != 'workflow_dispatch' || contains(inputs.platforms, 'linux_arm32')) &&
-      (github.event_name != 'schedule' || github.repository == 'musescore/MuseScore')
+    if: github.event_name != 'workflow_dispatch' || contains(inputs.platforms, 'linux_arm32')
     runs-on: ubuntu-22.04
     steps:
     - name: Cancel Previous Runs
       uses: styfle/cancel-workflow-action@0.12.1
       with:
         access_token: ${{ github.token }}
-    - name: Exit if current release branch configuration is incorrect
-      if: ${{ github.event_name == 'schedule' && github.event.schedule == '0 5 */1 */1 *' && env.CURRENT_RELEASE_BRANCH == '' }}
-      run: |
-        echo "::error::CURRENT_RELEASE_BRANCH is empty"
-        exit 1
-    - name: Clone repository (default)
+    - name: Clone repository
       uses: actions/checkout@v4
-      if: ${{ github.event_name != 'schedule' || github.event.schedule == '0 3 */1 */1 *' }}
-    - name: Clone repository (${{ env.CURRENT_RELEASE_BRANCH }})
-      uses: actions/checkout@v4
-      if: ${{ github.event_name == 'schedule' && github.event.schedule == '0 5 */1 */1 *' }}
-      with:
-        ref: ${{ env.CURRENT_RELEASE_BRANCH }}
-    - name: setup QEMU
+    - name: Setup QEMU
       run: |
         sudo apt-get update
         sudo apt-get install qemu-user-static -y
-    - name: "Configure workflow"
+    - name: Configure workflow
       env:
         pull_request_title: ${{ github.event.pull_request.title }}
         SENTRY_SERVER_MU4_KEY: ${{ secrets.SENTRY_SERVER_MU4_KEY }}
@@ -129,7 +110,7 @@ jobs:
         fi
 
         DO_PUBLISH='false'
-        if ${{ inputs.publish == 'on' }} || (${{github.event_name == 'schedule'}} && [ $BUILD_MODE == 'nightly' ]); then
+        if [ ${{ inputs.publish }} == "on" ]; then
           DO_PUBLISH='true'
           if [ -z "${{ secrets.OSUOSL_SSH_ENCRYPT_SECRET }}" ]; then
             echo "::warning::OSUOSL_SSH_ENCRYPT_SECRET is empty; not publishing to OSUOSL"
@@ -138,8 +119,9 @@ jobs:
         fi
 
         ADD_INFO="_${GITHUB_REF#refs/heads/}"
-        if [ "${{ github.event_name }}" == "schedule" ] && [ "${{ github.event.schedule }}" == "0 5 */1 */1 *" ]; then ADD_INFO="_${CURRENT_RELEASE_BRANCH}"; fi
-        if [ "${{ github.event_name }}" == "pull_request" ]; then ADD_INFO="_${{ github.event.pull_request.number }}_${pull_request_title}"; fi
+        if [ "${{ github.event_name }}" == "pull_request" ]; then
+          ADD_INFO="_${{ github.event.pull_request.number }}_${pull_request_title}"
+        fi
         UPLOAD_ARTIFACT_NAME="$(tr '":<>|*?/\\’' '_' <<<"MU4_${BUILD_NUMBER}_Lin_armv7l${ADD_INFO}")"
 
         echo "github.repository: ${{ github.repository }}"
@@ -199,33 +181,20 @@ jobs:
         path: ./build.artifacts/
 
   linux_arm64:
-    if: |
-      (github.event_name != 'workflow_dispatch' || contains(inputs.platforms, 'linux_arm64')) &&
-      (github.event_name != 'schedule' || github.repository == 'musescore/MuseScore')
+    if: github.event_name != 'workflow_dispatch' || contains(inputs.platforms, 'linux_arm64')
     runs-on: ubuntu-22.04
     steps:
     - name: Cancel Previous Runs
       uses: styfle/cancel-workflow-action@0.12.1
       with:
         access_token: ${{ github.token }}
-    - name: Exit if current release branch configuration is incorrect
-      if: ${{ github.event_name == 'schedule' && github.event.schedule == '0 5 */1 */1 *' && env.CURRENT_RELEASE_BRANCH == '' }}
-      run: |
-        echo "::error::CURRENT_RELEASE_BRANCH is empty"
-        exit 1
-    - name: Clone repository (default)
+    - name: Clone repository
       uses: actions/checkout@v4
-      if: ${{ github.event_name != 'schedule' || github.event.schedule == '0 3 */1 */1 *' }}
-    - name: Clone repository (${{ env.CURRENT_RELEASE_BRANCH }})
-      uses: actions/checkout@v4
-      if: ${{ github.event_name == 'schedule' && github.event.schedule == '0 5 */1 */1 *' }}
-      with:
-        ref: ${{ env.CURRENT_RELEASE_BRANCH }}
-    - name: setup QEMU
+    - name: Setup QEMU
       run: |
         sudo apt-get update
         sudo apt-get install qemu-user-static -y
-    - name: "Configure workflow"
+    - name: Configure workflow
       env:
         pull_request_title: ${{ github.event.pull_request.title }}
       run: |
@@ -263,7 +232,7 @@ jobs:
         fi
 
         DO_PUBLISH='false'
-        if [[ "${{ inputs.publish }}" == "on" || ("${{ github.event_name }}" == "schedule" && $BUILD_MODE == 'nightly') ]]; then
+        if [ "${{ inputs.publish }}" == "on" ]; then
           DO_PUBLISH='true'
           if [ -z "${{ secrets.OSUOSL_SSH_ENCRYPT_SECRET }}" ]; then
             echo "::warning::OSUOSL_SSH_ENCRYPT_SECRET is empty; not publishing to OSUOSL"
@@ -272,8 +241,9 @@ jobs:
         fi
 
         ADD_INFO="_${GITHUB_REF#refs/heads/}"
-        if [ "${{ github.event_name }}" == "schedule" ] && [ "${{ github.event.schedule }}" == "0 5 */1 */1 *" ]; then ADD_INFO="_${CURRENT_RELEASE_BRANCH}"; fi
-        if [ "${{ github.event_name }}" == "pull_request" ]; then ADD_INFO="_${{ github.event.pull_request.number }}_${pull_request_title}"; fi
+        if [ "${{ github.event_name }}" == "pull_request" ]; then
+          ADD_INFO="_${{ github.event.pull_request.number }}_${pull_request_title}"
+        fi
         UPLOAD_ARTIFACT_NAME="$(tr '":<>|*?/\\’' '_' <<<"MU4_${BUILD_NUMBER}_Lin_aarch64${ADD_INFO}")"
 
         echo "github.repository: ${{ github.repository }}"

--- a/.github/workflows/build_linux_arm.yml
+++ b/.github/workflows/build_linux_arm.yml
@@ -154,8 +154,11 @@ jobs:
       run: |
         C_URL=${SENTRY_URL}; if [ -z "$C_URL" ]; then C_URL="''"; fi
 
+        # Re. `export QT_SELECT=qt6`, see https://askubuntu.com/questions/1460242/ubuntu-22-04-with-qt6-qmake-could-not-find-a-qt-installation-of
+        # and accompanying `qtchooser` comment in `buildscripts/ci/linux/setup-arm.sh`.
         sudo docker run -i -v "${PWD}:/MuseScore" -v /usr/bin/qemu-arm-static:/usr/bin/qemu-arm-static "arm32v7/ubuntu:jammy" /bin/bash -c "\
           cd /MuseScore && \
+          export QT_SELECT=qt6 && \
           bash /MuseScore/buildscripts/ci/linux/setup-arm.sh --arch armv7l && \
           bash /MuseScore/buildscripts/ci/translation/run_lupdate.sh && \
           bash /MuseScore/buildscripts/ci/linux/build.sh -n ${{ env.BUILD_NUMBER }} --crash_log_url $C_URL --arch armv7l && \
@@ -280,8 +283,11 @@ jobs:
       run: |
         C_URL=${SENTRY_URL}; if [ -z "$C_URL" ]; then C_URL="''"; fi
 
+        # Re. `export QT_SELECT=qt6`, see https://askubuntu.com/questions/1460242/ubuntu-22-04-with-qt6-qmake-could-not-find-a-qt-installation-of
+        # and accompanying `qtchooser` comment in `buildscripts/ci/linux/setup-arm.sh`.
         sudo docker run -i -v "${PWD}:/MuseScore" -v /usr/bin/qemu-aarch64-static:/usr/bin/qemu-aarch64-static "arm64v8/ubuntu:jammy" /bin/bash -c "\
           cd /MuseScore && \
+          export QT_SELECT=qt6 && \
           bash /MuseScore/buildscripts/ci/linux/setup-arm.sh --arch aarch64 && \
           bash /MuseScore/buildscripts/ci/translation/run_lupdate.sh && \
           bash /MuseScore/buildscripts/ci/linux/build.sh -n ${{ env.BUILD_NUMBER }} --crash_log_url $C_URL --arch aarch64 && \

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -2,9 +2,6 @@ name: 'Build: macOS'
 
 on:
   pull_request:
-  schedule:
-    - cron: '0 3 */1 */1 *' # At 03:00 on every day-of-month for master
-    - cron: '0 5 */1 */1 *' # At 05:00 on every day-of-month for current release branch
   workflow_dispatch:
     inputs:
       build_mode:
@@ -38,32 +35,20 @@ on:
         required: false
 
 env:
-  CURRENT_RELEASE_BRANCH: 4.4.3
   DEVELOPER_DIR: /Applications/Xcode_15.4.app/Contents/Developer
 
 jobs:
   macos_universal:
     runs-on: macos-latest
-    if: github.event_name != 'schedule' || github.repository == 'musescore/MuseScore'
     steps:
     - name: Cancel Previous Runs
       uses: styfle/cancel-workflow-action@0.12.1
       with:
         access_token: ${{ github.token }}
-    - name: Exit if current release branch configuration is incorrect
-      if: ${{ github.event_name == 'schedule' && github.event.schedule == '0 5 */1 */1 *' && env.CURRENT_RELEASE_BRANCH == '' }}
-      run: |
-        echo "::error::CURRENT_RELEASE_BRANCH is empty"
-        exit 1
-    - name: Clone repository (default)
+    - name: Clone repository
       uses: actions/checkout@v4
-      if: ${{ github.event_name != 'schedule' || github.event.schedule == '0 3 */1 */1 *' }}
-    - name: Clone repository (${{ env.CURRENT_RELEASE_BRANCH }})
-      uses: actions/checkout@v4
-      if: ${{ github.event_name == 'schedule' && github.event.schedule == '0 5 */1 */1 *' }}
-      with:
-        ref: ${{ env.CURRENT_RELEASE_BRANCH }}
-    - name: "Configure workflow"
+
+    - name: Configure workflow
       env:
         pull_request_title: ${{ github.event.pull_request.title }}
         SENTRY_SERVER_MU4_KEY: ${{ secrets.SENTRY_SERVER_MU4_KEY }}
@@ -127,7 +112,7 @@ jobs:
         fi
 
         DO_PUBLISH='false'
-        if [[ "${{ inputs.publish }}" == "on" || ("${{ github.event_name }}" == "schedule" && $BUILD_MODE == 'nightly') ]]; then
+        if [ "${{ inputs.publish }}" == "on" ]; then
           DO_PUBLISH='true'
           if [ -z "${{ secrets.OSUOSL_SSH_ENCRYPT_SECRET }}" ]; then
             echo "::warning::OSUOSL_SSH_ENCRYPT_SECRET is empty; not publishing to OSUOSL"
@@ -136,8 +121,9 @@ jobs:
         fi
 
         ADD_INFO="_${GITHUB_REF#refs/heads/}"
-        if [ "${{ github.event_name }}" == "schedule" ] && [ "${{ github.event.schedule }}" == "0 5 */1 */1 *" ]; then ADD_INFO="_${CURRENT_RELEASE_BRANCH}"; fi
-        if [ "${{ github.event_name }}" == "pull_request" ]; then ADD_INFO="_${{ github.event.pull_request.number }}_${pull_request_title}"; fi
+        if [ "${{ github.event_name }}" == "pull_request" ]; then
+          ADD_INFO="_${{ github.event.pull_request.number }}_${pull_request_title}"
+        fi
         UPLOAD_ARTIFACT_NAME="$(tr '":<>|*?/\\’' '_' <<<"MU4_${BUILD_NUMBER}_Mac${ADD_INFO}")"
 
         echo "github.repository: ${{ github.repository }}"

--- a/.github/workflows/build_nightly.yml
+++ b/.github/workflows/build_nightly.yml
@@ -1,0 +1,53 @@
+name: "Build: Nightly"
+run-name: "${{ github.event.schedule == '0 3 * * *' && 'Build: Nightly - master branch' || 'Build: Nightly - current release branch' }}"
+
+on:
+  schedule:
+    - cron: "0 3 * * *" # Every night at 03:00 for master branch
+    - cron: "0 4 * * *" # Every night at 04:00 for current release branch
+  workflow_dispatch:
+
+permissions:
+  actions: write
+
+env:
+  CURRENT_RELEASE_BRANCH: 4.4.3
+  IS_CURRENT_RELEASE_BRANCH: ${{ github.event.schedule == '0 4 * * *' && 'true' || 'false' }}
+
+jobs:
+  trigger_nightly:
+    name: "Trigger nightly builds"
+    if: github.event_name != 'schedule' || github.repository == 'musescore/MuseScore'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger nightly builds
+        uses: actions/github-script@v7
+        with:
+          script: |
+            let ref;
+            if (context.eventName == 'schedule') {
+              if (process.env.IS_CURRENT_RELEASE_BRANCH == 'true') {
+                ref = process.env.CURRENT_RELEASE_BRANCH;
+                if (!ref) {
+                  core.notice('CURRENT_RELEASE_BRANCH is empty; exiting');
+                  return;
+                }
+              } else {
+                ref = 'master';
+              }
+            } else {
+              ref = context.ref.replace(/^(refs\/heads\/)/, "");
+            }
+
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'build_all.yml',
+              ref: ref,
+              inputs: {
+                platforms: 'linux_arm32 linux_arm64 linux_x64 macos windows_x64 windows_portable',
+                build_mode: 'nightly',
+                publish: 'on',
+                sentry_project: 'sandbox'
+              }
+            })

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -2,9 +2,6 @@ name: 'Build: Windows'
 
 on:
   pull_request:
-  schedule:
-    - cron: '0 3 */1 */1 *' # At 03:00 on every day-of-month for master
-    - cron: '0 5 */1 */1 *' # At 05:00 on every day-of-month for current release branch
   workflow_dispatch:
     inputs:
       platforms:
@@ -46,35 +43,19 @@ on:
         type: string
         required: false
 
-env:
-  CURRENT_RELEASE_BRANCH: 4.4.3
-
 jobs:
 
   windows_x64:
-    if: |
-      (github.event_name != 'workflow_dispatch' || contains(inputs.platforms, 'windows_x64')) &&
-      (github.event_name != 'schedule' || github.repository == 'musescore/MuseScore')
+    if: github.event_name != 'workflow_dispatch' || contains(inputs.platforms, 'windows_x64')
     runs-on: windows-2022
     steps:
     - name: Cancel Previous Runs
       uses: styfle/cancel-workflow-action@0.12.1
       with:
         access_token: ${{ github.token }}
-    - name: Exit if current release branch configuration is incorrect
-      if: ${{ github.event_name == 'schedule' && github.event.schedule == '0 5 */1 */1 *' && env.CURRENT_RELEASE_BRANCH == '' }}
-      run: |
-        echo "::error::CURRENT_RELEASE_BRANCH is empty"
-        exit 1
-    - name: Clone repository (default)
+    - name: Clone repository
       uses: actions/checkout@v4
-      if: ${{ github.event_name != 'schedule' || github.event.schedule == '0 3 */1 */1 *' }}
-    - name: Clone repository (${{ env.CURRENT_RELEASE_BRANCH }})
-      uses: actions/checkout@v4
-      if: ${{ github.event_name == 'schedule' && github.event.schedule == '0 5 */1 */1 *' }}
-      with:
-        ref: ${{ env.CURRENT_RELEASE_BRANCH }}
-    - name: "Configure workflow"
+    - name: Configure workflow
       shell: bash
       env:
         pull_request_title: ${{ github.event.pull_request.title }}
@@ -126,7 +107,7 @@ jobs:
         fi
 
         DO_PUBLISH='false'
-        if [[ "${{ inputs.publish }}" == "on" || ("${{ github.event_name }}" == "schedule" && $BUILD_MODE == 'nightly') ]]; then
+        if [ "${{ inputs.publish }}" == "on" ]; then
           DO_PUBLISH='true'
           if [ -z "${{ secrets.OSUOSL_SSH_ENCRYPT_SECRET }}" ]; then
             echo "::warning::OSUOSL_SSH_ENCRYPT_SECRET is empty; not publishing to OSUOSL"
@@ -135,8 +116,9 @@ jobs:
         fi
 
         ADD_INFO="_${GITHUB_REF#refs/heads/}"
-        if [ "${{ github.event_name }}" == "schedule" ] && [ "${{ github.event.schedule }}" == "0 5 */1 */1 *" ]; then ADD_INFO="_${CURRENT_RELEASE_BRANCH}"; fi
-        if [ "${{ github.event_name }}" == "pull_request" ]; then ADD_INFO="_${{ github.event.pull_request.number }}_${pull_request_title}"; fi
+        if [ "${{ github.event_name }}" == "pull_request" ]; then
+          ADD_INFO="_${{ github.event.pull_request.number }}_${pull_request_title}"
+        fi
         UPLOAD_ARTIFACT_NAME="$(tr '":<>|*?/\\’' '_' <<<"MU4_${BUILD_NUMBER}_Win${ADD_INFO}")"
 
         echo "github.repository: ${{ github.repository }}"
@@ -214,23 +196,16 @@ jobs:
     # Disable on pull_request
     if: |
       github.event_name != 'pull_request' &&
-      (github.event_name != 'workflow_dispatch' || contains(inputs.platforms, 'windows_portable')) &&
-      (github.event_name != 'schedule' || github.repository == 'musescore/MuseScore')
+      (github.event_name != 'workflow_dispatch' || contains(inputs.platforms, 'windows_portable'))
     runs-on: windows-2022
     steps:
     - name: Cancel Previous Runs
       uses: styfle/cancel-workflow-action@0.12.1
       with:
         access_token: ${{ github.token }}
-    - name: Clone repository (default)
+    - name: Clone repository
       uses: actions/checkout@v4
-      if: ${{ github.event_name != 'schedule' || github.event.schedule == '0 3 */1 */1 *' }}
-    - name: Clone repository (${{ env.CURRENT_RELEASE_BRANCH }})
-      uses: actions/checkout@v4
-      if: ${{ github.event_name == 'schedule' && github.event.schedule == '0 5 */1 */1 *' }}
-      with:
-        ref: ${{ env.CURRENT_RELEASE_BRANCH }}
-    - name: "Configure workflow"
+    - name: Configure workflow
       shell: bash
       env:
         pull_request_title: ${{ github.event.pull_request.title }}
@@ -256,7 +231,7 @@ jobs:
         fi
 
         DO_PUBLISH='false'
-        if [[ "${{ inputs.publish }}" == "on" || ("${{ github.event_name }}" == "schedule" && $BUILD_MODE == 'nightly') ]]; then
+        if [ "${{ inputs.publish }}" == "on" ]; then
           DO_PUBLISH='true'
           if [ -z "${{ secrets.OSUOSL_SSH_ENCRYPT_SECRET }}" ]; then
             echo "::warning::OSUOSL_SSH_ENCRYPT_SECRET is empty; not publishing to OSUOSL"
@@ -265,8 +240,9 @@ jobs:
         fi
 
         ADD_INFO="_${GITHUB_REF#refs/heads/}"
-        if [ "${{ github.event_name }}" == "schedule" ] && [ "${{ github.event.schedule }}" == "0 5 */1 */1 *" ]; then ADD_INFO="_${CURRENT_RELEASE_BRANCH}"; fi
-        if [ "${{ github.event_name }}" == "pull_request" ]; then ADD_INFO="_${{ github.event.pull_request.number }}_${pull_request_title}"; fi
+        if [ "${{ github.event_name }}" == "pull_request" ]; then
+          ADD_INFO="_${{ github.event.pull_request.number }}_${pull_request_title}"
+        fi
         UPLOAD_ARTIFACT_NAME="$(tr '":<>|*?/\\’' '_' <<<"MU4_${BUILD_NUMBER}_Win_portable${ADD_INFO}")"
 
         echo "github.repository: ${{ github.repository }}"

--- a/buildscripts/ci/linux/setup-arm.sh
+++ b/buildscripts/ci/linux/setup-arm.sh
@@ -192,6 +192,9 @@ if [[ ! -d "${qt_dir}" ]]; then
   exit 1
 fi
 
+# https://askubuntu.com/questions/1460242/ubuntu-22-04-with-qt6-qmake-could-not-find-a-qt-installation-of
+qtchooser -install qt6 $(which qmake6)
+
 ##########################################################################
 # GET TOOLS
 ##########################################################################


### PR DESCRIPTION
The idea is to trigger nightly builds from a separate workflow, instead of using a cron schedule on the nightly builds workflows themselves. For the master branch, this doesn't make a big difference, but for the current release branch, it does: in the old situation, the YAML workflow files from the master branch would be used (even while building the current release branch), while other scripts are used from the current release branch. This causes problems when the master branch and the current release branch diverge so that the YAML workflow files from master are not compatible anymore with the other scripts from the current release branch. In the new situation, the YAML files from the current release branch are used. Now, only the input parameters specified by the new trigger action must match the expectations of the YAML workflow files on the current release branch, but that's easy enough to accomplish.

Resolves: the fact that the 4.4.3 nightly builds are currently broken