### PR TITLE
Fix #21742: MusicXML import shows red notes when midi-program is set to guitar

### DIFF
--- a/src/framework/global/stringutils.cpp
+++ b/src/framework/global/stringutils.cpp
@@ -145,3 +145,30 @@ bool muse::strings::lessThanCaseInsensitive(const String& lhs, const String& rhs
 
     return lhsLower < rhsLower;
 }
+
+int muse::strings::levenshteinDistance(const std::string& s1, const std::string& s2)
+{
+    size_t N1 = s1.length();
+    size_t N2 = s2.length();
+    int i, j;
+    std::vector<int> T(N2 + 1);
+
+    for (i = 0; i <= N2; i++) {
+        T[i] = i;
+    }
+
+    for (i = 0; i < N1; i++) {
+        T[0] = i + 1;
+        int corner = i;
+        for (j = 0; j < N2; j++) {
+            int upper = T[j + 1];
+            if (s1[i] == s2[j]) {
+                T[j + 1] = corner;
+            } else {
+                T[j + 1] = std::min(T[j], std::min(upper, corner)) + 1;
+            }
+            corner = upper;
+        }
+    }
+    return T[N2];
+}

--- a/src/framework/global/stringutils.h
+++ b/src/framework/global/stringutils.h
@@ -55,6 +55,8 @@ std::string toString(const T& t)
 
 bool lessThanCaseInsensitive(const std::string& lhs, const std::string& rhs);
 bool lessThanCaseInsensitive(const String& lhs, const String& rhs);
+
+int levenshteinDistance(const std::string& s1, const std::string& s2);
 }
 
 #endif // MUSE_GLOBAL_STRINGUTILS_H


### PR DESCRIPTION
Resolves: #21742

<!-- Add a short description of and motivation for the changes here -->
This pull request changes the way an instrument is selected when importing an XML
- Before: the selected instrument was the first in the list among all the instruments with the same score
- Now: the selected instrument was the first in the list among all the instruments with the same score and the lowest Levenshtein distance (name of the imported instrument and the track name or long name of the selected instrument). Levenshtein distance is used only if the name of the importing instrument has some meaning (not empty and not meaningless names)

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
