### PR TITLE
fix crash when attempt to move slur anchor

### DIFF
--- a/src/engraving/rendering/score/slurtielayout.cpp
+++ b/src/engraving/rendering/score/slurtielayout.cpp
@@ -1582,6 +1582,9 @@ void SlurTieLayout::createSlurSegments(Slur* item, LayoutContext& ctx)
 {
     const ChordRest* startCR = item->startCR();
     const ChordRest* endCR = item->endCR();
+    if (!startCR || !endCR) {
+        return;
+    }
     const System* startSys = startCR->measure()->system();
     const System* endSys = endCR->measure()->system();
 


### PR DESCRIPTION
Resolves: #25901

<!-- Add a short description of and motivation for the changes here -->

[crash.zip](https://github.com/user-attachments/files/18053398/crash.zip)

To reproduce the issue:

1. Open the mscz file provided in the attachment above
2. Click any slur on the sheet (*not* TAB)
3. When the slur is selected, press <kbd>Shift+↓</kbd> (shift + arrow down)
4. See crash

This patch simply adds a nullptr check to ensure the crash doesn't happen. (The incorrect slur position issue might still needs to be fixed elsewhere)

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
