### PR TITLE
Percussion panel - expanded pad UX/interactions

### DIFF
--- a/src/notation/notationscene.qrc
+++ b/src/notation/notationscene.qrc
@@ -56,5 +56,6 @@
         <file>qml/MuseScore/NotationScene/PercussionPanel.qml</file>
         <file>qml/MuseScore/NotationScene/internal/PercussionPanelToolBar.qml</file>
         <file>qml/MuseScore/NotationScene/internal/PercussionPanelPad.qml</file>
+        <file>qml/MuseScore/NotationScene/internal/PercussionPanelPadContent.qml</file>
     </qresource>
 </RCC>

--- a/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
+++ b/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
@@ -168,6 +168,21 @@ Item {
                         padModel: model.padModelRole
                         panelMode: percModel.currentPanelMode
                         useNotationPreview: percModel.useNotationPreview
+
+                        dragParent: root
+
+                        onDragStarted: {
+                            padGrid.model.startDrag(index)
+                        }
+
+                        onDropped: function(dropEvent) {
+                            padGrid.model.endDrag(index)
+                            dropEvent.accepted = true
+                        }
+
+                        onDragCancelled: {
+                            padGrid.model.endDrag(-1)
+                        }
                     }
                 }
             }

--- a/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPad.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPad.qml
@@ -26,105 +26,156 @@ import Muse.UiComponents 1.0
 import Muse.GraphicalEffects 1.0
 import MuseScore.NotationScene 1.0
 
