### PR TITLE
Support usage of user-provided SMuFL fonts

### DIFF
--- a/src/appshell/view/preferences/folderspreferencesmodel.cpp
+++ b/src/appshell/view/preferences/folderspreferencesmodel.cpp
@@ -108,6 +108,11 @@ void FoldersPreferencesModel::load()
                 audioConfiguration()->userSoundFontDirectories()),
             configuration()->userDataPath().toQString(), FolderValueType::MultiDirectories
         },
+        {
+            FolderType::MusicFonts, muse::qtrc("appshell/preferences", "MusicFonts"),
+            notationConfiguration()->userMusicFontPath().toString(),
+            notationConfiguration()->userMusicFontPath().toString()
+        },
 #ifdef MUSE_MODULE_VST
         {
             FolderType::VST3, muse::qtrc("appshell/preferences", "VST3"), pathsToString(vstConfiguration()->userVstDirectories()),
@@ -144,6 +149,10 @@ void FoldersPreferencesModel::setupConnections()
         setFolderPaths(FolderType::SoundFonts, pathsToString(userSoundFontsPaths));
     });
 
+    notationConfiguration()->userMusicFontPathChanged().onReceive(this, [this](const muse::io::path_t& path) {
+        setFolderPaths(FolderType::MusicFonts, path.toQString());
+    });
+
     vstConfiguration()->userVstDirectoriesChanged().onReceive(this, [this](const io::paths_t& paths) {
         setFolderPaths(FolderType::VST3, pathsToString(paths));
     });
@@ -174,6 +183,10 @@ void FoldersPreferencesModel::saveFolderPaths(FoldersPreferencesModel::FolderTyp
     }
     case FolderType::SoundFonts: {
         audioConfiguration()->setUserSoundFontDirectories(pathsFromString(paths));
+        break;
+    }
+    case FolderType::MusicFonts: {
+        notationConfiguration()->setUserMusicFontPath(paths.toStdString());
         break;
     }
     case FolderType::VST3: {

--- a/src/appshell/view/preferences/folderspreferencesmodel.cpp
+++ b/src/appshell/view/preferences/folderspreferencesmodel.cpp
@@ -109,9 +109,9 @@ void FoldersPreferencesModel::load()
             configuration()->userDataPath().toQString(), FolderValueType::MultiDirectories
         },
         {
-            FolderType::MusicFonts, muse::qtrc("appshell/preferences", "MusicFonts"),
-            notationConfiguration()->userMusicFontsPath().toString(),
-            notationConfiguration()->userMusicFontsPath().toString()
+            FolderType::MusicFonts, muse::qtrc("appshell/preferences", "Musical symbol fonts"),
+            notationConfiguration()->userMusicFontsPath().toQString(),
+            notationConfiguration()->userMusicFontsPath().toQString()
         },
 #ifdef MUSE_MODULE_VST
         {

--- a/src/appshell/view/preferences/folderspreferencesmodel.cpp
+++ b/src/appshell/view/preferences/folderspreferencesmodel.cpp
@@ -110,8 +110,8 @@ void FoldersPreferencesModel::load()
         },
         {
             FolderType::MusicFonts, muse::qtrc("appshell/preferences", "MusicFonts"),
-            notationConfiguration()->userMusicFontPath().toString(),
-            notationConfiguration()->userMusicFontPath().toString()
+            notationConfiguration()->userMusicFontsPath().toString(),
+            notationConfiguration()->userMusicFontsPath().toString()
         },
 #ifdef MUSE_MODULE_VST
         {
@@ -149,7 +149,7 @@ void FoldersPreferencesModel::setupConnections()
         setFolderPaths(FolderType::SoundFonts, pathsToString(userSoundFontsPaths));
     });
 
-    notationConfiguration()->userMusicFontPathChanged().onReceive(this, [this](const muse::io::path_t& path) {
+    notationConfiguration()->userMusicFontsPathChanged().onReceive(this, [this](const muse::io::path_t& path) {
         setFolderPaths(FolderType::MusicFonts, path.toQString());
     });
 
@@ -186,7 +186,7 @@ void FoldersPreferencesModel::saveFolderPaths(FoldersPreferencesModel::FolderTyp
         break;
     }
     case FolderType::MusicFonts: {
-        notationConfiguration()->setUserMusicFontPath(paths.toStdString());
+        notationConfiguration()->setUserMusicFontsPath(paths.toStdString());
         break;
     }
     case FolderType::VST3: {

--- a/src/appshell/view/preferences/folderspreferencesmodel.h
+++ b/src/appshell/view/preferences/folderspreferencesmodel.h
@@ -72,6 +72,7 @@ private:
         Templates,
         Plugins,
         SoundFonts,
+        MusicFonts,
         VST3
     };
 

--- a/src/engraving/engravingmodule.cpp
+++ b/src/engraving/engravingmodule.cpp
@@ -183,7 +183,7 @@ void EngravingModule::onInit(const IApplication::RunMode& mode)
         // MusicSymbol[Text]
         auto addMusicFont = [this, fdb](const std::string& name, const FontDataKey& fontDataKey, const muse::io::path_t& filePath){
             fdb->addFont(FontDataKey(fontDataKey), filePath);
-            m_engravingfonts->addFont(name, fontDataKey.family().id().toStdString(), filePath);
+            m_engravingfonts->addInternalFont(name, fontDataKey.family().id().toStdString(), filePath);
         };
 
         addMusicFont("Bravura", FontDataKey(u"Bravura"), ":/fonts/bravura/Bravura.otf");

--- a/src/engraving/iengravingfontsprovider.h
+++ b/src/engraving/iengravingfontsprovider.h
@@ -1,5 +1,26 @@
-#ifndef MU_ENGRAVING_IENGRAVINGFONTSPROVIDER_H
-#define MU_ENGRAVING_IENGRAVINGFONTSPROVIDER_H
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2025 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
 
 #include <string>
 
@@ -31,5 +52,3 @@ public:
     virtual void loadAllFonts() = 0;
 };
 }
-
-#endif // MU_ENGRAVING_IENGRAVINGFONTSPROVIDER_H

--- a/src/engraving/iengravingfontsprovider.h
+++ b/src/engraving/iengravingfontsprovider.h
@@ -18,7 +18,7 @@ public:
 
     virtual void addInternalFont(const std::string& name, const std::string& family, const muse::io::path_t& filePath) = 0;
     virtual void addExternalFont(const std::string& name, const std::string& family, const muse::io::path_t& filePath,
-                                 const muse::io::path_t& metadataPath, bool isPrivate) = 0;
+                                 const muse::io::path_t& metadataPath) = 0;
     virtual IEngravingFontPtr fontByName(const std::string& name) const = 0;
     virtual std::vector<IEngravingFontPtr> fonts() const = 0;
 
@@ -26,7 +26,7 @@ public:
     virtual IEngravingFontPtr fallbackFont() const = 0;
     virtual bool isFallbackFont(const IEngravingFont* f) const = 0;
 
-    virtual void clearUserFonts() = 0;
+    virtual void clearExternalFonts() = 0;
 
     virtual void loadAllFonts() = 0;
 };

--- a/src/engraving/iengravingfontsprovider.h
+++ b/src/engraving/iengravingfontsprovider.h
@@ -16,16 +16,17 @@ class IEngravingFontsProvider : MODULE_EXPORT_INTERFACE
 public:
     virtual ~IEngravingFontsProvider() = default;
 
-    virtual void addFont(const std::string& name, const std::string& family, const muse::io::path_t& filePath) = 0;
+    virtual void addInternalFont(const std::string& name, const std::string& family, const muse::io::path_t& filePath) = 0;
+    virtual void addExternalFont(const std::string& name, const std::string& family, const muse::io::path_t& filePath,
+                                 const muse::io::path_t& metadataPath, bool isPrivate) = 0;
     virtual IEngravingFontPtr fontByName(const std::string& name) const = 0;
     virtual std::vector<IEngravingFontPtr> fonts() const = 0;
-
-    virtual void clearUserFonts() = 0;
-    virtual void addUserFont(const std::string& name, const std::string& family, const muse::io::path_t& filePath) = 0;
 
     virtual void setFallbackFont(const std::string& name) = 0;
     virtual IEngravingFontPtr fallbackFont() const = 0;
     virtual bool isFallbackFont(const IEngravingFont* f) const = 0;
