### PR TITLE
Tweaks to standard MIDI drumset

### DIFF
--- a/src/engraving/dom/drumset.cpp
+++ b/src/engraving/dom/drumset.cpp
@@ -292,28 +292,96 @@ void Drumset::initDrumset()
         smDrumset->drum(i).panelRow     = -1;
         smDrumset->drum(i).panelColumn  = -1;
     }
-    smDrumset->drum(35) = DrumInstrument(TConv::userName(DrumNum(35)), NoteHeadGroup::HEAD_NORMAL,   8, DirectionV::DOWN, 1);
-    smDrumset->drum(36) = DrumInstrument(TConv::userName(DrumNum(36)), NoteHeadGroup::HEAD_NORMAL,   7, DirectionV::DOWN, 1, Key_B);
-    smDrumset->drum(37) = DrumInstrument(TConv::userName(DrumNum(37)), NoteHeadGroup::HEAD_SLASHED1,    3, DirectionV::UP);
-    smDrumset->drum(38) = DrumInstrument(TConv::userName(DrumNum(38)), NoteHeadGroup::HEAD_NORMAL,   3, DirectionV::UP, 0, Key_A);
-    smDrumset->drum(40) = DrumInstrument(TConv::userName(DrumNum(40)), NoteHeadGroup::HEAD_NORMAL,   3, DirectionV::UP);
-    smDrumset->drum(41) = DrumInstrument(TConv::userName(DrumNum(41)), NoteHeadGroup::HEAD_NORMAL,   6, DirectionV::UP);
-    smDrumset->drum(42) = DrumInstrument(TConv::userName(DrumNum(42)), NoteHeadGroup::HEAD_CROSS,   -1, DirectionV::UP, 0, Key_G);
-    smDrumset->drum(43) = DrumInstrument(TConv::userName(DrumNum(43)), NoteHeadGroup::HEAD_NORMAL,   5, DirectionV::DOWN);
-    smDrumset->drum(44) = DrumInstrument(TConv::userName(DrumNum(44)), NoteHeadGroup::HEAD_CROSS,    9, DirectionV::DOWN, 1, Key_F);
-    smDrumset->drum(45) = DrumInstrument(TConv::userName(DrumNum(45)), NoteHeadGroup::HEAD_NORMAL,   4, DirectionV::UP);
-    smDrumset->drum(46) = DrumInstrument(TConv::userName(DrumNum(46)), NoteHeadGroup::HEAD_CROSS,    -1, DirectionV::UP);
-    smDrumset->drum(47) = DrumInstrument(TConv::userName(DrumNum(47)), NoteHeadGroup::HEAD_NORMAL,   2, DirectionV::UP);
-    smDrumset->drum(48) = DrumInstrument(TConv::userName(DrumNum(48)), NoteHeadGroup::HEAD_NORMAL,   1, DirectionV::UP);
-    smDrumset->drum(49) = DrumInstrument(TConv::userName(DrumNum(49)), NoteHeadGroup::HEAD_CROSS,   -2, DirectionV::UP, 0, Key_C);
-    smDrumset->drum(50) = DrumInstrument(TConv::userName(DrumNum(50)), NoteHeadGroup::HEAD_NORMAL,   0, DirectionV::UP, 0, Key_E);
-    smDrumset->drum(51) = DrumInstrument(TConv::userName(DrumNum(51)), NoteHeadGroup::HEAD_CROSS,    0, DirectionV::UP, 0, Key_D);
-    smDrumset->drum(52) = DrumInstrument(TConv::userName(DrumNum(52)), NoteHeadGroup::HEAD_CROSS,   -4, DirectionV::UP);
-    smDrumset->drum(53) = DrumInstrument(TConv::userName(DrumNum(53)), NoteHeadGroup::HEAD_DIAMOND,  0, DirectionV::UP);
-    smDrumset->drum(54) = DrumInstrument(TConv::userName(DrumNum(54)), NoteHeadGroup::HEAD_DIAMOND,  1, DirectionV::UP);
-    smDrumset->drum(55) = DrumInstrument(TConv::userName(DrumNum(55)), NoteHeadGroup::HEAD_CROSS,   -5, DirectionV::UP);
-    smDrumset->drum(56) = DrumInstrument(TConv::userName(DrumNum(56)), NoteHeadGroup::HEAD_TRIANGLE_DOWN, 1, DirectionV::UP);
-    smDrumset->drum(57) = DrumInstrument(TConv::userName(DrumNum(57)), NoteHeadGroup::HEAD_CROSS,   -3, DirectionV::UP);
-    smDrumset->drum(59) = DrumInstrument(TConv::userName(DrumNum(59)), NoteHeadGroup::HEAD_CROSS,    2, DirectionV::UP);
+    // Acoustic Bass Drum
+    smDrumset->drum(35) = DrumInstrument(TConv::userName(DrumNum(35)), NoteHeadGroup::HEAD_NORMAL, /*line*/ 8, DirectionV::DOWN,
+                                         /*panelRow*/ 2, /*panelColumn*/ 1, /*voice*/ 1);
+
+    // Bass Drum 1
+    smDrumset->drum(36) = DrumInstrument(TConv::userName(DrumNum(36)), NoteHeadGroup::HEAD_NORMAL, /*line*/ 7, DirectionV::DOWN,
+                                         /*panelRow*/ 2, /*panelColumn*/ 0, /*voice*/ 1, Key_B);
+
+    // Side Stick
+    smDrumset->drum(37) = DrumInstrument(TConv::userName(DrumNum(37)), NoteHeadGroup::HEAD_SLASHED1, /*line*/ 3, DirectionV::UP,
+                                         /*panelRow*/ 1, /*panelColumn*/ 1);
+
+    // Acoustic Snare
+    smDrumset->drum(38) = DrumInstrument(TConv::userName(DrumNum(38)), NoteHeadGroup::HEAD_NORMAL, /*line*/ 3, DirectionV::UP,
+                                         /*panelRow*/ 1, /*panelColumn*/ 0, /*voice*/ 0, Key_A);
+
+    // Electric Snare
+    smDrumset->drum(40) = DrumInstrument(TConv::userName(DrumNum(40)), NoteHeadGroup::HEAD_SLASH, /*line*/ 3, DirectionV::UP,
+                                         /*panelRow*/ 2, /*panelColumn*/ 6);
+
+    // Low Floor Tom
+    smDrumset->drum(41) = DrumInstrument(TConv::userName(DrumNum(41)), NoteHeadGroup::HEAD_NORMAL, /*line*/ 6, DirectionV::UP,
+                                         /*panelRow*/ 1, /*panelColumn*/ 7);
+
+    // Closed Hi-Hat
+    smDrumset->drum(42) = DrumInstrument(TConv::userName(DrumNum(42)), NoteHeadGroup::HEAD_CROSS, /*line*/ -1, DirectionV::UP,
+                                         /*panelRow*/ 0, /*panelColumn*/ 0, /*voice*/ 0, Key_G);
+
+    // High Floor Tom
+    smDrumset->drum(43) = DrumInstrument(TConv::userName(DrumNum(43)), NoteHeadGroup::HEAD_NORMAL, /*line*/ 5, DirectionV::UP,
+                                         /*panelRow*/ 1, /*panelColumn*/ 6);
+
+    // Pedal Hi-Hat
+    smDrumset->drum(44) = DrumInstrument(TConv::userName(DrumNum(44)), NoteHeadGroup::HEAD_CROSS, /*line*/ 9, DirectionV::DOWN,
+                                         /*panelRow*/ 2, /*panelColumn*/ 2, /*voice*/ 1, Key_F);
+
+    // Low Tom
+    smDrumset->drum(45) = DrumInstrument(TConv::userName(DrumNum(45)), NoteHeadGroup::HEAD_NORMAL, /*line*/ 4, DirectionV::UP,
+                                         /*panelRow*/ 1, /*panelColumn*/ 5);
+
+    // Open Hi-Hat
+    smDrumset->drum(46) = DrumInstrument(TConv::userName(DrumNum(46)), NoteHeadGroup::HEAD_XCIRCLE, /*line*/ -1, DirectionV::UP,
+                                         /*panelRow*/ 0, /*panelColumn*/ 1);
+
+    // Low-Mid Tom
+    smDrumset->drum(47) = DrumInstrument(TConv::userName(DrumNum(47)), NoteHeadGroup::HEAD_NORMAL, /*line*/ 2, DirectionV::UP,
+                                         /*panelRow*/ 1, /*panelColumn*/ 4);
+
+    // Hi-Mid Tom
+    smDrumset->drum(48) = DrumInstrument(TConv::userName(DrumNum(48)), NoteHeadGroup::HEAD_NORMAL, /*line*/ 1, DirectionV::UP,
+                                         /*panelRow*/ 1, /*panelColumn*/ 3);
+
+    // Crash Cymbal 1
+    smDrumset->drum(49) = DrumInstrument(TConv::userName(DrumNum(49)), NoteHeadGroup::HEAD_CROSS, /*line*/ -2, DirectionV::UP,
+                                         /*panelRow*/ 0, /*panelColumn*/ 4, /*voice*/ 0, Key_C);
+
+    // High Tom
+    smDrumset->drum(50) = DrumInstrument(TConv::userName(DrumNum(50)), NoteHeadGroup::HEAD_NORMAL, /*line*/ 0, DirectionV::UP,
+                                         /*panelRow*/ 1, /*panelColumn*/ 2, /*voice*/ 0, Key_E);
+
+    // Ride Cymbal 1
+    smDrumset->drum(51) = DrumInstrument(TConv::userName(DrumNum(51)), NoteHeadGroup::HEAD_CROSS, /*line*/ 0, DirectionV::UP,
+                                         /*panelRow*/ 0, /*panelColumn*/ 2, /*voice*/ 0, Key_D);
+
+    // Chinese Cymbal
+    smDrumset->drum(52) = DrumInstrument(TConv::userName(DrumNum(52)), NoteHeadGroup::HEAD_CROSS, /*line*/ -4, DirectionV::UP,
+                                         /*panelRow*/ 0, /*panelColumn*/ 6);
+
+    // Ride Bell
+    smDrumset->drum(53) = DrumInstrument(TConv::userName(DrumNum(53)), NoteHeadGroup::HEAD_DIAMOND, /*line*/ 0, DirectionV::UP,
+                                         /*panelRow*/ 0, /*panelColumn*/ 3);
+
+    // Tambourine
+    smDrumset->drum(54) = DrumInstrument(TConv::userName(DrumNum(54)), NoteHeadGroup::HEAD_DIAMOND, /*line*/ 1, DirectionV::UP,
+                                         /*panelRow*/ 2, /*panelColumn*/ 4);
+
+    // Splash Cymbal
+    smDrumset->drum(55) = DrumInstrument(TConv::userName(DrumNum(55)), NoteHeadGroup::HEAD_CROSS, /*line*/ -5, DirectionV::UP,
+                                         /*panelRow*/ 0, /*panelColumn*/ 7);
+
+    // Cowbell
+    smDrumset->drum(56) = DrumInstrument(TConv::userName(DrumNum(56)), NoteHeadGroup::HEAD_TRIANGLE_DOWN, /*line*/ 1, DirectionV::UP,
+                                         /*panelRow*/ 2, /*panelColumn*/ 3);
+
+    // Crash Cymbal 2
+    smDrumset->drum(57) = DrumInstrument(TConv::userName(DrumNum(57)), NoteHeadGroup::HEAD_CROSS, /*line*/ -3, DirectionV::UP,
+                                         /*panelRow*/ 0, /*panelColumn*/ 5);
+
+    // Ride Cymbal 2
+    smDrumset->drum(59) = DrumInstrument(TConv::userName(DrumNum(59)), NoteHeadGroup::HEAD_CROSS, /*line*/ 2, DirectionV::UP,
+                                         /*panelRow*/ 2, /*panelColumn*/ 5);
 }
 }

