### PR TITLE
Fix crash on delete linked staff and delete bend

### DIFF
--- a/src/engraving/dom/note.cpp
+++ b/src/engraving/dom/note.cpp
@@ -3719,6 +3719,9 @@ void Note::undoUnlink()
     for (EngravingItem* e : m_el) {
         e->undoUnlink();
     }
+    for (Spanner* s : m_spannerFor) {
+        s->undoUnlink();
+    }
 }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/25424#issuecomment-2454663630

This doesn't share the same cause as the crash reported in the issue itself.
