### PR TITLE
24908: Backport Save Corruption Check to v4.4.3

### DIFF
--- a/src/framework/global/CMakeLists.txt
+++ b/src/framework/global/CMakeLists.txt
@@ -120,6 +120,9 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/io/dir.cpp
     ${CMAKE_CURRENT_LIST_DIR}/io/dir.h
 
+    ${CMAKE_CURRENT_LIST_DIR}/io/devtools/allzerosfilecorruptor.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/io/devtools/allzerosfilecorruptor.h
+
     ${CMAKE_CURRENT_LIST_DIR}/serialization/xmlstreamreader.cpp
     ${CMAKE_CURRENT_LIST_DIR}/serialization/xmlstreamreader.h
     ${CMAKE_CURRENT_LIST_DIR}/serialization/xmlstreamwriter.cpp

--- a/src/framework/global/io/devtools/allzerosfilecorruptor.cpp
+++ b/src/framework/global/io/devtools/allzerosfilecorruptor.cpp
@@ -19,34 +19,19 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef MU_PROJECT_PROJECTERRORS_H
-#define MU_PROJECT_PROJECTERRORS_H
+#include "allzerosfilecorruptor.h"
 
-#include "types/ret.h"
+using namespace muse::io;
 
-namespace mu::project {
-enum class Err {
-    Undefined       = int(muse::Ret::Code::Undefined),
-    NoError         = int(muse::Ret::Code::Ok),
-    UnknownError    = int(muse::Ret::Code::ProjectFirst),
-
-    NoProjectError,
-    NoPartsError,
-    CorruptionError,
-    CorruptionUponOpenningError,
-    CorruptionUponSavingError,
-
-    FileOpenError,
-    InvalidCloudScoreId,
-
-    UnsupportedUrl,
-    MalformedOpenScoreUrl,
-};
-
-inline muse::Ret make_ret(Err e)
+AllZerosFileCorruptor::AllZerosFileCorruptor(const path_t& filePath)
+    : File(filePath)
 {
-    return muse::Ret(static_cast<int>(e));
-}
 }
 
-#endif // MU_PROJECT_PROJECTERRORS_H
+size_t AllZerosFileCorruptor::writeData(const uint8_t*, size_t len)
+{
+    // Ignore the actual data and write all zeros so as to corrupt the file.
+    uint8_t* corruptData = new uint8_t[len];
+    memset(corruptData, 0, len);
+    return File::writeData(corruptData, len);
+}

--- a/src/framework/global/io/devtools/allzerosfilecorruptor.h
+++ b/src/framework/global/io/devtools/allzerosfilecorruptor.h
@@ -19,34 +19,17 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef MU_PROJECT_PROJECTERRORS_H
-#define MU_PROJECT_PROJECTERRORS_H
+#pragma once
 
-#include "types/ret.h"
+#include "io/file.h"
 
-namespace mu::project {
-enum class Err {
-    Undefined       = int(muse::Ret::Code::Undefined),
-    NoError         = int(muse::Ret::Code::Ok),
-    UnknownError    = int(muse::Ret::Code::ProjectFirst),
-
-    NoProjectError,
-    NoPartsError,
-    CorruptionError,
-    CorruptionUponOpenningError,
-    CorruptionUponSavingError,
-
-    FileOpenError,
-    InvalidCloudScoreId,
-
-    UnsupportedUrl,
-    MalformedOpenScoreUrl,
-};
-
-inline muse::Ret make_ret(Err e)
+namespace muse::io {
+class AllZerosFileCorruptor : public File
 {
-    return muse::Ret(static_cast<int>(e));
-}
-}
+public:
+    AllZerosFileCorruptor(const path_t& filePath);
 
-#endif // MU_PROJECT_PROJECTERRORS_H
+private:
+    size_t writeData(const uint8_t* data, size_t len) override;
+};
+}

