### PR TITLE
Fix #23977: Export to MusicXml wavy line starts in second voices

### DIFF
--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -4572,11 +4572,31 @@ ChordRest* Score::findCR(Fraction tick, track_idx_t track) const
 }
 
 //---------------------------------------------------------
-//   findCRinStaff
+//   findChordRestEndingBeforeTickInStaff
 //    find last chord/rest on staff that ends before tick
 //---------------------------------------------------------
 
 ChordRest* Score::findChordRestEndingBeforeTickInStaff(const Fraction& tick, staff_idx_t staffIdx) const
+{
+    return findChordRestEndingBeforeTickInStaffAndVoice(tick, staffIdx, false, 0);
+}
+
+//-----------------------------------------------------------------
+//   findChordRestEndingBeforeTickInStaffAndVoice
+//    find last chord/rest on staff and voice that ends before tick
+//-----------------------------------------------------------------
+ChordRest* Score::findChordRestEndingBeforeTickInStaffAndVoice(const Fraction& tick, staff_idx_t staffIdx, voice_idx_t voice) const
+{
+    return findChordRestEndingBeforeTickInStaffAndVoice(tick, staffIdx, true, voice);
+}
+
+//-----------------------------------------------------------------
+//   findChordRestEndingBeforeTickInStaffAndVoice
+//    find last chord/rest on staff and voice that ends before tick
+//    allow no specific voice
+//-----------------------------------------------------------------
+ChordRest* Score::findChordRestEndingBeforeTickInStaffAndVoice(const Fraction& tick, staff_idx_t staffIdx, bool forceVoice,
+                                                               voice_idx_t voice) const
 {
     Fraction ptick = tick - Fraction::fromTicks(1);
     Measure* m = tick2measureMM(ptick);
@@ -4589,9 +4609,9 @@ ChordRest* Score::findChordRestEndingBeforeTickInStaff(const Fraction& tick, sta
         ptick = m->tick();
     }
 
-    Segment* s      = m->first(SegmentType::ChordRest);
-    track_idx_t strack      = staffIdx * VOICES;
-    track_idx_t etrack      = strack + VOICES;
+    Segment* s = m->first(SegmentType::ChordRest);
+    track_idx_t strack = forceVoice ? staffIdx * VOICES + voice : staffIdx * VOICES;
+    track_idx_t etrack = forceVoice ? strack + 1 : strack + VOICES;
     track_idx_t actualTrack = strack;
 
     Fraction lastTick = Fraction(-1, 1);
@@ -4602,7 +4622,7 @@ ChordRest* Score::findChordRestEndingBeforeTickInStaff(const Fraction& tick, sta
         // found a segment; now find longest cr on this staff that does not overlap tick
         for (track_idx_t t = strack; t < etrack; ++t) {
             ChordRest* cr = toChordRest(ns->element(t));
-            if (cr) {
+            if ((cr) && ((!forceVoice) || voice == cr->voice())) {
                 Fraction endTick = cr->tick() + cr->actualTicks();
                 if (endTick >= lastTick && endTick <= tick) {
                     s = ns;

--- a/src/engraving/dom/score.h
+++ b/src/engraving/dom/score.h
@@ -925,6 +925,7 @@ public:
 
     ChordRest* findCR(Fraction tick, track_idx_t track) const;
     ChordRest* findChordRestEndingBeforeTickInStaff(const Fraction& tick, staff_idx_t staffIdx) const;
+    ChordRest* findChordRestEndingBeforeTickInStaffAndVoice(const Fraction& tick, staff_idx_t staffIdx, voice_idx_t voice) const;
     ChordRest* findChordRestEndingBeforeTickInTrack(const Fraction& tick, track_idx_t trackIdx) const;
     void insertTime(const Fraction& tickPos, const Fraction& tickLen);
 
@@ -1055,6 +1056,8 @@ private:
     Note* getSelectedNote();
     ChordRest* nextTrack(ChordRest* cr, bool skipMeasureRepeatRests = true);
     ChordRest* prevTrack(ChordRest* cr, bool skipMeasureRepeatRests = true);
+    ChordRest* findChordRestEndingBeforeTickInStaffAndVoice(const Fraction& tick, staff_idx_t staffIdx, bool forceVoice,
+                                                            voice_idx_t voice) const;
 
     void addTempo();
     void addMetronome();

--- a/src/engraving/dom/trill.cpp
+++ b/src/engraving/dom/trill.cpp
@@ -452,6 +452,6 @@ String Trill::accessibleInfo() const
 
 void Trill::doComputeEndElement()
 {
-    setEndElement(score()->findChordRestEndingBeforeTickInStaff(tick2(), track2staff(track2())));
+    setEndElement(score()->findChordRestEndingBeforeTickInStaffAndVoice(tick2(), track2staff(track2()), voice()));
 }
 }

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -8504,15 +8504,18 @@ static void addWavyLine(ChordRest* cr, const Fraction& tick,
     if (!wavyLineType.empty()) {
         const Fraction ticks = cr->ticks();
         const track_idx_t track = cr->track();
-        const track_idx_t trk = (track / VOICES) * VOICES;           // first track of staff
         Trill*& trill = trills[wavyLineNo];
         if (wavyLineType == u"start" || wavyLineType == u"startstop") {
             if (trill) {
                 logger->logError(String(u"overlapping wavy-line number %1").arg(wavyLineNo + 1), xmlreader);
             } else {
                 trill = Factory::createTrill(cr->score()->dummy());
-                trill->setTrack(trk);
-                trill->setTrack2(trk);
+                trill->setTrack(track);
+                trill->setTrack2(track);
+
+                trill->setOrnament(Factory::createOrnament(cr));
+                trill->ornament()->setAnchor(ArticulationAnchor::AUTO);
+
                 if (wavyLineType == u"start") {
                     spanners[trill] = std::pair<int, int>(tick.ticks(), -1);
                     // LOGD("trill=%p inserted at first tick %d", trill, tick);


### PR DESCRIPTION
Resolves: #23977<!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->
Resolves: https://github.com/musescore/MuseScore/issues/25871

<!-- Add a short description of and motivation for the changes here -->
This PR changes the export and import procedure to MusicXML for Trills
- Export procedure takes into account the voice Trill is attached to
- Import procedure imports the Trills' voice 

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
