### PR TITLE
Range selection enhancements

### DIFF
--- a/src/engraving/dom/chordrest.cpp
+++ b/src/engraving/dom/chordrest.cpp
@@ -813,24 +813,11 @@ Segment* ChordRest::nextSegmentAfterCR(SegmentType types) const
 {
     Fraction end = tick() + actualTicks();
     for (Segment* s = segment()->next1MM(types); s; s = s->next1MM(types)) {
-        // chordrest ends at afrac+actualFraction
-        // we return the segment at or after the end of the chordrest
-        // Segment::afrac() is based on ticks; use DurationElement::afrac() if possible
-        EngravingItem* e = s;
-        if (s->isChordRestType()) {
-            // Find the first non-NULL element in the segment
-            for (EngravingItem* ee : s->elist()) {
-                if (ee) {
-                    e = ee;
-                    break;
-                }
-            }
-        }
-        if (e->tick() >= end) {
+        if (s->tick() >= end) {
             return s;
         }
     }
-    return 0;
+    return nullptr;
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -3560,7 +3560,10 @@ static Segment* findElementEndSegment(Score* score, EngravingItem* e, Segment* d
 
     if (Segment* ancestor = toSegment(e->findAncestor(ElementType::SEGMENT))) {
         if (ancestor->isType(Segment::CHORD_REST_OR_TIME_TICK_TYPE)) {
-            return ancestor;
+            // https://github.com/musescore/MuseScore/pull/25821#issuecomment-2617369881
+            if (Segment* next = ancestor->nextCR(e->track(), true)) {
+                return next;
+            }
         }
     }
 

--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -3525,7 +3525,7 @@ void Score::selectAdd(EngravingItem* e)
 static Segment* findElementStartSegment(Score* score, EngravingItem* e)
 {
     if (Segment* ancestor = toSegment(e->findAncestor(ElementType::SEGMENT))) {
-        if (ancestor->isChordRestType()) {
+        if (ancestor->isType(Segment::CHORD_REST_OR_TIME_TICK_TYPE)) {
             return ancestor;
         }
     }
@@ -3556,6 +3556,16 @@ static Segment* findElementEndSegment(Score* score, EngravingItem* e, Segment* d
     if (e->isSpanner() || e->isSpannerSegment()) {
         Spanner* sp = e->isSpanner() ? toSpanner(e) : toSpannerSegment(e)->spanner();
         return score->tick2segmentMM(sp->tick2(), true, Segment::CHORD_REST_OR_TIME_TICK_TYPE);
+    }
+
+    if (Segment* ancestor = toSegment(e->findAncestor(ElementType::SEGMENT))) {
+        if (ancestor->isType(Segment::CHORD_REST_OR_TIME_TICK_TYPE)) {
+            return ancestor;
+        }
+    }
+
+    if (Segment* seg = score->tick2segmentMM(e->tick(), true, Segment::CHORD_REST_OR_TIME_TICK_TYPE)) {
+        return seg;
     }
 
     return def;

--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -3578,17 +3578,14 @@ void Score::selectRange(EngravingItem* e, staff_idx_t staffIdx)
             return;
         }
     } else if (e->isNote() || e->isChordRest()) {
-        if (e->isNote()) {
-            e = e->parentItem();
-        }
-        ChordRest* cr = toChordRest(e);
+        ChordRest* cr = e->isNote() ? toChordRest(e->parentItem()) : toChordRest(e);
 
         if (m_selection.isNone() || (m_selection.isList() && !m_selection.isSingle())) {
             if (m_selection.isList()) {
                 deselectAll();
             }
             SegmentType st = SegmentType::ChordRest | SegmentType::EndBarLine | SegmentType::Clef;
-            m_selection.setRange(cr->segment(), cr->nextSegmentAfterCR(st), e->staffIdx(), e->staffIdx() + 1);
+            m_selection.setRange(cr->segment(), cr->nextSegmentAfterCR(st), cr->staffIdx(), cr->staffIdx() + 1);
             activeTrack = cr->track();
         } else if (m_selection.isSingle()) {
             EngravingItem* oe = m_selection.element();
@@ -3606,8 +3603,10 @@ void Score::selectRange(EngravingItem* e, staff_idx_t staffIdx)
                 m_selection.setRange(ocr->segment(), endSeg, oe->staffIdx(), oe->staffIdx() + 1);
                 m_selection.extendRangeSelection(cr);
             } else {
-                doSelect(e, SelectType::SINGLE, 0);
-                return;
+                deselectAll();
+                SegmentType st = SegmentType::ChordRest | SegmentType::EndBarLine | SegmentType::Clef;
+                m_selection.setRange(cr->segment(), cr->nextSegmentAfterCR(st), cr->staffIdx(), cr->staffIdx() + 1);
+                activeTrack = cr->track();
             }
         } else if (m_selection.isRange()) {
             m_selection.extendRangeSelection(cr);

--- a/src/engraving/dom/score.h
+++ b/src/engraving/dom/score.h
@@ -1089,6 +1089,9 @@ private:
     void selectAdd(EngravingItem* e);
     void selectRange(EngravingItem* e, staff_idx_t staffIdx);
 
+    bool trySelectSimilarInRange(EngravingItem* e);
+    bool tryExtendSingleSelectionToRange(EngravingItem* e, staff_idx_t staffIdx);
+
     muse::Ret putNote(const Position&, bool replace);
     void handleOverlappingChordRest(InputState& inputState);
 

--- a/src/notation/internal/inotationselectionrange.h
+++ b/src/notation/internal/inotationselectionrange.h
@@ -51,7 +51,7 @@ public:
 
     virtual std::vector<muse::RectF> boundingArea() const = 0;
     virtual bool containsPoint(const muse::PointF& point) const = 0;
-    virtual bool containsItem(const engraving::EngravingItem* item) const = 0;
+    virtual bool containsItem(const EngravingItem* item, engraving::staff_idx_t staffIdx = muse::nidx) const = 0;
 };
 
 using INotationSelectionRangePtr = std::shared_ptr<INotationSelectionRange>;

--- a/src/notation/internal/notationselectionrange.cpp
+++ b/src/notation/internal/notationselectionrange.cpp
@@ -88,18 +88,23 @@ bool NotationSelectionRange::containsPoint(const PointF& point) const
     return false;
 }
 
-bool NotationSelectionRange::containsItem(const EngravingItem* item) const
+/// When `item` is a Measure, use `staffIdx` to query whether a specific staff is contained in the selection.
+bool NotationSelectionRange::containsItem(const EngravingItem* item, engraving::staff_idx_t staffIdx) const
 {
     Fraction itemTick = item->tick();
     Fraction selectionStartTick = startTick();
     Fraction selectionEndTick = endTick();
 
-    if (item->isMeasure()) {
-        return itemTick >= selectionStartTick && itemTick < selectionEndTick;
-    }
-
     if (itemTick < selectionStartTick || itemTick >= selectionEndTick) {
         return false;
+    }
+
+    if (item->isMeasure()) {
+        if (staffIdx != muse::nidx) {
+            return startStaffIndex() <= staffIdx && staffIdx < endStaffIndex();
+        }
+
+        return true;
     }
 
     track_idx_t itemTrack = item->track();

--- a/src/notation/internal/notationselectionrange.cpp
+++ b/src/notation/internal/notationselectionrange.cpp
@@ -98,12 +98,8 @@ bool NotationSelectionRange::containsItem(const EngravingItem* item) const
         return itemTick >= selectionStartTick && itemTick < selectionEndTick;
     }
 
-    if (itemTick < selectionStartTick || itemTick > selectionEndTick) {
+    if (itemTick < selectionStartTick || itemTick >= selectionEndTick) {
         return false;
-    }
-
-    if (itemTick == selectionEndTick) {
-        return item->rtick() > Fraction(0, 1);
     }
 
     track_idx_t itemTrack = item->track();

--- a/src/notation/internal/notationselectionrange.h
+++ b/src/notation/internal/notationselectionrange.h
@@ -50,7 +50,7 @@ public:
 
     std::vector<muse::RectF> boundingArea() const override;
     bool containsPoint(const muse::PointF& point) const override;
-    bool containsItem(const EngravingItem* item) const override;
+    bool containsItem(const EngravingItem* item, engraving::staff_idx_t staffIdx = muse::nidx) const override;
 
 private:
     mu::engraving::Score* score() const;

--- a/src/notation/tests/mocks/notationselectionrangemock.h
+++ b/src/notation/tests/mocks/notationselectionrangemock.h
@@ -44,7 +44,7 @@ public:
 
     MOCK_METHOD(std::vector<muse::RectF>, boundingArea, (), (const, override));
     MOCK_METHOD(bool, containsPoint, (const muse::PointF&), (const, override));
-    MOCK_METHOD(bool, containsItem, (const engraving::EngravingItem*), (const, override));
+    MOCK_METHOD(bool, containsItem, (const engraving::EngravingItem*, engraving::staff_idx_t), (const, override));
 };
 }
 

--- a/src/notation/tests/notationviewinputcontroller_tests.cpp
+++ b/src/notation/tests/notationviewinputcontroller_tests.cpp
@@ -732,9 +732,11 @@ TEST_F(NotationViewInputControllerTests, Mouse_Press_On_Range_Context_Menu)
     EXPECT_CALL(*m_selection, isRange())
     .WillRepeatedly(Return(true));
 
-    //! [THEN] New element is in selected range
+    //! [THEN] New element is initially not in selected range,
+    //!        but is in selected range after performing selection
     EXPECT_CALL(*m_selectionRange, containsItem(contextMenuOnMeasureContext.element))
-    .WillRepeatedly(Return(true));
+    .WillOnce(Return(false))
+    .WillOnce(Return(true));
 
     std::vector<const EngravingItem*> playElements = { selectMeasureContext.element };
     EXPECT_CALL(*m_playbackController, playElements(playElements))
@@ -824,9 +826,13 @@ TEST_F(NotationViewInputControllerTests, Mouse_Press_On_Range_Context_Menu_New_S
     .WillOnce(ReturnRef(selectElements))
     .WillOnce(ReturnRef(contextMenuSelectElements));
 
-    //! [THEN] New element isn't in selected range
+    //! [THEN] Old element is not in selected range at the moment that it is selected
+    EXPECT_CALL(*m_selectionRange, containsItem(selectMeasureContext.element))
+    .WillOnce(Return(false));
+
+    //! [THEN] New element is not in selected range at the moment that it is selected
     EXPECT_CALL(*m_selectionRange, containsItem(contextMenuOnMeasureContext.element))
-    .WillRepeatedly(Return(false));
+    .WillOnce(Return(false));
 
     EXPECT_CALL(*m_playbackController, playElements(_))
     .Times(0);

--- a/src/notation/tests/notationviewinputcontroller_tests.cpp
+++ b/src/notation/tests/notationviewinputcontroller_tests.cpp
@@ -734,7 +734,7 @@ TEST_F(NotationViewInputControllerTests, Mouse_Press_On_Range_Context_Menu)
 
     //! [THEN] New element is initially not in selected range,
     //!        but is in selected range after performing selection
-    EXPECT_CALL(*m_selectionRange, containsItem(contextMenuOnMeasureContext.element))
+    EXPECT_CALL(*m_selectionRange, containsItem(contextMenuOnMeasureContext.element, _))
     .WillOnce(Return(false))
     .WillOnce(Return(true));
 
@@ -827,11 +827,11 @@ TEST_F(NotationViewInputControllerTests, Mouse_Press_On_Range_Context_Menu_New_S
     .WillOnce(ReturnRef(contextMenuSelectElements));
 
     //! [THEN] Old element is not in selected range at the moment that it is selected
-    EXPECT_CALL(*m_selectionRange, containsItem(selectMeasureContext.element))
+    EXPECT_CALL(*m_selectionRange, containsItem(selectMeasureContext.element, _))
     .WillOnce(Return(false));
 
     //! [THEN] New element is not in selected range at the moment that it is selected
-    EXPECT_CALL(*m_selectionRange, containsItem(contextMenuOnMeasureContext.element))
+    EXPECT_CALL(*m_selectionRange, containsItem(contextMenuOnMeasureContext.element, _))
     .WillOnce(Return(false));
 
     EXPECT_CALL(*m_playbackController, playElements(_))

--- a/src/notation/utilities/scorerangeutilities.cpp
+++ b/src/notation/utilities/scorerangeutilities.cpp
@@ -73,7 +73,7 @@ std::vector<muse::RectF> ScoreRangeUtilities::boundingArea(const Score* score,
         }
 
         double x1 = section.startSegment->pagePos().x();
-        const double x2 = section.endSegment->pageBoundingRect().topRight().x();
+        const double x2 = section.endSegment->pageBoundingRect().right();
         const int padding = 0.5 * scoreFirstStaff->spatium(startSegment->tick());
         const double y1 = topY + segmentFirstStaff->y() + section.startSegment->pagePos().y() - padding;
         const double y2 = bottomY + segmentLastStaff->y() + section.endSegment->pagePos().y() + padding;
@@ -98,7 +98,7 @@ std::vector<ScoreRangeUtilities::RangeSection> ScoreRangeUtilities::splitRangeBy
     const Segment* startSegment = rangeStartSegment;
     const Fraction rangeEndTick = rangeEndSegment->tick();
 
-    for (const Segment* segment = startSegment; segment && segment != rangeEndSegment && segment->tick() <= rangeEndTick;) {
+    for (const Segment* segment = startSegment; segment && segment != rangeEndSegment && segment->tick() < rangeEndTick;) {
         const System* currentSegmentSystem = segment->measure()->system();
 
         const Segment* nextSegment = segment->next1MMenabled();
@@ -123,7 +123,7 @@ std::vector<ScoreRangeUtilities::RangeSection> ScoreRangeUtilities::splitRangeBy
             }
         }
 
-        if (nextSegmentSystem != currentSegmentSystem || nextSegment == rangeEndSegment) {
+        if (nextSegmentSystem != currentSegmentSystem || nextSegment->tick() >= rangeEndTick) {
             RangeSection section;
             section.system = currentSegmentSystem;
             section.startSegment = startSegment;

--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -744,6 +744,8 @@ bool NotationViewInputController::needSelect(const ClickContext& ctx) const
 
     if (ctx.event->button() == Qt::LeftButton && ctx.event->modifiers() & Qt::ControlModifier) {
         return true;
+    } else if (ctx.event->button() == Qt::LeftButton && ctx.event->modifiers() & Qt::ShiftModifier) {
+        return !selection->isRange() || !selection->range()->containsItem(ctx.hitElement);
     } else if (ctx.event->button() == Qt::RightButton && selection->isRange()) {
         return !selection->range()->containsItem(ctx.hitElement);
     } else if (!ctx.hitElement->selected()) {

--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -665,6 +665,7 @@ void NotationViewInputController::mousePressEvent(QMouseEvent* event)
     ClickContext ctx;
     ctx.logicClickPos = logicPos;
     ctx.hitElement = hitElement;
+    ctx.hitStaff = hitStaffIndex;
     ctx.isHitGrip = viewInteraction()->isHitGrip(logicPos);
     ctx.event = event;
 
@@ -745,9 +746,9 @@ bool NotationViewInputController::needSelect(const ClickContext& ctx) const
     if (ctx.event->button() == Qt::LeftButton && ctx.event->modifiers() & Qt::ControlModifier) {
         return true;
     } else if (ctx.event->button() == Qt::LeftButton && ctx.event->modifiers() & Qt::ShiftModifier) {
-        return !selection->isRange() || !selection->range()->containsItem(ctx.hitElement);
+        return !selection->isRange() || !selection->range()->containsItem(ctx.hitElement, ctx.hitStaff);
     } else if (ctx.event->button() == Qt::RightButton && selection->isRange()) {
-        return !selection->range()->containsItem(ctx.hitElement);
+        return !selection->range()->containsItem(ctx.hitElement, ctx.hitStaff);
     } else if (!ctx.hitElement->selected()) {
         return true;
     }

--- a/src/notation/view/notationviewinputcontroller.h
+++ b/src/notation/view/notationviewinputcontroller.h
@@ -173,6 +173,7 @@ private:
         muse::PointF logicClickPos;
         const QMouseEvent* event = nullptr;
         mu::engraving::EngravingItem* hitElement = nullptr;
+        mu::engraving::staff_idx_t hitStaff = muse::nidx;
         bool isHitGrip = false;
     };
 


### PR DESCRIPTION
- **Create range selection when Shift+clicking item while not in range mode yet**

- ~**Allow Shift+selecting the chord/rest immediately after a range selection** (i.e. a bugfix)~ apparently not bug in master

- **Prevent ChordRest being selected when starting new range selection**
    If you first selected any element other than a Note or ChordRest (for example, a Dynamic), and then Shift+clicked a Note, the Note's parent Chord would be selected as a list selection (which is a very unusual state; normally, only Notes or Rests can be selected, and Chord is an internal object only). Now, instead, the clicked Note itself will be selected as a range selection, just like when Shift+clicking a Note/Rest while nothing is selected or while there is a list selection of notes.