### PR TITLE
PROPOSAL: Refactor EID class into a pseudo-UUID

### DIFF
--- a/src/engraving/dom/engravingitem.cpp
+++ b/src/engraving/dom/engravingitem.cpp
@@ -2801,7 +2801,7 @@ void EngravingItem::LayoutData::setWidthDebugHook(double w)
 void EngravingItem::LayoutData::dump(std::stringstream& ss) const
 {
     ss << "\n";
-    ss << m_item->typeName() << " id: " << m_item->eid().id() << "\n";
+    ss << m_item->typeName() << " id: " << m_item->eid().toStdString() << "\n";
 
     ss << "skip: " << (m_isSkipDraw ? "yes" : "no") << "\n";
     ss << "mag: " << m_mag << "\n";

--- a/src/engraving/dom/engravingobject.cpp
+++ b/src/engraving/dom/engravingobject.cpp
@@ -68,17 +68,6 @@ EngravingObject::EngravingObject(const ElementType& type, EngravingObject* paren
         m_score = static_cast<Score*>(this);
     }
 
-    // gen EID
-    if (type != ElementType::SCORE) {
-        Score* s = score();
-        if (s) {
-            MasterScore* ms = s->masterScore();
-            if (ms) {
-                m_eid = ms->eidRegister()->newEID(m_type);
-            }
-        }
-    }
-
     // reg to debug
     if (type != ElementType::SCORE) {
         if (m_score && m_score->elementsProvider()) {
@@ -102,17 +91,6 @@ EngravingObject::EngravingObject(const EngravingObject& se)
         }
     }
     m_links = 0;
-
-    // gen EID
-    if (m_type != ElementType::SCORE) {
-        Score* s = score();
-        if (s) {
-            MasterScore* ms = s->masterScore();
-            if (ms) {
-                m_eid = ms->eidRegister()->newEID(m_type);
-            }
-        }
-    }
 
     // reg to debug
     if (m_type != ElementType::SCORE) {
@@ -727,12 +705,19 @@ String EngravingObject::translatedTypeUserName() const
     return typeUserName().translated();
 }
 
-void EngravingObject::setEID(EID id)
+EID EngravingObject::eid() const
 {
-    m_eid = id;
-    if (registerId()) {
-        masterScore()->eidRegister()->registerItemEID(id, this);
-    }
+    return masterScore()->eidRegister()->EIDFromItem(this);
+}
+
+void EngravingObject::setEID(EID id) const
+{
+    masterScore()->eidRegister()->registerItemEID(id, this);
+}
+
+EID EngravingObject::assignNewEID() const
+{
+    return masterScore()->eidRegister()->newEIDForItem(this);
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/engravingobject.h
+++ b/src/engraving/dom/engravingobject.h
@@ -214,9 +214,9 @@ public:
     virtual TranslatableString typeUserName() const;
     virtual String translatedTypeUserName() const;
 
-    inline EID eid() const { return m_eid; }
-    void setEID(EID id);
-    virtual bool registerId() const { return false; }
+    EID eid() const;
+    void setEID(EID id) const;
+    EID assignNewEID() const;
 
     EngravingObject* parent() const;
     void setParent(EngravingObject* p);
@@ -300,7 +300,7 @@ private:
     void doSetScore(Score* sc);
 
     ElementType m_type = ElementType::INVALID;
-    mutable EID m_eid;
+
     EngravingObject* m_parent = nullptr;
     bool m_isParentExplicitlySet = false;
     EngravingObjectList m_children;

--- a/src/engraving/dom/measurebase.h
+++ b/src/engraving/dom/measurebase.h
@@ -189,8 +189,6 @@ public:
     bool isStartOfSystemLock() const;
     bool isEndOfSystemLock() const;
 
-    bool registerId() const override { return true; }
-
 protected:
 
     MeasureBase(const ElementType& type, System* system = 0);

--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -181,10 +181,6 @@ Score::Score(MasterScore* parent, bool forcePartStyle /* = true */)
     Score::validScores.insert(this);
     m_masterScore = parent;
 
-    if (m_masterScore) {
-        setEID(m_masterScore->eidRegister()->newEID(type()));
-    }
-
     if (DefaultStyle::defaultStyleForParts()) {
         m_style = *DefaultStyle::defaultStyleForParts();
     } else {

--- a/src/engraving/infrastructure/eid.cpp
+++ b/src/engraving/infrastructure/eid.cpp
@@ -19,55 +19,151 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+#include <string>
+#include <random>
+
+#include <logger.h>
+
 #include "eid.h"
 
 using namespace mu::engraving;
 
-EID::EID(ElementType type, uint32_t id)
-    : m_type(type), m_id(id)
+static constexpr char SEPARATOR = '_';
+
+static std::string int64ToBase64Str(uint64_t n)
 {
+    static constexpr char CHARS[65] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+    std::stringstream ss;
+    do {
+        ss << CHARS[n & 63];
+        n = n >> 6;
+    } while (n != 0);
+
+    return ss.str();
 }
 
-struct _Data {
-    uint16_t type = 0;
-    uint16_t reserved = 0;
-    uint32_t id = 0;
-};
-
-union _Pack
+static constexpr uint64_t charToInt(char c)
 {
-    uint64_t val;
-    _Data data;
-};
-
-uint64_t EID::toUint64() const
-{
-    _Pack pack = { 0 };
-    pack.data.type = static_cast<uint16_t>(m_type);
-    pack.data.id = m_id;
-    return pack.val;
+    switch (c) {
+    case 'A': return 0;
+    case 'B': return 1;
+    case 'C': return 2;
+    case 'D': return 3;
+    case 'E': return 4;
+    case 'F': return 5;
+    case 'G': return 6;
+    case 'H': return 7;
+    case 'I': return 8;
+    case 'J': return 9;
+    case 'K': return 10;
+    case 'L': return 11;
+    case 'M': return 12;
+    case 'N': return 13;
+    case 'O': return 14;
+    case 'P': return 15;
+    case 'Q': return 16;
+    case 'R': return 17;
+    case 'S': return 18;
+    case 'T': return 19;
+    case 'U': return 20;
+    case 'V': return 21;
+    case 'W': return 22;
+    case 'X': return 23;
+    case 'Y': return 24;
+    case 'Z': return 25;
+    case 'a': return 26;
+    case 'b': return 27;
+    case 'c': return 28;
+    case 'd': return 29;
+    case 'e': return 30;
+    case 'f': return 31;
+    case 'g': return 32;
+    case 'h': return 33;
+    case 'i': return 34;
+    case 'j': return 35;
+    case 'k': return 36;
+    case 'l': return 37;
+    case 'm': return 38;
+    case 'n': return 39;
+    case 'o': return 40;
+    case 'p': return 41;
+    case 'q': return 42;
+    case 'r': return 43;
+    case 's': return 44;
+    case 't': return 45;
+    case 'u': return 46;
+    case 'v': return 47;
+    case 'w': return 48;
+    case 'x': return 49;
+    case 'y': return 50;
+    case 'z': return 51;
+    case '0': return 52;
+    case '1': return 53;
+    case '2': return 54;
+    case '3': return 55;
+    case '4': return 56;
+    case '5': return 57;
+    case '6': return 58;
+    case '7': return 59;
+    case '8': return 60;
+    case '9': return 61;
+    case '+': return 62;
+    case '/': return 63;
+    default:
+        UNREACHABLE;
+    }
 }
 
-EID EID::fromUint64(uint64_t v)
+static uint64_t base64StrToInt64(const std::string& s)
 {
-    _Pack pack = { 0 };
-    pack.val = v;
-    return EID(static_cast<ElementType>(pack.data.type), pack.data.id);
+    uint64_t result = 0;
+
+    for (auto iter = s.rbegin(); iter != s.rend(); ++iter) {
+        result = result << 6;
+        result |= charToInt(*iter);
+    }
+
+    return result;
 }
 
 std::string EID::toStdString() const
 {
-    return std::to_string(toUint64());
+    std::stringstream ss;
+    ss << int64ToBase64Str(m_first) << SEPARATOR << int64ToBase64Str(m_second);
+    return ss.str();
 }
 
 EID EID::fromStdString(const std::string& s)
 {
-    uint64_t v = std::stoull(s);
-    return fromUint64(v);
+    std::stringstream ss(s);
+    std::string str;
+    std::vector<std::string> strings;
+
+    while (std::getline(ss, str, SEPARATOR)) {
+        strings.push_back(str);
+    }
+
+    if (strings.size() != 2) {
+        return EID::invalid();
+    }
+
+    const std::string& first = strings[0];
+    const std::string& second = strings[1];
+
+    return EID(base64StrToInt64(first), base64StrToInt64(second));
 }
 
 EID EID::fromStdString(const std::string_view& s)
 {
-    uint64_t v = std::stoull(s.data(), nullptr, 10);
-    return fromUint64(v);
+    return fromStdString(std::string(s));
+}
+
+EID EID::newUnique()
+{
+    static std::random_device s_device;
+    static std::mt19937_64 s_engine(s_device());
+    static std::uniform_int_distribution<uint64_t> s_unifDist;
+
+    return EID(s_unifDist(s_engine), s_unifDist(s_engine));
 }

--- a/src/engraving/infrastructure/eid.h
+++ b/src/engraving/infrastructure/eid.h
@@ -22,6 +22,7 @@
 #ifndef MU_ENGRAVING_EID_H
 #define MU_ENGRAVING_EID_H
 
+#include <bitset>
 #include <cstdint>
 #include <string>
 #include <string_view>
@@ -34,33 +35,43 @@ namespace mu::engraving {
 class EID
 {
 public:
-    EID(ElementType type = ElementType::INVALID, uint32_t id = 0);
+    bool isValid() const { return m_first != INVALID || m_second != INVALID; }
 
-    bool isValid() const { return m_type != ElementType::INVALID && m_id != 0; }
-
-    ElementType type() const { return m_type; }
-    uint32_t id() const { return m_id; }
-
-    inline bool operator ==(const EID& other) const { return m_type == other.m_type && m_id == other.m_id; }
-    inline bool operator !=(const EID& other) const { return !this->operator ==(other); }
-
-    uint64_t toUint64() const;
-    static EID fromUint64(uint64_t v);
+    inline bool operator ==(const EID& other) const { return m_first == other.m_first && m_second == other.m_second; }
+    inline bool operator !=(const EID& other) const { return m_first != other.m_first || m_second != other.m_second; }
 
     std::string toStdString() const;
     static EID fromStdString(const std::string& v);
     static EID fromStdString(const std::string_view& v);
+    static EID newUnique();
+    static EID invalid() { return EID(INVALID, INVALID); }
 
 private:
+    EID() = delete;
+    EID(uint64_t f, uint64_t s)
+        : m_first(f), m_second(s) {}
 
-    ElementType m_type = ElementType::INVALID;
-    uint32_t m_id = 0;
+    static constexpr uint64_t INVALID = uint64_t(-1);
+
+    uint64_t m_first = INVALID;
+    uint64_t m_second = INVALID;
+
+    friend struct std::hash<EID>;
 };
 }
 
+template<>
+struct std::hash<mu::engraving::EID>
+{
+    size_t operator()(const mu::engraving::EID& eid) const
+    {
+        return std::hash<uint64_t>()(eid.m_first) ^ (std::hash<uint64_t>()(eid.m_second) << 1);
+    }
+};
+
 inline muse::logger::Stream& operator<<(muse::logger::Stream& s, const mu::engraving::EID& v)
 {
-    s << "[" << static_cast<int>(v.type()) << "] " << v.id();
+    s << v.toStdString();
     return s;
 }
 

--- a/src/engraving/infrastructure/eidregister.h
+++ b/src/engraving/infrastructure/eidregister.h
@@ -22,7 +22,7 @@
 #pragma once
 
 #include <cstdint>
-#include <map>
+#include <unordered_map>
 
 #include "eid.h"
 #include "../types/types.h"
@@ -35,18 +35,16 @@ class EIDRegister
 public:
     EIDRegister() = default;
 
-    void init(uint32_t val);
-    uint32_t lastID() const { return m_lastID; }
+    EID newEIDForItem(const EngravingObject* item);
+    void registerItemEID(const EID& eid, const EngravingObject* item);
 
-    EID newEID(ElementType type);
-
-    void registerItemEID(EID eid, EngravingObject* item);
-    EngravingObject* itemFromEID(EID eid);
+    EngravingObject* itemFromEID(const EID& eid) const;
+    EID EIDFromItem(const EngravingObject* item) const;
 
 private:
     EIDRegister(const EIDRegister&) = delete;
 
-    uint32_t m_lastID = 0;
-    std::map<uint64_t, EngravingObject*> m_register;
+    std::unordered_map<EID, EngravingObject*> m_eidToItem;
+    std::unordered_map<EngravingObject*, EID> m_itemToEid;
 };
 }

--- a/src/engraving/rw/read410/read410.cpp
+++ b/src/engraving/rw/read410/read410.cpp
@@ -85,10 +85,7 @@ Err Read410::readScore(Score* score, XmlReader& e, rw::ReadInOutData* data)
         } else if (tag == "Revision") {
             e.skipCurrentElement();
         } else if (tag == "LastEID") {
-            int val = e.readInt(nullptr);
-            if (score->isMaster()) {
-                score->masterScore()->eidRegister()->init(val);
-            }
+            e.skipCurrentElement();
         } else if (tag == "Score") {
             if (!readScore410(score, e, ctx)) {
                 if (e.error() == muse::XmlStreamReader::CustomError) {
@@ -126,7 +123,10 @@ bool Read410::readScore410(Score* score, XmlReader& e, ReadContext& ctx)
         const AsciiStringView tag(e.name());
         if (tag == "eid") {
             AsciiStringView s = e.readAsciiText();
-            score->setEID(EID::fromStdString(s));
+            EID eid = EID::fromStdString(s);
+            if (eid.isValid()) {
+                score->setEID(eid);
+            }
         } else if (tag == "Staff") {
             StaffRead::readStaff(score, e, ctx);
         } else if (tag == "Omr") {

--- a/src/engraving/rw/read410/tread.cpp
+++ b/src/engraving/rw/read410/tread.cpp
@@ -511,7 +511,10 @@ bool TRead::readItemProperties(EngravingItem* item, XmlReader& e, ReadContext& c
 
     if (tag == "eid") {
         AsciiStringView s = e.readAsciiText();
-        item->setEID(EID::fromStdString(s));
+        EID eid = EID::fromStdString(s);
+        if (eid.isValid()) {
+            item->setEID(eid);
+        }
     } else if (TRead::readProperty(item, tag, e, ctx, Pid::SIZE_SPATIUM_DEPENDENT)) {
     } else if (TRead::readProperty(item, tag, e, ctx, Pid::OFFSET)) {
     } else if (TRead::readProperty(item, tag, e, ctx, Pid::MIN_DISTANCE)) {
@@ -4839,23 +4842,22 @@ void TRead::readSystemLocks(Score* score, XmlReader& e)
 
 void TRead::readSystemLock(Score* score, XmlReader& e)
 {
-    EID startMeasId;
-    EID endMeasId;
+    MeasureBase* startMeas = nullptr;
+    MeasureBase* endMeas = nullptr;
+    EIDRegister* eidRegister = score->masterScore()->eidRegister();
 
     while (e.readNextStartElement()) {
         AsciiStringView tag(e.name());
         if (tag == "startMeasure") {
-            startMeasId = EID::fromStdString(e.readAsciiText());
+            EID startMeasId = EID::fromStdString(e.readAsciiText());
+            startMeas = toMeasureBase(eidRegister->itemFromEID(startMeasId));
         } else if (tag == "endMeasure") {
-            endMeasId = EID::fromStdString(e.readAsciiText());
+            EID endMeasId = EID::fromStdString(e.readAsciiText());
+            endMeas = toMeasureBase(eidRegister->itemFromEID(endMeasId));
         } else {
             e.unknown();
         }
     }
-
-    EIDRegister* eidRegister = score->masterScore()->eidRegister();
-    MeasureBase* startMeas = toMeasureBase(eidRegister->itemFromEID(startMeasId));
-    MeasureBase* endMeas = toMeasureBase(eidRegister->itemFromEID(endMeasId));
 
     score->addSystemLock(new SystemLock(startMeas, endMeas));
 }

--- a/src/engraving/rw/write/measurewrite.cpp
+++ b/src/engraving/rw/write/measurewrite.cpp
@@ -55,9 +55,7 @@ void MeasureWrite::writeMeasure(const Measure* measure, XmlWriter& xml, WriteCon
         xml.tag("multiMeasureRest", measure->m_mmRestCount);
     }
     if (writeSystemElements) {
-        if (!MScore::testMode && !measure->score()->isPaletteScore()) {
-            xml.tag("eid", measure->eid().toUint64());
-        }
+        TWrite::writeItemEid(measure, xml, ctx);
         if (measure->repeatStart()) {
             xml.tag("startRepeat");
         }

--- a/src/engraving/rw/write/twrite.cpp
+++ b/src/engraving/rw/write/twrite.cpp
@@ -434,12 +434,25 @@ void TWrite::writeSystemLocks(const Score* score, XmlWriter& xml)
     xml.endElement();
 }
 
+void TWrite::writeItemEid(const EngravingObject* item, XmlWriter& xml, WriteContext& ctx)
+{
+    if (MScore::testMode || item->score()->isPaletteScore() || ctx.clipboardmode()) {
+        return;
+    }
+
+    EID eid = item->eid();
+    if (!eid.isValid()) {
+        eid = item->assignNewEID();
+    }
+    xml.tag("eid", eid.toStdString());
+}
+
 void TWrite::writeSystemLock(const SystemLock* systemLock, XmlWriter& xml)
 {
     xml.startElement("systemLock");
 
-    xml.tag("startMeasure", systemLock->startMB()->eid().toUint64());
-    xml.tag("endMeasure", systemLock->endMB()->eid().toUint64());
+    xml.tag("startMeasure", systemLock->startMB()->eid().toStdString());
+    xml.tag("endMeasure", systemLock->endMB()->eid().toStdString());
 
     xml.endElement();
 }
@@ -453,9 +466,7 @@ void TWrite::writeStyledProperties(const EngravingItem* item, XmlWriter& xml)
 
 void TWrite::writeItemProperties(const EngravingItem* item, XmlWriter& xml, WriteContext& ctx)
 {
-    if (!MScore::testMode && !item->score()->isPaletteScore() && !ctx.clipboardmode()) {
-        xml.tag("eid", item->eid().toUint64());
-    }
+    TWrite::writeItemEid(item, xml, ctx);
 
     bool autoplaceEnabled = item->score()->style().styleB(Sid::autoplaceEnabled);
     if (!autoplaceEnabled) {

--- a/src/engraving/rw/write/twrite.h
+++ b/src/engraving/rw/write/twrite.h
@@ -310,6 +310,8 @@ public:
 
     static void writeSystemLocks(const Score* score, XmlWriter& xml);
 
+    static void writeItemEid(const EngravingObject* item, XmlWriter& xml, WriteContext& ctx);
+
 private:
 
     static void writeStyledProperties(const EngravingItem* item, XmlWriter& xml);

--- a/src/engraving/rw/write/writer.cpp
+++ b/src/engraving/rw/write/writer.cpp
@@ -61,7 +61,6 @@ bool Writer::writeScore(Score* score, io::IODevice* device, bool onlySelection, 
     if (!MScore::testMode) {
         xml.tag("programVersion", application()->version().toString());
         xml.tag("programRevision", application()->revision());
-        xml.tag("LastEID", score->masterScore()->eidRegister()->lastID());
     }
 
     compat::WriteScoreHook hook;
@@ -114,9 +113,7 @@ void Writer::write(Score* score, XmlWriter& xml, WriteContext& ctx, bool selecti
 
     xml.startElement(score);
 
-    if (score->eid().isValid()) {
-        xml.tag("eid", score->eid().toUint64());
-    }
+    TWrite::writeItemEid(score, xml, ctx);
 
     if (Excerpt* e = score->excerpt()) {
         if (!e->name().empty()) {

--- a/src/engraving/tests/all_elements_data/random_elements.mscx
+++ b/src/engraving/tests/all_elements_data/random_elements.mscx
@@ -2,8 +2,8 @@
 <museScore version="4.50">
   <programVersion>4.5.0</programVersion>
   <programRevision></programRevision>
-  <LastEID>3891</LastEID>
   <Score>
+    <eid>JmhnU8B5YOF_UfuUZNkL07F</eid>
     <Division>480</Division>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -11,6 +11,7 @@
     <showMargins>0</showMargins>
     <open>1</open>
     <metaTag name="arranger"></metaTag>
+    <metaTag name="audioComUrl"></metaTag>
     <metaTag name="composer">Composer / arranger</metaTag>
     <metaTag name="copyright"></metaTag>
     <metaTag name="creationDate">2024-11-20</metaTag>
@@ -19,6 +20,7 @@
     <metaTag name="movementTitle"></metaTag>
     <metaTag name="platform">Linux</metaTag>
     <metaTag name="source"></metaTag>
+    <metaTag name="sourceRevisionId"></metaTag>
     <metaTag name="subtitle">Subtitle</metaTag>
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
@@ -208,27 +210,27 @@
       </Part>
     <Staff id="1">
       <Measure>
-        <eid>90194313307</eid>
+        <eid>nC+jdYDBe3G_FJUbCnllSgJ</eid>
         <voice>
           <KeySig>
-            <eid>124554051609</eid>
+            <eid>kKDg90Be8PL_ewZ0o17ybFC</eid>
             <concertKey>0</concertKey>
             </KeySig>
           <TimeSig>
-            <eid>115964117019</eid>
+            <eid>OI+rnfB9ZQH_I02Mc5RvQsP</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Dynamic>
             <subtype>p</subtype>
             <velocity>49</velocity>
-            <eid>16363825397798</eid>
+            <eid>ur3R8cdbE0O_lsqG71Gue7J</eid>
             </Dynamic>
           <Chord>
-            <eid>3006477107319</eid>
+            <eid>2nl6T5x8C/N_oXkgl7XYWzC</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>3002182139926</eid>
+              <eid>Vqv7jdyIicB_i9XPwUqeySI</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               </Note>
@@ -236,13 +238,13 @@
           </voice>
         </Measure>
       <Measure>
-        <eid>176093659227</eid>
+        <eid>uCcAv1SBV4_IDIdSQ5QTHJ</eid>
         <voice>
           <Chord>
-            <eid>3182570766455</eid>
+            <eid>W9Iv8kByKhE_YM+xJr2eZXB</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>3178275799062</eid>
+              <eid>yXzLSf6q10B_QSbBxdcct6H</eid>
               <pitch>69</pitch>
               <tpc>17</tpc>
               </Note>
@@ -250,17 +252,17 @@
           </voice>
         </Measure>
       <Measure>
-        <eid>219043332187</eid>
+        <eid>8HR3Oj2jvrG_LPl0gh8sF+J</eid>
         <voice>
           <Chord>
-            <eid>3216930504823</eid>
+            <eid>VCGKgu1WvPB_I9lq/cQIkZD</eid>
             <durationType>whole</durationType>
             <Articulation>
               <subtype>articAccentAbove</subtype>
-              <eid>14048838025250</eid>
+              <eid>A1r7rDb9NGL_ChPP3ashQAE</eid>
               </Articulation>
             <Note>
-              <eid>3212635537430</eid>
+              <eid>I3uNO0bPlkJ_YXqhwfqV8YJ</eid>
               <pitch>74</pitch>
               <tpc>16</tpc>
               </Note>
@@ -268,17 +270,17 @@
           </voice>
         </Measure>
       <Measure>
-        <eid>261993005147</eid>
+        <eid>7qg/+xbHhqJ_sUJvx3B19yG</eid>
         <voice>
           <Chord>
-            <eid>3285649981559</eid>
+            <eid>6TFalHGeypG_RmQv3Zo4SnL</eid>
             <durationType>whole</durationType>
             <Articulation>
               <subtype>articAccentAbove</subtype>
-              <eid>14010183319586</eid>
+              <eid>0b6cP3S1LVB_YlHqrPN3By</eid>
               </Articulation>
             <Note>
-              <eid>3281355014166</eid>
+              <eid>13M5K1U4p9J_xRNvMRUPvsD</eid>
               <pitch>77</pitch>
               <tpc>13</tpc>
               </Note>
@@ -286,17 +288,17 @@
           </voice>
         </Measure>
       <Measure>
-        <eid>304942678107</eid>
+        <eid>HtgZdAgYf5E_MXhkd3uhG+J</eid>
         <voice>
           <Chord>
-            <eid>3320009719927</eid>
+            <eid>uEjhF2vIoUH_9/7pv2E0UoM</eid>
             <durationType>whole</durationType>
             <Articulation>
               <subtype>articAccentAbove</subtype>
-              <eid>14040248090658</eid>
+              <eid>7tq5dg5V5JJ_OPfaE/5m1JH</eid>
               </Articulation>
             <Note>
-              <eid>3315714752534</eid>
+              <eid>zjjK4mPVfDP_DVGfynbDjjL</eid>
               <pitch>77</pitch>
               <tpc>13</tpc>
               </Note>
@@ -304,17 +306,17 @@
           </voice>
         </Measure>
       <Measure>
-        <eid>347892351067</eid>
+        <eid>fwq4rSRqM7I_gN5n+qeCxCE</eid>
         <voice>
           <Chord>
-            <eid>3354369458295</eid>
+            <eid>++s5z9yiMyI_10kJFHyfZvL</eid>
             <durationType>whole</durationType>
             <Articulation>
               <subtype>articStaccatoBelow</subtype>
-              <eid>14121852469282</eid>
+              <eid>H6vo9wx7fBF_GFaxDUak8mP</eid>
               </Articulation>
             <Note>
-              <eid>3350074490902</eid>
+              <eid>l+yaZyNCPHK_tB/zxMV45uL</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               </Note>
@@ -322,13 +324,13 @@
           </voice>
         </Measure>
       <Measure>
-        <eid>390842024027</eid>
+        <eid>ike683mHR6I_/IOUhH/Zt+E</eid>
         <voice>
           <Chord>
-            <eid>3388729196663</eid>
+            <eid>6/Xs3/H/epB_3jrTJb5delO</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>3384434229270</eid>
+              <eid>+Ko1OUnSSPG_14a0WdN/guP</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               </Note>
@@ -336,13 +338,13 @@
           </voice>
         </Measure>
       <Measure>
-        <eid>433791696987</eid>
+        <eid>uluU7VD/NfH_cYAWKcG6o5I</eid>
         <voice>
           <Chord>
-            <eid>3423088935031</eid>
+            <eid>JPHvCY5esL_bOjK7c4dvC</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>3418793967638</eid>
+              <eid>9T8m6tyd7wD_iNjYlIWDO+M</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               </Note>
@@ -350,13 +352,13 @@
           </voice>
         </Measure>
       <Measure>
-        <eid>476741369947</eid>
+        <eid>scOsEHc/3GD_x7+x7jdXbeI</eid>
         <voice>
           <Chord>
-            <eid>3457448673399</eid>
+            <eid>xNsi+Ajjo4I_qJN6IAGJBWC</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>3453153706006</eid>
+              <eid>LkLtgBiO+3P_0hgjuJH5it</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               </Note>
@@ -364,17 +366,17 @@
           </voice>
         </Measure>
       <Measure>
-        <eid>519691042907</eid>
+        <eid>ow1WLhVq3uN_JaXZP/Z43RF</eid>
         <voice>
           <Chord>
-            <eid>3491808411767</eid>
+            <eid>eOL7Xeto6qD_pW2SfYA0WaJ</eid>
             <durationType>whole</durationType>
             <Articulation>
               <subtype>articTenutoBelow</subtype>
-              <eid>14216341749794</eid>
+              <eid>ne3xn/vPG3N_LFB0cBraHr</eid>
               </Articulation>
             <Note>
-              <eid>3487513444374</eid>
+              <eid>XoMuHA8RggI_z8wHcD3tloG</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               </Note>
@@ -382,22 +384,22 @@
           </voice>
         </Measure>
       <Measure>
-        <eid>562640715867</eid>
+        <eid>zw7HHuScmKE_587xOQ20L5L</eid>
         <voice>
           <Dynamic>
             <subtype>ff</subtype>
             <velocity>112</velocity>
-            <eid>16432544874534</eid>
+            <eid>1I40j3rVj_D44skcoIbcN</eid>
             </Dynamic>
           <Chord>
-            <eid>3526168150135</eid>
+            <eid>qMi9hFyajnN_msCSIzTuCxM</eid>
             <durationType>whole</durationType>
             <Articulation>
               <subtype>articTenutoBelow</subtype>
-              <eid>14190571946018</eid>
+              <eid>7s0JyABH3dK_hVR+XcU9lrJ</eid>
               </Articulation>
             <Note>
-              <eid>3521873182742</eid>
+              <eid>7qMU0VfTz8C_3bivW2FAuQO</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               </Note>
@@ -405,17 +407,17 @@
           </voice>
         </Measure>
       <Measure>
-        <eid>605590388827</eid>
+        <eid>ZiLZqyTQsaC_rjvsieQeAbI</eid>
         <voice>
           <Chord>
-            <eid>3560527888503</eid>
+            <eid>1PPVwyNqQOI_SQ+zs/KA9YB</eid>
             <durationType>whole</durationType>
             <Articulation>
               <subtype>articTenutoBelow</subtype>
-              <eid>14207751815202</eid>
+              <eid>w/4jgIZi8/E_xCTP184oC6E</eid>
               </Articulation>
             <Note>
-              <eid>3556232921110</eid>
+              <eid>ZJdYgJzK0XC_aFDCE7bN82F</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               </Note>
@@ -423,25 +425,25 @@
           </voice>
         </Measure>
       <Measure>
-        <eid>648540061787</eid>
+        <eid>xxey+jre0bB_WrTGSM6v86B</eid>
         <voice>
           <KeySig>
-            <eid>14912126451737</eid>
+            <eid>KZHMOGbY3cM_rrTAME8UGGI</eid>
             <concertKey>4</concertKey>
             </KeySig>
           <TimeSig>
-            <eid>15582141349915</eid>
+            <eid>BG3L8AF6gxB_fvVIHCsWC7C</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Chord>
-            <eid>3624952397943</eid>
+            <eid>I/1MAzXUDjJ_vSb+dkJwYhM</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>3620657430550</eid>
+              <eid>QWAMZKj4/cF_jb18I/IzJfO</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>14959371091986</eid>
+                <eid>7JQJx40SH5N_vyuFwz7rkII</eid>
                 </Accidental>
               <pitch>67</pitch>
               <tpc>15</tpc>
@@ -449,53 +451,53 @@
             </Chord>
           <Tempo>
             <tempo>0.583333</tempo>
-            <eid>15646565859377</eid>
+            <eid>GtAA1SjIeMN_1Rvd2XsqwsC</eid>
             <text>Grave</text>
             </Tempo>
           <Chord>
-            <eid>3667902070903</eid>
+            <eid>dR3OlqJdAyG_6ElcsyYUMfF</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>3663607103510</eid>
+              <eid>jHbBR95UbYE_odmvGwYrl+N</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>3723736645751</eid>
+            <eid>2V1YdreE49J_kQFUt9QrnRM</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>3719441678358</eid>
+              <eid>Mq/iNBNeqqE_BxeDnYjTpOO</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>3788161155191</eid>
+            <eid>cL9qhNcHLjB_gcCgGiKj36O</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>3783866187798</eid>
+              <eid>+AVUOU7GkhE_YdX173jQ6SC</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>4041564225655</eid>
+            <eid>Ub6OwCqgyMD_lOF0uHbq5PI</eid>
             <durationType>quarter</durationType>
             <Note>
-              <eid>4037269258262</eid>
+              <eid>NCoG7l9+uoD_TkS9bttWMmP</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>4093103833207</eid>
+            <eid>AG3w1yO/UFI_bdhvSieIA2I</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>4088808865814</eid>
+              <eid>ij9ELC0efgI_kKa/MCCP9cE</eid>
               <Spanner type="Tie">
                 <Tie>
-                  <eid>4110283702305</eid>
+                  <eid>uWDn9GHJRuK_6kF4xHPW+YO</eid>
                   </Tie>
                 <next>
                   <location>
@@ -511,13 +513,13 @@
           </voice>
         </Measure>
       <Measure>
-        <eid>691489734747</eid>
+        <eid>5Nd82ofowrG_HXFH5CA+EDF</eid>
         <voice>
           <Chord>
-            <eid>4144643440759</eid>
+            <eid>EluoDsw6S7N_HGgOIZ/6JzP</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>4140348473366</eid>
+              <eid>MVQcmkm4UdO_boKLi4OuPYL</eid>
               <Spanner type="Tie">
                 <prev>
                   <location>
@@ -531,18 +533,18 @@
               </Note>
             </Chord>
           <Chord>
-            <eid>4226247819383</eid>
+            <eid>YLdjcvI3i8F_bzscOdG10nC</eid>
             <dots>2</dots>
             <durationType>half</durationType>
             <Note>
-              <eid>4221952851990</eid>
+              <eid>Sn7wPTYp6KB_z9xr/i6sEQP</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>14967961026578</eid>
+                <eid>yrRc05fPkUP_nQexo+TzpcH</eid>
                 </Accidental>
               <Spanner type="Tie">
                 <Tie>
-                  <eid>4243427688481</eid>
+                  <eid>39oCPciBYiJ_CuL4kX8QrmI</eid>
                   </Tie>
                 <next>
                   <location>
@@ -558,13 +560,13 @@
           </voice>
         </Measure>
       <Measure>
-        <eid>734439407707</eid>
+        <eid>DnANY2JiHTC_1dHdRmJzhgI</eid>
         <voice>
           <Chord>
-            <eid>4277787426935</eid>
+            <eid>byl0pAoE6oB_vOQr80ANrcG</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>4273492459542</eid>
+              <eid>U+KuB3RKSPP_NJWlPPiLc7K</eid>
               <Spanner type="Tie">
                 <prev>
                   <location>
@@ -578,18 +580,18 @@
               </Note>
             </Chord>
           <Chord>
-            <eid>4514010628215</eid>
+            <eid>OEojsvKu9eF_+23o43sOLLG</eid>
             <dots>2</dots>
             <durationType>half</durationType>
             <Note>
-              <eid>4509715660822</eid>
+              <eid>SYWUpgdNmPL_gHJyCu4KblL</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>14985140895762</eid>
+                <eid>AS/zeWSKCQH_sdt0OZeXao</eid>
                 </Accidental>
               <Spanner type="Tie">
                 <Tie>
-                  <eid>4531190497313</eid>
+                  <eid>66pGbkpnTBB_MzVTg7QFLl</eid>
                   </Tie>
                 <next>
                   <location>
@@ -605,13 +607,13 @@
           </voice>
         </Measure>
       <Measure>
-        <eid>777389080667</eid>
+        <eid>GIe8ZqyaQrN_sIaAIciaSKN</eid>
         <voice>
           <Chord>
-            <eid>4565550235767</eid>
+            <eid>rViH5eD9+fD_orv7zg/EQGM</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>4561255268374</eid>
+              <eid>/+AQAlow/4I_i3Q1GmNKlVG</eid>
               <Spanner type="Tie">
                 <prev>
                   <location>
@@ -625,18 +627,18 @@
               </Note>
             </Chord>
           <Chord>
-            <eid>4638564679799</eid>
+            <eid>b7T/SiLbmHH_7DCE6oh2rBE</eid>
             <dots>2</dots>
             <durationType>half</durationType>
             <Note>
-              <eid>4634269712406</eid>
+              <eid>Xpee8O572vJ_fm1P50cAuXI</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>14989435863058</eid>
+                <eid>gWVaRAM3JoJ_XOo5oT6AgTC</eid>
                 </Accidental>
               <Spanner type="Tie">
                 <Tie>
-                  <eid>4655744548897</eid>
+                  <eid>ab9xZ/d6kyF_6tWcYAOkgoG</eid>
                   </Tie>
                 <next>
                   <location>
@@ -652,17 +654,17 @@
           </voice>
         </Measure>
       <Measure>
-        <eid>820338753627</eid>
+        <eid>2cgogcdLeoP_aYAno7o3gcG</eid>
         <voice>
           <StaffText>
-            <eid>16621523435570</eid>
+            <eid>PWvFxckRTkC_rk/0ApkfrrP</eid>
             <text>Staff text</text>
             </StaffText>
           <Chord>
-            <eid>4690104287351</eid>
+            <eid>r+fxHWbPdQB_n517unTDxMJ</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>4685809319958</eid>
+              <eid>3GFWC2YTBBJ_SmDIHagDXUJ</eid>
               <Spanner type="Tie">
                 <prev>
                   <location>
@@ -676,18 +678,18 @@
               </Note>
             </Chord>
           <Chord>
-            <eid>4763118731383</eid>
+            <eid>vOIqDxHowZN_nP8qvnjs1e</eid>
             <dots>2</dots>
             <durationType>half</durationType>
             <Note>
-              <eid>4758823763990</eid>
+              <eid>ccx1pJZYrHM_YP5BHVcuxzF</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>15006615732242</eid>
+                <eid>cc+osdl4FaE_sL/kWqptWHD</eid>
                 </Accidental>
               <Spanner type="Tie">
                 <Tie>
-                  <eid>4780298600481</eid>
+                  <eid>5wWsv8EPYpI_809aYV0wTmB</eid>
                   </Tie>
                 <next>
                   <location>
@@ -703,13 +705,13 @@
           </voice>
         </Measure>
       <Measure>
-        <eid>863288426587</eid>
+        <eid>r8M+5apKZXN_6ZL3hPqW8AP</eid>
         <voice>
           <Chord>
-            <eid>4814658338935</eid>
+            <eid>+bUjLAMKb4B_tQrdg1iMBRI</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>4810363371542</eid>
+              <eid>elVlkHvCPrL_74fh151aMCN</eid>
               <Spanner type="Tie">
                 <prev>
                   <location>
@@ -723,18 +725,18 @@
               </Note>
             </Chord>
           <Chord>
-            <eid>4887672782967</eid>
+            <eid>i7MXTa5eZ3L_/c6bfRsqXhE</eid>
             <dots>2</dots>
             <durationType>half</durationType>
             <Note>
-              <eid>4883377815574</eid>
+              <eid>/qnUPIRM4lO_vePel3nFT+B</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>15015205666834</eid>
+                <eid>LTT5cZSHPmM_kct0XSzIH/B</eid>
                 </Accidental>
               <Spanner type="Tie">
                 <Tie>
-                  <eid>4904852652065</eid>
+                  <eid>u6iSgAJOxsD_xAHV4nVDIpH</eid>
                   </Tie>
                 <next>
                   <location>
@@ -750,18 +752,18 @@
           </voice>
         </Measure>
       <Measure>
-        <eid>906238099547</eid>
+        <eid>pAnDEv8CSwC_c+WQWHG7vpB</eid>
         <voice>
           <Dynamic>
             <subtype>mp</subtype>
             <velocity>64</velocity>
-            <eid>16527034155046</eid>
+            <eid>w7zTbeoOauH_3aLaXtmfEfP</eid>
             </Dynamic>
           <Chord>
-            <eid>4939212390519</eid>
+            <eid>wiKZVwfYsPH_DCHzDPwl6EL</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>4934917423126</eid>
+              <eid>DjLYkzxQFRH_BFS+no8z7DE</eid>
               <Spanner type="Tie">
                 <prev>
                   <location>
@@ -775,24 +777,24 @@
               </Note>
             </Chord>
           <Chord>
-            <eid>5025111736439</eid>
+            <eid>IzcI5G/nFQH_ZTCmaAifnwO</eid>
             <durationType>eighth</durationType>
             <Note>
-              <eid>5020816769046</eid>
+              <eid>qBzR+xDiiJP_NXoIpCH9fWH</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>15023795601426</eid>
+                <eid>upnZfkw4lgG_iFDjrK7UjjH</eid>
                 </Accidental>
               <pitch>67</pitch>
               <tpc>15</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>5106716115063</eid>
+            <eid>EwNAwn3fctP_MZbTe5fsHXJ</eid>
             <dots>1</dots>
             <durationType>half</durationType>
             <Note>
-              <eid>5102421147670</eid>
+              <eid>XvLTzL7rq6D_PPef6LosrSD</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               </Note>
@@ -800,16 +802,16 @@
           </voice>
         </Measure>
       <Measure>
-        <eid>949187772507</eid>
+        <eid>T0kUIDpVMrM_XNqYIVMn9EP</eid>
         <voice>
           <Chord>
-            <eid>5175435591799</eid>
+            <eid>iitlI8ceGOO_2DUPwbiCAgM</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>5171140624406</eid>
+              <eid>ZnUa7xMD0EC_3wKdu5oPGV</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>15032385536018</eid>
+                <eid>/Lmw/9LUSNK_V3a3Wya6rx</eid>
                 </Accidental>
               <pitch>67</pitch>
               <tpc>15</tpc>
@@ -818,16 +820,16 @@
           </voice>
         </Measure>
       <Measure>
-        <eid>992137445467</eid>
+        <eid>Cge6GREFOcK_H3xveodQuoI</eid>
         <voice>
           <Chord>
-            <eid>5218385264759</eid>
+            <eid>K6es7nugavM_xd+mQut689E</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>5214090297366</eid>
+              <eid>5oNJ7kjdQf_mniUv3RuD+G</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>15045270437906</eid>
+                <eid>2Z5LT605oYN_f5BLzXxVD5E</eid>
                 </Accidental>
               <pitch>67</pitch>
               <tpc>15</tpc>
@@ -836,16 +838,16 @@
           </voice>
         </Measure>
       <Measure>
-        <eid>1035087118427</eid>
+        <eid>5qYQoRHcdwL_cMLCF9YQSLP</eid>
         <voice>
           <Chord>
-            <eid>5261334937719</eid>
+            <eid>RKztp6LoZv_YMrAZGuMmWK</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>5257039970326</eid>
+              <eid>ZSb1620rTkN_O0yz/liYD5I</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>15058155339794</eid>
+                <eid>5WueO/yDZUG_k76is6ALtqC</eid>
                 </Accidental>
               <pitch>67</pitch>
               <tpc>15</tpc>
@@ -854,16 +856,16 @@
           </voice>
         </Measure>
       <Measure>
-        <eid>1078036791387</eid>
+        <eid>F8A16SY0TGM_QaTRvsxhT/N</eid>
         <voice>
           <Chord>
-            <eid>5304284610679</eid>
+            <eid>j9HrH2OBwRN_1baMQuOWnDD</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>5299989643286</eid>
+              <eid>voAXSAh2UkF_OIe8OKpAbIN</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>15071040241682</eid>
+                <eid>L9hWTDffqaP_4ar1ZTF0qjM</eid>
                 </Accidental>
               <pitch>67</pitch>
               <tpc>15</tpc>
@@ -872,16 +874,16 @@
           </voice>
         </Measure>
       <Measure>
-        <eid>1120986464347</eid>
+        <eid>IFk+kTqK3uP_oD15Q6TGRxI</eid>
         <voice>
           <Chord>
-            <eid>5347234283639</eid>
+            <eid>zG7kWPkH5DB_F5jqukmNybF</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>5342939316246</eid>
+              <eid>fNyfsH3x1lN_v3i4sH9ZDJN</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>15156939587602</eid>
+                <eid>DtridjQq3RD_Vctks6OUz0D</eid>
                 </Accidental>
               <pitch>67</pitch>
               <tpc>15</tpc>
@@ -890,16 +892,16 @@
           </voice>
         </Measure>
       <Measure>
-        <eid>1163936137307</eid>
+        <eid>xhxGZ+YpDlH_aVSr6aGgIPM</eid>
         <voice>
           <Chord>
-            <eid>5390183956599</eid>
+            <eid>7O2S/2Un3GK_n4D7KbIyznN</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>5385888989206</eid>
+              <eid>Ky7s5n30B9F_5QB6ZEzMmkN</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>15165529522194</eid>
+                <eid>fVGj67E8jYP_W2W7px/HHEM</eid>
                 </Accidental>
               <pitch>67</pitch>
               <tpc>15</tpc>
@@ -908,16 +910,16 @@
           </voice>
         </Measure>
       <Measure>
-        <eid>1206885810267</eid>
+        <eid>8GzQIfMpk/K_tlu5e7ONFKI</eid>
         <voice>
           <Chord>
-            <eid>5433133629559</eid>
+            <eid>9aFxutLgLQL_K7qpZn/eXKI</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>5428838662166</eid>
+              <eid>ZtDI1lZoXlG_k9acVoktbLN</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>15178414424082</eid>
+                <eid>6YDSFI0qsF_UqC3jn9OgkB</eid>
                 </Accidental>
               <pitch>67</pitch>
               <tpc>15</tpc>
@@ -926,16 +928,16 @@
           </voice>
         </Measure>
       <Measure>
-        <eid>1249835483227</eid>
+        <eid>WRcrCllvzpL_/Z8fI2XCytN</eid>
         <voice>
           <Chord>
-            <eid>5476083302519</eid>
+            <eid>7Bw+d5V52aL_h/cyDdzbh0G</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>5471788335126</eid>
+              <eid>ti3inCpq5oM_YsEwmtP0TYG</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>15187004358674</eid>
+                <eid>vhuDVn4K+9P_auxQXgoHI4B</eid>
                 </Accidental>
               <pitch>67</pitch>
               <tpc>15</tpc>
@@ -944,16 +946,16 @@
           </voice>
         </Measure>
       <Measure>
-        <eid>1292785156187</eid>
+        <eid>vUkF0mU9vaH_RM2vNRUjeZB</eid>
         <voice>
           <Chord>
-            <eid>5519032975479</eid>
+            <eid>zeGdU5Taa8H_x13VEJmZZ9L</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>5514738008086</eid>
+              <eid>R/LD198x/7D_R2aZm0ixvTP</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>15195594293266</eid>
+                <eid>iuACRS208AM_dNmAU08f1OP</eid>
                 </Accidental>
               <pitch>67</pitch>
               <tpc>15</tpc>
@@ -962,16 +964,16 @@
           </voice>
         </Measure>
       <Measure>
-        <eid>1335734829147</eid>
+        <eid>BbTlQAUh1aL_n/hSP564q9H</eid>
         <voice>
           <Chord>
-            <eid>5561982648439</eid>
+            <eid>vqFx8d8qBsI_sF0lr4cchpB</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>5557687681046</eid>
+              <eid>Hlq1jEIEcOB_N5C0GC0x56B</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>15212774162450</eid>
+                <eid>mF9Gz6CsRg_H1dk7RPWL4J</eid>
                 </Accidental>
               <pitch>67</pitch>
               <tpc>15</tpc>
@@ -980,16 +982,16 @@
           </voice>
         </Measure>
       <Measure>
-        <eid>1378684502107</eid>
+        <eid>hYH2DwkJOpM_UiaqpJgix/L</eid>
         <voice>
           <Chord>
-            <eid>5604932321399</eid>
+            <eid>VZqtyDVZe0M_4AGw59BJJZI</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>5600637354006</eid>
+              <eid>akoMhEGEZ7G_2kiwqwfn7BE</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>15221364097042</eid>
+                <eid>PAFLmEXS+sF_E6AqLc4TfcC</eid>
                 </Accidental>
               <pitch>67</pitch>
               <tpc>15</tpc>
@@ -998,16 +1000,16 @@
           </voice>
         </Measure>
       <Measure>
-        <eid>1421634175067</eid>
+        <eid>jnRlu+BekIF_C1PQTlSW2tI</eid>
         <voice>
           <Chord>
-            <eid>5656471928951</eid>
+            <eid>G0GS1oOCoMI_zRzHZVN6XxG</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>5652176961558</eid>
+              <eid>leXfp6xdUzN_b+O8E0k7tbP</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>15229954031634</eid>
+                <eid>1OlHVcXrTLK_mKYl1b/oJZH</eid>
                 </Accidental>
               <pitch>67</pitch>
               <tpc>15</tpc>
@@ -1016,16 +1018,16 @@
           </voice>
         </Measure>
       <Measure>
-        <eid>1464583848027</eid>
+        <eid>5KdiV469l9O_tpC6UOcG1NL</eid>
         <voice>
           <Chord>
-            <eid>5755256176759</eid>
+            <eid>diuEfRFxuQF_rvlA+xFWabO</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>5750961209366</eid>
+              <eid>WtYXBk/zlSB_NcF9ixDTNOB</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>15285788606482</eid>
+                <eid>gfF5JJzEfkL_VdhswEIF1sB</eid>
                 </Accidental>
               <pitch>67</pitch>
               <tpc>15</tpc>
@@ -1038,27 +1040,27 @@
       <Measure>
         <voice>
           <KeySig>
-            <eid>141733920793</eid>
+            <eid>q2HQSscdAlI_G2CzG1e8rOC</eid>
             <concertKey>0</concertKey>
             </KeySig>
           <TimeSig>
-            <eid>137438953499</eid>
+            <eid>PNTF96vAiR_rnJufUmz14I</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Dynamic>
             <subtype>p</subtype>
             <velocity>49</velocity>
-            <eid>16368120365094</eid>
+            <eid>RISr8HWot0F_SmEhNSR07jO</eid>
             </Dynamic>
           <Chord>
-            <eid>5905580032119</eid>
+            <eid>N4jVx4KBZgH_OZTX/SujI0K</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>5901285064726</eid>
+              <eid>gwPL9Cux8I_XGavA2iABIH</eid>
               <Accidental>
                 <subtype>accidentalFlat</subtype>
-                <eid>5918464933906</eid>
+                <eid>hJ9nqtjljE_sxr2jAk83QP</eid>
                 </Accidental>
               <pitch>63</pitch>
               <tpc>11</tpc>
@@ -1069,13 +1071,13 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>5952824672375</eid>
+            <eid>c3UiIFa0SOH_fnTwfn8cN6O</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>5948529704982</eid>
+              <eid>dM7Id8NUNEN_RpngGyYTpl</eid>
               <Accidental>
                 <subtype>accidentalSharp</subtype>
-                <eid>5974299508754</eid>
+                <eid>KCyjEA31BnC_GrAsvaGD73N</eid>
                 </Accidental>
               <pitch>68</pitch>
               <tpc>22</tpc>
@@ -1086,14 +1088,14 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>6000069312631</eid>
+            <eid>22gmYCNlqfP_0VPU9ewSnBI</eid>
             <durationType>whole</durationType>
             <Articulation>
               <subtype>articAccentBelow</subtype>
-              <eid>14035953123362</eid>
+              <eid>DfxtVzQUvdH_B32Leekg93P</eid>
               </Articulation>
             <Note>
-              <eid>5995774345238</eid>
+              <eid>iey2ojWE6pK_kkRL0IexSWP</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               </Note>
@@ -1103,14 +1105,14 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>6043018985591</eid>
+            <eid>iJTnNcFIXDL_wGZcbN77zTL</eid>
             <durationType>whole</durationType>
             <Articulation>
               <subtype>articAccentAbove</subtype>
-              <eid>14014478286882</eid>
+              <eid>3iE9JjOvp+L_GbRouxW8GDK</eid>
               </Articulation>
             <Note>
-              <eid>6038724018198</eid>
+              <eid>N7ugqCKsQJG_0AxTIulsXnM</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               </Note>
@@ -1120,14 +1122,14 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>6085968658551</eid>
+            <eid>H1saBmPDV0O_cDYu4tGJTEP</eid>
             <durationType>whole</durationType>
             <Articulation>
               <subtype>articAccentBelow</subtype>
-              <eid>14001593384994</eid>
+              <eid>KsrXXWPiaX_kfudHZ3wu1D</eid>
               </Articulation>
             <Note>
-              <eid>6081673691158</eid>
+              <eid>tIaEEpFKnSB_E40c2ZDWc1F</eid>
               <pitch>69</pitch>
               <tpc>17</tpc>
               </Note>
@@ -1137,14 +1139,14 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>6128918331511</eid>
+            <eid>2YwrMfBfq1C_LZXdAoaFjCP</eid>
             <durationType>whole</durationType>
             <Articulation>
               <subtype>articStaccatoBelow</subtype>
-              <eid>14130442403874</eid>
+              <eid>13f2BMklobK_8wKkwajODa</eid>
               </Articulation>
             <Note>
-              <eid>6124623364118</eid>
+              <eid>Kg8ZI0MGEdC_Y9I/NCDCp9M</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               </Note>
@@ -1154,13 +1156,13 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>6171868004471</eid>
+            <eid>f6xMQOR0uXO_5cwxNc1t+0F</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>6167573037078</eid>
+              <eid>yt5W+6U9P/L_cJeU6j5ey5J</eid>
               <Accidental>
                 <subtype>accidentalFlat</subtype>
-                <eid>6193342840850</eid>
+                <eid>L3ua2+e0noG_whblV/TMUvM</eid>
                 </Accidental>
               <pitch>70</pitch>
               <tpc>12</tpc>
@@ -1171,13 +1173,13 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>6219112644727</eid>
+            <eid>6SC7iuRMomN_bzLJHh7EyHI</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>6214817677334</eid>
+              <eid>qIQVvFZ7IRO_NSFbRi45MFG</eid>
               <Accidental>
                 <subtype>accidentalFlat</subtype>
-                <eid>6240587481106</eid>
+                <eid>qiVSLyvR5AG_BB7q835A7EN</eid>
                 </Accidental>
               <pitch>70</pitch>
               <tpc>12</tpc>
@@ -1188,13 +1190,13 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>6266357284983</eid>
+            <eid>GByjV4ho++D_xKfCm3Lp45I</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>6262062317590</eid>
+              <eid>N7IokwRZCpM_bR5XjnNzmkB</eid>
               <Accidental>
                 <subtype>accidentalFlat</subtype>
-                <eid>6287832121362</eid>
+                <eid>hDqZpwXw9bB_FBJgNx9a3BB</eid>
                 </Accidental>
               <pitch>70</pitch>
               <tpc>12</tpc>
@@ -1205,17 +1207,17 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>6313601925239</eid>
+            <eid>tZDRduQOCYC_Vljjp/WWQDI</eid>
             <durationType>whole</durationType>
             <Articulation>
               <subtype>articTenutoBelow</subtype>
-              <eid>14203456847906</eid>
+              <eid>pX4G+nQKPIE_xiuu8nqjYqB</eid>
               </Articulation>
             <Note>
-              <eid>6309306957846</eid>
+              <eid>8YeztvqWInM_3EEt3eRKf/O</eid>
               <Accidental>
                 <subtype>accidentalFlat</subtype>
-                <eid>6335076761618</eid>
+                <eid>8MMUXjLZVEM_V1yHMueLUsM</eid>
                 </Accidental>
               <pitch>63</pitch>
               <tpc>11</tpc>
@@ -1228,20 +1230,20 @@
           <Dynamic>
             <subtype>ff</subtype>
             <velocity>112</velocity>
-            <eid>16436839841830</eid>
+            <eid>qlFuQRpBO+D_ECaQy2nl0XN</eid>
             </Dynamic>
           <Chord>
-            <eid>6360846565495</eid>
+            <eid>8DYpBkO697N_L2H/1p3xu0K</eid>
             <durationType>whole</durationType>
             <Articulation>
               <subtype>articTenutoBelow</subtype>
-              <eid>14212046782498</eid>
+              <eid>X2Ga7f01PPF_O3fDpSxKZsO</eid>
               </Articulation>
             <Note>
-              <eid>6356551598102</eid>
+              <eid>Y4DgUJCFgmO_cF9PSpOLdaJ</eid>
               <Accidental>
                 <subtype>accidentalFlat</subtype>
-                <eid>6382321401874</eid>
+                <eid>kDTtu2APFsE_2mv1J5wzC8K</eid>
                 </Accidental>
               <pitch>63</pitch>
               <tpc>11</tpc>
@@ -1252,17 +1254,17 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>6408091205751</eid>
+            <eid>eDXQ/dWjxeO_m9xh1oeU6YF</eid>
             <durationType>whole</durationType>
             <Articulation>
               <subtype>articTenutoBelow</subtype>
-              <eid>14199161880610</eid>
+              <eid>2XDfZ86oE9I_S1vOL8NzQnK</eid>
               </Articulation>
             <Note>
-              <eid>6403796238358</eid>
+              <eid>Xwi4qKivFEE_fPtULrNScdL</eid>
               <Accidental>
                 <subtype>accidentalFlat</subtype>
-                <eid>6429566042130</eid>
+                <eid>pELIHwzTbkI_Qo1JOn2EkHL</eid>
                 </Accidental>
               <pitch>63</pitch>
               <tpc>11</tpc>
@@ -1273,22 +1275,22 @@
       <Measure>
         <voice>
           <KeySig>
-            <eid>14916421419033</eid>
+            <eid>0MxRFjFUPdG_N26CsJMkD8G</eid>
             <concertKey>4</concertKey>
             </KeySig>
           <TimeSig>
-            <eid>15586436317211</eid>
+            <eid>t8rZRoAIC6D_i+OeSEZIhiH</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Chord>
-            <eid>6455335846007</eid>
+            <eid>n0DRnV6MUML_+GrdE6nUVUF</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>6451040878614</eid>
+              <eid>CF7/8UZYloP_Ent3vjVIsFI</eid>
               <Accidental>
                 <subtype>accidentalFlat</subtype>
-                <eid>6476810682386</eid>
+                <eid>+FiOrvppDpL_KnKJukM5CfJ</eid>
                 </Accidental>
               <pitch>63</pitch>
               <tpc>11</tpc>
@@ -1299,10 +1301,10 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>6502580486263</eid>
+            <eid>sgnCtXvfF+K_agUsNEIBlTD</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>6498285518870</eid>
+              <eid>9V47CpSN5dG_UN1gRvPHPhM</eid>
               <pitch>56</pitch>
               <tpc>22</tpc>
               </Note>
@@ -1312,10 +1314,10 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>6558415061111</eid>
+            <eid>ut2yhtXlf7I_TLJS0Ojpn5</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>6554120093718</eid>
+              <eid>9DGbfaWJo1P_Ie3PfGQKYwP</eid>
               <pitch>56</pitch>
               <tpc>22</tpc>
               </Note>
@@ -1325,10 +1327,10 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>6614249635959</eid>
+            <eid>1S/HYZhr2yD_PcnBcXGx5tK</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>6609954668566</eid>
+              <eid>g5v8zrXR9PD_4y2tPjsGdiL</eid>
               <pitch>56</pitch>
               <tpc>22</tpc>
               </Note>
@@ -1338,14 +1340,14 @@
       <Measure>
         <voice>
           <StaffText>
-            <eid>16625818402866</eid>
+            <eid>d+t7P18KJ2K_r1o4c7SPuDM</eid>
             <text>Staff text</text>
             </StaffText>
           <Chord>
-            <eid>6833292968055</eid>
+            <eid>tEgN+bCulS_dCqPLJyU//N</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>6828998000662</eid>
+              <eid>NPE+Gx2jHYB_bfURJfGni7F</eid>
               <pitch>56</pitch>
               <tpc>22</tpc>
               </Note>
@@ -1355,10 +1357,10 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>6889127542903</eid>
+            <eid>V9nRSIzTcYM_hXzpHCe3j6G</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>6884832575510</eid>
+              <eid>OCejrM3WfxG_8lQ72FvYT7P</eid>
               <pitch>56</pitch>
               <tpc>22</tpc>
               </Note>
@@ -1370,13 +1372,13 @@
           <Dynamic>
             <subtype>mp</subtype>
             <velocity>64</velocity>
-            <eid>16531329122342</eid>
+            <eid>KSsr9HJiYlL_PeGraM95HuF</eid>
             </Dynamic>
           <Chord>
-            <eid>6944962117751</eid>
+            <eid>Gk5ni5Jco3D_ift/6o/HTEB</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>6940667150358</eid>
+              <eid>KtY8FahhNB_7BCVE91Po8G</eid>
               <pitch>66</pitch>
               <tpc>20</tpc>
               </Note>
@@ -1386,10 +1388,10 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>6992206758007</eid>
+            <eid>8ixnPZjzZwJ_4mswHiaa3RF</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>6987911790614</eid>
+              <eid>A3BksMCU/IF_KtvfjZrkz4E</eid>
               <pitch>66</pitch>
               <tpc>20</tpc>
               </Note>
@@ -1399,10 +1401,10 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>7039451398263</eid>
+            <eid>dPy0/ibUzq_NbvyaAU3ZYE</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>7035156430870</eid>
+              <eid>9Jadtl8073F_rKJ72qkT4DH</eid>
               <pitch>66</pitch>
               <tpc>20</tpc>
               </Note>
@@ -1412,13 +1414,13 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>7086696038519</eid>
+            <eid>GVPFwsg5BoO_B7TetLqn0qN</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>7082401071126</eid>
+              <eid>9mhOPmtGHkM_bu1O5KKf+8</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>15062450307090</eid>
+                <eid>EW4DPM/8YhI_s87WCaGJYXD</eid>
                 </Accidental>
               <pitch>67</pitch>
               <tpc>15</tpc>
@@ -1429,13 +1431,13 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>7129645711479</eid>
+            <eid>63mpLZY7DKM_g/tlYEyiZ0N</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>7125350744086</eid>
+              <eid>qVP/8xpoHOB_hZtEVWU+WKD</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>15075335208978</eid>
+                <eid>Z+iTsYoiLwL_+vk8CeB04mH</eid>
                 </Accidental>
               <pitch>65</pitch>
               <tpc>13</tpc>
@@ -1446,10 +1448,10 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>7172595384439</eid>
+            <eid>Mp253qaJeWH_FOa2cCXvlKP</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>7168300417046</eid>
+              <eid>BQsZWeC/DBF_Kgx4DIelOPN</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               </Note>
@@ -1459,13 +1461,13 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>7215545057399</eid>
+            <eid>com4Hn5cwdE_dCSZitmy7FJ</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>7211250090006</eid>
+              <eid>DDI+24On6SI_9G5WNc4b0wD</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>15169824489490</eid>
+                <eid>x4DBE5cdwuK_NGj2h4Obh5H</eid>
                 </Accidental>
               <pitch>62</pitch>
               <tpc>16</tpc>
@@ -1476,13 +1478,13 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>7258494730359</eid>
+            <eid>DQiIScPIC1G_4udh1ErJDcK</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>7254199762966</eid>
+              <eid>L0sciCZc7zN_KOINa3iWAvO</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>15182709391378</eid>
+                <eid>3e3nWwKp8+E_YBeHg224L1O</eid>
                 </Accidental>
               <pitch>72</pitch>
               <tpc>14</tpc>
@@ -1493,10 +1495,10 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>7301444403319</eid>
+            <eid>fEYUOgsIETD_ccyGDyMcsIE</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>7297149435926</eid>
+              <eid>hNzH1kxhyeP_HJmlVVeIhJC</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               </Note>
@@ -1506,10 +1508,10 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>7344394076279</eid>
+            <eid>7fqZ7gHAM7P_mropMp9GSqD</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>7340099108886</eid>
+              <eid>xNd6mnAQQ/_vsdwakf+em</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               </Note>
@@ -1519,10 +1521,10 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>7387343749239</eid>
+            <eid>sFBbirPCrgJ_rS63/KgYZPH</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>7383048781846</eid>
+              <eid>Lcyl7x8CwkD_63mnmmzuzsL</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               </Note>
@@ -1532,10 +1534,10 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>7438883356791</eid>
+            <eid>BVz2MMYKyoE_lLtoorjNGVE</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>7434588389398</eid>
+              <eid>blZkOInInVO_LGNZ9ziaDqG</eid>
               <pitch>69</pitch>
               <tpc>17</tpc>
               </Note>
@@ -1545,19 +1547,19 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>7490422964343</eid>
+            <eid>cDsf74JzZcD_7rhyVTZiNQK</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>7520487735318</eid>
+              <eid>d5FXGYmx5HK_Tf83xpd3qpO</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>15234248998930</eid>
+                <eid>9icqDKR8cBC_V4qIhlgCFfI</eid>
                 </Accidental>
               <pitch>67</pitch>
               <tpc>15</tpc>
               </Note>
             <Note>
-              <eid>7486127996950</eid>
+              <eid>h1bxMyEZVDH_tv/3JN7FEaB</eid>
               <pitch>69</pitch>
               <tpc>17</tpc>
               </Note>
@@ -1567,13 +1569,13 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>7559142441079</eid>
+            <eid>k5iohLPhS+E_Bhx7zyR63UK</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>7554847473686</eid>
+              <eid>D/yI1SeG62E_TRjWgj4tQYN</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>15290083573778</eid>
+                <eid>8+j0ZRzzrEG_oQoPdYyd3QE</eid>
                 </Accidental>
               <pitch>67</pitch>
               <tpc>15</tpc>
@@ -1586,36 +1588,36 @@
       <Measure>
         <voice>
           <KeySig>
-            <eid>154618822681</eid>
+            <eid>J9zVyTJnuiI_XPA/kcELPJI</eid>
             <concertKey>0</concertKey>
             </KeySig>
           <TimeSig>
-            <eid>150323855387</eid>
+            <eid>vG9uRIUtZyI_eqpoDPzYjkG</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Dynamic>
             <subtype>p</subtype>
             <velocity>49</velocity>
-            <eid>16372415332390</eid>
+            <eid>cOrGcSYvOuH_RVBDjO2+udP</eid>
             </Dynamic>
           <Chord>
-            <eid>7773890805879</eid>
+            <eid>il3XDNV5b3H_AOSwQ8CHepN</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>7769595838486</eid>
+              <eid>Z4l6/om1/JJ_r5rwiZxC1kK</eid>
               <pitch>55</pitch>
               <tpc>15</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>7821135446135</eid>
+            <eid>pQp1tEP2YVD_IwcaQ3hKp7B</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>7816840478742</eid>
+              <eid>qeTdI8eFFBK_JLRlLqnqlqO</eid>
               <Accidental>
                 <subtype>accidentalSharp</subtype>
-                <eid>7838315315218</eid>
+                <eid>THt5mQS00BM_9rwk/KIl97B</eid>
                 </Accidental>
               <pitch>56</pitch>
               <tpc>22</tpc>
@@ -1626,26 +1628,26 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>7885559955575</eid>
+            <eid>v7Gw4KP8A9D_eBNLGVakajB</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>7881264988182</eid>
+              <eid>OM4By2qW/kC_ElY6cUDEHbK</eid>
               <Accidental>
                 <subtype>accidentalFlat</subtype>
-                <eid>7907034791954</eid>
+                <eid>hQGBJmv3tIH_tKBW3RL35UG</eid>
                 </Accidental>
               <pitch>58</pitch>
               <tpc>12</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>7937099563127</eid>
+            <eid>qByt9Y3YffM_LaO+xK9sgbI</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>7932804595734</eid>
+              <eid>jSpfea8FQMN_Rz20KoEXnLN</eid>
               <Accidental>
                 <subtype>accidentalSharp</subtype>
-                <eid>7962869366802</eid>
+                <eid>Iu2P7pjfJbN_yW9XQ6XBN1J</eid>
                 </Accidental>
               <pitch>56</pitch>
               <tpc>22</tpc>
@@ -1656,34 +1658,34 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>8001524072567</eid>
+            <eid>3S01Kvbl8nG_XFlqKGrZeSL</eid>
             <durationType>half</durationType>
             <Articulation>
               <subtype>articAccentBelow</subtype>
-              <eid>14044543057954</eid>
+              <eid>hMnAgdpRqWK_x0tWZSQyGNH</eid>
               </Articulation>
             <Note>
-              <eid>7997229105174</eid>
+              <eid>iF2xejSsusO_z+yDToOdkCN</eid>
               <Accidental>
                 <subtype>accidentalSharp</subtype>
-                <eid>8022998908946</eid>
+                <eid>PYJLFupYgXN_D3cQHaD/27B</eid>
                 </Accidental>
               <pitch>56</pitch>
               <tpc>22</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>8293581848695</eid>
+            <eid>7ebiu4OLkAI_SZHPWn206ZN</eid>
             <durationType>half</durationType>
             <Articulation>
               <subtype>articAccentBelow</subtype>
-              <eid>14027363188770</eid>
+              <eid>GDINeo5frWB_6Gwp2zBireC</eid>
               </Articulation>
             <Note>
-              <eid>8289286881302</eid>
+              <eid>0RbcvTvw5zG_+m389MVOSEH</eid>
               <Accidental>
                 <subtype>accidentalFlat</subtype>
-                <eid>8319351652370</eid>
+                <eid>OEMGRZlSM5F_zaao1SwSW6J</eid>
                 </Accidental>
               <pitch>58</pitch>
               <tpc>12</tpc>
@@ -1694,40 +1696,40 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>8358006358135</eid>
+            <eid>XTAkwx7yN5E_jtYg65sfK8O</eid>
             <durationType>half</durationType>
             <Articulation>
               <subtype>articAccentBelow</subtype>
-              <eid>14031658156066</eid>
+              <eid>cnMf+SljQwC_fpt1SKSuPMJ</eid>
               </Articulation>
             <Note>
-              <eid>8353711390742</eid>
+              <eid>SCxdqXgf1zB_JWjLnQlbTOE</eid>
               <Accidental>
                 <subtype>accidentalSharp</subtype>
-                <eid>8379481194514</eid>
+                <eid>JZk+gUgXIr_Gkg7EcEpc7E</eid>
                 </Accidental>
               <pitch>56</pitch>
               <tpc>22</tpc>
               </Note>
             <Note>
-              <eid>8405250998294</eid>
+              <eid>f3zGYLhiPaO_JWGaPWP4Vq</eid>
               <Accidental>
                 <subtype>accidentalFlat</subtype>
-                <eid>8418135900178</eid>
+                <eid>YhU6CPeN+LI_Kuh2Y3WR/O</eid>
                 </Accidental>
               <pitch>58</pitch>
               <tpc>12</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>8443905704055</eid>
+            <eid>7PySRAyeRMH_cXGbgsVz0XC</eid>
             <durationType>half</durationType>
             <Articulation>
               <subtype>articAccentBelow</subtype>
-              <eid>14023068221474</eid>
+              <eid>hmGy7itGXIH_6oZXsPHk7NL</eid>
               </Articulation>
             <Note>
-              <eid>8439610736662</eid>
+              <eid>xEHc45ebN8P_G8gp+5NS9RI</eid>
               <pitch>56</pitch>
               <tpc>22</tpc>
               </Note>
@@ -1737,34 +1739,34 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>8504035246199</eid>
+            <eid>9DZRcmJUqMP_tI9o/Qg+N3E</eid>
             <durationType>half</durationType>
             <Articulation>
               <subtype>articAccentBelow</subtype>
-              <eid>14005888352290</eid>
+              <eid>nBdzOeDlbNL_HQi12fN1a9B</eid>
               </Articulation>
             <Note>
-              <eid>8499740278806</eid>
+              <eid>HJgGBRj7qdM_sX95KDlFndL</eid>
               <Accidental>
                 <subtype>accidentalFlat</subtype>
-                <eid>8525510082578</eid>
+                <eid>6c5t3+dgZ6H_AFa0OubbrRH</eid>
                 </Accidental>
               <pitch>58</pitch>
               <tpc>12</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>8555574853751</eid>
+            <eid>rXtqTOgavUC_MDCxO/cTKJG</eid>
             <durationType>half</durationType>
             <Articulation>
               <subtype>articAccentBelow</subtype>
-              <eid>14018773254178</eid>
+              <eid>KfAqc/T03dI_hEYyW/ZJSZK</eid>
               </Articulation>
             <Note>
-              <eid>8551279886358</eid>
+              <eid>Olkta3RU1ND_RBmmDcAqBkK</eid>
               <Accidental>
                 <subtype>accidentalSharp</subtype>
-                <eid>8581344657426</eid>
+                <eid>YBKOCyXGLXC_lxcCBZGvlvJ</eid>
                 </Accidental>
               <pitch>56</pitch>
               <tpc>22</tpc>
@@ -1775,34 +1777,34 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>8619999363191</eid>
+            <eid>zh+jwcdif+I_fO9QzN/SqGE</eid>
             <durationType>half</durationType>
             <Articulation>
               <subtype>articStaccatoBelow</subtype>
-              <eid>14117557501986</eid>
+              <eid>SntIHgTMm4_PGRPYyedCzO</eid>
               </Articulation>
             <Note>
-              <eid>8615704395798</eid>
+              <eid>TGQWnNRjM6M_Hezk6u8LJ2M</eid>
               <Accidental>
                 <subtype>accidentalFlat</subtype>
-                <eid>8641474199570</eid>
+                <eid>ehPqazSivzI_tdfbPD6pzKL</eid>
                 </Accidental>
               <pitch>58</pitch>
               <tpc>12</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>8671538970743</eid>
+            <eid>JdKsPf0B/tD_osZmENwdKNI</eid>
             <durationType>half</durationType>
             <Articulation>
               <subtype>articStaccatoBelow</subtype>
-              <eid>14126147436578</eid>
+              <eid>VVEASqWpW1M_SnA7JhLAfoO</eid>
               </Articulation>
             <Note>
-              <eid>8667244003350</eid>
+              <eid>pfC7EkKRu7E_WpBnxiG4ABH</eid>
               <Accidental>
                 <subtype>accidentalSharp</subtype>
-                <eid>8697308774418</eid>
+                <eid>XpQgxdW8uNL_ZP59qX555JE</eid>
                 </Accidental>
               <pitch>56</pitch>
               <tpc>22</tpc>
@@ -1813,26 +1815,26 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>8735963480183</eid>
+            <eid>26YdRIFPshK_sI8NkRlmp4B</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>8731668512790</eid>
+              <eid>QqGhoM9vQJH_I7glO2m29FE</eid>
               <Accidental>
                 <subtype>accidentalFlat</subtype>
-                <eid>8757438316562</eid>
+                <eid>s5V5uRf78kI_451/QCgDh2G</eid>
                 </Accidental>
               <pitch>58</pitch>
               <tpc>12</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>8864812499063</eid>
+            <eid>ENUn+fzYQBL_lpEVYRAuI0D</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>8860517531670</eid>
+              <eid>V8rZG1R977C_GdjZqeJb6fD</eid>
               <Accidental>
                 <subtype>accidentalSharp</subtype>
-                <eid>8890582302738</eid>
+                <eid>eJeyE0KpvIG_2RWJcgKZkDC</eid>
                 </Accidental>
               <pitch>56</pitch>
               <tpc>22</tpc>
@@ -1843,26 +1845,26 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>8929237008503</eid>
+            <eid>v07ELMw33N_y0Ze0g81N4C</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>8924942041110</eid>
+              <eid>196V7j4MK/O_DhwLketbTfM</eid>
               <Accidental>
                 <subtype>accidentalFlat</subtype>
-                <eid>8950711844882</eid>
+                <eid>F0SAlWZ70bL_v+DmII6DPX</eid>
                 </Accidental>
               <pitch>58</pitch>
               <tpc>12</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>8980776616055</eid>
+            <eid>O7+jchJ0aX_pDnQZt4TiWO</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>8976481648662</eid>
+              <eid>Z3L+nE0MN1M_3u11Os/Q1pB</eid>
               <Accidental>
                 <subtype>accidentalSharp</subtype>
-                <eid>9006546419730</eid>
+                <eid>fPg7XWWpdoF_xs8YY1U6A1G</eid>
                 </Accidental>
               <pitch>56</pitch>
               <tpc>22</tpc>
@@ -1873,26 +1875,26 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>9045201125495</eid>
+            <eid>bKRIX5Jbe5H_AOolqV90xBH</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>9040906158102</eid>
+              <eid>pW+U70fQmZK_ivPtxz1jFuM</eid>
               <Accidental>
                 <subtype>accidentalFlat</subtype>
-                <eid>9066675961874</eid>
+                <eid>MFUwfoBGE9O_fWuIsS9scGL</eid>
                 </Accidental>
               <pitch>58</pitch>
               <tpc>12</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>9096740733047</eid>
+            <eid>f/N8RB1bvTF_DTqdDcMeZvB</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>9092445765654</eid>
+              <eid>J2W+NnZnhNM_f3rr0EpTVIN</eid>
               <Accidental>
                 <subtype>accidentalSharp</subtype>
-                <eid>9122510536722</eid>
+                <eid>hI2MaGQ0l6N_mSrctSVVQoL</eid>
                 </Accidental>
               <pitch>56</pitch>
               <tpc>22</tpc>
@@ -1903,36 +1905,36 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>9161165242487</eid>
+            <eid>DYn4Fs8Lz+H_6tz14lYpNVI</eid>
             <durationType>half</durationType>
             <Articulation>
               <subtype>articTenutoBelow</subtype>
-              <eid>14194866913314</eid>
+              <eid>ky+Ghlj7iWH_7NPuiLPQk7K</eid>
               </Articulation>
             <Note>
-              <eid>9156870275094</eid>
+              <eid>JWBX4TCyFFE_ktvs/msIyLN</eid>
               <Accidental>
                 <subtype>accidentalSharp</subtype>
-                <eid>9182640078866</eid>
+                <eid>yc4UB8wi7wP_ejh/apd44gB</eid>
                 </Accidental>
               <pitch>56</pitch>
               <tpc>22</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>9375913607287</eid>
+            <eid>DbvuBBA7BeF_AucdVLttM5</eid>
             <durationType>half</durationType>
             <Articulation>
               <subtype>articTenutoBelow</subtype>
-              <eid>14220636717090</eid>
+              <eid>9d+5unpGVDN_a6D4L/zncs</eid>
               </Articulation>
             <Note>
-              <eid>9371618639894</eid>
+              <eid>2+bbrV9AIPP_7CvBqaFberE</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               </Note>
             <Note>
-              <eid>9410273345558</eid>
+              <eid>WD1MHHqaEoH_LnyEtxf/oeO</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               </Note>
@@ -1944,30 +1946,30 @@
           <Dynamic>
             <subtype>ff</subtype>
             <velocity>112</velocity>
-            <eid>16441134809126</eid>
+            <eid>G7RPUJc467D_1dp3tmCu3+H</eid>
             </Dynamic>
           <Chord>
-            <eid>9453223018615</eid>
+            <eid>px9tjw0dDXJ_AfVdmh0TTzH</eid>
             <durationType>half</durationType>
             <Articulation>
               <subtype>articTenutoBelow</subtype>
-              <eid>14237816586274</eid>
+              <eid>HhfhW9zvi5B_7yNahqJaxSN</eid>
               </Articulation>
             <Note>
-              <eid>9448928051222</eid>
+              <eid>a0xHf4oOuNC_3LxG7cLRjWM</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>9500467658871</eid>
+            <eid>nn8gT6IeiXF_9rqIYtOSjoG</eid>
             <durationType>half</durationType>
             <Articulation>
               <subtype>articTenutoBelow</subtype>
-              <eid>14224931684386</eid>
+              <eid>qU3wgmK9TYH_6oGgVe1JTN</eid>
               </Articulation>
             <Note>
-              <eid>9496172691478</eid>
+              <eid>zsrr7jds0RH_+YCl6+7uI5J</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               </Note>
@@ -1977,27 +1979,27 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>9560597201015</eid>
+            <eid>8PdcqpC9aVB_TN+LzCLlW9B</eid>
             <durationType>half</durationType>
             <Articulation>
               <subtype>articTenutoAbove</subtype>
-              <eid>14229226651682</eid>
+              <eid>a9NTrqAtgRI_VWCy0uSsmdM</eid>
               </Articulation>
             <Note>
-              <eid>9556302233622</eid>
+              <eid>yUFfG2QVaGN_ZoZ3f1c0jzJ</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>9607841841271</eid>
+            <eid>uDozxl72K+M_IsryWfGE0xE</eid>
             <durationType>half</durationType>
             <Articulation>
               <subtype>articTenutoBelow</subtype>
-              <eid>14233521618978</eid>
+              <eid>G9PaVgk+5xL_qVY79/x6cNF</eid>
               </Articulation>
             <Note>
-              <eid>9603546873878</eid>
+              <eid>hP39C+CBWL_GxKUOycDoUF</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               </Note>
@@ -2007,37 +2009,37 @@
       <Measure>
         <voice>
           <KeySig>
-            <eid>14920716386329</eid>
+            <eid>awg5LlSx3KP_GysajCHblWJ</eid>
             <concertKey>4</concertKey>
             </KeySig>
           <TimeSig>
-            <eid>15590731284507</eid>
+            <eid>PSmcQqNv/3M_/fT55ZtbOHI</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Chord>
-            <eid>9667971383415</eid>
+            <eid>WKDL7WUf/FH_EYGZYUQZPkE</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>9663676416022</eid>
+              <eid>XfQladnwMkK_IMcICuZ1XyI</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>14963666059282</eid>
+                <eid>QpXcKVxZ8uK_swpMnEupKJJ</eid>
                 </Accidental>
               <pitch>55</pitch>
               <tpc>15</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>9715216023671</eid>
+            <eid>JIMkGTVDS7C_TgLPCN0hPbC</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>9710921056278</eid>
+              <eid>EEj5PlEVbxM_RhKqAJMa0wB</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               </Note>
             <Note>
-              <eid>9749575761942</eid>
+              <eid>k6qYqqv4NjN_C9Xi4YvpZKO</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               </Note>
@@ -2047,28 +2049,28 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>9792525434999</eid>
+            <eid>lKyv0nOiAhP_ZBz36suyY4I</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>9788230467606</eid>
+              <eid>rRosHhI8vQH_OP57STG046K</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               </Note>
             <Note>
-              <eid>9822590205974</eid>
+              <eid>3AN7rXLutRP_TIXcExpYRbN</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>14972255993874</eid>
+                <eid>Hp6lmwl3pEL_vie+8AzhxdK</eid>
                 </Accidental>
               <pitch>60</pitch>
               <tpc>14</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>9856949944439</eid>
+            <eid>aIW5xYvALDM_Gwlfdgwl9DE</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>9852654977046</eid>
+              <eid>JZqJK1ycQ9H_Lj//kfzSAhB</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               </Note>
@@ -2078,24 +2080,24 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>9917079486583</eid>
+            <eid>1yWDITvCJ2L_8+V7TTUn5kP</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>9960029159446</eid>
+              <eid>HyXfnIGkFOP_8l7h58/2DAH</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               </Note>
             <Note>
-              <eid>9912784519190</eid>
+              <eid>/Kp05zVvU+C_kOSgMhqmj7L</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>9994388897911</eid>
+            <eid>H6SciB5B3yC_GEe0qXJK5cB</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>9990093930518</eid>
+              <eid>sscK3O0snvM_NBzVJrik15B</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               </Note>
@@ -2105,19 +2107,19 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>10054518440055</eid>
+            <eid>Son6+LWLF/K_dLSJCBZBylK</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>10050223472662</eid>
+              <eid>LyaKeJrULDP_6Fy7BVlru6N</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>10101763080311</eid>
+            <eid>WVKbApLSRSH_oZTvDB+J3EH</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>10097468112918</eid>
+              <eid>ntfqY0FBU0C_WWpiBfdjRVO</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               </Note>
@@ -2127,27 +2129,27 @@
       <Measure>
         <voice>
           <StaffText>
-            <eid>16630113370162</eid>
+            <eid>oRy4xa84gME_zCK9peAUHwI</eid>
             <text>Staff text</text>
             </StaffText>
           <Chord>
-            <eid>10161892622455</eid>
+            <eid>FZW3kpH/2uE_iWftWHByLhI</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>10157597655062</eid>
+              <eid>6+d6N9yNDD_vm5c9jaPOWE</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>15010910699538</eid>
+                <eid>+0WyHQPj0jH_7epUC4FMaxE</eid>
                 </Accidental>
               <pitch>53</pitch>
               <tpc>13</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>10209137262711</eid>
+            <eid>XkrIVFGaADK_BxKBKX/XrTO</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>10204842295318</eid>
+              <eid>MR9i7TmxHmK_1US9fhptIiE</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               </Note>
@@ -2157,22 +2159,22 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>10269266804855</eid>
+            <eid>KTkuKRMm+IF_YYgdzeOdGqN</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>10264971837462</eid>
+              <eid>dCKP73ULzNI_JAYwkZX7Y3D</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>10316511445111</eid>
+            <eid>781e4gHA81L_6mClAkzs8H</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>10312216477718</eid>
+              <eid>tIUB6dAk9+O_WravBHNblfD</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>15019500634130</eid>
+                <eid>B6YEJuMeXKE_1mAtqtq2vhN</eid>
                 </Accidental>
               <pitch>55</pitch>
               <tpc>15</tpc>
@@ -2185,22 +2187,22 @@
           <Dynamic>
             <subtype>mp</subtype>
             <velocity>64</velocity>
-            <eid>16535624089638</eid>
+            <eid>zMp/IgN0D8C_XTAkszIdjtI</eid>
             </Dynamic>
           <Chord>
-            <eid>10376640987255</eid>
+            <eid>ehssR3Y836M_4JSAjX1+IpL</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>10372346019862</eid>
+              <eid>wLp7IOBNgCG_Dxz33weWtSF</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>10423885627511</eid>
+            <eid>TSuM2hJUgpG_Mpo7SfiYVlE</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>10419590660118</eid>
+              <eid>OJGdCyyJfoE_UQfulYxVsgL</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               </Note>
@@ -2210,22 +2212,22 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>10484015169655</eid>
+            <eid>gSQOLAGPVZD_XQUF8st0/JP</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>10479720202262</eid>
+              <eid>ewZB7wmhnVN_jgqx7y3VKnF</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>10531259809911</eid>
+            <eid>B2pcGoxBwfK_0+1PJDAJSbC</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>10526964842518</eid>
+              <eid>a+chsfWrVyK_yk99nJyaYjH</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>15036680503314</eid>
+                <eid>fjV9aifNfrI_GEDb+KAzotI</eid>
                 </Accidental>
               <pitch>55</pitch>
               <tpc>15</tpc>
@@ -2236,22 +2238,22 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>10591389352055</eid>
+            <eid>hST8cQKkcbD_Tv9a4+1NFzI</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>10587094384662</eid>
+              <eid>m8VTtLjT0KC_UnQXpDBeMcG</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>10724533338231</eid>
+            <eid>/R5ocEEj15O_6e3rIFsbWjK</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>10720238370838</eid>
+              <eid>pHW+E5kXeRM_ykzKvn+aS2M</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>15049565405202</eid>
+                <eid>NiTeYQUuwiH_GdjrihjAAfM</eid>
                 </Accidental>
               <pitch>60</pitch>
               <tpc>14</tpc>
@@ -2262,23 +2264,23 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>10784662880375</eid>
+            <eid>y5fvzuaKMSL_Faa5bJVjsjJ</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>10780367912982</eid>
+              <eid>8pJjTg0oMAL_uXaNsqNOHdO</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>15066745274386</eid>
+                <eid>B/JZYWHgznM_/AClRPnop1J</eid>
                 </Accidental>
               <pitch>60</pitch>
               <tpc>14</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>10831907520631</eid>
+            <eid>FhAsNw87ORG_uVJuMqTPH0M</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>10827612553238</eid>
+              <eid>HA9yJcVG6LI_3RcozpqYJML</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               </Note>
@@ -2288,19 +2290,19 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>10892037062775</eid>
+            <eid>G7IAtL/gR4I_21oo/fUtkNB</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>10887742095382</eid>
+              <eid>Vk15wQSksPL_jo8DkCyjF4N</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>10939281703031</eid>
+            <eid>Gb7NS4iyP1L_F+bgSG124aE</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>10934986735638</eid>
+              <eid>sjp0LXmiCNL_cwcPhRmwUnE</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               </Note>
@@ -2310,22 +2312,22 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>10999411245175</eid>
+            <eid>4Lmhp4y2giO_3Smea7n0I6N</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>10995116277782</eid>
+              <eid>+zBI8D9ux6K_OTyoURsnuOB</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>11046655885431</eid>
+            <eid>wTQHmJOEAxJ_V3o3HkD1NVG</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>11042360918038</eid>
+              <eid>oIi6Z1AlooN_xvoxlrak67J</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>15161234554898</eid>
+                <eid>MzdHD7T6ElN_OmBVkE2zAUJ</eid>
                 </Accidental>
               <pitch>60</pitch>
               <tpc>14</tpc>
@@ -2336,23 +2338,23 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>11106785427575</eid>
+            <eid>RojfX36krEP_2NrvOhT92FN</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>11102490460182</eid>
+              <eid>MFHQLRTVtLI_W04JHXUNM+G</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>15174119456786</eid>
+                <eid>GCnUgr0M8VH_GZpnll7a7EI</eid>
                 </Accidental>
               <pitch>60</pitch>
               <tpc>14</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>11162620002423</eid>
+            <eid>9GctsOpcYs_IaNqz2FDmVH</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>11158325035030</eid>
+              <eid>l/ml5bp82UC_rVLegffuLqJ</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               </Note>
@@ -2362,19 +2364,19 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>11231339479159</eid>
+            <eid>qaR+R4RQKhI_AMYdrpNxafO</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>11227044511766</eid>
+              <eid>TiD3lKOC87B_KJIQgjvRI7B</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>11287174054007</eid>
+            <eid>RXtjTR1vkmJ_6R3/Xt/Hk1K</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>11282879086614</eid>
+              <eid>FU8cSq988uF_CBGShOjJQxE</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               </Note>
@@ -2384,23 +2386,23 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>11355893530743</eid>
+            <eid>D7uSlZ6PDvC_otHkJhb6jxK</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>11351598563350</eid>
+              <eid>nkrsT18fOkJ_pCbj/vlcI9M</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>15191299325970</eid>
+                <eid>CuHIGR/2k1K_5TwE20xdgrD</eid>
                 </Accidental>
               <pitch>60</pitch>
               <tpc>14</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>11407433138295</eid>
+            <eid>EB5VkeftpHD_IxVVU9Mf74F</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>11403138170902</eid>
+              <eid>OFzXrqXCwHM_v4/bqaBhyME</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               </Note>
@@ -2410,33 +2412,33 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>11471857647735</eid>
+            <eid>Or/twKQuc0E_0r7+SwkZwOF</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>11506217386006</eid>
+              <eid>2Xl/o8noxSC_uHQAKANX+dJ</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>15199889260562</eid>
+                <eid>ycWCZTypEdN_Ul/EtqYMJmE</eid>
                 </Accidental>
               <pitch>55</pitch>
               <tpc>15</tpc>
               </Note>
             <Note>
-              <eid>11467562680342</eid>
+              <eid>eHaPcI9XebB_d4pwCzV+ftB</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>11544872091767</eid>
+            <eid>4fWjOstkYfP_seLUIqD/AYN</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>11583526797334</eid>
+              <eid>upZZK3Ac1HE_oqDk4CGwLgC</eid>
               <pitch>55</pitch>
               <tpc>15</tpc>
               </Note>
             <Note>
-              <eid>11540577124374</eid>
+              <eid>lQVNDoG5ybC_JqOL1eqDloC</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               </Note>
@@ -2446,32 +2448,32 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>11630771437687</eid>
+            <eid>xi7Y4DQrZgM_nzoX4+sCAvH</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>11665131175958</eid>
+              <eid>7OBToMN5v7I_CZQcmFQ+ZKB</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               </Note>
             <Note>
-              <eid>11626476470294</eid>
+              <eid>oQ+NEBbp79B_U6KP2rna9F</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>11703785881719</eid>
+            <eid>VK6iW6N03zI_xlVQvw4GTwM</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>11699490914326</eid>
+              <eid>MdAYPnXamCO_fNuIjvdU39D</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               </Note>
             <Note>
-              <eid>11755325489174</eid>
+              <eid>J9/dOAKFYJC_oHGuIAPc/1F</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>15217069129746</eid>
+                <eid>XgFVzISov8J_lUPe56WbtL</eid>
                 </Accidental>
               <pitch>60</pitch>
               <tpc>14</tpc>
@@ -2482,23 +2484,23 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>11802570129527</eid>
+            <eid>2kT2gSxIIAL_XgzggVoUQ/C</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>11798275162134</eid>
+              <eid>tzoTgb7XVzH_AterRuKVMkE</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>15225659064338</eid>
+                <eid>yEptfvc2L3H_548VkeLBWyK</eid>
                 </Accidental>
               <pitch>60</pitch>
               <tpc>14</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>11854109737079</eid>
+            <eid>Ll1Hs0rhcpB_zwVtC8JSEmG</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>11849814769686</eid>
+              <eid>nSbpL/oqoQB_x6WcK2WWMrG</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               </Note>
@@ -2508,22 +2510,22 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>11918534246519</eid>
+            <eid>E3pVADbd71F_u7NqzA0toPH</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>11914239279126</eid>
+              <eid>BhP5vO2uw/_Vsp5zO07cOD</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>11970073854071</eid>
+            <eid>SN2YTeAl8dD_cpM+B+4M1BM</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>11965778886678</eid>
+              <eid>1GAAWXpJ3dL_zkQaajzhEEL</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>15238543966226</eid>
+                <eid>U/88oYRh5DP_PX67o/hvvGO</eid>
                 </Accidental>
               <pitch>60</pitch>
               <tpc>14</tpc>
@@ -2534,20 +2536,20 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>12034498363511</eid>
+            <eid>Uo2PiGMe/2_IhqI6P/ssIO</eid>
             <durationType>half</durationType>
             <Note>
-              <eid>12030203396118</eid>
+              <eid>h5lwa2C/ziF_aHxk4gmyCXG</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>15294378541074</eid>
+                <eid>ihiYwE7FWcC_5CkqTPrVViK</eid>
                 </Accidental>
               <pitch>60</pitch>
               <tpc>14</tpc>
               </Note>
             </Chord>
           <Rest>
-            <eid>12021613461532</eid>
+            <eid>LIOlPSfn7mJ_dpkwlNnB8wE</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>
@@ -2557,24 +2559,24 @@
       <Measure>
         <voice>
           <KeySig>
-            <eid>167503724569</eid>
+            <eid>Q39XWzCh0k_0N5z9qQ4FWO</eid>
             <concertKey>0</concertKey>
             </KeySig>
           <TimeSig>
-            <eid>163208757275</eid>
+            <eid>BEJx9ufp9JC_06hQB7VORsO</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Dynamic>
             <subtype>p</subtype>
             <velocity>49</velocity>
-            <eid>16376710299686</eid>
+            <eid>kBODqmTq+HJ_BrMPfUYnowD</eid>
             </Dynamic>
           <Chord>
-            <eid>12163347382391</eid>
+            <eid>XO2/FDd3IeM_+NiedlMCIdB</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>12159052414998</eid>
+              <eid>o0gGnsdxXrL_f+KwCKqW/dB</eid>
               <pitch>55</pitch>
               <tpc>15</tpc>
               </Note>
@@ -2584,13 +2586,13 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>12206297055351</eid>
+            <eid>rNi2HoGtSxI_S+rW7u8MjDL</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>12202002087958</eid>
+              <eid>MzTd4qS6iqJ_BSN7wqRKV0N</eid>
               <Accidental>
                 <subtype>accidentalSharp</subtype>
-                <eid>12227771891730</eid>
+                <eid>W1Bkee/EnOG_yutFbIwT1kL</eid>
                 </Accidental>
               <pitch>56</pitch>
               <tpc>22</tpc>
@@ -2601,17 +2603,17 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>12253541695607</eid>
+            <eid>x6RiJ2GPoaK_0bQAL40+o1B</eid>
             <durationType>whole</durationType>
             <Articulation>
               <subtype>articAccentAbove</subtype>
-              <eid>14053132992546</eid>
+              <eid>V/BpSZMIqbC_gBE+O/GAQVL</eid>
               </Articulation>
             <Note>
-              <eid>12249246728214</eid>
+              <eid>nM5Ge/MwaHK_VFgtAN+9lLC</eid>
               <Accidental>
                 <subtype>accidentalFlat</subtype>
-                <eid>12275016531986</eid>
+                <eid>HWGkQhKNl8B_ecHJnY0sHwK</eid>
                 </Accidental>
               <pitch>58</pitch>
               <tpc>12</tpc>
@@ -2622,17 +2624,17 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>12300786335863</eid>
+            <eid>J2VL4boQbFL_U4J2cqbL4jE</eid>
             <durationType>whole</durationType>
             <Articulation>
               <subtype>articAccentAbove</subtype>
-              <eid>14057427959842</eid>
+              <eid>XZU56vKRBfH_4OAGnIB/bEM</eid>
               </Articulation>
             <Note>
-              <eid>12296491368470</eid>
+              <eid>GMQER/OhWtC_luBlnH5ndbG</eid>
               <Accidental>
                 <subtype>accidentalSharp</subtype>
-                <eid>12322261172242</eid>
+                <eid>PZxU3h0RebO_dxzIAdH3/RD</eid>
                 </Accidental>
               <pitch>56</pitch>
               <tpc>22</tpc>
@@ -2641,21 +2643,21 @@
           <Clef>
             <concertClefType>C4</concertClefType>
             <transposingClefType>C4</transposingClefType>
-            <eid>14315125997592</eid>
+            <eid>bAJCE+cZhGI_fWNg+Z8HWWE</eid>
             </Clef>
           </voice>
         </Measure>
       <Measure>
         <voice>
           <Chord>
-            <eid>12348030976119</eid>
+            <eid>82W8UftSKp_wdlLMXrQTRF</eid>
             <durationType>whole</durationType>
             <Articulation>
               <subtype>articAccentBelow</subtype>
-              <eid>14061722927138</eid>
+              <eid>ysDwvjR/Qs_pe2b976kLzB</eid>
               </Articulation>
             <Note>
-              <eid>12343736008726</eid>
+              <eid>Sm9NLGePgVB_vYExBg84BsE</eid>
               <pitch>55</pitch>
               <tpc>15</tpc>
               </Note>
@@ -2665,14 +2667,14 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>12390980649079</eid>
+            <eid>i85K8jB0U1N_bveKQ3kL00G</eid>
             <durationType>whole</durationType>
             <Articulation>
               <subtype>articStaccatoBelow</subtype>
-              <eid>14134737371170</eid>
+              <eid>bCg0TItFZ4E_E3U0v1P/tIK</eid>
               </Articulation>
             <Note>
-              <eid>12386685681686</eid>
+              <eid>64pwS6ESiII_eZ5GVSHL5uM</eid>
               <pitch>53</pitch>
               <tpc>13</tpc>
               </Note>
@@ -2682,10 +2684,10 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>12433930322039</eid>
+            <eid>ZUMS0+SCx5P_aAnzrSVsWxM</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>12429635354646</eid>
+              <eid>BhFGOSqOPCE_CdQWj7UJzJD</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               </Note>
@@ -2695,15 +2697,15 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>12476879994999</eid>
+            <eid>ovlW9oQRdGP_PH3QJm2dnd</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>12472585027606</eid>
+              <eid>YWP3PgcA5dK_qCciF7vPmjM</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               </Note>
             <Note>
-              <eid>12502649798678</eid>
+              <eid>tYRVsnIvvEJ_NENuixXF6DM</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               </Note>
@@ -2713,15 +2715,15 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>12537009537143</eid>
+            <eid>3/FbrTaeKwP_6XPV4n633WH</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>12562779340822</eid>
+              <eid>g75I17uo+iF_P8O88G6cBHI</eid>
               <pitch>53</pitch>
               <tpc>13</tpc>
               </Note>
             <Note>
-              <eid>12532714569750</eid>
+              <eid>6e5ER2Ub9OI_s0XsVPh+lXN</eid>
               <pitch>55</pitch>
               <tpc>15</tpc>
               </Note>
@@ -2731,14 +2733,14 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>12597139079287</eid>
+            <eid>iB1GMNN1WTN_7PtzQcU6YIF</eid>
             <durationType>whole</durationType>
             <Articulation>
               <subtype>articTenutoBelow</subtype>
-              <eid>14242111553570</eid>
+              <eid>AQ8CKzCKJKO_S3lbE+ihhHF</eid>
               </Articulation>
             <Note>
-              <eid>12592844111894</eid>
+              <eid>bpqNYCS7jFD_sGW2XghtfDO</eid>
               <pitch>53</pitch>
               <tpc>13</tpc>
               </Note>
@@ -2750,22 +2752,22 @@
           <Dynamic>
             <subtype>ff</subtype>
             <velocity>112</velocity>
-            <eid>16445429776422</eid>
+            <eid>k6i9qOf2hAI_eb0xmZinf9O</eid>
             </Dynamic>
           <Chord>
-            <eid>12640088752247</eid>
+            <eid>+iz0rBJcflC_BAaa1uSokBM</eid>
             <durationType>whole</durationType>
             <Articulation>
               <subtype>articTenutoBelow</subtype>
-              <eid>14246406520866</eid>
+              <eid>uCpKpw55r5H_Yh60eBN7FdH</eid>
               </Articulation>
             <Note>
-              <eid>12635793784854</eid>
+              <eid>I12cJ3498VG_mTmrhUYyWdN</eid>
               <pitch>55</pitch>
               <tpc>15</tpc>
               </Note>
             <Note>
-              <eid>12665858555926</eid>
+              <eid>wtgjdlKOmmN_yL1VxpcVlkD</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               </Note>
@@ -2773,21 +2775,21 @@
           <Clef>
             <concertClefType>F</concertClefType>
             <transposingClefType>F</transposingClefType>
-            <eid>14465449852952</eid>
+            <eid>5U/pzosBH2H_jUkANTitcrP</eid>
             </Clef>
           </voice>
         </Measure>
       <Measure>
         <voice>
           <Chord>
-            <eid>12700218294391</eid>
+            <eid>Z2wv16Nx0XI_WDYJesAn1mI</eid>
             <durationType>whole</durationType>
             <Articulation>
               <subtype>articTenutoAbove</subtype>
-              <eid>14250701488162</eid>
+              <eid>n9WL2vgYQiF_dtOHjSSYYBP</eid>
               </Articulation>
             <Note>
-              <eid>12695923326998</eid>
+              <eid>0ltu8lYvBmC_wdJEC8/fhTI</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               </Note>
@@ -2797,19 +2799,19 @@
       <Measure>
         <voice>
           <KeySig>
-            <eid>14925011353625</eid>
+            <eid>g21yaB+tBaI_YwiyQP1DEGB</eid>
             <concertKey>4</concertKey>
             </KeySig>
           <TimeSig>
-            <eid>15595026251803</eid>
+            <eid>F9GWu/xTbzN_VLUpwGd2YHP</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Chord>
-            <eid>12743167967351</eid>
+            <eid>zlPgx2wePzN_ABYBNeYuAAE</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>12738872999958</eid>
+              <eid>i+bSL24lJYF_yvzkKrodz</eid>
               <pitch>56</pitch>
               <tpc>22</tpc>
               </Note>
@@ -2819,22 +2821,22 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>12790412607607</eid>
+            <eid>0eXRgaolLJI_zhzkOloZvHB</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>12816182411286</eid>
+              <eid>3BnwJ4kWcPL_he1Qvuw9bhN</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>14976550961170</eid>
+                <eid>KS1FJej7M8G_cqjQBg8hsEB</eid>
                 </Accidental>
               <pitch>53</pitch>
               <tpc>13</tpc>
               </Note>
             <Note>
-              <eid>12786117640214</eid>
+              <eid>p/PjBYAblNK_ycs6AhgBhCL</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>14980845928466</eid>
+                <eid>ga5OnP4v44D_dt3De/5nVcM</eid>
                 </Accidental>
               <pitch>55</pitch>
               <tpc>15</tpc>
@@ -2845,10 +2847,10 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>12850542149751</eid>
+            <eid>0KqqahEZOoM_pdyvKfZ/7cE</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>12846247182358</eid>
+              <eid>oz8b8O/ChEL_IUFK58R4xMK</eid>
               <pitch>56</pitch>
               <tpc>22</tpc>
               </Note>
@@ -2858,18 +2860,18 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>12897786790007</eid>
+            <eid>2RlojSjlH3C_8k1xO92b71I</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>12927851560982</eid>
+              <eid>Tce9WC4pXz_EhzGgFW2CP</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               </Note>
             <Note>
-              <eid>12893491822614</eid>
+              <eid>fadpTKZb2N_iWgDgTMQ/LF</eid>
               <Accidental>
                 <subtype>accidentalFlat</subtype>
-                <eid>12919261626386</eid>
+                <eid>WM3Uj0jAykB_/YXzhYQd9PK</eid>
                 </Accidental>
               <pitch>58</pitch>
               <tpc>12</tpc>
@@ -2880,14 +2882,14 @@
       <Measure>
         <voice>
           <StaffText>
-            <eid>16634408337458</eid>
+            <eid>YG5YadAA/jI_OPZNoMvxinO</eid>
             <text>Staff text</text>
             </StaffText>
           <Chord>
-            <eid>13125420056695</eid>
+            <eid>rxO6Vdd5CuB_EUTj5bU5JDH</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>13121125089302</eid>
+              <eid>nM00VE1Mhi_YIdmK/TTJPK</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               </Note>
@@ -2897,10 +2899,10 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>13168369729655</eid>
+            <eid>v15qTkPxHaD_SI6SEhJmDWL</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>13164074762262</eid>
+              <eid>rSb8K9/TPGM_y/JjdtHUmJ</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               </Note>
@@ -2912,16 +2914,16 @@
           <Dynamic>
             <subtype>mp</subtype>
             <velocity>64</velocity>
-            <eid>16539919056934</eid>
+            <eid>QjHcqkc96RI_C3HCLwSjnsH</eid>
             </Dynamic>
           <Chord>
-            <eid>13211319402615</eid>
+            <eid>f5lS+fTdSVD_jJLVQ0GWPmN</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>13207024435222</eid>
+              <eid>RjrNc0cydD_gcBx7JCxciO</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>15028090568722</eid>
+                <eid>u/ZOWg+fPo_4WCETWD167C</eid>
                 </Accidental>
               <pitch>55</pitch>
               <tpc>15</tpc>
@@ -2932,13 +2934,13 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>13254269075575</eid>
+            <eid>1YttpY4r04O_8HYrAhkFzvN</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>13249974108182</eid>
+              <eid>5dgWSZNZKLB_5AcXam9xu5K</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>15040975470610</eid>
+                <eid>Y67kdlvIe6F_Gi+mgKIah8</eid>
                 </Accidental>
               <pitch>55</pitch>
               <tpc>15</tpc>
@@ -2949,13 +2951,13 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>13297218748535</eid>
+            <eid>sF8Q8FEWpoE_qlO7SvY1jUG</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>13292923781142</eid>
+              <eid>gmOcfDzvOtE_rAry4aEjO9N</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>15053860372498</eid>
+                <eid>9pdMKdUq9fE_PvGQYGKVeeL</eid>
                 </Accidental>
               <pitch>55</pitch>
               <tpc>15</tpc>
@@ -2966,13 +2968,13 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>13340168421495</eid>
+            <eid>KLX0+8mLNKG_OyEBMxbNVTB</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>13335873454102</eid>
+              <eid>SHuhNumD8+M_JzBihOzBUGC</eid>
               <Accidental>
                 <subtype>accidentalFlat</subtype>
-                <eid>13361643257874</eid>
+                <eid>SpGREqT2VQE_JvSjscg0LLM</eid>
                 </Accidental>
               <pitch>58</pitch>
               <tpc>12</tpc>
@@ -2983,13 +2985,13 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>13387413061751</eid>
+            <eid>ralCduVqw8J_NFcSUjGtKqG</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>13383118094358</eid>
+              <eid>WAsjxHSKRfP_zmTptsaUdt</eid>
               <Accidental>
                 <subtype>accidentalFlat</subtype>
-                <eid>13408887898130</eid>
+                <eid>f65zxew9/rL_fZHEnQd0ISO</eid>
                 </Accidental>
               <pitch>58</pitch>
               <tpc>12</tpc>
@@ -3000,13 +3002,13 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>13443247636599</eid>
+            <eid>4DpCWAAlffD_t6OtEaJy/PK</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>13438952669206</eid>
+              <eid>tNJG+jo9nNF_LBXCOtiRPfK</eid>
               <Accidental>
                 <subtype>accidentalFlat</subtype>
-                <eid>13464722472978</eid>
+                <eid>wJS6C1FlIpL_FVq+/cVfNvP</eid>
                 </Accidental>
               <pitch>58</pitch>
               <tpc>12</tpc>
@@ -3017,10 +3019,10 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>13499082211447</eid>
+            <eid>Tuu+2Ygnq8N_bGh9BHjTTeJ</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>13494787244054</eid>
+              <eid>6noVNeTYd2G_eEN9drphdkM</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               </Note>
@@ -3030,22 +3032,22 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>13546326851703</eid>
+            <eid>04+iEA4hgYD_gJmGyfeeYNC</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>13589276524566</eid>
+              <eid>uGgDD0HZ9vI_ibZ8Eput7KE</eid>
               <Accidental>
                 <subtype>accidentalFlat</subtype>
-                <eid>13602161426450</eid>
+                <eid>2wuw4UbhcxF_cTnK5fujdvJ</eid>
                 </Accidental>
               <pitch>58</pitch>
               <tpc>12</tpc>
               </Note>
             <Note>
-              <eid>13542031884310</eid>
+              <eid>SofmvwOCYxP_AGUOw0qotFD</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>13606456393746</eid>
+                <eid>o58DJ4eMm9B_T3i7EHr67gO</eid>
                 </Accidental>
               <pitch>59</pitch>
               <tpc>19</tpc>
@@ -3056,13 +3058,13 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>13636521164919</eid>
+            <eid>0ZXf2J0myIM_m0+0Q22hJ7B</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>13632226197526</eid>
+              <eid>peuzbOhUYOE_vHUhTBBXOeD</eid>
               <Accidental>
                 <subtype>accidentalFlat</subtype>
-                <eid>13657996001298</eid>
+                <eid>aVMegKjMoYH_Xv+sJ9Adi9E</eid>
                 </Accidental>
               <pitch>58</pitch>
               <tpc>12</tpc>
@@ -3073,22 +3075,22 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>13688060772471</eid>
+            <eid>PCcPguxStsH_z3S0t47PaCM</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>13683765805078</eid>
+              <eid>AeXENZMotaF_t1jx86CZQdE</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>15204184227858</eid>
+                <eid>/HxgiSs1oAH_c77GDAYlHHH</eid>
                 </Accidental>
               <pitch>53</pitch>
               <tpc>13</tpc>
               </Note>
             <Note>
-              <eid>13718125543446</eid>
+              <eid>ICPslp+67eD_x2LxGmkF46K</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>15208479195154</eid>
+                <eid>1NrtEzbwjaM_ZslRydyGr1N</eid>
                 </Accidental>
               <pitch>55</pitch>
               <tpc>15</tpc>
@@ -3099,13 +3101,13 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>13756780249207</eid>
+            <eid>GhBO9851NuO_Oa1oMJkr0zB</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>13752485281814</eid>
+              <eid>QhuXnXOImHH_JKw2aKLKGaG</eid>
               <Accidental>
                 <subtype>accidentalFlat</subtype>
-                <eid>13778255085586</eid>
+                <eid>X35iap0g3hP_v4a+Er2we8I</eid>
                 </Accidental>
               <pitch>58</pitch>
               <tpc>12</tpc>
@@ -3116,13 +3118,13 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>13808319856759</eid>
+            <eid>33K6NMFh3y_Kx9hWi/fcsM</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>13804024889366</eid>
+              <eid>QsfYTqivS/J_8v4Ye+EQu3O</eid>
               <Accidental>
                 <subtype>accidentalFlat</subtype>
-                <eid>13829794693138</eid>
+                <eid>GQToP3rlyXB_pNU4V+1huaF</eid>
                 </Accidental>
               <pitch>58</pitch>
               <tpc>12</tpc>
@@ -3133,10 +3135,10 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>13859859464311</eid>
+            <eid>K2YugUTPkZG_Ed9XnQh6LrK</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>13855564496918</eid>
+              <eid>BXwjcVmbZ8D_WA3Kb7sQSSH</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               </Note>
@@ -3146,10 +3148,10 @@
       <Measure>
         <voice>
           <Chord>
-            <eid>13907104104567</eid>
+            <eid>AHDgOIGQ9uH_LWS3ruTPBiD</eid>
             <durationType>whole</durationType>
             <Note>
-              <eid>13902809137174</eid>
+              <eid>3y7Yyha7jvM_jcCE76dSWtD</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               </Note>

--- a/src/engraving/tests/chordsymbol_data/add-part-ref.mscx
+++ b/src/engraving/tests/chordsymbol_data/add-part-ref.mscx
@@ -104,7 +104,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>68719476740</eid>
       <name>Classical Guitar</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>

--- a/src/engraving/tests/chordsymbol_data/no-system-ref.mscx
+++ b/src/engraving/tests/chordsymbol_data/no-system-ref.mscx
@@ -203,7 +203,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>261993005060</eid>
       <name>Flute</name>
       <Division>480</Division>
       <Style>
@@ -314,7 +313,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>438086664196</eid>
       <name>Alto Saxophone</name>
       <Division>480</Division>
       <Style>

--- a/src/engraving/tests/chordsymbol_data/transpose-part-ref.mscx
+++ b/src/engraving/tests/chordsymbol_data/transpose-part-ref.mscx
@@ -125,7 +125,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>94489280516</eid>
       <name>Flute</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>

--- a/src/engraving/tests/compat206_data/articulations-double-ref.mscx
+++ b/src/engraving/tests/compat206_data/articulations-double-ref.mscx
@@ -1808,7 +1808,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>3929895075844</eid>
       <name>Piano</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>

--- a/src/engraving/tests/compat206_data/hairpin-ref.mscx
+++ b/src/engraving/tests/compat206_data/hairpin-ref.mscx
@@ -594,7 +594,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>1065151889412</eid>
       <name>Piano</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>

--- a/src/engraving/tests/compat206_data/lidemptytext-ref.mscx
+++ b/src/engraving/tests/compat206_data/lidemptytext-ref.mscx
@@ -227,7 +227,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>227633266692</eid>
       <name>Bass</name>
       <Division>480</Division>
       <Style>

--- a/src/engraving/tests/compat206_data/userstylesparts-ref.mscx
+++ b/src/engraving/tests/compat206_data/userstylesparts-ref.mscx
@@ -379,7 +379,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>219043332100</eid>
       <name>Piano</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
@@ -616,7 +615,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>373662154756</eid>
       <name>Flute 1</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>
@@ -876,7 +874,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>536870912004</eid>
       <name>Flute 2</name>
       <initialPartId>3</initialPartId>
       <Division>480</Division>

--- a/src/engraving/tests/copypaste_data/copypaste_parts-ref.mscx
+++ b/src/engraving/tests/copypaste_data/copypaste_parts-ref.mscx
@@ -837,7 +837,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>867583393796</eid>
       <name>Flute</name>
       <Division>480</Division>
       <Style>

--- a/src/engraving/tests/eid_tests.cpp
+++ b/src/engraving/tests/eid_tests.cpp
@@ -37,7 +37,7 @@ class Engraving_EIDTests : public ::testing::Test
 {
 };
 
-static void itemShouldBeRegistered(void*, EngravingItem* item)
+static void checkRegister(void*, EngravingItem* item)
 {
     EID eid = item->eid();
     if (eid.isValid()) {
@@ -55,9 +55,9 @@ TEST_F(Engraving_EIDTests, testRegisteredItems)
     MasterScore* score = ScoreRW::readScore(DATA_DIR + u"random_elements.mscx");
     EXPECT_TRUE(score);
 
-    score->scanElements(nullptr, itemShouldBeRegistered, true);
+    score->scanElements(nullptr, checkRegister, true);
     for (MeasureBase* mb = score->first(); mb; mb = mb->next()) {
-        itemShouldBeRegistered(nullptr, mb);
+        checkRegister(nullptr, mb);
     }
 
     delete score;

--- a/src/engraving/tests/eid_tests.cpp
+++ b/src/engraving/tests/eid_tests.cpp
@@ -39,7 +39,8 @@ class Engraving_EIDTests : public ::testing::Test
 
 static void itemShouldBeRegistered(void*, EngravingItem* item)
 {
-    if (item->registerId()) {
+    EID eid = item->eid();
+    if (eid.isValid()) {
         EngravingObject* registeredItem = item->masterScore()->eidRegister()->itemFromEID(item->eid());
         EXPECT_TRUE(registeredItem);
         EXPECT_EQ(registeredItem, item);

--- a/src/engraving/tests/exchangevoices_data/undoChangeVoice01-ref.mscx
+++ b/src/engraving/tests/exchangevoices_data/undoChangeVoice01-ref.mscx
@@ -557,7 +557,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>798863917060</eid>
       <name>Piano</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>

--- a/src/engraving/tests/exchangevoices_data/undoChangeVoice02-ref.mscx
+++ b/src/engraving/tests/exchangevoices_data/undoChangeVoice02-ref.mscx
@@ -541,7 +541,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>798863917060</eid>
       <name>Piano</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>

--- a/src/engraving/tests/measure_data/measureSplit-ref.mscx
+++ b/src/engraving/tests/measure_data/measureSplit-ref.mscx
@@ -1289,7 +1289,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>3062311682052</eid>
       <name>Flute</name>
       <Division>480</Division>
       <Style>
@@ -1993,7 +1992,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>4831838208004</eid>
       <name>Oboe</name>
       <Division>480</Division>
       <Style>

--- a/src/engraving/tests/parts_data/linked-ties-parts.mscx
+++ b/src/engraving/tests/parts_data/linked-ties-parts.mscx
@@ -396,7 +396,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>558345748484</eid>
       <name>Flute</name>
       <Division>480</Division>
       <Style>

--- a/src/engraving/tests/parts_data/part-54346-parts.mscx
+++ b/src/engraving/tests/parts_data/part-54346-parts.mscx
@@ -273,7 +273,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>399431958532</eid>
       <name>B♭ Trumpet</name>
       <Division>480</Division>
       <Style>
@@ -452,7 +451,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>670014898180</eid>
       <name>C Trumpet</name>
       <Division>480</Division>
       <Style>

--- a/src/engraving/tests/parts_data/part-all-appendmeasures.mscx
+++ b/src/engraving/tests/parts_data/part-all-appendmeasures.mscx
@@ -1079,7 +1079,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>2332167241732</eid>
       <name>Alto</name>
       <Division>480</Division>
       <Style>
@@ -1795,7 +1794,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>3921305141252</eid>
       <name>Tenor</name>
       <Division>480</Division>
       <Style>

--- a/src/engraving/tests/parts_data/part-all-insertmeasures.mscx
+++ b/src/engraving/tests/parts_data/part-all-insertmeasures.mscx
@@ -1075,7 +1075,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>2332167241732</eid>
       <name>Alto</name>
       <Division>480</Division>
       <Style>
@@ -1790,7 +1789,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>3921305141252</eid>
       <name>Tenor</name>
       <Division>480</Division>
       <Style>

--- a/src/engraving/tests/parts_data/part-all-parts.mscx
+++ b/src/engraving/tests/parts_data/part-all-parts.mscx
@@ -1061,7 +1061,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>2332167241732</eid>
       <name>Alto</name>
       <Division>480</Division>
       <Style>
@@ -1767,7 +1766,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>3921305141252</eid>
       <name>Tenor</name>
       <Division>480</Division>
       <Style>

--- a/src/engraving/tests/parts_data/part-all-uappendmeasures.mscx
+++ b/src/engraving/tests/parts_data/part-all-uappendmeasures.mscx
@@ -1061,7 +1061,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>2332167241732</eid>
       <name>Alto</name>
       <Division>480</Division>
       <Style>
@@ -1767,7 +1766,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>3921305141252</eid>
       <name>Tenor</name>
       <Division>480</Division>
       <Style>

--- a/src/engraving/tests/parts_data/part-all-uinsertmeasures.mscx
+++ b/src/engraving/tests/parts_data/part-all-uinsertmeasures.mscx
@@ -1061,7 +1061,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>2332167241732</eid>
       <name>Alto</name>
       <Division>480</Division>
       <Style>
@@ -1767,7 +1766,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>3921305141252</eid>
       <name>Tenor</name>
       <Division>480</Division>
       <Style>

--- a/src/engraving/tests/parts_data/part-breath-add.mscx
+++ b/src/engraving/tests/parts_data/part-breath-add.mscx
@@ -773,7 +773,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>1013612281860</eid>
       <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
@@ -1220,7 +1219,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>1675037245444</eid>
       <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>

--- a/src/engraving/tests/parts_data/part-breath-del.mscx
+++ b/src/engraving/tests/parts_data/part-breath-del.mscx
@@ -769,7 +769,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>1022202216452</eid>
       <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
@@ -1211,7 +1210,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>1692217114628</eid>
       <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>

--- a/src/engraving/tests/parts_data/part-breath-parts.mscx
+++ b/src/engraving/tests/parts_data/part-breath-parts.mscx
@@ -782,7 +782,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>1640677507076</eid>
       <name>Alto</name>
       <Division>480</Division>
       <Style>
@@ -1233,7 +1232,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>2710124363780</eid>
       <name>Tenor</name>
       <Division>480</Division>
       <Style>

--- a/src/engraving/tests/parts_data/part-breath-uadd.mscx
+++ b/src/engraving/tests/parts_data/part-breath-uadd.mscx
@@ -769,7 +769,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>1013612281860</eid>
       <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
@@ -1211,7 +1210,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>1675037245444</eid>
       <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>

--- a/src/engraving/tests/parts_data/part-breath-udel.mscx
+++ b/src/engraving/tests/parts_data/part-breath-udel.mscx
@@ -773,7 +773,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>1022202216452</eid>
       <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
@@ -1220,7 +1219,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>1692217114628</eid>
       <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>

--- a/src/engraving/tests/parts_data/part-breath-uradd.mscx
+++ b/src/engraving/tests/parts_data/part-breath-uradd.mscx
@@ -773,7 +773,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>1013612281860</eid>
       <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
@@ -1220,7 +1219,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>1675037245444</eid>
       <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>

--- a/src/engraving/tests/parts_data/part-breath-urdel.mscx
+++ b/src/engraving/tests/parts_data/part-breath-urdel.mscx
@@ -769,7 +769,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>1022202216452</eid>
       <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
@@ -1211,7 +1210,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>1692217114628</eid>
       <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>

--- a/src/engraving/tests/parts_data/part-chordline-add.mscx
+++ b/src/engraving/tests/parts_data/part-chordline-add.mscx
@@ -773,7 +773,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>1013612281860</eid>
       <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
@@ -1220,7 +1219,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>1675037245444</eid>
       <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>

--- a/src/engraving/tests/parts_data/part-chordline-del.mscx
+++ b/src/engraving/tests/parts_data/part-chordline-del.mscx
@@ -764,7 +764,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>1013612281860</eid>
       <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
@@ -1200,7 +1199,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>1675037245444</eid>
       <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>

--- a/src/engraving/tests/parts_data/part-chordline-parts.mscx
+++ b/src/engraving/tests/parts_data/part-chordline-parts.mscx
@@ -768,7 +768,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>1623497637892</eid>
       <name>Alto</name>
       <Division>480</Division>
       <Style>
@@ -1207,7 +1206,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>2680059592708</eid>
       <name>Tenor</name>
       <Division>480</Division>
       <Style>

--- a/src/engraving/tests/parts_data/part-chordline-uadd.mscx
+++ b/src/engraving/tests/parts_data/part-chordline-uadd.mscx
@@ -769,7 +769,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>1013612281860</eid>
       <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
@@ -1211,7 +1210,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>1675037245444</eid>
       <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>

--- a/src/engraving/tests/parts_data/part-chordline-udel.mscx
+++ b/src/engraving/tests/parts_data/part-chordline-udel.mscx
@@ -768,7 +768,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>1013612281860</eid>
       <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
@@ -1209,7 +1208,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>1675037245444</eid>
       <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>

--- a/src/engraving/tests/parts_data/part-chordline-uradd.mscx
+++ b/src/engraving/tests/parts_data/part-chordline-uradd.mscx
@@ -773,7 +773,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>1013612281860</eid>
       <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
@@ -1220,7 +1219,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>1675037245444</eid>
       <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>

--- a/src/engraving/tests/parts_data/part-chordline-urdel.mscx
+++ b/src/engraving/tests/parts_data/part-chordline-urdel.mscx
@@ -764,7 +764,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>1013612281860</eid>
       <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
@@ -1200,7 +1199,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>1675037245444</eid>
       <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>

--- a/src/engraving/tests/parts_data/part-empty-parts.mscx
+++ b/src/engraving/tests/parts_data/part-empty-parts.mscx
@@ -769,7 +769,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>1623497637892</eid>
       <name>Alto</name>
       <Division>480</Division>
       <Style>
@@ -1209,7 +1208,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>2680059592708</eid>
       <name>Tenor</name>
       <Division>480</Division>
       <Style>

--- a/src/engraving/tests/parts_data/part-fingering-add.mscx
+++ b/src/engraving/tests/parts_data/part-fingering-add.mscx
@@ -773,7 +773,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>1013612281860</eid>
       <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
@@ -1220,7 +1219,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>1675037245444</eid>
       <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>

--- a/src/engraving/tests/parts_data/part-fingering-del.mscx
+++ b/src/engraving/tests/parts_data/part-fingering-del.mscx
@@ -774,7 +774,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>1022202216452</eid>
       <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
@@ -1222,7 +1221,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>1692217114628</eid>
       <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>

--- a/src/engraving/tests/parts_data/part-fingering-parts.mscx
+++ b/src/engraving/tests/parts_data/part-fingering-parts.mscx
@@ -779,7 +779,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>1632087572484</eid>
       <name>Alto</name>
       <Division>480</Division>
       <Style>
@@ -1231,7 +1230,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>2697239461892</eid>
       <name>Tenor</name>
       <Division>480</Division>
       <Style>

--- a/src/engraving/tests/parts_data/part-fingering-uadd.mscx
+++ b/src/engraving/tests/parts_data/part-fingering-uadd.mscx
@@ -769,7 +769,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>1013612281860</eid>
       <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
@@ -1211,7 +1210,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>1675037245444</eid>
       <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>

--- a/src/engraving/tests/parts_data/part-fingering-udel.mscx
+++ b/src/engraving/tests/parts_data/part-fingering-udel.mscx
@@ -779,7 +779,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>1022202216452</eid>
       <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
@@ -1233,7 +1232,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>1692217114628</eid>
       <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>

--- a/src/engraving/tests/parts_data/part-fingering-uradd.mscx
+++ b/src/engraving/tests/parts_data/part-fingering-uradd.mscx
@@ -773,7 +773,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>1013612281860</eid>
       <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
@@ -1220,7 +1219,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>1675037245444</eid>
       <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>

--- a/src/engraving/tests/parts_data/part-fingering-urdel.mscx
+++ b/src/engraving/tests/parts_data/part-fingering-urdel.mscx
@@ -774,7 +774,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>1022202216452</eid>
       <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
@@ -1222,7 +1221,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>1692217114628</eid>
       <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>

--- a/src/engraving/tests/parts_data/part-image-add.mscx
+++ b/src/engraving/tests/parts_data/part-image-add.mscx
@@ -774,7 +774,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>1013612281860</eid>
       <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
@@ -1222,7 +1221,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>1675037245444</eid>
       <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>

--- a/src/engraving/tests/parts_data/part-image-del.mscx
+++ b/src/engraving/tests/parts_data/part-image-del.mscx
@@ -769,7 +769,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>1022202216452</eid>
       <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
@@ -1210,7 +1209,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>1692217114628</eid>
       <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>

--- a/src/engraving/tests/parts_data/part-image-parts.mscx
+++ b/src/engraving/tests/parts_data/part-image-parts.mscx
@@ -780,7 +780,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>1705102016516</eid>
       <name>Alto</name>
       <Division>480</Division>
       <Style>
@@ -1231,7 +1230,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>2800318676996</eid>
       <name>Tenor</name>
       <Division>480</Division>
       <Style>

--- a/src/engraving/tests/parts_data/part-image-uadd.mscx
+++ b/src/engraving/tests/parts_data/part-image-uadd.mscx
@@ -769,7 +769,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>1013612281860</eid>
       <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
@@ -1211,7 +1210,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>1675037245444</eid>
       <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>

--- a/src/engraving/tests/parts_data/part-image-udel.mscx
+++ b/src/engraving/tests/parts_data/part-image-udel.mscx
@@ -780,7 +780,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>1022202216452</eid>
       <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
@@ -1233,7 +1232,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>1692217114628</eid>
       <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>

--- a/src/engraving/tests/parts_data/part-image-uradd.mscx
+++ b/src/engraving/tests/parts_data/part-image-uradd.mscx
@@ -774,7 +774,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>1013612281860</eid>
       <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
@@ -1222,7 +1221,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>1675037245444</eid>
       <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>

--- a/src/engraving/tests/parts_data/part-image-urdel.mscx
+++ b/src/engraving/tests/parts_data/part-image-urdel.mscx
@@ -769,7 +769,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>1022202216452</eid>
       <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
@@ -1210,7 +1209,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>1692217114628</eid>
       <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>

--- a/src/engraving/tests/parts_data/part-measure-repeat-add.mscx
+++ b/src/engraving/tests/parts_data/part-measure-repeat-add.mscx
@@ -783,7 +783,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>1013612281860</eid>
       <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
@@ -1230,7 +1229,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>1675037245444</eid>
       <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>

--- a/src/engraving/tests/parts_data/part-measure-repeat-del.mscx
+++ b/src/engraving/tests/parts_data/part-measure-repeat-del.mscx
@@ -804,7 +804,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>1039382085636</eid>
       <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
@@ -1253,7 +1252,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>1700807049220</eid>
       <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>

--- a/src/engraving/tests/parts_data/part-measure-repeat-parts.mscx
+++ b/src/engraving/tests/parts_data/part-measure-repeat-parts.mscx
@@ -810,7 +810,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>1657857376260</eid>
       <name>Alto</name>
       <Division>480</Division>
       <Style>
@@ -1260,7 +1259,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>2714419331076</eid>
       <name>Tenor</name>
       <Division>480</Division>
       <Style>

--- a/src/engraving/tests/parts_data/part-measure-repeat-uadd.mscx
+++ b/src/engraving/tests/parts_data/part-measure-repeat-uadd.mscx
@@ -769,7 +769,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>1013612281860</eid>
       <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
@@ -1211,7 +1210,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>1675037245444</eid>
       <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>

--- a/src/engraving/tests/parts_data/part-measure-repeat-udel.mscx
+++ b/src/engraving/tests/parts_data/part-measure-repeat-udel.mscx
@@ -810,7 +810,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>1039382085636</eid>
       <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
@@ -1262,7 +1261,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>1700807049220</eid>
       <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>

--- a/src/engraving/tests/parts_data/part-measure-repeat-uradd.mscx
+++ b/src/engraving/tests/parts_data/part-measure-repeat-uradd.mscx
@@ -783,7 +783,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>1013612281860</eid>
       <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
@@ -1230,7 +1229,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>1675037245444</eid>
       <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>

--- a/src/engraving/tests/parts_data/part-measure-repeat-urdel.mscx
+++ b/src/engraving/tests/parts_data/part-measure-repeat-urdel.mscx
@@ -804,7 +804,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>1039382085636</eid>
       <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
@@ -1253,7 +1252,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>1700807049220</eid>
       <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>

--- a/src/engraving/tests/parts_data/part-spanners-parts.mscx
+++ b/src/engraving/tests/parts_data/part-spanners-parts.mscx
@@ -681,7 +681,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>936302870532</eid>
       <name>Flute</name>
       <Division>480</Division>
       <Style>
@@ -1053,7 +1052,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>1494648619012</eid>
       <name>Oboe</name>
       <Division>480</Division>
       <Style>

--- a/src/engraving/tests/parts_data/part-stemless-parts.mscx
+++ b/src/engraving/tests/parts_data/part-stemless-parts.mscx
@@ -480,7 +480,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>863288426500</eid>
       <name>Flute</name>
       <Division>480</Division>
       <Style>
@@ -767,7 +766,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>1391569403908</eid>
       <name>Oboe</name>
       <Division>480</Division>
       <Style>

--- a/src/engraving/tests/parts_data/part-symbol-add.mscx
+++ b/src/engraving/tests/parts_data/part-symbol-add.mscx
@@ -773,7 +773,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>1013612281860</eid>
       <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
@@ -1220,7 +1219,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>1675037245444</eid>
       <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>

--- a/src/engraving/tests/parts_data/part-symbol-del.mscx
+++ b/src/engraving/tests/parts_data/part-symbol-del.mscx
@@ -769,7 +769,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>1017907249156</eid>
       <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
@@ -1211,7 +1210,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>1683627180036</eid>
       <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>

--- a/src/engraving/tests/parts_data/part-symbol-parts.mscx
+++ b/src/engraving/tests/parts_data/part-symbol-parts.mscx
@@ -773,7 +773,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>1627792605188</eid>
       <name>Alto</name>
       <Division>480</Division>
       <Style>
@@ -1218,7 +1217,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>2688649527300</eid>
       <name>Tenor</name>
       <Division>480</Division>
       <Style>

--- a/src/engraving/tests/parts_data/part-symbol-uadd.mscx
+++ b/src/engraving/tests/parts_data/part-symbol-uadd.mscx
@@ -769,7 +769,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>1013612281860</eid>
       <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
@@ -1211,7 +1210,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>1675037245444</eid>
       <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>

--- a/src/engraving/tests/parts_data/part-symbol-udel.mscx
+++ b/src/engraving/tests/parts_data/part-symbol-udel.mscx
@@ -773,7 +773,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>1017907249156</eid>
       <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
@@ -1220,7 +1219,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>1683627180036</eid>
       <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>

--- a/src/engraving/tests/parts_data/part-symbol-uradd.mscx
+++ b/src/engraving/tests/parts_data/part-symbol-uradd.mscx
@@ -773,7 +773,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>1013612281860</eid>
       <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
@@ -1220,7 +1219,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>1675037245444</eid>
       <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>

--- a/src/engraving/tests/parts_data/part-symbol-urdel.mscx
+++ b/src/engraving/tests/parts_data/part-symbol-urdel.mscx
@@ -769,7 +769,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>1017907249156</eid>
       <name>Alto</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
@@ -1211,7 +1210,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>1683627180036</eid>
       <name>Tenor</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>

--- a/src/engraving/tests/parts_data/part-visible-tracks-part-ref.mscx
+++ b/src/engraving/tests/parts_data/part-visible-tracks-part-ref.mscx
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="4.50">
   <Score>
-    <eid>115964116996</eid>
     <name>Klarinet in B♭</name>
     <Tracklist sTrack="0" dstTrack="0"/>
     <Tracklist sTrack="2" dstTrack="1"/>

--- a/src/engraving/tests/parts_data/part-visible-tracks-score-ref.mscx
+++ b/src/engraving/tests/parts_data/part-visible-tracks-score-ref.mscx
@@ -194,7 +194,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>115964116996</eid>
       <name>Klarinet in B♭</name>
       <Tracklist sTrack="0" dstTrack="0"/>
       <Tracklist sTrack="2" dstTrack="1"/>

--- a/src/engraving/tests/parts_data/partExclusion-part-0.mscx
+++ b/src/engraving/tests/parts_data/partExclusion-part-0.mscx
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="4.50">
   <Score>
-    <eid>506806140932</eid>
     <name>Flute</name>
     <Division>480</Division>
     <Style>

--- a/src/engraving/tests/parts_data/partExclusion-part-1.mscx
+++ b/src/engraving/tests/parts_data/partExclusion-part-1.mscx
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="4.50">
   <Score>
-    <eid>506806140932</eid>
     <name>Flute</name>
     <Division>480</Division>
     <Style>

--- a/src/engraving/tests/parts_data/partPropertyLinking-part-0.mscx
+++ b/src/engraving/tests/parts_data/partPropertyLinking-part-0.mscx
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="4.50">
   <Score>
-    <eid>98784247812</eid>
     <name>Flute</name>
     <Division>480</Division>
     <Style>

--- a/src/engraving/tests/parts_data/partPropertyLinking-part-1.mscx
+++ b/src/engraving/tests/parts_data/partPropertyLinking-part-1.mscx
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="4.50">
   <Score>
-    <eid>98784247812</eid>
     <name>Flute</name>
     <Division>480</Division>
     <Style>

--- a/src/engraving/tests/parts_data/partStyle-score-ref.mscx
+++ b/src/engraving/tests/parts_data/partStyle-score-ref.mscx
@@ -311,7 +311,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>528280977412</eid>
       <name>Flute</name>
       <Division>480</Division>
       <Style>
@@ -510,7 +509,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>936302870532</eid>
       <name>Oboe</name>
       <Division>480</Division>
       <Style>

--- a/src/engraving/tests/parts_data/partStyle-score-reload-ref.mscx
+++ b/src/engraving/tests/parts_data/partStyle-score-reload-ref.mscx
@@ -306,7 +306,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>365072220164</eid>
       <name>Flute</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>
@@ -503,7 +502,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>644245094404</eid>
       <name>Oboe</name>
       <initialPartId>2</initialPartId>
       <Division>480</Division>

--- a/src/engraving/tests/parts_data/voices-ref.mscx
+++ b/src/engraving/tests/parts_data/voices-ref.mscx
@@ -1067,7 +1067,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>1958505086980</eid>
       <name>Piano</name>
       <Division>480</Division>
       <Style>
@@ -1813,7 +1812,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>3285649981444</eid>
       <name>Trombone</name>
       <Division>480</Division>
       <Style>
@@ -2313,7 +2311,6 @@
         </Staff>
       </Score>
     <Score>
-      <eid>4174708211716</eid>
       <name>Trombone</name>
       <Division>480</Division>
       <Style>

--- a/src/engraving/tests/spanners_data/glissando-cloning04-ref.mscx
+++ b/src/engraving/tests/spanners_data/glissando-cloning04-ref.mscx
@@ -133,7 +133,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>94489280516</eid>
       <name>Flute</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>

--- a/src/engraving/tests/system_locks_data/system_locks-1.mscx
+++ b/src/engraving/tests/system_locks_data/system_locks-1.mscx
@@ -2,8 +2,8 @@
 <museScore version="4.50">
   <programVersion>4.5.0</programVersion>
   <programRevision></programRevision>
-  <LastEID>1434</LastEID>
   <Score>
+    <eid>aBkRZg4B7oG_dp0UghSwJmC</eid>
     <Division>480</Division>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -143,329 +143,329 @@
       </Part>
     <Staff id="1">
       <Measure>
-        <eid>1533303324763</eid>
+        <eid>ndOCC1N7d7L_Nz0n0LN+/gK</eid>
         <voice>
           <KeySig>
-            <eid>1554778161177</eid>
+            <eid>XS4TN/GHeTD_S9J0gsFq2/L</eid>
             <concertKey>0</concertKey>
             </KeySig>
           <TimeSig>
-            <eid>1546188226587</eid>
+            <eid>bDX8op35+ZP_rF+Sys1Xfr</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Rest>
-            <eid>1563368095772</eid>
+            <eid>j/Fgwl7B6yL_wPhAvfr8yKH</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
-        <eid>1567663063131</eid>
+        <eid>kBCn+sWv0EC_G7DsGhyz4PD</eid>
         <voice>
           <Rest>
-            <eid>1580547964956</eid>
+            <eid>XpTpStuzTSO_mlpQRdfTRVG</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
-        <eid>1584842932315</eid>
+        <eid>GtRWgnCJ0mF_MmywqRFVXHJ</eid>
         <voice>
           <Rest>
-            <eid>1597727834140</eid>
+            <eid>kx6V1DFPsYC_JHBZkT4q9GK</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
-        <eid>1602022801499</eid>
+        <eid>AfhbCdUl7lP_QG4I2C7UWAI</eid>
         <voice>
           <Rest>
-            <eid>1614907703324</eid>
+            <eid>IZ/zpwOJU/O_HDPFgP1uSLM</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
-        <eid>1619202670683</eid>
+        <eid>lrnHp+PeYxL_OYqElbNOXUG</eid>
         <voice>
           <Rest>
-            <eid>1632087572508</eid>
+            <eid>e4wcvSfsZ9L_W/c4GhgHfPG</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
-        <eid>1636382539867</eid>
+        <eid>RxzKGY23PmN_syYQ+3Ou+FE</eid>
         <voice>
           <Rest>
-            <eid>1649267441692</eid>
+            <eid>qYEXBy6e1XP_lKcN2dHbpU</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
-        <eid>1653562409051</eid>
+        <eid>OVPQ/VFNoEG_Bgz7pbcX3VP</eid>
         <voice>
           <Rest>
-            <eid>1666447310876</eid>
+            <eid>wufYHnTxzOC_9QN7Iiot+XI</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
-        <eid>1670742278235</eid>
+        <eid>kGp/ImRFUiO_Eo+f4t/E9VG</eid>
         <voice>
           <Rest>
-            <eid>1683627180060</eid>
+            <eid>3qd8V7w3ugB_T4brjrJDaAG</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
-        <eid>1687922147419</eid>
+        <eid>H0v2lu7lLDO_KeST4MGjjxO</eid>
         <voice>
           <Rest>
-            <eid>1700807049244</eid>
+            <eid>iQgYritAJSH_wGK5yStTijH</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
-        <eid>1705102016603</eid>
+        <eid>AEwi5fmze0I_fdP9w87bmdB</eid>
         <voice>
           <Rest>
-            <eid>1717986918428</eid>
+            <eid>s8Y7eu6JyME_3Xj+wLBtb9J</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
-        <eid>1722281885787</eid>
+        <eid>Kt9S1I+5n+O_dvQmtE8m6aN</eid>
         <voice>
           <Rest>
-            <eid>1735166787612</eid>
+            <eid>NIqcq4pAiAD_zU8fjepZr7K</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
-        <eid>1739461754971</eid>
+        <eid>D1W0pDSIS9O_4K8LZhFWhi</eid>
         <voice>
           <Rest>
-            <eid>1752346656796</eid>
+            <eid>kXobvjOwWmH_hBssPxR4CbP</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
-        <eid>1756641624155</eid>
+        <eid>JqggfBGML9L_YTcouEjOwoC</eid>
         <voice>
           <Rest>
-            <eid>1769526525980</eid>
+            <eid>a8p0+v9De3D_Y3HXXsEQL5P</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
-        <eid>1773821493339</eid>
+        <eid>ODSpI079REM_Ex5SGQxb3SL</eid>
         <voice>
           <Rest>
-            <eid>1786706395164</eid>
+            <eid>Rc4nWLFaf9M_z1s7U4Pz7fC</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
-        <eid>1791001362523</eid>
+        <eid>49wXztQu+U_wLIbeEEHAkE</eid>
         <voice>
           <Rest>
-            <eid>1803886264348</eid>
+            <eid>j2Tv+rDiwRB_t1ach6nObaE</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
-        <eid>1808181231707</eid>
+        <eid>btZ633R/SoM_d0EOepi0SvD</eid>
         <voice>
           <Rest>
-            <eid>1821066133532</eid>
+            <eid>luH9LDq/WqM_z4aqwj8rJSN</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
-        <eid>1825361100891</eid>
+        <eid>OWs6WOeLPRI_D1glJIDFoxL</eid>
         <voice>
           <Rest>
-            <eid>1838246002716</eid>
+            <eid>JqcjZdNvHCL_+mvMZXgppVN</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
-        <eid>1842540970075</eid>
+        <eid>22urBUDwNyO_MUjYJu1BN5C</eid>
         <voice>
           <Rest>
-            <eid>1855425871900</eid>
+            <eid>KBsPcOw71zN_IsKcOW6MF4E</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
-        <eid>1859720839259</eid>
+        <eid>2js7S19L8BP_5CQ4HypDKjG</eid>
         <voice>
           <Rest>
-            <eid>1872605741084</eid>
+            <eid>GTiXCk102KP_J+xONjhrnM</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
-        <eid>1876900708443</eid>
+        <eid>XT65ZbNlEcM_DKVOwjlmg2K</eid>
         <voice>
           <Rest>
-            <eid>1889785610268</eid>
+            <eid>KLvw06j0pcP_MYF+DeuPJcL</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
-        <eid>1894080577627</eid>
+        <eid>hVx2a84iiyB_oTOM4c16idN</eid>
         <voice>
           <Rest>
-            <eid>1906965479452</eid>
+            <eid>D8ay13mKjWL_pUapcWWFohM</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
-        <eid>1911260446811</eid>
+        <eid>UeMvA9s/tsG_lzH75+O2hyP</eid>
         <voice>
           <Rest>
-            <eid>1924145348636</eid>
+            <eid>r/THP8IzJiI_B6E0BXutyFI</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
-        <eid>1928440315995</eid>
+        <eid>pVHMjyWaS3C_NUdTAA5CJ0L</eid>
         <voice>
           <Rest>
-            <eid>1941325217820</eid>
+            <eid>bDtOxbU1E9L_crSLdypZB7J</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
-        <eid>1945620185179</eid>
+        <eid>J2+yfvIKxSO_szhyK8xPLCO</eid>
         <voice>
           <Rest>
-            <eid>1958505087004</eid>
+            <eid>qF0/LqT9/sB_ZbYyQ2DF77E</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
-        <eid>1962800054363</eid>
+        <eid>6ooulpcZaVK_Vm8k1ih9t9N</eid>
         <voice>
           <Rest>
-            <eid>1975684956188</eid>
+            <eid>vxdzuxWvtSD_S/V7XDLdWw</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
-        <eid>1979979923547</eid>
+        <eid>U52zo9h/3JP_hEJay7Sv//L</eid>
         <voice>
           <Rest>
-            <eid>1992864825372</eid>
+            <eid>rHPjx+PzlOK_yDmFt8FslFL</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
-        <eid>1997159792731</eid>
+        <eid>ajp9kOW8ycE_K8BQLmhvtuF</eid>
         <voice>
           <Rest>
-            <eid>2010044694556</eid>
+            <eid>7j5eEH5D5HF_3a7dqIuugmM</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
-        <eid>2014339661915</eid>
+        <eid>T3vJ1ANIikN_XWl5PYFD3LD</eid>
         <voice>
           <Rest>
-            <eid>2027224563740</eid>
+            <eid>iKhZfhxRXmJ_4bxGKvUr0cK</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
-        <eid>2031519531099</eid>
+        <eid>/JmkMS6spyI_BzemDofUGjN</eid>
         <voice>
           <Rest>
-            <eid>2044404432924</eid>
+            <eid>UkXRQKH6uPM_FuHMgT4at4P</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
-        <eid>2048699400283</eid>
+        <eid>pc13oy8b9wB_e3MRKmFDeQ</eid>
         <voice>
           <Rest>
-            <eid>2061584302108</eid>
+            <eid>hxuP0sp4CnH_+xIpmdDv6lF</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
-        <eid>2065879269467</eid>
+        <eid>5+9PBLtwBkE_tz1weU/b0KF</eid>
         <voice>
           <Rest>
-            <eid>2078764171292</eid>
+            <eid>Uhu/BoLIHWH_X3pw13E0NXE</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
-        <eid>2083059138651</eid>
+        <eid>+116YvdJSbE_68+13qURrvE</eid>
         <voice>
           <Rest>
-            <eid>2095944040476</eid>
+            <eid>fsm+ase/uzJ_TyOeN2q7/9P</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
@@ -476,16 +476,16 @@
       <Measure>
         <voice>
           <KeySig>
-            <eid>5398773891097</eid>
+            <eid>WPRQM/TMJZC_7fP3KfcaevL</eid>
             <concertKey>0</concertKey>
             </KeySig>
           <TimeSig>
-            <eid>5128190951451</eid>
+            <eid>vpFH6T8rGrB_0dQRpJ7kdI</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Rest>
-            <eid>5123895984156</eid>
+            <eid>TJrAV26q0rJ_FMhvmGjnhbO</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
@@ -494,7 +494,7 @@
       <Measure>
         <voice>
           <Rest>
-            <eid>5136780886044</eid>
+            <eid>YA+qdF6NSWB_PzeLvDuvCrM</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
@@ -503,7 +503,7 @@
       <Measure>
         <voice>
           <Rest>
-            <eid>5145370820636</eid>
+            <eid>jKyOXgDge8_KlpxGLz7hRF</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
@@ -512,7 +512,7 @@
       <Measure>
         <voice>
           <Rest>
-            <eid>5153960755228</eid>
+            <eid>KfRWdqvcNSJ_PnP3HekF90D</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
@@ -521,7 +521,7 @@
       <Measure>
         <voice>
           <Rest>
-            <eid>5162550689820</eid>
+            <eid>x9rfTmnrnN_yt8dnUA7LRJ</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
@@ -530,7 +530,7 @@
       <Measure>
         <voice>
           <Rest>
-            <eid>5171140624412</eid>
+            <eid>TWG0WX6YgLG_sxbzfurApiC</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
@@ -539,7 +539,7 @@
       <Measure>
         <voice>
           <Rest>
-            <eid>5179730559004</eid>
+            <eid>I/qgyRyIojO_XYrpoE8BLdN</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
@@ -548,7 +548,7 @@
       <Measure>
         <voice>
           <Rest>
-            <eid>5188320493596</eid>
+            <eid>eYPvOxA5fAL_qHUbF6cbOwF</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
@@ -557,7 +557,7 @@
       <Measure>
         <voice>
           <Rest>
-            <eid>5196910428188</eid>
+            <eid>JHBnlytmXkC_YLHAvtR9YML</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
@@ -566,7 +566,7 @@
       <Measure>
         <voice>
           <Rest>
-            <eid>5205500362780</eid>
+            <eid>9kRadaV4/RC_o3YJkybEf+I</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
@@ -575,7 +575,7 @@
       <Measure>
         <voice>
           <Rest>
-            <eid>5214090297372</eid>
+            <eid>6Y0uro3Kg1N_6Nt3CP24ZQ</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
@@ -584,7 +584,7 @@
       <Measure>
         <voice>
           <Rest>
-            <eid>5222680231964</eid>
+            <eid>NHbsE3B6Mu_Yhff9elMweN</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
@@ -593,7 +593,7 @@
       <Measure>
         <voice>
           <Rest>
-            <eid>5231270166556</eid>
+            <eid>QBfGgQGNRvB_f25paTnVoK</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
@@ -602,7 +602,7 @@
       <Measure>
         <voice>
           <Rest>
-            <eid>5239860101148</eid>
+            <eid>1bB4KFN6+iH_kMRJ70xrqAF</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
@@ -611,7 +611,7 @@
       <Measure>
         <voice>
           <Rest>
-            <eid>5248450035740</eid>
+            <eid>mAO/DzgmwUN_86GBk18rdlI</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
@@ -620,7 +620,7 @@
       <Measure>
         <voice>
           <Rest>
-            <eid>5257039970332</eid>
+            <eid>YgJk523SS2K_RpLhGeQP+4P</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
@@ -629,7 +629,7 @@
       <Measure>
         <voice>
           <Rest>
-            <eid>5265629904924</eid>
+            <eid>V6KCTIdKDxP_4OFJu3oIBy</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
@@ -638,7 +638,7 @@
       <Measure>
         <voice>
           <Rest>
-            <eid>5274219839516</eid>
+            <eid>AvffpBSpXCC_OW3vepJtKIP</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
@@ -647,7 +647,7 @@
       <Measure>
         <voice>
           <Rest>
-            <eid>5282809774108</eid>
+            <eid>+qvuGo1y8MI_3RExJnmurlI</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
@@ -656,7 +656,7 @@
       <Measure>
         <voice>
           <Rest>
-            <eid>5291399708700</eid>
+            <eid>iEjcItak2YP_I7XtRrxmXoN</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
@@ -665,7 +665,7 @@
       <Measure>
         <voice>
           <Rest>
-            <eid>5299989643292</eid>
+            <eid>oYl9bHkzw6C_k++dS+zUJvH</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
@@ -674,7 +674,7 @@
       <Measure>
         <voice>
           <Rest>
-            <eid>5308579577884</eid>
+            <eid>Oaanax4hP8P_jf2F+S/0aUF</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
@@ -683,7 +683,7 @@
       <Measure>
         <voice>
           <Rest>
-            <eid>5317169512476</eid>
+            <eid>niNALVGq2xD_OBSM/hoAO6B</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
@@ -692,7 +692,7 @@
       <Measure>
         <voice>
           <Rest>
-            <eid>5325759447068</eid>
+            <eid>0qmLn/nOMfC_89jJ51/9vxP</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
@@ -701,7 +701,7 @@
       <Measure>
         <voice>
           <Rest>
-            <eid>5334349381660</eid>
+            <eid>Zd8Qne7xuiH_FyPbaU0JFnJ</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
@@ -710,7 +710,7 @@
       <Measure>
         <voice>
           <Rest>
-            <eid>5342939316252</eid>
+            <eid>UGkPai1OfMH_M/17QLgMMHO</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
@@ -719,7 +719,7 @@
       <Measure>
         <voice>
           <Rest>
-            <eid>5351529250844</eid>
+            <eid>Z5q9EVupG5I_PNyMhdOioTB</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
@@ -728,7 +728,7 @@
       <Measure>
         <voice>
           <Rest>
-            <eid>5360119185436</eid>
+            <eid>wYuSAAcnc7J_5CrOxXxIHSJ</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
@@ -737,7 +737,7 @@
       <Measure>
         <voice>
           <Rest>
-            <eid>5368709120028</eid>
+            <eid>WpfYWL/BusC_UrP8SzPIC7O</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
@@ -746,7 +746,7 @@
       <Measure>
         <voice>
           <Rest>
-            <eid>5377299054620</eid>
+            <eid>lEYrYiQLwWK_FhuNuVFhSyC</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
@@ -755,7 +755,7 @@
       <Measure>
         <voice>
           <Rest>
-            <eid>5385888989212</eid>
+            <eid>iwuAfU8tVtO_8+qqpVaKryM</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
@@ -764,7 +764,7 @@
       <Measure>
         <voice>
           <Rest>
-            <eid>5394478923804</eid>
+            <eid>VhwF4QoXwgN_EUSmiXQ3c1J</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
@@ -773,36 +773,36 @@
       </Staff>
     <SystemLocks>
       <systemLock>
-        <startMeasure>1533303324763</startMeasure>
-        <endMeasure>1602022801499</endMeasure>
+        <startMeasure>ndOCC1N7d7L_Nz0n0LN+/gK</startMeasure>
+        <endMeasure>AfhbCdUl7lP_QG4I2C7UWAI</endMeasure>
         </systemLock>
       <systemLock>
-        <startMeasure>1619202670683</startMeasure>
-        <endMeasure>1670742278235</endMeasure>
+        <startMeasure>lrnHp+PeYxL_OYqElbNOXUG</startMeasure>
+        <endMeasure>kGp/ImRFUiO_Eo+f4t/E9VG</endMeasure>
         </systemLock>
       <systemLock>
-        <startMeasure>1687922147419</startMeasure>
-        <endMeasure>1739461754971</endMeasure>
+        <startMeasure>H0v2lu7lLDO_KeST4MGjjxO</startMeasure>
+        <endMeasure>D1W0pDSIS9O_4K8LZhFWhi</endMeasure>
         </systemLock>
       <systemLock>
-        <startMeasure>1756641624155</startMeasure>
-        <endMeasure>1808181231707</endMeasure>
+        <startMeasure>JqggfBGML9L_YTcouEjOwoC</startMeasure>
+        <endMeasure>btZ633R/SoM_d0EOepi0SvD</endMeasure>
         </systemLock>
       <systemLock>
-        <startMeasure>1825361100891</startMeasure>
-        <endMeasure>1876900708443</endMeasure>
+        <startMeasure>OWs6WOeLPRI_D1glJIDFoxL</startMeasure>
+        <endMeasure>XT65ZbNlEcM_DKVOwjlmg2K</endMeasure>
         </systemLock>
       <systemLock>
-        <startMeasure>1894080577627</startMeasure>
-        <endMeasure>1945620185179</endMeasure>
+        <startMeasure>hVx2a84iiyB_oTOM4c16idN</startMeasure>
+        <endMeasure>J2+yfvIKxSO_szhyK8xPLCO</endMeasure>
         </systemLock>
       <systemLock>
-        <startMeasure>1962800054363</startMeasure>
-        <endMeasure>2014339661915</endMeasure>
+        <startMeasure>6ooulpcZaVK_Vm8k1ih9t9N</startMeasure>
+        <endMeasure>T3vJ1ANIikN_XWl5PYFD3LD</endMeasure>
         </systemLock>
       <systemLock>
-        <startMeasure>2031519531099</startMeasure>
-        <endMeasure>2083059138651</endMeasure>
+        <startMeasure>/JmkMS6spyI_BzemDofUGjN</startMeasure>
+        <endMeasure>+116YvdJSbE_68+13qURrvE</endMeasure>
         </systemLock>
       </SystemLocks>
     </Score>

--- a/src/engraving/tests/tools_data/undoResequencePart01-ref.mscx
+++ b/src/engraving/tests/tools_data/undoResequencePart01-ref.mscx
@@ -304,7 +304,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>489626271748</eid>
       <name>Flute</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>

--- a/src/engraving/tests/tools_data/undoResequencePart02-ref.mscx
+++ b/src/engraving/tests/tools_data/undoResequencePart02-ref.mscx
@@ -304,7 +304,6 @@
         </Measure>
       </Staff>
     <Score>
-      <eid>489626271748</eid>
       <name>Flute</name>
       <initialPartId>1</initialPartId>
       <Division>480</Division>

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -5093,7 +5093,7 @@ void MusicXmlParserDirection::wedge(const String& type, const int number,
 
 String MusicXmlExtendedSpannerDesc::toString() const
 {
-    String spStr = sp ? String::number(size_t(sp->eid().id())) : u"null";
+    String spStr = sp ? String::fromStdString(sp->eid().toStdString()) : u"null";
     return String(u"sp %1 tp %2 tick2 %3 track2 %4 %5 %6")
            .arg(spStr, tick2.toString())
            .arg(static_cast<int>(track2))


### PR DESCRIPTION
Resolves: see previous discussion [here](https://github.com/musescore/MuseScore/pull/25597#discussion_r1855475098).

The EID class has the purpose of giving a unique ID to every EngravingObject. It was initially conceived as a helper for debugging, but I can't say I have ever used it for that purpose. Instead, it has become clear to me that assigning unique IDs to items has extremely useful applications in establishing relationships between items _in our files_. Saving the [start- and end measure of a SystemLock](https://github.com/musescore/MuseScore/pull/25597) was an obvious first one, but the real big one to me will be part-score linking, as I've pointed out [here](https://github.com/musescore/MuseScore/issues/23688). 

The previous implementation of EID had a few shortcomings for this purpose:

- The IDs were incremental and were assigned when constructing every EngravingObject. But because many EngravingObjects are created (or re-created) at the layout stage (and in some cases even at drawing stage...), even doing nothing could cause the ID count to increase.
- A 32-bit ID is fine as a debugging tool, but is way too small to be used with the assumption of uniqueness. The previous point also compounds the problem because it's not unconceivable for it to overflow in a big score.

So, here's a few directions I've proposed:

- I've removed EID as a member variable of EngravingObject.
- No new EID gets created in the EngravingObject constructor.
- The item-EID relationship is stored in a register that exists only in the MasterScore.
- When _reading_ a file, if we encounter items with a saved EID code, we register them and use the register to re-establish all the relationships we need.
- When _writing_ items to file, we check the register again. If the item is already registered, then we reuse the same EID, otherwise we create and register a new one. This has a couple of advantages:
- items that already had an EID are re-saved with the same EID, which eliminates unnecessary diffs in the mscx file (very relevant if we imagine collaboration features in future);
- the unique EIDs are generated only when saving, which means they won't have any significant performance impact in the runtime.
- All of the above is done only for the items which need it (which means only measures, at the moment).

About the implementation details:
- There is a choice to be made between using progressive or random IDs. I decided to go with random IDs because it is quite clearly the most future-proof choice (again, very relevant for online collaboration). Unit testing may become a bit more annoying, but not future-proofing ourselves to avoid testing annoyance doesn't seems like a good tradeoff. Furthermore, thanks to the fact that IDs are actually reused when saving, random IDs may actually not be much of a problem in most tests.
- A 64-bit random number is _probably_ enough for our needs. But again, I'd rather future-proof and be _certain_, so I decided to create 128-bit IDs. 
- Didn't want to use strings to represent the IDs to avoid heap allocations, string comparisons etc. 
- Also didn't want to import external dependencies to create "true" UUIDs cause that's completely overkill imo.
- The best tradeoff between simplicity and safety that I found was to generate a pseudo-128bit-UUID as pair of pseudo-randomly-generated-64bit integers. This can be easily done with standard library tools and gives us a space of 10^38, which mean _we're fine_ 😅.
- Given that the EID register needs to be queried both by item and by eid, I actually implemented it as two separate and "opposite" unordered maps. Which feels wrong, so I'm still trying to think of a better solution. Perhaps just accepting that one of the two query directions is searched sequentially is the better alternative.