### PR TITLE
Fix regroup rhythms not maintaining selection

### DIFF
--- a/src/engraving/dom/cmd.cpp
+++ b/src/engraving/dom/cmd.cpp
@@ -2803,7 +2803,12 @@ void Score::cmdResetNoteAndRestGroupings()
 
     if (noSelection) {
         deselectAll();
+        return;
     }
+
+    // Reset selection to original selection
+    selection().setRangeTicks(sTick, eTick, sStaff, eStaff);
+    selection().updateSelectedElements();
 }
 
 static void resetBeamOffSet(void*, EngravingItem* e)

--- a/src/engraving/tests/rhythmicgrouping_tests.cpp
+++ b/src/engraving/tests/rhythmicgrouping_tests.cpp
@@ -103,3 +103,55 @@ TEST_F(Engraving_RhythmicGroupingTests, groupShortenNotes)
 {
     group("groupShortenNotes.mscx", "groupShortenNotes-ref.mscx");  // test for regrouping rhythms when notes should be shortened
 }
+
+TEST_F(Engraving_RhythmicGroupingTests, groupMaintainSelection)
+{
+    MasterScore* score = ScoreRW::readScore(RHYTHMICGRP_DATA_DIR + String::fromUtf8("groupSubbeats.mscx"));
+    ASSERT_TRUE(score);
+
+    score->cmdSelectAll();
+    // [GIVEN] A score with a selection
+
+    const Selection& selection = score->selection();
+    Fraction sTick = selection.tickStart();
+    Fraction eTick = selection.tickEnd();
+    staff_idx_t sStaff = selection.staffStart();
+    staff_idx_t eStaff = selection.staffEnd();
+
+    // [WHEN] Regrouping rhythms
+    score->cmdResetNoteAndRestGroupings();
+
+    // [EXPECT] Selection is maintained
+    EXPECT_EQ(sTick, score->selection().tickStart());
+    EXPECT_EQ(eTick, score->selection().tickEnd());
+    EXPECT_EQ(sStaff, score->selection().staffStart());
+    EXPECT_EQ(eStaff, score->selection().staffEnd());
+
+    delete score;
+}
+
+TEST_F(Engraving_RhythmicGroupingTests, groupMaintainSelectionMultipleStaves)
+{
+    MasterScore* score = ScoreRW::readScore(RHYTHMICGRP_DATA_DIR + String::fromUtf8("group8ths4-4.mscx"));
+    ASSERT_TRUE(score);
+
+    score->cmdSelectAll();
+    // [GIVEN] A score with a selection
+
+    const Selection& selection = score->selection();
+    Fraction sTick = selection.tickStart();
+    Fraction eTick = selection.tickEnd();
+    staff_idx_t sStaff = selection.staffStart();
+    staff_idx_t eStaff = selection.staffEnd();
+
+    // [WHEN] Regrouping rhythms
+    score->cmdResetNoteAndRestGroupings();
+
+    // [EXPECT] Selection is maintained
+    EXPECT_EQ(sTick, score->selection().tickStart());
+    EXPECT_EQ(eTick, score->selection().tickEnd());
+    EXPECT_EQ(sStaff, score->selection().staffStart());
+    EXPECT_EQ(eStaff, score->selection().staffEnd());
+
+    delete score;
+}


### PR DESCRIPTION
Resolves: #24955 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
cmdResetNoteAndRestGroupings already saved the current selection before actually regrouping rhythms. This commit updates the method to set the selection to the values saved in the case that the user had selected a range before calling regroup rhythms.

Also adds test to verify that selection is maintained when regrouping rhythms.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