--- a/src/engraving/dom/drumset.h
+++ b/src/engraving/dom/drumset.h
@@ -59,17 +59,18 @@ struct DrumInstrument {
 
     int line = 0;               ///< place notehead onto this line
     DirectionV stemDirection = DirectionV::AUTO;
-    int voice = 0;
-    char shortcut = '\0';      ///< accelerator key (CDEFGAB)
-    std::list<DrumInstrumentVariant> variants;
 
     int panelRow = -1;
     int panelColumn = -1;
 
+    int voice = 0;
+    char shortcut = '\0';      ///< accelerator key (CDEFGAB)
+    std::list<DrumInstrumentVariant> variants;
+
     DrumInstrument() {}
     DrumInstrument(const char* s, NoteHeadGroup nh, int l, DirectionV d,
-                   int v = 0, char sc = 0)
-        : name(String::fromUtf8(s)), notehead(nh), line(l), stemDirection(d), voice(v), shortcut(sc) {}
+                   int pr = -1, int pc = -1, int v = 0, char sc = 0)
+        : name(String::fromUtf8(s)), notehead(nh), line(l), stemDirection(d), panelRow(pr), panelColumn(pc), voice(v), shortcut(sc) {}
 
     void addVariant(DrumInstrumentVariant v) { variants.push_back(v); }
 

