### PR TITLE
Fix crash on measure-layout tag in first measure of piece

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -2889,7 +2889,7 @@ void MusicXmlParserPass2::measureLayout(Measure* measure)
     while (m_e.readNextStartElement()) {
         if (m_e.name() == "measure-distance") {
             const Spatium val(m_e.readDouble() / 10.0);
-            if (!measure->prev()->isHBox()) {
+            if (!measure->prev() || !measure->prev()->isHBox()) {
                 MeasureBase* gap = m_score->insertBox(ElementType::HBOX, measure);
                 toHBox(gap)->setBoxWidth(val);
             }


### PR DESCRIPTION
Resolves: #25710 
The crash was caused by a missing null check.  
We also need to insert an `HBox` before the first measure of a score if the first measure has a `measure-layout` tag.