### PR TITLE
Improved interactions for System Locks

### DIFF
--- a/src/app/configs/data/shortcuts.xml
+++ b/src/app/configs/data/shortcuts.xml
@@ -798,6 +798,11 @@
     <seq>Ctrl+Enter</seq>
     </SC>
   <SC>
+    <key>apply-system-lock</key>
+    <seq>Alt+Return</seq>
+    <seq>Alt+Enter</seq>
+    </SC>
+  <SC>
     <key>move-measure-to-prev-system</key>
     <seq>Alt+Up</seq>
     </SC>

--- a/src/app/configs/data/shortcuts_azerty.xml
+++ b/src/app/configs/data/shortcuts_azerty.xml
@@ -824,6 +824,11 @@
     <seq>Ctrl+Enter</seq>
     </SC>
   <SC>
+    <key>apply-system-lock</key>
+    <seq>Alt+Return</seq>
+    <seq>Alt+Enter</seq>
+    </SC>
+  <SC>
     <key>move-measure-to-prev-system</key>
     <seq>Alt+Up</seq>
     </SC>

--- a/src/app/configs/data/shortcuts_mac.xml
+++ b/src/app/configs/data/shortcuts_mac.xml
@@ -798,6 +798,11 @@
     <seq>Ctrl+Enter</seq>
     </SC>
   <SC>
+    <key>apply-system-lock</key>
+    <seq>Alt+Return</seq>
+    <seq>Alt+Enter</seq>
+    </SC>
+  <SC>
     <key>move-measure-to-prev-system</key>
     <seq>Alt+Up</seq>
     </SC>

--- a/src/engraving/dom/measure.cpp
+++ b/src/engraving/dom/measure.cpp
@@ -1383,8 +1383,7 @@ bool Measure::acceptDrop(EditData& data) const
         {
             LayoutMode layoutMode = score()->layoutMode();
             if (layoutMode == LayoutMode::PAGE || layoutMode == LayoutMode::SYSTEM) {
-                const System* sys = system();
-                viewer->setDropRectangle(sys->canvasBoundingRect().adjusted(sys->leftMargin(), 0.0, 0.0, 0.0));
+                viewer->setDropRectangle(canvasBoundingRect().adjusted(-x(), 0.0, 0.0, 0.0));
                 return true;
             }
             return false;
@@ -1726,7 +1725,7 @@ EngravingItem* Measure::drop(EditData& data)
             break;
         }
         case ActionIconType::SYSTEM_LOCK:
-            score()->toggleSystemLock({ system() });
+            score()->makeIntoSystem(system()->first(), this);
             break;
         default:
             break;

--- a/src/engraving/dom/score.h
+++ b/src/engraving/dom/score.h
@@ -361,6 +361,7 @@ public:
     void cmdMoveMeasureToPrevSystem();
     void cmdMoveMeasureToNextSystem();
     void cmdToggleSystemLock();
+    void cmdApplyLockToSelection();
     void cmdToggleScoreLock();
     void cmdMakeIntoSystem();
     void cmdAddStaffTypeChange(Measure* measure, staff_idx_t staffIdx, StaffTypeChange* stc);
@@ -1018,6 +1019,7 @@ public:
     void undoRemoveSystemLock(const SystemLock* lock);
     void undoRemoveAllLocks();
     void toggleSystemLock(const std::vector<System*>& systems);
+    void makeIntoSystem(MeasureBase* first, MeasureBase* last);
     void removeSystemLocksOnAddLayoutBreak(LayoutBreakType breakType, const MeasureBase* measure);
     void removeLayoutBreaksOnAddSystemLock(const SystemLock* lock);
 

--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -205,6 +205,7 @@ public:
     virtual void toggleSystemLock() = 0;
     virtual void toggleScoreLock() = 0;
     virtual void makeIntoSystem() = 0;
+    virtual void applySystemLock() = 0;
 
     virtual void addRemoveSystemLocks(AddRemoveSystemLockType intervalType, int interval = 0) = 0;
     virtual bool transpose(const TransposeOptions& options) = 0;

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -256,6 +256,7 @@ void NotationActionController::init()
     registerAction("section-break", &Interaction::toggleLayoutBreak, LayoutBreakType::SECTION, PlayMode::NoPlay,
                    &Controller::toggleLayoutBreakAvailable);
 
