### PR TITLE
Create MusicXML parser class for Note nodes

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -1387,49 +1387,6 @@ static SymId convertFermataToSymId(const String& mxmlName)
 }
 
 //---------------------------------------------------------
-//   convertNotehead
-//---------------------------------------------------------
-
-/**
- Convert a MusicXML notehead name to a MuseScore headgroup.
- */
-
-static NoteHeadGroup convertNotehead(String mxmlName)
-{
-    // map MusicXML notehead name to a MuseScore headgroup
-    static const std::map<String, NoteHeadGroup> map {
-        { u"slash", NoteHeadGroup::HEAD_SLASH },
-        { u"triangle", NoteHeadGroup::HEAD_TRIANGLE_UP },
-        { u"diamond", NoteHeadGroup::HEAD_DIAMOND },
-        { u"cross", NoteHeadGroup::HEAD_PLUS },
-        { u"x", NoteHeadGroup::HEAD_CROSS },
-        { u"circle-x", NoteHeadGroup::HEAD_XCIRCLE },
-        { u"inverted triangle", NoteHeadGroup::HEAD_TRIANGLE_DOWN },
-        { u"slashed", NoteHeadGroup::HEAD_SLASHED1 },
-        { u"back slashed", NoteHeadGroup::HEAD_SLASHED2 },
-        { u"normal", NoteHeadGroup::HEAD_NORMAL },
-        { u"do", NoteHeadGroup::HEAD_DO },
-        { u"re", NoteHeadGroup::HEAD_RE },
-        { u"mi", NoteHeadGroup::HEAD_MI },
-        { u"fa", NoteHeadGroup::HEAD_FA },
-        { u"fa up", NoteHeadGroup::HEAD_FA },
-        { u"so", NoteHeadGroup::HEAD_SOL },
-        { u"la", NoteHeadGroup::HEAD_LA },
-        { u"ti", NoteHeadGroup::HEAD_TI }
-    };
-
-    auto it = map.find(mxmlName);
-    if (it != map.end()) {
-        return it->second;
-    } else {
-        LOGD("unknown notehead %s", muPrintable(mxmlName));      // TODO
-    }
-
-    // default: return 0
-    return NoteHeadGroup::HEAD_NORMAL;
-}
-
-//---------------------------------------------------------
 //   addTextToNote
 //---------------------------------------------------------
 
@@ -2313,88 +2270,6 @@ static Measure* findMeasure(const Score* score, const Fraction& tick)
 }
 
 //---------------------------------------------------------
-//   removeBeam
-//---------------------------------------------------------
-
-/**
- Set beam mode for all elements and remove the beam
- */
-
-static void removeBeam(Beam*& beam)
-{
-    for (size_t i = 0; i < beam->elements().size(); ++i) {
-        beam->elements().at(i)->setBeamMode(BeamMode::NONE);
-    }
-    delete beam;
-    beam = nullptr;
-}
-
-//---------------------------------------------------------
-//   handleBeamAndStemDir
-//---------------------------------------------------------
-
-static void handleBeamAndStemDir(ChordRest* cr, const BeamMode bm, const DirectionV sd, Beam*& beam, bool hasBeamingInfo)
-{
-    if (!cr) {
-        return;
-    }
-    // create a new beam
-    if (bm == BeamMode::BEGIN) {
-        // if currently in a beam, delete it
-        if (beam) {
-            LOGD("handleBeamAndStemDir() new beam, removing previous incomplete beam %p", beam);
-            removeBeam(beam);
-        }
-        // create a new beam
-        beam = Factory::createBeam(cr->score()->dummy()->system());
-        beam->setTrack(cr->track());
-        beam->setDirection(sd);
-    }
-    // add ChordRest to beam
-    if (beam) {
-        // verify still in the same track (if still in the same voice)
-        // and in a beam ...
-        // (note no check is done on correct order of beam begin/continue/end)
-        // TODO: Some BEGINs are being skipped
-        if (cr->track() != beam->track()) {
-            LOGD("handleBeamAndStemDir() from track %zu to track %zu -> abort beam",
-                 beam->track(), cr->track());
-            // reset beam mode for all elements and remove the beam
-            removeBeam(beam);
-        } else if (bm == BeamMode::NONE) {
-            LOGD("handleBeamAndStemDir() in beam, bm BeamMode::NONE -> abort beam");
-            // reset beam mode for all elements and remove the beam
-            removeBeam(beam);
-        } else if (!(bm == BeamMode::BEGIN || bm == BeamMode::MID || bm == BeamMode::END || bm == BeamMode::BEGIN16
-                     || bm == BeamMode::BEGIN32)) {
-            LOGD("handleBeamAndStemDir() in beam, bm %d -> abort beam", static_cast<int>(bm));
-            // reset beam mode for all elements and remove the beam
-            removeBeam(beam);
-        } else {
-            // actually add cr to the beam
-            beam->add(cr);
-        }
-    }
-    // if no beam, set stem direction on chord itself
-    if (!beam) {
-        static_cast<Chord*>(cr)->setStemDirection(sd);
-        // set beam to none if score has beaming information and note can get beam, otherwise
-        // set to auto
-        bool canGetBeam = (cr->durationType().type() >= DurationType::V_EIGHTH
-                           && cr->durationType().type() <= DurationType::V_1024TH);
-        if (hasBeamingInfo && canGetBeam) {
-            cr->setBeamMode(BeamMode::NONE);
-        } else {
-            cr->setBeamMode(BeamMode::AUTO);
-        }
-    }
-    // terminate the current beam and add to the score
-    if (beam && bm == BeamMode::END) {
-        beam = nullptr;
-    }
-}
-
-//---------------------------------------------------------
 //   markUserAccidentals
 //---------------------------------------------------------
 
@@ -2543,6 +2418,19 @@ static bool canAddTempoText(const TempoMap* const tempoMap, const int tick)
     }
 
     return tempoMap->tempo(tick) == Constants::DEFAULT_TEMPO;
+}
+
+/**
+ Set beam mode for all elements and remove the beam
+ */
+
+static void removeBeam(Beam*& beam)
+{
+    for (size_t i = 0; i < beam->elements().size(); ++i) {
+        beam->elements().at(i)->setBeamMode(BeamMode::NONE);
+    }
+    delete beam;
+    beam = nullptr;
 }
 
 //---------------------------------------------------------
@@ -6006,526 +5894,6 @@ void MusicXmlParserPass2::divisions()
 }
 
 //---------------------------------------------------------
-//   isWholeMeasureRest
-//---------------------------------------------------------
-
-/**
- * Determine whole measure rest.
- */
-
-// By convention, whole measure rests do not have a "type" element
-// As of MusicXML 3.0, this can be indicated by an attribute "measure",
-// but for backwards compatibility the "old" convention still has to be supported.
-// Also verify the rest fits exactly in the measure, as some programs
-// (e.g. Cakewalk SONAR X2 Studio [Version: 19.0.0.306]) leave out
-// the type for all rests.
-// Sibelius calls all whole-measure rests "whole", even if the duration != 4/4
-
-static bool isWholeMeasureRest(const String& type, const Fraction dura, const Fraction mDura)
-{
-    if (!dura.isValid()) {
-        return false;
-    }
-
-    if (!mDura.isValid()) {
-        return false;
-    }
-
-    return (type.empty() && dura == mDura)
-           || (type == u"whole" && dura == mDura);
-}
-
-//---------------------------------------------------------
-//   determineDuration
-//---------------------------------------------------------
-
-/**
- * Determine duration for a note or rest.
- * This includes whole measure rest detection.
- */
-
-static TDuration determineDuration(const bool rest, const bool measureRest, const String& type, const int dots, const Fraction dura,
-                                   const Fraction mDura)
-{
-    //LOGD("determineDuration rest %d type '%s' dots %d dura %s mDura %s",
-    //       rest, muPrintable(type), dots, muPrintable(dura.print()), muPrintable(mDura.print()));
-
-    TDuration res;
-    if (rest) {
-        if (measureRest || isWholeMeasureRest(type, dura, mDura)) {
-            res.setType(DurationType::V_MEASURE);
-        } else if (type.empty()) {
-            // If no type, set duration type based on duration.
-            // Note that sometimes unusual duration (e.g. 261/256) are found.
-            res.setVal(dura.ticks());
-        } else {
-            ByteArray ba = type.toAscii();
-            res.setType(TConv::fromXml(ba.constChar(), DurationType::V_INVALID));
-            res.setDots(dots);
-        }
-    } else {
-        ByteArray ba = type.toAscii();
-        res.setType(TConv::fromXml(ba.constChar(), DurationType::V_INVALID));
-        res.setDots(dots);
-        if (res.type() == DurationType::V_INVALID) {
-            res.setType(DurationType::V_QUARTER);        // default, TODO: use dura ?
-        }
-    }
-
-    //LOGD("-> dur %hhd (%s) dots %d ticks %s",
-    //       res.type(), muPrintable(res.name()), res.dots(), muPrintable(dura.print()));
-
-    return res;
-}
-
-//---------------------------------------------------------
-//   findOrCreateChord
-//---------------------------------------------------------
-
-/**
- * Find (or create if not found) the chord at \a tick and \a track.
- * Note: staff move is a note property in MusicXML, but chord property in MuseScore
- * This is simply ignored here, effectively using the last chords value.
- */
-
-static Chord* findOrCreateChord(Score*, Measure* m,
-                                const Fraction& tick, const int track, const int move,
-                                const TDuration duration, const Fraction dura,
-                                BeamMode bm, bool small)
-{
-    //LOGD("findOrCreateChord tick %d track %d dur ticks %d ticks %s bm %hhd",
-    //       tick, track, duration.ticks(), muPrintable(dura.print()), bm);
-    Chord* c = m->findChord(tick, track);
-    if (c == 0) {
-        Segment* s = m->getSegment(SegmentType::ChordRest, tick);
-        c = Factory::createChord(s);
-        // better not to force beam end, as the beam palette does not support it
-        if (bm == BeamMode::END) {
-            c->setBeamMode(BeamMode::AUTO);
-        } else {
-            c->setBeamMode(bm);
-        }
-        c->setTrack(track);
-        // Chord is initialized with the smallness of its first note.
-        // If a non-small note is added later, this is handled in handleSmallness.
-        c->setSmall(small);
-
-        setChordRestDuration(c, duration, dura);
-        s->add(c);
-    }
-    c->setStaffMove(move);
-    return c;
-}
-
-//---------------------------------------------------------
-//   graceNoteType
-//---------------------------------------------------------
-
-/**
- * convert duration and slash to grace note type
- */
-
-NoteType graceNoteType(const TDuration duration, const bool slash)
-{
-    NoteType nt = NoteType::APPOGGIATURA;
-    if (slash) {
-        nt = NoteType::ACCIACCATURA;
-    } else {
-        if (duration.type() == DurationType::V_QUARTER) {
-            nt = NoteType::GRACE4;
-        } else if (duration.type() == DurationType::V_16TH) {
-            nt = NoteType::GRACE16;
-        } else if (duration.type() == DurationType::V_32ND) {
-            nt = NoteType::GRACE32;
-        }
-    }
-    return nt;
-}
-
-//---------------------------------------------------------
-//   createGraceChord
-//---------------------------------------------------------
-
-/**
- * Create a grace chord.
- */
-
-static Chord* createGraceChord(Score* score, const int track,
-                               const TDuration duration, const bool slash, const bool small)
-{
-    Chord* c = Factory::createChord(score->dummy()->segment());
-    c->setNoteType(graceNoteType(duration, slash));
-    c->setTrack(track);
-    // Chord is initialized with the smallness of its first note.
-    // If a non-small note is added later, this is handled in handleSmallness.
-    c->setSmall(small);
-    // note grace notes have no durations, use default fraction 0/1
-    setChordRestDuration(c, duration, Fraction());
-    return c;
-}
-
-//---------------------------------------------------------
-//   handleDisplayStep
-//---------------------------------------------------------
-
-/**
- * convert display-step and display-octave to staff line
- */
-
-static void handleDisplayStep(ChordRest* cr, int step, int octave, const Fraction& tick, double spatium)
-{
-    if (0 <= step && step <= 6 && 0 <= octave && octave <= 9) {
-        //LOGD("rest step=%d oct=%d", step, octave);
-        ClefType clef = cr->staff()->clef(tick);
-        int po = ClefInfo::pitchOffset(clef);
-        //LOGD(" clef=%hhd po=%d step=%d", clef, po, step);
-        int dp = 7 * (octave + 2) + step;
-        //LOGD(" dp=%d po-dp=%d", dp, po-dp);
-        cr->ryoffset() = (po - dp + 3) * spatium / 2;
-    }
-}
-
-//---------------------------------------------------------
-//   handleSmallness
-//---------------------------------------------------------
-
-static void handleSmallness(bool cueOrSmall, Note* note, Chord* c)
-{
-    if (cueOrSmall) {
-        note->setSmall(!c->isSmall()); // Avoid redundant smallness
-    } else {
-        note->setSmall(false);
-        if (c->isSmall()) {
-            // What was a small chord becomes small notes in a non-small chord
-            c->setSmall(false);
-            for (Note* otherNote : c->notes()) {
-                if (note != otherNote) {
-                    otherNote->setSmall(true);
-                }
-            }
-        }
-    }
-}
-
-//---------------------------------------------------------
-//   setNoteHead
-//---------------------------------------------------------
-
-/**
- Set the notehead parameters.
- */
-
-static void setNoteHead(Note* note, const Color noteheadColor, const bool noteheadParentheses, const String& noteheadFilled)
-{
-    Score* const score = note->score();
-
-    if (noteheadColor.isValid()) {
-        note->setColor(noteheadColor);
-    }
-    if (noteheadParentheses) {
-        Symbol* s = new Symbol(note);
-        s->setSym(SymId::noteheadParenthesisLeft);
-        s->setParent(note);
-        score->addElement(s);
-        s = new Symbol(note);
-        s->setSym(SymId::noteheadParenthesisRight);
-        s->setParent(note);
-        score->addElement(s);
-    }
-
-    if (noteheadFilled == u"no") {
-        note->setHeadType(NoteHeadType::HEAD_HALF);
-    } else if (noteheadFilled == u"yes") {
-        note->setHeadType(NoteHeadType::HEAD_QUARTER);
-    }
-}
-
-//---------------------------------------------------------
-//   computeBeamMode
-//---------------------------------------------------------
-
-/**
- Calculate the beam mode based on the collected beamTypes.
- */
-
-static BeamMode computeBeamMode(const std::map<int, String>& beamTypes)
-{
-    // Start with uniquely-handled beam modes
-    if (muse::value(beamTypes, 1) == u"continue"
-        && muse::value(beamTypes, 2) == u"begin") {
-        return BeamMode::BEGIN16;
-    } else if (muse::value(beamTypes, 1) == u"continue"
-               && muse::value(beamTypes, 2) == u"continue"
-               && muse::value(beamTypes, 3) == u"begin") {
-        return BeamMode::BEGIN32;
-    }
-    // Generic beam modes are naive to all except the first beam
-    else if (muse::value(beamTypes, 1) == u"begin") {
-        return BeamMode::BEGIN;
-    } else if (muse::value(beamTypes, 1) == u"continue") {
-        return BeamMode::MID;
-    } else if (muse::value(beamTypes, 1) == u"end") {
-        return BeamMode::END;
-    } else {
-        // backward-hook, forward-hook, and other unknown combinations
-        return BeamMode::AUTO;
-    }
-}
-
-//---------------------------------------------------------
-//   addFiguredBassElements
-//---------------------------------------------------------
-
-/**
- Add the figured bass elements.
- */
-
-static void addFiguredBassElements(FiguredBassList& fbl, const Fraction noteStartTime, const int msTrack,
-                                   const Fraction dura, Measure* measure)
-{
-    if (!fbl.empty()) {
-        Fraction sTick = noteStartTime;                  // starting tick
-        for (FiguredBass* fb : fbl) {
-            fb->setTrack(msTrack);
-            // No duration tag defaults ticks() to 0; set to note value
-            if (fb->ticks().isZero()) {
-                fb->setTicks(dura);
-            }
-            // TODO: set correct onNote value
-            Segment* s = measure->getSegment(SegmentType::ChordRest, sTick);
-            s->add(fb);
-            sTick += fb->ticks();
-        }
-        fbl.clear();
-    }
-}
-
-//---------------------------------------------------------
-//   addTremolo
-//---------------------------------------------------------
-
-static void addTremolo(ChordRest* cr,
-                       const int tremoloNr, const String& tremoloType, const String& tremoloSmufl,
-                       Chord*& tremStart,
-                       MusicXmlLogger* logger, const XmlStreamReader* const xmlreader,
-                       Fraction& timeMod)
-{
-    if (!cr->isChord()) {
-        return;
-    }
-    if (tremoloNr) {
-        //LOGD("tremolo %d type '%s' ticks %d tremStart %p", tremoloNr, muPrintable(tremoloType), ticks, _tremStart);
-        if (tremoloNr == 1 || tremoloNr == 2 || tremoloNr == 3 || tremoloNr == 4) {
-            if (tremoloType.empty() || tremoloType == u"single") {
-                TremoloType type = TremoloType::INVALID_TREMOLO;
-                switch (tremoloNr) {
-                case 1: type = TremoloType::R8;
-                    break;
-                case 2: type = TremoloType::R16;
-                    break;
-                case 3: type = TremoloType::R32;
-                    break;
-                case 4: type = TremoloType::R64;
-                    break;
-                }
-
-                if (type != TremoloType::INVALID_TREMOLO) {
-                    TremoloSingleChord* tremolo = Factory::createTremoloSingleChord(mu::engraving::toChord(cr));
-                    tremolo->setTremoloType(type);
-                    cr->add(tremolo);
-                }
-            } else if (tremoloType == u"start") {
-                if (tremStart) {
-                    logger->logError(u"MusicXml::import: double tremolo start", xmlreader);
-                }
-                tremStart = static_cast<Chord*>(cr);
-                // timeMod takes into account also the factor 2 of a two-note tremolo
-                if (timeMod.isValid() && ((timeMod.denominator() % 2) == 0)) {
-                    timeMod.setDenominator(timeMod.denominator() / 2);
-                }
-            } else if (tremoloType == u"stop") {
-                if (tremStart) {
-                    TremoloType type = TremoloType::INVALID_TREMOLO;
-                    switch (tremoloNr) {
-                    case 1: type = TremoloType::C8;
-                        break;
-                    case 2: type = TremoloType::C16;
-                        break;
-                    case 3: type = TremoloType::C32;
-                        break;
-                    case 4: type = TremoloType::C64;
-                        break;
-                    }
-
-                    if (type != TremoloType::INVALID_TREMOLO) {
-                        TremoloTwoChord* tremolo = Factory::createTremoloTwoChord(mu::engraving::toChord(cr));
-                        tremolo->setTremoloType(type);
-                        tremolo->setChords(tremStart, static_cast<Chord*>(cr));
-                        // fixup chord duration and type
-                        const Fraction tremDur = cr->ticks() * Fraction(1, 2);
-                        tremolo->chord1()->setDurationType(tremDur);
-                        tremolo->chord1()->setTicks(tremDur);
-                        tremolo->chord2()->setDurationType(tremDur);
-                        tremolo->chord2()->setTicks(tremDur);
-                        // add tremolo to first chord (only)
-                        tremStart->add(tremolo);
-                    }
-                    // timeMod takes into account also the factor 2 of a two-note tremolo
-                    if (timeMod.isValid() && ((timeMod.denominator() % 2) == 0)) {
-                        timeMod.setDenominator(timeMod.denominator() / 2);
-                    }
-                } else {
-                    logger->logError(u"MusicXml::import: double tremolo stop w/o start", xmlreader);
-                }
-                tremStart = nullptr;
-            }
-        } else {
-            logger->logError(String(u"unknown tremolo type %1").arg(tremoloNr), xmlreader);
-        }
-    } else if (tremoloNr == 0 && (tremoloType == u"unmeasured" || tremoloType.empty() || tremoloSmufl == u"buzzRoll")) {
-        // Out of all the SMuFL unmeasured tremolos, we only support 'buzzRoll'
-        TremoloSingleChord* tremolo = Factory::createTremoloSingleChord(mu::engraving::toChord(cr));
-        tremolo->setTremoloType(TremoloType::BUZZ_ROLL);
-        cr->add(tremolo);
-    }
-}
-
-//---------------------------------------------------------
-//   setPitch
-//---------------------------------------------------------
-
-// TODO: refactor: optimize parameters
-
-static void setPitch(Note* note, const MusicXmlInstruments& instruments, const String& instrumentId, const MusicXmlNotePitch& mnp,
-                     const int octaveShift, const Instrument* const instrument)
-{
-    if (mnp.unpitched()) {
-        if (hasDrumset(instruments) && muse::contains(instruments, instrumentId)) {
-            // step and oct are display-step and ...-oct
-            // get pitch from instrument definition in drumset instead
-            int unpitched = instruments.at(instrumentId).unpitched;
-            note->setPitch(std::clamp(unpitched, 0, 127));
-            // TODO - does this need to be key-aware?
-            note->setTpc(pitch2tpc(unpitched, Key::C, Prefer::NEAREST));             // TODO: necessary ?
-        } else {
-            //LOGD("disp step %d oct %d", displayStep, displayOctave);
-            xmlSetPitch(note, mnp.displayStep(), 0, 0.0, mnp.displayOctave(), 0, instrument);
-        }
-    } else {
-        xmlSetPitch(note, mnp.step(), mnp.alter(), mnp.tuning(), mnp.octave(), octaveShift, instrument);
-    }
-}
-
-//---------------------------------------------------------
-//   setDrumset
-//---------------------------------------------------------
-
-// set drumset information
-// note that in MuseScore, the drumset contains defaults for notehead,
-// line and stem direction, while a MusicXML file contains actuals.
-// the MusicXML values for each note are simply copied to the defaults
-
-static void setDrumset(Chord* c, MusicXmlParserPass1& pass1, const String& partId, const String& instrumentId,
-                       const Fraction& noteStartTime, const MusicXmlNotePitch& mnp, const DirectionV stemDir, const NoteHeadGroup headGroup)
-{
-    // determine staff line based on display-step / -octave and clef type
-    const ClefType clef = c->staff()->clef(noteStartTime);
-    const int po = ClefInfo::pitchOffset(clef);
-    const int pitch = MusicXmlStepAltOct2Pitch(mnp.displayStep(), 0, mnp.displayOctave());
-    int line = po - absStep(pitch);
-
-    // correct for number of staff lines
-    // see ExportMusicXml::unpitch2xml for explanation
-    // TODO handle other # staff lines ?
-    int staffLines = c->staff()->lines(Fraction(0, 1));
-    if (staffLines == 1) {
-        line -= 8;
-    }
-    if (staffLines == 3) {
-        line -= 2;
-    }
-
-    // the drum palette cannot handle stem direction AUTO,
-    // overrule if necessary
-    DirectionV overruledStemDir = stemDir;
-    if (stemDir == DirectionV::AUTO) {
-        if (line > 4) {
-            overruledStemDir = DirectionV::DOWN;
-        } else {
-            overruledStemDir = DirectionV::UP;
-        }
-    }
-    // this should be done in pass 1, would make _pass1 const here
-    pass1.setDrumsetDefault(partId, instrumentId, headGroup, line, overruledStemDir);
-}
-
-void MusicXmlParserPass2::xmlSetDrumsetPitch(Note* note, const Chord* chord, const Staff* staff, int step, int octave,
-                                             NoteHeadGroup headGroup, DirectionV& stemDir, Instrument* instrument)
-{
-    Drumset* ds = instrument->drumset();
-    // get line
-    // determine staff line based on display-step / -octave and clef type
-    const ClefType clef = staff->clef(chord->tick());
-    const int po = ClefInfo::pitchOffset(clef);
-    const int pitch = MusicXmlStepAltOct2Pitch(step, 0, octave);
-    int line = po - absStep(pitch);
-    const int staffLines = staff->lines(chord->tick());
-    if (staffLines == 1) {
-        line -= 8;
-    }
-    if (staffLines == 3) {
-        line -= 2;
-    }
-
-    const int firstDrum = ds->nextPitch(0);
-    int curDrum = firstDrum;
-    int newPitch = pitch;
-    bool matchFound = false;
-    do {
-        if (ds->line(curDrum) == line) {
-            if (ds->noteHead(curDrum) == headGroup) {
-                newPitch = curDrum;
-                matchFound = true;
-                break;
-            }
-        }
-        curDrum = ds->nextPitch(curDrum);
-    } while (curDrum != firstDrum);
-
-    // Find inferred instruments at this tick
-    if (configuration()->inferTextType()) {
-        InferredPercInstr instr = inferredPercInstr(chord->tick(), chord->track());
-        if (instr.track != muse::nidx) {
-            // Clear old instrument
-            ds->drum(newPitch) = DrumInstrument();
-
-            newPitch = instr.pitch;
-            ds->drum(newPitch) = ds->drum(newPitch) = DrumInstrument(
-                instr.name.toStdString().c_str(), headGroup, line, stemDir, static_cast<int>(chord->voice()));
-        }
-    }
-
-    // If there is no exact match add an entry to the drumkit with the XML line and notehead
-    if (!matchFound) {
-        // Create new instrument in drumkit
-        if (stemDir == DirectionV::AUTO) {
-            if (line > 4) {
-                stemDir = DirectionV::DOWN;
-            } else {
-                stemDir = DirectionV::UP;
-            }
-        }
-
-        ds->drum(newPitch) = DrumInstrument("drum", headGroup, line, stemDir, static_cast<int>(chord->voice()));
-    } else if (stemDir == DirectionV::AUTO) {
-        stemDir = ds->stemDirection(newPitch);
-    }
-
-    note->setPitch(newPitch);
-    note->setTpcFromPitch();
-}
-
-//---------------------------------------------------------
 //   note
 //---------------------------------------------------------
 
