### PR TITLE
Percussion panel - first round of refinements

### DIFF
--- a/src/framework/ui/view/iconcodes.h
+++ b/src/framework/ui/view/iconcodes.h
@@ -435,6 +435,8 @@ public:
         TIE_CHORD_OUTSIDE = 0xF466,
         TIE_CHORD_INSIDE = 0xF467,
 
+        SINGLE_NOTE = 0xF46C,
+
         TRIANGLE_SYMBOL = 0xF46D,
 
         FRETBOARD_VERTICAL = 0xF46F,

--- a/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
+++ b/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
@@ -271,7 +271,7 @@ Item {
             anchors.topMargin: (padGrid.cellHeight / 2) - (panelDisabledLabel.height / 2)
 
             font: ui.theme.bodyFont
-            text: qsTrc("notation", "Select an unpitched percussion staff to use available sounds")
+            text: qsTrc("notation", "Select an unpitched percussion staff to see available sounds")
         }
     }
 }

--- a/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
+++ b/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
@@ -89,6 +89,8 @@ Item {
         contentWidth: rowLayout.width
         contentHeight: rowLayout.height
 
+        StyledScrollBar.vertical: verticalScrollBar
+
         function goToBottom() {
             var endY = flickable.contentHeight * (1.0 - flickable.visibleArea.heightRatio)
             flickable.contentY = endY
@@ -273,5 +275,11 @@ Item {
             font: ui.theme.bodyFont
             text: qsTrc("notation", "Select an unpitched percussion staff to see available sounds")
         }
+    }
+
+    StyledScrollBar {
+        id: verticalScrollBar
+        height: root.height
+        anchors.right: root.right
     }
 }

--- a/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPadContent.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPadContent.qml
@@ -132,6 +132,17 @@ Column {
             text: Boolean(root.padModel) ? root.padModel.keyboardShortcut : ""
         }
 
+        StyledIconLabel {
+            id: midiNoteIcon
+
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.right: midiNoteLabel.left
+
+            color: ui.theme.fontPrimaryColor
+
+            iconCode: IconCode.SINGLE_NOTE
+        }
+
         StyledTextLabel {
             id: midiNoteLabel
 

--- a/src/notation/view/percussionpanel/percussionpanelmodel.cpp
+++ b/src/notation/view/percussionpanel/percussionpanelmodel.cpp
@@ -124,7 +124,9 @@ QList<QVariantMap> PercussionPanelModel::layoutMenuItems() const
     // Using IconCode for this instead of "checked" because we want the tick to display on the left
     const int notationPreviewIcon = static_cast<int>(m_useNotationPreview ? IconCode::Code::TICK_RIGHT_ANGLE : IconCode::Code::NONE);
 
-    const TranslatableString editLayoutTitle("notation", "Edit layout");
+    const TranslatableString editLayoutTitle = m_currentPanelMode == PanelMode::Mode::EDIT_LAYOUT
+                                               ? TranslatableString("notation", "Finish editing")
+                                               : TranslatableString("notation", "Edit layout");
     const int editLayoutIcon = static_cast<int>(IconCode::Code::CONFIGURE);
 
     const TranslatableString resetLayoutTitle("notation", "Reset layout");
@@ -156,7 +158,8 @@ void PercussionPanelModel::handleMenuItem(const QString& itemId)
     } else if (itemId == NOTATION_PREVIEW_CODE) {
         setUseNotationPreview(true);
     } else if (itemId == EDIT_LAYOUT_CODE) {
-        setCurrentPanelMode(PanelMode::Mode::EDIT_LAYOUT, false);
+        const bool currentlyEditing = m_currentPanelMode == PanelMode::Mode::EDIT_LAYOUT;
+        currentlyEditing ? finishEditing() : setCurrentPanelMode(PanelMode::Mode::EDIT_LAYOUT, false);
     } else if (itemId == RESET_LAYOUT_CODE) {
         // TODO: Need a mechanism for "default" layouts...
         // m_padListModel->resetLayout();


### PR DESCRIPTION
This PR contains a handful of refinements for the percussion panel:

1. Minor copy change for the "disabled" panel state per designers' request ("see" instead of "use")
2. While in edit layout mode, opening the layout menu will give you an option to finish editing
3. A small "single note" icon is shown next to the midi note lable
4. The vertical scroll bar is now positioned to the right of the panel (instead of immediately to the right of the pads)