### PR TITLE
Add i/o of MIDI program to MEI support

### DIFF
--- a/src/importexport/mei/internal/meiexporter.cpp
+++ b/src/importexport/mei/internal/meiexporter.cpp
@@ -746,7 +746,9 @@ bool MeiExporter::writeInstrDef(pugi::xml_node node, const Part* part)
         return false;
     }
 
-    const int midiProgram = part->instrument()->channel(0)->program();
+    const int midiProgram = part->midiProgram();
+    // const int midiChannel = part->midiChannel();
+    // const int midiPort = part->midiPort();
 
     if (midiProgram < 0) {
         return false;

--- a/src/importexport/mei/internal/meiexporter.cpp
+++ b/src/importexport/mei/internal/meiexporter.cpp
@@ -746,7 +746,7 @@ bool MeiExporter::writeInstrDef(pugi::xml_node node, const Part* part)
         return false;
     }
 
-    const int midiProgram = part->instrument()->program();
+    const int midiProgram = part->instrument()->channel(0)->program();
 
     if (midiProgram < 0) {
         return false;

--- a/src/importexport/mei/internal/meiexporter.h
+++ b/src/importexport/mei/internal/meiexporter.h
@@ -43,6 +43,7 @@ class ChordRest;
 class Clef;
 class EngravingItem;
 class Fingering;
+class InstrChannel;
 class Lyrics;
 class Measure;
 class Note;
@@ -93,6 +94,7 @@ private:
     bool writeStaffGrpEnd(const engraving::Staff* staff, std::vector<int>& ends);
     bool writeStaffDef(const engraving::Staff* staff, const engraving::Measure* measure, const engraving::Part* part, bool isPart);
     bool writeLabel(pugi::xml_node node, const engraving::Part* part);
+    bool writeInstrDef(pugi::xml_node node, const engraving::Part* part);
     bool writeEnding(const engraving::Measure* measure);
     bool writeEndingEnd(const engraving::Measure* measure);
     bool writeMeasure(const engraving::Measure* measure, int& measureN, bool& isFirst, bool& wasLastIrregular);

--- a/src/importexport/mei/internal/meiexporter.h
+++ b/src/importexport/mei/internal/meiexporter.h
@@ -43,7 +43,6 @@ class ChordRest;
 class Clef;
 class EngravingItem;
 class Fingering;
-class InstrChannel;
 class Lyrics;
 class Measure;
 class Note;

--- a/src/importexport/mei/internal/meiimporter.cpp
+++ b/src/importexport/mei/internal/meiimporter.cpp
@@ -2586,6 +2586,24 @@ bool MeiImporter::readHarm(pugi::xml_node harmNode, Measure* measure)
 }
 
 /**
+ * Read a instrDef (instrument definition).
+ */
+
+bool MeiImporter::readInstrDef(pugi::xml_node instrDefNode, Part* part)
+{
+    IF_ASSERT_FAILED(part) {
+        return false;
+    }
+
+    libmei::InstrDef meiInstrDef;
+    meiInstrDef.Read(instrDefNode);
+
+    part->setMidiProgram(meiInstrDef.GetMidiInstrnum());
+
+    return true;
+}
+
+/**
  * Read a lv.
  */
 
@@ -3127,6 +3145,9 @@ bool MeiImporter::buildScoreParts(pugi::xml_node scoreDefNode)
             this->readLines(labelAbbrNode, abbrLines, abbrLine);
             part->setShortName(abbrLines.join(u"\n"));
         }
+
+        pugi::xml_node instrDefNode = labelNode.parent().select_node("./instrDef").node();
+        readInstrDef(instrDefNode, part);
 
         m_score->appendPart(part);
 

--- a/src/importexport/mei/internal/meiimporter.cpp
+++ b/src/importexport/mei/internal/meiimporter.cpp
@@ -3146,7 +3146,7 @@ bool MeiImporter::buildScoreParts(pugi::xml_node scoreDefNode)
             part->setShortName(abbrLines.join(u"\n"));
         }
 
-        pugi::xml_node instrDefNode = labelNode.parent().select_node("./instrDef").node();
+        pugi::xml_node instrDefNode = labelNode.select_node("./following-sibling::instrDef").node();
         readInstrDef(instrDefNode, part);
 
         m_score->appendPart(part);

--- a/src/importexport/mei/internal/meiimporter.h
+++ b/src/importexport/mei/internal/meiimporter.h
@@ -89,6 +89,7 @@ private:
     bool readLinesWithSmufl(pugi::xml_node parentNode, muse::StringList& lines);
     bool readStaffDefs(pugi::xml_node parentNode);
     bool readStaffGrps(pugi::xml_node parentNode, int& staffSpan, int column, size_t& idx);