--- a/src/project/inotationproject.h
+++ b/src/project/inotationproject.h
@@ -69,7 +69,8 @@ public:
     virtual bool needAutoSave() const = 0;
     virtual void setNeedAutoSave(bool val) = 0;
 
-    virtual muse::Ret save(const muse::io::path_t& path = muse::io::path_t(), SaveMode saveMode = SaveMode::Save) = 0;
+    virtual muse::Ret save(
+        const muse::io::path_t& path = muse::io::path_t(), SaveMode saveMode = SaveMode::Save, bool createBackup = true) = 0;
     virtual muse::Ret writeToDevice(QIODevice* device) = 0;
 
     virtual ProjectMeta metaInfo() const = 0;

--- a/src/project/internal/notationproject.h
+++ b/src/project/internal/notationproject.h
@@ -94,7 +94,8 @@ public:
     bool needAutoSave() const override;
     void setNeedAutoSave(bool val) override;
 
-    muse::Ret save(const muse::io::path_t& path = muse::io::path_t(), SaveMode saveMode = SaveMode::Save) override;
+    muse::Ret save(
+        const muse::io::path_t& path = muse::io::path_t(), SaveMode saveMode = SaveMode::Save, bool createBackup = true) override;
     muse::Ret writeToDevice(QIODevice* device) override;
 
     ProjectMeta metaInfo() const override;
@@ -117,7 +118,7 @@ private:
     muse::Ret exportProject(const muse::io::path_t& path, const std::string& suffix);
     muse::Ret doSave(const muse::io::path_t& path, engraving::MscIoMode ioMode, bool generateBackup = true, bool createThumbnail = true,
                      bool isAutosave = false);
-    muse::Ret makeCurrentFileAsBackup();
+    muse::Ret makeBackup(muse::io::path_t filePath);
     muse::Ret writeProject(engraving::MscWriter& msczWriter, bool onlySelection, bool createThumbnail = true);
     muse::Ret checkSavedFileForCorruption(engraving::MscIoMode ioMode, const muse::io::path_t& path, const muse::io::path_t& scoreFileName);
 

--- a/src/project/internal/notationproject.h
+++ b/src/project/internal/notationproject.h
@@ -39,6 +39,8 @@
 #include "projectaudiosettings.h"
 #include "iprojectmigrator.h"
 
+#include "global/iglobalconfiguration.h"
+
 namespace mu::engraving {
 class MscReader;
 class MscWriter;
@@ -54,6 +56,7 @@ class NotationProject : public INotationProject, public muse::Injectable, public
     muse::Inject<INotationReadersRegister> readers = { this };
     muse::Inject<INotationWritersRegister> writers = { this };
     muse::Inject<IProjectMigrator> migrator = { this };
+    muse::Inject<muse::IGlobalConfiguration> globalConfiguration = { this };
 
 public:
     NotationProject(const muse::modularity::ContextPtr& iocCtx)
@@ -109,12 +112,14 @@ private:
     muse::Ret doImport(const muse::io::path_t& path, const muse::io::path_t& stylePath, bool forceMode);
 
     muse::Ret saveScore(const muse::io::path_t& path, const std::string& fileSuffix, bool generateBackup = true,
-                        bool createThumbnail = true);
+                        bool createThumbnail = true, bool isAutosave = false);
     muse::Ret saveSelectionOnScore(const muse::io::path_t& path = muse::io::path_t());
     muse::Ret exportProject(const muse::io::path_t& path, const std::string& suffix);
-    muse::Ret doSave(const muse::io::path_t& path, engraving::MscIoMode ioMode, bool generateBackup = true, bool createThumbnail = true);
+    muse::Ret doSave(const muse::io::path_t& path, engraving::MscIoMode ioMode, bool generateBackup = true, bool createThumbnail = true,
+                     bool isAutosave = false);
     muse::Ret makeCurrentFileAsBackup();
     muse::Ret writeProject(engraving::MscWriter& msczWriter, bool onlySelection, bool createThumbnail = true);
