### PR TITLE
fixed #24177: Shortcuts , and . make a < and > instead

### DIFF
--- a/src/framework/shortcuts/CMakeLists.txt
+++ b/src/framework/shortcuts/CMakeLists.txt
@@ -46,6 +46,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/internal/shortcutsconfiguration.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/midiremote.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/midiremote.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/keymapper.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/keymapper.h
 
     ${CMAKE_CURRENT_LIST_DIR}/view/shortcutsmodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/shortcutsmodel.h
@@ -63,12 +65,12 @@ if (OS_IS_MAC)
     find_library(CARBON_LIBRARY Carbon)
 
     set(MODULE_SRC ${MODULE_SRC}
-        ${CMAKE_CURRENT_LIST_DIR}/internal/platform/macos/macosshortcutsinstancemodel.mm
-        ${CMAKE_CURRENT_LIST_DIR}/internal/platform/macos/macosshortcutsinstancemodel.h
+        ${CMAKE_CURRENT_LIST_DIR}/internal/platform/macos/macoskeymapper.mm
+        ${CMAKE_CURRENT_LIST_DIR}/internal/platform/macos/macoskeymapper.h
     )
 
     set_source_files_properties(
-        ${CMAKE_CURRENT_LIST_DIR}/internal/platform/macos/macosshortcutsinstancemodel.mm
+        ${CMAKE_CURRENT_LIST_DIR}/internal/platform/macos/macoskeymapper.mm
         PROPERTIES
         SKIP_UNITY_BUILD_INCLUSION ON
         SKIP_PRECOMPILE_HEADERS ON

--- a/src/framework/shortcuts/internal/keymapper.cpp
+++ b/src/framework/shortcuts/internal/keymapper.cpp
@@ -19,27 +19,23 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef MUSE_SHORTCUTS_MACOSSHORTCUTSINSTANCEMODEL_H
-#define MUSE_SHORTCUTS_MACOSSHORTCUTSINSTANCEMODEL_H
+#include "keymapper.h"
 
-#include <QObject>
+#include <QApplication>
+#include <QKeyEvent>
 
-#include "../../shortcutsinstancemodel.h"
+#ifdef Q_OS_MAC
+#include "platform/macos/macoskeymapper.h"
+#else
+#endif
 
-namespace muse::shortcuts {
-class MacOSShortcutsInstanceModel : public ShortcutsInstanceModel
+using namespace muse::shortcuts;
+
+QString KeyMapper::translateToCurrentKeyboardLayout(const QKeySequence& sequence)
 {
-    Q_OBJECT
-
-public:
-    explicit MacOSShortcutsInstanceModel(QObject* parent = nullptr);
-
-private:
-    void doLoadShortcuts() override;
-    void doActivate(const QString& seq) override;
-
-    QHash<QString, QString> m_macSequenceMap;
-};
+#ifdef Q_OS_MAC
+    return MacOSKeyMapper::translateToCurrentKeyboardLayout(sequence);
+#else
+    return sequence.toString();
+#endif
 }
-
-#endif // MUSE_SHORTCUTS_MACOSSHORTCUTSINSTANCEMODEL_H

--- a/src/framework/shortcuts/internal/keymapper.cpp
+++ b/src/framework/shortcuts/internal/keymapper.cpp
@@ -39,3 +39,12 @@ QString KeyMapper::translateToCurrentKeyboardLayout(const QKeySequence& sequence
     return sequence.toString();
 #endif
 }
+
+QString KeyMapper::translateToEnglishKeyboardLayout(const QKeySequence& sequence)
+{
+#ifdef Q_OS_MAC
+    return MacOSKeyMapper::translateToEnglishKeyboardLayout(sequence);
+#else
+    return sequence.toString();
+#endif
+}

--- a/src/framework/shortcuts/internal/keymapper.h
+++ b/src/framework/shortcuts/internal/keymapper.h
@@ -29,5 +29,6 @@ class KeyMapper
 {
 public:
     static QString translateToCurrentKeyboardLayout(const QKeySequence& sequence);
+    static QString translateToEnglishKeyboardLayout(const QKeySequence& sequence);
 };
 }

--- a/src/framework/shortcuts/internal/keymapper.h
+++ b/src/framework/shortcuts/internal/keymapper.h
@@ -1,0 +1,33 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <QString>
+#include <QKeySequence>
+
+namespace muse::shortcuts {
+class KeyMapper
+{
+public:
+    static QString translateToCurrentKeyboardLayout(const QKeySequence& sequence);
+};
+}

