### PR TITLE
Use time tick segments when pasting list of elements

### DIFF
--- a/src/engraving/dom/select.cpp
+++ b/src/engraving/dom/select.cpp
@@ -1149,6 +1149,8 @@ muse::ByteArray Selection::symbolListMimeData() const
                                 continue;
         */
         case ElementType::ARTICULATION:
+        case ElementType::ORNAMENT:
+        case ElementType::FERMATA:
             // ignore articulations not attached to chords/rest
             if (e->explicitParent()->isChord()) {
                 Chord* par = toChord(e->explicitParent());

--- a/src/engraving/rw/read410/read410.cpp
+++ b/src/engraving/rw/read410/read410.cpp
@@ -830,237 +830,235 @@ void Read410::pasteSymbols(XmlReader& e, ChordRest* dst)
                 destTick = startTick + Fraction::fromTicks(e.readInt());
             } else if (tag == "segDelta") {
                 segDelta = e.readInt();
-            } else {
-                if (tag == "Harmony" || tag == "FretDiagram") {
-                    //
-                    // Harmony elements (= chord symbols) are positioned respecting
-                    // the original tickOffset: advance to destTick (or near)
-                    // same for FretDiagram elements
-                    //
-                    Segment* harmSegm;
-                    for (harmSegm = startSegm; harmSegm && (harmSegm->tick() < destTick);
-                         harmSegm = harmSegm->nextCR()) {
+            } else if (tag == "Harmony" || tag == "FretDiagram") {
+                //
+                // Harmony elements (= chord symbols) are positioned respecting
+                // the original tickOffset: advance to destTick (or near)
+                // same for FretDiagram elements
+                //
+                Segment* harmSegm;
+                for (harmSegm = startSegm; harmSegm && (harmSegm->tick() < destTick);
+                     harmSegm = harmSegm->nextCR()) {
+                }
+                // if destTick overshot, no dest. segment: create one
+                if (destTick >= lastTick) {
+                    harmSegm = nullptr;
+                } else if (!harmSegm || harmSegm->tick() > destTick) {
+                    Measure* meas     = score->tick2measure(destTick);
+                    harmSegm          = meas ? meas->undoGetSegment(SegmentType::ChordRest, destTick) : nullptr;
+                }
+                if (destTrack >= maxTrack || harmSegm == nullptr) {
+                    LOGD("PasteSymbols: no track or segment for %s", tag.ascii());
+                    e.skipCurrentElement();                       // ignore
+                    continue;
+                }
+                if (tag == "Harmony") {
+                    Harmony* el = Factory::createHarmony(harmSegm);
+                    el->setTrack(trackZeroVoice(destTrack));
+                    TRead::read(el, e, ctx);
+                    el->setTrack(trackZeroVoice(destTrack));
+                    // transpose
+                    Staff* staffDest = score->staff(track2staff(destTrack));
+                    Interval interval = staffDest->transpose(destTick);
+                    if (!ctx.style().styleB(Sid::concertPitch) && !interval.isZero()) {
+                        interval.flip();
+                        int rootTpc = transposeTpc(el->rootTpc(), interval, true);
+                        int baseTpc = transposeTpc(el->baseTpc(), interval, true);
+                        score->undoTransposeHarmony(el, rootTpc, baseTpc);
                     }
-                    // if destTick overshot, no dest. segment: create one
-                    if (destTick >= lastTick) {
-                        harmSegm = nullptr;
-                    } else if (!harmSegm || harmSegm->tick() > destTick) {
-                        Measure* meas     = score->tick2measure(destTick);
-                        harmSegm          = meas ? meas->undoGetSegment(SegmentType::ChordRest, destTick) : nullptr;
-                    }
-                    if (destTrack >= maxTrack || harmSegm == nullptr) {
-                        LOGD("PasteSymbols: no track or segment for %s", tag.ascii());
-                        e.skipCurrentElement();                   // ignore
-                        continue;
-                    }
-                    if (tag == "Harmony") {
-                        Harmony* el = Factory::createHarmony(harmSegm);
-                        el->setTrack(trackZeroVoice(destTrack));
-                        TRead::read(el, e, ctx);
-                        el->setTrack(trackZeroVoice(destTrack));
-                        // transpose
-                        Staff* staffDest = score->staff(track2staff(destTrack));
-                        Interval interval = staffDest->transpose(destTick);
-                        if (!ctx.style().styleB(Sid::concertPitch) && !interval.isZero()) {
-                            interval.flip();
-                            int rootTpc = transposeTpc(el->rootTpc(), interval, true);
-                            int baseTpc = transposeTpc(el->baseTpc(), interval, true);
-                            score->undoTransposeHarmony(el, rootTpc, baseTpc);
-                        }
-                        el->setParent(harmSegm);
-                        score->undoAddElement(el);
-                    } else {
-                        FretDiagram* el = Factory::createFretDiagram(harmSegm);
-                        el->setTrack(trackZeroVoice(destTrack));
-                        TRead::read(el, e, ctx);
-                        el->setTrack(trackZeroVoice(destTrack));
-                        el->setParent(harmSegm);
-                        score->undoAddElement(el);
-                    }
-                } else if (tag == "Dynamic") {
-                    ChordRest* destCR = score->findCR(destTick, destTrack);
-                    if (!destCR) {
-                        e.skipCurrentElement();
-                        continue;
-                    }
-                    Dynamic* d = Factory::createDynamic(destCR->segment());
-                    d->setTrack(destTrack);
-                    TRead::read(d, e, ctx);
-                    d->setTrack(destTrack);
-                    d->setParent(destCR->segment());
-                    score->undoAddElement(d);
-                } else if (tag == "HairPin") {
-                    if (destTrack >= maxTrack) {
-                        LOGD("PasteSymbols: no track for %s", tag.ascii());
-                        e.skipCurrentElement();
-                        continue;
-                    }
-                    Hairpin* h = Factory::createHairpin(score->dummy()->segment());
-                    h->setTrack(destTrack);
-                    TRead::read(h, e, ctx);
-                    h->setTrack(destTrack);
-                    h->setTrack2(destTrack);
-                    h->setTick(destTick);
-                    score->undoAddElement(h);
+                    el->setParent(harmSegm);
+                    score->undoAddElement(el);
                 } else {
-                    //
-                    // All other elements are positioned respecting the distance in chords
-                    //
-                    for (; currSegm && segDelta > 0; segDelta--) {
-                        currSegm = currSegm->nextCR(destTrack);
-                    }
-                    // check the intended dest. track and segment exist
-                    if (destTrack >= maxTrack || currSegm == nullptr) {
-                        LOGD("PasteSymbols: no track or segment for %s", tag.ascii());
-                        e.skipCurrentElement();                   // ignore
-                        continue;
-                    }
-                    // check there is a segment element in the required track
-                    if (currSegm->element(destTrack) == nullptr) {
-                        LOGD("PasteSymbols: no track element for %s", tag.ascii());
-                        e.skipCurrentElement();
-                        continue;
-                    }
-                    ChordRest* cr = toChordRest(currSegm->element(destTrack));
+                    FretDiagram* el = Factory::createFretDiagram(harmSegm);
+                    el->setTrack(trackZeroVoice(destTrack));
+                    TRead::read(el, e, ctx);
+                    el->setTrack(trackZeroVoice(destTrack));
+                    el->setParent(harmSegm);
+                    score->undoAddElement(el);
+                }
+            } else if (tag == "Dynamic") {
+                ChordRest* destCR = score->findCR(destTick, destTrack);
+                if (!destCR) {
+                    e.skipCurrentElement();
+                    continue;
+                }
+                Dynamic* d = Factory::createDynamic(destCR->segment());
+                d->setTrack(destTrack);
+                TRead::read(d, e, ctx);
+                d->setTrack(destTrack);
+                d->setParent(destCR->segment());
+                score->undoAddElement(d);
+            } else if (tag == "HairPin") {
+                if (destTrack >= maxTrack) {
+                    LOGD("PasteSymbols: no track for %s", tag.ascii());
+                    e.skipCurrentElement();
+                    continue;
+                }
+                Hairpin* h = Factory::createHairpin(score->dummy()->segment());
+                h->setTrack(destTrack);
+                TRead::read(h, e, ctx);
+                h->setTrack(destTrack);
+                h->setTrack2(destTrack);
+                h->setTick(destTick);
+                score->undoAddElement(h);
+            } else {
+                //
+                // All other elements are positioned respecting the distance in chords
+                //
+                for (; currSegm && segDelta > 0; segDelta--) {
+                    currSegm = currSegm->nextCR(destTrack);
+                }
+                // check the intended dest. track and segment exist
+                if (destTrack >= maxTrack || currSegm == nullptr) {
+                    LOGD("PasteSymbols: no track or segment for %s", tag.ascii());
+                    e.skipCurrentElement();                       // ignore
+                    continue;
+                }
+                // check there is a segment element in the required track
+                if (currSegm->element(destTrack) == nullptr) {
+                    LOGD("PasteSymbols: no track element for %s", tag.ascii());
+                    e.skipCurrentElement();
+                    continue;
+                }
+                ChordRest* cr = toChordRest(currSegm->element(destTrack));
 
-                    if (tag == "Articulation") {
-                        Articulation* el = Factory::createArticulation(cr);
-                        TRead::read(el, e, ctx);
-                        el->setTrack(destTrack);
-                        el->setParent(cr);
-                        if (!el->isFermata() && cr->isRest()) {
-                            delete el;
-                        } else {
-                            score->undoAddElement(el);
-                        }
-                    } else if (tag == "StaffText" || tag == "PlayTechAnnotation" || tag == "Capo" || tag == "Sticking"
-                               || tag == "HarpPedalDiagram" || tag == "StringTunings") {
-                        EngravingItem* el = Factory::createItemByName(tag, score->dummy());
-                        TRead::readItem(el, e, ctx);
-                        el->setTrack(destTrack);
-                        el->setParent(currSegm);
-                        if (el->isSticking() && cr->isRest()) {
-                            delete el;
-                        } else {
-                            score->undoAddElement(el);
-                        }
-                    } else if (tag == "FiguredBass") {
-                        // FiguredBass always belongs to first staff voice
-                        destTrack = trackZeroVoice(destTrack);
-                        Fraction ticks;
-                        FiguredBass* el = Factory::createFiguredBass(currSegm);
-                        el->setTrack(destTrack);
-                        TRead::read(el, e, ctx);
-                        el->setTrack(destTrack);
-                        // if f.b. is off-note, we have to locate a place before currSegm
-                        // where an on-note f.b. element could (potentially) be
-                        // (while having an off-note f.b. without an on-note one before it
-                        // is un-idiomatic, possible mismatch in rhythmic patterns between
-                        // copy source and paste destination does not allow to be too picky)
-                        if (!el->onNote()) {
-                            FiguredBass* onNoteFB = nullptr;
-                            Segment* prevSegm = currSegm;
-                            bool done1    = false;
-                            while (prevSegm) {
-                                if (done1) {
-                                    break;
-                                }
-                                prevSegm = prevSegm->prev1(SegmentType::ChordRest);
-                                // if there is a ChordRest in the dest. track
-                                // this segment is a (potential) f.b. location
-                                if (prevSegm->element(destTrack) != nullptr) {
+                if (tag == "Articulation") {
+                    Articulation* el = Factory::createArticulation(cr);
+                    TRead::read(el, e, ctx);
+                    el->setTrack(destTrack);
+                    el->setParent(cr);
+                    if (!el->isFermata() && cr->isRest()) {
+                        delete el;
+                    } else {
+                        score->undoAddElement(el);
+                    }
+                } else if (tag == "StaffText" || tag == "PlayTechAnnotation" || tag == "Capo" || tag == "Sticking"
+                           || tag == "HarpPedalDiagram" || tag == "StringTunings") {
+                    EngravingItem* el = Factory::createItemByName(tag, score->dummy());
+                    TRead::readItem(el, e, ctx);
+                    el->setTrack(destTrack);
+                    el->setParent(currSegm);
+                    if (el->isSticking() && cr->isRest()) {
+                        delete el;
+                    } else {
+                        score->undoAddElement(el);
+                    }
+                } else if (tag == "FiguredBass") {
+                    // FiguredBass always belongs to first staff voice
+                    destTrack = trackZeroVoice(destTrack);
+                    Fraction ticks;
+                    FiguredBass* el = Factory::createFiguredBass(currSegm);
+                    el->setTrack(destTrack);
+                    TRead::read(el, e, ctx);
+                    el->setTrack(destTrack);
+                    // if f.b. is off-note, we have to locate a place before currSegm
+                    // where an on-note f.b. element could (potentially) be
+                    // (while having an off-note f.b. without an on-note one before it
+                    // is un-idiomatic, possible mismatch in rhythmic patterns between
+                    // copy source and paste destination does not allow to be too picky)
+                    if (!el->onNote()) {
+                        FiguredBass* onNoteFB = nullptr;
+                        Segment* prevSegm = currSegm;
+                        bool done1    = false;
+                        while (prevSegm) {
+                            if (done1) {
+                                break;
+                            }
+                            prevSegm = prevSegm->prev1(SegmentType::ChordRest);
+                            // if there is a ChordRest in the dest. track
+                            // this segment is a (potential) f.b. location
+                            if (prevSegm->element(destTrack) != nullptr) {
+                                done1 = true;
+                            }
+                            // in any case, look for a f.b. in annotations:
+                            // if there is a f.b. element in the right track,
+                            // this is an (actual) f.b. location
+                            for (EngravingItem* a : prevSegm->annotations()) {
+                                if (a->isFiguredBass() && a->track() == destTrack) {
+                                    onNoteFB = toFiguredBass(a);
                                     done1 = true;
                                 }
-                                // in any case, look for a f.b. in annotations:
-                                // if there is a f.b. element in the right track,
-                                // this is an (actual) f.b. location
-                                for (EngravingItem* a : prevSegm->annotations()) {
-                                    if (a->isFiguredBass() && a->track() == destTrack) {
-                                        onNoteFB = toFiguredBass(a);
-                                        done1 = true;
-                                    }
-                                }
                             }
-                            if (!prevSegm) {
-                                LOGD("PasteSymbols: can't place off-note FiguredBass");
+                        }
+                        if (!prevSegm) {
+                            LOGD("PasteSymbols: can't place off-note FiguredBass");
+                            delete el;
+                            continue;
+                        }
+                        // by default, split on-note duration in half: half on-note and half off-note
+                        Fraction totTicks  = currSegm->tick() - prevSegm->tick();
+                        Fraction destTick1 = prevSegm->tick() + (totTicks * Fraction(1, 2));
+                        ticks         = totTicks * Fraction(1, 2);
+                        if (onNoteFB) {
+                            onNoteFB->setTicks(totTicks * Fraction(1, 2));
+                        }
+                        // look for a segment at this tick; if none, create one
+                        Segment* nextSegm = prevSegm;
+                        while (nextSegm && nextSegm->tick() < destTick1) {
+                            nextSegm = nextSegm->next1(SegmentType::ChordRest);
+                        }
+                        if (!nextSegm || nextSegm->tick() > destTick1) {                        // no ChordRest segm at this tick
+                            nextSegm = Factory::createSegment(prevSegm->measure(), SegmentType::ChordRest, destTick1);
+                            if (!nextSegm) {
+                                LOGD("PasteSymbols: can't find or create destination segment for FiguredBass");
                                 delete el;
                                 continue;
                             }
-                            // by default, split on-note duration in half: half on-note and half off-note
-                            Fraction totTicks  = currSegm->tick() - prevSegm->tick();
-                            Fraction destTick1 = prevSegm->tick() + (totTicks * Fraction(1, 2));
-                            ticks         = totTicks * Fraction(1, 2);
-                            if (onNoteFB) {
-                                onNoteFB->setTicks(totTicks * Fraction(1, 2));
-                            }
-                            // look for a segment at this tick; if none, create one
-                            Segment* nextSegm = prevSegm;
-                            while (nextSegm && nextSegm->tick() < destTick1) {
-                                nextSegm = nextSegm->next1(SegmentType::ChordRest);
-                            }
-                            if (!nextSegm || nextSegm->tick() > destTick1) {                    // no ChordRest segm at this tick
-                                nextSegm = Factory::createSegment(prevSegm->measure(), SegmentType::ChordRest, destTick1);
-                                if (!nextSegm) {
-                                    LOGD("PasteSymbols: can't find or create destination segment for FiguredBass");
-                                    delete el;
-                                    continue;
-                                }
-                                score->undoAddElement(nextSegm);
-                            }
-                            currSegm = nextSegm;
-                        } else {
-                            // by default, assign to FiguredBass element the duration of the chord it refers to
-                            ticks = toChordRest(currSegm->element(destTrack))->ticks();
+                            score->undoAddElement(nextSegm);
                         }
-                        // in both cases, look for an existing f.b. element in segment and remove it, if found
-                        FiguredBass* oldFB = nullptr;
-                        for (EngravingItem* a : currSegm->annotations()) {
-                            if (a->isFiguredBass() && a->track() == destTrack) {
-                                oldFB = toFiguredBass(a);
-                                break;
-                            }
-                        }
-                        if (oldFB) {
-                            score->undoRemoveElement(oldFB);
-                        }
-                        el->setParent(currSegm);
-                        el->setTicks(ticks);
-                        score->undoAddElement(el);
-                    } else if (tag == "Lyrics") {
-                        // with lyrics, skip rests
-                        while (!cr->isChord() && currSegm) {
-                            currSegm = currSegm->nextCR(destTrack);
-                            if (currSegm) {
-                                cr = toChordRest(currSegm->element(destTrack));
-                            } else {
-                                break;
-                            }
-                        }
-                        if (currSegm == nullptr) {
-                            LOGD("PasteSymbols: no segment for Lyrics");
-                            e.skipCurrentElement();
-                            continue;
-                        }
-                        if (!cr->isChord()) {
-                            LOGD("PasteSymbols: can't paste Lyrics to rest");
-                            e.skipCurrentElement();
-                            continue;
-                        }
-                        Lyrics* el = Factory::createLyrics(cr);
-                        el->setTrack(destTrack);
-                        TRead::read(el, e, ctx);
-                        el->setTrack(destTrack);
-                        el->setParent(cr);
-                        score->undoAddElement(el);
+                        currSegm = nextSegm;
                     } else {
-                        LOGD("PasteSymbols: element %s not handled", tag.ascii());
-                        e.skipCurrentElement();                // ignore
+                        // by default, assign to FiguredBass element the duration of the chord it refers to
+                        ticks = toChordRest(currSegm->element(destTrack))->ticks();
                     }
-                }                         // if !Harmony
-            }                             // if element
-        }                                 // outer while readNextstartElement()
-    }                                     // inner while readNextstartElement()
-}                                         // pasteSymbolList()
+                    // in both cases, look for an existing f.b. element in segment and remove it, if found
+                    FiguredBass* oldFB = nullptr;
+                    for (EngravingItem* a : currSegm->annotations()) {
+                        if (a->isFiguredBass() && a->track() == destTrack) {
+                            oldFB = toFiguredBass(a);
+                            break;
+                        }
+                    }
+                    if (oldFB) {
+                        score->undoRemoveElement(oldFB);
+                    }
+                    el->setParent(currSegm);
+                    el->setTicks(ticks);
+                    score->undoAddElement(el);
+                } else if (tag == "Lyrics") {
+                    // with lyrics, skip rests
+                    while (!cr->isChord() && currSegm) {
+                        currSegm = currSegm->nextCR(destTrack);
+                        if (currSegm) {
+                            cr = toChordRest(currSegm->element(destTrack));
+                        } else {
+                            break;
+                        }
+                    }
+                    if (currSegm == nullptr) {
+                        LOGD("PasteSymbols: no segment for Lyrics");
+                        e.skipCurrentElement();
+                        continue;
+                    }
+                    if (!cr->isChord()) {
+                        LOGD("PasteSymbols: can't paste Lyrics to rest");
+                        e.skipCurrentElement();
+                        continue;
+                    }
+                    Lyrics* el = Factory::createLyrics(cr);
+                    el->setTrack(destTrack);
+                    TRead::read(el, e, ctx);
+                    el->setTrack(destTrack);
+                    el->setParent(cr);
+                    score->undoAddElement(el);
+                } else {
+                    LOGD("PasteSymbols: element %s not handled", tag.ascii());
+                    e.skipCurrentElement(); // ignore
+                }
+            }
+        } // outer while readNextstartElement()
+    } // inner while readNextstartElement()
+}
 
 void Read410::readTremoloCompat(compat::TremoloCompat* tc, XmlReader& xml)
 {

--- a/src/engraving/rw/read410/read410.cpp
+++ b/src/engraving/rw/read410/read410.cpp
@@ -25,30 +25,30 @@
 
 #include "dom/anchors.h"
 #include "dom/audio.h"
+#include "dom/beam.h"
+#include "dom/breath.h"
+#include "dom/chord.h"
+#include "dom/dynamic.h"
 #include "dom/excerpt.h"
 #include "dom/factory.h"
+#include "dom/figuredbass.h"
+#include "dom/fret.h"
+#include "dom/hairpin.h"
+#include "dom/harmony.h"
+#include "dom/lyrics.h"
 #include "dom/masterscore.h"
+#include "dom/measurerepeat.h"
+#include "dom/mscoreview.h"
+#include "dom/note.h"
 #include "dom/part.h"
 #include "dom/score.h"
 #include "dom/spanner.h"
 #include "dom/staff.h"
+#include "dom/sticking.h"
 #include "dom/text.h"
-#include "dom/tuplet.h"
-#include "dom/chord.h"
-#include "dom/beam.h"
-#include "dom/lyrics.h"
-#include "dom/note.h"
-#include "dom/measurerepeat.h"
-#include "dom/staff.h"
-#include "dom/harmony.h"
 #include "dom/tie.h"
-#include "dom/breath.h"
-#include "dom/mscoreview.h"
-#include "dom/fret.h"
-#include "dom/dynamic.h"
-#include "dom/hairpin.h"
-#include "dom/figuredbass.h"
 #include "dom/tremolotwochord.h"
+#include "dom/tuplet.h"
 
 #include "../compat/tremolocompat.h"
 #include "staffread.h"
@@ -802,7 +802,6 @@ void Read410::pasteSymbols(XmlReader& e, ChordRest* dst)
     Fraction startTick   = dst->tick();        // the initial tick and track where to start pasting
     track_idx_t startTrack  = dst->track();
     track_idx_t maxTrack    = score->ntracks();
-    Fraction lastTick = score->lastSegment()->tick();
 
     while (e.readNextStartElement()) {
         if (done) {
@@ -836,24 +835,16 @@ void Read410::pasteSymbols(XmlReader& e, ChordRest* dst)
                 // the original tickOffset: advance to destTick (or near)
                 // same for FretDiagram elements
                 //
-                Segment* harmSegm;
-                for (harmSegm = startSegm; harmSegm && (harmSegm->tick() < destTick);
-                     harmSegm = harmSegm->nextCR()) {
-                }
-                // if destTick overshot, no dest. segment: create one
-                if (destTick >= lastTick) {
-                    harmSegm = nullptr;
-                } else if (!harmSegm || harmSegm->tick() > destTick) {
-                    Measure* meas     = score->tick2measure(destTick);
-                    harmSegm          = meas ? meas->undoGetSegment(SegmentType::ChordRest, destTick) : nullptr;
-                }
-                if (destTrack >= maxTrack || harmSegm == nullptr) {
-                    LOGD("PasteSymbols: no track or segment for %s", tag.ascii());
-                    e.skipCurrentElement();                       // ignore
+                Measure* meas = score->tick2measure(destTick);
+                Segment* seg = meas ? meas->undoGetChordRestOrTimeTickSegment(destTick) : nullptr;
+
+                if (destTrack >= maxTrack || seg == nullptr) {
+                    LOGD() << "No track or segment for " << tag << " at tick " << destTick.ticks();
+                    e.skipCurrentElement(); // ignore
                     continue;
                 }
                 if (tag == "Harmony") {
-                    Harmony* el = Factory::createHarmony(harmSegm);
+                    Harmony* el = Factory::createHarmony(seg);
                     el->setTrack(trackZeroVoice(destTrack));
                     TRead::read(el, e, ctx);
                     el->setTrack(trackZeroVoice(destTrack));
@@ -866,28 +857,36 @@ void Read410::pasteSymbols(XmlReader& e, ChordRest* dst)
                         int baseTpc = transposeTpc(el->baseTpc(), interval, true);
                         score->undoTransposeHarmony(el, rootTpc, baseTpc);
                     }
-                    el->setParent(harmSegm);
+                    el->setParent(seg);
                     score->undoAddElement(el);
                 } else {
-                    FretDiagram* el = Factory::createFretDiagram(harmSegm);
+                    FretDiagram* el = Factory::createFretDiagram(seg);
                     el->setTrack(trackZeroVoice(destTrack));
                     TRead::read(el, e, ctx);
                     el->setTrack(trackZeroVoice(destTrack));
-                    el->setParent(harmSegm);
+                    el->setParent(seg);
                     score->undoAddElement(el);
                 }
-            } else if (tag == "Dynamic") {
-                ChordRest* destCR = score->findCR(destTick, destTrack);
-                if (!destCR) {
+            } else if (tag == "Dynamic"
+                       || tag == "StaffText"
+                       || tag == "PlayTechAnnotation"
+                       || tag == "Capo"
+                       || tag == "HarpPedalDiagram"
+                       || tag == "StringTunings") {
+                Measure* meas = score->tick2measure(destTick);
+                Segment* seg = meas ? meas->undoGetChordRestOrTimeTickSegment(destTick) : nullptr;
+                if (!seg) {
+                    LOGD() << "No segment for Dynamic at tick " << destTick.ticks();
                     e.skipCurrentElement();
                     continue;
                 }
-                Dynamic* d = Factory::createDynamic(destCR->segment());
-                d->setTrack(destTrack);
-                TRead::read(d, e, ctx);
-                d->setTrack(destTrack);
-                d->setParent(destCR->segment());
-                score->undoAddElement(d);
+
+                EngravingItem* el = Factory::createItemByName(tag, score->dummy());
+                el->setTrack(destTrack);
+                TRead::readItem(el, e, ctx);
+                el->setTrack(destTrack);
+                el->setParent(seg);
+                score->undoAddElement(el);
             } else if (tag == "HairPin") {
                 if (destTrack >= maxTrack) {
                     LOGD("PasteSymbols: no track for %s", tag.ascii());
@@ -922,7 +921,9 @@ void Read410::pasteSymbols(XmlReader& e, ChordRest* dst)
                 }
                 ChordRest* cr = toChordRest(currSegm->element(destTrack));
 
-                if (tag == "Articulation") {
+                if (tag == "Articulation"
+                    || tag == "Fermata"
+                    || tag == "Ornament") {
                     Articulation* el = Factory::createArticulation(cr);
                     TRead::read(el, e, ctx);
                     el->setTrack(destTrack);
@@ -932,17 +933,17 @@ void Read410::pasteSymbols(XmlReader& e, ChordRest* dst)
                     } else {
                         score->undoAddElement(el);
                     }
-                } else if (tag == "StaffText" || tag == "PlayTechAnnotation" || tag == "Capo" || tag == "Sticking"
-                           || tag == "HarpPedalDiagram" || tag == "StringTunings") {
-                    EngravingItem* el = Factory::createItemByName(tag, score->dummy());
-                    TRead::readItem(el, e, ctx);
+                } else if (tag == "Sticking") {
+                    if (!cr->isChord()) {
+                        LOGD() << "Not pasting Sticking onto Rest";
+                        e.skipCurrentElement();
+                        continue;
+                    }
+                    Sticking* el = Factory::createSticking(currSegm);
+                    TRead::read(el, e, ctx);
                     el->setTrack(destTrack);
                     el->setParent(currSegm);
-                    if (el->isSticking() && cr->isRest()) {
-                        delete el;
-                    } else {
-                        score->undoAddElement(el);
-                    }
+                    score->undoAddElement(el);
                 } else if (tag == "FiguredBass") {
                     // FiguredBass always belongs to first staff voice
                     destTrack = trackZeroVoice(destTrack);


### PR DESCRIPTION
Specifically for text items, dynamics in particular, we are no longer limited to just chordrest segments, but we can and should now paste them onto time tick segments, for better accuracy.

Before: Ctrl+selecting these dynamics and hairpin and then copy-pasting them does the following:
<img width="507" alt="Scherm­afbeelding 2024-12-17 om 00 46 47" src="https://github.com/user-attachments/assets/ddf3253b-e599-48ff-a356-6b06df6281b9" />
After:
<img width="552" alt="Scherm­afbeelding 2024-12-17 om 00 49 13" src="https://github.com/user-attachments/assets/d3d0df15-1014-4495-aa6b-88bbdc6c8f9f" />


For sticking and especially figured bass, the existing code contains some special logic, that I didn't want to touch right now. In the future, we will probably overhaul this part of the code anyway.

Code review hint: it's easiest to review the first commit separately with "hide whitespace changes" turned on.

@mike-spa I'll request your review since this seems quite related to your anchors-for-all-text-elements work.