### PR TITLE
set `CMAKE_MSVC_RUNTIME_LIBRARY` to "MultiThreadedDLL"

### DIFF
--- a/buildscripts/cmake/SetupBuildEnvironment.cmake
+++ b/buildscripts/cmake/SetupBuildEnvironment.cmake
@@ -66,6 +66,11 @@ endif(OS_IS_MAC)
 
 # MSVC-specific
 if(CC_IS_MSVC)
+    # TODO: remove this
+    # It is necessary because of the following line in src/app/CMakeLists.txt:
+    # `set_target_properties(${QtLibrary} PROPERTIES MAP_IMPORTED_CONFIG_DEBUG "RELEASE")`
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL") # i.e. not MultiThreaded$<$<CONFIG:Debug>:Debug>DLL
+
     add_compile_options("/EHsc")
     add_compile_options("/utf-8")
 

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -335,6 +335,10 @@ if (OS_IS_WIN)
     foreach (QtLibrary ${QT_LIBRARIES})
         #message(STATUS "Library ${QtLibrary}")
         # always use release libs
+        # TODO: remove this
+        # That's not trivial, because for the libraries that are installed manually
+        # below, we would need to manually specify the correct debug/release names.
+        # The real solution would be to use windeployqt.
         set_target_properties(${QtLibrary} PROPERTIES MAP_IMPORTED_CONFIG_DEBUG "RELEASE")
         get_target_property(QtSharedLibrary ${QtLibrary} LOCATION_RELEASE)
         if (EXISTS ${QtSharedLibrary})


### PR DESCRIPTION
to prevent build failures and/or crashes in debug builds because debug/release mismatches: for Qt, we always use release builds, and therefore we'll also have to build against the release MSVC runtime, even in debug mode. This means we're missing out on useful debug assertions, but it's the only way for now.