+
+    virtual void clearUserFonts() = 0;
 
     virtual void loadAllFonts() = 0;
 };

--- a/src/engraving/iengravingfontsprovider.h
+++ b/src/engraving/iengravingfontsprovider.h
@@ -20,6 +20,9 @@ public:
     virtual IEngravingFontPtr fontByName(const std::string& name) const = 0;
     virtual std::vector<IEngravingFontPtr> fonts() const = 0;
 
+    virtual void clearUserFonts() = 0;
+    virtual void addUserFont(const std::string& name, const std::string& family, const muse::io::path_t& filePath) = 0;
+
     virtual void setFallbackFont(const std::string& name) = 0;
     virtual IEngravingFontPtr fallbackFont() const = 0;
     virtual bool isFallbackFont(const IEngravingFont* f) const = 0;

--- a/src/engraving/internal/engravingfont.cpp
+++ b/src/engraving/internal/engravingfont.cpp
@@ -43,8 +43,8 @@ using namespace mu::engraving;
 // ScoreFont
 // =============================================
 
-EngravingFont::EngravingFont(const std::string& name, const std::string& family, const path_t& filePath,
-                             const path_t& metadataPath,
+EngravingFont::EngravingFont(const std::string& name, const std::string& family,
+                             const path_t& filePath, const path_t& metadataPath,
                              const modularity::ContextPtr& iocCtx)
     : muse::Injectable(iocCtx),  m_symbols(static_cast<size_t>(SymId::lastSym) + 1),
     m_name(name),

--- a/src/engraving/internal/engravingfont.cpp
+++ b/src/engraving/internal/engravingfont.cpp
@@ -44,11 +44,13 @@ using namespace mu::engraving;
 // =============================================
 
 EngravingFont::EngravingFont(const std::string& name, const std::string& family, const path_t& filePath,
+                             const path_t& metadataPath,
                              const modularity::ContextPtr& iocCtx)
     : muse::Injectable(iocCtx),  m_symbols(static_cast<size_t>(SymId::lastSym) + 1),
     m_name(name),
     m_family(family),
-    m_fontPath(filePath)
+    m_fontPath(filePath),
+    m_metadataPath(metadataPath)
 {
 }
 
@@ -60,6 +62,7 @@ EngravingFont::EngravingFont(const EngravingFont& other)
     m_name     = other.m_name;
     m_family   = other.m_family;
     m_fontPath = other.m_fontPath;
+    m_metadataPath = other.m_metadataPath;
 }
 
 // =============================================
@@ -116,7 +119,7 @@ void EngravingFont::ensureLoad()
         computeMetrics(sym, code);
     }
 
-    File metadataFile(FileInfo(m_fontPath).path() + u"/metadata.json");
+    File metadataFile(m_metadataPath);
     if (!metadataFile.open(IODevice::ReadOnly)) {
         LOGE() << "Failed to open glyph metadata file: " << metadataFile.filePath();
         return;

--- a/src/engraving/internal/engravingfont.h
+++ b/src/engraving/internal/engravingfont.h
@@ -55,7 +55,7 @@ class EngravingFont : public IEngravingFont, public muse::Injectable
     muse::Inject<IEngravingFontsProvider> engravingFonts = { this };
 public:
     EngravingFont(const std::string& name, const std::string& family, const muse::io::path_t& filePath,
-                  const muse::modularity::ContextPtr& iocCtx);
+                  const muse::io::path_t& metadataPath, const muse::modularity::ContextPtr& iocCtx);
     EngravingFont(const EngravingFont& other);
 
     const std::string& name() const override;
@@ -138,6 +138,7 @@ private:
 
     std::string m_name;
     std::string m_family;
+    muse::io::path_t m_metadataPath;
     muse::io::path_t m_fontPath;
 
     std::unordered_map<Sid, PropertyValue> m_engravingDefaults;

--- a/src/engraving/internal/engravingfont.h
+++ b/src/engraving/internal/engravingfont.h
@@ -138,8 +138,8 @@ private:
 
     std::string m_name;
     std::string m_family;
-    muse::io::path_t m_metadataPath;
     muse::io::path_t m_fontPath;
+    muse::io::path_t m_metadataPath;
 
     std::unordered_map<Sid, PropertyValue> m_engravingDefaults;
     double m_textEnclosureThickness = 0;

--- a/src/engraving/internal/engravingfont.h
+++ b/src/engraving/internal/engravingfont.h
@@ -19,8 +19,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef MU_ENGRAVING_ENGRAVINGFONT_H
-#define MU_ENGRAVING_ENGRAVINGFONT_H
+#pragma once
 
 #include <unordered_map>
 
@@ -145,5 +144,3 @@ private:
     double m_textEnclosureThickness = 0;
 };
 }
-
-#endif // MU_ENGRAVING_ENGRAVINGFONT_H

--- a/src/engraving/internal/engravingfontsprovider.cpp
+++ b/src/engraving/internal/engravingfontsprovider.cpp
@@ -37,7 +37,8 @@ EngravingFontsProvider::EngravingFontsProvider(const muse::modularity::ContextPt
 void EngravingFontsProvider::addInternalFont(const std::string& name, const std::string& family, const muse::io::path_t& filePath)
 {
     muse::io::path_t basePath = muse::io::dirpath(filePath.toQString());
-    std::shared_ptr<EngravingFont> f = std::make_shared<EngravingFont>(name, family, filePath, basePath + "/metadata.json", iocContext());
+    muse::io::path_t metadataPath = basePath + "/metadata.json";
+    std::shared_ptr<EngravingFont> f = std::make_shared<EngravingFont>(name, family, filePath, metadataPath, iocContext());
     m_symbolFonts.push_back(f);
     m_fallback.font = nullptr;
 }

--- a/src/engraving/internal/engravingfontsprovider.cpp
+++ b/src/engraving/internal/engravingfontsprovider.cpp
@@ -49,6 +49,11 @@ std::shared_ptr<EngravingFont> EngravingFontsProvider::doFontByName(const std::s
             return f;
         }
     }
+    for (const std::shared_ptr<EngravingFont>& f : m_userSymbolFonts) {
+        if (muse::strings::toLower(f->name()) == name_lo) {
+            return f;
+        }
+    }
     return nullptr;
 }
 
@@ -63,10 +68,24 @@ IEngravingFontPtr EngravingFontsProvider::fontByName(const std::string& name) co
     return font;
 }
 
+void EngravingFontsProvider::clearUserFonts()
+{
+    m_userSymbolFonts.clear();
+}
+
+void EngravingFontsProvider::addUserFont(const std::string& name, const std::string& family, const muse::io::path_t& filePath)
+{
+    std::shared_ptr<EngravingFont> f = std::make_shared<EngravingFont>(name, family, filePath, iocContext());
+    m_userSymbolFonts.push_back(f);
+}
+
 std::vector<IEngravingFontPtr> EngravingFontsProvider::fonts() const
 {
     std::vector<IEngravingFontPtr> fs;
     for (const std::shared_ptr<EngravingFont>& f : m_symbolFonts) {
+        fs.push_back(f);
+    }
+    for (const std::shared_ptr<EngravingFont>& f : m_userSymbolFonts) {
         fs.push_back(f);
     }
     return fs;
@@ -105,6 +124,9 @@ bool EngravingFontsProvider::isFallbackFont(const IEngravingFont* f) const
 void EngravingFontsProvider::loadAllFonts()
 {
     for (std::shared_ptr<EngravingFont>& f : m_symbolFonts) {
+        f->ensureLoad();
+    }
+    for (std::shared_ptr<EngravingFont>& f : m_userSymbolFonts) {
         f->ensureLoad();
     }
 }

--- a/src/engraving/internal/engravingfontsprovider.h
+++ b/src/engraving/internal/engravingfontsprovider.h
@@ -40,7 +40,7 @@ public:
 
     void addInternalFont(const std::string& name, const std::string& family, const muse::io::path_t& filePath) override;
     void addExternalFont(const std::string& name, const std::string& family, const muse::io::path_t& filePath,
-                         const muse::io::path_t& metadataPath, bool isPrivate) override;
+                         const muse::io::path_t& metadataPath) override;
     IEngravingFontPtr fontByName(const std::string& name) const override;
     std::vector<IEngravingFontPtr> fonts() const override;
 
