### PR TITLE
Fix #18272: batch convert for transposing chromatically to key in cmd

### DIFF
--- a/buildscripts/packaging/Linux+BSD/mscore.1.in
+++ b/buildscripts/packaging/Linux+BSD/mscore.1.in
@@ -53,6 +53,7 @@
 .Op Fl \-score\-transpose
 .Op Fl \-template\-mode
 .Op Fl \-test\-mode
+.Op Fl \-transpose
 .Op Fl \-version
 .Op Ar
 .\" should be .Ss semantically but that renders badly
@@ -267,6 +268,9 @@ Transpose the given score and export the data to
 a single JSON file, print it to stdout
 .It Fl \-template\-mode
 Save files in template mode (e.g. without page sizes)
+.It Fl \-transpose
+Transpose the given score (only if the \-o option is also set),
+then exports the given file in accordance with the \-o option
 .El
 .Pp
 MuseScore supports the automatic Qt command line options (see below).
@@ -280,7 +284,7 @@ document honouring the following specification:
 The top-level element must be a JSONArray, which may be empty.
 .It
 Each array element must be a JSONObject with the following keys:
-.Bl -tag -width plugin
+.Bl -tag -width transpose
 .It Li in
 Value is the name of the input file (score to convert), as JSONString.
 .It Li plugin
@@ -301,6 +305,9 @@ and
 .Li out
 .Em must
 be given.
+.It Li transpose
+Value is a JSONString with the transposing options.
+Optional.
 .El
 .It
 The conversion output target may be a filename (with extension,
@@ -437,6 +444,22 @@ Convert a score to PDF from the command line:
 .Pp
 .Dl Nm Fl o No "\(aqMy Score.pdf\(aq" "\(aqMy Score.mscz\(aq"
 .Pp
+Transpose, then convert a score to PDF from the command line:
+.Pp
+.Bd -literal -offset indent
+-o 'My Transposed Score.pdf' --transpose '{"mode": "by_interval", 
+"direction": "up", "transposeInterval": 12, 
+"transposeKeySignatures": true}' 'My Score.mscz'
+.Ed
+.Pp
+Transpose to another score from the command line:
+.Pp
+.Bd -literal -offset indent
+-o 'My Transposed Score.mscz' --transpose '{"mode": "diatonically", 
+"direction": "down", "transposeInterval": 3, 
+"useDoubleSharpsFlats": true}' 'My Score.mscz'
+.Ed
+.Pp
 Run a batch job converting multiple documents:
 .Pp
 .Dl Nm Fl j No job.json
@@ -460,6 +483,28 @@ similar to the following:
       "Reunion.musicxml",
       "Reunion.mid"
     ]
+  },
+  {
+    "in": "Reunion.mscz",
+    "out": "Reunion\-transposed.mscz",
+    "transpose": 
+	{
+	  "mode": "by_interval", 
+	  "direction": "up", 
+	  "transposeInterval": 12, 
+	  "transposeKeySignatures": true
+	}
+  },
+  {
+    "in": "Reunion.mscz",
+    "out": "Reunion\-transposed.pdf",
+    "transpose": 
+	{
+	  "mode": "diatonically", 
+	  "direction": "down", 
+	  "transposeInterval": 2, 
+	  "useDoubleSharpsFlats": true
+	}
   },
   {
     "in": "Piece with excerpts.mscz",

--- a/src/app/internal/commandlineparser.cpp
+++ b/src/app/internal/commandlineparser.cpp
@@ -112,6 +112,10 @@ void CommandLineParser::init()
                                           "Use with '-o <file>.mp3' or with '-j <file>', override the sound profile in the given score(s). "
                                           "Possible values: \"MuseScore Basic\", \"Muse Sounds\"", "sound-profile"));
 
+    m_parser.addOption(QCommandLineOption("transpose",
+                                          "Transpose the given score before executing the '-o' options",
+                                          "options"));
+
     // MusicXML
     m_parser.addOption(QCommandLineOption("musicxml-use-default-font",
                                           "Apply default typeface (Edwin) to imported scores"));
@@ -292,6 +296,11 @@ void CommandLineParser::parse(int argc, char** argv)
             }
             m_options.converterTask.inputFile = scorefiles[0];
             m_options.converterTask.outputFile = fromUserInputPath(m_parser.value("o"));
