### PR TITLE
Fix finding Docker image for ARM Linux builds

### DIFF
--- a/.github/workflows/build_linux_arm.yml
+++ b/.github/workflows/build_linux_arm.yml
@@ -173,7 +173,7 @@ jobs:
       run: |
         C_URL=${SENTRY_URL}; if [ -z "$C_URL" ]; then C_URL="''"; fi
 
-        sudo docker run -i -v "${PWD}:/MuseScore" -v /usr/bin/qemu-arm-static:/usr/bin/qemu-arm-static "arm32v7/ubuntu:jammy" /bin/bash -c "cd /MuseScore && \
+        sudo docker run --platform linux/arm -i -v "${PWD}:/MuseScore" -v /usr/bin/qemu-arm-static:/usr/bin/qemu-arm-static "arm32v7/ubuntu:jammy" /bin/bash -c "cd /MuseScore && \
         bash /MuseScore/buildscripts/ci/linux/setup-arm.sh --arch armv7l && \
         bash /MuseScore/buildscripts/ci/linux/build.sh -n ${{ env.BUILD_NUMBER }} --crash_log_url $C_URL --arch armv7l && \
         bash /MuseScore/buildscripts/ci/linux/package.sh --arch armv7l && \
@@ -302,7 +302,7 @@ jobs:
       run: |
         C_URL=${SENTRY_URL}; if [ -z "$C_URL" ]; then C_URL="''"; fi
 
-        sudo docker run -i -v "${PWD}:/MuseScore" -v /usr/bin/qemu-aarch64-static:/usr/bin/qemu-aarch64-static "arm64v8/ubuntu:jammy" /bin/bash -c "cd /MuseScore && \
+        sudo docker run --platform linux/arm64 -i -v "${PWD}:/MuseScore" -v /usr/bin/qemu-aarch64-static:/usr/bin/qemu-aarch64-static "arm64v8/ubuntu:jammy" /bin/bash -c "cd /MuseScore && \
         bash /MuseScore/buildscripts/ci/linux/setup-arm.sh --arch aarch64 && \
         bash /MuseScore/buildscripts/ci/linux/build.sh -n ${{ env.BUILD_NUMBER }} --crash_log_url $C_URL --arch aarch64 && \
         bash /MuseScore/buildscripts/ci/linux/package.sh --arch aarch64 && \


### PR DESCRIPTION
It's unclear why this is necessary; maybe docker changed something. And I also don't know if this is the solution; let's try