+    bool readInstrDef(pugi::xml_node instrDefNode, Part* part);
     bool readSectionElements(pugi::xml_node parentNode);
     bool readEnding(pugi::xml_node endingNode);
     bool readMeasure(pugi::xml_node measureNode);

--- a/src/importexport/mei/tests/data/arpeg-01.mei
+++ b/src/importexport/mei/tests/data/arpeg-01.mei
@@ -34,6 +34,7 @@
                      <staffGrp bar.thru="true" symbol="brace">
                         <label>Piano</label>
                         <labelAbbr>Pno.</labelAbbr>
+                        <instrDef midi.instrnum="0" />
                         <staffDef n="1" lines="5" meter.count="4" meter.unit="4">
                            <clef shape="G" line="2" />
                         </staffDef>

--- a/src/importexport/mei/tests/data/arpeg-01.mscx
+++ b/src/importexport/mei/tests/data/arpeg-01.mscx
@@ -40,6 +40,7 @@
         <trackName></trackName>
         <instrumentId>keyboard.piano</instrumentId>
         <Channel>
+          <program value="0"/>
           </Channel>
         </Instrument>
       </Part>

--- a/src/importexport/mei/tests/data/artic-01.mei
+++ b/src/importexport/mei/tests/data/artic-01.mei
@@ -34,6 +34,7 @@
                      <staffDef n="1" lines="5" meter.count="4" meter.unit="4">
                         <label>Violin</label>
                         <labelAbbr>Vln.</labelAbbr>
+                        <instrDef midi.instrnum="40" />
                         <clef shape="G" line="2" />
                      </staffDef>
                   </staffGrp>

--- a/src/importexport/mei/tests/data/artic-01.mscx
+++ b/src/importexport/mei/tests/data/artic-01.mscx
@@ -33,6 +33,7 @@
         <trackName></trackName>
         <instrumentId>strings.violin</instrumentId>
         <Channel>
+          <program value="40"/>
           </Channel>
         </Instrument>
       </Part>

--- a/src/importexport/mei/tests/data/breaks-01.mei
+++ b/src/importexport/mei/tests/data/breaks-01.mei
@@ -29,6 +29,7 @@
                      <staffGrp bar.thru="true" symbol="brace">
                         <label>Piano</label>
                         <labelAbbr>Pno.</labelAbbr>
+                        <instrDef midi.instrnum="0" />
                         <staffDef n="1" lines="5" meter.sym="common">
                            <clef shape="C" line="1" />
                         </staffDef>

--- a/src/importexport/mei/tests/data/breaks-01.mscx
+++ b/src/importexport/mei/tests/data/breaks-01.mscx
@@ -40,6 +40,7 @@
         <trackName></trackName>
         <instrumentId>keyboard.piano</instrumentId>
         <Channel>
+          <program value="0"/>
           </Channel>
         </Instrument>
       </Part>

--- a/src/importexport/mei/tests/data/btrem-01.mei
+++ b/src/importexport/mei/tests/data/btrem-01.mei
@@ -32,6 +32,7 @@
                      <staffDef n="1" lines="5" meter.count="4" meter.unit="4">
                         <label>Violine</label>
                         <labelAbbr>Vl.</labelAbbr>
+                        <instrDef midi.instrnum="40" />
                         <clef shape="G" line="2" />
                      </staffDef>
                   </staffGrp>

--- a/src/importexport/mei/tests/data/btrem-01.mscx
+++ b/src/importexport/mei/tests/data/btrem-01.mscx
@@ -27,12 +27,13 @@
           </StaffType>
         </Staff>
       <trackName></trackName>
-      <Instrument id="piano">
+      <Instrument id="violin">
         <longName>Violine</longName>
         <shortName>Vl.</shortName>
         <trackName></trackName>
-        <instrumentId>keyboard.piano</instrumentId>
+        <instrumentId>strings.violin</instrumentId>
         <Channel>
+          <program value="40"/>
           </Channel>
         </Instrument>
       </Part>

--- a/src/importexport/mei/tests/data/color-01.mei
+++ b/src/importexport/mei/tests/data/color-01.mei
@@ -34,6 +34,7 @@
                      <staffDef n="1" lines="5" meter.count="4" meter.unit="4">
                         <label>Violin</label>
                         <labelAbbr>Vln.</labelAbbr>
+                        <instrDef midi.instrnum="40" />
                         <clef shape="G" line="2" />
                      </staffDef>
                   </staffGrp>

--- a/src/importexport/mei/tests/data/color-01.mscx
+++ b/src/importexport/mei/tests/data/color-01.mscx
@@ -33,6 +33,7 @@
         <trackName></trackName>
         <instrumentId>strings.violin</instrumentId>
         <Channel>
