### PR TITLE
Add playback speed popup to docked Playback Toolbar

### DIFF
--- a/src/framework/uicomponents/qml/Muse/UiComponents/IncrementalPropertyControl.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/IncrementalPropertyControl.qml
@@ -230,7 +230,7 @@ Item {
             scrolled = 0
         }
 
-        onTextChanged: function(newTextValue) {
+        onTextEdited: function(newTextValue) {
             if (prv.isCustom) {
                 root.valueEdited(newTextValue)
                 return

--- a/src/framework/uicomponents/qml/Muse/UiComponents/TimeInputField.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/TimeInputField.qml
@@ -32,6 +32,10 @@ Row {
 
     property font font: ui.theme.largeBodyFont
 
+    property NavigationPanel navigationPanel: null
+    property int navigationOrderStart: 0
+    readonly property int navigationOrderEnd: millisecondsField.navigation.order
+
     signal timeEdited(var newTime)
 
     spacing: 0
@@ -45,6 +49,11 @@ Row {
         value: root.time.getHours()
 
         font: root.font
+
+        navigation.panel: root.navigationPanel
+        navigation.order: root.navigationOrderStart
+        navigation.name: "hours"
+        accessible.name: qsTrc("global", "Hours")
 
         onValueEdited: function(newValue) {
             var newTime = root.time
@@ -68,6 +77,11 @@ Row {
         displayedNumberLength: 2
         font: root.font
 
+        navigation.panel: root.navigationPanel
+        navigation.order: root.navigationOrderStart + 1
+        navigation.name: "minutes"
+        accessible.name: qsTrc("global", "Minutes")
+
         onValueEdited: function(newValue) {
             var newTime = root.time
             newTime.setMinutes(newValue)
@@ -89,6 +103,11 @@ Row {
 
         displayedNumberLength: 2
         font: root.font
+
+        navigation.panel: root.navigationPanel
+        navigation.order: root.navigationOrderStart + 2
+        navigation.name: "seconds"
+        accessible.name: qsTrc("global", "Seconds")
 
         onValueEdited: function(newValue) {
             var newTime = root.time
@@ -113,6 +132,11 @@ Row {
         value: root.time.getMilliseconds() / precision
 
         font: root.font
+
+        navigation.panel: root.navigationPanel
+        navigation.order: root.navigationOrderStart + 3
+        navigation.name: "milliseconds"
+        accessible.name: qsTrc("global", "Milliseconds")
 
         onValueEdited: function(newValue) {
             var newTime = root.time

--- a/src/playback/playback.qrc
+++ b/src/playback/playback.qrc
@@ -4,6 +4,7 @@
         <file>qml/MuseScore/Playback/PlaybackToolBar.qml</file>
         <file>qml/MuseScore/Playback/internal/MeasureAndBeatFields.qml</file>
         <file>qml/MuseScore/Playback/internal/TempoSlider.qml</file>
+        <file>qml/MuseScore/Playback/internal/TempoOverridePopup.qml</file>
         <file>qml/MuseScore/Playback/MixerPanel.qml</file>
         <file>qml/MuseScore/Playback/internal/MixerPanelToolbar.qml</file>
         <file>qml/MuseScore/Playback/internal/MixerPanelSection.qml</file>

--- a/src/playback/playback.qrc
+++ b/src/playback/playback.qrc
@@ -3,8 +3,8 @@
         <file>qml/MuseScore/Playback/qmldir</file>
         <file>qml/MuseScore/Playback/PlaybackToolBar.qml</file>
         <file>qml/MuseScore/Playback/internal/MeasureAndBeatFields.qml</file>
-        <file>qml/MuseScore/Playback/internal/TempoSlider.qml</file>
-        <file>qml/MuseScore/Playback/internal/TempoOverridePopup.qml</file>
+        <file>qml/MuseScore/Playback/internal/PlaybackSpeedSlider.qml</file>
+        <file>qml/MuseScore/Playback/internal/PlaybackSpeedPopup.qml</file>
         <file>qml/MuseScore/Playback/MixerPanel.qml</file>
         <file>qml/MuseScore/Playback/internal/MixerPanelToolbar.qml</file>
         <file>qml/MuseScore/Playback/internal/MixerPanelSection.qml</file>

--- a/src/playback/qml/MuseScore/Playback/PlaybackToolBar.qml
+++ b/src/playback/qml/MuseScore/Playback/PlaybackToolBar.qml
@@ -89,6 +89,9 @@ Item {
             visible: root.floating
 
             playbackModel: thePlaybackModel
+
+            navigationPanel: navPanel
+            navigationOrderStart: playbackActions.navigationOrderEnd + 1
         }
     }
 }

--- a/src/playback/qml/MuseScore/Playback/PlaybackToolBar.qml
+++ b/src/playback/qml/MuseScore/Playback/PlaybackToolBar.qml
@@ -34,7 +34,7 @@ Item {
 
     property bool floating: false
 
-    width: content.width
+    width: content.width + (floating ? 12 : 0)
     height: content.height
 
     property NavigationPanel navigationPanel: NavigationPanel {
@@ -75,7 +75,7 @@ Item {
         }
 
         StyledSlider {
-            width: playbackActions.width - 12
+            width: playbackActions.width
             visible: root.floating
             value: thePlaybackModel.playPosition
 
@@ -85,7 +85,7 @@ Item {
         }
 
         PlaybackSpeedSlider {
-            width: playbackActions.width - 12
+            width: playbackActions.width
             visible: root.floating
 
             playbackModel: thePlaybackModel

--- a/src/playback/qml/MuseScore/Playback/PlaybackToolBar.qml
+++ b/src/playback/qml/MuseScore/Playback/PlaybackToolBar.qml
@@ -48,12 +48,12 @@ Item {
     property alias navigationPanelOrder: navPanel.order
 
     PlaybackToolBarModel {
-        id: playbackModel
+        id: thePlaybackModel
         isToolbarFloating: root.floating
     }
 
     Component.onCompleted: {
-        playbackModel.load()
+        thePlaybackModel.load()
     }
 
     Column {
@@ -63,12 +63,12 @@ Item {
 
         width: childrenRect.width
 
-        enabled: playbackModel.isPlayAllowed
+        enabled: thePlaybackModel.isPlayAllowed
 
         PlaybackToolBarActions {
             id: playbackActions
 
-            playbackModel: playbackModel
+            playbackModel: thePlaybackModel
             floating: root.floating
 
             navPanel: root.navigationPanel
@@ -77,21 +77,18 @@ Item {
         StyledSlider {
             width: playbackActions.width - 12
             visible: root.floating
-            value: playbackModel.playPosition
+            value: thePlaybackModel.playPosition
 
             onMoved: {
-                playbackModel.playPosition = value
+                thePlaybackModel.playPosition = value
             }
         }
 
-        TempoSlider {
+        PlaybackSpeedSlider {
             width: playbackActions.width - 12
             visible: root.floating
-            value: playbackModel.tempoMultiplier
 
-            onMoved: function(newValue) {
-                playbackModel.tempoMultiplier = newValue
-            }
+            playbackModel: thePlaybackModel
         }
     }
 }

--- a/src/playback/qml/MuseScore/Playback/internal/MeasureAndBeatFields.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/MeasureAndBeatFields.qml
@@ -36,6 +36,10 @@ Item {
 
     property font font: ui.theme.largeBodyFont
 
+    property NavigationPanel navigationPanel: null
+    property int navigationOrderStart: 0
+    readonly property int navigationOrderEnd: beatNumberField.navigation.order
+
     signal measureNumberEdited(var newValue)
     signal beatNumberEdited(var newValue)
 
@@ -66,6 +70,11 @@ Item {
 
                 font: root.font
 
+                navigation.panel: root.navigationPanel
+                navigation.order: root.navigationOrderStart
+                navigation.name: "measure"
+                accessible.name: qsTrc("playback", "Measure", "Measure number")
+
                 onValueEdited: function(newValue) {
                     root.measureNumberEdited(newValue)
                 }
@@ -93,6 +102,11 @@ Item {
                 addLeadingZeros: false
 
                 font: root.font
+
+                navigation.panel: root.navigationPanel
+                navigation.order: root.navigationOrderStart + 1
+                navigation.name: "beat"
+                accessible.name: qsTrc("playback", "Beat", "Beat number")
 
                 onValueEdited: function(newValue) {
                     root.beatNumberEdited(newValue)

--- a/src/playback/qml/MuseScore/Playback/internal/PlaybackSpeedPopup.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/PlaybackSpeedPopup.qml
@@ -42,7 +42,7 @@ StyledPopupView {
 
         StyledTextLabel {
             Layout.fillWidth: true
-            text: qsTrc("playback", "Override tempo")
+            text: qsTrc("playback", "Speed")
             font: ui.theme.bodyBoldFont
             horizontalAlignment: Text.AlignLeft
         }

--- a/src/playback/qml/MuseScore/Playback/internal/PlaybackSpeedPopup.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/PlaybackSpeedPopup.qml
@@ -36,6 +36,13 @@ StyledPopupView {
     contentWidth: contentColumn.implicitWidth
     contentHeight: contentColumn.implicitHeight
 
+    NavigationPanel {
+        id: navPanel
+        name: "PlaybackSpeedPopup"
+        section: root.navigationSection
+        accessible.name: qsTrc("playback", "Playback speed popup")
+    }
+
     ColumnLayout {
         id: contentColumn
         spacing: 8
@@ -75,6 +82,9 @@ StyledPopupView {
                 step: 5
                 measureUnitsSymbol: "%"
                 decimals: 0
+
+                navigation.panel: navPanel
+                navigation.accessible.name: qsTrc("playback", "Speed")
 
                 onValueEdited: function(newValue) {
                     root.playbackModel.tempoMultiplier = newValue / 100

--- a/src/playback/qml/MuseScore/Playback/internal/PlaybackSpeedPopup.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/PlaybackSpeedPopup.qml
@@ -50,28 +50,11 @@ StyledPopupView {
         StyledTextLabel {
             Layout.fillWidth: true
             text: qsTrc("playback", "Speed")
-            font: ui.theme.bodyBoldFont
             horizontalAlignment: Text.AlignLeft
         }
 
         RowLayout {
             spacing: 12
-
-            StyledSlider {
-                Layout.preferredWidth: 200
-                Layout.preferredHeight: 30
-
-                value: root.playbackModel.tempoMultiplier
-                from: 0.1
-                to: 3.0
-                stepSize: 0.05
-
-                fillBackground: false
-
-                onMoved: {
-                    root.playbackModel.tempoMultiplier = value
-                }
-            }
 
             IncrementalPropertyControl {
                 Layout.preferredWidth: 76
@@ -88,6 +71,22 @@ StyledPopupView {
 
                 onValueEdited: function(newValue) {
                     root.playbackModel.tempoMultiplier = newValue / 100
+                }
+            }
+
+            StyledSlider {
+                Layout.preferredWidth: 200
+                Layout.preferredHeight: 30
+
+                value: root.playbackModel.tempoMultiplier
+                from: 0.1
+                to: 3.0
+                stepSize: 0.05
+
+                fillBackground: false
+
+                onMoved: {
+                    root.playbackModel.tempoMultiplier = value
                 }
             }
         }

--- a/src/playback/qml/MuseScore/Playback/internal/PlaybackSpeedSlider.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/PlaybackSpeedSlider.qml
@@ -19,73 +19,59 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import QtQuick 2.15
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Layouts
 
-import Muse.UiComponents 1.0
-import Muse.Ui 1.0
+import Muse.UiComponents
+import Muse.Ui
+
+import MuseScore.Playback
 
 RowLayout {
     id: root
 
-    property real value: 0
-    property real from: 0.1
-    property real to: 3
-    property real stepSize: 0.05
+    property PlaybackToolBarModel playbackModel: null
 
-    signal moved(real newValue)
-
-    height: 30
-    spacing: 0
+    spacing: 12
 
     StyledTextLabel {
-        Layout.fillHeight: true
-        Layout.alignment: Qt.AlignVCenter
-
-        text: qsTrc("playback", "Tempo")
-        font: ui.theme.largeBodyFont
-    }
-
-    Item {
         Layout.fillWidth: true
         Layout.fillHeight: true
+
+        text: qsTrc("playback", "Speed")
+        font: ui.theme.largeBodyFont
+        horizontalAlignment: Text.AlignLeft
     }
 
-    NumberInputField {
-        value: Math.round(root.value * 100)
-        minValue: root.from * 100
-        maxValue: root.to * 100
+    IncrementalPropertyControl {
+        Layout.preferredWidth: 76
+        currentValue: (root.playbackModel.tempoMultiplier * 100).toFixed(decimals)
 
-        live: false
-
-        addLeadingZeros: false
-        font: ui.theme.largeBodyFont
+        maxValue: 300
+        minValue: 10
+        step: 5
+        measureUnitsSymbol: "%"
+        decimals: 0
 
         onValueEdited: function(newValue) {
-            root.moved(newValue / 100)
+            root.playbackModel.tempoMultiplier = newValue / 100
         }
-    }
-
-    StyledTextLabel {
-        text: "%"
-        font: ui.theme.largeBodyFont
     }
 
     StyledSlider {
         id: slider
 
         Layout.preferredWidth: root.width / 2
-        Layout.leftMargin: 12
 
-        value: root.value
-        from: root.from
-        to: root.to
-        stepSize: root.stepSize
+        value: root.playbackModel.tempoMultiplier
+        from: 0.1
+        to: 3.0
+        stepSize: 0.05
 
         fillBackground: false
 
         onMoved: {
-            root.moved(slider.value)
+            root.playbackModel.tempoMultiplier = value
         }
     }
 }

--- a/src/playback/qml/MuseScore/Playback/internal/PlaybackSpeedSlider.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/PlaybackSpeedSlider.qml
@@ -32,6 +32,9 @@ RowLayout {
 
     property PlaybackToolBarModel playbackModel: null
 
+    property NavigationPanel navigationPanel: null
+    property int navigationOrderStart: 0
+
     spacing: 12
 
     StyledTextLabel {
@@ -52,6 +55,10 @@ RowLayout {
         step: 5
         measureUnitsSymbol: "%"
         decimals: 0
+
+        navigation.panel: root.navigationPanel
+        navigation.order: root.navigationOrderStart
+        navigation.accessible.name: qsTrc("playback", "Speed")
 
         onValueEdited: function(newValue) {
             root.playbackModel.tempoMultiplier = newValue / 100

--- a/src/playback/qml/MuseScore/Playback/internal/PlaybackToolBarActions.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/PlaybackToolBarActions.qml
@@ -19,17 +19,20 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import QtQuick 2.15
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Layouts
 
-import Muse.UiComponents 1.0
-import Muse.Ui 1.0
-import MuseScore.CommonScene 1.0
+import Muse.UiComponents
+import Muse.Ui
+
+import MuseScore.CommonScene
+import MuseScore.Playback
 
 Item {
     id: root
 
-    property var playbackModel: null
+    property PlaybackToolBarModel playbackModel: null
+
     property NavigationPanel navPanel: null
     property bool floating: false
 
@@ -154,8 +157,8 @@ Item {
         }
     }
 
-    Item {
-        id: tempoViewContainer
+    FlatButton {
+        id: tempoButton
 
         anchors.left: measureAndBeatFields.right
         anchors.leftMargin: 6
@@ -166,11 +169,11 @@ Item {
         width: 48
         height: parent.height
 
-        TempoView {
-            id: tempoView
+        accentButton: tempoOverridePopup.isOpened
+        transparent: !accentButton
 
-            anchors.verticalCenter: parent.verticalCenter
-            anchors.right: parent.right
+        contentItem: TempoView {
+            anchors.centerIn: parent
 
             noteSymbol: root.playbackModel.tempo.noteSymbol
             tempoValue: root.playbackModel.tempo.value
@@ -178,10 +181,20 @@ Item {
             noteSymbolFont.pixelSize: ui.theme.iconsFont.pixelSize
             tempoValueFont: timeField.font
         }
+
+        onClicked: {
+            tempoOverridePopup.toggleOpened()
+        }
+
+        TempoOverridePopup {
+            id: tempoOverridePopup
+
+            playbackModel: root.playbackModel
+        }
     }
 
     SeparatorLine {
-        anchors.left: tempoViewContainer.right
+        anchors.left: tempoButton.right
         anchors.leftMargin: 12
         anchors.topMargin: 2
         anchors.bottomMargin: 2

--- a/src/playback/qml/MuseScore/Playback/internal/PlaybackToolBarActions.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/PlaybackToolBarActions.qml
@@ -179,21 +179,24 @@ Item {
 
         readonly property int navigationOrderEnd: item?.navigation?.order ?? measureAndBeatFields.navigationOrderEnd
 
+        // Fixed width prevents items from jumping around; but we
+        // scale it according to the font size to prevent clipping
+        readonly property real tempoViewWidth: 60 * (ui.theme.bodyFont.pixelSize / ui.theme.defaultFont.pixelSize)
+
         sourceComponent: root.floating ? tempoViewComponent : tempoButtonComponent
 
         Component {
             id: tempoViewComponent
 
             Item {
-                // 2 * ui.theme.defaultButtonSize ≈ "60 but scaled to body text size"
-                // See https://github.com/musescore/MuseScore/pull/25621#issuecomment-2564382857
-                implicitWidth: 2 * ui.theme.defaultButtonSize
-                implicitHeight: ui.theme.defaultButtonSize
+                implicitWidth: tempoLoader.tempoViewWidth
+                implicitHeight: root.height
 
                 TempoView {
                     id: tempoView
                     anchors.right: parent.right
                     anchors.verticalCenter: parent.verticalCenter
+                    anchors.verticalCenterOffset: 1 // for nicer visual alignment
 
                     noteSymbol: root.playbackModel.tempo.noteSymbol
                     tempoValue: root.playbackModel.tempo.value
@@ -208,10 +211,8 @@ Item {
             id: tempoButtonComponent
 
             FlatButton {
-                // 2 * ui.theme.defaultButtonSize ≈ "60 but scaled to body text size"
-                // See https://github.com/musescore/MuseScore/pull/25621#issuecomment-2564382857
-                implicitWidth: 2 * ui.theme.defaultButtonSize
-                implicitHeight: ui.theme.defaultButtonSize
+                implicitWidth: tempoLoader.tempoViewWidth
+                implicitHeight: root.height
 
                 accentButton: playbackSpeedPopup.isOpened
                 transparent: !accentButton
@@ -223,6 +224,7 @@ Item {
 
                 contentItem: TempoView {
                     anchors.centerIn: parent
+                    anchors.verticalCenterOffset: 1 // for nicer visual alignment
 
                     noteSymbol: root.playbackModel.tempo.noteSymbol
                     tempoValue: root.playbackModel.tempo.value

--- a/src/playback/qml/MuseScore/Playback/internal/PlaybackToolBarActions.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/PlaybackToolBarActions.qml
@@ -34,6 +34,8 @@ Item {
     property PlaybackToolBarModel playbackModel: null
 
     property NavigationPanel navPanel: null
+    readonly property int navigationOrderEnd: tempoButton.navigation.order
+
     property bool floating: false
 
     width: childrenRect.width
@@ -54,6 +56,8 @@ Item {
 
         orientation: Qt.Horizontal
         interactive: false
+
+        readonly property int navigationOrderEnd: count
 
         delegate: FlatButton {
             id: btn
@@ -128,6 +132,9 @@ Item {
         maxMillisecondsNumber: 9
         time: root.playbackModel.playTime
 
+        navigationPanel: root.navPanel
+        navigationOrderStart: buttonsListView.navigationOrderEnd + 1
+
         onTimeEdited: function(newTime) {
             root.playbackModel.playTime = newTime
         }
@@ -147,6 +154,9 @@ Item {
         maxBeatNumber: root.playbackModel.maxBeatNumber
 
         font: timeField.font
+
+        navigationPanel: root.navPanel
+        navigationOrderStart: timeField.navigationOrderEnd + 1
 
         onMeasureNumberEdited: function(newValue) {
             root.playbackModel.measureNumber = newValue
@@ -171,6 +181,9 @@ Item {
 
         accentButton: playbackSpeedPopup.isOpened
         transparent: !accentButton
+
+        navigation.panel: root.navPanel
+        navigation.order: measureAndBeatFields.navigationOrderEnd + 1
 
         contentItem: TempoView {
             anchors.centerIn: parent

--- a/src/playback/qml/MuseScore/Playback/internal/PlaybackToolBarActions.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/PlaybackToolBarActions.qml
@@ -34,7 +34,7 @@ Item {
     property PlaybackToolBarModel playbackModel: null
 
     property NavigationPanel navPanel: null
-    readonly property int navigationOrderEnd: tempoButton.navigation.order
+    readonly property int navigationOrderEnd: tempoLoader.navigationOrderEnd
 
     property bool floating: false
 
@@ -167,47 +167,74 @@ Item {
         }
     }
 
-    FlatButton {
-        id: tempoButton
+    Loader {
+        id: tempoLoader
 
         anchors.left: measureAndBeatFields.right
         anchors.leftMargin: 6
 
-        //! NOTE: explicit width prevents the content from jumping around
-        // when a score is being played
-        // See: https://github.com/musescore/MuseScore/issues/9633
-        width: 48
-        height: parent.height
+        readonly property int navigationOrderEnd: item?.navigation?.order ?? measureAndBeatFields.navigationOrderEnd
 
-        accentButton: playbackSpeedPopup.isOpened
-        transparent: !accentButton
+        sourceComponent: root.floating ? tempoViewComponent : tempoButtonComponent
 
-        navigation.panel: root.navPanel
-        navigation.order: measureAndBeatFields.navigationOrderEnd + 1
+        Component {
+            id: tempoViewComponent
 
-        contentItem: TempoView {
-            anchors.centerIn: parent
+            Item {
+                implicitWidth: tempoView.implicitWidth
+                implicitHeight: ui.theme.defaultButtonSize
 
-            noteSymbol: root.playbackModel.tempo.noteSymbol
-            tempoValue: root.playbackModel.tempo.value
+                TempoView {
+                    id: tempoView
+                    anchors.centerIn: parent
 
-            noteSymbolFont.pixelSize: ui.theme.iconsFont.pixelSize
-            tempoValueFont: timeField.font
+                    noteSymbol: root.playbackModel.tempo.noteSymbol
+                    tempoValue: root.playbackModel.tempo.value
+
+                    noteSymbolFont.pixelSize: ui.theme.iconsFont.pixelSize
+                    tempoValueFont: timeField.font
+                }
+            }
         }
 
-        onClicked: {
-            playbackSpeedPopup.toggleOpened()
-        }
+        Component {
+            id: tempoButtonComponent
 
-        PlaybackSpeedPopup {
-            id: playbackSpeedPopup
+            FlatButton {
+                implicitHeight: ui.theme.defaultButtonSize
+                margins: 8
 
-            playbackModel: root.playbackModel
+                accentButton: playbackSpeedPopup.isOpened
+                transparent: !accentButton
+
+                navigation.panel: root.navPanel
+                navigation.order: measureAndBeatFields.navigationOrderEnd + 1
+
+                contentItem: TempoView {
+                    anchors.centerIn: parent
+
+                    noteSymbol: root.playbackModel.tempo.noteSymbol
+                    tempoValue: root.playbackModel.tempo.value
+
+                    noteSymbolFont.pixelSize: ui.theme.iconsFont.pixelSize
+                    tempoValueFont: timeField.font
+                }
+
+                onClicked: {
+                    playbackSpeedPopup.toggleOpened()
+                }
+
+                PlaybackSpeedPopup {
+                    id: playbackSpeedPopup
+
+                    playbackModel: root.playbackModel
+                }
+            }
         }
     }
 
     SeparatorLine {
-        anchors.left: tempoButton.right
+        anchors.left: tempoLoader.right
         anchors.leftMargin: 12
         anchors.topMargin: 2
         anchors.bottomMargin: 2

--- a/src/playback/qml/MuseScore/Playback/internal/PlaybackToolBarActions.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/PlaybackToolBarActions.qml
@@ -38,7 +38,11 @@ Item {
 
     property bool floating: false
 
-    width: childrenRect.width
+    // Not `+ endSeparator.width`: this way, the separator itself is outside the view,
+    // which means that it will be exactly at the position of the KDDockWidgets separator
+    // between this toolbar and the undo/redo toolbar.
+    width: endSeparator.visible ? endSeparator.x
+                                : tempoLoader.x + tempoLoader.width
     height: 30
 
     ListView {
@@ -181,12 +185,15 @@ Item {
             id: tempoViewComponent
 
             Item {
-                implicitWidth: tempoView.implicitWidth
+                // 2 * ui.theme.defaultButtonSize ≈ "60 but scaled to body text size"
+                // See https://github.com/musescore/MuseScore/pull/25621#issuecomment-2564382857
+                implicitWidth: 2 * ui.theme.defaultButtonSize
                 implicitHeight: ui.theme.defaultButtonSize
 
                 TempoView {
                     id: tempoView
-                    anchors.centerIn: parent
+                    anchors.right: parent.right
+                    anchors.verticalCenter: parent.verticalCenter
 
                     noteSymbol: root.playbackModel.tempo.noteSymbol
                     tempoValue: root.playbackModel.tempo.value
@@ -201,11 +208,15 @@ Item {
             id: tempoButtonComponent
 
             FlatButton {
+                // 2 * ui.theme.defaultButtonSize ≈ "60 but scaled to body text size"
+                // See https://github.com/musescore/MuseScore/pull/25621#issuecomment-2564382857
+                implicitWidth: 2 * ui.theme.defaultButtonSize
                 implicitHeight: ui.theme.defaultButtonSize
-                margins: 8
 
                 accentButton: playbackSpeedPopup.isOpened
                 transparent: !accentButton
+
+                toolTipTitle: qsTrc("playback", "Speed")
 
                 navigation.panel: root.navPanel
                 navigation.order: measureAndBeatFields.navigationOrderEnd + 1
@@ -234,8 +245,9 @@ Item {
     }
 
     SeparatorLine {
+        id: endSeparator
         anchors.left: tempoLoader.right
-        anchors.leftMargin: 12
+        anchors.leftMargin: 6
         anchors.topMargin: 2
         anchors.bottomMargin: 2
 

--- a/src/playback/qml/MuseScore/Playback/internal/PlaybackToolBarActions.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/PlaybackToolBarActions.qml
@@ -169,7 +169,7 @@ Item {
         width: 48
         height: parent.height
 
-        accentButton: tempoOverridePopup.isOpened
+        accentButton: playbackSpeedPopup.isOpened
         transparent: !accentButton
 
         contentItem: TempoView {
@@ -183,11 +183,11 @@ Item {
         }
 
         onClicked: {
-            tempoOverridePopup.toggleOpened()
+            playbackSpeedPopup.toggleOpened()
         }
 
-        TempoOverridePopup {
-            id: tempoOverridePopup
+        PlaybackSpeedPopup {
+            id: playbackSpeedPopup
 
             playbackModel: root.playbackModel
         }

--- a/src/playback/qml/MuseScore/Playback/internal/TempoOverridePopup.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/TempoOverridePopup.qml
@@ -1,0 +1,85 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2023 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import QtQuick
+import QtQuick.Layouts
+
+import Muse.Ui
+import Muse.UiComponents
+
+import MuseScore.Playback
+
+StyledPopupView {
+    id: root
+
+    property PlaybackToolBarModel playbackModel: null
+
+    contentWidth: contentColumn.implicitWidth
+    contentHeight: contentColumn.implicitHeight
+
+    ColumnLayout {
+        id: contentColumn
+        spacing: 8
+
+        StyledTextLabel {
+            Layout.fillWidth: true
+            text: qsTrc("playback", "Override tempo")
+            font: ui.theme.bodyBoldFont
+            horizontalAlignment: Text.AlignLeft
+        }
+
+        RowLayout {
+            spacing: 12
+
+            StyledSlider {
+                Layout.preferredWidth: 200
+                Layout.preferredHeight: 30
+
+                value: root.playbackModel.tempoMultiplier
+                from: 0.1
+                to: 3.0
+                stepSize: 0.05
+
+                fillBackground: false
+
+                onMoved: {
+                    root.playbackModel.tempoMultiplier = value
+                }
+            }
+
+            IncrementalPropertyControl {
+                Layout.preferredWidth: 76
+                currentValue: (root.playbackModel.tempoMultiplier * 100).toFixed(decimals)
+
+                maxValue: 300
+                minValue: 10
+                step: 5
+                measureUnitsSymbol: "%"
+                decimals: 0
+
+                onValueEdited: function(newValue) {
+                    root.playbackModel.tempoMultiplier = newValue / 100
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/23739 (not the glitches mentioned in the initial comment, because those are covered by another issue, but the request to access the tempo slider without undocking the toolbar)

<img width="534" alt="Scherm­afbeelding 2024-12-02 om 16 05 37" src="https://github.com/user-attachments/assets/b450a1f2-1db6-4c62-911b-83dfc660019e">


Built during FOSDEM 2023, but I never finished it until today :)