### PR TITLE
Move standard drumset to instruments.xml

### DIFF
--- a/share/instruments/instruments.xml
+++ b/share/instruments/instruments.xml
@@ -7308,7 +7308,6 @@
             </Instrument>
             <Instrument id="drumset">
                   <family>drums</family>
-                  <!--Drums for the basic drumset are hard-coded in instrument.cpp for some reason.-->
                   <trackName>Large Drum Kit</trackName>
                   <longName>Drum Kit</longName>
                   <shortName>D. Kit</shortName>
@@ -7319,6 +7318,220 @@
                   <barlineSpan>1</barlineSpan>
                   <drumset>1</drumset>
                   <singleNoteDynamics>0</singleNoteDynamics>
+                  <Drum pitch="35"> <!--Acoustic Bass Drum-->
+                        <head>normal</head>
+                        <line>8</line>
+                        <voice>1</voice>
+                        <name>Acoustic Bass Drum</name>
+                        <stem>2</stem>
+                        <panelRow>2</panelRow>
+                        <panelColumn>1</panelColumn>
+                  </Drum>
+                  <Drum pitch="36"> <!--Electric Bass Drum-->
+                        <head>normal</head>
+                        <line>7</line>
+                        <voice>1</voice>
+                        <name>Bass Drum 1</name>
+                        <stem>2</stem>
+                        <shortcut>B</shortcut>
+                        <panelRow>2</panelRow>
+                        <panelColumn>0</panelColumn>
+                  </Drum>
+                  <Drum pitch="37"> <!--Side Stick-->
+                        <head>slashed1</head>
+                        <line>3</line>
+                        <voice>0</voice>
+                        <name>Side Stick</name>
+                        <stem>1</stem>
+                        <panelRow>1</panelRow>
+                        <panelColumn>1</panelColumn>
+                  </Drum>
+                  <Drum pitch="38"> <!--Acoustic Snare-->
+                        <head>normal</head>
+                        <line>3</line>
+                        <voice>0</voice>
+                        <name>Acoustic Snare</name>
+                        <stem>1</stem>
+                        <shortcut>A</shortcut>
+                        <panelRow>1</panelRow>
+                        <panelColumn>0</panelColumn>
+                  </Drum>
+                  <Drum pitch="40"> <!--Electric Snare-->
+                        <head>slash</head>
+                        <line>3</line>
+                        <voice>0</voice>
+                        <name>Electric Snare</name>
+                        <stem>1</stem>
+                        <panelRow>2</panelRow>
+                        <panelColumn>6</panelColumn>
+                  </Drum>
+                  <Drum pitch="41"> <!--Low Floor Tom-->
+                        <head>normal</head>
+                        <line>6</line>
+                        <voice>0</voice>
+                        <name>Low Floor Tom</name>
+                        <stem>1</stem>
+                        <panelRow>1</panelRow>
+                        <panelColumn>7</panelColumn>
+                  </Drum>
+                  <Drum pitch="42"> <!--Closed Hi-hat-->
+                        <head>cross</head>
+                        <line>-1</line>
+                        <voice>0</voice>
+                        <name>Closed Hi-Hat</name>
+                        <stem>1</stem>
+                        <shortcut>G</shortcut>
+                        <panelRow>0</panelRow>
+                        <panelColumn>0</panelColumn>
+                  </Drum>
+                  <Drum pitch="43"> <!--High Floor Tom-->
+                        <head>normal</head>
+                        <line>5</line>
+                        <voice>0</voice>
+                        <name>High Floor Tom</name>
+                        <stem>1</stem>
+                        <panelRow>1</panelRow>
+                        <panelColumn>6</panelColumn>
+                  </Drum>
+                  <Drum pitch="44"> <!--Pedal Hi-hat-->
+                        <head>cross</head>
+                        <line>9</line>
+                        <voice>1</voice>
+                        <name>Pedal Hi-Hat</name>
+                        <stem>2</stem>
+                        <shortcut>F</shortcut>
+                        <panelRow>2</panelRow>
+                        <panelColumn>2</panelColumn>
+                  </Drum>
+                  <Drum pitch="45"> <!--Low Tom-->
+                        <head>normal</head>
+                        <line>4</line>
+                        <voice>0</voice>
+                        <name>Low Tom</name>
+                        <stem>1</stem>
+                        <panelRow>1</panelRow>
+                        <panelColumn>5</panelColumn>
+                  </Drum>
+                  <Drum pitch="46"> <!--Open Hi-hat-->
+                        <head>xcircle</head>
+                        <line>-1</line>
+                        <voice>0</voice>
+                        <name>Open Hi-Hat</name>
+                        <stem>1</stem>
+                        <panelRow>0</panelRow>
+                        <panelColumn>1</panelColumn>
+                  </Drum>
+                  <Drum pitch="47"> <!--Low-Mid Tom-->
+                        <head>normal</head>
+                        <line>2</line>
+                        <voice>0</voice>
+                        <name>Low-Mid Tom</name>
+                        <stem>1</stem>
+                        <panelRow>1</panelRow>
+                        <panelColumn>4</panelColumn>
+                  </Drum>
+                  <Drum pitch="48"> <!--Hi-Mid Tom-->
+                        <head>normal</head>
+                        <line>1</line>
+                        <voice>0</voice>
+                        <name>Hi-Mid Tom</name>
+                        <stem>1</stem>
+                        <panelRow>1</panelRow>
+                        <panelColumn>3</panelColumn>
+                  </Drum>
+                  <Drum pitch="49"> <!--Crash Cymbal 1-->
+                        <head>cross</head>
+                        <line>-2</line>
+                        <voice>0</voice>
+                        <name>Crash Cymbal 1</name>
+                        <stem>1</stem>
+                        <shortcut>C</shortcut>
+                        <panelRow>0</panelRow>
+                        <panelColumn>4</panelColumn>
+                  </Drum>
+                  <Drum pitch="50"> <!--High Tom-->
+                        <head>normal</head>
+                        <line>0</line>
+                        <voice>0</voice>
+                        <name>High Tom</name>
+                        <stem>1</stem>
+                        <shortcut>E</shortcut>
+                        <panelRow>1</panelRow>
+                        <panelColumn>2</panelColumn>
+                  </Drum>
+                  <Drum pitch="51"> <!--Ride Cymbal 1-->
+                        <head>cross</head>
+                        <line>0</line>
+                        <voice>0</voice>
+                        <name>Ride Cymbal 1</name>
+                        <stem>1</stem>
+                        <shortcut>D</shortcut>
+                        <panelRow>0</panelRow>
+                        <panelColumn>2</panelColumn>
+                  </Drum>
+                  <Drum pitch="52"> <!--Chinese Cymbal-->
+                        <head>cross</head>
+                        <line>-4</line>
+                        <voice>0</voice>
+                        <name>Chinese Cymbal</name>
+                        <stem>1</stem>
+                        <panelRow>0</panelRow>
+                        <panelColumn>6</panelColumn>
+                  </Drum>
+                  <Drum pitch="53"> <!--Ride Bell-->
+                        <head>diamond</head>
+                        <line>0</line>
+                        <voice>0</voice>
+                        <name>Ride Bell</name>
+                        <stem>1</stem>
+                        <panelRow>0</panelRow>
+                        <panelColumn>3</panelColumn>
+                  </Drum>
+                  <Drum pitch="54"> <!--Tambourine-->
+                        <head>diamond</head>
+                        <line>1</line>
+                        <voice>0</voice>
+                        <name>Tambourine</name>
+                        <stem>1</stem>
+                        <panelRow>2</panelRow>
+                        <panelColumn>4</panelColumn>
+                  </Drum>
+                  <Drum pitch="55"> <!--Splash Cymbal-->
+                        <head>cross</head>
+                        <line>-5</line>
+                        <voice>0</voice>
+                        <name>Splash Cymbal</name>
+                        <stem>1</stem>
+                        <panelRow>0</panelRow>
+                        <panelColumn>7</panelColumn>
+                  </Drum>
+                  <Drum pitch="56"> <!--Cowbell-->
+                        <head>triangle-down</head>
+                        <line>1</line>
+                        <voice>0</voice>
+                        <name>Cowbell</name>
+                        <stem>1</stem>
+                        <panelRow>2</panelRow>
+                        <panelColumn>3</panelColumn>
+                  </Drum>
+                  <Drum pitch="57"> <!--Crash Cymbal 2-->
+                        <head>cross</head>
+                        <line>-3</line>
+                        <voice>0</voice>
+                        <name>Crash Cymbal 2</name>
+                        <stem>1</stem>
+                        <panelRow>0</panelRow>
+                        <panelColumn>5</panelColumn>
+                  </Drum>
+                  <Drum pitch="59"> <!--Ride Cymbal 2-->
+                        <head>cross</head>
+                        <line>2</line>
+                        <voice>0</voice>
+                        <name>Ride Cymbal 2</name>
+                        <stem>1</stem>
+                        <panelRow>2</panelRow>
+                        <panelColumn>5</panelColumn>
+                  </Drum>
                   <Channel>
                         <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
                         <controller ctrl="0" value="1"/> <!--Bank MSB-->