+
+            // Only if "-o" is set "transpose" has some meaning
+            if (m_parser.isSet("transpose")) {
+                m_options.converterTask.params[CmdOptions::ParamKey::ScoreTransposeOptions] = m_parser.value("transpose");
+            }
         }
     }
 

--- a/src/app/internal/consoleapp.cpp
+++ b/src/app/internal/consoleapp.cpp
@@ -26,6 +26,8 @@
 #ifndef Q_OS_WASM
 #include <QThreadPool>
 #endif
+#include <QJsonObject>
+#include <QJsonDocument>
 
 #include "modularity/ioc.h"
 
@@ -279,9 +281,13 @@ int ConsoleApp::processConverter(const CmdOptions::ConverterTask& task)
     case ConvertType::Batch:
         ret = converter()->batchConvert(task.inputFile, stylePath, forceMode, soundProfile, extensionUri);
         break;
-    case ConvertType::File:
-        ret = converter()->fileConvert(task.inputFile, task.outputFile, stylePath, forceMode, soundProfile, extensionUri);
-        break;
+    case ConvertType::File: {
+        QJsonDocument docTransposeOptions
+            = QJsonDocument::fromJson(QString::fromStdString(
+                                          task.params[CmdOptions::ParamKey::ScoreTransposeOptions].toString().toStdString()).toUtf8());
+        ret = converter()->fileConvert(task.inputFile, task.outputFile, stylePath, forceMode, soundProfile, extensionUri,
+                                       docTransposeOptions.object());
+    } break;
     case ConvertType::ConvertScoreParts:
         ret = converter()->convertScoreParts(task.inputFile, task.outputFile, stylePath);
         break;

--- a/src/app/internal/consoleapp.cpp
+++ b/src/app/internal/consoleapp.cpp
@@ -26,8 +26,6 @@
 #ifndef Q_OS_WASM
 #include <QThreadPool>
 #endif
-#include <QJsonObject>
-#include <QJsonDocument>
 
 #include "modularity/ioc.h"
 
@@ -282,11 +280,9 @@ int ConsoleApp::processConverter(const CmdOptions::ConverterTask& task)
         ret = converter()->batchConvert(task.inputFile, stylePath, forceMode, soundProfile, extensionUri);
         break;
     case ConvertType::File: {
-        QJsonDocument docTransposeOptions
-            = QJsonDocument::fromJson(QString::fromStdString(
-                                          task.params[CmdOptions::ParamKey::ScoreTransposeOptions].toString().toStdString()).toUtf8());
+        std::string transposeOptionsJson = task.params[CmdOptions::ParamKey::ScoreTransposeOptions].toString().toStdString();
         ret = converter()->fileConvert(task.inputFile, task.outputFile, stylePath, forceMode, soundProfile, extensionUri,
-                                       docTransposeOptions.object());
+                                       transposeOptionsJson);
     } break;
     case ConvertType::ConvertScoreParts:
         ret = converter()->convertScoreParts(task.inputFile, task.outputFile, stylePath);

--- a/src/converter/CMakeLists.txt
+++ b/src/converter/CMakeLists.txt
@@ -35,6 +35,8 @@ set(MODULE_SRC
 
     ${CMAKE_CURRENT_LIST_DIR}/internal/convertercontroller.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/convertercontroller.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/converterutils.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/converterutils.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/compat/backendapi.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/compat/backendapi.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/compat/backendjsonwriter.cpp

--- a/src/converter/convertercodes.h
+++ b/src/converter/convertercodes.h
@@ -19,8 +19,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef MU_CONVERTER_CONVERTERCODES_H
-#define MU_CONVERTER_CONVERTERCODES_H
+#pragma once
 
 #include "types/ret.h"
 
@@ -34,8 +33,10 @@ enum class Err {
     BatchJobFileFailedParse = 1302,
 
     ConvertFailed = 1303,
+    TransposeFailed = 1304,
 
     ConvertTypeUnknown = 1310,
+    InvalidTransposeOptions = 1311,
 
     InFileFailedLoad = 1320,
 
@@ -53,5 +54,3 @@ inline muse::Ret make_ret(Err e, const std::string& text)
     return muse::Ret(static_cast<int>(e), text);
 }
 }
