### PR TITLE
Avoid loading Muse Sampler in Debug

### DIFF
--- a/src/app/appfactory.cpp
+++ b/src/app/appfactory.cpp
@@ -228,9 +228,21 @@ std::shared_ptr<muse::IApplication> AppFactory::newGuiApp(const CmdOptions& opti
     app->addModule(new muse::draw::DrawModule());
     app->addModule(new muse::midi::MidiModule());
     app->addModule(new muse::mpe::MpeModule());
+
 #ifdef MUSE_MODULE_MUSESAMPLER
-    app->addModule(new muse::musesampler::MuseSamplerModule());
+    bool needAdd = true;
+    if (runtime::isDebug()) {
+#ifndef MUSE_MODULE_MUSESAMPLER_ENABLE_DEBUG
+        needAdd = false;
+        LOGI() << "Muse Sampler is not a debuggable binary. Skipping adding.";
 #endif
+    }
+
+    if (needAdd) {
+        app->addModule(new muse::musesampler::MuseSamplerModule());
+    }
+#endif
+
     app->addModule(new muse::network::NetworkModule());
     app->addModule(new muse::shortcuts::ShortcutsModule());
 #ifdef MUSE_MODULE_UI

--- a/src/framework/cmake/MuseDeclareOptions.cmake
+++ b/src/framework/cmake/MuseDeclareOptions.cmake
@@ -40,7 +40,9 @@ declare_muse_module_opt(LEARN ON)
 declare_muse_module_opt(MIDI ON)
 declare_muse_module_opt(MPE ON)
 declare_muse_module_opt(MULTIINSTANCES ON)
+
 declare_muse_module_opt(MUSESAMPLER ON)
+option(MUSE_MODULE_MUSESAMPLER_ENABLE_DEBUG "Enable musesampler debug support" OFF)
 
 declare_muse_module_opt(NETWORK ON)
 option(MUSE_MODULE_NETWORK_WEBSOCKET "Enable websocket support" OFF)

--- a/src/framework/musesampler/CMakeLists.txt
+++ b/src/framework/musesampler/CMakeLists.txt
@@ -45,4 +45,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/internal/musesampleractioncontroller.h
     )
 
+if(MUSE_MODULE_MUSESAMPLER_ENABLE_DEBUG)
+    set(MODULE_DEF -DMUSE_MODULE_MUSESAMPLER_ENABLE_DEBUG)
+endif()
+
 setup_module()


### PR DESCRIPTION
Resolves: #25641

by default musesampler is now disabled in debug mode
if you need debugging - you need to enable the flag `MUSE_MODULE_MUSESAMPLER_DEBUG_ENABLE`