### PR TITLE
Fix MSVC and macOS (Clang) compiler warnings

### DIFF
--- a/src/engraving/dom/tie.cpp
+++ b/src/engraving/dom/tie.cpp
@@ -248,7 +248,7 @@ void Tie::updatePossibleJumpPoints()
             continue;
         }
 
-        Note* nextNote = searchTieNote(note, firstCrSeg);
+        nextNote = searchTieNote(note, firstCrSeg);
 
         if (nextNote) {
             bool hasIncomingTie = nextNote->tieBack();

--- a/src/engraving/dom/timesig.h
+++ b/src/engraving/dom/timesig.h
@@ -119,8 +119,8 @@ public:
     EngravingItem* prevSegmentElement() override;
     String accessibleInfo() const override;
 
-    void initElementStyle(const ElementStyle*);
-    void styleChanged();
+    void initElementStyle(const ElementStyle*) override;
+    void styleChanged() override;
     Sid getPropertyStyle(Pid id) const override;
 
     bool showOnThisStaff() const;

--- a/src/engraving/infrastructure/eidregister.cpp
+++ b/src/engraving/infrastructure/eidregister.cpp
@@ -44,6 +44,10 @@ void EIDRegister::registerItemEID(const EID& eid, const EngravingObject* item)
 
     inserted = m_itemToEid.emplace(const_cast<EngravingObject*>(item), eid).second;
     assert(inserted);
+
+#ifdef NDEBUG
+    UNUSED(inserted);
+#endif
 }
 
 EngravingObject* EIDRegister::itemFromEID(const EID& eid) const

