### PR TITLE
Decouple `EngravingItem` icon engine logic from palette module

### DIFF
--- a/src/engraving/CMakeLists.txt
+++ b/src/engraving/CMakeLists.txt
@@ -207,6 +207,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/rendering/layoutoptions.h
     ${CMAKE_CURRENT_LIST_DIR}/rendering/paddingtable.cpp
     ${CMAKE_CURRENT_LIST_DIR}/rendering/paddingtable.h
+    ${CMAKE_CURRENT_LIST_DIR}/rendering/engravingitempreviewpainter.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/rendering/engravingitempreviewpainter.h
 
     ${RENDERING_SCORE_SRC}
     ${RENDERING_SINGLE_SRC}

--- a/src/engraving/rendering/engravingitempreviewpainter.cpp
+++ b/src/engraving/rendering/engravingitempreviewpainter.cpp
@@ -1,0 +1,191 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2024 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "engravingitempreviewpainter.h"
+
+#include "engraving/dom/actionicon.h"
+#include "engraving/style/defaultstyle.h"
+#include "engraving/dom/masterscore.h"
+
+using namespace mu::engraving::rendering;
+using namespace muse::draw;
+
+/// Paint an EngravingItem - include a staff if specified in the params.
+void EngravingItemPreviewPainter::paintPreview(mu::engraving::EngravingItem* element, PaintParams& params)
+{
+    IF_ASSERT_FAILED(element && params.painter) {
+        return;
+    }
+
+    Painter* painter = params.painter;
+    painter->setPen(params.color);
+
+    if (element->isActionIcon()) {
+        paintPreviewForActionIcon(element, params);
+        return; // never draw staff for icon elements
+    }
+
+    PointF origin = params.rect.center(); // draw element at center of cell by default
+    if (params.drawStaff) {
+        const double topLinePos = paintStaff(params); // draw dummy staff lines onto rect.
+        origin.setY(topLinePos); // vertical position relative to staff instead of cell center.
+    }
+
+    painter->translate(origin);
+
+    painter->translate(params.xoffset * params.spatium, params.yoffset * params.spatium); // additional offset for element only
+
+    paintPreviewForItem(element, params);
+}
+
+void EngravingItemPreviewPainter::paintItem(mu::engraving::EngravingItem* element, PaintParams& params)
+{
+    IF_ASSERT_FAILED(element && params.painter) {
+        return;
+    }
+
+    const auto doPaint = [](void* context, EngravingItem* item) {
+        PaintParams* ctx = static_cast<PaintParams*>(context);
+        Painter* painter = ctx->painter;
+
+        painter->save();
+        painter->translate(item->pos()); // necessary for drawing child items
+
+        const Color colorBackup = item->getProperty(Pid::COLOR).value<Color>();
+        const Color frameColorBackup = item->getProperty(Pid::FRAME_FG_COLOR).value<Color>();
+        const bool colorsInversionEnabledBackup = item->colorsInversionEnabled();
+
+        item->setColorsInverionEnabled(ctx->colorsInversionEnabled);
+
+        if (!ctx->useElementColors) {
+            const Color color = ctx->color;
+            item->setProperty(Pid::COLOR, color);
+            item->setProperty(Pid::FRAME_FG_COLOR, color);
+        }
+
+        engravingRender()->drawItem(item, painter);
+
+        item->setColorsInverionEnabled(colorsInversionEnabledBackup);
+        item->setProperty(Pid::COLOR, colorBackup);
+        item->setProperty(Pid::FRAME_FG_COLOR, frameColorBackup);
+
+        painter->restore();
+    };
+
+    element->scanElements(&params, doPaint);
+}
+
+/// Paint an icon element so that it fills a QRect, preserving aspect ratio, and
+/// leaving a small margin around the edges.
+void EngravingItemPreviewPainter::paintPreviewForActionIcon(mu::engraving::EngravingItem* element, PaintParams& params)
+{
+    IF_ASSERT_FAILED(element && element->isActionIcon() && params.painter) {
+        return;
+    }
+
+    Painter* painter = params.painter;
+    painter->save();
+
+    double DPIscaling = (mu::engraving::DPI / mu::engraving::DPI_F) / params.dpi;
+
+    ActionIcon* action = toActionIcon(element);
+    action->setFontSize(ActionIcon::DEFAULT_FONT_SIZE * params.mag * DPIscaling);
+
+    engravingRender()->layoutItem(action);
+
+    painter->translate(params.rect.center() - action->ldata()->bbox().center());
+    engravingRender()->drawItem(action, painter);
+    painter->restore();
+}
+
+/// Paint a 5 line staff centered within a QRect and return the distance from the
+/// top of the QRect to the uppermost staff line.
+double EngravingItemPreviewPainter::paintStaff(PaintParams& params)
+{
+    IF_ASSERT_FAILED(params.painter) {
+        return 0.0;
+    }
+
+    Painter* painter = params.painter;
+    painter->save();
+
+    Color staffLinesColor(params.color);
+    staffLinesColor.setAlpha(127); //reduce alpha of staff lines to half
+    Pen pen(staffLinesColor);
+    pen.setWidthF(engraving::DefaultStyle::defaultStyle().styleS(Sid::staffLineWidth).val() * params.spatium);
+    painter->setPen(pen);
+
+    constexpr int numStaffLines = 5;
+    const double staffHeight = params.spatium * (numStaffLines - 1);
+    const double topLineDist = params.rect.center().y() - (staffHeight / 2.0);
+
+    // lines bounded horizontally by edge of target (with small margin)
+    constexpr double margin = 3.0;
+    const double x1 = params.rect.left() + margin;
+    const double x2 = params.rect.right() - margin;
+
+    // draw staff lines with middle line centered vertically on target
+    double y = topLineDist;
+    for (int i = 0; i < numStaffLines; ++i) {
+        painter->drawLine(LineF(x1, y, x2, y));
+        y += params.spatium;
+    }
+
+    painter->restore();
+    return topLineDist;
+}
+
+/// Paint a non-icon element centered at the origin of the painter's coordinate
+/// system. If drawStaff is true then the element is only centered horizontally;
+/// i.e. vertical alignment is unchanged from the default so that item will appear
+/// at the correct height on the staff.
+void EngravingItemPreviewPainter::paintPreviewForItem(mu::engraving::EngravingItem* element, PaintParams& params)
+{
+    IF_ASSERT_FAILED(element && !element->isActionIcon() && params.painter) {
+        return;
+    }
+
+    Painter* painter = params.painter;
+    painter->save();
+
+    mu::engraving::MScore::pixelRatio = mu::engraving::DPI / params.dpi;
+
+    const double sizeRatio = params.spatium / gpaletteScore->style().spatium();
+    painter->scale(sizeRatio, sizeRatio); // scale coordinates so element is drawn at correct size
+
+    // calculate bbox
+    engravingRender()->layoutItem(element);
+
+    PointF origin = element->ldata()->bbox().center();
+
+    if (params.drawStaff) {
+        // y = 0 is position of the element's parent.
+        // If the parent is the staff (or a segment on the staff) then
+        // y = 0 corresponds to the position of the top staff line.
+        origin.setY(0.0);
+    }
+
+    painter->translate(-1.0 * origin); // shift coordinates so element is drawn at correct position
+
+    paintItem(element, params);
+    painter->restore();
+}