--- a/src/importexport/musicxml/tests/data/testImportDrums2_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testImportDrums2_ref.mscx
@@ -63,6 +63,8 @@
           <voice>1</voice>
           <name>Acoustic Bass Drum</name>
           <stem>2</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>1</panelColumn>
           </Drum>
         <Drum pitch="36">
           <head>normal</head>
@@ -71,6 +73,8 @@
           <name>Bass Drum 1</name>
           <stem>2</stem>
           <shortcut>B</shortcut>
+          <panelRow>2</panelRow>
+          <panelColumn>0</panelColumn>
           </Drum>
         <Drum pitch="37">
           <head>slashed1</head>
@@ -78,6 +82,8 @@
           <voice>0</voice>
           <name>Side Stick</name>
           <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>1</panelColumn>
           </Drum>
         <Drum pitch="38">
           <head>normal</head>
@@ -86,13 +92,17 @@
           <name>Acoustic Snare</name>
           <stem>1</stem>
           <shortcut>A</shortcut>
+          <panelRow>1</panelRow>
+          <panelColumn>0</panelColumn>
           </Drum>
         <Drum pitch="40">
-          <head>normal</head>
+          <head>slash</head>
           <line>3</line>
           <voice>0</voice>
           <name>Electric Snare</name>
           <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>6</panelColumn>
           </Drum>
         <Drum pitch="41">
           <head>normal</head>