--- a/src/engraving/playback/playbackmodel.cpp
+++ b/src/engraving/playback/playbackmodel.cpp
@@ -950,9 +950,10 @@ PlaybackContextPtr PlaybackModel::playbackCtx(const InstrumentTrackId& trackId)
 
 void PlaybackModel::applyTiedNotesTickBoundaries(const Note* note, TickBoundaries& tickBoundaries)
 {
-    if (const Tie* tie = note->tieFor()) {
+    const Tie* tie;
+    if (tie = note->tieFor()) {
         applyTieTickBoundaries(tie, tickBoundaries);
-    } else if (const Tie* tie = note->tieBack()) {
+    } else if (tie = note->tieBack()) {
         applyTieTickBoundaries(tie, tickBoundaries);
     }
 }

--- a/src/engraving/tests/playback/playbackeventsrendering_tests.cpp
+++ b/src/engraving/tests/playback/playbackeventsrendering_tests.cpp
@@ -1105,11 +1105,11 @@ TEST_F(Engraving_PlaybackEventsRendererTests, Glissando_on_tied_notes)
 
     ASSERT_EQ(result.size(), 1);
     ASSERT_EQ(result.begin()->second.size(), 1);
-    mpe::NoteEvent noteEvent = std::get<mpe::NoteEvent>(result.begin()->second.at(0));
-    EXPECT_EQ(noteEvent.expressionCtx().articulations.size(), 1);
-    EXPECT_TRUE(noteEvent.expressionCtx().articulations.contains(ArticulationType::Standard));
-    EXPECT_EQ(noteEvent.pitchCtx().nominalPitchLevel, nominalPitchLevel);
-    EXPECT_EQ(noteEvent.arrangementCtx().nominalDuration, QUARTER_NOTE_DURATION + glissandoNoteDuration); // A4 + 1st glissando note
+    mpe::NoteEvent resultingNoteEvent = std::get<mpe::NoteEvent>(result.begin()->second.at(0));
+    EXPECT_EQ(resultingNoteEvent.expressionCtx().articulations.size(), 1);
+    EXPECT_TRUE(resultingNoteEvent.expressionCtx().articulations.contains(ArticulationType::Standard));
+    EXPECT_EQ(resultingNoteEvent.pitchCtx().nominalPitchLevel, nominalPitchLevel);
+    EXPECT_EQ(resultingNoteEvent.arrangementCtx().nominalDuration, QUARTER_NOTE_DURATION + glissandoNoteDuration); // A4 + 1st glissando note
 
     // [GIVEN] Tied A4 with discrete glissando
     chord = findChord(score, 1440, 0);
@@ -2350,11 +2350,11 @@ TEST_F(Engraving_PlaybackEventsRendererTests, Single_Note_Tremolo_OnTiedNote)
     // [THEN] Note event has normal duration and standard articulation (no tremolo)
     ASSERT_EQ(result.size(), 1);
     ASSERT_EQ(result.begin()->second.size(), 1);
-    mpe::NoteEvent noteEvent = std::get<mpe::NoteEvent>(result.begin()->second.at(0));
-    EXPECT_EQ(noteEvent.expressionCtx().articulations.size(), 1);
-    EXPECT_TRUE(noteEvent.expressionCtx().articulations.contains(ArticulationType::Standard));
-    EXPECT_EQ(noteEvent.pitchCtx().nominalPitchLevel, pitchLevel(PitchClass::A, 4));
-    EXPECT_EQ(noteEvent.arrangementCtx().nominalDuration, HALF_NOTE_DURATION);
+    mpe::NoteEvent resultingNoteEvent = std::get<mpe::NoteEvent>(result.begin()->second.at(0));
+    EXPECT_EQ(resultingNoteEvent.expressionCtx().articulations.size(), 1);
+    EXPECT_TRUE(resultingNoteEvent.expressionCtx().articulations.contains(ArticulationType::Standard));
+    EXPECT_EQ(resultingNoteEvent.pitchCtx().nominalPitchLevel, pitchLevel(PitchClass::A, 4));
+    EXPECT_EQ(resultingNoteEvent.arrangementCtx().nominalDuration, HALF_NOTE_DURATION);
 
     // [GIVEN] Chord of the 2nd tied note (with tremolo)
     chord = findChord(score, 2880);

--- a/src/importexport/guitarpro/internal/guitarbendimport/benddatacollector.cpp
+++ b/src/importexport/guitarpro/internal/guitarbendimport/benddatacollector.cpp
@@ -63,7 +63,7 @@ BendDataContext BendDataCollector::collectBendDataContext()
     for (const auto& [track, trackInfo] : m_bendInfoForNote) {
         for (const auto& [tick, tickInfo] : trackInfo) {
             for (const auto& [note, importedBendInfo] : tickInfo) {
-                int idx = muse::indexOf(note->chord()->notes(), note);
+                int idx = static_cast<int>(muse::indexOf(note->chord()->notes(), note));
                 fillBendDataForNote(bendDataCtx, importedBendInfo, idx);
             }
         }

--- a/src/importexport/guitarpro/internal/guitarbendimport/benddataprocessor.cpp
+++ b/src/importexport/guitarpro/internal/guitarbendimport/benddataprocessor.cpp
@@ -158,7 +158,7 @@ static void createGuitarBends(const BendDataContext& bendDataCtx, mu::engraving:
         Note* startNote = startChordNotes[noteIndex];
         Note* note = endChordNotes[noteIndex];
 
-        if (bendChordData.noteDataByIdx.find(noteIndex) == bendChordData.noteDataByIdx.end()) {
+        if (bendChordData.noteDataByIdx.find(static_cast<int>(noteIndex)) == bendChordData.noteDataByIdx.end()) {
             Tie* tie = Factory::createTie(score->dummy());
             startNote->add(tie);
             tie->setEndNote(note);

--- a/src/importexport/guitarpro/internal/guitarbendimport/benddataprocessor.cpp
+++ b/src/importexport/guitarpro/internal/guitarbendimport/benddataprocessor.cpp
@@ -166,20 +166,19 @@ static void createGuitarBends(const BendDataContext& bendDataCtx, mu::engraving:
             continue;
         }
 
-        const auto& bendNoteData = bendChordData.noteDataByIdx.at(noteIndex);
-        int pitch = bendNoteData.quarterTones / 2;
+        const auto& bendNoteData = bendChordData.noteDataByIdx.at(static_cast<int>(noteIndex));
+        const int pitch = bendNoteData.quarterTones / 2;
 
         if (bendNoteData.type == GuitarBendType::PRE_BEND) {
-            int pitch = bendNoteData.quarterTones / 2;
             note->setPitch(note->pitch() + pitch);
             note->setTpcFromPitch();
             GuitarBend* bend = score->addGuitarBend(bendNoteData.type, note);
             QuarterOffset quarterOff = bendNoteData.quarterTones % 2 ? QuarterOffset::QUARTER_SHARP : QuarterOffset::NONE;
             bend->setEndNotePitch(note->pitch(), quarterOff);
-            Note* startNote = bend->startNote();
-            if (startNote) {
-                startNote->setPitch(note->pitch() - pitch);
-                startNote->setTpcFromPitch();
+            Note* bendStartNote = bend->startNote();
+            if (bendStartNote) {
+                bendStartNote->setPitch(note->pitch() - pitch);
+                bendStartNote->setTpcFromPitch();
             }
         } else if (bendNoteData.type == GuitarBendType::SLIGHT_BEND) {
             GuitarBend* bend = score->addGuitarBend(bendNoteData.type, note);

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -8157,9 +8157,9 @@ void MusicXmlParserNotations::articulations()
             const String smufl = m_e.attribute("smufl");
 
             if (!smufl.empty()) {
-                SymId id = SymNames::symIdByName(smufl, SymId::noSym);
+                SymId sid = SymNames::symIdByName(smufl, SymId::noSym);
                 Notation artic = Notation::notationWithAttributes(String::fromAscii(m_e.name().ascii()),
-                                                                  m_e.attributes(), u"articulations", id);
+                                                                  m_e.attributes(), u"articulations", sid);
                 m_notations.push_back(artic);
             }
             m_e.skipCurrentElement();  // skip but don't log

--- a/src/musesounds/internal/musesoundsrepository.cpp
+++ b/src/musesounds/internal/musesoundsrepository.cpp
@@ -151,8 +151,8 @@ SoundCatalogueInfoList MuseSoundsRepository::parseSounds(const JsonDocument& sou
 
     std::string museSoundsAppName = platformMuseSoundsAppName();
 
-    for (size_t i = 0; i < catalogs.size(); ++i) {
-        JsonObject catalogueObj = catalogs.at(i).toObject();
+    for (size_t catalogIdx = 0; catalogIdx < catalogs.size(); ++catalogIdx) {
+        JsonObject catalogueObj = catalogs.at(catalogIdx).toObject();
         if (catalogueObj.empty()) {
             continue;
         }
@@ -165,8 +165,8 @@ SoundCatalogueInfoList MuseSoundsRepository::parseSounds(const JsonDocument& sou
             continue;
         }
 
-        for (size_t i = 0; i < soundsItems.size(); ++i) {
-            JsonObject soundItemObj = soundsItems.at(i).toObject();
+        for (size_t soundIdx = 0; soundIdx < soundsItems.size(); ++soundIdx) {
+            JsonObject soundItemObj = soundsItems.at(soundIdx).toObject();
             if (soundItemObj.empty()) {
                 continue;
             }


### PR DESCRIPTION
* reg.: declaration of 'xxx' hides previous local declaration (C4456)
* reg.: conversion from 'size_t' to 'int', possible loss of data (C4267)
* reg.: overrides a member function but is not marked 'override' [-Winconsistent-missing-override] (generates a lot of noise in the mac builds)
* reg.: variable set but not used [-Wunused-but-set-variable]