### PR TITLE
Percussion panel - refinements round 3

### DIFF
--- a/src/appshell/CMakeLists.txt
+++ b/src/appshell/CMakeLists.txt
@@ -86,6 +86,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/view/preferences/importpreferencesmodel.h
     ${CMAKE_CURRENT_LIST_DIR}/view/preferences/audiomidipreferencesmodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/preferences/audiomidipreferencesmodel.h
+    ${CMAKE_CURRENT_LIST_DIR}/view/preferences/percussionpreferencesmodel.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/view/preferences/percussionpreferencesmodel.h
     ${CMAKE_CURRENT_LIST_DIR}/view/preferences/commonaudioapiconfigurationmodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/preferences/commonaudioapiconfigurationmodel.h
     ${CMAKE_CURRENT_LIST_DIR}/view/preferences/braillepreferencesmodel.cpp

--- a/src/appshell/appshell.qrc
+++ b/src/appshell/appshell.qrc
@@ -102,5 +102,6 @@
         <file>qml/Preferences/internal/MixerSection.qml</file>
         <file>qml/DevTools/Extensions/ExtensionsListView.qml</file>
         <file>qml/platform/PlatformMenuBar.qml</file>
+        <file>qml/Preferences/PercussionPreferencesPage.qml</file>
     </qresource>
 </RCC>

--- a/src/appshell/appshellmodule.cpp
+++ b/src/appshell/appshellmodule.cpp
@@ -56,6 +56,7 @@
 #include "view/preferences/scorepreferencesmodel.h"
 #include "view/preferences/importpreferencesmodel.h"
 #include "view/preferences/audiomidipreferencesmodel.h"
+#include "view/preferences/percussionpreferencesmodel.h"
 #include "view/preferences/commonaudioapiconfigurationmodel.h"
 #include "view/preferences/braillepreferencesmodel.h"
 #include "view/framelesswindow/framelesswindowmodel.h"
@@ -150,6 +151,7 @@ void AppShellModule::registerUiTypes()
     qmlRegisterType<ScorePreferencesModel>("MuseScore.Preferences", 1, 0, "ScorePreferencesModel");
     qmlRegisterType<ImportPreferencesModel>("MuseScore.Preferences", 1, 0, "ImportPreferencesModel");
     qmlRegisterType<AudioMidiPreferencesModel>("MuseScore.Preferences", 1, 0, "AudioMidiPreferencesModel");
+    qmlRegisterType<PercussionPreferencesModel>("MuseScore.Preferences", 1, 0, "PercussionPreferencesModel");
     qmlRegisterType<CommonAudioApiConfigurationModel>("MuseScore.Preferences", 1, 0, "CommonAudioApiConfigurationModel");
     qmlRegisterType<BraillePreferencesModel>("MuseScore.Preferences", 1, 0, "BraillePreferencesModel");
 

