### PR TITLE
Allow pasting single element onto range selection

### DIFF
--- a/src/engraving/dom/paste.cpp
+++ b/src/engraving/dom/paste.cpp
@@ -431,11 +431,6 @@ std::vector<EngravingItem*> Score::cmdPaste(const IMimeData* ms, MuseScoreView* 
     std::vector<EngravingItem*> droppedElements;
 
     if (ms->hasFormat(mimeSymbolFormat)) {
-        if (!m_selection.isList()) {
-            LOGE() << "Cannot paste single element onto non-list selection";
-            return {};
-        }
-
         muse::ByteArray data = ms->data(mimeSymbolFormat);
 
         PointF dragOffset;
@@ -452,18 +447,21 @@ std::vector<EngravingItem*> Score::cmdPaste(const IMimeData* ms, MuseScoreView* 
         }
 
         std::vector<EngravingItem*> targetElements;
-        if (m_selection.isList()) {
+        switch (m_selection.state()) {
+        case SelState::NONE:
+            UNREACHABLE;
+            return {};
+        case SelState::LIST:
             targetElements = m_selection.elements();
-        } else if (m_selection.isRange()) {
-            if (!el->systemFlag()) {
-                return {};
-            }
+            break;
+        case SelState::RANGE:
             for (EngravingItem* el : m_selection.elements()) {
                 if (el->isNote() || el->isRest()) {
                     targetElements.push_back(el);
                     break;
                 }
             }
+            break;
         }
 
         if (targetElements.empty()) {

--- a/src/engraving/dom/paste.cpp
+++ b/src/engraving/dom/paste.cpp
@@ -455,12 +455,14 @@ std::vector<EngravingItem*> Score::cmdPaste(const IMimeData* ms, MuseScoreView* 
             targetElements = m_selection.elements();
             break;
         case SelState::RANGE:
-            for (EngravingItem* el : m_selection.elements()) {
-                if (el->isNote() || el->isRest()) {
-                    targetElements.push_back(el);
-                    break;
-                }
-            }
+            // TODO: make this as smart as `NotationInteraction::applyPaletteElement`,
+            // without duplicating logic. (Currently, for range selections, we only
+            // paste onto the "top-left corner".
+            mu::engraving::Segment* firstSegment = m_selection.startSegment();
+            staff_idx_t firstStaffIndex = m_selection.staffStart();
+
+            // The usage of `firstElementForNavigation` is inspired by `NotationInteraction::applyPaletteElement`.
+            targetElements = { firstSegment->firstElementForNavigation(firstStaffIndex) };
             break;
         }
 


### PR DESCRIPTION
Limitation: it will be pasted only once in the top-left corner of the range. To fix this, we'd need to reuse all the complicated logic from `NotationInteraction::applyPaletteElement`; duplicating it is of course no option, so we'd need to extract that somehow to make it reusable. That is currently out of scope.

(@Tantacrul FYI)