### PR TITLE
[techdebt] Addresses code issues identified in issue 17082

### DIFF
--- a/src/engraving/dom/chord.h
+++ b/src/engraving/dom/chord.h
@@ -190,8 +190,10 @@ public:
 
     Chord* graceNoteAt(size_t idx) const;
 
-    int upLine() const override;
-    int downLine() const override;
+    int line(bool up) const { return up ? upLine() : downLine(); }
+    int line() const { return ldata()->up ? upLine() : downLine(); }
+    int upLine() const;
+    int downLine() const;
     PointF stemPos() const override;            ///< page coordinates
     PointF stemPosBeam() const override;        ///< page coordinates
     double stemPosX() const override;

--- a/src/engraving/dom/chordrest.h
+++ b/src/engraving/dom/chordrest.h
@@ -87,10 +87,6 @@ public:
     virtual double upPos()   const = 0;
     virtual double downPos() const = 0;
 
-    int line(bool up) const { return up ? upLine() : downLine(); }
-    int line() const { return ldata()->up ? upLine() : downLine(); }
-    virtual int upLine() const = 0;
-    virtual int downLine() const = 0;
     virtual PointF stemPos() const = 0;
     virtual double stemPosX() const = 0;
     virtual PointF stemPosBeam() const = 0;

--- a/src/engraving/dom/rest.cpp
+++ b/src/engraving/dom/rest.cpp
@@ -648,26 +648,6 @@ double Rest::intrinsicMag() const
 }
 
 //---------------------------------------------------------
-//   upLine
-//---------------------------------------------------------
-
-int Rest::upLine() const
-{
-    double _spatium = spatium();
-    return lrint((pos().y() + ldata()->bbox().top() + _spatium) * 2 / _spatium);
-}
-
-//---------------------------------------------------------
-//   downLine
-//---------------------------------------------------------
-
-int Rest::downLine() const
-{
-    double _spatium = spatium();
-    return lrint((pos().y() + ldata()->bbox().top() + _spatium) * 2 / _spatium);
-}
-
-//---------------------------------------------------------
 //   stemPos
 //    point to connect stem
 //---------------------------------------------------------

--- a/src/engraving/dom/rest.h
+++ b/src/engraving/dom/rest.h
@@ -110,8 +110,6 @@ public:
 
     DeadSlapped* deadSlapped() const { return m_deadSlapped; }
 
-    int upLine() const override;
-    int downLine() const override;
     PointF stemPos() const override;
     double stemPosX() const override;
     PointF stemPosBeam() const override;

--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -4652,6 +4652,10 @@ ChordRest* Score::findChordRestEndingBeforeTickInTrack(const Fraction& tick, tra
 
 ChordRest* Score::cmdNextPrevSystem(ChordRest* cr, bool next)
 {
+    IF_ASSERT_FAILED(cr) {
+        return nullptr;
+    }
+
     auto newCR = cr;
     auto currentMeasure = cr->measure();
     auto currentSystem = currentMeasure->system() ? currentMeasure->system() : currentMeasure->coveringMMRestOrThis()->system();
@@ -4659,6 +4663,10 @@ ChordRest* Score::cmdNextPrevSystem(ChordRest* cr, bool next)
         return cr;
     }
     auto destinationMeasure = currentSystem->firstMeasure();
+    if (!destinationMeasure) {
+        return cr;
+    }
+
     auto firstSegment = destinationMeasure->first(SegmentType::ChordRest);
 
     // Case: Go to next system
@@ -4668,6 +4676,9 @@ ChordRest* Score::cmdNextPrevSystem(ChordRest* cr, bool next)
             currentSystem = destinationMeasure->system()
                             ? destinationMeasure->system()
                             : destinationMeasure->coveringMMRestOrThis()->system();
+            if (!currentSystem) {
+                return cr;
+            }
             if ((destinationMeasure = currentSystem->firstMeasure())) {
                 if ((newCR = destinationMeasure->first()->nextChordRest(trackZeroVoice(cr->track()), false))) {
                     cr = newCR;
@@ -4696,10 +4707,8 @@ ChordRest* Score::cmdNextPrevSystem(ChordRest* cr, bool next)
         // and not in first measure of entire score
         if ((destinationMeasure != firstMeasure() && destinationMeasure != firstMeasureMM())
             && (currentSegment == firstSegment || (currentMeasure->mmRest() && currentMeasure->mmRest()->isFirstInSystem()))) {
-            if (!(destinationMeasure = destinationMeasure->prevMeasure())) {
-                if (!(destinationMeasure = destinationMeasure->prevMeasureMM())) {
-                    return cr;
-                }
+            if (!(destinationMeasure = destinationMeasure->prevMeasureMM())) {
+                return cr;
             }
             if (!(currentSystem = destinationMeasure->system()
                                   ? destinationMeasure->system()

--- a/src/engraving/rendering/score/beamtremololayout.cpp
+++ b/src/engraving/rendering/score/beamtremololayout.cpp
@@ -332,8 +332,9 @@ void BeamTremoloLayout::setSmallInnerBeamPos(const BeamBase::LayoutData* ldata, 
         if (!cr->isChord()) {
             continue;
         }
+        const Chord* c = toChord(cr);
         beamCount = std::max(beamCount, strokeCount(ldata, cr));
-        noteOutsideStaff |= (cr->downLine() < -2 && !ldata->up) || (cr->upLine() >= 11 && ldata->up);
+        noteOutsideStaff |= (c->downLine() < -2 && !ldata->up) || (c->upLine() >= 11 && ldata->up);
     }
 
     // AND stems have been extended to the second stave line when the notes are far enough outside of the stave


### PR DESCRIPTION
Resolves (partially - we should still take a more holistic look at our `cmdNextPrev...` methods): #17082 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

- Modified `Rest::downLine` to call `Rest::upLine`. This makes explicit that they are supposed to be identical functions.
- Modified `Score::cmdNextPrevSystem` to check `destinationMeasure` for `nullptr` before dereferencing it.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
