### PR TITLE
fixed #25098: correct pitchbend midi export in chords

### DIFF
--- a/src/importexport/midi/internal/midiexport/exportmidi.cpp
+++ b/src/importexport/midi/internal/midiexport/exportmidi.cpp
@@ -236,7 +236,7 @@ bool ExportMidi::write(QIODevice* device, bool midiExpandRepeats, bool exportRPN
 
     EventsHolder events;
     CompatMidiRendererInternal::Context context;
-    context.eachStringHasChannel = false;
+    context.eachStringHasChannel = true;
     context.instrumentsHaveEffects = false;
     context.harmonyChannelSetting = CompatMidiRendererInternal::HarmonyChannelSetting::DEFAULT;
     context.sndController = CompatMidiRender::getControllerForSnd(m_score, synthState.ccToUse());


### PR DESCRIPTION
historical moment of changing one 'false' to 'true', happy to be here

see bends export before and after: pitchbend used to be summed up, resulting same big pitch to be applied to both notes of chord

<img width="367" alt="Screenshot 2024-11-06 at 13 24 18" src="https://github.com/user-attachments/assets/f7e7fdc7-8b69-4d5d-a505-d33255aab5dc">

[bends-midi.zip](https://github.com/user-attachments/files/17639714/bends-midi.zip)
