### PR TITLE
Fix MSVC compiler and Visual Studio warnings

### DIFF
--- a/src/engraving/compat/midi/compatmidirenderinternal.cpp
+++ b/src/engraving/compat/midi/compatmidirenderinternal.cpp
@@ -749,26 +749,23 @@ static void collectNote(EventsHolder& events, const Note* note, const CollectNot
             collectBend(stretchedBend->pitchValues(), stretchedBend->staffIdx(), noteChannel, tick1, tick1 + getPlayTicksForBend(
                             note).ticks(), pitchWheelRenderer, noteEffect);
         }
+    } else if (bendFor) {
+        collectGuitarBend(note, noteChannel, tick1, noteParams.graceOffsetOn, noteParams.previousChordTicks, pitchWheelRenderer,
+                          noteEffect);
     } else {
-        const GuitarBend* bendFor = note->bendFor();
-        if (bendFor) {
-            collectGuitarBend(note, noteChannel, tick1, noteParams.graceOffsetOn, noteParams.previousChordTicks, pitchWheelRenderer,
-                              noteEffect);
-        } else {
-            // old bends implementation
-            for (const EngravingItem* e : note->el()) {
-                if (!e || (e->type() != ElementType::BEND)) {
-                    continue;
-                }
-
-                const Bend* bend = toBend(e);
-                if (!bend->playBend()) {
-                    break;
-                }
-
-                collectBend(bend->points(), bend->staffIdx(), noteChannel, tick1, tick1 + getPlayTicksForBend(
-                                note).ticks(), pitchWheelRenderer, noteEffect);
+        // old bends implementation
+        for (const EngravingItem* e : note->el()) {
+            if (!e || (e->type() != ElementType::BEND)) {
+                continue;
             }
+
+            const Bend* bend = toBend(e);
+            if (!bend->playBend()) {
+                break;
+            }
+
+            collectBend(bend->points(), bend->staffIdx(), noteChannel, tick1, tick1 + getPlayTicksForBend(
+                            note).ticks(), pitchWheelRenderer, noteEffect);
         }
     }
 }

--- a/src/engraving/dom/segment.h
+++ b/src/engraving/dom/segment.h
@@ -297,9 +297,9 @@ public:
 
     bool hasAccidentals() const;
 
-    EngravingItem* preAppendedItem(int track) { return m_preAppendedItems[track]; }
-    void preAppend(EngravingItem* item, int track) { m_preAppendedItems[track] = item; }
-    void clearPreAppended(int track) { m_preAppendedItems[track] = nullptr; }
+    EngravingItem* preAppendedItem(track_idx_t track) { return m_preAppendedItems[track]; }
+    void preAppend(EngravingItem* item, track_idx_t track) { m_preAppendedItems[track] = item; }
+    void clearPreAppended(track_idx_t track) { m_preAppendedItems[track] = nullptr; }
     void addPreAppendedToShape();
 
     bool goesBefore(const Segment* nextSegment) const;

--- a/src/engraving/dom/vibrato.cpp
+++ b/src/engraving/dom/vibrato.cpp
@@ -29,7 +29,6 @@
 
 #include "score.h"
 #include "system.h"
-#include "chord.h"
 #include "trill.h"
 
 #include "log.h"

--- a/src/engraving/infrastructure/shape.h
+++ b/src/engraving/infrastructure/shape.h
@@ -158,8 +158,6 @@ public:
     double bottom() const;
     double rightMostEdgeAtHeight(double yAbove, double yBelow) const;
     double leftMostEdgeAtHeight(double yAbove, double yBelow) const;
-
-    double xMostEdgeAtY(const bool isTop, const bool isLeft) const;
     double leftMostEdgeAtTop() const;
 
     bool contains(const PointF&) const;

--- a/src/engraving/rendering/score/chordlayout.cpp
+++ b/src/engraving/rendering/score/chordlayout.cpp
@@ -2675,13 +2675,13 @@ void ChordLayout::appendGraceNotes(Chord* chord)
     if (!gnb.empty()) {
         // If this segment already contains grace notes in the same voice (could happen if a
         // previous chord has appended grace-notes-after here) put them in the same vector.
-        EngravingItem* item = segment->preAppendedItem(static_cast<int>(track));
+        EngravingItem* item = segment->preAppendedItem(track);
         if (item && item->isGraceNotesGroup()) {
             GraceNotesGroup* gng = toGraceNotesGroup(item);
             gng->insert(gng->end(), gnb.begin(), gnb.end());
         } else {
             gnb.setAppendedSegment(segment);
-            segment->preAppend(&gnb, static_cast<int>(track));
+            segment->preAppend(&gnb, track);
         }
     }
 
@@ -2695,7 +2695,7 @@ void ChordLayout::appendGraceNotes(Chord* chord)
         }
         if (followingSeg) {
             gna.setAppendedSegment(followingSeg);
-            followingSeg->preAppend(&gna, static_cast<int>(track));
+            followingSeg->preAppend(&gna, track);
         }
     }
 }
