### PR TITLE
add courtesy keysig to last measure even if it is followed by frame

### DIFF
--- a/src/engraving/rendering/score/systemlayout.cpp
+++ b/src/engraving/rendering/score/systemlayout.cpp
@@ -342,9 +342,9 @@ System* SystemLayout::collectSystem(LayoutContext& ctx)
     // Create end barlines and system trailer if needed (cautionary time/key signatures etc)
     Measure* lm  = system->lastMeasure();
     if (lm) {
+        MeasureLayout::createEndBarLines(lm, true, ctx);
         Measure* nm = lm->nextMeasure();
         if (nm) {
-            MeasureLayout::createEndBarLines(lm, true, ctx);
             MeasureLayout::addSystemTrailer(lm, nm, ctx);
         }
     }

--- a/src/engraving/rendering/score/systemlayout.cpp
+++ b/src/engraving/rendering/score/systemlayout.cpp
@@ -326,11 +326,9 @@ System* SystemLayout::collectSystem(LayoutContext& ctx)
      * **********************************************************/
 
     // Brake cross-measure beams
-    // Create end barlines
     if (ctx.state().prevMeasure() && ctx.state().prevMeasure()->isMeasure()) {
         Measure* pm = toMeasure(ctx.mutState().prevMeasure());
         BeamLayout::breakCrossMeasureBeams(pm, ctx);
-        MeasureLayout::createEndBarLines(pm, true, ctx);
     }
 
     // hide empty staves
@@ -341,11 +339,12 @@ System* SystemLayout::collectSystem(LayoutContext& ctx)
     SystemLayout::layoutSystem(system, ctx, layoutSystemMinWidth, ctx.state().firstSystem(), ctx.state().firstSystemIndent());
     curSysWidth += system->leftMargin();
 
-    // add system trailer if needed (cautionary time/key signatures etc)
+    // Create end barlines and system trailer if needed (cautionary time/key signatures etc)
     Measure* lm  = system->lastMeasure();
     if (lm) {
         Measure* nm = lm->nextMeasure();
         if (nm) {
+            MeasureLayout::createEndBarLines(lm, true, ctx);
             MeasureLayout::addSystemTrailer(lm, nm, ctx);
         }
     }


### PR DESCRIPTION
Resolves: #22256 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->
Resolves: #19759

<!-- Add a short description of and motivation for the changes here -->
- creating courtesy keysig was disabled by `MeasureLayout::createEndBarLines(measure, **false**, ctx);`, which sets `ElementFlag::KEYSIG` of measurebase to `false`, so before adding trailer, we need to re-`createEndBarLines` with truthy `isLastMeasureInSystem` value
- this was already (almost) done, with one exception - it processed last measureBase of system, but we need last real measure (not frame)

![keysig-frame](https://github.com/user-attachments/assets/72f88e64-4c91-49a7-8729-226db8fe1849)

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
