### PR TITLE
Enforce volta anchor on all pre MU4 scores

### DIFF
--- a/src/engraving/dom/spanner.cpp
+++ b/src/engraving/dom/spanner.cpp
@@ -1150,6 +1150,7 @@ Measure* Spanner::startMeasure() const
 
 Measure* Spanner::endMeasure() const
 {
+    assert(anchor() == Spanner::Anchor::MEASURE);
     return toMeasure(m_endElement);
 }
 

--- a/src/engraving/rw/read114/read114.cpp
+++ b/src/engraving/rw/read114/read114.cpp
@@ -1152,6 +1152,11 @@ static void readVolta114(XmlReader& e, ReadContext& ctx, Volta* volta)
             e.unknown();
         }
     }
+    if (volta->anchor() != Volta::VOLTA_ANCHOR) {
+        // Volta strictly assumes that its anchor is measure, so don't let old scores override this.
+        LOGW("Correcting volta anchor type from %d to %d", int(volta->anchor()), int(Volta::VOLTA_ANCHOR));
+        volta->setAnchor(Volta::VOLTA_ANCHOR);
+    }
     volta->setOffset(PointF());          // ignore offsets
     volta->setAutoplace(true);
 }

--- a/src/engraving/rw/read206/read206.cpp
+++ b/src/engraving/rw/read206/read206.cpp
@@ -2055,6 +2055,11 @@ static void readVolta206(XmlReader& e, ReadContext& ctx, Volta* volta)
             e.unknown();
         }
     }
+    if (volta->anchor() != Volta::VOLTA_ANCHOR) {
+        // Volta strictly assumes that its anchor is measure, so don't let old scores override this.
+        LOGW("Correcting volta anchor type from %d to %d", int(volta->anchor()), int(Volta::VOLTA_ANCHOR));
+        volta->setAnchor(Volta::VOLTA_ANCHOR);
+    }
     adjustPlacement(volta);
 }
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/25031

This correction was applied to Musescore 3 scores, but not MuseScore 1 & 2 scores.