@@ -100,6 +110,8 @@
           <voice>0</voice>
           <name>Low Floor Tom</name>
           <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>7</panelColumn>
           </Drum>
         <Drum pitch="42">
           <head>cross</head>
@@ -108,13 +120,17 @@
           <name>Closed Hi-Hat</name>
           <stem>1</stem>
           <shortcut>G</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>0</panelColumn>
           </Drum>
         <Drum pitch="43">
           <head>normal</head>
           <line>5</line>
           <voice>0</voice>
           <name>High Floor Tom</name>
-          <stem>2</stem>
+          <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>6</panelColumn>
           </Drum>
         <Drum pitch="44">
           <head>cross</head>
@@ -123,6 +139,8 @@
           <name>Pedal Hi-Hat</name>
           <stem>2</stem>
           <shortcut>F</shortcut>
+          <panelRow>2</panelRow>
+          <panelColumn>2</panelColumn>
           </Drum>
         <Drum pitch="45">
           <head>normal</head>
@@ -130,13 +148,17 @@
           <voice>0</voice>
           <name>Low Tom</name>
           <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>5</panelColumn>
           </Drum>
         <Drum pitch="46">
-          <head>cross</head>
+          <head>xcircle</head>
           <line>-1</line>
           <voice>0</voice>
           <name>Open Hi-Hat</name>
           <stem>1</stem>
