### PR TITLE
24908: Retried saves won't create backups and backups will be created for the target file

### DIFF
--- a/src/project/inotationproject.h
+++ b/src/project/inotationproject.h
@@ -69,7 +69,8 @@ public:
     virtual bool needAutoSave() const = 0;
     virtual void setNeedAutoSave(bool val) = 0;
 
-    virtual muse::Ret save(const muse::io::path_t& path = muse::io::path_t(), SaveMode saveMode = SaveMode::Save) = 0;
+    virtual muse::Ret save(
+        const muse::io::path_t& path = muse::io::path_t(), SaveMode saveMode = SaveMode::Save, bool forceNoBackupCreate = false) = 0;
     virtual muse::Ret writeToDevice(QIODevice* device) = 0;
 
     virtual ProjectMeta metaInfo() const = 0;

--- a/src/project/inotationproject.h
+++ b/src/project/inotationproject.h
@@ -70,7 +70,7 @@ public:
     virtual void setNeedAutoSave(bool val) = 0;
 
     virtual muse::Ret save(
-        const muse::io::path_t& path = muse::io::path_t(), SaveMode saveMode = SaveMode::Save, bool forceNoBackupCreate = false) = 0;
+        const muse::io::path_t& path = muse::io::path_t(), SaveMode saveMode = SaveMode::Save, bool createBackup = true) = 0;
     virtual muse::Ret writeToDevice(QIODevice* device) = 0;
 
     virtual ProjectMeta metaInfo() const = 0;

--- a/src/project/internal/notationproject.cpp
+++ b/src/project/internal/notationproject.cpp
@@ -460,7 +460,7 @@ void NotationProject::setCloudAudioInfo(const CloudAudioInfo& audioInfo)
     m_masterNotation->masterScore()->setMetaTag(AUDIO_COM_URL_TAG, audioInfo.url.toString());
 }
 