@@ -48,7 +48,7 @@ public:
     IEngravingFontPtr fallbackFont() const override;
     bool isFallbackFont(const IEngravingFont* f) const override;
 
-    void clearUserFonts() override;
+    void clearExternalFonts() override;
 
     void loadAllFonts() override;
 
@@ -64,8 +64,7 @@ private:
 
     mutable Fallback m_fallback;
     std::vector<std::shared_ptr<EngravingFont> > m_symbolFonts;
-    std::vector<std::shared_ptr<EngravingFont> > m_externalSystemSymbolFonts;
-    std::vector<std::shared_ptr<EngravingFont> > m_externalPrivateSymbolFonts;
+    std::unordered_map<std::string, std::shared_ptr<EngravingFont> > m_externalSymbolFonts;
 };
 }
 

--- a/src/engraving/internal/engravingfontsprovider.h
+++ b/src/engraving/internal/engravingfontsprovider.h
@@ -42,6 +42,9 @@ public:
     IEngravingFontPtr fontByName(const std::string& name) const override;
     std::vector<IEngravingFontPtr> fonts() const override;
 
+    void clearUserFonts() override;
+    void addUserFont(const std::string& name, const std::string& family, const muse::io::path_t& filePath) override;
+
     void setFallbackFont(const std::string& name) override;
     IEngravingFontPtr fallbackFont() const override;
     bool isFallbackFont(const IEngravingFont* f) const override;
@@ -60,6 +63,7 @@ private:
 
     mutable Fallback m_fallback;
     std::vector<std::shared_ptr<EngravingFont> > m_symbolFonts;
+    std::vector<std::shared_ptr<EngravingFont> > m_userSymbolFonts;
 };
 }
 

--- a/src/engraving/internal/engravingfontsprovider.h
+++ b/src/engraving/internal/engravingfontsprovider.h
@@ -38,16 +38,17 @@ public:
 
     EngravingFontsProvider(const muse::modularity::ContextPtr& iocCtx);
 
-    void addFont(const std::string& name, const std::string& family, const muse::io::path_t& filePath) override;
+    void addInternalFont(const std::string& name, const std::string& family, const muse::io::path_t& filePath) override;
+    void addExternalFont(const std::string& name, const std::string& family, const muse::io::path_t& filePath,
+                         const muse::io::path_t& metadataPath, bool isPrivate) override;
     IEngravingFontPtr fontByName(const std::string& name) const override;
     std::vector<IEngravingFontPtr> fonts() const override;
-
-    void clearUserFonts() override;
-    void addUserFont(const std::string& name, const std::string& family, const muse::io::path_t& filePath) override;
 
     void setFallbackFont(const std::string& name) override;
     IEngravingFontPtr fallbackFont() const override;
     bool isFallbackFont(const IEngravingFont* f) const override;
+
+    void clearUserFonts() override;
 
     void loadAllFonts() override;
 
@@ -63,7 +64,8 @@ private:
 
     mutable Fallback m_fallback;
     std::vector<std::shared_ptr<EngravingFont> > m_symbolFonts;
-    std::vector<std::shared_ptr<EngravingFont> > m_userSymbolFonts;
+    std::vector<std::shared_ptr<EngravingFont> > m_externalSystemSymbolFonts;
+    std::vector<std::shared_ptr<EngravingFont> > m_externalPrivateSymbolFonts;
 };
 }
 

--- a/src/framework/ui/internal/uiconfiguration.cpp
+++ b/src/framework/ui/internal/uiconfiguration.cpp
@@ -332,10 +332,8 @@ ThemeList UiConfiguration::themes() const
 QStringList UiConfiguration::possibleFontFamilies() const
 {
     QStringList allFonts = QFontDatabase::families();
-    for (const auto& font : engravingFonts()->fonts()) {
-        QString fontName = QString::fromStdString(font->name());
-        allFonts.removeAll(fontName);
-        allFonts.removeAll(fontName + " Text");
+    for (const QString& fontFamily : m_nonTextFonts) {
+        allFonts.removeAll(fontFamily);
     }
     return allFonts;
 }
@@ -504,6 +502,11 @@ void UiConfiguration::setBodyFontSize(int size)
 muse::async::Notification UiConfiguration::fontChanged() const
 {
     return m_fontChanged;
+}
+
+void UiConfiguration::setNonTextFonts(const QStringList& fontFamilies)
+{
+    m_nonTextFonts = fontFamilies;
 }
 
 std::string UiConfiguration::iconsFontFamily() const

--- a/src/framework/ui/internal/uiconfiguration.cpp
+++ b/src/framework/ui/internal/uiconfiguration.cpp
@@ -329,15 +329,6 @@ ThemeList UiConfiguration::themes() const
     return m_themes;
 }
 
-QStringList UiConfiguration::possibleFontFamilies() const
-{
-    QStringList allFonts = QFontDatabase::families();
-    for (const QString& fontFamily : m_nonTextFonts) {
-        allFonts.removeAll(fontFamily);
-    }
-    return allFonts;
-}
-
 QStringList UiConfiguration::possibleAccentColors() const
 {
     static const QStringList lightAccentColors {
@@ -365,6 +356,20 @@ QStringList UiConfiguration::possibleAccentColors() const
     }
 
     return lightAccentColors;
+}
+
+QStringList UiConfiguration::possibleFontFamilies() const
+{
+    QStringList allFonts = QFontDatabase::families();
+    for (const QString& fontFamily : m_nonTextFonts) {
+        allFonts.removeAll(fontFamily);
+    }
+    return allFonts;
+}
+
+void UiConfiguration::setNonTextFonts(const QStringList& fontFamilies)
+{
+    m_nonTextFonts = fontFamilies;
 }
 
 void UiConfiguration::resetThemes()
@@ -502,11 +507,6 @@ void UiConfiguration::setBodyFontSize(int size)
 muse::async::Notification UiConfiguration::fontChanged() const
 {
     return m_fontChanged;
-}
-
-void UiConfiguration::setNonTextFonts(const QStringList& fontFamilies)
-{
-    m_nonTextFonts = fontFamilies;
 }
 
 std::string UiConfiguration::iconsFontFamily() const

--- a/src/framework/ui/internal/uiconfiguration.cpp
+++ b/src/framework/ui/internal/uiconfiguration.cpp
@@ -332,10 +332,10 @@ ThemeList UiConfiguration::themes() const
 QStringList UiConfiguration::possibleFontFamilies() const
 {
     QStringList allFonts = QFontDatabase::families();
-    QStringList smuflFonts
-        = { "Bravura", "Campania", "Edwin", "Finale Broadway", "Finale Maestro", "Gootville", "Leland", "MScore", "MuseJazz", "Petaluma" };
-    for (const QString& font : smuflFonts) {
-        allFonts.removeAll(font);
+    for (const auto& font : engravingFonts()->fonts()) {
+        QString fontName = QString::fromStdString(font->name());
+        allFonts.removeAll(fontName);
+        allFonts.removeAll(fontName + " Text");
     }
     return allFonts;
 }

--- a/src/framework/ui/internal/uiconfiguration.h
+++ b/src/framework/ui/internal/uiconfiguration.h
@@ -34,6 +34,7 @@
 #include "types/val.h"
 #include "uiarrangement.h"
 #include "async/asyncable.h"
+#include "engraving/iengravingfontsprovider.h"
 
 namespace muse::ui {
 class UiConfiguration : public IUiConfiguration, public Injectable, public async::Asyncable
@@ -41,6 +42,7 @@ class UiConfiguration : public IUiConfiguration, public Injectable, public async
     Inject<IMainWindow> mainWindow = { this };
     Inject<IPlatformTheme> platformTheme = { this };
     Inject<IGlobalConfiguration> globalConfiguration = { this };
+    INJECT(mu::engraving::IEngravingFontsProvider, engravingFonts)
 
 public:
 

--- a/src/framework/ui/internal/uiconfiguration.h
+++ b/src/framework/ui/internal/uiconfiguration.h
@@ -20,8 +20,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef MUSE_UI_UICONFIGURATION_H
-#define MUSE_UI_UICONFIGURATION_H
+#pragma once
 
 #include "iuiconfiguration.h"
 
@@ -52,8 +51,9 @@ public:
     void deinit();
 
     ThemeList themes() const override;
-    QStringList possibleFontFamilies() const override;
     QStringList possibleAccentColors() const override;
+    QStringList possibleFontFamilies() const override;
+    void setNonTextFonts(const QStringList& fontFamilies) override;
 
     bool isDarkMode() const override;
     void setIsDarkMode(bool dark) override;
@@ -76,7 +76,6 @@ public:
     int fontSize(FontSizeType type = FontSizeType::BODY) const override;
     void setBodyFontSize(int size) override;
     async::Notification fontChanged() const override;
-    void setNonTextFonts(const QStringList& fontFamilies) override;
 
     std::string iconsFontFamily() const override;
     int iconsFontSize(IconSizeType type) const override;
@@ -168,5 +167,3 @@ private:
     Config m_config;
 };
 }