+          <panelRow>0</panelRow>
+          <panelColumn>1</panelColumn>
           </Drum>
         <Drum pitch="47">
           <head>normal</head>
@@ -144,6 +166,8 @@
           <voice>0</voice>
           <name>Low-Mid Tom</name>
           <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>4</panelColumn>
           </Drum>
         <Drum pitch="48">
           <head>normal</head>
@@ -151,6 +175,8 @@
           <voice>0</voice>
           <name>Hi-Mid Tom</name>
           <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>3</panelColumn>
           </Drum>
         <Drum pitch="49">
           <head>cross</head>
@@ -159,6 +185,8 @@
           <name>Crash Cymbal 1</name>
           <stem>1</stem>
           <shortcut>C</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>4</panelColumn>
           </Drum>
         <Drum pitch="50">
           <head>normal</head>
@@ -167,6 +195,8 @@
           <name>High Tom</name>
           <stem>1</stem>
           <shortcut>E</shortcut>
+          <panelRow>1</panelRow>
+          <panelColumn>2</panelColumn>
           </Drum>
         <Drum pitch="51">
           <head>cross</head>
@@ -175,6 +205,8 @@
           <name>Ride Cymbal 1</name>
           <stem>1</stem>
           <shortcut>D</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>2</panelColumn>
           </Drum>
         <Drum pitch="52">
           <head>cross</head>
@@ -182,6 +214,8 @@
           <voice>0</voice>
           <name>Chinese Cymbal</name>
           <stem>1</stem>
+          <panelRow>0</panelRow>
+          <panelColumn>6</panelColumn>
           </Drum>
         <Drum pitch="53">
           <head>diamond</head>
@@ -189,6 +223,8 @@
           <voice>0</voice>
           <name>Ride Bell</name>
           <stem>1</stem>
+          <panelRow>0</panelRow>
+          <panelColumn>3</panelColumn>
           </Drum>
         <Drum pitch="54">
           <head>diamond</head>
@@ -196,6 +232,8 @@
           <voice>0</voice>
           <name>Tambourine</name>
           <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>4</panelColumn>
           </Drum>
         <Drum pitch="55">
           <head>cross</head>
@@ -203,6 +241,8 @@
           <voice>0</voice>
           <name>Splash Cymbal</name>
           <stem>1</stem>
+          <panelRow>0</panelRow>
+          <panelColumn>7</panelColumn>
           </Drum>
         <Drum pitch="56">
           <head>triangle-down</head>
@@ -210,6 +250,8 @@
           <voice>0</voice>
           <name>Cowbell</name>
           <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>3</panelColumn>
           </Drum>
         <Drum pitch="57">
           <head>cross</head>
@@ -217,6 +259,8 @@
           <voice>0</voice>
           <name>Crash Cymbal 2</name>
           <stem>1</stem>
+          <panelRow>0</panelRow>
+          <panelColumn>5</panelColumn>
           </Drum>
         <Drum pitch="59">
           <head>cross</head>
@@ -224,6 +268,8 @@
           <voice>0</voice>
           <name>Ride Cymbal 2</name>
           <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>5</panelColumn>
           </Drum>
         <Drum pitch="81">
           <head>normal</head>

--- a/src/importexport/musicxml/tests/data/testImportDrums_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testImportDrums_ref.mscx
@@ -52,6 +52,8 @@
           <voice>1</voice>
           <name>Acoustic Bass Drum</name>
           <stem>2</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>1</panelColumn>
           </Drum>
         <Drum pitch="36">
           <head>normal</head>
@@ -60,6 +62,8 @@
           <name>Bass Drum 1</name>
           <stem>2</stem>
           <shortcut>B</shortcut>