+    registerAction("apply-system-lock", &Interaction::applySystemLock);
     registerAction("move-measure-to-prev-system", &Interaction::moveMeasureToPrevSystem);
     registerAction("move-measure-to-next-system", &Interaction::moveMeasureToNextSystem);
     registerAction("toggle-system-lock", &Interaction::toggleSystemLock);

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -1763,7 +1763,7 @@ bool NotationInteraction::applyPaletteElement(mu::engraving::EngravingItem* elem
             mu::engraving::LayoutBreak* breakElement = toLayoutBreak(element);
             score->cmdToggleLayoutBreak(breakElement->layoutBreakType());
         } else if (element->isActionIcon() && toActionIcon(element)->actionType() == ActionIconType::SYSTEM_LOCK) {
-            score->cmdToggleSystemLock();
+            score->cmdApplyLockToSelection();
         } else if (element->isSlur() && addSingle) {
             doAddSlur(toSlur(element));
         } else if (element->isSLine() && !element->isGlissando() && !element->isGuitarBend() && addSingle) {
@@ -2022,9 +2022,7 @@ bool NotationInteraction::applyPaletteElement(mu::engraving::EngravingItem* elem
                 }
             }
         } else if (element->isActionIcon() && toActionIcon(element)->actionType() == ActionIconType::SYSTEM_LOCK) {
-            if (sel.isRange()) {
-                score->toggleSystemLock(sel.selectedSystems());
-            }
+            score->cmdApplyLockToSelection();
         } else {
             track_idx_t track1 = sel.staffStart() * mu::engraving::VOICES;
             track_idx_t track2 = sel.staffEnd() * mu::engraving::VOICES;
@@ -4526,6 +4524,13 @@ void NotationInteraction::makeIntoSystem()
 {
     startEdit(TranslatableString("undoableAction", "Make measure(s) into one system"));
     score()->cmdMakeIntoSystem();
+    apply();
+}
+
+void NotationInteraction::applySystemLock()
+{
+    startEdit(TranslatableString("undoableAction", "Apply system lock to selection"));
+    score()->cmdApplyLockToSelection();
     apply();
 }
 

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -208,6 +208,7 @@ public:
     void toggleSystemLock() override;
     void toggleScoreLock() override;
     void makeIntoSystem() override;
+    void applySystemLock() override;
 
     void addRemoveSystemLocks(AddRemoveSystemLockType intervalType, int interval = 0) override;
     bool transpose(const TransposeOptions& options) override;

--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -631,6 +631,12 @@ const UiActionList NotationUiActions::m_actions = {
              TranslatableString("action", "Add/remove page break"),
              TranslatableString("action", "Add/remove page break")
              ),
+    UiAction("apply-system-lock",
+             mu::context::UiCtxProjectOpened,
+             mu::context::CTX_NOTATION_FOCUSED,
+             TranslatableString("action", "Add/remove system lock"),
+             TranslatableString("action", "Add/remove system lock")
+             ),
     UiAction("move-measure-to-prev-system",
              mu::context::UiCtxProjectOpened,
              mu::context::CTX_NOTATION_FOCUSED,

--- a/src/notation/tests/mocks/notationinteractionmock.h
+++ b/src/notation/tests/mocks/notationinteractionmock.h
@@ -167,6 +167,7 @@ public:
     MOCK_METHOD(void, toggleSystemLock, (), (override));
     MOCK_METHOD(void, toggleScoreLock, (), (override));
     MOCK_METHOD(void, makeIntoSystem, (), (override));
+    MOCK_METHOD(void, applySystemLock, (), (override));
 
     MOCK_METHOD(void, addRemoveSystemLocks, (AddRemoveSystemLockType, int), (override));
     MOCK_METHOD(bool, transpose, (const TransposeOptions&), (override));


### PR DESCRIPTION
Slightly different interaction when adding a Lock from the palette, more similar to the other layout breaks. Also new action with shortcut `alt+Enter` which performs the equivalent operation of "Add system break" (which has shortcut `Enter`) but using system locks.