### PR TITLE
Fix MSVC compiler warning

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/importmxmlpass2.cpp
@@ -2240,8 +2240,8 @@ void MusicXMLParserPass2::part()
                 matchingNote->setTieBack(unendedTie);
             } else {
                 // try other voices in the stave
-                const Part* part = startChord->part();
-                for (track_idx_t track = part->startTrack(); track < part->endTrack() + VOICES; track++) {
+                const Part* p = startChord->part();
+                for (track_idx_t track = p->startTrack(); track < p->endTrack() + VOICES; track++) {
                     nextEl = nextSeg ? nextSeg->element(track) : nullptr;
                     nextChord = nextEl && nextEl->isChord() ? toChord(nextEl) : nullptr;
                     if (nextChord && nextChord->vStaffIdx() != startChord->vStaffIdx()) {


### PR DESCRIPTION
reg.: declaration of 'part' hides previous local declaration (C4456)

See also #24672