### PR TITLE
Fix #23090: Added style option to use expression font for dynamics

### DIFF
--- a/src/engraving/dom/dynamic.cpp
+++ b/src/engraving/dom/dynamic.cpp
@@ -252,7 +252,7 @@ double Dynamic::customTextOffset() const
     referenceDynamic.setXmlText(referenceString);
     renderer()->layoutItem(toTextBase(&referenceDynamic));
 
-    TextFragment referenceFragment;
+    std::shared_ptr<TextFragment> referenceFragment;
     if (!referenceDynamic.ldata()->blocks.empty()) {
         TextBlock referenceBlock = referenceDynamic.ldata()->blocks.front();
         if (!referenceBlock.fragments().empty()) {
@@ -265,9 +265,9 @@ double Dynamic::customTextOffset() const
         return 0.0;
     }
     for (const TextBlock& block : ldata->blocks) {
-        for (const TextFragment& fragment : block.fragments()) {
-            if (fragment.text == referenceFragment.text) {
-                return fragment.pos.x() - referenceFragment.pos.x();
+        for (const std::shared_ptr<TextFragment>& fragment : block.fragments()) {
+            if (fragment->text == referenceFragment->text) {
+                return fragment->pos.x() - referenceFragment->pos.x();
             }
         }
     }

--- a/src/engraving/dom/dynamic.cpp
+++ b/src/engraving/dom/dynamic.cpp
@@ -23,6 +23,7 @@
 
 #include "types/translatablestring.h"
 #include "types/typesconv.h"
+#include "types/symnames.h"
 
 #include "anchors.h"
 #include "dynamichairpingroup.h"
@@ -48,58 +49,85 @@ namespace mu::engraving {
 //-----------------------------------------------------------------------------
 
 // variant with ligatures, works for both emmentaler and bravura:
+constexpr DynamicType P = DynamicType::P;
+constexpr DynamicType M = DynamicType::M;
+constexpr DynamicType F = DynamicType::F;
+constexpr DynamicType S = DynamicType::S;
+constexpr DynamicType Z = DynamicType::Z;
+constexpr DynamicType R = DynamicType::R;
+constexpr DynamicType N = DynamicType::N;
 const std::vector<Dyn> Dynamic::DYN_LIST = {
-    // dynamic:
-    { DynamicType::OTHER,  -1, 0,   true, "" },
-    { DynamicType::PPPPPP,  1, 0,   false,
+    { DynamicType::OTHER,  -1, 0,   true, {}, "", "" },
+    { DynamicType::PPPPPP,  1, 0,   false, { P, P, P, P, P, P }, "pppppp",
       "<sym>dynamicPiano</sym><sym>dynamicPiano</sym><sym>dynamicPiano</sym><sym>dynamicPiano</sym><sym>dynamicPiano</sym><sym>dynamicPiano</sym>" },
-    { DynamicType::PPPPP,   5, 0,   false,
+    { DynamicType::PPPPP,   5, 0,   false, { P, P, P, P, P }, "ppppp",
       "<sym>dynamicPiano</sym><sym>dynamicPiano</sym><sym>dynamicPiano</sym><sym>dynamicPiano</sym><sym>dynamicPiano</sym>" },
-    { DynamicType::PPPP,    10, 0,  false,
+    { DynamicType::PPPP,    10, 0,  false, { P, P, P, P }, "pppp",
       "<sym>dynamicPiano</sym><sym>dynamicPiano</sym><sym>dynamicPiano</sym><sym>dynamicPiano</sym>" },
-    { DynamicType::PPP,     16, 0,  false,
+    { DynamicType::PPP,     16, 0,  false, { P, P, P }, "ppp",
       "<sym>dynamicPiano</sym><sym>dynamicPiano</sym><sym>dynamicPiano</sym>" },
-    { DynamicType::PP,      33, 0,  false,  "<sym>dynamicPiano</sym><sym>dynamicPiano</sym>" },
-    { DynamicType::P,       49, 0,  false,  "<sym>dynamicPiano</sym>" },
+    { DynamicType::PP,      33, 0,  false, { P, P }, "pp",
+      "<sym>dynamicPiano</sym><sym>dynamicPiano</sym>" },
+    { DynamicType::P,       49, 0,  false, { P }, "p",
+      "<sym>dynamicPiano</sym>" },
 
-    { DynamicType::MP,      64, 0,   false, "<sym>dynamicMezzo</sym><sym>dynamicPiano</sym>" },
-    { DynamicType::MF,      80, 0,   false, "<sym>dynamicMezzo</sym><sym>dynamicForte</sym>" },
+    { DynamicType::MP,      64, 0,   false, { M, P }, "mp",
+      "<sym>dynamicMezzo</sym><sym>dynamicPiano</sym>" },
+    { DynamicType::MF,      80, 0,   false, { M, F }, "mf",
+      "<sym>dynamicMezzo</sym><sym>dynamicForte</sym>" },
 
-    { DynamicType::F,       96, 0,   false, "<sym>dynamicForte</sym>" },
-    { DynamicType::FF,      112, 0,  false, "<sym>dynamicForte</sym><sym>dynamicForte</sym>" },
-    { DynamicType::FFF,     126, 0,  false, "<sym>dynamicForte</sym><sym>dynamicForte</sym><sym>dynamicForte</sym>" },
-    { DynamicType::FFFF,    127, 0,  false,
+    { DynamicType::F,       96, 0,   false, { F }, "f",
+      "<sym>dynamicForte</sym>" },
+    { DynamicType::FF,      112, 0,  false, { F, F }, "ff",
+      "<sym>dynamicForte</sym><sym>dynamicForte</sym>" },
+    { DynamicType::FFF,     126, 0,  false, { F, F, F }, "fff",
+      "<sym>dynamicForte</sym><sym>dynamicForte</sym><sym>dynamicForte</sym>" },
+    { DynamicType::FFFF,    127, 0,  false, { F, F, F, F }, "ffff",
       "<sym>dynamicForte</sym><sym>dynamicForte</sym><sym>dynamicForte</sym><sym>dynamicForte</sym>" },
-    { DynamicType::FFFFF,   127, 0,  false,
+    { DynamicType::FFFFF,   127, 0,  false, { F, F, F, F, F }, "fffff",
       "<sym>dynamicForte</sym><sym>dynamicForte</sym><sym>dynamicForte</sym><sym>dynamicForte</sym><sym>dynamicForte</sym>" },
-    { DynamicType::FFFFFF,  127, 0,  false,
+    { DynamicType::FFFFFF,  127, 0,  false, { F, F, F, F, F, F }, "ffffff",
       "<sym>dynamicForte</sym><sym>dynamicForte</sym><sym>dynamicForte</sym><sym>dynamicForte</sym><sym>dynamicForte</sym><sym>dynamicForte</sym>" },
 
-    { DynamicType::FP,      96, -47,  true, "<sym>dynamicForte</sym><sym>dynamicPiano</sym>" },
-    { DynamicType::PF,      49, 47,   true, "<sym>dynamicPiano</sym><sym>dynamicForte</sym>" },
+    { DynamicType::FP,      96, -47,  true, { F, P }, "fp",
+      "<sym>dynamicForte</sym><sym>dynamicPiano</sym>" },
+    { DynamicType::PF,      49, 47,   true, { P, F }, "pf",
+      "<sym>dynamicPiano</sym><sym>dynamicForte</sym>" },
 
-    { DynamicType::SF,      112, -18, true, "<sym>dynamicSforzando</sym><sym>dynamicForte</sym>" },
-    { DynamicType::SFZ,     112, -18, true, "<sym>dynamicSforzando</sym><sym>dynamicForte</sym><sym>dynamicZ</sym>" },
-    { DynamicType::SFF,     126, -18, true, "<sym>dynamicSforzando</sym><sym>dynamicForte</sym><sym>dynamicForte</sym>" },
-    { DynamicType::SFFZ,    126, -18, true,
+    { DynamicType::SF,      112, -18, true, { S, F }, "sf",
+      "<sym>dynamicSforzando</sym><sym>dynamicForte</sym>" },
+    { DynamicType::SFZ,     112, -18, true, { S, F, Z }, "sfz",
+      "<sym>dynamicSforzando</sym><sym>dynamicForte</sym><sym>dynamicZ</sym>" },
+    { DynamicType::SFF,     126, -18, true, { S, F, F }, "sff",
+      "<sym>dynamicSforzando</sym><sym>dynamicForte</sym><sym>dynamicForte</sym>" },
+    { DynamicType::SFFZ,    126, -18, true, { S, F, F, Z }, "sffz",
       "<sym>dynamicSforzando</sym><sym>dynamicForte</sym><sym>dynamicForte</sym><sym>dynamicZ</sym>" },
-    { DynamicType::SFFF,    127, -18, true,
+    { DynamicType::SFFF,    127, -18, true, { S, F, F, F }, "sfff",
       "<sym>dynamicSforzando</sym><sym>dynamicForte</sym><sym>dynamicForte</sym><sym>dynamicForte</sym>" },
-    { DynamicType::SFFFZ,   127, -18, true,
+    { DynamicType::SFFFZ,   127, -18, true, { S, F, F, F, Z }, "sfffz",
       "<sym>dynamicSforzando</sym><sym>dynamicForte</sym><sym>dynamicForte</sym><sym>dynamicForte</sym><sym>dynamicZ</sym>" },
-    { DynamicType::SFP,     112, -47, true, "<sym>dynamicSforzando</sym><sym>dynamicForte</sym><sym>dynamicPiano</sym>" },
-    { DynamicType::SFPP,    112, -79, true,
+    { DynamicType::SFP,     112, -47, true, { S, F, P }, "sfp",
+      "<sym>dynamicSforzando</sym><sym>dynamicForte</sym><sym>dynamicPiano</sym>" },
+    { DynamicType::SFPP,    112, -79, true, { S, F, P, P }, "sfpp",
       "<sym>dynamicSforzando</sym><sym>dynamicForte</sym><sym>dynamicPiano</sym><sym>dynamicPiano</sym>" },
 
-    { DynamicType::RFZ,     112, -18, true, "<sym>dynamicRinforzando</sym><sym>dynamicForte</sym><sym>dynamicZ</sym>" },
-    { DynamicType::RF,      112, -18, true, "<sym>dynamicRinforzando</sym><sym>dynamicForte</sym>" },
-    { DynamicType::FZ,      112, -18, true, "<sym>dynamicForte</sym><sym>dynamicZ</sym>" },
+    { DynamicType::RFZ,     112, -18, true, { R, F, Z }, "rfz",
+      "<sym>dynamicRinforzando</sym><sym>dynamicForte</sym><sym>dynamicZ</sym>" },
+    { DynamicType::RF,      112, -18, true, { R, F }, "rf",
+      "<sym>dynamicRinforzando</sym><sym>dynamicForte</sym>" },
+    { DynamicType::FZ,      112, -18, true, { F, Z }, "fz",
+      "<sym>dynamicForte</sym><sym>dynamicZ</sym>" },
 
-    { DynamicType::M,       96, -16,  true, "<sym>dynamicMezzo</sym>" },
-    { DynamicType::R,       112, -18, true, "<sym>dynamicRinforzando</sym>" },
-    { DynamicType::S,       112, -18, true, "<sym>dynamicSforzando</sym>" },
-    { DynamicType::Z,       80, 0,    true, "<sym>dynamicZ</sym>" },
-    { DynamicType::N,       49, -48,  true, "<sym>dynamicNiente</sym>" }
+    { DynamicType::M,       96, -16,  true, { M }, "m",
+      "<sym>dynamicMezzo</sym>" },
+    { DynamicType::R,       112, -18, true, { R }, "r",
+      "<sym>dynamicRinforzando</sym>" },
+    { DynamicType::S,       112, -18, true, { S }, "s",
+      "<sym>dynamicSforzando</sym>" },
+    { DynamicType::Z,       80, 0,    true, { Z }, "z",
+      "<sym>dynamicZ</sym>" },
+    { DynamicType::N,       49, -48,  true, { N }, "n",
+      "<sym>dynamicNiente</sym>" }
 };
 
 //---------------------------------------------------------
@@ -112,6 +140,107 @@ static const ElementStyle dynamicsStyle {
     { Sid::dynamicsSize, Pid::DYNAMICS_SIZE },
     { Sid::centerOnNotehead, Pid::CENTER_ON_NOTEHEAD },
 };
+
+//---------------------------------------------------------
+//   DynamicFragment
+//---------------------------------------------------------
+
+DynamicFragment::DynamicFragment(CharFormat charFormat, String dynamicText, bool displayAsExpression)
+{
+    format = charFormat;
+    m_dynamicText = dynamicText;
+    calculatePlainText(getDynamics(dynamicText));
+    setDisplayAsExpressionText(displayAsExpression);
+}
+
+DynamicFragment::DynamicFragment(const DynamicFragment& dynamicFragment)
+    : TextFragment(dynamicFragment)
+{
+    m_displayAsExpressionText = dynamicFragment.m_displayAsExpressionText;
+    m_dynamicText = dynamicFragment.m_dynamicText;
+    m_plainText = dynamicFragment.m_plainText;
+}
+
+DynamicFragment& DynamicFragment::operator =(const DynamicFragment& dynamicFragment)
+{
+    TextFragment::operator =(dynamicFragment);
+    m_dynamicText = dynamicFragment.m_dynamicText;
+    m_plainText = dynamicFragment.m_plainText;
+
+    return *this;
+}
+
+void DynamicFragment::setText(String newText)
+{
+    std::vector<DynamicType> dynamics = getDynamics(newText);
+    calculateDynamicText(dynamics);
+    calculatePlainText(dynamics);
+    setDisplayAsExpressionText(m_displayAsExpressionText);
+}
+
+std::vector<DynamicType> DynamicFragment::getDynamics(String text)
+{
+    static std::shared_ptr<IEngravingFontsProvider> provider = muse::modularity::globalIoc()->resolve<IEngravingFontsProvider>("engraving");
+
+    std::vector<DynamicType> dynamics;
+    for (char32_t i = 0; i < text.size(); i++) {
+        SymId symId = provider->fallbackFont()->fromCode(text[i]);
+        DynamicType dt = TConv::dynamicType(symId);
+        if (dt == DynamicType::OTHER) {
+            return dynamics;
+        }
+        dynamics.push_back(dt);
+    }
+
+    return dynamics;
+}
+
+void DynamicFragment::setDisplayAsExpressionText(bool asExpression)
+{
+    m_displayAsExpressionText = asExpression;
+    if (asExpression) {
+        TextFragment::setText(m_plainText);
+    } else {
+        format.setFontFamily(u"ScoreText");
+        TextFragment::setText(m_dynamicText);
+    }
+}
+
+void DynamicFragment::calculateDynamicText(std::vector<DynamicType> dynamics)
+{
+    static std::shared_ptr<IEngravingFontsProvider> provider = muse::modularity::globalIoc()->resolve<IEngravingFontsProvider>("engraving");
+
+    m_dynamicText.clear();
+    for (DynamicType dynamic : dynamics) {
+        m_dynamicText += provider->fallbackFont()->symCode(TConv::symId(dynamic));
+    }
+}
+
+void DynamicFragment::calculatePlainText(std::vector<DynamicType> dynamics)
+{
+    m_plainText.clear();
+    for (DynamicType dynamic : dynamics) {
+        for (const Dyn& dyn : Dynamic::dynamicList()) {
+            if (dyn.type == dynamic) {
+                m_plainText += *dyn.plainText;
+                break;
+            }
+        }
+    }
+}
+
+String DynamicFragment::toSymbolXml()
+{
+    static std::shared_ptr<IEngravingFontsProvider> provider = muse::modularity::globalIoc()->resolve<IEngravingFontsProvider>("engraving");
+
+    String xmlText;
+    for (size_t i = 0; i < m_dynamicText.size(); i++) {
+        SymId symId = provider->fallbackFont()->fromCode(m_dynamicText.at(i).unicode());
+        xmlText += u"<sym>" + String::fromAscii(SymNames::nameForSymId(symId).ascii()) + u"</sym>";
+    }
+
+    return xmlText;
+}
 
 //---------------------------------------------------------
 //   Dynamic
@@ -438,9 +567,23 @@ void Dynamic::setDynamicType(const String& tag)
     setXmlText(tag);
 }
 
+bool Dynamic::isDynamicType(String s)
+{
+    static std::shared_ptr<IEngravingFontsProvider> provider = muse::modularity::globalIoc()->resolve<IEngravingFontsProvider>("engraving");
+
+    for (char32_t i = 0; i < s.size(); i++) {
+        SymId symId = provider->fallbackFont()->fromCode(s[i]);
+        if (TConv::dynamicType(symId) == DynamicType::OTHER) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 String Dynamic::dynamicText(DynamicType t)
 {
-    return String::fromUtf8(DYN_LIST[int(t)].text);
+    return String::fromStdString(DYN_LIST[int(t)].text);
 }
 
 Expression* Dynamic::snappedExpression() const
@@ -537,6 +680,16 @@ TranslatableString Dynamic::subtypeUserName() const
 void Dynamic::startEdit(EditData& ed)
 {
     if (ed.editTextualProperties) {
+        if (useExpressionFontFace()) {
+            for (TextBlock block : ldata()->blocks) {
+                for (std::shared_ptr<TextFragment> fragment : block.fragments()) {
+                    if (DynamicFragment* dynamicFragment = dynamic_cast<DynamicFragment*>(fragment.get())) {
+                        dynamicFragment->setDisplayAsExpressionText(false);
+                    }
+                }
+            }
+        }
+
         TextBase::startEdit(ed);
     } else {
         startEditNonTextual(ed);
@@ -768,8 +921,17 @@ void Dynamic::editDrag(EditData& ed)
 void Dynamic::endEdit(EditData& ed)
 {
     if (ed.editTextualProperties) {
+        if (useExpressionFontFace()) {
+            for (TextBlock block : ldata()->blocks) {
+                for (std::shared_ptr<TextFragment> fragment : block.fragments()) {
+                    if (DynamicFragment* dynamicFragment = dynamic_cast<DynamicFragment*>(fragment.get())) {
+                        dynamicFragment->setDisplayAsExpressionText(true);
+                    }
+                }
+            }
+        }
         TextBase::endEdit(ed);
-        if (!xmlText().contains(String::fromUtf8(DYN_LIST[int(m_dynamicType)].text))) {
+        if (!xmlText().contains(String::fromStdString(DYN_LIST[int(m_dynamicType)].text))) {
             m_dynamicType = DynamicType::OTHER;
         }
     } else {
@@ -933,6 +1095,20 @@ Sid Dynamic::getPropertyStyle(Pid pid) const
     }
 }
 
+void Dynamic::styleChanged()
+{
+    for (const TextBlock& block : ldata()->blocks) {
+        for (const std::shared_ptr<TextFragment>& fragment : block.fragments()) {
+            DynamicFragment* dynamicFragment = dynamic_cast<DynamicFragment*>(fragment.get());
+            if (dynamicFragment) {
+                dynamicFragment->setDisplayAsExpressionText(useExpressionFontFace());
+            }
+        }
+    }
+
+    TextBase::styleChanged();
+}
+
 //---------------------------------------------------------
 //   accessibleInfo
 //---------------------------------------------------------
@@ -956,5 +1132,10 @@ String Dynamic::screenReaderInfo() const
         s = TConv::translatedUserName(dynamicType());
     }
     return String(u"%1: %2").arg(EngravingItem::accessibleInfo(), s);
+}
+
+bool Dynamic::useExpressionFontFace() const
+{
+    return style().styleB(Sid::dynamicsOverrideFont) && style().styleB(Sid::dynamicsUseExpressionFont);
 }
 }

--- a/src/engraving/dom/dynamic.cpp
+++ b/src/engraving/dom/dynamic.cpp
@@ -266,7 +266,7 @@ double Dynamic::customTextOffset() const
     }
     for (const TextBlock& block : ldata->blocks) {
         for (const std::shared_ptr<TextFragment>& fragment : block.fragments()) {
-            if (fragment->text == referenceFragment->text) {
+            if (fragment->text() == referenceFragment->text()) {
                 return fragment->pos.x() - referenceFragment->pos.x();
             }
         }

--- a/src/engraving/dom/harppedaldiagram.cpp
+++ b/src/engraving/dom/harppedaldiagram.cpp
@@ -140,7 +140,7 @@ void HarpPedalDiagram::setIsDiagram(bool diagram)
 
 void HarpPedalDiagram::setPedal(HarpStringType harpString, PedalPosition pedal)
 {
-    m_pedalState.at(harpString) = pedal;
+    m_pedalState.at(static_cast<size_t>(harpString)) = pedal;
     setPlayableTpcs();
 }
 

--- a/src/engraving/dom/harppedaldiagram.h
+++ b/src/engraving/dom/harppedaldiagram.h
@@ -25,7 +25,6 @@
 
 #include "pitchspelling.h"
 #include "textbase.h"
-#include "pitchspelling.h"
 
 using namespace mu;
 
@@ -39,7 +38,7 @@ enum class PedalPosition : char {
 };
 
 // Use for indexes of _pedalState
-enum HarpStringType : char {
+enum class HarpStringType : char {
     D, C, B, E, F, G, A
 };
 

--- a/src/engraving/dom/page.cpp
+++ b/src/engraving/dom/page.cpp
@@ -380,10 +380,10 @@ void Page::doRebuildBspTree()
 
 TextBlock Page::replaceTextMacros(const TextBlock& tb) const
 {
-    std::list<std::shared_ptr<TextFragment>> newFragments = { std::make_shared<TextFragment>() };
+    std::list<std::shared_ptr<TextFragment> > newFragments = { std::make_shared<TextFragment>() };
     for (const std::shared_ptr<TextFragment>& tf: tb.fragments()) {
         const CharFormat defaultFormat = tf->format;
-        const String& s = tf->text;
+        const String& s = tf->text();
 
         for (size_t i = 0, n = s.size(); i < n; ++i) {
             newFragments.back()->format = defaultFormat;
@@ -409,7 +409,7 @@ TextBlock Page::replaceTextMacros(const TextBlock& tb) const
                         const CharFormat pageNumberFormat = formatForMacro(String('$' + nc));
                         // If the default format equals the format for this macro, we don't need to create a new fragment...
                         if (defaultFormat == pageNumberFormat) {
-                            newFragments.back()->text += pageNumberString;
+                            newFragments.back()->appendText(pageNumberString);
                             break;
                         }
                         std::shared_ptr<TextFragment> pageNumberFragment = std::make_shared<TextFragment>(pageNumberString);
@@ -420,7 +420,7 @@ TextBlock Page::replaceTextMacros(const TextBlock& tb) const
                 }
                 break;
                 case 'n':
-                    newFragments.back()->text += String::number(score()->npages() + score()->pageNumberOffset());
+                    newFragments.back()->appendText(String::number(score()->npages() + score()->pageNumberOffset()));
                     break;
                 case 'i': // not on first page
                     if (!m_no) {
@@ -428,43 +428,43 @@ TextBlock Page::replaceTextMacros(const TextBlock& tb) const
                     }
                 // FALLTHROUGH
                 case 'I':
-                    newFragments.back()->text += score()->metaTag(u"partName");
+                    newFragments.back()->appendText(score()->metaTag(u"partName"));
                     break;
                 case 'f':
-                    newFragments.back()->text += masterScore()->fileInfo()->fileName(false).toString();
+                    newFragments.back()->appendText(masterScore()->fileInfo()->fileName(false).toString());
                     break;
                 case 'F':
-                    newFragments.back()->text += masterScore()->fileInfo()->path().toString();
+                    newFragments.back()->appendText(masterScore()->fileInfo()->path().toString());
                     break;
                 case 'd':
-                    newFragments.back()->text += muse::Date::currentDate().toString(muse::DateFormat::ISODate);
+                    newFragments.back()->appendText(muse::Date::currentDate().toString(muse::DateFormat::ISODate));
                     break;
                 case 'D':
                 {
                     String creationDate = score()->metaTag(u"creationDate");
                     if (creationDate.isEmpty()) {
-                        newFragments.back()->text += masterScore()->fileInfo()->birthTime().date().toString(
-                            muse::DateFormat::ISODate);
+                        newFragments.back()->appendText(masterScore()->fileInfo()->birthTime().date().toString(
+                                                            muse::DateFormat::ISODate));
                     } else {
-                        newFragments.back()->text += muse::Date::fromStringISOFormat(creationDate).toString(
-                            muse::DateFormat::ISODate);
+                        newFragments.back()->appendText(muse::Date::fromStringISOFormat(creationDate).toString(
+                                                            muse::DateFormat::ISODate));
                     }
                 }
                 break;
                 case 'm':
                     if (score()->dirty() || !masterScore()->saved()) {
-                        newFragments.back()->text += muse::Time::currentTime().toString(muse::DateFormat::ISODate);
+                        newFragments.back()->appendText(muse::Time::currentTime().toString(muse::DateFormat::ISODate));
                     } else {
-                        newFragments.back()->text += masterScore()->fileInfo()->lastModified().time().toString(
-                            muse::DateFormat::ISODate);
+                        newFragments.back()->appendText(masterScore()->fileInfo()->lastModified().time().toString(
+                                                            muse::DateFormat::ISODate));
                     }
                     break;
                 case 'M':
                     if (score()->dirty() || !masterScore()->saved()) {
-                        newFragments.back()->text += muse::Date::currentDate().toString(muse::DateFormat::ISODate);
+                        newFragments.back()->appendText(muse::Date::currentDate().toString(muse::DateFormat::ISODate));
                     } else {
-                        newFragments.back()->text += masterScore()->fileInfo()->lastModified().date().toString(
-                            muse::DateFormat::ISODate);
+                        newFragments.back()->appendText(masterScore()->fileInfo()->lastModified().date().toString(
+                                                            muse::DateFormat::ISODate));
                     }
                     break;
                 case 'C': // only on first page
@@ -478,7 +478,7 @@ TextBlock Page::replaceTextMacros(const TextBlock& tb) const
                     const CharFormat copyrightFormat = formatForMacro(String('$' + nc));
                     // If the default format equals the format for this macro, we don't need to create a new fragment...
                     if (defaultFormat == copyrightFormat) {
-                        newFragments.back()->text += copyrightString;
+                        newFragments.back()->appendText(copyrightString);
                         break;
                     }
                     std::shared_ptr<TextFragment> copyrightFragment = std::make_shared<TextFragment>(copyrightString);
@@ -489,25 +489,25 @@ TextBlock Page::replaceTextMacros(const TextBlock& tb) const
                 break;
                 case 'v':
                     if (score()->dirty()) {
-                        newFragments.back()->text += score()->appVersion();
+                        newFragments.back()->appendText(score()->appVersion());
                     } else {
-                        newFragments.back()->text += score()->mscoreVersion();
+                        newFragments.back()->appendText(score()->mscoreVersion());
                     }
                     break;
                 case 'r':
                     if (score()->dirty()) {
-                        newFragments.back()->text += revision;
+                        newFragments.back()->appendText(revision);
                     } else {
                         int rev = score()->mscoreRevision();
                         if (rev > 99999) { // MuseScore 1.3 is decimal 5702, 2.0 and later uses a 7-digit hex SHA
-                            newFragments.back()->text += String::number(rev, 16);
+                            newFragments.back()->appendText(String::number(rev, 16));
                         } else {
-                            newFragments.back()->text += String::number(rev, 10);
+                            newFragments.back()->appendText(String::number(rev, 10));
                         }
                     }
                     break;
                 case '$':
-                    newFragments.back()->text += '$';
+                    newFragments.back()->appendText(String('$'));
                     break;
                 case ':':
                 {
@@ -520,19 +520,19 @@ TextBlock Page::replaceTextMacros(const TextBlock& tb) const
                         tag += s.at(k);
                     }
                     if (k != n) {      // found ':' ?
-                        newFragments.back()->text += score()->metaTag(tag);
+                        newFragments.back()->appendText(score()->metaTag(tag));
                         i = k - 1;
                     }
                 }
                 break;
                 default:
-                    newFragments.back()->text += '$';
-                    newFragments.back()->text += nc;
+                    newFragments.back()->appendText(String('$'));
+                    newFragments.back()->appendText(nc);
                     break;
                 }
                 ++i;
             } else {
-                newFragments.back()->text += c;
+                newFragments.back()->appendText(c);
             }
         }
     }

--- a/src/engraving/dom/textbase.h
+++ b/src/engraving/dom/textbase.h
@@ -219,7 +219,6 @@ public:
 public:
     mutable CharFormat format;
     PointF pos;                    // y is relative to TextBlock->y()
-    mutable String text;
 
     TextFragment() = default;
     TextFragment(const String& s);
@@ -227,16 +226,22 @@ public:
     TextFragment(const TextFragment& f);
 
     TextFragment& operator =(const TextFragment& f);
-
     bool operator ==(const TextFragment& f) const;
 
     virtual std::shared_ptr<TextFragment> clone() { return std::make_shared<TextFragment>(*this); }
+
+    String text() const { return m_text; }
+    virtual void setText(String text) { m_text = text; }
+    virtual void appendText(String text) { m_text += text; }
 
     std::shared_ptr<TextFragment> split(int column);
     void draw(muse::draw::Painter*, const TextBase*) const;
     muse::draw::Font font(const TextBase*) const;
     int columns() const;
     void changeFormat(FormatId id, const FormatValue& data);
+
+private:
+    String m_text;
 };
 
 //---------------------------------------------------------

--- a/src/engraving/dom/textbase.h
+++ b/src/engraving/dom/textbase.h
@@ -230,7 +230,9 @@ public:
 
     bool operator ==(const TextFragment& f) const;
 
-    TextFragment split(int column);
+    virtual std::shared_ptr<TextFragment> clone() { return std::make_shared<TextFragment>(*this); }
+
+    std::shared_ptr<TextFragment> split(int column);
     void draw(muse::draw::Painter*, const TextBase*) const;
     muse::draw::Font font(const TextBase*) const;
     int columns() const;
@@ -251,9 +253,9 @@ public:
     bool operator !=(const TextBlock& x) const { return m_fragments != x.m_fragments; }
     void draw(muse::draw::Painter*, const TextBase*) const;
     void layout(const TextBase*);
-    const std::list<TextFragment>& fragments() const { return m_fragments; }
-    std::list<TextFragment>& fragments() { return m_fragments; }
-    std::list<TextFragment> fragmentsWithoutEmpty();
+    const std::list<std::shared_ptr<TextFragment> >& fragments() const { return m_fragments; }
+    std::list<std::shared_ptr<TextFragment> >& fragments() { return m_fragments; }
+    std::list<std::shared_ptr<TextFragment> > fragmentsWithoutEmpty();
     const Shape& shape() const { return m_shape; }
     const RectF& boundingRect() const { return m_shape.bbox(); }
     RectF boundingRect(int col1, int col2, const TextBase*) const;
@@ -267,8 +269,8 @@ public:
     TextBlock split(int column, TextCursor* cursor);
     double xpos(size_t col, const TextBase*) const;
     const CharFormat* formatAt(int) const;
-    const TextFragment* fragment(int col) const;
-    std::list<TextFragment>::iterator fragment(int column, int* rcol, int* ridx);
+    const std::shared_ptr<TextFragment> fragment(int col) const;
+    std::list<std::shared_ptr<TextFragment> >::iterator fragment(int column, int* rcol, int* ridx);
     double y() const { return m_y; }
     void setY(double val) { m_y = val; }
     double lineSpacing() const { return m_lineSpacing; }
@@ -280,7 +282,7 @@ public:
 private:
     void simplify();
 
-    std::list<TextFragment> m_fragments;
+    std::list<std::shared_ptr<TextFragment> > m_fragments;
     double m_y = 0.0;
     double m_lineSpacing = 0.0;
     Shape m_shape;
@@ -382,7 +384,7 @@ public:
     int subtype() const override;
     TranslatableString subtypeUserName() const override;
 
-    std::list<TextFragment> fragmentList() const;   // for MusicXML formatted export
+    std::list<std::shared_ptr<TextFragment> > fragmentList() const;   // for MusicXML formatted export
 
     static bool validateText(String& s);
     bool inHexState() const { return m_hexState >= 0; }

--- a/src/engraving/dom/undo.cpp
+++ b/src/engraving/dom/undo.cpp
@@ -3230,7 +3230,7 @@ std::vector<const EngravingObject*> ChangeHarpPedalState::objectItems() const
 void ChangeSingleHarpPedal::flip(EditData*)
 {
     HarpStringType f_type = type;
-    PedalPosition f_pos = diagram->getPedalState()[type];
+    PedalPosition f_pos = diagram->getPedalState()[(size_t)type];
     if (f_pos == pos) {
         return;
     }

--- a/src/engraving/rendering/score/tlayout.cpp
+++ b/src/engraving/rendering/score/tlayout.cpp
@@ -5512,35 +5512,35 @@ void TLayout::layoutStringTunings(StringTunings* item, LayoutContext& ctx)
     }
 
     for (TextBlock& block : item->mutldata()->blocks) {
-        for (TextFragment& fragment : block.fragments()) {
-            Font font = fragment.font(item);
+        for (std::shared_ptr<TextFragment>& fragment : block.fragments()) {
+            Font font = fragment->font(item);
             if (font.type() == Font::Type::MusicSymbol) {
                 // HACK: the music symbol doesn't have a good baseline
                 // to go with text so we correct it here
                 const double baselineAdjustment = 0.35 * font.pointSizeF();
-                fragment.pos.setY(fragment.pos.y() + baselineAdjustment);
+                fragment->pos.setY(fragment->pos.y() + baselineAdjustment);
             }
         }
     }
 
     double secondStringXAlign = 0.0;
-    for (const TextFragment& fragment : item->fragmentList()) {
-        if (fragment.font(item).type() == Font::Type::MusicSymbol) {
-            secondStringXAlign = std::max(secondStringXAlign, fragment.pos.x());
+    for (const std::shared_ptr<TextFragment>& fragment : item->fragmentList()) {
+        if (fragment->font(item).type() == Font::Type::MusicSymbol) {
+            secondStringXAlign = std::max(secondStringXAlign, fragment->pos.x());
         }
     }
 
     for (TextBlock& block : item->mutldata()->blocks) {
         double xMove = 0.0;
-        for (TextFragment& fragment : block.fragments()) {
+        for (std::shared_ptr<TextFragment>& fragment : block.fragments()) {
             if (block.fragments().front() == fragment) {  // skip first
                 continue;
             }
 
-            if (fragment.font(item).type() == Font::Type::MusicSymbol) {
-                xMove = secondStringXAlign - fragment.pos.x();
+            if (fragment->font(item).type() == Font::Type::MusicSymbol) {
+                xMove = secondStringXAlign - fragment->pos.x();
             }
-            fragment.pos.setX(fragment.pos.x() + xMove);
+            fragment->pos.setX(fragment->pos.x() + xMove);
         }
     }
 

--- a/src/engraving/rendering/single/singlelayout.cpp
+++ b/src/engraving/rendering/single/singlelayout.cpp
@@ -1444,8 +1444,8 @@ void SingleLayout::layout(StaffText* item, const Context& ctx)
 
         for (TextBlock& block : item->mutldata()->blocks) {
             auto& fragments = block.fragments();
-            for (std::list<TextFragment>::iterator it = fragments.begin(); it != fragments.end(); ++it) {
-                it->pos.setX(it->pos.x() + xMove);
+            for (std::list<std::shared_ptr<TextFragment> >::iterator it = fragments.begin(); it != fragments.end(); ++it) {
+                (*it)->pos.setX((*it)->pos.x() + xMove);
             }
         }
     }
@@ -1463,13 +1463,13 @@ void SingleLayout::layout(StringTunings* item, const Context& ctx)
     layoutTextBase(item, ctx, item->mutldata());
 
     for (TextBlock& block : item->mutldata()->blocks) {
-        for (TextFragment& fragment : block.fragments()) {
-            Font font = fragment.font(item);
+        for (std::shared_ptr<TextFragment>& fragment : block.fragments()) {
+            Font font = fragment->font(item);
             if (font.type() != Font::Type::MusicSymbol) {
                 // HACK: the music symbol doesn't have a good baseline
                 // to go with text so we correct text here
                 const double baselineAdjustment = font.pointSizeF();
-                fragment.pos.setY(fragment.pos.y() - baselineAdjustment);
+                fragment->pos.setY(fragment->pos.y() - baselineAdjustment);
             }
         }
     }

--- a/src/engraving/style/styledef.cpp
+++ b/src/engraving/style/styledef.cpp
@@ -695,6 +695,7 @@ const std::array<StyleDef::StyleValue, size_t(Sid::STYLES)> StyleDef::styleValue
 
     styleDef(dynamicsOverrideFont,                       false),
     styleDef(dynamicsFont,                               PropertyValue(String(u"Leland"))),
+    styleDef(dynamicsUseExpressionFont,                  false),
     styleDef(dynamicsSize,                               1.0), // percentage of the standard size
     styleDef(dynamicsPlacement,                          PlacementV::BELOW),
     styleDef(dynamicsPosAbove,                           PointF(.0, -1.0)),

--- a/src/engraving/style/styledef.h
+++ b/src/engraving/style/styledef.h
@@ -708,6 +708,7 @@ enum class Sid {
 
     dynamicsOverrideFont,
     dynamicsFont,
+    dynamicsUseExpressionFont,
     dynamicsSize,
     dynamicsPlacement,
     dynamicsPosAbove,

--- a/src/engraving/tests/textbase_tests.cpp
+++ b/src/engraving/tests/textbase_tests.cpp
@@ -179,8 +179,8 @@ TEST_F(Engraving_TextBaseTests, musicalSymbolsNotBold)
     staffText->setXmlText(u"<b>Allegro <sym>metNoteQuarterUp</sym> = 120</b>");
     score->renderer()->layoutItem(staffText);
     auto fragmentList = staffText->fragmentList();
-    EXPECT_TRUE(fragmentList.front().font(staffText).bold());
-    EXPECT_TRUE(!std::next(fragmentList.begin())->font(staffText).bold());
+    EXPECT_TRUE(fragmentList.front()->font(staffText).bold());
+    EXPECT_TRUE(!(*std::next(fragmentList.begin()))->font(staffText).bold());
 }
 
 TEST_F(Engraving_TextBaseTests, musicalSymbolsNotItalic)
@@ -190,6 +190,6 @@ TEST_F(Engraving_TextBaseTests, musicalSymbolsNotItalic)
     dynamic->setXmlText(u"molto <sym>dynamicForte</sym>");
     score->renderer()->layoutItem(dynamic);
     auto fragmentList = dynamic->fragmentList();
-    EXPECT_TRUE(fragmentList.front().font(dynamic).italic());
-    EXPECT_TRUE(!std::next(fragmentList.begin())->font(dynamic).italic());
+    EXPECT_TRUE(fragmentList.front()->font(dynamic).italic());
+    EXPECT_TRUE(!(*std::next(fragmentList.begin()))->font(dynamic).italic());
 }

--- a/src/engraving/types/typesconv.cpp
+++ b/src/engraving/types/typesconv.cpp
@@ -881,7 +881,7 @@ DynamicType TConv::dynamicType(SymId v)
         return i.symId == v;
     });
 
-    IF_ASSERT_FAILED(it != DYNAMIC_TYPES.cend()) {
+    if (it == DYNAMIC_TYPES.cend()) {
         return DynamicType::OTHER;
     }
     return it->type;

--- a/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
@@ -1441,7 +1441,7 @@ static CharFormat formatForWords(const MStyle& s)
 
 static void creditWords(XmlWriter& xml, const MStyle& s, const page_idx_t pageNr,
                         const double x, const double y, const String& just, const String& val,
-                        const std::list<TextFragment>& words, const String& creditType)
+                        const std::list<std::shared_ptr<TextFragment> >& words, const String& creditType)
 {
     // prevent incorrect MusicXML for empty text
     if (words.empty()) {
@@ -1601,10 +1601,10 @@ void ExportMusicXml::credits(XmlWriter& xml)
         const double tm = getTenthsFromInches(_score->styleD(Sid::pageOddTopMargin));
         LOGD("page h=%g w=%g lm=%g rm=%g tm=%g bm=%g", h, w, lm, rm, tm, bm);
         */
-        TextFragment f(XmlWriter::xmlString(rights));
-        f.changeFormat(FormatId::FontFamily, style.styleSt(Sid::footerFontFace));
-        f.changeFormat(FormatId::FontSize, style.styleD(Sid::footerFontSize));
-        std::list<TextFragment> list;
+        std::shared_ptr<TextFragment> f = std::make_shared<TextFragment>(XmlWriter::xmlString(rights));
+        f->changeFormat(FormatId::FontFamily, style.styleSt(Sid::footerFontFace));
+        f->changeFormat(FormatId::FontSize, style.styleD(Sid::footerFontSize));
+        std::list<std::shared_ptr<TextFragment> > list;
         list.push_back(f);
         for (page_idx_t pageIdx = 0; pageIdx < m_score->npages(); ++pageIdx) {
             creditWords(xml, style, pageIdx + 1, w / 2, bm, u"center", u"bottom", list, u"rights");
@@ -4771,12 +4771,12 @@ static size_t indexOf(const String& src_, const std::wregex& re, size_t from, st
     return std::u16string::npos;
 }
 
-static bool findMetronome(const std::list<TextFragment>& list,
-                          std::list<TextFragment>& wordsLeft,  // words left of metronome
+static bool findMetronome(const std::list<std::shared_ptr<TextFragment> >& list,
+                          std::list<std::shared_ptr<TextFragment> >& wordsLeft,  // words left of metronome
                           bool& hasParen,      // parenthesis
                           String& metroLeft,  // left part of metronome
                           String& metroRight, // right part of metronome
-                          std::list<TextFragment>& wordsRight // words right of metronome
+                          std::list<std::shared_ptr<TextFragment> >& wordsRight // words right of metronome
                           )
 {
     String words = MScoreTextToMusicXml::toPlainTextPlusSymbols(list);
@@ -4858,7 +4858,7 @@ static bool findMetronome(const std::list<TextFragment>& list,
             }
             metroPos = corrPos;
 
-            std::list<TextFragment> mid;       // not used
+            std::list<std::shared_ptr<TextFragment> > mid;       // not used
             MScoreTextToMusicXml::split(list, metroPos, metroLen, wordsLeft, mid, wordsRight);
             return true;
         }
@@ -4886,12 +4886,12 @@ static void beatUnit(XmlWriter& xml, const TDuration dur)
 
 static void wordsMetronome(XmlWriter& xml, const MStyle& s, TextBase const* const text, const int offset)
 {
-    const std::list<TextFragment> list = text->fragmentList();
-    std::list<TextFragment> wordsLeft;          // words left of metronome
+    const std::list<std::shared_ptr<TextFragment> > list = text->fragmentList();
+    std::list<std::shared_ptr<TextFragment> > wordsLeft;          // words left of metronome
     bool hasParen;                          // parenthesis
     String metroLeft;                      // left part of metronome
     String metroRight;                     // right part of metronome
-    std::list<TextFragment> wordsRight;         // words right of metronome
+    std::list<std::shared_ptr<TextFragment> > wordsRight;         // words right of metronome
 
     // set the default words format
     const String mtf = s.styleSt(Sid::musicalTextFont);

--- a/src/importexport/musicxml/internal/musicxml/shared/musicxmlfonthandler.cpp
+++ b/src/importexport/musicxml/internal/musicxml/shared/musicxmlfonthandler.cpp
@@ -78,11 +78,11 @@ String MScoreTextToMusicXml::toPlainText(const String& text)
 //    convert to plain text plus <sym>[name]</sym> encoded symbols
 //---------------------------------------------------------
 
-String MScoreTextToMusicXml::toPlainTextPlusSymbols(const std::list<std::shared_ptr<TextFragment>>& list)
+String MScoreTextToMusicXml::toPlainTextPlusSymbols(const std::list<std::shared_ptr<TextFragment> >& list)
 {
     String res;
     for (const std::shared_ptr<TextFragment>& f : list) {
-        res += f->text;
+        res += f->text();
     }
     return res;
 }
@@ -100,7 +100,7 @@ static int plainTextPlusSymbolsFragmentSize(const std::shared_ptr<TextFragment>&
 //   plainTextPlusSymbolsSize
 //---------------------------------------------------------
 
-static int plainTextPlusSymbolsListSize(const std::list<std::shared_ptr<TextFragment>>& list)
+static int plainTextPlusSymbolsListSize(const std::list<std::shared_ptr<TextFragment> >& list)
 {
     int res = 0;
     for (const std::shared_ptr<TextFragment>& f : list) {
@@ -120,8 +120,9 @@ static int plainTextPlusSymbolsListSize(const std::list<std::shared_ptr<TextFrag
  Return true if OK, false on error.
  */
 
-bool MScoreTextToMusicXml::split(const std::list<std::shared_ptr<TextFragment>>& in, const int pos, const int len,
-                                 std::list<std::shared_ptr<TextFragment>>& left, std::list<std::shared_ptr<TextFragment>>& mid, std::list<std::shared_ptr<TextFragment>>& right)
+bool MScoreTextToMusicXml::split(const std::list<std::shared_ptr<TextFragment> >& in, const int pos, const int len,
+                                 std::list<std::shared_ptr<TextFragment> >& left, std::list<std::shared_ptr<TextFragment> >& mid,
+                                 std::list<std::shared_ptr<TextFragment> >& right)
 {
     //LOGD("MScoreTextToMXML::split in size %d pos %d len %d", plainTextPlusSymbolsListSize(in), pos, len);
     //LOGD("-> in");
@@ -137,12 +138,12 @@ bool MScoreTextToMusicXml::split(const std::list<std::shared_ptr<TextFragment>>&
     right.clear();
 
     // set pos to begin of first fragment
-    std::list<std::shared_ptr<TextFragment>>::const_iterator fragmentNr = in.begin();
+    std::list<std::shared_ptr<TextFragment> >::const_iterator fragmentNr = in.begin();
     std::shared_ptr<TextFragment> fragment;
     if (fragmentNr != in.end()) {
         fragment = *fragmentNr;
     }
-    std::list<std::shared_ptr<TextFragment>>* currentDest = &left;
+    std::list<std::shared_ptr<TextFragment> >* currentDest = &left;
     int currentMaxSize = pos;
 
     // while text left
@@ -195,14 +196,14 @@ bool MScoreTextToMusicXml::split(const std::list<std::shared_ptr<TextFragment>>&
 //   writeTextFragments
 //---------------------------------------------------------
 
-void MScoreTextToMusicXml::writeTextFragments(const std::list<std::shared_ptr<TextFragment>>& fr, XmlWriter& xml)
+void MScoreTextToMusicXml::writeTextFragments(const std::list<std::shared_ptr<TextFragment> >& fr, XmlWriter& xml)
 {
     //dumpText(fr);
     bool firstTime = true;   // write additional attributes only the first time characters are written
     for (const std::shared_ptr<TextFragment>& f : fr) {
         newFormat = f->format;
         String formatAttr = updateFormat();
-        xml.tagRaw(tagname + (firstTime ? attribs : String()) + formatAttr, f->text);
+        xml.tagRaw(tagname + (firstTime ? attribs : String()) + formatAttr, f->text());
         firstTime = false;
     }
 }

--- a/src/importexport/musicxml/internal/musicxml/shared/musicxmlfonthandler.cpp
+++ b/src/importexport/musicxml/internal/musicxml/shared/musicxmlfonthandler.cpp
@@ -78,11 +78,11 @@ String MScoreTextToMusicXml::toPlainText(const String& text)
 //    convert to plain text plus <sym>[name]</sym> encoded symbols
 //---------------------------------------------------------
 
-String MScoreTextToMusicXml::toPlainTextPlusSymbols(const std::list<TextFragment>& list)
+String MScoreTextToMusicXml::toPlainTextPlusSymbols(const std::list<std::shared_ptr<TextFragment>>& list)
 {
     String res;
-    for (const TextFragment& f : list) {
-        res += f.text;
+    for (const std::shared_ptr<TextFragment>& f : list) {
+        res += f->text;
     }
     return res;
 }
@@ -91,19 +91,19 @@ String MScoreTextToMusicXml::toPlainTextPlusSymbols(const std::list<TextFragment
 //   plainTextPlusSymbolsSize
 //---------------------------------------------------------
 
-static int plainTextPlusSymbolsFragmentSize(const TextFragment& f)
+static int plainTextPlusSymbolsFragmentSize(const std::shared_ptr<TextFragment>& f)
 {
-    return f.columns();
+    return f->columns();
 }
 
 //---------------------------------------------------------
 //   plainTextPlusSymbolsSize
 //---------------------------------------------------------
 
-static int plainTextPlusSymbolsListSize(const std::list<TextFragment>& list)
+static int plainTextPlusSymbolsListSize(const std::list<std::shared_ptr<TextFragment>>& list)
 {
     int res = 0;
-    for (const TextFragment& f : list) {
+    for (const std::shared_ptr<TextFragment>& f : list) {
         res += plainTextPlusSymbolsFragmentSize(f);
     }
     return res;
@@ -120,8 +120,8 @@ static int plainTextPlusSymbolsListSize(const std::list<TextFragment>& list)
  Return true if OK, false on error.
  */
 
-bool MScoreTextToMusicXml::split(const std::list<TextFragment>& in, const int pos, const int len,
-                                 std::list<TextFragment>& left, std::list<TextFragment>& mid, std::list<TextFragment>& right)
+bool MScoreTextToMusicXml::split(const std::list<std::shared_ptr<TextFragment>>& in, const int pos, const int len,
+                                 std::list<std::shared_ptr<TextFragment>>& left, std::list<std::shared_ptr<TextFragment>>& mid, std::list<std::shared_ptr<TextFragment>>& right)
 {
     //LOGD("MScoreTextToMXML::split in size %d pos %d len %d", plainTextPlusSymbolsListSize(in), pos, len);
     //LOGD("-> in");
@@ -137,12 +137,12 @@ bool MScoreTextToMusicXml::split(const std::list<TextFragment>& in, const int po
     right.clear();
 
     // set pos to begin of first fragment
-    std::list<TextFragment>::const_iterator fragmentNr = in.begin();
-    TextFragment fragment;
+    std::list<std::shared_ptr<TextFragment>>::const_iterator fragmentNr = in.begin();
+    std::shared_ptr<TextFragment> fragment;
     if (fragmentNr != in.end()) {
         fragment = *fragmentNr;
     }
-    std::list<TextFragment>* currentDest = &left;
+    std::list<std::shared_ptr<TextFragment>>* currentDest = &left;
     int currentMaxSize = pos;
 
     // while text left
@@ -172,7 +172,7 @@ bool MScoreTextToMusicXml::split(const std::list<TextFragment>& in, const int po
             }
         } else {
             // split current fragment
-            TextFragment rightPart = fragment.split(currentMaxSize - plainTextPlusSymbolsListSize(*currentDest));
+            std::shared_ptr<TextFragment> rightPart = fragment->split(currentMaxSize - plainTextPlusSymbolsListSize(*currentDest));
             // add first part to current destination
             currentDest->push_back(fragment);
             fragment = rightPart;
@@ -195,14 +195,14 @@ bool MScoreTextToMusicXml::split(const std::list<TextFragment>& in, const int po
 //   writeTextFragments
 //---------------------------------------------------------
 
-void MScoreTextToMusicXml::writeTextFragments(const std::list<TextFragment>& fr, XmlWriter& xml)
+void MScoreTextToMusicXml::writeTextFragments(const std::list<std::shared_ptr<TextFragment>>& fr, XmlWriter& xml)
 {
     //dumpText(fr);
     bool firstTime = true;   // write additional attributes only the first time characters are written
-    for (const TextFragment& f : fr) {
-        newFormat = f.format;
+    for (const std::shared_ptr<TextFragment>& f : fr) {
+        newFormat = f->format;
         String formatAttr = updateFormat();
-        xml.tagRaw(tagname + (firstTime ? attribs : String()) + formatAttr, f.text);
+        xml.tagRaw(tagname + (firstTime ? attribs : String()) + formatAttr, f->text);
         firstTime = false;
     }
 }

--- a/src/importexport/musicxml/internal/musicxml/shared/musicxmlfonthandler.h
+++ b/src/importexport/musicxml/internal/musicxml/shared/musicxmlfonthandler.h
@@ -35,10 +35,11 @@ class MScoreTextToMusicXml
 public:
     MScoreTextToMusicXml(const muse::String& tag, const muse::String& attr, const engraving::CharFormat& defFmt, const muse::String& mtf);
     static muse::String toPlainText(const muse::String& text);
-    static muse::String toPlainTextPlusSymbols(const std::list<engraving::TextFragment>& list);
-    static bool split(const std::list<engraving::TextFragment>& in, const int pos, const int len, std::list<engraving::TextFragment>& left,
-                      std::list<engraving::TextFragment>& mid, std::list<engraving::TextFragment>& right);
-    void writeTextFragments(const std::list<engraving::TextFragment>& fr, engraving::XmlWriter& xml);
+    static muse::String toPlainTextPlusSymbols(const std::list<std::shared_ptr<engraving::TextFragment> >& list);
+    static bool split(const std::list<std::shared_ptr<engraving::TextFragment> >& in, const int pos, const int len,
+                      std::list<std::shared_ptr<engraving::TextFragment> >& left, std::list<std::shared_ptr<engraving::TextFragment> >& mid,
+                      std::list<std::shared_ptr<engraving::TextFragment> >& right);
+    void writeTextFragments(const std::list<std::shared_ptr<engraving::TextFragment> >& fr, engraving::XmlWriter& xml);
 
 private:
     muse::String updateFormat();

--- a/src/notation/view/widgets/editstyle.cpp
+++ b/src/notation/view/widgets/editstyle.cpp
@@ -642,6 +642,7 @@ EditStyle::EditStyle(QWidget* parent)
         { StyleId::dynamicsSize,            true,  dynamicsSize,               resetDynamicsSize },
         { StyleId::dynamicsOverrideFont,    false, dynamicsOverrideFont,       0 },
         { StyleId::dynamicsFont,            false, dynamicsFont,               0 },
+        { StyleId::dynamicsUseExpressionFont, false, dynamicsUseExpressionFont, 0 },
 
         { StyleId::dynamicsHairpinVoiceBasedPlacement, false, dynamicsAndHairpinPos, resetDynamicsAndHairpinPos },
         { StyleId::dynamicsHairpinsAutoCenterOnGrandStaff, false, dynamicsAndHairpinsCenterOnGrandStaff, 0 },
@@ -1090,6 +1091,10 @@ EditStyle::EditStyle(QWidget* parent)
     });
     connect(dynamicsAndHairpinPos, &QComboBox::currentIndexChanged, dynamicsAndHairpinsAboveOnVocalStaves, [=]() {
         dynamicsAndHairpinsAboveOnVocalStaves->setEnabled(dynamicsAndHairpinPos->currentIndex() != int(DirectionV::UP));
+    });
+
+    connect(dynamicsFontChoose, &QRadioButton::toggled, dynamicsFont, [=]() {
+        dynamicsFont->setEnabled(dynamicsFontChoose->isChecked());
     });
 
     WidgetUtils::setWidgetIcon(resetTextStyleName, IconCode::Code::UNDO);

--- a/src/notation/view/widgets/editstyle.ui
+++ b/src/notation/view/widgets/editstyle.ui
@@ -8326,37 +8326,13 @@
                <string>Dynamics</string>
               </property>
               <layout class="QGridLayout" name="gridLayout_672">
-               <item row="5" column="0">
-                <widget class="QLabel" name="label_220">
-                 <property name="text">
-                  <string>Autoplace min. distance:</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="3" column="1">
+               <item row="4" column="1">
                 <widget class="mu::notation::OffsetSelect" name="dynamicsPosAbove" native="true"/>
                </item>
-               <item row="4" column="0">
-                <widget class="QLabel" name="label_223">
-                 <property name="text">
-                  <string>Position below:</string>
-                 </property>
-                </widget>
+               <item row="5" column="1">
+                <widget class="mu::notation::OffsetSelect" name="dynamicsPosBelow" native="true"/>
                </item>
-               <item row="4" column="2">
-                <widget class="QToolButton" name="resetDynamicsPosBelow">
-                 <property name="toolTip">
-                  <string>Reset to default</string>
-                 </property>
-                 <property name="accessibleName">
-                  <string>Reset 'Position below' value</string>
-                 </property>
-                 <property name="text">
-                  <string notr="true"/>
-                 </property>
-                </widget>
-               </item>
-               <item row="2" column="2">
+               <item row="3" column="2">
                 <widget class="QToolButton" name="resetDynamicsSize">
                  <property name="toolTip">
                   <string>Reset to default</string>
@@ -8369,40 +8345,156 @@
                  </property>
                 </widget>
                </item>
-               <item row="1" column="2">
-                <widget class="QToolButton" name="resetAvoidBarLines">
-                 <property name="toolTip">
-                  <string>Reset to default</string>
-                 </property>
-                 <property name="accessibleName">
-                  <string>Reset 'Avoid barlines' setting</string>
-                 </property>
-                 <property name="text">
-                  <string notr="true"/>
-                 </property>
-                </widget>
-               </item>
                <item row="5" column="2">
-                <widget class="QToolButton" name="resetDynamicsMinDistance">
+                <widget class="QToolButton" name="resetDynamicsPosBelow">
                  <property name="toolTip">
                   <string>Reset to default</string>
                  </property>
                  <property name="accessibleName">
-                  <string>Reset 'Autoplace min. distance' value</string>
+                  <string>Reset 'Position below' value</string>
                  </property>
                  <property name="text">
                   <string notr="true"/>
                  </property>
                 </widget>
                </item>
-               <item row="3" column="0">
-                <widget class="QLabel" name="label_221">
+               <item row="6" column="0">
+                <widget class="QLabel" name="label_220">
                  <property name="text">
-                  <string>Position above:</string>
+                  <string>Autoplace min. distance:</string>
                  </property>
                 </widget>
                </item>
-               <item row="2" column="1">
+               <item row="4" column="2">
+                <widget class="QToolButton" name="resetDynamicsPosAbove">
+                 <property name="toolTip">
+                  <string>Reset to default</string>
+                 </property>
+                 <property name="accessibleName">
+                  <string>Reset 'Position above' value</string>
+                 </property>
+                 <property name="text">
+                  <string notr="true"/>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="0" colspan="4">
+                <widget class="QGroupBox" name="dynamicsOverrideFont">
+                 <property name="enabled">
+                  <bool>true</bool>
+                 </property>
+                 <property name="focusPolicy">
+                  <enum>Qt::StrongFocus</enum>
+                 </property>
+                 <property name="accessibleName">
+                  <string>Override score font</string>
+                 </property>
+                 <property name="title">
+                  <string>Override score font</string>
+                 </property>
+                 <property name="checkable">
+                  <bool>true</bool>
+                 </property>
+                 <layout class="QVBoxLayout" name="verticalLayout_73">
+                  <property name="spacing">
+                   <number>7</number>
+                  </property>
+                  <property name="leftMargin">
+                   <number>8</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>8</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>7</number>
+                  </property>
+                  <item>
+                   <layout class="QHBoxLayout" name="chooseFont">
+                    <property name="spacing">
+                     <number>5</number>
+                    </property>
+                    <item>
+                     <widget class="QRadioButton" name="dynamicsFontChoose">
+                      <property name="sizePolicy">
+                       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                        <horstretch>0</horstretch>
+                        <verstretch>0</verstretch>
+                       </sizepolicy>
+                      </property>
+                      <property name="text">
+                       <string>Choose font:</string>
+                      </property>
+                      <property name="checked">
+                       <bool>true</bool>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QComboBox" name="dynamicsFont">
+                      <property name="enabled">
+                       <bool>true</bool>
+                      </property>
+                      <property name="sizePolicy">
+                       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                        <horstretch>0</horstretch>
+                        <verstretch>0</verstretch>
+                       </sizepolicy>
+                      </property>
+                      <property name="minimumSize">
+                       <size>
+                        <width>225</width>
+                        <height>0</height>
+                       </size>
+                      </property>
+                      <property name="maximumSize">
+                       <size>
+                        <width>16777215</width>
+                        <height>16777215</height>
+                       </size>
+                      </property>
+                      <property name="accessibleDescription">
+                       <string/>
+                      </property>
+                      <property name="autoFillBackground">
+                       <bool>false</bool>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <spacer name="horizontalSpacer_73">
+                      <property name="orientation">
+                       <enum>Qt::Horizontal</enum>
+                      </property>
+                      <property name="sizeHint" stdset="0">
+                       <size>
+                        <width>40</width>
+                        <height>20</height>
+                       </size>
+                      </property>
+                     </spacer>
+                    </item>
+                   </layout>
+                  </item>
+                  <item>
+                   <widget class="QRadioButton" name="dynamicsUseExpressionFont">
+                    <property name="minimumSize">
+                     <size>
+                      <width>0</width>
+                      <height>24</height>
+                     </size>
+                    </property>
+                    <property name="autoFillBackground">
+                     <bool>false</bool>
+                    </property>
+                    <property name="text">
+                     <string>Use expression text style</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item row="3" column="1">
                 <widget class="QDoubleSpinBox" name="dynamicsSize">
                  <property name="keyboardTracking">
                   <bool>false</bool>
@@ -8418,7 +8510,70 @@
                  </property>
                 </widget>
                </item>
-               <item row="5" column="1">
+               <item row="5" column="0">
+                <widget class="QLabel" name="label_223">
+                 <property name="text">
+                  <string>Position below:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="0">
+                <widget class="QLabel" name="label_225">
+                 <property name="text">
+                  <string>Scale:</string>
+                 </property>
+                 <property name="margin">
+                  <number>0</number>
+                 </property>
+                </widget>
+               </item>
+               <item row="6" column="3">
+                <spacer name="horizontalSpacer_30">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item row="6" column="2">
+                <widget class="QToolButton" name="resetDynamicsMinDistance">
+                 <property name="toolTip">
+                  <string>Reset to default</string>
+                 </property>
+                 <property name="accessibleName">
+                  <string>Reset 'Autoplace min. distance' value</string>
+                 </property>
+                 <property name="text">
+                  <string notr="true"/>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="0">
+                <widget class="QCheckBox" name="avoidBarLines">
+                 <property name="text">
+                  <string>Avoid barlines</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="2">
+                <widget class="QToolButton" name="resetAvoidBarLines">
+                 <property name="toolTip">
+                  <string>Reset to default</string>
+                 </property>
+                 <property name="accessibleName">
+                  <string>Reset 'Avoid barlines' setting</string>
+                 </property>
+                 <property name="text">
+                  <string notr="true"/>
+                 </property>
+                </widget>
+               </item>
+               <item row="6" column="1">
                 <widget class="QDoubleSpinBox" name="dynamicsMinDistance">
                  <property name="keyboardTracking">
                   <bool>false</bool>
@@ -8443,83 +8598,12 @@
                  </property>
                 </widget>
                </item>
-               <item row="1" column="0">
-                <widget class="QCheckBox" name="avoidBarLines">
+               <item row="4" column="0">
+                <widget class="QLabel" name="label_221">
                  <property name="text">
-                  <string>Avoid barlines</string>
+                  <string>Position above:</string>
                  </property>
                 </widget>
-               </item>
-               <item row="3" column="2">
-                <widget class="QToolButton" name="resetDynamicsPosAbove">
-                 <property name="toolTip">
-                  <string>Reset to default</string>
-                 </property>
-                 <property name="accessibleName">
-                  <string>Reset 'Position above' value</string>
-                 </property>
-                 <property name="text">
-                  <string notr="true"/>
-                 </property>
-                </widget>
-               </item>
-               <item row="4" column="1">
-                <widget class="mu::notation::OffsetSelect" name="dynamicsPosBelow" native="true"/>
-               </item>
-               <item row="2" column="0">
-                <widget class="QLabel" name="label_225">
-                 <property name="text">
-                  <string>Scale:</string>
-                 </property>
-                 <property name="margin">
-                  <number>0</number>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="0" colspan="4">
-                <widget class="QGroupBox" name="dynamicsOverrideFont">
-                 <property name="accessibleName">
-                  <string>Override score font</string>
-                 </property>
-                 <property name="title">
-                  <string>Override score font</string>
-                 </property>
-                 <property name="checkable">
-                  <bool>true</bool>
-                 </property>
-                 <layout class="QHBoxLayout" name="horizontalLayout_14">
-                  <item>
-                   <widget class="QLabel" name="label_224">
-                    <property name="text">
-                     <string>Font:</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QComboBox" name="dynamicsFont">
-                    <property name="minimumSize">
-                     <size>
-                      <width>0</width>
-                      <height>0</height>
-                     </size>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item row="5" column="3">
-                <spacer name="horizontalSpacer_30">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>40</width>
-                   <height>20</height>
-                  </size>
-                 </property>
-                </spacer>
                </item>
               </layout>
              </widget>
@@ -8530,6 +8614,23 @@
                <string>Hairpins</string>
               </property>
               <layout class="QGridLayout" name="gridLayout_7">
+               <item row="0" column="1">
+                <widget class="mu::notation::OffsetSelect" name="hairpinPosAbove" native="true">
+                 <property name="focusPolicy">
+                  <enum>Qt::StrongFocus</enum>
+                 </property>
+                </widget>
+               </item>
+               <item row="5" column="0">
+                <widget class="QLabel" name="label_117">
+                 <property name="text">
+                  <string>Autoplace, distance to dynamics:</string>
+                 </property>
+                 <property name="buddy">
+                  <cstring>autoplaceHairpinDynamicsDistance</cstring>
+                 </property>
+                </widget>
+               </item>
                <item row="5" column="2">
                 <widget class="QToolButton" name="resetAutoplaceHairpinDynamicsDistance">
                  <property name="sizePolicy">
@@ -8549,84 +8650,6 @@
                  </property>
                 </widget>
                </item>
-               <item row="0" column="0">
-                <widget class="QLabel" name="label_95">
-                 <property name="text">
-                  <string>Position above:</string>
-                 </property>
-                 <property name="buddy">
-                  <cstring>hairpinPosAbove</cstring>
-                 </property>
-                </widget>
-               </item>
-               <item row="3" column="1">
-                <widget class="QDoubleSpinBox" name="hairpinHeight">
-                 <property name="keyboardTracking">
-                  <bool>false</bool>
-                 </property>
-                 <property name="suffix">
-                  <string extracomment="spatium unit">sp</string>
-                 </property>
-                 <property name="singleStep">
-                  <double>0.100000000000000</double>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="1">
-                <widget class="mu::notation::OffsetSelect" name="hairpinPosAbove" native="true">
-                 <property name="focusPolicy">
-                  <enum>Qt::StrongFocus</enum>
-                 </property>
-                </widget>
-               </item>
-               <item row="5" column="0">
-                <widget class="QLabel" name="label_117">
-                 <property name="text">
-                  <string>Autoplace, distance to dynamics:</string>
-                 </property>
-                 <property name="buddy">
-                  <cstring>autoplaceHairpinDynamicsDistance</cstring>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="2">
-                <widget class="QToolButton" name="resetHairpinPosAbove">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="toolTip">
-                  <string>Reset to default</string>
-                 </property>
-                 <property name="accessibleName">
-                  <string>Reset 'Position above' value</string>
-                 </property>
-                 <property name="text">
-                  <string notr="true"/>
-                 </property>
-                </widget>
-               </item>
-               <item row="4" column="2">
-                <widget class="QToolButton" name="resetHairpinContinueHeight">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="toolTip">
-                  <string>Reset to default</string>
-                 </property>
-                 <property name="accessibleName">
-                  <string>Reset 'Continue height' value</string>
-                 </property>
-                 <property name="text">
-                  <string notr="true"/>
-                 </property>
-                </widget>
-               </item>
                <item row="3" column="0">
                 <widget class="QLabel" name="label_9">
                  <property name="text">
@@ -8637,13 +8660,13 @@
                  </property>
                 </widget>
                </item>
-               <item row="6" column="0">
-                <widget class="QLabel" name="label_8">
+               <item row="4" column="0">
+                <widget class="QLabel" name="label_10">
                  <property name="text">
-                  <string>Line thickness:</string>
+                  <string>Continue height:</string>
                  </property>
                  <property name="buddy">
-                  <cstring>hairpinLineWidth</cstring>
+                  <cstring>hairpinContinueHeight</cstring>
                  </property>
                 </widget>
                </item>
@@ -8679,10 +8702,126 @@
                  </property>
                 </widget>
                </item>
+               <item row="1" column="0">
+                <widget class="QLabel" name="label_129">
+                 <property name="text">
+                  <string>Position below:</string>
+                 </property>
+                 <property name="buddy">
+                  <cstring>hairpinPosBelow</cstring>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="1">
+                <widget class="QDoubleSpinBox" name="hairpinContinueHeight">
+                 <property name="keyboardTracking">
+                  <bool>false</bool>
+                 </property>
+                 <property name="suffix">
+                  <string extracomment="spatium unit">sp</string>
+                 </property>
+                 <property name="singleStep">
+                  <double>0.100000000000000</double>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="2">
+                <widget class="QToolButton" name="resetHairpinPosAbove">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="toolTip">
+                  <string>Reset to default</string>
+                 </property>
+                 <property name="accessibleName">
+                  <string>Reset 'Position above' value</string>
+                 </property>
+                 <property name="text">
+                  <string notr="true"/>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="3">
+                <spacer name="horizontalSpacer_671">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item row="3" column="2">
+                <widget class="QToolButton" name="resetHairpinHeight">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="toolTip">
+                  <string>Reset to default</string>
+                 </property>
+                 <property name="accessibleName">
+                  <string>Reset 'Height' value</string>
+                 </property>
+                 <property name="text">
+                  <string notr="true"/>
+                 </property>
+                </widget>
+               </item>
+               <item row="6" column="0">
+                <widget class="QLabel" name="label_8">
+                 <property name="text">
+                  <string>Line thickness:</string>
+                 </property>
+                 <property name="buddy">
+                  <cstring>hairpinLineWidth</cstring>
+                 </property>
+                </widget>
+               </item>
                <item row="1" column="1">
                 <widget class="mu::notation::OffsetSelect" name="hairpinPosBelow" native="true">
                  <property name="focusPolicy">
                   <enum>Qt::StrongFocus</enum>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="2">
+                <widget class="QToolButton" name="resetHairpinContinueHeight">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="toolTip">
+                  <string>Reset to default</string>
+                 </property>
+                 <property name="accessibleName">
+                  <string>Reset 'Continue height' value</string>
+                 </property>
+                 <property name="text">
+                  <string notr="true"/>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="1">
+                <widget class="QDoubleSpinBox" name="hairpinHeight">
+                 <property name="keyboardTracking">
+                  <bool>false</bool>
+                 </property>
+                 <property name="suffix">
+                  <string extracomment="spatium unit">sp</string>
+                 </property>
+                 <property name="singleStep">
+                  <double>0.100000000000000</double>
                  </property>
                 </widget>
                </item>
@@ -8699,13 +8838,13 @@
                  </property>
                 </widget>
                </item>
-               <item row="1" column="0">
-                <widget class="QLabel" name="label_129">
+               <item row="0" column="0">
+                <widget class="QLabel" name="label_95">
                  <property name="text">
-                  <string>Position below:</string>
+                  <string>Position above:</string>
                  </property>
                  <property name="buddy">
-                  <cstring>hairpinPosBelow</cstring>
+                  <cstring>hairpinPosAbove</cstring>
                  </property>
                 </widget>
                </item>
@@ -8727,61 +8866,6 @@
                   <string notr="true"/>
                  </property>
                 </widget>
-               </item>
-               <item row="4" column="1">
-                <widget class="QDoubleSpinBox" name="hairpinContinueHeight">
-                 <property name="keyboardTracking">
-                  <bool>false</bool>
-                 </property>
-                 <property name="suffix">
-                  <string extracomment="spatium unit">sp</string>
-                 </property>
-                 <property name="singleStep">
-                  <double>0.100000000000000</double>
-                 </property>
-                </widget>
-               </item>
-               <item row="4" column="0">
-                <widget class="QLabel" name="label_10">
-                 <property name="text">
-                  <string>Continue height:</string>
-                 </property>
-                 <property name="buddy">
-                  <cstring>hairpinContinueHeight</cstring>
-                 </property>
-                </widget>
-               </item>
-               <item row="3" column="2">
-                <widget class="QToolButton" name="resetHairpinHeight">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="toolTip">
-                  <string>Reset to default</string>
-                 </property>
-                 <property name="accessibleName">
-                  <string>Reset 'Height' value</string>
-                 </property>
-                 <property name="text">
-                  <string notr="true"/>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="3">
-                <spacer name="horizontalSpacer_671">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>40</width>
-                   <height>20</height>
-                  </size>
-                 </property>
-                </spacer>
                </item>
               </layout>
              </widget>

--- a/src/notation/view/widgets/timeline.cpp
+++ b/src/notation/view/widgets/timeline.cpp
@@ -1448,9 +1448,9 @@ void Timeline::jumpMarkerMeta(Segment* seg, int* stagger, int pos)
         elementType = ElementType::JUMP;
     } else {
         Marker* marker = toMarker(std::get<3>(_repeatInfo));
-        std::list<TextFragment> tf_list = marker->fragmentList();
-        for (TextFragment tf : tf_list) {
-            text.push_back(tf.text);
+        std::list<std::shared_ptr<TextFragment>> tf_list = marker->fragmentList();
+        for (std::shared_ptr<TextFragment> tf : tf_list) {
+            text.push_back(tf->text);
         }
         measure = marker->measure();
         if (marker->markerType() == MarkerType::FINE

--- a/src/notation/view/widgets/timeline.cpp
+++ b/src/notation/view/widgets/timeline.cpp
@@ -1448,9 +1448,9 @@ void Timeline::jumpMarkerMeta(Segment* seg, int* stagger, int pos)
         elementType = ElementType::JUMP;
     } else {
         Marker* marker = toMarker(std::get<3>(_repeatInfo));
-        std::list<std::shared_ptr<TextFragment>> tf_list = marker->fragmentList();
+        std::list<std::shared_ptr<TextFragment> > tf_list = marker->fragmentList();
         for (std::shared_ptr<TextFragment> tf : tf_list) {
-            text.push_back(tf->text);
+            text.push_back(tf->text());
         }
         measure = marker->measure();
         if (marker->markerType() == MarkerType::FINE


### PR DESCRIPTION
Resolves: #23090  <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

The new option appears in **Format > Style > Dynamics & hairpins**. It's mainly useful for accessibility purposes.

![image](https://github.com/user-attachments/assets/224b5239-1bb5-48de-b148-12b54913bf1a)

It's governed by a new style parameter, `dynamicsUseExpressionFont`, which is `false` by default.

When set to `true`, dynamic symbols (***p***, ***mf***, etc.) are rendered in the same font as surrounding text.

Disabled (default) | Enabled (new)
:---:|:---:
<img width="175px" src="https://github.com/musescore/MuseScore/assets/11011881/cbcffee0-99dd-44e3-866e-f4e79588167f"/> | <img width="175px" src="https://github.com/musescore/MuseScore/assets/11011881/bc185d16-dc4c-4089-b6d7-8fda7424545d"/>
Traditional | Accessible

The option can be enabled or disabled at any time to convert existing scores to and from the accessible rendering.

#### Editing dynamics

While editing, dynamics always use the traditional rendering so that users know which characters are "special".

Editing | Not editing
---|---
![image](https://github.com/user-attachments/assets/cfc5ea4f-f993-4693-b1e6-b756fe7b8cf7) | ![image](https://github.com/user-attachments/assets/2b3a9b8b-8877-4a65-b6a3-712a01c12c64)


<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)

@shoogle 