+          <program value="40"/>
           </Channel>
         </Instrument>
       </Part>

--- a/src/importexport/mei/tests/data/dynamic-01.mei
+++ b/src/importexport/mei/tests/data/dynamic-01.mei
@@ -34,6 +34,7 @@
                      <staffDef n="1" lines="5" meter.count="4" meter.unit="4">
                         <label>Oboe</label>
                         <labelAbbr>Ob.</labelAbbr>
+                        <instrDef midi.instrnum="68" />
                         <clef shape="G" line="2" />
                      </staffDef>
                   </staffGrp>

--- a/src/importexport/mei/tests/data/dynamic-01.mscx
+++ b/src/importexport/mei/tests/data/dynamic-01.mscx
@@ -33,6 +33,7 @@
         <trackName></trackName>
         <instrumentId>wind.reed.oboe</instrumentId>
         <Channel>
+          <program value="68"/>
           </Channel>
         </Instrument>
       </Part>

--- a/src/importexport/mei/tests/data/fermata-01.mei
+++ b/src/importexport/mei/tests/data/fermata-01.mei
@@ -35,11 +35,13 @@
                         <staffDef n="1" lines="5" meter.count="4" meter.unit="4">
                            <label>Viola</label>
                            <labelAbbr>Vla.</labelAbbr>
+                           <instrDef midi.instrnum="41" />
                            <clef shape="C" line="3" />
                         </staffDef>
                         <staffDef n="2" lines="5" meter.count="4" meter.unit="4">
                            <label>Violoncello</label>
                            <labelAbbr>Vc.</labelAbbr>
+                           <instrDef midi.instrnum="42" />
                            <clef shape="F" line="4" />
                         </staffDef>
                      </staffGrp>

--- a/src/importexport/mei/tests/data/fermata-01.mscx
+++ b/src/importexport/mei/tests/data/fermata-01.mscx
@@ -35,6 +35,7 @@
         <trackName></trackName>
         <instrumentId>strings.viola</instrumentId>
         <Channel>
+          <program value="41"/>
           </Channel>
         </Instrument>
       </Part>
@@ -51,6 +52,7 @@
         <trackName></trackName>
         <instrumentId>strings.cello</instrumentId>
         <Channel>
+          <program value="42"/>
           </Channel>
         </Instrument>
       </Part>

--- a/src/importexport/mei/tests/data/fig-bass-01.mei
+++ b/src/importexport/mei/tests/data/fig-bass-01.mei
@@ -34,6 +34,7 @@
                      <staffGrp bar.thru="true" symbol="brace">
                         <label>Piano</label>
                         <labelAbbr>Pno.</labelAbbr>
+                        <instrDef midi.instrnum="0" />
                         <staffDef n="1" lines="5" meter.count="4" meter.unit="4">
                            <clef shape="G" line="2" />
                         </staffDef>

--- a/src/importexport/mei/tests/data/fig-bass-01.mscx
+++ b/src/importexport/mei/tests/data/fig-bass-01.mscx
@@ -40,6 +40,7 @@
         <trackName></trackName>
         <instrumentId>keyboard.piano</instrumentId>
         <Channel>
+          <program value="0"/>
           </Channel>
         </Instrument>
       </Part>

--- a/src/importexport/mei/tests/data/jump-02.mei
+++ b/src/importexport/mei/tests/data/jump-02.mei
@@ -34,6 +34,7 @@
                      <staffDef n="1" lines="5" meter.count="4" meter.unit="4">
                         <label>Flute</label>
                         <labelAbbr>Fl.</labelAbbr>
+                        <instrDef midi.instrnum="72" />
                         <clef shape="G" line="2" />
                      </staffDef>
                   </staffGrp>

--- a/src/importexport/mei/tests/data/jump-02.mscx
+++ b/src/importexport/mei/tests/data/jump-02.mscx
@@ -33,6 +33,7 @@
         <trackName></trackName>
         <instrumentId>wind.flutes.flute</instrumentId>
         <Channel>
+          <program value="72"/>
           </Channel>
         </Instrument>
       </Part>

--- a/src/importexport/mei/tests/data/lyric-01.mei
+++ b/src/importexport/mei/tests/data/lyric-01.mei
@@ -34,6 +34,7 @@
                      <staffDef n="1" lines="5" meter.count="4" meter.unit="4">
                         <label>Voice</label>
                         <labelAbbr>Vo.</labelAbbr>
+                        <instrDef midi.instrnum="52" />
                         <clef shape="G" line="2" />
                      </staffDef>
                   </staffGrp>

