### PR TITLE
Fix #19121: Create dynamics with shortcut or through "Add -> Text" menu

### DIFF
--- a/src/app/configs/data/shortcuts.xml
+++ b/src/app/configs/data/shortcuts.xml
@@ -739,6 +739,10 @@
     <seq>Ctrl+T</seq>
     </SC>
   <SC>
+    <key>dynamics</key>
+    <seq>Ctrl+D</seq>
+    </SC>
+  <SC>
     <key>expression-text</key>
     <seq>Ctrl+E</seq>
     </SC>

--- a/src/app/configs/data/shortcuts_azerty.xml
+++ b/src/app/configs/data/shortcuts_azerty.xml
@@ -765,6 +765,10 @@
     <seq>Ctrl+T</seq>
     </SC>
   <SC>
+    <key>dynamics</key>
+    <seq>Ctrl+D</seq>
+    </SC>
+  <SC>
     <key>expression-text</key>
     <seq>Ctrl+E</seq>
     </SC>

--- a/src/app/configs/data/shortcuts_mac.xml
+++ b/src/app/configs/data/shortcuts_mac.xml
@@ -739,6 +739,10 @@
     <seq>Ctrl+T</seq>
     </SC>
   <SC>
+    <key>dynamics</key>
+    <seq>Ctrl+D</seq>
+    </SC>
+  <SC>
     <key>expression-text</key>
     <seq>Ctrl+E</seq>
     </SC>

--- a/src/appshell/view/appmenumodel.cpp
+++ b/src/appshell/view/appmenumodel.cpp
@@ -609,6 +609,7 @@ MenuItemList AppMenuModel::makeTextItems()
         makeSeparator(),
         makeMenuItem("system-text"),
         makeMenuItem("staff-text"),
+        makeMenuItem("dynamics"),
         makeMenuItem("expression-text"),
         makeMenuItem("rehearsalmark-text"),
         makeMenuItem("instrument-change-text"),

--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -943,6 +943,15 @@ TextBase* Score::addText(TextStyleType type, EngravingItem* destinationElement)
         undoAddElement(textBox);
         break;
     }
+    case TextStyleType::DYNAMICS: {
+        ChordRest* chordRest = chordOrRest(destinationElement);
+        if (!chordRest) {
+            break;
+        }
+        textBox = Factory::createDynamic(dummy()->segment());
+        chordRest->undoAddAnnotation(textBox);
+        break;
+    }
     case TextStyleType::HARP_PEDAL_DIAGRAM:
     case TextStyleType::HARP_PEDAL_TEXT_DIAGRAM: {
         ChordRest* chordRest = getSelectedChordRest();

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -327,6 +327,7 @@ void NotationActionController::init()
 
     registerAction("system-text", [this]() { addText(TextStyleType::SYSTEM); });
     registerAction("staff-text", [this]() { addText(TextStyleType::STAFF); });
+    registerAction("dynamics", [this]() { addText(TextStyleType::DYNAMICS); });
     registerAction("expression-text", [this]() { addText(TextStyleType::EXPRESSION); });
     registerAction("rehearsalmark-text", [this]() { addText(TextStyleType::REHEARSAL_MARK); });
     registerAction("instrument-change-text", [this]() { addText(TextStyleType::INSTRUMENT_CHANGE); });

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -4613,6 +4613,7 @@ Ret NotationInteraction::canAddTextToItem(TextStyleType type, const EngravingIte
     static const std::set<TextStyleType> needSelectNoteOrRestTypes {
         TextStyleType::SYSTEM,
         TextStyleType::STAFF,
+        TextStyleType::DYNAMICS,
         TextStyleType::EXPRESSION,
         TextStyleType::REHEARSAL_MARK,
         TextStyleType::INSTRUMENT_CHANGE,

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -4676,6 +4676,10 @@ void NotationInteraction::addText(TextStyleType type, EngravingItem* item)
         }
     }
 
+    if (text->hasVoiceAssignmentProperties()) {
+        text->setInitialTrackAndVoiceAssignment(item->track(), false);
+    }
+
     apply();
     showItem(text);
 

--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -1276,6 +1276,12 @@ const UiActionList NotationUiActions::m_actions = {
              TranslatableString("action", "St&aff text"),
              TranslatableString("action", "Add text: staff text")
              ),
+    UiAction("dynamics",
+             mu::context::UiCtxProjectOpened,
+             mu::context::CTX_ANY,
+             TranslatableString("action", "&Dynamic"),
+             TranslatableString("action", "Add text: dynamic")
+             ),
     UiAction("expression-text",
              mu::context::UiCtxProjectOpened,
              mu::context::CTX_ANY,
@@ -1309,7 +1315,7 @@ const UiActionList NotationUiActions::m_actions = {
     UiAction("chord-text",
              mu::context::UiCtxProjectOpened,
              mu::context::CTX_ANY,
-             TranslatableString("action", "Chor&d symbol"),
+             TranslatableString("action", "C&hord symbol"),
              TranslatableString("action", "Add text: chord symbol")
              ),
     UiAction("roman-numeral-text",

--- a/src/notation/view/noteinputbarmodel.cpp
+++ b/src/notation/view/noteinputbarmodel.cpp
@@ -740,6 +740,7 @@ MenuItemList NoteInputBarModel::makeTextItems()
         makeMenuItem("system-text"),
         makeMenuItem("staff-text"),
         makeMenuItem("expression-text"),
+        makeMenuItem("dynamics"),
         makeMenuItem("rehearsalmark-text"),
         makeMenuItem("instrument-change-text"),
         makeMenuItem("fingering-text"),


### PR DESCRIPTION
Resolves: #19121

<!-- Add a short description of and motivation for the changes here -->
Hello. We are working on a project to add functionality to an open source project as a student experiment at the University of Tokyo.
We believe that some of the results of this project are practical, so we have created a pull request. We would appreciate it if you could review this if you have the time.
Thanks in advance.

Part 1: this PR
* The first commit added a shortcut to add a dynamics text box and assigned Ctrl+D.
* In the second commit, we changed the code so that the dynamics you type with Ctrl+Shift+Alphabets will be interpreted and reflected in the playback.

Part 2: See #25254

Part 3: See #25255

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)