-Ret NotationProject::save(const muse::io::path_t& path, SaveMode saveMode, bool forceNoBackupCreate)
+Ret NotationProject::save(const muse::io::path_t& path, SaveMode saveMode, bool createBackup)
 {
     TRACEFUNC;
 
@@ -481,7 +481,10 @@ Ret NotationProject::save(const muse::io::path_t& path, SaveMode saveMode, bool 
 
         std::string suffix = io::suffix(savePath);
 
-        Ret ret = saveScore(savePath, suffix, !forceNoBackupCreate /*generateBackup*/);
+        // Whether a backup file will be created depends on both the caller's and user's will
+        bool shouldCreateBackup = createBackup && configuration()->createBackupBeforeSaving();
+
+        Ret ret = saveScore(savePath, suffix, shouldCreateBackup);
         if (ret) {
             if (saveMode != SaveMode::SaveCopy) {
                 markAsSaved(savePath);
@@ -694,11 +697,6 @@ Ret NotationProject::doSave(const muse::io::path_t& path, engraving::MscIoMode i
 Ret NotationProject::makeBackup(muse::io::path_t filePath)
 {
     TRACEFUNC;
-
-    bool create = configuration()->createBackupBeforeSaving();
-    if (!create) {
-        return make_ret(Ret::Code::Ok);
-    }
 
     if (io::suffix(filePath) != engraving::MSCZ) {
         LOGW() << "backup allowed only for MSCZ, currently: " << filePath;

--- a/src/project/internal/notationproject.cpp
+++ b/src/project/internal/notationproject.cpp
@@ -460,7 +460,7 @@ void NotationProject::setCloudAudioInfo(const CloudAudioInfo& audioInfo)
     m_masterNotation->masterScore()->setMetaTag(AUDIO_COM_URL_TAG, audioInfo.url.toString());
 }
 
-Ret NotationProject::save(const muse::io::path_t& path, SaveMode saveMode)
+Ret NotationProject::save(const muse::io::path_t& path, SaveMode saveMode, bool forceNoBackupCreate)
 {
     TRACEFUNC;
 
@@ -481,7 +481,7 @@ Ret NotationProject::save(const muse::io::path_t& path, SaveMode saveMode)
 
         std::string suffix = io::suffix(savePath);
 
-        Ret ret = saveScore(savePath, suffix);
+        Ret ret = saveScore(savePath, suffix, !forceNoBackupCreate /*generateBackup*/);
         if (ret) {
             if (saveMode != SaveMode::SaveCopy) {
                 markAsSaved(savePath);
@@ -625,7 +625,7 @@ Ret NotationProject::doSave(const muse::io::path_t& path, engraving::MscIoMode i
     // Step 3: create backup if need
     {
         if (generateBackup) {
-            makeCurrentFileAsBackup();
+            makeBackup(targetContainerPath);
         }
     }
 
@@ -691,7 +691,7 @@ Ret NotationProject::doSave(const muse::io::path_t& path, engraving::MscIoMode i
     return make_ret(Ret::Code::Ok);
 }
 
-Ret NotationProject::makeCurrentFileAsBackup()
+Ret NotationProject::makeBackup(muse::io::path_t filePath)
 {
     TRACEFUNC;
 
@@ -700,12 +700,6 @@ Ret NotationProject::makeCurrentFileAsBackup()
         return make_ret(Ret::Code::Ok);
     }
 
-    if (isNewlyCreated()) {
-        LOGD() << "project just created";
-        return make_ret(Ret::Code::Ok);
-    }
-
-    muse::io::path_t filePath = m_path;
     if (io::suffix(filePath) != engraving::MSCZ) {
         LOGW() << "backup allowed only for MSCZ, currently: " << filePath;
         return make_ret(Ret::Code::Ok);
@@ -713,8 +707,8 @@ Ret NotationProject::makeCurrentFileAsBackup()
 
     Ret ret = fileSystem()->exists(filePath);
     if (!ret) {
-        LOGE() << "project file does not exist";
-        return ret;
+        LOGI() << "Backup won't be created, file does not exist: " << filePath;
+        return make_ret(Ret::Code::Ok);
     }
 
     muse::io::path_t backupPath = configuration()->projectBackupPath(filePath);

--- a/src/project/internal/notationproject.h
+++ b/src/project/internal/notationproject.h
@@ -94,7 +94,8 @@ public:
     bool needAutoSave() const override;
     void setNeedAutoSave(bool val) override;
 
-    muse::Ret save(const muse::io::path_t& path = muse::io::path_t(), SaveMode saveMode = SaveMode::Save) override;
+    muse::Ret save(const muse::io::path_t& path = muse::io::path_t(), SaveMode saveMode = SaveMode::Save,
+                   bool forceNoBackupCreate = false) override;
     muse::Ret writeToDevice(QIODevice* device) override;
 
     ProjectMeta metaInfo() const override;
@@ -117,7 +118,7 @@ private:
     muse::Ret exportProject(const muse::io::path_t& path, const std::string& suffix);
     muse::Ret doSave(const muse::io::path_t& path, engraving::MscIoMode ioMode, bool generateBackup = true, bool createThumbnail = true,
                      bool isAutosave = false);
-    muse::Ret makeCurrentFileAsBackup();
+    muse::Ret makeBackup(muse::io::path_t filePath);
     muse::Ret writeProject(engraving::MscWriter& msczWriter, bool onlySelection, bool createThumbnail = true);
     muse::Ret checkSavedFileForCorruption(engraving::MscIoMode ioMode, const muse::io::path_t& path, const muse::io::path_t& scoreFileName);
 

--- a/src/project/internal/notationproject.h
+++ b/src/project/internal/notationproject.h
@@ -94,8 +94,8 @@ public:
     bool needAutoSave() const override;
     void setNeedAutoSave(bool val) override;
 
-    muse::Ret save(const muse::io::path_t& path = muse::io::path_t(), SaveMode saveMode = SaveMode::Save,
-                   bool forceNoBackupCreate = false) override;
+    muse::Ret save(
+        const muse::io::path_t& path = muse::io::path_t(), SaveMode saveMode = SaveMode::Save, bool createBackup = true) override;
     muse::Ret writeToDevice(QIODevice* device) override;
 
     ProjectMeta metaInfo() const override;

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -915,7 +915,7 @@ bool ProjectActionsController::saveProjectAt(const SaveLocation& location, SaveM
     return false;
 }
 
-bool ProjectActionsController::saveProjectLocally(const muse::io::path_t& filePath, SaveMode saveMode, bool forceNoBackupCreate)
+bool ProjectActionsController::saveProjectLocally(const muse::io::path_t& filePath, SaveMode saveMode, bool createBackup)
 {
     INotationProjectPtr project = currentNotationProject();
     if (!project) {
@@ -928,7 +928,7 @@ bool ProjectActionsController::saveProjectLocally(const muse::io::path_t& filePa
     }
 
     if (ret) {
-        ret = project->save(filePath, saveMode, forceNoBackupCreate);
+        ret = project->save(filePath, saveMode, createBackup);
     }
 
     if (!ret) {
@@ -942,7 +942,7 @@ bool ProjectActionsController::saveProjectLocally(const muse::io::path_t& filePa
                     // Retry the save. Do not create a backup this time because the target file has been corrupted
                     // already. Creating a backup file of a corrupted file now makes no sense and will corrupt
                     // the healthy backup file created on the first save attempt.
-                    saveProjectLocally(filePath, saveMode, true /*forceNoBackupCreate*/);
+                    saveProjectLocally(filePath, saveMode, false /*createBackup*/);
                 });
                 break;
 

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -915,7 +915,7 @@ bool ProjectActionsController::saveProjectAt(const SaveLocation& location, SaveM
     return false;
 }
 
-bool ProjectActionsController::saveProjectLocally(const muse::io::path_t& filePath, SaveMode saveMode)
+bool ProjectActionsController::saveProjectLocally(const muse::io::path_t& filePath, SaveMode saveMode, bool forceNoBackupCreate)
 {
     INotationProjectPtr project = currentNotationProject();
     if (!project) {
@@ -928,7 +928,7 @@ bool ProjectActionsController::saveProjectLocally(const muse::io::path_t& filePa
     }
 
     if (ret) {
-        ret = project->save(filePath, saveMode);
+        ret = project->save(filePath, saveMode, forceNoBackupCreate);
     }
 
     if (!ret) {
@@ -939,7 +939,10 @@ bool ProjectActionsController::saveProjectLocally(const muse::io::path_t& filePa
             switch (warnScoreHasBecomeCorruptedAfterSave(ret)) {
             case RETRY_SAVE_BTN_ID:
                 async::Async::call(this, [this, filePath, saveMode]() {
-                    saveProjectLocally(filePath, saveMode);
+                    // Retry the save. Do not create a backup this time because the target file has been corrupted
+                    // already. Creating a backup file of a corrupted file now makes no sense and will corrupt
+                    // the healthy backup file created on the first save attempt.
+                    saveProjectLocally(filePath, saveMode, true /*forceNoBackupCreate*/);
                 });
                 break;
 

--- a/src/project/internal/projectactionscontroller.h
+++ b/src/project/internal/projectactionscontroller.h
@@ -93,7 +93,7 @@ public:
     bool closeOpenedProject(bool quitApp = false) override;
     bool saveProject(const muse::io::path_t& path = muse::io::path_t()) override;
     bool saveProjectLocally(
-        const muse::io::path_t& path = muse::io::path_t(), SaveMode saveMode = SaveMode::Save, bool forceNoBackupCreate = false) override;
+        const muse::io::path_t& path = muse::io::path_t(), SaveMode saveMode = SaveMode::Save, bool createBackup = true) override;
 
     // mi::IProjectProvider
     bool isProjectOpened(const muse::io::path_t& scorePath) const override;

--- a/src/project/internal/projectactionscontroller.h
+++ b/src/project/internal/projectactionscontroller.h
@@ -92,7 +92,8 @@ public:
     muse::Ret openProject(const ProjectFile& file) override;
     bool closeOpenedProject(bool quitApp = false) override;
     bool saveProject(const muse::io::path_t& path = muse::io::path_t()) override;
-    bool saveProjectLocally(const muse::io::path_t& path = muse::io::path_t(), SaveMode saveMode = SaveMode::Save) override;
+    bool saveProjectLocally(
+        const muse::io::path_t& path = muse::io::path_t(), SaveMode saveMode = SaveMode::Save, bool forceNoBackupCreate = false) override;
 
     // mi::IProjectProvider
     bool isProjectOpened(const muse::io::path_t& scorePath) const override;

--- a/src/project/iprojectfilescontroller.h
+++ b/src/project/iprojectfilescontroller.h
@@ -43,7 +43,8 @@ public:
     virtual muse::Ret openProject(const ProjectFile& file) = 0;
     virtual bool closeOpenedProject(bool quitApp = false) = 0;
     virtual bool saveProject(const muse::io::path_t& path = muse::io::path_t()) = 0;
-    virtual bool saveProjectLocally(const muse::io::path_t& path = muse::io::path_t(), SaveMode saveMode = SaveMode::Save) = 0;
+    virtual bool saveProjectLocally(
+        const muse::io::path_t& path = muse::io::path_t(), SaveMode saveMode = SaveMode::Save, bool forceNoBackupCreate = false) = 0;
 
     virtual const ProjectBeingDownloaded& projectBeingDownloaded() const = 0;
     virtual muse::async::Notification projectBeingDownloadedChanged() const = 0;

--- a/src/project/iprojectfilescontroller.h
+++ b/src/project/iprojectfilescontroller.h
@@ -44,7 +44,7 @@ public:
     virtual bool closeOpenedProject(bool quitApp = false) = 0;
     virtual bool saveProject(const muse::io::path_t& path = muse::io::path_t()) = 0;
     virtual bool saveProjectLocally(
-        const muse::io::path_t& path = muse::io::path_t(), SaveMode saveMode = SaveMode::Save, bool forceNoBackupCreate = false) = 0;
+        const muse::io::path_t& path = muse::io::path_t(), SaveMode saveMode = SaveMode::Save, bool createBackup = true) = 0;
 
     virtual const ProjectBeingDownloaded& projectBeingDownloaded() const = 0;
     virtual muse::async::Notification projectBeingDownloadedChanged() const = 0;


### PR DESCRIPTION
Resolves: #24908 (continuation)

**Key points:**
- Retried saves upon corruption won't create backups. On the first save, the target file will be corrupted already so backing it up won't help and will overwrite the healthy backup file created on the first save attempt. We want the healthy backup file to remain intact.
- I've changed the code to create a backup of the file being saved to. Currently MSS always backs up the **_original_** file even if you are doing a "Save as" and saving to another file. On the Corrupt dialog we offer a `Save as` button and don't want to overwrite the healhy backup with the corrupted original file when doing a "Save as". This would defeat the whole idea of this PR (which is to make sure a healthy backup file will be available if MSS corrupts a file).

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