--- a/src/importexport/mei/tests/data/lyric-01.mscx
+++ b/src/importexport/mei/tests/data/lyric-01.mscx
@@ -33,6 +33,7 @@
         <trackName></trackName>
         <instrumentId>voice.vocals</instrumentId>
         <Channel>
+          <program value="52"/>
           </Channel>
         </Instrument>
       </Part>

--- a/src/importexport/mei/tests/data/lyric-02.mei
+++ b/src/importexport/mei/tests/data/lyric-02.mei
@@ -35,16 +35,19 @@
                         <staffDef n="1" lines="5" meter.count="4" meter.unit="2">
                            <label>Soprano</label>
                            <labelAbbr>S.</labelAbbr>
+                           <instrDef midi.instrnum="52" />
                            <clef shape="G" line="2" />
                         </staffDef>
                         <staffDef n="2" lines="5" meter.count="4" meter.unit="2">
                            <label>Alto</label>
                            <labelAbbr>A.</labelAbbr>
+                           <instrDef midi.instrnum="52" />
                            <clef shape="G" line="2" />
                         </staffDef>
                         <staffDef n="3" lines="5" meter.count="4" meter.unit="2">
                            <label>Bass</label>
                            <labelAbbr>B.</labelAbbr>
+                           <instrDef midi.instrnum="52" />
                            <clef shape="F" line="4" />
                         </staffDef>
                      </staffGrp>

--- a/src/importexport/mei/tests/data/lyric-02.mscx
+++ b/src/importexport/mei/tests/data/lyric-02.mscx
@@ -34,6 +34,7 @@
         <trackName></trackName>
         <instrumentId>voice.soprano</instrumentId>
         <Channel>
+          <program value="52"/>
           </Channel>
         </Instrument>
       </Part>
@@ -50,6 +51,7 @@
         <trackName></trackName>
         <instrumentId>voice.alto</instrumentId>
         <Channel>
+          <program value="52"/>
           </Channel>
         </Instrument>
       </Part>
@@ -66,6 +68,7 @@
         <trackName></trackName>
         <instrumentId>voice.bass</instrumentId>
         <Channel>
+          <program value="52"/>
           </Channel>
         </Instrument>
       </Part>

--- a/src/importexport/mei/tests/data/lyric-03.mei
+++ b/src/importexport/mei/tests/data/lyric-03.mei
@@ -35,11 +35,13 @@
                         <staffDef n="1" lines="5" keysig="1s" meter.sym="cut">
                            <label>Tenor</label>
                            <labelAbbr>T.</labelAbbr>
+                           <instrDef midi.instrnum="52" />
                            <clef shape="G" line="2" dis="8" dis.place="below" />
                         </staffDef>
                         <staffDef n="2" lines="5" keysig="1s" meter.sym="cut">
                            <label>Bass</label>
                            <labelAbbr>B.</labelAbbr>
+                           <instrDef midi.instrnum="52" />
                            <clef shape="F" line="4" />
                         </staffDef>
                      </staffGrp>

--- a/src/importexport/mei/tests/data/lyric-03.mscx
+++ b/src/importexport/mei/tests/data/lyric-03.mscx
@@ -34,6 +34,7 @@
         <trackName></trackName>
         <instrumentId>voice.tenor</instrumentId>
         <Channel>
+          <program value="52"/>
           </Channel>
         </Instrument>
       </Part>
@@ -50,6 +51,7 @@
         <trackName></trackName>
         <instrumentId>voice.bass</instrumentId>
         <Channel>
+          <program value="52"/>
           </Channel>
         </Instrument>
       </Part>

--- a/src/importexport/mei/tests/data/measure-02.mei
+++ b/src/importexport/mei/tests/data/measure-02.mei
@@ -35,21 +35,25 @@
                         <staffDef n="1" lines="5" meter.count="3" meter.unit="4">
                            <label>Violin</label>
                            <labelAbbr>Vln.</labelAbbr>
+                           <instrDef midi.instrnum="40" />
                            <clef shape="G" line="2" />
                         </staffDef>
                         <staffDef n="2" lines="5" meter.count="3" meter.unit="4">
                            <label>Violin 2</label>
                            <labelAbbr>Vln. 2</labelAbbr>
+                           <instrDef midi.instrnum="40" />
                            <clef shape="G" line="2" />
                         </staffDef>
                         <staffDef n="3" lines="5" meter.count="3" meter.unit="4">
                            <label>Viola</label>
                            <labelAbbr>Vla.</labelAbbr>
+                           <instrDef midi.instrnum="41" />
                            <clef shape="C" line="3" />
                         </staffDef>
                         <staffDef n="4" lines="5" meter.count="3" meter.unit="4">
                            <label>Violoncello</label>
                            <labelAbbr>Vc.</labelAbbr>
