### PR TITLE
fix typo int -> bool

### DIFF
--- a/src/engraving/dom/measurebase.h
+++ b/src/engraving/dom/measurebase.h
@@ -171,7 +171,7 @@ public:
     void setNoBreak(bool v) { setFlag(ElementFlag::NO_BREAK, v); }
 
     bool hasCourtesyKeySig() const { return flag(ElementFlag::KEYSIG); }
-    void setHasCourtesyKeySig(int v) { setFlag(ElementFlag::KEYSIG, v); }
+    void setHasCourtesyKeySig(bool v) { setFlag(ElementFlag::KEYSIG, v); }
 
     virtual void computeMinWidth() { }
 


### PR DESCRIPTION
`void setHasCourtesyKeySig(int v) { setFlag(ElementFlag::KEYSIG, v); }`
should be
`void setHasCourtesyKeySig(bool v) { setFlag(ElementFlag::KEYSIG, v); }`

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
