### PR TITLE
Account for durationType when merging rests

### DIFF
--- a/src/engraving/dom/rest.cpp
+++ b/src/engraving/dom/rest.cpp
@@ -455,9 +455,9 @@ int Rest::computeVoiceOffset(int lines, LayoutData* ldata) const
             EngravingItem* e = s->element(baseTrack + v);
             // try to find match in any other voice
             if (e) {
-                if (e->type() == ElementType::REST) {
+                if (e->isRest()) {
                     Rest* r = toRest(e);
-                    if (r->globalTicks() == globalTicks()) {
+                    if (r->globalTicks() == globalTicks() && r->durationType() == durationType()) {
                         matchFound = true;
                         ldata->mergedRests.push_back(r);
                         continue;


### PR DESCRIPTION
Resolves: Rests incorrectly merging for full measure rests and special tuplets.
![image](https://github.com/user-attachments/assets/c704f038-af7a-4649-a98c-4b9bc0453699)
@rpatters1 

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
