### PR TITLE
Fix #11128: Disable Mixer Knob and Slider Scroll

### DIFF
--- a/src/framework/audio/qml/Muse/Audio/KnobControl.qml
+++ b/src/framework/audio/qml/Muse/Audio/KnobControl.qml
@@ -45,7 +45,7 @@ Dial {
     width: implicitWidth
     height: width
 
-    wheelEnabled: true
+    wheelEnabled: false
 
     from: 0
     to: 1

--- a/src/framework/audio/qml/Muse/Audio/VolumeSlider.qml
+++ b/src/framework/audio/qml/Muse/Audio/VolumeSlider.qml
@@ -44,7 +44,7 @@ Slider {
     value: convertor.volumeLevelToLocal(root.volumeLevel)
     stepSize: 0.1
     orientation: Qt.Vertical
-    wheelEnabled: true
+    wheelEnabled: false
 
     signal increaseRequested()
     signal decreaseRequested()


### PR DESCRIPTION
Resolves: #11128

This pull request disables the ability to scroll to edit the Mixer's knob and slider values on individual channel strips. This solves the issue of unexpected behavior when trying to horizontally scroll the Mixer with a trackpad.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
