### PR TITLE
Fix #19359 - Failing exporting score parts using .json

### DIFF
--- a/src/converter/internal/convertercontroller.cpp
+++ b/src/converter/internal/convertercontroller.cpp
@@ -107,7 +107,8 @@ Ret ConverterController::fileConvert(const muse::io::path_t& in, const muse::io:
     }
 
     // Check if this is a part conversion job
-    if (out.toString().contains('*')) {
+    QString baseName = QString::fromStdString(io::completeBasename(out).toStdString());
+    if (baseName.endsWith('*')) {
         return convertScoreParts(in, out, stylePath, forceMode);
     }
 
@@ -390,20 +391,17 @@ Ret ConverterController::convertScorePartsToPngs(INotationWriterPtr writer, mu::
 {
     TRACEFUNC;
 
-    Ret ret = convertPageByPage(writer, masterNotation->notation(), out);
-    if (!ret) {
-        return ret;
-    }
-
-    INotationPtrList excerpts;
+    INotationPtrList notations;
     for (IExcerptNotationPtr e : masterNotation->excerpts()) {
-        excerpts.push_back(e->notation());
+        notations.push_back(e->notation());
     }
 
-    muse::io::path_t pngFilePath = io::dirpath(out) + "/" + muse::io::path_t(io::completeBasename(out) + "-excerpt.png");
-
-    for (size_t i = 0; i < excerpts.size(); i++) {
-        Ret ret2 = convertPageByPage(writer, excerpts[i], pngFilePath);
+    for (size_t i = 0; i < notations.size(); i++) {
+        QString partName = notations[i]->name();
+        QString baseName = QString::fromStdString(io::completeBasename(out).toStdString());
+        baseName.chop(1);  // Remove the * placeholder
+        muse::io::path_t pngFilePath = io::dirpath(out) + "/" + baseName.toStdString() + partName.toStdString() + ".png";;
+        Ret ret2 = convertPageByPage(writer, notations[i], pngFilePath);
         if (!ret2) {
             return ret2;
         }

--- a/src/converter/internal/convertercontroller.cpp
+++ b/src/converter/internal/convertercontroller.cpp
@@ -353,29 +353,16 @@ Ret ConverterController::convertScorePartsToPdf(INotationWriterPtr writer, IMast
     TRACEFUNC;
 
     INotationPtrList notations;
-    notations.push_back(masterNotation->notation());
-
     for (IExcerptNotationPtr e : masterNotation->excerpts()) {
         notations.push_back(e->notation());
     }
 
-    File file(out);
-    if (!file.open(File::WriteOnly)) {
-        return make_ret(Err::OutFileFailedOpen);
-    }
-
     for (size_t i = 0; i < notations.size(); ++i) {
-        QString partName;
-        if (i == 0){
-            partName = "";
-        }
-        else {
-            partName = notations[i]->name();
-        }
+        QString partName = notations[i]->name();
         QString baseName = QString::fromStdString(io::completeBasename(out).toStdString());
-        baseName.replace('*', partName);
+        baseName.chop(1);  // Remove the * placeholder
 
-        muse::io::path_t partOut = io::dirpath(out) + "/" + baseName.toStdString() + ".pdf";
+        muse::io::path_t partOut = io::dirpath(out) + "/" + baseName.toStdString() + partName.toStdString() + ".pdf";
 
         File file(partOut);
         if (!file.open(File::WriteOnly)) {
@@ -394,20 +381,6 @@ Ret ConverterController::convertScorePartsToPdf(INotationWriterPtr writer, IMast
 
         file.close();
     }
-
-
-    INotationWriter::Options options {
-        { INotationWriter::OptionKey::UNIT_TYPE, Val(INotationWriter::UnitType::MULTI_PART) },
-    };
-
-
-    Ret ret = writer->writeList(notations, file, options);
-    if (!ret) {
-        LOGE() << "failed write, err: " << ret.toString() << ", path: " << out;
-        return make_ret(Err::OutFileFailedWrite);
-    }
-
-    file.close();
 
     return make_ret(Ret::Code::Ok);
 }

--- a/src/converter/internal/convertercontroller.cpp
+++ b/src/converter/internal/convertercontroller.cpp
@@ -365,8 +365,17 @@ Ret ConverterController::convertScorePartsToPdf(INotationWriterPtr writer, IMast
     }
 
     for (size_t i = 0; i < notations.size(); ++i) {
-        QString partName = (i == 0) ? "full" : QString("part%1").arg(i);
-        muse::io::path_t partOut = io::dirpath(out) + "/" + io::completeBasename(out) + "_" + partName.toStdString() + ".pdf";
+        QString partName;
+        if (i == 0){
+            partName = "";
+        }
+        else {
+            partName = notations[i]->name();
+        }
+        QString baseName = QString::fromStdString(io::completeBasename(out).toStdString());
+        baseName.replace('*', partName);
+
+        muse::io::path_t partOut = io::dirpath(out) + "/" + baseName.toStdString() + ".pdf";
 
         File file(partOut);
         if (!file.open(File::WriteOnly)) {

--- a/src/converter/internal/convertercontroller.cpp
+++ b/src/converter/internal/convertercontroller.cpp
@@ -45,6 +45,7 @@ using namespace muse::io;
 static const std::string PDF_SUFFIX = "pdf";
 static const std::string PNG_SUFFIX = "png";
 static const std::string SVG_SUFFIX = "svg";
+static const std::string MP3_SUFFIX = "mp3";
 
 Ret ConverterController::batchConvert(const muse::io::path_t& batchJobFile, const muse::io::path_t& stylePath, bool forceMode,
                                       const String& soundProfile, const muse::UriQuery& extensionUri, muse::ProgressPtr progress)
@@ -106,19 +107,6 @@ Ret ConverterController::fileConvert(const muse::io::path_t& in, const muse::io:
         return make_ret(Err::UnknownError);
     }
 
-    // Check if this is a part conversion job
-    QString baseName = QString::fromStdString(io::completeBasename(out).toStdString());
-    if (baseName.endsWith('*')) {
-        return convertScoreParts(in, out, stylePath, forceMode);
-    }
-
-    std::string suffix = io::suffix(out);
-
-    auto writer = writers()->writer(suffix);
-    if (!writer) {
-        return make_ret(Err::ConvertTypeUnknown);
-    }
-
     Ret ret = notationProject->load(in, stylePath, forceMode);
     if (!ret) {
         LOGE() << "failed load notation, err: " << ret.toString() << ", path: " << in;
@@ -131,6 +119,19 @@ Ret ConverterController::fileConvert(const muse::io::path_t& in, const muse::io:
     }
 
     globalContext()->setCurrentProject(notationProject);
+
+    // Check if this is a part conversion job
+    QString baseName = QString::fromStdString(io::completeBasename(out).toStdString());
+    if (baseName.endsWith('*')) {
+        return convertScoreParts(in, out, stylePath, forceMode);
+    }
+
+    std::string suffix = io::suffix(out);
+
+    auto writer = writers()->writer(suffix);
+    if (!writer) {
+        return make_ret(Err::ConvertTypeUnknown);
+    }
 
     // use a extension for convert
     if (extensionUri.isValid()) {
@@ -189,6 +190,9 @@ Ret ConverterController::convertScoreParts(const muse::io::path_t& in, const mus
         ret = convertScorePartsToPdf(writer, notationProject->masterNotation(), out);
     } else if (suffix == PNG_SUFFIX) {
         ret = convertScorePartsToPngs(writer, notationProject->masterNotation(), out);
+    } 
+    else if (suffix == MP3_SUFFIX) {
+        ret = convertScorePartsToMp3(writer, notationProject->masterNotation(), out);
     } else {
         ret = make_ret(Ret::Code::NotSupported);
     }
@@ -409,6 +413,45 @@ Ret ConverterController::convertScorePartsToPngs(INotationWriterPtr writer, mu::
 
     return make_ret(Ret::Code::Ok);
 }
+
+Ret ConverterController::convertScorePartsToMp3(INotationWriterPtr writer, IMasterNotationPtr masterNotation,
+                                                const muse::io::path_t& out) const
+{
+    TRACEFUNC;
+
+    INotationPtrList notations;
+    for (IExcerptNotationPtr e : masterNotation->excerpts()) {
+        notations.push_back(e->notation());
+    }
+
+    for (size_t i = 0; i < notations.size(); ++i) {
+        QString partName = notations[i]->name();
+        QString baseName = QString::fromStdString(io::completeBasename(out).toStdString());
+        baseName.chop(1);  // Remove the * placeholder
+
+        muse::io::path_t partOut = io::dirpath(out) + "/" + baseName.toStdString() + partName.toStdString() + ".mp3";
+
+        File file(partOut);
+        if (!file.open(File::WriteOnly)) {
+            return make_ret(Err::OutFileFailedOpen);
+        }
+
+        INotationWriter::Options options {
+            { INotationWriter::OptionKey::UNIT_TYPE, Val(INotationWriter::UnitType::PER_PART) },
+        };
+        file.setMeta("file_path", partOut.toStdString());
+        Ret ret = writer->write(notations[i], file, options);
+        if (!ret) {
+            LOGE() << "failed write, err: " << ret.toString() << ", path: " << partOut;
+            return make_ret(Err::OutFileFailedWrite);
+        }
+
+        file.close();
+    }
+
+    return make_ret(Ret::Code::Ok);
+}
+
 
 Ret ConverterController::exportScoreMedia(const muse::io::path_t& in, const muse::io::path_t& out,
                                           const muse::io::path_t& highlightConfigPath,

--- a/src/converter/internal/convertercontroller.h
+++ b/src/converter/internal/convertercontroller.h
@@ -48,14 +48,12 @@ public:
     ConverterController(const muse::modularity::ContextPtr& iocCtx)
         : muse::Injectable(iocCtx) {}
 
-    muse::Ret fileConvert(const muse::io::path_t& in, const muse::io::path_t& out,
-                          const muse::io::path_t& stylePath = muse::io::path_t(), bool forceMode = false,
-                          const muse::String& soundProfile = muse::String(),
+    muse::Ret fileConvert(const muse::io::path_t& in, const muse::io::path_t& out, const muse::io::path_t& stylePath = muse::io::path_t(),
+                          bool forceMode = false, const muse::String& soundProfile = muse::String(),
                           const muse::UriQuery& extensionUri = muse::UriQuery()) override;
 
-    muse::Ret batchConvert(const muse::io::path_t& batchJobFile,
-                           const muse::io::path_t& stylePath = muse::io::path_t(), bool forceMode = false,
-                           const muse::String& soundProfile = muse::String(),
+    muse::Ret batchConvert(const muse::io::path_t& batchJobFile, const muse::io::path_t& stylePath = muse::io::path_t(),
+                           bool forceMode = false, const muse::String& soundProfile = muse::String(),
                            const muse::UriQuery& extensionUri = muse::UriQuery(), muse::ProgressPtr progress = nullptr) override;
 
     muse::Ret convertScoreParts(const muse::io::path_t& in, const muse::io::path_t& out,

--- a/src/converter/internal/convertercontroller.h
+++ b/src/converter/internal/convertercontroller.h
@@ -96,6 +96,8 @@ private:
                                      const muse::io::path_t& out) const;
     muse::Ret convertScorePartsToPngs(project::INotationWriterPtr writer, notation::IMasterNotationPtr masterNotation,
                                       const muse::io::path_t& out) const;
+    muse::Ret convertScorePartsToMp3(project::INotationWriterPtr writer, notation::IMasterNotationPtr masterNotation,
+                                     const muse::io::path_t& out) const;
 };
 }
 

--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/ChooseInstrumentsPage.qml
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/ChooseInstrumentsPage.qml
@@ -25,11 +25,13 @@ import QtQuick.Layouts 1.15
 import Muse.Ui 1.0
 import Muse.UiComponents 1.0
 import MuseScore.InstrumentsScene 1.0
+import MuseScore.Project 1.0
 
 import "internal"
 
 Rectangle {
     id: root
+    required property InstrumentsOnScoreListModel instrumentsOnScoreModel
 
     property bool canSelectMultipleInstruments: true
     property string currentInstrumentId: ""
@@ -201,6 +203,7 @@ Rectangle {
 
             Layout.fillWidth: true
             Layout.fillHeight: true
+            instrumentsOnScoreModel: root.instrumentsOnScoreModel
         }
 
         SeparatorLine {

--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/ChooseInstrumentsPage.qml
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/ChooseInstrumentsPage.qml
@@ -25,21 +25,21 @@ import QtQuick.Layouts 1.15
 import Muse.Ui 1.0
 import Muse.UiComponents 1.0
 import MuseScore.InstrumentsScene 1.0
-import MuseScore.Project 1.0
 
 import "internal"
 
 Rectangle {
     id: root
+
     required property InstrumentsOnScoreListModel instrumentsOnScoreModel
 
     property bool canSelectMultipleInstruments: true
     property string currentInstrumentId: ""
     property string description: instrumentsModel.selectedInstrument ? instrumentsModel.selectedInstrument.description : ""
 
-    property bool hasSelectedInstruments: root.canSelectMultipleInstruments
-                                          ? instrumentsOnScoreView.hasInstruments
-                                          : Boolean(instrumentsModel.selectedInstrument)
+    readonly property bool hasSelectedInstruments: root.canSelectMultipleInstruments
+                                                   ? instrumentsOnScoreModel.count > 0
+                                                   : Boolean(instrumentsModel.selectedInstrument)
 
     property NavigationSection navigationSection: null
 
@@ -203,6 +203,7 @@ Rectangle {
 
             Layout.fillWidth: true
             Layout.fillHeight: true
+
             instrumentsOnScoreModel: root.instrumentsOnScoreModel
         }
 

--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/ChooseInstrumentsPage.qml
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/ChooseInstrumentsPage.qml
@@ -49,7 +49,7 @@ Rectangle {
 
     function instruments() {
         if (root.canSelectMultipleInstruments) {
-            return instrumentsOnScoreView.instruments()
+            return root.instrumentsOnScoreModel.instruments()
         }
 
         return [ instrumentsModel.selectedInstrument ]
@@ -57,7 +57,7 @@ Rectangle {
 
     function currentOrder() {
         if (root.canSelectMultipleInstruments) {
-            return instrumentsOnScoreView.currentOrder()
+            return root.instrumentsOnScoreModel.currentOrder()
         }
 
         return undefined
@@ -82,7 +82,7 @@ Rectangle {
         id: prv
 
         function addSelectedInstrumentsToScore() {
-            instrumentsOnScoreView.addInstruments(instrumentsModel.selectedInstrumentIdList())
+            root.instrumentsOnScoreModel.addInstruments(instrumentsModel.selectedInstrumentIdList())
 
             Qt.callLater(instrumentsOnScoreView.scrollViewToEnd)
         }
@@ -229,7 +229,7 @@ Rectangle {
             }
 
             FlatButton {
-                enabled: instrumentsOnScoreView.isMovingUpAvailable
+                enabled: root.instrumentsOnScoreModel.isMovingUpAvailable
                 icon: IconCode.ARROW_UP
 
                 navigation.name: "Up"
@@ -239,12 +239,12 @@ Rectangle {
                 toolTipTitle: qsTrc("instruments", "Move selected instruments up")
 
                 onClicked: {
-                    instrumentsOnScoreView.moveSelectedInstrumentsUp()
+                    root.instrumentsOnScoreModel.moveSelectionUp()
                 }
             }
 
             FlatButton {
-                enabled: instrumentsOnScoreView.isMovingDownAvailable
+                enabled: root.instrumentsOnScoreModel.isMovingDownAvailable
                 icon: IconCode.ARROW_DOWN
 
                 navigation.name: "Down"
@@ -254,7 +254,7 @@ Rectangle {
                 toolTipTitle: qsTrc("instruments", "Move selected instruments down")
 
                 onClicked: {
-                    instrumentsOnScoreView.moveSelectedInstrumentsDown()
+                    root.instrumentsOnScoreModel.moveSelectionDown()
                 }
             }
         }

--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/InstrumentsDialog.qml
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/InstrumentsDialog.qml
@@ -30,7 +30,7 @@ import MuseScore.Project 1.0
 StyledDialogView {
     id: root
 
-    required property InstrumentsOnScoreListModel instrumentsOnScoreModel
+    // required property InstrumentsOnScoreListModel instrumentsOnScoreModel
     property bool canSelectMultipleInstruments: true
     property string currentInstrumentId: ""
 
@@ -54,6 +54,10 @@ StyledDialogView {
         root.hide()
     }
 
+    InstrumentsOnScoreListModel {
+        id: theInstrumentsOnScoreModel
+    }
+
     ColumnLayout {
         anchors.fill: parent
         spacing: 20
@@ -72,7 +76,8 @@ StyledDialogView {
             onSubmitRequested: {
                 root.submit()
             }
-            instrumentsOnScoreModel: instrumentsOnScoreModel
+
+            instrumentsOnScoreModel: theInstrumentsOnScoreModel
         }
 
         RowLayout {

--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/InstrumentsDialog.qml
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/InstrumentsDialog.qml
@@ -25,12 +25,10 @@ import QtQuick.Layouts 1.15
 import Muse.Ui 1.0
 import Muse.UiComponents 1.0
 import MuseScore.InstrumentsScene 1.0
-import MuseScore.Project 1.0
 
 StyledDialogView {
     id: root
 
-    // required property InstrumentsOnScoreListModel instrumentsOnScoreModel
     property bool canSelectMultipleInstruments: true
     property string currentInstrumentId: ""
 
@@ -52,6 +50,10 @@ StyledDialogView {
 
         root.ret = { errcode: 0, value: result }
         root.hide()
+    }
+
+    Component.onCompleted: {
+        theInstrumentsOnScoreModel.load()
     }
 
     InstrumentsOnScoreListModel {

--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/InstrumentsDialog.qml
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/InstrumentsDialog.qml
@@ -25,10 +25,12 @@ import QtQuick.Layouts 1.15
 import Muse.Ui 1.0
 import Muse.UiComponents 1.0
 import MuseScore.InstrumentsScene 1.0
+import MuseScore.Project 1.0
 
 StyledDialogView {
     id: root
 
+    required property InstrumentsOnScoreListModel instrumentsOnScoreModel
     property bool canSelectMultipleInstruments: true
     property string currentInstrumentId: ""
 
@@ -70,6 +72,7 @@ StyledDialogView {
             onSubmitRequested: {
                 root.submit()
             }
+            instrumentsOnScoreModel: instrumentsOnScoreModel
         }
 
         RowLayout {

--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/InstrumentsOnScoreView.qml
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/InstrumentsOnScoreView.qml
@@ -26,9 +26,11 @@ import QtQuick.Controls 2.12
 import Muse.Ui 1.0
 import Muse.UiComponents 1.0
 import MuseScore.InstrumentsScene 1.0
+import MuseScore.Project 1.0
 
 Item {
     id: root
+    required property InstrumentsOnScoreListModel instrumentsOnScoreModel
 
     readonly property bool hasInstruments: instrumentsOnScoreModel.count > 0
     readonly property alias isMovingUpAvailable: instrumentsOnScoreModel.isMovingUpAvailable
@@ -60,9 +62,7 @@ Item {
         instrumentsView.positionViewAtEnd()
     }
 
-    InstrumentsOnScoreListModel {
-        id: instrumentsOnScoreModel
-    }
+
 
     Component.onCompleted: {
         instrumentsOnScoreModel.load()

--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/InstrumentsOnScoreView.qml
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/InstrumentsOnScoreView.qml
@@ -26,46 +26,16 @@ import QtQuick.Controls 2.12
 import Muse.Ui 1.0
 import Muse.UiComponents 1.0
 import MuseScore.InstrumentsScene 1.0
-import MuseScore.Project 1.0
 
 Item {
     id: root
-    required property InstrumentsOnScoreListModel instrumentsOnScoreModel
 
-    readonly property bool hasInstruments: instrumentsOnScoreModel.count > 0
-    // readonly property alias isMovingUpAvailable: instrumentsOnScoreModel.isMovingUpAvailable
-    // readonly property alias isMovingDownAvailable: instrumentsOnScoreModel.isMovingDownAvailable
+    required property InstrumentsOnScoreListModel instrumentsOnScoreModel
 
     property alias navigation: instrumentsView.navigation
 
-    // function instruments() {
-    //     return instrumentsOnScoreModel.instruments()
-    // }
-
-    // function currentOrder() {
-    //     return instrumentsOnScoreModel.currentOrder()
-    // }
-
-    // function addInstruments(instruments) {
-    //     instrumentsOnScoreModel.addInstruments(instruments)
-    // }
-
-    // function moveSelectedInstrumentsUp() {
-    //     instrumentsOnScoreModel.moveSelectionUp()
-    // }
-
-    // function moveSelectedInstrumentsDown() {
-    //     instrumentsOnScoreModel.moveSelectionDown()
-    // }
-
     function scrollViewToEnd() {
         instrumentsView.positionViewAtEnd()
-    }
-
-
-
-    Component.onCompleted: {
-        instrumentsOnScoreModel.load()
     }
 
     StyledTextLabel {
@@ -96,14 +66,14 @@ Item {
             navigation.row: 0
             navigation.column: 0
 
-            model: instrumentsOnScoreModel.orders
+            model: root.instrumentsOnScoreModel.orders
 
-            currentIndex: instrumentsOnScoreModel.currentOrderIndex
+            currentIndex: root.instrumentsOnScoreModel.currentOrderIndex
 
             displayText: qsTrc("instruments", "Order:") + " " + currentText
 
             onActivated: function(index, value) {
-                instrumentsOnScoreModel.currentOrderIndex = index
+                root.instrumentsOnScoreModel.currentOrderIndex = index
             }
         }
 
@@ -118,10 +88,10 @@ Item {
             icon: IconCode.DELETE_TANK
             toolTipTitle: qsTrc("instruments", "Remove selected instruments from score")
 
-            enabled: instrumentsOnScoreModel.isRemovingAvailable
+            enabled: root.instrumentsOnScoreModel.isRemovingAvailable
 
             onClicked: {
-                instrumentsOnScoreModel.removeSelection()
+                root.instrumentsOnScoreModel.removeSelection()
             }
         }
     }
@@ -135,7 +105,7 @@ Item {
         anchors.left: parent.left
         anchors.right: parent.right
 
-        model: instrumentsOnScoreModel
+        model: root.instrumentsOnScoreModel
 
         accessible.name: instrumentsLabel.text
 
@@ -187,15 +157,15 @@ Item {
             }
 
             onClicked: {
-                instrumentsOnScoreModel.selectRow(model.index)
+                root.instrumentsOnScoreModel.selectRow(model.index)
             }
 
             onDoubleClicked: {
-                instrumentsOnScoreModel.removeSelection()
+                root.instrumentsOnScoreModel.removeSelection()
             }
 
             onRemoveSelectionRequested: {
-                instrumentsOnScoreModel.removeSelection()
+                root.instrumentsOnScoreModel.removeSelection()
             }
         }
     }

--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/InstrumentsOnScoreView.qml
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/InstrumentsOnScoreView.qml
@@ -33,30 +33,30 @@ Item {
     required property InstrumentsOnScoreListModel instrumentsOnScoreModel
 
     readonly property bool hasInstruments: instrumentsOnScoreModel.count > 0
-    readonly property alias isMovingUpAvailable: instrumentsOnScoreModel.isMovingUpAvailable
-    readonly property alias isMovingDownAvailable: instrumentsOnScoreModel.isMovingDownAvailable
+    // readonly property alias isMovingUpAvailable: instrumentsOnScoreModel.isMovingUpAvailable
+    // readonly property alias isMovingDownAvailable: instrumentsOnScoreModel.isMovingDownAvailable
 
     property alias navigation: instrumentsView.navigation
 
-    function instruments() {
-        return instrumentsOnScoreModel.instruments()
-    }
+    // function instruments() {
+    //     return instrumentsOnScoreModel.instruments()
+    // }
 
-    function currentOrder() {
-        return instrumentsOnScoreModel.currentOrder()
-    }
+    // function currentOrder() {
+    //     return instrumentsOnScoreModel.currentOrder()
+    // }
 
-    function addInstruments(instruments) {
-        instrumentsOnScoreModel.addInstruments(instruments)
-    }
+    // function addInstruments(instruments) {
+    //     instrumentsOnScoreModel.addInstruments(instruments)
+    // }
 
-    function moveSelectedInstrumentsUp() {
-        instrumentsOnScoreModel.moveSelectionUp()
-    }
+    // function moveSelectedInstrumentsUp() {
+    //     instrumentsOnScoreModel.moveSelectionUp()
+    // }
 
-    function moveSelectedInstrumentsDown() {
-        instrumentsOnScoreModel.moveSelectionDown()
-    }
+    // function moveSelectedInstrumentsDown() {
+    //     instrumentsOnScoreModel.moveSelectionDown()
+    // }
 
     function scrollViewToEnd() {
         instrumentsView.positionViewAtEnd()

--- a/src/project/qml/MuseScore/Project/internal/NewScore/ChooseInstrumentsAndTemplatesPage.qml
+++ b/src/project/qml/MuseScore/Project/internal/NewScore/ChooseInstrumentsAndTemplatesPage.qml
@@ -75,6 +75,14 @@ Item {
         pageLoader.item.navigation.requestActive()
     }
 
+    Component.onCompleted: {
+        theInstrumentsOnScoreModel.load()
+    }
+
+    InstrumentsOnScoreListModel {
+        id: theInstrumentsOnScoreModel
+    }
+
     StyledTabBar {
         id: bar
 
@@ -138,10 +146,6 @@ Item {
 
             bar.completed = true
         }
-    }
-
-    InstrumentsOnScoreListModel {
-        id: theInstrumentsOnScoreModel
     }
 
     Loader {

--- a/src/project/qml/MuseScore/Project/internal/NewScore/ChooseInstrumentsAndTemplatesPage.qml
+++ b/src/project/qml/MuseScore/Project/internal/NewScore/ChooseInstrumentsAndTemplatesPage.qml
@@ -27,9 +27,10 @@ import Muse.Ui 1.0
 import Muse.UiComponents 1.0
 import MuseScore.Project 1.0
 import MuseScore.InstrumentsScene 1.0
-
 Item {
     id: root
+
+    required property InstrumentsOnScoreListModel instrumentsOnScoreModel
 
     property string preferredScoreCreationMode: ""
 
@@ -140,6 +141,10 @@ Item {
         }
     }
 
+    InstrumentsOnScoreListModel {
+        id: instrumentsOnScoreModel
+    }
+
     Loader {
         id: pageLoader
 
@@ -168,6 +173,7 @@ Item {
 
         ChooseInstrumentsPage {
             navigationSection: root.navigationSection
+            instrumentsOnScoreModel: instrumentsOnScoreModel
         }
     }
 

--- a/src/project/qml/MuseScore/Project/internal/NewScore/ChooseInstrumentsAndTemplatesPage.qml
+++ b/src/project/qml/MuseScore/Project/internal/NewScore/ChooseInstrumentsAndTemplatesPage.qml
@@ -27,10 +27,9 @@ import Muse.Ui 1.0
 import Muse.UiComponents 1.0
 import MuseScore.Project 1.0
 import MuseScore.InstrumentsScene 1.0
+
 Item {
     id: root
-
-    required property InstrumentsOnScoreListModel instrumentsOnScoreModel
 
     property string preferredScoreCreationMode: ""
 
@@ -142,7 +141,7 @@ Item {
     }
 
     InstrumentsOnScoreListModel {
-        id: instrumentsOnScoreModel
+        id: theInstrumentsOnScoreModel
     }
 
     Loader {
@@ -173,7 +172,7 @@ Item {
 
         ChooseInstrumentsPage {
             navigationSection: root.navigationSection
-            instrumentsOnScoreModel: instrumentsOnScoreModel
+            instrumentsOnScoreModel: theInstrumentsOnScoreModel
         }
     }
 


### PR DESCRIPTION
Resolves: #19359 

- Refactors the parseBatchJob function to correctly parse json conversion jobs with multiple outs and part conversions;
- Refactors batchConvert function to correctly call part-conversion functions;
- Refactors convertScorePartsToPngs and convertScorePartsToPdf to correctly convert the score parts;
- Adds convertScorePartsToMp3 to generate MP3 files of each score part

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
