### PR TITLE
Fix Issue 25266: Wrong icon in the Accidentals palette

### DIFF
--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -842,7 +842,7 @@ const UiActionList NotationUiActions::m_actions = {
              mu::context::CTX_NOTATION_OPENED,
              TranslatableString("action", "Add brackets to accidental"),
              TranslatableString("action", "Add brackets to accidental"),
-             IconCode::Code::BRACKET
+             IconCode::Code::BRACKET_PARENTHESES_SQUARE
              ),
     UiAction("add-braces",
              mu::context::UiCtxProjectOpened,


### PR DESCRIPTION
Resolves: #25266

One of the icons on the accidentals palette was set wrongly in notationuiactions.cpp

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