-
-#endif // MUSE_UI_UICONFIGURATION_H

--- a/src/framework/ui/internal/uiconfiguration.h
+++ b/src/framework/ui/internal/uiconfiguration.h
@@ -34,7 +34,6 @@
 #include "types/val.h"
 #include "uiarrangement.h"
 #include "async/asyncable.h"
-#include "engraving/iengravingfontsprovider.h"
 
 namespace muse::ui {
 class UiConfiguration : public IUiConfiguration, public Injectable, public async::Asyncable
@@ -42,7 +41,6 @@ class UiConfiguration : public IUiConfiguration, public Injectable, public async
     Inject<IMainWindow> mainWindow = { this };
     Inject<IPlatformTheme> platformTheme = { this };
     Inject<IGlobalConfiguration> globalConfiguration = { this };
-    INJECT(mu::engraving::IEngravingFontsProvider, engravingFonts)
 
 public:
 
@@ -78,6 +76,7 @@ public:
     int fontSize(FontSizeType type = FontSizeType::BODY) const override;
     void setBodyFontSize(int size) override;
     async::Notification fontChanged() const override;
+    void setNonTextFonts(const QStringList& fontFamilies) override;
 
     std::string iconsFontFamily() const override;
     int iconsFontSize(IconSizeType type) const override;
@@ -163,6 +162,8 @@ private:
     ThemeList m_themes;
     size_t m_currentThemeIndex = 0;
     std::optional<double> m_customDPI;
+
+    QStringList m_nonTextFonts;
 
     Config m_config;
 };

--- a/src/framework/ui/iuiconfiguration.h
+++ b/src/framework/ui/iuiconfiguration.h
@@ -70,6 +70,7 @@ public:
     virtual int fontSize(FontSizeType type = FontSizeType::BODY) const = 0;
     virtual void setBodyFontSize(int size) = 0;
     virtual async::Notification fontChanged() const = 0;
+    virtual void setNonTextFonts(const QStringList& fontFamilies) = 0;
 
     virtual std::string iconsFontFamily() const = 0;
     virtual int iconsFontSize(IconSizeType type) const = 0;

--- a/src/framework/ui/iuiconfiguration.h
+++ b/src/framework/ui/iuiconfiguration.h
@@ -20,8 +20,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef MUSE_UI_IUICONFIGURATION_H
-#define MUSE_UI_IUICONFIGURATION_H
+#pragma once
 
 #include <optional>
 
@@ -46,8 +45,9 @@ public:
     virtual ~IUiConfiguration() = default;
 
     virtual ThemeList themes() const = 0;
-    virtual QStringList possibleFontFamilies() const = 0;
     virtual QStringList possibleAccentColors() const = 0;
+    virtual QStringList possibleFontFamilies() const = 0;
+    virtual void setNonTextFonts(const QStringList& fontFamilies) = 0;
 
     virtual bool isDarkMode() const = 0;
     virtual void setIsDarkMode(bool dark) = 0;
@@ -70,7 +70,6 @@ public:
     virtual int fontSize(FontSizeType type = FontSizeType::BODY) const = 0;
     virtual void setBodyFontSize(int size) = 0;
     virtual async::Notification fontChanged() const = 0;
-    virtual void setNonTextFonts(const QStringList& fontFamilies) = 0;
 
     virtual std::string iconsFontFamily() const = 0;
     virtual int iconsFontSize(IconSizeType type) const = 0;
@@ -122,5 +121,3 @@ public:
     virtual int tooltipDelay() const = 0;
 };
 }
-
-#endif // MUSE_UI_IUICONFIGURATION_H

--- a/src/framework/ui/tests/mocks/uiconfigurationmock.h
+++ b/src/framework/ui/tests/mocks/uiconfigurationmock.h
@@ -19,8 +19,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef MUSE_UI_UICONFIGURATIONMOCK_H
-#define MUSE_UI_UICONFIGURATIONMOCK_H
+#pragma once
 
 #include <gmock/gmock.h>
 
@@ -31,9 +30,9 @@ class UiConfigurationMock : public IUiConfiguration
 {
 public:
     MOCK_METHOD(ThemeList, themes, (), (const, override));
-
-    MOCK_METHOD(QStringList, possibleFontFamilies, (), (const, override));
     MOCK_METHOD(QStringList, possibleAccentColors, (), (const, override));
+    MOCK_METHOD(QStringList, possibleFontFamilies, (), (const, override));
+    MOCK_METHOD(void, setNonTextFonts, (const QStringList&), (override));
 
     MOCK_METHOD(bool, isDarkMode, (), (const, override));
     MOCK_METHOD(void, setIsDarkMode, (bool), (override));
@@ -56,7 +55,6 @@ public:
     MOCK_METHOD(int, fontSize, (FontSizeType), (const, override));
     MOCK_METHOD(void, setBodyFontSize, (int), (override));
     MOCK_METHOD(async::Notification, fontChanged, (), (const, override));
-    MOCK_METHOD(void, setNonTextFonts, (const QStringList&), (override));
 
     MOCK_METHOD(std::string, iconsFontFamily, (), (const, override));
     MOCK_METHOD(int, iconsFontSize, (IconSizeType), (const, override));
@@ -107,5 +105,3 @@ public:
     MOCK_METHOD(int, tooltipDelay, (), (const, override));
 };
 }
-
-#endif // MUSE_UI_UICONFIGURATIONMOCK_H

--- a/src/framework/ui/tests/mocks/uiconfigurationmock.h
+++ b/src/framework/ui/tests/mocks/uiconfigurationmock.h
@@ -56,6 +56,7 @@ public:
     MOCK_METHOD(int, fontSize, (FontSizeType), (const, override));
     MOCK_METHOD(void, setBodyFontSize, (int), (override));
     MOCK_METHOD(async::Notification, fontChanged, (), (const, override));
+    MOCK_METHOD(void, setNonTextFonts, (const QStringList&), (override));
 
     MOCK_METHOD(std::string, iconsFontFamily, (), (const, override));
     MOCK_METHOD(int, iconsFontSize, (IconSizeType), (const, override));

--- a/src/notation/CMakeLists.txt
+++ b/src/notation/CMakeLists.txt
@@ -123,6 +123,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/internal/notationcreator.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/mscoreerrorscontroller.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/mscoreerrorscontroller.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/engravingfontscontroller.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/engravingfontscontroller.h
 
     ${CMAKE_CURRENT_LIST_DIR}/view/abstractnotationpaintview.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/abstractnotationpaintview.h

--- a/src/notation/inotationconfiguration.h
+++ b/src/notation/inotationconfiguration.h
@@ -132,9 +132,9 @@ public:
     virtual void setAddAccidentalDotsArticulationsToNextNoteEntered(bool value) = 0;
     virtual muse::async::Notification addAccidentalDotsArticulationsToNextNoteEnteredChanged() const = 0;
 
-    virtual muse::io::path_t userMusicFontPath() const = 0;
-    virtual void setUserMusicFontPath(const muse::io::path_t& path) = 0;
-    virtual muse::async::Channel<muse::io::path_t> userMusicFontPathChanged() const = 0;
+    virtual muse::io::path_t userMusicFontsPath() const = 0;
+    virtual void setUserMusicFontsPath(const muse::io::path_t& path) = 0;
+    virtual muse::async::Channel<muse::io::path_t> userMusicFontsPathChanged() const = 0;
 
     virtual bool isMidiInputEnabled() const = 0;
     virtual void setIsMidiInputEnabled(bool enabled) = 0;

