### PR TITLE
page numbers in MusicXML export

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
@@ -423,7 +423,7 @@ private:
     void keysigTimesig(const Measure* m, const Part* p);
     void chordAttributes(Chord* chord, Notations& notations, Technical& technical, TrillHash& trillStart, TrillHash& trillStop);
     void wavyLineStartStop(const ChordRest* cr, Notations& notations, Ornaments& ornaments, TrillHash& trillStart, TrillHash& trillStop);
-    void print(const Measure* const m, const int partNr, const int firstStaffOfPart, const int nrStavesInPart,
+    void print(const Measure* const m, const int partNr, const int firstStaffOfPart, const size_t nrStavesInPart,
                const MeasurePrintContext& mpc);
     void measureLayout(const double distance);
     void findAndExportClef(const Measure* const m, const int staves, const track_idx_t strack, const track_idx_t etrack);
@@ -7161,7 +7161,7 @@ static bool hasPageBreak(const System* const system)
  */
 
 void ExportMusicXml::print(const Measure* const m, const int partNr, const int firstStaffOfPart,
-                           const int nrStavesInPart, const MeasurePrintContext& mpc)
+                           const size_t nrStavesInPart, const MeasurePrintContext& mpc)
 {
     const MeasureBase* const prevSysMB = lastMeasureBase(mpc.prevSystem);
 
@@ -7169,33 +7169,40 @@ void ExportMusicXml::print(const Measure* const m, const int partNr, const int f
     const bool prevMeasSectionBreak = prevSysMB ? prevSysMB->sectionBreak() : false;
     const bool prevPageBreak = hasPageBreak(mpc.lastSystemPrevPage);
 
-    String newSystemOrPage;               // new-[system|page]="yes" or empty
-    if (!mpc.scoreStart) {
-        IMusicXmlConfiguration::MusicXmlExportBreaksType exportBreaksType = configuration()->exportBreaksType();
+    XmlWriter::Attributes attributes;
 
+    IMusicXmlConfiguration::MusicXmlExportBreaksType exportBreaksType = configuration()->exportBreaksType();
+    if (!mpc.scoreStart) {
         if (exportBreaksType == IMusicXmlConfiguration::MusicXmlExportBreaksType::All) {
             if (mpc.pageStart) {
-                newSystemOrPage = u" new-page=\"yes\"";
+                attributes.push_back({ "new-page", "yes" });
             } else if (mpc.systemStart) {
-                newSystemOrPage = u" new-system=\"yes\"";
+                attributes.push_back({ "new-system", "yes" });
             }
         } else if (exportBreaksType == IMusicXmlConfiguration::MusicXmlExportBreaksType::Manual) {
             if (mpc.pageStart && prevPageBreak) {
-                newSystemOrPage = u" new-page=\"yes\"";
+                attributes.push_back({ "new-page", "yes" });
             } else if (mpc.systemStart && (prevMeasLineBreak || prevMeasSectionBreak)) {
-                newSystemOrPage = u" new-system=\"yes\"";
+                attributes.push_back({ "new-system", "yes" });
             }
         }
     }
 
-    bool doBreak = mpc.scoreStart || (!newSystemOrPage.empty());
+    if (mpc.pageStart && m->system()) {
+        const int pageNumber = m->system()->page()->no() + 1 + m->score()->pageNumberOffset();
+        if (exportBreaksType != IMusicXmlConfiguration::MusicXmlExportBreaksType::No) {
+            attributes.push_back({ "page-number", pageNumber });
+        }
+    }
+
+    bool doBreak = mpc.scoreStart || !attributes.empty();
     bool doLayout = configuration()->exportLayout();
 
     if (doBreak) {
         if (doLayout) {
-            m_xml.startElementRaw(String(u"print%1").arg(newSystemOrPage));
+            m_xml.startElement("print", attributes);
             const MStyle& style = score()->style();
-            const double pageWidth  = getTenthsFromInches(style.styleD(Sid::pageWidth));
+            const double pageWidth = getTenthsFromInches(style.styleD(Sid::pageWidth));
             const double lm = getTenthsFromInches(style.styleD(Sid::pageOddLeftMargin));
             const double rm = getTenthsFromInches(style.styleD(Sid::pageWidth)
                                                   - style.styleD(Sid::pagePrintableWidth)
@@ -7243,7 +7250,7 @@ void ExportMusicXml::print(const Measure* const m, const int partNr, const int f
             }
 
             // Staff layout elements.
-            for (int staffIdx = (firstStaffOfPart == 0) ? 1 : 0; staffIdx < nrStavesInPart; staffIdx++) {
+            for (size_t staffIdx = (firstStaffOfPart == 0) ? 1 : 0; staffIdx < nrStavesInPart; ++staffIdx) {
                 // calculate distance between this and previous staff using the bounding boxes
                 const int staffNr = firstStaffOfPart + staffIdx;
                 const RectF& prevBbox = system->staff(staffNr - 1)->bbox();
@@ -7260,8 +7267,8 @@ void ExportMusicXml::print(const Measure* const m, const int partNr, const int f
             }
 
             m_xml.endElement();
-        } else if (!newSystemOrPage.empty()) {
-            m_xml.tagRaw(String(u"print%1").arg(newSystemOrPage));
+        } else if (!attributes.empty()) {
+            m_xml.tag("print", attributes);
         }
     } else if (m->prev() && m->prev()->isHBox()) {
         m_xml.startElement("print");
@@ -8185,7 +8192,7 @@ void ExportMusicXml::writeMeasure(const Measure* const m,
 
     m_xml.startElementRaw(measureTag);
 
-    print(m, partIndex, staffCount, static_cast<int>(staves), mpc);
+    print(m, partIndex, staffCount, staves, mpc);
 
     m_attr.start();
 


### PR DESCRIPTION
This PR will add `page-number` elements to MusicXML export. 

NB: The first page always applies to `MusicXmlExportBreaksType::Manual`. So before adjusting all the test files, I'd like to ask for comments on this implementation. What is your take @miiizen? 