### PR TITLE
Fix #24916 disable concert pitch in chamber music templates

### DIFF
--- a/share/templates/03-Chamber_Music/01-String_Quartet/score_style.mss
+++ b/share/templates/03-Chamber_Music/01-String_Quartet/score_style.mss
@@ -340,7 +340,7 @@
     <chordExtensionAdjust>0</chordExtensionAdjust>
     <chordModifierMag>1</chordModifierMag>
     <chordModifierAdjust>0</chordModifierAdjust>
-    <concertPitch>1</concertPitch>
+    <concertPitch>0</concertPitch>
     <createMultiMeasureRests>0</createMultiMeasureRests>
     <minEmptyMeasures>2</minEmptyMeasures>
     <minMMRestWidth>6</minMMRestWidth>

--- a/share/templates/03-Chamber_Music/02-Wind_Quartet/02-Wind_Quartet.mscx
+++ b/share/templates/03-Chamber_Music/02-Wind_Quartet/02-Wind_Quartet.mscx
@@ -636,6 +636,10 @@
         <voice>
           <BarLine>
             </BarLine>
+          <KeySig>
+            <concertKey>0</concertKey>
+            <actualKey>2</actualKey>
+            </KeySig>
           <TimeSig>
             <sigN>4</sigN>
             <sigD>4</sigD>

--- a/share/templates/03-Chamber_Music/02-Wind_Quartet/score_style.mss
+++ b/share/templates/03-Chamber_Music/02-Wind_Quartet/score_style.mss
@@ -340,7 +340,7 @@
     <chordExtensionAdjust>0</chordExtensionAdjust>
     <chordModifierMag>1</chordModifierMag>
     <chordModifierAdjust>0</chordModifierAdjust>
-    <concertPitch>1</concertPitch>
+    <concertPitch>0</concertPitch>
     <createMultiMeasureRests>0</createMultiMeasureRests>
     <minEmptyMeasures>2</minEmptyMeasures>
     <minMMRestWidth>6</minMMRestWidth>

--- a/share/templates/03-Chamber_Music/03-Wind_Quintet/03-Wind_Quintet.mscx
+++ b/share/templates/03-Chamber_Music/03-Wind_Quintet/03-Wind_Quintet.mscx
@@ -607,6 +607,10 @@
         <voice>
           <BarLine>
             </BarLine>
+          <KeySig>
+            <concertKey>0</concertKey>
+            <actualKey>2</actualKey>
+            </KeySig>
           <TimeSig>
             <sigN>4</sigN>
             <sigD>4</sigD>
@@ -714,6 +718,10 @@
         <voice>
           <BarLine>
             </BarLine>
+          <KeySig>
+            <concertKey>0</concertKey>
+            <actualKey>1</actualKey>
+            </KeySig>
           <TimeSig>
             <sigN>4</sigN>
             <sigD>4</sigD>

--- a/share/templates/03-Chamber_Music/03-Wind_Quintet/score_style.mss
+++ b/share/templates/03-Chamber_Music/03-Wind_Quintet/score_style.mss
@@ -340,7 +340,7 @@
     <chordExtensionAdjust>0</chordExtensionAdjust>
     <chordModifierMag>1</chordModifierMag>
     <chordModifierAdjust>0</chordModifierAdjust>
-    <concertPitch>1</concertPitch>
+    <concertPitch>0</concertPitch>
     <createMultiMeasureRests>0</createMultiMeasureRests>
     <minEmptyMeasures>2</minEmptyMeasures>
     <minMMRestWidth>6</minMMRestWidth>

--- a/share/templates/03-Chamber_Music/04-Saxophone_Quartet/04-Saxophone_Quartet.mscx
+++ b/share/templates/03-Chamber_Music/04-Saxophone_Quartet/04-Saxophone_Quartet.mscx
@@ -332,6 +332,10 @@
         <voice>
           <BarLine>
             </BarLine>
+          <KeySig>
+            <concertKey>0</concertKey>
+            <actualKey>2</actualKey>
+            </KeySig>
           <TimeSig>
             <sigN>4</sigN>
             <sigD>4</sigD>
@@ -493,6 +497,10 @@
         <voice>
           <BarLine>
             </BarLine>
+          <KeySig>
+            <concertKey>0</concertKey>
+            <actualKey>3</actualKey>
+            </KeySig>
           <TimeSig>
             <sigN>4</sigN>
             <sigD>4</sigD>
@@ -648,6 +656,10 @@
         <voice>
           <BarLine>
             </BarLine>
+          <KeySig>
+            <concertKey>0</concertKey>
+            <actualKey>2</actualKey>
+            </KeySig>
           <TimeSig>
             <sigN>4</sigN>
             <sigD>4</sigD>