+          <panelRow>2</panelRow>
+          <panelColumn>0</panelColumn>
           </Drum>
         <Drum pitch="37">
           <head>slashed1</head>
@@ -67,6 +71,8 @@
           <voice>0</voice>
           <name>Side Stick</name>
           <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>1</panelColumn>
           </Drum>
         <Drum pitch="38">
           <head>normal</head>
@@ -75,13 +81,17 @@
           <name>Acoustic Snare</name>
           <stem>1</stem>
           <shortcut>A</shortcut>
+          <panelRow>1</panelRow>
+          <panelColumn>0</panelColumn>
           </Drum>
         <Drum pitch="40">
-          <head>normal</head>
+          <head>slash</head>
           <line>3</line>
           <voice>0</voice>
           <name>Electric Snare</name>
           <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>6</panelColumn>
           </Drum>
         <Drum pitch="41">
           <head>normal</head>
@@ -89,6 +99,8 @@
           <voice>0</voice>
           <name>Low Floor Tom</name>
           <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>7</panelColumn>
           </Drum>
         <Drum pitch="42">
           <head>cross</head>
@@ -97,13 +109,17 @@
           <name>Closed Hi-Hat</name>
           <stem>1</stem>
           <shortcut>G</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>0</panelColumn>
           </Drum>
         <Drum pitch="43">
           <head>normal</head>
           <line>5</line>
           <voice>0</voice>
           <name>High Floor Tom</name>
-          <stem>2</stem>
+          <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>6</panelColumn>
           </Drum>
         <Drum pitch="44">
           <head>cross</head>
@@ -112,6 +128,8 @@
           <name>Pedal Hi-Hat</name>
           <stem>2</stem>
           <shortcut>F</shortcut>
+          <panelRow>2</panelRow>
+          <panelColumn>2</panelColumn>
           </Drum>
         <Drum pitch="45">
           <head>normal</head>
@@ -119,13 +137,17 @@
           <voice>0</voice>
           <name>Low Tom</name>
           <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>5</panelColumn>
           </Drum>
         <Drum pitch="46">
-          <head>cross</head>
+          <head>xcircle</head>
           <line>-1</line>
           <voice>0</voice>
           <name>Open Hi-Hat</name>
           <stem>1</stem>
+          <panelRow>0</panelRow>
+          <panelColumn>1</panelColumn>
           </Drum>
         <Drum pitch="47">
           <head>normal</head>
@@ -133,6 +155,8 @@
           <voice>0</voice>
           <name>Low-Mid Tom</name>
           <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>4</panelColumn>
           </Drum>
         <Drum pitch="48">
           <head>normal</head>
@@ -140,6 +164,8 @@
           <voice>0</voice>
           <name>Hi-Mid Tom</name>
           <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>3</panelColumn>
           </Drum>
         <Drum pitch="49">
           <head>cross</head>
@@ -148,6 +174,8 @@
           <name>Crash Cymbal 1</name>
           <stem>1</stem>
           <shortcut>C</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>4</panelColumn>
           </Drum>
         <Drum pitch="50">
           <head>normal</head>
@@ -156,6 +184,8 @@
           <name>High Tom</name>
           <stem>1</stem>
           <shortcut>E</shortcut>
+          <panelRow>1</panelRow>
+          <panelColumn>2</panelColumn>
           </Drum>
         <Drum pitch="51">
           <head>cross</head>
@@ -164,6 +194,8 @@
           <name>Ride Cymbal 1</name>
           <stem>1</stem>
           <shortcut>D</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>2</panelColumn>
           </Drum>
         <Drum pitch="52">
           <head>cross</head>
@@ -171,6 +203,8 @@
           <voice>0</voice>
           <name>Chinese Cymbal</name>
           <stem>1</stem>
+          <panelRow>0</panelRow>
+          <panelColumn>6</panelColumn>
           </Drum>
         <Drum pitch="53">
           <head>diamond</head>
