### PR TITLE
Fix crash on creating parts with lv

### DIFF
--- a/src/engraving/dom/laissezvib.cpp
+++ b/src/engraving/dom/laissezvib.cpp
@@ -106,4 +106,16 @@ void LaissezVibSegment::editDrag(EditData& ed)
     ups(Grip::DRAG).off = PointF();
     roffset() += ed.delta;
 }
+
+String LaissezVibSegment::formatBarsAndBeats() const
+{
+    const Spanner* spanner = this->spanner();
+    const Segment* startSeg = spanner ? spanner->startSegment() : nullptr;
+
+    if (!startSeg) {
+        return EngravingItem::formatBarsAndBeats();
+    }
+
+    return startSeg->formatBarsAndBeats();
+}
 }

--- a/src/engraving/dom/laissezvib.h
+++ b/src/engraving/dom/laissezvib.h
@@ -47,6 +47,8 @@ public:
         ld_field<PointF> posRelativeToNote = { "[LaissezVibSegment] posRelativeToNote", PointF() };
     };
     DECLARE_LAYOUTDATA_METHODS(LaissezVibSegment)
+private:
+    String formatBarsAndBeats() const override;
 };
 
 class LaissezVib : public Tie

--- a/src/engraving/dom/note.cpp
+++ b/src/engraving/dom/note.cpp
@@ -654,6 +654,9 @@ Note::Note(const Note& n, bool link)
         m_tieFor->setParent(this);
         m_tieFor->setStartNote(this);
         m_tieFor->setTick(m_tieFor->startNote()->tick());
+        if (link) {
+            score()->undo(new Link(m_tieFor, n.m_tieFor));
+        }
     } else if (n.m_tieFor) {
         m_tieFor = Factory::copyTie(*n.m_tieFor);
         m_tieFor->setStartNote(this);

--- a/src/engraving/dom/slurtie.cpp
+++ b/src/engraving/dom/slurtie.cpp
@@ -54,7 +54,6 @@ SlurTieSegment::SlurTieSegment(const SlurTieSegment& b)
         m_ups[i]   = b.m_ups[i];
         m_ups[i].p = PointF();
     }
-    mutldata()->path.set_value(b.ldata()->path());
 }
 
 bool SlurTieSegment::isEditAllowed(EditData& ed) const


### PR DESCRIPTION
Resolves: #25569
This crash was caused by cloning `LayoutData` which didn't need to be cloned.

The final commit also fixes a bug & crash (on Linux) in the lv tie accessibility text.  As lv ties don't have an end note, we don't need to find or display information about this.