### PR TITLE
Windows: prevent mysterious compile errors in debug builds

### DIFF
--- a/buildscripts/cmake/SetupBuildEnvironment.cmake
+++ b/buildscripts/cmake/SetupBuildEnvironment.cmake
@@ -55,7 +55,6 @@ if(MUSE_COMPILE_ASAN)
         add_link_options("-fsanitize=address")
     elseif(CC_IS_MSVC)
         add_compile_options("/fsanitize=address")
-        add_link_options("/fsanitize=address")
     endif()
 endif()
 

--- a/src/framework/audio/CMakeLists.txt
+++ b/src/framework/audio/CMakeLists.txt
@@ -301,6 +301,15 @@ set(MODULE_QRC audio.qrc)
 set(MODULE_ROOT ${CMAKE_CURRENT_LIST_DIR})
 set(MODULE_QML_IMPORT ${CMAKE_CURRENT_LIST_DIR}/qml)
 
+if (OS_IS_WIN)
+    # Prevent mysterious compile errors in debug builds
+    set_source_files_properties(
+        ${CMAKE_CURRENT_LIST_DIR}/internal/worker/audiostream.cpp
+        PROPERTIES
+        SKIP_UNITY_BUILD_INCLUSION ON
+    )
+endif()
+
 setup_module()
 
 if (MUSE_MODULE_AUDIO_TESTS)

--- a/src/inspector/CMakeLists.txt
+++ b/src/inspector/CMakeLists.txt
@@ -238,9 +238,3 @@ set(MODULE_LINK
 
 set(MODULE_USE_UNITBUILD ON)
 setup_module()
-
-target_sources(inspector
-  PRIVATE
-    types/voicetypes.h
-    models/inspectormodelwithvoiceandpositionoptions.h models/inspectormodelwithvoiceandpositionoptions.cpp
-)

--- a/src/inspector/CMakeLists.txt
+++ b/src/inspector/CMakeLists.txt
@@ -236,5 +236,4 @@ set(MODULE_LINK
     engraving
     )
 
-set(MODULE_USE_UNITBUILD ON)
 setup_module()


### PR DESCRIPTION
These errors became apparent since #25157. Before that PR, our debug builds were apparently no real debug builds, because they used `/MT` instead of `/MDd` or `/MTd`.