### PR TITLE
Percussion panel - implement panel disabled state

### DIFF
--- a/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
+++ b/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
@@ -190,6 +190,7 @@ Item {
                         height: parent.height + pad.totalBorderWidth - padGrid.spacing
 
                         padModel: model.padModelRole
+                        panelEnabled: percModel.enabled
                         panelMode: percModel.currentPanelMode
                         useNotationPreview: percModel.useNotationPreview
 
@@ -258,6 +259,19 @@ Item {
                     flickable.goToBottom()
                 }
             }
+        }
+
+        StyledTextLabel {
+            id: panelDisabledLabel
+
+            visible: !percModel.enabled
+
+            anchors.top: parent.top
+            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.topMargin: (padGrid.cellHeight / 2) - (panelDisabledLabel.height / 2)
+
+            font: ui.theme.bodyFont
+            text: qsTrc("notation", "Select an unpitched percussion stave to use available sounds")
         }
     }
 }

--- a/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPad.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPad.qml
@@ -31,6 +31,8 @@ DropArea {
 
     property var padModel: null
 
+    property bool panelEnabled: false
+
     property int panelMode: -1
     property bool useNotationPreview: false
     property bool showEditOutline: false
@@ -46,6 +48,8 @@ DropArea {
     QtObject {
         id: prv
         readonly property bool isEmptySlot: Boolean(root.padModel) ? root.padModel.isEmptySlot : true
+        readonly property color enabledBackgroundColor: Utils.colorWithAlpha(ui.theme.buttonColor, ui.theme.buttonOpacityNormal)
+        readonly property color disabledBackgroundColor: Utils.colorWithAlpha(ui.theme.buttonColor, ui.theme.itemOpacityDisabled)
     }
 
     Rectangle {
@@ -121,7 +125,7 @@ DropArea {
 
                 Rectangle {
                     id: emptySlotBackground
-                    color: ui.theme.backgroundSecondaryColor
+                    color: root.panelEnabled ? prv.enabledBackgroundColor : prv.disabledBackgroundColor
                 }
             }
         }
@@ -172,7 +176,7 @@ DropArea {
             anchors.margins: padLoader.anchors.margins
             radius: draggableArea.radius - originBackgroundFill.anchors.margins
 
-            color: root.containsDrag ? ui.theme.buttonColor : ui.theme.backgroundSecondaryColor
+            color: root.containsDrag ? ui.theme.buttonColor : prv.enabledBackgroundColor
         }
     }
 }

--- a/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelToolBar.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelToolBar.qml
@@ -67,17 +67,19 @@ Item {
             }
         }
 
