### PR TITLE
Fix #25429: Disable the display of the key signature when changing transposing instruments if score is in concert pitch

### DIFF
--- a/src/engraving/dom/transpose.cpp
+++ b/src/engraving/dom/transpose.cpp
@@ -588,6 +588,31 @@ void Score::transposeKeys(staff_idx_t staffStart, staff_idx_t staffEnd, const Fr
         }
 
         bool createKey = tickStart.isZero();
+/*
+        // If we change to "Display transposed" we should regenerate Key Signatures for instrument change
+        if (flip) {
+            LOGI() << "tpacebes pasamos por aqui";
+            Part* part = staff(staffIdx)->part();
+            for (Segment* s = firstSegment(SegmentType::ChordRest); s; s = s->next1(SegmentType::ChordRest)) {
+                // If there are Intrument changes
+                if (s->findAnnotation(ElementType::INSTRUMENT_CHANGE, part->startTrack(), part->endTrack() - 1)) {
+                    Fraction sTickStart = s->tick();
+                    KeySigEvent kse;
+
+                    // Check, if some key signature is already there, if no, mark new one "for instrument change"
+                    Segment* segKeySig = s->prev1(SegmentType::KeySig);
+                    KeySig* ksig = segKeySig ? toKeySig(segKeySig->element(staffIdx * VOICES)) : nullptr;
+                    bool forInstChange = !(ksig && ksig->tick() == sTickStart && !ksig->generated());
+                    kse.setForInstrumentChange(forInstChange);
+                    Key cKey = staff(staffIdx)->concertKey(sTickStart);
+                    LOGI() << "tpacebes cKey vale " << forInstChange;
+                    kse.setConcertKey(cKey);
+                    score()->undoChangeKeySig(staff(staffIdx), sTickStart, kse);
+                }
+            }
+        }
+        */
+
         for (Segment* s = firstSegment(SegmentType::KeySig); s; s = s->next1(SegmentType::KeySig)) {
             if (!s->enabled() || s->tick() < tickStart) {
                 continue;
@@ -596,6 +621,14 @@ void Score::transposeKeys(staff_idx_t staffStart, staff_idx_t staffEnd, const Fr
                 break;
             }
             KeySig* ks = toKeySig(s->element(staffIdx * VOICES));
+            /*
+            // To Display concert pitch we delete KeySignatures for instrument change
+            if (!flip) {
+                if (ks && !ks->generated() && ks->forInstrumentChange()) {
+                    ks->parentItem()->remove(ks);
+                }
+            }
+            */
             if (!ks || ks->generated()) {
                 continue;
             }


### PR DESCRIPTION
Resolves: #25429 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
Avoid the display of the key signature when changing any instrument if the score is in concert pitch as it is not needed

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