@@ -6549,519 +5917,12 @@ Note* MusicXmlParserPass2::note(const String& partId,
                                 MusicXmlTupletStates& tupletStates,
                                 Tuplets& tuplets, ArpeggioMap& arpMap, DelayedArpMap& delayedArps)
 {
-    if (m_e.asciiAttribute("print-spacing") == "no") {
-        notePrintSpacingNo(dura);
-        return 0;
-    }
+    MusicXmlParserNote noteParser { m_e, m_score, m_logger, m_pass1, *this, partId, measure, sTime, prevSTime, missingPrev, dura,
+                                    missingCurr, currentVoice, gcl, gac, currBeams, fbl, alt, tupletStates, tuplets, arpMap, delayedArps };
 
-    bool chord = false;
-    bool cue = false;
-    bool isSmall = false;
-    bool grace = false;
-    bool rest = false;
-    bool measureRest = false;
-    int staff = 0;
-    String type;
-    String voice;
-    DirectionV stemDir = DirectionV::AUTO;
-    bool noStem = false;
-    bool hasHead = true;
-    NoteHeadGroup headGroup = NoteHeadGroup::HEAD_NORMAL;
-    NoteHeadScheme headScheme = NoteHeadScheme::HEAD_AUTO;
-    const Color noteColor = Color::fromString(m_e.asciiAttribute("color").ascii());
-    Color noteheadColor;
-    Color stemColor;
-    bool noteheadParentheses = false;
-    String noteheadFilled;
-    int velocity = round(m_e.doubleAttribute("dynamics") * 0.9);
-    bool graceSlash = false;
-    bool printObject = m_e.asciiAttribute("print-object") != "no";
-    bool isSingleDrumset = false;
-    BeamMode bm;
-    std::map<int, String> beamTypes;
-    String instrumentId;
-    String tieType;
-    MusicXmlParserLyric lyric { m_pass1.getMusicXmlPart(partId).lyricNumberHandler(), m_e, m_score, m_logger,
-                                m_pass1.isVocalStaff(partId) };
-    MusicXmlParserNotations notations { m_e, m_score, m_logger, *this };
-
-    MusicXmlNoteDuration mnd { m_divs, m_logger, &m_pass1 };
-    MusicXmlNotePitch mnp { m_logger };
-
-    while (m_e.readNextStartElement()) {
-        if (mnp.readProperties(m_e, m_score)) {
-            // element handled
-        } else if (mnd.readProperties(m_e)) {
-            // element handled
-        } else if (m_e.name() == "beam") {
-            beam(beamTypes);
-        } else if (m_e.name() == "chord") {
-            chord = true;
-            m_e.skipCurrentElement();  // skip but don't log
-        } else if (m_e.name() == "cue") {
-            cue = true;
-            m_e.skipCurrentElement();  // skip but don't log
-        } else if (m_e.name() == "grace") {
-            grace = true;
-            graceSlash = m_e.asciiAttribute("slash") == "yes";
-            m_e.skipCurrentElement();  // skip but don't log
-        } else if (m_e.name() == "instrument") {
-            instrumentId = m_e.attribute("id");
-            m_e.skipCurrentElement();  // skip but don't log
-        } else if (m_e.name() == "lyric") {
-            // lyrics on grace notes not (yet) supported by MuseScore
-            // add to main note instead
-            lyric.parse();
-        } else if (m_e.name() == "notations") {
-            notations.parse();
-            addError(notations.errors());
-        } else if (m_e.name() == "notehead") {
-            noteheadColor = Color::fromString(m_e.asciiAttribute("color").ascii());
-            noteheadParentheses = m_e.asciiAttribute("parentheses") == "yes";
-            noteheadFilled = m_e.attribute("filled");
-            String noteheadValue = m_e.readText();
-            if (noteheadValue == "none") {
-                hasHead = false;
-            } else if (noteheadValue == "named" && m_pass1.exporterSoftware() == MusicXmlExporterSoftware::NOTEFLIGHT) {
-                headScheme = NoteHeadScheme::HEAD_PITCHNAME;
-            } else {
-                headGroup = convertNotehead(noteheadValue);
-            }
-        } else if (m_e.name() == "rest") {
-            rest = true;
-            measureRest = m_e.asciiAttribute("measure") == "yes";
-            mnp.displayStepOctave(m_e);
-        } else if (m_e.name() == "staff") {
-            bool ok = false;
-            String strStaff = m_e.readText();
-            staff = m_pass1.getMusicXmlPart(partId).staffNumberToIndex(strStaff.toInt(&ok));
-            if (!ok) {
-                // error already reported in pass 1
-                staff = -1;
-            }
-        } else if (m_e.name() == "stem") {
-            stemColor = Color::fromString(m_e.asciiAttribute("color").ascii());
-            stem(stemDir, noStem);
-        } else if (m_e.name() == "tie") {
-            tieType = m_e.attribute("type");
-            m_e.skipCurrentElement();
-        } else if (m_e.name() == "type") {
-            isSmall = m_e.asciiAttribute("size") == "cue" || m_e.asciiAttribute("size") == "grace-cue";
-            type = m_e.readText();
-        } else if (m_e.name() == "voice") {
-            voice = m_e.readText();
-        } else {
-            skipLogCurrElem();
-        }
-    }
-
-    // Bug fix for Sibelius 7.1.3 which does not write <voice> for notes with <chord>
-    if (!chord) {
-        // remember voice
-        currentVoice = voice;
-    } else if (voice.empty()) {
-        // use voice from last note w/o <chord>
-        voice = currentVoice;
-    }
-
-    // Assume voice 1 if voice is empty (legal in a single voice part)
-    if (voice.empty()) {
-        voice = u"1";
-    }
-
-    // Define currBeam based on currentVoice to handle multi-voice beaming (and instantiate if not already)
-    if (!muse::contains(currBeams, currentVoice)) {
-        currBeams.insert({ currentVoice, (Beam*)nullptr });
-    }
-    Beam*& currBeam = currBeams[currentVoice];
-
-    bm = computeBeamMode(beamTypes);
-
-    // check for timing error(s) and set dura
-    // keep in this order as checkTiming() might change dura
-    String errorStr = mnd.checkTiming(type, rest, grace);
-    dura = mnd.duration();
-    if (!errorStr.empty()) {
-        m_logger->logError(errorStr, &m_e);
-    }
-
-    IF_ASSERT_FAILED(m_pass1.getPart(partId)) {
-        return nullptr;
-    }
-
-    // At this point all checks have been done, the note should be added
-    // note: in case of error exit from here, the postponed <note> children
-    // must still be skipped
-
-    int msMove = 0;
-    int msTrack = 0;
-    int msVoice = 0;
-
-    int voiceInt = m_pass1.voiceToInt(voice);
-    if (!m_pass1.determineStaffMoveVoice(partId, staff, voiceInt, msMove, msTrack, msVoice)) {
-        m_logger->logDebugInfo(String(u"could not map staff %1 voice '%2'").arg(staff + 1).arg(voice), &m_e);
-        addError(checkAtEndElement(m_e, u"note"));
-        return 0;
-    }
-
-    // start time for note:
-    // - sTime for non-chord / first chord note
-    // - prevTime for others
-    Fraction noteStartTime = chord ? prevSTime : sTime;
-    Fraction timeMod = mnd.timeMod();
-
-    // determine tuplet state, used twice (before and after note allocation)
-    MusicXmlTupletFlags tupletAction;
-
-    // handle tuplet state for the previous chord or rest
-    if (!chord && !grace) {
-        Tuplet* tuplet = tuplets[voice];
-        MusicXmlTupletState& tupletState = tupletStates[voice];
-        tupletAction = tupletState.determineTupletAction(mnd.duration(), timeMod, notations.tupletDesc().type,
-                                                         mnd.normalType(), missingPrev, missingCurr);
-        if (tupletAction & MusicXmlTupletFlag::STOP_PREVIOUS) {
-            // tuplet start while already in tuplet
-            if (missingPrev.isValid() && missingPrev > Fraction(0, 1)) {
-                const int track = msTrack + msVoice;
-                Rest* const extraRest = addRest(m_score, measure, noteStartTime, track, msMove,
-                                                TDuration { missingPrev* tuplet->ratio() }, missingPrev);
-                if (extraRest) {
-                    extraRest->setTuplet(tuplet);
-                    tuplet->add(extraRest);
-                    noteStartTime += missingPrev;
-                }
-            }
-            // recover by simply stopping the current tuplet first
-            const int normalNotes = timeMod.numerator();
-            handleTupletStop(tuplet, normalNotes);
-        }
-    }
-
-    Chord* c { nullptr };
-    ChordRest* cr { nullptr };
-    Note* note { nullptr };
-
-    TDuration duration = determineDuration(rest, measureRest, type, mnd.dots(), dura, measure->ticks());
-
-    Part* part = m_pass1.getPart(partId);
-    Instrument* instrument = part->instrument(noteStartTime);
-    const MusicXmlInstruments& instruments = m_pass1.getInstruments(partId);
-    isSingleDrumset = instrument->drumset() && instruments.size() == 1;
-    // begin allocation
-    if (rest) {
-        const int track = msTrack + msVoice;
-        cr = addRest(m_score, measure, noteStartTime, track, msMove,
-                     duration, dura);
-    } else {
-        if (!grace) {
-            // regular note
-            // if there is already a chord just add to it
-            // else create a new one
-            // this basically ignores <chord/> errors
-            c = findOrCreateChord(m_score, measure,
-                                  noteStartTime,
-                                  msTrack + msVoice, msMove,
-                                  duration, dura, bm, isSmall || cue);
-        } else {
-            // grace note
-            // TODO: check if explicit stem direction should also be set for grace notes
-            // (the DOM parser does that, but seems to have no effect on the autotester)
-            if (!chord || gcl.empty()) {
-                c = createGraceChord(m_score, msTrack + msVoice, duration, graceSlash, isSmall || cue);
-                // TODO FIX
-                // the setStaffMove() below results in identical behaviour as 2.0:
-                // grace note will be at the wrong staff with the wrong pitch,
-                // seems to use the line value calculated for the right staff
-                // leaving it places the note at the wrong staff with the right pitch
-                // this affects only grace notes where staff move differs from
-                // the main note, e.g. DebuMandSample.xml first grace in part 2
-                // c->setStaffMove(msMove);
-                // END TODO
-                gcl.push_back(c);
-            } else {
-                c = gcl.back();
-            }
-        }
-        note = Factory::createNote(c);
-        const staff_idx_t ottavaStaff = (msTrack - m_pass1.trackForPart(partId)) / VOICES;
-        const int octaveShift = m_pass1.octaveShift(partId, ottavaStaff, noteStartTime);
-        const Staff* st = c->staff();
-        if (isSingleDrumset && mnp.unpitched() && instrumentId.empty()) {
-            xmlSetDrumsetPitch(note, c, st, mnp.displayStep(), mnp.displayOctave(), headGroup, stemDir, instrument);
-        } else {
-            setPitch(note, instruments, instrumentId, mnp, octaveShift, instrument);
-        }
-        c->add(note);
-        cr = c;
-    }
-    // end allocation
-
-    if (rest) {
-        const track_idx_t track = msTrack + msVoice;
-        if (cr) {
-            if (currBeam) {
-                if (currBeam->track() == track) {
-                    cr->setBeamMode(BeamMode::MID);
-                    currBeam->add(cr);
-                } else {
-                    removeBeam(currBeam);
-                }
-            } else {
-                cr->setBeamMode(BeamMode::NONE);
-            }
-            cr->setSmall(isSmall);
-            if (noteColor.isValid()) {
-                cr->setColor(noteColor);
-            }
-            cr->setVisible(printObject);
-            handleDisplayStep(cr, mnp.displayStep(), mnp.displayOctave(), noteStartTime, m_score->style().spatium());
-        }
-    } else {
-        handleSmallness(cue || isSmall, note, c);
-        note->setPlay(!cue);          // cue notes don't play
-        note->setHeadGroup(headGroup);
-        if (headScheme != NoteHeadScheme::HEAD_AUTO) {
-            note->setHeadScheme(headScheme);
-        }
-        if (noteColor.isValid()) {
-            note->setColor(noteColor);
-        }
-        Stem* stem = c->stem();
-        if (!stem) {
-            stem = Factory::createStem(c);
-            if (stemColor.isValid()) {
-                stem->setColor(stemColor);
-            } else if (noteColor.isValid()) {
-                stem->setColor(noteColor);
-            }
-            c->add(stem);
-        }
-        setNoteHead(note, noteheadColor, noteheadParentheses, noteheadFilled);
-        note->setVisible(hasHead && printObject);
-        stem->setVisible(printObject);
-
-        if (!grace) {
-            // regular note
-            // handle beam
-            if (!chord) {
-                handleBeamAndStemDir(c, bm, stemDir, currBeam, m_pass1.hasBeamingInfo());
-            }
-
-            // append any grace chord after chord to the previous chord
-            Chord* const prevChord = measure->findChord(prevSTime, msTrack + msVoice);
-            if (prevChord && prevChord != c) {
-                addGraceChordsAfter(prevChord, gcl, gac);
-            }
-
-            // append any grace chord
-            addGraceChordsBefore(c, gcl);
-        }
-
-        if (mnd.calculatedDuration().isValid()
-            && mnd.specifiedDuration().isValid()
-            && mnd.calculatedDuration().isNotZero()
-            && mnd.calculatedDuration() != mnd.specifiedDuration()) {
-            // convert duration into note length
-            Fraction durationMult { (mnd.specifiedDuration() / mnd.calculatedDuration()).reduced() };
-            durationMult = (1000 * durationMult).reduced();
-            const int noteLen = durationMult.numerator() / durationMult.denominator();
-
-            NoteEventList nel;
-            NoteEvent ne;
-            ne.setLen(noteLen);
-            nel.push_back(ne);
-            note->setPlayEvents(nel);
-            if (c) {
-                c->setPlayEventType(PlayEventType::User);
-            }
-        }
-
-        if (velocity > 0) {
-            note->setUserVelocity(velocity);
-        }
-
-        if (mnp.unpitched() && !isSingleDrumset) {
-            setDrumset(c, m_pass1, partId, instrumentId, noteStartTime, mnp, stemDir, headGroup);
-        }
-
-        // accidental handling
-        //LOGD("note acc %p type %hhd acctype %hhd",
-        //       acc, acc ? acc->accidentalType() : static_cast<mu::engraving::AccidentalType>(0), accType);
-        Accidental* acc = mnp.acc();
-        if (!acc && mnp.accType() != AccidentalType::NONE) {
-            acc = Factory::createAccidental(m_score->dummy());
-            acc->setAccidentalType(mnp.accType());
-        }
-
-        if (acc) {
-            acc->setVisible(printObject);
-            note->add(acc);
-            // save alter value for user accidental
-            if (acc->accidentalType() != AccidentalType::NONE) {
-                alt = mnp.alter();
-            }
-        }
-
-        c->setNoStem(noStem);
-    }
-
-    // cr can be 0 here (if a rest cannot be added)
-    // TODO: complete and cleanup handling this case
-    if (cr) {
-        cr->setVisible(printObject);
-    }
-
-    // handle notations
-    if (cr) {
-        notations.addToScore(cr, note,
-                             noteStartTime.ticks(), m_slurs, m_glissandi, m_spanners, m_trills, m_ties, m_unstartedTieNotes, m_unendedTieNotes, arpMap,
-                             delayedArps);
-
-        // if no tie added yet, convert the "tie" into "tied" and add it.
-        if (note && !note->tieFor() && !note->tieBack() && !tieType.empty()) {
-            Notation notation = Notation(u"tied");
-            const String type2 = u"type";
-            notation.addAttribute(type2, tieType);
-            addTie(notation, note, cr->track(), m_ties, m_unstartedTieNotes, m_unendedTieNotes, m_logger, &m_e);
-        }
-    }
-
-    // handle grace after state: remember current grace list size
-    if (grace && notations.mustStopGraceAFter()) {
-        gac = gcl.size();
-    }
-
-    // handle tremolo before handling tuplet (two note tremolos modify timeMod)
-    if (cr && notations.hasTremolo()) {
-        addTremolo(cr, notations.tremoloNr(), notations.tremoloType(), notations.tremoloSmufl(), m_tremStart, m_logger, &m_e, timeMod);
-    }
-
-    // handle tuplet state for the current chord or rest
-    if (cr) {
-        if (!chord && !grace) {
-            Tuplet*& tuplet = tuplets[voice];
-            // do tuplet if valid time-modification is not 1/1 and is not 1/2 (tremolo)
-            // TODO: check interaction tuplet and tremolo handling
-            if (timeMod.isValid() && timeMod != Fraction(1, 1) && timeMod != Fraction(1, 2)) {
-                const int actualNotes = timeMod.denominator();
-                const int normalNotes = timeMod.numerator();
-                if (tupletAction & MusicXmlTupletFlag::START_NEW) {
-                    // create a new tuplet
-                    handleTupletStart(cr, tuplet, actualNotes, normalNotes, notations.tupletDesc());
-                }
-                if (tupletAction & MusicXmlTupletFlag::ADD_CHORD) {
-                    cr->setTuplet(tuplet);
-                    tuplet->add(cr);
-                }
-                if (tupletAction & MusicXmlTupletFlag::STOP_CURRENT) {
-                    if (missingCurr.isValid() && missingCurr > Fraction(0, 1)) {
-                        LOGD("add missing %s to current tuplet", muPrintable(missingCurr.toString()));
-                        const int track = msTrack + msVoice;
-                        Rest* const extraRest = addRest(m_score, measure, noteStartTime + dura, track, msMove,
-                                                        TDuration { missingCurr* tuplet->ratio() }, missingCurr);
-                        if (extraRest) {
-                            extraRest->setTuplet(tuplet);
-                            tuplet->add(extraRest);
-                        }
-                    }
-                    handleTupletStop(tuplet, normalNotes);
-                }
-            } else if (tuplet) {
-                // stop any still incomplete tuplet
-                handleTupletStop(tuplet, 2);
-            }
-        }
-    }
-
-    // Add all lyrics from grace notes attached to this chord
-    if (c && !c->graceNotes().empty() && !m_graceNoteLyrics.empty()) {
-        for (GraceNoteLyrics gnl : m_graceNoteLyrics) {
-            if (gnl.lyric) {
-                addLyric(m_logger, &m_e, cr, gnl.lyric, gnl.no, m_extendedLyrics);
-                if (gnl.extend) {
-                    m_extendedLyrics.addLyric(gnl.lyric);
-                }
-            }
-        }
-        m_graceNoteLyrics.clear();
-    }
-
-    if (cr) {
-        addInferredStickings(cr, lyric.inferredStickings());
-    }
-
-    // add lyrics found by lyric
-    if (cr && !grace) {
-        // add lyrics and stop corresponding extends
-        addLyrics(m_logger, &m_e, cr, lyric.numberedLyrics(), lyric.extendedLyrics(), m_extendedLyrics);
-        if (rest) {
-            // stop all extends
-            m_extendedLyrics.setExtend(-1, cr->track(), cr->tick());
-        }
-    } else if (c && grace) {
-        // Add grace note lyrics to main chord later
-        addGraceNoteLyrics(lyric.numberedLyrics(), lyric.extendedLyrics(), m_graceNoteLyrics);
-    }
-
-    // add figured bass element
-    addFiguredBassElements(fbl, noteStartTime, msTrack, dura, measure);
-
-    // convert to slash or rhythmic notation if needed
-    // TODO in the case of slash notation, we assume that given notes do in fact correspond to slash beats
-    if (c && m_measureStyleSlash != MusicXmlSlash::NONE) {
-        c->setSlash(true, m_measureStyleSlash == MusicXmlSlash::SLASH);
-    }
-
-    // don't count chord or grace note duration
-    // note that this does not check the MusicXML requirement that notes in a chord
-    // cannot have a duration longer than the first note in the chord
-    if (chord || grace) {
-        dura.set(0, 1);
-    }
-
-    addError(checkAtEndElement(m_e, u"note"));
-
+    Note* note = noteParser.parse();
+    addError(noteParser.errors());
     return note;
-}
-
-//---------------------------------------------------------
-//   notePrintSpacingNo
-//---------------------------------------------------------
-
-/**
- Parse the /score-partwise/part/measure/note node for a note with print-spacing="no".
- These are handled like a forward: only moving the time forward.
- */
-
-void MusicXmlParserPass2::notePrintSpacingNo(Fraction& dura)
-{
-    //_logger->logDebugTrace("MusicXmlParserPass1::notePrintSpacingNo", &_e);
-
-    bool chord = false;
-    bool grace = false;
-
-    while (m_e.readNextStartElement()) {
-        if (m_e.name() == "chord") {
-            chord = true;
-            m_e.skipCurrentElement();  // skip but don't log
-        } else if (m_e.name() == "duration") {
-            duration(dura);
-        } else if (m_e.name() == "grace") {
-            grace = true;
-            m_e.skipCurrentElement();  // skip but don't log
-        } else {
-            m_e.skipCurrentElement();              // skip but don't log
-        }
-    }
-
-    // don't count chord or grace note duration
-    // note that this does not check the MusicXML requirement that notes in a chord
-    // cannot have a duration longer than the first note in the chord
-    if (chord || grace) {
-        dura.set(0, 1);
-    }
-
-    addError(checkAtEndElement(m_e, u"note"));
 }
 
 //---------------------------------------------------------
@@ -7550,24 +6411,6 @@ void MusicXmlParserPass2::harmony(const String& partId, Measure* measure, const 
         // No harmony at this tick, add to the map
         harmonyMap.insert(std::pair<int, HarmonyDesc>((sTime + offset).ticks(), newHarmonyDesc));
     }
-}
-
-//---------------------------------------------------------
-//   beam
-//---------------------------------------------------------
-
-/**
- Parse the /score-partwise/part/measure/note/beam node.
- Collects beamTypes, used in computeBeamMode.
- */
-
-void MusicXmlParserPass2::beam(std::map<int, String>& beamTypes)
-{
-    bool hasBeamNo;
-    int beamNo = m_e.asciiAttribute("number").toInt(&hasBeamNo);
-    String s = m_e.readText();
-
-    beamTypes.insert({ hasBeamNo ? beamNo : 1, s });
 }
 
 //---------------------------------------------------------