--- a/src/framework/shortcuts/internal/platform/macos/macoskeymapper.h
+++ b/src/framework/shortcuts/internal/platform/macos/macoskeymapper.h
@@ -1,0 +1,33 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <QString>
+#include <QKeySequence>
+
+namespace muse::shortcuts {
+class MacOSKeyMapper
+{
+public:
+    static QString translateToCurrentKeyboardLayout(const QKeySequence& sequence);
+};
+}

--- a/src/framework/shortcuts/internal/platform/macos/macoskeymapper.h
+++ b/src/framework/shortcuts/internal/platform/macos/macoskeymapper.h
@@ -29,5 +29,6 @@ class MacOSKeyMapper
 {
 public:
     static QString translateToCurrentKeyboardLayout(const QKeySequence& sequence);
+    static QString translateToEnglishKeyboardLayout(const QKeySequence& sequence);
 };
 }

--- a/src/framework/shortcuts/internal/platform/macos/macosshortcutsinstancemodel.mm
+++ b/src/framework/shortcuts/internal/platform/macos/macosshortcutsinstancemodel.mm
@@ -372,88 +372,39 @@ MacOSShortcutsInstanceModel::MacOSShortcutsInstanceModel(QObject* parent)
 void MacOSShortcutsInstanceModel::doLoadShortcuts()
 {
     m_shortcuts.clear();
-
-    // RULE: If a sequence is used for several shortcuts but the values for autoRepeat vary depending on
-    // the context, then we should force autoRepeat to false for all shortcuts sharing the sequence in
-    // question. This prevents the creation of ambiguous shortcuts (see QShortcutEvent::isAmbiguous)
-    auto recordAutoRepeat = [this](const QString& sequence, bool autoRepeat) {
-        auto search = m_shortcuts.find(sequence);
-        if (search == m_shortcuts.end()) {
-            // Sequence not found, add it...
-            m_shortcuts.insert(sequence, QVariant(autoRepeat));
-        } else if (search.value().toBool() && !autoRepeat) {
-            // Sequence already exists, but we need to enforce the above rule...
-            search.value() = false;
-        }
-    };
-
     m_macSequenceMap.clear();
-
-    // Suppose the user uses for example a Cyrillic keyboard layout. When they try to press Cmd+A,
-    // Qt will see Cmd+Ф instead, so the QML `Shortcut` object for Cmd+A will not be triggered.
-    // We will a workaround: we treat the shortcuts from the shortcuts file as "a combination of
-    // physical keys" rather than "a character that would be typed"; i.e. `Shift+,` rather than `<`.
-    // We use native macOS APIs to translate from the combination of keys to the character that would
-    // be typed. We create a QML `Shortcut` object for e.g. `Cmd+Ф`; that will be triggered by Qt.
-    // We store a reverse mapping here, so that we can look up the original sequence when the shortcut
-    // is triggered, and then trigger the corresponding action.
-    //
-    // There is one catch; there are two cases where the untranslated sequence is not a combination of
-    // physical keys:
-    // - When the current keyboard layout is different from what the shortcuts file was designed for;
-    //   for example, the AZERTY layout does not have a `.` key, but instead a `.` is typed as `Shift+;`.
-    // - When the sequence was recorded as a character, e.g. `>` rather than `Shift+.`, which is the case
-    //   for all custom shortcuts.
-    // In these cases, the translation will produce unexpected results. Therefore, in our reverse map,
-    // we also store a mapping from the untranslated sequence to the untranslated sequence itself. This
-    // takes precedence over mapping from translated sequences to untranslated sequences.
-    //
-    // The resulting behaviour when a shortcut is pressed by the user is the following:
-    // - If there is an action that is bound to exactly the sequence as Qt sees it, then that action is
-    //   triggered.
-    // - Otherwise, we look up the received sequence in the reverse map, to see by which combination of
-    //   physical keys it would be produced, and trigger the action that is bound to that combination.
-    auto recordMapping = [this](const QString& translatedSequence, const QString& rawSequence, bool overrideExisting) {
-        auto search = m_macSequenceMap.find(translatedSequence);
-        if (search == m_macSequenceMap.end()) {
-            m_macSequenceMap.insert(translatedSequence, rawSequence);
-        } else if (overrideExisting) {
-            search.value() = rawSequence;
-        }
-    };
 
     ShortcutList shortcuts = shortcutsRegister()->shortcuts();
 
     for (const Shortcut& sc : shortcuts) {
         for (const std::string& seq : sc.sequences) {
-            QString untranslatedSequence = QString::fromStdString(seq);
+            QString sequence = QString::fromStdString(seq);
 
-            // Always record the untranslated sequence
-            recordMapping(untranslatedSequence, untranslatedSequence, true);
-            recordAutoRepeat(untranslatedSequence, sc.autoRepeat);
-
-            // Attempt to translate from combination of keys to character, e.g., `Shift+.` becomes `>`, in the case of a QWERTY layout
-            QString translatedSequence
-                = translateToCurrentKeyboardLayout(QKeySequence::fromString(untranslatedSequence, QKeySequence::PortableText));
-            if (translatedSequence.isEmpty()) {
-                LOGW() << "Failed to translate sequence " << untranslatedSequence;
+            QString seqStr = translateToCurrentKeyboardLayout(QKeySequence::fromString(sequence, QKeySequence::PortableText));
+            if (seqStr.isEmpty()) {
+                LOGW() << "Failed to translate sequence " << sequence;
                 continue;
             }
 
-            // If it was successful, record the translated sequence too, and map it to the untranslated sequence
-            recordMapping(translatedSequence, untranslatedSequence, false);
-            recordAutoRepeat(translatedSequence, sc.autoRepeat);
+            // RULE: If a sequence is used for several shortcuts but the values for autoRepeat vary depending on
+            // the context, then we should force autoRepeat to false for all shortcuts sharing the sequence in
+            // question. This prevents the creation of ambiguous shortcuts (see QShortcutEvent::isAmbiguous)
+            auto search = m_shortcuts.find(seqStr);
+            if (search == m_shortcuts.end()) {
+                // Sequence not found, add it...
+                m_shortcuts.insert(seqStr, QVariant(sc.autoRepeat));
+                m_macSequenceMap.insert(seqStr, sequence);
+            } else if (search.value().toBool() && !sc.autoRepeat) {
+                // Sequence already exists, but we need to enforce the above rule...
+                search.value() = false;
+            }
         }
     }
-
-    assert(m_shortcuts.size() == m_macSequenceMap.size());
 
     emit shortcutsChanged();
 }
 
 void MacOSShortcutsInstanceModel::doActivate(const QString& seq)
 {
-    // `seq` will always be in the map, because it comes from one of the QML `Shortcut` objects
-    // and for every such object, we have also created an entry in the map, in `doLoadShortcuts`.
     ShortcutsInstanceModel::doActivate(m_macSequenceMap.value(seq));
 }

--- a/src/framework/shortcuts/internal/shortcutsinstancemodel.cpp
+++ b/src/framework/shortcuts/internal/shortcutsinstancemodel.cpp
@@ -86,7 +86,7 @@ void ShortcutsInstanceModel::doLoadShortcuts()
             if (search == m_shortcuts.end()) {
                 // Sequence not found, add it...
                 m_shortcuts.insert(seqStrTr, QVariant(sc.autoRepeat));
-                m_shortcutMap.insert(seqStr, seqStrTr);
+                m_shortcutMap.insert(seqStr, QKeySequence(seqStrTr));
             } else if (search.value().toBool() && !sc.autoRepeat) {
                 // Sequence already exists, but we need to enforce the above rule...
                 search.value() = false;
@@ -99,5 +99,5 @@ void ShortcutsInstanceModel::doLoadShortcuts()
 
 void ShortcutsInstanceModel::doActivate(const QString& seq)
 {
-    controller()->activate(m_shortcutMap.value(seq).toStdString());
+    controller()->activate(m_shortcutMap.value(seq).toString().toStdString());
 }

--- a/src/framework/shortcuts/internal/shortcutsinstancemodel.cpp
+++ b/src/framework/shortcuts/internal/shortcutsinstancemodel.cpp
@@ -21,6 +21,8 @@
  */
 #include "shortcutsinstancemodel.h"
 
+#include "keymapper.h"
+
 #include "log.h"
 
 using namespace muse::shortcuts;
@@ -38,6 +40,10 @@ void ShortcutsInstanceModel::init()
 
     shortcutsRegister()->activeChanged().onNotify(this, [this](){
         emit activeChanged();
+    });
+
+    connect(qApp->inputMethod(), &QInputMethod::localeChanged, this, [this]() {
+        doLoadShortcuts();
     });
 
     doLoadShortcuts();
@@ -61,11 +67,17 @@ void ShortcutsInstanceModel::activate(const QString& seq)
 void ShortcutsInstanceModel::doLoadShortcuts()
 {
     m_shortcuts.clear();
+    m_shortcutMap.clear();
 
     const ShortcutList& shortcuts = shortcutsRegister()->shortcuts();
     for (const Shortcut& sc : shortcuts) {
         for (const std::string& seq : sc.sequences) {
             QString seqStr = QString::fromStdString(seq);
+            QString seqStrTr = KeyMapper::translateToCurrentKeyboardLayout(QKeySequence(seqStr));
+            if (seqStrTr.isEmpty()) {
+                LOGW() << "Failed to translate sequence " << seqStr;
+                continue;
+            }
 
             // RULE: If a sequence is used for several shortcuts but the values for autoRepeat vary depending on
             // the context, then we should force autoRepeat to false for all shortcuts sharing the sequence in
@@ -73,7 +85,8 @@ void ShortcutsInstanceModel::doLoadShortcuts()
             auto search = m_shortcuts.find(seqStr);
             if (search == m_shortcuts.end()) {
                 // Sequence not found, add it...
-                m_shortcuts.insert(seqStr, QVariant(sc.autoRepeat));
+                m_shortcuts.insert(seqStrTr, QVariant(sc.autoRepeat));
+                m_shortcutMap.insert(seqStr, seqStrTr);
             } else if (search.value().toBool() && !sc.autoRepeat) {
                 // Sequence already exists, but we need to enforce the above rule...
                 search.value() = false;
@@ -86,5 +99,5 @@ void ShortcutsInstanceModel::doLoadShortcuts()
 
 void ShortcutsInstanceModel::doActivate(const QString& seq)
 {
-    controller()->activate(seq.toStdString());
+    controller()->activate(m_shortcutMap.value(seq).toStdString());
 }

--- a/src/framework/shortcuts/internal/shortcutsinstancemodel.h
+++ b/src/framework/shortcuts/internal/shortcutsinstancemodel.h
@@ -63,7 +63,7 @@ protected:
 
     // Key = sequence (QString), value = autoRepeat (QVariant/bool)
     QVariantMap m_shortcuts;
-    QHash<QString, QString> m_shortcutMap;
+    QHash<QString, QKeySequence> m_shortcutMap;
 };
 }
 

--- a/src/framework/shortcuts/internal/shortcutsinstancemodel.h
+++ b/src/framework/shortcuts/internal/shortcutsinstancemodel.h
@@ -63,6 +63,7 @@ protected:
 
     // Key = sequence (QString), value = autoRepeat (QVariant/bool)
     QVariantMap m_shortcuts;
+    QHash<QString, QString> m_shortcutMap;
 };
 }
 

--- a/src/framework/shortcuts/shortcutsmodule.cpp
+++ b/src/framework/shortcuts/shortcutsmodule.cpp
@@ -27,11 +27,7 @@
 
 #include "modularity/ioc.h"
 
-#if defined(Q_OS_MACOS)
-#include "internal/platform/macos/macosshortcutsinstancemodel.h"
-#else
 #include "internal/shortcutsinstancemodel.h"
-#endif
 
 #include "internal/shortcutsregister.h"
 #include "internal/shortcutscontroller.h"
@@ -98,11 +94,7 @@ void ShortcutsModule::registerResources()
 
 void ShortcutsModule::registerUiTypes()
 {
-#if defined(Q_OS_MACOS)
-    qmlRegisterType<MacOSShortcutsInstanceModel>("Muse.Shortcuts", 1, 0, "ShortcutsInstanceModel");
-#else
     qmlRegisterType<ShortcutsInstanceModel>("Muse.Shortcuts", 1, 0, "ShortcutsInstanceModel");
-#endif
 
     qmlRegisterType<ShortcutsModel>("Muse.Shortcuts", 1, 0, "ShortcutsModel");
     qmlRegisterType<EditShortcutModel>("Muse.Shortcuts", 1, 0, "EditShortcutModel");

--- a/src/framework/shortcuts/view/editshortcutmodel.cpp
+++ b/src/framework/shortcuts/view/editshortcutmodel.cpp
@@ -24,6 +24,8 @@
 
 #include <QKeySequence>
 
+#include "internal/keymapper.h"
+
 #include "translation.h"
 #include "shortcutstypes.h"
 #include "log.h"
@@ -73,6 +75,7 @@ void EditShortcutModel::clearNewSequence()
     }
 
     m_newSequence = QKeySequence();
+    m_newSequenceEng = QKeySequence();
     m_conflictShortcut.clear();
 
     emit newSequenceChanged();
@@ -107,6 +110,10 @@ void EditShortcutModel::inputKey(Qt::Key key, Qt::KeyboardModifiers modifiers)
     }
 
     m_newSequence = newSequence;
+
+    QKeyCombination combinationEng(modifiers, key);
+    m_newSequenceEng = KeyMapper::translateToEnglishKeyboardLayout(QKeySequence(combinationEng));
+
     checkNewSequenceForConflicts();
 
     emit newSequenceChanged();
@@ -202,7 +209,14 @@ QString EditShortcutModel::originSequenceInNativeFormat() const
 
 QString EditShortcutModel::newSequenceInNativeFormat() const
 {
-    return m_newSequence.toString(QKeySequence::NativeText);
+    QString seq = m_newSequence.toString(QKeySequence::NativeText);
+    if (seq.isEmpty()) {
+        return QString();
+    }
+
+    QString seqTr = m_newSequenceEng.toString(QKeySequence::NativeText);
+
+    return QString("%1 (%2)").arg(seq, seqTr);
 }
 
 QString EditShortcutModel::conflictWarning() const
@@ -252,5 +266,5 @@ void EditShortcutModel::applyNewSequence()
 
 QString EditShortcutModel::newSequence() const
 {
-    return m_newSequence.toString();
+    return m_newSequenceEng.toString();
 }

--- a/src/framework/shortcuts/view/editshortcutmodel.cpp
+++ b/src/framework/shortcuts/view/editshortcutmodel.cpp
@@ -86,12 +86,14 @@ void EditShortcutModel::inputKey(Qt::Key key, Qt::KeyboardModifiers modifiers)
         return;
     }
 
