### PR TITLE
Percussion panel - notation interaction basics

### DIFF
--- a/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
+++ b/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
@@ -49,11 +49,15 @@ Item {
     */
 
     Component.onCompleted: {
-        padGrid.model.load()
+        padGrid.model.init()
     }
 
     PercussionPanelModel {
         id: percModel
+
+        Component.onCompleted: {
+            percModel.init()
+        }
     }
 
     // TODO: Will live inside percussion panel until #22050 is implemented

--- a/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPadContent.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPadContent.qml
@@ -50,18 +50,10 @@ Column {
             hoverEnabled: true
 
             onPressed: {
-                var instName = Boolean(root.padModel) ? root.padModel.instrumentName : ""
-
-                // Placeholder logic...
-                switch(root.panelMode) {
-                case PanelMode.EDIT_LAYOUT: return
-                case PanelMode.SOUND_PREVIEW:
-                    console.log("PLAYING: " + instName)
-                    break
-                case PanelMode.WRITE:
-                    console.log("WRITING: " + instName)
-                    break
+                if (!Boolean(root.padModel)) {
+                    return
                 }
+                root.padModel.triggerPad()
             }
         }
 

--- a/src/notation/view/percussionpanel/percussionpanelmodel.h
+++ b/src/notation/view/percussionpanel/percussionpanelmodel.h
@@ -24,6 +24,11 @@
 
 #include <QObject>
 
+#include "modularity/ioc.h"
+#include "async/asyncable.h"
+
+#include "context/iglobalcontext.h"
+
 #include "percussionpanelpadlistmodel.h"
 
 class PanelMode
@@ -39,8 +44,10 @@ public:
     Q_ENUM(Mode)
 };
 
-class PercussionPanelModel : public QObject
+class PercussionPanelModel : public QObject, public muse::Injectable, public muse::async::Asyncable
 {
+    muse::Inject<context::IGlobalContext> globalContext = { this };
+
     Q_OBJECT
 
     Q_PROPERTY(PanelMode::Mode currentPanelMode READ currentPanelMode WRITE setCurrentPanelMode NOTIFY currentPanelModeChanged)
@@ -61,6 +68,8 @@ public:
 
     PercussionPanelPadListModel* padListModel() const;
 
+    Q_INVOKABLE void init();
+
     QList<QVariantMap> layoutMenuItems() const;
     Q_INVOKABLE void handleMenuItem(const QString& itemId);
 
@@ -73,6 +82,11 @@ signals:
     void padListModelChanged();
 
 private:
+    void setUpConnections();
+
+    const mu::notation::INotationPtr notation() const;
+    const mu::notation::INotationInteractionPtr interaction() const;
+
     PanelMode::Mode m_currentPanelMode = PanelMode::Mode::WRITE;
     PanelMode::Mode m_panelModeToRestore = PanelMode::Mode::WRITE;
     bool m_useNotationPreview = false;

--- a/src/notation/view/percussionpanel/percussionpanelmodel.h
+++ b/src/notation/view/percussionpanel/percussionpanelmodel.h
@@ -28,6 +28,7 @@
 #include "async/asyncable.h"
 
 #include "context/iglobalcontext.h"
+#include "playback/iplaybackcontroller.h"
 
 #include "percussionpanelpadlistmodel.h"
 
@@ -47,6 +48,7 @@ public:
 class PercussionPanelModel : public QObject, public muse::Injectable, public muse::async::Asyncable
 {
     muse::Inject<context::IGlobalContext> globalContext = { this };
+    muse::Inject<playback::IPlaybackController> playbackController = { this };
 
     Q_OBJECT
 
@@ -84,8 +86,13 @@ signals:
 private:
     void setUpConnections();
 
+    void writePitch(int pitch);
+    void playPitch(int pitch);
+
     const mu::notation::INotationPtr notation() const;
     const mu::notation::INotationInteractionPtr interaction() const;
+
+    mu::engraving::Score* score() const;
 
     PanelMode::Mode m_currentPanelMode = PanelMode::Mode::WRITE;
     PanelMode::Mode m_panelModeToRestore = PanelMode::Mode::WRITE;

--- a/src/notation/view/percussionpanel/percussionpanelpadlistmodel.cpp
+++ b/src/notation/view/percussionpanel/percussionpanelpadlistmodel.cpp
@@ -128,6 +128,10 @@ void PercussionPanelPadListModel::resetLayout()
         const QString midiNote = QString::fromStdString(muse::pitchToString(pitch));
         model->setMidiNote(midiNote);
 
+        model->padTriggered().onNotify(this, [this, pitch]() {
+            m_triggeredChannel.send(pitch);
+        });
+
         model->setIsEmptySlot(false);
 
         m_padModels.append(model);

--- a/src/notation/view/percussionpanel/percussionpanelpadlistmodel.h
+++ b/src/notation/view/percussionpanel/percussionpanelpadlistmodel.h
@@ -24,6 +24,8 @@
 
 #include <QAbstractListModel>
 
+#include "engraving/dom/drumset.h"
+
 #include "percussionpanelpadmodel.h"
 
 static constexpr int NUM_COLUMNS(8);
@@ -42,7 +44,7 @@ public:
     QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
     QHash<int, QByteArray> roleNames() const override;
 
-    Q_INVOKABLE void load();
+    Q_INVOKABLE void init();
 
     Q_INVOKABLE void addRow();
     Q_INVOKABLE void deleteRow(int row);
@@ -54,6 +56,7 @@ public:
     int numColumns() const { return NUM_COLUMNS; }
     int numPads() const { return m_padModels.count(); }
 
+    void setDrumset(const mu::engraving::Drumset* drumset);
     void resetLayout();
 
 signals:
@@ -65,27 +68,12 @@ private:
         PadModelRole = Qt::UserRole + 1,
     };
 
-    //! NOTE: Probably a placeholder struct...
-    struct PadInfo {
-        QString instrumentName;
-
-        QString keyboardShortcut;
-        QString midiNote;
-
-        bool isEmptySlot = true;
-
-        bool isValid() const
-        {
-            return !instrumentName.isEmpty() && !keyboardShortcut.isEmpty() && !midiNote.isEmpty();
-        }
-    };
-
     bool indexIsValid(int index) const;
     void movePad(int fromIndex, int toIndex);
 
     int numEmptySlotsAtRow(int row) const;
 
-    QList<PercussionPanelPadModel*> createDefaultItems();
+    const mu::engraving::Drumset* m_drumset = nullptr;
     QList<PercussionPanelPadModel*> m_padModels;
 
     int m_dragStartIndex = -1;

--- a/src/notation/view/percussionpanel/percussionpanelpadlistmodel.h
+++ b/src/notation/view/percussionpanel/percussionpanelpadlistmodel.h
@@ -24,13 +24,16 @@
 
 #include <QAbstractListModel>
 
+#include "async/asyncable.h"
+#include "async/channel.h"
+
 #include "engraving/dom/drumset.h"
 
 #include "percussionpanelpadmodel.h"
 
 static constexpr int NUM_COLUMNS(8);
 
-class PercussionPanelPadListModel : public QAbstractListModel
+class PercussionPanelPadListModel : public QAbstractListModel, public muse::async::Asyncable
 {
     Q_OBJECT
 
@@ -59,6 +62,8 @@ public:
     void setDrumset(const mu::engraving::Drumset* drumset);
     void resetLayout();
 
+    muse::async::Channel<int /*pitch*/> padTriggered() const { return m_triggeredChannel; }
+
 signals:
     void numPadsChanged();
     void rowIsEmptyChanged(int row, bool empty);
@@ -77,4 +82,6 @@ private:
     QList<PercussionPanelPadModel*> m_padModels;
 
     int m_dragStartIndex = -1;
+
+    muse::async::Channel<int /*pitch*/> m_triggeredChannel;
 };

--- a/src/notation/view/percussionpanel/percussionpanelpadmodel.cpp
+++ b/src/notation/view/percussionpanel/percussionpanelpadmodel.cpp
@@ -66,3 +66,8 @@ void PercussionPanelPadModel::setIsEmptySlot(bool isEmptySlot)
     m_isEmptySlot = isEmptySlot;
     emit isEmptySlotChanged();
 }
+
+void PercussionPanelPadModel::triggerPad()
+{
+    m_triggeredNotification.notify();
+}

--- a/src/notation/view/percussionpanel/percussionpanelpadmodel.h
+++ b/src/notation/view/percussionpanel/percussionpanelpadmodel.h
@@ -24,7 +24,10 @@
 
 #include <QObject>
 
-class PercussionPanelPadModel : public QObject
+#include "async/asyncable.h"
+#include "async/notification.h"
+
+class PercussionPanelPadModel : public QObject, public muse::async::Asyncable
 {
     Q_OBJECT
 
@@ -50,6 +53,9 @@ public:
     bool isEmptySlot() const { return m_isEmptySlot; }
     void setIsEmptySlot(bool isEmptySlot);
 
+    Q_INVOKABLE void triggerPad();
+    muse::async::Notification padTriggered() const { return m_triggeredNotification; }
+
 signals:
     void instrumentNameChanged();
 
@@ -65,4 +71,6 @@ private:
     QString m_midiNote;
 
     bool m_isEmptySlot = true;
+
+    muse::async::Notification m_triggeredNotification;
 };


### PR DESCRIPTION
This PR takes the first steps into notation interaction for the percussion panel:

- Pads are initialised based on the current stave's drumset
- Clicking a pad will write to the score or preview the sound depending on the current panel mode