### PR TITLE
25452: Fixing indent on menu items with check marks and/or icons

### DIFF
--- a/src/framework/uicomponents/qml/Muse/UiComponents/internal/StyledMenuItem.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/internal/StyledMenuItem.qml
@@ -136,12 +136,12 @@ ListItemBlank {
 
         result += rowLayout.anchors.leftMargin
         if (primaryIconLabel.visible) {
-            result += Math.ceil(primaryIconLabel.width)
+            result += Math.ceil(primaryIconLabel.Layout.preferredWidth)
             result += rowLayout.spacing
         }
 
         if (secondaryIconLabel.visible) {
-            result += Math.ceil(secondaryIconLabel.width)
+            result += Math.ceil(secondaryIconLabel.Layout.preferredWidth)
             result += rowLayout.spacing
         }
 
@@ -183,7 +183,7 @@ ListItemBlank {
         StyledIconLabel {
             id: primaryIconLabel
             Layout.alignment: Qt.AlignLeft
-            width: 16
+            Layout.preferredWidth: 16
             iconCode: {
                 if (root.iconAndCheckMarkMode !== StyledMenuItem.ShowBoth && itemPrv.hasIcon) {
                     return root.modelData?.icon ?? IconCode.NONE
@@ -201,7 +201,7 @@ ListItemBlank {
         StyledIconLabel {
             id: secondaryIconLabel
             Layout.alignment: Qt.AlignLeft
-            width: 16
+            Layout.preferredWidth: 16
             iconCode: root.modelData?.icon ?? IconCode.NONE
             visible: root.iconAndCheckMarkMode === StyledMenuItem.ShowBoth
         }


### PR DESCRIPTION
Resolves: #25452

The widths of the labels for the check mark and the icon were set to 16 which was on the low side. The Layout seems to respect those widths only for empty labels (no check mark, no icon): try changing those widths to 100 for example. The result is only the menu items without check marks and icons are indented, those with check marks and/or icons do not move. Therefore I have set the preferred widths on the Layout instead.

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