--- a/src/engraving/rendering/engravingitempreviewpainter.h
+++ b/src/engraving/rendering/engravingitempreviewpainter.h
@@ -1,0 +1,62 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2024 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "modularity/ioc.h"
+#include "engraving/dom/engravingitem.h"
+#include "engraving/rendering/isinglerenderer.h"
+
+namespace mu::engraving::rendering {
+class EngravingItemPreviewPainter
+{
+    INJECT_STATIC(engraving::rendering::ISingleRenderer, engravingRender)
+
+public:
+    struct PaintParams
+    {
+        muse::draw::Painter* painter = nullptr;
+
+        Color color;
+
+        double mag = 1.0;
+        double xoffset = 0.0;
+        double yoffset = 0.0;
+
+        muse::RectF rect;
+        double dpi = 1.0;
+        double spatium = 1.0;
+
+        bool useElementColors = false;
+        bool colorsInversionEnabled = false;
+        bool drawStaff = false;
+    };
+
+    static void paintPreview(mu::engraving::EngravingItem* element, PaintParams& params);
+    static void paintItem(mu::engraving::EngravingItem* element, PaintParams& params);
+
+private:
+    static void paintPreviewForItem(mu::engraving::EngravingItem* element, PaintParams& params);
+    static void paintPreviewForActionIcon(mu::engraving::EngravingItem* element, PaintParams& params);
+    static double paintStaff(PaintParams& params);
+};
+}

