### PR TITLE
Percussion panel - open "customize kit" dialog with the customize kit button

### DIFF
--- a/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelToolBar.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelToolBar.qml
@@ -173,7 +173,7 @@ Item {
             navigation.row: 0
 
             onClicked: {
-                api.launcher.open("muse://devtools/interactive/sample")
+                root.model.customizeKit()
             }
         }
     }

--- a/src/notation/view/notationcontextmenumodel.cpp
+++ b/src/notation/view/notationcontextmenumodel.cpp
@@ -120,7 +120,7 @@ MenuItemList NotationContextMenuModel::makeMeasureItems()
     items << makeSeparator();
 
     if (isDrumsetStaff()) {
-        items << makeMenuItem("edit-drumset");
+        items << makeMenuItem("customize-kit");
     }
 
     items << makeMenuItem("staff-properties");

--- a/src/notation/view/percussionpanel/percussionpanelmodel.cpp
+++ b/src/notation/view/percussionpanel/percussionpanelmodel.cpp
@@ -152,6 +152,11 @@ void PercussionPanelModel::finishEditing()
     setCurrentPanelMode(m_panelModeToRestore);
 }
 
+void PercussionPanelModel::customizeKit()
+{
+    dispatcher()->dispatch("customize-kit");
+}
+
 void PercussionPanelModel::setUpConnections()
 {
     const auto updatePadModels = [this](const mu::engraving::Drumset* drumset) {

--- a/src/notation/view/percussionpanel/percussionpanelmodel.h
+++ b/src/notation/view/percussionpanel/percussionpanelmodel.h
@@ -28,6 +28,7 @@
 #include "async/asyncable.h"
 
 #include "context/iglobalcontext.h"
+#include "actions/iactionsdispatcher.h"
 #include "playback/iplaybackcontroller.h"
 
 #include "percussionpanelpadlistmodel.h"
@@ -48,6 +49,7 @@ public:
 class PercussionPanelModel : public QObject, public muse::Injectable, public muse::async::Asyncable
 {
     muse::Inject<context::IGlobalContext> globalContext = { this };
+    muse::Inject<muse::actions::IActionsDispatcher> dispatcher = { this };
     muse::Inject<playback::IPlaybackController> playbackController = { this };
 
     Q_OBJECT
@@ -76,6 +78,8 @@ public:
     Q_INVOKABLE void handleMenuItem(const QString& itemId);
 
     Q_INVOKABLE void finishEditing();
+
+    Q_INVOKABLE void customizeKit();
 
 signals:
     void currentPanelModeChanged(const PanelMode::Mode& panelMode);

--- a/src/palette/internal/paletteactionscontroller.cpp
+++ b/src/palette/internal/paletteactionscontroller.cpp
@@ -30,14 +30,14 @@ using namespace muse::actions;
 static const muse::UriQuery MASTER_PALETTE_URI("musescore://palette/masterpalette?sync=false&modal=false");
 static const muse::UriQuery SPECIAL_CHARACTERS_URI("musescore://palette/specialcharacters?sync=false");
 static const muse::UriQuery TIME_SIGNATURE_PROPERTIES_URI("musescore://palette/timesignatureproperties");
-static const muse::UriQuery EDIT_DRUMSET_URI("musescore://palette/editdrumset");
+static const muse::UriQuery CUSTOMIZE_KIT_URI("musescore://palette/customizekit");
 
 void PaletteActionsController::init()
 {
     dispatcher()->reg(this, "masterpalette", this, &PaletteActionsController::toggleMasterPalette);
     dispatcher()->reg(this, "show-keys", this, &PaletteActionsController::toggleSpecialCharactersDialog);
     dispatcher()->reg(this, "time-signature-properties", this, &PaletteActionsController::openTimeSignaturePropertiesDialog);
-    dispatcher()->reg(this, "edit-drumset", this, &PaletteActionsController::openEditDrumsetDialog);
+    dispatcher()->reg(this, "customize-kit", this, &PaletteActionsController::openCustomizeKitDialog);
 
     interactive()->currentUri().ch.onReceive(this, [this](const Uri& uri) {
         //! NOTE If MasterPalette are not open, then it is reasonably to compare with the current uri,
@@ -94,7 +94,7 @@ void PaletteActionsController::openTimeSignaturePropertiesDialog()
     interactive()->open(TIME_SIGNATURE_PROPERTIES_URI);
 }
 
-void PaletteActionsController::openEditDrumsetDialog()
+void PaletteActionsController::openCustomizeKitDialog()
 {
-    interactive()->open(EDIT_DRUMSET_URI);
+    interactive()->open(CUSTOMIZE_KIT_URI);
 }

--- a/src/palette/internal/paletteactionscontroller.h
+++ b/src/palette/internal/paletteactionscontroller.h
@@ -47,7 +47,7 @@ private:
     void toggleMasterPalette(const muse::actions::ActionData& args);
     void toggleSpecialCharactersDialog();
     void openTimeSignaturePropertiesDialog();
-    void openEditDrumsetDialog();
+    void openCustomizeKitDialog();
 
     muse::ValCh<bool> m_masterPaletteOpened;
     muse::async::Channel<muse::actions::ActionCodeList> m_actionsReceiveAvailableChanged;

--- a/src/palette/internal/paletteuiactions.cpp
+++ b/src/palette/internal/paletteuiactions.cpp
@@ -53,11 +53,11 @@ const UiActionList PaletteUiActions::m_actions = {
              TranslatableString("action", "Time signature properties…"),
              TranslatableString("action", "Time signature properties…")
              ),
-    UiAction("edit-drumset",
+    UiAction("customize-kit",
              mu::context::UiCtxProjectOpened,
              mu::context::CTX_NOTATION_OPENED,
-             TranslatableString("action", "Edit drumset…"),
-             TranslatableString("action", "Edit drumset…")
+             TranslatableString("action", "Customize kit…"),
+             TranslatableString("action", "Customize kit…")
              ),
     UiAction("apply-current-palette-element",
              mu::context::UiCtxProjectOpened,

--- a/src/palette/palettemodule.cpp
+++ b/src/palette/palettemodule.cpp
@@ -46,7 +46,7 @@
 
 #include "view/widgets/masterpalette.h"
 #include "view/widgets/specialcharactersdialog.h"
-#include "view/widgets/editdrumsetdialog.h"
+#include "view/widgets/customizekitdialog.h"
 #include "view/widgets/timesignaturepropertiesdialog.h"
 #include "view/widgets/keyedit.h"
 #include "view/widgets/timedialog.h"
@@ -91,7 +91,7 @@ void PaletteModule::resolveImports()
         ir->registerWidgetUri<MasterPalette>(Uri("musescore://palette/masterpalette"));
         ir->registerWidgetUri<SpecialCharactersDialog>(Uri("musescore://palette/specialcharacters"));
         ir->registerWidgetUri<TimeSignaturePropertiesDialog>(Uri("musescore://palette/timesignatureproperties"));
-        ir->registerWidgetUri<EditDrumsetDialog>(Uri("musescore://palette/editdrumset"));
+        ir->registerWidgetUri<CustomizeKitDialog>(Uri("musescore://palette/customizekit"));
         ir->registerWidgetUri<KeyEditor>(Uri("musescore://notation/keysignatures"));
         ir->registerWidgetUri<TimeDialog>(Uri("musescore://notation/timesignatures"));
 

--- a/src/palette/qml/MuseScore/Palette/DrumsetPanel.qml
+++ b/src/palette/qml/MuseScore/Palette/DrumsetPanel.qml
@@ -53,18 +53,18 @@ Item {
                 anchors.horizontalCenter: parent.horizontalCenter
 
                 height: 20
-                width: editDrumsetButton.width
+                width: customizeKitButton.width
 
                 text: drumsetView.pitchName
             }
 
             FlatButton {
-                id: editDrumsetButton
+                id: customizeKitButton
 
-                text: qsTrc("palette", "Edit drumset")
+                text: qsTrc("palette", "Customize kit")
 
                 onClicked: {
-                    drumsetView.editDrumset()
+                    drumsetView.customizeKit()
                 }
             }
         }

--- a/src/palette/view/drumsetpanelview.cpp
+++ b/src/palette/view/drumsetpanelview.cpp
@@ -86,9 +86,9 @@ QString DrumsetPanelView::pitchName() const
     return m_pitchName;
 }
 
-void DrumsetPanelView::editDrumset()
+void DrumsetPanelView::customizeKit()
 {
-    dispatcher()->dispatch("edit-drumset");
+    dispatcher()->dispatch("customize-kit");
 }
 
 void DrumsetPanelView::componentComplete()

--- a/src/palette/view/drumsetpanelview.h
+++ b/src/palette/view/drumsetpanelview.h
@@ -49,7 +49,7 @@ public:
 
     QString pitchName() const;
 
-    Q_INVOKABLE void editDrumset();
+    Q_INVOKABLE void customizeKit();
 
 signals:
     void pitchNameChanged();

--- a/src/palette/view/widgets/customizekitdialog.cpp
+++ b/src/palette/view/widgets/customizekitdialog.cpp
@@ -20,7 +20,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include "editdrumsetdialog.h"
+#include "customizekitdialog.h"
 
 #include "io/file.h"
 
@@ -50,17 +50,17 @@ using namespace muse::io;
 using namespace mu::notation;
 using namespace mu::engraving;
 
-static const QString EDIT_DRUMSET_DIALOG_NAME("EditDrumsetDialog");
+static const QString CUSTOMIZE_KIT_DIALOG_NAME("CustomizeKitDialog");
 static const std::string_view POSSIBLE_SHORTCUTS("ABCDEFG");
 
 enum Column : char {
     PITCH, NOTE, SHORTCUT, NAME
 };
 
-class EditDrumsetTreeWidgetItem : public QTreeWidgetItem
+class CustomizeKitTreeWidgetItem : public QTreeWidgetItem
 {
 public:
-    EditDrumsetTreeWidgetItem(QTreeWidget* parent)
+    CustomizeKitTreeWidgetItem(QTreeWidget* parent)
         : QTreeWidgetItem(parent) {}
 
     bool operator<(const QTreeWidgetItem& other) const override
@@ -107,7 +107,7 @@ NoteHeadGroup noteHeadNames[] = {
 };
 
 //---------------------------------------------------------
-//   EditDrumsetDialog
+//   CustomizeKitDialog
 //---------------------------------------------------------
 
 struct SymbolIcon {
@@ -123,22 +123,22 @@ struct SymbolIcon {
         QPixmap image(w, h);
         image.fill(Qt::transparent);
         muse::draw::Painter painter(&image, "generateicon");
-        const muse::RectF& bbox = EditDrumsetDialog::engravingFonts()->fallbackFont()->bbox(id, 1);
+        const muse::RectF& bbox = CustomizeKitDialog::engravingFonts()->fallbackFont()->bbox(id, 1);
         const qreal actualSymbolScale = std::min(w / bbox.width(), h / bbox.height());
         qreal mag = std::min(defaultScale, actualSymbolScale);
         const qreal& xStShift = (w - mag * bbox.width()) / 2 - mag * bbox.left();
         const qreal& yStShift = (h - mag * bbox.height()) / 2 - mag * bbox.top();
         const muse::PointF& stPtPos = muse::PointF(xStShift, yStShift);
-        EditDrumsetDialog::engravingFonts()->fallbackFont()->draw(id, &painter, mag, stPtPos);
+        CustomizeKitDialog::engravingFonts()->fallbackFont()->draw(id, &painter, mag, stPtPos);
         icon.addPixmap(image);
         return SymbolIcon(id, icon);
     }
 };
 
-EditDrumsetDialog::EditDrumsetDialog(QWidget* parent)
+CustomizeKitDialog::CustomizeKitDialog(QWidget* parent)
     : QDialog(parent)
 {
-    setObjectName(EDIT_DRUMSET_DIALOG_NAME);
+    setObjectName(CUSTOMIZE_KIT_DIALOG_NAME);
 
     m_notation = globalContext()->currentNotation();
     if (!m_notation) {
@@ -178,16 +178,16 @@ EditDrumsetDialog::EditDrumsetDialog(QWidget* parent)
         noteHead->addItem(TConv::translatedUserName(g), int(g));
     }
 
-    connect(pitchList, &QTreeWidget::currentItemChanged, this, &EditDrumsetDialog::itemChanged);
-    connect(buttonBox, &QDialogButtonBox::clicked, this, &EditDrumsetDialog::bboxClicked);
-    connect(name, &QLineEdit::textChanged, this, &EditDrumsetDialog::nameChanged);
-    connect(noteHead, &QComboBox::currentIndexChanged, this, &EditDrumsetDialog::valueChanged);
-    connect(staffLine, &QSpinBox::valueChanged, this, &EditDrumsetDialog::valueChanged);
-    connect(voice, &QComboBox::currentIndexChanged, this, &EditDrumsetDialog::valueChanged);
-    connect(stemDirection, &QComboBox::currentIndexChanged, this, &EditDrumsetDialog::valueChanged);
-    connect(shortcut, &QComboBox::currentIndexChanged, this, &EditDrumsetDialog::shortcutChanged);
-    connect(loadButton, &QPushButton::clicked, this, &EditDrumsetDialog::load);
-    connect(saveButton, &QPushButton::clicked, this, &EditDrumsetDialog::save);
+    connect(pitchList, &QTreeWidget::currentItemChanged, this, &CustomizeKitDialog::itemChanged);
+    connect(buttonBox, &QDialogButtonBox::clicked, this, &CustomizeKitDialog::bboxClicked);
+    connect(name, &QLineEdit::textChanged, this, &CustomizeKitDialog::nameChanged);
+    connect(noteHead, &QComboBox::currentIndexChanged, this, &CustomizeKitDialog::valueChanged);
+    connect(staffLine, &QSpinBox::valueChanged, this, &CustomizeKitDialog::valueChanged);
+    connect(voice, &QComboBox::currentIndexChanged, this, &CustomizeKitDialog::valueChanged);
+    connect(stemDirection, &QComboBox::currentIndexChanged, this, &CustomizeKitDialog::valueChanged);
+    connect(shortcut, &QComboBox::currentIndexChanged, this, &CustomizeKitDialog::shortcutChanged);
+    connect(loadButton, &QPushButton::clicked, this, &CustomizeKitDialog::load);
+    connect(saveButton, &QPushButton::clicked, this, &CustomizeKitDialog::save);
     pitchList->setColumnWidth(0, 40);
     pitchList->setColumnWidth(1, 60);
     pitchList->setColumnWidth(2, 30);
@@ -266,8 +266,8 @@ EditDrumsetDialog::EditDrumsetDialog(QWidget* parent)
     quarterCmb->setCurrentIndex(quarterCmb->findData(SymNames::nameForSymId(SymId::noteheadBlack).ascii()));
     doubleWholeCmb->setCurrentIndex(quarterCmb->findData(SymNames::nameForSymId(SymId::noteheadDoubleWhole).ascii()));
 
-    connect(customGbox, &QGroupBox::toggled, this, &EditDrumsetDialog::customGboxToggled);
-    connect(quarterCmb, &QComboBox::currentIndexChanged, this, &EditDrumsetDialog::customQuarterChanged);
+    connect(customGbox, &QGroupBox::toggled, this, &CustomizeKitDialog::customGboxToggled);
+    connect(quarterCmb, &QComboBox::currentIndexChanged, this, &CustomizeKitDialog::customQuarterChanged);
 
     Q_ASSERT(pitchList->topLevelItemCount() > 0);
     pitchList->setCurrentItem(pitchList->topLevelItem(0));
@@ -285,7 +285,7 @@ EditDrumsetDialog::EditDrumsetDialog(QWidget* parent)
 //   customGboxToggled
 //---------------------------------------------------------
 
-void EditDrumsetDialog::customGboxToggled(bool checked)
+void CustomizeKitDialog::customGboxToggled(bool checked)
 {
     noteHead->setEnabled(!checked);
     if (checked) {
@@ -295,14 +295,14 @@ void EditDrumsetDialog::customGboxToggled(bool checked)
     }
 }
 
-void EditDrumsetDialog::loadPitchesList()
+void CustomizeKitDialog::loadPitchesList()
 {
     pitchList->blockSignals(true);
     pitchList->clear();
     pitchList->blockSignals(false);
 
     for (int i = 0; i < 128; ++i) {
-        QTreeWidgetItem* item = new EditDrumsetTreeWidgetItem(pitchList);
+        QTreeWidgetItem* item = new CustomizeKitTreeWidgetItem(pitchList);
         item->setText(Column::PITCH, QString("%1").arg(i));
         item->setText(Column::NOTE, pitch2string(i));
         if (m_editedDrumset.shortcut(i) == 0) {
@@ -317,7 +317,7 @@ void EditDrumsetDialog::loadPitchesList()
     pitchList->sortItems(3, Qt::SortOrder::DescendingOrder);
 }
 
-void EditDrumsetDialog::setEnabledPitchControls(bool enable)
+void CustomizeKitDialog::setEnabledPitchControls(bool enable)
 {
     customGbox->setEnabled(enable);
     noteHead->setEnabled(enable);
@@ -337,7 +337,7 @@ void EditDrumsetDialog::setEnabledPitchControls(bool enable)
 //   nameChanged
 //---------------------------------------------------------
 
-void EditDrumsetDialog::nameChanged(const QString& n)
+void CustomizeKitDialog::nameChanged(const QString& n)
 {
     QTreeWidgetItem* item = pitchList->currentItem();
     if (item) {
@@ -358,7 +358,7 @@ void EditDrumsetDialog::nameChanged(const QString& n)
 //   shortcutChanged
 //---------------------------------------------------------
 
-void EditDrumsetDialog::shortcutChanged()
+void CustomizeKitDialog::shortcutChanged()
 {
     QTreeWidgetItem* item = pitchList->currentItem();
     if (!item) {
@@ -400,7 +400,7 @@ void EditDrumsetDialog::shortcutChanged()
 //---------------------------------------------------------
 //   bboxClicked
 //---------------------------------------------------------
-void EditDrumsetDialog::bboxClicked(QAbstractButton* button)
+void CustomizeKitDialog::bboxClicked(QAbstractButton* button)
 {
     switch (buttonBox->buttonRole(button)) {
     case QDialogButtonBox::ApplyRole:
@@ -415,7 +415,7 @@ void EditDrumsetDialog::bboxClicked(QAbstractButton* button)
     }
 }
 
-void EditDrumsetDialog::apply()
+void CustomizeKitDialog::apply()
 {
     valueChanged();    //save last changes in name
 
@@ -424,12 +424,12 @@ void EditDrumsetDialog::apply()
     notifyAboutNoteInputStateChanged();
 }
 
-void EditDrumsetDialog::notifyAboutNoteInputStateChanged()
+void CustomizeKitDialog::notifyAboutNoteInputStateChanged()
 {
     m_notation->interaction()->noteInput()->stateChanged().notify();
 }
 
-void EditDrumsetDialog::cancel()
+void CustomizeKitDialog::cancel()
 {
     m_notation->parts()->replaceDrumset(m_instrumentKey, m_originDrumset);
 }
@@ -437,7 +437,7 @@ void EditDrumsetDialog::cancel()
 //---------------------------------------------------------
 //   fillCustomNoteheadsDataFromComboboxes
 //---------------------------------------------------------
-void EditDrumsetDialog::fillCustomNoteheadsDataFromComboboxes(int pitch)
+void CustomizeKitDialog::fillCustomNoteheadsDataFromComboboxes(int pitch)
 {
     m_editedDrumset.drum(pitch).notehead = NoteHeadGroup::HEAD_CUSTOM;
     m_editedDrumset.drum(pitch).noteheads[int(NoteHeadType::HEAD_WHOLE)] = SymNames::symIdByName(wholeCmb->currentData().toString());
@@ -447,7 +447,7 @@ void EditDrumsetDialog::fillCustomNoteheadsDataFromComboboxes(int pitch)
         = SymNames::symIdByName(doubleWholeCmb->currentData().toString());
 }
 
-void EditDrumsetDialog::fillNoteheadsComboboxes(bool customGroup, int pitch)
+void CustomizeKitDialog::fillNoteheadsComboboxes(bool customGroup, int pitch)
 {
     if (customGroup) {
         wholeCmb->setCurrentIndex(quarterCmb->findData(
@@ -480,7 +480,7 @@ void EditDrumsetDialog::fillNoteheadsComboboxes(bool customGroup, int pitch)
 //---------------------------------------------------------
 //   itemChanged
 //---------------------------------------------------------
-void EditDrumsetDialog::itemChanged(QTreeWidgetItem* current, QTreeWidgetItem* previous)
+void CustomizeKitDialog::itemChanged(QTreeWidgetItem* current, QTreeWidgetItem* previous)
 {
     if (previous) {
         int pitch = previous->data(0, Qt::UserRole).toInt();
@@ -546,7 +546,7 @@ void EditDrumsetDialog::itemChanged(QTreeWidgetItem* current, QTreeWidgetItem* p
 //---------------------------------------------------------
 //   setCustomNoteheadsGUIEnabled
 //---------------------------------------------------------
-void EditDrumsetDialog::setCustomNoteheadsGUIEnabled(bool enabled)
+void CustomizeKitDialog::setCustomNoteheadsGUIEnabled(bool enabled)
 {
     customGbox->setChecked(enabled);
     noteHead->setEnabled(!enabled);
@@ -558,7 +558,7 @@ void EditDrumsetDialog::setCustomNoteheadsGUIEnabled(bool enabled)
 //---------------------------------------------------------
 //   valueChanged
 //---------------------------------------------------------
-void EditDrumsetDialog::valueChanged()
+void CustomizeKitDialog::valueChanged()
 {
     if (!pitchList->currentItem()) {
         return;
@@ -592,7 +592,7 @@ void EditDrumsetDialog::valueChanged()
 //---------------------------------------------------------
 //   updateExample
 //---------------------------------------------------------
-void EditDrumsetDialog::updateExample()
+void CustomizeKitDialog::updateExample()
 {
     drumNote->clear();
     int pitch = pitchList->currentItem()->data(0, Qt::UserRole).toInt();
@@ -632,7 +632,7 @@ void EditDrumsetDialog::updateExample()
 //   load
 //---------------------------------------------------------
 
-void EditDrumsetDialog::load()
+void CustomizeKitDialog::load()
 {
     std::vector<std::string> filter = { muse::trc("palette", "MuseScore drumset file") + " (*.drm)" };
     muse::io::path_t dir = notationConfiguration()->userStylesPath();
@@ -681,7 +681,7 @@ void EditDrumsetDialog::load()
 //   save
 //---------------------------------------------------------
 
-void EditDrumsetDialog::save()
+void CustomizeKitDialog::save()
 {
     std::vector<std::string> filter = { muse::trc("palette", "MuseScore drumset file") + " (*.drm)" };
     muse::io::path_t dir = notationConfiguration()->userStylesPath();
@@ -712,7 +712,7 @@ void EditDrumsetDialog::save()
 //---------------------------------------------------------
 //   customQuarterChanged
 //---------------------------------------------------------
-void EditDrumsetDialog::customQuarterChanged(int)
+void CustomizeKitDialog::customQuarterChanged(int)
 {
     updateExample();
 }

--- a/src/palette/view/widgets/customizekitdialog.h
+++ b/src/palette/view/widgets/customizekitdialog.h
@@ -19,10 +19,10 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef MU_PALETTE_EDITDRUMSETDIALOG_H
-#define MU_PALETTE_EDITDRUMSETDIALOG_H
+#ifndef MU_PALETTE_CUSTOMIZEKITDIALOG_H
+#define MU_PALETTE_CUSTOMIZEKITDIALOG_H
 
-#include "ui_editdrumsetdialog.h"
+#include "ui_customizekitdialog.h"
 
 #include "modularity/ioc.h"
 #include "global/iinteractive.h"
@@ -35,10 +35,10 @@
 
 namespace mu::palette {
 //---------------------------------------------------------
-//   EditDrumsetDialog
+//   CustomizeKitDialog
 //---------------------------------------------------------
 
-class EditDrumsetDialog : public QDialog, private Ui::EditDrumsetDialog
+class CustomizeKitDialog : public QDialog, private Ui::CustomizeKitDialog
 {
     Q_OBJECT
 
@@ -50,7 +50,7 @@ public:
     INJECT_STATIC(engraving::IEngravingFontsProvider, engravingFonts)
 
 public:
-    EditDrumsetDialog(QWidget* parent = nullptr);
+    CustomizeKitDialog(QWidget* parent = nullptr);
 
 private slots:
     void bboxClicked(QAbstractButton* button);
@@ -85,4 +85,4 @@ private:
 };
 }
 
-#endif // MU_PALETTE_EDITDRUMSETDIALOG_H
+#endif // MU_PALETTE_CUSTOMIZEKITDIALOG_H

--- a/src/palette/view/widgets/customizekitdialog.ui
+++ b/src/palette/view/widgets/customizekitdialog.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>EditDrumsetDialog</class>
- <widget class="QDialog" name="EditDrumsetDialog">
+ <class>CustomizeKitDialog</class>
+ <widget class="QDialog" name="CustomizeKitDialog">
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Edit Drumset</string>
+   <string>Customize Kit</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
@@ -476,7 +476,7 @@
   <connection>
    <sender>buttonBox</sender>
    <signal>accepted()</signal>
-   <receiver>EditDrumsetDialog</receiver>
+   <receiver>CustomizeKitDialog</receiver>
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
@@ -492,7 +492,7 @@
   <connection>
    <sender>buttonBox</sender>
    <signal>rejected()</signal>
-   <receiver>EditDrumsetDialog</receiver>
+   <receiver>CustomizeKitDialog</receiver>
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">

--- a/src/palette/view/widgets/widgets.cmake
+++ b/src/palette/view/widgets/widgets.cmake
@@ -19,8 +19,8 @@ set(WIDGETS_SRC
     ${CMAKE_CURRENT_LIST_DIR}/symboldialog.cpp
     ${CMAKE_CURRENT_LIST_DIR}/specialcharactersdialog.cpp
     ${CMAKE_CURRENT_LIST_DIR}/specialcharactersdialog.h
-    ${CMAKE_CURRENT_LIST_DIR}/editdrumsetdialog.h
-    ${CMAKE_CURRENT_LIST_DIR}/editdrumsetdialog.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/customizekitdialog.h
+    ${CMAKE_CURRENT_LIST_DIR}/customizekitdialog.cpp
     ${CMAKE_CURRENT_LIST_DIR}/drumsetpalette.cpp
     ${CMAKE_CURRENT_LIST_DIR}/drumsetpalette.h
     )
@@ -33,6 +33,6 @@ set (WIDGETS_UI
     ${CMAKE_CURRENT_LIST_DIR}/note_groups.ui
     ${CMAKE_CURRENT_LIST_DIR}/symboldialog.ui
     ${CMAKE_CURRENT_LIST_DIR}/specialcharactersdialog.ui
-    ${CMAKE_CURRENT_LIST_DIR}/editdrumsetdialog.ui
+    ${CMAKE_CURRENT_LIST_DIR}/customizekitdialog.ui
     )
 


### PR DESCRIPTION
Firstly we're renaming the "edit drumset" dialog to the "customize kit" dialog, secondly we're connecting this up to the "customize kit" button in the percussion panel toolbar.