### PR TITLE
Percussion panel - UX refinements

### DIFF
--- a/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
+++ b/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
@@ -85,6 +85,11 @@ Item {
         contentWidth: rowLayout.width
         contentHeight: rowLayout.height
 
+        function goToBottom() {
+            var endY = flickable.contentHeight * (1.0 - flickable.visibleArea.heightRatio)
+            flickable.contentY = endY
+        }
+
         RowLayout {
             id: rowLayout
 
@@ -150,7 +155,7 @@ Item {
 
                 readonly property int numRows: Math.floor(model.numPads / numColumns)
                 readonly property int numColumns: model.numColumns
-                readonly property int spacing: 20
+                readonly property int spacing: 12
 
                 property Item draggedPad: null
 
@@ -246,9 +251,9 @@ Item {
                 orientation: Qt.Horizontal
                 onClicked: {
                     padGrid.model.addRow()
+                    flickable.goToBottom()
                 }
             }
         }
     }
 }
-

--- a/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
+++ b/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
@@ -105,6 +105,8 @@ Item {
                 visible: percModel.currentPanelMode === PanelMode.EDIT_LAYOUT
 
                 Repeater {
+                    id: deleteRepeater
+
                     model: padGrid.numRows
 
                     delegate: Item {
@@ -119,13 +121,24 @@ Item {
                             anchors.verticalCenter: parent.verticalCenter
                             anchors.right: parent.right
 
-                            visible: model.index > 0
+                            visible: padGrid.numRows > 1 && padGrid.model.rowIsEmpty(model.index)
 
                             icon: IconCode.DELETE_TANK
                             backgroundRadius: deleteButton.width / 2
 
                             onClicked: {
                                 padGrid.model.deleteRow(model.index)
+                            }
+
+                            Connections {
+                                target: padGrid.model
+
+                                function onRowIsEmptyChanged(row, isEmpty) {
+                                    if (row !== model.index) {
+                                        return
+                                    }
+                                    deleteButton.visible = padGrid.numRows > 1 && isEmpty
+                                }
                             }
                         }
                     }

--- a/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
+++ b/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
@@ -139,6 +139,8 @@ Item {
                 readonly property int numColumns: model.numColumns
                 readonly property int spacing: 20
 
+                property Item draggedPad: null
+
                 Layout.alignment: Qt.AlignTop
                 Layout.fillHeight: true
 
@@ -169,21 +171,48 @@ Item {
                         panelMode: percModel.currentPanelMode
                         useNotationPreview: percModel.useNotationPreview
 
+                        showOriginBackground: pad.containsDrag || pad === padGrid.draggedPad
+
                         dragParent: root
 
                         onDragStarted: {
+                            padGrid.draggedPad = pad
                             padGrid.model.startDrag(index)
                         }
 
                         onDropped: function(dropEvent) {
+                            padGrid.draggedPad = null
                             padGrid.model.endDrag(index)
                             dropEvent.accepted = true
                         }
 
                         onDragCancelled: {
+                            padGrid.draggedPad = null
                             padGrid.model.endDrag(-1)
                         }
                     }
+
+                    states: [
+                        // If this is the drop target - move the draggable area to the origin of the dragged pad (preview the drop)
+                        State {
+                            name: "DROP_TARGET"
+                            when: Boolean(padGrid.draggedPad) && pad.containsDrag && padGrid.draggedPad !== pad
+                            ParentChange {
+                                target: pad.draggableArea
+                                parent: padGrid.draggedPad
+                            }
+                            AnchorChanges {
+                                target: pad.draggableArea
+                                anchors.verticalCenter: padGrid.draggedPad.verticalCenter
+                                anchors.horizontalCenter: padGrid.draggedPad.horizontalCenter
+                            }
+                            // Origin background not needed for the dragged pad when a preview is taking place...
+                            PropertyChanges {
+                                target: padGrid.draggedPad
+                                showOriginBackground: false
+                            }
+                        }
+                    ]
                 }
             }
 

--- a/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
+++ b/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
@@ -171,6 +171,9 @@ Item {
                         panelMode: percModel.currentPanelMode
                         useNotationPreview: percModel.useNotationPreview
 
+                        // When dragging, only show the outline for the dragged pad and the drag target...
+                        showEditOutline: percModel.currentPanelMode === PanelMode.EDIT_LAYOUT
+                                         && (!Boolean(padGrid.draggedPad) || padGrid.draggedPad === pad || pad.containsDrag)
                         showOriginBackground: pad.containsDrag || pad === padGrid.draggedPad
 
                         dragParent: root

--- a/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPad.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPad.qml
@@ -35,6 +35,8 @@ DropArea {
     property bool useNotationPreview: false
 
     property alias totalBorderWidth: padLoader.anchors.margins
+    property alias showOriginBackground: originBackground.visible
+    property alias draggableArea: draggableArea
 
     property var dragParent: null
     signal dragStarted()
@@ -118,8 +120,7 @@ DropArea {
 
                 Rectangle {
                     id: emptySlotBackground
-
-                    color: root.containsDrag ? ui.theme.buttonColor : ui.theme.backgroundSecondaryColor
+                    color: ui.theme.backgroundSecondaryColor
                 }
             }
         }
@@ -152,7 +153,7 @@ DropArea {
     }
 
     Rectangle {
-        id: dragSourceBackground
+        id: originBackground
 
         anchors.fill: parent
 
@@ -163,19 +164,14 @@ DropArea {
 
         color: draggableArea.color
 
-        // This spawns behind a pad when it is dragged away from the source position
-        visible: dragHandler.active
+        Rectangle {
+            id: originBackgroundFill
 
-        Loader {
             anchors.fill: parent
             anchors.margins: padLoader.anchors.margins
+            radius: draggableArea.radius - originBackgroundFill.anchors.margins
 
-            active: dragHandler.active
-
-            layer.enabled: padLoader.layer.enabled
-            layer.effect: padLoader.layer.effect
-
-            sourceComponent: emptySlotComponent
+            color: root.containsDrag ? ui.theme.buttonColor : ui.theme.backgroundSecondaryColor
         }
     }
 }

--- a/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPad.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPad.qml
@@ -33,6 +33,7 @@ DropArea {
 
     property int panelMode: -1
     property bool useNotationPreview: false
+    property bool showEditOutline: false
 
     property alias totalBorderWidth: padLoader.anchors.margins
     property alias showOriginBackground: originBackground.visible
@@ -58,7 +59,7 @@ DropArea {
 
         color: ui.theme.backgroundPrimaryColor
 
-        border.color: root.panelMode === PanelMode.EDIT_LAYOUT ? ui.theme.accentColor : "transparent"
+        border.color: root.showEditOutline ? ui.theme.accentColor : "transparent"
         border.width: 2
 
         DragHandler {

--- a/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelToolBar.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelToolBar.qml
@@ -23,7 +23,7 @@ import QtQuick 2.15
 
 import Muse.Ui 1.0
 import Muse.UiComponents 1.0
-
+import Muse.GraphicalEffects 1.0
 import MuseScore.NotationScene 1.0
 
 Item {
@@ -52,16 +52,33 @@ Item {
     Row {
         id: centralButtonsRow
 
+        readonly property int buttonWidth: Math.max(writeButton.implicitWidth, previewButton.implicitWidth)
+
         anchors.verticalCenter: parent.verticalCenter
         x: prv.centerX - (centralButtonsRow.width / 2)
+
+        // We only want to round the outer corners of the buttons...
+        layer.enabled: ui.isEffectsAllowed
+        layer.effect: EffectOpacityMask {
+            maskSource: Rectangle {
+                width: centralButtonsRow.width
+                height: centralButtonsRow.height
+                radius: 3
+            }
+        }
 
         visible: model.currentPanelMode !== PanelMode.EDIT_LAYOUT
 
         FlatButton {
+            id: writeButton
+
+            width: centralButtonsRow.buttonWidth
+
             icon: IconCode.EDIT
             text: qsTrc("notation", "Write")
             orientation: Qt.Horizontal
             accentButton: model.currentPanelMode === PanelMode.WRITE
+            backgroundRadius: 0
 
             navigation.panel: navPanel
             navigation.row: 0
@@ -71,11 +88,23 @@ Item {
             }
         }
 
+        Rectangle {
+            id: separator
+            height: parent.height
+            width: 1
+            color: ui.theme.strokeColor
+        }
+
         FlatButton {
+            id: previewButton
+
+            width: centralButtonsRow.buttonWidth
+
             icon: IconCode.PLAY
             text: qsTrc("notation", "Preview")
             orientation: Qt.Horizontal
             accentButton: model.currentPanelMode === PanelMode.SOUND_PREVIEW
+            backgroundRadius: 0
 
             navigation.panel: navPanel
             navigation.row: 0

--- a/src/notation/view/percussionpanel/percussionpanelpadlistmodel.h
+++ b/src/notation/view/percussionpanel/percussionpanelpadlistmodel.h
@@ -46,6 +46,7 @@ public:
 
     Q_INVOKABLE void addRow();
     Q_INVOKABLE void deleteRow(int row);
+    Q_INVOKABLE bool rowIsEmpty(int row) const;
 
     Q_INVOKABLE void startDrag(int startIndex);
     Q_INVOKABLE void endDrag(int endIndex);
@@ -57,6 +58,7 @@ public:
 
 signals:
     void numPadsChanged();
+    void rowIsEmptyChanged(int row, bool empty);
 
 private:
     enum Roles {
@@ -80,6 +82,8 @@ private:
 
     bool indexIsValid(int index) const;
     void movePad(int fromIndex, int toIndex);
+
+    int numEmptySlotsAtRow(int row) const;
 
     QList<PercussionPanelPadModel*> createDefaultItems();
     QList<PercussionPanelPadModel*> m_padModels;


### PR DESCRIPTION
This PR contains five UX refinements for the percussion panel based on some designer feedback:

1. Drag and drops will now "preview" - i.e. the target pad will visually move to the original position of the dragged pad before the drop is confirmed in the model.
2. When a drag is in progress, edit outlines will disappear for all pads except the target pad and the dragged pad.
3. Only empty rows can be deleted.
4. The panel now repositions itself to ensure that the last row is always visible when a row is added.
5. The write/preview toggle as been brought in-line with the spec - only the outer corners are rounded, a spacer has been added, and both buttons have equal widths.