--- a/src/palette/internal/palettecelliconengine.cpp
+++ b/src/palette/internal/palettecelliconengine.cpp
@@ -30,6 +30,7 @@
 #include "engraving/dom/engravingitem.h"
 #include "engraving/dom/masterscore.h"
 #include "engraving/style/defaultstyle.h"
+#include "engraving/rendering/engravingitempreviewpainter.h"
 
 #include "log.h"
 
@@ -70,26 +71,22 @@ void PaletteCellIconEngine::paintCell(Painter& painter, const RectF& rect, bool 
         return;
     }
 
-    painter.setPen(configuration()->elementsColor());
+    rendering::EngravingItemPreviewPainter::PaintParams params;
+    params.painter = &painter;
 
-    if (element->isActionIcon()) {
-        paintActionIcon(painter, rect, element, dpi);
-        return; // never draw staff for icon elements
-    }
+    params.color = configuration()->elementsColor();
 
-    const bool drawStaff = m_cell->drawStaff;
-    const qreal spatium = configuration()->paletteSpatium() * m_extraMag * m_cell->mag;
+    params.mag = m_extraMag * m_cell->mag;
+    params.xoffset = m_cell->xoffset;
+    params.yoffset = m_cell->yoffset;
 
-    PointF origin = rect.center(); // draw element at center of cell by default
-    if (drawStaff) {
-        const qreal topLinePos = paintStaff(painter, rect, spatium); // draw dummy staff lines onto rect.
-        origin.setY(topLinePos); // vertical position relative to staff instead of cell center.
-    }
+    params.rect = rect;
+    params.dpi = dpi;
+    params.spatium = configuration()->paletteSpatium() * params.mag;
 
-    painter.translate(origin);
-    painter.translate(m_cell->xoffset * spatium, m_cell->yoffset * spatium); // additional offset for element onlym
+    params.drawStaff = m_cell->drawStaff;
 
-    paintScoreElement(painter, element, spatium, drawStaff, dpi);
+    rendering::EngravingItemPreviewPainter::paintPreview(element, params);
 }
 
 void PaletteCellIconEngine::paintBackground(Painter& painter, const RectF& rect, bool selected, bool current) const
@@ -99,125 +96,4 @@ void PaletteCellIconEngine::paintBackground(Painter& painter, const RectF& rect,
         c.setAlpha(selected ? 100 : 60);
         painter.fillRect(rect, c);
     }