@@ -8183,7 +8396,7 @@
                         <head>cross</head>
                         <line>0</line>
                         <voice>0</voice>
-                        <name>Closed Hi-hat</name>
+                        <name>Closed Hi-Hat</name>
                         <stem>1</stem>
                         <shortcut>B</shortcut>
                         <panelRow>0</panelRow>
@@ -10979,6 +11192,220 @@
                   <stafftype staffTypePreset="perc5Line">percussion</stafftype>
                   <barlineSpan>1</barlineSpan>
                   <drumset>1</drumset>
+                  <Drum pitch="35"> <!--Acoustic Bass Drum-->
+                        <head>normal</head>
+                        <line>8</line>
+                        <voice>1</voice>
+                        <name>Acoustic Bass Drum</name>
+                        <stem>2</stem>
+                        <panelRow>2</panelRow>
+                        <panelColumn>1</panelColumn>
+                  </Drum>
+                  <Drum pitch="36"> <!--Electric Bass Drum-->
+                        <head>normal</head>
+                        <line>7</line>
+                        <voice>1</voice>
+                        <name>Bass Drum 1</name>
+                        <stem>2</stem>
+                        <shortcut>B</shortcut>
+                        <panelRow>2</panelRow>
+                        <panelColumn>0</panelColumn>
+                  </Drum>
+                  <Drum pitch="37"> <!--Side Stick-->
+                        <head>slashed1</head>
+                        <line>3</line>
+                        <voice>0</voice>
+                        <name>Side Stick</name>
+                        <stem>1</stem>
+                        <panelRow>1</panelRow>
+                        <panelColumn>1</panelColumn>
+                  </Drum>
+                  <Drum pitch="38"> <!--Acoustic Snare-->
+                        <head>normal</head>
+                        <line>3</line>
+                        <voice>0</voice>
+                        <name>Acoustic Snare</name>
+                        <stem>1</stem>
+                        <shortcut>A</shortcut>
+                        <panelRow>1</panelRow>
+                        <panelColumn>0</panelColumn>
+                  </Drum>
+                  <Drum pitch="40"> <!--Electric Snare-->
+                        <head>slash</head>
+                        <line>3</line>
+                        <voice>0</voice>
+                        <name>Electric Snare</name>
+                        <stem>1</stem>
+                        <panelRow>2</panelRow>
+                        <panelColumn>6</panelColumn>
+                  </Drum>
+                  <Drum pitch="41"> <!--Low Floor Tom-->
+                        <head>normal</head>
+                        <line>6</line>
+                        <voice>0</voice>
+                        <name>Low Floor Tom</name>
+                        <stem>1</stem>
+                        <panelRow>1</panelRow>
+                        <panelColumn>7</panelColumn>
+                  </Drum>
+                  <Drum pitch="42"> <!--Closed Hi-hat-->
+                        <head>cross</head>
+                        <line>-1</line>
+                        <voice>0</voice>
+                        <name>Closed Hi-Hat</name>
+                        <stem>1</stem>
+                        <shortcut>G</shortcut>
+                        <panelRow>0</panelRow>
+                        <panelColumn>0</panelColumn>
+                  </Drum>
+                  <Drum pitch="43"> <!--High Floor Tom-->
+                        <head>normal</head>
+                        <line>5</line>
+                        <voice>0</voice>
+                        <name>High Floor Tom</name>
+                        <stem>1</stem>
+                        <panelRow>1</panelRow>
+                        <panelColumn>6</panelColumn>
+                  </Drum>
+                  <Drum pitch="44"> <!--Pedal Hi-hat-->
+                        <head>cross</head>
+                        <line>9</line>
+                        <voice>1</voice>
+                        <name>Pedal Hi-Hat</name>
+                        <stem>2</stem>
+                        <shortcut>F</shortcut>
+                        <panelRow>2</panelRow>
+                        <panelColumn>2</panelColumn>
+                  </Drum>
+                  <Drum pitch="45"> <!--Low Tom-->
+                        <head>normal</head>
+                        <line>4</line>
+                        <voice>0</voice>
+                        <name>Low Tom</name>
+                        <stem>1</stem>
+                        <panelRow>1</panelRow>
+                        <panelColumn>5</panelColumn>
+                  </Drum>
+                  <Drum pitch="46"> <!--Open Hi-hat-->
+                        <head>xcircle</head>
+                        <line>-1</line>
+                        <voice>0</voice>
+                        <name>Open Hi-Hat</name>
+                        <stem>1</stem>
+                        <panelRow>0</panelRow>
+                        <panelColumn>1</panelColumn>
+                  </Drum>
+                  <Drum pitch="47"> <!--Low-Mid Tom-->
+                        <head>normal</head>
+                        <line>2</line>
+                        <voice>0</voice>
+                        <name>Low-Mid Tom</name>
+                        <stem>1</stem>
+                        <panelRow>1</panelRow>
+                        <panelColumn>4</panelColumn>
+                  </Drum>
+                  <Drum pitch="48"> <!--Hi-Mid Tom-->
+                        <head>normal</head>
+                        <line>1</line>
+                        <voice>0</voice>
+                        <name>Hi-Mid Tom</name>
+                        <stem>1</stem>
+                        <panelRow>1</panelRow>
+                        <panelColumn>3</panelColumn>
+                  </Drum>
+                  <Drum pitch="49"> <!--Crash Cymbal 1-->
+                        <head>cross</head>
+                        <line>-2</line>
+                        <voice>0</voice>
+                        <name>Crash Cymbal 1</name>
+                        <stem>1</stem>
+                        <shortcut>C</shortcut>
+                        <panelRow>0</panelRow>
+                        <panelColumn>4</panelColumn>
+                  </Drum>
+                  <Drum pitch="50"> <!--High Tom-->
+                        <head>normal</head>
+                        <line>0</line>
+                        <voice>0</voice>
+                        <name>High Tom</name>
+                        <stem>1</stem>
+                        <shortcut>E</shortcut>
+                        <panelRow>1</panelRow>
+                        <panelColumn>2</panelColumn>
+                  </Drum>
+                  <Drum pitch="51"> <!--Ride Cymbal 1-->
+                        <head>cross</head>
+                        <line>0</line>
+                        <voice>0</voice>
+                        <name>Ride Cymbal 1</name>
+                        <stem>1</stem>
+                        <shortcut>D</shortcut>
+                        <panelRow>0</panelRow>
+                        <panelColumn>2</panelColumn>
+                  </Drum>
+                  <Drum pitch="52"> <!--Chinese Cymbal-->
+                        <head>cross</head>
+                        <line>-4</line>
+                        <voice>0</voice>
+                        <name>Chinese Cymbal</name>
+                        <stem>1</stem>
+                        <panelRow>0</panelRow>
+                        <panelColumn>6</panelColumn>
+                  </Drum>
+                  <Drum pitch="53"> <!--Ride Bell-->
+                        <head>diamond</head>
+                        <line>0</line>
+                        <voice>0</voice>
+                        <name>Ride Bell</name>
+                        <stem>1</stem>
+                        <panelRow>0</panelRow>
+                        <panelColumn>3</panelColumn>
+                  </Drum>
+                  <Drum pitch="54"> <!--Tambourine-->
+                        <head>diamond</head>
+                        <line>1</line>
+                        <voice>0</voice>
+                        <name>Tambourine</name>
+                        <stem>1</stem>
+                        <panelRow>2</panelRow>
+                        <panelColumn>4</panelColumn>
+                  </Drum>
+                  <Drum pitch="55"> <!--Splash Cymbal-->
+                        <head>cross</head>
+                        <line>-5</line>
+                        <voice>0</voice>
+                        <name>Splash Cymbal</name>
+                        <stem>1</stem>
+                        <panelRow>0</panelRow>
+                        <panelColumn>7</panelColumn>
+                  </Drum>
+                  <Drum pitch="56"> <!--Cowbell-->
+                        <head>triangle-down</head>
+                        <line>1</line>
+                        <voice>0</voice>
+                        <name>Cowbell</name>
+                        <stem>1</stem>
+                        <panelRow>2</panelRow>
+                        <panelColumn>3</panelColumn>
+                  </Drum>
+                  <Drum pitch="57"> <!--Crash Cymbal 2-->
+                        <head>cross</head>
+                        <line>-3</line>
+                        <voice>0</voice>
+                        <name>Crash Cymbal 2</name>
+                        <stem>1</stem>
+                        <panelRow>0</panelRow>
+                        <panelColumn>5</panelColumn>
+                  </Drum>
+                  <Drum pitch="59"> <!--Ride Cymbal 2-->
+                        <head>cross</head>
+                        <line>2</line>
+                        <voice>0</voice>
+                        <name>Ride Cymbal 2</name>
+                        <stem>1</stem>
+                        <panelRow>2</panelRow>
+                        <panelColumn>5</panelColumn>
+                  </Drum>
                   <Channel>
                         <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
                         <controller ctrl="0" value="1"/> <!--Bank MSB-->

