### PR TITLE
Fix - Crash due to too big custom Time Signature

### DIFF
--- a/buildscripts/ci/tools/osuosl/publish.sh
+++ b/buildscripts/ci/tools/osuosl/publish.sh
@@ -128,7 +128,7 @@ if [ "$BUILD_MODE" == "nightly" ]; then
     fi  
     num_to_keep=$(((num_days + num_today) * num_branches * num_variants))  
     start_line_num=$((num_to_keep + 1))  
-    ssh -i $SSH_KEY musescore-nightlies@ftp-osl.osuosl.org "cd ~/ftp/$FTP_PATH && ls -t MuseScore{-Studio-,}Nightly-* MuseScore-4.*-x86_64.{7z,paf.exe} | tail -n +${start_line_num} | xargs rm -f"
+    ssh -i $SSH_KEY musescore-nightlies@ftp-osl.osuosl.org "cd ~/ftp/$FTP_PATH && ls -t MuseScore{-Studio-,}Nightly* | tail -n +${start_line_num} | xargs rm -f"
 fi
 
 # Sending index.html

--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -561,6 +561,10 @@ void Score::rebuildTempoAndTimeSigMaps(Measure* measure, std::optional<BeatsPerS
                 } else if (e->isTempoText()) {
                     TempoText* tt = toTempoText(e);
 
+                    if (!tt->playTempoText()) {
+                        continue;
+                    }
+
                     if (tt->isNormal() && !tt->isRelative() && !tempoPrimo) {
                         tempoPrimo = tt->tempo();
                     } else if (tt->isRelative()) {
@@ -631,7 +635,7 @@ void Score::fixAnacrusisTempo(const std::vector<Measure*>& measures) const
         for (const Segment& s : m->segments()) {
             if (s.isChordRestType()) {
                 for (EngravingItem* e : s.annotations()) {
-                    if (e->isTempoText()) {
+                    if (e->isTempoText() && toTempoText(e)->playTempoText()) {
                         return toTempoText(e);
                     }
                 }

--- a/src/engraving/dom/tempotext.cpp
+++ b/src/engraving/dom/tempotext.cpp
@@ -330,30 +330,14 @@ void TempoText::setTempo(BeatsPerSecond v)
 }
 
 //---------------------------------------------------------
-//   undoSetTempo
-//---------------------------------------------------------
-
-void TempoText::undoSetTempo(double v)
-{
-    undoChangeProperty(Pid::TEMPO, v, propertyFlags(Pid::TEMPO));
-}
-
-//---------------------------------------------------------
-//   undoSetFollowText
-//---------------------------------------------------------
-
-void TempoText::undoSetFollowText(bool v)
-{
-    undoChangeProperty(Pid::TEMPO_FOLLOW_TEXT, v, propertyFlags(Pid::TEMPO));
-}
-
-//---------------------------------------------------------
 //   getProperty
 //---------------------------------------------------------
 
 PropertyValue TempoText::getProperty(Pid propertyId) const
 {
     switch (propertyId) {
+    case Pid::PLAY:
+        return m_playTempoText;
     case Pid::TEMPO:
         return m_tempo;
     case Pid::TEMPO_FOLLOW_TEXT:
@@ -370,12 +354,16 @@ PropertyValue TempoText::getProperty(Pid propertyId) const
 bool TempoText::setProperty(Pid propertyId, const PropertyValue& v)
 {
     switch (propertyId) {
+    case Pid::PLAY:
+        setPlayTempoText(v.toBool());
+        score()->setUpTempoMapLater();
+        break;
     case Pid::TEMPO:
         setTempo(v.value<BeatsPerSecond>());
         score()->setUpTempoMapLater();
         break;
     case Pid::TEMPO_FOLLOW_TEXT:
-        m_followText = v.toBool();
+        setFollowText(v.toBool());
         break;
     default:
         if (!TextBase::setProperty(propertyId, v)) {
@@ -394,6 +382,8 @@ bool TempoText::setProperty(Pid propertyId, const PropertyValue& v)
 PropertyValue TempoText::propertyDefault(Pid id) const
 {
     switch (id) {
+    case Pid::PLAY:
+        return true;
     case Pid::TEXT_STYLE:
         return TextStyleType::TEMPO;
     case Pid::TEMPO:

--- a/src/engraving/dom/tempotext.h
+++ b/src/engraving/dom/tempotext.h
@@ -61,7 +61,6 @@ public:
     BeatsPerSecond tempo() const { return m_tempo; }
     double tempoBpm() const;
     void setTempo(BeatsPerSecond v);
-    void undoSetTempo(double v);
     bool isRelative() { return m_isRelative; }
     void setRelative(double v) { m_isRelative = true; m_relative = v; }
 
@@ -74,9 +73,11 @@ public:
     bool isTempoPrimo() const { return m_tempoTextType == TempoTextType::TEMPO_PRIMO; }
     void setTempoPrimo() { setTempoTextType(TempoTextType::TEMPO_PRIMO); }
 
+    bool playTempoText() const { return m_playTempoText; }
+    void setPlayTempoText(bool v) { m_playTempoText = v; }
+
     bool followText() const { return m_followText; }
     void setFollowText(bool v) { m_followText = v; }
-    void undoSetFollowText(bool v);
 
     void updateTempo();
     void updateRelative();
@@ -104,6 +105,7 @@ protected:
     TempoTextType m_tempoTextType;
     BeatsPerSecond m_tempo;             // beats per second
     bool m_followText = false;          // parse text to determine tempo
+    bool m_playTempoText = true;
     double m_relative = 0.0;
     bool m_isRelative = false;
 };

--- a/src/engraving/rw/read400/tread.cpp
+++ b/src/engraving/rw/read400/tread.cpp
@@ -483,7 +483,8 @@ void TRead::read(TempoText* t, XmlReader& e, ReadContext& ctx)
 {
     while (e.readNextStartElement()) {
         const AsciiStringView tag(e.name());
-        if (tag == "tempo") {
+        if (readProperty(t, tag, e, ctx, Pid::PLAY)) {
+        } else if (tag == "tempo") {
             t->setTempo(TConv::fromXml(e.readAsciiText(), Constants::DEFAULT_TEMPO));
         } else if (tag == "followText") {
             t->setFollowText(e.readInt());

--- a/src/engraving/rw/read410/tread.cpp
+++ b/src/engraving/rw/read410/tread.cpp
@@ -649,7 +649,8 @@ void TRead::read(TempoText* t, XmlReader& e, ReadContext& ctx)
 {
     while (e.readNextStartElement()) {
         const AsciiStringView tag(e.name());
-        if (tag == "tempo") {
+        if (readProperty(t, tag, e, ctx, Pid::PLAY)) {
+        } else if (tag == "tempo") {
             t->setTempo(TConv::fromXml(e.readAsciiText(), Constants::DEFAULT_TEMPO));
         } else if (tag == "followText") {
             t->setFollowText(e.readInt());

--- a/src/engraving/rw/write/twrite.cpp
+++ b/src/engraving/rw/write/twrite.cpp
@@ -2939,6 +2939,7 @@ void TWrite::write(const SoundFlag* item, XmlWriter& xml, WriteContext&)
 void TWrite::write(const TempoText* item, XmlWriter& xml, WriteContext& ctx)
 {
     xml.startElement(item);
+    writeProperty(item, xml, Pid::PLAY);
     xml.tag("tempo", TConv::toXml(item->tempo()));
     if (item->followText()) {
         xml.tag("followText", item->followText());

--- a/src/framework/global/iglobalconfiguration.h
+++ b/src/framework/global/iglobalconfiguration.h
@@ -78,6 +78,7 @@ public:
     virtual void setMetricUnit(bool metricUnit) = 0;
 
     virtual std::string museScoreUrl() const = 0;
+    virtual std::string museHubWebUrl() const = 0;
 
     virtual bool highResolutionTimers() const = 0;
 };

--- a/src/framework/global/internal/globalconfiguration.cpp
+++ b/src/framework/global/internal/globalconfiguration.cpp
@@ -40,6 +40,7 @@ static const Settings::Key METRIC_UNIT_KEY("global", "application/metricUnit");
 static const Settings::Key HIGH_RESOLUTION_TIMERS("global", "application/highResolutionTimers");
 
 static const std::string MUSESCORE_URL("https://www.musescore.org/");
+static const std::string MUSEHUB_WEB_URL("https://www.musehub.com/");
 
 void GlobalConfiguration::init()
 {
@@ -172,6 +173,11 @@ void GlobalConfiguration::setMetricUnit(bool metricUnit)
 std::string GlobalConfiguration::museScoreUrl() const
 {
     return MUSESCORE_URL;
+}
+
+std::string GlobalConfiguration::museHubWebUrl() const
+{
+    return MUSEHUB_WEB_URL;
 }
 
 bool GlobalConfiguration::highResolutionTimers() const

--- a/src/framework/global/internal/globalconfiguration.h
+++ b/src/framework/global/internal/globalconfiguration.h
@@ -61,6 +61,7 @@ public:
     void setMetricUnit(bool metricUnit) override;
 
     std::string museScoreUrl() const override;
+    std::string museHubWebUrl() const override;
 
     bool highResolutionTimers() const override;
 

--- a/src/framework/global/tests/mocks/globalconfigurationmock.h
+++ b/src/framework/global/tests/mocks/globalconfigurationmock.h
@@ -51,6 +51,7 @@ public:
     MOCK_METHOD(void, setMetricUnit, (bool), (override));
 
     MOCK_METHOD(std::string, museScoreUrl, (), (const, override));
+    MOCK_METHOD(std::string, museHubWebUrl, (), (const, override));
 
     MOCK_METHOD(bool, highResolutionTimers, (), (const, override));
 };

--- a/src/framework/ui/view/iconcodes.h
+++ b/src/framework/ui/view/iconcodes.h
@@ -391,6 +391,8 @@ public:
         WAVEFORM = 0xF43C,
         CROSS_STAFF_BEAMING = 0xF43D,
 
+        MAGNET = 0xF43E,
+
         TEMPO_CHANGE = 0xF43F,
 
         PLUGIN = 0xF440,

--- a/src/framework/update/internal/musesoundscheckupdateservice.cpp
+++ b/src/framework/update/internal/musesoundscheckupdateservice.cpp
@@ -37,7 +37,6 @@
 
 static const muse::Uri MUSEHUB_APP_URI("musehub://?from=musescore");
 static const muse::Uri MUSEHUB_APP_V1_URI("muse-hub://?from=musescore");
-static const std::string MUSEHUB_WEB_URL = "https://www.musehub.com/";
 
 using namespace muse::update;
 using namespace muse::network;
@@ -209,7 +208,7 @@ muse::RetVal<ReleaseInfo> MuseSoundsCheckUpdateService::parseRelease(const QByte
     if (result.val.actions.empty()) {
         result.val.actions.push_back(Val(MUSEHUB_APP_URI.toString()));
         result.val.actions.push_back(Val(MUSEHUB_APP_V1_URI.toString()));
-        result.val.actions.push_back(Val(MUSEHUB_WEB_URL));
+        result.val.actions.push_back(Val(globalConfiguration()->museHubWebUrl()));
     }
 
 #elif defined(Q_OS_MAC)
@@ -221,7 +220,7 @@ muse::RetVal<ReleaseInfo> MuseSoundsCheckUpdateService::parseRelease(const QByte
     // def
     if (result.val.actions.empty()) {
         result.val.actions.push_back(Val(MUSEHUB_APP_URI.toString()));
-        result.val.actions.push_back(Val(MUSEHUB_WEB_URL));
+        result.val.actions.push_back(Val(globalConfiguration()->museHubWebUrl()));
     }
 #else
     QJsonArray actionsArr = actionsObj.value("linux").toArray();
@@ -231,7 +230,7 @@ muse::RetVal<ReleaseInfo> MuseSoundsCheckUpdateService::parseRelease(const QByte
 
     // def
     if (result.val.actions.empty()) {
-        result.val.actions.push_back(Val(MUSEHUB_WEB_URL));
+        result.val.actions.push_back(Val(globalConfiguration()->museHubWebUrl()));
     }
 #endif
 

--- a/src/framework/update/internal/musesoundscheckupdateservice.h
+++ b/src/framework/update/internal/musesoundscheckupdateservice.h
@@ -33,6 +33,7 @@
 #include "languages/ilanguagesconfiguration.h"
 #include "iinteractive.h"
 
+#include "../global/iglobalconfiguration.h"
 #include "../iupdateconfiguration.h"
 #include "../imusesoundscheckupdateservice.h"
 
@@ -40,6 +41,7 @@ namespace muse::update {
 class MuseSoundsCheckUpdateService : public IMuseSoundsCheckUpdateService, public Injectable, public async::Asyncable
 {
     Inject<network::INetworkManagerCreator> networkManagerCreator = { this };
+    Inject<IGlobalConfiguration> globalConfiguration = { this };
     Inject<IUpdateConfiguration> configuration = { this };
     Inject<io::IFileSystem> fileSystem = { this };
     Inject<ISystemInfo> systemInfo = { this };

--- a/src/palette/view/widgets/timedialog.cpp
+++ b/src/palette/view/widgets/timedialog.cpp
@@ -54,7 +54,7 @@ TimeDialog::TimeDialog(QWidget* parent)
     sp->setReadOnly(false);
     sp->setSelectable(true);
 
-    connect(zNominal, &QSpinBox::valueChanged, this, &TimeDialog::zChanged);
+    connect(zNominal, &QSpinBox::editingFinished, this, &TimeDialog::zChanged);
     connect(nNominal, &QComboBox::currentIndexChanged, this, &TimeDialog::nChanged);
     connect(sp, &PaletteWidget::boxClicked, this, &TimeDialog::paletteChanged);
     connect(sp, &PaletteWidget::changed, this, &TimeDialog::setDirty);
@@ -148,10 +148,14 @@ void TimeDialog::save()
 //   zChanged
 //---------------------------------------------------------
 
-void TimeDialog::zChanged(int val)
+void TimeDialog::zChanged()
 {
-    Q_UNUSED(val);
-    Fraction sig(zNominal->value(), denominator());
+    int numerator = zNominal->value();  
+    int denominator = this->denominator();  
+
+    Fraction sig(numerator, denominator);
+
+    // Update beam groups view
     groups->setSig(sig, Groups::endings(sig), zText->text(), nText->text());
 }
 

--- a/src/palette/view/widgets/timedialog.h
+++ b/src/palette/view/widgets/timedialog.h
@@ -53,7 +53,7 @@ public:
 
 private slots:
     void addClicked();
-    void zChanged(int);
+    void zChanged();
     void nChanged(int);
     void paletteChanged(int idx);
     void textChanged();

--- a/src/palette/view/widgets/timedialog.ui
+++ b/src/palette/view/widgets/timedialog.ui
@@ -79,7 +79,7 @@
               <number>1</number>
              </property>
              <property name="maximum">
-              <number>999999</number>
+              <number>999</number>
              </property>
              <property name="value">
               <number>4</number>

--- a/src/playback/view/internal/abstractaudioresourceitem.cpp
+++ b/src/playback/view/internal/abstractaudioresourceitem.cpp
@@ -4,6 +4,7 @@
 #include <QTimer>
 
 #include "stringutils.h"
+#include "ui/view/iconcodes.h"
 
 using namespace muse;
 using namespace mu::playback;
@@ -79,6 +80,19 @@ QVariantMap AbstractAudioResourceItem::buildMenuItem(const QString& itemId,
 QVariantMap AbstractAudioResourceItem::buildSeparator() const
 {
     static QVariantMap result;
+    return result;
+}
+
+QVariantMap AbstractAudioResourceItem::buildExternalLinkMenuItem(const QString& menuId, const QString& title) const
+{
+    QVariantMap result;
+
+    result["id"] = menuId;
+    result["title"] = title;
+
+    const int openLinkIcon = static_cast<int>(ui::IconCode::Code::OPEN_LINK);
+    result["icon"] = openLinkIcon;
+
     return result;
 }
 

--- a/src/playback/view/internal/abstractaudioresourceitem.h
+++ b/src/playback/view/internal/abstractaudioresourceitem.h
@@ -25,12 +25,14 @@
 
 #include <QObject>
 
+#include "async/asyncable.h"
+
 #include "audio/audiotypes.h"
 
 #include "types/uri.h"
 
 namespace mu::playback {
-class AbstractAudioResourceItem : public QObject
+class AbstractAudioResourceItem : public QObject, public muse::async::Asyncable
 {
     Q_OBJECT
 
@@ -70,6 +72,8 @@ protected:
                               const QVariantList& subItems = QVariantList()) const;
 
     QVariantMap buildSeparator() const;
+
+    QVariantMap buildExternalLinkMenuItem(const QString& menuId, const QString& title) const;
 
     void sortResourcesList(muse::audio::AudioResourceMetaList& list);
 

--- a/src/playback/view/internal/inputresourceitem.cpp
+++ b/src/playback/view/internal/inputresourceitem.cpp
@@ -45,6 +45,7 @@ using namespace muse::audio::synth;
 static const QString VST_MENU_ITEM_ID("VST3");
 static const QString SOUNDFONTS_MENU_ITEM_ID = muse::qtrc("playback", "SoundFonts");
 static const QString MUSE_MENU_ITEM_ID("Muse Sounds");
+static const QString GET_MORE_SOUNDS_ID("getMoreSounds");
 
 static const muse::String MS_BASIC_SOUNDFONT_NAME(u"MS Basic");
 
@@ -90,6 +91,9 @@ void InputResourceItem::requestAvailableResources()
             result << buildSoundFontsMenuItem(sfResourcesSearch->second);
         }
 
+        result << buildSeparator();
+        result << buildExternalLinkMenuItem(GET_MORE_SOUNDS_ID, muse::qtrc("playback", "Get more sounds"));
+
         emit availableResourceListResolved(result);
     })
     .onReject(this, [](const int errCode, const std::string& errText) {
@@ -101,6 +105,13 @@ void InputResourceItem::requestAvailableResources()
 
 void InputResourceItem::handleMenuItem(const QString& menuItemId)
 {
+    if (menuItemId == GET_MORE_SOUNDS_ID) {
+        const QString url = QString::fromStdString(globalConfiguration()->museHubWebUrl());
+        const QString urlParams("muse-sounds?utm_source=mss-mixer&utm_medium=mh&utm_campaign=mss-mixer-ms-mainpage");
+        interactive()->openUrl(url + urlParams);
+        return;
+    }
+
     const AudioResourceId& newSelectedResourceId = menuItemId.toStdString();
 
     for (const auto& pairByType : m_availableResourceMap) {

--- a/src/playback/view/internal/inputresourceitem.h
+++ b/src/playback/view/internal/inputresourceitem.h
@@ -30,7 +30,10 @@
 #include <QString>
 
 #include "modularity/ioc.h"
-#include "async/asyncable.h"
+
+#include "global/iglobalconfiguration.h"
+#include "iinteractive.h"
+
 #include "audio/iplayback.h"
 #include "audio/audiotypes.h"
 #include "midi/miditypes.h"
@@ -38,10 +41,12 @@
 #include "abstractaudioresourceitem.h"
 
 namespace mu::playback {
-class InputResourceItem : public AbstractAudioResourceItem, public muse::async::Asyncable
+class InputResourceItem : public AbstractAudioResourceItem
 {
     Q_OBJECT
 
+    INJECT(muse::IGlobalConfiguration, globalConfiguration)
+    INJECT(muse::IInteractive, interactive)
     INJECT(muse::audio::IPlayback, playback)
 
 public:

--- a/src/playback/view/internal/outputresourceitem.cpp
+++ b/src/playback/view/internal/outputresourceitem.cpp
@@ -17,6 +17,8 @@ static const QString& NO_FX_MENU_ITEM_ID()
     return resultStr;
 }
 
+static const QString GET_MORE_EFFECTS("getMoreEffects");
+
 OutputResourceItem::OutputResourceItem(QObject* parent, const audio::AudioFxParams& params)
     : AbstractAudioResourceItem(parent),
     m_currentFxParams(params)
@@ -67,6 +69,9 @@ void OutputResourceItem::requestAvailableResources()
                                     subItems);
         }
 
+        result << buildSeparator();
+        result << buildExternalLinkMenuItem(GET_MORE_EFFECTS, muse::qtrc("playback", "Get more effects"));
+
         emit availableResourceListResolved(result);
     })
     .onReject(this, [](const int errCode, const std::string& errText) {
@@ -80,6 +85,11 @@ void OutputResourceItem::handleMenuItem(const QString& menuItemId)
 {
     if (menuItemId == NO_FX_MENU_ITEM_ID()) {
         updateCurrentFxParams(AudioResourceMeta());
+        return;
+    } else if (menuItemId == GET_MORE_EFFECTS) {
+        const QString url = QString::fromStdString(globalConfiguration()->museHubWebUrl());
+        const QString urlParams("plugins?utm_source=mss-mixer-fx&utm_medium=mh-fx&utm_campaign=mss-mixer-fx-mainpage");
+        interactive()->openUrl(url + urlParams);
         return;
     }
 

--- a/src/playback/view/internal/outputresourceitem.h
+++ b/src/playback/view/internal/outputresourceitem.h
@@ -28,7 +28,10 @@
 #include <map>
 
 #include "modularity/ioc.h"
-#include "async/asyncable.h"
+
+#include "global/iglobalconfiguration.h"
+#include "iinteractive.h"
+
 #include "audio/iaudiooutput.h"
 #include "audio/iplayback.h"
 #include "audio/audiotypes.h"
@@ -41,13 +44,15 @@
 #endif
 
 namespace mu::playback {
-class OutputResourceItem : public AbstractAudioResourceItem, public muse::async::Asyncable
+class OutputResourceItem : public AbstractAudioResourceItem
 {
     Q_OBJECT
 
     Q_PROPERTY(QString id READ id NOTIFY fxParamsChanged)
     Q_PROPERTY(bool isActive READ isActive WRITE setIsActive NOTIFY isActiveChanged)
 
+    INJECT(muse::IGlobalConfiguration, globalConfiguration)
+    INJECT(muse::IInteractive, interactive)
     INJECT(muse::audio::IPlayback, playback)
 
 public:


### PR DESCRIPTION
Resolves: #12970 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
### Summary of Changes:

- **Numerator Field Limit**: Added a maximum value of `999` to the numerator field (`zNominal`) to restrict user input.
- **Graphics Rendering Optimization**: Modified the graphics rendering behavior to avoid continuous re-renders while typing. The graphics now only re-render when the user presses Enter or moves focus away from the numerator field.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