-}
-
-/// Paint an icon element so that it fills a QRect, preserving aspect ratio, and
-/// leaving a small margin around the edges.
-void PaletteCellIconEngine::paintActionIcon(Painter& painter, const RectF& rect, EngravingItem* element, double dpi) const
-{
-    IF_ASSERT_FAILED(element && element->isActionIcon()) {
-        return;
-    }
-
-    painter.save();
-
-    double DPIscaling = (mu::engraving::DPI / mu::engraving::DPI_F) / dpi;
-
-    ActionIcon* action = toActionIcon(element);
-    action->setFontSize(ActionIcon::DEFAULT_FONT_SIZE * m_cell->mag * m_extraMag * DPIscaling);
-
-    engravingRender()->layoutItem(action);
-
-    painter.translate(rect.center() - action->ldata()->bbox().center());
-    engravingRender()->drawItem(action, &painter);
-    painter.restore();
-}
-
-/// Paint a 5 line staff centered within a QRect and return the distance from the
-/// top of the QRect to the uppermost staff line.
-qreal PaletteCellIconEngine::paintStaff(Painter& painter, const RectF& rect, qreal spatium) const
-{
-    painter.save();
-
-    Color staffLinesColor(configuration()->elementsColor());
-    staffLinesColor.setAlpha(127);//reduce alpha of staff lines to half
-    Pen pen(staffLinesColor);
-    pen.setWidthF(engraving::DefaultStyle::defaultStyle().styleS(Sid::staffLineWidth).val() * spatium);
-    painter.setPen(pen);
-
-    constexpr int numStaffLines = 5;
-    const qreal staffHeight = spatium * (numStaffLines - 1);
-    const qreal topLineDist = rect.center().y() - (staffHeight / 2.0);
-
-    // lines bounded horizontally by edge of target (with small margin)
-    constexpr qreal margin = 3.0;
-    const qreal x1 = rect.left() + margin;
-    const qreal x2 = rect.right() - margin;
-
-    // draw staff lines with middle line centered vertically on target
-    qreal y = topLineDist;
-    for (int i = 0; i < numStaffLines; ++i) {
-        painter.drawLine(LineF(x1, y, x2, y));
-        y += spatium;
-    }
-
-    painter.restore();
-    return topLineDist;
-}
-
-/// Paint a non-icon element centered at the origin of the painter's coordinate
-/// system. If alignToStaff is true then the element is only centered horizontally;
-/// i.e. vertical alignment is unchanged from the default so that item will appear
-/// at the correct height on the staff.
-void PaletteCellIconEngine::paintScoreElement(Painter& painter, EngravingItem* item, qreal spatium, bool alignToStaff, qreal dpi) const
-{
-    IF_ASSERT_FAILED(item && !item->isActionIcon()) {
-        return;
-    }
-
-    painter.save();
-
-    mu::engraving::MScore::pixelRatio = mu::engraving::DPI / dpi;
-
-    const qreal sizeRatio = spatium / gpaletteScore->style().spatium();
-    painter.scale(sizeRatio, sizeRatio); // scale coordinates so element is drawn at correct size
-
-    // calculate bbox
-    engravingRender()->layoutItem(item);
-
-    PointF origin = item->ldata()->bbox().center();
-
-    if (alignToStaff) {
-        // y = 0 is position of the element's parent.
-        // If the parent is the staff (or a segment on the staff) then
-        // y = 0 corresponds to the position of the top staff line.
-        origin.setY(0.0);
-    }
-
-    painter.translate(-1.0 * origin); // shift coordinates so element is drawn at correct position
-
-    PaintContext ctx;
-    ctx.painter = &painter;
-
-    item->scanElements(&ctx, paintPaletteItem);
-    painter.restore();
-}
-
-void PaletteCellIconEngine::paintPaletteItem(void* context, EngravingItem* item)
-{
-    PaintContext* ctx = static_cast<PaintContext*>(context);
-    Painter* painter = ctx->painter;
-
-    painter->save();
-    painter->translate(item->pos()); // necessary for drawing child elements
-
-    Color colorBackup = item->getProperty(Pid::COLOR).value<Color>();
-    Color frameColorBackup = item->getProperty(Pid::FRAME_FG_COLOR).value<Color>();
-    bool colorsInversionEnabledBackup = item->colorsInversionEnabled();
-
-    item->setColorsInverionEnabled(ctx->colorsInversionEnabled);
-
-    if (!ctx->useElementColors) {
-        Color color = configuration()->elementsColor();
-        item->setProperty(Pid::COLOR, color);
-        item->setProperty(Pid::FRAME_FG_COLOR, color);
-    }
-
-    engravingRender()->drawItem(item, painter);
-
-    item->setColorsInverionEnabled(colorsInversionEnabledBackup);
-    item->setProperty(Pid::COLOR, colorBackup);
-    item->setProperty(Pid::FRAME_FG_COLOR, frameColorBackup);
-
-    painter->restore();
 }

