### PR TITLE
25413: Text won't move after edit

### DIFF
--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -3392,13 +3392,12 @@ void NotationInteraction::endEditText()
         return;
     }
 
-    doEndEditElement(false /*clearEditData*/);
+    EngravingItem* editedElement = m_editData.element;
+    doEndEditElement();
 
-    if (m_editData.element) {
-        notifyAboutTextEditingEnded(toTextBase(m_editData.element));
+    if (editedElement) {
+        notifyAboutTextEditingEnded(toTextBase(editedElement));
     }
-
-    m_editData.clear();
 
     notifyAboutTextEditingChanged();
     notifyAboutSelectionChangedIfNeed();
@@ -3754,15 +3753,12 @@ void NotationInteraction::endEditElement()
     notifyAboutNotationChanged();
 }
 
-void NotationInteraction::doEndEditElement(bool clearEditData)
+void NotationInteraction::doEndEditElement()
 {
     if (m_editData.element) {
         m_editData.element->endEdit(m_editData);
     }
-
-    if (clearEditData) {
-        m_editData.clear();
-    }
+    m_editData.clear();
 }
 
 void NotationInteraction::onElementDestroyed(EngravingItem* element)

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -310,7 +310,7 @@ private:
     bool needStartEditGrip(QKeyEvent* event) const;
     bool handleKeyPress(QKeyEvent* event);
 
-    void doEndEditElement(bool clearEditData = true);
+    void doEndEditElement();
     void doEndDrag();
 
     bool doDropStandard();


### PR DESCRIPTION
Resolves: #25413 
Caused by: [24506](https://github.com/musescore/MuseScore/pull/24506)

The UI actions' enabled state is updated when handling `notifyAboutTextEditingEnded` in `uicontextresolver.cpp` line 62 but with `m_editData` not cleared yet (see [PR24506](https://github.com/musescore/MuseScore/pull/24506)) the UI actions think there is an element being edited and do not update their enabled state properly.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