--- a/src/appshell/qml/Preferences/PercussionPreferencesPage.qml
+++ b/src/appshell/qml/Preferences/PercussionPreferencesPage.qml
@@ -31,6 +31,14 @@ import "internal"
 PreferencesPage {
     id: root
 
+    PercussionPreferencesModel {
+        id: percussionPreferencesModel
+    }
+
+    Component.onCompleted: {
+        percussionPreferencesModel.init()
+    }
+
     BaseSection {
         id: percussionPanelPreferences
 
@@ -40,6 +48,8 @@ PreferencesPage {
 
         CheckBox {
             id: unpitchedSelectedCheckbox
+
+            visible: percussionPreferencesModel.useNewPercussionPanel
             width: parent.width
 
             text: qsTrc("appshell/preferences", "Open the percussion panel when an unpitched staff is selected")
@@ -48,14 +58,17 @@ PreferencesPage {
             navigation.panel: percussionPanelPreferences.navigation
             navigation.row: 0
 
+            checked: percussionPreferencesModel.autoShowPercussionPanel
+
             onClicked:  {
-                // TODO: configuration - toggle autoShowPercussionPanel
+                percussionPreferencesModel.autoShowPercussionPanel = !unpitchedSelectedCheckbox.checked
             }
         }
 
         StyledTextLabel {
             id: padSwapInfo
 
+            visible: percussionPreferencesModel.useNewPercussionPanel
             width: parent.width
 
             horizontalAlignment: Text.AlignLeft
@@ -68,6 +81,8 @@ PreferencesPage {
 
             property int navigationRowStart: unpitchedSelectedCheckbox.navigation.row + 1
             property int navigationRowEnd: radioButtons.navigationRowStart + model.length
+
+            visible: percussionPreferencesModel.useNewPercussionPanel
 
             width: parent.width
             spacing: percussionPanelPreferences.spacing
@@ -92,10 +107,10 @@ PreferencesPage {
                     navigation.panel: percussionPanelPreferences.navigation
                     navigation.row: radioButtons.navigationRowStart + model.index
 
-                    // TODO: checked: modelData.value === pad swap preference
+                    checked: modelData.value === percussionPreferencesModel.percussionPanelMoveMidiNotesAndShortcuts
 
                     onToggled: {
-                        // TODO: configuration - change pad swap preference
+                        percussionPreferencesModel.percussionPanelMoveMidiNotesAndShortcuts = modelData.value
                     }
                 }
 
@@ -115,7 +130,7 @@ PreferencesPage {
                         anchors.fill: parent
 
                         onClicked: {
-                            // TODO: configuration - change pad swap preference
+                            percussionPreferencesModel.percussionPanelMoveMidiNotesAndShortcuts = modelData.value
                         }
                     }
                 }
@@ -125,6 +140,7 @@ PreferencesPage {
         CheckBox {
             id: alwaysAsk
 
+            visible: percussionPreferencesModel.useNewPercussionPanel
             width: parent.width
 
             text: qsTrc("global", "Always ask")
@@ -133,29 +149,26 @@ PreferencesPage {
             navigation.panel: percussionPanelPreferences.navigation
             navigation.row: radioButtons.navigationRowEnd
 
+            checked: percussionPreferencesModel.showPercussionPanelPadSwapDialog
+
             onClicked:  {
-                // TODO: configuration - toggle "show pad swap dialog"
+                percussionPreferencesModel.showPercussionPanelPadSwapDialog = !alwaysAsk.checked
             }
         }
-    }
 
-    FlatButton {
-        id: useNewPercussionPanel
+        FlatButton {
+            id: useNewPercussionPanel
 
-        anchors {
-            top: percussionPanelPreferences.bottom
-            topMargin: percussionPanelPreferences.spacing
-            left: parent.left
-        }
+            text: percussionPreferencesModel.useNewPercussionPanel ? qsTrc("notation", "Switch to old percussion panel")
+                                                                   : qsTrc("notation", "Switch to new percussion panel")
 
-        text: qsTrc("notation", "Switch to old percussion panel") // TODO: "old/new" depending on current configuration...
+            navigation.name: "SwitchPercussionPanels"
+            navigation.panel: percussionPanelPreferences.navigation
+            navigation.row: alwaysAsk.navigation.row + 1
 
-        navigation.name: "SwitchPercussionPanels"
-        navigation.panel: percussionPanelPreferences.navigation
-        navigation.row: alwaysAsk.navigation.row + 1
-
-        onClicked: {
-            // TODO: configuration - toggle use of new percussion panel
+            onClicked: {
+                percussionPreferencesModel.useNewPercussionPanel = !percussionPreferencesModel.useNewPercussionPanel
+            }
         }
     }
 }

--- a/src/appshell/qml/Preferences/PercussionPreferencesPage.qml
+++ b/src/appshell/qml/Preferences/PercussionPreferencesPage.qml
@@ -1,0 +1,161 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2024 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import QtQuick 2.15
+
+import Muse.Ui 1.0
+import Muse.UiComponents 1.0
+import MuseScore.Preferences 1.0
+
+import "internal"
+
+PreferencesPage {
+    id: root
+
+    BaseSection {
+        id: percussionPanelPreferences
+
+        title: qsTrc("appshell/preferences", "Percussion")
+
+        navigation.section: root.navigationSection
+
+        CheckBox {
+            id: unpitchedSelectedCheckbox
+            width: parent.width
+
+            text: qsTrc("appshell/preferences", "Open the percussion panel when an unpitched staff is selected")
+
+            navigation.name: "UnpitchedSelectedCheckbox"
+            navigation.panel: percussionPanelPreferences.navigation
+            navigation.row: 0
+
+            onClicked:  {
+                // TODO: configuration - toggle autoShowPercussionPanel
+            }
+        }
+
+        StyledTextLabel {
+            id: padSwapInfo
+
+            width: parent.width
+
+            horizontalAlignment: Text.AlignLeft
+            wrapMode: Text.Wrap
+            text: qsTrc("notation", "When swapping the positions of two drum pads:")
+        }
+
+        RadioButtonGroup {
+            id: radioButtons
+
+            property int navigationRowStart: unpitchedSelectedCheckbox.navigation.row + 1
+            property int navigationRowEnd: radioButtons.navigationRowStart + model.length
+
+            width: parent.width
+            spacing: percussionPanelPreferences.spacing
+
+            orientation: ListView.Vertical
+
+            model: [
+                { text: qsTrc("notation", "Move MIDI notes and keyboard shortcuts with their sounds"), value: true },
+                { text: qsTrc("notation", "Leave MIDI notes and keyboard shortcuts fixed to original pad positions"), value: false }
+            ]
+
+            delegate: Row {
+                width: parent.width
+                spacing: 6
+
+                RoundedRadioButton {
+                    id: radioButton
+
+                    anchors.verticalCenter: parent.verticalCenter
+
+                    navigation.name: modelData.text
+                    navigation.panel: percussionPanelPreferences.navigation
+                    navigation.row: radioButtons.navigationRowStart + model.index
+
+                    // TODO: checked: modelData.value === pad swap preference
+
+                    onToggled: {
+                        // TODO: configuration - change pad swap preference
+                    }
+                }
+
+                //! NOTE: Can't use radioButton.text because it won't wrap
+                StyledTextLabel {
+                    width: parent.width - parent.spacing - radioButton.width
+
+                    anchors.verticalCenter: parent.verticalCenter
+
+                    horizontalAlignment: Text.AlignLeft
+                    wrapMode: Text.Wrap
+                    text: modelData.text
+
+                    MouseArea {
+                        id: mouseArea
+
+                        anchors.fill: parent
+
+                        onClicked: {
+                            // TODO: configuration - change pad swap preference
+                        }
+                    }
+                }
+            }
+        }
+
+        CheckBox {
+            id: alwaysAsk
+
+            width: parent.width
+
+            text: qsTrc("global", "Always ask")
+
+            navigation.name: "AlwaysAskCheckBox"
+            navigation.panel: percussionPanelPreferences.navigation
+            navigation.row: radioButtons.navigationRowEnd
+
+            onClicked:  {
+                // TODO: configuration - toggle "show pad swap dialog"
+            }
+        }
+    }
+
+    FlatButton {
+        id: useNewPercussionPanel
+
+        anchors {
+            top: percussionPanelPreferences.bottom
+            topMargin: percussionPanelPreferences.spacing
+            left: parent.left
+        }
+
+        text: qsTrc("notation", "Switch to old percussion panel") // TODO: "old/new" depending on current configuration...
+
+        navigation.name: "SwitchPercussionPanels"
+        navigation.panel: percussionPanelPreferences.navigation
+        navigation.row: alwaysAsk.navigation.row + 1
+
+        onClicked: {
+            // TODO: configuration - toggle use of new percussion panel
+        }
+    }
+}

--- a/src/appshell/qml/Preferences/PercussionPreferencesPage.qml
+++ b/src/appshell/qml/Preferences/PercussionPreferencesPage.qml
@@ -73,7 +73,7 @@ PreferencesPage {
 
             horizontalAlignment: Text.AlignLeft
             wrapMode: Text.Wrap
-            text: qsTrc("notation", "When swapping the positions of two drum pads:")
+            text: qsTrc("notation/percussion", "When swapping the positions of two drum pads:")
         }
 
         RadioButtonGroup {
@@ -90,8 +90,8 @@ PreferencesPage {
             orientation: ListView.Vertical
 
             model: [
-                { text: qsTrc("notation", "Move MIDI notes and keyboard shortcuts with their sounds"), value: true },
-                { text: qsTrc("notation", "Leave MIDI notes and keyboard shortcuts fixed to original pad positions"), value: false }
+                { text: qsTrc("notation/percussion", "Move MIDI notes and keyboard shortcuts with their sounds"), value: true },
+                { text: qsTrc("notation/percussion", "Leave MIDI notes and keyboard shortcuts fixed to original pad positions"), value: false }
             ]
 
             delegate: Row {
@@ -159,8 +159,8 @@ PreferencesPage {
         FlatButton {
             id: useNewPercussionPanel
 
-            text: percussionPreferencesModel.useNewPercussionPanel ? qsTrc("notation", "Switch to old percussion panel")
-                                                                   : qsTrc("notation", "Switch to new percussion panel")
+            text: percussionPreferencesModel.useNewPercussionPanel ? qsTrc("notation/percussion", "Switch to old percussion panel")
+                                                                   : qsTrc("notation/percussion", "Switch to new percussion panel")
 
             navigation.name: "SwitchPercussionPanels"
             navigation.panel: percussionPanelPreferences.navigation

--- a/src/appshell/view/notationpagemodel.cpp
+++ b/src/appshell/view/notationpagemodel.cpp
@@ -66,6 +66,11 @@ void NotationPageModel::init()
 
     updateDrumsetPanelVisibility();
     updatePercussionPanelVisibility();
+
+    notationConfiguration()->useNewPercussionPanelChanged().onNotify(this, [this]() {
+        updateDrumsetPanelVisibility();
+        updatePercussionPanelVisibility();
+    });
 }
 
 QString NotationPageModel::notationToolBarName() const
@@ -150,7 +155,6 @@ void NotationPageModel::onNotationChanged()
         return;
     }
 
-    // TODO: Delete when the new percussion panel is finished
     if (!notationConfiguration()->useNewPercussionPanel()) {
         INotationNoteInputPtr noteInput = notation->interaction()->noteInput();
         noteInput->stateChanged().onNotify(this, [this]() {
@@ -235,7 +239,6 @@ void NotationPageModel::updatePercussionPanelVisibility()
     };
 
     // This should never be open when the old drumset panel is in use...
-    // TODO: Delete when the new percussion panel is finished
     if (!notationConfiguration()->useNewPercussionPanel()) {
         setPercussionPanelOpen(false);
         return;

--- a/src/appshell/view/notationpagemodel.h
+++ b/src/appshell/view/notationpagemodel.h
@@ -85,7 +85,7 @@ private:
 
     void toggleDock(const QString& name);
 
-    void updateDrumsetPanelVisibility(); // TODO: Delete when the new percussion panel is finished
+    void updateDrumsetPanelVisibility();
     void updatePercussionPanelVisibility();
 };
 }

--- a/src/appshell/view/preferences/percussionpreferencesmodel.cpp
+++ b/src/appshell/view/preferences/percussionpreferencesmodel.cpp
@@ -1,0 +1,87 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2024 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "percussionpreferencesmodel.h"
+
+PercussionPreferencesModel::PercussionPreferencesModel(QObject* parent)
+    : QObject(parent), muse::Injectable(muse::iocCtxForQmlObject(this))
+{
+}
+
+void PercussionPreferencesModel::init()
+{
+    configuration()->useNewPercussionPanelChanged().onNotify(this, [this]() {
+        emit useNewPercussionPanelChanged();
+    });
+
+    configuration()->autoShowPercussionPanelChanged().onNotify(this, [this]() {
+        emit autoShowPercussionPanelChanged();
+    });
+
+    configuration()->showPercussionPanelPadSwapDialogChanged().onNotify(this, [this]() {
+        emit showPercussionPanelPadSwapDialogChanged();
+    });
+
+    configuration()->percussionPanelMoveMidiNotesAndShortcutsChanged().onNotify(this, [this]() {
+        emit percussionPanelMoveMidiNotesAndShortcutsChanged();
+    });
+}
+
+bool PercussionPreferencesModel::useNewPercussionPanel() const
+{
+    return configuration()->useNewPercussionPanel();
+}
+
+void PercussionPreferencesModel::setUseNewPercussionPanel(bool use)
+{
+    configuration()->setUseNewPercussionPanel(use);
+}
+
+bool PercussionPreferencesModel::autoShowPercussionPanel() const
+{
+    return configuration()->autoShowPercussionPanel();
+}
+
+void PercussionPreferencesModel::setAutoShowPercussionPanel(bool autoShow)
+{
+    configuration()->setAutoShowPercussionPanel(autoShow);
+}
+
+bool PercussionPreferencesModel::showPercussionPanelPadSwapDialog() const
+{
+    return configuration()->showPercussionPanelPadSwapDialog();
+}
+
+void PercussionPreferencesModel::setShowPercussionPanelPadSwapDialog(bool show)
+{
+    configuration()->setShowPercussionPanelPadSwapDialog(show);
+}
+
+bool PercussionPreferencesModel::percussionPanelMoveMidiNotesAndShortcuts() const
+{
+    return configuration()->percussionPanelMoveMidiNotesAndShortcuts();
+}
+
+void PercussionPreferencesModel::setPercussionPanelMoveMidiNotesAndShortcuts(bool move)
+{
+    configuration()->setPercussionPanelMoveMidiNotesAndShortcuts(move);
+}

--- a/src/appshell/view/preferences/percussionpreferencesmodel.h
+++ b/src/appshell/view/preferences/percussionpreferencesmodel.h
@@ -1,0 +1,71 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2024 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QObject>
+
+#include "modularity/ioc.h"
+#include "notation/inotationconfiguration.h"
+
+#include "async/asyncable.h"
+
+class PercussionPreferencesModel : public QObject, public muse::Injectable, public muse::async::Asyncable
+{
+    Q_OBJECT
+
+    Q_PROPERTY(bool useNewPercussionPanel READ useNewPercussionPanel WRITE setUseNewPercussionPanel NOTIFY useNewPercussionPanelChanged)
+
+    Q_PROPERTY(bool autoShowPercussionPanel READ autoShowPercussionPanel
+               WRITE setAutoShowPercussionPanel NOTIFY autoShowPercussionPanelChanged)
+
+    Q_PROPERTY(bool showPercussionPanelPadSwapDialog READ showPercussionPanelPadSwapDialog
+               WRITE setShowPercussionPanelPadSwapDialog NOTIFY showPercussionPanelPadSwapDialogChanged)
+
+    Q_PROPERTY(bool percussionPanelMoveMidiNotesAndShortcuts READ percussionPanelMoveMidiNotesAndShortcuts
+               WRITE setPercussionPanelMoveMidiNotesAndShortcuts NOTIFY percussionPanelMoveMidiNotesAndShortcutsChanged)
+
+    muse::Inject<mu::notation::INotationConfiguration> configuration = { this };
+
+public:
+    explicit PercussionPreferencesModel(QObject* parent = nullptr);
+
+    Q_INVOKABLE void init();
+
+    bool useNewPercussionPanel() const;
+    void setUseNewPercussionPanel(bool use);
+
+    bool autoShowPercussionPanel() const;
+    void setAutoShowPercussionPanel(bool autoShow);
+
+    bool showPercussionPanelPadSwapDialog() const;
+    void setShowPercussionPanelPadSwapDialog(bool show);
+
+    bool percussionPanelMoveMidiNotesAndShortcuts() const;
+    void setPercussionPanelMoveMidiNotesAndShortcuts(bool move);
+
+signals:
+    void useNewPercussionPanelChanged();
+    void autoShowPercussionPanelChanged();
+    void showPercussionPanelPadSwapDialogChanged();
+    void percussionPanelMoveMidiNotesAndShortcutsChanged();
+};

--- a/src/appshell/view/preferences/preferencesmodel.cpp
+++ b/src/appshell/view/preferences/preferencesmodel.cpp
@@ -178,6 +178,9 @@ void PreferencesModel::load(const QString& currentPageId)
         makeItem("midi-device-mapping", QT_TRANSLATE_NOOP("appshell/preferences", "MIDI mappings"), IconCode::Code::MIDI_INPUT,
                  "Preferences/MidiDeviceMappingPreferencesPage.qml"),
 
+        makeItem("percussion", QT_TRANSLATE_NOOP("appshell/preferences", "Percussion"), IconCode::Code::PERCUSSION,
+                 "Preferences/PercussionPreferencesPage.qml"),
+
         makeItem("import", QT_TRANSLATE_NOOP("appshell/preferences", "Import"), IconCode::Code::IMPORT,
                  "Preferences/ImportPreferencesPage.qml"),
 

--- a/src/context/internal/uicontextresolver.cpp
+++ b/src/context/internal/uicontextresolver.cpp
@@ -67,7 +67,7 @@ void UiContextResolver::init()
                 notifyAboutContextChanged();
             });
 
-            notation->interaction()->noteInput()->noteInputStarted().onNotify(this, [this]() {
+            notation->interaction()->noteInput()->noteInputStarted().onReceive(this, [this](bool) {
                 notifyAboutContextChanged();
             });
 

--- a/src/framework/ui/view/iconcodes.h
+++ b/src/framework/ui/view/iconcodes.h
@@ -460,6 +460,8 @@ public:
         LV_CHORD_OUTSIDE = 0xF47F,
         LV_CHORD_INSIDE = 0xF480,
 
+        PERCUSSION = 0xF479,
+
         SYSTEM_LOCK_START = 0xF481,
         SYSTEM_LOCK_END = 0xF482,
 

--- a/src/notation/inotationconfiguration.h
+++ b/src/notation/inotationconfiguration.h
@@ -193,12 +193,21 @@ public:
     virtual muse::ValCh<bool> midiUseWrittenPitch() const = 0;
     virtual void setMidiUseWrittenPitch(bool useWrittenPitch) = 0;
 
-    // TODO: Delete when the new percussion panel is finished
     virtual bool useNewPercussionPanel() const = 0;
     virtual void setUseNewPercussionPanel(bool use) = 0;
+    virtual muse::async::Notification useNewPercussionPanelChanged() const = 0;
 
     virtual bool autoShowPercussionPanel() const = 0;
     virtual void setAutoShowPercussionPanel(bool autoShow) = 0;
+    virtual muse::async::Notification autoShowPercussionPanelChanged() const = 0;
+
+    virtual bool showPercussionPanelPadSwapDialog() const = 0;
+    virtual void setShowPercussionPanelPadSwapDialog(bool show) = 0;
+    virtual muse::async::Notification showPercussionPanelPadSwapDialogChanged() const = 0;
+
+    virtual bool percussionPanelMoveMidiNotesAndShortcuts() const = 0;
+    virtual void setPercussionPanelMoveMidiNotesAndShortcuts(bool move) = 0;
+    virtual muse::async::Notification percussionPanelMoveMidiNotesAndShortcutsChanged() const = 0;
 
     virtual muse::io::path_t styleFileImportPath() const = 0;
     virtual void setStyleFileImportPath(const muse::io::path_t& path) = 0;

--- a/src/notation/inotationnoteinput.h
+++ b/src/notation/inotationnoteinput.h
@@ -37,14 +37,14 @@ public:
 
     virtual NoteInputState state() const = 0;
 
-    virtual void startNoteInput() = 0;
+    virtual void startNoteInput(bool focusNotation = true) = 0;
     virtual void endNoteInput(bool resetState = false) = 0;
     virtual void toggleNoteInputMethod(NoteInputMethod method) = 0;
     virtual void addNote(NoteName noteName, NoteAddingMode addingMode) = 0;
     virtual void padNote(const Pad& pad)  = 0;
     virtual muse::Ret putNote(const muse::PointF& pos, bool replace, bool insert) = 0;
     virtual void removeNote(const muse::PointF& pos) = 0;
-    virtual muse::async::Notification noteInputStarted() const = 0;
+    virtual muse::async::Channel</*focusNotation*/ bool> noteInputStarted() const = 0;
     virtual muse::async::Notification noteInputEnded() const = 0;
 
     virtual void addTuplet(const TupletOptions& options) = 0;

--- a/src/notation/internal/notationconfiguration.cpp
+++ b/src/notation/internal/notationconfiguration.cpp
@@ -93,6 +93,8 @@ static const Settings::Key PIANO_KEYBOARD_NUMBER_OF_KEYS(module_name,  "pianoKey
 
 static const Settings::Key USE_NEW_PERCUSSION_PANEL_KEY(module_name,  "ui/useNewPercussionPanel");
 static const Settings::Key AUTO_SHOW_PERCUSSION_PANEL_KEY(module_name,  "ui/autoShowPercussionPanel");
+static const Settings::Key SHOW_PERCUSSION_PANEL_SWAP_DIALOG(module_name,  "ui/showPercussionPanelPadSwapDialog");
+static const Settings::Key PERCUSSION_PANEL_MOVE_MIDI_NOTES_AND_SHORTCUTS(module_name,  "ui/percussionPanelMoveMidiNotesAndShortcuts");
 
 static const Settings::Key STYLE_FILE_IMPORT_PATH_KEY(module_name, "import/style/styleFile");
 
@@ -225,8 +227,25 @@ void NotationConfiguration::init()
         m_midiInputUseWrittenPitch.set(val.toBool());
     });
 
-    settings()->setDefaultValue(USE_NEW_PERCUSSION_PANEL_KEY, Val(false));
+    settings()->setDefaultValue(USE_NEW_PERCUSSION_PANEL_KEY, Val(false)); // TODO: true when new percussion panel is ready
+    settings()->valueChanged(USE_NEW_PERCUSSION_PANEL_KEY).onReceive(this, [this](const Val&) {
+        m_useNewPercussionPanelChanged.notify();
+    });
+
     settings()->setDefaultValue(AUTO_SHOW_PERCUSSION_PANEL_KEY, Val(true));
+    settings()->valueChanged(AUTO_SHOW_PERCUSSION_PANEL_KEY).onReceive(this, [this](const Val&) {
+        m_autoShowPercussionPanelChanged.notify();
+    });
+
+    settings()->setDefaultValue(SHOW_PERCUSSION_PANEL_SWAP_DIALOG, Val(true));
+    settings()->valueChanged(SHOW_PERCUSSION_PANEL_SWAP_DIALOG).onReceive(this, [this](const Val&) {
+        m_showPercussionPanelPadSwapDialogChanged.notify();
+    });
+
+    settings()->setDefaultValue(PERCUSSION_PANEL_MOVE_MIDI_NOTES_AND_SHORTCUTS, Val(true));
+    settings()->valueChanged(PERCUSSION_PANEL_MOVE_MIDI_NOTES_AND_SHORTCUTS).onReceive(this, [this](const Val&) {
+        m_percussionPanelMoveMidiNotesAndShortcutsChanged.notify();
+    });
 
     engravingConfiguration()->scoreInversionChanged().onNotify(this, [this]() {
         m_foregroundChanged.notify();
@@ -888,6 +907,11 @@ void NotationConfiguration::setUseNewPercussionPanel(bool use)
     settings()->setSharedValue(USE_NEW_PERCUSSION_PANEL_KEY, Val(use));
 }
 
+Notification NotationConfiguration::useNewPercussionPanelChanged() const
+{
+    return m_useNewPercussionPanelChanged;
+}
+
 bool NotationConfiguration::autoShowPercussionPanel() const
 {
     return settings()->value(AUTO_SHOW_PERCUSSION_PANEL_KEY).toBool();
@@ -896,6 +920,41 @@ bool NotationConfiguration::autoShowPercussionPanel() const
 void NotationConfiguration::setAutoShowPercussionPanel(bool autoShow)
 {
     settings()->setSharedValue(AUTO_SHOW_PERCUSSION_PANEL_KEY, Val(autoShow));
+}
+
+Notification NotationConfiguration::autoShowPercussionPanelChanged() const
+{
+    return m_autoShowPercussionPanelChanged;
+}
+
+bool NotationConfiguration::showPercussionPanelPadSwapDialog() const
+{
+    return settings()->value(SHOW_PERCUSSION_PANEL_SWAP_DIALOG).toBool();
+}
+
+void NotationConfiguration::setShowPercussionPanelPadSwapDialog(bool show)
+{
+    settings()->setSharedValue(SHOW_PERCUSSION_PANEL_SWAP_DIALOG, Val(show));
+}
+
+Notification NotationConfiguration::showPercussionPanelPadSwapDialogChanged() const
+{
+    return m_showPercussionPanelPadSwapDialogChanged;
+}
+
+bool NotationConfiguration::percussionPanelMoveMidiNotesAndShortcuts() const
+{
+    return settings()->value(PERCUSSION_PANEL_MOVE_MIDI_NOTES_AND_SHORTCUTS).toBool();
+}
+
+void NotationConfiguration::setPercussionPanelMoveMidiNotesAndShortcuts(bool move)
+{
+    settings()->setSharedValue(PERCUSSION_PANEL_MOVE_MIDI_NOTES_AND_SHORTCUTS, Val(move));
+}
+
+Notification NotationConfiguration::percussionPanelMoveMidiNotesAndShortcutsChanged() const
+{
+    return m_percussionPanelMoveMidiNotesAndShortcutsChanged;
 }
 
 void NotationConfiguration::setPianoKeyboardNumberOfKeys(int number)

--- a/src/notation/internal/notationconfiguration.h
+++ b/src/notation/internal/notationconfiguration.h
@@ -200,9 +200,19 @@ public:
 
     bool useNewPercussionPanel() const override;
     void setUseNewPercussionPanel(bool use) override;
+    muse::async::Notification useNewPercussionPanelChanged() const override;
 
     bool autoShowPercussionPanel() const override;
     void setAutoShowPercussionPanel(bool autoShow) override;
+    muse::async::Notification autoShowPercussionPanelChanged() const override;
+
+    bool showPercussionPanelPadSwapDialog() const override;
+    void setShowPercussionPanelPadSwapDialog(bool show);
+    muse::async::Notification showPercussionPanelPadSwapDialogChanged() const override;
+
+    bool percussionPanelMoveMidiNotesAndShortcuts() const override;
+    void setPercussionPanelMoveMidiNotesAndShortcuts(bool move);
+    muse::async::Notification percussionPanelMoveMidiNotesAndShortcutsChanged() const override;
 
     muse::io::path_t styleFileImportPath() const override;
     void setStyleFileImportPath(const muse::io::path_t& path) override;
@@ -224,6 +234,7 @@ private:
 
     muse::async::Notification m_backgroundChanged;
     muse::async::Notification m_foregroundChanged;
+
     muse::async::Channel<muse::Orientation> m_canvasOrientationChanged;
     muse::async::Channel<muse::io::path_t> m_userStylesPathChanged;
     muse::async::Notification m_scoreOrderListPathsChanged;
@@ -233,6 +244,10 @@ private:
     muse::ValCh<int> m_pianoKeyboardNumberOfKeys;
     muse::ValCh<bool> m_midiInputUseWrittenPitch;
     muse::async::Channel<QColor> m_anchorColorChanged;
+    muse::async::Notification m_useNewPercussionPanelChanged;
+    muse::async::Notification m_autoShowPercussionPanelChanged;
+    muse::async::Notification m_showPercussionPanelPadSwapDialogChanged;
+    muse::async::Notification m_percussionPanelMoveMidiNotesAndShortcutsChanged;
 
     int m_styleDialogLastPageIndex = 0;
     int m_styleDialogLastSubPageIndex = 0;

--- a/src/notation/internal/notationnoteinput.cpp
+++ b/src/notation/internal/notationnoteinput.cpp
@@ -89,7 +89,7 @@ NoteInputState NotationNoteInput::state() const
 }
 
 //! NOTE Copied from `void ScoreView::startNoteEntry()`
-void NotationNoteInput::startNoteInput()
+void NotationNoteInput::startNoteInput(bool focusNotation)
 {
     TRACEFUNC;
 
@@ -143,7 +143,7 @@ void NotationNoteInput::startNoteInput()
         break;
     }
 
-    notifyAboutNoteInputStarted();
+    notifyAboutNoteInputStarted(focusNotation);
     notifyAboutStateChanged();
 
     m_interaction->showItem(el);
@@ -399,7 +399,7 @@ void NotationNoteInput::removeNote(const PointF& pos)
     MScoreErrorsController(iocContext()).checkAndShowMScoreError();
 }
 
-Notification NotationNoteInput::noteInputStarted() const
+Channel</*focusNotation*/ bool> NotationNoteInput::noteInputStarted() const
 {
     return m_noteInputStarted;
 }
@@ -675,9 +675,9 @@ void NotationNoteInput::notifyNoteAddedChanged()
     m_noteAdded.notify();
 }
 
-void NotationNoteInput::notifyAboutNoteInputStarted()
+void NotationNoteInput::notifyAboutNoteInputStarted(bool focusNotation)
 {
-    m_noteInputStarted.notify();
+    m_noteInputStarted.send(focusNotation);
 }
 
 void NotationNoteInput::notifyAboutNoteInputEnded()

--- a/src/notation/internal/notationnoteinput.h
+++ b/src/notation/internal/notationnoteinput.h
@@ -51,14 +51,14 @@ public:
 
     NoteInputState state() const override;
 
-    void startNoteInput() override;
+    void startNoteInput(bool focusNotation = true) override;
     void endNoteInput(bool resetState = false) override;
     void toggleNoteInputMethod(NoteInputMethod method) override;
     void addNote(NoteName noteName, NoteAddingMode addingMode) override;
     void padNote(const Pad& pad) override;
     muse::Ret putNote(const muse::PointF& pos, bool replace, bool insert) override;
     void removeNote(const muse::PointF& pos) override;
-    muse::async::Notification noteInputStarted() const override;
+    muse::async::Channel</*focusNotation*/ bool> noteInputStarted() const override;
     muse::async::Notification noteInputEnded() const override;
 
     void addTuplet(const TupletOptions& options) override;
@@ -95,7 +95,7 @@ private:
     void updateInputState();
     void notifyAboutStateChanged();
     void notifyNoteAddedChanged();
-    void notifyAboutNoteInputStarted();
+    void notifyAboutNoteInputStarted(bool focusNotation = true);
     void notifyAboutNoteInputEnded();
 
     std::set<SymbolId> articulationIds() const;
@@ -106,7 +106,7 @@ private:
 
     muse::async::Notification m_stateChanged;
     muse::async::Notification m_noteAdded;
-    muse::async::Notification m_noteInputStarted;
+    muse::async::Channel</*focusNotation*/ bool> m_noteInputStarted;
     muse::async::Notification m_noteInputEnded;
 
     ScoreCallbacks* m_scoreCallbacks = nullptr;

--- a/src/notation/notationmodule.cpp
+++ b/src/notation/notationmodule.cpp
@@ -153,6 +153,7 @@ void NotationModule::resolveImports()
         ir->registerQmlUri(Uri("musescore://notation/parts"), "MuseScore/NotationScene/PartsDialog.qml");
         ir->registerQmlUri(Uri("musescore://notation/selectmeasurescount"), "MuseScore/NotationScene/SelectMeasuresCountDialog.qml");
         ir->registerQmlUri(Uri("musescore://notation/editgridsize"), "MuseScore/NotationScene/EditGridSizeDialog.qml");
+        ir->registerQmlUri(Uri("musescore://notation/percussionpanelpadswap"), "MuseScore/NotationScene/PercussionPanelPadSwapDialog.qml");
     }
 }
 

--- a/src/notation/notationscene.qrc
+++ b/src/notation/notationscene.qrc
@@ -65,5 +65,6 @@
         <file>qml/MuseScore/NotationScene/internal/EditStyle/StyleControlRowWithReset.qml</file>
         <file>qml/MuseScore/NotationScene/internal/EditStyle/TextFieldWithReset.qml</file>
         <file>qml/MuseScore/NotationScene/internal/EditStyle/IconAndTextButtonSelector.qml</file>
+        <file>qml/MuseScore/NotationScene/PercussionPanelPadSwapDialog.qml</file>
     </qresource>
 </RCC>

--- a/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
+++ b/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
@@ -411,7 +411,7 @@ Item {
                 enabled: !padGrid.isKeyboardSwapActive
 
                 icon: IconCode.PLUS
-                text: qsTrc("notation", "Add row")
+                text: qsTrc("notation/percussion", "Add row")
                 orientation: Qt.Horizontal
 
                 navigation.panel: addRowButtonPanel
@@ -433,7 +433,7 @@ Item {
             anchors.topMargin: (padGrid.cellHeight / 2) - (panelDisabledLabel.height / 2)
 
             font: ui.theme.bodyFont
-            text: qsTrc("notation", "Select an unpitched percussion staff to see available sounds")
+            text: qsTrc("notation/percussion", "Select an unpitched percussion staff to see available sounds")
         }
     }
 

--- a/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
+++ b/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
@@ -195,6 +195,18 @@ Item {
                     // This variable ensures we stay within a given pad when tabbing back-and-forth between
                     // "main" and "footer" controls
                     property var currentPadNavigationIndex: [0, 0]
+                    function onNavigationEvent(event) {
+                        var navigationRow = gridPrv.currentPadNavigationIndex[0]
+                        var navigationColumn = gridPrv.currentPadNavigationIndex[1]
+
+                        if (navigationRow >= padGrid.numRows || navigationColumn >= padGrid.numColumns) {
+                            gridPrv.currentPadNavigationIndex = [0, 0]
+                        }
+
+                        if (event.type === NavigationEvent.AboutActive) {
+                            event.setData("controlIndex", gridPrv.currentPadNavigationIndex)
+                        }
+                    }
                 }
 
                 Layout.alignment: Qt.AlignTop
@@ -217,9 +229,7 @@ Item {
                     order: toolbar.navigationOrderEnd + 1
 
                     onNavigationEvent: function(event) {
-                        if (event.type === NavigationEvent.AboutActive) {
-                            event.setData("controlIndex", gridPrv.currentPadNavigationIndex)
-                        }
+                        gridPrv.onNavigationEvent(event)
                     }
                 }
 
@@ -233,9 +243,7 @@ Item {
                     enabled: percModel.currentPanelMode !== PanelMode.EDIT_LAYOUT
 
                     onNavigationEvent: function(event) {
-                        if (event.type === NavigationEvent.AboutActive) {
-                            event.setData("controlIndex", gridPrv.currentPadNavigationIndex)
-                        }
+                        gridPrv.onNavigationEvent(event)
                     }
                 }
 
@@ -275,6 +283,7 @@ Item {
                             padGrid.swapOriginPad = pad
                             padGrid.isKeyboardSwapActive = isKeyboardSwap
                             padGrid.model.startPadSwap(index)
+                            pad.padNavigation.requestActive()
                         }
 
                         onEndPadSwapRequested: {
@@ -294,6 +303,17 @@ Item {
                                 return;
                             }
                             gridPrv.currentPadNavigationIndex = [pad.navigationRow, pad.navigationColumn]
+                        }
+
+                        Connections {
+                            target: padGrid.model
+
+                            function onPadFocusRequested(padIndex) {
+                                if (index !== padIndex) {
+                                    return
+                                }
+                                pad.padNavigation.requestActive()
+                            }
                         }
                     }
 

--- a/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
+++ b/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
@@ -86,10 +86,42 @@ Item {
         panelWidth: root.width
     }
 
+    StyledIconLabel {
+        id: soundTitleIcon
+
+        anchors.verticalCenter: soundTitleLabel.verticalCenter
+        anchors.right: soundTitleLabel.left
+
+        anchors.rightMargin: 6
+
+        visible: percModel.enabled && !percModel.soundTitle.isEmpty
+
+        color: ui.theme.fontPrimaryColor
+
+        iconCode: IconCode.AUDIO
+    }
+
+    StyledTextLabel {
+        id: soundTitleLabel
+
+        anchors {
+            top: toolbar.bottom
+            right: parent.right
+
+            topMargin: 8
+            bottomMargin: 8
+            rightMargin: 16
+        }
+
+        visible: percModel.enabled && !percModel.soundTitle.isEmpty
+
+        text: percModel.soundTitle
+    }
+
     StyledFlickable {
         id: flickable
 
-        anchors.top: toolbar.bottom
+        anchors.top: soundTitleLabel.bottom
         anchors.bottom: parent.bottom
         anchors.horizontalCenter: parent.horizontalCenter
 

--- a/src/notation/qml/MuseScore/NotationScene/PercussionPanelPadSwapDialog.qml
+++ b/src/notation/qml/MuseScore/NotationScene/PercussionPanelPadSwapDialog.qml
@@ -114,7 +114,7 @@ StyledDialogView {
                 horizontalAlignment: Text.AlignLeft
                 wrapMode: Text.Wrap
 
-                text: qsTrc("notation", "Do you also want to move the MIDI notes and keyboard shortcuts that trigger these sounds?")
+                text: qsTrc("notation/percussion", "Do you also want to move the MIDI notes and keyboard shortcuts that trigger these sounds?")
             }
 
             RadioButtonGroup {
@@ -126,8 +126,8 @@ StyledDialogView {
                 orientation: ListView.Vertical
 
                 model: [
-                    { text: qsTrc("notation", "Move MIDI notes and keyboard shortcuts with their sounds"), value: true },
-                    { text: qsTrc("notation", "Leave MIDI notes and keyboard shortcuts fixed to original pad positions"), value: false }
+                    { text: qsTrc("notation/percussion", "Move MIDI notes and keyboard shortcuts with their sounds"), value: true },
+                    { text: qsTrc("notation/percussion", "Leave MIDI notes and keyboard shortcuts fixed to original pad positions"), value: false }
                 ]
 
                 delegate: Row {

--- a/src/notation/qml/MuseScore/NotationScene/PercussionPanelPadSwapDialog.qml
+++ b/src/notation/qml/MuseScore/NotationScene/PercussionPanelPadSwapDialog.qml
@@ -27,6 +27,8 @@ import Muse.UiComponents 1.0
 StyledDialogView {
     id: root
 
+    property bool moveMidiNotesAndShortcuts: true
+
     contentWidth: 500
     contentHeight: contentRow.implicitHeight + contentColumn.spacing + buttonBox.implicitHeight
 
@@ -55,11 +57,6 @@ StyledDialogView {
 
     onAccessibilityActivateRequested: {
         accessibleInfo.readInfo()
-    }
-
-    QtObject {
-        id: prv
-        property bool moveMidiNotesAndShortcuts: true
     }
 
     AccessibleItem {
@@ -146,11 +143,11 @@ StyledDialogView {
                         navigation.panel: contentNavigationPanel
                         navigation.row: model.index
 
-                        checked: modelData.value === prv.moveMidiNotesAndShortcuts
+                        checked: modelData.value === root.moveMidiNotesAndShortcuts
 
                         onToggled: {
                             // TODO: Live update the pads when this value is changed...
-                            prv.moveMidiNotesAndShortcuts = modelData.value
+                            root.moveMidiNotesAndShortcuts = modelData.value
                         }
                     }
 
@@ -171,7 +168,7 @@ StyledDialogView {
 
                             onClicked: {
                                 // TODO: Live update the pads when this value is changed...
-                                prv.moveMidiNotesAndShortcuts = modelData.value
+                                root.moveMidiNotesAndShortcuts = modelData.value
                             }
                         }
                     }
@@ -230,7 +227,7 @@ StyledDialogView {
                 return
             }
 
-            root.done({ moveMidiNotesAndShortcuts: prv.moveMidiNotesAndShortcuts, rememberMyChoice: rememberMyChoice.checked })
+            root.done({ moveMidiNotesAndShortcuts: root.moveMidiNotesAndShortcuts, rememberMyChoice: rememberMyChoice.checked })
         }
     }
 }

--- a/src/notation/qml/MuseScore/NotationScene/PercussionPanelPadSwapDialog.qml
+++ b/src/notation/qml/MuseScore/NotationScene/PercussionPanelPadSwapDialog.qml
@@ -1,0 +1,236 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2024 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import QtQuick 2.15
+
+import Muse.Ui 1.0
+import Muse.UiComponents 1.0
+
+StyledDialogView {
+    id: root
+
+    contentWidth: 500
+    contentHeight: contentRow.implicitHeight + contentColumn.spacing + buttonBox.implicitHeight
+
+    margins: 16
+
+    //! NOTE: Actually making this empty will display "MuseScore Studio"
+    title: " "
+
+    function done(data = {}) {
+        let value = Object.assign(data)
+
+        root.ret = {
+            errcode: 0,
+            value: value
+        }
+
+        root.hide()
+    }
+
+    onNavigationActivateRequested: {
+        var btn = buttonBox.firstFocusBtn
+        if (btn) {
+            btn.navigation.requestActive()
+        }
+    }
+
+    onAccessibilityActivateRequested: {
+        accessibleInfo.readInfo()
+    }
+
+    QtObject {
+        id: prv
+        property bool moveMidiNotesAndShortcuts: true
+    }
+
+    AccessibleItem {
+        id: accessibleInfo
+
+        accessibleParent: radioButtons.accessible
+        visualItem: titleLabel
+        role: MUAccessible.StaticText
+        name: titleLabel.text
+
+        function readInfo() {
+            accessibleInfo.ignored = false
+            accessibleInfo.focused = true
+        }
+
+        function resetFocus() {
+            accessibleInfo.ignored = true
+            accessibleInfo.focused = false
+        }
+    }
+
+    NavigationPanel {
+        id: contentNavigationPanel
+
+        name: "contentNavigationPanel"
+        section: root.navigationSection
+        order: 0
+    }
+
+    Row {
+        id: contentRow
+
+        width: parent.width
+        spacing: 28
+
+        StyledIconLabel {
+            id: icon
+
+            font.pixelSize: 48
+            iconCode: IconCode.QUESTION
+        }
+
+        Column {
+            id: contentColumn
+
+            width: contentRow.width - contentRow.spacing - icon.width
+            spacing: 16
+
+            StyledTextLabel {
+                id: titleLabel
+
+                width: parent.width
+
+                font: ui.theme.largeBodyBoldFont
+                horizontalAlignment: Text.AlignLeft
+                wrapMode: Text.Wrap
+
+                text: qsTrc("notation", "Do you also want to move the MIDI notes and keyboard shortcuts that trigger these sounds?")
+            }
+
+            RadioButtonGroup {
+                id: radioButtons
+
+                width: parent.width
+                spacing: contentColumn.spacing
+
+                orientation: ListView.Vertical
+
+                model: [
+                    { text: qsTrc("notation", "Move MIDI notes and keyboard shortcuts with their sounds"), value: true },
+                    { text: qsTrc("notation", "Leave MIDI notes and keyboard shortcuts fixed to original pad positions"), value: false }
+                ]
+
+                delegate: Row {
+                    width: parent.width
+                    spacing: 6
+
+                    RoundedRadioButton {
+                        id: radioButton
+
+                        anchors.verticalCenter: parent.verticalCenter
+
+                        navigation.name: modelData.text
+                        navigation.panel: contentNavigationPanel
+                        navigation.row: model.index
+
+                        checked: modelData.value === prv.moveMidiNotesAndShortcuts
+
+                        onToggled: {
+                            // TODO: Live update the pads when this value is changed...
+                            prv.moveMidiNotesAndShortcuts = modelData.value
+                        }
+                    }
+
+                    //! NOTE: Can't use radioButton.text because it won't wrap
+                    StyledTextLabel {
+                        width: parent.width - parent.spacing - radioButton.width
+
+                        anchors.verticalCenter: parent.verticalCenter
+
+                        horizontalAlignment: Text.AlignLeft
+                        wrapMode: Text.Wrap
+                        text: modelData.text
+
+                        MouseArea {
+                            id: mouseArea
+
+                            anchors.fill: parent
+
+                            onClicked: {
+                                // TODO: Live update the pads when this value is changed...
+                                prv.moveMidiNotesAndShortcuts = modelData.value
+                            }
+                        }
+                    }
+                }
+            }
+
+            CheckBox {
+                id: rememberMyChoice
+
+                width: parent.width
+
+                navigation.panel: contentNavigationPanel
+                navigation.row: radioButtons.model.length
+                navigation.accessible.name: rememberMyChoice.text
+
+                text: qsTrc("global", "Remember my choice")
+                checked: false
+                onClicked: {
+                    rememberMyChoice.checked = !rememberMyChoice.checked
+                }
+            }
+
+
+            StyledTextLabel {
+                id: preferenceInfo
+
+                width: parent.width
+
+                horizontalAlignment: Text.AlignLeft
+                wrapMode: Text.Wrap
+
+                text: qsTrc("global", "This setting can be changed at any time in Preferences")
+            }
+        }
+    }
+
+    ButtonBox {
+        id: buttonBox
+
+        anchors {
+            top: contentRow.bottom
+            topMargin: contentColumn.spacing
+            right: parent.right
+        }
+
+        navigationPanel.section: root.navigationSection
+        navigationPanel.order: contentNavigationPanel.order + 1
+
+        buttons: [ ButtonBoxModel.Cancel, ButtonBoxModel.Done ]
+
+        isAccessibilityDisabledWhenInit: true
+
+        onStandardButtonClicked: function(buttonId) {
+            if (buttonId === ButtonBoxModel.Cancel) {
+                root.reject()
+                return
+            }
+
+            root.done({ moveMidiNotesAndShortcuts: prv.moveMidiNotesAndShortcuts, rememberMyChoice: rememberMyChoice.checked })
+        }
+    }
+}

--- a/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPad.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPad.qml
@@ -88,7 +88,7 @@ DropArea {
         enabled: Boolean(root.padModel) || root.panelMode === PanelMode.EDIT_LAYOUT
 
         accessible.role: MUAccessible.Button
-        accessible.name: Boolean(root.padModel) ? root.padModel.instrumentName : qsTrc("notation", "Empty pad")
+        accessible.name: Boolean(root.padModel) ? root.padModel.padName : qsTrc("notation", "Empty pad")
 
         accessible.description: prv.accessibleDescription
 
@@ -115,7 +115,7 @@ DropArea {
         enabled: Boolean(root.padModel)
 
         accessible.role: MUAccessible.Button
-        accessible.name: Boolean(root.padModel) ? root.padModel.instrumentName + " " + qsTrc("notation", "footer") : ""
+        accessible.name: Boolean(root.padModel) ? root.padModel.padName + " " + qsTrc("notation", "footer") : ""
 
         accessible.description: prv.accessibleDescription
 

--- a/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPad.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPad.qml
@@ -67,10 +67,10 @@ DropArea {
         readonly property real footerHeight: 24
         readonly property string accessibleDescription: {
             //: %1 will be the row number of a percussion panel pad
-            let line1 = qsTrc("notation", "Row: %1").arg(root.navigationRow + 1)
+            let line1 = qsTrc("notation/percussion", "Row: %1").arg(root.navigationRow + 1)
 
             //: %1 will be the column number of a percussion panel pad
-            let line2 = qsTrc("notation", "Column: %1").arg(root.navigationColumn + 1)
+            let line2 = qsTrc("notation/percussion", "Column: %1").arg(root.navigationColumn + 1)
 
             return line1 + ", " + line2
         }
@@ -88,7 +88,7 @@ DropArea {
         enabled: Boolean(root.padModel) || root.panelMode === PanelMode.EDIT_LAYOUT
 
         accessible.role: MUAccessible.Button
-        accessible.name: Boolean(root.padModel) ? root.padModel.padName : qsTrc("notation", "Empty pad")
+        accessible.name: Boolean(root.padModel) ? root.padModel.padName : qsTrc("notation/percussion", "Empty pad")
 
         accessible.description: prv.accessibleDescription
 
@@ -115,7 +115,7 @@ DropArea {
         enabled: Boolean(root.padModel)
 
         accessible.role: MUAccessible.Button
-        accessible.name: Boolean(root.padModel) ? root.padModel.padName + " " + qsTrc("notation", "footer") : ""
+        accessible.name: Boolean(root.padModel) ? root.padModel.padName + " " + qsTrc("notation/percussion", "footer") : ""
 
         accessible.description: prv.accessibleDescription
 

--- a/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPadContent.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPadContent.qml
@@ -66,7 +66,7 @@ Column {
                 }
 
                 if (mouseArea.containsMouse && root.useNotationPreview) {
-                    ui.tooltip.show(root, root.padModel.instrumentName)
+                    ui.tooltip.show(root, root.padModel.padName)
                 } else {
                     ui.tooltip.hide(root)
                 }
@@ -74,7 +74,7 @@ Column {
         }
 
         Rectangle {
-            id: instrumentNameBackground
+            id: padNameBackground
 
             visible: !root.useNotationPreview
             anchors.fill: parent
@@ -83,7 +83,7 @@ Column {
         }
 
         StyledTextLabel {
-            id: instrumentNameLabel
+            id: padNameLabel
 
             visible: !root.useNotationPreview
 
@@ -94,7 +94,7 @@ Column {
             maximumLineCount: 4
             font: ui.theme.bodyBoldFont
 
-            text: Boolean(root.padModel) ? root.padModel.instrumentName : ""
+            text: Boolean(root.padModel) ? root.padModel.padName : ""
         }
 
         PaintedEngravingItem {
@@ -115,7 +115,7 @@ Column {
                 name: "MOUSE_HOVERED"
                 when: mouseArea.containsMouse && !mouseArea.pressed && !root.padSwapActive
                 PropertyChanges {
-                    target: instrumentNameBackground
+                    target: padNameBackground
                     color: Utils.colorWithAlpha(ui.theme.accentColor, ui.theme.buttonOpacityHover)
                 }
                 PropertyChanges {
@@ -127,7 +127,7 @@ Column {
                 name: "MOUSE_HIT"
                 when: mouseArea.pressed || root.padSwapActive
                 PropertyChanges {
-                    target: instrumentNameBackground
+                    target: padNameBackground
                     color: Utils.colorWithAlpha(ui.theme.accentColor, ui.theme.buttonOpacityHit)
                 }
                 PropertyChanges {

--- a/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelToolBar.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelToolBar.qml
@@ -70,7 +70,7 @@ Item {
             enabled: root.model.enabled
 
             icon: IconCode.EDIT
-            text: qsTrc("notation", "Write")
+            text: qsTrc("notation/percussion", "Write")
             orientation: Qt.Horizontal
             accentButton: root.model.currentPanelMode === PanelMode.WRITE
             backgroundRadius: 0
@@ -137,7 +137,7 @@ Item {
             enabled: root.model.enabled
 
             icon: IconCode.PLAY
-            text: qsTrc("notation", "Preview")
+            text: qsTrc("notation/percussion", "Preview")
             orientation: Qt.Horizontal
             accentButton: root.model.currentPanelMode === PanelMode.SOUND_PREVIEW
             backgroundRadius: 0
@@ -198,7 +198,7 @@ Item {
         enabled: root.model.enabled
 
         visible: root.model.currentPanelMode === PanelMode.EDIT_LAYOUT
-        text: qsTrc("notation", "Finish editing")
+        text: qsTrc("notation/percussion", "Finish editing")
         orientation: Qt.Horizontal
         accentButton: true
 
@@ -230,7 +230,7 @@ Item {
             enabled: root.model.enabled
 
             icon: IconCode.SPLIT_VIEW_HORIZONTAL
-            text: qsTrc("notation", "Layout")
+            text: qsTrc("notation/percussion", "Layout")
             orientation: Qt.Horizontal
 
             navigation.panel: rightSideNavPanel
@@ -251,7 +251,7 @@ Item {
 
         FlatButton {
             enabled: root.model.enabled && root.model.currentPanelMode !== PanelMode.EDIT_LAYOUT
-            text: qsTrc("notation", "Customize kit")
+            text: qsTrc("notation/percussion", "Customize kit")
             orientation: Qt.Horizontal
 
             navigation.panel: rightSideNavPanel

--- a/src/notation/qml/MuseScore/NotationScene/qmldir
+++ b/src/notation/qml/MuseScore/NotationScene/qmldir
@@ -13,3 +13,4 @@ SelectionFilterPanel 1.0 SelectionFilterPanel.qml
 UndoHistoryPanel 1.0 UndoHistoryPanel.qml
 PianoKeyboardPanel 1.0 PianoKeyboardPanel.qml
 PercussionPanel 1.0 PercussionPanel.qml
+PercussionPanelPadSwapDialog 1.0 PercussionPanelPadSwapDialog.qml

--- a/src/notation/tests/mocks/notationconfigurationmock.h
+++ b/src/notation/tests/mocks/notationconfigurationmock.h
@@ -185,9 +185,19 @@ public:
 
     MOCK_METHOD(bool, useNewPercussionPanel, (), (const, override));
     MOCK_METHOD(void, setUseNewPercussionPanel, (bool), (override));
+    MOCK_METHOD(muse::async::Notification, useNewPercussionPanelChanged, (), (const, override));
 
     MOCK_METHOD(bool, autoShowPercussionPanel, (), (const, override));
     MOCK_METHOD(void, setAutoShowPercussionPanel, (bool), (override));
+    MOCK_METHOD(muse::async::Notification, autoShowPercussionPanelChanged, (), (const, override));
+
+    MOCK_METHOD(bool, showPercussionPanelPadSwapDialog, (), (const, override));
+    MOCK_METHOD(void, setShowPercussionPanelPadSwapDialog, (bool), (override));
+    MOCK_METHOD(muse::async::Notification, showPercussionPanelPadSwapDialogChanged, (), (const, override));
+
+    MOCK_METHOD(bool, percussionPanelMoveMidiNotesAndShortcuts, (), (const, override));
+    MOCK_METHOD(void, setPercussionPanelMoveMidiNotesAndShortcuts, (bool), (override));
+    MOCK_METHOD(muse::async::Notification, percussionPanelMoveMidiNotesAndShortcutsChanged, (), (const, override));
 
     MOCK_METHOD(muse::io::path_t, styleFileImportPath, (), (const, override));
     MOCK_METHOD(void, setStyleFileImportPath, (const muse::io::path_t&), (override));

--- a/src/notation/view/abstractnotationpaintview.cpp
+++ b/src/notation/view/abstractnotationpaintview.cpp
@@ -248,8 +248,18 @@ void AbstractNotationPaintView::onLoadNotation(INotationPtr)
     });
 
     onNoteInputStateChanged();
+    if (isNoteEnterMode()) {
+        emit activeFocusRequested();
+    }
+
     interaction->noteInput()->stateChanged().onNotify(this, [this]() {
         onNoteInputStateChanged();
+    });
+
+    interaction->noteInput()->noteInputStarted().onReceive(this, [this](bool focusNotation) {
+        if (focusNotation) {
+            emit activeFocusRequested();
+        }
     });
 
     interaction->selectionChanged().onNotify(this, [this]() {
@@ -457,12 +467,7 @@ void AbstractNotationPaintView::onNoteInputStateChanged()
 {
     TRACEFUNC;
 
-    bool noteEnterMode = isNoteEnterMode();
-    setAcceptHoverEvents(noteEnterMode);
-
-    if (noteEnterMode) {
-        emit activeFocusRequested();
-    }
+    setAcceptHoverEvents(isNoteEnterMode());
 
     if (INotationInteractionPtr interaction = notationInteraction()) {
         interaction->hideShadowNote();

--- a/src/notation/view/percussionpanel/percussionpanelmodel.cpp
+++ b/src/notation/view/percussionpanel/percussionpanelmodel.cpp
@@ -292,7 +292,7 @@ void PercussionPanelModel::writePitch(int pitch)
 
     undoStack->prepareChanges(muse::TranslatableString("undoableAction", "Enter percussion note"));
 
-    interaction()->noteInput()->startNoteInput();
+    interaction()->noteInput()->startNoteInput(/*focusNotation*/ false);
 
     score()->addMidiPitch(pitch, false, /*transpose*/ false);
     undoStack->commitChanges();

--- a/src/notation/view/percussionpanel/percussionpanelmodel.cpp
+++ b/src/notation/view/percussionpanel/percussionpanelmodel.cpp
@@ -204,6 +204,7 @@ void PercussionPanelModel::finishEditing(bool discardChanges)
     if (inst->drumset() && updatedDrumset
         && *inst->drumset() == *updatedDrumset) {
         setCurrentPanelMode(m_panelModeToRestore);
+        m_padListModel->focusLastActivePad();
         return;
     }
 
@@ -214,6 +215,7 @@ void PercussionPanelModel::finishEditing(bool discardChanges)
     undoStack->commitChanges();
 
     setCurrentPanelMode(m_panelModeToRestore);
+    m_padListModel->focusLastActivePad();
 }
 
 void PercussionPanelModel::customizeKit()

--- a/src/notation/view/percussionpanel/percussionpanelmodel.cpp
+++ b/src/notation/view/percussionpanel/percussionpanelmodel.cpp
@@ -210,11 +210,17 @@ void PercussionPanelModel::finishEditing(bool discardChanges)
         if (!model) {
             continue;
         }
+
         const int row = i / m_padListModel->numColumns();
         const int column = i % m_padListModel->numColumns();
+
         engraving::DrumInstrument& drum = updatedDrumset->drum(model->pitch());
+
         drum.panelRow = row;
         drum.panelColumn = column;
+
+        const QString& shortcut = model->keyboardShortcut();
+        drum.shortcut = shortcut.isEmpty() ? '\0' : shortcut.toLatin1().at(0);
     }
 
     // Return if nothing changed after edit...
@@ -319,7 +325,8 @@ void PercussionPanelModel::updateSoundTitle(const InstrumentTrackId& trackId)
 bool PercussionPanelModel::eventFilter(QObject* watched, QEvent* event)
 {
     // Finish editing on escape...
-    if (m_currentPanelMode != PanelMode::Mode::EDIT_LAYOUT || event->type() != QEvent::Type::ShortcutOverride) {
+    if (m_currentPanelMode != PanelMode::Mode::EDIT_LAYOUT || event->type() != QEvent::Type::ShortcutOverride
+        || m_padListModel->swapInProgress()) {
         return QObject::eventFilter(watched, event);
     }
     QKeyEvent* keyEvent = dynamic_cast<QKeyEvent*>(event);

--- a/src/notation/view/percussionpanel/percussionpanelmodel.cpp
+++ b/src/notation/view/percussionpanel/percussionpanelmodel.cpp
@@ -27,7 +27,7 @@
 #include "engraving/dom/factory.h"
 #include "engraving/dom/undo.h"
 
-static const QString INSTRUMENT_NAMES_CODE("percussion-instrument-names");
+static const QString PAD_NAMES_CODE("percussion-pad-names");
 static const QString NOTATION_PREVIEW_CODE("percussion-notation-preview");
 static const QString EDIT_LAYOUT_CODE("percussion-edit-layout");
 static const QString RESET_LAYOUT_CODE("percussion-reset-layout");
@@ -108,9 +108,9 @@ void PercussionPanelModel::init()
 
 QList<QVariantMap> PercussionPanelModel::layoutMenuItems() const
 {
-    const TranslatableString instrumentNamesTitle("notation", "Instrument names");
+    const TranslatableString padNamesTitle("notation", "Pad names");
     // Using IconCode for this instead of "checked" because we want the tick to display on the left
-    const int instrumentNamesIcon = static_cast<int>(m_useNotationPreview ? IconCode::Code::NONE : IconCode::Code::TICK_RIGHT_ANGLE);
+    const int padNamesIcon = static_cast<int>(m_useNotationPreview ? IconCode::Code::NONE : IconCode::Code::TICK_RIGHT_ANGLE);
 
     const TranslatableString notationPreviewTitle("notation", "Notation preview");
     // Using IconCode for this instead of "checked" because we want the tick to display on the left
@@ -125,8 +125,8 @@ QList<QVariantMap> PercussionPanelModel::layoutMenuItems() const
     const int resetLayoutIcon = static_cast<int>(IconCode::Code::UNDO);
 
     QList<QVariantMap> menuItems = {
-        { { "id", INSTRUMENT_NAMES_CODE },
-            { "title", instrumentNamesTitle.qTranslated() }, { "icon", instrumentNamesIcon }, { "enabled", true } },
+        { { "id", PAD_NAMES_CODE },
+            { "title", padNamesTitle.qTranslated() }, { "icon", padNamesIcon }, { "enabled", true } },
 
         { { "id", NOTATION_PREVIEW_CODE },
             { "title", notationPreviewTitle.qTranslated() }, { "icon", notationPreviewIcon }, { "enabled", true } },
@@ -145,7 +145,7 @@ QList<QVariantMap> PercussionPanelModel::layoutMenuItems() const
 
 void PercussionPanelModel::handleMenuItem(const QString& itemId)
 {
-    if (itemId == INSTRUMENT_NAMES_CODE) {
+    if (itemId == PAD_NAMES_CODE) {
         setUseNotationPreview(false);
     } else if (itemId == NOTATION_PREVIEW_CODE) {
         setUseNotationPreview(true);

--- a/src/notation/view/percussionpanel/percussionpanelmodel.cpp
+++ b/src/notation/view/percussionpanel/percussionpanelmodel.cpp
@@ -125,20 +125,20 @@ void PercussionPanelModel::init()
 
 QList<QVariantMap> PercussionPanelModel::layoutMenuItems() const
 {
-    const TranslatableString padNamesTitle("notation", "Pad names");
+    const TranslatableString padNamesTitle("notation/percussion", "Pad names");
     // Using IconCode for this instead of "checked" because we want the tick to display on the left
     const int padNamesIcon = static_cast<int>(m_useNotationPreview ? IconCode::Code::NONE : IconCode::Code::TICK_RIGHT_ANGLE);
 
-    const TranslatableString notationPreviewTitle("notation", "Notation preview");
+    const TranslatableString notationPreviewTitle("notation/percussion", "Notation preview");
     // Using IconCode for this instead of "checked" because we want the tick to display on the left
     const int notationPreviewIcon = static_cast<int>(m_useNotationPreview ? IconCode::Code::TICK_RIGHT_ANGLE : IconCode::Code::NONE);
 
     const TranslatableString editLayoutTitle = m_currentPanelMode == PanelMode::Mode::EDIT_LAYOUT
-                                               ? TranslatableString("notation", "Finish editing")
-                                               : TranslatableString("notation", "Edit layout");
+                                               ? TranslatableString("notation/percussion", "Finish editing")
+                                               : TranslatableString("notation/percussion", "Edit layout");
     const int editLayoutIcon = static_cast<int>(IconCode::Code::CONFIGURE);
 
-    const TranslatableString resetLayoutTitle("notation", "Reset layout");
+    const TranslatableString resetLayoutTitle("notation/percussion", "Reset layout");
     const int resetLayoutIcon = static_cast<int>(IconCode::Code::UNDO);
 
     QList<QVariantMap> menuItems = {

--- a/src/notation/view/percussionpanel/percussionpanelmodel.cpp
+++ b/src/notation/view/percussionpanel/percussionpanelmodel.cpp
@@ -40,6 +40,7 @@ PercussionPanelModel::PercussionPanelModel(QObject* parent)
     : QObject(parent)
 {
     m_padListModel = new PercussionPanelPadListModel(this);
+    qApp->installEventFilter(this);
 }
 
 bool PercussionPanelModel::enabled() const
@@ -263,6 +264,21 @@ void PercussionPanelModel::setUpConnections()
         case PanelMode::Mode::SOUND_PREVIEW: playPitch(pitch);
         }
     });
+}
+
+bool PercussionPanelModel::eventFilter(QObject* watched, QEvent* event)
+{
+    // Finish editing on escape...
+    if (m_currentPanelMode != PanelMode::Mode::EDIT_LAYOUT || event->type() != QEvent::Type::ShortcutOverride) {
+        return QObject::eventFilter(watched, event);
+    }
+    QKeyEvent* keyEvent = dynamic_cast<QKeyEvent*>(event);
+    if (!keyEvent || keyEvent->key() != Qt::Key_Escape) {
+        return QObject::eventFilter(watched, event);
+    }
+    finishEditing();
+    event->setAccepted(true);
+    return true;
 }
 
 void PercussionPanelModel::writePitch(int pitch)

--- a/src/notation/view/percussionpanel/percussionpanelmodel.h
+++ b/src/notation/view/percussionpanel/percussionpanelmodel.h
@@ -59,6 +59,8 @@ class PercussionPanelModel : public QObject, public muse::Injectable, public mus
 
     Q_PROPERTY(bool enabled READ enabled NOTIFY enabledChanged)
 
+    Q_PROPERTY(QString soundTitle READ soundTitle NOTIFY soundTitleChanged)
+
     Q_PROPERTY(PanelMode::Mode currentPanelMode READ currentPanelMode WRITE setCurrentPanelMode NOTIFY currentPanelModeChanged)
     Q_PROPERTY(bool useNotationPreview READ useNotationPreview WRITE setUseNotationPreview NOTIFY useNotationPreviewChanged)
 
@@ -71,6 +73,9 @@ public:
 
     bool enabled() const;
     void setEnabled(bool enabled);
+
+    QString soundTitle() const;
+    void setSoundTitle(const QString& soundTitle);
 
     PanelMode::Mode currentPanelMode() const;
     void setCurrentPanelMode(const PanelMode::Mode& panelMode);
@@ -94,6 +99,8 @@ public:
 signals:
     void enabledChanged();
 
+    void soundTitleChanged();
+
     void currentPanelModeChanged(const PanelMode::Mode& panelMode);
     void useNotationPreviewChanged(bool useNotationPreview);
 
@@ -102,6 +109,8 @@ signals:
 private:
     void setUpConnections();
 
+    void updateSoundTitle(const InstrumentTrackId& trackId);
+
     bool eventFilter(QObject* watched, QEvent* event) override;
 
     void writePitch(int pitch);
@@ -109,12 +118,17 @@ private:
 
     void resetLayout();
 
+    mu::engraving::InstrumentTrackId currentTrackId() const;
+
+    const project::IProjectAudioSettingsPtr audioSettings() const;
     const mu::notation::INotationPtr notation() const;
     const mu::notation::INotationInteractionPtr interaction() const;
 
     mu::engraving::Score* score() const;
 
     bool m_enabled = false;
+
+    QString m_soundTitle;
 
     PanelMode::Mode m_currentPanelMode = PanelMode::Mode::WRITE;
     PanelMode::Mode m_panelModeToRestore = PanelMode::Mode::WRITE;

--- a/src/notation/view/percussionpanel/percussionpanelmodel.h
+++ b/src/notation/view/percussionpanel/percussionpanelmodel.h
@@ -102,6 +102,8 @@ signals:
 private:
     void setUpConnections();
 
+    bool eventFilter(QObject* watched, QEvent* event) override;
+
     void writePitch(int pitch);
     void playPitch(int pitch);
 

--- a/src/notation/view/percussionpanel/percussionpanelpadlistmodel.cpp
+++ b/src/notation/view/percussionpanel/percussionpanelpadlistmodel.cpp
@@ -75,6 +75,9 @@ void PercussionPanelPadListModel::addEmptyRow()
     }
     emit layoutChanged();
     emit numPadsChanged();
+
+    const int indexToFocus = numPads() - NUM_COLUMNS;
+    emit padFocusRequested(indexToFocus);
 }
 
 void PercussionPanelPadListModel::deleteRow(int row)
@@ -119,6 +122,7 @@ void PercussionPanelPadListModel::endPadSwap(int endIndex)
         emit layoutChanged();
     }
     m_padSwapStartIndex = -1;
+    emit padFocusRequested(endIndex);
 }
 
 void PercussionPanelPadListModel::setDrumset(const engraving::Drumset* drumset)
@@ -180,6 +184,16 @@ mu::engraving::Drumset PercussionPanelPadListModel::constructDefaultLayout(const
     }
 
     return defaultLayout;
+}
+
+void PercussionPanelPadListModel::focusLastActivePad()
+{
+    for (int i = m_padModels.size() - 1; i >= 0; --i) {
+        if (m_padModels.at(i)) {
+            emit padFocusRequested(i);
+            return;
+        }
+    }
 }
 
 void PercussionPanelPadListModel::load()

--- a/src/notation/view/percussionpanel/percussionpanelpadlistmodel.cpp
+++ b/src/notation/view/percussionpanel/percussionpanelpadlistmodel.cpp
@@ -271,7 +271,7 @@ PercussionPanelPadModel* PercussionPanelPadListModel::createPadModelForPitch(int
     }
 
     PercussionPanelPadModel* model = new PercussionPanelPadModel(this);
-    model->setInstrumentName(m_drumset->name(pitch));
+    model->setPadName(m_drumset->name(pitch));
 
     const QString shortcut = m_drumset->shortcut(pitch) ? QChar(m_drumset->shortcut(pitch)) : QString("-");
     model->setKeyboardShortcut(shortcut);

--- a/src/notation/view/percussionpanel/percussionpanelpadlistmodel.h
+++ b/src/notation/view/percussionpanel/percussionpanelpadlistmodel.h
@@ -71,12 +71,15 @@ public:
 
     mu::engraving::Drumset constructDefaultLayout(const engraving::Drumset* templateDrumset) const;
 
+    void focusLastActivePad();
+
     muse::async::Notification hasActivePadsChanged() const { return m_hasActivePadsChanged; }
     muse::async::Channel<int /*pitch*/> padTriggered() const { return m_triggeredChannel; }
 
 signals:
     void numPadsChanged();
     void rowIsEmptyChanged(int row, bool empty);
+    void padFocusRequested(int padIndex); //! NOTE: This won't work if it is called immediately before a layoutChange
 
 private:
     static constexpr int NUM_COLUMNS = 8;

--- a/src/notation/view/percussionpanel/percussionpanelpadlistmodel.h
+++ b/src/notation/view/percussionpanel/percussionpanelpadlistmodel.h
@@ -105,7 +105,8 @@ private:
 
     void movePad(int fromIndex, int toIndex);
 
-    void applyPadSwapOptions(int fromIndex, int toIndex);
+    muse::RetVal<muse::Val> openPadSwapDialog();
+    void swapMidiNotesAndShortcuts(int fromIndex, int toIndex);
 
     int numEmptySlotsAtRow(int row) const;
 

--- a/src/notation/view/percussionpanel/percussionpanelpadlistmodel.h
+++ b/src/notation/view/percussionpanel/percussionpanelpadlistmodel.h
@@ -24,16 +24,23 @@
 
 #include <QAbstractListModel>
 
+#include "modularity/ioc.h"
 #include "async/asyncable.h"
 #include "async/channel.h"
+
+#include "iinteractive.h"
+#include "inotationconfiguration.h"
 
 #include "engraving/dom/drumset.h"
 
 #include "percussionpanelpadmodel.h"
 
 namespace mu::notation {
-class PercussionPanelPadListModel : public QAbstractListModel, public muse::async::Asyncable
+class PercussionPanelPadListModel : public QAbstractListModel, public muse::Injectable, public muse::async::Asyncable
 {
+    muse::Inject<muse::IInteractive> interactive = { this };
+    muse::Inject<INotationConfiguration> configuration = { this };
+
     Q_OBJECT
 
     Q_PROPERTY(int numColumns READ numColumns CONSTANT)
@@ -58,6 +65,7 @@ public:
 
     Q_INVOKABLE void startPadSwap(int startIndex);
     Q_INVOKABLE void endPadSwap(int endIndex);
+    bool swapInProgress() const { return indexIsValid(m_padSwapStartIndex); }
 
     bool hasActivePads() const { return m_drumset; }
 
@@ -96,6 +104,8 @@ private:
     int createModelIndexForPitch(int pitch) const;
 
     void movePad(int fromIndex, int toIndex);
+
+    void applyPadSwapOptions(int fromIndex, int toIndex);
 
     int numEmptySlotsAtRow(int row) const;
 

--- a/src/notation/view/percussionpanel/percussionpanelpadmodel.cpp
+++ b/src/notation/view/percussionpanel/percussionpanelpadmodel.cpp
@@ -29,14 +29,14 @@ PercussionPanelPadModel::PercussionPanelPadModel(QObject* parent)
 {
 }
 
-void PercussionPanelPadModel::setInstrumentName(const QString& instrumentName)
+void PercussionPanelPadModel::setPadName(const QString& padName)
 {
-    if (m_instrumentName == instrumentName) {
+    if (m_padName == padName) {
         return;
     }
 
-    m_instrumentName = instrumentName;
-    emit instrumentNameChanged();
+    m_padName = padName;
+    emit padNameChanged();
 }
 
 void PercussionPanelPadModel::setKeyboardShortcut(const QString& keyboardShortcut)

--- a/src/notation/view/percussionpanel/percussionpanelpadmodel.h
+++ b/src/notation/view/percussionpanel/percussionpanelpadmodel.h
@@ -36,7 +36,7 @@ class PercussionPanelPadModel : public QObject, public muse::async::Asyncable
 {
     Q_OBJECT
 
-    Q_PROPERTY(QString instrumentName READ instrumentName NOTIFY instrumentNameChanged)
+    Q_PROPERTY(QString padName READ padName NOTIFY padNameChanged)
 
     Q_PROPERTY(QString keyboardShortcut READ keyboardShortcut NOTIFY keyboardShortcutChanged)
     Q_PROPERTY(QString midiNote READ midiNote NOTIFY midiNoteChanged)
@@ -46,8 +46,8 @@ class PercussionPanelPadModel : public QObject, public muse::async::Asyncable
 public:
     explicit PercussionPanelPadModel(QObject* parent = nullptr);
 
-    QString instrumentName() const { return m_instrumentName; }
-    void setInstrumentName(const QString& instrumentName);
+    QString padName() const { return m_padName; }
+    void setPadName(const QString& padName);
 
     QString keyboardShortcut() const { return m_keyboardShortcut; }
     void setKeyboardShortcut(const QString& keyboardShortcut);
@@ -66,7 +66,7 @@ public:
     muse::async::Notification padTriggered() const { return m_triggeredNotification; }
 
 signals:
-    void instrumentNameChanged();
+    void padNameChanged();
 
     void keyboardShortcutChanged();
     void midiNoteChanged();
@@ -74,7 +74,7 @@ signals:
     void notationPreviewItemChanged();
 
 private:
-    QString m_instrumentName;
+    QString m_padName;
 
     QString m_keyboardShortcut;
     int m_pitch = -1;

--- a/src/project/internal/projectaudiosettings.h
+++ b/src/project/internal/projectaudiosettings.h
@@ -48,6 +48,7 @@ public:
     const muse::audio::AudioInputParams& trackInputParams(const engraving::InstrumentTrackId& partId) const override;
     void setTrackInputParams(const engraving::InstrumentTrackId& partId, const muse::audio::AudioInputParams& params) override;
     void clearTrackInputParams() override;
+    muse::async::Channel<engraving::InstrumentTrackId> trackInputParamsChanged() const override;
 
     bool trackHasExistingOutputParams(const engraving::InstrumentTrackId& partId) const override;
     const muse::audio::AudioOutputParams& trackOutputParams(const engraving::InstrumentTrackId& partId) const override;
@@ -115,6 +116,7 @@ private:
     std::unordered_map<engraving::InstrumentTrackId, muse::audio::AudioOutputParams> m_trackOutputParamsMap;
 
     muse::async::Notification m_settingsChanged;
+    muse::async::Channel<engraving::InstrumentTrackId> m_trackInputParamsChanged;
 
     mu::playback::SoundProfileName m_activeSoundProfileName;
 };

--- a/src/project/iprojectaudiosettings.h
+++ b/src/project/iprojectaudiosettings.h
@@ -49,6 +49,7 @@ public:
     virtual const muse::audio::AudioInputParams& trackInputParams(const engraving::InstrumentTrackId& trackId) const = 0;
     virtual void setTrackInputParams(const engraving::InstrumentTrackId& trackId, const muse::audio::AudioInputParams& params) = 0;
     virtual void clearTrackInputParams() = 0;
+    virtual muse::async::Channel<engraving::InstrumentTrackId> trackInputParamsChanged() const = 0;
 
     virtual bool trackHasExistingOutputParams(const engraving::InstrumentTrackId& trackId) const = 0;
     virtual const muse::audio::AudioOutputParams& trackOutputParams(const engraving::InstrumentTrackId& trackId) const = 0;

--- a/src/project/qml/MuseScore/Project/AlsoShareAudioComDialog.qml
+++ b/src/project/qml/MuseScore/Project/AlsoShareAudioComDialog.qml
@@ -142,7 +142,7 @@ StyledDialogView {
             Layout.fillWidth: true
             horizontalAlignment: Text.AlignLeft
 
-            text: qsTrc("project/cloud", "You can change this setting in Preferences at any time.")
+            text: qsTrc("global", "You can change this setting in Preferences at any time.")
             font: ui.theme.bodyFont
         }
 
@@ -162,7 +162,7 @@ StyledDialogView {
                 navigation.row: 1
                 navigation.accessible.name: text + "; " + preferenceInfo.text
 
-                text: qsTrc("project/cloud", "Remember my choice")
+                text: qsTrc("global", "Remember my choice")
 
                 checked: root.rememberChoice
 

--- a/src/stubs/notation/notationconfigurationstub.cpp
+++ b/src/stubs/notation/notationconfigurationstub.cpp
@@ -477,11 +477,17 @@ void NotationConfigurationStub::setMidiUseWrittenPitch(bool)
 
 bool NotationConfigurationStub::useNewPercussionPanel() const
 {
-    return false
+    return false;
 }
 
 void NotationConfigurationStub::setUseNewPercussionPanel(bool)
 {
+}
+
+muse::async::Notification NotationConfigurationStub::useNewPercussionPanelChanged() const
+{
+    static muse::async::Notification n;
+    return n;
 }
 
 bool NotationConfigurationStub::autoShowPercussionPanel() const
@@ -491,6 +497,42 @@ bool NotationConfigurationStub::autoShowPercussionPanel() const
 
 void NotationConfigurationStub::setAutoShowPercussionPanel(bool)
 {
+}
+
+muse::async::Notification NotationConfigurationStub::autoShowPercussionPanelChanged() const
+{
+    static muse::async::Notification n;
+    return n;
+}
+
+bool NotationConfigurationStub::showPercussionPanelPadSwapDialog() const
+{
+    return true;
+}
+
+void NotationConfigurationStub::setShowPercussionPanelPadSwapDialog(bool)
+{
+}
+
+muse::async::Notification NotationConfigurationStub::showPercussionPanelPadSwapDialogChanged() const
+{
+    static muse::async::Notification n;
+    return n;
+}
+
+bool NotationConfigurationStub::percussionPanelMoveMidiNotesAndShortcuts() const
+{
+    return true;
+}
+
+void NotationConfigurationStub::setPercussionPanelMoveMidiNotesAndShortcuts(bool)
+{
+}
+
+muse::async::Notification NotationConfigurationStub::percussionPanelMoveMidiNotesAndShortcutsChanged() const
+{
+    static muse::async::Notification n;
+    return n;
 }
 
 muse::io::path_t NotationConfigurationStub::styleFileImportPath() const

--- a/src/stubs/notation/notationconfigurationstub.h
+++ b/src/stubs/notation/notationconfigurationstub.h
@@ -176,9 +176,19 @@ public:
 
     bool useNewPercussionPanel() const override;
     void setUseNewPercussionPanel(bool use) override;
+    muse::async::Notification useNewPercussionPanelChanged() const override;
 
     bool autoShowPercussionPanel() const override;
     void setAutoShowPercussionPanel(bool autoShow) override;
+    muse::async::Notification autoShowPercussionPanelChanged() const override;
+
+    bool showPercussionPanelPadSwapDialog() const override;
+    void setShowPercussionPanelPadSwapDialog(bool show);
+    muse::async::Notification showPercussionPanelPadSwapDialogChanged() const override;
+
+    bool percussionPanelMoveMidiNotesAndShortcuts() const override;
+    void setPercussionPanelMoveMidiNotesAndShortcuts(bool move);
+    muse::async::Notification percussionPanelMoveMidiNotesAndShortcutsChanged() const override;
 
     muse::io::path_t styleFileImportPath() const override;
     void setStyleFileImportPath(const muse::io::path_t& path)  override;


### PR DESCRIPTION
This round of refinements:

1. Pressing escape while the percussion panel is in edit mode will finish editing and keep the changes (60d9b722813d28d355aa8a30fccb9e9edf2a90e9)
2. Keyboard navigation fixes (mainly ea82362c0e31aed4d6744ea6d0e9cbf6c08b94e0)
2.1. The last active pad is focused when finishing editing
2.2. Focus remains on the "destination pad" after a pad swap
2.3. When adding a row, focus moves to the first pad in the new row
2.4. Entering notes via write mode no longer switches focus to the notation (ab11c42780d46bed20500f79b6a255c090861d3a & 3dd2de230d985ed1041148df75cf995fd3e229b1)
3. Implemented a "sound title label" detailing the currently selected sound in the mixer (749759866ecd412f304bc2d6ed52b7dfd84c3c21)
4. Small copy change from "Instrument names" to "Pad names" (36cc850adc4cf2c59e8bb64ab47a429a01ae2a1c)
5. Implemented the "pad swap dialog" and associated preferences (71e9a3045fb1c6e53029023bfa9868d9867b7944, 2545c9de37d0db05fe85123e5e0998025e5c9e54, 7c43a4821d8427418da43640898e14a683f1f745)
6. Added `notation/percussion` translation context (a7283615ea1a5260a8ab94d077489f4f6e46bb66)