### PR TITLE
fix issue 25617: prevent crash importing MusicXML file containing grace rest followed by tuple starting with rest

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -6730,9 +6730,13 @@ Note* MusicXmlParserPass2::note(const String& partId,
     isSingleDrumset = instrument->drumset() && instruments.size() == 1;
     // begin allocation
     if (rest) {
-        const int track = msTrack + msVoice;
-        cr = addRest(m_score, measure, noteStartTime, track, msMove,
-                     duration, dura);
+        if (!grace) {
+            const int track = msTrack + msVoice;
+            cr = addRest(m_score, measure, noteStartTime, track, msMove,
+                         duration, dura);
+        } else {
+            LOGD("ignoring grace rest");
+        }
     } else {
         if (!grace) {
             // regular note


### PR DESCRIPTION
Resolves: #25617

See https://musescore.org/en/node/371987, which describes a crash caused by a MusicXML file containing a grace rest (which is not supported by libmscore and not handled correctly by the MusicXML importer). Trivial fix: ignore grace rests.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