@@ -804,6 +816,10 @@
           <BarLine>
             <span>1</span>
             </BarLine>
+          <KeySig>
+            <concertKey>0</concertKey>
+            <actualKey>3</actualKey>
+            </KeySig>
           <TimeSig>
             <sigN>4</sigN>
             <sigD>4</sigD>

--- a/share/templates/03-Chamber_Music/04-Saxophone_Quartet/score_style.mss
+++ b/share/templates/03-Chamber_Music/04-Saxophone_Quartet/score_style.mss
@@ -340,7 +340,7 @@
     <chordExtensionAdjust>0</chordExtensionAdjust>
     <chordModifierMag>1</chordModifierMag>
     <chordModifierAdjust>0</chordModifierAdjust>
-    <concertPitch>1</concertPitch>
+    <concertPitch>0</concertPitch>
     <createMultiMeasureRests>0</createMultiMeasureRests>
     <minEmptyMeasures>2</minEmptyMeasures>
     <minMMRestWidth>6</minMMRestWidth>

--- a/share/templates/03-Chamber_Music/05-Brass_Quartet/05-Brass_Quartet.mscx
+++ b/share/templates/03-Chamber_Music/05-Brass_Quartet/05-Brass_Quartet.mscx
@@ -333,6 +333,10 @@
         <voice>
           <BarLine>
             </BarLine>
+          <KeySig>
+            <concertKey>0</concertKey>
+            <actualKey>2</actualKey>
+            </KeySig>
           <TimeSig>
             <sigN>4</sigN>
             <sigD>4</sigD>
@@ -494,6 +498,10 @@
         <voice>
           <BarLine>
             </BarLine>
+          <KeySig>
+            <concertKey>0</concertKey>
+            <actualKey>2</actualKey>
+            </KeySig>
           <TimeSig>
             <sigN>4</sigN>
             <sigD>4</sigD>

--- a/share/templates/03-Chamber_Music/05-Brass_Quartet/score_style.mss
+++ b/share/templates/03-Chamber_Music/05-Brass_Quartet/score_style.mss
@@ -340,7 +340,7 @@
     <chordExtensionAdjust>0</chordExtensionAdjust>
     <chordModifierMag>1</chordModifierMag>
     <chordModifierAdjust>0</chordModifierAdjust>
-    <concertPitch>1</concertPitch>
+    <concertPitch>0</concertPitch>
     <createMultiMeasureRests>0</createMultiMeasureRests>
     <minEmptyMeasures>2</minEmptyMeasures>
     <minMMRestWidth>6</minMMRestWidth>

--- a/share/templates/03-Chamber_Music/06-Brass_Quintet/06-Brass_Quintet.mscx
+++ b/share/templates/03-Chamber_Music/06-Brass_Quintet/06-Brass_Quintet.mscx
@@ -403,6 +403,10 @@
         <voice>
           <BarLine>
             </BarLine>
+          <KeySig>
+            <concertKey>0</concertKey>
+            <actualKey>2</actualKey>
+            </KeySig>
           <TimeSig>
             <sigN>4</sigN>
             <sigD>4</sigD>
@@ -513,6 +517,10 @@
         <voice>
           <BarLine>
             </BarLine>
+          <KeySig>
+            <concertKey>0</concertKey>
+            <actualKey>2</actualKey>
+            </KeySig>
           <TimeSig>
             <sigN>4</sigN>
             <sigD>4</sigD>
@@ -620,6 +628,10 @@
         <voice>
           <BarLine>
             </BarLine>
+          <KeySig>
+            <concertKey>0</concertKey>
+            <actualKey>1</actualKey>
+            </KeySig>
           <TimeSig>
             <sigN>4</sigN>
             <sigD>4</sigD>

--- a/share/templates/03-Chamber_Music/06-Brass_Quintet/score_style.mss
+++ b/share/templates/03-Chamber_Music/06-Brass_Quintet/score_style.mss
@@ -340,7 +340,7 @@
     <chordExtensionAdjust>0</chordExtensionAdjust>
     <chordModifierMag>1</chordModifierMag>
     <chordModifierAdjust>0</chordModifierAdjust>
-    <concertPitch>1</concertPitch>
+    <concertPitch>0</concertPitch>
     <createMultiMeasureRests>0</createMultiMeasureRests>
     <minEmptyMeasures>2</minEmptyMeasures>
     <minMMRestWidth>6</minMMRestWidth>


### PR DESCRIPTION
Resolves: #24916  <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
This PR changes concert pitch to be off by default for chamber music templates by setting the `concertPitch` to 0 in the `score_style.mss` file in each template.

Since all other templates have concert pitch off by default, this seems like a reasonable default for chamber music templates as well. Is there any reason they were set to concert pitch on by default or was this an oversight?

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