+                           <instrDef midi.instrnum="42" />
                            <clef shape="F" line="4" />
                         </staffDef>
                      </staffGrp>

--- a/src/importexport/mei/tests/data/measure-02.mscx
+++ b/src/importexport/mei/tests/data/measure-02.mscx
@@ -35,6 +35,7 @@
         <trackName></trackName>
         <instrumentId>strings.violin</instrumentId>
         <Channel>
+          <program value="40"/>
           </Channel>
         </Instrument>
       </Part>
@@ -46,12 +47,13 @@
         <barLineSpan>1</barLineSpan>
         </Staff>
       <trackName></trackName>
-      <Instrument id="piano">
+      <Instrument id="violin">
         <longName>Violin 2</longName>
         <shortName>Vln. 2</shortName>
         <trackName></trackName>
-        <instrumentId>keyboard.piano</instrumentId>
+        <instrumentId>strings.violin</instrumentId>
         <Channel>
+          <program value="40"/>
           </Channel>
         </Instrument>
       </Part>
@@ -69,6 +71,7 @@
         <trackName></trackName>
         <instrumentId>strings.viola</instrumentId>
         <Channel>
+          <program value="41"/>
           </Channel>
         </Instrument>
       </Part>
@@ -85,6 +88,7 @@
         <trackName></trackName>
         <instrumentId>strings.cello</instrumentId>
         <Channel>
+          <program value="42"/>
           </Channel>
         </Instrument>
       </Part>

--- a/src/importexport/mei/tests/data/measure-repeat-01.mei
+++ b/src/importexport/mei/tests/data/measure-repeat-01.mei
@@ -32,6 +32,7 @@
                      <staffDef n="1" lines="5" meter.count="4" meter.unit="4">
                         <label>Classical Guitar</label>
                         <labelAbbr>Guit.</labelAbbr>
+                        <instrDef midi.instrnum="52" />
                         <clef shape="G" line="2" dis="8" dis.place="below" />
                      </staffDef>
                   </staffGrp>

--- a/src/importexport/mei/tests/data/measure-repeat-01.mscx
+++ b/src/importexport/mei/tests/data/measure-repeat-01.mscx
@@ -33,6 +33,7 @@
         <trackName></trackName>
         <instrumentId>pluck.guitar.nylon-string</instrumentId>
         <Channel>
+          <program value="52"/>
           </Channel>
         </Instrument>
       </Part>

