### PR TITLE
Fix #25702: Update shortcut definitions in "Playback settings" context without restarting

### DIFF
--- a/src/framework/ui/uiaction.h
+++ b/src/framework/ui/uiaction.h
@@ -91,7 +91,7 @@ struct UiAction
                && description == other.description
                && iconCode == other.iconCode
                && checkable == other.checkable
-               && shortcuts == shortcuts;
+               && shortcuts == other.shortcuts;
     }
 };
 

--- a/src/framework/uicomponents/view/abstractmenumodel.cpp
+++ b/src/framework/uicomponents/view/abstractmenumodel.cpp
@@ -106,6 +106,10 @@ void AbstractMenuModel::load()
     uiActionsRegister()->actionStateChanged().onReceive(this, [this](const ActionCodeList& codes) {
         onActionsStateChanges(codes);
     });
+
+    shortcutsRegister()->shortcutsChanged().onNotify(this, [this]() {
+        updateShortcutsAll();
+    });
 }
 
 QVariantList AbstractMenuModel::itemsProperty() const
@@ -314,4 +318,42 @@ MenuItem& AbstractMenuModel::menu(MenuItemList& items, const QString& menuId)
 
     static MenuItem dummy;
     return dummy;
+}
+
+void AbstractMenuModel::updateShortcutsMenuItem(const std::vector<MenuItem*>& menuItemList)
+{
+    auto screg = shortcutsRegister();
+
+    for (MenuItem* menuItem : menuItemList) {
+        if (!menuItem) {
+            continue;
+        }
+
+        UiAction action = menuItem->action();
+        action.shortcuts = screg->shortcut(action.code).sequences;
+        menuItem->setAction(action);
+
+        std::vector<MenuItem*> subMenuItemList;
+        for (MenuItem* menuSubItem : menuItem->subitems()) {
+            if (!menuSubItem) {
+                continue;
+            }
+            subMenuItemList.insert(subMenuItemList.end(), menuSubItem);
+        }
+        updateShortcutsMenuItem(subMenuItemList);
+    }
+}
+
+void AbstractMenuModel::updateShortcutsAll()
+{
+    std::vector<MenuItem*> menuItemList;
+
+    for (MenuItem* menuItem : m_items) {
+        if (!menuItem) {
+            continue;
+        }
+        menuItemList.insert(menuItemList.end(), menuItem);
+    }
+
+    updateShortcutsMenuItem(menuItemList);
 }

--- a/src/framework/uicomponents/view/abstractmenumodel.cpp
+++ b/src/framework/uicomponents/view/abstractmenumodel.cpp
@@ -320,40 +320,28 @@ MenuItem& AbstractMenuModel::menu(MenuItemList& items, const QString& menuId)
     return dummy;
 }
 
-void AbstractMenuModel::updateShortcutsMenuItem(const std::vector<MenuItem*>& menuItemList)
-{
-    auto screg = shortcutsRegister();
-
-    for (MenuItem* menuItem : menuItemList) {
-        if (!menuItem) {
-            continue;
-        }
-
-        UiAction action = menuItem->action();
-        action.shortcuts = screg->shortcut(action.code).sequences;
-        menuItem->setAction(action);
-
-        std::vector<MenuItem*> subMenuItemList;
-        for (MenuItem* menuSubItem : menuItem->subitems()) {
-            if (!menuSubItem) {
-                continue;
-            }
-            subMenuItemList.insert(subMenuItemList.end(), menuSubItem);
-        }
-        updateShortcutsMenuItem(subMenuItemList);
-    }
-}
-
 void AbstractMenuModel::updateShortcutsAll()
 {
-    std::vector<MenuItem*> menuItemList;
-
     for (MenuItem* menuItem : m_items) {
         if (!menuItem) {
             continue;
         }
-        menuItemList.insert(menuItemList.end(), menuItem);
-    }
 
-    updateShortcutsMenuItem(menuItemList);
+        updateShortcuts(menuItem);
+    }
+}
+
+void AbstractMenuModel::updateShortcuts(MenuItem* item)
+{
+    UiAction action = item->action();
+    action.shortcuts = shortcutsRegister()->shortcut(action.code).sequences;
+    item->setAction(action);
+
+    for (MenuItem* subItem : item->subitems()) {
+        if (!subItem) {
+            continue;
+        }
+
+        updateShortcuts(subItem);
+    }
 }

--- a/src/framework/uicomponents/view/abstractmenumodel.h
+++ b/src/framework/uicomponents/view/abstractmenumodel.h
@@ -30,6 +30,7 @@
 
 #include "modularity/ioc.h"
 #include "ui/iuiactionsregister.h"
+#include "shortcuts/ishortcutsregister.h"
 #include "actions/iactionsdispatcher.h"
 
 namespace muse::uicomponents {
@@ -43,6 +44,7 @@ class AbstractMenuModel : public QAbstractListModel, public muse::Injectable, pu
 public:
     muse::Inject<ui::IUiActionsRegister> uiActionsRegister = { this };
     muse::Inject<muse::actions::IActionsDispatcher> dispatcher = { this };
+    muse::Inject<shortcuts::IShortcutsRegister> shortcutsRegister = { this };
 
 public:
     explicit AbstractMenuModel(QObject* parent = nullptr);
@@ -97,6 +99,8 @@ private:
     MenuItem& item(MenuItemList& items, const QString& itemId);
     MenuItem& item(MenuItemList& items, const muse::actions::ActionCode& actionCode);
     MenuItem& menu(MenuItemList& items, const QString& menuId);
+    void updateShortcutsMenuItem(const std::vector<MenuItem*>& menuItemList);
+    void updateShortcutsAll();
 
     MenuItemList m_items;
 };