@@ -8247,7 +7090,7 @@ void MusicXmlParserNotations::glissandoSlide()
 //---------------------------------------------------------
 
 static void addGlissandoSlide(const Notation& notation, Note* note,
-                              Glissando* glissandi[MAX_NUMBER_LEVEL][2], MusicXmlSpannerMap& spanners,
+                              std::array<std::array<engraving::Glissando*, 2>, MAX_NUMBER_LEVEL>& glissandi, MusicXmlSpannerMap& spanners,
                               MusicXmlLogger* logger, const XmlStreamReader* const xmlreader)
 {
     int glissandoNumber = notation.attribute(u"number").toInt();
@@ -8752,7 +7595,8 @@ void MusicXmlParserNotations::addNotation(const Notation& notation, ChordRest* c
  */
 
 void MusicXmlParserNotations::addToScore(ChordRest* const cr, Note* const note, const int tick, SlurStack& slurs,
-                                         Glissando* glissandi[MAX_NUMBER_LEVEL][2], MusicXmlSpannerMap& spanners,
+                                         std::array<std::array<engraving::Glissando*, 2>, MAX_NUMBER_LEVEL>& glissandi,
+                                         MusicXmlSpannerMap& spanners,
                                          TrillStack& trills, MusicXmlTieMap& ties, std::vector<Note*>& unstartedTieNotes,
                                          std::vector<Note*>& unendedTieNotes, ArpeggioMap& arpMap,
                                          DelayedArpMap& delayedArps)
@@ -8784,34 +7628,6 @@ void MusicXmlParserNotations::addToScore(ChordRest* const cr, Note* const note, 
         Dynamic* dynamic = Factory::createDynamic(m_score->dummy()->segment());
         dynamic->setDynamicType(d);
         addElemOffset(dynamic, cr->track(), m_dynamicsPlacement, cr->measure(), Fraction::fromTicks(tick), m_pass2);
-    }
-}
-
-//---------------------------------------------------------
-//   stem
-//---------------------------------------------------------
-
-/**
- Parse the /score-partwise/part/measure/note/stem node.
- */
-
-void MusicXmlParserPass2::stem(DirectionV& sd, bool& nost)
-{
-    // defaults
-    sd = DirectionV::AUTO;
-    nost = false;
-
-    String s = m_e.readText();
-
-    if (s == u"up") {
-        sd = DirectionV::UP;
-    } else if (s == u"down") {
-        sd = DirectionV::DOWN;
-    } else if (s == u"none") {
-        nost = true;
-    } else if (s == u"double") {
-    } else {
-        m_logger->logError(String(u"unknown stem direction %1").arg(s), &m_e);
     }
 }
 
@@ -8910,12 +7726,12 @@ void MusicXmlParserNotations::otherNotation()
  MusicXmlParserDirection constructor.
  */
 
-MusicXmlParserDirection::MusicXmlParserDirection(XmlStreamReader& e,
+MusicXmlParserDirection::MusicXmlParserDirection(XmlStreamReader& xmlReader,
                                                  Score* score,
                                                  MusicXmlParserPass1& pass1,
                                                  MusicXmlParserPass2& pass2,
                                                  MusicXmlLogger* logger)
-    : m_e(e), m_score(score), m_pass1(pass1), m_pass2(pass2), m_logger(logger),
+    : m_e(xmlReader), m_score(score), m_pass1(pass1), m_pass2(pass2), m_logger(logger),
     m_hasDefaultY(false), m_defaultY(0.0), m_hasRelativeY(false), m_relativeY(0.0),
     m_tpoMetro(0), m_tpoSound(0), m_offset(0, 1)
 {
@@ -8925,5 +7741,1158 @@ MusicXmlParserDirection::MusicXmlParserDirection(XmlStreamReader& e,
 bool HarmonyDesc::fretDiagramVisible() const
 {
     return m_fretDiagram ? m_fretDiagram->visible() : false;
+}
+
+MusicXmlParserNote::MusicXmlParserNote(muse::XmlStreamReader& e, engraving::Score* score, MusicXmlLogger* logger,
+                                       MusicXmlParserPass1& pass1,
+                                       MusicXmlParserPass2& pass2, const muse::String& partId, engraving::Measure* measure,
+                                       const Fraction sTime, const Fraction prevSTime, Fraction& missingPrev, Fraction& dura,
+                                       Fraction& missingCurr, String& currentVoice, GraceChordList& gcl, size_t& gac, Beams& currBeams,
+                                       FiguredBassList& fbl, int& alt, MusicXmlTupletStates& tupletStates, Tuplets& tuplets,
+                                       ArpeggioMap& arpMap, DelayedArpMap& delayedArps)
+    : m_e(e), m_score(score), m_logger(logger), m_pass1(pass1), m_pass2(pass2), m_partId(partId), m_measure(measure), m_sTime(sTime),
+    m_prevSTime(prevSTime), m_missingPrev(missingPrev), m_dura(dura), m_missingCurr(missingCurr), m_currentVoice(currentVoice), m_gcl(gcl),
+    m_gac(gac), m_currBeams(currBeams), m_fbl(fbl), m_alt(alt), m_tupletStates(tupletStates), m_tuplets(tuplets), m_arpMap(arpMap),
+    m_delayedArps(delayedArps)
+{
+}
+
+/**
+ Parse the /score-partwise/part/measure/note/beam node.
+ Collects beamTypes, used in computeBeamMode.
+ */
+
+void MusicXmlParserNote::beam(std::map<int, String>& beamTypes)
+{
+    bool hasBeamNo;
+    int beamNo = m_e.asciiAttribute("number").toInt(&hasBeamNo);
+    String s = m_e.readText();
+
+    beamTypes.insert({ hasBeamNo ? beamNo : 1, s });
+}
+
+/**
+ Calculate the beam mode based on the collected beamTypes.
+ */
+
+BeamMode MusicXmlParserNote::computeBeamMode(const std::map<int, String>& beamTypes)
+{
+    // Start with uniquely-handled beam modes
+    if (muse::value(beamTypes, 1) == u"continue"
+        && muse::value(beamTypes, 2) == u"begin") {
+        return BeamMode::BEGIN16;
+    } else if (muse::value(beamTypes, 1) == u"continue"
+               && muse::value(beamTypes, 2) == u"continue"
+               && muse::value(beamTypes, 3) == u"begin") {
+        return BeamMode::BEGIN32;
+    }
+    // Generic beam modes are naive to all except the first beam
+    else if (muse::value(beamTypes, 1) == u"begin") {
+        return BeamMode::BEGIN;
+    } else if (muse::value(beamTypes, 1) == u"continue") {
+        return BeamMode::MID;
+    } else if (muse::value(beamTypes, 1) == u"end") {
+        return BeamMode::END;
+    } else {
+        // backward-hook, forward-hook, and other unknown combinations
+        return BeamMode::AUTO;
+    }
+}
+
+void MusicXmlParserNote::handleBeamAndStemDir(ChordRest* cr, const BeamMode bm, const DirectionV sd, Beam*& beam, bool hasBeamingInfo)
+{
+    if (!cr) {
+        return;
+    }
+    // create a new beam
+    if (bm == BeamMode::BEGIN) {
+        // if currently in a beam, delete it
+        if (beam) {
+            LOGD("handleBeamAndStemDir() new beam, removing previous incomplete beam %p", beam);
+            removeBeam(beam);
+        }
+        // create a new beam
+        beam = Factory::createBeam(cr->score()->dummy()->system());
+        beam->setTrack(cr->track());
+        beam->setDirection(sd);
+    }
+    // add ChordRest to beam
+    if (beam) {
+        // verify still in the same track (if still in the same voice)
+        // and in a beam ...
+        // (note no check is done on correct order of beam begin/continue/end)
+        // TODO: Some BEGINs are being skipped
+        if (cr->track() != beam->track()) {
+            LOGD("handleBeamAndStemDir() from track %zu to track %zu -> abort beam",
+                 beam->track(), cr->track());
+            // reset beam mode for all elements and remove the beam
+            removeBeam(beam);
+        } else if (bm == BeamMode::NONE) {
+            LOGD("handleBeamAndStemDir() in beam, bm BeamMode::NONE -> abort beam");
+            // reset beam mode for all elements and remove the beam
+            removeBeam(beam);
+        } else if (!(bm == BeamMode::BEGIN || bm == BeamMode::MID || bm == BeamMode::END || bm == BeamMode::BEGIN16
+                     || bm == BeamMode::BEGIN32)) {
+            LOGD("handleBeamAndStemDir() in beam, bm %d -> abort beam", static_cast<int>(bm));
+            // reset beam mode for all elements and remove the beam
+            removeBeam(beam);
+        } else {
+            // actually add cr to the beam
+            beam->add(cr);
+        }
+    }
+    // if no beam, set stem direction on chord itself
+    if (!beam) {
+        static_cast<Chord*>(cr)->setStemDirection(sd);
+        // set beam to none if score has beaming information and note can get beam, otherwise
+        // set to auto
+        bool canGetBeam = (cr->durationType().type() >= DurationType::V_EIGHTH
+                           && cr->durationType().type() <= DurationType::V_1024TH);
+        if (hasBeamingInfo && canGetBeam) {
+            cr->setBeamMode(BeamMode::NONE);
+        } else {
+            cr->setBeamMode(BeamMode::AUTO);
+        }
+    }
+    // terminate the current beam and add to the score
+    if (beam && bm == BeamMode::END) {
+        beam = nullptr;
+    }
+}
+
+/**
+ Convert a MusicXML notehead name to a MuseScore headgroup.
+ */
+
+NoteHeadGroup MusicXmlParserNote::convertNotehead(String mxmlName)
+{
+    // map MusicXML notehead name to a MuseScore headgroup
+    static const std::map<String, NoteHeadGroup> map {
+        { u"slash", NoteHeadGroup::HEAD_SLASH },
+        { u"triangle", NoteHeadGroup::HEAD_TRIANGLE_UP },
+        { u"diamond", NoteHeadGroup::HEAD_DIAMOND },
+        { u"cross", NoteHeadGroup::HEAD_PLUS },
+        { u"x", NoteHeadGroup::HEAD_CROSS },
+        { u"circle-x", NoteHeadGroup::HEAD_XCIRCLE },
+        { u"inverted triangle", NoteHeadGroup::HEAD_TRIANGLE_DOWN },
+        { u"slashed", NoteHeadGroup::HEAD_SLASHED1 },
+        { u"back slashed", NoteHeadGroup::HEAD_SLASHED2 },
+        { u"normal", NoteHeadGroup::HEAD_NORMAL },
+        { u"do", NoteHeadGroup::HEAD_DO },
+        { u"re", NoteHeadGroup::HEAD_RE },
+        { u"mi", NoteHeadGroup::HEAD_MI },
+        { u"fa", NoteHeadGroup::HEAD_FA },
+        { u"fa up", NoteHeadGroup::HEAD_FA },
+        { u"so", NoteHeadGroup::HEAD_SOL },
+        { u"la", NoteHeadGroup::HEAD_LA },
+        { u"ti", NoteHeadGroup::HEAD_TI }
+    };
+
+    auto it = map.find(mxmlName);
+    if (it != map.end()) {
+        return it->second;
+    } else {
+        LOGD("unknown notehead %s", muPrintable(mxmlName));      // TODO
+    }
+
+    // default: return 0
+    return NoteHeadGroup::HEAD_NORMAL;
+}
+
+/**
+ Parse the /score-partwise/part/measure/note/stem node.
+ */
+
+void MusicXmlParserNote::stem(DirectionV& stemDirection, bool& noStem)
+{
+    // defaults
+    stemDirection = DirectionV::AUTO;
+    noStem = false;
+
+    String s = m_e.readText();
+
+    if (s == u"up") {
+        stemDirection = DirectionV::UP;
+    } else if (s == u"down") {
+        stemDirection = DirectionV::DOWN;
+    } else if (s == u"none") {
+        noStem = true;
+    } else if (s == u"double") {
+    } else {
+        m_logger->logError(String(u"unknown stem direction %1").arg(s), &m_e);
+    }
+}
+
+/**
+ * Determine whole measure rest.
+ */
+
+// By convention, whole measure rests do not have a "type" element
+// As of MusicXML 3.0, this can be indicated by an attribute "measure",
+// but for backwards compatibility the "old" convention still has to be supported.
+// Also verify the rest fits exactly in the measure, as some programs
+// (e.g. Cakewalk SONAR X2 Studio [Version: 19.0.0.306]) leave out
+// the type for all rests.
+// Sibelius calls all whole-measure rests "whole", even if the duration != 4/4
+
+bool MusicXmlParserNote::isWholeMeasureRest(const String& type, const Fraction dura, const Fraction mDura)
+{
+    if (!dura.isValid()) {
+        return false;
+    }
+
+    if (!mDura.isValid()) {
+        return false;
+    }
+
+    return (type.empty() && dura == mDura)
+           || (type == u"whole" && dura == mDura);
+}
+
+/**
+ * Determine duration for a note or rest.
+ * This includes whole measure rest detection.
+ */
+
+TDuration MusicXmlParserNote::determineDuration(const bool rest, const bool measureRest, const String& type, const int dots,
+                                                const Fraction dura, const Fraction mDura)
+{
+    //LOGD("determineDuration rest %d type '%s' dots %d dura %s mDura %s",
+    //       rest, muPrintable(type), dots, muPrintable(dura.print()), muPrintable(mDura.print()));
+
+    TDuration res;
+    if (rest) {
+        if (measureRest || isWholeMeasureRest(type, dura, mDura)) {
+            res.setType(DurationType::V_MEASURE);
+        } else if (type.empty()) {
+            // If no type, set duration type based on duration.
+            // Note that sometimes unusual duration (e.g. 261/256) are found.
+            res.setVal(dura.ticks());
+        } else {
+            ByteArray ba = type.toAscii();
+            res.setType(TConv::fromXml(ba.constChar(), DurationType::V_INVALID));
+            res.setDots(dots);
+        }
+    } else {
+        ByteArray ba = type.toAscii();
+        res.setType(TConv::fromXml(ba.constChar(), DurationType::V_INVALID));
+        res.setDots(dots);
+        if (res.type() == DurationType::V_INVALID) {
+            res.setType(DurationType::V_QUARTER);        // default, TODO: use dura ?
+        }
+    }
+
+    //LOGD("-> dur %hhd (%s) dots %d ticks %s",
+    //       res.type(), muPrintable(res.name()), res.dots(), muPrintable(dura.print()));
+
+    return res;
+}
+
+/**
+ * Find (or create if not found) the chord at \a tick and \a track.
+ * Note: staff move is a note property in MusicXML, but chord property in MuseScore
+ * This is simply ignored here, effectively using the last chords value.
+ */
+
+Chord* MusicXmlParserNote::findOrCreateChord(Score*, Measure* m,
+                                             const Fraction& tick, const int track, const int move,
+                                             const TDuration duration, const Fraction dura,
+                                             BeamMode bm, bool small)
+{
+    //LOGD("findOrCreateChord tick %d track %d dur ticks %d ticks %s bm %hhd",
+    //       tick, track, duration.ticks(), muPrintable(dura.print()), bm);
+    Chord* c = m->findChord(tick, track);
+    if (c == 0) {
+        Segment* s = m->getSegment(SegmentType::ChordRest, tick);
+        c = Factory::createChord(s);
+        // better not to force beam end, as the beam palette does not support it
+        if (bm == BeamMode::END) {
+            c->setBeamMode(BeamMode::AUTO);
+        } else {
+            c->setBeamMode(bm);
+        }
+        c->setTrack(track);
+        // Chord is initialized with the smallness of its first note.
+        // If a non-small note is added later, this is handled in handleSmallness.
+        c->setSmall(small);
+
+        setChordRestDuration(c, duration, dura);
+        s->add(c);
+    }
+    c->setStaffMove(move);
+    return c;
+}
+
+/**
+ * convert duration and slash to grace note type
+ */
+
+NoteType MusicXmlParserNote::graceNoteType(const TDuration duration, const bool slash)
+{
+    NoteType nt = NoteType::APPOGGIATURA;
+    if (slash) {
+        nt = NoteType::ACCIACCATURA;
+    } else {
+        if (duration.type() == DurationType::V_QUARTER) {
+            nt = NoteType::GRACE4;
+        } else if (duration.type() == DurationType::V_16TH) {
+            nt = NoteType::GRACE16;
+        } else if (duration.type() == DurationType::V_32ND) {
+            nt = NoteType::GRACE32;
+        }
+    }
+    return nt;
+}
+
+Chord* MusicXmlParserNote::createGraceChord(Score* score, const int track,
+                                            const TDuration duration, const bool slash, const bool small)
+{
+    Chord* c = Factory::createChord(score->dummy()->segment());
+    c->setNoteType(graceNoteType(duration, slash));
+    c->setTrack(track);
+    // Chord is initialized with the smallness of its first note.
+    // If a non-small note is added later, this is handled in handleSmallness.
+    c->setSmall(small);
+    // note grace notes have no durations, use default fraction 0/1
+    setChordRestDuration(c, duration, Fraction());
+    return c;
+}
+
+// TODO: refactor: optimize parameters
+
+void MusicXmlParserNote::setPitch(Note* note, const MusicXmlInstruments& instruments, const String& instrumentId,
+                                  const MusicXmlNotePitch& mnp,
+                                  const int octaveShift, const Instrument* const instrument)
+{
+    if (mnp.unpitched()) {
+        if (hasDrumset(instruments) && muse::contains(instruments, instrumentId)) {
+            // step and oct are display-step and ...-oct
+            // get pitch from instrument definition in drumset instead
+            int unpitched = instruments.at(instrumentId).unpitched;
+            note->setPitch(std::clamp(unpitched, 0, 127));
+            // TODO - does this need to be key-aware?
+            note->setTpc(pitch2tpc(unpitched, Key::C, Prefer::NEAREST));             // TODO: necessary ?
+        } else {
+            //LOGD("disp step %d oct %d", displayStep, displayOctave);
+            xmlSetPitch(note, mnp.displayStep(), 0, 0.0, mnp.displayOctave(), 0, instrument);
+        }
+    } else {
+        xmlSetPitch(note, mnp.step(), mnp.alter(), mnp.tuning(), mnp.octave(), octaveShift, instrument);
+    }
+}
+
+/**
+ * convert display-step and display-octave to staff line
+ */
+
+void MusicXmlParserNote::handleDisplayStep(ChordRest* cr, int step, int octave, const Fraction& tick, double spatium)
+{
+    if (0 <= step && step <= 6 && 0 <= octave && octave <= 9) {
+        //LOGD("rest step=%d oct=%d", step, octave);
+        ClefType clef = cr->staff()->clef(tick);
+        int po = ClefInfo::pitchOffset(clef);
+        //LOGD(" clef=%hhd po=%d step=%d", clef, po, step);
+        int dp = 7 * (octave + 2) + step;
+        //LOGD(" dp=%d po-dp=%d", dp, po-dp);
+        cr->ryoffset() = (po - dp + 3) * spatium / 2;
+    }
+}
+
+void MusicXmlParserNote::handleSmallness(bool cueOrSmall, Note* note, Chord* c)
+{
+    if (cueOrSmall) {
+        note->setSmall(!c->isSmall()); // Avoid redundant smallness
+    } else {
+        note->setSmall(false);
+        if (c->isSmall()) {
+            // What was a small chord becomes small notes in a non-small chord
+            c->setSmall(false);
+            for (Note* otherNote : c->notes()) {
+                if (note != otherNote) {
+                    otherNote->setSmall(true);
+                }
+            }
+        }
+    }
+}
+
+/**
+ Set the notehead parameters.
+ */
+
+void MusicXmlParserNote::setNoteHead(Note* note, const Color noteheadColor, const bool noteheadParentheses, const String& noteheadFilled)
+{
+    Score* const score = note->score();
+
+    if (noteheadColor.isValid()) {
+        note->setColor(noteheadColor);
+    }
+    if (noteheadParentheses) {
+        Symbol* s = new Symbol(note);
+        s->setSym(SymId::noteheadParenthesisLeft);
+        s->setParent(note);
+        score->addElement(s);
+        s = new Symbol(note);
+        s->setSym(SymId::noteheadParenthesisRight);
+        s->setParent(note);
+        score->addElement(s);
+    }
+
+    if (noteheadFilled == u"no") {
+        note->setHeadType(NoteHeadType::HEAD_HALF);
+    } else if (noteheadFilled == u"yes") {
+        note->setHeadType(NoteHeadType::HEAD_QUARTER);
+    }
+}
+
+void MusicXmlParserNote::addTremolo(ChordRest* cr,
+                                    const int tremoloNr, const String& tremoloType, const String& tremoloSmufl,
+                                    Chord*& tremStart,
+                                    MusicXmlLogger* logger, const XmlStreamReader* const xmlreader,
+                                    Fraction& timeMod)
+{
+    if (!cr->isChord()) {
+        return;
+    }
+    if (tremoloNr) {
+        //LOGD("tremolo %d type '%s' ticks %d tremStart %p", tremoloNr, muPrintable(tremoloType), ticks, _tremStart);
+        if (tremoloNr == 1 || tremoloNr == 2 || tremoloNr == 3 || tremoloNr == 4) {
+            if (tremoloType.empty() || tremoloType == u"single") {
+                TremoloType type = TremoloType::INVALID_TREMOLO;
+                switch (tremoloNr) {
+                case 1: type = TremoloType::R8;
+                    break;
+                case 2: type = TremoloType::R16;
+                    break;
+                case 3: type = TremoloType::R32;
+                    break;
+                case 4: type = TremoloType::R64;
+                    break;
+                }
+
+                if (type != TremoloType::INVALID_TREMOLO) {
+                    TremoloSingleChord* tremolo = Factory::createTremoloSingleChord(mu::engraving::toChord(cr));
+                    tremolo->setTremoloType(type);
+                    cr->add(tremolo);
+                }
+            } else if (tremoloType == u"start") {
+                if (tremStart) {
+                    logger->logError(u"MusicXml::import: double tremolo start", xmlreader);
+                }
+                tremStart = static_cast<Chord*>(cr);
+                // timeMod takes into account also the factor 2 of a two-note tremolo
+                if (timeMod.isValid() && ((timeMod.denominator() % 2) == 0)) {
+                    timeMod.setDenominator(timeMod.denominator() / 2);
+                }
+            } else if (tremoloType == u"stop") {
+                if (tremStart) {
+                    TremoloType type = TremoloType::INVALID_TREMOLO;
+                    switch (tremoloNr) {
+                    case 1: type = TremoloType::C8;
+                        break;
+                    case 2: type = TremoloType::C16;
+                        break;
+                    case 3: type = TremoloType::C32;
+                        break;
+                    case 4: type = TremoloType::C64;
+                        break;
+                    }
+
+                    if (type != TremoloType::INVALID_TREMOLO) {
+                        TremoloTwoChord* tremolo = Factory::createTremoloTwoChord(mu::engraving::toChord(cr));
+                        tremolo->setTremoloType(type);
+                        tremolo->setChords(tremStart, static_cast<Chord*>(cr));
+                        // fixup chord duration and type
+                        const Fraction tremDur = cr->ticks() * Fraction(1, 2);
+                        tremolo->chord1()->setDurationType(tremDur);
+                        tremolo->chord1()->setTicks(tremDur);
+                        tremolo->chord2()->setDurationType(tremDur);
+                        tremolo->chord2()->setTicks(tremDur);
+                        // add tremolo to first chord (only)
+                        tremStart->add(tremolo);
+                    }
+                    // timeMod takes into account also the factor 2 of a two-note tremolo
+                    if (timeMod.isValid() && ((timeMod.denominator() % 2) == 0)) {
+                        timeMod.setDenominator(timeMod.denominator() / 2);
+                    }
+                } else {
+                    logger->logError(u"MusicXml::import: double tremolo stop w/o start", xmlreader);
+                }
+                tremStart = nullptr;
+            }
+        } else {
+            logger->logError(String(u"unknown tremolo type %1").arg(tremoloNr), xmlreader);
+        }
+    } else if (tremoloNr == 0 && (tremoloType == u"unmeasured" || tremoloType.empty() || tremoloSmufl == u"buzzRoll")) {
+        // Out of all the SMuFL unmeasured tremolos, we only support 'buzzRoll'
+        TremoloSingleChord* tremolo = Factory::createTremoloSingleChord(mu::engraving::toChord(cr));
+        tremolo->setTremoloType(TremoloType::BUZZ_ROLL);
+        cr->add(tremolo);
+    }
+}
+
+/**
+ Add the figured bass elements.
+ */
+
+void MusicXmlParserNote::addFiguredBassElements(FiguredBassList& fbl, const Fraction noteStartTime, const int msTrack,
+                                                const Fraction dura, Measure* measure)
+{
+    if (!fbl.empty()) {
+        Fraction sTick = noteStartTime;                  // starting tick
+        for (FiguredBass* fb : fbl) {
+            fb->setTrack(msTrack);
+            // No duration tag defaults ticks() to 0; set to note value
+            if (fb->ticks().isZero()) {
+                fb->setTicks(dura);
+            }
+            // TODO: set correct onNote value
+            Segment* s = measure->getSegment(SegmentType::ChordRest, sTick);
+            s->add(fb);
+            sTick += fb->ticks();
+        }
+        fbl.clear();
+    }
+}
+
+/**
+ set drumset information
+ note that in MuseScore, the drumset contains defaults for notehead,
+ line and stem direction, while a MusicXML file contains actuals.
+ the MusicXML values for each note are simply copied to the defaults
+ */
+
+void MusicXmlParserNote::setDrumset(Chord* c, MusicXmlParserPass1& pass1, const String& partId, const String& instrumentId,
+                                    const Fraction& noteStartTime, const MusicXmlNotePitch& mnp, const DirectionV stemDir,
+                                    const NoteHeadGroup headGroup)
+{
+    // determine staff line based on display-step / -octave and clef type
+    const ClefType clef = c->staff()->clef(noteStartTime);
+    const int po = ClefInfo::pitchOffset(clef);
+    const int pitch = MusicXmlStepAltOct2Pitch(mnp.displayStep(), 0, mnp.displayOctave());
+    int line = po - absStep(pitch);
+
+    // correct for number of staff lines
+    // see ExportMusicXml::unpitch2xml for explanation
+    // TODO handle other # staff lines ?
+    int staffLines = c->staff()->lines(Fraction(0, 1));
+    if (staffLines == 1) {
+        line -= 8;
+    }
+    if (staffLines == 3) {
+        line -= 2;
+    }
+
+    // the drum palette cannot handle stem direction AUTO,
+    // overrule if necessary
+    DirectionV overruledStemDir = stemDir;
+    if (stemDir == DirectionV::AUTO) {
+        if (line > 4) {
+            overruledStemDir = DirectionV::DOWN;
+        } else {
+            overruledStemDir = DirectionV::UP;
+        }
+    }
+    // this should be done in pass 1, would make _pass1 const here
+    pass1.setDrumsetDefault(partId, instrumentId, headGroup, line, overruledStemDir);
+}
+
+void MusicXmlParserNote::xmlSetDrumsetPitch(Note* note, const Chord* chord, const Staff* staff, int step, int octave,
+                                            NoteHeadGroup headGroup, DirectionV& stemDir, Instrument* instrument)
+{
+    Drumset* ds = instrument->drumset();
+    // get line
+    // determine staff line based on display-step / -octave and clef type
+    const ClefType clef = staff->clef(chord->tick());
+    const int po = ClefInfo::pitchOffset(clef);
+    const int pitch = MusicXmlStepAltOct2Pitch(step, 0, octave);
+    int line = po - absStep(pitch);
+    const int staffLines = staff->lines(chord->tick());
+    if (staffLines == 1) {
+        line -= 8;
+    }
+    if (staffLines == 3) {
+        line -= 2;
+    }
+
+    const int firstDrum = ds->nextPitch(0);
+    int curDrum = firstDrum;
+    int newPitch = pitch;
+    bool matchFound = false;
+    do {
+        if (ds->line(curDrum) == line) {
+            if (ds->noteHead(curDrum) == headGroup) {
+                newPitch = curDrum;
+                matchFound = true;
+                break;
+            }
+        }
+        curDrum = ds->nextPitch(curDrum);
+    } while (curDrum != firstDrum);
+
+    // Find inferred instruments at this tick
+    if (configuration()->inferTextType()) {
+        InferredPercInstr instr = m_pass2.inferredPercInstr(chord->tick(), chord->track());
+        if (instr.track != muse::nidx) {
+            // Clear old instrument
+            ds->drum(newPitch) = DrumInstrument();
+
+            newPitch = instr.pitch;
+            ds->drum(newPitch) = ds->drum(newPitch) = DrumInstrument(
+                instr.name.toStdString().c_str(), headGroup, line, stemDir, static_cast<int>(chord->voice()));
+        }
+    }
+
+    // If there is no exact match add an entry to the drumkit with the XML line and notehead
+    if (!matchFound) {
+        // Create new instrument in drumkit
+        if (stemDir == DirectionV::AUTO) {
+            if (line > 4) {
+                stemDir = DirectionV::DOWN;
+            } else {
+                stemDir = DirectionV::UP;
+            }
+        }
+
+        ds->drum(newPitch) = DrumInstrument("drum", headGroup, line, stemDir, static_cast<int>(chord->voice()));
+    } else if (stemDir == DirectionV::AUTO) {
+        stemDir = ds->stemDirection(newPitch);
+    }
+
+    note->setPitch(newPitch);
+    note->setTpcFromPitch();
+}
+
+//---------------------------------------------------------
+//   notePrintSpacingNo
+//---------------------------------------------------------
+
+/**
+ Parse the /score-partwise/part/measure/note node for a note with print-spacing="no".
+ These are handled like a forward: only moving the time forward.
+ */
+
+void MusicXmlParserNote::notePrintSpacingNo(Fraction& dura)
+{
+    //_logger->logDebugTrace("MusicXmlParserPass1::notePrintSpacingNo", &_e);
+
+    bool chord = false;
+    bool grace = false;
+
+    while (m_e.readNextStartElement()) {
+        if (m_e.name() == "chord") {
+            chord = true;
+            m_e.skipCurrentElement();  // skip but don't log
+        } else if (m_e.name() == "duration") {
+            m_pass2.duration(dura);
+        } else if (m_e.name() == "grace") {
+            grace = true;
+            m_e.skipCurrentElement();  // skip but don't log
+        } else {
+            m_e.skipCurrentElement();              // skip but don't log
+        }
+    }
+
+    // don't count chord or grace note duration
+    // note that this does not check the MusicXML requirement that notes in a chord
+    // cannot have a duration longer than the first note in the chord
+    if (chord || grace) {
+        dura.set(0, 1);
+    }
+
+    addError(checkAtEndElement(m_e, u"note"));
+}
+
+void MusicXmlParserNote::addError(const String& error)
+{
+    if (!error.empty()) {
+        m_logger->logError(error, &m_e);
+        m_errors += errorStringWithLocation(m_e.lineNumber(), m_e.columnNumber(), error) + u'\n';
+    }
+}
+
+void MusicXmlParserNote::skipLogCurrElem()
+{
+    //_logger->logDebugInfo(String("skipping '%1'").arg(_e.name().toString()), &_e);
+    m_e.skipCurrentElement();
+}
+
+Note* MusicXmlParserNote::parse()
+{
+    if (m_e.asciiAttribute("print-spacing") == "no") {
+        notePrintSpacingNo(m_dura);
+        return 0;
+    }
+
+    bool chord = false;
+    bool cue = false;
+    bool isSmall = false;
+    bool grace = false;
+    bool rest = false;
+    bool measureRest = false;
+    int staff = 0;
+    String type;
+    String voice;
+    DirectionV stemDir = DirectionV::AUTO;
+    bool noStem = false;
+    bool hasHead = true;
+    NoteHeadGroup headGroup = NoteHeadGroup::HEAD_NORMAL;
+    NoteHeadScheme headScheme = NoteHeadScheme::HEAD_AUTO;
+    const Color noteColor = Color::fromString(m_e.asciiAttribute("color").ascii());
+    Color noteheadColor;
+    Color stemColor;
+    bool noteheadParentheses = false;
+    String noteheadFilled;
+    int velocity = round(m_e.doubleAttribute("dynamics") * 0.9);
+    bool graceSlash = false;
+    bool printObject = m_e.asciiAttribute("print-object") != "no";
+    bool isSingleDrumset = false;
+    BeamMode bm;
+    std::map<int, String> beamTypes;
+    String instrumentId;
+    String tieType;
+    MusicXmlParserLyric lyric { m_pass1.getMusicXmlPart(m_partId).lyricNumberHandler(), m_e, m_score, m_logger,
+                                m_pass1.isVocalStaff(m_partId) };
+    MusicXmlParserNotations notations { m_e, m_score, m_logger, m_pass2 };
+
+    MusicXmlNoteDuration mnd { m_pass2.divs(), m_logger, &m_pass1 };
+    MusicXmlNotePitch mnp { m_logger };
+
+    while (m_e.readNextStartElement()) {
+        if (mnp.readProperties(m_e, m_score)) {
+            // element handled
+        } else if (mnd.readProperties(m_e)) {
+            // element handled
+        } else if (m_e.name() == "beam") {
+            beam(beamTypes);
+        } else if (m_e.name() == "chord") {
+            chord = true;
+            m_e.skipCurrentElement();  // skip but don't log
+        } else if (m_e.name() == "cue") {
+            cue = true;
+            m_e.skipCurrentElement();  // skip but don't log
+        } else if (m_e.name() == "grace") {
+            grace = true;
+            graceSlash = m_e.asciiAttribute("slash") == "yes";
+            m_e.skipCurrentElement();  // skip but don't log
+        } else if (m_e.name() == "instrument") {
+            instrumentId = m_e.attribute("id");
+            m_e.skipCurrentElement();  // skip but don't log
+        } else if (m_e.name() == "lyric") {
+            // lyrics on grace notes not (yet) supported by MuseScore
+            // add to main note instead
+            lyric.parse();
+        } else if (m_e.name() == "notations") {
+            notations.parse();
+            addError(notations.errors());
+        } else if (m_e.name() == "notehead") {
+            noteheadColor = Color::fromString(m_e.asciiAttribute("color").ascii());
+            noteheadParentheses = m_e.asciiAttribute("parentheses") == "yes";
+            noteheadFilled = m_e.attribute("filled");
+            String noteheadValue = m_e.readText();
+            if (noteheadValue == "none") {
+                hasHead = false;
+            } else if (noteheadValue == "named" && m_pass1.exporterSoftware() == MusicXmlExporterSoftware::NOTEFLIGHT) {
+                headScheme = NoteHeadScheme::HEAD_PITCHNAME;
+            } else {
+                headGroup = convertNotehead(noteheadValue);
+            }
+        } else if (m_e.name() == "rest") {
+            rest = true;
+            measureRest = m_e.asciiAttribute("measure") == "yes";
+            mnp.displayStepOctave(m_e);
+        } else if (m_e.name() == "staff") {
+            bool ok = false;
+            String strStaff = m_e.readText();
+            staff = m_pass1.getMusicXmlPart(m_partId).staffNumberToIndex(strStaff.toInt(&ok));
+            if (!ok) {
+                // error already reported in pass 1
+                staff = -1;
+            }
+        } else if (m_e.name() == "stem") {
+            stemColor = Color::fromString(m_e.asciiAttribute("color").ascii());
+            stem(stemDir, noStem);
+        } else if (m_e.name() == "tie") {
+            tieType = m_e.attribute("type");
+            m_e.skipCurrentElement();
+        } else if (m_e.name() == "type") {
+            isSmall = m_e.asciiAttribute("size") == "cue" || m_e.asciiAttribute("size") == "grace-cue";
+            type = m_e.readText();
+        } else if (m_e.name() == "voice") {
+            voice = m_e.readText();
+        } else {
+            skipLogCurrElem();
+        }
+    }
+
+    // Bug fix for Sibelius 7.1.3 which does not write <voice> for notes with <chord>
+    if (!chord) {
+        // remember voice
+        m_currentVoice = voice;
+    } else if (voice.empty()) {
+        // use voice from last note w/o <chord>
+        voice = m_currentVoice;
+    }
+
+    // Assume voice 1 if voice is empty (legal in a single voice part)
+    if (voice.empty()) {
+        voice = u"1";
+    }
+
+    // Define currBeam based on currentVoice to handle multi-voice beaming (and instantiate if not already)
+    if (!muse::contains(m_currBeams, m_currentVoice)) {
+        m_currBeams.insert({ m_currentVoice, (Beam*)nullptr });
+    }
+    Beam*& currBeam = m_currBeams[m_currentVoice];
+
+    bm = computeBeamMode(beamTypes);
+
+    // check for timing error(s) and set dura
+    // keep in this order as checkTiming() might change dura
+    String errorStr = mnd.checkTiming(type, rest, grace);
+    m_dura = mnd.duration();
+    if (!errorStr.empty()) {
+        m_logger->logError(errorStr, &m_e);
+    }
+
+    IF_ASSERT_FAILED(m_pass1.getPart(m_partId)) {
+        return nullptr;
+    }
+
+    // At this point all checks have been done, the note should be added
+    // note: in case of error exit from here, the postponed <note> children
+    // must still be skipped
+
+    int msMove = 0;
+    int msTrack = 0;
+    int msVoice = 0;
+
+    int voiceInt = m_pass1.voiceToInt(voice);
+    if (!m_pass1.determineStaffMoveVoice(m_partId, staff, voiceInt, msMove, msTrack, msVoice)) {
+        m_logger->logDebugInfo(String(u"could not map staff %1 voice '%2'").arg(staff + 1).arg(voice), &m_e);
+        addError(checkAtEndElement(m_e, u"note"));
+        return 0;
+    }
+
+    // start time for note:
+    // - sTime for non-chord / first chord note
+    // - prevTime for others
+    Fraction noteStartTime = chord ? m_prevSTime : m_sTime;
+    Fraction timeMod = mnd.timeMod();
+
+    // determine tuplet state, used twice (before and after note allocation)
+    MusicXmlTupletFlags tupletAction;
+
+    // handle tuplet state for the previous chord or rest
+    if (!chord && !grace) {
+        Tuplet* tuplet = m_tuplets[voice];
+        MusicXmlTupletState& m_tupletState = m_tupletStates[voice];
+        tupletAction = m_tupletState.determineTupletAction(mnd.duration(), timeMod, notations.tupletDesc().type,
+                                                           mnd.normalType(), m_missingPrev, m_missingCurr);
+        if (tupletAction & MusicXmlTupletFlag::STOP_PREVIOUS) {
+            // tuplet start while already in tuplet
+            if (m_missingPrev.isValid() && m_missingPrev > Fraction(0, 1)) {
+                const int track = msTrack + msVoice;
+                Rest* const extraRest = addRest(m_score, m_measure, noteStartTime, track, msMove,
+                                                TDuration { m_missingPrev* tuplet->ratio() }, m_missingPrev);
+                if (extraRest) {
+                    extraRest->setTuplet(tuplet);
+                    tuplet->add(extraRest);
+                    noteStartTime += m_missingPrev;
+                }
+            }
+            // recover by simply stopping the current tuplet first
+            const int normalNotes = timeMod.numerator();
+            handleTupletStop(tuplet, normalNotes);
+        }
+    }
+
+    Chord* c { nullptr };
+    ChordRest* cr { nullptr };
+    Note* note { nullptr };
+
+    TDuration duration = determineDuration(rest, measureRest, type, mnd.dots(), m_dura, m_measure->ticks());
+
+    Part* part = m_pass1.getPart(m_partId);
+    Instrument* instrument = part->instrument(noteStartTime);
+    const MusicXmlInstruments& instruments = m_pass1.getInstruments(m_partId);
+    isSingleDrumset = instrument->drumset() && instruments.size() == 1;
+    // begin allocation
+    if (rest) {
+        const int track = msTrack + msVoice;
+        cr = addRest(m_score, m_measure, noteStartTime, track, msMove,
+                     duration, m_dura);
+    } else {
+        if (!grace) {
+            // regular note
+            // if there is already a chord just add to it
+            // else create a new one
+            // this basically ignores <chord/> errors
+            c = findOrCreateChord(m_score, m_measure,
+                                  noteStartTime,
+                                  msTrack + msVoice, msMove,
+                                  duration, m_dura, bm, isSmall || cue);
+        } else {
+            // grace note
+            // TODO: check if explicit stem direction should also be set for grace notes
+            // (the DOM parser does that, but seems to have no effect on the autotester)
+            if (!chord || m_gcl.empty()) {
+                c = createGraceChord(m_score, msTrack + msVoice, duration, graceSlash, isSmall || cue);
+                // TODO FIX
+                // the setStaffMove() below results in identical behaviour as 2.0:
+                // grace note will be at the wrong staff with the wrong pitch,
+                // seems to use the line value calculated for the right staff
+                // leaving it places the note at the wrong staff with the right pitch
+                // this affects only grace notes where staff move differs from
+                // the main note, e.g. DebuMandSample.xml first grace in part 2
+                // c->setStaffMove(msMove);
+                // END TODO
+                m_gcl.push_back(c);
+            } else {
+                c = m_gcl.back();
+            }
+        }
+        note = Factory::createNote(c);
+        const staff_idx_t ottavaStaff = (msTrack - m_pass1.trackForPart(m_partId)) / VOICES;
+        const int octaveShift = m_pass1.octaveShift(m_partId, ottavaStaff, noteStartTime);
+        const Staff* st = c->staff();
+        if (isSingleDrumset && mnp.unpitched() && instrumentId.empty()) {
+            xmlSetDrumsetPitch(note, c, st, mnp.displayStep(), mnp.displayOctave(), headGroup, stemDir, instrument);
+        } else {
+            setPitch(note, instruments, instrumentId, mnp, octaveShift, instrument);
+        }
+        c->add(note);
+        cr = c;
+    }
+    // end allocation
+
+    if (rest) {
+        const track_idx_t track = msTrack + msVoice;
+        if (cr) {
+            if (currBeam) {
+                if (currBeam->track() == track) {
+                    cr->setBeamMode(BeamMode::MID);
+                    currBeam->add(cr);
+                } else {
+                    removeBeam(currBeam);
+                }
+            } else {
+                cr->setBeamMode(BeamMode::NONE);
+            }
+            cr->setSmall(isSmall);
+            if (noteColor.isValid()) {
+                cr->setColor(noteColor);
+            }
+            cr->setVisible(printObject);
+            handleDisplayStep(cr, mnp.displayStep(), mnp.displayOctave(), noteStartTime, m_score->style().spatium());
+        }
+    } else {
+        handleSmallness(cue || isSmall, note, c);
+        note->setPlay(!cue);          // cue notes don't play
+        note->setHeadGroup(headGroup);
+        if (headScheme != NoteHeadScheme::HEAD_AUTO) {
+            note->setHeadScheme(headScheme);
+        }
+        if (noteColor.isValid()) {
+            note->setColor(noteColor);
+        }
+        Stem* stem = c->stem();
+        if (!stem) {
+            stem = Factory::createStem(c);
+            if (stemColor.isValid()) {
+                stem->setColor(stemColor);
+            } else if (noteColor.isValid()) {
+                stem->setColor(noteColor);
+            }
+            c->add(stem);
+        }
+        setNoteHead(note, noteheadColor, noteheadParentheses, noteheadFilled);
+        note->setVisible(hasHead && printObject);
+        stem->setVisible(printObject);
+
+        if (!grace) {
+            // regular note
+            // handle beam
+            if (!chord) {
+                handleBeamAndStemDir(c, bm, stemDir, currBeam, m_pass1.hasBeamingInfo());
+            }
+
+            // append any grace chord after chord to the previous chord
+            Chord* const prevChord = m_measure->findChord(m_prevSTime, msTrack + msVoice);
+            if (prevChord && prevChord != c) {
+                addGraceChordsAfter(prevChord, m_gcl, m_gac);
+            }
+
+            // append any grace chord
+            addGraceChordsBefore(c, m_gcl);
+        }
+
+        if (mnd.calculatedDuration().isValid()
+            && mnd.specifiedDuration().isValid()
+            && mnd.calculatedDuration().isNotZero()
+            && mnd.calculatedDuration() != mnd.specifiedDuration()) {
+            // convert duration into note length
+            Fraction durationMult { (mnd.specifiedDuration() / mnd.calculatedDuration()).reduced() };
+            durationMult = (1000 * durationMult).reduced();
+            const int noteLen = durationMult.numerator() / durationMult.denominator();
+
+            NoteEventList nel;
+            NoteEvent ne;
+            ne.setLen(noteLen);
+            nel.push_back(ne);
+            note->setPlayEvents(nel);
+            if (c) {
+                c->setPlayEventType(PlayEventType::User);
+            }
+        }
+
+        if (velocity > 0) {
+            note->setUserVelocity(velocity);
+        }
+
+        if (mnp.unpitched() && !isSingleDrumset) {
+            setDrumset(c, m_pass1, m_partId, instrumentId, noteStartTime, mnp, stemDir, headGroup);
+        }
+
+        // accidental handling
+        //LOGD("note acc %p type %hhd acctype %hhd",
+        //       acc, acc ? acc->accidentalType() : static_cast<mu::engraving::AccidentalType>(0), accType);
+        Accidental* acc = mnp.acc();
+        if (!acc && mnp.accType() != AccidentalType::NONE) {
+            acc = Factory::createAccidental(m_score->dummy());
+            acc->setAccidentalType(mnp.accType());
+        }
+
+        if (acc) {
+            acc->setVisible(printObject);
+            note->add(acc);
+            // save alter value for user accidental
+            if (acc->accidentalType() != AccidentalType::NONE) {
+                m_alt = mnp.alter();
+            }
+        }
+
+        c->setNoStem(noStem);
+    }
+
+    // cr can be 0 here (if a rest cannot be added)
+    // TODO: complete and cleanup handling this case
+    if (cr) {
+        cr->setVisible(printObject);
+    }
+
+    // handle notations
+    if (cr) {
+        notations.addToScore(cr, note,
+                             noteStartTime.ticks(), m_pass2.slurs(), m_pass2.glissandi(), m_pass2.spanners(), m_pass2.trills(),
+                             m_pass2.ties(), m_pass2.unstartedTieNotes(), m_pass2.unendedTieNotes(), m_arpMap,
+                             m_delayedArps);
+
+        // if no tie added yet, convert the "tie" into "tied" and add it.
+        if (note && !note->tieFor() && !note->tieBack() && !tieType.empty()) {
+            Notation notation = Notation(u"tied");
+            const String type2 = u"type";
+            notation.addAttribute(type2, tieType);
+            addTie(notation, note, cr->track(), m_pass2.ties(), m_pass2.unstartedTieNotes(), m_pass2.unendedTieNotes(), m_logger, &m_e);
+        }
+    }
+
+    // handle grace after state: remember current grace list size
+    if (grace && notations.mustStopGraceAFter()) {
+        m_gac = m_gcl.size();
+    }
+
+    // handle tremolo before handling tuplet (two note tremolos modify timeMod)
+    if (cr && notations.hasTremolo()) {
+        addTremolo(cr, notations.tremoloNr(), notations.tremoloType(), notations.tremoloSmufl(),
+                   m_pass2.tremStart(), m_logger, &m_e, timeMod);
+    }
+
+    // handle tuplet state for the current chord or rest
+    if (cr) {
+        if (!chord && !grace) {
+            Tuplet*& tuplet = m_tuplets[voice];
+            // do tuplet if valid time-modification is not 1/1 and is not 1/2 (tremolo)
+            // TODO: check interaction tuplet and tremolo handling
+            if (timeMod.isValid() && timeMod != Fraction(1, 1) && timeMod != Fraction(1, 2)) {
+                const int actualNotes = timeMod.denominator();
+                const int normalNotes = timeMod.numerator();
+                if (tupletAction & MusicXmlTupletFlag::START_NEW) {
+                    // create a new tuplet
+                    handleTupletStart(cr, tuplet, actualNotes, normalNotes, notations.tupletDesc());
+                }
+                if (tupletAction & MusicXmlTupletFlag::ADD_CHORD) {
+                    cr->setTuplet(tuplet);
+                    tuplet->add(cr);
+                }
+                if (tupletAction & MusicXmlTupletFlag::STOP_CURRENT) {
+                    if (m_missingCurr.isValid() && m_missingCurr > Fraction(0, 1)) {
+                        LOGD("add missing %s to current tuplet", muPrintable(m_missingCurr.toString()));
+                        const int track = msTrack + msVoice;
+                        Rest* const extraRest = addRest(m_score, m_measure, noteStartTime + m_dura, track, msMove,
+                                                        TDuration { m_missingCurr* tuplet->ratio() }, m_missingCurr);
+                        if (extraRest) {
+                            extraRest->setTuplet(tuplet);
+                            tuplet->add(extraRest);
+                        }
+                    }
+                    handleTupletStop(tuplet, normalNotes);
+                }
+            } else if (tuplet) {
+                // stop any still incomplete tuplet
+                handleTupletStop(tuplet, 2);
+            }
+        }
+    }
+
+    // Add all lyrics from grace notes attached to this chord
+    if (c && !c->graceNotes().empty() && !m_pass2.graceNoteLyrics().empty()) {
+        for (GraceNoteLyrics gnl : m_pass2.graceNoteLyrics()) {
+            if (gnl.lyric) {
+                addLyric(m_logger, &m_e, cr, gnl.lyric, gnl.no, m_pass2.extendedLyrics());
+                if (gnl.extend) {
+                    m_pass2.extendedLyrics().addLyric(gnl.lyric);
+                }
+            }
+        }
+        m_pass2.graceNoteLyrics().clear();
+    }
+
+    if (cr) {
+        addInferredStickings(cr, lyric.inferredStickings());
+    }
+
+    // add lyrics found by lyric
+    if (cr && !grace) {
+        // add lyrics and stop corresponding extends
+        addLyrics(m_logger, &m_e, cr, lyric.numberedLyrics(), lyric.extendedLyrics(), m_pass2.extendedLyrics());
+        if (rest) {
+            // stop all extends
+            m_pass2.extendedLyrics().setExtend(-1, cr->track(), cr->tick());
+        }
+    } else if (c && grace) {
+        // Add grace note lyrics to main chord later
+        addGraceNoteLyrics(lyric.numberedLyrics(), lyric.extendedLyrics(), m_pass2.graceNoteLyrics());
+    }
+
+    // add figured bass element
+    addFiguredBassElements(m_fbl, noteStartTime, msTrack, m_dura, m_measure);
+
+    // convert to slash or rhythmic notation if needed
+    // TODO in the case of slash notation, we assume that given notes do in fact correspond to slash beats
+    if (c && m_pass2.measureStyleSlash() != MusicXmlSlash::NONE) {
+        c->setSlash(true, m_pass2.measureStyleSlash() == MusicXmlSlash::SLASH);
+    }
+
+    // don't count chord or grace note duration
+    // note that this does not check the MusicXML requirement that notes in a chord
+    // cannot have a duration longer than the first note in the chord
+    if (chord || grace) {
+        m_dura.set(0, 1);
+    }
+
+    addError(checkAtEndElement(m_e, u"note"));
+
+    return note;
 }
 }

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -7926,14 +7926,13 @@ TDuration MusicXmlParserNote::determineDuration(const bool rest, const bool meas
  * This is simply ignored here, effectively using the last chords value.
  */
 
-Chord* MusicXmlParserNote::findOrCreateChord(const Fraction& tick, const int track, const int move,
-                                             const TDuration duration, const Fraction dura)
+Chord* MusicXmlParserNote::findOrCreateChord(const TDuration duration) const
 {
     //LOGD("findOrCreateChord tick %d track %d dur ticks %d ticks %s bm %hhd",
     //       tick, track, duration.ticks(), muPrintable(dura.print()), m_beamMode);
-    Chord* c = m_measure->findChord(tick, track);
+    Chord* c = m_measure->findChord(m_noteStartTime, track());
     if (c == 0) {
-        Segment* s = m_measure->getSegment(SegmentType::ChordRest, tick);
+        Segment* s = m_measure->getSegment(SegmentType::ChordRest, m_noteStartTime);
         c = Factory::createChord(s);
         // better not to force beam end, as the beam palette does not support it
         if (m_beamMode == BeamMode::END) {
@@ -7941,15 +7940,15 @@ Chord* MusicXmlParserNote::findOrCreateChord(const Fraction& tick, const int tra
         } else {
             c->setBeamMode(m_beamMode);
         }
-        c->setTrack(track);
+        c->setTrack(track());
         // Chord is initialized with the smallness of its first note.
         // If a non-small note is added later, this is handled in handleSmallness.
         c->setSmall(isSmall());
 
-        setChordRestDuration(c, duration, dura);
+        setChordRestDuration(c, duration, m_dura);
         s->add(c);
     }
-    c->setStaffMove(move);
+    c->setStaffMove(m_staffMove);
     return c;
 }
 
@@ -7957,10 +7956,10 @@ Chord* MusicXmlParserNote::findOrCreateChord(const Fraction& tick, const int tra
  * convert duration and slash to grace note type
  */
 
-NoteType MusicXmlParserNote::graceNoteType(const TDuration duration, const bool slash)
+NoteType MusicXmlParserNote::graceNoteType(const TDuration duration) const
 {
     NoteType nt = NoteType::APPOGGIATURA;
-    if (slash) {
+    if (m_graceSlash) {
         nt = NoteType::ACCIACCATURA;
     } else {
         if (duration.type() == DurationType::V_QUARTER) {
@@ -7974,12 +7973,11 @@ NoteType MusicXmlParserNote::graceNoteType(const TDuration duration, const bool 
     return nt;
 }
 
-Chord* MusicXmlParserNote::createGraceChord(const int track,
-                                            const TDuration duration, const bool slash)
+Chord* MusicXmlParserNote::createGraceChord(const TDuration duration) const
 {
     Chord* c = Factory::createChord(m_score->dummy()->segment());
-    c->setNoteType(graceNoteType(duration, slash));
-    c->setTrack(track);
+    c->setNoteType(graceNoteType(duration));
+    c->setTrack(track());
     // Chord is initialized with the smallness of its first note.
     // If a non-small note is added later, this is handled in handleSmallness.
     c->setSmall(isSmall());
@@ -7990,14 +7988,13 @@ Chord* MusicXmlParserNote::createGraceChord(const int track,
 
 // TODO: refactor: optimize parameters
 
-void MusicXmlParserNote::setPitch(const MusicXmlInstruments& instruments, const String& instrumentId,
-                                  const int octaveShift, const Instrument* const instrument)
+void MusicXmlParserNote::setPitch(const MusicXmlInstruments& instruments, const int octaveShift, const Instrument* const instrument)
 {
     if (m_notePitch.unpitched()) {
-        if (hasDrumset(instruments) && muse::contains(instruments, instrumentId)) {
+        if (hasDrumset(instruments) && muse::contains(instruments, m_instrumentId)) {
             // step and oct are display-step and ...-oct
             // get pitch from instrument definition in drumset instead
-            int unpitched = instruments.at(instrumentId).unpitched;
+            int unpitched = instruments.at(m_instrumentId).unpitched;
             m_note->setPitch(std::clamp(unpitched, 0, 127));
             // TODO - does this need to be key-aware?
             m_note->setTpc(pitch2tpc(unpitched, Key::C, Prefer::NEAREST));             // TODO: necessary ?
@@ -8014,16 +8011,18 @@ void MusicXmlParserNote::setPitch(const MusicXmlInstruments& instruments, const 
  * convert display-step and display-octave to staff line
  */
 
-void MusicXmlParserNote::handleDisplayStep(int step, int octave, const Fraction& tick, double spatium)
+void MusicXmlParserNote::handleDisplayStep()
 {
+    const int step = m_notePitch.displayStep();
+    const int octave = m_notePitch.displayOctave();
     if (0 <= step && step <= 6 && 0 <= octave && octave <= 9) {
         //LOGD("rest step=%d oct=%d", step, octave);
-        ClefType clef = m_chordRest->staff()->clef(tick);
+        ClefType clef = m_chordRest->staff()->clef(m_noteStartTime);
         int po = ClefInfo::pitchOffset(clef);
         //LOGD(" clef=%hhd po=%d step=%d", clef, po, step);
         int dp = 7 * (octave + 2) + step;
         //LOGD(" dp=%d po-dp=%d", dp, po-dp);
-        m_chordRest->ryoffset() = (po - dp + 3) * spatium / 2;
+        m_chordRest->ryoffset() = (po - dp + 3) * m_score->style().spatium() / 2;
     }
 }
 
@@ -8049,14 +8048,14 @@ void MusicXmlParserNote::handleSmallness()
  Set the notehead parameters.
  */
 
-void MusicXmlParserNote::setNoteHead(const Color noteheadColor, const bool noteheadParentheses, const String& noteheadFilled)
+void MusicXmlParserNote::setNoteHead()
 {
     Score* const score = m_note->score();
 
-    if (noteheadColor.isValid()) {
-        m_note->setColor(noteheadColor);
+    if (m_noteheadColor.isValid()) {
+        m_note->setColor(m_noteheadColor);
     }
-    if (noteheadParentheses) {
+    if (m_noteheadParentheses) {
         Symbol* s = new Symbol(m_note);
         s->setSym(SymId::noteheadParenthesisLeft);
         s->setParent(m_note);
@@ -8067,19 +8066,21 @@ void MusicXmlParserNote::setNoteHead(const Color noteheadColor, const bool noteh
         score->addElement(s);
     }
 
-    if (noteheadFilled == u"no") {
+    if (m_noteheadFilled == u"no") {
         m_note->setHeadType(NoteHeadType::HEAD_HALF);
-    } else if (noteheadFilled == u"yes") {
+    } else if (m_noteheadFilled == u"yes") {
         m_note->setHeadType(NoteHeadType::HEAD_QUARTER);
     }
 }
 
-void MusicXmlParserNote::addTremolo(const int tremoloNr, const String& tremoloType, const String& tremoloSmufl,
-                                    Chord*& tremStart, Fraction& timeMod)
+void MusicXmlParserNote::addTremolo(Chord*& tremStart)
 {
     if (!m_chordRest->isChord()) {
         return;
     }
+    const int tremoloNr = m_notationsParser.tremoloNr();
+    const String& tremoloType = m_notationsParser.tremoloType();
+    const String& tremoloSmufl = m_notationsParser.tremoloSmufl();
     if (tremoloNr) {
         //LOGD("tremolo %d type '%s' ticks %d tremStart %p", tremoloNr, muPrintable(tremoloType), ticks, _tremStart);
         if (tremoloNr == 1 || tremoloNr == 2 || tremoloNr == 3 || tremoloNr == 4) {
@@ -8107,8 +8108,8 @@ void MusicXmlParserNote::addTremolo(const int tremoloNr, const String& tremoloTy
                 }
                 tremStart = static_cast<Chord*>(m_chordRest);
                 // timeMod takes into account also the factor 2 of a two-note tremolo
-                if (timeMod.isValid() && ((timeMod.denominator() % 2) == 0)) {
-                    timeMod.setDenominator(timeMod.denominator() / 2);
+                if (m_timeMod.isValid() && ((m_timeMod.denominator() % 2) == 0)) {
+                    m_timeMod.setDenominator(m_timeMod.denominator() / 2);
                 }
             } else if (tremoloType == u"stop") {
                 if (tremStart) {
@@ -8138,8 +8139,8 @@ void MusicXmlParserNote::addTremolo(const int tremoloNr, const String& tremoloTy
                         tremStart->add(tremolo);
                     }
                     // timeMod takes into account also the factor 2 of a two-note tremolo
-                    if (timeMod.isValid() && ((timeMod.denominator() % 2) == 0)) {
-                        timeMod.setDenominator(timeMod.denominator() / 2);
+                    if (m_timeMod.isValid() && ((m_timeMod.denominator() % 2) == 0)) {
+                        m_timeMod.setDenominator(m_timeMod.denominator() / 2);
                     }
                 } else {
                     m_logger->logError(u"MusicXml::import: double tremolo stop w/o start", &m_e);
@@ -8161,12 +8162,12 @@ void MusicXmlParserNote::addTremolo(const int tremoloNr, const String& tremoloTy
  Add the figured bass elements.
  */
 
-void MusicXmlParserNote::addFiguredBassElements(const Fraction noteStartTime, const int msTrack, const Fraction dura)
+void MusicXmlParserNote::addFiguredBassElements(const Fraction dura)
 {
     if (!m_fbl.empty()) {
-        Fraction sTick = noteStartTime;                  // starting tick
+        Fraction sTick = m_noteStartTime;                  // starting tick
         for (FiguredBass* fb : m_fbl) {
-            fb->setTrack(msTrack);
+            fb->setTrack(m_track);
             // No duration tag defaults ticks() to 0; set to note value
             if (fb->ticks().isZero()) {
                 fb->setTicks(dura);
@@ -8187,11 +8188,10 @@ void MusicXmlParserNote::addFiguredBassElements(const Fraction noteStartTime, co
  the MusicXML values for each note are simply copied to the defaults
  */
 
-void MusicXmlParserNote::setDrumset(const String& instrumentId, const Fraction& noteStartTime,
-                                    const NoteHeadGroup headGroup)
+void MusicXmlParserNote::setDrumset() const
 {
     // determine staff line based on display-step / -octave and clef type
-    const ClefType clef = m_chord->staff()->clef(noteStartTime);
+    const ClefType clef = m_chord->staff()->clef(m_noteStartTime);
     const int po = ClefInfo::pitchOffset(clef);
     const int pitch = MusicXmlStepAltOct2Pitch(m_notePitch.displayStep(), 0, m_notePitch.displayOctave());
     int line = po - absStep(pitch);
@@ -8218,12 +8218,13 @@ void MusicXmlParserNote::setDrumset(const String& instrumentId, const Fraction& 
         }
     }
     // this should be done in pass 1, would make _pass1 const here
-    m_pass1.setDrumsetDefault(m_partId, instrumentId, headGroup, line, overruledStemDir);
+    m_pass1.setDrumsetDefault(m_partId, m_instrumentId, m_headGroup, line, overruledStemDir);
 }
 
-void MusicXmlParserNote::xmlSetDrumsetPitch(const Staff* staff, int step, int octave,
-                                            NoteHeadGroup headGroup, Instrument* instrument)
+void MusicXmlParserNote::xmlSetDrumsetPitch(const Staff* staff, Instrument* instrument)
 {
+    const int step = m_notePitch.displayStep();
+    const int octave = m_notePitch.displayOctave();
     Drumset* ds = instrument->drumset();
     // get line
     // determine staff line based on display-step / -octave and clef type
@@ -8245,7 +8246,7 @@ void MusicXmlParserNote::xmlSetDrumsetPitch(const Staff* staff, int step, int oc
     bool matchFound = false;
     do {
         if (ds->line(curDrum) == line) {
-            if (ds->noteHead(curDrum) == headGroup) {
+            if (ds->noteHead(curDrum) == m_headGroup) {
                 newPitch = curDrum;
                 matchFound = true;
                 break;
@@ -8263,7 +8264,7 @@ void MusicXmlParserNote::xmlSetDrumsetPitch(const Staff* staff, int step, int oc
 
             newPitch = instr.pitch;
             ds->drum(newPitch) = ds->drum(newPitch) = DrumInstrument(
-                instr.name.toStdString().c_str(), headGroup, line, m_stemDir, static_cast<int>(m_chord->voice()));
+                instr.name.toStdString().c_str(), m_headGroup, line, m_stemDir, static_cast<int>(m_chord->voice()));
         }
     }
 
@@ -8278,7 +8279,7 @@ void MusicXmlParserNote::xmlSetDrumsetPitch(const Staff* staff, int step, int oc
             }
         }
 
-        ds->drum(newPitch) = DrumInstrument("drum", headGroup, line, m_stemDir, static_cast<int>(m_chord->voice()));
+        ds->drum(newPitch) = DrumInstrument("drum", m_headGroup, line, m_stemDir, static_cast<int>(m_chord->voice()));
     } else if (m_stemDir == DirectionV::AUTO) {
         m_stemDir = ds->stemDirection(newPitch);
     }
@@ -8405,18 +8406,12 @@ Note* MusicXmlParserNote::parse()
     String type;
     String voice;
     bool hasHead = true;
-    NoteHeadGroup headGroup = NoteHeadGroup::HEAD_NORMAL;
     NoteHeadScheme headScheme = NoteHeadScheme::HEAD_AUTO;
     const Color noteColor = Color::fromString(m_e.asciiAttribute("color").ascii());
-    Color noteheadColor;
     Color stemColor;
-    bool noteheadParentheses = false;
-    String noteheadFilled;
     int velocity = round(m_e.doubleAttribute("dynamics") * 0.9);
-    bool graceSlash = false;
     bool printObject = m_e.asciiAttribute("print-object") != "no";
     bool isSingleDrumset = false;
-    String instrumentId;
     String tieType;
 
     while (m_e.readNextStartElement()) {
@@ -8434,10 +8429,10 @@ Note* MusicXmlParserNote::parse()
             m_e.skipCurrentElement();  // skip but don't log
         } else if (m_e.name() == "grace") {
             grace = true;
-            graceSlash = m_e.asciiAttribute("slash") == "yes";
+            m_graceSlash = m_e.asciiAttribute("slash") == "yes";
             m_e.skipCurrentElement();  // skip but don't log
         } else if (m_e.name() == "instrument") {
-            instrumentId = m_e.attribute("id");
+            m_instrumentId = m_e.attribute("id");
             m_e.skipCurrentElement();  // skip but don't log
         } else if (m_e.name() == "lyric") {
             // lyrics on grace notes not (yet) supported by MuseScore
@@ -8447,16 +8442,16 @@ Note* MusicXmlParserNote::parse()
             m_notationsParser.parse();
             addError(m_notationsParser.errors());
         } else if (m_e.name() == "notehead") {
-            noteheadColor = Color::fromString(m_e.asciiAttribute("color").ascii());
-            noteheadParentheses = m_e.asciiAttribute("parentheses") == "yes";
-            noteheadFilled = m_e.attribute("filled");
+            m_noteheadColor = Color::fromString(m_e.asciiAttribute("color").ascii());
+            m_noteheadParentheses = m_e.asciiAttribute("parentheses") == "yes";
+            m_noteheadFilled = m_e.attribute("filled");
             String noteheadValue = m_e.readText();
             if (noteheadValue == "none") {
                 hasHead = false;
             } else if (noteheadValue == "named" && m_pass1.exporterSoftware() == MusicXmlExporterSoftware::NOTEFLIGHT) {
                 headScheme = NoteHeadScheme::HEAD_PITCHNAME;
             } else {
-                headGroup = convertNotehead(noteheadValue);
+                m_headGroup = convertNotehead(noteheadValue);
             }
         } else if (m_e.name() == "rest") {
             rest = true;
@@ -8524,12 +8519,8 @@ Note* MusicXmlParserNote::parse()
     // note: in case of error exit from here, the postponed <note> children
     // must still be skipped
 
-    int msMove = 0;
-    int msTrack = 0;
-    int msVoice = 0;
-
     int voiceInt = m_pass1.voiceToInt(voice);
-    if (!m_pass1.determineStaffMoveVoice(m_partId, staff, voiceInt, msMove, msTrack, msVoice)) {
+    if (!m_pass1.determineStaffMoveVoice(m_partId, staff, voiceInt, m_staffMove, m_track, m_voice)) {
         m_logger->logDebugInfo(String(u"could not map staff %1 voice '%2'").arg(staff + 1).arg(voice), &m_e);
         addError(checkAtEndElement(m_e, u"note"));
         return 0;
@@ -8538,8 +8529,8 @@ Note* MusicXmlParserNote::parse()
     // start time for note:
     // - sTime for non-chord / first chord note
     // - prevTime for others
-    Fraction noteStartTime = chord ? m_prevSTime : m_sTime;
-    Fraction timeMod = m_noteDuration.timeMod();
+    m_noteStartTime = chord ? m_prevSTime : m_sTime;
+    m_timeMod = m_noteDuration.timeMod();
 
     // determine tuplet state, used twice (before and after note allocation)
     MusicXmlTupletFlags tupletAction;
@@ -8548,22 +8539,21 @@ Note* MusicXmlParserNote::parse()
     if (!chord && !grace) {
         Tuplet* tuplet = m_tuplets[voice];
         MusicXmlTupletState& m_tupletState = m_tupletStates[voice];
-        tupletAction = m_tupletState.determineTupletAction(m_noteDuration.duration(), timeMod, m_notationsParser.tupletDesc().type,
+        tupletAction = m_tupletState.determineTupletAction(m_noteDuration.duration(), m_timeMod, m_notationsParser.tupletDesc().type,
                                                            m_noteDuration.normalType(), m_missingPrev, m_missingCurr);
         if (tupletAction & MusicXmlTupletFlag::STOP_PREVIOUS) {
             // tuplet start while already in tuplet
             if (m_missingPrev.isValid() && m_missingPrev > Fraction(0, 1)) {
-                const int track = msTrack + msVoice;
-                Rest* const extraRest = addRest(m_score, m_measure, noteStartTime, track, msMove,
+                Rest* const extraRest = addRest(m_score, m_measure, m_noteStartTime, track(), m_staffMove,
                                                 TDuration { m_missingPrev* tuplet->ratio() }, m_missingPrev);
                 if (extraRest) {
                     extraRest->setTuplet(tuplet);
                     tuplet->add(extraRest);
-                    noteStartTime += m_missingPrev;
+                    m_noteStartTime += m_missingPrev;
                 }
             }
             // recover by simply stopping the current tuplet first
-            const int normalNotes = timeMod.numerator();
+            const int normalNotes = m_timeMod.numerator();
             handleTupletStop(tuplet, normalNotes);
         }
     }
@@ -8571,13 +8561,12 @@ Note* MusicXmlParserNote::parse()
     TDuration duration = determineDuration(rest, measureRest, type, m_noteDuration.dots(), m_dura, m_measure->ticks());
 
     Part* part = m_pass1.getPart(m_partId);
-    Instrument* instrument = part->instrument(noteStartTime);
+    Instrument* instrument = part->instrument(m_noteStartTime);
     const MusicXmlInstruments& instruments = m_pass1.getInstruments(m_partId);
     isSingleDrumset = instrument->drumset() && instruments.size() == 1;
     // begin allocation
     if (rest) {
-        const int track = msTrack + msVoice;
-        m_chordRest = addRest(m_score, m_measure, noteStartTime, track, msMove,
+        m_chordRest = addRest(m_score, m_measure, m_noteStartTime, track(), m_staffMove,
                               duration, m_dura);
     } else {
         if (!grace) {
@@ -8585,13 +8574,13 @@ Note* MusicXmlParserNote::parse()
             // if there is already a chord just add to it
             // else create a new one
             // this basically ignores <chord/> errors
-            m_chord = findOrCreateChord(noteStartTime, msTrack + msVoice, msMove, duration, m_dura);
+            m_chord = findOrCreateChord(duration);
         } else {
             // grace note
             // TODO: check if explicit stem direction should also be set for grace notes
             // (the DOM parser does that, but seems to have no effect on the autotester)
             if (!chord || m_gcl.empty()) {
-                m_chord = createGraceChord(msTrack + msVoice, duration, graceSlash);
+                m_chord = createGraceChord(duration);
                 // TODO FIX
                 // the setStaffMove() below results in identical behaviour as 2.0:
                 // grace note will be at the wrong staff with the wrong pitch,
@@ -8607,13 +8596,13 @@ Note* MusicXmlParserNote::parse()
             }
         }
         m_note = Factory::createNote(m_chord);
-        const staff_idx_t ottavaStaff = (msTrack - m_pass1.trackForPart(m_partId)) / VOICES;
-        const int octaveShift = m_pass1.octaveShift(m_partId, ottavaStaff, noteStartTime);
+        const staff_idx_t ottavaStaff = (m_track - m_pass1.trackForPart(m_partId)) / VOICES;
+        const int octaveShift = m_pass1.octaveShift(m_partId, ottavaStaff, m_noteStartTime);
         const Staff* st = m_chord->staff();
-        if (isSingleDrumset && m_notePitch.unpitched() && instrumentId.empty()) {
-            xmlSetDrumsetPitch(st, m_notePitch.displayStep(), m_notePitch.displayOctave(), headGroup, instrument);
+        if (isSingleDrumset && m_notePitch.unpitched() && m_instrumentId.empty()) {
+            xmlSetDrumsetPitch(st, instrument);
         } else {
-            setPitch(instruments, instrumentId, octaveShift, instrument);
+            setPitch(instruments, octaveShift, instrument);
         }
         m_chord->add(m_note);
         m_chordRest = m_chord;
@@ -8621,10 +8610,9 @@ Note* MusicXmlParserNote::parse()
     // end allocation
 
     if (rest) {
-        const track_idx_t track = msTrack + msVoice;
         if (m_chordRest) {
             if (currBeam) {
-                if (currBeam->track() == track) {
+                if (currBeam->track() == track()) {
                     m_chordRest->setBeamMode(BeamMode::MID);
                     currBeam->add(m_chordRest);
                 } else {
@@ -8638,12 +8626,12 @@ Note* MusicXmlParserNote::parse()
                 m_chordRest->setColor(noteColor);
             }
             m_chordRest->setVisible(printObject);
-            handleDisplayStep(m_notePitch.displayStep(), m_notePitch.displayOctave(), noteStartTime, m_score->style().spatium());
+            handleDisplayStep();
         }
     } else {
         handleSmallness();
         m_note->setPlay(!m_cue);          // cue notes don't play
-        m_note->setHeadGroup(headGroup);
+        m_note->setHeadGroup(m_headGroup);
         if (headScheme != NoteHeadScheme::HEAD_AUTO) {
             m_note->setHeadScheme(headScheme);
         }
@@ -8660,7 +8648,7 @@ Note* MusicXmlParserNote::parse()
             }
             m_chord->add(stem);
         }
-        setNoteHead(noteheadColor, noteheadParentheses, noteheadFilled);
+        setNoteHead();
         m_note->setVisible(hasHead && printObject);
         stem->setVisible(printObject);
 
@@ -8672,7 +8660,7 @@ Note* MusicXmlParserNote::parse()
             }
 
             // append any grace chord after chord to the previous chord
-            Chord* const prevChord = m_measure->findChord(m_prevSTime, msTrack + msVoice);
+            Chord* const prevChord = m_measure->findChord(m_prevSTime, track());
             if (prevChord && prevChord != m_chord) {
                 addGraceChordsAfter(prevChord, m_gcl, m_gac);
             }
@@ -8705,7 +8693,7 @@ Note* MusicXmlParserNote::parse()
         }
 
         if (m_notePitch.unpitched() && !isSingleDrumset) {
-            setDrumset(instrumentId, noteStartTime, headGroup);
+            setDrumset();
         }
 
         // accidental handling
@@ -8734,7 +8722,7 @@ Note* MusicXmlParserNote::parse()
     if (m_chordRest) {
         m_chordRest->setVisible(printObject);
         m_notationsParser.addToScore(m_chordRest, m_note,
-                                     noteStartTime.ticks(), m_pass2.slurs(), m_pass2.glissandi(), m_pass2.spanners(), m_pass2.trills(),
+                                     m_noteStartTime.ticks(), m_pass2.slurs(), m_pass2.glissandi(), m_pass2.spanners(), m_pass2.trills(),
                                      m_pass2.ties(), m_pass2.unstartedTieNotes(), m_pass2.unendedTieNotes(), m_arpMap,
                                      m_delayedArps);
 
@@ -8750,8 +8738,7 @@ Note* MusicXmlParserNote::parse()
 
     // handle tremolo before handling tuplet (two note tremolos modify timeMod)
     if (m_chordRest && m_notationsParser.hasTremolo()) {
-        addTremolo(m_notationsParser.tremoloNr(), m_notationsParser.tremoloType(), m_notationsParser.tremoloSmufl(),
-                   m_pass2.tremStart(), timeMod);
+        addTremolo(m_pass2.tremStart());
     }
 
     // handle tuplet state for the current chord or rest
@@ -8760,9 +8747,9 @@ Note* MusicXmlParserNote::parse()
             Tuplet*& tuplet = m_tuplets[voice];
             // do tuplet if valid time-modification is not 1/1 and is not 1/2 (tremolo)
             // TODO: check interaction tuplet and tremolo handling
-            if (timeMod.isValid() && timeMod != Fraction(1, 1) && timeMod != Fraction(1, 2)) {
-                const int actualNotes = timeMod.denominator();
-                const int normalNotes = timeMod.numerator();
+            if (m_timeMod.isValid() && m_timeMod != Fraction(1, 1) && m_timeMod != Fraction(1, 2)) {
+                const int actualNotes = m_timeMod.denominator();
+                const int normalNotes = m_timeMod.numerator();
                 if (tupletAction & MusicXmlTupletFlag::START_NEW) {
                     // create a new tuplet
                     handleTupletStart(m_chordRest, tuplet, actualNotes, normalNotes, m_notationsParser.tupletDesc());
@@ -8774,8 +8761,7 @@ Note* MusicXmlParserNote::parse()
                 if (tupletAction & MusicXmlTupletFlag::STOP_CURRENT) {
                     if (m_missingCurr.isValid() && m_missingCurr > Fraction(0, 1)) {
                         LOGD("add missing %s to current tuplet", muPrintable(m_missingCurr.toString()));
-                        const int track = msTrack + msVoice;
-                        Rest* const extraRest = addRest(m_score, m_measure, noteStartTime + m_dura, track, msMove,
+                        Rest* const extraRest = addRest(m_score, m_measure, m_noteStartTime + m_dura, track(), m_staffMove,
                                                         TDuration { m_missingCurr* tuplet->ratio() }, m_missingCurr);
                         if (extraRest) {
                             extraRest->setTuplet(tuplet);
@@ -8822,7 +8808,7 @@ Note* MusicXmlParserNote::parse()
     }
 
     // add figured bass element
-    addFiguredBassElements(noteStartTime, msTrack, m_dura);
+    addFiguredBassElements(m_dura);
 
     // convert to slash or rhythmic notation if needed
     // TODO in the case of slash notation, we assume that given notes do in fact correspond to slash beats

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -238,8 +238,6 @@ void MusicXmlLyricsExtend::setExtend(const int no, const track_idx_t track, cons
 
 /**
  Convert MusicXML \a step (0=C, 1=D, etc.) / \a alter / \a octave to midi pitch.
- Note: same code is in pass 1 and in pass 2.
- TODO: combine
  */
 
 static int MusicXmlStepAltOct2Pitch(int step, int alter, int octave)
@@ -2300,21 +2298,21 @@ static void coerceGraceCue(Chord* mainChord, Chord* graceChord)
  to the chord \a c grace note after list
  */
 
-static void addGraceChordsAfter(Chord* c, GraceChordList& gcl, size_t& gac)
+static void addGraceChordsAfter(Chord* c, GraceChordList& graceChordList, size_t& graceAfterCount)
 {
     if (!c) {
         return;
     }
 
-    while (gac > 0) {
-        if (gcl.size() > 0) {
-            Chord* graceChord = muse::takeFirst(gcl);
+    while (graceAfterCount > 0) {
+        if (graceChordList.size() > 0) {
+            Chord* graceChord = muse::takeFirst(graceChordList);
             graceChord->toGraceAfter();
             c->add(graceChord);              // TODO check if same voice ?
             coerceGraceCue(c, graceChord);
             LOGD("addGraceChordsAfter chord %p grace after chord %p", c, graceChord);
         }
-        gac--;
+        graceAfterCount--;
     }
 }
 
@@ -7684,11 +7682,14 @@ MusicXmlParserNote::MusicXmlParserNote(muse::XmlStreamReader& e, engraving::Scor
                                        FiguredBassList& fbl, int& alt, MusicXmlTupletStates& tupletStates, Tuplets& tuplets,
                                        ArpeggioMap& arpMap, DelayedArpMap& delayedArps)
     : m_e(e), m_score(score), m_logger(logger), m_pass1(pass1), m_pass2(pass2), m_partId(partId), m_measure(measure), m_sTime(sTime),
-    m_prevSTime(prevSTime), m_missingPrev(missingPrev), m_dura(dura), m_missingCurr(missingCurr), m_currentVoice(currentVoice), m_gcl(gcl),
-    m_gac(gac), m_currBeams(currBeams), m_fbl(fbl), m_alt(alt), m_tupletStates(tupletStates), m_tuplets(tuplets), m_arpMap(arpMap),
-    m_delayedArps(delayedArps), m_lyricParser(m_pass1.getMusicXmlPart(m_partId).lyricNumberHandler(), m_e, m_score, m_logger,
-                                              m_pass1.isVocalStaff(m_partId)), m_notationsParser(m_e, m_score, m_logger, m_pass2),
-    m_noteDuration(m_pass2.divs(), m_logger, &m_pass1), m_notePitch(m_logger)
+    m_prevSTime(prevSTime), m_missingPrev(missingPrev), m_durationFraction(dura), m_missingCurr(missingCurr), m_currentVoice(currentVoice),
+    m_graceChordsList(gcl), m_graceAfterCount(gac), m_currBeams(currBeams), m_figuredBassList(fbl), m_alter(alt), m_tupletStates(
+        tupletStates), m_tuplets(tuplets), m_arpMap(arpMap), m_delayedArps(delayedArps), m_lyricParser(m_pass1.getMusicXmlPart(
+                                                                                                           m_partId).lyricNumberHandler(), m_e, m_score, m_logger, m_pass1.isVocalStaff(
+                                                                                                           m_partId)), m_notationsParser(
+        m_e, m_score, m_logger,
+        m_pass2),
+    m_noteDurationParser(m_pass2.divs(), m_logger, &m_pass1), m_notePitchParser(m_logger)
 {
 }
 
@@ -7886,29 +7887,28 @@ bool MusicXmlParserNote::isWholeMeasureRest(const String& type, const Fraction d
  * This includes whole measure rest detection.
  */
 
-TDuration MusicXmlParserNote::determineDuration(const bool rest, const bool measureRest, const String& type, const int dots,
-                                                const Fraction dura, const Fraction mDura)
+TDuration MusicXmlParserNote::determineDuration(const bool rest, const bool measureRest, const String& type)
 {
     //LOGD("determineDuration rest %d type '%s' dots %d dura %s mDura %s",
     //       rest, muPrintable(type), dots, muPrintable(dura.print()), muPrintable(mDura.print()));
 
     TDuration res;
     if (rest) {
-        if (measureRest || isWholeMeasureRest(type, dura, mDura)) {
+        if (measureRest || isWholeMeasureRest(type, m_durationFraction, m_measure->ticks())) {
             res.setType(DurationType::V_MEASURE);
         } else if (type.empty()) {
             // If no type, set duration type based on duration.
             // Note that sometimes unusual duration (e.g. 261/256) are found.
-            res.setVal(dura.ticks());
+            res.setVal(m_durationFraction.ticks());
         } else {
             ByteArray ba = type.toAscii();
             res.setType(TConv::fromXml(ba.constChar(), DurationType::V_INVALID));
-            res.setDots(dots);
+            res.setDots(m_noteDurationParser.dots());
         }
     } else {
         ByteArray ba = type.toAscii();
         res.setType(TConv::fromXml(ba.constChar(), DurationType::V_INVALID));
-        res.setDots(dots);
+        res.setDots(m_noteDurationParser.dots());
         if (res.type() == DurationType::V_INVALID) {
             res.setType(DurationType::V_QUARTER);        // default, TODO: use dura ?
         }
@@ -7926,7 +7926,7 @@ TDuration MusicXmlParserNote::determineDuration(const bool rest, const bool meas
  * This is simply ignored here, effectively using the last chords value.
  */
 
-Chord* MusicXmlParserNote::findOrCreateChord(const TDuration duration) const
+Chord* MusicXmlParserNote::findOrCreateChord() const
 {
     //LOGD("findOrCreateChord tick %d track %d dur ticks %d ticks %s bm %hhd",
     //       tick, track, duration.ticks(), muPrintable(dura.print()), m_beamMode);
@@ -7945,7 +7945,7 @@ Chord* MusicXmlParserNote::findOrCreateChord(const TDuration duration) const
         // If a non-small note is added later, this is handled in handleSmallness.
         c->setSmall(isSmall());
 
-        setChordRestDuration(c, duration, m_dura);
+        setChordRestDuration(c, m_duration, m_durationFraction);
         s->add(c);
     }
     c->setStaffMove(m_staffMove);
@@ -7956,33 +7956,33 @@ Chord* MusicXmlParserNote::findOrCreateChord(const TDuration duration) const
  * convert duration and slash to grace note type
  */
 
-NoteType MusicXmlParserNote::graceNoteType(const TDuration duration) const
+NoteType MusicXmlParserNote::graceNoteType() const
 {
     NoteType nt = NoteType::APPOGGIATURA;
     if (m_graceSlash) {
         nt = NoteType::ACCIACCATURA;
     } else {
-        if (duration.type() == DurationType::V_QUARTER) {
+        if (m_duration.type() == DurationType::V_QUARTER) {
             nt = NoteType::GRACE4;
-        } else if (duration.type() == DurationType::V_16TH) {
+        } else if (m_duration.type() == DurationType::V_16TH) {
             nt = NoteType::GRACE16;
-        } else if (duration.type() == DurationType::V_32ND) {
+        } else if (m_duration.type() == DurationType::V_32ND) {
             nt = NoteType::GRACE32;
         }
     }
     return nt;
 }
 
-Chord* MusicXmlParserNote::createGraceChord(const TDuration duration) const
+Chord* MusicXmlParserNote::createGraceChord() const
 {
     Chord* c = Factory::createChord(m_score->dummy()->segment());
-    c->setNoteType(graceNoteType(duration));
+    c->setNoteType(graceNoteType());
     c->setTrack(track());
     // Chord is initialized with the smallness of its first note.
     // If a non-small note is added later, this is handled in handleSmallness.
     c->setSmall(isSmall());
     // note grace notes have no durations, use default fraction 0/1
-    setChordRestDuration(c, duration, Fraction());
+    setChordRestDuration(c, m_duration, Fraction());
     return c;
 }
 
@@ -7990,7 +7990,7 @@ Chord* MusicXmlParserNote::createGraceChord(const TDuration duration) const
 
 void MusicXmlParserNote::setPitch(const MusicXmlInstruments& instruments, const int octaveShift, const Instrument* const instrument)
 {
-    if (m_notePitch.unpitched()) {
+    if (m_notePitchParser.unpitched()) {
         if (hasDrumset(instruments) && muse::contains(instruments, m_instrumentId)) {
             // step and oct are display-step and ...-oct
             // get pitch from instrument definition in drumset instead
@@ -8000,10 +8000,11 @@ void MusicXmlParserNote::setPitch(const MusicXmlInstruments& instruments, const 
             m_note->setTpc(pitch2tpc(unpitched, Key::C, Prefer::NEAREST));             // TODO: necessary ?
         } else {
             //LOGD("disp step %d oct %d", displayStep, displayOctave);
-            xmlSetPitch(m_note, m_notePitch.displayStep(), 0, 0.0, m_notePitch.displayOctave(), 0, instrument);
+            xmlSetPitch(m_note, m_notePitchParser.displayStep(), 0, 0.0, m_notePitchParser.displayOctave(), 0, instrument);
         }
     } else {
-        xmlSetPitch(m_note, m_notePitch.step(), m_notePitch.alter(), m_notePitch.tuning(), m_notePitch.octave(), octaveShift, instrument);
+        xmlSetPitch(m_note, m_notePitchParser.step(), m_notePitchParser.alter(), m_notePitchParser.tuning(),
+                    m_notePitchParser.octave(), octaveShift, instrument);
     }
 }
 
@@ -8013,8 +8014,8 @@ void MusicXmlParserNote::setPitch(const MusicXmlInstruments& instruments, const 
 
 void MusicXmlParserNote::handleDisplayStep()
 {
-    const int step = m_notePitch.displayStep();
-    const int octave = m_notePitch.displayOctave();
+    const int step = m_notePitchParser.displayStep();
+    const int octave = m_notePitchParser.displayOctave();
     if (0 <= step && step <= 6 && 0 <= octave && octave <= 9) {
         //LOGD("rest step=%d oct=%d", step, octave);
         ClefType clef = m_chordRest->staff()->clef(m_noteStartTime);
@@ -8162,22 +8163,22 @@ void MusicXmlParserNote::addTremolo(Chord*& tremStart)
  Add the figured bass elements.
  */
 
-void MusicXmlParserNote::addFiguredBassElements(const Fraction dura)
+void MusicXmlParserNote::addFiguredBassElements()
 {
-    if (!m_fbl.empty()) {
+    if (!m_figuredBassList.empty()) {
         Fraction sTick = m_noteStartTime;                  // starting tick
-        for (FiguredBass* fb : m_fbl) {
+        for (FiguredBass* fb : m_figuredBassList) {
             fb->setTrack(m_track);
             // No duration tag defaults ticks() to 0; set to note value
             if (fb->ticks().isZero()) {
-                fb->setTicks(dura);
+                fb->setTicks(m_durationFraction);
             }
             // TODO: set correct onNote value
             Segment* s = m_measure->getSegment(SegmentType::ChordRest, sTick);
             s->add(fb);
             sTick += fb->ticks();
         }
-        m_fbl.clear();
+        m_figuredBassList.clear();
     }
 }
 
@@ -8193,7 +8194,7 @@ void MusicXmlParserNote::setDrumset() const
     // determine staff line based on display-step / -octave and clef type
     const ClefType clef = m_chord->staff()->clef(m_noteStartTime);
     const int po = ClefInfo::pitchOffset(clef);
-    const int pitch = MusicXmlStepAltOct2Pitch(m_notePitch.displayStep(), 0, m_notePitch.displayOctave());
+    const int pitch = MusicXmlStepAltOct2Pitch(m_notePitchParser.displayStep(), 0, m_notePitchParser.displayOctave());
     int line = po - absStep(pitch);
 
     // correct for number of staff lines
@@ -8223,8 +8224,8 @@ void MusicXmlParserNote::setDrumset() const
 
 void MusicXmlParserNote::xmlSetDrumsetPitch(const Staff* staff, Instrument* instrument)
 {
-    const int step = m_notePitch.displayStep();
-    const int octave = m_notePitch.displayOctave();
+    const int step = m_notePitchParser.displayStep();
+    const int octave = m_notePitchParser.displayOctave();
     Drumset* ds = instrument->drumset();
     // get line
     // determine staff line based on display-step / -octave and clef type
@@ -8297,7 +8298,7 @@ void MusicXmlParserNote::xmlSetDrumsetPitch(const Staff* staff, Instrument* inst
  These are handled like a forward: only moving the time forward.
  */
 
-void MusicXmlParserNote::notePrintSpacingNo(Fraction& dura)
+void MusicXmlParserNote::notePrintSpacingNo()
 {
     //_logger->logDebugTrace("MusicXmlParserPass1::notePrintSpacingNo", &_e);
 
@@ -8309,7 +8310,7 @@ void MusicXmlParserNote::notePrintSpacingNo(Fraction& dura)
             chord = true;
             m_e.skipCurrentElement();  // skip but don't log
         } else if (m_e.name() == "duration") {
-            m_pass2.duration(dura);
+            m_pass2.duration(m_durationFraction);
         } else if (m_e.name() == "grace") {
             grace = true;
             m_e.skipCurrentElement();  // skip but don't log
@@ -8322,7 +8323,7 @@ void MusicXmlParserNote::notePrintSpacingNo(Fraction& dura)
     // note that this does not check the MusicXML requirement that notes in a chord
     // cannot have a duration longer than the first note in the chord
     if (chord || grace) {
-        dura.set(0, 1);
+        m_durationFraction.set(0, 1);
     }
 
     addError(checkAtEndElement(m_e, u"note"));
@@ -8394,7 +8395,7 @@ void MusicXmlParserNote::addInferredStickings()const
 Note* MusicXmlParserNote::parse()
 {
     if (m_e.asciiAttribute("print-spacing") == "no") {
-        notePrintSpacingNo(m_dura);
+        notePrintSpacingNo();
         return 0;
     }
 
@@ -8415,9 +8416,9 @@ Note* MusicXmlParserNote::parse()
     String tieType;
 
     while (m_e.readNextStartElement()) {
-        if (m_notePitch.readProperties(m_e, m_score)) {
+        if (m_notePitchParser.readProperties(m_e, m_score)) {
             // element handled
-        } else if (m_noteDuration.readProperties(m_e)) {
+        } else if (m_noteDurationParser.readProperties(m_e)) {
             // element handled
         } else if (m_e.name() == "beam") {
             beam();
@@ -8456,7 +8457,7 @@ Note* MusicXmlParserNote::parse()
         } else if (m_e.name() == "rest") {
             rest = true;
             measureRest = m_e.asciiAttribute("measure") == "yes";
-            m_notePitch.displayStepOctave(m_e);
+            m_notePitchParser.displayStepOctave(m_e);
         } else if (m_e.name() == "staff") {
             bool ok = false;
             String strStaff = m_e.readText();
@@ -8505,8 +8506,8 @@ Note* MusicXmlParserNote::parse()
 
     // check for timing error(s) and set dura
     // keep in this order as checkTiming() might change dura
-    String errorStr = m_noteDuration.checkTiming(type, rest, grace);
-    m_dura = m_noteDuration.duration();
+    String errorStr = m_noteDurationParser.checkTiming(type, rest, grace);
+    m_durationFraction = m_noteDurationParser.duration();
     if (!errorStr.empty()) {
         m_logger->logError(errorStr, &m_e);
     }
@@ -8530,7 +8531,7 @@ Note* MusicXmlParserNote::parse()
     // - sTime for non-chord / first chord note
     // - prevTime for others
     m_noteStartTime = chord ? m_prevSTime : m_sTime;
-    m_timeMod = m_noteDuration.timeMod();
+    m_timeMod = m_noteDurationParser.timeMod();
 
     // determine tuplet state, used twice (before and after note allocation)
     MusicXmlTupletFlags tupletAction;
@@ -8539,8 +8540,8 @@ Note* MusicXmlParserNote::parse()
     if (!chord && !grace) {
         Tuplet* tuplet = m_tuplets[voice];
         MusicXmlTupletState& m_tupletState = m_tupletStates[voice];
-        tupletAction = m_tupletState.determineTupletAction(m_noteDuration.duration(), m_timeMod, m_notationsParser.tupletDesc().type,
-                                                           m_noteDuration.normalType(), m_missingPrev, m_missingCurr);
+        tupletAction = m_tupletState.determineTupletAction(m_noteDurationParser.duration(), m_timeMod, m_notationsParser.tupletDesc().type,
+                                                           m_noteDurationParser.normalType(), m_missingPrev, m_missingCurr);
         if (tupletAction & MusicXmlTupletFlag::STOP_PREVIOUS) {
             // tuplet start while already in tuplet
             if (m_missingPrev.isValid() && m_missingPrev > Fraction(0, 1)) {
@@ -8558,7 +8559,7 @@ Note* MusicXmlParserNote::parse()
         }
     }
 
-    TDuration duration = determineDuration(rest, measureRest, type, m_noteDuration.dots(), m_dura, m_measure->ticks());
+    m_duration = determineDuration(rest, measureRest, type);
 
     Part* part = m_pass1.getPart(m_partId);
     Instrument* instrument = part->instrument(m_noteStartTime);
@@ -8567,20 +8568,20 @@ Note* MusicXmlParserNote::parse()
     // begin allocation
     if (rest) {
         m_chordRest = addRest(m_score, m_measure, m_noteStartTime, track(), m_staffMove,
-                              duration, m_dura);
+                              m_duration, m_durationFraction);
     } else {
         if (!grace) {
             // regular note
             // if there is already a chord just add to it
             // else create a new one
             // this basically ignores <chord/> errors
-            m_chord = findOrCreateChord(duration);
+            m_chord = findOrCreateChord();
         } else {
             // grace note
             // TODO: check if explicit stem direction should also be set for grace notes
             // (the DOM parser does that, but seems to have no effect on the autotester)
-            if (!chord || m_gcl.empty()) {
-                m_chord = createGraceChord(duration);
+            if (!chord || m_graceChordsList.empty()) {
+                m_chord = createGraceChord();
                 // TODO FIX
                 // the setStaffMove() below results in identical behaviour as 2.0:
                 // grace note will be at the wrong staff with the wrong pitch,
@@ -8590,16 +8591,16 @@ Note* MusicXmlParserNote::parse()
                 // the main note, e.g. DebuMandSample.xml first grace in part 2
                 // c->setStaffMove(msMove);
                 // END TODO
-                m_gcl.push_back(m_chord);
+                m_graceChordsList.push_back(m_chord);
             } else {
-                m_chord = m_gcl.back();
+                m_chord = m_graceChordsList.back();
             }
         }
         m_note = Factory::createNote(m_chord);
         const staff_idx_t ottavaStaff = (m_track - m_pass1.trackForPart(m_partId)) / VOICES;
         const int octaveShift = m_pass1.octaveShift(m_partId, ottavaStaff, m_noteStartTime);
         const Staff* st = m_chord->staff();
-        if (isSingleDrumset && m_notePitch.unpitched() && m_instrumentId.empty()) {
+        if (isSingleDrumset && m_notePitchParser.unpitched() && m_instrumentId.empty()) {
             xmlSetDrumsetPitch(st, instrument);
         } else {
             setPitch(instruments, octaveShift, instrument);
@@ -8662,19 +8663,19 @@ Note* MusicXmlParserNote::parse()
             // append any grace chord after chord to the previous chord
             Chord* const prevChord = m_measure->findChord(m_prevSTime, track());
             if (prevChord && prevChord != m_chord) {
-                addGraceChordsAfter(prevChord, m_gcl, m_gac);
+                addGraceChordsAfter(prevChord, m_graceChordsList, m_graceAfterCount);
             }
 
             // append any grace chord
-            addGraceChordsBefore(m_chord, m_gcl);
+            addGraceChordsBefore(m_chord, m_graceChordsList);
         }
 
-        if (m_noteDuration.calculatedDuration().isValid()
-            && m_noteDuration.specifiedDuration().isValid()
-            && m_noteDuration.calculatedDuration().isNotZero()
-            && m_noteDuration.calculatedDuration() != m_noteDuration.specifiedDuration()) {
+        if (m_noteDurationParser.calculatedDuration().isValid()
+            && m_noteDurationParser.specifiedDuration().isValid()
+            && m_noteDurationParser.calculatedDuration().isNotZero()
+            && m_noteDurationParser.calculatedDuration() != m_noteDurationParser.specifiedDuration()) {
             // convert duration into note length
-            Fraction durationMult { (m_noteDuration.specifiedDuration() / m_noteDuration.calculatedDuration()).reduced() };
+            Fraction durationMult { (m_noteDurationParser.specifiedDuration() / m_noteDurationParser.calculatedDuration()).reduced() };
             durationMult = (1000 * durationMult).reduced();
             const int noteLen = durationMult.numerator() / durationMult.denominator();
 
@@ -8692,17 +8693,17 @@ Note* MusicXmlParserNote::parse()
             m_note->setUserVelocity(velocity);
         }
 
-        if (m_notePitch.unpitched() && !isSingleDrumset) {
+        if (m_notePitchParser.unpitched() && !isSingleDrumset) {
             setDrumset();
         }
 
         // accidental handling
         //LOGD("note acc %p type %hhd acctype %hhd",
         //       acc, acc ? acc->accidentalType() : static_cast<mu::engraving::AccidentalType>(0), accType);
-        Accidental* acc = m_notePitch.acc();
-        if (!acc && m_notePitch.accType() != AccidentalType::NONE) {
+        Accidental* acc = m_notePitchParser.acc();
+        if (!acc && m_notePitchParser.accType() != AccidentalType::NONE) {
             acc = Factory::createAccidental(m_score->dummy());
-            acc->setAccidentalType(m_notePitch.accType());
+            acc->setAccidentalType(m_notePitchParser.accType());
         }
 
         if (acc) {
@@ -8710,7 +8711,7 @@ Note* MusicXmlParserNote::parse()
             m_note->add(acc);
             // save alter value for user accidental
             if (acc->accidentalType() != AccidentalType::NONE) {
-                m_alt = m_notePitch.alter();
+                m_alter = m_notePitchParser.alter();
             }
         }
 
@@ -8761,7 +8762,7 @@ Note* MusicXmlParserNote::parse()
                 if (tupletAction & MusicXmlTupletFlag::STOP_CURRENT) {
                     if (m_missingCurr.isValid() && m_missingCurr > Fraction(0, 1)) {
                         LOGD("add missing %s to current tuplet", muPrintable(m_missingCurr.toString()));
-                        Rest* const extraRest = addRest(m_score, m_measure, m_noteStartTime + m_dura, track(), m_staffMove,
+                        Rest* const extraRest = addRest(m_score, m_measure, m_noteStartTime + m_durationFraction, track(), m_staffMove,
                                                         TDuration { m_missingCurr* tuplet->ratio() }, m_missingCurr);
                         if (extraRest) {
                             extraRest->setTuplet(tuplet);
@@ -8808,7 +8809,7 @@ Note* MusicXmlParserNote::parse()
     }
 
     // add figured bass element
-    addFiguredBassElements(m_dura);
+    addFiguredBassElements();
 
     // convert to slash or rhythmic notation if needed
     // TODO in the case of slash notation, we assume that given notes do in fact correspond to slash beats
@@ -8820,7 +8821,7 @@ Note* MusicXmlParserNote::parse()
     // note that this does not check the MusicXML requirement that notes in a chord
     // cannot have a duration longer than the first note in the chord
     if (chord || grace) {
-        m_dura.set(0, 1);
+        m_durationFraction.set(0, 1);
     }
 
     addError(checkAtEndElement(m_e, u"note"));

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -7753,7 +7753,9 @@ MusicXmlParserNote::MusicXmlParserNote(muse::XmlStreamReader& e, engraving::Scor
     : m_e(e), m_score(score), m_logger(logger), m_pass1(pass1), m_pass2(pass2), m_partId(partId), m_measure(measure), m_sTime(sTime),
     m_prevSTime(prevSTime), m_missingPrev(missingPrev), m_dura(dura), m_missingCurr(missingCurr), m_currentVoice(currentVoice), m_gcl(gcl),
     m_gac(gac), m_currBeams(currBeams), m_fbl(fbl), m_alt(alt), m_tupletStates(tupletStates), m_tuplets(tuplets), m_arpMap(arpMap),
-    m_delayedArps(delayedArps)
+    m_delayedArps(delayedArps), m_lyricParser(m_pass1.getMusicXmlPart(m_partId).lyricNumberHandler(), m_e, m_score, m_logger,
+                                              m_pass1.isVocalStaff(m_partId)), m_notationsParser(m_e, m_score, m_logger, m_pass2),
+    m_noteDuration(m_pass2.divs(), m_logger, &m_pass1), m_notePitch(m_logger)
 {
 }
 
@@ -7762,36 +7764,36 @@ MusicXmlParserNote::MusicXmlParserNote(muse::XmlStreamReader& e, engraving::Scor
  Collects beamTypes, used in computeBeamMode.
  */
 
-void MusicXmlParserNote::beam(std::map<int, String>& beamTypes)
+void MusicXmlParserNote::beam()
 {
     bool hasBeamNo;
     int beamNo = m_e.asciiAttribute("number").toInt(&hasBeamNo);
     String s = m_e.readText();
 
-    beamTypes.insert({ hasBeamNo ? beamNo : 1, s });
+    m_beamTypes.insert({ hasBeamNo ? beamNo : 1, s });
 }
 
 /**
  Calculate the beam mode based on the collected beamTypes.
  */
 
-BeamMode MusicXmlParserNote::computeBeamMode(const std::map<int, String>& beamTypes)
+BeamMode MusicXmlParserNote::computeBeamMode() const
 {
     // Start with uniquely-handled beam modes
-    if (muse::value(beamTypes, 1) == u"continue"
-        && muse::value(beamTypes, 2) == u"begin") {
+    if (muse::value(m_beamTypes, 1) == u"continue"
+        && muse::value(m_beamTypes, 2) == u"begin") {
         return BeamMode::BEGIN16;
-    } else if (muse::value(beamTypes, 1) == u"continue"
-               && muse::value(beamTypes, 2) == u"continue"
-               && muse::value(beamTypes, 3) == u"begin") {
+    } else if (muse::value(m_beamTypes, 1) == u"continue"
+               && muse::value(m_beamTypes, 2) == u"continue"
+               && muse::value(m_beamTypes, 3) == u"begin") {
         return BeamMode::BEGIN32;
     }
     // Generic beam modes are naive to all except the first beam
-    else if (muse::value(beamTypes, 1) == u"begin") {
+    else if (muse::value(m_beamTypes, 1) == u"begin") {
         return BeamMode::BEGIN;
-    } else if (muse::value(beamTypes, 1) == u"continue") {
+    } else if (muse::value(m_beamTypes, 1) == u"continue") {
         return BeamMode::MID;
-    } else if (muse::value(beamTypes, 1) == u"end") {
+    } else if (muse::value(m_beamTypes, 1) == u"end") {
         return BeamMode::END;
     } else {
         // backward-hook, forward-hook, and other unknown combinations
@@ -7799,9 +7801,9 @@ BeamMode MusicXmlParserNote::computeBeamMode(const std::map<int, String>& beamTy
     }
 }
 
-void MusicXmlParserNote::handleBeamAndStemDir(ChordRest* cr, const BeamMode bm, const DirectionV sd, Beam*& beam, bool hasBeamingInfo)
+void MusicXmlParserNote::handleBeamAndStemDir(const BeamMode bm, Beam*& beam, bool hasBeamingInfo)
 {
-    if (!cr) {
+    if (!m_chord) {
         return;
     }
     // create a new beam
@@ -7812,19 +7814,19 @@ void MusicXmlParserNote::handleBeamAndStemDir(ChordRest* cr, const BeamMode bm, 
             removeBeam(beam);
         }
         // create a new beam
-        beam = Factory::createBeam(cr->score()->dummy()->system());
-        beam->setTrack(cr->track());
-        beam->setDirection(sd);
+        beam = Factory::createBeam(m_chord->score()->dummy()->system());
+        beam->setTrack(m_chord->track());
+        beam->setDirection(m_stemDir);
     }
-    // add ChordRest to beam
+    // add Chord to beam
     if (beam) {
         // verify still in the same track (if still in the same voice)
         // and in a beam ...
         // (note no check is done on correct order of beam begin/continue/end)
         // TODO: Some BEGINs are being skipped
-        if (cr->track() != beam->track()) {
+        if (m_chord->track() != beam->track()) {
             LOGD("handleBeamAndStemDir() from track %zu to track %zu -> abort beam",
-                 beam->track(), cr->track());
+                 beam->track(), m_chord->track());
             // reset beam mode for all elements and remove the beam
             removeBeam(beam);
         } else if (bm == BeamMode::NONE) {
@@ -7838,20 +7840,20 @@ void MusicXmlParserNote::handleBeamAndStemDir(ChordRest* cr, const BeamMode bm, 
             removeBeam(beam);
         } else {
             // actually add cr to the beam
-            beam->add(cr);
+            beam->add(m_chord);
         }
     }
     // if no beam, set stem direction on chord itself
     if (!beam) {
-        static_cast<Chord*>(cr)->setStemDirection(sd);
+        static_cast<Chord*>(m_chord)->setStemDirection(m_stemDir);
         // set beam to none if score has beaming information and note can get beam, otherwise
         // set to auto
-        bool canGetBeam = (cr->durationType().type() >= DurationType::V_EIGHTH
-                           && cr->durationType().type() <= DurationType::V_1024TH);
+        bool canGetBeam = (m_chord->durationType().type() >= DurationType::V_EIGHTH
+                           && m_chord->durationType().type() <= DurationType::V_1024TH);
         if (hasBeamingInfo && canGetBeam) {
-            cr->setBeamMode(BeamMode::NONE);
+            m_chord->setBeamMode(BeamMode::NONE);
         } else {
-            cr->setBeamMode(BeamMode::AUTO);
+            m_chord->setBeamMode(BeamMode::AUTO);
         }
     }
     // terminate the current beam and add to the score
@@ -7903,20 +7905,16 @@ NoteHeadGroup MusicXmlParserNote::convertNotehead(String mxmlName)
  Parse the /score-partwise/part/measure/note/stem node.
  */
 
-void MusicXmlParserNote::stem(DirectionV& stemDirection, bool& noStem)
+void MusicXmlParserNote::stem()
 {
-    // defaults
-    stemDirection = DirectionV::AUTO;
-    noStem = false;
-
     String s = m_e.readText();
 
     if (s == u"up") {
-        stemDirection = DirectionV::UP;
+        m_stemDir = DirectionV::UP;
     } else if (s == u"down") {
-        stemDirection = DirectionV::DOWN;
+        m_stemDir = DirectionV::DOWN;
     } else if (s == u"none") {
-        noStem = true;
+        m_noStem = true;
     } else if (s == u"double") {
     } else {
         m_logger->logError(String(u"unknown stem direction %1").arg(s), &m_e);
@@ -7994,16 +7992,14 @@ TDuration MusicXmlParserNote::determineDuration(const bool rest, const bool meas
  * This is simply ignored here, effectively using the last chords value.
  */
 
-Chord* MusicXmlParserNote::findOrCreateChord(Score*, Measure* m,
-                                             const Fraction& tick, const int track, const int move,
-                                             const TDuration duration, const Fraction dura,
-                                             BeamMode bm, bool small)
+Chord* MusicXmlParserNote::findOrCreateChord(const Fraction& tick, const int track, const int move,
+                                             const TDuration duration, const Fraction dura, BeamMode bm)
 {
     //LOGD("findOrCreateChord tick %d track %d dur ticks %d ticks %s bm %hhd",
     //       tick, track, duration.ticks(), muPrintable(dura.print()), bm);
-    Chord* c = m->findChord(tick, track);
+    Chord* c = m_measure->findChord(tick, track);
     if (c == 0) {
-        Segment* s = m->getSegment(SegmentType::ChordRest, tick);
+        Segment* s = m_measure->getSegment(SegmentType::ChordRest, tick);
         c = Factory::createChord(s);
         // better not to force beam end, as the beam palette does not support it
         if (bm == BeamMode::END) {
@@ -8014,7 +8010,7 @@ Chord* MusicXmlParserNote::findOrCreateChord(Score*, Measure* m,
         c->setTrack(track);
         // Chord is initialized with the smallness of its first note.
         // If a non-small note is added later, this is handled in handleSmallness.
-        c->setSmall(small);
+        c->setSmall(isSmall());
 
         setChordRestDuration(c, duration, dura);
         s->add(c);
@@ -8044,15 +8040,15 @@ NoteType MusicXmlParserNote::graceNoteType(const TDuration duration, const bool 
     return nt;
 }
 
-Chord* MusicXmlParserNote::createGraceChord(Score* score, const int track,
-                                            const TDuration duration, const bool slash, const bool small)
+Chord* MusicXmlParserNote::createGraceChord(const int track,
+                                            const TDuration duration, const bool slash)
 {
-    Chord* c = Factory::createChord(score->dummy()->segment());
+    Chord* c = Factory::createChord(m_score->dummy()->segment());
     c->setNoteType(graceNoteType(duration, slash));
     c->setTrack(track);
     // Chord is initialized with the smallness of its first note.
     // If a non-small note is added later, this is handled in handleSmallness.
-    c->setSmall(small);
+    c->setSmall(isSmall());
     // note grace notes have no durations, use default fraction 0/1
     setChordRestDuration(c, duration, Fraction());
     return c;
@@ -8060,24 +8056,23 @@ Chord* MusicXmlParserNote::createGraceChord(Score* score, const int track,
 
 // TODO: refactor: optimize parameters
 
-void MusicXmlParserNote::setPitch(Note* note, const MusicXmlInstruments& instruments, const String& instrumentId,
-                                  const MusicXmlNotePitch& mnp,
+void MusicXmlParserNote::setPitch(const MusicXmlInstruments& instruments, const String& instrumentId,
                                   const int octaveShift, const Instrument* const instrument)
 {
-    if (mnp.unpitched()) {
+    if (m_notePitch.unpitched()) {
         if (hasDrumset(instruments) && muse::contains(instruments, instrumentId)) {
             // step and oct are display-step and ...-oct
             // get pitch from instrument definition in drumset instead
             int unpitched = instruments.at(instrumentId).unpitched;
-            note->setPitch(std::clamp(unpitched, 0, 127));
+            m_note->setPitch(std::clamp(unpitched, 0, 127));
             // TODO - does this need to be key-aware?
-            note->setTpc(pitch2tpc(unpitched, Key::C, Prefer::NEAREST));             // TODO: necessary ?
+            m_note->setTpc(pitch2tpc(unpitched, Key::C, Prefer::NEAREST));             // TODO: necessary ?
         } else {
             //LOGD("disp step %d oct %d", displayStep, displayOctave);
-            xmlSetPitch(note, mnp.displayStep(), 0, 0.0, mnp.displayOctave(), 0, instrument);
+            xmlSetPitch(m_note, m_notePitch.displayStep(), 0, 0.0, m_notePitch.displayOctave(), 0, instrument);
         }
     } else {
-        xmlSetPitch(note, mnp.step(), mnp.alter(), mnp.tuning(), mnp.octave(), octaveShift, instrument);
+        xmlSetPitch(m_note, m_notePitch.step(), m_notePitch.alter(), m_notePitch.tuning(), m_notePitch.octave(), octaveShift, instrument);
     }
 }
 
@@ -8085,30 +8080,30 @@ void MusicXmlParserNote::setPitch(Note* note, const MusicXmlInstruments& instrum
  * convert display-step and display-octave to staff line
  */
 
-void MusicXmlParserNote::handleDisplayStep(ChordRest* cr, int step, int octave, const Fraction& tick, double spatium)
+void MusicXmlParserNote::handleDisplayStep(int step, int octave, const Fraction& tick, double spatium)
 {
     if (0 <= step && step <= 6 && 0 <= octave && octave <= 9) {
         //LOGD("rest step=%d oct=%d", step, octave);
-        ClefType clef = cr->staff()->clef(tick);
+        ClefType clef = m_chordRest->staff()->clef(tick);
         int po = ClefInfo::pitchOffset(clef);
         //LOGD(" clef=%hhd po=%d step=%d", clef, po, step);
         int dp = 7 * (octave + 2) + step;
         //LOGD(" dp=%d po-dp=%d", dp, po-dp);
-        cr->ryoffset() = (po - dp + 3) * spatium / 2;
+        m_chordRest->ryoffset() = (po - dp + 3) * spatium / 2;
     }
 }
 
-void MusicXmlParserNote::handleSmallness(bool cueOrSmall, Note* note, Chord* c)
+void MusicXmlParserNote::handleSmallness()
 {
-    if (cueOrSmall) {
-        note->setSmall(!c->isSmall()); // Avoid redundant smallness
+    if (isSmall()) {
+        m_note->setSmall(!m_chord->isSmall()); // Avoid redundant smallness
     } else {
-        note->setSmall(false);
-        if (c->isSmall()) {
+        m_note->setSmall(false);
+        if (m_chord->isSmall()) {
             // What was a small chord becomes small notes in a non-small chord
-            c->setSmall(false);
-            for (Note* otherNote : c->notes()) {
-                if (note != otherNote) {
+            m_chord->setSmall(false);
+            for (Note* otherNote : m_chord->notes()) {
+                if (m_note != otherNote) {
                     otherNote->setSmall(true);
                 }
             }
@@ -8120,38 +8115,35 @@ void MusicXmlParserNote::handleSmallness(bool cueOrSmall, Note* note, Chord* c)
  Set the notehead parameters.
  */
 
-void MusicXmlParserNote::setNoteHead(Note* note, const Color noteheadColor, const bool noteheadParentheses, const String& noteheadFilled)
+void MusicXmlParserNote::setNoteHead(const Color noteheadColor, const bool noteheadParentheses, const String& noteheadFilled)
 {
-    Score* const score = note->score();
+    Score* const score = m_note->score();
 
     if (noteheadColor.isValid()) {
-        note->setColor(noteheadColor);
+        m_note->setColor(noteheadColor);
     }
     if (noteheadParentheses) {
-        Symbol* s = new Symbol(note);
+        Symbol* s = new Symbol(m_note);
         s->setSym(SymId::noteheadParenthesisLeft);
-        s->setParent(note);
+        s->setParent(m_note);
         score->addElement(s);
-        s = new Symbol(note);
+        s = new Symbol(m_note);
         s->setSym(SymId::noteheadParenthesisRight);
-        s->setParent(note);
+        s->setParent(m_note);
         score->addElement(s);
     }
 
     if (noteheadFilled == u"no") {
-        note->setHeadType(NoteHeadType::HEAD_HALF);
+        m_note->setHeadType(NoteHeadType::HEAD_HALF);
     } else if (noteheadFilled == u"yes") {
-        note->setHeadType(NoteHeadType::HEAD_QUARTER);
+        m_note->setHeadType(NoteHeadType::HEAD_QUARTER);
     }
 }
 
-void MusicXmlParserNote::addTremolo(ChordRest* cr,
-                                    const int tremoloNr, const String& tremoloType, const String& tremoloSmufl,
-                                    Chord*& tremStart,
-                                    MusicXmlLogger* logger, const XmlStreamReader* const xmlreader,
-                                    Fraction& timeMod)
+void MusicXmlParserNote::addTremolo(const int tremoloNr, const String& tremoloType, const String& tremoloSmufl,
+                                    Chord*& tremStart, Fraction& timeMod)
 {
-    if (!cr->isChord()) {
+    if (!m_chordRest->isChord()) {
         return;
     }
     if (tremoloNr) {
@@ -8171,15 +8163,15 @@ void MusicXmlParserNote::addTremolo(ChordRest* cr,
                 }
 
                 if (type != TremoloType::INVALID_TREMOLO) {
-                    TremoloSingleChord* tremolo = Factory::createTremoloSingleChord(mu::engraving::toChord(cr));
+                    TremoloSingleChord* tremolo = Factory::createTremoloSingleChord(mu::engraving::toChord(m_chordRest));
                     tremolo->setTremoloType(type);
-                    cr->add(tremolo);
+                    m_chordRest->add(tremolo);
                 }
             } else if (tremoloType == u"start") {
                 if (tremStart) {
-                    logger->logError(u"MusicXml::import: double tremolo start", xmlreader);
+                    m_logger->logError(u"MusicXml::import: double tremolo start", &m_e);
                 }
-                tremStart = static_cast<Chord*>(cr);
+                tremStart = static_cast<Chord*>(m_chordRest);
                 // timeMod takes into account also the factor 2 of a two-note tremolo
                 if (timeMod.isValid() && ((timeMod.denominator() % 2) == 0)) {
                     timeMod.setDenominator(timeMod.denominator() / 2);
@@ -8199,11 +8191,11 @@ void MusicXmlParserNote::addTremolo(ChordRest* cr,
                     }
 
                     if (type != TremoloType::INVALID_TREMOLO) {
-                        TremoloTwoChord* tremolo = Factory::createTremoloTwoChord(mu::engraving::toChord(cr));
+                        TremoloTwoChord* tremolo = Factory::createTremoloTwoChord(mu::engraving::toChord(m_chordRest));
                         tremolo->setTremoloType(type);
-                        tremolo->setChords(tremStart, static_cast<Chord*>(cr));
+                        tremolo->setChords(tremStart, static_cast<Chord*>(m_chordRest));
                         // fixup chord duration and type
-                        const Fraction tremDur = cr->ticks() * Fraction(1, 2);
+                        const Fraction tremDur = m_chordRest->ticks() * Fraction(1, 2);
                         tremolo->chord1()->setDurationType(tremDur);
                         tremolo->chord1()->setTicks(tremDur);
                         tremolo->chord2()->setDurationType(tremDur);
@@ -8216,18 +8208,18 @@ void MusicXmlParserNote::addTremolo(ChordRest* cr,
                         timeMod.setDenominator(timeMod.denominator() / 2);
                     }
                 } else {
-                    logger->logError(u"MusicXml::import: double tremolo stop w/o start", xmlreader);
+                    m_logger->logError(u"MusicXml::import: double tremolo stop w/o start", &m_e);
                 }
                 tremStart = nullptr;
             }
         } else {
-            logger->logError(String(u"unknown tremolo type %1").arg(tremoloNr), xmlreader);
+            m_logger->logError(String(u"unknown tremolo type %1").arg(tremoloNr), &m_e);
         }
     } else if (tremoloNr == 0 && (tremoloType == u"unmeasured" || tremoloType.empty() || tremoloSmufl == u"buzzRoll")) {
         // Out of all the SMuFL unmeasured tremolos, we only support 'buzzRoll'
-        TremoloSingleChord* tremolo = Factory::createTremoloSingleChord(mu::engraving::toChord(cr));
+        TremoloSingleChord* tremolo = Factory::createTremoloSingleChord(mu::engraving::toChord(m_chordRest));
         tremolo->setTremoloType(TremoloType::BUZZ_ROLL);
-        cr->add(tremolo);
+        m_chordRest->add(tremolo);
     }
 }
 
@@ -8235,23 +8227,22 @@ void MusicXmlParserNote::addTremolo(ChordRest* cr,
  Add the figured bass elements.
  */
 
-void MusicXmlParserNote::addFiguredBassElements(FiguredBassList& fbl, const Fraction noteStartTime, const int msTrack,
-                                                const Fraction dura, Measure* measure)
+void MusicXmlParserNote::addFiguredBassElements(const Fraction noteStartTime, const int msTrack, const Fraction dura)
 {
-    if (!fbl.empty()) {
+    if (!m_fbl.empty()) {
         Fraction sTick = noteStartTime;                  // starting tick
-        for (FiguredBass* fb : fbl) {
+        for (FiguredBass* fb : m_fbl) {
             fb->setTrack(msTrack);
             // No duration tag defaults ticks() to 0; set to note value
             if (fb->ticks().isZero()) {
                 fb->setTicks(dura);
             }
             // TODO: set correct onNote value
-            Segment* s = measure->getSegment(SegmentType::ChordRest, sTick);
+            Segment* s = m_measure->getSegment(SegmentType::ChordRest, sTick);
             s->add(fb);
             sTick += fb->ticks();
         }
-        fbl.clear();
+        m_fbl.clear();
     }
 }
 
@@ -8262,20 +8253,19 @@ void MusicXmlParserNote::addFiguredBassElements(FiguredBassList& fbl, const Frac
  the MusicXML values for each note are simply copied to the defaults
  */
 
-void MusicXmlParserNote::setDrumset(Chord* c, MusicXmlParserPass1& pass1, const String& partId, const String& instrumentId,
-                                    const Fraction& noteStartTime, const MusicXmlNotePitch& mnp, const DirectionV stemDir,
+void MusicXmlParserNote::setDrumset(const String& instrumentId, const Fraction& noteStartTime,
                                     const NoteHeadGroup headGroup)
 {
     // determine staff line based on display-step / -octave and clef type
-    const ClefType clef = c->staff()->clef(noteStartTime);
+    const ClefType clef = m_chord->staff()->clef(noteStartTime);
     const int po = ClefInfo::pitchOffset(clef);
-    const int pitch = MusicXmlStepAltOct2Pitch(mnp.displayStep(), 0, mnp.displayOctave());
+    const int pitch = MusicXmlStepAltOct2Pitch(m_notePitch.displayStep(), 0, m_notePitch.displayOctave());
     int line = po - absStep(pitch);
 
     // correct for number of staff lines
     // see ExportMusicXml::unpitch2xml for explanation
     // TODO handle other # staff lines ?
-    int staffLines = c->staff()->lines(Fraction(0, 1));
+    int staffLines = m_chord->staff()->lines(Fraction(0, 1));
     if (staffLines == 1) {
         line -= 8;
     }
@@ -8285,8 +8275,8 @@ void MusicXmlParserNote::setDrumset(Chord* c, MusicXmlParserPass1& pass1, const 
 
     // the drum palette cannot handle stem direction AUTO,
     // overrule if necessary
-    DirectionV overruledStemDir = stemDir;
-    if (stemDir == DirectionV::AUTO) {
+    DirectionV overruledStemDir = m_stemDir;
+    if (m_stemDir == DirectionV::AUTO) {
         if (line > 4) {
             overruledStemDir = DirectionV::DOWN;
         } else {
@@ -8294,20 +8284,20 @@ void MusicXmlParserNote::setDrumset(Chord* c, MusicXmlParserPass1& pass1, const 
         }
     }
     // this should be done in pass 1, would make _pass1 const here
-    pass1.setDrumsetDefault(partId, instrumentId, headGroup, line, overruledStemDir);
+    m_pass1.setDrumsetDefault(m_partId, instrumentId, headGroup, line, overruledStemDir);
 }
 
-void MusicXmlParserNote::xmlSetDrumsetPitch(Note* note, const Chord* chord, const Staff* staff, int step, int octave,
-                                            NoteHeadGroup headGroup, DirectionV& stemDir, Instrument* instrument)
+void MusicXmlParserNote::xmlSetDrumsetPitch(const Staff* staff, int step, int octave,
+                                            NoteHeadGroup headGroup, Instrument* instrument)
 {
     Drumset* ds = instrument->drumset();
     // get line
     // determine staff line based on display-step / -octave and clef type
-    const ClefType clef = staff->clef(chord->tick());
+    const ClefType clef = staff->clef(m_chord->tick());
     const int po = ClefInfo::pitchOffset(clef);
     const int pitch = MusicXmlStepAltOct2Pitch(step, 0, octave);
     int line = po - absStep(pitch);
-    const int staffLines = staff->lines(chord->tick());
+    const int staffLines = staff->lines(m_chord->tick());
     if (staffLines == 1) {
         line -= 8;
     }
@@ -8332,35 +8322,35 @@ void MusicXmlParserNote::xmlSetDrumsetPitch(Note* note, const Chord* chord, cons
 
     // Find inferred instruments at this tick
     if (configuration()->inferTextType()) {
-        InferredPercInstr instr = m_pass2.inferredPercInstr(chord->tick(), chord->track());
+        InferredPercInstr instr = m_pass2.inferredPercInstr(m_chord->tick(), m_chord->track());
         if (instr.track != muse::nidx) {
             // Clear old instrument
             ds->drum(newPitch) = DrumInstrument();
 
             newPitch = instr.pitch;
             ds->drum(newPitch) = ds->drum(newPitch) = DrumInstrument(
-                instr.name.toStdString().c_str(), headGroup, line, stemDir, static_cast<int>(chord->voice()));
+                instr.name.toStdString().c_str(), headGroup, line, m_stemDir, static_cast<int>(m_chord->voice()));
         }
     }
 
     // If there is no exact match add an entry to the drumkit with the XML line and notehead
     if (!matchFound) {
         // Create new instrument in drumkit
-        if (stemDir == DirectionV::AUTO) {
+        if (m_stemDir == DirectionV::AUTO) {
             if (line > 4) {
-                stemDir = DirectionV::DOWN;
+                m_stemDir = DirectionV::DOWN;
             } else {
-                stemDir = DirectionV::UP;
+                m_stemDir = DirectionV::UP;
             }
         }
 
-        ds->drum(newPitch) = DrumInstrument("drum", headGroup, line, stemDir, static_cast<int>(chord->voice()));
-    } else if (stemDir == DirectionV::AUTO) {
-        stemDir = ds->stemDirection(newPitch);
+        ds->drum(newPitch) = DrumInstrument("drum", headGroup, line, m_stemDir, static_cast<int>(m_chord->voice()));
+    } else if (m_stemDir == DirectionV::AUTO) {
+        m_stemDir = ds->stemDirection(newPitch);
     }
 
-    note->setPitch(newPitch);
-    note->setTpcFromPitch();
+    m_note->setPitch(newPitch);
+    m_note->setTpcFromPitch();
 }
 
 //---------------------------------------------------------
@@ -8425,16 +8415,12 @@ Note* MusicXmlParserNote::parse()
     }
 
     bool chord = false;
-    bool cue = false;
-    bool isSmall = false;
     bool grace = false;
     bool rest = false;
     bool measureRest = false;
     int staff = 0;
     String type;
     String voice;
-    DirectionV stemDir = DirectionV::AUTO;
-    bool noStem = false;
     bool hasHead = true;
     NoteHeadGroup headGroup = NoteHeadGroup::HEAD_NORMAL;
     NoteHeadScheme headScheme = NoteHeadScheme::HEAD_AUTO;
@@ -8448,28 +8434,21 @@ Note* MusicXmlParserNote::parse()
     bool printObject = m_e.asciiAttribute("print-object") != "no";
     bool isSingleDrumset = false;
     BeamMode bm;
-    std::map<int, String> beamTypes;
     String instrumentId;
     String tieType;
-    MusicXmlParserLyric lyric { m_pass1.getMusicXmlPart(m_partId).lyricNumberHandler(), m_e, m_score, m_logger,
-                                m_pass1.isVocalStaff(m_partId) };
-    MusicXmlParserNotations notations { m_e, m_score, m_logger, m_pass2 };
-
-    MusicXmlNoteDuration mnd { m_pass2.divs(), m_logger, &m_pass1 };
-    MusicXmlNotePitch mnp { m_logger };
 
     while (m_e.readNextStartElement()) {
-        if (mnp.readProperties(m_e, m_score)) {
+        if (m_notePitch.readProperties(m_e, m_score)) {
             // element handled
-        } else if (mnd.readProperties(m_e)) {
+        } else if (m_noteDuration.readProperties(m_e)) {
             // element handled
         } else if (m_e.name() == "beam") {
-            beam(beamTypes);
+            beam();
         } else if (m_e.name() == "chord") {
             chord = true;
             m_e.skipCurrentElement();  // skip but don't log
         } else if (m_e.name() == "cue") {
-            cue = true;
+            m_cue = true;
             m_e.skipCurrentElement();  // skip but don't log
         } else if (m_e.name() == "grace") {
             grace = true;
@@ -8481,10 +8460,10 @@ Note* MusicXmlParserNote::parse()
         } else if (m_e.name() == "lyric") {
             // lyrics on grace notes not (yet) supported by MuseScore
             // add to main note instead
-            lyric.parse();
+            m_lyricParser.parse();
         } else if (m_e.name() == "notations") {
-            notations.parse();
-            addError(notations.errors());
+            m_notationsParser.parse();
+            addError(m_notationsParser.errors());
         } else if (m_e.name() == "notehead") {
             noteheadColor = Color::fromString(m_e.asciiAttribute("color").ascii());
             noteheadParentheses = m_e.asciiAttribute("parentheses") == "yes";
@@ -8500,7 +8479,7 @@ Note* MusicXmlParserNote::parse()
         } else if (m_e.name() == "rest") {
             rest = true;
             measureRest = m_e.asciiAttribute("measure") == "yes";
-            mnp.displayStepOctave(m_e);
+            m_notePitch.displayStepOctave(m_e);
         } else if (m_e.name() == "staff") {
             bool ok = false;
             String strStaff = m_e.readText();
@@ -8511,12 +8490,12 @@ Note* MusicXmlParserNote::parse()
             }
         } else if (m_e.name() == "stem") {
             stemColor = Color::fromString(m_e.asciiAttribute("color").ascii());
-            stem(stemDir, noStem);
+            stem();
         } else if (m_e.name() == "tie") {
             tieType = m_e.attribute("type");
             m_e.skipCurrentElement();
         } else if (m_e.name() == "type") {
-            isSmall = m_e.asciiAttribute("size") == "cue" || m_e.asciiAttribute("size") == "grace-cue";
+            m_isSmall = m_e.asciiAttribute("size") == "cue" || m_e.asciiAttribute("size") == "grace-cue";
             type = m_e.readText();
         } else if (m_e.name() == "voice") {
             voice = m_e.readText();
@@ -8545,12 +8524,12 @@ Note* MusicXmlParserNote::parse()
     }
     Beam*& currBeam = m_currBeams[m_currentVoice];
 
-    bm = computeBeamMode(beamTypes);
+    bm = computeBeamMode();
 
     // check for timing error(s) and set dura
     // keep in this order as checkTiming() might change dura
-    String errorStr = mnd.checkTiming(type, rest, grace);
-    m_dura = mnd.duration();
+    String errorStr = m_noteDuration.checkTiming(type, rest, grace);
+    m_dura = m_noteDuration.duration();
     if (!errorStr.empty()) {
         m_logger->logError(errorStr, &m_e);
     }
@@ -8578,7 +8557,7 @@ Note* MusicXmlParserNote::parse()
     // - sTime for non-chord / first chord note
     // - prevTime for others
     Fraction noteStartTime = chord ? m_prevSTime : m_sTime;
-    Fraction timeMod = mnd.timeMod();
+    Fraction timeMod = m_noteDuration.timeMod();
 
     // determine tuplet state, used twice (before and after note allocation)
     MusicXmlTupletFlags tupletAction;
@@ -8587,8 +8566,8 @@ Note* MusicXmlParserNote::parse()
     if (!chord && !grace) {
         Tuplet* tuplet = m_tuplets[voice];
         MusicXmlTupletState& m_tupletState = m_tupletStates[voice];
-        tupletAction = m_tupletState.determineTupletAction(mnd.duration(), timeMod, notations.tupletDesc().type,
-                                                           mnd.normalType(), m_missingPrev, m_missingCurr);
+        tupletAction = m_tupletState.determineTupletAction(m_noteDuration.duration(), timeMod, m_notationsParser.tupletDesc().type,
+                                                           m_noteDuration.normalType(), m_missingPrev, m_missingCurr);
         if (tupletAction & MusicXmlTupletFlag::STOP_PREVIOUS) {
             // tuplet start while already in tuplet
             if (m_missingPrev.isValid() && m_missingPrev > Fraction(0, 1)) {
@@ -8607,11 +8586,7 @@ Note* MusicXmlParserNote::parse()
         }
     }
 
-    Chord* c { nullptr };
-    ChordRest* cr { nullptr };
-    Note* note { nullptr };
-
-    TDuration duration = determineDuration(rest, measureRest, type, mnd.dots(), m_dura, m_measure->ticks());
+    TDuration duration = determineDuration(rest, measureRest, type, m_noteDuration.dots(), m_dura, m_measure->ticks());
 
     Part* part = m_pass1.getPart(m_partId);
     Instrument* instrument = part->instrument(noteStartTime);
@@ -8620,24 +8595,21 @@ Note* MusicXmlParserNote::parse()
     // begin allocation
     if (rest) {
         const int track = msTrack + msVoice;
-        cr = addRest(m_score, m_measure, noteStartTime, track, msMove,
-                     duration, m_dura);
+        m_chordRest = addRest(m_score, m_measure, noteStartTime, track, msMove,
+                              duration, m_dura);
     } else {
         if (!grace) {
             // regular note
             // if there is already a chord just add to it
             // else create a new one
             // this basically ignores <chord/> errors
-            c = findOrCreateChord(m_score, m_measure,
-                                  noteStartTime,
-                                  msTrack + msVoice, msMove,
-                                  duration, m_dura, bm, isSmall || cue);
+            m_chord = findOrCreateChord(noteStartTime, msTrack + msVoice, msMove, duration, m_dura, bm);
         } else {
             // grace note
             // TODO: check if explicit stem direction should also be set for grace notes
             // (the DOM parser does that, but seems to have no effect on the autotester)
             if (!chord || m_gcl.empty()) {
-                c = createGraceChord(m_score, msTrack + msVoice, duration, graceSlash, isSmall || cue);
+                m_chord = createGraceChord(msTrack + msVoice, duration, graceSlash);
                 // TODO FIX
                 // the setStaffMove() below results in identical behaviour as 2.0:
                 // grace note will be at the wrong staff with the wrong pitch,
@@ -8647,92 +8619,92 @@ Note* MusicXmlParserNote::parse()
                 // the main note, e.g. DebuMandSample.xml first grace in part 2
                 // c->setStaffMove(msMove);
                 // END TODO
-                m_gcl.push_back(c);
+                m_gcl.push_back(m_chord);
             } else {
-                c = m_gcl.back();
+                m_chord = m_gcl.back();
             }
         }
-        note = Factory::createNote(c);
+        m_note = Factory::createNote(m_chord);
         const staff_idx_t ottavaStaff = (msTrack - m_pass1.trackForPart(m_partId)) / VOICES;
         const int octaveShift = m_pass1.octaveShift(m_partId, ottavaStaff, noteStartTime);
-        const Staff* st = c->staff();
-        if (isSingleDrumset && mnp.unpitched() && instrumentId.empty()) {
-            xmlSetDrumsetPitch(note, c, st, mnp.displayStep(), mnp.displayOctave(), headGroup, stemDir, instrument);
+        const Staff* st = m_chord->staff();
+        if (isSingleDrumset && m_notePitch.unpitched() && instrumentId.empty()) {
+            xmlSetDrumsetPitch(st, m_notePitch.displayStep(), m_notePitch.displayOctave(), headGroup, instrument);
         } else {
-            setPitch(note, instruments, instrumentId, mnp, octaveShift, instrument);
+            setPitch(instruments, instrumentId, octaveShift, instrument);
         }
-        c->add(note);
-        cr = c;
+        m_chord->add(m_note);
+        m_chordRest = m_chord;
     }
     // end allocation
 
     if (rest) {
         const track_idx_t track = msTrack + msVoice;
-        if (cr) {
+        if (m_chordRest) {
             if (currBeam) {
                 if (currBeam->track() == track) {
-                    cr->setBeamMode(BeamMode::MID);
-                    currBeam->add(cr);
+                    m_chordRest->setBeamMode(BeamMode::MID);
+                    currBeam->add(m_chordRest);
                 } else {
                     removeBeam(currBeam);
                 }
             } else {
-                cr->setBeamMode(BeamMode::NONE);
+                m_chordRest->setBeamMode(BeamMode::NONE);
             }
-            cr->setSmall(isSmall);
+            m_chordRest->setSmall(m_isSmall);
             if (noteColor.isValid()) {
-                cr->setColor(noteColor);
+                m_chordRest->setColor(noteColor);
             }
-            cr->setVisible(printObject);
-            handleDisplayStep(cr, mnp.displayStep(), mnp.displayOctave(), noteStartTime, m_score->style().spatium());
+            m_chordRest->setVisible(printObject);
+            handleDisplayStep(m_notePitch.displayStep(), m_notePitch.displayOctave(), noteStartTime, m_score->style().spatium());
         }
     } else {
-        handleSmallness(cue || isSmall, note, c);
-        note->setPlay(!cue);          // cue notes don't play
-        note->setHeadGroup(headGroup);
+        handleSmallness();
+        m_note->setPlay(!m_cue);          // cue notes don't play
+        m_note->setHeadGroup(headGroup);
         if (headScheme != NoteHeadScheme::HEAD_AUTO) {
-            note->setHeadScheme(headScheme);
+            m_note->setHeadScheme(headScheme);
         }
         if (noteColor.isValid()) {
-            note->setColor(noteColor);
+            m_note->setColor(noteColor);
         }
-        Stem* stem = c->stem();
+        Stem* stem = m_chord->stem();
         if (!stem) {
-            stem = Factory::createStem(c);
+            stem = Factory::createStem(m_chord);
             if (stemColor.isValid()) {
                 stem->setColor(stemColor);
             } else if (noteColor.isValid()) {
                 stem->setColor(noteColor);
             }
-            c->add(stem);
+            m_chord->add(stem);
         }
-        setNoteHead(note, noteheadColor, noteheadParentheses, noteheadFilled);
-        note->setVisible(hasHead && printObject);
+        setNoteHead(noteheadColor, noteheadParentheses, noteheadFilled);
+        m_note->setVisible(hasHead && printObject);
         stem->setVisible(printObject);
 
         if (!grace) {
             // regular note
             // handle beam
             if (!chord) {
-                handleBeamAndStemDir(c, bm, stemDir, currBeam, m_pass1.hasBeamingInfo());
+                handleBeamAndStemDir(bm, currBeam, m_pass1.hasBeamingInfo());
             }
 
             // append any grace chord after chord to the previous chord
             Chord* const prevChord = m_measure->findChord(m_prevSTime, msTrack + msVoice);
-            if (prevChord && prevChord != c) {
+            if (prevChord && prevChord != m_chord) {
                 addGraceChordsAfter(prevChord, m_gcl, m_gac);
             }
 
             // append any grace chord
-            addGraceChordsBefore(c, m_gcl);
+            addGraceChordsBefore(m_chord, m_gcl);
         }
 
-        if (mnd.calculatedDuration().isValid()
-            && mnd.specifiedDuration().isValid()
-            && mnd.calculatedDuration().isNotZero()
-            && mnd.calculatedDuration() != mnd.specifiedDuration()) {
+        if (m_noteDuration.calculatedDuration().isValid()
+            && m_noteDuration.specifiedDuration().isValid()
+            && m_noteDuration.calculatedDuration().isNotZero()
+            && m_noteDuration.calculatedDuration() != m_noteDuration.specifiedDuration()) {
             // convert duration into note length
-            Fraction durationMult { (mnd.specifiedDuration() / mnd.calculatedDuration()).reduced() };
+            Fraction durationMult { (m_noteDuration.specifiedDuration() / m_noteDuration.calculatedDuration()).reduced() };
             durationMult = (1000 * durationMult).reduced();
             const int noteLen = durationMult.numerator() / durationMult.denominator();
 
@@ -8740,76 +8712,68 @@ Note* MusicXmlParserNote::parse()
             NoteEvent ne;
             ne.setLen(noteLen);
             nel.push_back(ne);
-            note->setPlayEvents(nel);
-            if (c) {
-                c->setPlayEventType(PlayEventType::User);
+            m_note->setPlayEvents(nel);
+            if (m_chord) {
+                m_chord->setPlayEventType(PlayEventType::User);
             }
         }
 
         if (velocity > 0) {
-            note->setUserVelocity(velocity);
+            m_note->setUserVelocity(velocity);
         }
 
-        if (mnp.unpitched() && !isSingleDrumset) {
-            setDrumset(c, m_pass1, m_partId, instrumentId, noteStartTime, mnp, stemDir, headGroup);
+        if (m_notePitch.unpitched() && !isSingleDrumset) {
+            setDrumset(instrumentId, noteStartTime, headGroup);
         }
 
         // accidental handling
         //LOGD("note acc %p type %hhd acctype %hhd",
         //       acc, acc ? acc->accidentalType() : static_cast<mu::engraving::AccidentalType>(0), accType);
-        Accidental* acc = mnp.acc();
-        if (!acc && mnp.accType() != AccidentalType::NONE) {
+        Accidental* acc = m_notePitch.acc();
+        if (!acc && m_notePitch.accType() != AccidentalType::NONE) {
             acc = Factory::createAccidental(m_score->dummy());
-            acc->setAccidentalType(mnp.accType());
+            acc->setAccidentalType(m_notePitch.accType());
         }
 
         if (acc) {
             acc->setVisible(printObject);
-            note->add(acc);
+            m_note->add(acc);
             // save alter value for user accidental
             if (acc->accidentalType() != AccidentalType::NONE) {
-                m_alt = mnp.alter();
+                m_alt = m_notePitch.alter();
             }
         }
 
-        c->setNoStem(noStem);
+        m_chord->setNoStem(m_noStem);
     }
 
     // cr can be 0 here (if a rest cannot be added)
     // TODO: complete and cleanup handling this case
-    if (cr) {
-        cr->setVisible(printObject);
-    }
-
-    // handle notations
-    if (cr) {
-        notations.addToScore(cr, note,
-                             noteStartTime.ticks(), m_pass2.slurs(), m_pass2.glissandi(), m_pass2.spanners(), m_pass2.trills(),
-                             m_pass2.ties(), m_pass2.unstartedTieNotes(), m_pass2.unendedTieNotes(), m_arpMap,
-                             m_delayedArps);
+    if (m_chordRest) {
+        m_chordRest->setVisible(printObject);
+        m_notationsParser.addToScore(m_chordRest, m_note,
+                                     noteStartTime.ticks(), m_pass2.slurs(), m_pass2.glissandi(), m_pass2.spanners(), m_pass2.trills(),
+                                     m_pass2.ties(), m_pass2.unstartedTieNotes(), m_pass2.unendedTieNotes(), m_arpMap,
+                                     m_delayedArps);
 
         // if no tie added yet, convert the "tie" into "tied" and add it.
-        if (note && !note->tieFor() && !note->tieBack() && !tieType.empty()) {
+        if (m_note && !m_note->tieFor() && !m_note->tieBack() && !tieType.empty()) {
             Notation notation = Notation(u"tied");
             const String type2 = u"type";
             notation.addAttribute(type2, tieType);
-            addTie(notation, note, cr->track(), m_pass2.ties(), m_pass2.unstartedTieNotes(), m_pass2.unendedTieNotes(), m_logger, &m_e);
+            addTie(notation, m_note, m_chordRest->track(), m_pass2.ties(), m_pass2.unstartedTieNotes(),
+                   m_pass2.unendedTieNotes(), m_logger, &m_e);
         }
     }
 
-    // handle grace after state: remember current grace list size
-    if (grace && notations.mustStopGraceAFter()) {
-        m_gac = m_gcl.size();
-    }
-
     // handle tremolo before handling tuplet (two note tremolos modify timeMod)
-    if (cr && notations.hasTremolo()) {
-        addTremolo(cr, notations.tremoloNr(), notations.tremoloType(), notations.tremoloSmufl(),
-                   m_pass2.tremStart(), m_logger, &m_e, timeMod);
+    if (m_chordRest && m_notationsParser.hasTremolo()) {
+        addTremolo(m_notationsParser.tremoloNr(), m_notationsParser.tremoloType(), m_notationsParser.tremoloSmufl(),
+                   m_pass2.tremStart(), timeMod);
     }
 
     // handle tuplet state for the current chord or rest
-    if (cr) {
+    if (m_chordRest) {
         if (!chord && !grace) {
             Tuplet*& tuplet = m_tuplets[voice];
             // do tuplet if valid time-modification is not 1/1 and is not 1/2 (tremolo)
@@ -8819,11 +8783,11 @@ Note* MusicXmlParserNote::parse()
                 const int normalNotes = timeMod.numerator();
                 if (tupletAction & MusicXmlTupletFlag::START_NEW) {
                     // create a new tuplet
-                    handleTupletStart(cr, tuplet, actualNotes, normalNotes, notations.tupletDesc());
+                    handleTupletStart(m_chordRest, tuplet, actualNotes, normalNotes, m_notationsParser.tupletDesc());
                 }
                 if (tupletAction & MusicXmlTupletFlag::ADD_CHORD) {
-                    cr->setTuplet(tuplet);
-                    tuplet->add(cr);
+                    m_chordRest->setTuplet(tuplet);
+                    tuplet->add(m_chordRest);
                 }
                 if (tupletAction & MusicXmlTupletFlag::STOP_CURRENT) {
                     if (m_missingCurr.isValid() && m_missingCurr > Fraction(0, 1)) {
@@ -8846,10 +8810,10 @@ Note* MusicXmlParserNote::parse()
     }
 
     // Add all lyrics from grace notes attached to this chord
-    if (c && !c->graceNotes().empty() && !m_pass2.graceNoteLyrics().empty()) {
+    if (m_chord && !m_chord->graceNotes().empty() && !m_pass2.graceNoteLyrics().empty()) {
         for (GraceNoteLyrics gnl : m_pass2.graceNoteLyrics()) {
             if (gnl.lyric) {
-                addLyric(m_logger, &m_e, cr, gnl.lyric, gnl.no, m_pass2.extendedLyrics());
+                addLyric(m_logger, &m_e, m_chordRest, gnl.lyric, gnl.no, m_pass2.extendedLyrics());
                 if (gnl.extend) {
                     m_pass2.extendedLyrics().addLyric(gnl.lyric);
                 }
@@ -8858,30 +8822,30 @@ Note* MusicXmlParserNote::parse()
         m_pass2.graceNoteLyrics().clear();
     }
 
-    if (cr) {
-        addInferredStickings(cr, lyric.inferredStickings());
+    if (m_chordRest) {
+        addInferredStickings(m_chordRest, m_lyricParser.inferredStickings());
     }
 
     // add lyrics found by lyric
-    if (cr && !grace) {
+    if (m_chordRest && !grace) {
         // add lyrics and stop corresponding extends
-        addLyrics(m_logger, &m_e, cr, lyric.numberedLyrics(), lyric.extendedLyrics(), m_pass2.extendedLyrics());
+        addLyrics(m_logger, &m_e, m_chordRest, m_lyricParser.numberedLyrics(), m_lyricParser.extendedLyrics(), m_pass2.extendedLyrics());
         if (rest) {
             // stop all extends
-            m_pass2.extendedLyrics().setExtend(-1, cr->track(), cr->tick());
+            m_pass2.extendedLyrics().setExtend(-1, m_chordRest->track(), m_chordRest->tick());
         }
-    } else if (c && grace) {
+    } else if (m_chord && grace) {
         // Add grace note lyrics to main chord later
-        addGraceNoteLyrics(lyric.numberedLyrics(), lyric.extendedLyrics(), m_pass2.graceNoteLyrics());
+        addGraceNoteLyrics(m_lyricParser.numberedLyrics(), m_lyricParser.extendedLyrics(), m_pass2.graceNoteLyrics());
     }
 
     // add figured bass element
-    addFiguredBassElements(m_fbl, noteStartTime, msTrack, m_dura, m_measure);
+    addFiguredBassElements(noteStartTime, msTrack, m_dura);
 
     // convert to slash or rhythmic notation if needed
     // TODO in the case of slash notation, we assume that given notes do in fact correspond to slash beats
-    if (c && m_pass2.measureStyleSlash() != MusicXmlSlash::NONE) {
-        c->setSlash(true, m_pass2.measureStyleSlash() == MusicXmlSlash::SLASH);
+    if (m_chord && m_pass2.measureStyleSlash() != MusicXmlSlash::NONE) {
+        m_chord->setSlash(true, m_pass2.measureStyleSlash() == MusicXmlSlash::SLASH);
     }
 
     // don't count chord or grace note duration
@@ -8893,6 +8857,6 @@ Note* MusicXmlParserNote::parse()
 
     addError(checkAtEndElement(m_e, u"note"));
 
-    return note;
+    return m_note;
 }
 }

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -874,73 +874,6 @@ static String nextPartOfFormattedString(XmlStreamReader& e)
 }
 
 //---------------------------------------------------------
-//   addLyric
-//---------------------------------------------------------
-
-/**
- Add a single lyric to the score or delete it (if number too high)
- */
-
-static void addLyric(MusicXmlLogger* logger, const XmlStreamReader* const xmlreader,
-                     ChordRest* cr, Lyrics* l, int lyricNo, MusicXmlLyricsExtend& extendedLyrics)
-{
-    if (lyricNo > MAX_LYRICS) {
-        logger->logError(String(u"too much lyrics (>%1)")
-                         .arg(MAX_LYRICS), xmlreader);
-        delete l;
-    } else {
-        l->setNo(lyricNo);
-        cr->add(l);
-        extendedLyrics.setExtend(lyricNo, cr->track(), cr->tick(), l);
-    }
-}
-
-//---------------------------------------------------------
-//   addLyrics
-//---------------------------------------------------------
-
-/**
- Add a notes lyrics to the score
- */
-
-static void addLyrics(MusicXmlLogger* logger, const XmlStreamReader* const xmlreader,
-                      ChordRest* cr,
-                      const std::map<int, Lyrics*>& numbrdLyrics,
-                      const std::set<Lyrics*>& extLyrics,
-                      MusicXmlLyricsExtend& extendedLyrics)
-{
-    for (const int lyricNo : muse::keys(numbrdLyrics)) {
-        Lyrics* const lyric = numbrdLyrics.at(lyricNo);
-        addLyric(logger, xmlreader, cr, lyric, lyricNo, extendedLyrics);
-        if (muse::contains(extLyrics, lyric)) {
-            extendedLyrics.addLyric(lyric);
-        }
-    }
-}
-
-static void addGraceNoteLyrics(const std::map<int, Lyrics*>& numberedLyrics, std::set<Lyrics*> extendedLyrics,
-                               std::vector<GraceNoteLyrics>& gnLyrics)
-{
-    for (const int lyricNo : muse::keys(numberedLyrics)) {
-        Lyrics* const lyric = numberedLyrics.at(lyricNo);
-        if (lyric) {
-            bool extend = muse::contains(extendedLyrics, lyric);
-            const GraceNoteLyrics gnl = GraceNoteLyrics(lyric, extend, lyricNo);
-            gnLyrics.push_back(gnl);
-        }
-    }
-}
-
-static void addInferredStickings(ChordRest* cr, const std::vector<Sticking*>& numberedStickings)
-{
-    for (Sticking* sticking : numberedStickings) {
-        sticking->setParent(cr->segment());
-        sticking->setTrack(cr->track());
-        cr->score()->addElement(sticking);
-    }
-}
-
-//---------------------------------------------------------
 //   addElemOffset
 //---------------------------------------------------------
 
@@ -7777,37 +7710,37 @@ void MusicXmlParserNote::beam()
  Calculate the beam mode based on the collected beamTypes.
  */
 
-BeamMode MusicXmlParserNote::computeBeamMode() const
+void MusicXmlParserNote::computeBeamMode()
 {
     // Start with uniquely-handled beam modes
     if (muse::value(m_beamTypes, 1) == u"continue"
         && muse::value(m_beamTypes, 2) == u"begin") {
-        return BeamMode::BEGIN16;
+        m_beamMode = BeamMode::BEGIN16;
     } else if (muse::value(m_beamTypes, 1) == u"continue"
                && muse::value(m_beamTypes, 2) == u"continue"
                && muse::value(m_beamTypes, 3) == u"begin") {
-        return BeamMode::BEGIN32;
+        m_beamMode = BeamMode::BEGIN32;
     }
     // Generic beam modes are naive to all except the first beam
     else if (muse::value(m_beamTypes, 1) == u"begin") {
-        return BeamMode::BEGIN;
+        m_beamMode = BeamMode::BEGIN;
     } else if (muse::value(m_beamTypes, 1) == u"continue") {
-        return BeamMode::MID;
+        m_beamMode = BeamMode::MID;
     } else if (muse::value(m_beamTypes, 1) == u"end") {
-        return BeamMode::END;
+        m_beamMode = BeamMode::END;
     } else {
         // backward-hook, forward-hook, and other unknown combinations
-        return BeamMode::AUTO;
+        m_beamMode = BeamMode::AUTO;
     }
 }
 
-void MusicXmlParserNote::handleBeamAndStemDir(const BeamMode bm, Beam*& beam, bool hasBeamingInfo)
+void MusicXmlParserNote::handleBeamAndStemDir(Beam*& beam)
 {
     if (!m_chord) {
         return;
     }
     // create a new beam
-    if (bm == BeamMode::BEGIN) {
+    if (m_beamMode == BeamMode::BEGIN) {
         // if currently in a beam, delete it
         if (beam) {
             LOGD("handleBeamAndStemDir() new beam, removing previous incomplete beam %p", beam);
@@ -7829,13 +7762,14 @@ void MusicXmlParserNote::handleBeamAndStemDir(const BeamMode bm, Beam*& beam, bo
                  beam->track(), m_chord->track());
             // reset beam mode for all elements and remove the beam
             removeBeam(beam);
-        } else if (bm == BeamMode::NONE) {
+        } else if (m_beamMode == BeamMode::NONE) {
             LOGD("handleBeamAndStemDir() in beam, bm BeamMode::NONE -> abort beam");
             // reset beam mode for all elements and remove the beam
             removeBeam(beam);
-        } else if (!(bm == BeamMode::BEGIN || bm == BeamMode::MID || bm == BeamMode::END || bm == BeamMode::BEGIN16
-                     || bm == BeamMode::BEGIN32)) {
-            LOGD("handleBeamAndStemDir() in beam, bm %d -> abort beam", static_cast<int>(bm));
+        } else if (!(m_beamMode == BeamMode::BEGIN || m_beamMode == BeamMode::MID || m_beamMode == BeamMode::END
+                     || m_beamMode == BeamMode::BEGIN16
+                     || m_beamMode == BeamMode::BEGIN32)) {
+            LOGD("handleBeamAndStemDir() in beam, bm %d -> abort beam", static_cast<int>(m_beamMode));
             // reset beam mode for all elements and remove the beam
             removeBeam(beam);
         } else {
@@ -7850,14 +7784,14 @@ void MusicXmlParserNote::handleBeamAndStemDir(const BeamMode bm, Beam*& beam, bo
         // set to auto
         bool canGetBeam = (m_chord->durationType().type() >= DurationType::V_EIGHTH
                            && m_chord->durationType().type() <= DurationType::V_1024TH);
-        if (hasBeamingInfo && canGetBeam) {
+        if (m_pass1.hasBeamingInfo() && canGetBeam) {
             m_chord->setBeamMode(BeamMode::NONE);
         } else {
             m_chord->setBeamMode(BeamMode::AUTO);
         }
     }
     // terminate the current beam and add to the score
-    if (beam && bm == BeamMode::END) {
+    if (beam && m_beamMode == BeamMode::END) {
         beam = nullptr;
     }
 }
@@ -7993,19 +7927,19 @@ TDuration MusicXmlParserNote::determineDuration(const bool rest, const bool meas
  */
 
 Chord* MusicXmlParserNote::findOrCreateChord(const Fraction& tick, const int track, const int move,
-                                             const TDuration duration, const Fraction dura, BeamMode bm)
+                                             const TDuration duration, const Fraction dura)
 {
     //LOGD("findOrCreateChord tick %d track %d dur ticks %d ticks %s bm %hhd",
-    //       tick, track, duration.ticks(), muPrintable(dura.print()), bm);
+    //       tick, track, duration.ticks(), muPrintable(dura.print()), m_beamMode);
     Chord* c = m_measure->findChord(tick, track);
     if (c == 0) {
         Segment* s = m_measure->getSegment(SegmentType::ChordRest, tick);
         c = Factory::createChord(s);
         // better not to force beam end, as the beam palette does not support it
-        if (bm == BeamMode::END) {
+        if (m_beamMode == BeamMode::END) {
             c->setBeamMode(BeamMode::AUTO);
         } else {
-            c->setBeamMode(bm);
+            c->setBeamMode(m_beamMode);
         }
         c->setTrack(track);
         // Chord is initialized with the smallness of its first note.
@@ -8407,6 +8341,55 @@ void MusicXmlParserNote::skipLogCurrElem()
     m_e.skipCurrentElement();
 }
 
+/**
+ Add a single lyric to the score or delete it (if number too high)
+ */
+
+void MusicXmlParserNote::addLyric(Lyrics* l, int lyricNo)
+{
+    if (lyricNo > MAX_LYRICS) {
+        m_logger->logError(String(u"too much lyrics (>%1)")
+                           .arg(MAX_LYRICS), &m_e);
+        delete l;
+    } else {
+        l->setNo(lyricNo);
+        m_chordRest->add(l);
+        m_pass2.extendedLyrics().setExtend(lyricNo, m_chordRest->track(), m_chordRest->tick(), l);
+    }
+}
+
+void MusicXmlParserNote::addLyrics()
+{
+    for (const int lyricNo : muse::keys(m_lyricParser.numberedLyrics())) {
+        Lyrics* const lyric = m_lyricParser.numberedLyrics().at(lyricNo);
+        addLyric(lyric, lyricNo);
+        if (muse::contains(m_lyricParser.extendedLyrics(), lyric)) {
+            m_pass2.extendedLyrics().addLyric(lyric);
+        }
+    }
+}
+
+void MusicXmlParserNote::addGraceNoteLyrics()
+{
+    for (const int lyricNo : muse::keys(m_lyricParser.numberedLyrics())) {
+        Lyrics* const lyric = m_lyricParser.numberedLyrics().at(lyricNo);
+        if (lyric) {
+            bool extend = muse::contains(m_lyricParser.extendedLyrics(), lyric);
+            const GraceNoteLyrics gnl = GraceNoteLyrics(lyric, extend, lyricNo);
+            m_pass2.graceNoteLyrics().push_back(gnl);
+        }
+    }
+}
+
+void MusicXmlParserNote::addInferredStickings()const
+{
+    for (Sticking* sticking : m_lyricParser.inferredStickings()) {
+        sticking->setParent(m_chordRest->segment());
+        sticking->setTrack(m_chordRest->track());
+        m_chordRest->score()->addElement(sticking);
+    }
+}
+
 Note* MusicXmlParserNote::parse()
 {
     if (m_e.asciiAttribute("print-spacing") == "no") {
@@ -8433,7 +8416,6 @@ Note* MusicXmlParserNote::parse()
     bool graceSlash = false;
     bool printObject = m_e.asciiAttribute("print-object") != "no";
     bool isSingleDrumset = false;
-    BeamMode bm;
     String instrumentId;
     String tieType;
 
@@ -8524,7 +8506,7 @@ Note* MusicXmlParserNote::parse()
     }
     Beam*& currBeam = m_currBeams[m_currentVoice];
 
-    bm = computeBeamMode();
+    computeBeamMode();
 
     // check for timing error(s) and set dura
     // keep in this order as checkTiming() might change dura
@@ -8603,7 +8585,7 @@ Note* MusicXmlParserNote::parse()
             // if there is already a chord just add to it
             // else create a new one
             // this basically ignores <chord/> errors
-            m_chord = findOrCreateChord(noteStartTime, msTrack + msVoice, msMove, duration, m_dura, bm);
+            m_chord = findOrCreateChord(noteStartTime, msTrack + msVoice, msMove, duration, m_dura);
         } else {
             // grace note
             // TODO: check if explicit stem direction should also be set for grace notes
@@ -8686,7 +8668,7 @@ Note* MusicXmlParserNote::parse()
             // regular note
             // handle beam
             if (!chord) {
-                handleBeamAndStemDir(bm, currBeam, m_pass1.hasBeamingInfo());
+                handleBeamAndStemDir(currBeam);
             }
 
             // append any grace chord after chord to the previous chord
@@ -8813,7 +8795,7 @@ Note* MusicXmlParserNote::parse()
     if (m_chord && !m_chord->graceNotes().empty() && !m_pass2.graceNoteLyrics().empty()) {
         for (GraceNoteLyrics gnl : m_pass2.graceNoteLyrics()) {
             if (gnl.lyric) {
-                addLyric(m_logger, &m_e, m_chordRest, gnl.lyric, gnl.no, m_pass2.extendedLyrics());
+                addLyric(gnl.lyric, gnl.no);
                 if (gnl.extend) {
                     m_pass2.extendedLyrics().addLyric(gnl.lyric);
                 }
@@ -8823,20 +8805,20 @@ Note* MusicXmlParserNote::parse()
     }
 
     if (m_chordRest) {
-        addInferredStickings(m_chordRest, m_lyricParser.inferredStickings());
+        addInferredStickings();
     }
 
     // add lyrics found by lyric
     if (m_chordRest && !grace) {
         // add lyrics and stop corresponding extends
-        addLyrics(m_logger, &m_e, m_chordRest, m_lyricParser.numberedLyrics(), m_lyricParser.extendedLyrics(), m_pass2.extendedLyrics());
+        addLyrics();
         if (rest) {
             // stop all extends
             m_pass2.extendedLyrics().setExtend(-1, m_chordRest->track(), m_chordRest->tick());
         }
     } else if (m_chord && grace) {
         // Add grace note lyrics to main chord later
-        addGraceNoteLyrics(m_lyricParser.numberedLyrics(), m_lyricParser.extendedLyrics(), m_pass2.graceNoteLyrics());
+        addGraceNoteLyrics();
     }
 
     // add figured bass element

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.h
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.h
@@ -416,12 +416,11 @@ private:
     void handleBeamAndStemDir(engraving::Beam*& beam);
 
     static bool isWholeMeasureRest(const muse::String& type, const engraving::Fraction dura, const engraving::Fraction mDura);
-    static engraving::TDuration determineDuration(const bool rest, const bool measureRest, const muse::String& type, const int dots,
-                                                  const engraving::Fraction dura, const engraving::Fraction mDura);
+    engraving::TDuration determineDuration(const bool rest, const bool measureRest, const muse::String& type);
 
-    engraving::Chord* findOrCreateChord(const engraving::TDuration duration) const;
-    engraving::Chord* createGraceChord(const engraving::TDuration duration) const;
-    engraving::NoteType graceNoteType(const engraving::TDuration duration) const;
+    engraving::Chord* findOrCreateChord() const;
+    engraving::Chord* createGraceChord() const;
+    engraving::NoteType graceNoteType() const;
 
     void setPitch(const MusicXmlInstruments& instruments, const int octaveShift, const engraving::Instrument* const instrument);
 
@@ -431,7 +430,7 @@ private:
     void setNoteHead();
 
     void addTremolo(engraving::Chord*& tremStart);
-    void addFiguredBassElements(const engraving::Fraction dura);
+    void addFiguredBassElements();
 
     void setDrumset() const;
     void xmlSetDrumsetPitch(const engraving::Staff* staff, engraving::Instrument* instrument);
@@ -441,7 +440,7 @@ private:
     void addLyrics();
     void addLyric(engraving::Lyrics* l, int lyricNo);
 
-    void notePrintSpacingNo(engraving::Fraction& dura);
+    void notePrintSpacingNo();
     void addError(const muse::String& error);
 
     inline engraving::track_idx_t track() const { return m_track + m_voice; }
@@ -458,19 +457,19 @@ private:
     engraving::Note* m_note = nullptr;
 
     // ARGS FROM MusicXmlParserPass2::note
-    //TODO reduce
+    // TODO reduce by creating xml parser context object
     engraving::Measure* m_measure;
     const engraving::Fraction m_sTime;
     const engraving::Fraction m_prevSTime;
     engraving::Fraction& m_missingPrev;
-    engraving::Fraction& m_dura;
+    engraving::Fraction& m_durationFraction;
     engraving::Fraction& m_missingCurr;
     muse::String& m_currentVoice;
-    GraceChordList& m_gcl;
-    size_t& m_gac;
+    GraceChordList& m_graceChordsList;
+    size_t& m_graceAfterCount;
     Beams& m_currBeams;
-    FiguredBassList& m_fbl;
-    int& m_alt;
+    FiguredBassList& m_figuredBassList;
+    int& m_alter;
     MusicXmlTupletStates& m_tupletStates;
     Tuplets& m_tuplets;
     ArpeggioMap& m_arpMap;
@@ -478,8 +477,8 @@ private:
 
     MusicXmlParserLyric m_lyricParser;
     MusicXmlParserNotations m_notationsParser;
-    MusicXmlNoteDuration m_noteDuration;
-    MusicXmlNotePitch m_notePitch;
+    MusicXmlNoteDuration m_noteDurationParser;
+    MusicXmlNotePitch m_notePitchParser;
 
     bool m_cue = false;
     bool m_isSmall = false;
@@ -502,6 +501,7 @@ private:
 
     engraving::Fraction m_noteStartTime;
     engraving::Fraction m_timeMod;
+    engraving::TDuration m_duration;
 };
 
 //---------------------------------------------------------

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.h
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.h
@@ -419,36 +419,32 @@ private:
     static engraving::TDuration determineDuration(const bool rest, const bool measureRest, const muse::String& type, const int dots,
                                                   const engraving::Fraction dura, const engraving::Fraction mDura);
 
-    engraving::Chord* findOrCreateChord(const engraving::Fraction& tick, const int track, const int move,
-                                        const engraving::TDuration duration, const engraving::Fraction dura);
-    engraving::Chord* createGraceChord(const int track, const engraving::TDuration duration, const bool slash);
-    static engraving::NoteType graceNoteType(const engraving::TDuration duration, const bool slash);
+    engraving::Chord* findOrCreateChord(const engraving::TDuration duration) const;
+    engraving::Chord* createGraceChord(const engraving::TDuration duration) const;
+    engraving::NoteType graceNoteType(const engraving::TDuration duration) const;
 
-    void setPitch(const MusicXmlInstruments& instruments, const muse::String& instrumentId, const int octaveShift,
-                  const engraving::Instrument* const instrument);
+    void setPitch(const MusicXmlInstruments& instruments, const int octaveShift, const engraving::Instrument* const instrument);
 
-    void handleDisplayStep(int step, int octave, const engraving::Fraction& tick, double spatium);
+    inline bool isSmall() const { return m_cue || m_isSmall; }
+    void handleDisplayStep();
     void handleSmallness();
-    void setNoteHead(const engraving::Color noteheadColor, const bool noteheadParentheses, const muse::String& noteheadFilled);
+    void setNoteHead();
 
-    void addTremolo(const int tremoloNr, const muse::String& tremoloType, const muse::String& tremoloSmufl, engraving::Chord*& tremStart,
-                    engraving::Fraction& timeMod);
+    void addTremolo(engraving::Chord*& tremStart);
+    void addFiguredBassElements(const engraving::Fraction dura);
 
-    void addFiguredBassElements(const engraving::Fraction noteStartTime, const int msTrack, const engraving::Fraction dura);
-
-    void setDrumset(const muse::String& instrumentId, const engraving::Fraction& noteStartTime, const engraving::NoteHeadGroup headGroup);
-    void xmlSetDrumsetPitch(const engraving::Staff* staff, int step, int octave, engraving::NoteHeadGroup headGroup,
-                            engraving::Instrument* instrument);
+    void setDrumset() const;
+    void xmlSetDrumsetPitch(const engraving::Staff* staff, engraving::Instrument* instrument);
 
     void addInferredStickings() const;
     void addGraceNoteLyrics();
     void addLyrics();
     void addLyric(engraving::Lyrics* l, int lyricNo);
 
-    bool isSmall() const { return m_cue || m_isSmall; }
-
     void notePrintSpacingNo(engraving::Fraction& dura);
     void addError(const muse::String& error);
+
+    inline engraving::track_idx_t track() const { return m_track + m_voice; }
 
     muse::XmlStreamReader& m_e;
     engraving::Score* m_score;
@@ -487,11 +483,25 @@ private:
 
     bool m_cue = false;
     bool m_isSmall = false;
+    engraving::NoteHeadGroup m_headGroup = engraving::NoteHeadGroup::HEAD_NORMAL;
+    engraving::Color m_noteheadColor = engraving::Color::BLACK;
+    bool m_noteheadParentheses = false;
+    muse::String m_noteheadFilled;
+    bool m_graceSlash = false;
     engraving::DirectionV m_stemDir = engraving::DirectionV::AUTO;
     bool m_noStem = false;
 
     std::map<int, muse::String> m_beamTypes;
     engraving::BeamMode m_beamMode;
+
+    muse::String m_instrumentId;
+
+    int m_staffMove = 0;
+    int m_track = 0;
+    int m_voice = 0;
+
+    engraving::Fraction m_noteStartTime;
+    engraving::Fraction m_timeMod;
 };
 
 //---------------------------------------------------------

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.h
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.h
@@ -411,17 +411,16 @@ private:
     static engraving::NoteHeadGroup convertNotehead(muse::String mxmlName);
 
     void stem();
-
     void beam();
-    engraving::BeamMode computeBeamMode() const;
-    void handleBeamAndStemDir(const engraving::BeamMode bm, engraving::Beam*& beam, bool hasBeamingInfo);
+    void computeBeamMode();
+    void handleBeamAndStemDir(engraving::Beam*& beam);
 
     static bool isWholeMeasureRest(const muse::String& type, const engraving::Fraction dura, const engraving::Fraction mDura);
     static engraving::TDuration determineDuration(const bool rest, const bool measureRest, const muse::String& type, const int dots,
                                                   const engraving::Fraction dura, const engraving::Fraction mDura);
 
     engraving::Chord* findOrCreateChord(const engraving::Fraction& tick, const int track, const int move,
-                                        const engraving::TDuration duration, const engraving::Fraction dura, engraving::BeamMode bm);
+                                        const engraving::TDuration duration, const engraving::Fraction dura);
     engraving::Chord* createGraceChord(const int track, const engraving::TDuration duration, const bool slash);
     static engraving::NoteType graceNoteType(const engraving::TDuration duration, const bool slash);
 
@@ -441,10 +440,14 @@ private:
     void xmlSetDrumsetPitch(const engraving::Staff* staff, int step, int octave, engraving::NoteHeadGroup headGroup,
                             engraving::Instrument* instrument);
 
+    void addInferredStickings() const;
+    void addGraceNoteLyrics();
+    void addLyrics();
+    void addLyric(engraving::Lyrics* l, int lyricNo);
+
     bool isSmall() const { return m_cue || m_isSmall; }
 
     void notePrintSpacingNo(engraving::Fraction& dura);
-
     void addError(const muse::String& error);
 
     muse::XmlStreamReader& m_e;
@@ -488,6 +491,7 @@ private:
     bool m_noStem = false;
 
     std::map<int, muse::String> m_beamTypes;
+    engraving::BeamMode m_beamMode;
 };
 
 //---------------------------------------------------------


### PR DESCRIPTION
This new class has moved the logic from `MusicXmlParserPass2::note()` to `MusicXmlParserNote::parse()`.  I have also moved all the static methods called during note parsing to the note parser class.  
I have focussed on tidying the internals of the class and reducing the lengthy parameter lists required by the old static methods. The class constructor is currently very bloated and really needs reducing in size.  

I have added methods to access the collections of unfinished spanners/lyrics/arpeggios from `MusicXmlParserPass2`.  Currently these return references in lieu of a proper interface pending a decision on the following: As parsers get more fragmented (I'd like a `MusicXmlParserMeasure` and `MusicXmlParserPart` class), `MusicXmlParserPass2` may have its functionality stripped down to the point where it can become a context object, holding score wide details and parse info such as current tick, measure, `partId` and all the lists of unfinished spanners. However, we could just create a new `MusicXmlImportContext` object with a proper robust interface sooner rather than later.