--- a/src/importexport/mei/tests/data/midi-01.mei
+++ b/src/importexport/mei/tests/data/midi-01.mei
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/5.0/mei-basic.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.0/mei-basic.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0+basic">
+   <meiHead>
+      <fileDesc>
+         <titleStmt>
+            <title type="main">MIDI test</title>
+            <respStmt>
+               <persName role="composer">Klaus Rettinghaus</persName>
+            </respStmt>
+         </titleStmt>
+         <pubStmt>
+            <date isodate="2024-11-29T11:17:44" />
+         </pubStmt>
+      </fileDesc>
+   </meiHead>
+   <music>
+      <body>
+         <mdiv>
+            <score>
+               <scoreDef>
+                  <pgHead>
+                     <rend halign="center" valign="top">
+                        <rend type="title" fontsize="x-large">MIDI test</rend>
+                     </rend>
+                     <rend halign="right" valign="bottom">
+                        <rend type="composer">Klaus Rettinghaus</rend>
+                     </rend>
+                  </pgHead>
+                  <staffGrp>
+                     <staffGrp bar.thru="true" symbol="brace">
+                        <label>Piano</label>
+                        <labelAbbr>Pno.</labelAbbr>
+                        <instrDef midi.instrnum="0" />
+                        <staffDef n="1" lines="5" meter.count="4" meter.unit="4">
+                           <clef shape="G" line="2" />
+                        </staffDef>
+                        <staffDef n="2" lines="5" meter.count="4" meter.unit="4">
+                           <clef shape="F" line="4" />
+                        </staffDef>
+                     </staffGrp>
+                     <staffGrp bar.thru="true" symbol="brace">
+                        <label>Harp</label>
+                        <labelAbbr>Hp.</labelAbbr>
+                        <instrDef midi.instrnum="46" />
+                        <staffDef n="3" lines="5" meter.count="4" meter.unit="4">
+                           <clef shape="G" line="2" />
+                        </staffDef>
+                        <staffDef n="4" lines="5" meter.count="4" meter.unit="4">
+                           <clef shape="F" line="4" />
+                        </staffDef>
+                     </staffGrp>
+                     <staffDef n="5" lines="5" meter.count="4" meter.unit="4">
+                        <label>Violin</label>
+                        <labelAbbr>Vl.</labelAbbr>
+                        <instrDef midi.instrnum="40" />
+                        <clef shape="G" line="2" />
+                     </staffDef>
+                  </staffGrp>
+               </scoreDef>
+               <section xml:id="s1">
+                  <measure xml:id="m5wq5im" n="1">
+                     <staff xml:id="m1s1" n="1">
+                        <layer xml:id="m1s1l1" n="1">
+                           <chord xml:id="cnf1nq" dur="1">
+                              <note xml:id="n5ocit8" pname="g" oct="4" />
+                              <note xml:id="n1p15en1" pname="e" oct="5" />
+                           </chord>
+                        </layer>
+                     </staff>
+                     <staff xml:id="m1s2" n="2">
+                        <layer xml:id="m1s2l1" n="1">
+                           <chord xml:id="c78oeh8" dur="1">
+                              <note xml:id="nqe3k9" pname="b" oct="2" />
+                              <note xml:id="n6apouv" pname="g" oct="3" />
+                              <note xml:id="nw56njv" pname="f" oct="4" />
+                           </chord>
+                        </layer>
+                     </staff>
+                     <staff xml:id="m1s3" n="3">
+                        <layer xml:id="m1s3l1" n="1">
+                           <chord xml:id="c1paf6qk" dur="1">
+                              <note xml:id="n152su8r" pname="e" oct="4" />
+                              <note xml:id="n7lsdj4" pname="g" oct="4" />
+                              <note xml:id="npr0wpq" pname="c" oct="5" />
+                              <note xml:id="n1vdydsx" pname="e" oct="5" />
+                           </chord>
+                        </layer>
+                     </staff>
+                     <staff xml:id="m1s4" n="4">
+                        <layer xml:id="m1s4l1" n="1">
+                           <chord xml:id="c10olgvf" dur="1">
+                              <note xml:id="n1id2x3o" pname="d" oct="2" />
+                              <note xml:id="nzjnncn" pname="f" oct="2" />
+                              <note xml:id="njdi3ur" pname="a" oct="2" />
+                              <note xml:id="n3nst0x" pname="b" oct="2" />
+                              <note xml:id="nlz4t4s" pname="f" oct="3" />
+                              <note xml:id="n13jabuc" pname="a" oct="3" />
+                              <note xml:id="n1v2u45z" pname="b" oct="3" />
+                           </chord>
+                        </layer>
+                     </staff>
+                     <staff xml:id="m1s5" n="5">
+                        <layer xml:id="m1s5l1" n="1">
+                           <note xml:id="n1pvx4s4" dur="1" pname="a" oct="4" />
+                        </layer>
+                     </staff>
+                     <arpeg xml:id="a197fu5a" order="down" startid="#c1paf6qk" arrow="true" plist="#c10olgvf" />
+                  </measure>
+               </section>
+            </score>
+         </mdiv>
+      </body>
+   </music>
+</mei>

