### PR TITLE
Fix crash on system locks with old EIDs

### DIFF
--- a/src/engraving/infrastructure/eidregister.cpp
+++ b/src/engraving/infrastructure/eidregister.cpp
@@ -49,7 +49,9 @@ void EIDRegister::registerItemEID(const EID& eid, const EngravingObject* item)
 EngravingObject* EIDRegister::itemFromEID(const EID& eid) const
 {
     auto iter = m_eidToItem.find(eid);
-    assert(iter != m_eidToItem.end());
+    IF_ASSERT_FAILED(iter != m_eidToItem.end()) {
+        return nullptr;
+    }
     return iter->second;
 }
 

--- a/src/engraving/rw/read410/tread.cpp
+++ b/src/engraving/rw/read410/tread.cpp
@@ -4859,5 +4859,9 @@ void TRead::readSystemLock(Score* score, XmlReader& e)
         }
     }
 
+    IF_ASSERT_FAILED(startMeas && endMeas) {
+        return;
+    }
+
     score->addSystemLock(new SystemLock(startMeas, endMeas));
 }


### PR DESCRIPTION
Resolves: #25742 
Resolves: #25743 
