### PR TITLE
Fix - Command (or Control) F should activate the search field

### DIFF
--- a/src/app/configs/data/shortcuts.xml
+++ b/src/app/configs/data/shortcuts.xml
@@ -828,6 +828,10 @@
     <std>22</std>
     </SC>
   <SC>
+    <key>nav-search-control</key>
+    <std>22</std>
+    </SC>
+  <SC>
     <key>zoomin</key>
     <seq>Ctrl+=</seq>
     </SC>

--- a/src/app/configs/data/shortcuts_azerty.xml
+++ b/src/app/configs/data/shortcuts_azerty.xml
@@ -854,6 +854,10 @@
     <std>22</std>
     </SC>
   <SC>
+    <key>nav-search-control</key>
+    <std>22</std>
+    </SC>
+  <SC>
     <key>zoomin</key>
     <seq>Ctrl++</seq>
     </SC>

--- a/src/app/configs/data/shortcuts_mac.xml
+++ b/src/app/configs/data/shortcuts_mac.xml
@@ -828,6 +828,10 @@
     <std>22</std>
     </SC>
   <SC>
+    <key>nav-search-control</key>
+    <std>22</std>
+    </SC>
+  <SC>
     <key>zoomin</key>
     <seq>Ctrl++</seq>
     </SC>

--- a/src/appshell/qml/DevTools/Preferences/SettingsPage.qml
+++ b/src/appshell/qml/DevTools/Preferences/SettingsPage.qml
@@ -41,6 +41,7 @@ ColumnLayout {
 
     SearchField {
         id: searchField
+        navigation.name: "SearchControl"
     }
 
     StyledListView {

--- a/src/appshell/qml/HomePage/PluginsPage.qml
+++ b/src/appshell/qml/HomePage/PluginsPage.qml
@@ -104,7 +104,7 @@ FocusScope {
 
                 Layout.preferredWidth: 220
 
-                navigation.name: "PluginsSearch"
+                navigation.name: "SearchControl"
                 navigation.panel: navTopPanel
                 navigation.order: 1
                 accessible.name: qsTrc("appshell", "Plugins search")

--- a/src/appshell/qml/Preferences/internal/AdvancedTopSection.qml
+++ b/src/appshell/qml/Preferences/internal/AdvancedTopSection.qml
@@ -66,7 +66,7 @@ BaseSection {
             //: Search advanced preferences
             hint: qsTrc("appshell/preferences", "Search advanced")
 
-            navigation.name: "SearchAdvancedField"
+            navigation.name: "SearchControl"
             navigation.panel: root.navigation
             navigation.column: 1
         }

--- a/src/framework/learn/qml/Muse/Learn/LearnPage.qml
+++ b/src/framework/learn/qml/Muse/Learn/LearnPage.qml
@@ -110,7 +110,7 @@ FocusScope {
 
             Layout.preferredWidth: 220
 
-            navigation.name: "LearnSearch"
+            navigation.name: "SearchControl"
             navigation.panel: navSearchPanel
             navigation.order: 1
 

--- a/src/framework/shortcuts/qml/Muse/Shortcuts/internal/ShortcutsTopPanel.qml
+++ b/src/framework/shortcuts/qml/Muse/Shortcuts/internal/ShortcutsTopPanel.qml
@@ -96,7 +96,7 @@ RowLayout {
 
         hint: qsTrc("shortcuts", "Search shortcut")
 
-        navigation.name: "ShortcutSearchField"
+        navigation.name: "SearchControl"
         navigation.panel: root.navigation
         navigation.column: 2
     }

--- a/src/framework/ui/internal/navigationcontroller.h
+++ b/src/framework/ui/internal/navigationcontroller.h
@@ -115,6 +115,8 @@ private:
     void goToLastControl();
     void goToNextRowControl();
     void goToPrevRowControl();
+    bool activateSearchControl(INavigationSection* activeSec);
+    void goToSearchControl();
 
     void goToControl(MoveDirection direction, INavigationPanel* activePanel = nullptr);
 

--- a/src/framework/ui/internal/navigationuiactions.cpp
+++ b/src/framework/ui/internal/navigationuiactions.cpp
@@ -95,6 +95,10 @@ const UiActionList NavigationUiActions::m_actions = {
     UiAction("nav-prevrow-control",
              ui::UiCtxAny,
              muse::shortcuts::CTX_NOT_PROJECT_FOCUSED
+             ),
+    UiAction("nav-search-control",
+             ui::UiCtxAny,
+             muse::shortcuts::CTX_ANY
              )
 };
 

--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/InstrumentsView.qml
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/InstrumentsView.qml
@@ -63,7 +63,7 @@ Item {
         anchors.left: parent.left
         anchors.right: parent.right
 
-        navigation.name: "SearchInstruments"
+        navigation.name: "SearchControl"
         navigation.panel: instrumentsView.navigation
         navigation.row: 1
         navigation.column: 0

--- a/src/palette/qml/MuseScore/Palette/internal/PalettesPanelHeader.qml
+++ b/src/palette/qml/MuseScore/Palette/internal/PalettesPanelHeader.qml
@@ -174,6 +174,7 @@ Item {
         objectName: "SearchPalettesField"
         width: parent.width
 
+        navigation.name: "SearchControl"
         navigation.panel: navPanel
         navigation.order: 3
         navigation.onActiveChanged: {

--- a/src/project/qml/MuseScore/Project/ScoresPage.qml
+++ b/src/project/qml/MuseScore/Project/ScoresPage.qml
@@ -102,7 +102,7 @@ FocusScope {
 
             Layout.preferredWidth: 220
 
-            navigation.name: "Scores Search"
+            navigation.name: "SearchControl"
             navigation.panel: navSearchPanel
             navigation.order: 1
             accessible.name: qsTrc("project", "Search recent scores")

--- a/src/project/qml/MuseScore/Project/internal/NewScore/TitleListView.qml
+++ b/src/project/qml/MuseScore/Project/internal/NewScore/TitleListView.qml
@@ -60,7 +60,7 @@ Item {
         anchors.top: title.bottom
         anchors.topMargin: 16
 
-        navigation.name: "Search"
+        navigation.name: "SearchControl"
         navigation.panel: view.navigation
         navigation.row: 1
 


### PR DESCRIPTION
Resolves: #22420 

Also Implemented in Palettes Panel but it might conflict with the Find/Go To search Field shortcut.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
