### PR TITLE
Update nightly builds removal pattern

### DIFF
--- a/buildscripts/ci/tools/osuosl/publish.sh
+++ b/buildscripts/ci/tools/osuosl/publish.sh
@@ -128,7 +128,7 @@ if [ "$BUILD_MODE" == "nightly" ]; then
     fi  
     num_to_keep=$(((num_days + num_today) * num_branches * num_variants))  
     start_line_num=$((num_to_keep + 1))  
-    ssh -i $SSH_KEY musescore-nightlies@ftp-osl.osuosl.org "cd ~/ftp/$FTP_PATH && ls -t MuseScore{-Studio-,}Nightly-* MuseScore-4.*-x86_64.{7z,paf.exe} | tail -n +${start_line_num} | xargs rm -f"
+    ssh -i $SSH_KEY musescore-nightlies@ftp-osl.osuosl.org "cd ~/ftp/$FTP_PATH && ls -t MuseScore{-Studio-,}Nightly* | tail -n +${start_line_num} | xargs rm -f"
 fi
 
 # Sending index.html


### PR DESCRIPTION
- there are some Windows nightly builds named like `MuseScore-Studio-Nightly241670505-4.3.2-22b46f2-x86_64.7z`, i.e. no dash after "Nightly"
- all `MuseScore-4.*-x86_64.{7z,paf.exe}` have been removed by now

1000th PR, by the way