### PR TITLE
Fix - Crash due to large custom Time Signature

### DIFF
--- a/src/palette/view/widgets/timedialog.cpp
+++ b/src/palette/view/widgets/timedialog.cpp
@@ -54,7 +54,7 @@ TimeDialog::TimeDialog(QWidget* parent)
     sp->setReadOnly(false);
     sp->setSelectable(true);
 
-    connect(zNominal, &QSpinBox::valueChanged, this, &TimeDialog::zChanged);
+    connect(zNominal, &QSpinBox::editingFinished, this, &TimeDialog::zChanged);
     connect(nNominal, &QComboBox::currentIndexChanged, this, &TimeDialog::nChanged);
     connect(sp, &PaletteWidget::boxClicked, this, &TimeDialog::paletteChanged);
     connect(sp, &PaletteWidget::changed, this, &TimeDialog::setDirty);
@@ -148,10 +148,14 @@ void TimeDialog::save()
 //   zChanged
 //---------------------------------------------------------
 
-void TimeDialog::zChanged(int val)
+void TimeDialog::zChanged()
 {
-    Q_UNUSED(val);
-    Fraction sig(zNominal->value(), denominator());
+    int numerator = zNominal->value();
+    int denominator = this->denominator();
+
+    Fraction sig(numerator, denominator);
+
+    // Update beam groups view
     groups->setSig(sig, Groups::endings(sig), zText->text(), nText->text());
 }
 

--- a/src/palette/view/widgets/timedialog.h
+++ b/src/palette/view/widgets/timedialog.h
@@ -53,7 +53,7 @@ public:
 
 private slots:
     void addClicked();
-    void zChanged(int);
+    void zChanged();
     void nChanged(int);
     void paletteChanged(int idx);
     void textChanged();

--- a/src/palette/view/widgets/timedialog.ui
+++ b/src/palette/view/widgets/timedialog.ui
@@ -79,7 +79,7 @@
               <number>1</number>
              </property>
              <property name="maximum">
-              <number>999999</number>
+              <number>999</number>
              </property>
              <property name="value">
               <number>4</number>


### PR DESCRIPTION
Resolves: #12970 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
### Summary of Changes:

- **Numerator Field Limit**: Added a maximum value of `999` to the numerator field (`zNominal`) to restrict user input.
- **Graphics Rendering Optimization**: Modified the graphics rendering behavior to avoid continuous re-renders while typing. The graphics now only re-render when the user presses Enter or moves focus away from the numerator field.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