+    muse::Ret checkSavedFileForCorruption(engraving::MscIoMode ioMode, const muse::io::path_t& path, const muse::io::path_t& scoreFileName);
 
     void listenIfNeedSaveChanges();
     void markAsSaved(const muse::io::path_t& path);

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -58,6 +58,9 @@ static const muse::Uri UPLOAD_PROGRESS_URI("musescore://project/upload/progress"
 static const QString MUSESCORE_URL_SCHEME("musescore");
 static const QString OPEN_SCORE_URL_HOSTNAME("open-score");
 
+static constexpr int RETRY_SAVE_BTN_ID = int(IInteractive::Button::CustomButton);
+static constexpr int SAVE_AS_BTN_ID    = RETRY_SAVE_BTN_ID + 1;
+
 void ProjectActionsController::init()
 {
     dispatcher()->reg(this, "file-new", this, &ProjectActionsController::newProject);
@@ -931,7 +934,23 @@ bool ProjectActionsController::saveProjectLocally(const muse::io::path_t& filePa
 
     if (!ret) {
         LOGE() << ret.toString();
-        warnScoreCouldnotBeSaved(ret);
+        if (ret.code() != (int)Err::CorruptionUponSavingError) {
+            warnScoreCouldnotBeSaved(ret);
+        } else {
+            switch (warnScoreHasBecomeCorruptedAfterSave(ret)) {
+            case RETRY_SAVE_BTN_ID:
+                async::Async::call(this, [this, filePath, saveMode]() {
+                    saveProjectLocally(filePath, saveMode);
+                });
+                break;
+
+            case SAVE_AS_BTN_ID:
+                async::Async::call(this, [this]() {
+                    saveProject(SaveMode::SaveAs);
+                });
+                break;
+            }
+        }
         return false;
     }
 
@@ -1576,6 +1595,40 @@ void ProjectActionsController::warnScoreCouldnotBeSaved(const Ret& ret)
 void ProjectActionsController::warnScoreCouldnotBeSaved(const std::string& errorText)
 {
     interactive()->warning(muse::trc("project/save", "Your score could not be saved"), errorText);
+}
+
+int ProjectActionsController::warnScoreHasBecomeCorruptedAfterSave(const Ret& ret)
+{
+    const QString errDetailsMessage = QString::fromStdString(ret.toString()).toHtmlEscaped();
+
+    const QString supportForumLink = String("<a href=\"%1\" style=\"text-decoration: none\">musescore.org</a>")
+                                     .arg(configuration()->supportForumUrl().toString());
+
+    const std::string title = muse::trc("project/save", "An error occurred while saving your score");
+
+    const std::string body = muse::qtrc("project/save",
+                                        "To preserve your score, try saving it again. "
+                                        "If this message still appears, please save your score as new copy. "
+                                        "You can also get help for this issue on %1.<br/><br/>"
+                                        "Error details (please cite when asking for support): %2")
+                             .arg(supportForumLink, errDetailsMessage)
+                             .toStdString();
+
+    IInteractive::ButtonDatas buttons;
+
+    IInteractive::ButtonData saveAsBtn(SAVE_AS_BTN_ID, muse::trc("project/save", "Save as…"));
+    saveAsBtn.role = IInteractive::ButtonRole::ContinueRole;
+    buttons.push_back(saveAsBtn);
+
+    IInteractive::ButtonData retryBtn(RETRY_SAVE_BTN_ID, muse::trc("project", "Try again"), true /*accent*/);
+    retryBtn.role = IInteractive::ButtonRole::ContinueRole;
+    buttons.push_back(retryBtn);
+
+    IInteractive::ButtonData cancelBtn = interactive()->buttonData(IInteractive::Button::Cancel);
+    buttons.push_back(cancelBtn);
+
+    return interactive()->error(title, IInteractive::Text(body, IInteractive::TextFormat::RichText),
+                                buttons, retryBtn.btn).button();
 }
 
 void ProjectActionsController::revertCorruptedScoreToLastSaved()

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -916,7 +916,7 @@ bool ProjectActionsController::saveProjectAt(const SaveLocation& location, SaveM
     return false;
 }
 
-bool ProjectActionsController::saveProjectLocally(const muse::io::path_t& filePath, SaveMode saveMode)
+bool ProjectActionsController::saveProjectLocally(const muse::io::path_t& filePath, SaveMode saveMode, bool createBackup)
 {
     INotationProjectPtr project = currentNotationProject();
     if (!project) {
@@ -929,7 +929,7 @@ bool ProjectActionsController::saveProjectLocally(const muse::io::path_t& filePa
     }
 
     if (ret) {
-        ret = project->save(filePath, saveMode);
+        ret = project->save(filePath, saveMode, createBackup);
     }
 
     if (!ret) {
@@ -940,7 +940,10 @@ bool ProjectActionsController::saveProjectLocally(const muse::io::path_t& filePa
             switch (warnScoreHasBecomeCorruptedAfterSave(ret)) {
             case RETRY_SAVE_BTN_ID:
                 async::Async::call(this, [this, filePath, saveMode]() {
-                    saveProjectLocally(filePath, saveMode);
+                    // Retry the save. Do not create a backup this time because the target file has been corrupted
+                    // already. Creating a backup file of a corrupted file now makes no sense and will corrupt
+                    // the healthy backup file created on the first save attempt.
+                    saveProjectLocally(filePath, saveMode, false /*createBackup*/);
                 });
                 break;
 

--- a/src/project/internal/projectactionscontroller.h
+++ b/src/project/internal/projectactionscontroller.h
@@ -180,6 +180,7 @@ private:
 
     void warnScoreCouldnotBeSaved(const muse::Ret& ret);
     void warnScoreCouldnotBeSaved(const std::string& errorText);
+    int warnScoreHasBecomeCorruptedAfterSave(const muse::Ret& ret);
 
     void revertCorruptedScoreToLastSaved();
 

--- a/src/project/internal/projectactionscontroller.h
+++ b/src/project/internal/projectactionscontroller.h
@@ -92,7 +92,8 @@ public:
     muse::Ret openProject(const ProjectFile& file) override;
     bool closeOpenedProject(bool quitApp = false) override;
     bool saveProject(const muse::io::path_t& path = muse::io::path_t()) override;
-    bool saveProjectLocally(const muse::io::path_t& path = muse::io::path_t(), SaveMode saveMode = SaveMode::Save) override;
+    bool saveProjectLocally(
+        const muse::io::path_t& path = muse::io::path_t(), SaveMode saveMode = SaveMode::Save, bool createBackup = true) override;
 
     // mi::IProjectProvider
     bool isProjectOpened(const muse::io::path_t& scorePath) const override;

--- a/src/project/iprojectfilescontroller.h
+++ b/src/project/iprojectfilescontroller.h
@@ -43,7 +43,8 @@ public:
     virtual muse::Ret openProject(const ProjectFile& file) = 0;
     virtual bool closeOpenedProject(bool quitApp = false) = 0;
     virtual bool saveProject(const muse::io::path_t& path = muse::io::path_t()) = 0;
-    virtual bool saveProjectLocally(const muse::io::path_t& path = muse::io::path_t(), SaveMode saveMode = SaveMode::Save) = 0;
+    virtual bool saveProjectLocally(
+        const muse::io::path_t& path = muse::io::path_t(), SaveMode saveMode = SaveMode::Save, bool createBackup = true) = 0;
 
     virtual const ProjectBeingDownloaded& projectBeingDownloaded() const = 0;
     virtual muse::async::Notification projectBeingDownloadedChanged() const = 0;


### PR DESCRIPTION
Resolves: #24908 (backport to v4.4.3)

This is PR to backport the changes for #24908 to version 4.4.3 of MuseScore.

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