-
-#endif // MU_CONVERTER_CONVERTERCODES_H

--- a/src/converter/iconvertercontroller.h
+++ b/src/converter/iconvertercontroller.h
@@ -19,10 +19,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef MU_CONVERTER_ICONVERTERCONTROLLER_H
-#define MU_CONVERTER_ICONVERTERCONTROLLER_H
-
-#include <QJsonObject>
+#pragma once
 
 #include "modularity/imoduleinterface.h"
 #include "global/types/ret.h"
@@ -40,8 +37,7 @@ public:
     virtual muse::Ret fileConvert(const muse::io::path_t& in, const muse::io::path_t& out,
                                   const muse::io::path_t& stylePath = muse::io::path_t(), bool forceMode = false,
                                   const muse::String& soundProfile = muse::String(),
-                                  const muse::UriQuery& extensionUri = muse::UriQuery(),
-                                  const QJsonObject& transposeOptionsObj = QJsonObject()) = 0;
+                                  const muse::UriQuery& extensionUri = muse::UriQuery(), const std::string& transposeOptionsJson = {}) = 0;
 
     virtual muse::Ret batchConvert(const muse::io::path_t& batchJobFile,
                                    const muse::io::path_t& stylePath = muse::io::path_t(), bool forceMode = false,
@@ -68,5 +64,3 @@ public:
     virtual muse::Ret updateSource(const muse::io::path_t& in, const std::string& newSource, bool forceMode = false) = 0;
 };
 }
-
-#endif // MU_CONVERTER_ICONVERTERCONTROLLER_H

--- a/src/converter/iconvertercontroller.h
+++ b/src/converter/iconvertercontroller.h
@@ -22,6 +22,8 @@
 #ifndef MU_CONVERTER_ICONVERTERCONTROLLER_H
 #define MU_CONVERTER_ICONVERTERCONTROLLER_H
 
+#include <QJsonObject>
+
 #include "modularity/imoduleinterface.h"
 #include "global/types/ret.h"
 #include "global/types/uri.h"