--- a/src/importexport/mei/tests/data/midi-01.mscx
+++ b/src/importexport/mei/tests/data/midi-01.mscx
@@ -1,0 +1,272 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="4.50">
+  <Score>
+    <Division>480</Division>
+    <Style>
+      <spatium>1.74978</spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer">Klaus Rettinghaus</metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="meiHead">&lt;meiHead&gt;&lt;fileDesc&gt;&lt;titleStmt&gt;&lt;title type=&quot;main&quot;&gt;MIDI test&lt;/title&gt;&lt;respStmt&gt;&lt;persName role=&quot;composer&quot;&gt;Klaus Rettinghaus&lt;/persName&gt;&lt;/respStmt&gt;&lt;/titleStmt&gt;&lt;pubStmt&gt;&lt;date isodate=&quot;2024-11-29T11:17:44&quot;/&gt;&lt;/pubStmt&gt;&lt;/fileDesc&gt;&lt;/meiHead&gt;</metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle">MIDI test</metaTag>
+    <Part id="1">
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <bracket type="1" span="2" col="0" visible="1"/>
+        <barLineSpan>1</barLineSpan>
+        </Staff>
+      <Staff id="2">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        </Staff>
+      <trackName></trackName>
+      <Instrument id="piano">
+        <longName>Piano</longName>
+        <shortName>Pno.</shortName>
+        <trackName></trackName>
+        <instrumentId>keyboard.piano</instrumentId>
+        <Channel>
+          <program value="0"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Part id="2">
+      <Staff id="3">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <bracket type="1" span="2" col="0" visible="1"/>
+        <barLineSpan>1</barLineSpan>
+        </Staff>
+      <Staff id="4">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        </Staff>
+      <trackName></trackName>
+      <Instrument id="harp">
+        <longName>Harp</longName>
+        <shortName>Hp.</shortName>
+        <trackName></trackName>
+        <instrumentId>pluck.harp</instrumentId>
+        <Channel>
+          <program value="46"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Part id="3">
+      <Staff id="5">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        </Staff>
+      <trackName></trackName>
+      <Instrument id="violin">
+        <longName>Violin</longName>
+        <shortName>Vl.</shortName>
+        <trackName></trackName>
+        <instrumentId>strings.violin</instrumentId>
+        <Channel>
+          <program value="40"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <VBox>
+        <height>10</height>
+        <Text>
+          <style>title</style>
+          <text>MIDI test</text>
+          </Text>
+        <Text>
+          <style>composer</style>
+          <text>Klaus Rettinghaus</text>
+          </Text>
+        </VBox>
+      <Measure>
+        <voice>
+          <Clef>
+            <concertClefType>G</concertClefType>
+            <transposingClefType>G</transposingClefType>
+            <isHeader>1</isHeader>
+            </Clef>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Chord>
+            <durationType>whole</durationType>
+            <Note>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            <Note>
+              <pitch>76</pitch>
+              <tpc>18</tpc>
+              </Note>
+            </Chord>
+          <BarLine>
+            </BarLine>
+          </voice>
+        </Measure>
+      </Staff>
+    <Staff id="2">
+      <Measure>
+        <voice>
+          <Clef>
+            <concertClefType>F</concertClefType>
+            <transposingClefType>F</transposingClefType>
+            <isHeader>1</isHeader>
+            </Clef>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Chord>
+            <durationType>whole</durationType>
+            <Note>
+              <pitch>47</pitch>
+              <tpc>19</tpc>
+              </Note>
+            <Note>
+              <pitch>55</pitch>
+              <tpc>15</tpc>
+              </Note>
+            <Note>
+              <pitch>65</pitch>
+              <tpc>13</tpc>
+              </Note>
+            </Chord>
+          <BarLine>
+            </BarLine>
+          </voice>
+        </Measure>
+      </Staff>
+    <Staff id="3">
+      <Measure>
+        <voice>
+          <Clef>
+            <concertClefType>G</concertClefType>
+            <transposingClefType>G</transposingClefType>
+            <isHeader>1</isHeader>
+            </Clef>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Chord>
+            <durationType>whole</durationType>
+            <Note>
+              <pitch>64</pitch>
+              <tpc>18</tpc>
+              </Note>
+            <Note>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            <Note>
+              <pitch>72</pitch>
+              <tpc>14</tpc>
+              </Note>
+            <Note>
+              <pitch>76</pitch>
+              <tpc>18</tpc>
+              </Note>
+            <Arpeggio>
+              <subtype>2</subtype>
+              <span>5</span>
+              </Arpeggio>
+            </Chord>
+          <BarLine>
+            </BarLine>
+          </voice>
+        </Measure>
+      </Staff>
+    <Staff id="4">
+      <Measure>
+        <voice>
+          <Clef>
+            <concertClefType>F</concertClefType>
+            <transposingClefType>F</transposingClefType>
+            <isHeader>1</isHeader>
+            </Clef>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Chord>
+            <durationType>whole</durationType>
+            <Note>
+              <pitch>38</pitch>
+              <tpc>16</tpc>
+              </Note>
+            <Note>
+              <pitch>41</pitch>
+              <tpc>13</tpc>
+              </Note>
+            <Note>
+              <pitch>45</pitch>
+              <tpc>17</tpc>
+              </Note>
+            <Note>
+              <pitch>47</pitch>
+              <tpc>19</tpc>
+              </Note>
+            <Note>
+              <pitch>53</pitch>
+              <tpc>13</tpc>
+              </Note>
+            <Note>
+              <pitch>57</pitch>
+              <tpc>17</tpc>
+              </Note>
+            <Note>
+              <pitch>59</pitch>
+              <tpc>19</tpc>
+              </Note>
+            </Chord>
+          <BarLine>
+            </BarLine>
+          </voice>
+        </Measure>
+      </Staff>
+    <Staff id="5">
+      <Measure>
+        <voice>
+          <Clef>
+            <concertClefType>G</concertClefType>
+            <transposingClefType>G</transposingClefType>
+            <isHeader>1</isHeader>
+            </Clef>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Chord>
+            <durationType>whole</durationType>
+            <Note>
+              <pitch>69</pitch>
+              <tpc>17</tpc>
+              </Note>
+            </Chord>
+          <BarLine>
+            </BarLine>
+          </voice>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/src/importexport/mei/tests/data/octave-01.mei
+++ b/src/importexport/mei/tests/data/octave-01.mei
@@ -34,6 +34,7 @@
                      <staffGrp bar.thru="true" symbol="brace">
                         <label>Piano</label>
                         <labelAbbr>Pno.</labelAbbr>