--- a/src/engraving/dom/drumset.cpp
+++ b/src/engraving/dom/drumset.cpp
@@ -277,7 +277,6 @@ DrumInstrumentVariant Drumset::findVariant(int p, const std::vector<Articulation
 
 //---------------------------------------------------------
 //   initDrumset
-//    initialize standard midi drumset
 //---------------------------------------------------------
 
 void Drumset::initDrumset()
@@ -292,96 +291,5 @@ void Drumset::initDrumset()
         smDrumset->drum(i).panelRow     = -1;
         smDrumset->drum(i).panelColumn  = -1;
     }
-    // Acoustic Bass Drum
-    smDrumset->drum(35) = DrumInstrument(TConv::userName(DrumNum(35)), NoteHeadGroup::HEAD_NORMAL, /*line*/ 8, DirectionV::DOWN,
-                                         /*panelRow*/ 2, /*panelColumn*/ 1, /*voice*/ 1);
-
-    // Bass Drum 1
-    smDrumset->drum(36) = DrumInstrument(TConv::userName(DrumNum(36)), NoteHeadGroup::HEAD_NORMAL, /*line*/ 7, DirectionV::DOWN,
-                                         /*panelRow*/ 2, /*panelColumn*/ 0, /*voice*/ 1, Key_B);
-
-    // Side Stick
-    smDrumset->drum(37) = DrumInstrument(TConv::userName(DrumNum(37)), NoteHeadGroup::HEAD_SLASHED1, /*line*/ 3, DirectionV::UP,
-                                         /*panelRow*/ 1, /*panelColumn*/ 1);
-
-    // Acoustic Snare
-    smDrumset->drum(38) = DrumInstrument(TConv::userName(DrumNum(38)), NoteHeadGroup::HEAD_NORMAL, /*line*/ 3, DirectionV::UP,
-                                         /*panelRow*/ 1, /*panelColumn*/ 0, /*voice*/ 0, Key_A);
-
-    // Electric Snare
-    smDrumset->drum(40) = DrumInstrument(TConv::userName(DrumNum(40)), NoteHeadGroup::HEAD_SLASH, /*line*/ 3, DirectionV::UP,
-                                         /*panelRow*/ 2, /*panelColumn*/ 6);
-
-    // Low Floor Tom
-    smDrumset->drum(41) = DrumInstrument(TConv::userName(DrumNum(41)), NoteHeadGroup::HEAD_NORMAL, /*line*/ 6, DirectionV::UP,
-                                         /*panelRow*/ 1, /*panelColumn*/ 7);
-
-    // Closed Hi-Hat
-    smDrumset->drum(42) = DrumInstrument(TConv::userName(DrumNum(42)), NoteHeadGroup::HEAD_CROSS, /*line*/ -1, DirectionV::UP,
-                                         /*panelRow*/ 0, /*panelColumn*/ 0, /*voice*/ 0, Key_G);
-
-    // High Floor Tom
-    smDrumset->drum(43) = DrumInstrument(TConv::userName(DrumNum(43)), NoteHeadGroup::HEAD_NORMAL, /*line*/ 5, DirectionV::UP,
-                                         /*panelRow*/ 1, /*panelColumn*/ 6);
-
-    // Pedal Hi-Hat
-    smDrumset->drum(44) = DrumInstrument(TConv::userName(DrumNum(44)), NoteHeadGroup::HEAD_CROSS, /*line*/ 9, DirectionV::DOWN,
-                                         /*panelRow*/ 2, /*panelColumn*/ 2, /*voice*/ 1, Key_F);
-
-    // Low Tom
-    smDrumset->drum(45) = DrumInstrument(TConv::userName(DrumNum(45)), NoteHeadGroup::HEAD_NORMAL, /*line*/ 4, DirectionV::UP,
-                                         /*panelRow*/ 1, /*panelColumn*/ 5);
-
-    // Open Hi-Hat
-    smDrumset->drum(46) = DrumInstrument(TConv::userName(DrumNum(46)), NoteHeadGroup::HEAD_XCIRCLE, /*line*/ -1, DirectionV::UP,
-                                         /*panelRow*/ 0, /*panelColumn*/ 1);
-
-    // Low-Mid Tom
-    smDrumset->drum(47) = DrumInstrument(TConv::userName(DrumNum(47)), NoteHeadGroup::HEAD_NORMAL, /*line*/ 2, DirectionV::UP,
-                                         /*panelRow*/ 1, /*panelColumn*/ 4);
-
-    // Hi-Mid Tom
-    smDrumset->drum(48) = DrumInstrument(TConv::userName(DrumNum(48)), NoteHeadGroup::HEAD_NORMAL, /*line*/ 1, DirectionV::UP,
-                                         /*panelRow*/ 1, /*panelColumn*/ 3);
-
-    // Crash Cymbal 1
-    smDrumset->drum(49) = DrumInstrument(TConv::userName(DrumNum(49)), NoteHeadGroup::HEAD_CROSS, /*line*/ -2, DirectionV::UP,
-                                         /*panelRow*/ 0, /*panelColumn*/ 4, /*voice*/ 0, Key_C);
-
-    // High Tom
-    smDrumset->drum(50) = DrumInstrument(TConv::userName(DrumNum(50)), NoteHeadGroup::HEAD_NORMAL, /*line*/ 0, DirectionV::UP,
-                                         /*panelRow*/ 1, /*panelColumn*/ 2, /*voice*/ 0, Key_E);
-
-    // Ride Cymbal 1
-    smDrumset->drum(51) = DrumInstrument(TConv::userName(DrumNum(51)), NoteHeadGroup::HEAD_CROSS, /*line*/ 0, DirectionV::UP,
-                                         /*panelRow*/ 0, /*panelColumn*/ 2, /*voice*/ 0, Key_D);
-
-    // Chinese Cymbal
-    smDrumset->drum(52) = DrumInstrument(TConv::userName(DrumNum(52)), NoteHeadGroup::HEAD_CROSS, /*line*/ -4, DirectionV::UP,
-                                         /*panelRow*/ 0, /*panelColumn*/ 6);
-
-    // Ride Bell
-    smDrumset->drum(53) = DrumInstrument(TConv::userName(DrumNum(53)), NoteHeadGroup::HEAD_DIAMOND, /*line*/ 0, DirectionV::UP,
-                                         /*panelRow*/ 0, /*panelColumn*/ 3);
-
-    // Tambourine
-    smDrumset->drum(54) = DrumInstrument(TConv::userName(DrumNum(54)), NoteHeadGroup::HEAD_DIAMOND, /*line*/ 1, DirectionV::UP,
-                                         /*panelRow*/ 2, /*panelColumn*/ 4);
-
-    // Splash Cymbal
-    smDrumset->drum(55) = DrumInstrument(TConv::userName(DrumNum(55)), NoteHeadGroup::HEAD_CROSS, /*line*/ -5, DirectionV::UP,
-                                         /*panelRow*/ 0, /*panelColumn*/ 7);
-
-    // Cowbell
-    smDrumset->drum(56) = DrumInstrument(TConv::userName(DrumNum(56)), NoteHeadGroup::HEAD_TRIANGLE_DOWN, /*line*/ 1, DirectionV::UP,
-                                         /*panelRow*/ 2, /*panelColumn*/ 3);
-
-    // Crash Cymbal 2
-    smDrumset->drum(57) = DrumInstrument(TConv::userName(DrumNum(57)), NoteHeadGroup::HEAD_CROSS, /*line*/ -3, DirectionV::UP,
-                                         /*panelRow*/ 0, /*panelColumn*/ 5);
-
-    // Ride Cymbal 2
-    smDrumset->drum(59) = DrumInstrument(TConv::userName(DrumNum(59)), NoteHeadGroup::HEAD_CROSS, /*line*/ 2, DirectionV::UP,
-                                         /*panelRow*/ 2, /*panelColumn*/ 5);
 }
 }

--- a/src/engraving/dom/instrtemplate.cpp
+++ b/src/engraving/dom/instrtemplate.cpp
@@ -604,6 +604,9 @@ void InstrumentTemplate::read(XmlReader& e)
     }
     if (id.empty()) {
         id = trackName.toLower().replace(u' ', u'-');
+    } else if (id == "drumset") {
+        delete smDrumset;
+        smDrumset = drumset;
     }
 
     if (staffCount == 0) {


### PR DESCRIPTION
The standard drumset was only used by the Large Drum Kit and the Percussion Synthesizer; the only unpitched percussion instruments that didn't specify any `<Drum>` elements in `instruments.xml`.