### PR TITLE
Percussion panel - fix panel resetting when finishing edit layout

### DIFF
--- a/src/notation/view/percussionpanel/percussionpanelmodel.cpp
+++ b/src/notation/view/percussionpanel/percussionpanelmodel.cpp
@@ -155,6 +155,9 @@ void PercussionPanelModel::finishEditing()
 void PercussionPanelModel::setUpConnections()
 {
     const auto updatePadModels = [this](const mu::engraving::Drumset* drumset) {
+        if (drumset == m_padListModel->drumset()) {
+            return;
+        }
         m_padListModel->setDrumset(drumset);
         m_padListModel->resetLayout(); //! NOTE: Placeholder until we implement saving/loading
     };

--- a/src/notation/view/percussionpanel/percussionpanelpadlistmodel.h
+++ b/src/notation/view/percussionpanel/percussionpanelpadlistmodel.h
@@ -60,6 +60,8 @@ public:
     int numPads() const { return m_padModels.count(); }
 
     void setDrumset(const mu::engraving::Drumset* drumset);
+    const mu::engraving::Drumset* drumset() const { return m_drumset; }
+
     void resetLayout();
 
     muse::async::Channel<int /*pitch*/> padTriggered() const { return m_triggeredChannel; }


### PR DESCRIPTION
Fixes a bug I noticed while working on the panel - edit layout is broken because the panel resets itself as soon as "Finish Editing" is clicked.

The bug happens because we call `resetLayout` whenever the note input state changes - and returning to "write" mode after editing the layout causes the note input state to change.

The call to `resetLayout` is a placeholder anyway until we implement saving/loading layouts for the panel - the purpose for now is to update the panel when the selected drumset changes.