### PR TITLE
Fixes in editstyle.ui: Reset 'x' value

### DIFF
--- a/src/notation/view/widgets/editstyle.ui
+++ b/src/notation/view/widgets/editstyle.ui
@@ -6136,7 +6136,7 @@
                      <string>Reset to default</string>
                     </property>
                     <property name="accessibleName">
-                     <string>Reset 'Break H-bar if it collides with number' value</string>
+                     <string>Reset 'Break H-bar if number overlaps' value</string>
                     </property>
                     <property name="text">
                      <string notr="true"/>
@@ -6291,7 +6291,7 @@
                      <string>Reset to default</string>
                     </property>
                     <property name="accessibleName">
-                     <string>Reset 'H-bar horizontal stroke thickness' value</string>
+                     <string>Reset 'Horizontal stroke thickness' value</string>
                     </property>
                     <property name="text">
                      <string notr="true"/>
@@ -6320,7 +6320,7 @@
                      <string>Reset to default</string>
                     </property>
                     <property name="accessibleName">
-                     <string>Reset 'H-bar margin within barlines' value</string>
+                     <string>Reset 'Margin within barlines' value</string>
                     </property>
                     <property name="text">
                      <string notr="true"/>
@@ -6369,7 +6369,7 @@
                      <string>Reset to default</string>
                     </property>
                     <property name="accessibleName">
-                     <string>Reset 'H-bar vertical stroke thickness' value</string>
+                     <string>Reset 'Vertical stroke thickness' value</string>
                     </property>
                     <property name="text">
                      <string notr="true"/>
@@ -6408,7 +6408,7 @@
                      <string>Reset to default</string>
                     </property>
                     <property name="accessibleName">
-                     <string>Reset 'H-bar vertical stroke height' value</string>
+                     <string>Reset 'Vertical stroke height' value</string>
                     </property>
                     <property name="text">
                      <string notr="true"/>


### PR DESCRIPTION
Fixes in editstyle.ui: Reset 'x' value

Greetings,
Gootector

Resolves: #NNNNN <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