@@ -178,6 +212,8 @@
           <voice>0</voice>
           <name>Ride Bell</name>
           <stem>1</stem>
+          <panelRow>0</panelRow>
+          <panelColumn>3</panelColumn>
           </Drum>
         <Drum pitch="54">
           <head>diamond</head>
@@ -185,6 +221,8 @@
           <voice>0</voice>
           <name>Tambourine</name>
           <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>4</panelColumn>
           </Drum>
         <Drum pitch="55">
           <head>cross</head>
@@ -192,6 +230,8 @@
           <voice>0</voice>
           <name>Splash Cymbal</name>
           <stem>1</stem>
+          <panelRow>0</panelRow>
+          <panelColumn>7</panelColumn>
           </Drum>
         <Drum pitch="56">
           <head>triangle-down</head>
@@ -199,6 +239,8 @@
           <voice>0</voice>
           <name>Cowbell</name>
           <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>3</panelColumn>
           </Drum>
         <Drum pitch="57">
           <head>cross</head>
@@ -206,6 +248,8 @@
           <voice>0</voice>
           <name>Crash Cymbal 2</name>
           <stem>1</stem>
+          <panelRow>0</panelRow>
+          <panelColumn>5</panelColumn>
           </Drum>
         <Drum pitch="59">
           <head>cross</head>
@@ -213,6 +257,8 @@
           <voice>0</voice>
           <name>Ride Cymbal 2</name>
           <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>5</panelColumn>
           </Drum>
         <Drum pitch="81">
           <head>normal</head>

--- a/src/importexport/musicxml/tests/data/testStickingLyrics_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testStickingLyrics_ref.mscx
@@ -63,6 +63,8 @@
           <voice>1</voice>
           <name>Acoustic Bass Drum</name>
           <stem>2</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>1</panelColumn>
           </Drum>
         <Drum pitch="36">
           <head>normal</head>
@@ -71,6 +73,8 @@
           <name>Bass Drum 1</name>
           <stem>2</stem>
           <shortcut>B</shortcut>
+          <panelRow>2</panelRow>
+          <panelColumn>0</panelColumn>
           </Drum>
         <Drum pitch="37">
           <head>slashed1</head>
@@ -78,6 +82,8 @@
           <voice>0</voice>
           <name>Side Stick</name>
           <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>1</panelColumn>
           </Drum>
         <Drum pitch="38">
           <head>normal</head>
@@ -86,13 +92,17 @@
           <name>Acoustic Snare</name>
           <stem>1</stem>
           <shortcut>A</shortcut>
+          <panelRow>1</panelRow>
+          <panelColumn>0</panelColumn>
           </Drum>
         <Drum pitch="40">
-          <head>normal</head>
+          <head>slash</head>
           <line>3</line>
           <voice>0</voice>
           <name>Electric Snare</name>
           <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>6</panelColumn>
           </Drum>
         <Drum pitch="41">
           <head>normal</head>
@@ -100,6 +110,8 @@
           <voice>0</voice>
           <name>Low Floor Tom</name>
           <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>7</panelColumn>
           </Drum>
         <Drum pitch="42">
           <head>cross</head>
@@ -108,13 +120,17 @@
           <name>Closed Hi-Hat</name>
           <stem>1</stem>
           <shortcut>G</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>0</panelColumn>
           </Drum>
         <Drum pitch="43">
           <head>normal</head>
           <line>5</line>
           <voice>0</voice>
           <name>High Floor Tom</name>
-          <stem>2</stem>
+          <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>6</panelColumn>
           </Drum>
         <Drum pitch="44">
           <head>cross</head>
@@ -123,6 +139,8 @@
           <name>Pedal Hi-Hat</name>
           <stem>2</stem>
           <shortcut>F</shortcut>
+          <panelRow>2</panelRow>
+          <panelColumn>2</panelColumn>
           </Drum>
         <Drum pitch="45">
           <head>normal</head>
