### PR TITLE
Don't "install" third-party libs and headers

### DIFF
--- a/src/framework/CMakeLists.txt
+++ b/src/framework/CMakeLists.txt
@@ -116,6 +116,7 @@ if (MUSE_ENABLE_UNIT_TESTS)
         FULL_DOCS "List XML files outputted by google test."
     )
 
+    set(INSTALL_GTEST OFF)
     add_subdirectory(testing/thirdparty/googletest)
 endif()
 

--- a/src/framework/audio/CMakeLists.txt
+++ b/src/framework/audio/CMakeLists.txt
@@ -242,7 +242,7 @@ if (MUSE_MODULE_AUDIO_EXPORT)
         ${CMAKE_CURRENT_LIST_DIR}/internal/soundtracks/soundtrackwriter.h
         )
 
-    add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/thirdparty/lame lame)
+    add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/thirdparty/lame lame EXCLUDE_FROM_ALL)
     set(MODULE_LINK
         ${MODULE_LINK}
         lame

--- a/src/framework/audio/cmake/SetupFlac.cmake
+++ b/src/framework/audio/cmake/SetupFlac.cmake
@@ -41,5 +41,5 @@ if (MUE_COMPILE_USE_SYSTEM_FLAC)
     endif()
 endif()
 
-add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../thirdparty/flac flac)
+add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../thirdparty/flac flac EXCLUDE_FROM_ALL)
 set(FLAC_TARGETS flac)

--- a/src/framework/audio/cmake/SetupOpusEnc.cmake
+++ b/src/framework/audio/cmake/SetupOpusEnc.cmake
@@ -28,6 +28,6 @@ if (MUE_COMPILE_USE_SYSTEM_OPUSENC)
 
     set(LIBOPUSENC_TARGETS PkgConfig::libopusenc PkgConfig::opus)
 else()
-    add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../thirdparty/opusenc opusenc)
+    add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../thirdparty/opusenc opusenc EXCLUDE_FROM_ALL)
     set(LIBOPUSENC_TARGETS opusenc)
 endif()

--- a/src/framework/dockwindow/CMakeLists.txt
+++ b/src/framework/dockwindow/CMakeLists.txt
@@ -73,7 +73,7 @@ endif(NOT BUILD_SHARED_LIBS)
 set(KDDockWidgets_QT6 ON CACHE BOOL "Build against Qt 6" FORCE)
 set(KDDockWidgets_QTQUICK ON CACHE BOOL "Build for QtQuick instead of QtWidgets" FORCE)
 set(KDDockWidgets_EXAMPLES OFF CACHE BOOL "Build the examples" FORCE)
-add_subdirectory(thirdparty/KDDockWidgets)
+add_subdirectory(thirdparty/KDDockWidgets EXCLUDE_FROM_ALL)
 
 set(MODULE_LINK kddockwidgets)
 


### PR DESCRIPTION
The libraries are linked statically, so they needn't and shouldn't be installed alongside MuseScore's executable.

The idea of using the EXCLUDE_FROM_ALL option for this comes from https://stackoverflow.com/a/64900982.