### PR TITLE
Percussion panel - refinements round 2

### DIFF
--- a/src/engraving/dom/drumset.h
+++ b/src/engraving/dom/drumset.h
@@ -54,7 +54,7 @@ struct DrumInstrument {
 
     // if notehead = HEAD_CUSTOM, custom, use noteheads
     NoteHeadGroup notehead = NoteHeadGroup::HEAD_INVALID;   ///< notehead symbol set
-    SymId noteheads[int(NoteHeadType::HEAD_TYPES)]
+    std::array<SymId, int(NoteHeadType::HEAD_TYPES)> noteheads
         = { SymId::noteheadWhole, SymId::noteheadHalf, SymId::noteheadBlack, SymId::noteheadDoubleWhole };
 
     int line = 0;               ///< place notehead onto this line

--- a/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
+++ b/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
@@ -301,7 +301,7 @@ Item {
                         // If this is the swap target - move the swappable area to the swap origin (preview the swap)
                         State {
                             name: "SWAP_TARGET"
-                            when: Boolean(padGrid.swapOriginPad) && (pad.containsDrag || pad.padNavigationCtrl.active) && padGrid.swapOriginPad !== pad
+                            when: Boolean(padGrid.swapOriginPad) && (pad.containsDrag || pad.padNavigation.active) && padGrid.swapOriginPad !== pad
 
                             ParentChange {
                                 target: pad.swappableArea

--- a/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPadContent.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPadContent.qml
@@ -82,6 +82,7 @@ Column {
             anchors.fill: parent
 
             engravingItem: Boolean(root.padModel) ? root.padModel.notationPreviewItem : null
+            spatium: 6.25 // Value approximated visually (needs to accomodate "extreme ledger line" situations)
         }
 
         states: [

--- a/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPadContent.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPadContent.qml
@@ -37,13 +37,11 @@ Column {
 
     property bool padSwapActive: false
 
-    Rectangle {
+    Item {
         id: mainContentArea
 
         width: parent.width
         height: parent.height - separator.height - footerArea.height
-
-        color: Utils.colorWithAlpha(ui.theme.accentColor, ui.theme.buttonOpacityNormal)
 
         MouseArea {
             id: mouseArea
@@ -52,11 +50,36 @@ Column {
             hoverEnabled: true
 
             onPressed: {
+                ui.tooltip.hide(root)
+
                 if (!Boolean(root.padModel)) {
                     return
                 }
+
                 root.padModel.triggerPad()
             }
+
+            onContainsMouseChanged: {
+                if (!Boolean(root.padModel)) {
+                    ui.tooltip.hide(root)
+                    return
+                }
+
+                if (mouseArea.containsMouse && root.useNotationPreview) {
+                    ui.tooltip.show(root, root.padModel.instrumentName)
+                } else {
+                    ui.tooltip.hide(root)
+                }
+            }
+        }
+
+        Rectangle {
+            id: instrumentNameBackground
+
+            visible: !root.useNotationPreview
+            anchors.fill: parent
+
+            color: Utils.colorWithAlpha(ui.theme.accentColor, ui.theme.buttonOpacityNormal)
         }
 
         StyledTextLabel {
@@ -83,6 +106,8 @@ Column {
 
             engravingItem: Boolean(root.padModel) ? root.padModel.notationPreviewItem : null
             spatium: 6.25 // Value approximated visually (needs to accomodate "extreme ledger line" situations)
+
+            opacity: 0.9
         }
 
         states: [
@@ -90,16 +115,24 @@ Column {
                 name: "MOUSE_HOVERED"
                 when: mouseArea.containsMouse && !mouseArea.pressed && !root.padSwapActive
                 PropertyChanges {
-                    target: mainContentArea
+                    target: instrumentNameBackground
                     color: Utils.colorWithAlpha(ui.theme.accentColor, ui.theme.buttonOpacityHover)
+                }
+                PropertyChanges {
+                    target: notationPreview
+                    opacity: 0.7
                 }
             },
             State {
                 name: "MOUSE_HIT"
                 when: mouseArea.pressed || root.padSwapActive
                 PropertyChanges {
-                    target: mainContentArea
+                    target: instrumentNameBackground
                     color: Utils.colorWithAlpha(ui.theme.accentColor, ui.theme.buttonOpacityHit)
+                }
+                PropertyChanges {
+                    target: notationPreview
+                    opacity: 1.0
                 }
             }
         ]

--- a/src/notation/view/paintedengravingitem.cpp
+++ b/src/notation/view/paintedengravingitem.cpp
@@ -43,6 +43,21 @@ void PaintedEngravingItem::setEngravingItemVariant(QVariant engravingItemVariant
         return;
     }
     m_item = item;
+    emit engravingItemVariantChanged();
+}
+
+double PaintedEngravingItem::spatium() const
+{
+    return m_spatium;
+}
+
+void PaintedEngravingItem::setSpatium(double spatium)
+{
+    if (spatium == m_spatium) {
+        return;
+    }
+    m_spatium = spatium;
+    emit spatiumChanged();
 }
 
 void PaintedEngravingItem::paint(QPainter* painter)
@@ -64,16 +79,16 @@ void PaintedEngravingItem::paintNotationPreview(muse::draw::Painter& painter, qr
     EngravingItemPreviewPainter::PaintParams params;
     params.painter = &painter;
 
-    params.color = muse::draw::Color::BLACK; // TODO: set this properly
+    params.color = configuration()->defaultColor();
 
     params.rect = muse::RectF(0, 0, parentItem()->width(), parentItem()->height());
     params.dpi = dpi;
 
-    params.spatium = configuration()->paletteSpatium(); // TODO: don't use the palette for this
+    params.spatium = m_spatium;
 
     params.drawStaff = true;
 
-    painter.fillRect(params.rect, muse::draw::Color::WHITE); // TODO: set this properly
+    painter.fillRect(params.rect, configuration()->scoreInversionColor());
 
     EngravingItemPreviewPainter::paintPreview(m_item.get(), params);
 }

--- a/src/notation/view/paintedengravingitem.h
+++ b/src/notation/view/paintedengravingitem.h
@@ -25,7 +25,7 @@
 #include <QQuickPaintedItem>
 
 #include "modularity/ioc.h"
-#include "palette/ipaletteconfiguration.h"
+#include "engraving/iengravingconfiguration.h"
 
 #include "engraving/dom/engravingitem.h"
 
@@ -34,12 +34,12 @@
 namespace mu::notation {
 class PaintedEngravingItem : public QQuickPaintedItem
 {
-    // TODO: don't use the palette for this
-    INJECT_STATIC(palette::IPaletteConfiguration, configuration)
+    INJECT_STATIC(engraving::IEngravingConfiguration, configuration)
 
     Q_OBJECT
 
     Q_PROPERTY(QVariant engravingItem READ engravingItemVariant WRITE setEngravingItemVariant NOTIFY engravingItemVariantChanged)
+    Q_PROPERTY(double spatium READ spatium WRITE setSpatium NOTIFY spatiumChanged)
 
 public:
     explicit PaintedEngravingItem(QQuickItem* parent = nullptr);
@@ -47,14 +47,19 @@ public:
     QVariant engravingItemVariant() const;
     void setEngravingItemVariant(QVariant engravingItemVariant);
 
+    double spatium() const;
+    void setSpatium(double spatium);
+
     void paint(QPainter* painter) override;
 
 signals:
     void engravingItemVariantChanged();
+    void spatiumChanged();
 
 private:
     void paintNotationPreview(muse::draw::Painter& painter, qreal dpi) const;
 
     mu::engraving::ElementPtr m_item;
+    double m_spatium = 1.0;
 };
 }

--- a/src/notation/view/percussionpanel/percussionpanelmodel.cpp
+++ b/src/notation/view/percussionpanel/percussionpanelmodel.cpp
@@ -27,8 +27,6 @@
 #include "engraving/dom/factory.h"
 #include "engraving/dom/undo.h"
 
-#include "defer.h"
-
 static const QString INSTRUMENT_NAMES_CODE("percussion-instrument-names");
 static const QString NOTATION_PREVIEW_CODE("percussion-notation-preview");
 static const QString EDIT_LAYOUT_CODE("percussion-edit-layout");
@@ -210,12 +208,9 @@ void PercussionPanelModel::finishEditing(bool discardChanges)
 
     INotationUndoStackPtr undoStack = notation()->undoStack();
 
-    DEFER {
-        undoStack->commitChanges();
-    };
-
     undoStack->prepareChanges(muse::TranslatableString("undoableAction", "Edit percussion panel layout"));
     score()->undo(new engraving::ChangeDrumset(inst, updatedDrumset, staff->part()));
+    undoStack->commitChanges();
 
     setCurrentPanelMode(m_panelModeToRestore);
 }
@@ -277,15 +272,12 @@ void PercussionPanelModel::writePitch(int pitch)
         return;
     }
 
-    DEFER {
-        undoStack->commitChanges();
-    };
-
     undoStack->prepareChanges(muse::TranslatableString("undoableAction", "Enter percussion note"));
 
     interaction()->noteInput()->startNoteInput();
 
     score()->addMidiPitch(pitch, false, /*transpose*/ false);
+    undoStack->commitChanges();
 
     const mu::engraving::InputState& inputState = score()->inputState();
     if (inputState.cr()) {
@@ -351,12 +343,9 @@ void PercussionPanelModel::resetLayout()
 
     INotationUndoStackPtr undoStack = notation()->undoStack();
 
-    DEFER {
-        undoStack->commitChanges();
-    };
-
     undoStack->prepareChanges(muse::TranslatableString("undoableAction", "Reset percussion panel layout"));
     score()->undo(new engraving::ChangeDrumset(inst, &defaultLayout, staff->part()));
+    undoStack->commitChanges();
 }
 
 const INotationPtr PercussionPanelModel::notation() const

--- a/src/notation/view/percussionpanel/percussionpanelmodel.cpp
+++ b/src/notation/view/percussionpanel/percussionpanelmodel.cpp
@@ -160,6 +160,13 @@ void PercussionPanelModel::handleMenuItem(const QString& itemId)
 
 void PercussionPanelModel::finishEditing(bool discardChanges)
 {
+    if (!interaction()) {
+        //! NOTE: Can happen if we close the project while editing the layout...
+        m_padListModel->setDrumset(nullptr);
+        setCurrentPanelMode(m_panelModeToRestore);
+        return;
+    }
+
     Drumset* updatedDrumset = m_padListModel->drumset();
     m_padListModel->removeEmptyRows();
 

--- a/src/notation/view/percussionpanel/percussionpanelmodel.cpp
+++ b/src/notation/view/percussionpanel/percussionpanelmodel.cpp
@@ -63,7 +63,7 @@ PanelMode::Mode PercussionPanelModel::currentPanelMode() const
     return m_currentPanelMode;
 }
 
-void PercussionPanelModel::setCurrentPanelMode(const PanelMode::Mode& panelMode, bool updateNoteInput)
+void PercussionPanelModel::setCurrentPanelMode(const PanelMode::Mode& panelMode)
 {
     if (m_currentPanelMode == panelMode) {
         return;
@@ -76,13 +76,6 @@ void PercussionPanelModel::setCurrentPanelMode(const PanelMode::Mode& panelMode,
 
     m_currentPanelMode = panelMode;
     emit currentPanelModeChanged(m_currentPanelMode);
-
-    if (!updateNoteInput || !interaction() || !interaction()->noteInput()) {
-        return;
-    }
-
-    const INotationNoteInputPtr noteInput = interaction()->noteInput();
-    panelMode == PanelMode::Mode::WRITE ? noteInput->startNoteInput() : noteInput->endNoteInput();
 }
 
 bool PercussionPanelModel::useNotationPreview() const
@@ -159,7 +152,7 @@ void PercussionPanelModel::handleMenuItem(const QString& itemId)
         setUseNotationPreview(true);
     } else if (itemId == EDIT_LAYOUT_CODE) {
         const bool currentlyEditing = m_currentPanelMode == PanelMode::Mode::EDIT_LAYOUT;
-        currentlyEditing ? finishEditing() : setCurrentPanelMode(PanelMode::Mode::EDIT_LAYOUT, false);
+        currentlyEditing ? finishEditing() : setCurrentPanelMode(PanelMode::Mode::EDIT_LAYOUT);
     } else if (itemId == RESET_LAYOUT_CODE) {
         resetLayout();
     }
@@ -185,7 +178,7 @@ void PercussionPanelModel::finishEditing(bool discardChanges)
 
     if (discardChanges) {
         m_padListModel->setDrumset(inst->drumset());
-        setCurrentPanelMode(m_panelModeToRestore, false);
+        setCurrentPanelMode(m_panelModeToRestore);
         return;
     }
 
@@ -216,7 +209,7 @@ void PercussionPanelModel::finishEditing(bool discardChanges)
     undoStack->prepareChanges(muse::TranslatableString("undoableAction", "Edit percussion panel layout"));
     score()->undo(new engraving::ChangeDrumset(inst, updatedDrumset, staff->part()));
 
-    setCurrentPanelMode(m_panelModeToRestore, false);
+    setCurrentPanelMode(m_panelModeToRestore);
 }
 
 void PercussionPanelModel::customizeKit()

--- a/src/notation/view/percussionpanel/percussionpanelmodel.cpp
+++ b/src/notation/view/percussionpanel/percussionpanelmodel.cpp
@@ -189,12 +189,6 @@ void PercussionPanelModel::finishEditing(bool discardChanges)
         return;
     }
 
-    // Return if nothing changed after edit...
-    if (inst->drumset() && updatedDrumset
-        && *inst->drumset() == *updatedDrumset) {
-        return;
-    }
-
     for (int i = 0; i < m_padListModel->padList().size(); ++i) {
         const PercussionPanelPadModel* model = m_padListModel->padList().at(i);
         if (!model) {
@@ -205,6 +199,13 @@ void PercussionPanelModel::finishEditing(bool discardChanges)
         engraving::DrumInstrument& drum = updatedDrumset->drum(model->pitch());
         drum.panelRow = row;
         drum.panelColumn = column;
+    }
+
+    // Return if nothing changed after edit...
+    if (inst->drumset() && updatedDrumset
+        && *inst->drumset() == *updatedDrumset) {
+        setCurrentPanelMode(m_panelModeToRestore);
+        return;
     }
 
     INotationUndoStackPtr undoStack = notation()->undoStack();

--- a/src/notation/view/percussionpanel/percussionpanelmodel.h
+++ b/src/notation/view/percussionpanel/percussionpanelmodel.h
@@ -73,7 +73,7 @@ public:
     void setEnabled(bool enabled);
 
     PanelMode::Mode currentPanelMode() const;
-    void setCurrentPanelMode(const PanelMode::Mode& panelMode, bool updateNoteInput = true);
+    void setCurrentPanelMode(const PanelMode::Mode& panelMode);
 
     bool useNotationPreview() const;
     void setUseNotationPreview(bool useNotationPreview);

--- a/src/notation/view/percussionpanel/percussionpanelmodel.h
+++ b/src/notation/view/percussionpanel/percussionpanelmodel.h
@@ -30,6 +30,7 @@
 #include "context/iglobalcontext.h"
 #include "actions/iactionsdispatcher.h"
 #include "playback/iplaybackcontroller.h"
+#include "iinstrumentsrepository.h"
 
 #include "percussionpanelpadlistmodel.h"
 
@@ -52,6 +53,7 @@ class PercussionPanelModel : public QObject, public muse::Injectable, public mus
     muse::Inject<context::IGlobalContext> globalContext = { this };
     muse::Inject<muse::actions::IActionsDispatcher> dispatcher = { this };
     muse::Inject<playback::IPlaybackController> playbackController = { this };
+    muse::Inject<IInstrumentsRepository> instrumentsRepository = { this };
 
     Q_OBJECT
 
@@ -83,7 +85,9 @@ public:
     QList<QVariantMap> layoutMenuItems() const;
     Q_INVOKABLE void handleMenuItem(const QString& itemId);
 
-    Q_INVOKABLE void finishEditing();
+    //! NOTE: There are a handful of circumstances where we should discard changes (e.g. undoing/redoing a layout change mid
+    //! edit, resetting the layout mid edit, or selecting a different drumset mid edit)
+    Q_INVOKABLE void finishEditing(bool discardChanges = false);
 
     Q_INVOKABLE void customizeKit();
 
@@ -100,6 +104,8 @@ private:
 
     void writePitch(int pitch);
     void playPitch(int pitch);
+
+    void resetLayout();
 
     const mu::notation::INotationPtr notation() const;
     const mu::notation::INotationInteractionPtr interaction() const;

--- a/src/notation/view/percussionpanel/percussionpanelpadlistmodel.h
+++ b/src/notation/view/percussionpanel/percussionpanelpadlistmodel.h
@@ -69,6 +69,8 @@ public:
 
     QList<PercussionPanelPadModel*> padList() const { return m_padModels; }
 
+    mu::engraving::Drumset constructDefaultLayout(const engraving::Drumset* templateDrumset) const;
+
     muse::async::Notification hasActivePadsChanged() const { return m_hasActivePadsChanged; }
     muse::async::Channel<int /*pitch*/> padTriggered() const { return m_triggeredChannel; }
 


### PR DESCRIPTION
Continuing to work on the long list of refinements for the percussion panel:

1. Fixed a bug where pads were disappearing during layout editing (caused by a typo)
2. Addressed some to-dos that were left after #25436 (mainly setting colours properly in notation preview)
3. Implemented hover tooltip & hover/hit opacity changes for notation preview
4. Implemented an undoable "reset layout" function (the biggest change in this PR)
5. Removed some undesirable behaviour where we entered/exited note input when switching panel modes
6. Fixed a crash when closing the project while editing pad layouts
7. Fixed a logic error when finishing editing
8. Removed redundant `DEFER` uses from `PercussionPanelModel` (tech debt)