@@ -130,13 +148,17 @@
           <voice>0</voice>
           <name>Low Tom</name>
           <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>5</panelColumn>
           </Drum>
         <Drum pitch="46">
-          <head>cross</head>
+          <head>xcircle</head>
           <line>-1</line>
           <voice>0</voice>
           <name>Open Hi-Hat</name>
           <stem>1</stem>
+          <panelRow>0</panelRow>
+          <panelColumn>1</panelColumn>
           </Drum>
         <Drum pitch="47">
           <head>normal</head>
@@ -144,6 +166,8 @@
           <voice>0</voice>
           <name>Low-Mid Tom</name>
           <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>4</panelColumn>
           </Drum>
         <Drum pitch="48">
           <head>normal</head>
@@ -151,6 +175,8 @@
           <voice>0</voice>
           <name>Hi-Mid Tom</name>
           <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>3</panelColumn>
           </Drum>
         <Drum pitch="49">
           <head>cross</head>
@@ -159,6 +185,8 @@
           <name>Crash Cymbal 1</name>
           <stem>1</stem>
           <shortcut>C</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>4</panelColumn>
           </Drum>
         <Drum pitch="50">
           <head>normal</head>
@@ -167,6 +195,8 @@
           <name>High Tom</name>
           <stem>1</stem>
           <shortcut>E</shortcut>
+          <panelRow>1</panelRow>
+          <panelColumn>2</panelColumn>
           </Drum>
         <Drum pitch="51">
           <head>cross</head>
@@ -175,6 +205,8 @@
           <name>Ride Cymbal 1</name>
           <stem>1</stem>
           <shortcut>D</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>2</panelColumn>
           </Drum>
         <Drum pitch="52">
           <head>cross</head>
@@ -182,6 +214,8 @@
           <voice>0</voice>
           <name>Chinese Cymbal</name>
           <stem>1</stem>
+          <panelRow>0</panelRow>
+          <panelColumn>6</panelColumn>
           </Drum>
         <Drum pitch="53">
           <head>diamond</head>
@@ -189,6 +223,8 @@
           <voice>0</voice>
           <name>Ride Bell</name>
           <stem>1</stem>
+          <panelRow>0</panelRow>
+          <panelColumn>3</panelColumn>
           </Drum>
         <Drum pitch="54">
           <head>diamond</head>
@@ -196,6 +232,8 @@
           <voice>0</voice>
           <name>Tambourine</name>
           <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>4</panelColumn>
           </Drum>
         <Drum pitch="55">
           <head>cross</head>
@@ -203,6 +241,8 @@
           <voice>0</voice>
           <name>Splash Cymbal</name>
           <stem>1</stem>
+          <panelRow>0</panelRow>
+          <panelColumn>7</panelColumn>
           </Drum>
         <Drum pitch="56">
           <head>triangle-down</head>
@@ -210,6 +250,8 @@
           <voice>0</voice>
           <name>Cowbell</name>
           <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>3</panelColumn>
           </Drum>
         <Drum pitch="57">
           <head>cross</head>
@@ -217,6 +259,8 @@
           <voice>0</voice>
           <name>Crash Cymbal 2</name>
           <stem>1</stem>
+          <panelRow>0</panelRow>
+          <panelColumn>5</panelColumn>
           </Drum>
         <Drum pitch="59">
           <head>cross</head>
@@ -224,6 +268,8 @@
           <voice>0</voice>
           <name>Ride Cymbal 2</name>
           <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>5</panelColumn>
           </Drum>
         <clef>PERC</clef>
         <singleNoteDynamics>0</singleNoteDynamics>


### PR DESCRIPTION
Since we introduced new `panelRow` and `panelColumn` tags in #25608, we should also update the panel layout for our standard MIDI drumset (A.K.A "Large Drum Kit").

Some additional tweaks were also requested and implemented in this PR:

1. Stem direction for High Floor Tom is now up
2. Notehead for Open Hi-Hat is now an x-circle
3. Notehead for Electric Snare is now a slash