### PR TITLE
21837: Save Location Dialog - Ability to click on entire area of each save option

### DIFF
--- a/src/project/qml/MuseScore/Project/AskSaveLocationTypeDialog.qml
+++ b/src/project/qml/MuseScore/Project/AskSaveLocationTypeDialog.qml
@@ -75,10 +75,11 @@ StyledDialogView {
             }
 
             SaveLocationOption {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
                 title: qsTrc("project/save", "To the Cloud (free)")
                 description: qsTrc("project/save", "Files are saved privately on your own personal account. \
 You can share drafts with others and publish your finished scores publicly too.")
-                buttonText: qsTrc("project/save", "Save to the cloud")
 
                 imageSource: "qrc:/SaveToCloud/images/Cloud.png"
 
@@ -87,15 +88,16 @@ You can share drafts with others and publish your finished scores publicly too."
                 navigation.accessible.name: qsTrc("project/save", "Save to the cloud (free)")
                 navigation.accessible.description: description
 
-                onButtonClicked: {
+                onClicked: {
                     root.done(SaveLocationType.Cloud)
                 }
             }
 
             SaveLocationOption {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
                 title: qsTrc("project/save", "On your computer")
                 description: qsTrc("project/save", "If you prefer to save your files on your computer, you can do that here.")
-                buttonText: qsTrc("project/save", "Save to computer")
 
                 imageSource: "qrc:/SaveToCloud/images/Laptop.png"
 
@@ -104,7 +106,7 @@ You can share drafts with others and publish your finished scores publicly too."
                 navigation.accessible.name: qsTrc("project/save", "Save on your computer")
                 navigation.accessible.description: description
 
-                onButtonClicked: {
+                onClicked: {
                     root.done(SaveLocationType.Local)
                 }
             }

--- a/src/project/qml/MuseScore/Project/internal/SaveToCloud/SaveLocationOption.qml
+++ b/src/project/qml/MuseScore/Project/internal/SaveToCloud/SaveLocationOption.qml
@@ -25,80 +25,115 @@ import QtQuick.Layouts 1.15
 import Muse.Ui 1.0
 import Muse.UiComponents 1.0
 
-ColumnLayout {
+Item {
     id: root
 
     property alias title: titleLabel.text
     property alias description: descriptionLabel.text
-    property alias buttonText: button.text
-
     property alias imageSource: image.source
 
-    property alias navigation: button.navigation
+    property alias navigation: navCtrl
 
-    signal buttonClicked
+    signal clicked
 
     readonly property int radius: 6
 
-    spacing: 0
+    ColumnLayout {
+        anchors.fill: parent
+        spacing: 0
 
-    RoundedRectangle {
-        Layout.fillWidth: true
-        implicitHeight: 208
+        RoundedRectangle {
+            Layout.fillWidth: true
+            implicitHeight: 208
 
-        color: ui.theme.isDark ? "#44495A" : "#D7DEE5"
+            color: ui.theme.isDark ? "#44495A" : "#D7DEE5"
 
-        topLeftRadius: root.radius
-        topRightRadius: root.radius
+            topLeftRadius: root.radius
+            topRightRadius: root.radius
 
-        Image {
-            id: image
-            anchors.fill: parent
+            Image {
+                id: image
+                anchors.fill: parent
 
-            fillMode: Image.PreserveAspectFit
+                fillMode: Image.PreserveAspectFit
+            }
         }
-    }
 
-    RoundedRectangle {
-        Layout.fillWidth: true
-        Layout.fillHeight: true
+        RoundedRectangle {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
 
-        color: ui.theme.backgroundSecondaryColor
+            color: ui.theme.backgroundSecondaryColor
 
-        bottomLeftRadius: root.radius
-        bottomRightRadius: root.radius
+            bottomLeftRadius: root.radius
+            bottomRightRadius: root.radius
 
-        ColumnLayout {
-            anchors.fill: parent
-            anchors.margins: 24
-            spacing: 24
+            ColumnLayout {
+                anchors.fill: parent
+                anchors.margins: 24
+                spacing: 12
 
-            StyledTextLabel {
-                id: titleLabel
-                Layout.fillWidth: true
-                font: ui.theme.headerBoldFont
-                horizontalAlignment: Text.AlignLeft
-            }
+                StyledTextLabel {
+                    id: titleLabel
+                    Layout.fillWidth: true
+                    font: ui.theme.headerBoldFont
+                    horizontalAlignment: Text.AlignLeft
+                }
 
-            StyledTextLabel {
-                id: descriptionLabel
-                Layout.fillWidth: true
-                Layout.fillHeight: true
-                wrapMode: Text.WordWrap
-                maximumLineCount: 0
-                font: ui.theme.largeBodyFont
-                horizontalAlignment: Text.AlignLeft
-                verticalAlignment: Text.AlignTop
-            }
-
-            FlatButton {
-                id: button
-                accentButton: true
-
-                onClicked: {
-                    root.buttonClicked()
+                StyledTextLabel {
+                    id: descriptionLabel
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    wrapMode: Text.WordWrap
+                    maximumLineCount: 0
+                    font: ui.theme.largeBodyFont
+                    horizontalAlignment: Text.AlignLeft
+                    verticalAlignment: Text.AlignTop
                 }
             }
         }
     }
+
+    NavigationControl {
+        id: navCtrl
+        name: root.objectName !== "" ? root.objectName : "SaveLocationOption"
+        enabled: root.enabled && root.visible
+
+        accessible.role: MUAccessible.Button
+        accessible.name: root.titleLabel
+        accessible.description: root.description
+        accessible.visualItem: root
+        accessible.enabled: navCtrl.enabled
+
+        onTriggered: root.clicked()
+    }
+
+    NavigationFocusBorder {
+        navigationCtrl: navCtrl
+        drawOutsideParent: false
+        border.width: Math.max(3, ui.theme.navCtrlBorderWidth)
+    }
+
+    MouseArea {
+        id: mouseArea
+        anchors.fill: parent
+
+        hoverEnabled: true
+        cursorShape: "PointingHandCursor"
+
+        onClicked: root.clicked()
+    }
+
+    states: [
+        State {
+            name: "HOVERED"
+            when: mouseArea.containsMouse
+
+            PropertyChanges {
+                root {
+                    opacity: 0.5
+                }
+            }
+        }
+    ]
 }


### PR DESCRIPTION
Resolves: #21837

I agree it would be nice to be able to click on the entire areas of the save options so here is a PR for this.
**KEY POINTS:**

1. I have removed the buttons and now you can click anywhere on the entire area of each save option to activate it.
2. Visually, the area that is hovered becomes half transparent and the mouse turns into a hand to indicate to the user they can click on it.
3. Since the buttons are gone, their texts are not used anymore, at least on this dialog. Since they were translatable, should we check if they are used elsewhere and delete them from the translations if they are not?
4. I added proper navigation with the keyboard so now each save option receives the keyboard focus and draws the focus rectangle (but I have made it slightly thicker - 3px - since the save option areas are large).
5. I had to add an `Item` around the topmost `ColumnLayout` since `NavigationFocusBorder` uses anchors and they are not allowed inside layouts.
6. I reduced the spacing within the lower Rectangle from 24 to 12 (line 74 in SaveLocationOption.qml) because the description of the cloud save option was getting truncated with a lot of remaining text not appearing (I have my font size set at a slightly higher than the default value).
7. Wondering if we should keep the buttons in case some users don't know they should click on the save options?
8. Is the change to transparency good enough when a save option is hovered? Initially I also had a border of the accent color appear but then removed it.

P.S. Here is a screenshot:
![image](https://github.com/user-attachments/assets/8adf4eb0-f632-4159-a782-e91af0a07eb2)

I have hovered over the left option, this is why it is semi-transparent. I have the right option focused with the keyboard to show the focus border. Hmmm.... maybe it looks a bit confusing having both things demonstrated in the same screenshot...

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
