### PR TITLE
Fixed StyledToolbarView with calculation

### DIFF
--- a/src/framework/uicomponents/qml/Muse/UiComponents/StyledToolBarView.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/StyledToolBarView.qml
@@ -63,6 +63,23 @@ Rectangle {
 
         anchors.verticalCenter: parent.verticalCenter
 
+        width: {
+            var result = 0
+            var children = content.children
+
+            for (var i = 0; i < children.length; ++i) {
+                result += children[i].width + spacing
+
+            }
+
+            if (result > 0) {
+                result -= spacing
+            }
+
+            return result
+        }
+        height: childrenRect.height
+
         clip: true
         spacing: 4
 


### PR DESCRIPTION
Fixed this bug: when first opened, the toolbar is shown outside of windows, and restores its position when the window size is changed

https://github.com/user-attachments/assets/26b80ea9-53b9-4502-99ab-616cec783138

We use `Flow` to add the ability to wrap elements to the new line (not yet implemented, but planned). To support such ability, we must limit the width of the flow. To avoid cyclic dependency, I decided to calculate the width manually. When adding a feature for wrapping to the next line, it is planned to pass the maximum width for the toolbar from the outside and take it into account in the new function.