### PR TITLE
Qt 6.8 preparation: Add Windows deploy script

### DIFF
--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -160,6 +160,10 @@ jobs:
       run: |
         IF ${{ env.SENTRY_URL != 0 }} == true ( SET C_URL="${{ env.SENTRY_URL }}" ) ELSE ( SET C_URL="" )
         buildscripts\ci\windows\build.bat -n ${{ env.BUILD_NUMBER }} --crash_log_url %C_URL%
+    - name: Deploy
+      shell: cmd
+      run: |
+        buildscripts\ci\windows\deploy.bat
     - name: Package
       shell: cmd
       run: |
@@ -281,6 +285,10 @@ jobs:
       run: |
         IF ${{ env.SENTRY_URL != 0 }} == true ( SET C_URL="${{ env.SENTRY_URL }}" ) ELSE ( SET C_URL="" )
         buildscripts\ci\windows\build.bat --portable ON -n ${{ env.BUILD_NUMBER }} --crash_log_url %C_URL%
+    - name: Deploy
+      shell: cmd
+      run: |
+        buildscripts\ci\windows\deploy.bat --portable ON
     - name: Package
       shell: cmd
       run: |

--- a/buildscripts/ci/windows/deploy.bat
+++ b/buildscripts/ci/windows/deploy.bat
@@ -1,0 +1,18 @@
+SET INSTALL_DIR=build.install
+SET BUILD_WIN_PORTABLE=OFF
+
+:GETOPTS
+IF /I "%1" == "--portable" SET BUILD_WIN_PORTABLE=%2& SHIFT
+SHIFT
+IF NOT "%1" == "" GOTO GETOPTS
+
+IF %BUILD_WIN_PORTABLE% == ON ( 
+    SET INSTALL_DIR=build.install/App/MuseScore
+)
+
+:: Add Qt DLLs, plugins, translations, and QML files
+windeployqt --verbose 2 ^
+    --qmldir . ^
+    --release ^
+    %INSTALL_DIR%/bin/MuseScore4.exe ^
+    || EXIT /b 1

--- a/buildscripts/ci/windows/setup.bat
+++ b/buildscripts/ci/windows/setup.bat
@@ -46,6 +46,9 @@ SET "QT_URL=https://github.com/cbjeukendrup/musescore_build_qt/releases/download
 CALL "wget.exe" -q --show-progress --no-check-certificate "%QT_URL%" -O "%TEMP_DIR%\%Qt_ARCHIVE%"
 CALL "7z" x -y "%TEMP_DIR%\%Qt_ARCHIVE%" "-o%QT_DIR%"
 
+SET PATH=%QT_DIR%\bin;%PATH%
+ECHO %QT_DIR%\bin>>%GITHUB_PATH%
+
 :: Install dependencies
 ECHO "=== Install dependencies ==="
 CALL "wget.exe" -q --show-progress --no-check-certificate "https://s3.amazonaws.com/utils.musescore.org/musescore_dependencies_win32.7z" -O %TEMP_DIR%\musescore_dependencies_win32.7z


### PR DESCRIPTION
Facilitates the Qt 6.8 update, and removes some unnecessarily installed files from KDDockWidgets and Opus. See commit messages for details.

I chose to make a separate Deploy script, instead of adding these things to the Package script. The Package script is long enough already.