--- a/src/palette/internal/palettecelliconengine.h
+++ b/src/palette/internal/palettecelliconengine.h
@@ -47,22 +47,9 @@ public:
 
     void paint(QPainter* painter, const QRect& rect, QIcon::Mode mode, QIcon::State state) override;
 
-    struct PaintContext
-    {
-        muse::draw::Painter* painter = nullptr;
-        bool useElementColors = false;
-        bool colorsInversionEnabled = false;
-    };
-
-    static void paintPaletteItem(void* context, mu::engraving::EngravingItem* element);
-
 private:
     void paintCell(muse::draw::Painter& painter, const muse::RectF& rect, bool selected, bool current, qreal dpi) const;
     void paintBackground(muse::draw::Painter& painter, const muse::RectF& rect, bool selected, bool current) const;
-    void paintActionIcon(muse::draw::Painter& painter, const muse::RectF& rect, mu::engraving::EngravingItem* element, double dpi) const;
-    qreal paintStaff(muse::draw::Painter& painter, const muse::RectF& rect, qreal spatium) const;
-    void paintScoreElement(muse::draw::Painter& painter, mu::engraving::EngravingItem* element, qreal spatium, bool alignToStaff,
-                           qreal dpi) const;
 
     PaletteCellConstPtr m_cell;
     qreal m_extraMag = 1.0;

--- a/src/palette/view/widgets/palettewidget.cpp
+++ b/src/palette/view/widgets/palettewidget.cpp
@@ -59,6 +59,7 @@
 #include "engraving/style/defaultstyle.h"
 #include "engraving/style/style.h"
 #include "engraving/compat/dummyelement.h"
+#include "engraving/rendering/engravingitempreviewpainter.h"
 
 #include "internal/palettecelliconengine.h"
 
@@ -609,10 +610,11 @@ QPixmap PaletteWidget::pixmapForCellAt(int paletteIdx) const
 
     painter.setPen(Pen(color));
 
-    PaletteCellIconEngine::PaintContext ctx;
-    ctx.painter = &painter;
+    rendering::EngravingItemPreviewPainter::PaintParams params;
+    params.painter = &painter;
+    params.color = configuration()->elementsColor();
 
-    element->scanElements(&ctx, PaletteCellIconEngine::paintPaletteItem);
+    rendering::EngravingItemPreviewPainter::paintItem(element.get(), params);
 
     element->setPos(pos);
     return pm;
@@ -1089,12 +1091,15 @@ void PaletteWidget::paintEvent(QPaintEvent* /*event*/)
 
         painter.setPen(Pen(color));
 
-        PaletteCellIconEngine::PaintContext ctx;
-        ctx.painter = &painter;
-        ctx.useElementColors = m_paintOptions.useElementColors;
-        ctx.colorsInversionEnabled = m_paintOptions.colorsInverionsEnabled;
+        rendering::EngravingItemPreviewPainter::PaintParams params;
+        params.painter = &painter;
+        params.color = configuration()->elementsColor();
 
-        el->scanElements(&ctx, PaletteCellIconEngine::paintPaletteItem);
+        params.useElementColors = m_paintOptions.useElementColors;
+        params.colorsInversionEnabled = m_paintOptions.colorsInverionsEnabled;
+
+        rendering::EngravingItemPreviewPainter::paintItem(el.get(), params);
+
         painter.restore();
     }
 }


### PR DESCRIPTION
Currently, our logic for painting engraving items in the UI is completely contained within the palette module. This is a problem for the new Percussion Panel, where we're going to build a "notation preview" completely outwith the pallete module.

To resolve this, this PR introduces an `EngravingItemPreviewPainter` class to the engraving module and moves the existing logic to `engravingitempreviewpainter.cpp`, allowing us to reuse the painting logic wherever we need it.