### PR TITLE
Allow more spanners to get removed from range selection

### DIFF
--- a/src/engraving/dom/select.cpp
+++ b/src/engraving/dom/select.cpp
@@ -716,19 +716,20 @@ void Selection::updateSelectedElements()
         if (sp->isVolta()) {
             continue;
         }
-        if (sp->isSlur() || sp->isHairpin()) {
+        if (sp->isSlur() || sp->isHairpin() || sp->isOttava() || sp->isPedal() || sp->isTrill() || sp->isTextLine() || sp->isLetRing()
+            || sp->isPalmMute()) {
             // ignore if start & end elements not calculated yet
             if (!sp->startElement() || !sp->endElement()) {
                 continue;
             }
-            if ((sp->tick() >= stick && sp->tick() < etick) || (sp->tick2() >= stick && sp->tick2() < etick)) {
+            if ((sp->tick() >= stick && sp->tick() < etick) || (sp->tick2() >= stick && sp->tick2() <= etick)) {
                 EngravingItem* startCR = sp->startCR();
                 EngravingItem* endCR = sp->endCR();
                 const bool canSelectStart = (sp->startElement()->isTimeTickAnchor() || canSelect(startCR));
                 const bool canSelectEnd = (sp->endElement()->isTimeTickAnchor() || canSelect(endCR));
                 if (canSelectStart && canSelectEnd) {
                     for (auto seg : sp->spannerSegments()) {
-                        appendFiltered(seg);               // slur with start or end in range selection
+                        appendFiltered(seg);               // spanner with start or end in range selection
                     }
                 }
             }
@@ -991,7 +992,6 @@ muse::ByteArray Selection::symbolListMimeData() const
     track_idx_t bottomTrack = 0;
     Segment* firstSeg    = 0;
     Fraction firstTick   = Fraction(0x7FFFFFFF, 1);
-    MapData mapData;
     Segment* seg         = 0;
     std::multimap<int64_t, MapData> map;
 
@@ -1147,8 +1147,7 @@ muse::ByteArray Selection::symbolListMimeData() const
             firstSeg  = seg;
             firstTick = seg->tick();
         }
-        mapData.e = e;
-        mapData.s = seg;
+        MapData mapData = { e, seg };
         map.insert(std::pair<int64_t, MapData>(((int64_t)track << 32) + seg->tick().ticks(), mapData));
     }
 


### PR DESCRIPTION
like ottavas, pedal lines, trill lines, staff and system text lines, let ring and palm mute lines

Follow up to #20634

Resolves: #15321 (well, adds to it)