### PR TITLE
Fix #25048: Export Tempo as system text in MusicXML 

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
@@ -4993,7 +4993,6 @@ void ExportMusicXml::tempoText(TempoText const* const text, staff_idx_t staff)
            muPrintable(text->xmlText()));
     */
     m_attr.doAttr(m_xml, false);
-    #
 
     XmlWriter::Attributes tempoAttrs;
     tempoAttrs = { { "placement", (text->placement() == PlacementV::BELOW) ? "below" : "above" } };

--- a/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
@@ -4998,7 +4998,7 @@ void ExportMusicXml::tempoText(TempoText const* const text, staff_idx_t staff)
     XmlWriter::Attributes tempoAttrs;
     tempoAttrs = { { "placement", (text->placement() == PlacementV::BELOW) ? "below" : "above" } };
     if (text->systemFlag()) {
-        tempoAttrs.push_back({ "system", "only-top" });
+        tempoAttrs.push_back({ "system", text->isLinked() ? "also-top" : "only-top" });
     }
 
     m_xml.startElement("direction", tempoAttrs);

--- a/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
@@ -4993,7 +4993,15 @@ void ExportMusicXml::tempoText(TempoText const* const text, staff_idx_t staff)
            muPrintable(text->xmlText()));
     */
     m_attr.doAttr(m_xml, false);
