### PR TITLE
Qt 6.8 preparation: Qt::UniqueConnection can only be used with QObject member functions

### DIFF
--- a/src/framework/dockwindow/view/dockwindow.h
+++ b/src/framework/dockwindow/view/dockwindow.h
@@ -151,6 +151,9 @@ private:
     uicomponents::QmlListProperty<DockPageView> m_pages;
     async::Channel<QStringList> m_docksOpenStatusChanged;
 
+    class UniqueConnectionHolder;
+    QHash<DockPageView*, UniqueConnectionHolder*> m_pageConnections;
+
     bool m_hasGeometryBeenRestored = false;
     bool m_reloadCurrentPageAllowed = false;
 };


### PR DESCRIPTION
This has been the case always, but only since a few Qt versions it causes an assertion failure.

This is my quick-and-dirty fix cherry-picked from #25016. I'm not sure if it is the simplest/cleanest thing we can do, but it is the closest equivalent to a capturing lambda.

@Eism I'm aware that this may be obsoleted by your work on the KDDockWidgets 2.1 update; if that's the case, feel free to close this!

Resolves: https://github.com/musescore/MuseScore/issues/24716
Resolves: https://github.com/musescore/MuseScore/issues/25307