### PR TITLE
Fix #24548: Bring rehearsal marks added via. shortcut or "Add -> Text" menu in line with rehearsal marks added from palette

### DIFF
--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -735,7 +735,11 @@ TextBase* Score::addText(TextStyleType type, EngravingItem* destinationElement)
         if (!chordRest) {
             break;
         }
-        textBox = Factory::createRehearsalMark(dummy()->segment());
+        textBox = Factory::createRehearsalMark(chordRest->segment());
+        textBox->setParent(chordRest->segment());
+        textBox->setTrack(0);
+        RehearsalMark* r = toRehearsalMark(textBox);
+        textBox->setXmlText(score()->createRehearsalMarkText(r));
         chordRest->undoAddAnnotation(textBox);
         break;
     }

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -4578,6 +4578,10 @@ void NotationInteraction::addText(TextStyleType type, EngravingItem* item)
     if (!text->isInstrumentChange()) {
         startEditText(text);
     }
+
+    if (text->isRehearsalMark() || text->isTempoText()) {
+        text->cursor()->selectWord();
+    }
 }
 
 Ret NotationInteraction::canAddImageToItem(const EngravingItem* item) const


### PR DESCRIPTION
Resolves (partially): #24548

Continuation of #25254
* The first commit sets the default string when the rehearsal mark is added by shortcut.
* The second commit is to select areas that the user may want to change immediately with keyboard input after adding a text element with a shortcut. Specifically, the numeric part of the tempo text and the default text of the rehearsal mark added above.
* See #25254 for the part that allows text to be added no matter which range is selected.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