--- a/src/notation/inotationconfiguration.h
+++ b/src/notation/inotationconfiguration.h
@@ -132,6 +132,10 @@ public:
     virtual void setAddAccidentalDotsArticulationsToNextNoteEntered(bool value) = 0;
     virtual muse::async::Notification addAccidentalDotsArticulationsToNextNoteEnteredChanged() const = 0;
 
+    virtual muse::io::path_t userMusicFontPath() const = 0;
+    virtual void setUserMusicFontPath(const muse::io::path_t& path) = 0;
+    virtual muse::async::Channel<muse::io::path_t> userMusicFontPathChanged() const = 0;
+
     virtual bool isMidiInputEnabled() const = 0;
     virtual void setIsMidiInputEnabled(bool enabled) = 0;
     virtual muse::async::Notification isMidiInputEnabledChanged() const = 0;

--- a/src/notation/internal/engravingfontscontroller.cpp
+++ b/src/notation/internal/engravingfontscontroller.cpp
@@ -1,0 +1,94 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2024 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "engravingfontscontroller.h"
+
+#include "engraving/infrastructure/smufl.h"
+#include "engraving/internal/engravingfont.h"
+#include "draw/internal/ifontsdatabase.h"
+#include "infrastructure/smufl.h"
+#include "log.h"
+
+#include <QDirIterator>
+
+using namespace mu::notation;
+
+std::string EngravingFontsController::moduleName() const
+{
+    return "engraving_fonts";
+}
+
+void EngravingFontsController::init()
+{
+    mu::engraving::Smufl::init();
+
+    auto musicFontsPath = configuration()->userMusicFontPathChanged();
+    musicFontsPath.onReceive(this, [this](const muse::io::path_t& dir) {
+        scanDirectory(dir);
+    });
+
+    scanDirectory(configuration()->userMusicFontPath());
+}
+
+void EngravingFontsController::scanDirectory(const muse::io::path_t& path) const
+{
+    using namespace muse::draw;
+
+    std::shared_ptr<IFontsDatabase> fdb = ioc()->resolve<IFontsDatabase>(moduleName());
+    engravingFonts()->clearUserFonts();
+
+    QDirIterator iterator(path.toQString(), QDir::Dirs | QDir::NoDotAndDotDot | QDir::Readable);
+
+    while (iterator.hasNext()) {
+        QString fontDir = iterator.next();
+        muse::String fontName;
+
+        muse::io::path_t symbolFontPath;
+        muse::io::path_t textFontPath;
+        QDirIterator fontFiles(iterator.filePath(), { "*.otf", "*.ttf" }, QDir::Files);
+
+        while (fontFiles.hasNext()) {
+            fontFiles.next();
+            QString name = fontFiles.fileInfo().baseName();
+            if (name.endsWith("Text")) {
+                textFontPath = fontFiles.filePath();
+            } else {
+                symbolFontPath = fontFiles.filePath();
+                fontName = name;
+            }
+        }
+
+        if (symbolFontPath.empty() || !QFileInfo::exists(iterator.filePath() + "/metadata.json")) {
+            continue;
+        }
+        if (textFontPath.empty()) {
+            textFontPath = symbolFontPath;
+        }
+
+        engravingFonts()->addUserFont(fontName.toStdString(), fontName.toStdString(), symbolFontPath);
+        fdb->addFont(FontDataKey(fontName), symbolFontPath);
+        fdb->addFont(FontDataKey(fontName + u" Text"), textFontPath);
+        fdb->insertSubstitution(fontName + u" Text", u"Leland Text");
+    }
+
+    engravingFonts()->loadAllFonts();
+}

--- a/src/notation/internal/engravingfontscontroller.cpp
+++ b/src/notation/internal/engravingfontscontroller.cpp
@@ -22,20 +22,17 @@
 
 #include "engravingfontscontroller.h"
 
-#include "engraving/infrastructure/smufl.h"
-#include "engraving/internal/engravingfont.h"
-#include "log.h"
-
 #include <QDirIterator>
 #include <QFontDatabase>
 #include <QStandardPaths>
