### PR TITLE
Fix #25169: Crash when switching to note entry mode

### DIFF
--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -477,7 +477,9 @@ void MasterNotation::applyOptions(mu::engraving::MasterScore* score, const Score
 
     {
         mu::engraving::ScoreLoad sl;
-        score->doLayout();
+        for (mu::engraving::Score* s : score->scoreList()) {
+            s->doLayout();
+        }
     }
 }
 


### PR DESCRIPTION
Resolves: #25169

As I mentioned [here](https://github.com/musescore/MuseScore/issues/25169#issuecomment-2416812406), this crash isn't actually reachable in debug builds due to an assertion failure when opening the template. At first I assumed this was related to #25169 but apparently not! They actually have completely different causes, so we'll address them separately.

The culprit for this crash appears to be `MasterNotation::applyOptions`. After clearing all measures in all excerpts, we only call `Score::doLayout` on the master notation. This leaves us with some invalid data in excerpts, eventually leading to a crash when we switch to note entry mode. 