### PR TITLE
Percussion panel - save/load drum pad panel positions

### DIFF
--- a/src/engraving/dom/drumset.cpp
+++ b/src/engraving/dom/drumset.cpp
@@ -51,7 +51,7 @@ String Drumset::translatedName(int pitch) const
 
 void Drumset::save(XmlWriter& xml) const
 {
-    for (int i = 0; i < 128; ++i) {
+    for (int i = 0; i < DRUM_INSTRUMENTS; ++i) {
         if (!isValid(i)) {
             continue;
         }
@@ -174,7 +174,7 @@ bool Drumset::readProperties(XmlReader& e, int pitch)
 void Drumset::load(XmlReader& e)
 {
     int pitch = e.intAttribute("pitch", -1);
-    if (pitch < 0 || pitch > 127) {
+    if (pitch < 0 || pitch > DRUM_INSTRUMENTS - 1) {
         LOGD("load drumset: invalid pitch %d", pitch);
         return;
     }
@@ -192,7 +192,7 @@ void Drumset::load(XmlReader& e)
 
 void Drumset::clear()
 {
-    for (int i = 0; i < 128; ++i) {
+    for (int i = 0; i < DRUM_INSTRUMENTS; ++i) {
         m_drum[i].name = u"";
         m_drum[i].notehead = NoteHeadGroup::HEAD_INVALID;
         m_drum[i].shortcut = 0;
@@ -206,7 +206,7 @@ void Drumset::clear()
 
 int Drumset::nextPitch(int ii) const
 {
-    for (int i = ii + 1; i < 127; ++i) {
+    for (int i = ii + 1; i < DRUM_INSTRUMENTS - 1; ++i) {
         if (isValid(i)) {
             return i;
         }
@@ -230,7 +230,7 @@ int Drumset::prevPitch(int ii) const
             return i;
         }
     }
-    for (int i = 127; i >= ii; --i) {
+    for (int i = DRUM_INSTRUMENTS - 1; i >= ii; --i) {
         if (isValid(i)) {
             return i;
         }
@@ -273,7 +273,7 @@ DrumInstrumentVariant Drumset::findVariant(int p, const std::vector<Articulation
 void Drumset::initDrumset()
 {
     smDrumset = new Drumset;
-    for (int i = 0; i < 128; ++i) {
+    for (int i = 0; i < DRUM_INSTRUMENTS; ++i) {
         smDrumset->drum(i).notehead = NoteHeadGroup::HEAD_INVALID;
         smDrumset->drum(i).line     = 0;
         smDrumset->drum(i).shortcut = 0;

--- a/src/engraving/dom/drumset.h
+++ b/src/engraving/dom/drumset.h
@@ -36,6 +36,13 @@ struct DrumInstrumentVariant {
     int pitch = INVALID_PITCH;
     TremoloType tremolo = TremoloType::INVALID_TREMOLO;
     String articulationName;
+
+    bool operator==(const DrumInstrumentVariant& other) const
+    {
+        return pitch == other.pitch
+               && tremolo == other.tremolo
+               && articulationName == other.articulationName;
+    }
 };
 
 //---------------------------------------------------------
@@ -56,12 +63,28 @@ struct DrumInstrument {
     char shortcut = '\0';      ///< accelerator key (CDEFGAB)
     std::list<DrumInstrumentVariant> variants;
 
+    int panelRow = -1;
+    int panelColumn = -1;
+
     DrumInstrument() {}
     DrumInstrument(const char* s, NoteHeadGroup nh, int l, DirectionV d,
                    int v = 0, char sc = 0)
         : name(String::fromUtf8(s)), notehead(nh), line(l), stemDirection(d), voice(v), shortcut(sc) {}
 
     void addVariant(DrumInstrumentVariant v) { variants.push_back(v); }
+
+    bool operator==(const DrumInstrument& other) const
+    {
+        return notehead == other.notehead
+               && noteheads == other.noteheads
+               && line == other.line
+               && stemDirection == other.stemDirection
+               && voice == other.voice
+               && shortcut == other.shortcut
+               && variants == other.variants
+               && panelRow == other.panelRow
+               && panelColumn == other.panelColumn;
+    }
 };
 
 static const int DRUM_INSTRUMENTS = 128;
@@ -75,17 +98,18 @@ static const int DRUM_INSTRUMENTS = 128;
 class Drumset
 {
 public:
-
-    bool isValid(int pitch) const { return !m_drum[pitch].name.empty(); }
-    NoteHeadGroup noteHead(int pitch) const { return m_drum[pitch].notehead; }
-    SymId noteHeads(int pitch, NoteHeadType t) const { return m_drum[pitch].noteheads[int(t)]; }
-    int line(int pitch) const { return m_drum[pitch].line; }
-    int voice(int pitch) const { return m_drum[pitch].voice; }
-    DirectionV stemDirection(int pitch) const { return m_drum[pitch].stemDirection; }
-    const String& name(int pitch) const { return m_drum[pitch].name; }
+    bool isValid(int pitch) const { return !m_drums[pitch].name.empty(); }
+    NoteHeadGroup noteHead(int pitch) const { return m_drums[pitch].notehead; }
+    SymId noteHeads(int pitch, NoteHeadType t) const { return m_drums[pitch].noteheads[int(t)]; }
+    int line(int pitch) const { return m_drums[pitch].line; }
+    int voice(int pitch) const { return m_drums[pitch].voice; }
+    DirectionV stemDirection(int pitch) const { return m_drums[pitch].stemDirection; }
+    const String& name(int pitch) const { return m_drums[pitch].name; }
     String translatedName(int pitch) const;
-    int shortcut(int pitch) const { return m_drum[pitch].shortcut; }
-    std::list<DrumInstrumentVariant> variants(int pitch) const { return m_drum[pitch].variants; }
+    int shortcut(int pitch) const { return m_drums[pitch].shortcut; }
+    std::list<DrumInstrumentVariant> variants(int pitch) const { return m_drums[pitch].variants; }
+    int panelRow(int pitch) const { return m_drums[pitch].panelRow; }
+    int panelColumn(int pitch) const { return m_drums[pitch].panelColumn; }
 
     void save(XmlWriter&) const;
     void load(XmlReader&);
@@ -93,15 +117,26 @@ public:
     void clear();
     int nextPitch(int) const;
     int prevPitch(int) const;
-    DrumInstrument& drum(int i) { return m_drum[i]; }
-    const DrumInstrument& drum(int i) const { return m_drum[i]; }
-    void setDrum(int pitch, const DrumInstrument& di) { m_drum[pitch] = di; }
+    DrumInstrument& drum(int i) { return m_drums[i]; }
+    const DrumInstrument& drum(int i) const { return m_drums[i]; }
+    void setDrum(int pitch, const DrumInstrument& di) { m_drums[pitch] = di; }
     DrumInstrumentVariant findVariant(int pitch, const std::vector<Articulation*>& articulations, TremoloType tremType) const;
 
     static void initDrumset();
-private:
 
-    DrumInstrument m_drum[DRUM_INSTRUMENTS];
+    bool operator==(const Drumset& other) const
+    {
+        for (int pitch = 0; pitch < DRUM_INSTRUMENTS; ++pitch) {
+            if (m_drums[pitch] == other.m_drums[pitch]) {
+                continue;
+            }
+            return false;
+        }
+        return true;
+    }
+
+private:
+    DrumInstrument m_drums[DRUM_INSTRUMENTS];
 };
 
 extern Drumset* smDrumset;

--- a/src/engraving/dom/input.cpp
+++ b/src/engraving/dom/input.cpp
@@ -50,7 +50,7 @@ bool InputState::isValid() const
 //   drumset
 //---------------------------------------------------------
 
-const Drumset* InputState::drumset() const
+Drumset* InputState::drumset() const
 {
     if (!m_segment || m_track == muse::nidx) {
         return nullptr;

--- a/src/engraving/dom/input.h
+++ b/src/engraving/dom/input.h
@@ -77,7 +77,7 @@ public:
     Segment* lastSegment() const { return m_lastSegment; }
     void setLastSegment(Segment* s) { m_lastSegment = s; }
 
-    const Drumset* drumset() const;
+    Drumset* drumset() const;
 
     int drumNote() const { return m_drumNote; }
     void setDrumNote(int v) { m_drumNote = v; }

--- a/src/importexport/guitarpro/internal/guitarprodrumset.cpp
+++ b/src/importexport/guitarpro/internal/guitarprodrumset.cpp
@@ -42,6 +42,8 @@ void initGuitarProDrumset()
             gpDrumset->drum(i).shortcut = 0;
             gpDrumset->drum(i).voice    = 0;
             gpDrumset->drum(i).stemDirection = DirectionV::UP;
+            gpDrumset->drum(i).panelRow = -1;
+            gpDrumset->drum(i).panelColumn = -1;
         }
         // new drumset determined via guitar pro (third argument specifies position on staff, 10 = C3, 9 = D3, 8 = E3,...)
 

--- a/src/importexport/guitarpro/internal/guitarprodrumset.cpp
+++ b/src/importexport/guitarpro/internal/guitarprodrumset.cpp
@@ -36,7 +36,7 @@ void initGuitarProDrumset()
 
     if (!gpDrumset) {
         gpDrumset = new Drumset();
-        for (int i = 0; i < 128; ++i) {
+        for (int i = 0; i < DRUM_INSTRUMENTS; ++i) {
             gpDrumset->drum(i).notehead = NoteHeadGroup::HEAD_INVALID;
             gpDrumset->drum(i).line     = 0;
             gpDrumset->drum(i).shortcut = 0;

--- a/src/importexport/ove/internal/importove.cpp
+++ b/src/importexport/ove/internal/importove.cpp
@@ -649,6 +649,8 @@ void OveToMScore::convertTrackHeader(ovebase::Track* track, Part* part)
             drumset->drum(i).stemDirection = smDrumset->drum(i).stemDirection;
             drumset->drum(i).voice     = smDrumset->drum(i).voice;
             drumset->drum(i).shortcut = 0;
+            drumset->drum(i).panelRow = smDrumset->drum(i).panelRow;
+            drumset->drum(i).panelColumn = smDrumset->drum(i).panelColumn;
         }
         QList<ovebase::Track::DrumNode> nodes = track->getDrumKit();
         for (int i = 0; i < nodes.size(); ++i) {

--- a/src/notation/notationtypes.h
+++ b/src/notation/notationtypes.h
@@ -247,7 +247,7 @@ struct NoteInputState
     engraving::voice_idx_t currentVoiceIndex = 0;
     engraving::track_idx_t currentTrack = 0;
     int currentString = 0;
-    const Drumset* drumset = nullptr;
+    Drumset* drumset = nullptr;
     StaffGroup staffGroup = StaffGroup::STANDARD;
     const Staff* staff = nullptr;
     Segment* segment = nullptr;

--- a/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
+++ b/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
@@ -255,7 +255,7 @@ Item {
                 text: qsTrc("notation", "Add row")
                 orientation: Qt.Horizontal
                 onClicked: {
-                    padGrid.model.addRow()
+                    padGrid.model.addEmptyRow()
                     flickable.goToBottom()
                 }
             }

--- a/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPad.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPad.qml
@@ -47,7 +47,6 @@ DropArea {
 
     QtObject {
         id: prv
-        readonly property bool isEmptySlot: Boolean(root.padModel) ? root.padModel.isEmptySlot : true
         readonly property color enabledBackgroundColor: Utils.colorWithAlpha(ui.theme.buttonColor, ui.theme.buttonOpacityNormal)
         readonly property color disabledBackgroundColor: Utils.colorWithAlpha(ui.theme.buttonColor, ui.theme.itemOpacityDisabled)
     }
@@ -70,7 +69,7 @@ DropArea {
             id: dragHandler
 
             target: draggableArea
-            enabled: root.panelMode === PanelMode.EDIT_LAYOUT && !prv.isEmptySlot
+            enabled: Boolean(root.padModel) && root.panelMode === PanelMode.EDIT_LAYOUT
 
             dragThreshold: 0 // prevents the flickable from stealing drag events
 
@@ -107,7 +106,7 @@ DropArea {
                 }
             }
 
-            sourceComponent: prv.isEmptySlot ? emptySlotComponent : padContentComponent
+            sourceComponent: Boolean(root.padModel) ? padContentComponent : emptySlotComponent
 
             Component {
                 id: padContentComponent

--- a/src/notation/view/percussionpanel/percussionpanelmodel.h
+++ b/src/notation/view/percussionpanel/percussionpanelmodel.h
@@ -71,7 +71,7 @@ public:
     void setEnabled(bool enabled);
 
     PanelMode::Mode currentPanelMode() const;
-    void setCurrentPanelMode(const PanelMode::Mode& panelMode);
+    void setCurrentPanelMode(const PanelMode::Mode& panelMode, bool updateNoteInput = true);
 
     bool useNotationPreview() const;
     void setUseNotationPreview(bool useNotationPreview);

--- a/src/notation/view/percussionpanel/percussionpanelpadlistmodel.cpp
+++ b/src/notation/view/percussionpanel/percussionpanelpadlistmodel.cpp
@@ -66,7 +66,7 @@ void PercussionPanelPadListModel::init()
 void PercussionPanelPadListModel::addRow()
 {
     for (size_t i = 0; i < NUM_COLUMNS; ++i) {
-        m_padModels.append(new PercussionPanelPadModel(this));
+        m_padModels.append(nullptr);
     }
     emit layoutChanged();
     emit numPadsChanged();
@@ -146,14 +146,12 @@ void PercussionPanelPadListModel::resetLayout()
 
         model->setNotationPreviewItem(PercussionUtilities::getDrumNoteForPreview(m_drumset, pitch));
 
-        model->setIsEmptySlot(false);
-
         m_padModels.append(model);
     }
 
     // Fill the remainder of the column with empty pads...
     while (m_padModels.size() % NUM_COLUMNS > 0) {
-        m_padModels.append(new PercussionPanelPadModel(this));
+        m_padModels.append(nullptr);
     }
 
     endResetModel();
@@ -192,8 +190,7 @@ int PercussionPanelPadListModel::numEmptySlotsAtRow(int row) const
     int count = 0;
     const size_t rowStartIdx = row * NUM_COLUMNS;
     for (size_t i = rowStartIdx; i < rowStartIdx + NUM_COLUMNS; ++i) {
-        const PercussionPanelPadModel* model = m_padModels.at(i);
-        if (model && model->isEmptySlot()) {
+        if (!m_padModels.at(i)) {
             ++count;
         }
     }

--- a/src/notation/view/percussionpanel/percussionpanelpadlistmodel.h
+++ b/src/notation/view/percussionpanel/percussionpanelpadlistmodel.h
@@ -41,6 +41,7 @@ class PercussionPanelPadListModel : public QAbstractListModel, public muse::asyn
 
 public:
     explicit PercussionPanelPadListModel(QObject* parent = nullptr);
+    ~PercussionPanelPadListModel();
 
     int rowCount(const QModelIndex&) const override { return m_padModels.count(); }
     QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
@@ -48,8 +49,11 @@ public:
 
     Q_INVOKABLE void init();
 
-    Q_INVOKABLE void addRow();
+    Q_INVOKABLE void addEmptyRow();
     Q_INVOKABLE void deleteRow(int row);
+
+    void removeEmptyRows();
+
     Q_INVOKABLE bool rowIsEmpty(int row) const;
 
     Q_INVOKABLE void startDrag(int startIndex);
@@ -60,10 +64,10 @@ public:
     int numColumns() const { return NUM_COLUMNS; }
     int numPads() const { return m_padModels.count(); }
 
-    void setDrumset(const mu::engraving::Drumset* drumset);
-    const mu::engraving::Drumset* drumset() const { return m_drumset; }
+    void setDrumset(const engraving::Drumset* drumset);
+    engraving::Drumset* drumset() const { return m_drumset; }
 
-    void resetLayout();
+    QList<PercussionPanelPadModel*> padList() const { return m_padModels; }
 
     muse::async::Notification hasActivePadsChanged() const { return m_hasActivePadsChanged; }
     muse::async::Channel<int /*pitch*/> padTriggered() const { return m_triggeredChannel; }
@@ -79,12 +83,18 @@ private:
         PadModelRole = Qt::UserRole + 1,
     };
 
+    void load();
+
     bool indexIsValid(int index) const;
+
+    PercussionPanelPadModel* createPadModelForPitch(int pitch);
+    int createModelIndexForPitch(int pitch) const;
+
     void movePad(int fromIndex, int toIndex);
 
     int numEmptySlotsAtRow(int row) const;
 
-    const mu::engraving::Drumset* m_drumset = nullptr;
+    engraving::Drumset* m_drumset = nullptr; //! NOTE: Pointer may be invalid, see PercussionPanelModel::setUpConnections
     QList<PercussionPanelPadModel*> m_padModels;
 
     int m_dragStartIndex = -1;

--- a/src/notation/view/percussionpanel/percussionpanelpadmodel.cpp
+++ b/src/notation/view/percussionpanel/percussionpanelpadmodel.cpp
@@ -74,16 +74,6 @@ const QVariant PercussionPanelPadModel::notationPreviewItemVariant() const
     return QVariant::fromValue(m_notationPreviewItem);
 }
 
-void PercussionPanelPadModel::setIsEmptySlot(bool isEmptySlot)
-{
-    if (m_isEmptySlot == isEmptySlot) {
-        return;
-    }
-
-    m_isEmptySlot = isEmptySlot;
-    emit isEmptySlotChanged();
-}
-
 void PercussionPanelPadModel::triggerPad()
 {
     m_triggeredNotification.notify();

--- a/src/notation/view/percussionpanel/percussionpanelpadmodel.cpp
+++ b/src/notation/view/percussionpanel/percussionpanelpadmodel.cpp
@@ -49,13 +49,13 @@ void PercussionPanelPadModel::setKeyboardShortcut(const QString& keyboardShortcu
     emit keyboardShortcutChanged();
 }
 
-void PercussionPanelPadModel::setMidiNote(const QString& midiNote)
+void PercussionPanelPadModel::setPitch(int pitch)
 {
-    if (m_midiNote == midiNote) {
+    if (m_pitch == pitch) {
         return;
     }
 
-    m_midiNote = midiNote;
+    m_pitch = pitch;
     emit midiNoteChanged();
 }
 

--- a/src/notation/view/percussionpanel/percussionpanelpadmodel.h
+++ b/src/notation/view/percussionpanel/percussionpanelpadmodel.h
@@ -41,8 +41,6 @@ class PercussionPanelPadModel : public QObject, public muse::async::Asyncable
 
     Q_PROPERTY(QVariant notationPreviewItem READ notationPreviewItemVariant NOTIFY notationPreviewItemChanged)
 
-    Q_PROPERTY(bool isEmptySlot READ isEmptySlot NOTIFY isEmptySlotChanged)
-
 public:
     explicit PercussionPanelPadModel(QObject* parent = nullptr);
 
@@ -60,9 +58,6 @@ public:
 
     const QVariant notationPreviewItemVariant() const;
 
-    bool isEmptySlot() const { return m_isEmptySlot; }
-    void setIsEmptySlot(bool isEmptySlot);
-
     Q_INVOKABLE void triggerPad();
     muse::async::Notification padTriggered() const { return m_triggeredNotification; }
 
@@ -74,8 +69,6 @@ signals:
 
     void notationPreviewItemChanged();
 
-    void isEmptySlotChanged();
-
 private:
     QString m_instrumentName;
 
@@ -83,8 +76,6 @@ private:
     QString m_midiNote;
 
     mu::engraving::ElementPtr m_notationPreviewItem;
-
-    bool m_isEmptySlot = true;
 
     muse::async::Notification m_triggeredNotification;
 };

--- a/src/notation/view/percussionpanel/percussionpanelpadmodel.h
+++ b/src/notation/view/percussionpanel/percussionpanelpadmodel.h
@@ -24,6 +24,8 @@
 
 #include <QObject>
 
+#include "global/utils.h"
+
 #include "async/asyncable.h"
 #include "async/notification.h"
 
@@ -50,8 +52,10 @@ public:
     QString keyboardShortcut() const { return m_keyboardShortcut; }
     void setKeyboardShortcut(const QString& keyboardShortcut);
 
-    QString midiNote() const { return m_midiNote; }
-    void setMidiNote(const QString& midiNote);
+    int pitch() const { return m_pitch; }
+    void setPitch(int pitch);
+
+    QString midiNote() const { return QString::fromStdString(muse::pitchToString(m_pitch)); }
 
     void setNotationPreviewItem(mu::engraving::ElementPtr item);
     mu::engraving::ElementPtr notationPreviewItem() const { return m_notationPreviewItem; }
@@ -73,7 +77,7 @@ private:
     QString m_instrumentName;
 
     QString m_keyboardShortcut;
-    QString m_midiNote;
+    int m_pitch = -1;
 
     mu::engraving::ElementPtr m_notationPreviewItem;
 

--- a/src/palette/view/widgets/customizekitdialog.cpp
+++ b/src/palette/view/widgets/customizekitdialog.cpp
@@ -301,7 +301,7 @@ void CustomizeKitDialog::loadPitchesList()
     pitchList->clear();
     pitchList->blockSignals(false);
 
-    for (int i = 0; i < 128; ++i) {
+    for (int i = 0; i < DRUM_INSTRUMENTS; ++i) {
         QTreeWidgetItem* item = new CustomizeKitTreeWidgetItem(pitchList);
         item->setText(Column::PITCH, QString("%1").arg(i));
         item->setText(Column::NOTE, pitch2string(i));

--- a/src/palette/view/widgets/drumsetpalette.cpp
+++ b/src/palette/view/widgets/drumsetpalette.cpp
@@ -86,7 +86,7 @@ void DrumsetPalette::updateDrumset()
 
     TRACEFUNC;
 
-    for (int pitch = 0; pitch < 128; ++pitch) {
+    for (int pitch = 0; pitch < engraving::DRUM_INSTRUMENTS; ++pitch) {
         if (!m_drumset->isValid(pitch)) {
             continue;
         }


### PR DESCRIPTION
The main focus of this PR is to save/load drum pad layouts in the percussion panel. This is done by introducing two new drumset tags - `panelRow` and `panelColumn`.

A couple of to-dos to consider before taking this out of draft mode:

- [x] Editing pad positions is not yet an undoable action, so it doesn't alter the "needs save state".
- [ ] The reset layout action is no longer functional after this PR. A new system needs to be devised for this.