### PR TITLE
Revert "fixed #22273: not for text elements"

### DIFF
--- a/src/notation/tests/notationviewinputcontroller_tests.cpp
+++ b/src/notation/tests/notationviewinputcontroller_tests.cpp
@@ -337,7 +337,7 @@ TEST_F(NotationViewInputControllerTests, Mouse_Press_Range_Start_Drag_From_Selec
  * @details User pressed left mouse button on already selected text element
  *          We should change text cursor position
  */
-TEST_F(NotationViewInputControllerTests, Mouse_Press_On_Selected_Text_Element)
+TEST_F(NotationViewInputControllerTests, DISABLED_Mouse_Press_On_Selected_Text_Element)
 {
     //! [GIVEN] There is a test score
     engraving::MasterScore* score = engraving::ScoreRW::readScore(TEST_SCORE_PATH);

--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -753,7 +753,7 @@ void NotationViewInputController::handleLeftClick(const ClickContext& ctx)
     INotationSelectionPtr selection = viewInteraction()->selection();
 
     if (!selection->isRange()) {
-        if (ctx.hitElement && ctx.hitElement->needStartEditingAfterSelecting() && !ctx.hitElement->isTextBase()) {
+        if (ctx.hitElement && ctx.hitElement->needStartEditingAfterSelecting()) {
             if (ctx.hitElement->hasGrips() && !ctx.hitElement->isImage() && selection->elements().size() == 1) {
                 viewInteraction()->startEditGrip(ctx.hitElement, ctx.hitElement->gripsCount() > 4 ? Grip::DRAG : Grip::MIDDLE);
             } else {


### PR DESCRIPTION
This reverts commit 48a9dc2ddb0881ba969d13e8dfe4cda8fd65a156.

Resolves: #25213

but brings back #22273 (which is a less serious issue)