+                        <instrDef midi.instrnum="0" />
                         <staffDef n="1" lines="5" meter.count="4" meter.unit="4">
                            <clef shape="G" line="2" />
                         </staffDef>

--- a/src/importexport/mei/tests/data/octave-01.mscx
+++ b/src/importexport/mei/tests/data/octave-01.mscx
@@ -40,6 +40,7 @@
         <trackName></trackName>
         <instrumentId>keyboard.piano</instrumentId>
         <Channel>
+          <program value="0"/>
           </Channel>
         </Instrument>
       </Part>

--- a/src/importexport/mei/tests/data/pedal-01.mei
+++ b/src/importexport/mei/tests/data/pedal-01.mei
@@ -34,6 +34,7 @@
                      <staffGrp bar.thru="true" symbol="brace">
                         <label>Piano</label>
                         <labelAbbr>Pno.</labelAbbr>
+                        <instrDef midi.instrnum="0" />
                         <staffDef n="1" lines="5" meter.count="4" meter.unit="4">
                            <clef shape="G" line="2" />
                         </staffDef>

--- a/src/importexport/mei/tests/data/pedal-01.mscx
+++ b/src/importexport/mei/tests/data/pedal-01.mscx
@@ -40,6 +40,7 @@
         <trackName></trackName>
         <instrumentId>keyboard.piano</instrumentId>
         <Channel>
+          <program value="0"/>
           </Channel>
         </Instrument>
       </Part>

--- a/src/importexport/mei/tests/data/roman-numeral-01.mei
+++ b/src/importexport/mei/tests/data/roman-numeral-01.mei
@@ -34,6 +34,7 @@
                      <staffGrp bar.thru="true" symbol="brace">
                         <label>Piano</label>
                         <labelAbbr>Pno.</labelAbbr>
+                        <instrDef midi.instrnum="0" />
                         <staffDef n="1" lines="5" meter.count="2" meter.unit="4">
                            <clef shape="G" line="2" />
                         </staffDef>

--- a/src/importexport/mei/tests/data/roman-numeral-01.mscx
+++ b/src/importexport/mei/tests/data/roman-numeral-01.mscx
@@ -40,6 +40,7 @@
         <trackName></trackName>
         <instrumentId>keyboard.piano</instrumentId>
         <Channel>
+          <program value="0"/>
           </Channel>
         </Instrument>
       </Part>

--- a/src/importexport/mei/tests/data/tempo-01.mei
+++ b/src/importexport/mei/tests/data/tempo-01.mei
@@ -35,11 +35,13 @@
                         <staffDef n="1" lines="5" meter.count="4" meter.unit="4">
                            <label>Violin</label>
                            <labelAbbr>Vln.</labelAbbr>
+                           <instrDef midi.instrnum="40" />
                            <clef shape="G" line="2" />
                         </staffDef>
                         <staffDef n="2" lines="5" meter.count="4" meter.unit="4">
                            <label>Viola</label>
                            <labelAbbr>Vla.</labelAbbr>
+                           <instrDef midi.instrnum="41" />
                            <clef shape="C" line="3" />
                         </staffDef>
                      </staffGrp>

--- a/src/importexport/mei/tests/data/tempo-01.mscx
+++ b/src/importexport/mei/tests/data/tempo-01.mscx
@@ -35,6 +35,7 @@
         <trackName></trackName>
         <instrumentId>strings.violin</instrumentId>
         <Channel>
+          <program value="40"/>
           </Channel>
         </Instrument>
       </Part>
@@ -51,6 +52,7 @@
         <trackName></trackName>
         <instrumentId>strings.viola</instrumentId>
         <Channel>
+          <program value="41"/>
           </Channel>
         </Instrument>
       </Part>

--- a/src/importexport/mei/tests/mei_tests.cpp
+++ b/src/importexport/mei/tests/mei_tests.cpp
@@ -195,6 +195,10 @@ TEST_F(Mei_Tests, mei_key_signature_01) {
     meiReadTest("key-signature-01");
 }
 
+TEST_F(Mei_Tests, mei_midi_01) {
+    meiReadTest("midi-01");
+}
+
 TEST_F(Mei_Tests, mei_label_01) {
     meiReadTest("label-01");
 }


### PR DESCRIPTION
This PR adds reading/writing of MIDI program information to the MEI support in order to store the original instrument. An appropriate test has been added and others were extended

Pinging @lpugin 