### PR TITLE
Fix crash on join measures containing parts

### DIFF
--- a/src/engraving/dom/excerpt.cpp
+++ b/src/engraving/dom/excerpt.cpp
@@ -1660,7 +1660,7 @@ void Excerpt::cloneStaff2(Staff* srcStaff, Staff* dstStaff, const Fraction& star
         for (Segment& seg : nm->segments()) {
             seg.checkEmpty();
             if (seg.empty()) {
-                score->removeElement(&seg);
+                score->doUndoRemoveElement(&seg);
             }
         }
         if (!nm->hasVoices(dstStaffIdx, nm->tick(), nm->ticks())) {

--- a/src/engraving/dom/joinMeasure.cpp
+++ b/src/engraving/dom/joinMeasure.cpp
@@ -115,11 +115,9 @@ void MasterScore::joinMeasure(const Fraction& tick1, const Fraction& tick2)
     }
 
     MeasureBase* next = m2->next();
-    for (Score* s : scoreList()) {
-        Measure* sM1 = s->tick2measure(startTick);
-        Measure* sM2 = s->tick2measure(m2->tick());
-        s->deleteMeasures(sM1, sM2, true);
-    }
+    Measure* deleteStart = tick2measure(startTick);
+    Measure* deleteEnd = tick2measure(m2->tick());
+    deleteMeasures(deleteStart, deleteEnd, true);
     InsertMeasureOptions options;
     options.createEmptyMeasures = true;
     options.moveSignaturesClef = false;

--- a/src/engraving/dom/measure.cpp
+++ b/src/engraving/dom/measure.cpp
@@ -763,7 +763,6 @@ void Measure::add(EngravingItem* e)
         while (s && s->rtick() == t) {
             if (!seg->isChordRestType() && (seg->segmentType() == s->segmentType())) {
                 LOGD("there is already a <%s> segment", seg->subTypeName());
-                return;
             }
             if (seg->goesBefore(s)) {
                 break;


### PR DESCRIPTION
Resolves: #25257

This fixes the crash, but causes one when closing the score after joining the 2nd & 3rd measures in the example score.  I'm also not happy with the behaviour of this function & slurs to and from grace notes in the first place.  This needs more time so I'll have a look for 4.5.
I can't work out why the new crash is happening.  It is caused by a heap use after free error when accessing `score()->rootItem()` in `~EngravingObject` (line 140) after excerpts have been deleted in `~MasterScore`.
<details>
<summary>ASAN output</summary>

```
==43579==ERROR: AddressSanitizer: heap-use-after-free on address 0x0001659c5ef8 at pc 0x000105a3a4ed bp 0x000321f6d630 sp 0x000321f6d628
READ of size 8 at 0x0001659c5ef8 thread T0
    #0 0x105a3a4ec in mu::engraving::Score::rootItem() const score.h:301
    #1 0x105a39304 in mu::engraving::EngravingObject::~EngravingObject() engravingobject.cpp:140
    #2 0x1059eeb35 in mu::engraving::EngravingItem::~EngravingItem() engravingitem.cpp:114
    #3 0x10592ca8f in mu::engraving::Spanner::~Spanner() spanner.h:151
    #4 0x10592ca14 in mu::engraving::SLine::~SLine() line.h:102
    #5 0x10592c9ef in mu::engraving::TextLineBase::~TextLineBase() textlinebase.h:93
    #6 0x105ad0c54 in mu::engraving::Hairpin::~Hairpin() hairpin.h:105
    #7 0x105ad0c34 in mu::engraving::Hairpin::~Hairpin() hairpin.h:105
    #8 0x105c42778 in mu::engraving::Hairpin::~Hairpin() hairpin.h:105
    #9 0x105a3960b in mu::engraving::EngravingObject::~EngravingObject() engravingobject.cpp:147
    #10 0x1059eeb35 in mu::engraving::EngravingItem::~EngravingItem() engravingitem.cpp:114
    #11 0x10647aefa in mu::engraving::Segment::~Segment() segment.cpp:237
    #12 0x10647b2c4 in mu::engraving::Segment::~Segment() segment.cpp:221
    #13 0x106ed3288 in mu::engraving::compat::DummyElement::~DummyElement() dummyelement.cpp:51
    #14 0x106ed34a4 in mu::engraving::compat::DummyElement::~DummyElement() dummyelement.cpp:47
    #15 0x106ed34c8 in mu::engraving::compat::DummyElement::~DummyElement() dummyelement.cpp:47
    #16 0x10632825b in mu::engraving::RootItem::~RootItem() rootitem.cpp:42
    #17 0x106328284 in mu::engraving::RootItem::~RootItem() rootitem.cpp:39
    #18 0x1063282a8 in mu::engraving::RootItem::~RootItem() rootitem.cpp:39
    #19 0x106338149 in mu::engraving::Score::~Score() score.cpp:271
    #20 0x105f3e5b7 in mu::engraving::MasterScore::~MasterScore() masterscore.cpp:108
    #21 0x105f3e944 in mu::engraving::MasterScore::~MasterScore() masterscore.cpp:97
    #22 0x105f3ee48 in mu::engraving::MasterScore::~MasterScore() masterscore.cpp:97
    #23 0x1052fac15 in mu::engraving::EngravingProject::~EngravingProject() engravingproject.cpp:66
    #24 0x1052fac74 in mu::engraving::EngravingProject::~EngravingProject() engravingproject.cpp:65
    #25 0x1052fac98 in mu::engraving::EngravingProject::~EngravingProject() engravingproject.cpp:65
    #26 0x1052ff998 in std::__1::default_delete<mu::engraving::EngravingProject>::operator()[abi:ne180100](mu::engraving::EngravingProject*) const unique_ptr.h:66
    #27 0x1052ff5c6 in std::__1::__shared_ptr_pointer<mu::engraving::EngravingProject*, std::__1::shared_ptr<mu::engraving::EngravingProject>::__shared_ptr_default_delete<mu::engraving::EngravingProject, mu::engraving::EngravingProject>, std::__1::allocator<mu::engraving::EngravingProject>>::__on_zero_shared() shared_ptr.h:228
    #28 0x1046481dd in std::__1::__shared_count::__release_shared[abi:ne180100]() shared_ptr.h:157
    #29 0x104648128 in std::__1::__shared_weak_count::__release_shared[abi:ne180100]() shared_ptr.h:186
    #30 0x10530038b in std::__1::shared_ptr<mu::engraving::EngravingProject>::~shared_ptr[abi:ne180100]() shared_ptr.h:648
    #31 0x1052fa784 in std::__1::shared_ptr<mu::engraving::EngravingProject>::~shared_ptr[abi:ne180100]() shared_ptr.h:646
    #32 0x10a004bd7 in std::__1::shared_ptr<mu::engraving::EngravingProject>::operator=[abi:ne180100](std::__1::shared_ptr<mu::engraving::EngravingProject>&&) shared_ptr.h:663
    #33 0x10a0045c3 in mu::project::NotationProject::~NotationProject() notationproject.cpp:87
    #34 0x10a004cd4 in mu::project::NotationProject::~NotationProject() notationproject.cpp:84
    #35 0x10a0ffef6 in std::__1::allocator<mu::project::NotationProject>::destroy[abi:ne180100](mu::project::NotationProject*) allocator.h:176
    #36 0x10a0ffe6c in void std::__1::allocator_traits<std::__1::allocator<mu::project::NotationProject>>::destroy[abi:ne180100]<mu::project::NotationProject, void>(std::__1::allocator<mu::project::NotationProject>&, mu::project::NotationProject*) allocator_traits.h:311
    #37 0x10a0ffd64 in void std::__1::__shared_ptr_emplace<mu::project::NotationProject, std::__1::allocator<mu::project::NotationProject>>::__on_zero_shared_impl[abi:ne180100]<std::__1::allocator<mu::project::NotationProject>, 0>() shared_ptr.h:284
    #38 0x10a0fefe4 in std::__1::__shared_ptr_emplace<mu::project::NotationProject, std::__1::allocator<mu::project::NotationProject>>::__on_zero_shared() shared_ptr.h:287
    #39 0x1046481dd in std::__1::__shared_count::__release_shared[abi:ne180100]() shared_ptr.h:157
    #40 0x104648128 in std::__1::__shared_weak_count::__release_shared[abi:ne180100]() shared_ptr.h:186
    #41 0x1080ce04b in std::__1::shared_ptr<mu::project::INotationProject>::~shared_ptr[abi:ne180100]() shared_ptr.h:648
    #42 0x1080cdfb4 in std::__1::shared_ptr<mu::project::INotationProject>::~shared_ptr[abi:ne180100]() shared_ptr.h:646
    #43 0x10a06ab41 in mu::project::ProjectActionsController::closeOpenedProject(bool) projectactionscontroller.cpp:715
    #44 0x10a1507fe in mu::project::ProjectActionsController::init()::$_0::operator()() const projectactionscontroller.cpp:68
    #45 0x10a150574 in decltype(std::declval<mu::project::ProjectActionsController::init()::$_0&>()()) std::__1::__invoke[abi:ne180100]<mu::project::ProjectActionsController::init()::$_0&>(mu::project::ProjectActionsController::init()::$_0&) invoke.h:344
    #46 0x10a150534 in void std::__1::__invoke_void_return_wrapper<void, true>::__call[abi:ne180100]<mu::project::ProjectActionsController::init()::$_0&>(mu::project::ProjectActionsController::init()::$_0&) invoke.h:419
    #47 0x10a15050c in std::__1::__function::__alloc_func<mu::project::ProjectActionsController::init()::$_0, std::__1::allocator<mu::project::ProjectActionsController::init()::$_0>, void ()>::operator()[abi:ne180100]() function.h:169
    #48 0x10a14d068 in std::__1::__function::__func<mu::project::ProjectActionsController::init()::$_0, std::__1::allocator<mu::project::ProjectActionsController::init()::$_0>, void ()>::operator()() function.h:311
    #49 0x104849a77 in std::__1::__function::__value_func<void ()>::operator()[abi:ne180100]() const function.h:428
    #50 0x104800bb4 in std::__1::function<void ()>::operator()() const function.h:981
    #51 0x105152e5c in muse::actions::IActionsDispatcher::reg(muse::actions::Actionable*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::function<void ()> const&)::'lambda'(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, muse::actions::ActionData const&)::operator()(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, muse::actions::ActionData const&) const iactionsdispatcher.h:53
    #52 0x105152e34 in decltype(std::declval<muse::actions::IActionsDispatcher::reg(muse::actions::Actionable*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::function<void ()> const&)::'lambda'(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, muse::actions::ActionData const&)&>()(std::declval<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&>(), std::declval<muse::actions::ActionData const&>())) std::__1::__invoke[abi:ne180100]<muse::actions::IActionsDispatcher::reg(muse::actions::Actionable*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::function<void ()> const&)::'lambda'(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, muse::actions::ActionData const&)&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, muse::actions::ActionData const&>(muse::actions::IActionsDispatcher::reg(muse::actions::Actionable*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::function<void ()> const&)::'lambda'(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, muse::actions::ActionData const&)&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, muse::actions::ActionData const&) invoke.h:344
    #53 0x105152de4 in void std::__1::__invoke_void_return_wrapper<void, true>::__call[abi:ne180100]<muse::actions::IActionsDispatcher::reg(muse::actions::Actionable*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::function<void ()> const&)::'lambda'(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, muse::actions::ActionData const&)&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, muse::actions::ActionData const&>(muse::actions::IActionsDispatcher::reg(muse::actions::Actionable*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::function<void ()> const&)::'lambda'(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, muse::actions::ActionData const&)&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, muse::actions::ActionData const&) invoke.h:419
    #54 0x105152dac in std::__1::__function::__alloc_func<muse::actions::IActionsDispatcher::reg(muse::actions::Actionable*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::function<void ()> const&)::'lambda'(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, muse::actions::ActionData const&), std::__1::allocator<muse::actions::IActionsDispatcher::reg(muse::actions::Actionable*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::function<void ()> const&)::'lambda'(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, muse::actions::ActionData const&)>, void (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, muse::actions::ActionData const&)>::operator()[abi:ne180100](std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, muse::actions::ActionData const&) function.h:169
    #55 0x10514f718 in std::__1::__function::__func<muse::actions::IActionsDispatcher::reg(muse::actions::Actionable*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::function<void ()> const&)::'lambda'(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, muse::actions::ActionData const&), std::__1::allocator<muse::actions::IActionsDispatcher::reg(muse::actions::Actionable*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::function<void ()> const&)::'lambda'(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, muse::actions::ActionData const&)>, void (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, muse::actions::ActionData const&)>::operator()(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, muse::actions::ActionData const&) function.h:311
    #56 0x108396717 in std::__1::__function::__value_func<void (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, muse::actions::ActionData const&)>::operator()[abi:ne180100](std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, muse::actions::ActionData const&) const function.h:428
    #57 0x108380414 in std::__1::function<void (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, muse::actions::ActionData const&)>::operator()(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, muse::actions::ActionData const&) const function.h:981
    #58 0x10837f0df in muse::actions::ActionsDispatcher::dispatch(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, muse::actions::ActionData const&) actionsdispatcher.cpp:69
    #59 0x10837db35 in muse::actions::ActionsDispatcher::dispatch(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) actionsdispatcher.cpp:44
    #60 0x1094d526f in mu::notation::NotationSwitchListModel::closeNotation(int) notationswitchlistmodel.cpp:253
    #61 0x108da7c79 in mu::notation::NotationSwitchListModel::qt_static_metacall(QObject*, QMetaObject::Call, int, void**) moc_notationswitchlistmodel.cpp:104
    #62 0x108da86a9 in mu::notation::NotationSwitchListModel::qt_metacall(QMetaObject::Call, int, void**) moc_notationswitchlistmodel.cpp:164
    #63 0x137d42b86 in CallMethod(QQmlObjectOrGadget const&, int, QMetaType, int, QMetaType const*, QV4::ExecutionEngine*, QV4::CallData*, QMetaObject::Call) qv4qobjectwrapper.cpp:1382
    #64 0x137d3ed97 in CallPrecise(QQmlObjectOrGadget const&, QQmlPropertyData const&, QV4::ExecutionEngine*, QV4::CallData*, QMetaObject::Call) qv4qobjectwrapper.cpp:1642
    #65 0x137d3d247 in QV4::QObjectMethod::callInternal(QV4::Value const*, QV4::Value const*, int) const qv4qobjectwrapper.cpp:2245
    #66 0x137d90309 in QV4::Moth::VME::interpret(QV4::JSTypesStackFrame*, QV4::ExecutionEngine*, char const*) qv4vme_moth.cpp:875
    #67 0x137d8ed06 in QV4::Moth::VME::exec(QV4::JSTypesStackFrame*, QV4::ExecutionEngine*) qv4vme_moth.cpp:557
    #68 0x137cfc19a in QV4::Function::call(QV4::Value const*, QV4::Value const*, int, QV4::ExecutionContext const*) qv4function.cpp:100
    #69 0x137cfbe7e in QV4::Function::call(QV4::Value const*, void**, QMetaType const*, int, QV4::ExecutionContext const*) qv4function.cpp:64
    #70 0x137e1329b in QQmlJavaScriptExpression::evaluate(void**, QMetaType const*, int) qqmljavascriptexpression.cpp:311
    #71 0x137dcf59c in QQmlBoundSignalExpression::evaluate(void**) qqmlboundsignal.cpp:231
    #72 0x137dcfadf in QQmlBoundSignal_callback(QQmlNotifierEndpoint*, void**) qqmlboundsignal.cpp:350
    #73 0x137e36a89 in QQmlNotifier::emitNotify(QQmlNotifierEndpoint*, void**) qqmlnotifier.cpp:104
    #74 0x13a200407 in void doActivate<false>(QObject*, int, void**) qobject.cpp:3804
    #75 0x137ec92b5 in QQmlVMEMetaObject::metaCall(QObject*, QMetaObject::Call, int, void**) qqmlvmemetaobject.cpp:973
    #76 0x137d41091 in CallMethod(QQmlObjectOrGadget const&, int, QMetaType, int, QMetaType const*, QV4::ExecutionEngine*, QV4::CallData*, QMetaObject::Call) qv4qobjectwrapper.cpp:1400
    #77 0x137d3ec95 in CallPrecise(QQmlObjectOrGadget const&, QQmlPropertyData const&, QV4::ExecutionEngine*, QV4::CallData*, QMetaObject::Call) qv4qobjectwrapper.cpp:1648
    #78 0x137d3d247 in QV4::QObjectMethod::callInternal(QV4::Value const*, QV4::Value const*, int) const qv4qobjectwrapper.cpp:2245
    #79 0x137d90309 in QV4::Moth::VME::interpret(QV4::JSTypesStackFrame*, QV4::ExecutionEngine*, char const*) qv4vme_moth.cpp:875
    #80 0x137d8ed06 in QV4::Moth::VME::exec(QV4::JSTypesStackFrame*, QV4::ExecutionEngine*) qv4vme_moth.cpp:557
    #81 0x137cfc19a in QV4::Function::call(QV4::Value const*, QV4::Value const*, int, QV4::ExecutionContext const*) qv4function.cpp:100
    #82 0x137cfbe7e in QV4::Function::call(QV4::Value const*, void**, QMetaType const*, int, QV4::ExecutionContext const*) qv4function.cpp:64
    #83 0x137e1329b in QQmlJavaScriptExpression::evaluate(void**, QMetaType const*, int) qqmljavascriptexpression.cpp:311
    #84 0x137dcf59c in QQmlBoundSignalExpression::evaluate(void**) qqmlboundsignal.cpp:231
    #85 0x137dcfadf in QQmlBoundSignal_callback(QQmlNotifierEndpoint*, void**) qqmlboundsignal.cpp:350
    #86 0x137e36a89 in QQmlNotifier::emitNotify(QQmlNotifierEndpoint*, void**) qqmlnotifier.cpp:104
    #87 0x13a200407 in void doActivate<false>(QObject*, int, void**) qobject.cpp:3804
    #88 0x137ec92b5 in QQmlVMEMetaObject::metaCall(QObject*, QMetaObject::Call, int, void**) qqmlvmemetaobject.cpp:973
    #89 0x137d42b86 in CallMethod(QQmlObjectOrGadget const&, int, QMetaType, int, QMetaType const*, QV4::ExecutionEngine*, QV4::CallData*, QMetaObject::Call) qv4qobjectwrapper.cpp:1382
    #90 0x137d3ed97 in CallPrecise(QQmlObjectOrGadget const&, QQmlPropertyData const&, QV4::ExecutionEngine*, QV4::CallData*, QMetaObject::Call) qv4qobjectwrapper.cpp:1642
    #91 0x137d3d247 in QV4::QObjectMethod::callInternal(QV4::Value const*, QV4::Value const*, int) const qv4qobjectwrapper.cpp:2245
    #92 0x137d90309 in QV4::Moth::VME::interpret(QV4::JSTypesStackFrame*, QV4::ExecutionEngine*, char const*) qv4vme_moth.cpp:875
    #93 0x137d8ed06 in QV4::Moth::VME::exec(QV4::JSTypesStackFrame*, QV4::ExecutionEngine*) qv4vme_moth.cpp:557
    #94 0x137cfc19a in QV4::Function::call(QV4::Value const*, QV4::Value const*, int, QV4::ExecutionContext const*) qv4function.cpp:100
    #95 0x137cfbe7e in QV4::Function::call(QV4::Value const*, void**, QMetaType const*, int, QV4::ExecutionContext const*) qv4function.cpp:64
    #96 0x137e1329b in QQmlJavaScriptExpression::evaluate(void**, QMetaType const*, int) qqmljavascriptexpression.cpp:311
    #97 0x137dcf59c in QQmlBoundSignalExpression::evaluate(void**) qqmlboundsignal.cpp:231
    #98 0x137dcfadf in QQmlBoundSignal_callback(QQmlNotifierEndpoint*, void**) qqmlboundsignal.cpp:350
    #99 0x137e36a89 in QQmlNotifier::emitNotify(QQmlNotifierEndpoint*, void**) qqmlnotifier.cpp:104
    #100 0x13a200407 in void doActivate<false>(QObject*, int, void**) qobject.cpp:3804
    #101 0x136fed009 in QQuickMouseArea::setPressed(Qt::MouseButton, bool, Qt::MouseEventSource) qquickmousearea.cpp:1266
    #102 0x136fedb30 in QQuickMouseArea::mouseReleaseEvent(QMouseEvent*) qquickmousearea.cpp:798
    #103 0x136fcb733 in QQuickItem::event(QEvent*) qquickitem.cpp:8453
    #104 0x1392b7e96 in QApplicationPrivate::notify_helper(QObject*, QEvent*) qapplication.cpp:3409
    #105 0x1392b8ff6 in QApplication::notify(QObject*, QEvent*) qapplication.cpp
    #106 0x13a1af6d9 in QCoreApplication::notifyInternal2(QObject*, QEvent*) qcoreapplication.cpp:1067
    #107 0x137149539 in QQuickDeliveryAgentPrivate::deliverMatchingPointsToItem(QQuickItem*, bool, QPointerEvent*, bool) qquickdeliveryagent.cpp:2021
    #108 0x137148bcf in QQuickDeliveryAgentPrivate::deliverUpdatedPoints(QPointerEvent*) qquickdeliveryagent.cpp:1865
    #109 0x137142fcc in QQuickDeliveryAgentPrivate::deliverPointerEvent(QPointerEvent*) qquickdeliveryagent.cpp:1740
    #110 0x137140c69 in QQuickDeliveryAgentPrivate::handleMouseEvent(QMouseEvent*) qquickdeliveryagent.cpp:1513
    #111 0x137140393 in QQuickDeliveryAgent::event(QEvent*) qquickdeliveryagent.cpp:716
    #112 0x13706ad83 in QQuickWindow::event(QEvent*) qquickwindow.cpp:1490
    #113 0x1392b7e96 in QApplicationPrivate::notify_helper(QObject*, QEvent*) qapplication.cpp:3409
    #114 0x1392b8ff6 in QApplication::notify(QObject*, QEvent*) qapplication.cpp
    #115 0x13a1af6d9 in QCoreApplication::notifyInternal2(QObject*, QEvent*) qcoreapplication.cpp:1067
    #116 0x13b0019aa in QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) qguiapplication.cpp:2263
    #117 0x13b04f3fb in QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) qwindowsysteminterface.cpp:1166
    #118 0x13e45ed0a in QCocoaEventDispatcherPrivate::postedEventsSourceCallback(void*) qcocoaeventdispatcher.mm:925
    #119 0x7ff8091697d5 in __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__+0x10 (CoreFoundation:x86_64+0x7c7d5)
    #120 0x7ff809169778 in __CFRunLoopDoSource0+0x9c (CoreFoundation:x86_64+0x7c778)
    #121 0x7ff809169547 in __CFRunLoopDoSources0+0xd6 (CoreFoundation:x86_64+0x7c547)
    #122 0x7ff8091681b7 in __CFRunLoopRun+0x396 (CoreFoundation:x86_64+0x7b1b7)
    #123 0x7ff809167858 in CFRunLoopRunSpecific+0x22c (CoreFoundation:x86_64+0x7a858)
    #124 0x7ff814060a08 in RunCurrentEventLoopInMode+0x123 (HIToolbox:x86_64+0x2ea08)
    #125 0x7ff814060645 in ReceiveNextEventCommon+0xc8 (HIToolbox:x86_64+0x2e645)
    #126 0x7ff814060560 in _BlockUntilNextEventMatchingListInModeWithFilter+0x41 (HIToolbox:x86_64+0x2e560)
    #127 0x7ff80c739170 in _DPSNextEvent+0x36f (AppKit:x86_64+0x3f170)
    #128 0x7ff80d04daef in -[NSApplication(NSEventRouting) _nextEventMatchingEventMask:untilDate:inMode:dequeue:]+0x4f8 (AppKit:x86_64+0x953aef)
    #129 0x7ff80c72a584 in -[NSApplication run]+0x25a (AppKit:x86_64+0x30584)
    #130 0x13e45db2c in QCocoaEventDispatcher::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) qcocoaeventdispatcher.mm:430
    #131 0x13a1b88b5 in QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) qeventloop.cpp:230
    #132 0x13a1afcf1 in QCoreApplication::exec() qcoreapplication.cpp:1382
    #133 0x104639993 in main main.cpp:206
    #134 0x21986c344  (<unknown module>)

0x0001659c5ef8 is located 50936 bytes inside of 207840-byte region [0x0001659b9800,0x0001659ec3e0)
freed by thread T0 here:
    #0 0x13c22b33d in _ZdlPv+0x7d (libclang_rt.asan_osx_dynamic.dylib:x86_64+0x6233d)
    #1 0x105a643bb in mu::engraving::Score::operator delete(void*) score.h:268
    #2 0x10633a281 in mu::engraving::Score::~Score() score.cpp:235
    #3 0x105a5211c in mu::engraving::Excerpt::~Excerpt() excerpt.cpp:85
    #4 0x105a52184 in mu::engraving::Excerpt::~Excerpt() excerpt.cpp:84
    #5 0x105f5b7db in void muse::DeleteAll<std::__1::__wrap_iter<mu::engraving::Excerpt* const*>>(std::__1::__wrap_iter<mu::engraving::Excerpt* const*>, std::__1::__wrap_iter<mu::engraving::Excerpt* const*>) containers.h:434
    #6 0x105f3ed8e in void muse::DeleteAll<std::__1::vector<mu::engraving::Excerpt*, std::__1::allocator<mu::engraving::Excerpt*>>>(std::__1::vector<mu::engraving::Excerpt*, std::__1::allocator<mu::engraving::Excerpt*>> const&) containers.h:442
    #7 0x105f3e521 in mu::engraving::MasterScore::~MasterScore() masterscore.cpp:107
    #8 0x105f3e944 in mu::engraving::MasterScore::~MasterScore() masterscore.cpp:97
    #9 0x105f3ee48 in mu::engraving::MasterScore::~MasterScore() masterscore.cpp:97
    #10 0x1052fac15 in mu::engraving::EngravingProject::~EngravingProject() engravingproject.cpp:66
    #11 0x1052fac74 in mu::engraving::EngravingProject::~EngravingProject() engravingproject.cpp:65
    #12 0x1052fac98 in mu::engraving::EngravingProject::~EngravingProject() engravingproject.cpp:65
    #13 0x1052ff998 in std::__1::default_delete<mu::engraving::EngravingProject>::operator()[abi:ne180100](mu::engraving::EngravingProject*) const unique_ptr.h:66
    #14 0x1052ff5c6 in std::__1::__shared_ptr_pointer<mu::engraving::EngravingProject*, std::__1::shared_ptr<mu::engraving::EngravingProject>::__shared_ptr_default_delete<mu::engraving::EngravingProject, mu::engraving::EngravingProject>, std::__1::allocator<mu::engraving::EngravingProject>>::__on_zero_shared() shared_ptr.h:228
    #15 0x1046481dd in std::__1::__shared_count::__release_shared[abi:ne180100]() shared_ptr.h:157
    #16 0x104648128 in std::__1::__shared_weak_count::__release_shared[abi:ne180100]() shared_ptr.h:186
    #17 0x10530038b in std::__1::shared_ptr<mu::engraving::EngravingProject>::~shared_ptr[abi:ne180100]() shared_ptr.h:648
    #18 0x1052fa784 in std::__1::shared_ptr<mu::engraving::EngravingProject>::~shared_ptr[abi:ne180100]() shared_ptr.h:646
    #19 0x10a004bd7 in std::__1::shared_ptr<mu::engraving::EngravingProject>::operator=[abi:ne180100](std::__1::shared_ptr<mu::engraving::EngravingProject>&&) shared_ptr.h:663
    #20 0x10a0045c3 in mu::project::NotationProject::~NotationProject() notationproject.cpp:87
    #21 0x10a004cd4 in mu::project::NotationProject::~NotationProject() notationproject.cpp:84
    #22 0x10a0ffef6 in std::__1::allocator<mu::project::NotationProject>::destroy[abi:ne180100](mu::project::NotationProject*) allocator.h:176
    #23 0x10a0ffe6c in void std::__1::allocator_traits<std::__1::allocator<mu::project::NotationProject>>::destroy[abi:ne180100]<mu::project::NotationProject, void>(std::__1::allocator<mu::project::NotationProject>&, mu::project::NotationProject*) allocator_traits.h:311
    #24 0x10a0ffd64 in void std::__1::__shared_ptr_emplace<mu::project::NotationProject, std::__1::allocator<mu::project::NotationProject>>::__on_zero_shared_impl[abi:ne180100]<std::__1::allocator<mu::project::NotationProject>, 0>() shared_ptr.h:284
    #25 0x10a0fefe4 in std::__1::__shared_ptr_emplace<mu::project::NotationProject, std::__1::allocator<mu::project::NotationProject>>::__on_zero_shared() shared_ptr.h:287
    #26 0x1046481dd in std::__1::__shared_count::__release_shared[abi:ne180100]() shared_ptr.h:157
    #27 0x104648128 in std::__1::__shared_weak_count::__release_shared[abi:ne180100]() shared_ptr.h:186
    #28 0x1080ce04b in std::__1::shared_ptr<mu::project::INotationProject>::~shared_ptr[abi:ne180100]() shared_ptr.h:648
    #29 0x1080cdfb4 in std::__1::shared_ptr<mu::project::INotationProject>::~shared_ptr[abi:ne180100]() shared_ptr.h:646

previously allocated by thread T0 here:
    #0 0x13c22af1d in _Znwm+0x7d (libclang_rt.asan_osx_dynamic.dylib:x86_64+0x61f1d)
    #1 0x105a64360 in mu::engraving::Score::operator new(unsigned long) score.h:268
    #2 0x105f41e5d in mu::engraving::MasterScore::createScore() masterscore.cpp:269
    #3 0x106a45217 in mu::engraving::MscLoader::loadMscz(mu::engraving::MasterScore*, mu::engraving::MscReader const&, mu::engraving::SettingsCompat&, bool, mu::engraving::rw::ReadInOutData*) mscloader.cpp:160
    #4 0x1052fd22f in mu::engraving::EngravingProject::loadMscz(mu::engraving::MscReader const&, mu::engraving::SettingsCompat&, bool) engravingproject.cpp:148
    #5 0x10a00ada8 in mu::project::NotationProject::doLoad(muse::io::path_t const&, muse::io::path_t const&, bool, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) notationproject.cpp:158
    #6 0x10a00655a in mu::project::NotationProject::load(muse::io::path_t const&, muse::io::path_t const&, bool, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) notationproject.cpp:120
    #7 0x10a062fbb in mu::project::ProjectActionsController::loadProject(muse::io::path_t const&) projectactionscontroller.cpp:289
    #8 0x10a061b27 in mu::project::ProjectActionsController::doOpenProject(muse::io::path_t const&) projectactionscontroller.cpp:324
    #9 0x10a05c67e in mu::project::ProjectActionsController::openProject(muse::io::path_t const&, QString const&) projectactionscontroller.cpp:272
    #10 0x10a059052 in mu::project::ProjectActionsController::openProject(mu::project::ProjectFile const&) projectactionscontroller.cpp:195
    #11 0x10a053019 in mu::project::ProjectActionsController::openProject(muse::actions::ActionData const&) projectactionscontroller.cpp:177
    #12 0x10a14c26c in void muse::actions::IActionsDispatcher::reg<mu::project::ProjectActionsController>(muse::actions::Actionable*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::project::ProjectActionsController*, void (mu::project::ProjectActionsController::*)(muse::actions::ActionData const&))::'lambda'(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, muse::actions::ActionData const&)::operator()(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, muse::actions::ActionData const&) const iactionsdispatcher.h:88
    #13 0x10a14c164 in decltype(std::declval<mu::project::ProjectActionsController>()(std::declval<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&>(), std::declval<muse::actions::ActionData const&>())) std::__1::__invoke[abi:ne180100]<void muse::actions::IActionsDispatcher::reg<mu::project::ProjectActionsController>(muse::actions::Actionable*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::project::ProjectActionsController*, void (mu::project::ProjectActionsController::*)(muse::actions::ActionData const&))::'lambda'(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, muse::actions::ActionData const&)&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, muse::actions::ActionData const&>(mu::project::ProjectActionsController&&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, muse::actions::ActionData const&) invoke.h:344
    #14 0x10a14c114 in void std::__1::__invoke_void_return_wrapper<void, true>::__call[abi:ne180100]<void muse::actions::IActionsDispatcher::reg<mu::project::ProjectActionsController>(muse::actions::Actionable*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::project::ProjectActionsController*, void (mu::project::ProjectActionsController::*)(muse::actions::ActionData const&))::'lambda'(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, muse::actions::ActionData const&)&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, muse::actions::ActionData const&>(void muse::actions::IActionsDispatcher::reg<mu::project::ProjectActionsController>(muse::actions::Actionable*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::project::ProjectActionsController*, void (mu::project::ProjectActionsController::*)(muse::actions::ActionData const&))::'lambda'(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, muse::actions::ActionData const&)&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, muse::actions::ActionData const&) invoke.h:419
    #15 0x10a14c0dc in std::__1::__function::__alloc_func<void muse::actions::IActionsDispatcher::reg<mu::project::ProjectActionsController>(muse::actions::Actionable*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::project::ProjectActionsController*, void (mu::project::ProjectActionsController::*)(muse::actions::ActionData const&))::'lambda'(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, muse::actions::ActionData const&), std::__1::allocator<void muse::actions::IActionsDispatcher::reg<mu::project::ProjectActionsController>(muse::actions::Actionable*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::project::ProjectActionsController*, void (mu::project::ProjectActionsController::*)(muse::actions::ActionData const&))::'lambda'(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, muse::actions::ActionData const&)>, void (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, muse::actions::ActionData const&)>::operator()[abi:ne180100](std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, muse::actions::ActionData const&) function.h:169
    #16 0x10a148c28 in std::__1::__function::__func<void muse::actions::IActionsDispatcher::reg<mu::project::ProjectActionsController>(muse::actions::Actionable*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::project::ProjectActionsController*, void (mu::project::ProjectActionsController::*)(muse::actions::ActionData const&))::'lambda'(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, muse::actions::ActionData const&), std::__1::allocator<void muse::actions::IActionsDispatcher::reg<mu::project::ProjectActionsController>(muse::actions::Actionable*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, mu::project::ProjectActionsController*, void (mu::project::ProjectActionsController::*)(muse::actions::ActionData const&))::'lambda'(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, muse::actions::ActionData const&)>, void (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, muse::actions::ActionData const&)>::operator()(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, muse::actions::ActionData const&) function.h:311
    #17 0x108396717 in std::__1::__function::__value_func<void (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, muse::actions::ActionData const&)>::operator()[abi:ne180100](std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, muse::actions::ActionData const&) const function.h:428
    #18 0x108380414 in std::__1::function<void (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, muse::actions::ActionData const&)>::operator()(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, muse::actions::ActionData const&) const function.h:981
    #19 0x10837f0df in muse::actions::ActionsDispatcher::dispatch(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, muse::actions::ActionData const&) actionsdispatcher.cpp:69
    #20 0x109f19204 in mu::project::ScoresPageModel::openScore(QString const&, QString const&) scorespagemodel.cpp:51
    #21 0x109dcf080 in mu::project::ScoresPageModel::qt_static_metacall(QObject*, QMetaObject::Call, int, void**) moc_scorespagemodel.cpp:115
    #22 0x109dcf929 in mu::project::ScoresPageModel::qt_metacall(QMetaObject::Call, int, void**) moc_scorespagemodel.cpp:197
    #23 0x137d42b86 in CallMethod(QQmlObjectOrGadget const&, int, QMetaType, int, QMetaType const*, QV4::ExecutionEngine*, QV4::CallData*, QMetaObject::Call) qv4qobjectwrapper.cpp:1382
    #24 0x137d3ed97 in CallPrecise(QQmlObjectOrGadget const&, QQmlPropertyData const&, QV4::ExecutionEngine*, QV4::CallData*, QMetaObject::Call) qv4qobjectwrapper.cpp:1642
    #25 0x137d3d247 in QV4::QObjectMethod::callInternal(QV4::Value const*, QV4::Value const*, int) const qv4qobjectwrapper.cpp:2245
    #26 0x137ddff72 in QQmlDelayedCallQueue::DelayedFunctionCall::execute(QV4::ExecutionEngine*) const qqmldelayedcallqueue.cpp:77
    #27 0x137de0d97 in QQmlDelayedCallQueue::executeAllExpired_Later() qqmldelayedcallqueue.cpp:206
    #28 0x13a1f8328 in QObject::event(QEvent*) qobject.cpp:1369
    #29 0x1392b7e96 in QApplicationPrivate::notify_helper(QObject*, QEvent*) qapplication.cpp:3409

SUMMARY: AddressSanitizer: heap-use-after-free score.h:301 in mu::engraving::Score::rootItem() const
Shadow bytes around the buggy address:
  0x0001659c5c00: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0001659c5c80: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0001659c5d00: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0001659c5d80: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0001659c5e00: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
=>0x0001659c5e80: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd[fd]
  0x0001659c5f00: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0001659c5f80: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0001659c6000: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0001659c6080: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0001659c6100: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==43579==ABORTING
```

</details>