-    m_xml.startElement("direction", { { "placement", (text->placement() == PlacementV::BELOW) ? "below" : "above" } });
+    #
+
+    XmlWriter::Attributes tempoAttrs;
+    tempoAttrs = { { "placement", (text->placement() == PlacementV::BELOW) ? "below" : "above" } };
+    if (text->systemFlag()) {
+        tempoAttrs.push_back({ "system", "only-top" });
+    }
+
+    m_xml.startElement("direction", tempoAttrs);
     wordsMetronome(m_xml, m_score->style(), text, offset);
 
     if (staff) {

--- a/src/importexport/musicxml/tests/data/testClefs2.xml
+++ b/src/importexport/musicxml/tests/data/testClefs2.xml
@@ -49,7 +49,7 @@
           <line>4</line>
           </clef>
         </attributes>
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>quarter</beat-unit>

--- a/src/importexport/musicxml/tests/data/testColorExport.xml
+++ b/src/importexport/musicxml/tests/data/testColorExport.xml
@@ -50,7 +50,7 @@
           </root>
         <kind text="7">dominant</kind>
         </harmony>
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <metronome parentheses="no" color="#942193">
             <beat-unit>quarter</beat-unit>

--- a/src/importexport/musicxml/tests/data/testColorExport_ref.xml
+++ b/src/importexport/musicxml/tests/data/testColorExport_ref.xml
@@ -50,7 +50,7 @@
           </root>
         <kind text="7">dominant</kind>
         </harmony>
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <metronome parentheses="no" color="#942193">
             <beat-unit>quarter</beat-unit>

--- a/src/importexport/musicxml/tests/data/testDirections2.xml
+++ b/src/importexport/musicxml/tests/data/testDirections2.xml
@@ -77,7 +77,7 @@
           <line>2</line>
           </clef>
         </attributes>
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <words font-weight="bold" font-size="12">Lento</words>
           </direction-type>
@@ -95,7 +95,7 @@
         <duration>4</duration>
         <voice>1</voice>
         </note>
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <words font-weight="bold" font-size="12">Andante</words>
           </direction-type>

--- a/src/importexport/musicxml/tests/data/testExcludeInvisibleElements_invisible_ref.xml
+++ b/src/importexport/musicxml/tests/data/testExcludeInvisibleElements_invisible_ref.xml
@@ -157,7 +157,7 @@
         </note>
       </measure>
     <measure number="3">
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>quarter</beat-unit>
@@ -186,7 +186,7 @@
         <type>quarter</type>
         <stem>up</stem>
         </note>
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <metronome parentheses="no" print-object="no">
             <beat-unit>quarter</beat-unit>

--- a/src/importexport/musicxml/tests/data/testExcludeInvisibleElements_noinvisible_ref.xml
+++ b/src/importexport/musicxml/tests/data/testExcludeInvisibleElements_noinvisible_ref.xml
@@ -144,7 +144,7 @@
         </note>
       </measure>
     <measure number="3">
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>quarter</beat-unit>

--- a/src/importexport/musicxml/tests/data/testInvalidLayout_ref.xml
+++ b/src/importexport/musicxml/tests/data/testInvalidLayout_ref.xml
@@ -50,7 +50,7 @@
           <multiple-rest>3</multiple-rest>
           </measure-style>
         </attributes>
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>quarter</beat-unit>

--- a/src/importexport/musicxml/tests/data/testInvisibleDirection.xml
+++ b/src/importexport/musicxml/tests/data/testInvisibleDirection.xml
@@ -48,7 +48,7 @@
           <line>2</line>
           </clef>
         </attributes>
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <metronome parentheses="no" print-object="no">
             <beat-unit>quarter</beat-unit>

--- a/src/importexport/musicxml/tests/data/testSound1_ref.xml
+++ b/src/importexport/musicxml/tests/data/testSound1_ref.xml
@@ -43,7 +43,7 @@
           <line>2</line>
           </clef>
         </attributes>
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <metronome parentheses="no" print-object="no">
             <beat-unit>quarter</beat-unit>

--- a/src/importexport/musicxml/tests/data/testSound2_ref.xml
+++ b/src/importexport/musicxml/tests/data/testSound2_ref.xml
@@ -43,7 +43,7 @@
           <line>2</line>
           </clef>
         </attributes>
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <metronome parentheses="no" print-object="no">
             <beat-unit>quarter</beat-unit>

--- a/src/importexport/musicxml/tests/data/testSwing_ref.xml
+++ b/src/importexport/musicxml/tests/data/testSwing_ref.xml
@@ -52,7 +52,7 @@
           <octave-change>1</octave-change>
           </transpose>
         </attributes>
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>quarter</beat-unit>

--- a/src/importexport/musicxml/tests/data/testSystemDirection.xml
+++ b/src/importexport/musicxml/tests/data/testSystemDirection.xml
@@ -118,7 +118,7 @@
           <words>Stave text</words>
           </direction-type>
         </direction>
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <words font-weight="bold" font-size="12">Largo</words>
           </direction-type>

--- a/src/importexport/musicxml/tests/data/testTempo1.xml
+++ b/src/importexport/musicxml/tests/data/testTempo1.xml
@@ -48,7 +48,7 @@
           <line>2</line>
           </clef>
         </attributes>
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <words font-weight="bold" font-size="12">Largo </words>
           </direction-type>
@@ -145,7 +145,7 @@
         </note>
       </measure>
     <measure number="3">
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <words font-weight="bold" font-size="12">Andante</words>
           </direction-type>
@@ -235,7 +235,7 @@
         </note>
       </measure>
     <measure number="5">
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <words font-weight="bold" font-size="12">Vivace</words>
           </direction-type>

--- a/src/importexport/musicxml/tests/data/testTempo2_ref.xml
+++ b/src/importexport/musicxml/tests/data/testTempo2_ref.xml
@@ -49,7 +49,7 @@
           <line>2</line>
           </clef>
         </attributes>
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>quarter</beat-unit>
@@ -100,7 +100,7 @@
         </note>
       </measure>
     <measure number="2">
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>quarter</beat-unit>
@@ -152,7 +152,7 @@
         </note>
       </measure>
     <measure number="3">
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>half</beat-unit>

--- a/src/importexport/musicxml/tests/data/testTempo3_ref.xml
+++ b/src/importexport/musicxml/tests/data/testTempo3_ref.xml
@@ -54,7 +54,7 @@
           <words>Swing!</words>
           </direction-type>
         </direction>
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>half</beat-unit>

--- a/src/importexport/musicxml/tests/data/testTempo4_ref.xml
+++ b/src/importexport/musicxml/tests/data/testTempo4_ref.xml
@@ -63,7 +63,7 @@
           <line>2</line>
           </clef>
         </attributes>
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>quarter</beat-unit>
@@ -102,7 +102,7 @@
           <line>2</line>
           </clef>
         </attributes>
-      <direction placement="above">
+      <direction placement="above" system="also-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>quarter</beat-unit>

--- a/src/importexport/musicxml/tests/data/testTempo5.xml
+++ b/src/importexport/musicxml/tests/data/testTempo5.xml
@@ -49,7 +49,7 @@
           <line>2</line>
           </clef>
         </attributes>
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>breve</beat-unit>
@@ -69,7 +69,7 @@
         </note>
       </measure>
     <measure number="2">
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>whole</beat-unit>
@@ -89,7 +89,7 @@
         </note>
       </measure>
     <measure number="3">
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>half</beat-unit>
@@ -109,7 +109,7 @@
         </note>
       </measure>
     <measure number="4">
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>quarter</beat-unit>
@@ -129,7 +129,7 @@
         </note>
       </measure>
     <measure number="5">
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>eighth</beat-unit>
@@ -149,7 +149,7 @@
         </note>
       </measure>
     <measure number="6">
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>16th</beat-unit>
@@ -169,7 +169,7 @@
         </note>
       </measure>
     <measure number="7">
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>32nd</beat-unit>
@@ -189,7 +189,7 @@
         </note>
       </measure>
     <measure number="8">
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>64th</beat-unit>
@@ -209,7 +209,7 @@
         </note>
       </measure>
     <measure number="9">
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>128th</beat-unit>
@@ -229,7 +229,7 @@
         </note>
       </measure>
     <measure number="10">
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>256th</beat-unit>
@@ -249,7 +249,7 @@
         </note>
       </measure>
     <measure number="11">
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>512th</beat-unit>
@@ -269,7 +269,7 @@
         </note>
       </measure>
     <measure number="12">
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>1024th</beat-unit>

--- a/src/importexport/musicxml/tests/data/testTempo6.xml
+++ b/src/importexport/musicxml/tests/data/testTempo6.xml
@@ -49,7 +49,7 @@
           <line>2</line>
           </clef>
         </attributes>
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>quarter</beat-unit>
@@ -73,7 +73,7 @@
         </note>
       </measure>
     <measure number="2">
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>quarter</beat-unit>
@@ -97,7 +97,7 @@
         </note>
       </measure>
     <measure number="3">
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>quarter</beat-unit>

--- a/src/importexport/musicxml/tests/data/testTempoOverlap_ref.xml
+++ b/src/importexport/musicxml/tests/data/testTempoOverlap_ref.xml
@@ -82,7 +82,7 @@
           <words>Direction metronome with sound tempo</words>
           </direction-type>
         </direction>
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>quarter</beat-unit>
@@ -98,7 +98,7 @@
         </note>
       </measure>
     <measure number="2">
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>quarter</beat-unit>
@@ -114,7 +114,7 @@
         </note>
       </measure>
     <measure number="3">
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>quarter</beat-unit>
@@ -130,7 +130,7 @@
         </note>
       </measure>
     <measure number="4">
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>quarter</beat-unit>
@@ -152,7 +152,7 @@
           <words>Voice</words>
           </direction-type>
         </direction>
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>quarter</beat-unit>
@@ -168,7 +168,7 @@
         </note>
       </measure>
     <measure number="6">
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>quarter</beat-unit>
@@ -189,7 +189,7 @@
           <words>Voice</words>
           </direction-type>
         </direction>
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>quarter</beat-unit>
@@ -211,7 +211,7 @@
           <words>Direction words (empty) with sound tempo</words>
           </direction-type>
         </direction>
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <metronome parentheses="no" print-object="no">
             <beat-unit>quarter</beat-unit>
@@ -227,7 +227,7 @@
         </note>
       </measure>
     <measure number="9">
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <metronome parentheses="no" print-object="no">
             <beat-unit>quarter</beat-unit>
@@ -254,7 +254,7 @@
           <words>Sound tempo only</words>
           </direction-type>
         </direction>
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <metronome parentheses="no" print-object="no">
             <beat-unit>quarter</beat-unit>
@@ -270,7 +270,7 @@
         </note>
       </measure>
     <measure number="11">
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <metronome parentheses="no" print-object="no">
             <beat-unit>quarter</beat-unit>
@@ -286,7 +286,7 @@
         </note>
       </measure>
     <measure number="12">
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <metronome parentheses="no" print-object="no">
             <beat-unit>quarter</beat-unit>
@@ -302,7 +302,7 @@
         </note>
       </measure>
     <measure number="13">
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <metronome parentheses="no" print-object="no">
             <beat-unit>quarter</beat-unit>
@@ -324,7 +324,7 @@
           <words>Voice</words>
           </direction-type>
         </direction>
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <metronome parentheses="no" print-object="no">
             <beat-unit>quarter</beat-unit>
@@ -340,7 +340,7 @@
         </note>
       </measure>
     <measure number="15">
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <metronome parentheses="no" print-object="no">
             <beat-unit>quarter</beat-unit>
@@ -361,7 +361,7 @@
           <words>Voice</words>
           </direction-type>
         </direction>
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <metronome parentheses="no" print-object="no">
             <beat-unit>quarter</beat-unit>
@@ -401,7 +401,7 @@
           <line>4</line>
           </clef>
         </attributes>
-      <direction placement="above">
+      <direction placement="above" system="also-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>quarter</beat-unit>
@@ -420,7 +420,7 @@
       <backup>
         <duration>4</duration>
         </backup>
-      <direction placement="above">
+      <direction placement="above" system="also-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>quarter</beat-unit>
@@ -444,7 +444,7 @@
           </direction-type>
         <staff>1</staff>
         </direction>
-      <direction placement="above">
+      <direction placement="above" system="also-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>quarter</beat-unit>
@@ -463,7 +463,7 @@
       <backup>
         <duration>4</duration>
         </backup>
-      <direction placement="above">
+      <direction placement="above" system="also-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>quarter</beat-unit>
@@ -481,7 +481,7 @@
         </note>
       </measure>
     <measure number="3">
-      <direction placement="above">
+      <direction placement="above" system="also-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>quarter</beat-unit>
@@ -506,7 +506,7 @@
           </direction-type>
         <staff>2</staff>
         </direction>
-      <direction placement="above">
+      <direction placement="above" system="also-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>quarter</beat-unit>
@@ -524,7 +524,7 @@
         </note>
       </measure>
     <measure number="4">
-      <direction placement="above">
+      <direction placement="above" system="also-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>quarter</beat-unit>
@@ -543,7 +543,7 @@
       <backup>
         <duration>4</duration>
         </backup>
-      <direction placement="above">
+      <direction placement="above" system="also-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>quarter</beat-unit>
@@ -562,7 +562,7 @@
       </measure>
     <measure number="5">
       <print new-system="yes"/>
-      <direction placement="above">
+      <direction placement="above" system="also-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>quarter</beat-unit>
@@ -581,7 +581,7 @@
       <backup>
         <duration>4</duration>
         </backup>
-      <direction placement="above">
+      <direction placement="above" system="also-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>quarter</beat-unit>
@@ -605,7 +605,7 @@
           </direction-type>
         <staff>1</staff>
         </direction>
-      <direction placement="above">
+      <direction placement="above" system="also-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>quarter</beat-unit>
@@ -630,7 +630,7 @@
           </direction-type>
         <staff>2</staff>
         </direction>
-      <direction placement="above">
+      <direction placement="above" system="also-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>quarter</beat-unit>
@@ -654,7 +654,7 @@
           </direction-type>
         <staff>1</staff>
         </direction>
-      <direction placement="above">
+      <direction placement="above" system="also-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>quarter</beat-unit>
@@ -673,7 +673,7 @@
       <backup>
         <duration>4</duration>
         </backup>
-      <direction placement="above">
+      <direction placement="above" system="also-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>quarter</beat-unit>
@@ -698,7 +698,7 @@
           </direction-type>
         <staff>1</staff>
         </direction>
-      <direction placement="above">
+      <direction placement="above" system="also-top">
         <direction-type>
           <metronome parentheses="no" print-object="no">
             <beat-unit>quarter</beat-unit>
@@ -717,7 +717,7 @@
       <backup>
         <duration>4</duration>
         </backup>
-      <direction placement="above">
+      <direction placement="above" system="also-top">
         <direction-type>
           <metronome parentheses="no" print-object="no">
             <beat-unit>quarter</beat-unit>
@@ -741,7 +741,7 @@
           </direction-type>
         <staff>1</staff>
         </direction>
-      <direction placement="above">
+      <direction placement="above" system="also-top">
         <direction-type>
           <metronome parentheses="no" print-object="no">
             <beat-unit>quarter</beat-unit>
@@ -766,7 +766,7 @@
           </direction-type>
         <staff>2</staff>
         </direction>
-      <direction placement="above">
+      <direction placement="above" system="also-top">
         <direction-type>
           <metronome parentheses="no" print-object="no">
             <beat-unit>quarter</beat-unit>
@@ -785,7 +785,7 @@
       </measure>
     <measure number="10">
       <print new-system="yes"/>
-      <direction placement="above">
+      <direction placement="above" system="also-top">
         <direction-type>
           <metronome parentheses="no" print-object="no">
             <beat-unit>quarter</beat-unit>
@@ -804,7 +804,7 @@
       <backup>
         <duration>4</duration>
         </backup>
-      <direction placement="above">
+      <direction placement="above" system="also-top">
         <direction-type>
           <metronome parentheses="no" print-object="no">
             <beat-unit>quarter</beat-unit>
@@ -828,7 +828,7 @@
           </direction-type>
         <staff>1</staff>
         </direction>
-      <direction placement="above">
+      <direction placement="above" system="also-top">
         <direction-type>
           <metronome parentheses="no" print-object="no">
             <beat-unit>quarter</beat-unit>
@@ -847,7 +847,7 @@
       <backup>
         <duration>4</duration>
         </backup>
-      <direction placement="above">
+      <direction placement="above" system="also-top">
         <direction-type>
           <metronome parentheses="no" print-object="no">
             <beat-unit>quarter</beat-unit>
@@ -865,7 +865,7 @@
         </note>
       </measure>
     <measure number="12">
-      <direction placement="above">
+      <direction placement="above" system="also-top">
         <direction-type>
           <metronome parentheses="no" print-object="no">
             <beat-unit>quarter</beat-unit>
@@ -890,7 +890,7 @@
           </direction-type>
         <staff>2</staff>
         </direction>
-      <direction placement="above">
+      <direction placement="above" system="also-top">
         <direction-type>
           <metronome parentheses="no" print-object="no">
             <beat-unit>quarter</beat-unit>
@@ -908,7 +908,7 @@
         </note>
       </measure>
     <measure number="13">
-      <direction placement="above">
+      <direction placement="above" system="also-top">
         <direction-type>
           <metronome parentheses="no" print-object="no">
             <beat-unit>quarter</beat-unit>
@@ -927,7 +927,7 @@
       <backup>
         <duration>4</duration>
         </backup>
-      <direction placement="above">
+      <direction placement="above" system="also-top">
         <direction-type>
           <metronome parentheses="no" print-object="no">
             <beat-unit>quarter</beat-unit>
@@ -946,7 +946,7 @@
       </measure>
     <measure number="14">
       <print new-system="yes"/>
-      <direction placement="above">
+      <direction placement="above" system="also-top">
         <direction-type>
           <metronome parentheses="no" print-object="no">
             <beat-unit>quarter</beat-unit>
@@ -965,7 +965,7 @@
       <backup>
         <duration>4</duration>
         </backup>
-      <direction placement="above">
+      <direction placement="above" system="also-top">
         <direction-type>
           <metronome parentheses="no" print-object="no">
             <beat-unit>quarter</beat-unit>
@@ -989,7 +989,7 @@
           </direction-type>
         <staff>1</staff>
         </direction>
-      <direction placement="above">
+      <direction placement="above" system="also-top">
         <direction-type>
           <metronome parentheses="no" print-object="no">
             <beat-unit>quarter</beat-unit>
@@ -1014,7 +1014,7 @@
           </direction-type>
         <staff>2</staff>
         </direction>
-      <direction placement="above">
+      <direction placement="above" system="also-top">
         <direction-type>
           <metronome parentheses="no" print-object="no">
             <beat-unit>quarter</beat-unit>
@@ -1038,7 +1038,7 @@
           </direction-type>
         <staff>1</staff>
         </direction>
-      <direction placement="above">
+      <direction placement="above" system="also-top">
         <direction-type>
           <metronome parentheses="no" print-object="no">
             <beat-unit>quarter</beat-unit>
@@ -1057,7 +1057,7 @@
       <backup>
         <duration>4</duration>
         </backup>
-      <direction placement="above">
+      <direction placement="above" system="also-top">
         <direction-type>
           <metronome parentheses="no" print-object="no">
             <beat-unit>quarter</beat-unit>
@@ -1099,7 +1099,7 @@
           <octave-change>-1</octave-change>
           </transpose>
         </attributes>
-      <direction placement="above">
+      <direction placement="above" system="also-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>quarter</beat-unit>
@@ -1115,7 +1115,7 @@
         </note>
       </measure>
     <measure number="2">
-      <direction placement="above">
+      <direction placement="above" system="also-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>quarter</beat-unit>
@@ -1131,7 +1131,7 @@
         </note>
       </measure>
     <measure number="3">
-      <direction placement="above">
+      <direction placement="above" system="also-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>quarter</beat-unit>
@@ -1152,7 +1152,7 @@
           <words>Bass</words>
           </direction-type>
         </direction>
-      <direction placement="above">
+      <direction placement="above" system="also-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>quarter</beat-unit>
@@ -1174,7 +1174,7 @@
           <words>Bass</words>
           </direction-type>
         </direction>
-      <direction placement="above">
+      <direction placement="above" system="also-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>quarter</beat-unit>
@@ -1190,7 +1190,7 @@
         </note>
       </measure>
     <measure number="6">
-      <direction placement="above">
+      <direction placement="above" system="also-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>quarter</beat-unit>
@@ -1211,7 +1211,7 @@
           <words>Bass</words>
           </direction-type>
         </direction>
-      <direction placement="above">
+      <direction placement="above" system="also-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>quarter</beat-unit>
@@ -1228,7 +1228,7 @@
       </measure>
     <measure number="8">
       <print new-system="yes"/>
-      <direction placement="above">
+      <direction placement="above" system="also-top">
         <direction-type>
           <metronome parentheses="no" print-object="no">
             <beat-unit>quarter</beat-unit>
@@ -1244,7 +1244,7 @@
         </note>
       </measure>
     <measure number="9">
-      <direction placement="above">
+      <direction placement="above" system="also-top">
         <direction-type>
           <metronome parentheses="no" print-object="no">
             <beat-unit>quarter</beat-unit>
@@ -1261,7 +1261,7 @@
       </measure>
     <measure number="10">
       <print new-system="yes"/>
-      <direction placement="above">
+      <direction placement="above" system="also-top">
         <direction-type>
           <metronome parentheses="no" print-object="no">
             <beat-unit>quarter</beat-unit>
@@ -1277,7 +1277,7 @@
         </note>
       </measure>
     <measure number="11">
-      <direction placement="above">
+      <direction placement="above" system="also-top">
         <direction-type>
           <metronome parentheses="no" print-object="no">
             <beat-unit>quarter</beat-unit>
@@ -1293,7 +1293,7 @@
         </note>
       </measure>
     <measure number="12">
-      <direction placement="above">
+      <direction placement="above" system="also-top">
         <direction-type>
           <metronome parentheses="no" print-object="no">
             <beat-unit>quarter</beat-unit>
@@ -1314,7 +1314,7 @@
           <words>Bass</words>
           </direction-type>
         </direction>
-      <direction placement="above">
+      <direction placement="above" system="also-top">
         <direction-type>
           <metronome parentheses="no" print-object="no">
             <beat-unit>quarter</beat-unit>
@@ -1336,7 +1336,7 @@
           <words>Bass</words>
           </direction-type>
         </direction>
-      <direction placement="above">
+      <direction placement="above" system="also-top">
         <direction-type>
           <metronome parentheses="no" print-object="no">
             <beat-unit>quarter</beat-unit>
@@ -1352,7 +1352,7 @@
         </note>
       </measure>
     <measure number="15">
-      <direction placement="above">
+      <direction placement="above" system="also-top">
         <direction-type>
           <metronome parentheses="no" print-object="no">
             <beat-unit>quarter</beat-unit>
@@ -1373,7 +1373,7 @@
           <words>Bass</words>
           </direction-type>
         </direction>
-      <direction placement="above">
+      <direction placement="above" system="also-top">
         <direction-type>
           <metronome parentheses="no" print-object="no">
             <beat-unit>quarter</beat-unit>

--- a/src/importexport/musicxml/tests/data/testTempoPrecision_ref.xml
+++ b/src/importexport/musicxml/tests/data/testTempoPrecision_ref.xml
@@ -48,7 +48,7 @@
           <line>2</line>
           </clef>
         </attributes>
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>quarter</beat-unit>
@@ -64,7 +64,7 @@
         </note>
       </measure>
     <measure number="2">
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <words font-weight="bold" font-size="12">Andante</words>
           </direction-type>

--- a/src/importexport/musicxml/tests/data/testTuplets4.xml
+++ b/src/importexport/musicxml/tests/data/testTuplets4.xml
@@ -49,7 +49,7 @@
           <line>2</line>
           </clef>
         </attributes>
-      <direction placement="above">
+      <direction placement="above" system="only-top">
         <direction-type>
           <metronome parentheses="no">
             <beat-unit>quarter</beat-unit>


### PR DESCRIPTION
Properly mark tempo as system text in MusicXML export.

Resolves: #25048 and #17431