--- a/src/framework/uicomponents/view/abstractmenumodel.h
+++ b/src/framework/uicomponents/view/abstractmenumodel.h
@@ -99,8 +99,9 @@ private:
     MenuItem& item(MenuItemList& items, const QString& itemId);
     MenuItem& item(MenuItemList& items, const muse::actions::ActionCode& actionCode);
     MenuItem& menu(MenuItemList& items, const QString& menuId);
-    void updateShortcutsMenuItem(const std::vector<MenuItem*>& menuItemList);
+
     void updateShortcutsAll();
+    void updateShortcuts(MenuItem* item);
 
     MenuItemList m_items;
 };

--- a/src/framework/uicomponents/view/abstracttoolbarmodel.cpp
+++ b/src/framework/uicomponents/view/abstracttoolbarmodel.cpp
@@ -327,51 +327,38 @@ ToolBarItem& AbstractToolBarModel::item(const ToolBarItemList& items, const Acti
     return dummy;
 }
 
-void AbstractToolBarModel::updateShortcutsMenuItem(const std::vector<MenuItem*>& menuItemList)
-{
-    auto screg = shortcutsRegister();
-
-    for (MenuItem* menuItem : menuItemList) {
-        if (!menuItem) {
-            continue;
-        }
-
-        UiAction action = menuItem->action();
-        action.shortcuts = screg->shortcut(action.code).sequences;
-        menuItem->setAction(action);
-
-        std::vector<MenuItem*> subMenuItemList;
-        for (MenuItem* menuSubItem : menuItem->subitems()) {
-            if (!menuSubItem) {
-                continue;
-            }
-            subMenuItemList.insert(subMenuItemList.end(), menuSubItem);
-        }
-        updateShortcutsMenuItem(subMenuItemList);
-    }
-}
-
 void AbstractToolBarModel::updateShortcutsAll()
 {
-    auto screg = shortcutsRegister();
-    std::vector<MenuItem*> menuItemList;
-
     for (ToolBarItem* toolBarItem : m_items) {
         if (!toolBarItem) {
             continue;
         }
 
         UiAction action = toolBarItem->action();
-        action.shortcuts = screg->shortcut(action.code).sequences;
-
+        action.shortcuts = shortcutsRegister()->shortcut(action.code).sequences;
         toolBarItem->setAction(action);
 
         for (MenuItem* menuItem : toolBarItem->menuItems()) {
             if (!menuItem) {
                 continue;
             }
-            menuItemList.insert(menuItemList.end(), menuItem);
+
+            updateShortcuts(menuItem);
         }
     }
-    // updateShortcutsMenuItem(menuItemList);
+}
+
+void AbstractToolBarModel::updateShortcuts(MenuItem* menuItem)
+{
+    UiAction action = menuItem->action();
+    action.shortcuts = shortcutsRegister()->shortcut(action.code).sequences;
+    menuItem->setAction(action);
+
+    for (MenuItem* subItem : menuItem->subitems()) {
+        if (!subItem) {
+            continue;
+        }
+
+        updateShortcuts(subItem);
+    }
 }

--- a/src/framework/uicomponents/view/abstracttoolbarmodel.h
+++ b/src/framework/uicomponents/view/abstracttoolbarmodel.h
@@ -28,10 +28,12 @@
 
 #include "modularity/ioc.h"
 #include "ui/iuiactionsregister.h"
+#include "shortcuts/ishortcutsregister.h"
 #include "actions/iactionsdispatcher.h"
 
 namespace muse::uicomponents {
 class ToolBarItem;
+class MenuItem;
 using ToolBarItemList = QList<ToolBarItem*>;
 class ToolBarItemType
 {
@@ -56,6 +58,7 @@ class AbstractToolBarModel : public QAbstractListModel, public Injectable, publi
 public:
     Inject<ui::IUiActionsRegister> uiActionsRegister = { this };
     Inject<actions::IActionsDispatcher> dispatcher = { this };
+    Inject<shortcuts::IShortcutsRegister> shortcutsRegister = { this };
 
 public:
     explicit AbstractToolBarModel(QObject* parent = nullptr);
@@ -111,6 +114,8 @@ protected:
 private:
     ToolBarItem& item(const ToolBarItemList& items, const QString& itemId);
     ToolBarItem& item(const ToolBarItemList& items, const actions::ActionCode& actionCode);
+    void updateShortcutsMenuItem(const std::vector<MenuItem*>& menuItemList);
+    void updateShortcutsAll();
 
     ToolBarItemList m_items;
 };

--- a/src/framework/uicomponents/view/abstracttoolbarmodel.h
+++ b/src/framework/uicomponents/view/abstracttoolbarmodel.h
@@ -114,8 +114,9 @@ protected:
 private:
     ToolBarItem& item(const ToolBarItemList& items, const QString& itemId);
     ToolBarItem& item(const ToolBarItemList& items, const actions::ActionCode& actionCode);
-    void updateShortcutsMenuItem(const std::vector<MenuItem*>& menuItemList);
+
     void updateShortcutsAll();
+    void updateShortcuts(MenuItem* menuItem);
 
     ToolBarItemList m_items;
 };


### PR DESCRIPTION
Resolves: #25702 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
This PR updates the shortcuts definition in Toolbars and Menus when the shortcuts definition changes. A fix for " _UiAction::operator==(const UiAction& other) const :_ " within uiaction.h has been included to make this PR work

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