-        visible: model.currentPanelMode !== PanelMode.EDIT_LAYOUT
+        visible: root.model.currentPanelMode !== PanelMode.EDIT_LAYOUT
 
         FlatButton {
             id: writeButton
 
             width: centralButtonsRow.buttonWidth
 
+            enabled: root.model.enabled
+
             icon: IconCode.EDIT
             text: qsTrc("notation", "Write")
             orientation: Qt.Horizontal
-            accentButton: model.currentPanelMode === PanelMode.WRITE
+            accentButton: root.model.currentPanelMode === PanelMode.WRITE
             backgroundRadius: 0
 
             navigation.panel: navPanel
@@ -100,10 +102,12 @@ Item {
 
             width: centralButtonsRow.buttonWidth
 
+            enabled: root.model.enabled
+
             icon: IconCode.PLAY
             text: qsTrc("notation", "Preview")
             orientation: Qt.Horizontal
-            accentButton: model.currentPanelMode === PanelMode.SOUND_PREVIEW
+            accentButton: root.model.currentPanelMode === PanelMode.SOUND_PREVIEW
             backgroundRadius: 0
 
             navigation.panel: navPanel
@@ -121,7 +125,9 @@ Item {
         anchors.verticalCenter: parent.verticalCenter
         x: prv.centerX - (finishEditingButton.width / 2)
 
-        visible: model.currentPanelMode === PanelMode.EDIT_LAYOUT
+        enabled: root.model.enabled
+
+        visible: root.model.currentPanelMode === PanelMode.EDIT_LAYOUT
         text: qsTrc("notation", "Finish editing")
         orientation: Qt.Horizontal
         accentButton: true
@@ -144,6 +150,8 @@ Item {
         spacing: prv.spacing
 
         FlatButton {
+            enabled: root.model.enabled
+
             icon: IconCode.SPLIT_VIEW_HORIZONTAL
             text: qsTrc("notation", "Layout")
             orientation: Qt.Horizontal
@@ -165,7 +173,7 @@ Item {
         }
 
         FlatButton {
-            enabled: model.currentPanelMode !== PanelMode.EDIT_LAYOUT
+            enabled: root.model.enabled && root.model.currentPanelMode !== PanelMode.EDIT_LAYOUT
             text: qsTrc("notation", "Customize kit")
             orientation: Qt.Horizontal
 

--- a/src/notation/view/percussionpanel/percussionpanelmodel.cpp
+++ b/src/notation/view/percussionpanel/percussionpanelmodel.cpp
@@ -43,6 +43,20 @@ PercussionPanelModel::PercussionPanelModel(QObject* parent)
     m_padListModel = new PercussionPanelPadListModel(this);
 }
 
+bool PercussionPanelModel::enabled() const
+{
+    return m_enabled;
+}
+
+void PercussionPanelModel::setEnabled(bool enabled)
+{
+    if (m_enabled == enabled) {
+        return;
+    }
+    m_enabled = enabled;
+    emit enabledChanged();
+}
+
 PanelMode::Mode PercussionPanelModel::currentPanelMode() const
 {
     return m_currentPanelMode;
@@ -187,6 +201,10 @@ void PercussionPanelModel::setUpConnections()
         }
         const INotationNoteInputPtr ni = interaction()->noteInput();
         updatePadModels(ni->state().drumset);
+    });
+
+    m_padListModel->hasActivePadsChanged().onNotify(this, [this]() {
+        setEnabled(m_padListModel->hasActivePads());
     });
 
     m_padListModel->padTriggered().onReceive(this, [this](int pitch) {

--- a/src/notation/view/percussionpanel/percussionpanelmodel.cpp
+++ b/src/notation/view/percussionpanel/percussionpanelmodel.cpp
@@ -163,6 +163,11 @@ void PercussionPanelModel::setUpConnections()
         if (drumset == m_padListModel->drumset()) {
             return;
         }
+
+        if (m_currentPanelMode == PanelMode::Mode::EDIT_LAYOUT) {
+            finishEditing();
+        }
+
         m_padListModel->setDrumset(drumset);
         m_padListModel->resetLayout(); //! NOTE: Placeholder until we implement saving/loading
     };

--- a/src/notation/view/percussionpanel/percussionpanelmodel.h
+++ b/src/notation/view/percussionpanel/percussionpanelmodel.h
@@ -55,6 +55,8 @@ class PercussionPanelModel : public QObject, public muse::Injectable, public mus
 
     Q_OBJECT
 
+    Q_PROPERTY(bool enabled READ enabled NOTIFY enabledChanged)
+
     Q_PROPERTY(PanelMode::Mode currentPanelMode READ currentPanelMode WRITE setCurrentPanelMode NOTIFY currentPanelModeChanged)
     Q_PROPERTY(bool useNotationPreview READ useNotationPreview WRITE setUseNotationPreview NOTIFY useNotationPreviewChanged)
 
@@ -64,6 +66,9 @@ class PercussionPanelModel : public QObject, public muse::Injectable, public mus
 
 public:
     explicit PercussionPanelModel(QObject* parent = nullptr);
+
+    bool enabled() const;
+    void setEnabled(bool enabled);
 
     PanelMode::Mode currentPanelMode() const;
     void setCurrentPanelMode(const PanelMode::Mode& panelMode);
@@ -83,6 +88,8 @@ public:
     Q_INVOKABLE void customizeKit();
 
 signals:
+    void enabledChanged();
+
     void currentPanelModeChanged(const PanelMode::Mode& panelMode);
     void useNotationPreviewChanged(bool useNotationPreview);
 
@@ -98,6 +105,8 @@ private:
     const mu::notation::INotationInteractionPtr interaction() const;
 
     mu::engraving::Score* score() const;
+
+    bool m_enabled = false;
 
     PanelMode::Mode m_currentPanelMode = PanelMode::Mode::WRITE;
     PanelMode::Mode m_panelModeToRestore = PanelMode::Mode::WRITE;

--- a/src/notation/view/percussionpanel/percussionpanelpadlistmodel.cpp
+++ b/src/notation/view/percussionpanel/percussionpanelpadlistmodel.cpp
@@ -104,7 +104,14 @@ void PercussionPanelPadListModel::setDrumset(const mu::engraving::Drumset* drums
     if (drumset == m_drumset) {
         return;
     }
+
+    const bool drumsetWasValid = m_drumset;
+
     m_drumset = drumset;
+
+    if (drumsetWasValid ^ bool(m_drumset)) {
+        m_hasActivePadsChanged.notify();
+    }
 }
 
 void PercussionPanelPadListModel::resetLayout()

--- a/src/notation/view/percussionpanel/percussionpanelpadlistmodel.h
+++ b/src/notation/view/percussionpanel/percussionpanelpadlistmodel.h
@@ -55,6 +55,8 @@ public:
     Q_INVOKABLE void startDrag(int startIndex);
     Q_INVOKABLE void endDrag(int endIndex);
 
+    bool hasActivePads() const { return m_drumset; }
+
     int numColumns() const { return NUM_COLUMNS; }
     int numPads() const { return m_padModels.count(); }
 
@@ -63,6 +65,7 @@ public:
 
     void resetLayout();
 
+    muse::async::Notification hasActivePadsChanged() const { return m_hasActivePadsChanged; }
     muse::async::Channel<int /*pitch*/> padTriggered() const { return m_triggeredChannel; }
 
 signals:
@@ -86,6 +89,7 @@ private:
 
     int m_dragStartIndex = -1;
 
+    muse::async::Notification m_hasActivePadsChanged;
     muse::async::Channel<int /*pitch*/> m_triggeredChannel;
 };
 }


### PR DESCRIPTION
If the currently selected stave isn't unpitched percussion, the percussion panel should enter a "disabled" state. This state disables/greys-out the buttons in the toolbar, changes the pad background colours, and displays a text label.

This PR also makes some minor changes to pad background colours to bring them in line with the spec, and ensures that we leave layout edit mode when switching staves.