### PR TITLE
ensure save dialog appears after undoing all changes

### DIFF
--- a/src/project/internal/notationproject.cpp
+++ b/src/project/internal/notationproject.cpp
@@ -910,13 +910,7 @@ void NotationProject::markAsUnsaved()
 void NotationProject::listenIfNeedSaveChanges()
 {
     m_masterNotation->notation()->undoStack()->changesChannel().onReceive(this, [this](const ScoreChangesRange&) {
-        bool isStackClean = m_masterNotation && m_masterNotation->notation()->undoStack()->isStackClean();
-
-        if (isStackClean && !m_hasNonUndoStackChanges) {
-            setNeedSave(false);
-        } else {
-            setNeedSave(true);
-        }
+        setNeedSave(true);
     });
 
     auto listenNonUndoStackChanges = [this](const INotationPtr& notation) {


### PR DESCRIPTION
Resolves: #25278 

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