-Rectangle {
+DropArea {
     id: root
 
     property var padModel: null
 
-    property bool isEmptySlot: Boolean(root.padModel) ? root.padModel.isEmptySlot : true
-
     property int panelMode: -1
     property bool useNotationPreview: false
 
-    property alias totalBorderWidth: contentColumn.anchors.margins
+    property alias totalBorderWidth: padLoader.anchors.margins
 
-    radius: root.width / 6
+    property var dragParent: null
+    signal dragStarted()
+    signal dragCancelled()
 
-    color: ui.theme.backgroundPrimaryColor
+    QtObject {
+        id: prv
+        readonly property bool isEmptySlot: Boolean(root.padModel) ? root.padModel.isEmptySlot : true
+    }
 
-    border.color: root.panelMode === PanelMode.EDIT_LAYOUT ? ui.theme.accentColor : "transparent"
-    border.width: 2
+    Rectangle {
+        id: draggableArea
 
-    Column {
-        id: contentColumn
+        // Protrudes slightly from behind the components in the loader to produce the edit mode "border with gap" effect
+        width: root.width
+        height: root.height
+
+        radius: root.width / 6
+
+        color: ui.theme.backgroundPrimaryColor
+
+        border.color: root.panelMode === PanelMode.EDIT_LAYOUT ? ui.theme.accentColor : "transparent"
+        border.width: 2
+
+        DragHandler {
+            id: dragHandler
+
+            target: draggableArea
+            enabled: root.panelMode === PanelMode.EDIT_LAYOUT && !prv.isEmptySlot
+
+            dragThreshold: 0 // prevents the flickable from stealing drag events
+
+            onActiveChanged: {
+                if (dragHandler.active) {
+                    root.dragStarted()
+                    return
+                }
+                if (!draggableArea.Drag.drop()) {
+                    root.dragCancelled()
+                }
+            }
+        }
+
+        Drag.active: dragHandler.active
+        Drag.hotSpot.x: root.width / 2
+        Drag.hotSpot.y: root.height / 2
+
+        Loader {
+            // Loads either an empty slot or the pad content
+            id: padLoader
+
+            anchors.fill: parent
+            // Defined as 1 in the spec, but causes some aliasing in practice...
+            anchors.margins: 2 + draggableArea.border.width
+
+            // Can't simply use clip as this won't take into account radius...
+            layer.enabled: ui.isEffectsAllowed
+            layer.effect: EffectOpacityMask {
+                maskSource: Rectangle {
+                    width: padLoader.width
+                    height: padLoader.height
+                    radius: draggableArea.radius - padLoader.anchors.margins
+                }
+            }
+
+            sourceComponent: prv.isEmptySlot ? emptySlotComponent : padContentComponent
+
+            Component {
+                id: padContentComponent
+
+                PercussionPanelPadContent {
+                    padModel: root.padModel
+                    panelMode: root.panelMode
+                    useNotationPreview: root.useNotationPreview
+                    dragActive: dragHandler.active
+                }
+            }
+
+            Component {
+                id: emptySlotComponent
+
+                Rectangle {
+                    id: emptySlotBackground
+
+                    color: root.containsDrag ? ui.theme.buttonColor : ui.theme.backgroundSecondaryColor
+                }
+            }
+        }
+
+        states: [
+            State {
+                name: "DRAGGED"
+                when: dragHandler.active
+                ParentChange {
+                    target: draggableArea
+                    parent: root.dragParent
+                }
+                AnchorChanges {
+                    target: draggableArea
+                    anchors.horizontalCenter: undefined
+                    anchors.verticalCenter: undefined
+                }
+            },
+            //! NOTE: Workaround for a bug in Qt 6.2.4 - see PR #24106 comment
+            // https://bugreports.qt.io/browse/QTBUG-99436
+            State {
+                name: "DROPPED"
+                when: !dragHandler.active
+                ParentChange {
+                    target: draggableArea
+                    parent: root
+                }
+            }
+        ]
+    }
+
+    Rectangle {
+        id: dragSourceBackground
 
         anchors.fill: parent
-        anchors.margins: 2 + root.border.width // Defined as 1 in the spec, but causes some aliasing in practice...
 
-        // Can't simply use clip as this won't take into account radius...
-        layer.enabled: ui.isEffectsAllowed
-        layer.effect: EffectOpacityMask {
-            maskSource: Rectangle {
-                width: contentColumn.width
-                height: contentColumn.height
-                radius: root.radius - contentColumn.anchors.margins
-            }
-        }
+        radius: draggableArea.radius
 
-        Rectangle {
-            id: mainContentArea
+        border.color: draggableArea.border.color
+        border.width: draggableArea.border.width
 
-            width: parent.width
-            height: parent.height - separator.height - footerArea.height
+        color: draggableArea.color
 
-            color: root.isEmptySlot ? ui.theme.backgroundSecondaryColor : Utils.colorWithAlpha(ui.theme.accentColor, ui.theme.buttonOpacityNormal)
+        // This spawns behind a pad when it is dragged away from the source position
+        visible: dragHandler.active
 
-            StyledTextLabel {
-                id: instrumentNameLabel
+        Loader {
+            anchors.fill: parent
+            anchors.margins: padLoader.anchors.margins
 
-                visible: !root.useNotationPreview
+            active: dragHandler.active
 
-                anchors.centerIn: parent
-                width: parent.width - root.radius
+            layer.enabled: padLoader.layer.enabled
+            layer.effect: padLoader.layer.effect
 
-                wrapMode: Text.WordWrap
-                maximumLineCount: 4
-                font: ui.theme.bodyBoldFont
-
-                text: Boolean(root.padModel) ? root.padModel.instrumentName : ""
-            }
-        }
-
-        Rectangle {
-            id: separator
-
-            width: parent.width
-            height: 1
-
-            color: root.isEmptySlot ? ui.theme.backgroundSecondaryColor : ui.theme.accentColor
-        }
-
-        Rectangle {
-            id: footerArea
-
-            width: parent.width
-            height: 24
-
-            color: ui.theme.backgroundSecondaryColor
-
-            StyledTextLabel {
-                id: shortcutLabel
-
-                anchors.verticalCenter: parent.verticalCenter
-                anchors.left: parent.left
-                anchors.margins: 6
-
-                font: ui.theme.bodyFont
-
-                text: Boolean(root.padModel) ? root.padModel.keyboardShortcut : ""
-            }
-
-            StyledTextLabel {
-                id: midiNoteLabel
-
-                anchors.verticalCenter: parent.verticalCenter
-                anchors.right: parent.right
-                anchors.margins: 6
-
-                font: ui.theme.bodyFont
-
-                text: Boolean(root.padModel) ? root.padModel.midiNote : ""
-            }
+            sourceComponent: emptySlotComponent
         }
     }
 }

--- a/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPadContent.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPadContent.qml
@@ -1,0 +1,146 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2024 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import QtQuick 2.15
+
+import Muse.Ui 1.0
+import Muse.UiComponents 1.0
+import MuseScore.NotationScene 1.0
+
+Column {
+    id: root
+
+    property var padModel: null
+
+    property int panelMode: -1
+    property bool useNotationPreview: false
+
+    property bool dragActive: false
+
+    Rectangle {
+        id: mainContentArea
+
+        width: parent.width
+        height: parent.height - separator.height - footerArea.height
+
+        color: Utils.colorWithAlpha(ui.theme.accentColor, ui.theme.buttonOpacityNormal)
+
+        MouseArea {
+            id: mouseArea
+
+            anchors.fill: parent
+            hoverEnabled: true
+
+            onPressed: {
+                var instName = Boolean(root.padModel) ? root.padModel.instrumentName : ""
+
+                // Placeholder logic...
+                switch(root.panelMode) {
+                case PanelMode.EDIT_LAYOUT: return
+                case PanelMode.SOUND_PREVIEW:
+                    console.log("PLAYING: " + instName)
+                    break
+                case PanelMode.WRITE:
+                    console.log("WRITING: " + instName)
+                    break
+                }
+            }
+        }
+
+        StyledTextLabel {
+            id: instrumentNameLabel
+
+            visible: !root.useNotationPreview
+
+            anchors.centerIn: parent
+            width: parent.width - 12
+
+            wrapMode: Text.WordWrap
+            maximumLineCount: 4
+            font: ui.theme.bodyBoldFont
+
+            text: Boolean(root.padModel) ? root.padModel.instrumentName : ""
+        }
+
+        states: [
+            State {
+                name: "MOUSE_HOVERED"
+                when: mouseArea.containsMouse && !mouseArea.pressed && !root.dragActive
+                PropertyChanges {
+                    target: mainContentArea
+                    color: Utils.colorWithAlpha(ui.theme.accentColor, ui.theme.buttonOpacityHover)
+                }
+            },
+            State {
+                name: "MOUSE_HIT"
+                when: mouseArea.pressed || root.dragActive
+                PropertyChanges {
+                    target: mainContentArea
+                    color: Utils.colorWithAlpha(ui.theme.accentColor, ui.theme.buttonOpacityHit)
+                }
+            }
+        ]
+    }
+
+    Rectangle {
+        id: separator
+
+        width: parent.width
+        height: 1
+
+        color: ui.theme.accentColor
+    }
+
+    Rectangle {
+        id: footerArea
+
+        width: parent.width
+        height: 24
+
+        color: Utils.colorWithAlpha(ui.theme.buttonColor, ui.theme.buttonOpacityNormal)
+
+        StyledTextLabel {
+            id: shortcutLabel
+
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.left: parent.left
+            anchors.margins: 6
+
+            font: ui.theme.bodyFont
+            color: ui.theme.fontPrimaryColor
+
+            text: Boolean(root.padModel) ? root.padModel.keyboardShortcut : ""
+        }
+
+        StyledTextLabel {
+            id: midiNoteLabel
+
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.right: parent.right
+            anchors.margins: 6
+
+            font: ui.theme.bodyFont
+            color: ui.theme.fontPrimaryColor
+
+            text: Boolean(root.padModel) ? root.padModel.midiNote : ""
+        }
+    }
+}

--- a/src/notation/view/percussionpanel/percussionpanelpadlistmodel.cpp
+++ b/src/notation/view/percussionpanel/percussionpanelpadlistmodel.cpp
@@ -29,7 +29,7 @@ PercussionPanelPadListModel::PercussionPanelPadListModel(QObject* parent)
 
 QVariant PercussionPanelPadListModel::data(const QModelIndex& index, int role) const
 {
-    if (index.row() < 0 || index.row() >= m_padModels.count()) {
+    if (!indexIsValid(index.row())) {
         return QVariant();
     }
 
@@ -61,7 +61,7 @@ void PercussionPanelPadListModel::load()
 void PercussionPanelPadListModel::addRow()
 {
     for (size_t i = 0; i < NUM_COLUMNS; ++i) {
-        m_padModels.append(new PercussionPanelPadModel(QObject::parent()));
+        m_padModels.append(new PercussionPanelPadModel(this));
     }
     emit layoutChanged();
     emit numPadsChanged();
@@ -81,13 +81,12 @@ void PercussionPanelPadListModel::startDrag(int startIndex)
 
 void PercussionPanelPadListModel::endDrag(int endIndex)
 {
-    movePad(m_dragStartIndex, endIndex);
+    if (indexIsValid(m_dragStartIndex) && indexIsValid(endIndex)) {
+        movePad(m_dragStartIndex, endIndex);
+    } else {
+        emit layoutChanged();
+    }
     m_dragStartIndex = -1;
-}
-
-bool PercussionPanelPadListModel::isDragActive() const
-{
-    return m_dragStartIndex > -1;
 }
 
 void PercussionPanelPadListModel::resetLayout()
@@ -134,6 +133,11 @@ QList<PercussionPanelPadModel*> PercussionPanelPadListModel::createDefaultItems(
     }
 
     return padModels;
+}
+
+bool PercussionPanelPadListModel::indexIsValid(int index) const
+{
+    return index > -1 && index < m_padModels.count();
 }
 
 void PercussionPanelPadListModel::movePad(int fromIndex, int toIndex)

--- a/src/notation/view/percussionpanel/percussionpanelpadlistmodel.h
+++ b/src/notation/view/percussionpanel/percussionpanelpadlistmodel.h
@@ -49,7 +49,6 @@ public:
 
     Q_INVOKABLE void startDrag(int startIndex);
     Q_INVOKABLE void endDrag(int endIndex);
-    Q_INVOKABLE bool isDragActive() const;
 
     int numColumns() const { return NUM_COLUMNS; }
     int numPads() const { return m_padModels.count(); }
@@ -79,6 +78,7 @@ private:
         }
     };
 
+    bool indexIsValid(int index) const;
     void movePad(int fromIndex, int toIndex);
 
     QList<PercussionPanelPadModel*> createDefaultItems();


### PR DESCRIPTION
- Percussion panel pads can now be rearranged by dragging & dropping while in edit layout mode
- Various pad states are now represented visually (hovered, "hit", etc.)
- Pad content has been encapsulated into a new component - this will only increase in size once we implement notation preview, etc.