@@ -2705,8 +2705,8 @@ void ChordLayout::appendGraceNotes(Chord* chord)
 *  is needed and must be called AFTER horizontal spacing is calculated. */
 void ChordLayout::repositionGraceNotesAfter(Segment* segment, size_t tracks)
 {
-    for (size_t track = 0; track < tracks; track++) {
-        EngravingItem* item = segment->preAppendedItem(static_cast<int>(track));
+    for (track_idx_t track = 0; track < tracks; track++) {
+        EngravingItem* item = segment->preAppendedItem(track);
         if (!item || !item->isGraceNotesGroup()) {
             continue;
         }

--- a/src/engraving/rendering/score/measurelayout.cpp
+++ b/src/engraving/rendering/score/measurelayout.cpp
@@ -1005,7 +1005,7 @@ void MeasureLayout::updateGraceNotes(Measure* measure, LayoutContext& ctx)
 {
     // Clean everything
     for (Segment& s : measure->segments()) {
-        for (unsigned track = 0; track < ctx.dom().ntracks(); ++track) {
+        for (track_idx_t track = 0; track < ctx.dom().ntracks(); ++track) {
             EngravingItem* e = s.preAppendedItem(track);
             if (e && e->isGraceNotesGroup()) {
                 s.clearPreAppended(track);
@@ -1035,7 +1035,7 @@ void MeasureLayout::updateGraceNotes(Measure* measure, LayoutContext& ctx)
 
     // Layout grace note groups
     for (Segment& s : measure->segments()) {
-        for (unsigned track = 0; track < ctx.dom().ntracks(); ++track) {
+        for (track_idx_t track = 0; track < ctx.dom().ntracks(); ++track) {
             EngravingItem* e = s.preAppendedItem(track);
             if (e && e->isGraceNotesGroup()) {
                 GraceNotesGroup* gng = toGraceNotesGroup(e);

--- a/src/notation/view/widgets/editstyle.ui
+++ b/src/notation/view/widgets/editstyle.ui
@@ -6049,7 +6049,7 @@
                 </widget>
                </item>
                <item row="6" column="0" colspan="7">
-                <widget class="QGroupBox" name="groupBox">
+                <widget class="QGroupBox" name="groupBox_1">
                  <property name="title">
                   <string>Number layout</string>
                  </property>
@@ -10809,7 +10809,7 @@
          </spacer>
         </item>
         <item>
-         <widget class="QGroupBox" name="groupBox">
+         <widget class="QGroupBox" name="groupBox_21">
           <property name="title">
            <string>Trill cue note</string>
           </property>


### PR DESCRIPTION
* reg.: declaration of 'bendFor' hides previous local declaration (C4456)
* reg.: declaration of 'groupBox' hides class member (C4458)
* reg.: Function definition for 'xMostEdgeAtY' not found (VCR001) and remove a superfluous include
* reg. 'argument': conversion from 'size_t' to 'int', possible loss of data (C4267)