### PR TITLE
Keysigs on section break

### DIFF
--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -2730,6 +2730,15 @@ void Score::deleteItem(EngravingItem* el)
                 }
             }
         }
+        // remove section break key signatures
+        bool isFirst = mb && mb->tick().isZero();
+        for (KeySig* ks : lb->keySigs()) {
+            if (isFirst) {
+                ks->setForSectionBreak(false);
+            } else {
+                deleteItem(ks);
+            }
+        }
     }
     break;
 
@@ -5961,12 +5970,14 @@ void Score::undoAddElement(EngravingItem* element, bool addToLinkedStaves, bool 
             MeasureBase* m = lb->measure();
 
             // add Key Signature on Section Break
+            // TODO: special case for instrument change
             Fraction tick = m->endTick();
             int ticks = tick.ticks();
             for (Staff* staff : score()->staves()) {
                 KeyList* kl = staff->keyList();
                 if (kl->currentKeyTick(ticks) != ticks) {
                     KeySigEvent ks = kl->key(ticks);
+                    ks.setForSectionBreak(true);
                     undoChangeKeySig(staff, tick, ks);
                 }
             }

--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -5959,6 +5959,17 @@ void Score::undoAddElement(EngravingItem* element, bool addToLinkedStaves, bool 
         if (lb->layoutBreakType() == LayoutBreakType::SECTION) {
             doUndoAddElement(lb);
             MeasureBase* m = lb->measure();
+
+            // add Key Signature on Section Break
+            Fraction tick = m->endTick();
+            int ticks = tick.ticks();
+            for (Staff* staff : score()->staves()) {
+                KeyList* kl = staff->keyList();
+                if (kl->currentKeyTick(ticks) != ticks) {
+                    KeySigEvent ks = kl->key(ticks);
+                    undoChangeKeySig(staff, tick, ks);
+                }
+            }
             if (m->isBox()) {
                 // for frames, use linked frames
                 LinkedObjects* links = m->links();

--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -2733,7 +2733,22 @@ void Score::deleteItem(EngravingItem* el)
         // remove section break key signatures
         bool isFirst = mb && mb->tick().isZero();
         for (KeySig* ks : lb->keySigs()) {
-            if (isFirst) {
+            Staff* staff = ks->staff();
+            Fraction tick = ks->tick();
+            KeySigEvent actualKey = ks->keySigEvent();
+            KeySigEvent prevKey = staff->prevKey(tick);
+
+            // do not remove keysig on first measure, or if signatures differ
+
+            // if previous signature is "forInstrumentChange",
+            // comparation returns false, even if they are otherwise identical
+            // (because one is forInstrumentChange and second not)
+            // so we need to remove "forInstrumentChange" flag first
+            if (prevKey.forInstrumentChange()) {
+                prevKey.setForInstrumentChange(false);
+            }
+
+            if (isFirst || actualKey != prevKey) {
                 ks->setForSectionBreak(false);
             } else {
                 deleteItem(ks);
@@ -5970,13 +5985,13 @@ void Score::undoAddElement(EngravingItem* element, bool addToLinkedStaves, bool 
             MeasureBase* m = lb->measure();
 
             // add Key Signature on Section Break
-            // TODO: special case for instrument change
             Fraction tick = m->endTick();
             int ticks = tick.ticks();
             for (Staff* staff : score()->staves()) {
                 KeyList* kl = staff->keyList();
-                if (kl->currentKeyTick(ticks) != ticks) {
-                    KeySigEvent ks = kl->key(ticks);
+                KeySigEvent ks = kl->key(ticks);
+                if (kl->currentKeyTick(ticks) != ticks || ks.forInstrumentChange()) {
+                    ks.setForInstrumentChange(false);
                     ks.setForSectionBreak(true);
                     undoChangeKeySig(staff, tick, ks);
                 }

--- a/src/engraving/dom/key.h
+++ b/src/engraving/dom/key.h
@@ -82,6 +82,8 @@ public:
     bool isAtonal() const { return m_mode == KeyMode::NONE; }
     void setForInstrumentChange(bool forInstrumentChange) { m_forInstrumentChange = forInstrumentChange; }
     bool forInstrumentChange() const { return m_forInstrumentChange; }
+    void setForSectionBreak(bool forSectionBreak) { m_forSectionBreak = forSectionBreak; }
+    bool forSectionBreak() const { return m_forSectionBreak; }
     void initFromSubtype(int);      // for backward compatibility
     int degInKey(int degree) const; // return "absolute degree"
     SymId symInKey(SymId sym, int degree) const;
@@ -97,6 +99,7 @@ private:
     KeyMode m_mode = KeyMode::UNKNOWN;
     bool m_custom = false;
     bool m_forInstrumentChange = false;
+    bool m_forSectionBreak = false;
     std::vector<CustDef> m_customKeyDefs;
 };
 

--- a/src/engraving/dom/keysig.h
+++ b/src/engraving/dom/keysig.h
@@ -89,6 +89,9 @@ public:
     void setForInstrumentChange(bool forInstrumentChange) { m_sig.setForInstrumentChange(forInstrumentChange); }
     bool forInstrumentChange() const { return m_sig.forInstrumentChange(); }
 
+    void setForSectionBreak(bool forSectionBreak) { m_sig.setForSectionBreak(forSectionBreak); }
+    bool forSectionBreak() const { return m_sig.forSectionBreak(); }
+
     PropertyValue getProperty(Pid propertyId) const override;
     bool setProperty(Pid propertyId, const PropertyValue&) override;
     PropertyValue propertyDefault(Pid id) const override;

--- a/src/engraving/dom/layoutbreak.cpp
+++ b/src/engraving/dom/layoutbreak.cpp
@@ -24,9 +24,11 @@
 
 #include "types/typesconv.h"
 
+#include "keysig.h"
 #include "layoutbreak.h"
 #include "measurebase.h"
 #include "score.h"
+#include "segment.h"
 
 using namespace mu;
 using namespace muse::draw;
@@ -286,6 +288,30 @@ PropertyValue LayoutBreak::propertyDefault(Pid id) const
 muse::TranslatableString LayoutBreak::subtypeUserName() const
 {
     return TConv::userName(layoutBreakType());
+}
+
+//---------------------------------------------------------
+//   keySigs
+//---------------------------------------------------------
+
+std::vector<KeySig*> LayoutBreak::keySigs(bool all) const
+{
+    std::vector<KeySig*> keysigs;
+    Measure* measure = this->measure()->nextMeasure();
+    if (measure && measure->isMMRest()) {
+        // propagate to original measure
+        measure = measure->mmRestFirst();
+    }
+    Segment* seg = measure ? measure->findFirstR(SegmentType::KeySig, Fraction(0, 1)) : nullptr;
+    if (seg) {
+        for (staff_idx_t i = 0; i <= score()->nstaves(); i++) {
+            KeySig* ks = toKeySig(seg->element(i * VOICES));
+            if (ks && (all || ks->forSectionBreak())) {
+                keysigs.push_back(ks);
+            }
+        }
+    }
+    return keysigs;
 }
 
 void LayoutBreak::added()

--- a/src/engraving/dom/layoutbreak.h
+++ b/src/engraving/dom/layoutbreak.h
@@ -77,6 +77,8 @@ public:
     const RectF& iconBorderRect() const { return m_iconBorderRect; }
     const muse::draw::PainterPath& iconPath() const { return m_iconPath; }
 
+    std::vector<KeySig*> keySigs(bool all=false) const;
+
 protected:
     void added() override;
     void removed() override;


### PR DESCRIPTION
Resolves: #25168 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
- On section break add key signature, and mark them "forSectionBreak".
- When removing section break, remove "for section break" signatures.

- If signature already there, it is preserved (not marked "for section break" and not removed after section break deletion.
- New signatures added after section break are also not marked as "for section break", so not removed, after section break deletion.


<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