@@ -38,7 +40,8 @@ public:
     virtual muse::Ret fileConvert(const muse::io::path_t& in, const muse::io::path_t& out,
                                   const muse::io::path_t& stylePath = muse::io::path_t(), bool forceMode = false,
                                   const muse::String& soundProfile = muse::String(),
-                                  const muse::UriQuery& extensionUri = muse::UriQuery()) = 0;
+                                  const muse::UriQuery& extensionUri = muse::UriQuery(),
+                                  const QJsonObject& transposeOptionsObj = QJsonObject()) = 0;
 
     virtual muse::Ret batchConvert(const muse::io::path_t& batchJobFile,
                                    const muse::io::path_t& stylePath = muse::io::path_t(), bool forceMode = false,

--- a/src/converter/internal/compat/backendapi.h
+++ b/src/converter/internal/compat/backendapi.h
@@ -96,9 +96,6 @@ private:
 
     static muse::RetVal<QByteArray> scorePartJson(mu::engraving::Score* score, const std::string& fileName);
 
-    static muse::RetVal<notation::TransposeOptions> parseTransposeOptions(const std::string& optionsJson);
-    static muse::Ret applyTranspose(const notation::INotationPtr notation, const std::string& optionsJson);
-
     static void switchToPageView(notation::IMasterNotationPtr masterNotation);
     static void renderExcerptsContents(notation::IMasterNotationPtr masterNotation);
 

--- a/src/converter/internal/convertercontroller.cpp
+++ b/src/converter/internal/convertercontroller.cpp
@@ -30,6 +30,8 @@
 #include "global/io/dir.h"
 #include "global/stringutils.h"
 
+#include "internal/converterutils.h"
+
 #include "convertercodes.h"
 #include "compat/backendapi.h"
 
@@ -73,7 +75,7 @@ Ret ConverterController::batchConvert(const muse::io::path_t& batchJobFile, cons
             progress->progressChanged.send(current, total, job.in.toStdString());
         }
 
-        Ret ret = fileConvert(job.in, job.out, stylePath, forceMode, soundProfile, extensionUri);
+        Ret ret = fileConvert(job.in, job.out, stylePath, forceMode, soundProfile, extensionUri, job.transposeOptions);
         if (!ret) {
             errors.emplace_back(String(u"failed convert, err: %1, in: %2, out: %3")
                                 .arg(String::fromStdString(ret.toString())).arg(job.in.toString()).arg(job.out.toString()));
@@ -95,11 +97,13 @@ Ret ConverterController::batchConvert(const muse::io::path_t& batchJobFile, cons
 }
 
 Ret ConverterController::fileConvert(const muse::io::path_t& in, const muse::io::path_t& out, const muse::io::path_t& stylePath,
-                                     bool forceMode, const String& soundProfile, const muse::UriQuery& extensionUri)
+                                     bool forceMode, const String& soundProfile, const muse::UriQuery& extensionUri,
+                                     const QJsonObject& transposeOptionsObj)
 {
     TRACEFUNC;
 
     LOGI() << "in: " << in << ", out: " << out;
+
     auto notationProject = notationCreator()->newProject(iocContext());
     IF_ASSERT_FAILED(notationProject) {
         return make_ret(Err::UnknownError);
@@ -115,6 +119,14 @@ Ret ConverterController::fileConvert(const muse::io::path_t& in, const muse::io:
     if (!ret) {
         LOGE() << "failed load notation, err: " << ret.toString() << ", path: " << in;
         return make_ret(Err::InFileFailedLoad);
+    }
+
+    if (!(transposeOptionsObj.isEmpty())) {
+        ret = ConverterUtils::applyTranspose(notationProject->masterNotation()->notation(), transposeOptionsObj);
+        if (!ret) {
+            QJsonDocument doc(transposeOptionsObj);
+            LOGE() << "Failed to transpose with options: " << doc.toJson(QJsonDocument::Compact).toStdString();
+        }
     }
 
     if (!soundProfile.isEmpty()) {
@@ -219,6 +231,9 @@ RetVal<ConverterController::BatchJob> ConverterController::parseBatchJob(const m
         Job job;
         job.in = correctUserInputPath(obj["in"].toString());
         job.out = correctUserInputPath(obj["out"].toString());
+
+        QJsonDocument doc(obj["transpose"].toObject());
+        job.transposeOptions = doc.object();
 
         if (!job.in.empty() && !job.out.empty()) {
             rv.val.push_back(std::move(job));

--- a/src/converter/internal/convertercontroller.h
+++ b/src/converter/internal/convertercontroller.h
@@ -51,7 +51,8 @@ public:
     muse::Ret fileConvert(const muse::io::path_t& in, const muse::io::path_t& out,
                           const muse::io::path_t& stylePath = muse::io::path_t(), bool forceMode = false,
                           const muse::String& soundProfile = muse::String(),
-                          const muse::UriQuery& extensionUri = muse::UriQuery()) override;
+                          const muse::UriQuery& extensionUri = muse::UriQuery(),
+                          const QJsonObject& transposeOptionsObj = QJsonObject()) override;
 
     muse::Ret batchConvert(const muse::io::path_t& batchJobFile,
                            const muse::io::path_t& stylePath = muse::io::path_t(), bool forceMode = false,
@@ -82,6 +83,7 @@ private:
     struct Job {
         muse::io::path_t in;
         muse::io::path_t out;
+        QJsonObject transposeOptions;
     };
 
     using BatchJob = std::list<Job>;

--- a/src/converter/internal/convertercontroller.h
+++ b/src/converter/internal/convertercontroller.h
@@ -19,8 +19,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef MU_CONVERTER_CONVERTERCONTROLLER_H
-#define MU_CONVERTER_CONVERTERCONTROLLER_H
+#pragma once
 
 #include <list>
 
@@ -51,8 +50,7 @@ public:
     muse::Ret fileConvert(const muse::io::path_t& in, const muse::io::path_t& out,
                           const muse::io::path_t& stylePath = muse::io::path_t(), bool forceMode = false,
                           const muse::String& soundProfile = muse::String(),
-                          const muse::UriQuery& extensionUri = muse::UriQuery(),
-                          const QJsonObject& transposeOptionsObj = QJsonObject()) override;
+                          const muse::UriQuery& extensionUri = muse::UriQuery(), const std::string& transposeOptionsJson = {}) override;
 
     muse::Ret batchConvert(const muse::io::path_t& batchJobFile,
                            const muse::io::path_t& stylePath = muse::io::path_t(), bool forceMode = false,
@@ -83,12 +81,17 @@ private:
     struct Job {
         muse::io::path_t in;
         muse::io::path_t out;
-        QJsonObject transposeOptions;
+        std::optional<notation::TransposeOptions> transposeOptions;
     };
 
     using BatchJob = std::list<Job>;
 
     muse::RetVal<BatchJob> parseBatchJob(const muse::io::path_t& batchJobFile) const;
+
+    muse::Ret fileConvert(const muse::io::path_t& in, const muse::io::path_t& out,
+                          const muse::io::path_t& stylePath = muse::io::path_t(), bool forceMode = false,
+                          const muse::String& soundProfile = muse::String(),
+                          const muse::UriQuery& extensionUri = muse::UriQuery(), const std::optional<notation::TransposeOptions>& transposeOptions = std::nullopt);
 
     muse::Ret convertByExtension(project::INotationWriterPtr writer, notation::INotationPtr notation, const muse::io::path_t& out,
                                  const muse::UriQuery& extensionUri);
@@ -102,5 +105,3 @@ private:
                                       const muse::io::path_t& out) const;
 };
 }
-
-#endif // MU_CONVERTER_CONVERTERCONTROLLER_H

--- a/src/converter/internal/converterutils.cpp
+++ b/src/converter/internal/converterutils.cpp
@@ -1,0 +1,143 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "converterutils.h"
+
+#include <QJsonDocument>
+
+RetVal<TransposeOptions> ConverterUtils::parseTransposeOptions(const QJsonObject& optionsObj)
+{
+    TransposeOptions options;
+
+    const QString modeName = optionsObj["mode"].toString();
+    if (modeName == "by_key" || modeName == "to_key") { // "by_key" for backwards compatibility
+        options.mode = TransposeMode::TO_KEY;
+    } else if (modeName == "by_interval") {
+        options.mode = TransposeMode::BY_INTERVAL;
+    } else if (modeName == "diatonically") {
+        options.mode = TransposeMode::DIATONICALLY;
+    } else {
+        LOGW() << "Transpose: invalid \"mode\" option: " << modeName;
+        return make_ret(Ret::Code::InternalError);
+    }
+
+    const QString directionName = optionsObj["direction"].toString();
+    if (directionName == "up") {
+        options.direction = TransposeDirection::UP;
+    } else if (directionName == "down") {
+        options.direction = TransposeDirection::DOWN;
+    } else if (directionName == "closest") {
+        options.direction = TransposeDirection::CLOSEST;
+    } else {
+        LOGW() << "Transpose: invalid \"direction\" option: " << directionName;
+        return make_ret(Ret::Code::InternalError);
+    }
+
+    constexpr int defaultKey = int(Key::INVALID);
+    const Key targetKey = Key(optionsObj["targetKey"].toInt(defaultKey));
+    if (options.mode == TransposeMode::TO_KEY) {
+        const bool targetKeyValid = int(Key::MIN) <= int(targetKey) && int(targetKey) <= int(Key::MAX);
+        if (!targetKeyValid) {
+            LOGW() << "Transpose: invalid targetKey: " << int(targetKey);
+            return make_ret(Ret::Code::InternalError);
+        }
+    }
+
+    const int transposeInterval = optionsObj["transposeInterval"].toInt(-1);
+    constexpr int INTERVAL_LIST_SIZE = 26;
+
+    if (options.mode != TransposeMode::TO_KEY) {
+        const bool transposeIntervalValid = -1 < transposeInterval && transposeInterval < INTERVAL_LIST_SIZE;
+        if (!transposeIntervalValid) {
+            LOGW() << "Transpose: invalid transposeInterval: " << transposeInterval;
+            return make_ret(Ret::Code::InternalError);
+        }
+    }
+
+    options.interval = transposeInterval;
+    options.key = targetKey;
+    options.needTransposeKeys = optionsObj["transposeKeySignatures"].toBool();
+    options.needTransposeChordNames = optionsObj["transposeChordNames"].toBool();
+    options.needTransposeDoubleSharpsFlats = optionsObj["useDoubleSharpsFlats"].toBool();
+
+    RetVal<TransposeOptions> result;
+    result.ret = make_ret(Ret::Code::Ok);
+    result.val = options;
+
+    return result;
+}
+
+RetVal<TransposeOptions> ConverterUtils::parseTransposeOptions(const std::string& optionsJson)
+{
+    QJsonDocument doc = QJsonDocument::fromJson(QString::fromStdString(optionsJson).toUtf8());
+    if (!doc.isObject()) {
+        LOGW() << "Transpose options JSON is not an object: " << optionsJson;
+        return make_ret(Ret::Code::InternalError);
+    }
+
+    QJsonObject optionsObj = doc.object();
+
+    return parseTransposeOptions(optionsObj);
+}
+
+Ret ConverterUtils::applyTranspose(const INotationPtr notation, const QJsonObject& optionsObj)
+{
+    RetVal<TransposeOptions> options = parseTransposeOptions(optionsObj);
+    if (!options.ret) {
+        return options.ret;
+    }
+
+    INotationInteractionPtr interaction = notation ? notation->interaction() : nullptr;
+    if (!interaction) {
+        return make_ret(Ret::Code::InternalError);
+    }
+
+    interaction->selectAll();
+
+    bool ok = interaction->transpose(options.val);
+    if (!ok) {
+        LOGW() << "Error transpose";
+    }
+
+    return ok ? make_ret(Ret::Code::Ok) : make_ret(Ret::Code::InternalError);
+}
+
+Ret ConverterUtils::applyTranspose(const INotationPtr notation, const std::string& optionsJson)
+{
+    RetVal<TransposeOptions> options = parseTransposeOptions(optionsJson);
+    if (!options.ret) {
+        return options.ret;
+    }
+
+    INotationInteractionPtr interaction = notation ? notation->interaction() : nullptr;
+    if (!interaction) {
+        return make_ret(Ret::Code::InternalError);
+    }
+
+    interaction->selectAll();
+
+    bool ok = interaction->transpose(options.val);
+    if (!ok) {
+        LOGW() << "Error transpose";
+    }
+
+    return ok ? make_ret(Ret::Code::Ok) : make_ret(Ret::Code::InternalError);
+}

--- a/src/converter/internal/converterutils.h
+++ b/src/converter/internal/converterutils.h
@@ -19,23 +19,19 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef MU_CONVERTER_CONVERTERUTILS_H
-#define MU_CONVERTER_CONVERTERUTILS_H
+#pragma once
 
-#include <QJsonObject>
+#include "notation/inotation.h"
+#include "notation/notationtypes.h"
 
 namespace mu::converter {
 class ConverterUtils
 {
 public:
     static muse::RetVal<notation::TransposeOptions> parseTransposeOptions(const std::string& optionsJson);
-
     static muse::RetVal<notation::TransposeOptions> parseTransposeOptions(const QJsonObject& optionsObj);
 
     static muse::Ret applyTranspose(const notation::INotationPtr notation, const std::string& optionsJson);
-
-    static muse::Ret applyTranspose(const notation::INotationPtr notation, const QJsonObject& optionsObj);
+    static muse::Ret applyTranspose(const notation::INotationPtr notation, const notation::TransposeOptions& options);
 };
 }
-
-#endif // MU_CONVERTER_CONVERTERUTILS_H

--- a/src/converter/internal/converterutils.h
+++ b/src/converter/internal/converterutils.h
@@ -1,0 +1,41 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#ifndef MU_CONVERTER_CONVERTERUTILS_H
+#define MU_CONVERTER_CONVERTERUTILS_H
+
+#include <QJsonObject>
+
+namespace mu::converter {
+class ConverterUtils
+{
+public:
+    static muse::RetVal<notation::TransposeOptions> parseTransposeOptions(const std::string& optionsJson);
+
+    static muse::RetVal<notation::TransposeOptions> parseTransposeOptions(const QJsonObject& optionsObj);
+
+    static muse::Ret applyTranspose(const notation::INotationPtr notation, const std::string& optionsJson);
+
+    static muse::Ret applyTranspose(const notation::INotationPtr notation, const QJsonObject& optionsObj);
+};
+}
+
+#endif // MU_CONVERTER_CONVERTERUTILS_H


### PR DESCRIPTION
Resolves: #18272

Support batch convert to transpose chromatically by command line: command line options and "json" processing

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
