### PR TITLE
#24536 ensure playback position rewinds to start reliably when end of score reached

### DIFF
--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -1290,7 +1290,7 @@ void PlaybackController::setupSequencePlayer()
         updateCurrentTempo();
 
         secs_t endSecs = playbackEndSecs();
-        if (pos == endSecs) {
+        if (pos + milisecsToSecs(1) >= endSecs) {
             stop();
         }
     });


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/24536

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)

@RomanPudashkin 