### PR TITLE
Fix #15406: Add text to the first element in a range selection

### DIFF
--- a/src/notation/internal/inotationselectionrange.h
+++ b/src/notation/internal/inotationselectionrange.h
@@ -33,9 +33,11 @@ public:
     virtual ~INotationSelectionRange() = default;
 
     virtual engraving::staff_idx_t startStaffIndex() const = 0;
+    virtual engraving::Segment* rangeStartSegment() const = 0;
     virtual Fraction startTick() const = 0;
 
     virtual engraving::staff_idx_t endStaffIndex() const = 0;
+    virtual engraving::Segment* rangeEndSegment() const = 0;
     virtual Fraction endTick() const = 0;
 
     struct MeasureRange {

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -6308,7 +6308,16 @@ void NotationInteraction::setGetViewRectFunc(const std::function<RectF()>& func)
 namespace mu::notation {
 EngravingItem* contextItem(INotationInteractionPtr interaction)
 {
-    EngravingItem* item = interaction->selection()->element();
+    EngravingItem* item = nullptr;
+    const INotationSelectionPtr sel = interaction->selection();
+
+    if (sel->isRange()) {
+        const INotationSelectionRangePtr range = sel->range();
+        item = range->rangeStartSegment()->firstElementForNavigation(range->startStaffIndex());
+    } else {
+        item = sel->element();
+    }
+
     if (item == nullptr) {
         return interaction->hitElementContext().element;
     }

--- a/src/notation/internal/notationselectionrange.h
+++ b/src/notation/internal/notationselectionrange.h
@@ -37,9 +37,11 @@ public:
     NotationSelectionRange(IGetScore* getScore);
 
     engraving::staff_idx_t startStaffIndex() const override;
+    engraving::Segment* rangeStartSegment() const override;
     Fraction startTick() const override;
 
     engraving::staff_idx_t endStaffIndex() const override;
+    engraving::Segment* rangeEndSegment() const override;
     Fraction endTick() const override;
 
     MeasureRange measureRange() const override;
@@ -52,9 +54,6 @@ public:
 
 private:
     mu::engraving::Score* score() const;
-
-    mu::engraving::Segment* rangeStartSegment() const;
-    mu::engraving::Segment* rangeEndSegment() const;
 
     mu::engraving::staff_idx_t selectionLastVisibleStaff(const System* system) const;
     mu::engraving::staff_idx_t selectionFirstVisibleStaff(const System* system) const;

--- a/src/notation/tests/mocks/notationselectionrangemock.h
+++ b/src/notation/tests/mocks/notationselectionrangemock.h
@@ -31,9 +31,11 @@ class NotationSelectionRangeMock : public INotationSelectionRange
 {
 public:
     MOCK_METHOD(engraving::staff_idx_t, startStaffIndex, (), (const, override));
+    MOCK_METHOD(engraving::Segment*, rangeStartSegment, (), (const, override));
     MOCK_METHOD(Fraction, startTick, (), (const, override));
 
     MOCK_METHOD(engraving::staff_idx_t, endStaffIndex, (), (const, override));
+    MOCK_METHOD(engraving::Segment*, rangeEndSegment, (), (const, override));
     MOCK_METHOD(Fraction, endTick, (), (const, override));
 
     MOCK_METHOD(MeasureRange, measureRange, (), (const, override));


### PR DESCRIPTION
Resolves: #15406
Resolves (partially): #24548

Continuation of #25252
* If a shortcut to add text is executed when a range is selected, it will add text to the first element of the first staff in the selected range instead of generating an error.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