+
+#include "log.h"
 
 using namespace mu::notation;
 
 void EngravingFontsController::init()
 {
-    auto musicFontsPath = configuration()->userMusicFontsPathChanged();
-    musicFontsPath.onReceive(this, [this](const muse::io::path_t&) {
+    configuration()->userMusicFontsPathChanged().onReceive(this, [this](const muse::io::path_t&) {
         scanAllDirectories();
     });
 
@@ -49,17 +46,17 @@ void EngravingFontsController::scanAllDirectories() const
     // Standard locations as described in https://w3c.github.io/smufl/latest/specification/font-metadata-locations.html
 
     // These standard location roughly match up with what the following returns, but some adjustments are needed.
-    QStringList standardLocations = QStandardPaths::standardLocations(QStandardPaths::GenericDataLocation).first(2);
+    // QStringList globalFontsPaths = QStandardPaths::standardLocations(QStandardPaths::GenericDataLocation).first(2);
 
 #if defined(Q_OS_WIN)
     // On Windows, the second standard location returned by Qt is %ProgramData%, but we want %CommonProgramFiles%
     QStringList globalFontsPaths {
-        standardLocations.first(),
+        QStandardPaths::standardLocations(QStandardPaths::GenericDataLocation).first(),
         qgetenv("CommonProgramFiles").replace("\\", "/")
     };
 #elif defined(Q_OS_MACOS)
     // MacOS is correctly handled by Qt
-    QStringList globalFontsPaths = standardLocations;
+    QStringList globalFontsPaths = QStandardPaths::standardLocations(QStandardPaths::GenericDataLocation).first(2);
 #elif defined(Q_OS_LINUX)
     // On Unix systems, we want $XDG_DATA_HOME (user-specific) and $XDG_DATA_DIRS (system-wide)
     QStringList globalFontsPaths { qgetenv("XDG_DATA_HOME") };
@@ -68,20 +65,23 @@ void EngravingFontsController::scanAllDirectories() const
 
     // The first location is the user-wide location, so we should iterate in reverse order so that
     // user-specific fonts can override system-wide fonts
-    for (auto it = globalFontsPaths.rbegin(); it != globalFontsPaths.rend(); ++it) {
+    for (auto it = globalFontsPaths.crbegin(); it != globalFontsPaths.crend(); ++it) {
         scanDirectory(*it + "/SMuFL/Fonts", false);
     }
 
     // Scan MuseScore-specific "private" location last so that it can override global fonts
-    scanDirectory(configuration()->userMusicFontsPath(), true);
+    muse::io::path_t userFontsPath = configuration()->userMusicFontsPath();
+    if (!userFontsPath.empty()) {
+        scanDirectory(userFontsPath, true);
+    }
+
+    engravingFonts()->loadAllFonts();
 
     QStringList musicFonts;
-
-    for (const auto& font : engravingFonts()->fonts()) {
+    for (const engraving::IEngravingFontPtr& font : engravingFonts()->fonts()) {
         musicFonts << QString::fromStdString(font->name());
         musicFonts << QString::fromStdString(font->name() + " Text");
     }
-
     uiConfiguration()->setNonTextFonts(musicFonts);
 }
 
@@ -97,11 +97,13 @@ void EngravingFontsController::scanDirectory(const muse::io::path_t& path, bool 
         iterator.next();
         QString fontDir = iterator.filePath();
         muse::io::path_t metadataPath;
-        QDirIterator fontFiles(fontDir, { "*.json" }, QDir::Files);
 
-        while (fontFiles.hasNext()) {
-            fontFiles.next();
-            metadataPath = fontFiles.filePath();
+        {
+            QDirIterator jsonFilesIterator(fontDir, { "*.json" }, QDir::Files);
+            while (jsonFilesIterator.hasNext()) {
+                jsonFilesIterator.next();
+                metadataPath = jsonFilesIterator.filePath();
+            }
         }
 
         if (metadataPath.empty()) {
@@ -111,15 +113,15 @@ void EngravingFontsController::scanDirectory(const muse::io::path_t& path, bool 
         // We assume the font name is the same as the directory name,
         // but maybe we should instead read the metadata.json file to get the font name
 
-        muse::String fontName = iterator.fileName();
-        muse::String fontFamily = fontName;
+        QString fontName = iterator.fileName();
+        QString fontFamily = fontName;
 
         if (fontName.contains(u"Text")) {
             LOGI() << "Skipping text music font: " << fontName;
             continue;
         }
 
-        auto findFontPath = [this, isPrivate, fontDir](muse::String fontName) {
+        auto findFontPath = [this, isPrivate, fontDir](QString fontName) {
             if (isPrivate) {
                 return findFontPathPrivate(fontDir, fontName);
             } else {
@@ -129,14 +131,14 @@ void EngravingFontsController::scanDirectory(const muse::io::path_t& path, bool 
 
         muse::io::path_t symbolFontPath = findFontPath(fontName);
         if (symbolFontPath.empty()) {
-            muse::String tmp = fontName;
-            symbolFontPath = findFontPath(tmp.replace(u" ", u""));
+            QString tmp = fontName;
+            symbolFontPath = findFontPath(tmp.replace(" ", ""));
         }
 
-        muse::io::path_t textFontPath = findFontPath(fontName + u" Text");
+        muse::io::path_t textFontPath = findFontPath(fontName + " Text");
         if (symbolFontPath.empty()) {
-            muse::String tmp = fontName;
-            symbolFontPath = findFontPath(tmp.replace(u" ", u"") + u"Text");
+            QString tmp = fontName;
+            symbolFontPath = findFontPath(tmp.replace(" ", "") + "Text");
         }
 
         if (textFontPath.empty()) {
@@ -148,24 +150,23 @@ void EngravingFontsController::scanDirectory(const muse::io::path_t& path, bool 
             continue;
         }
 
+        muse::String fontNameStr = muse::String::fromQString(fontName);
         engravingFonts()->addExternalFont(fontName.toStdString(), fontFamily.toStdString(), symbolFontPath, metadataPath);
-        fdb->addFont(FontDataKey(fontName), symbolFontPath);
-        fdb->addFont(FontDataKey(fontName + u" Text"), textFontPath);
-        fdb->insertSubstitution(fontName + u" Text", u"Leland Text");
+        fdb->addFont(FontDataKey(fontNameStr), symbolFontPath);
+        fdb->addFont(FontDataKey(fontNameStr + u" Text"), textFontPath);
+        fdb->insertSubstitution(fontNameStr + u" Text", u"Leland Text");
     }
-
-    engravingFonts()->loadAllFonts();
 }
 
-muse::io::path_t EngravingFontsController::findFontPathPrivate(QString metadataDir, muse::String fontName) const
+muse::io::path_t EngravingFontsController::findFontPathPrivate(const QString& metadataDir, const QString& fontName) const
 {
     // Search in the folder where the metadata lives
 
     QStringList testPaths {
-        metadataDir + "/" + fontName.toQString() + ".ttf",
-        metadataDir + "/" + fontName.toQString() + ".otf"
+        metadataDir + "/" + fontName + ".ttf",
+        metadataDir + "/" + fontName + ".otf"
     };
-    for (QString testPath : testPaths) {
+    for (const QString& testPath : testPaths) {
         if (QFile::exists(testPath)) {
             return testPath;
         }
@@ -173,18 +174,18 @@ muse::io::path_t EngravingFontsController::findFontPathPrivate(QString metadataD
     return muse::io::path_t();
 }
 
-muse::io::path_t EngravingFontsController::findFontPathGlobal(muse::String fontName) const
+muse::io::path_t EngravingFontsController::findFontPathGlobal(const QString& fontName) const
 {
     QStringList fontLocations = QStandardPaths::standardLocations(QStandardPaths::FontsLocation);
 #if defined(Q_OS_WIN)
     // Qt does not include the local fonts folder in the standard locations
     fontLocations << qgetenv("LocalAppData").replace("\\", "/") + "/Microsoft/Windows/Fonts";
 #endif
-    for (QString& dir : fontLocations) {
+    for (const QString& dir : fontLocations) {
         QDirIterator it(dir, { "*.ttf", "*.otf" }, QDir::Files);
         while (it.hasNext()) {
             it.next();
-            if (it.fileName() == fontName + u".ttf" || it.fileName() == fontName + u".otf") {
+            if (it.fileName() == fontName + ".ttf" || it.fileName() == fontName + ".otf") {
                 return it.filePath();
             }
         }

--- a/src/notation/internal/engravingfontscontroller.h
+++ b/src/notation/internal/engravingfontscontroller.h
@@ -26,20 +26,25 @@
 #include "async/asyncable.h"
 #include "modularity/ioc.h"
 #include "inotationconfiguration.h"
-#include "modularity/imodulesetup.h"
+#include "draw/internal/ifontsdatabase.h"
+#include "ui/iuiconfiguration.h"
 
 namespace mu::notation {
-class EngravingFontsController : public muse::async::Asyncable, muse::modularity::IModuleSetup
+class EngravingFontsController : public muse::async::Asyncable, muse::Injectable
 {
-    INJECT(mu::notation::INotationConfiguration, configuration)
-    INJECT(mu::engraving::IEngravingFontsProvider, engravingFonts)
+    muse::Inject<mu::notation::INotationConfiguration> configuration = { this };
+    muse::Inject<mu::engraving::IEngravingFontsProvider> engravingFonts = { this };
+    muse::Inject<muse::draw::IFontsDatabase> fontsDatabase = { this };
+    muse::Inject<muse::ui::IUiConfiguration> uiConfiguration = { this };
 
 public:
-    std::string moduleName() const override;
     void init();
 
 private:
+    void scanAllDirectories() const;
     void scanDirectory(const muse::io::path_t& path, bool isPrivate) const;
+    muse::io::path_t findFontPathGlobal(muse::String fontName) const;
+    muse::io::path_t findFontPathPrivate(QString metadataDir, muse::String fontName) const;
 };
 }
 

--- a/src/notation/internal/engravingfontscontroller.h
+++ b/src/notation/internal/engravingfontscontroller.h
@@ -1,0 +1,46 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2024 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef MU_NOTATION_ENGRAVINGFONTSCONTROLLER_H
+#define MU_NOTATION_ENGRAVINGFONTSCONTROLLER_H
+
+#include "async/asyncable.h"
+#include "modularity/ioc.h"
+#include "inotationconfiguration.h"
+#include "modularity/imodulesetup.h"
+
+namespace mu::notation {
+class EngravingFontsController : public muse::async::Asyncable, muse::modularity::IModuleSetup
+{
+    INJECT(mu::notation::INotationConfiguration, configuration)
+    INJECT(mu::engraving::IEngravingFontsProvider, engravingFonts)
+
+public:
+    std::string moduleName() const override;
+    void init();
+
+private:
+    void scanDirectory(const muse::io::path_t& path) const;
+};
+}
+
+#endif // MU_NOTATION_ENGRAVINGFONTSCONTROLLER_H

--- a/src/notation/internal/engravingfontscontroller.h
+++ b/src/notation/internal/engravingfontscontroller.h
@@ -20,8 +20,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef MU_NOTATION_ENGRAVINGFONTSCONTROLLER_H
-#define MU_NOTATION_ENGRAVINGFONTSCONTROLLER_H
+#pragma once
 
 #include "async/asyncable.h"
 #include "modularity/ioc.h"
@@ -43,9 +42,7 @@ public:
 private:
     void scanAllDirectories() const;
     void scanDirectory(const muse::io::path_t& path, bool isPrivate) const;
-    muse::io::path_t findFontPathGlobal(muse::String fontName) const;
-    muse::io::path_t findFontPathPrivate(QString metadataDir, muse::String fontName) const;
+    muse::io::path_t findFontPathGlobal(const QString& fontName) const;
+    muse::io::path_t findFontPathPrivate(const QString& metadataDir, const QString& fontName) const;
 };
 }
-
-#endif // MU_NOTATION_ENGRAVINGFONTSCONTROLLER_H

--- a/src/notation/internal/engravingfontscontroller.h
+++ b/src/notation/internal/engravingfontscontroller.h
@@ -39,7 +39,7 @@ public:
     void init();
 
 private:
-    void scanDirectory(const muse::io::path_t& path) const;
+    void scanDirectory(const muse::io::path_t& path, bool isPrivate) const;
 };
 }
 

--- a/src/notation/internal/notationconfiguration.cpp
+++ b/src/notation/internal/notationconfiguration.cpp
@@ -748,16 +748,17 @@ async::Channel<muse::io::path_t> NotationConfiguration::partStyleFilePathChanged
     return engravingConfiguration()->partStyleFilePathChanged();
 }
 
-muse::io::path_t NotationConfiguration::userMusicFontPath() const {
+muse::io::path_t NotationConfiguration::userMusicFontsPath() const
+{
     return settings()->value(USER_MUSIC_FONTS_PATH).toPath();
 }
 
-void NotationConfiguration::setUserMusicFontPath(const muse::io::path_t& path)
+void NotationConfiguration::setUserMusicFontsPath(const muse::io::path_t& path)
 {
     settings()->setSharedValue(USER_MUSIC_FONTS_PATH, Val(path));
 }
 
-muse::async::Channel<muse::io::path_t> NotationConfiguration::userMusicFontPathChanged() const
+muse::async::Channel<muse::io::path_t> NotationConfiguration::userMusicFontsPathChanged() const
 {
     return m_userMusicFontsPathChanged;
 }

--- a/src/notation/internal/notationconfiguration.cpp
+++ b/src/notation/internal/notationconfiguration.cpp
@@ -228,8 +228,8 @@ void NotationConfiguration::init()
 #endif
     }
 
-    settings()->setDefaultValue(USER_MUSIC_FONTS_PATH, Val(globalConfiguration()->userDataPath() + "/MusicFonts"));
-    settings()->valueChanged(USER_MUSIC_FONTS_PATH).onReceive(nullptr, [this](const Val& val) {
+    settings()->setDefaultValue(USER_MUSIC_FONTS_PATH, Val(io::path_t {}));
+    settings()->valueChanged(USER_MUSIC_FONTS_PATH).onReceive(this, [this](const Val& val) {
         m_userMusicFontsPathChanged.send(val.toString());
     });
 

--- a/src/notation/internal/notationconfiguration.cpp
+++ b/src/notation/internal/notationconfiguration.cpp
@@ -64,6 +64,7 @@ static const Settings::Key KEYBOARD_ZOOM_PRECISION(module_name, "ui/canvas/zoomP
 static const Settings::Key MOUSE_ZOOM_PRECISION(module_name, "ui/canvas/zoomPrecisionMouse");
 
 static const Settings::Key USER_STYLES_PATH(module_name, "application/paths/myStyles");
+static const Settings::Key USER_MUSIC_FONTS_PATH(module_name, "application/paths/myMusicFonts");
 
 static const Settings::Key DEFAULT_NOTE_INPUT_METHOD(module_name, "score/defaultInputMethod");
 
@@ -226,6 +227,11 @@ void NotationConfiguration::init()
             );
 #endif
     }
+
+    settings()->setDefaultValue(USER_MUSIC_FONTS_PATH, Val(globalConfiguration()->userDataPath() + "/MusicFonts"));
+    settings()->valueChanged(USER_MUSIC_FONTS_PATH).onReceive(nullptr, [this](const Val& val) {
+        m_userMusicFontsPathChanged.send(val.toString());
+    });
 
     settings()->setDefaultValue(DEFAULT_NOTE_INPUT_METHOD, Val(BY_NOTE_NAME_INPUT_METHOD));
     settings()->valueChanged(DEFAULT_NOTE_INPUT_METHOD).onReceive(this, [this](const Val&) {
@@ -740,6 +746,20 @@ void NotationConfiguration::setPartStyleFilePath(const muse::io::path_t& path)
 async::Channel<muse::io::path_t> NotationConfiguration::partStyleFilePathChanged() const
 {
     return engravingConfiguration()->partStyleFilePathChanged();
+}
+
+muse::io::path_t NotationConfiguration::userMusicFontPath() const {
+    return settings()->value(USER_MUSIC_FONTS_PATH).toPath();
+}
+
+void NotationConfiguration::setUserMusicFontPath(const muse::io::path_t& path)
+{
+    settings()->setSharedValue(USER_MUSIC_FONTS_PATH, Val(path));
+}
+
+muse::async::Channel<muse::io::path_t> NotationConfiguration::userMusicFontPathChanged() const
+{
+    return m_userMusicFontsPathChanged;
 }
 
 NoteInputMethod NotationConfiguration::defaultNoteInputMethod() const

--- a/src/notation/internal/notationconfiguration.h
+++ b/src/notation/internal/notationconfiguration.h
@@ -137,10 +137,10 @@ public:
     void setAddAccidentalDotsArticulationsToNextNoteEntered(bool value) override;
     muse::async::Notification addAccidentalDotsArticulationsToNextNoteEnteredChanged() const override;
 
-    muse::io::path_t userMusicFontPath() const override;
-    void setUserMusicFontPath(const muse::io::path_t& path) override;
+    muse::io::path_t userMusicFontsPath() const override;
+    void setUserMusicFontsPath(const muse::io::path_t& path) override;
 
-    muse::async::Channel<muse::io::path_t> userMusicFontPathChanged() const override;
+    muse::async::Channel<muse::io::path_t> userMusicFontsPathChanged() const override;
 
     bool isMidiInputEnabled() const override;
     void setIsMidiInputEnabled(bool enabled) override;

--- a/src/notation/internal/notationconfiguration.h
+++ b/src/notation/internal/notationconfiguration.h
@@ -19,8 +19,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef MU_NOTATION_NOTATIONCONFIGURATION_H
-#define MU_NOTATION_NOTATIONCONFIGURATION_H
+#pragma once
 
 #include "async/asyncable.h"
 
@@ -139,7 +138,6 @@ public:
 
     muse::io::path_t userMusicFontsPath() const override;
     void setUserMusicFontsPath(const muse::io::path_t& path) override;
-
     muse::async::Channel<muse::io::path_t> userMusicFontsPathChanged() const override;
 
     bool isMidiInputEnabled() const override;
@@ -319,5 +317,3 @@ private:
     int m_styleDialogLastSubPageIndex = 0;
 };
 }
-
-#endif // MU_NOTATION_NOTATIONCONFIGURATION_H

--- a/src/notation/internal/notationconfiguration.h
+++ b/src/notation/internal/notationconfiguration.h
@@ -137,6 +137,11 @@ public:
     void setAddAccidentalDotsArticulationsToNextNoteEntered(bool value) override;
     muse::async::Notification addAccidentalDotsArticulationsToNextNoteEnteredChanged() const override;
 
+    muse::io::path_t userMusicFontPath() const override;
+    void setUserMusicFontPath(const muse::io::path_t& path) override;
+
+    muse::async::Channel<muse::io::path_t> userMusicFontPathChanged() const override;
+
     bool isMidiInputEnabled() const override;
     void setIsMidiInputEnabled(bool enabled) override;
     muse::async::Notification isMidiInputEnabledChanged() const override;
@@ -288,6 +293,7 @@ private:
     muse::async::Notification m_mouseZoomPrecisionChanged;
     muse::async::Channel<muse::Orientation> m_canvasOrientationChanged;
     muse::async::Channel<muse::io::path_t> m_userStylesPathChanged;
+    muse::async::Channel<muse::io::path_t> m_userMusicFontsPathChanged;
     muse::async::Notification m_scoreOrderListPathsChanged;
     muse::async::Notification m_isLimitCanvasScrollAreaChanged;
     muse::async::Channel<int> m_selectionProximityChanged;

--- a/src/notation/notationmodule.cpp
+++ b/src/notation/notationmodule.cpp
@@ -36,6 +36,7 @@
 #include "internal/mscnotationwriter.h"
 #include "internal/instrumentsrepository.h"
 #include "internal/notationcreator.h"
+#include "internal/engravingfontscontroller.h"
 
 #include "view/notationpaintview.h"
 #include "view/notationswitchlistmodel.h"
@@ -121,6 +122,7 @@ void NotationModule::registerExports()
     m_notationUiActions = std::make_shared<NotationUiActions>(m_actionController);
     m_midiInputOutputController = std::make_shared<MidiInputOutputController>();
     m_instrumentsRepository = std::make_shared<InstrumentsRepository>();
+    m_engravingFontsController = std::make_shared<EngravingFontsController>();
 
     ioc()->registerExport<INotationConfiguration>(moduleName(), m_configuration);
     ioc()->registerExport<INotationCreator>(moduleName(), new NotationCreator());
@@ -240,6 +242,7 @@ void NotationModule::onInit(const IApplication::RunMode& mode)
     m_instrumentsRepository->init();
     m_actionController->init();
     m_notationUiActions->init();
+    m_engravingFontsController->init();
 
     if (mode == IApplication::RunMode::GuiApp) {
         m_midiInputOutputController->init();

--- a/src/notation/notationmodule.h
+++ b/src/notation/notationmodule.h
@@ -32,6 +32,7 @@ class NotationActionController;
 class NotationUiActions;
 class MidiInputOutputController;
 class InstrumentsRepository;
+class EngravingFontsController;
 class NotationModule : public muse::modularity::IModuleSetup
 {
 public:
@@ -49,6 +50,7 @@ private:
     std::shared_ptr<NotationUiActions> m_notationUiActions;
     std::shared_ptr<MidiInputOutputController> m_midiInputOutputController;
     std::shared_ptr<InstrumentsRepository> m_instrumentsRepository;
+    std::shared_ptr<EngravingFontsController> m_engravingFontsController;
 };
 }
 

--- a/src/notation/notationmodule.h
+++ b/src/notation/notationmodule.h
@@ -19,8 +19,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef MU_NOTATION_NOTATIONMODULE_H
-#define MU_NOTATION_NOTATIONMODULE_H
+#pragma once
 
 #include <memory>
 
@@ -53,5 +52,3 @@ private:
     std::shared_ptr<EngravingFontsController> m_engravingFontsController;
 };
 }
-
-#endif // MU_NOTATION_NOTATIONMODULE_H

--- a/src/notation/tests/mocks/notationconfigurationmock.h
+++ b/src/notation/tests/mocks/notationconfigurationmock.h
@@ -122,9 +122,9 @@ public:
     MOCK_METHOD(void, setAddAccidentalDotsArticulationsToNextNoteEntered, (bool), (override));
     MOCK_METHOD(muse::async::Notification, addAccidentalDotsArticulationsToNextNoteEnteredChanged, (), (const, override));
 
-    MOCK_METHOD(muse::io::path_t, userMusicFontPath, (), (const, override));
-    MOCK_METHOD(void, setUserMusicFontPath, (const muse::io::path_t&), (override));
-    MOCK_METHOD(muse::async::Channel<muse::io::path_t>, userMusicFontPathChanged, (), (const, override));
+    MOCK_METHOD(muse::io::path_t, userMusicFontsPath, (), (const, override));
+    MOCK_METHOD(void, setUserMusicFontsPath, (const muse::io::path_t&), (override));
+    MOCK_METHOD(muse::async::Channel<muse::io::path_t>, userMusicFontsPathChanged, (), (const, override));
 
     MOCK_METHOD(bool, isMidiInputEnabled, (), (const, override));
     MOCK_METHOD(void, setIsMidiInputEnabled, (bool), (override));

--- a/src/notation/tests/mocks/notationconfigurationmock.h
+++ b/src/notation/tests/mocks/notationconfigurationmock.h
@@ -122,6 +122,10 @@ public:
     MOCK_METHOD(void, setAddAccidentalDotsArticulationsToNextNoteEntered, (bool), (override));
     MOCK_METHOD(muse::async::Notification, addAccidentalDotsArticulationsToNextNoteEnteredChanged, (), (const, override));
 
+    MOCK_METHOD(muse::io::path_t, userMusicFontPath, (), (const, override));
+    MOCK_METHOD(void, setUserMusicFontPath, (const muse::io::path_t&), (override));
+    MOCK_METHOD(muse::async::Channel<muse::io::path_t>, userMusicFontPathChanged, (), (const, override));
+
     MOCK_METHOD(bool, isMidiInputEnabled, (), (const, override));
     MOCK_METHOD(void, setIsMidiInputEnabled, (bool), (override));
     MOCK_METHOD(muse::async::Notification, isMidiInputEnabledChanged, (), (const, override));

--- a/src/notation/view/widgets/editstyle.cpp
+++ b/src/notation/view/widgets/editstyle.cpp
@@ -834,9 +834,14 @@ EditStyle::EditStyle(QWidget* parent)
 
     musicalSymbolFont->clear();
     dynamicsFont->clear();
+    musicalTextFont->clear();
     for (auto i : engravingFonts()->fonts()) {
-        musicalSymbolFont->addItem(QString::fromStdString(i->name()), QString::fromStdString(i->name()));
-        dynamicsFont->addItem(QString::fromStdString(i->name()), QString::fromStdString(i->name()));
+        QString fontDisplayName = QString::fromStdString(i->name());
+        QString fontFamilyName = QString::fromStdString(i->family());
+        musicalSymbolFont->addItem(fontDisplayName, fontDisplayName);
+        dynamicsFont->addItem(fontDisplayName, fontDisplayName);
+        // musicalTextFont must be a font family name!
+        musicalTextFont->addItem(fontDisplayName + " Text", fontFamilyName + " Text");
     }
 
     static const SymId ids[] = {
@@ -2391,41 +2396,21 @@ void EditStyle::setValues()
     spinFBLineHeight->setValue(styleValue(StyleId::figuredBassLineHeight).toDouble() * 100.0);
 
     QString mfont(styleValue(StyleId::musicalSymbolFont).value<String>());
+    QString dynFont(styleValue(StyleId::dynamicsFont).value<String>());
+    QString tfont(styleValue(StyleId::musicalTextFont).value<String>());
     int idx = 0;
     for (const auto& i : engravingFonts()->fonts()) {
         if (QString::fromStdString(i->name()).toLower() == mfont.toLower()) {
             musicalSymbolFont->setCurrentIndex(idx);
-            break;
         }
-        ++idx;
-    }
-
-    QString dynFont(styleValue(StyleId::dynamicsFont).value<String>());
-    idx = 0;
-    for (const auto& i : engravingFonts()->fonts()) {
         if (QString::fromStdString(i->name()).toLower() == dynFont.toLower()) {
             dynamicsFont->setCurrentIndex(idx);
-            break;
+        }
+        if ((QString::fromStdString(i->family()) + " Text").toLower() == tfont.toLower()) {
+            musicalTextFont->setCurrentIndex(idx);
         }
         ++idx;
     }
-
-    musicalTextFont->blockSignals(true);
-    musicalTextFont->clear();
-    // CAUTION: the second element, the itemdata, is a font family name!
-    // It's also stored in score file as the musicalTextFont
-    musicalTextFont->addItem("Leland Text", "Leland Text");
-    musicalTextFont->addItem("Bravura Text", "Bravura Text");
-    musicalTextFont->addItem("Emmentaler Text", "MScore Text");
-    musicalTextFont->addItem("Gonville Text", "Gootville Text");
-    musicalTextFont->addItem("MuseJazz Text", "MuseJazz Text");
-    musicalTextFont->addItem("Petaluma Text", "Petaluma Text");
-    musicalTextFont->addItem("Finale Maestro Text", "Finale Maestro Text");
-    musicalTextFont->addItem("Finale Broadway Text", "Finale Broadway Text");
-    QString tfont(styleValue(StyleId::musicalTextFont).value<String>());
-    idx = musicalTextFont->findData(tfont);
-    musicalTextFont->setCurrentIndex(idx);
-    musicalTextFont->blockSignals(false);
 
     toggleHeaderOddEven(styleValue(StyleId::headerOddEven).toBool());
     toggleFooterOddEven(styleValue(StyleId::footerOddEven).toBool());


### PR DESCRIPTION
Relevant issues: #24761 and #16189

Based on the work of @cbjeukendrup in https://github.com/cbjeukendrup/MuseScore/tree/custom-music-fonts.
This PR introduces functionality that allows users to provide custom SMuFL fonts in MuseScore.
It adds a new folder selection in Preferences -> Folders -> MusicFonts (Default: `MuseScore4[Development]/MusicFonts`).
It searches through this folder for directories with SMuFL files - `<font name>.ttf/.otf` files and a matching metadata json file (`<font name>.json`, `metadata.json` or `<font name>_metadata.json`).

It also supports the standard installation directories as specified by the [SMuFL docs](https://w3c.github.io/smufl/latest/specification/font-metadata-locations.html).

So, if you wanted to add the [Sebastian](https://github.com/fkretlow/sebastian/tree/master) font, you would create a directory in MusicFonts called `Sebastian` and place the files `Sebastian.otf`, `SebastianText.otf` and `metadata.json` (renamed from `Sebastian.json`) inside it.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
