### PR TITLE
Don't copy microtonal accidentals into trill

### DIFF
--- a/src/engraving/dom/ornament.cpp
+++ b/src/engraving/dom/ornament.cpp
@@ -283,6 +283,11 @@ void Ornament::computeNotesAboveAndBelow(AccidentalState* accState)
         }
         note->setTrack(track());
 
+        if (Accidental::isMicrotonal(note->accidentalType())) {
+            // If mainNote has microtonal accidental, don't clone it to the ornament note because microtonal intervals are not supported.
+            note->setAccidentalType(Accidental::value2subtype(tpc2alter(note->tpc())));
+        }
+
         bool autoMode = (above && _intervalAbove.type == IntervalType::AUTO) || (!above && _intervalBelow.type == IntervalType::AUTO);
         if (autoMode) {
             // NOTE: In AUTO mode, the ornament note should match not only any alteration from the

--- a/src/engraving/rendering/score/beamtremololayout.cpp
+++ b/src/engraving/rendering/score/beamtremololayout.cpp
@@ -1278,7 +1278,7 @@ int BeamTremoloLayout::getBeamCount(const BeamBase::LayoutData* ldata, const std
 
 double BeamTremoloLayout::chordBeamAnchorX(const BeamBase::LayoutData* ldata, const ChordRest* cr, ChordBeamAnchorType anchorType)
 {
-    double pagePosX = ldata->trem ? ldata->trem->pagePos().x() : ldata->beam->pagePos().x();
+    double pagePosX = ldata->trem ? ldata->trem->pagePos().x() : ldata->beam ? ldata->beam->pagePos().x() : 0.0;
     double stemPosX = cr->stemPosX() + cr->pagePos().x() - pagePosX;
 
     if (!cr->isChord() || !toChord(cr)->stem()) {


### PR DESCRIPTION
Resolves: #24670 

Microtonal accidentals are not supported within trills (they can't be, in the current system, because the system is based on intervals, and "traditional" intervals stop making sense with microtonals). The crash happens because the trill copies the microtonal from the main note, but then tries to use normal interval-transposition logic to compute the trill note, which results in a mess. Only solution is, for now, to ignore microtonal accidentals.