+    Qt::KeyboardModifiers correctedModifiers = modifiers;
+
     // remove shift-modifier for non-letter keys, except a few keys
-    if ((modifiers & Qt::ShiftModifier) && !isShiftAllowed(key)) {
-        modifiers &= ~Qt::ShiftModifier;
+    if ((modifiers & Qt::ShiftModifier) && !isShiftAllowed(key, QKeySequence(key).toString())) {
+        correctedModifiers &= ~Qt::ShiftModifier;
     }
 
-    QKeyCombination combination(modifiers, key);
+    QKeyCombination combination(correctedModifiers, key);
 
     for (int i = 0; i < m_newSequence.count(); i++) {
         if (m_newSequence[i] == combination) {
@@ -110,9 +112,10 @@ void EditShortcutModel::inputKey(Qt::Key key, Qt::KeyboardModifiers modifiers)
     emit newSequenceChanged();
 }
 
-bool EditShortcutModel::isShiftAllowed(Qt::Key key)
+bool EditShortcutModel::isShiftAllowed(Qt::Key key, const QString& keyStr)
 {
-    if (key >= Qt::Key_A && key <= Qt::Key_Z) {
+    bool isLetter = keyStr.size() == 1 && keyStr.at(0).isLetter();
+    if (isLetter) {
         return true;
     }
 

--- a/src/framework/shortcuts/view/editshortcutmodel.h
+++ b/src/framework/shortcuts/view/editshortcutmodel.h
@@ -74,6 +74,7 @@ private:
     QVariantMap m_conflictShortcut;
 
     QKeySequence m_newSequence;
+    QKeySequence m_newSequenceEng;
 };
 }
 

--- a/src/framework/shortcuts/view/editshortcutmodel.h
+++ b/src/framework/shortcuts/view/editshortcutmodel.h
@@ -47,7 +47,7 @@ public:
     QString originSequenceInNativeFormat() const;
     QString newSequenceInNativeFormat() const;
     QString conflictWarning() const;
-    bool isShiftAllowed(Qt::Key key);
+    bool isShiftAllowed(Qt::Key key, const QString& keyStr);
 
     Q_INVOKABLE void load(const QVariant& shortcut, const QVariantList& allShortcuts);
     Q_INVOKABLE void inputKey(Qt::Key key, Qt::KeyboardModifiers modifiers);


### PR DESCRIPTION
Resolves: #24177

The main idea of ​​this PR is to transfer the dialog for editing shortcuts from character-based to key combinations.
Now, whenever we enter a shortcut, we translate the entered combination to key combinations, map it to the English layout, and write it to a file. Then, when opening the app, we translate the combination to the current layout.
After this, only English characters will remain in the shortcut files.


https://github.com/user-attachments/assets/1e056311-e185-4597-b253-524148bdd6de

