### PR TITLE
Fix #25371: Check if a previous selection exists before trying to restore it

### DIFF
--- a/src/notation/internal/notationactioncontroller.h
+++ b/src/notation/internal/notationactioncontroller.h
@@ -78,6 +78,8 @@ private:
     INotationUndoStackPtr currentNotationUndoStack() const;
     INotationMidiInputPtr currentNotationMidiInput() const;
 
+    mu::engraving::Score* currentNotationScore() const;
+
     void toggleNoteInput();
     void toggleNoteInputMethod(NoteInputMethod method);
     void toggleNoteInputInsert();


### PR DESCRIPTION
Resolves #25371

Caused by #24157 where we restore a previous selection if the selection is currently null. This caused a problem in newly opened scores where there is no previous selection (so we revert to selecting the first item in the score).

The proposed fix is pretty simple - check if a previous selection exists before trying to restore it.