### PR TITLE
[Backend] The score on YouTube not displaying correctly (Does not display the entire score). 4.4.3

### DIFF
--- a/src/importexport/videoexport/internal/videowriter.cpp
+++ b/src/importexport/videoexport/internal/videowriter.cpp
@@ -134,6 +134,8 @@ muse::Ret VideoWriter::generatePagedOriginalVideo(INotationProjectPtr project, c
     score->setShowUnprintable(false);
     score->setShowVBox(false);
 
+    score->doLayout();
+
     PageList pages = masterNotation->notation()->elements()->pages();
     if (pages.empty()) {
         LOGE() << "No pages";


### PR DESCRIPTION
see https://github.com/musescore/MuseScore/pull/25183