### PR TITLE
Fix MOC and MSVC Compiler warnings

### DIFF
--- a/src/notation/view/widgets/editstyle.cpp
+++ b/src/notation/view/widgets/editstyle.cpp
@@ -857,12 +857,13 @@ EditStyle::EditStyle(QWidget* parent)
     groupBox_rests->layout()->addWidget(restOffsetSelector.widget);
 
     // ====================================================
-    // Measure repeats
+    // Measure repeats / (Multimeasure) rests
     // ====================================================
 
     // Define string here instead of in the .ui file to avoid MSVC compiler warning C4125, which would
     // be triggered by the decimal digit immediately following a non-ASCII character (curly quote).
     oneMeasureRepeatShow1->setText(muse::qtrc("EditStyleBase", "Show ‘1’ on 1-measure repeats"));
+    singleMMRestShowNumber->setText(muse::qtrc("EditStyleBase", "Show number ‘1’"));
 
     // ====================================================
     // BEAMS (QML)

--- a/src/notation/view/widgets/editstyle.ui
+++ b/src/notation/view/widgets/editstyle.ui
@@ -6041,7 +6041,7 @@
                   <item row="0" column="2">
                    <widget class="QCheckBox" name="singleMMRestShowNumber">
                     <property name="text">
-                     <string>Show number ‘1’</string>
+                     <string notr="true">Show number '1'</string>
                     </property>
                    </widget>
                   </item>

--- a/src/notation/view/widgets/editstyle.ui
+++ b/src/notation/view/widgets/editstyle.ui
@@ -7556,11 +7556,11 @@
       <widget class="QWidget" name="PageSlursTies">
        <layout class="QVBoxLayout" name="verticalLayout_13">
         <item>
-         <widget class="QScrollArea" name="scrollArea_4">
+         <widget class="QScrollArea" name="scrollArea_41">
           <property name="widgetResizable">
            <bool>true</bool>
           </property>
-          <widget class="QWidget" name="scrollAreaWidgetContents_5">
+          <widget class="QWidget" name="scrollAreaWidgetContents_51">
            <property name="geometry">
             <rect>
              <x>0</x>
@@ -7590,7 +7590,7 @@
               <property name="flat">
                <bool>false</bool>
               </property>
-              <layout class="QGridLayout" name="gridLayout_22">
+              <layout class="QGridLayout" name="gridLayout_221">
                <item row="0" column="0">
                 <widget class="QGroupBox" name="groupBox_slurs">
                  <property name="title">
@@ -10938,7 +10938,7 @@
           <property name="title">
            <string>Trill cue note</string>
           </property>
-          <layout class="QVBoxLayout" name="verticalLayout_69">
+          <layout class="QVBoxLayout" name="verticalLayout_691">
            <item>
             <widget class="QRadioButton" name="ornamentShowCueNoteOnlyNonSeconds">
              <property name="text">


### PR DESCRIPTION
* reg. decimal digit terminates octal escape sequence (C4125)
* reg. The name 'xxx' (QWidget) is already in use, defaulting to 'xxx_1'.