### PR TITLE
[Backend] The score on YouTube not displaying correctly (Does not display the entire score)

### DIFF
--- a/src/importexport/videoexport/internal/videowriter.cpp
+++ b/src/importexport/videoexport/internal/videowriter.cpp
@@ -134,6 +134,8 @@ muse::Ret VideoWriter::generatePagedOriginalVideo(INotationProjectPtr project, c
     score->setShowUnprintable(false);
     score->setShowVBox(false);
 
+    score->doLayout();
+
     PageList pages = masterNotation->notation()->elements()->pages();
     if (pages.empty()) {
         LOGE() << "No pages";


### PR DESCRIPTION
The first page may contain only a text box. Then when calculating the height for the video, we will take this first page and get the height of the text box (smallest rectangle containing all (visible) page elements), which is incorrect, since for the video converter we turn off the display of text boxes a little higher in the code. We need first to make a layout (apply changes) and then get the first page