### PR TITLE
Percussion panel - implement keyboard swapping

### DIFF
--- a/src/framework/uicomponents/qml/Muse/UiComponents/FlatButton.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/FlatButton.qml
@@ -60,6 +60,7 @@ FocusScope {
     property real backgroundRadius: 3
 
     property bool drawFocusBorderInsideRect: false
+    property bool disableFocusBorder: false
 
     property int orientation: Qt.Vertical
     readonly property bool isVertical: root.orientation === Qt.Vertical
@@ -149,7 +150,7 @@ FocusScope {
             border.color: ui.theme.strokeColor
 
             NavigationFocusBorder {
-                navigationCtrl: navCtrl
+                navigationCtrl: disableFocusBorder ? null : navCtrl
                 drawOutsideParent: !root.drawFocusBorderInsideRect
             }
 

--- a/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
+++ b/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
@@ -58,6 +58,15 @@ Item {
         Component.onCompleted: {
             percModel.init()
         }
+
+        onCurrentPanelModeChanged: {
+            // TODO: This is a placeholder, changing the panel mode shouldn't cancel a keyboard swap
+            if (padGrid.isKeyboardSwapActive) {
+                padGrid.swapOriginPad = null
+                padGrid.isKeyboardSwapActive = false
+                padGrid.model.endPadSwap(-1)
+            }
+        }
     }
 
     // TODO: Will live inside percussion panel until #22050 is implemented
@@ -122,6 +131,7 @@ Item {
                 width: rowLayout.sideColumnsWidth
 
                 visible: percModel.currentPanelMode === PanelMode.EDIT_LAYOUT
+                enabled: !padGrid.isKeyboardSwapActive
 
                 Repeater {
                     id: deleteRepeater
@@ -175,6 +185,7 @@ Item {
                 readonly property int spacing: 12
 
                 property Item swapOriginPad: null
+                property bool isKeyboardSwapActive: false
 
                 QtObject {
                     id: gridPrv
@@ -246,9 +257,10 @@ Item {
 
                         // When swapping, only show the outline for the swap origin  and the swap target...
                         showEditOutline: percModel.currentPanelMode === PanelMode.EDIT_LAYOUT
-                                         && (!Boolean(padGrid.swapOriginPad) || padGrid.swapOriginPad === pad || pad.containsDrag)
-                        showOriginBackground: pad.containsDrag || pad === padGrid.swapOriginPad
+                                         && (!Boolean(padGrid.swapOriginPad) || padGrid.swapOriginPad === pad)
+                        showOriginBackground: pad.containsDrag || (pad === padGrid.swapOriginPad && !padGrid.isKeyboardSwapActive)
 
+                        panelHasActiveKeyboardSwap: padGrid.isKeyboardSwapActive
                         dragParent: root
 
                         navigationRow: index / padGrid.numColumns
@@ -256,19 +268,21 @@ Item {
                         padNavigationCtrl.panel: padsNavPanel
                         footerNavigationCtrl.panel: padFootersNavPanel
 
-                        onStartPadSwapRequested: {
+                        onStartPadSwapRequested: function(isKeyboardSwap) {
                             padGrid.swapOriginPad = pad
+                            padGrid.isKeyboardSwapActive = isKeyboardSwap
                             padGrid.model.startPadSwap(index)
                         }
 
-                        onDropped: function(dropEvent) {
+                        onEndPadSwapRequested: {
                             padGrid.swapOriginPad = null
+                            padGrid.isKeyboardSwapActive = false
                             padGrid.model.endPadSwap(index)
-                            dropEvent.accepted = true
                         }
 
                         onCancelPadSwapRequested: {
                             padGrid.swapOriginPad = null
+                            padGrid.isKeyboardSwapActive = false
                             padGrid.model.endPadSwap(-1)
                         }
 
@@ -284,7 +298,8 @@ Item {
                         // If this is the swap target - move the swappable area to the swap origin (preview the swap)
                         State {
                             name: "SWAP_TARGET"
-                            when: Boolean(padGrid.swapOriginPad) && pad.containsDrag && padGrid.swapOriginPad !== pad
+                            when: Boolean(padGrid.swapOriginPad) && (pad.containsDrag || pad.padNavigationCtrl.active) && padGrid.swapOriginPad !== pad
+
                             ParentChange {
                                 target: pad.swappableArea
                                 parent: padGrid.swapOriginPad
@@ -294,10 +309,28 @@ Item {
                                 anchors.verticalCenter: padGrid.swapOriginPad.verticalCenter
                                 anchors.horizontalCenter: padGrid.swapOriginPad.horizontalCenter
                             }
+                            PropertyChanges {
+                                target: pad
+                                showEditOutline: true
+                            }
+
                             // Origin background not needed for the dragged pad when a preview is taking place...
                             PropertyChanges {
                                 target: padGrid.swapOriginPad
                                 showOriginBackground: false
+                            }
+
+                            // In the case of a keyboard swap, we also need to move the origin pad
+                            ParentChange {
+                                // TODO: not a nice solution to use null here (works, but throws an error)
+                                target: padGrid.isKeyboardSwapActive ? padGrid.swapOriginPad.swappableArea : null
+                                parent: pad
+                            }
+                            AnchorChanges {
+                                // TODO: not a nice solution to use null here (works, but throws an error)
+                                target: padGrid.isKeyboardSwapActive ? padGrid.swapOriginPad.swappableArea : null
+                                anchors.verticalCenter: pad.verticalCenter
+                                anchors.horizontalCenter: pad.horizontalCenter
                             }
                         }
                     ]
@@ -322,6 +355,7 @@ Item {
                 Layout.bottomMargin: (padGrid.cellHeight / 2) - (height / 2)
 
                 visible: percModel.currentPanelMode === PanelMode.EDIT_LAYOUT
+                enabled: !padGrid.isKeyboardSwapActive
 
                 icon: IconCode.PLUS
                 text: qsTrc("notation", "Add row")

--- a/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
+++ b/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
@@ -69,8 +69,8 @@ Item {
         width: parent.width
         height: 36
 
-        navigation.section: root.navigationSection
-        navigation.order: root.contentNavigationPanelOrderStart
+        navigationSection: root.navigationSection
+        navigationOrderStart: root.contentNavigationPanelOrderStart
 
         model: percModel
 

--- a/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
+++ b/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
@@ -174,7 +174,7 @@ Item {
                 readonly property int numColumns: model.numColumns
                 readonly property int spacing: 12
 
-                property Item draggedPad: null
+                property Item swapOriginPad: null
 
                 QtObject {
                     id: gridPrv
@@ -244,10 +244,10 @@ Item {
                         panelMode: percModel.currentPanelMode
                         useNotationPreview: percModel.useNotationPreview
 
-                        // When dragging, only show the outline for the dragged pad and the drag target...
+                        // When swapping, only show the outline for the swap origin  and the swap target...
                         showEditOutline: percModel.currentPanelMode === PanelMode.EDIT_LAYOUT
-                                         && (!Boolean(padGrid.draggedPad) || padGrid.draggedPad === pad || pad.containsDrag)
-                        showOriginBackground: pad.containsDrag || pad === padGrid.draggedPad
+                                         && (!Boolean(padGrid.swapOriginPad) || padGrid.swapOriginPad === pad || pad.containsDrag)
+                        showOriginBackground: pad.containsDrag || pad === padGrid.swapOriginPad
 
                         dragParent: root
 
@@ -256,20 +256,20 @@ Item {
                         padNavigationCtrl.panel: padsNavPanel
                         footerNavigationCtrl.panel: padFootersNavPanel
 
-                        onDragStarted: {
-                            padGrid.draggedPad = pad
-                            padGrid.model.startDrag(index)
+                        onStartPadSwapRequested: {
+                            padGrid.swapOriginPad = pad
+                            padGrid.model.startPadSwap(index)
                         }
 
                         onDropped: function(dropEvent) {
-                            padGrid.draggedPad = null
-                            padGrid.model.endDrag(index)
+                            padGrid.swapOriginPad = null
+                            padGrid.model.endPadSwap(index)
                             dropEvent.accepted = true
                         }
 
-                        onDragCancelled: {
-                            padGrid.draggedPad = null
-                            padGrid.model.endDrag(-1)
+                        onCancelPadSwapRequested: {
+                            padGrid.swapOriginPad = null
+                            padGrid.model.endPadSwap(-1)
                         }
 
                         onHasActiveControlChanged: {
@@ -281,22 +281,22 @@ Item {
                     }
 
                     states: [
-                        // If this is the drop target - move the draggable area to the origin of the dragged pad (preview the drop)
+                        // If this is the swap target - move the swappable area to the swap origin (preview the swap)
                         State {
-                            name: "DROP_TARGET"
-                            when: Boolean(padGrid.draggedPad) && pad.containsDrag && padGrid.draggedPad !== pad
+                            name: "SWAP_TARGET"
+                            when: Boolean(padGrid.swapOriginPad) && pad.containsDrag && padGrid.swapOriginPad !== pad
                             ParentChange {
-                                target: pad.draggableArea
-                                parent: padGrid.draggedPad
+                                target: pad.swappableArea
+                                parent: padGrid.swapOriginPad
                             }
                             AnchorChanges {
-                                target: pad.draggableArea
-                                anchors.verticalCenter: padGrid.draggedPad.verticalCenter
-                                anchors.horizontalCenter: padGrid.draggedPad.horizontalCenter
+                                target: pad.swappableArea
+                                anchors.verticalCenter: padGrid.swapOriginPad.verticalCenter
+                                anchors.horizontalCenter: padGrid.swapOriginPad.horizontalCenter
                             }
                             // Origin background not needed for the dragged pad when a preview is taking place...
                             PropertyChanges {
-                                target: padGrid.draggedPad
+                                target: padGrid.swapOriginPad
                                 showOriginBackground: false
                             }
                         }

--- a/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPad.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPad.qml
@@ -46,9 +46,17 @@ DropArea {
 
     readonly property bool hasActiveControl: padNavCtrl.active || footerNavCtrl.active
 
+    property bool panelHasActiveKeyboardSwap: false
+
     property var dragParent: null
-    signal startPadSwapRequested()
+    signal startPadSwapRequested(var isKeyboardSwap)
+    signal endPadSwapRequested()
     signal cancelPadSwapRequested()
+
+    onDropped: function(dropEvent)  {
+        root.endPadSwapRequested()
+        dropEvent.accepted = true
+    }
 
     QtObject {
         id: prv
@@ -88,7 +96,11 @@ DropArea {
             if (!Boolean(root.padModel)) {
                 return
             }
-            root.padModel.triggerPad()
+            if (root.panelMode !== PanelMode.EDIT_LAYOUT) {
+                root.padModel.triggerPad()
+                return
+            }
+            root.panelHasActiveKeyboardSwap ? root.endPadSwapRequested() : root.startPadSwapRequested(true)
         }
     }
 
@@ -133,13 +145,13 @@ DropArea {
             id: dragHandler
 
             target: swappableArea
-            enabled: root.panelMode === PanelMode.EDIT_LAYOUT && !prv.isEmptySlot
+            enabled: root.panelMode === PanelMode.EDIT_LAYOUT && !prv.isEmptySlot && !root.panelHasActiveKeyboardSwap
 
             dragThreshold: 0 // prevents the flickable from stealing drag events
 
             onActiveChanged: {
                 if (dragHandler.active) {
-                    root.startPadSwapRequested()
+                    root.startPadSwapRequested(false)
                     return
                 }
                 if (!swappableArea.Drag.drop()) {
@@ -197,13 +209,6 @@ DropArea {
         }
 
         NavigationFocusBorder {
-            id: padFocusBorder
-
-            padding: root.panelMode === PanelMode.EDIT_LAYOUT ? 0 : root.totalBorderWidth * -1
-            navigationCtrl: padNavCtrl
-        }
-
-        NavigationFocusBorder {
             id: footerFocusBorder
 
             anchors {
@@ -245,6 +250,27 @@ DropArea {
                 }
             }
         ]
+    }
+
+    //! NOTE: Ideally this would be swappableArea's child, but we don't want it to move when "previewing" a drop
+    NavigationFocusBorder {
+        id: padFocusBorder
+
+        property real extraSize: root.showEditOutline ? padFocusBorder.border.width * 2 : 0
+        property real extraRadius: root.showEditOutline ? root.totalBorderWidth + padFocusBorder.anchors.margins : 0
+
+        anchors {
+            fill: null
+            centerIn: parent
+        }
+
+        width: swappableArea.width + padFocusBorder.extraSize
+        height: swappableArea.height + padFocusBorder.extraSize
+
+        radius: swappableArea.radius + padFocusBorder.extraRadius
+
+        padding: root.showEditOutline ? 0 : root.totalBorderWidth * -1
+        navigationCtrl: padNavCtrl
     }
 
     Rectangle {

--- a/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPad.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPad.qml
@@ -37,7 +37,7 @@ DropArea {
 
     property alias totalBorderWidth: padLoader.anchors.margins
     property alias showOriginBackground: originBackground.visible
-    property alias draggableArea: draggableArea
+    property alias swappableArea: swappableArea
 
     property int navigationRow: -1
     property int navigationColumn: -1
@@ -47,8 +47,8 @@ DropArea {
     readonly property bool hasActiveControl: padNavCtrl.active || footerNavCtrl.active
 
     property var dragParent: null
-    signal dragStarted()
-    signal dragCancelled()
+    signal startPadSwapRequested()
+    signal cancelPadSwapRequested()
 
     QtObject {
         id: prv
@@ -116,7 +116,7 @@ DropArea {
     }
 
     Rectangle {
-        id: draggableArea
+        id: swappableArea
 
         // Protrudes slightly from behind the components in the loader to produce the edit mode "border with gap" effect
         width: root.width
@@ -132,18 +132,18 @@ DropArea {
         DragHandler {
             id: dragHandler
 
-            target: draggableArea
+            target: swappableArea
             enabled: root.panelMode === PanelMode.EDIT_LAYOUT && !prv.isEmptySlot
 
             dragThreshold: 0 // prevents the flickable from stealing drag events
 
             onActiveChanged: {
                 if (dragHandler.active) {
-                    root.dragStarted()
+                    root.startPadSwapRequested()
                     return
                 }
-                if (!draggableArea.Drag.drop()) {
-                    root.dragCancelled()
+                if (!swappableArea.Drag.drop()) {
+                    root.cancelPadSwapRequested()
                 }
             }
         }
@@ -158,7 +158,7 @@ DropArea {
 
             anchors.fill: parent
             // Defined as 1 in the spec, but causes some aliasing in practice...
-            anchors.margins: 2 + draggableArea.border.width
+            anchors.margins: 2 + swappableArea.border.width
 
             // Can't simply use clip as this won't take into account radius...
             layer.enabled: ui.isEffectsAllowed
@@ -166,7 +166,7 @@ DropArea {
                 maskSource: Rectangle {
                     width: padLoader.width
                     height: padLoader.height
-                    radius: draggableArea.radius - padLoader.anchors.margins
+                    radius: swappableArea.radius - padLoader.anchors.margins
                 }
             }
 
@@ -182,7 +182,7 @@ DropArea {
 
                     footerHeight: prv.footerHeight
 
-                    dragActive: dragHandler.active
+                    padSwapActive: dragHandler.active
                 }
             }
 
@@ -225,11 +225,11 @@ DropArea {
                 name: "DRAGGED"
                 when: dragHandler.active
                 ParentChange {
-                    target: draggableArea
+                    target: swappableArea
                     parent: root.dragParent
                 }
                 AnchorChanges {
-                    target: draggableArea
+                    target: swappableArea
                     anchors.horizontalCenter: undefined
                     anchors.verticalCenter: undefined
                 }
@@ -240,7 +240,7 @@ DropArea {
                 name: "DROPPED"
                 when: !dragHandler.active
                 ParentChange {
-                    target: draggableArea
+                    target: swappableArea
                     parent: root
                 }
             }
@@ -252,19 +252,19 @@ DropArea {
 
         anchors.fill: parent
 
-        radius: draggableArea.radius
+        radius: swappableArea.radius
 
-        border.color: draggableArea.border.color
-        border.width: draggableArea.border.width
+        border.color: swappableArea.border.color
+        border.width: swappableArea.border.width
 
-        color: draggableArea.color
+        color: swappableArea.color
 
         Rectangle {
             id: originBackgroundFill
 
             anchors.fill: parent
             anchors.margins: padLoader.anchors.margins
-            radius: draggableArea.radius - originBackgroundFill.anchors.margins
+            radius: swappableArea.radius - originBackgroundFill.anchors.margins
 
             color: root.containsDrag ? ui.theme.buttonColor : ui.theme.backgroundSecondaryColor
         }

--- a/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPadContent.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPadContent.qml
@@ -35,7 +35,7 @@ Column {
 
     property alias footerHeight: footerArea.height
 
-    property bool dragActive: false
+    property bool padSwapActive: false
 
     Rectangle {
         id: mainContentArea
@@ -77,7 +77,7 @@ Column {
         states: [
             State {
                 name: "MOUSE_HOVERED"
-                when: mouseArea.containsMouse && !mouseArea.pressed && !root.dragActive
+                when: mouseArea.containsMouse && !mouseArea.pressed && !root.padSwapActive
                 PropertyChanges {
                     target: mainContentArea
                     color: Utils.colorWithAlpha(ui.theme.accentColor, ui.theme.buttonOpacityHover)
@@ -85,7 +85,7 @@ Column {
             },
             State {
                 name: "MOUSE_HIT"
-                when: mouseArea.pressed || root.dragActive
+                when: mouseArea.pressed || root.padSwapActive
                 PropertyChanges {
                     target: mainContentArea
                     color: Utils.colorWithAlpha(ui.theme.accentColor, ui.theme.buttonOpacityHit)

--- a/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPadContent.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPadContent.qml
@@ -33,6 +33,8 @@ Column {
     property int panelMode: -1
     property bool useNotationPreview: false
 
+    property alias footerHeight: footerArea.height
+
     property bool dragActive: false
 
     Rectangle {
@@ -105,7 +107,6 @@ Column {
         id: footerArea
 
         width: parent.width
-        height: 24
 
         color: Utils.colorWithAlpha(ui.theme.buttonColor, ui.theme.buttonOpacityNormal)
 

--- a/src/notation/view/percussionpanel/percussionpanelpadlistmodel.cpp
+++ b/src/notation/view/percussionpanel/percussionpanelpadlistmodel.cpp
@@ -79,19 +79,19 @@ bool PercussionPanelPadListModel::rowIsEmpty(int row) const
     return numEmptySlotsAtRow(row) == NUM_COLUMNS;
 }
 
-void PercussionPanelPadListModel::startDrag(int startIndex)
+void PercussionPanelPadListModel::startPadSwap(int startIndex)
 {
-    m_dragStartIndex = startIndex;
+    m_padSwapStartIndex = startIndex;
 }
 
-void PercussionPanelPadListModel::endDrag(int endIndex)
+void PercussionPanelPadListModel::endPadSwap(int endIndex)
 {
-    if (indexIsValid(m_dragStartIndex) && indexIsValid(endIndex)) {
-        movePad(m_dragStartIndex, endIndex);
+    if (indexIsValid(m_padSwapStartIndex) && indexIsValid(endIndex)) {
+        movePad(m_padSwapStartIndex, endIndex);
     } else {
         emit layoutChanged();
     }
-    m_dragStartIndex = -1;
+    m_padSwapStartIndex = -1;
 }
 
 void PercussionPanelPadListModel::setDrumset(const mu::engraving::Drumset* drumset)

--- a/src/notation/view/percussionpanel/percussionpanelpadlistmodel.h
+++ b/src/notation/view/percussionpanel/percussionpanelpadlistmodel.h
@@ -53,8 +53,8 @@ public:
     Q_INVOKABLE void deleteRow(int row);
     Q_INVOKABLE bool rowIsEmpty(int row) const;
 
-    Q_INVOKABLE void startDrag(int startIndex);
-    Q_INVOKABLE void endDrag(int endIndex);
+    Q_INVOKABLE void startPadSwap(int startIndex);
+    Q_INVOKABLE void endPadSwap(int endIndex);
 
     int numColumns() const { return NUM_COLUMNS; }
     int numPads() const { return m_padModels.count(); }
@@ -83,7 +83,7 @@ private:
     const mu::engraving::Drumset* m_drumset = nullptr;
     QList<PercussionPanelPadModel*> m_padModels;
 
-    int m_dragStartIndex = -1;
+    int m_padSwapStartIndex = -1;
 
     muse::async::Channel<int /*pitch*/> m_triggeredChannel;
 };


### PR DESCRIPTION
This PR implements implements "keyboard swapping" in the percussion panel (the ability to change a pad's position using the keyboard only).

Draft for now as this depends on #25518 (the first two commits in this PR). There are also a couple of to-dos I would like to address before merging.