### PR TITLE
Fix #22382 Part 2: Add new preference to play notes on muted tracks when editing

### DIFF
--- a/src/appshell/qml/Preferences/NoteInputPreferencesPage.qml
+++ b/src/appshell/qml/Preferences/NoteInputPreferencesPage.qml
@@ -70,6 +70,7 @@ PreferencesPage {
             playNotesWhenEditing: noteInputModel.playNotesWhenEditing
             playChordWhenEditing: noteInputModel.playChordWhenEditing
             playChordSymbolWhenEditing: noteInputModel.playChordSymbolWhenEditing
+            playNotesOnMutedTracksWhenEditing: noteInputModel.playNotesOnMutedTracksWhenEditing
             notePlayDurationMilliseconds: noteInputModel.notePlayDurationMilliseconds
 
             navigation.section: root.navigationSection
@@ -85,6 +86,10 @@ PreferencesPage {
 
             onPlayChordSymbolWhenEditingChangeRequested: function(play) {
                 noteInputModel.playChordSymbolWhenEditing = play
+            }
+
+            onPlayNotesOnMutedTracksWhenEditingChangeRequested: function(play) {
+                noteInputModel.playNotesOnMutedTracksWhenEditing = play
             }
 
             onNotePlayDurationChangeRequested: function(duration) {

--- a/src/appshell/qml/Preferences/internal/NoteInputPlaySection.qml
+++ b/src/appshell/qml/Preferences/internal/NoteInputPlaySection.qml
@@ -30,11 +30,13 @@ BaseSection {
     property alias playNotesWhenEditing: playNotesBox.checked
     property alias playChordWhenEditing: playChordBox.checked
     property alias playChordSymbolWhenEditing: playChordSymbolBox.checked
+    property alias playNotesOnMutedTracksWhenEditing: playNotesOnMutedTracksBox.checked
     property alias notePlayDurationMilliseconds: notePlayDurationControl.currentValue
 
     signal playNotesWhenEditingChangeRequested(bool play)
     signal playChordWhenEditingChangeRequested(bool play)
     signal playChordSymbolWhenEditingChangeRequested(bool play)
+    signal playNotesOnMutedTracksWhenEditingChangeRequested(bool play)
     signal notePlayDurationChangeRequested(int duration)
 
     CheckBox {
@@ -106,6 +108,22 @@ BaseSection {
 
         onClicked: {
             root.playChordSymbolWhenEditingChangeRequested(!checked)
+        }
+    }
+    CheckBox {
+        id: playNotesOnMutedTracksBox
+        width: parent.width
+
+        text: qsTrc("appshell/preferences", "Play notes on muted tracks")
+
+        enabled: root.playNotesWhenEditing
+
+        navigation.name: "playNotesOnMutedTracksBox"
+        navigation.panel: root.navigation
+        navigation.row: 4
+
+        onClicked: {
+            root.playNotesOnMutedTracksWhenEditingChangeRequested(!checked)
         }
     }
 }

--- a/src/appshell/view/preferences/noteinputpreferencesmodel.cpp
+++ b/src/appshell/view/preferences/noteinputpreferencesmodel.cpp
@@ -71,6 +71,11 @@ bool NoteInputPreferencesModel::playChordSymbolWhenEditing() const
     return playbackConfiguration()->playHarmonyWhenEditing();
 }
 
+bool NoteInputPreferencesModel::playNotesOnMutedTracksWhenEditing() const
+{
+    return playbackConfiguration()->playNotesOnMutedTracksWhenEditing();
+}
+
 bool NoteInputPreferencesModel::dynamicsApplyToAllVoices() const
 {
     return engravingConfiguration()->dynamicsApplyToAllVoices();
@@ -154,6 +159,16 @@ void NoteInputPreferencesModel::setPlayChordSymbolWhenEditing(bool value)
 
     playbackConfiguration()->setPlayHarmonyWhenEditing(value);
     emit playChordSymbolWhenEditingChanged(value);
+}
+
+void NoteInputPreferencesModel::setPlayNotesOnMutedTracksWhenEditing(bool value)
+{
+    if (value == playNotesOnMutedTracksWhenEditing()) {
+        return;
+    }
+
+    playbackConfiguration()->setPlayNotesOnMutedTracksWhenEditing(value);
+    emit playNotesOnMutedTracksWhenEditingChanged(value);
 }
 
 void NoteInputPreferencesModel::setDynamicsApplyToAllVoices(bool value)

--- a/src/appshell/view/preferences/noteinputpreferencesmodel.h
+++ b/src/appshell/view/preferences/noteinputpreferencesmodel.h
@@ -51,6 +51,8 @@ class NoteInputPreferencesModel : public QObject, public muse::Injectable
     Q_PROPERTY(
         bool playChordSymbolWhenEditing READ playChordSymbolWhenEditing WRITE setPlayChordSymbolWhenEditing NOTIFY playChordSymbolWhenEditingChanged)
     Q_PROPERTY(
+        bool playNotesOnMutedTracksWhenEditing READ playNotesOnMutedTracksWhenEditing WRITE setPlayNotesOnMutedTracksWhenEditing NOTIFY playNotesOnMutedTracksWhenEditingChanged)
+    Q_PROPERTY(
         bool dynamicsApplyToAllVoices READ dynamicsApplyToAllVoices WRITE setDynamicsApplyToAllVoices NOTIFY dynamicsApplyToAllVoicesChanged FINAL)
 
     muse::Inject<muse::shortcuts::IShortcutsConfiguration> shortcutsConfiguration = { this };
@@ -70,6 +72,7 @@ public:
     int notePlayDurationMilliseconds() const;
     bool playChordWhenEditing() const;
     bool playChordSymbolWhenEditing() const;
+    bool playNotesOnMutedTracksWhenEditing() const;
 
     bool dynamicsApplyToAllVoices() const;
 
@@ -82,6 +85,7 @@ public slots:
     void setNotePlayDurationMilliseconds(int duration);
     void setPlayChordWhenEditing(bool value);
     void setPlayChordSymbolWhenEditing(bool value);
+    void setPlayNotesOnMutedTracksWhenEditing(bool value);
     void setDynamicsApplyToAllVoices(bool value);
 
 signals:
@@ -93,6 +97,7 @@ signals:
     void notePlayDurationMillisecondsChanged(int duration);
     void playChordWhenEditingChanged(bool value);
     void playChordSymbolWhenEditingChanged(bool value);
+    void playNotesOnMutedTracksWhenEditingChanged(bool value);
     void dynamicsApplyToAllVoicesChanged(bool value);
 };
 }

--- a/src/framework/audio/audiomodule.cpp
+++ b/src/framework/audio/audiomodule.cpp
@@ -48,12 +48,6 @@
 
 #include "log.h"
 
-using namespace muse;
-using namespace muse::modularity;
-using namespace muse::audio;
-using namespace muse::audio::synth;
-using namespace muse::audio::fx;
-
 #ifdef MUSE_MODULE_AUDIO_JACK
 #include "internal/platform/jack/jackaudiodriver.h"
 #endif
@@ -78,6 +72,12 @@ using namespace muse::audio::fx;
 #ifdef Q_OS_WASM
 #include "internal/platform/web/webaudiodriver.h"
 #endif
+
+using namespace muse;
+using namespace muse::modularity;
+using namespace muse::audio;
+using namespace muse::audio::synth;
+using namespace muse::audio::fx;
 
 static void measureInputLag(const float* buf, const size_t size)
 {

--- a/src/framework/audio/internal/worker/mixerchannel.h
+++ b/src/framework/audio/internal/worker/mixerchannel.h
@@ -25,6 +25,8 @@
 #include "global/modularity/ioc.h"
 #include "global/async/asyncable.h"
 #include "global/async/notification.h"
+#include "playback/iplaybackcontroller.h"
+#include "playback/iplaybackconfiguration.h"
 
 #include "../../ifxresolver.h"
 #include "../../ifxprocessor.h"
@@ -35,6 +37,8 @@ namespace muse::audio {
 class MixerChannel : public ITrackAudioOutput, public Injectable, public async::Asyncable
 {
     Inject<fx::IFxResolver> fxResolver = { this };
+    muse::Inject<mu::playback::IPlaybackController> playbackController = { };
+    muse::Inject<mu::playback::IPlaybackConfiguration> playbackConfiguration = { this };
 
 public:
     explicit MixerChannel(const TrackId trackId, IAudioSourcePtr source, const unsigned int sampleRate,
@@ -66,6 +70,7 @@ public:
 
 private:
     void completeOutput(float* buffer, unsigned int samplesCount) const;
+    bool playNotesOnMutedTracksWhenEditing() const;
 
     TrackId m_trackId = -1;
 

--- a/src/playback/internal/playbackconfiguration.cpp
+++ b/src/playback/internal/playbackconfiguration.cpp
@@ -39,6 +39,7 @@ static const Settings::Key PLAYBACK_CURSOR_TYPE_KEY(moduleName, "application/pla
 static const Settings::Key PLAY_NOTES_WHEN_EDITING(moduleName, "score/note/playOnClick");
 static const Settings::Key PLAY_CHORD_WHEN_EDITING(moduleName, "score/chord/playOnAddNote");
 static const Settings::Key PLAY_HARMONY_WHEN_EDITING(moduleName, "score/harmony/play/onedit");
+static const Settings::Key PLAY_NOTES_ON_MUTED_TRACKS_WHEN_EDITING(moduleName, "score/note/playOnMutedTracks");
 
 static const Settings::Key SOUND_PRESETS_MULTI_SELECTION_KEY(moduleName, "application/playback/soundPresetsMultiSelectionEnabled");
 
@@ -94,6 +95,8 @@ void PlaybackConfiguration::init()
     settings()->setDefaultValue(PLAY_NOTES_WHEN_EDITING, Val(true));
     settings()->setDefaultValue(PLAY_CHORD_WHEN_EDITING, Val(true));
     settings()->setDefaultValue(PLAY_HARMONY_WHEN_EDITING, Val(true));
+    settings()->setDefaultValue(PLAY_NOTES_ON_MUTED_TRACKS_WHEN_EDITING, Val(false));
+
     settings()->setDefaultValue(PLAYBACK_CURSOR_TYPE_KEY, Val(PlaybackCursorType::STEPPED));
     settings()->setDefaultValue(SOUND_PRESETS_MULTI_SELECTION_KEY, Val(false));
     settings()->setDefaultValue(MIXER_RESET_SOUND_FLAGS_WHEN_CHANGE_SOUND_WARNING, Val(true));
@@ -159,6 +162,16 @@ bool PlaybackConfiguration::playHarmonyWhenEditing() const
 void PlaybackConfiguration::setPlayHarmonyWhenEditing(bool value)
 {
     settings()->setSharedValue(PLAY_HARMONY_WHEN_EDITING, Val(value));
+}
+
+bool PlaybackConfiguration::playNotesOnMutedTracksWhenEditing() const
+{
+    return settings()->value(PLAY_NOTES_ON_MUTED_TRACKS_WHEN_EDITING).toBool();
+}
+
+void PlaybackConfiguration::setPlayNotesOnMutedTracksWhenEditing(bool value)
+{
+    settings()->setSharedValue(PLAY_NOTES_ON_MUTED_TRACKS_WHEN_EDITING, Val(value));
 }
 
 PlaybackCursorType PlaybackConfiguration::cursorType() const

--- a/src/playback/internal/playbackconfiguration.h
+++ b/src/playback/internal/playbackconfiguration.h
@@ -47,6 +47,9 @@ public:
     bool playHarmonyWhenEditing() const override;
     void setPlayHarmonyWhenEditing(bool value) override;
 
+    bool playNotesOnMutedTracksWhenEditing() const override;
+    void setPlayNotesOnMutedTracksWhenEditing(bool value) override;
+
     PlaybackCursorType cursorType() const override;
 
     bool isMixerSectionVisible(MixerSectionType sectionType) const override;

--- a/src/playback/iplaybackconfiguration.h
+++ b/src/playback/iplaybackconfiguration.h
@@ -40,6 +40,9 @@ public:
     virtual bool playChordWhenEditing() const = 0;
     virtual void setPlayChordWhenEditing(bool value) = 0;
 
+    virtual bool playNotesOnMutedTracksWhenEditing() const = 0;
+    virtual void setPlayNotesOnMutedTracksWhenEditing(bool value) = 0;
+
     virtual bool playHarmonyWhenEditing() const = 0;
     virtual void setPlayHarmonyWhenEditing(bool value) = 0;
 

--- a/src/stubs/playback/playbackconfigurationstub.cpp
+++ b/src/stubs/playback/playbackconfigurationstub.cpp
@@ -51,6 +51,15 @@ void PlaybackConfigurationStub::setPlayHarmonyWhenEditing(bool)
 {
 }
 
+bool PlaybackConfigurationStub::playNotesOnMutedTracksWhenEditing() const
+{
+    return false;
+}
+
+void PlaybackConfigurationStub::setPlayNotesOnMutedTracksWhenEditing(bool)
+{
+}
+
 PlaybackCursorType PlaybackConfigurationStub::cursorType() const
 {
     return PlaybackCursorType::SMOOTH;

--- a/src/stubs/playback/playbackconfigurationstub.h
+++ b/src/stubs/playback/playbackconfigurationstub.h
@@ -37,6 +37,9 @@ public:
     bool playHarmonyWhenEditing() const override;
     void setPlayHarmonyWhenEditing(bool value) override;
 
+    bool playNotesOnMutedTracksWhenEditing() const override;
+    void setPlayNotesOnMutedTracksWhenEditing(bool value) override;
+
     PlaybackCursorType cursorType() const override;
 
     bool isMixerSectionVisible(MixerSectionType sectionType) const override;


### PR DESCRIPTION
Resolves: #22382 Part 2<!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
This pull request implement the second (and last) part of the functionality as described in **"2. Add a new preference to control whether, when the above preference is ON, you hear notes added/clicked/selected on instruments that are muted in the mixer."** section

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [X] I created a unit test or vtest to verify the changes I made (if applicable)
