### PR TITLE
Create compatibility options for EIDs

### DIFF
--- a/src/engraving/iengravingconfiguration.h
+++ b/src/engraving/iengravingconfiguration.h
@@ -119,6 +119,9 @@ public:
 
     virtual bool isAccessibleEnabled() const = 0;
 
+    virtual bool doNotSaveEIDsForBackCompat() const = 0;
+    virtual void setDoNotSaveEIDsForBackCompat(bool doNotSave) = 0;
+
     /// these configurations will be removed after solving https://github.com/musescore/MuseScore/issues/14294
     virtual bool guitarProImportExperimental() const = 0;
     virtual bool useStretchedBends() const = 0;

--- a/src/engraving/infrastructure/eid.cpp
+++ b/src/engraving/infrastructure/eid.cpp
@@ -112,6 +112,7 @@ static constexpr uint64_t charToInt(char c)
     case '/': return 63;
     default:
         UNREACHABLE;
+        return uint64_t(-1);
     }
 }
 

--- a/src/engraving/internal/engravingconfiguration.cpp
+++ b/src/engraving/internal/engravingconfiguration.cpp
@@ -52,6 +52,8 @@ static const Settings::Key UNLINKED_COLOR("engraving", "engraving/colors/unlinke
 
 static const Settings::Key DYNAMICS_APPLY_TO_ALL_VOICES("engraving", "score/dynamicsApplyToAllVoices");
 
+static const Settings::Key DO_NOT_SAVE_EIDS_FOR_BACK_COMPAT("engraving", "engraving/compat/doNotSaveEIDsForBackCompat");
+
 struct VoiceColor {
     Settings::Key key;
     Color color;
@@ -126,6 +128,10 @@ void EngravingConfiguration::init()
     settings()->valueChanged(UNLINKED_COLOR).onReceive(nullptr, [this](const Val& val) {
         m_unlinkedColorChanged.send(Color::fromQColor(val.toQColor()));
     });
+
+    settings()->setDefaultValue(DO_NOT_SAVE_EIDS_FOR_BACK_COMPAT, Val(false));
+    settings()->setDescription(DO_NOT_SAVE_EIDS_FOR_BACK_COMPAT, muse::trc("engraving", "Do not save EIDs"));
+    settings()->setCanBeManuallyEdited(DO_NOT_SAVE_EIDS_FOR_BACK_COMPAT, false);
 }
 
 muse::io::path_t EngravingConfiguration::appDataPath() const
@@ -365,6 +371,16 @@ muse::async::Notification EngravingConfiguration::debuggingOptionsChanged() cons
 bool EngravingConfiguration::isAccessibleEnabled() const
 {
     return accessibilityConfiguration() ? accessibilityConfiguration()->enabled() : false;
+}
+
+bool EngravingConfiguration::doNotSaveEIDsForBackCompat() const
+{
+    return settings()->value(DO_NOT_SAVE_EIDS_FOR_BACK_COMPAT).toBool();
+}
+
+void EngravingConfiguration::setDoNotSaveEIDsForBackCompat(bool doNotSave)
+{
+    settings()->setSharedValue(DO_NOT_SAVE_EIDS_FOR_BACK_COMPAT, Val(doNotSave));
 }
 
 bool EngravingConfiguration::guitarProImportExperimental() const

--- a/src/engraving/internal/engravingconfiguration.h
+++ b/src/engraving/internal/engravingconfiguration.h
@@ -102,6 +102,9 @@ public:
 
     bool isAccessibleEnabled() const override;
 
+    bool doNotSaveEIDsForBackCompat() const override;
+    void setDoNotSaveEIDsForBackCompat(bool doNotSave) override;
+
     bool guitarProImportExperimental() const override;
     bool useStretchedBends() const override;
     bool shouldAddParenthesisOnStandardStaff() const override;

--- a/src/engraving/rw/write/twrite.cpp
+++ b/src/engraving/rw/write/twrite.cpp
@@ -436,7 +436,7 @@ void TWrite::writeSystemLocks(const Score* score, XmlWriter& xml)
 
 void TWrite::writeItemEid(const EngravingObject* item, XmlWriter& xml, WriteContext& ctx)
 {
-    if (MScore::testMode || item->score()->isPaletteScore() || ctx.clipboardmode()) {
+    if (MScore::testMode || ctx.configuration()->doNotSaveEIDsForBackCompat() || item->score()->isPaletteScore() || ctx.clipboardmode()) {
         return;
     }
 

--- a/src/engraving/tests/mocks/engravingconfigurationmock.h
+++ b/src/engraving/tests/mocks/engravingconfigurationmock.h
@@ -85,6 +85,9 @@ public:
 
     MOCK_METHOD(bool, isAccessibleEnabled, (), (const, override));
 
+    MOCK_METHOD(bool, doNotSaveEIDsForBackCompat, (), (const, override));
+    MOCK_METHOD(void, setDoNotSaveEIDsForBackCompat, (bool), (override));
+
     MOCK_METHOD(bool, guitarProImportExperimental, (), (const, override));
     MOCK_METHOD(bool, useStretchedBends, (), (const, override));
     MOCK_METHOD(bool, shouldAddParenthesisOnStandardStaff, (), (const, override));


### PR DESCRIPTION
Resolves: #25736

This option is available _exclusively_ in the DevTools page and is intended **exclusively for internal testing**. It is just a workaround to temporarily allow our QAs to open 4.5 files in pre 4.5 builds without crashing @DmitryArefiev @zacjansheski. This option will be removed, at some point.

Since https://github.com/musescore/MuseScore/pull/25666, we have completely changed the way we assign and write item IDs. Older builds are not able to read the new IDs and therefore crash on opening new files. It is (obviosly) not possible to retroactively change that. Unfortunately, it is also not possible to write IDs in a "compatibility" mode that's readable for the older builds, because they are just too different. The only thing that can be done is saving the file _without_ IDs. This will allow them to be opened by older versions without crashing.

HOWEVER

The whole reasons for introducing these new IDs is because they will be used to reference things in our files. This means that removing IDs will, at best, remove information from the files (for example, they will erase SystemLocks), and at worst, as we start using them more and more, just corrupt the whole file. So please use this options with extreme caution 😅. 

Also, do keep in mind that the new IDs are just the first step towards big changes that we want to make to our file format (some of which we may already start in 4.5). When we do that, new files will become unreadable for older versions in any case.

You can find the option here:
![image](https://github.com/user-attachments/assets/600614c7-9f0e-4d03-879c-16132c400935)
