### PR TITLE
Fix width of PageTabButton when Roboto font is used

### DIFF
--- a/src/framework/uicomponents/qml/Muse/UiComponents/PageTabButton.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/PageTabButton.qml
@@ -132,6 +132,12 @@ RadioDelegate {
         implicitHeight: contentRow.implicitHeight
 
         TextMetrics {
+            id: textMetricsNormal
+            font: root.normalStateFont
+            text: root.title
+        }
+
+        TextMetrics {
             id: textMetricsSelected
             font: root.selectedStateFont
             text: root.title
@@ -155,7 +161,7 @@ RadioDelegate {
                 horizontalAlignment: root.isVertical ? Text.AlignHCenter : Text.AlignLeft
                 font: root.normalStateFont
                 text: root.title
-                width: textMetricsSelected.advanceWidth
+                width: Math.max(textMetricsNormal.advanceWidth, textMetricsSelected.advanceWidth)
 
                 visible: !root.iconOnly
             }


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/25502