### PR TITLE
Fix crash when replacing instrument via popup in instruments panel

### DIFF
--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/InstrumentSettingsPopup.qml
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/InstrumentSettingsPopup.qml
@@ -30,7 +30,8 @@ StyledPopupView {
 
     property bool needActiveFirstItem: false
 
-    property bool unloadAfterClose: true
+    signal replaceInstrumentRequested()
+    signal resetAllFormattingRequested()
 
     contentHeight: contentColumn.childrenRect.height
 
@@ -115,10 +116,8 @@ StyledPopupView {
             visible: settingsModel.isMainScore
 
             onClicked: {
-                root.unloadAfterClose = false
+                root.replaceInstrumentRequested()
                 root.close()
-                settingsModel.replaceInstrument()
-                root.unloadAfterClose = true
             }
         }
 
@@ -133,10 +132,8 @@ StyledPopupView {
             visible: !settingsModel.isMainScore
 
             onClicked: {
-                root.unloadAfterClose = false
-                settingsModel.resetAllFormatting()
+                root.resetAllFormattingRequested()
                 root.close()
-                root.unloadAfterClose = true
             }
         }
     }

--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/InstrumentSettingsPopup.qml
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/InstrumentSettingsPopup.qml
@@ -30,6 +30,8 @@ StyledPopupView {
 
     property bool needActiveFirstItem: false
 
+    property bool unloadAfterClose: true
+
     contentHeight: contentColumn.childrenRect.height
 
     onOpened: {
@@ -113,9 +115,10 @@ StyledPopupView {
             visible: settingsModel.isMainScore
 
             onClicked: {
+                root.unloadAfterClose = false
                 root.close()
-
                 settingsModel.replaceInstrument()
+                root.unloadAfterClose = true
             }
         }
 
@@ -130,9 +133,10 @@ StyledPopupView {
             visible: !settingsModel.isMainScore
 
             onClicked: {
-                root.close()
-
+                root.unloadAfterClose = false
                 settingsModel.resetAllFormatting()
+                root.close()
+                root.unloadAfterClose = true
             }
         }
     }

--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/InstrumentsTreeItemDelegate.qml
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/InstrumentsTreeItemDelegate.qml
@@ -132,10 +132,10 @@ FocusableControl {
     Loader {
         id: popupLoader
 
-        property alias openedPopup: popupLoader.item
-        property bool isPopupOpened: Boolean(openedPopup) && openedPopup.isOpened
+        readonly property StyledPopupView openedPopup: popupLoader.item as StyledPopupView
+        readonly property bool isPopupOpened: Boolean(openedPopup) && openedPopup.isOpened
 
-        function openPopup(comp, btn, item) {
+        function openPopup(comp: Component, btn: Item, item) {
             popupLoader.sourceComponent = comp
             if (!openedPopup) {
                 return
@@ -152,10 +152,7 @@ FocusableControl {
 
             openedPopup.closed.connect(function() {
                 root.popupClosed()
-
-                Qt.callLater(function() {
-                    popupLoader.sourceComponent = null
-                })
+                Qt.callLater(maybeUnload)
             })
 
             openedPopup.open()
@@ -165,6 +162,26 @@ FocusableControl {
             if (isPopupOpened) {
                 openedPopup.close()
             }
+        }
+
+        function unload() {
+            sourceComponent = null
+        }
+
+        function maybeUnload() {
+            if (!openedPopup) {
+                return
+            }
+            if (openedPopup.unloadAfterClose) {
+                unload()
+                return
+            }
+
+            openedPopup.unloadAfterCloseChanged.connect(function() {
+                if (openedPopup && openedPopup.unloadAfterClose && !openedPopup.isOpened) {
+                    unload()
+                }
+            })
         }
     }
 

--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/StaffSettingsPopup.qml
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/StaffSettingsPopup.qml
@@ -30,6 +30,8 @@ StyledPopupView {
 
     property bool needActiveFirstItem: false
 
+    property bool unloadAfterClose: true
+
     contentHeight: contentColumn.childrenRect.height
     contentWidth: 240
 

--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/StaffSettingsPopup.qml
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/StaffSettingsPopup.qml
@@ -30,8 +30,6 @@ StyledPopupView {
 
     property bool needActiveFirstItem: false
 
-    property bool unloadAfterClose: true
-
     contentHeight: contentColumn.childrenRect.height
     contentWidth: 240
 

--- a/src/instrumentsscene/view/instrumentsettingsmodel.cpp
+++ b/src/instrumentsscene/view/instrumentsettingsmodel.cpp
@@ -21,9 +21,6 @@
  */
 #include "instrumentsettingsmodel.h"
 
-#include "log.h"
-#include "translation.h"
-
 using namespace muse;
 using namespace mu::instrumentsscene;
 using namespace mu::notation;
@@ -57,50 +54,6 @@ void InstrumentSettingsModel::load(const QVariant& instrument)
     });
 
     emit dataChanged();
-}
-
-void InstrumentSettingsModel::replaceInstrument()
-{
-    if (!masterNotationParts()) {
-        return;
-    }
-
-    RetVal<Instrument> selectedInstrument = selectInstrumentsScenario()->selectInstrument(m_instrumentKey);
-    if (!selectedInstrument.ret) {
-        LOGE() << selectedInstrument.ret.toString();
-        return;
-    }
-
-    const Instrument& newInstrument = selectedInstrument.val;
-    masterNotationParts()->replaceInstrument(m_instrumentKey, newInstrument);
-
-    m_instrumentKey.instrumentId = newInstrument.id();
-    m_instrumentName = newInstrument.nameAsPlainText();
-    m_instrumentAbbreviature = newInstrument.abbreviatureAsPlainText();
-
-    emit dataChanged();
-}
-
-void InstrumentSettingsModel::resetAllFormatting()
-{
-    if (!masterNotationParts() || !notationParts()) {
-        return;
-    }
-
-    std::string title = muse::trc("instruments", "Are you sure you want to reset all formatting?");
-    std::string body = muse::trc("instruments", "This action can not be undone");
-
-    IInteractive::Button button = interactive()->question(title, body, {
-        IInteractive::Button::No,
-        IInteractive::Button::Yes
-    }).standardButton();
-
-    if (button == IInteractive::Button::No) {
-        return;
-    }
-
-    const Part* masterPart = masterNotationParts()->part(m_instrumentKey.partId);
-    notationParts()->replacePart(m_instrumentKey.partId, masterPart->clone());
 }
 
 QString InstrumentSettingsModel::instrumentName() const
@@ -152,11 +105,5 @@ INotationPtr InstrumentSettingsModel::currentMasterNotation() const
 INotationPartsPtr InstrumentSettingsModel::notationParts() const
 {
     INotationPtr notation = currentNotation();
-    return notation ? notation->parts() : nullptr;
-}
-
-INotationPartsPtr InstrumentSettingsModel::masterNotationParts() const
-{
-    INotationPtr notation = currentMasterNotation();
     return notation ? notation->parts() : nullptr;
 }

--- a/src/instrumentsscene/view/instrumentsettingsmodel.h
+++ b/src/instrumentsscene/view/instrumentsettingsmodel.h
@@ -28,8 +28,6 @@
 
 #include "modularity/ioc.h"
 #include "context/iglobalcontext.h"
-#include "notation/iselectinstrumentscenario.h"
-#include "global/iinteractive.h"
 
 #include "notation/notationtypes.h"
 
@@ -38,9 +36,7 @@ class InstrumentSettingsModel : public QObject, public muse::async::Asyncable
 {
     Q_OBJECT
 
-    INJECT(notation::ISelectInstrumentsScenario, selectInstrumentsScenario)
     INJECT(context::IGlobalContext, context)
-    INJECT(muse::IInteractive, interactive)
 
     Q_PROPERTY(QString instrumentName READ instrumentName WRITE setInstrumentName NOTIFY dataChanged)
     Q_PROPERTY(QString abbreviature READ abbreviature WRITE setAbbreviature NOTIFY dataChanged)
@@ -51,8 +47,6 @@ public:
     explicit InstrumentSettingsModel(QObject* parent = nullptr);
 
     Q_INVOKABLE void load(const QVariant& instrument);
-    Q_INVOKABLE void replaceInstrument();
-    Q_INVOKABLE void resetAllFormatting();
 
     QString instrumentName() const;
     QString abbreviature() const;
@@ -71,7 +65,6 @@ private:
     notation::INotationPtr currentNotation() const;
     notation::INotationPtr currentMasterNotation() const;
     notation::INotationPartsPtr notationParts() const;
-    notation::INotationPartsPtr masterNotationParts() const;
 
     notation::InstrumentKey m_instrumentKey;
     QString m_instrumentName;

--- a/src/instrumentsscene/view/instrumentspaneltreemodel.cpp
+++ b/src/instrumentsscene/view/instrumentspaneltreemodel.cpp
@@ -324,7 +324,7 @@ void InstrumentsPanelTreeModel::load()
     beginResetModel();
     deleteItems();
 
-    m_rootItem = new RootTreeItem(m_masterNotation, m_notation);
+    m_rootItem = new RootTreeItem(m_masterNotation, m_notation, this);
 
     async::NotifyList<const Part*> masterParts = m_masterNotation->parts()->partList();
     sortParts(masterParts);

--- a/src/instrumentsscene/view/parttreeitem.h
+++ b/src/instrumentsscene/view/parttreeitem.h
@@ -24,12 +24,17 @@
 
 #include "abstractinstrumentspaneltreeitem.h"
 
-#include "notation/inotationparts.h"
+#include "modularity/ioc.h"
+#include "iinteractive.h"
+#include "notation/iselectinstrumentscenario.h"
 
 namespace mu::instrumentsscene {
-class PartTreeItem : public AbstractInstrumentsPanelTreeItem
+class PartTreeItem : public AbstractInstrumentsPanelTreeItem, public muse::Injectable
 {
     Q_OBJECT
+
+    muse::Inject<notation::ISelectInstrumentsScenario> selectInstrumentsScenario { this };
+    muse::Inject<muse::IInteractive> interactive { this };
 
 public:
     PartTreeItem(notation::IMasterNotationPtr masterNotation, notation::INotationPtr notation, QObject* parent);
@@ -38,8 +43,6 @@ public:
 
     bool isSelectable() const override;
 
-    Q_INVOKABLE QString instrumentId() const;
-
     MoveParams buildMoveParams(int sourceRow, int count, AbstractInstrumentsPanelTreeItem* destinationParent,
                                int destinationRow) const override;
 
@@ -47,6 +50,10 @@ public:
                       bool updateNotation) override;
 
     void removeChildren(int row, int count, bool deleteChild) override;
+
+    Q_INVOKABLE QString instrumentId() const;
+    Q_INVOKABLE void replaceInstrument();
+    Q_INVOKABLE void resetAllFormatting();
 
 private:
     void listenVisibilityChanged();


### PR DESCRIPTION
The problem is that the popup is unloaded as soon as it is closed, and it is closed as soon as the "replace instrument" dialog appears. The unloading causes the popup and its content and the model of that content to be deleted. But the "onClicked" signal handler is still being executed at that point. This is (naturally) not allowed by Qt and causes a crash.

Probably introduced by 95249f7043efb2d67008c4ec47f36aa105867948; that commit fixed a mistake, but that mistake prevented the unloading, and thus the crash.

Resolves: #25439