### PR TITLE
11565 confirmation dialog for reset preferences and make sure all preferences reset correctly

### DIFF
--- a/src/appshell/iappshellconfiguration.h
+++ b/src/appshell/iappshellconfiguration.h
@@ -75,7 +75,7 @@ public:
     virtual void applySettings() = 0;
     virtual void rollbackSettings() = 0;
 
-    virtual void revertToFactorySettings(bool keepDefaultSettings = false, bool notifyAboutChanges = true) const = 0;
+    virtual void revertToFactorySettings(bool keepDefaultSettings = false, bool notifyAboutChanges = true) = 0;
 
     virtual muse::io::paths_t sessionProjectsPaths() const = 0;
     virtual muse::Ret setSessionProjectsPaths(const muse::io::paths_t& paths) = 0;

--- a/src/appshell/iappshellconfiguration.h
+++ b/src/appshell/iappshellconfiguration.h
@@ -23,7 +23,7 @@
 #define MU_APPSHELL_IAPPSHELLCONFIGURATION_H
 
 #include "modularity/imoduleinterface.h"
-#include "types/retval.h"
+#include "types/ret.h"
 
 #include "io/path.h"
 #include "appshelltypes.h"
@@ -40,11 +40,13 @@ public:
     virtual bool hasCompletedFirstLaunchSetup() const = 0;
     virtual void setHasCompletedFirstLaunchSetup(bool has) = 0;
 
-    virtual muse::ValCh<StartupModeType> startupModeType() const = 0;
+    virtual StartupModeType startupModeType() const = 0;
     virtual void setStartupModeType(StartupModeType type) = 0;
+    virtual muse::async::Notification startupModeTypeChanged() const = 0;
 
-    virtual muse::ValCh<muse::io::path_t> startupScorePath() const = 0;
+    virtual muse::io::path_t startupScorePath() const = 0;
     virtual void setStartupScorePath(const muse::io::path_t& scorePath) = 0;
+    virtual muse::async::Notification startupScorePathChanged() const = 0;
 
     virtual muse::io::path_t userDataPath() const = 0;
 

--- a/src/appshell/iappshellconfiguration.h
+++ b/src/appshell/iappshellconfiguration.h
@@ -40,10 +40,10 @@ public:
     virtual bool hasCompletedFirstLaunchSetup() const = 0;
     virtual void setHasCompletedFirstLaunchSetup(bool has) = 0;
 
-    virtual StartupModeType startupModeType() const = 0;
+    virtual muse::ValCh<StartupModeType> startupModeType() const = 0;
     virtual void setStartupModeType(StartupModeType type) = 0;
 
-    virtual muse::io::path_t startupScorePath() const = 0;
+    virtual muse::ValCh<muse::io::path_t> startupScorePath() const = 0;
     virtual void setStartupScorePath(const muse::io::path_t& scorePath) = 0;
 
     virtual muse::io::path_t userDataPath() const = 0;

--- a/src/appshell/internal/applicationactioncontroller.cpp
+++ b/src/appshell/internal/applicationactioncontroller.cpp
@@ -326,11 +326,14 @@ void ApplicationActionController::revertToFactorySettings()
                                                  "The list of recent scores will also be cleared.\n\n"
                                                  "This action will not delete any of your scores.");
 
+    IInteractive::ButtonData cancelBtn = interactive()->buttonData(IInteractive::Button::Cancel);
+    cancelBtn.accent = true;
+
     int revertBtn = int(IInteractive::Button::Apply);
     IInteractive::Result result = interactive()->warning(title, question,
-                                                         { interactive()->buttonData(IInteractive::Button::Cancel),
-                                                           IInteractive::ButtonData(revertBtn, muse::trc("appshell", "Revert"), true) },
-                                                         revertBtn);
+                                                         { cancelBtn,
+                                                           IInteractive::ButtonData(revertBtn, muse::trc("appshell", "Revert")) },
+                                                         cancelBtn.btn);
 
     if (result.standardButton() == IInteractive::Button::Cancel) {
         return;

--- a/src/appshell/internal/applicationactioncontroller.cpp
+++ b/src/appshell/internal/applicationactioncontroller.cpp
@@ -333,7 +333,8 @@ void ApplicationActionController::revertToFactorySettings()
     IInteractive::Result result = interactive()->warning(title, question,
                                                          { cancelBtn,
                                                            IInteractive::ButtonData(revertBtn, muse::trc("appshell", "Revert")) },
-                                                         cancelBtn.btn);
+                                                         cancelBtn.btn, { muse::IInteractive::Option::WithIcon },
+                                                         muse::trc("appshell", "Revert to factory settings"));
 
     if (result.standardButton() == IInteractive::Button::Cancel) {
         return;

--- a/src/appshell/internal/appshellconfiguration.cpp
+++ b/src/appshell/internal/appshellconfiguration.cpp
@@ -63,13 +63,13 @@ void AppShellConfiguration::init()
     settings()->setDefaultValue(HAS_COMPLETED_FIRST_LAUNCH_SETUP, Val(false));
 
     settings()->setDefaultValue(STARTUP_MODE_TYPE, Val(StartupModeType::StartEmpty));
-    settings()->valueChanged(STARTUP_MODE_TYPE).onReceive(nullptr, [this](const Val& val) {
-        m_startupModeTypeChanged.send(val.toEnum<StartupModeType>());
+    settings()->valueChanged(STARTUP_MODE_TYPE).onReceive(this, [this](const Val&) {
+        m_startupModeTypeChanged.notify();
     });
 
     settings()->setDefaultValue(STARTUP_SCORE_PATH, Val(projectConfiguration()->myFirstProjectPath().toStdString()));
-    settings()->valueChanged(STARTUP_SCORE_PATH).onReceive(nullptr, [this](const Val& val) {
-        m_startupScorePathChanged.send(val.toString());
+    settings()->valueChanged(STARTUP_SCORE_PATH).onReceive(this, [this](const Val&) {
+        m_startupScorePathChanged.notify();
     });
 
     fileSystem()->makePath(sessionDataPath());
@@ -85,12 +85,9 @@ void AppShellConfiguration::setHasCompletedFirstLaunchSetup(bool has)
     settings()->setSharedValue(HAS_COMPLETED_FIRST_LAUNCH_SETUP, Val(has));
 }
 
-ValCh<StartupModeType> AppShellConfiguration::startupModeType() const
+StartupModeType AppShellConfiguration::startupModeType() const
 {
-    ValCh<StartupModeType> result;
-    result.ch = m_startupModeTypeChanged;
-    result.val = settings()->value(STARTUP_MODE_TYPE).toEnum<StartupModeType>();
-    return result;
+    return settings()->value(STARTUP_MODE_TYPE).toEnum<StartupModeType>();
 }
 
 void AppShellConfiguration::setStartupModeType(StartupModeType type)
@@ -98,17 +95,24 @@ void AppShellConfiguration::setStartupModeType(StartupModeType type)
     settings()->setSharedValue(STARTUP_MODE_TYPE, Val(type));
 }
 
-muse::ValCh<muse::io::path_t> AppShellConfiguration::startupScorePath() const
+async::Notification AppShellConfiguration::startupModeTypeChanged() const
 {
-    ValCh<muse::io::path_t> result;
-    result.ch = m_startupScorePathChanged;
-    result.val = settings()->value(STARTUP_SCORE_PATH).toString();
-    return result;
+    return m_startupModeTypeChanged;
+}
+
+muse::io::path_t AppShellConfiguration::startupScorePath() const
+{
+    return settings()->value(STARTUP_SCORE_PATH).toString();
 }
 
 void AppShellConfiguration::setStartupScorePath(const muse::io::path_t& scorePath)
 {
     settings()->setSharedValue(STARTUP_SCORE_PATH, Val(scorePath.toStdString()));
+}
+
+async::Notification AppShellConfiguration::startupScorePathChanged() const
+{
+    return m_startupScorePathChanged;
 }
 
 muse::io::path_t AppShellConfiguration::userDataPath() const

--- a/src/appshell/internal/appshellconfiguration.cpp
+++ b/src/appshell/internal/appshellconfiguration.cpp
@@ -63,7 +63,14 @@ void AppShellConfiguration::init()
     settings()->setDefaultValue(HAS_COMPLETED_FIRST_LAUNCH_SETUP, Val(false));
 
     settings()->setDefaultValue(STARTUP_MODE_TYPE, Val(StartupModeType::StartEmpty));
+    settings()->valueChanged(STARTUP_MODE_TYPE).onReceive(nullptr, [this](const Val& val) {
+        m_startupModeTypeChanged.send(val.toEnum<StartupModeType>());
+    });
+
     settings()->setDefaultValue(STARTUP_SCORE_PATH, Val(projectConfiguration()->myFirstProjectPath().toStdString()));
+    settings()->valueChanged(STARTUP_SCORE_PATH).onReceive(nullptr, [this](const Val& val) {
+        m_startupScorePathChanged.send(val.toString());
+    });
 
     fileSystem()->makePath(sessionDataPath());
 }
@@ -78,9 +85,12 @@ void AppShellConfiguration::setHasCompletedFirstLaunchSetup(bool has)
     settings()->setSharedValue(HAS_COMPLETED_FIRST_LAUNCH_SETUP, Val(has));
 }
 
-StartupModeType AppShellConfiguration::startupModeType() const
+ValCh<StartupModeType> AppShellConfiguration::startupModeType() const
 {
-    return settings()->value(STARTUP_MODE_TYPE).toEnum<StartupModeType>();
+    ValCh<StartupModeType> result;
+    result.ch = m_startupModeTypeChanged;
+    result.val = settings()->value(STARTUP_MODE_TYPE).toEnum<StartupModeType>();
+    return result;
 }
 
 void AppShellConfiguration::setStartupModeType(StartupModeType type)
@@ -88,9 +98,12 @@ void AppShellConfiguration::setStartupModeType(StartupModeType type)
     settings()->setSharedValue(STARTUP_MODE_TYPE, Val(type));
 }
 
-muse::io::path_t AppShellConfiguration::startupScorePath() const
+muse::ValCh<muse::io::path_t> AppShellConfiguration::startupScorePath() const
 {
-    return settings()->value(STARTUP_SCORE_PATH).toString();
+    ValCh<muse::io::path_t> result;
+    result.ch = m_startupScorePathChanged;
+    result.val = settings()->value(STARTUP_SCORE_PATH).toString();
+    return result;
 }
 
 void AppShellConfiguration::setStartupScorePath(const muse::io::path_t& scorePath)

--- a/src/appshell/internal/appshellconfiguration.cpp
+++ b/src/appshell/internal/appshellconfiguration.cpp
@@ -233,11 +233,6 @@ void AppShellConfiguration::rollbackSettings()
 void AppShellConfiguration::revertToFactorySettings(bool keepDefaultSettings, bool notifyAboutChanges)
 {
     settings()->reset(keepDefaultSettings, notifyAboutChanges);
-
-    // Unreset the "First Launch Completed" setting so the first-time launch wizard
-    // does not appear. If more settings need to be unresettable in the future,
-    // we could pass those to settings->reset or add "IsNonResettable" to Settings::Item.
-    setHasCompletedFirstLaunchSetup(true);
 }
 
 muse::io::paths_t AppShellConfiguration::sessionProjectsPaths() const

--- a/src/appshell/internal/appshellconfiguration.cpp
+++ b/src/appshell/internal/appshellconfiguration.cpp
@@ -230,9 +230,14 @@ void AppShellConfiguration::rollbackSettings()
     settings()->rollbackTransaction();
 }
 
-void AppShellConfiguration::revertToFactorySettings(bool keepDefaultSettings, bool notifyAboutChanges) const
+void AppShellConfiguration::revertToFactorySettings(bool keepDefaultSettings, bool notifyAboutChanges)
 {
     settings()->reset(keepDefaultSettings, notifyAboutChanges);
+
+    // Unreset the "First Launch Completed" setting so the first-time launch wizard
+    // does not appear. If more settings need to be unresettable in the future,
+    // we could pass those to settings->reset or add "IsNonResettable" to Settings::Item.
+    setHasCompletedFirstLaunchSetup(true);
 }
 
 muse::io::paths_t AppShellConfiguration::sessionProjectsPaths() const

--- a/src/appshell/internal/appshellconfiguration.h
+++ b/src/appshell/internal/appshellconfiguration.h
@@ -28,7 +28,6 @@
 #include "global/iglobalconfiguration.h"
 #include "global/iapplication.h"
 #include "global/io/ifilesystem.h"
-#include "global/async/channel.h"
 #include "multiinstances/imultiinstancesprovider.h"
 #include "ui/iuiconfiguration.h"
 #include "project/iprojectconfiguration.h"
@@ -60,11 +59,13 @@ public:
     bool hasCompletedFirstLaunchSetup() const override;
     void setHasCompletedFirstLaunchSetup(bool has) override;
 
-    muse::ValCh<StartupModeType> startupModeType() const override;
+    StartupModeType startupModeType() const override;
     void setStartupModeType(StartupModeType type) override;
+    muse::async::Notification startupModeTypeChanged() const override;
 
-    muse::ValCh<muse::io::path_t> startupScorePath() const override;
+    muse::io::path_t startupScorePath() const override;
     void setStartupScorePath(const muse::io::path_t& scorePath) override;
+    muse::async::Notification startupScorePathChanged() const override;
 
     muse::io::path_t userDataPath() const override;
 
@@ -113,8 +114,8 @@ private:
 
     QString m_preferencesDialogCurrentPageId;
 
-    muse::async::Channel<StartupModeType> m_startupModeTypeChanged;
-    muse::async::Channel<muse::io::path_t> m_startupScorePathChanged;
+    muse::async::Notification m_startupModeTypeChanged;
+    muse::async::Notification m_startupScorePathChanged;
 };
 }
 

--- a/src/appshell/internal/appshellconfiguration.h
+++ b/src/appshell/internal/appshellconfiguration.h
@@ -28,6 +28,7 @@
 #include "global/iglobalconfiguration.h"
 #include "global/iapplication.h"
 #include "global/io/ifilesystem.h"
+#include "global/async/channel.h"
 #include "multiinstances/imultiinstancesprovider.h"
 #include "ui/iuiconfiguration.h"
 #include "project/iprojectconfiguration.h"
@@ -59,10 +60,10 @@ public:
     bool hasCompletedFirstLaunchSetup() const override;
     void setHasCompletedFirstLaunchSetup(bool has) override;
 
-    StartupModeType startupModeType() const override;
+    muse::ValCh<StartupModeType> startupModeType() const override;
     void setStartupModeType(StartupModeType type) override;
 
-    muse::io::path_t startupScorePath() const override;
+    muse::ValCh<muse::io::path_t> startupScorePath() const override;
     void setStartupScorePath(const muse::io::path_t& scorePath) override;
 
     muse::io::path_t userDataPath() const override;
@@ -111,6 +112,9 @@ private:
     muse::io::paths_t parseSessionProjectsPaths(const QByteArray& json) const;
 
     QString m_preferencesDialogCurrentPageId;
+
+    muse::async::Channel<StartupModeType> m_startupModeTypeChanged;
+    muse::async::Channel<muse::io::path_t> m_startupScorePathChanged;
 };
 }
 

--- a/src/appshell/internal/appshellconfiguration.h
+++ b/src/appshell/internal/appshellconfiguration.h
@@ -94,7 +94,7 @@ public:
     void applySettings() override;
     void rollbackSettings() override;
 
-    void revertToFactorySettings(bool keepDefaultSettings = false, bool notifyAboutChanges = true) const override;
+    void revertToFactorySettings(bool keepDefaultSettings = false, bool notifyAboutChanges = true) override;
 
     muse::io::paths_t sessionProjectsPaths() const override;
     muse::Ret setSessionProjectsPaths(const muse::io::paths_t& paths) override;

--- a/src/appshell/internal/sessionsmanager.cpp
+++ b/src/appshell/internal/sessionsmanager.cpp
@@ -48,7 +48,7 @@ void SessionsManager::deinit()
         return;
     }
 
-    if (configuration()->startupModeType() != StartupModeType::ContinueLastSession) {
+    if (configuration()->startupModeType().val != StartupModeType::ContinueLastSession) {
         reset();
     }
 }

--- a/src/appshell/internal/sessionsmanager.cpp
+++ b/src/appshell/internal/sessionsmanager.cpp
@@ -48,7 +48,7 @@ void SessionsManager::deinit()
         return;
     }
 
-    if (configuration()->startupModeType().val != StartupModeType::ContinueLastSession) {
+    if (configuration()->startupModeType() != StartupModeType::ContinueLastSession) {
         reset();
     }
 }

--- a/src/appshell/internal/startupscenario.cpp
+++ b/src/appshell/internal/startupscenario.cpp
@@ -152,7 +152,7 @@ StartupModeType StartupScenario::resolveStartupModeType() const
         return modeTypeTromString(m_startupTypeStr);
     }
 
-    return configuration()->startupModeType();
+    return configuration()->startupModeType().val;
 }
 
 void StartupScenario::onStartupPageOpened(StartupModeType modeType)
@@ -173,7 +173,7 @@ void StartupScenario::onStartupPageOpened(StartupModeType modeType)
         break;
     case StartupModeType::StartWithScore: {
         project::ProjectFile file
-            = m_startupScoreFile.isValid() ? m_startupScoreFile : project::ProjectFile(configuration()->startupScorePath());
+            = m_startupScoreFile.isValid() ? m_startupScoreFile : project::ProjectFile(configuration()->startupScorePath().val);
         openScore(file);
     } break;
     }

--- a/src/appshell/internal/startupscenario.cpp
+++ b/src/appshell/internal/startupscenario.cpp
@@ -152,7 +152,7 @@ StartupModeType StartupScenario::resolveStartupModeType() const
         return modeTypeTromString(m_startupTypeStr);
     }
 
-    return configuration()->startupModeType().val;
+    return configuration()->startupModeType();
 }
 
 void StartupScenario::onStartupPageOpened(StartupModeType modeType)
@@ -173,7 +173,7 @@ void StartupScenario::onStartupPageOpened(StartupModeType modeType)
         break;
     case StartupModeType::StartWithScore: {
         project::ProjectFile file
-            = m_startupScoreFile.isValid() ? m_startupScoreFile : project::ProjectFile(configuration()->startupScorePath().val);
+            = m_startupScoreFile.isValid() ? m_startupScoreFile : project::ProjectFile(configuration()->startupScorePath());
         openScore(file);
     } break;
     }

--- a/src/appshell/qml/Preferences/BraillePreferencesPage.qml
+++ b/src/appshell/qml/Preferences/BraillePreferencesPage.qml
@@ -34,6 +34,10 @@ PreferencesPage {
         id: preferencesModel
     }
 
+    Component.onCompleted: {
+        preferencesModel.load()
+    }
+
     Column {
         width: parent.width
         spacing: root.sectionsSpacing

--- a/src/appshell/qml/Preferences/ImportPreferencesPage.qml
+++ b/src/appshell/qml/Preferences/ImportPreferencesPage.qml
@@ -42,6 +42,7 @@ PreferencesPage {
         spacing: root.sectionsSpacing
 
         ImportStyleSection {
+            id: importStyleSection
             styleFileImportPath: importPreferencesModel.styleFileImportPath
             fileChooseTitle: importPreferencesModel.styleChooseTitle()
             filePathFilter: importPreferencesModel.stylePathFilter()
@@ -144,5 +145,9 @@ PreferencesPage {
                 importPreferencesModel.meiImportLayout = meiImportLayout
             }
         }
+    }
+
+    function reset() {
+        importStyleSection.reset()
     }
 }

--- a/src/appshell/qml/Preferences/PreferencesDialog.qml
+++ b/src/appshell/qml/Preferences/PreferencesDialog.qml
@@ -149,6 +149,10 @@ StyledDialogView {
             navigation.order: 100000
 
             onRevertFactorySettingsRequested: {
+                if (!preferencesModel.askForConfirmationOfPreferencesReset()) {
+                    return;
+                }
+
                 var pages = preferencesModel.availablePages()
 
                 for (var i in pages) {

--- a/src/appshell/qml/Preferences/UpdatePreferencesPage.qml
+++ b/src/appshell/qml/Preferences/UpdatePreferencesPage.qml
@@ -34,6 +34,10 @@ PreferencesPage {
         id: updateModel
     }
 
+    Component.onCompleted: {
+        updateModel.load()
+    }
+
     Column {
         width: parent.width
         spacing: root.sectionsSpacing

--- a/src/appshell/qml/Preferences/internal/ImportStyleSection.qml
+++ b/src/appshell/qml/Preferences/internal/ImportStyleSection.qml
@@ -41,7 +41,12 @@ BaseSection {
     QtObject {
         id: prv
 
-        property bool useStyleFile: root.styleFileImportPath !== ""
+        property bool useStyleFileExplicitlySet: root.styleFileImportPath !== ""
+        property bool useStyleFile: prv.useStyleFileExplicitlySet || root.styleFileImportPath !== ""
+    }
+
+    function reset() {
+        prv.useStyleFileExplicitlySet = false
     }
 
     RoundedRadioButton {
@@ -57,7 +62,7 @@ BaseSection {
         navigation.column: 0
 
         onToggled: {
-            prv.useStyleFile = false
+            prv.useStyleFileExplicitlySet = false
             root.styleFileImportPathChangeRequested("")
         }
     }
@@ -81,7 +86,7 @@ BaseSection {
             navigation.column: 0
 
             onToggled: {
-                prv.useStyleFile = true
+                prv.useStyleFileExplicitlySet = true
             }
         }
 

--- a/src/appshell/view/preferences/advancedpreferencesmodel.cpp
+++ b/src/appshell/view/preferences/advancedpreferencesmodel.cpp
@@ -58,7 +58,7 @@ bool AdvancedPreferencesModel::setData(const QModelIndex& index, const QVariant&
 
     switch (role) {
     case ValueRole:
-        changeVal(index.row(), value);
+        changeVal(index.row(), Val::fromQVariant(value));
         emit dataChanged(index, index, { ValueRole });
         return true;
     default:
@@ -96,20 +96,38 @@ void AdvancedPreferencesModel::load()
     for (auto it = items.cbegin(); it != items.cend(); ++it) {
         if (it->second.canBeManuallyEdited) {
             m_items << it->second;
+
+            muse::Settings::Key key = it->second.key;
+            settings()->valueChanged(key).onReceive(this, [this, key](const Val& val) {
+                for (int i = 0; i < m_items.size(); ++i) {
+                    if (m_items[i].key == key) {
+                        if (!(m_items[i].value == val)) { // Notice the ! to negate the condition, so == becomes !=
+                            changeModelVal(m_items[i], val);
+                            QModelIndex modelIndex = index(i, 0);
+                            emit dataChanged(modelIndex, modelIndex, { ValueRole });
+                        }
+                        break;
+                    }
+                }
+            });
         }
     }
 
     endResetModel();
 }
 
-void AdvancedPreferencesModel::changeVal(int index, QVariant newVal)
+void AdvancedPreferencesModel::changeVal(int index, const Val& newVal)
 {
     Settings::Item& item = m_items[index];
-    Val::Type type = item.value.type();
-    item.value = Val::fromQVariant(newVal);
-    item.value.setType(type);
-
+    changeModelVal(item, newVal);
     settings()->setSharedValue(item.key, item.value);
+}
+
+void AdvancedPreferencesModel::changeModelVal(Settings::Item& item, const Val& newVal)
+{
+    Val::Type type = item.value.type();
+    item.value = newVal;
+    item.value.setType(type);
 }
 
 void AdvancedPreferencesModel::resetToDefault()
@@ -117,7 +135,7 @@ void AdvancedPreferencesModel::resetToDefault()
     beginResetModel();
 
     for (int i = 0; i < m_items.size(); ++i) {
-        changeVal(i, m_items[i].defaultValue.toQVariant());
+        changeVal(i, m_items[i].defaultValue);
     }
 
     endResetModel();

--- a/src/appshell/view/preferences/advancedpreferencesmodel.h
+++ b/src/appshell/view/preferences/advancedpreferencesmodel.h
@@ -54,6 +54,7 @@ private:
         MaxValueRole
     };
 
+    QModelIndex findIndex(const muse::Settings::Key& key);
     void changeVal(int index, const muse::Val& newVal);
     void changeModelVal(muse::Settings::Item& item, const muse::Val& newVal);
     QString typeToString(muse::Val::Type type) const;

--- a/src/appshell/view/preferences/advancedpreferencesmodel.h
+++ b/src/appshell/view/preferences/advancedpreferencesmodel.h
@@ -24,10 +24,11 @@
 
 #include <QAbstractListModel>
 
+#include "async/asyncable.h"
 #include "settings.h"
 
 namespace mu::appshell {
-class AdvancedPreferencesModel : public QAbstractListModel
+class AdvancedPreferencesModel : public QAbstractListModel, public muse::async::Asyncable
 {
     Q_OBJECT
 
@@ -53,7 +54,8 @@ private:
         MaxValueRole
     };
 
-    void changeVal(int index, QVariant newVal);
+    void changeVal(int index, const muse::Val& newVal);
+    void changeModelVal(muse::Settings::Item& item, const muse::Val& newVal);
     QString typeToString(muse::Val::Type type) const;
 
     QList<muse::Settings::Item> m_items;

--- a/src/appshell/view/preferences/audiomidipreferencesmodel.cpp
+++ b/src/appshell/view/preferences/audiomidipreferencesmodel.cpp
@@ -92,6 +92,10 @@ void AudioMidiPreferencesModel::init()
         emit midiOutputDeviceIdChanged();
     });
 
+    midiConfiguration()->useMIDI20OutputChanged().onReceive(this, [this](bool) {
+        emit useMIDI20OutputChanged();
+    });
+
     playbackConfiguration()->muteHiddenInstrumentsChanged().onReceive(this, [this](bool mute) {
         emit muteHiddenInstrumentsChanged(mute);
     });

--- a/src/appshell/view/preferences/braillepreferencesmodel.cpp
+++ b/src/appshell/view/preferences/braillepreferencesmodel.cpp
@@ -32,6 +32,21 @@ BraillePreferencesModel::BraillePreferencesModel(QObject* parent)
 {
 }
 
+void BraillePreferencesModel::load()
+{
+    brailleConfiguration()->braillePanelEnabledChanged().onNotify(this, [this]() {
+        emit braillePanelEnabledChanged(braillePanelEnabled());
+    });
+
+    brailleConfiguration()->intervalDirectionChanged().onNotify(this, [this]() {
+        emit intervalDirectionChanged(intervalDirection());
+    });
+
+    brailleConfiguration()->brailleTableChanged().onNotify(this, [this]() {
+        emit brailleTableChanged(brailleTable());
+    });
+}
+
 bool BraillePreferencesModel::braillePanelEnabled() const
 {
     return brailleConfiguration()->braillePanelEnabled();

--- a/src/appshell/view/preferences/braillepreferencesmodel.h
+++ b/src/appshell/view/preferences/braillepreferencesmodel.h
@@ -25,11 +25,12 @@
 
 #include <QObject>
 
+#include "async/asyncable.h"
 #include "modularity/ioc.h"
 #include "braille/ibrailleconfiguration.h"
 
 namespace mu::appshell {
-class BraillePreferencesModel : public QObject, public muse::Injectable
+class BraillePreferencesModel : public QObject, public muse::Injectable, public muse::async::Asyncable
 {
     Q_OBJECT
 
@@ -41,6 +42,8 @@ class BraillePreferencesModel : public QObject, public muse::Injectable
 
 public:
     explicit BraillePreferencesModel(QObject* parent = nullptr);
+
+    Q_INVOKABLE void load();
 
     bool braillePanelEnabled() const;
     QString brailleTable() const;

--- a/src/appshell/view/preferences/canvaspreferencesmodel.cpp
+++ b/src/appshell/view/preferences/canvaspreferencesmodel.cpp
@@ -37,6 +37,25 @@ void CanvasPreferencesModel::load()
     setupConnections();
 }
 
+void CanvasPreferencesModel::setupConnections()
+{
+    notationConfiguration()->defaultZoomChanged().onNotify(this, [this]() {
+        emit defaultZoomChanged();
+    });
+    notationConfiguration()->mouseZoomPrecisionChanged().onNotify(this, [this]() {
+        emit mouseZoomPrecisionChanged();
+    });
+    notationConfiguration()->canvasOrientation().ch.onReceive(this, [this](muse::Orientation) {
+        emit scrollPagesOrientationChanged();
+    });
+    notationConfiguration()->isLimitCanvasScrollAreaChanged().onNotify(this, [this]() {
+        emit limitScrollAreaChanged();
+    });
+    notationConfiguration()->selectionProximityChanged().onReceive(this, [this](int selectionProximity) {
+        emit selectionProximityChanged(selectionProximity);
+    });
+}
+
 QVariantList CanvasPreferencesModel::zoomTypes() const
 {
     QVariantList types = {
@@ -138,13 +157,6 @@ void CanvasPreferencesModel::setSelectionProximity(int proximity)
 
     notationConfiguration()->setSelectionProximity(proximity);
     emit selectionProximityChanged(proximity);
-}
-
-void CanvasPreferencesModel::setupConnections()
-{
-    notationConfiguration()->canvasOrientation().ch.onReceive(this, [this](muse::Orientation) {
-        emit scrollPagesOrientationChanged();
-    });
 }
 
 ZoomType CanvasPreferencesModel::defaultZoomType() const

--- a/src/appshell/view/preferences/generalpreferencesmodel.cpp
+++ b/src/appshell/view/preferences/generalpreferencesmodel.cpp
@@ -46,11 +46,11 @@ void GeneralPreferencesModel::load()
         setIsNeedRestart(need);
     });
 
-    configuration()->startupModeType().ch.onReceive(this, [this](const StartupModeType&) {
+    configuration()->startupModeTypeChanged().onNotify(this, [this]() {
         emit startupModesChanged();
     });
 
-    configuration()->startupScorePath().ch.onReceive(this, [this](const muse::io::path_t&) {
+    configuration()->startupScorePathChanged().onNotify(this, [this]() {
         emit startupModesChanged();
     });
 }
@@ -212,8 +212,8 @@ GeneralPreferencesModel::StartModeList GeneralPreferencesModel::allStartupModes(
         StartMode mode;
         mode.type = type;
         mode.title = modeTitles[type];
-        mode.checked = configuration()->startupModeType().val == type;
-        mode.scorePath = canSelectScorePath ? configuration()->startupScorePath().val.toQString() : QString();
+        mode.checked = configuration()->startupModeType() == type;
+        mode.scorePath = canSelectScorePath ? configuration()->startupScorePath().toQString() : QString();
         mode.canSelectScorePath = canSelectScorePath;
 
         modes << mode;
@@ -237,7 +237,7 @@ void GeneralPreferencesModel::setCurrentStartupMode(int modeIndex)
     }
 
     StartupModeType selectedType = modes[modeIndex].type;
-    if (selectedType == configuration()->startupModeType().val) {
+    if (selectedType == configuration()->startupModeType()) {
         return;
     }
 
@@ -247,11 +247,10 @@ void GeneralPreferencesModel::setCurrentStartupMode(int modeIndex)
 
 void GeneralPreferencesModel::setStartupScorePath(const QString& scorePath)
 {
-    if (scorePath.isEmpty() || scorePath == configuration()->startupScorePath().val.toQString()) {
+    if (scorePath.isEmpty() || scorePath == configuration()->startupScorePath().toQString()) {
         return;
     }
 
     configuration()->setStartupScorePath(scorePath);
-
     emit startupModesChanged();
 }

--- a/src/appshell/view/preferences/generalpreferencesmodel.cpp
+++ b/src/appshell/view/preferences/generalpreferencesmodel.cpp
@@ -45,6 +45,14 @@ void GeneralPreferencesModel::load()
     languagesService()->needRestartToApplyLanguageChangeChanged().onReceive(this, [this](bool need) {
         setIsNeedRestart(need);
     });
+
+    configuration()->startupModeType().ch.onReceive(this, [this](const StartupModeType&) {
+        emit startupModesChanged();
+    });
+
+    configuration()->startupScorePath().ch.onReceive(this, [this](const muse::io::path_t&) {
+        emit startupModesChanged();
+    });
 }
 
 void GeneralPreferencesModel::checkUpdateForCurrentLanguage()
@@ -204,8 +212,8 @@ GeneralPreferencesModel::StartModeList GeneralPreferencesModel::allStartupModes(
         StartMode mode;
         mode.type = type;
         mode.title = modeTitles[type];
-        mode.checked = configuration()->startupModeType() == type;
-        mode.scorePath = canSelectScorePath ? configuration()->startupScorePath().toQString() : QString();
+        mode.checked = configuration()->startupModeType().val == type;
+        mode.scorePath = canSelectScorePath ? configuration()->startupScorePath().val.toQString() : QString();
         mode.canSelectScorePath = canSelectScorePath;
 
         modes << mode;
@@ -229,7 +237,7 @@ void GeneralPreferencesModel::setCurrentStartupMode(int modeIndex)
     }
 
     StartupModeType selectedType = modes[modeIndex].type;
-    if (selectedType == configuration()->startupModeType()) {
+    if (selectedType == configuration()->startupModeType().val) {
         return;
     }
 
@@ -239,7 +247,7 @@ void GeneralPreferencesModel::setCurrentStartupMode(int modeIndex)
 
 void GeneralPreferencesModel::setStartupScorePath(const QString& scorePath)
 {
-    if (scorePath.isEmpty() || scorePath == configuration()->startupScorePath().toQString()) {
+    if (scorePath.isEmpty() || scorePath == configuration()->startupScorePath().val.toQString()) {
         return;
     }
 

--- a/src/appshell/view/preferences/importpreferencesmodel.cpp
+++ b/src/appshell/view/preferences/importpreferencesmodel.cpp
@@ -36,6 +36,41 @@ ImportPreferencesModel::ImportPreferencesModel(QObject* parent)
 
 void ImportPreferencesModel::load()
 {
+    notationConfiguration()->styleFileImportPathChanged().onReceive(this, [this](const std::string& val) {
+        emit styleFileImportPathChanged(QString::fromStdString(val));
+    });
+
+    oveConfiguration()->importOvertureCharsetChanged().onReceive(this, [this](const std::string& val) {
+        emit currentOvertureCharsetChanged(QString::fromStdString(val));
+    });
+
+    musicXmlConfiguration()->importLayoutChanged().onReceive(this, [this](bool val) {
+        emit importLayoutChanged(val);
+    });
+
+    musicXmlConfiguration()->importBreaksChanged().onReceive(this, [this](bool val) {
+        emit importBreaksChanged(val);
+    });
+
+    musicXmlConfiguration()->needUseDefaultFontChanged().onReceive(this, [this](bool val) {
+        emit needUseDefaultFontChanged(val);
+    });
+
+    musicXmlConfiguration()->inferTextTypeChanged().onReceive(this, [this](bool val) {
+        emit inferTextTypeChanged(val);
+    });
+
+    midiImportExportConfiguration()->midiShortestNoteChanged().onReceive(this, [this](int val) {
+        emit currentShortestNoteChanged(val);
+    });
+
+    meiConfiguration()->meiImportLayoutChanged().onReceive(this, [this](bool val) {
+        emit meiImportLayoutChanged(val);
+    });
+
+    musicXmlConfiguration()->needAskAboutApplyingNewStyleChanged().onReceive(this, [this](bool val) {
+        emit needAskAboutApplyingNewStyleChanged(val);
+    });
 }
 
 QVariantList ImportPreferencesModel::charsets() const

--- a/src/appshell/view/preferences/noteinputpreferencesmodel.cpp
+++ b/src/appshell/view/preferences/noteinputpreferencesmodel.cpp
@@ -36,6 +36,38 @@ void NoteInputPreferencesModel::load()
     playbackConfiguration()->playNotesWhenEditingChanged().onNotify(this, [this]() {
         emit playNotesWhenEditingChanged(playNotesWhenEditing());
     });
+
+    shortcutsConfiguration()->advanceToNextNoteOnKeyReleaseChanged().onReceive(this, [this](bool value) {
+        emit advanceToNextNoteOnKeyReleaseChanged(value);
+    });
+
+    notationConfiguration()->colorNotesOutsideOfUsablePitchRangeChanged().onReceive(this, [this](bool value) {
+        emit colorNotesOutsideOfUsablePitchRangeChanged(value);
+    });
+
+    notationConfiguration()->warnGuitarBendsChanged().onReceive(this, [this](bool value) {
+        emit warnGuitarBendsChanged(value);
+    });
+
+    notationConfiguration()->delayBetweenNotesInRealTimeModeMillisecondsChanged().onReceive(this, [this](int value) {
+        emit delayBetweenNotesInRealTimeModeMillisecondsChanged(value);
+    });
+
+    notationConfiguration()->notePlayDurationMillisecondsChanged().onReceive(this, [this](int value) {
+        emit notePlayDurationMillisecondsChanged(value);
+    });
+
+    playbackConfiguration()->playChordWhenEditingChanged().onReceive(this, [this](bool value) {
+        emit playChordWhenEditingChanged(value);
+    });
+
+    playbackConfiguration()->playHarmonyWhenEditingChanged().onReceive(this, [this](bool value) {
+        emit playChordSymbolWhenEditingChanged(value);
+    });
+
+    engravingConfiguration()->dynamicsApplyToAllVoicesChanged().onReceive(this, [this](bool value) {
+        emit dynamicsApplyToAllVoicesChanged(value);
+    });
 }
 
 bool NoteInputPreferencesModel::advanceToNextNoteOnKeyRelease() const

--- a/src/appshell/view/preferences/preferencesmodel.cpp
+++ b/src/appshell/view/preferences/preferencesmodel.cpp
@@ -211,8 +211,8 @@ bool PreferencesModel::askForConfirmationOfPreferencesReset()
 {
     std::string title = muse::trc("appshell", "Are you sure you want to reset preferences?");
     std::string question = muse::trc("appshell", "This action will reset all your app preferences and delete all custom palettes and custom shortcuts.\n\n"
-                                     "This action will not delete any of your scores.\n\n"
-                                     "This action cannot be undone.");
+                                                 "This action will not delete any of your scores.\n\n"
+                                                 "This action cannot be undone.");
 
     muse::IInteractive::ButtonData cancelBtn = interactive()->buttonData(muse::IInteractive::Button::Cancel);
     muse::IInteractive::ButtonData resetBtn = interactive()->buttonData(muse::IInteractive::Button::Reset);

--- a/src/appshell/view/preferences/preferencesmodel.cpp
+++ b/src/appshell/view/preferences/preferencesmodel.cpp
@@ -228,6 +228,10 @@ void PreferencesModel::resetFactorySettings()
     QApplication::setOverrideCursor(Qt::WaitCursor);
     QApplication::processEvents();
     configuration()->revertToFactorySettings(KEEP_DEFAULT_SETTINGS);
+
+    // Unreset the "First Launch Completed" setting so the first-time launch wizard does not appear.
+    configuration()->setHasCompletedFirstLaunchSetup(true);
+
     configuration()->startEditSettings();
     QApplication::restoreOverrideCursor();
 }

--- a/src/appshell/view/preferences/preferencesmodel.cpp
+++ b/src/appshell/view/preferences/preferencesmodel.cpp
@@ -210,13 +210,13 @@ void PreferencesModel::load(const QString& currentPageId)
 bool PreferencesModel::askForConfirmationOfPreferencesReset()
 {
     std::string title = muse::trc("appshell", "Are you sure you want to reset preferences?");
-    std::string question = muse::trc("appshell", "This action will reset all your app preferences and delete all custom palettes and custom shortcuts.\n\n"
-                                                 "This action will not delete any of your scores.\n\n"
+    std::string question = muse::trc("appshell", "This action will reset all your app preferences and delete all custom shortcuts. "
+                                                 "It will not delete any of your scores.\n\n"
                                                  "This action cannot be undone.");
 
     muse::IInteractive::ButtonData cancelBtn = interactive()->buttonData(muse::IInteractive::Button::Cancel);
     muse::IInteractive::ButtonData resetBtn = interactive()->buttonData(muse::IInteractive::Button::Reset);
-    cancelBtn.accent = true;
+    resetBtn.accent = true;
 
     muse::IInteractive::Result result = interactive()->warning(title, question, { cancelBtn, resetBtn }, cancelBtn.btn);
     return result.standardButton() == muse::IInteractive::Button::Reset;

--- a/src/appshell/view/preferences/preferencesmodel.cpp
+++ b/src/appshell/view/preferences/preferencesmodel.cpp
@@ -216,7 +216,7 @@ bool PreferencesModel::askForConfirmationOfPreferencesReset()
 
     muse::IInteractive::ButtonData cancelBtn = interactive()->buttonData(muse::IInteractive::Button::Cancel);
     muse::IInteractive::ButtonData resetBtn = interactive()->buttonData(muse::IInteractive::Button::Reset);
-    resetBtn.accent = true;
+    cancelBtn.accent = true;
 
     muse::IInteractive::Result result = interactive()->warning(title, question, { cancelBtn, resetBtn }, cancelBtn.btn);
     return result.standardButton() == muse::IInteractive::Button::Reset;

--- a/src/appshell/view/preferences/preferencesmodel.cpp
+++ b/src/appshell/view/preferences/preferencesmodel.cpp
@@ -211,7 +211,8 @@ bool PreferencesModel::askForConfirmationOfPreferencesReset()
 {
     std::string title = muse::trc("appshell", "Are you sure you want to reset preferences?");
     std::string question = muse::trc("appshell", "This action will reset all your app preferences and delete all custom palettes and custom shortcuts.\n\n"
-                                                 "This action will not delete any of your scores.");
+                                     "This action will not delete any of your scores.\n\n"
+                                     "This action cannot be undone.");
 
     muse::IInteractive::ButtonData cancelBtn = interactive()->buttonData(muse::IInteractive::Button::Cancel);
     muse::IInteractive::ButtonData resetBtn = interactive()->buttonData(muse::IInteractive::Button::Reset);

--- a/src/appshell/view/preferences/preferencesmodel.cpp
+++ b/src/appshell/view/preferences/preferencesmodel.cpp
@@ -207,6 +207,20 @@ void PreferencesModel::load(const QString& currentPageId)
     endResetModel();
 }
 
+bool PreferencesModel::askForConfirmationOfPreferencesReset()
+{
+    std::string title = muse::trc("appshell", "Are you sure you want to reset preferences?");
+    std::string question = muse::trc("appshell", "This action will reset all your app preferences and delete all custom palettes and custom shortcuts.\n\n"
+                                                 "This action will not delete any of your scores.");
+
+    muse::IInteractive::ButtonData cancelBtn = interactive()->buttonData(muse::IInteractive::Button::Cancel);
+    muse::IInteractive::ButtonData resetBtn = interactive()->buttonData(muse::IInteractive::Button::Reset);
+    cancelBtn.accent = true;
+
+    muse::IInteractive::Result result = interactive()->warning(title, question, { cancelBtn, resetBtn }, cancelBtn.btn);
+    return result.standardButton() == muse::IInteractive::Button::Reset;
+}
+
 void PreferencesModel::resetFactorySettings()
 {
     static constexpr bool KEEP_DEFAULT_SETTINGS = true;

--- a/src/appshell/view/preferences/preferencesmodel.cpp
+++ b/src/appshell/view/preferences/preferencesmodel.cpp
@@ -218,7 +218,9 @@ bool PreferencesModel::askForConfirmationOfPreferencesReset()
     muse::IInteractive::ButtonData resetBtn = interactive()->buttonData(muse::IInteractive::Button::Reset);
     cancelBtn.accent = true;
 
-    muse::IInteractive::Result result = interactive()->warning(title, question, { cancelBtn, resetBtn }, cancelBtn.btn);
+    muse::IInteractive::Result result = interactive()->warning(title, question, { cancelBtn, resetBtn }, cancelBtn.btn,
+                                                               { muse::IInteractive::Option::WithIcon },
+                                                               muse::trc("appshell", "Reset preferences"));
     return result.standardButton() == muse::IInteractive::Button::Reset;
 }
 

--- a/src/appshell/view/preferences/preferencesmodel.h
+++ b/src/appshell/view/preferences/preferencesmodel.h
@@ -31,6 +31,7 @@
 
 #include "iappshellconfiguration.h"
 #include "preferencepageitem.h"
+#include "iinteractive.h"
 
 namespace mu::appshell {
 class PreferencesModel : public QAbstractItemModel, public muse::Injectable
@@ -42,6 +43,7 @@ class PreferencesModel : public QAbstractItemModel, public muse::Injectable
     muse::Inject<muse::actions::IActionsDispatcher> dispatcher = { this };
     muse::Inject<IAppShellConfiguration> configuration = { this };
     muse::Inject<muse::ui::IUiActionsRegister> actionsRegister = { this };
+    muse::Inject<muse::IInteractive> interactive = { this };
 
 public:
     explicit PreferencesModel(QObject* parent = nullptr);
@@ -57,6 +59,7 @@ public:
     QString currentPageId() const;
 
     Q_INVOKABLE void load(const QString& currentPageId);
+    Q_INVOKABLE bool askForConfirmationOfPreferencesReset();
     Q_INVOKABLE void resetFactorySettings();
     Q_INVOKABLE void apply();
     Q_INVOKABLE void cancel();

--- a/src/appshell/view/preferences/scorepreferencesmodel.cpp
+++ b/src/appshell/view/preferences/scorepreferencesmodel.cpp
@@ -106,12 +106,12 @@ void ScorePreferencesModel::load()
         setPath(DefaultFileType::SecondScoreOrderList, secondScoreOrderListPath());
     });
 
-    notationConfiguration()->defaultStyleFilePathChanged().onReceive(this, [this](const io::path_t&) {
-        setPath(DefaultFileType::Style, stylePath());
+    notationConfiguration()->defaultStyleFilePathChanged().onReceive(this, [this](const io::path_t& val) {
+        setPath(DefaultFileType::Style, val.toQString());
     });
 
-    notationConfiguration()->partStyleFilePathChanged().onReceive(this, [this](const io::path_t&) {
-        setPath(DefaultFileType::PartStyle, partStylePath());
+    notationConfiguration()->partStyleFilePathChanged().onReceive(this, [this](const io::path_t& val) {
+        setPath(DefaultFileType::PartStyle, val.toQString());
     });
 }
 

--- a/src/appshell/view/preferences/scorepreferencesmodel.cpp
+++ b/src/appshell/view/preferences/scorepreferencesmodel.cpp
@@ -100,6 +100,19 @@ void ScorePreferencesModel::load()
     };
 
     endResetModel();
+
+    notationConfiguration()->scoreOrderListPathsChanged().onNotify(this, [this]() {
+        setPath(DefaultFileType::FirstScoreOrderList, firstScoreOrderListPath());
+        setPath(DefaultFileType::SecondScoreOrderList, secondScoreOrderListPath());
+    });
+
+    notationConfiguration()->defaultStyleFilePathChanged().onReceive(this, [this](const io::path_t&) {
+        setPath(DefaultFileType::Style, stylePath());
+    });
+
+    notationConfiguration()->partStyleFilePathChanged().onReceive(this, [this](const io::path_t&) {
+        setPath(DefaultFileType::PartStyle, partStylePath());
+    });
 }
 
 void ScorePreferencesModel::savePath(ScorePreferencesModel::DefaultFileType fileType, const QString& path)

--- a/src/appshell/view/preferences/updatepreferencesmodel.cpp
+++ b/src/appshell/view/preferences/updatepreferencesmodel.cpp
@@ -31,6 +31,13 @@ UpdatePreferencesModel::UpdatePreferencesModel(QObject* parent)
 {
 }
 
+void UpdatePreferencesModel::load()
+{
+    updateConfiguration()->needCheckForUpdateChanged().onNotify(this, [this]() {
+        emit needCheckForNewAppVersionChanged(needCheckForNewAppVersion());
+    });
+}
+
 bool UpdatePreferencesModel::isAppUpdatable() const
 {
     return updateConfiguration()->isAppUpdatable();

--- a/src/appshell/view/preferences/updatepreferencesmodel.h
+++ b/src/appshell/view/preferences/updatepreferencesmodel.h
@@ -24,11 +24,12 @@
 
 #include <QObject>
 
+#include "async/asyncable.h"
 #include "modularity/ioc.h"
 #include "update/iupdateconfiguration.h"
 
 namespace mu::appshell {
-class UpdatePreferencesModel : public QObject, public muse::Injectable
+class UpdatePreferencesModel : public QObject, public muse::Injectable, public muse::async::Asyncable
 {
     Q_OBJECT
 
@@ -39,6 +40,8 @@ class UpdatePreferencesModel : public QObject, public muse::Injectable
 
 public:
     explicit UpdatePreferencesModel(QObject* parent = nullptr);
+
+    Q_INVOKABLE void load();
 
     bool needCheckForNewAppVersion() const;
 

--- a/src/engraving/iengravingconfiguration.h
+++ b/src/engraving/iengravingconfiguration.h
@@ -44,9 +44,11 @@ public:
 
     virtual muse::io::path_t defaultStyleFilePath() const = 0;
     virtual void setDefaultStyleFilePath(const muse::io::path_t& path) = 0;
+    virtual muse::async::Channel<muse::io::path_t> defaultStyleFilePathChanged() const = 0;
 
     virtual muse::io::path_t partStyleFilePath() const = 0;
     virtual void setPartStyleFilePath(const muse::io::path_t& path) = 0;
+    virtual muse::async::Channel<muse::io::path_t> partStyleFilePathChanged() const = 0;
 
     virtual SizeF defaultPageSize() const = 0;
 

--- a/src/engraving/iengravingconfiguration.h
+++ b/src/engraving/iengravingconfiguration.h
@@ -76,6 +76,7 @@ public:
 
     virtual bool dynamicsApplyToAllVoices() const = 0;
     virtual void setDynamicsApplyToAllVoices(bool v) = 0;
+    virtual muse::async::Channel<bool> dynamicsApplyToAllVoicesChanged() const = 0;
 
     virtual Color formattingColor() const = 0;
     virtual muse::async::Channel<Color> formattingColorChanged() const = 0;

--- a/src/engraving/internal/engravingconfiguration.cpp
+++ b/src/engraving/internal/engravingconfiguration.cpp
@@ -108,6 +108,9 @@ void EngravingConfiguration::init()
     VOICE_COLORS[ALL_VOICES_IDX] = VoiceColor { std::move(ALL_VOICES_COLOR), currentColor };
 
     settings()->setDefaultValue(DYNAMICS_APPLY_TO_ALL_VOICES, Val(true));
+    settings()->valueChanged(DYNAMICS_APPLY_TO_ALL_VOICES).onReceive(nullptr, [this](const Val& val) {
+        m_dynamicsApplyToAllVoicesChanged.send(val.toBool());
+    });
 
     settings()->setDefaultValue(FRAME_COLOR, Val(Color("#A0A0A4").toQColor()));
     settings()->setDescription(FRAME_COLOR, muse::trc("engraving", "Frame color"));
@@ -321,6 +324,11 @@ bool EngravingConfiguration::dynamicsApplyToAllVoices() const
 void EngravingConfiguration::setDynamicsApplyToAllVoices(bool v)
 {
     settings()->setSharedValue(DYNAMICS_APPLY_TO_ALL_VOICES, Val(v));
+}
+
+muse::async::Channel<bool> EngravingConfiguration::dynamicsApplyToAllVoicesChanged() const
+{
+    return m_dynamicsApplyToAllVoicesChanged;
 }
 
 muse::async::Notification EngravingConfiguration::scoreInversionChanged() const

--- a/src/engraving/internal/engravingconfiguration.cpp
+++ b/src/engraving/internal/engravingconfiguration.cpp
@@ -116,7 +116,7 @@ void EngravingConfiguration::init()
     VOICE_COLORS[ALL_VOICES_IDX] = VoiceColor { std::move(ALL_VOICES_COLOR), currentColor };
 
     settings()->setDefaultValue(DYNAMICS_APPLY_TO_ALL_VOICES, Val(true));
-    settings()->valueChanged(DYNAMICS_APPLY_TO_ALL_VOICES).onReceive(nullptr, [this](const Val& val) {
+    settings()->valueChanged(DYNAMICS_APPLY_TO_ALL_VOICES).onReceive(this, [this](const Val& val) {
         m_dynamicsApplyToAllVoicesChanged.send(val.toBool());
     });
 

--- a/src/engraving/internal/engravingconfiguration.cpp
+++ b/src/engraving/internal/engravingconfiguration.cpp
@@ -74,6 +74,14 @@ void EngravingConfiguration::init()
         "#6038FC", // "all voices"
     };
 
+    settings()->valueChanged(DEFAULT_STYLE_FILE_PATH).onReceive(nullptr, [this](const Val& val) {
+        m_defaultStyleFilePathChanged.send(val.toPath());
+    });
+
+    settings()->valueChanged(PART_STYLE_FILE_PATH).onReceive(nullptr, [this](const Val& val) {
+        m_partStyleFilePathChanged.send(val.toPath());
+    });
+
     settings()->setDefaultValue(INVERT_SCORE_COLOR, Val(false));
     settings()->valueChanged(INVERT_SCORE_COLOR).onReceive(nullptr, [this](const Val&) {
         m_scoreInversionChanged.notify();
@@ -162,6 +170,11 @@ void EngravingConfiguration::setDefaultStyleFilePath(const muse::io::path_t& pat
     settings()->setSharedValue(DEFAULT_STYLE_FILE_PATH, Val(path.toStdString()));
 }
 
+async::Channel<muse::io::path_t> EngravingConfiguration::defaultStyleFilePathChanged() const
+{
+    return m_defaultStyleFilePathChanged;
+}
+
 muse::io::path_t EngravingConfiguration::partStyleFilePath() const
 {
     return settings()->value(PART_STYLE_FILE_PATH).toPath();
@@ -170,6 +183,11 @@ muse::io::path_t EngravingConfiguration::partStyleFilePath() const
 void EngravingConfiguration::setPartStyleFilePath(const muse::io::path_t& path)
 {
     settings()->setSharedValue(PART_STYLE_FILE_PATH, Val(path.toStdString()));
+}
+
+async::Channel<muse::io::path_t> EngravingConfiguration::partStyleFilePathChanged() const
+{
+    return m_partStyleFilePathChanged;
 }
 
 static bool defaultPageSizeIsLetter()

--- a/src/engraving/internal/engravingconfiguration.cpp
+++ b/src/engraving/internal/engravingconfiguration.cpp
@@ -74,11 +74,11 @@ void EngravingConfiguration::init()
         "#6038FC", // "all voices"
     };
 
-    settings()->valueChanged(DEFAULT_STYLE_FILE_PATH).onReceive(nullptr, [this](const Val& val) {
+    settings()->valueChanged(DEFAULT_STYLE_FILE_PATH).onReceive(this, [this](const Val& val) {
         m_defaultStyleFilePathChanged.send(val.toPath());
     });
 
-    settings()->valueChanged(PART_STYLE_FILE_PATH).onReceive(nullptr, [this](const Val& val) {
+    settings()->valueChanged(PART_STYLE_FILE_PATH).onReceive(this, [this](const Val& val) {
         m_partStyleFilePathChanged.send(val.toPath());
     });
 

--- a/src/engraving/internal/engravingconfiguration.cpp
+++ b/src/engraving/internal/engravingconfiguration.cpp
@@ -74,10 +74,12 @@ void EngravingConfiguration::init()
         "#6038FC", // "all voices"
     };
 
+    settings()->setDefaultValue(DEFAULT_STYLE_FILE_PATH, Val(muse::io::path_t()));
     settings()->valueChanged(DEFAULT_STYLE_FILE_PATH).onReceive(this, [this](const Val& val) {
         m_defaultStyleFilePathChanged.send(val.toPath());
     });
 
+    settings()->setDefaultValue(PART_STYLE_FILE_PATH, Val(muse::io::path_t()));
     settings()->valueChanged(PART_STYLE_FILE_PATH).onReceive(this, [this](const Val& val) {
         m_partStyleFilePathChanged.send(val.toPath());
     });

--- a/src/engraving/internal/engravingconfiguration.h
+++ b/src/engraving/internal/engravingconfiguration.h
@@ -50,9 +50,11 @@ public:
 
     muse::io::path_t defaultStyleFilePath() const override;
     void setDefaultStyleFilePath(const muse::io::path_t& path) override;
+    muse::async::Channel<muse::io::path_t> defaultStyleFilePathChanged() const override;
 
     muse::io::path_t partStyleFilePath() const override;
     void setPartStyleFilePath(const muse::io::path_t& path) override;
+    muse::async::Channel<muse::io::path_t> partStyleFilePathChanged() const override;
 
     SizeF defaultPageSize() const override;
 
@@ -128,6 +130,8 @@ private:
     muse::async::Channel<Color> m_frameColorChanged;
     muse::async::Channel<Color> m_invisibleColorChanged;
     muse::async::Channel<Color> m_unlinkedColorChanged;
+    muse::async::Channel<muse::io::path_t> m_defaultStyleFilePathChanged;
+    muse::async::Channel<muse::io::path_t> m_partStyleFilePathChanged;
 
     muse::ValNt<DebuggingOptions> m_debuggingOptions;
 

--- a/src/engraving/internal/engravingconfiguration.h
+++ b/src/engraving/internal/engravingconfiguration.h
@@ -83,6 +83,7 @@ public:
 
     bool dynamicsApplyToAllVoices() const override;
     void setDynamicsApplyToAllVoices(bool v) override;
+    muse::async::Channel<bool> dynamicsApplyToAllVoicesChanged() const override;
 
     muse::async::Notification scoreInversionChanged() const override;
 
@@ -122,6 +123,7 @@ public:
 private:
     muse::async::Channel<voice_idx_t, Color> m_voiceColorChanged;
     muse::async::Notification m_scoreInversionChanged;
+    muse::async::Channel<bool> m_dynamicsApplyToAllVoicesChanged;
     muse::async::Channel<Color> m_formattingColorChanged;
     muse::async::Channel<Color> m_frameColorChanged;
     muse::async::Channel<Color> m_invisibleColorChanged;

--- a/src/engraving/tests/mocks/engravingconfigurationmock.h
+++ b/src/engraving/tests/mocks/engravingconfigurationmock.h
@@ -34,9 +34,11 @@ public:
 
     MOCK_METHOD(muse::io::path_t, defaultStyleFilePath, (), (const, override));
     MOCK_METHOD(void, setDefaultStyleFilePath, (const muse::io::path_t&), (override));
+    MOCK_METHOD(muse::async::Channel<muse::io::path_t>, defaultStyleFilePathChanged, (), (const, override));
 
     MOCK_METHOD(muse::io::path_t, partStyleFilePath, (), (const, override));
     MOCK_METHOD(void, setPartStyleFilePath, (const muse::io::path_t&), (override));
+    MOCK_METHOD(muse::async::Channel<muse::io::path_t>, partStyleFilePathChanged, (), (const, override));
 
     MOCK_METHOD(SizeF, defaultPageSize, (), (const, override));
 

--- a/src/engraving/tests/mocks/engravingconfigurationmock.h
+++ b/src/engraving/tests/mocks/engravingconfigurationmock.h
@@ -62,6 +62,7 @@ public:
 
     MOCK_METHOD(bool, dynamicsApplyToAllVoices, (), (const, override));
     MOCK_METHOD(void, setDynamicsApplyToAllVoices, (bool), (override));
+    MOCK_METHOD((muse::async::Channel<bool>), dynamicsApplyToAllVoicesChanged, (), (const, override));
 
     MOCK_METHOD(bool, scoreInversionEnabled, (), (const, override));
     MOCK_METHOD(void, setScoreInversionEnabled, (bool), (override));

--- a/src/framework/audio/audiotypes.h
+++ b/src/framework/audio/audiotypes.h
@@ -69,6 +69,8 @@ using PlaybackSetupData = mpe::PlaybackSetupData;
 
 static constexpr TrackId INVALID_TRACK_ID = -1;
 
+static constexpr char DEFAULT_DEVICE_ID[] = "default";
+
 #ifdef Q_OS_WIN
 static constexpr size_t MINIMUM_BUFFER_SIZE = 256;
 #else

--- a/src/framework/audio/internal/audioconfiguration.cpp
+++ b/src/framework/audio/internal/audioconfiguration.cpp
@@ -54,6 +54,8 @@ static const AudioResourceAttributes DEFAULT_AUDIO_RESOURCE_ATTRIBUTES = {
 static const AudioResourceMeta DEFAULT_AUDIO_RESOURCE_META
     = { DEFAULT_SOUND_FONT_NAME, AudioResourceType::FluidSoundfont, "Fluid", DEFAULT_AUDIO_RESOURCE_ATTRIBUTES, false /*hasNativeEditor*/ };
 
+static constexpr char DEFAULT_DEVICE_ID[] = "default"; // Must match DEFAULT_DEVICE_ID in wasapiaudiodriver.cpp!
+
 void AudioConfiguration::init()
 {
     int defaultBufferSize = 0;
@@ -70,6 +72,7 @@ void AudioConfiguration::init()
 
     settings()->setDefaultValue(AUDIO_API_KEY, Val("Core Audio"));
 
+    settings()->setDefaultValue(AUDIO_OUTPUT_DEVICE_ID_KEY, Val(DEFAULT_DEVICE_ID));
     settings()->valueChanged(AUDIO_OUTPUT_DEVICE_ID_KEY).onReceive(nullptr, [this](const Val&) {
         m_audioOutputDeviceIdChanged.notify();
     });

--- a/src/framework/audio/internal/audioconfiguration.cpp
+++ b/src/framework/audio/internal/audioconfiguration.cpp
@@ -54,8 +54,6 @@ static const AudioResourceAttributes DEFAULT_AUDIO_RESOURCE_ATTRIBUTES = {
 static const AudioResourceMeta DEFAULT_AUDIO_RESOURCE_META
     = { DEFAULT_SOUND_FONT_NAME, AudioResourceType::FluidSoundfont, "Fluid", DEFAULT_AUDIO_RESOURCE_ATTRIBUTES, false /*hasNativeEditor*/ };
 
-static constexpr char DEFAULT_DEVICE_ID[] = "default"; // Must match DEFAULT_DEVICE_ID in wasapiaudiodriver.cpp!
-
 void AudioConfiguration::init()
 {
     int defaultBufferSize = 0;

--- a/src/framework/audio/internal/audioconfiguration.h
+++ b/src/framework/audio/internal/audioconfiguration.h
@@ -79,6 +79,8 @@ public:
     bool shouldMeasureInputLag() const override;
 
 private:
+    static constexpr char DEFAULT_DEVICE_ID[] = "default"; // Must match DEFAULT_DEVICE_ID in wasapiaudiodriver.cpp and possibly others!
+
     void updateSamplesToPreallocate();
 
     async::Channel<io::paths_t> m_soundFontDirsChanged;

--- a/src/framework/audio/internal/audioconfiguration.h
+++ b/src/framework/audio/internal/audioconfiguration.h
@@ -79,8 +79,6 @@ public:
     bool shouldMeasureInputLag() const override;
 
 private:
-    static constexpr char DEFAULT_DEVICE_ID[] = "default"; // Must match DEFAULT_DEVICE_ID in wasapiaudiodriver.cpp and possibly others!
-
     void updateSamplesToPreallocate();
 
     async::Channel<io::paths_t> m_soundFontDirsChanged;

--- a/src/framework/audio/internal/platform/jack/jackaudiodriver.cpp
+++ b/src/framework/audio/internal/platform/jack/jackaudiodriver.cpp
@@ -33,8 +33,6 @@
 #include "log.h"
 #include "runtime.h"
 
-static constexpr char JACK_DEFAULT_DEVICE_ID[] = "default";
-
 using namespace muse::audio;
 
 struct JackData
@@ -88,7 +86,7 @@ void jackCleanup()
 
 JackAudioDriver::JackAudioDriver()
 {
-    m_deviceId = JACK_DEFAULT_DEVICE_ID;
+    m_deviceId = DEFAULT_DEVICE_ID;
 }
 
 JackAudioDriver::~JackAudioDriver()
@@ -226,7 +224,7 @@ bool JackAudioDriver::selectOutputDevice(const AudioDeviceID& deviceId)
 
 bool JackAudioDriver::resetToDefaultOutputDevice()
 {
-    return selectOutputDevice(JACK_DEFAULT_DEVICE_ID);
+    return selectOutputDevice(DEFAULT_DEVICE_ID);
 }
 
 async::Notification JackAudioDriver::outputDeviceChanged() const
@@ -237,7 +235,7 @@ async::Notification JackAudioDriver::outputDeviceChanged() const
 AudioDeviceList JackAudioDriver::availableOutputDevices() const
 {
     AudioDeviceList devices;
-    devices.push_back({ JACK_DEFAULT_DEVICE_ID, muse::trc("audio", "System default") });
+    devices.push_back({ DEFAULT_DEVICE_ID, muse::trc("audio", "System default") });
 
     return devices;
 }

--- a/src/framework/audio/internal/platform/lin/linuxaudiodriver.cpp
+++ b/src/framework/audio/internal/platform/lin/linuxaudiodriver.cpp
@@ -34,8 +34,6 @@
 #include "log.h"
 #include "runtime.h"
 
-static constexpr char DEFAULT_DEVICE_ID[] = "default";
-
 using namespace muse;
 using namespace muse::audio;
 

--- a/src/framework/audio/internal/platform/win/wasapiaudiodriver.cpp
+++ b/src/framework/audio/internal/platform/win/wasapiaudiodriver.cpp
@@ -34,7 +34,7 @@ using namespace winrt;
 using namespace muse;
 using namespace muse::audio;
 
-static constexpr char DEFAULT_DEVICE_ID[] = "default";
+static constexpr char DEFAULT_DEVICE_ID[] = "default"; // Must match DEFAULT_DEVICE_ID in audioconfiguration.cpp!
 
 inline int refTimeToSamples(const REFERENCE_TIME& t, double sampleRate) noexcept
 {

--- a/src/framework/audio/internal/platform/win/wasapiaudiodriver.cpp
+++ b/src/framework/audio/internal/platform/win/wasapiaudiodriver.cpp
@@ -34,8 +34,6 @@ using namespace winrt;
 using namespace muse;
 using namespace muse::audio;
 
-static constexpr char DEFAULT_DEVICE_ID[] = "default"; // Must match DEFAULT_DEVICE_ID in audioconfiguration.cpp and possibly others!
-
 inline int refTimeToSamples(const REFERENCE_TIME& t, double sampleRate) noexcept
 {
     return sampleRate * ((double)t) * 0.0000001;

--- a/src/framework/audio/internal/platform/win/wasapiaudiodriver.cpp
+++ b/src/framework/audio/internal/platform/win/wasapiaudiodriver.cpp
@@ -34,7 +34,7 @@ using namespace winrt;
 using namespace muse;
 using namespace muse::audio;
 
-static constexpr char DEFAULT_DEVICE_ID[] = "default"; // Must match DEFAULT_DEVICE_ID in audioconfiguration.cpp!
+static constexpr char DEFAULT_DEVICE_ID[] = "default"; // Must match DEFAULT_DEVICE_ID in audioconfiguration.cpp and possibly others!
 
 inline int refTimeToSamples(const REFERENCE_TIME& t, double sampleRate) noexcept
 {

--- a/src/framework/audio/internal/platform/win/wincoreaudiodriver.cpp
+++ b/src/framework/audio/internal/platform/win/wincoreaudiodriver.cpp
@@ -82,7 +82,6 @@ void copyWavFormat(WAVEFORMATEXTENSIBLE& dest, const WAVEFORMATEX* src) noexcept
 static void logError(HRESULT hr);
 
 static WinCoreData* s_data = nullptr;
-static constexpr char DEFAULT_DEVICE_ID[] = "default";
 static IAudioDriver::Spec s_activeSpec;
 static HRESULT s_lastError = S_OK;
 

--- a/src/framework/autobot/internal/autobotinteractive.cpp
+++ b/src/framework/autobot/internal/autobotinteractive.cpp
@@ -36,17 +36,17 @@ std::shared_ptr<IInteractive> AutobotInteractive::realInteractive() const
     return m_real;
 }
 
-IInteractive::Result AutobotInteractive::question(const std::string& title, const std::string& text, const Buttons& buttons,
+IInteractive::Result AutobotInteractive::question(const std::string& contentTitle, const std::string& text, const Buttons& buttons,
                                                   const Button& def, const Options& options,
                                                   const std::string& dialogTitle) const
 {
-    return m_real->question(title, text, buttons, def, options, dialogTitle);
+    return m_real->question(contentTitle, text, buttons, def, options, dialogTitle);
 }
 
-IInteractive::Result AutobotInteractive::question(const std::string& title, const Text& text, const ButtonDatas& buttons,
+IInteractive::Result AutobotInteractive::question(const std::string& contentTitle, const Text& text, const ButtonDatas& buttons,
                                                   int defBtn, const Options& options, const std::string& dialogTitle) const
 {
-    return m_real->question(title, text, buttons, defBtn, options, dialogTitle);
+    return m_real->question(contentTitle, text, buttons, defBtn, options, dialogTitle);
 }
 
 IInteractive::ButtonData AutobotInteractive::buttonData(Button b) const
@@ -54,54 +54,54 @@ IInteractive::ButtonData AutobotInteractive::buttonData(Button b) const
     return m_real->buttonData(b);
 }
 
-IInteractive::Result AutobotInteractive::info(const std::string& title, const std::string& text, const Buttons& buttons,
+IInteractive::Result AutobotInteractive::info(const std::string& contentTitle, const std::string& text, const Buttons& buttons,
                                               int defBtn, const Options& options, const std::string& dialogTitle) const
 {
-    return m_real->info(title, text, buttons, defBtn, options, dialogTitle);
+    return m_real->info(contentTitle, text, buttons, defBtn, options, dialogTitle);
 }
 
-IInteractive::Result AutobotInteractive::info(const std::string& title, const Text& text, const ButtonDatas& buttons, int defBtn,
+IInteractive::Result AutobotInteractive::info(const std::string& contentTitle, const Text& text, const ButtonDatas& buttons, int defBtn,
                                               const Options& options, const std::string& dialogTitle) const
 {
-    return m_real->info(title, text, buttons, defBtn, options, dialogTitle);
+    return m_real->info(contentTitle, text, buttons, defBtn, options, dialogTitle);
 }
 
-IInteractive::Result AutobotInteractive::warning(const std::string& title, const std::string& text, const Buttons& buttons,
+IInteractive::Result AutobotInteractive::warning(const std::string& contentTitle, const std::string& text, const Buttons& buttons,
                                                  const Button& def, const Options& options, const std::string& dialogTitle) const
 {
-    return m_real->warning(title, text, buttons, def, options, dialogTitle);
+    return m_real->warning(contentTitle, text, buttons, def, options, dialogTitle);
 }
 
-IInteractive::Result AutobotInteractive::warning(const std::string& title, const Text& text, const ButtonDatas& buttons,
+IInteractive::Result AutobotInteractive::warning(const std::string& contentTitle, const Text& text, const ButtonDatas& buttons,
                                                  int defBtn, const Options& options, const std::string& dialogTitle) const
 {
-    return m_real->warning(title, text, buttons, defBtn, options, dialogTitle);
+    return m_real->warning(contentTitle, text, buttons, defBtn, options, dialogTitle);
 }
 
-IInteractive::Result AutobotInteractive::warning(const std::string& title, const Text& text, const std::string& detailedText,
+IInteractive::Result AutobotInteractive::warning(const std::string& contentTitle, const Text& text, const std::string& detailedText,
                                                  const ButtonDatas& buttons, int defBtn,
                                                  const Options& options, const std::string& dialogTitle) const
 {
-    return m_real->warning(title, text, detailedText, buttons, defBtn, options, dialogTitle);
+    return m_real->warning(contentTitle, text, detailedText, buttons, defBtn, options, dialogTitle);
 }
 
-IInteractive::Result AutobotInteractive::error(const std::string& title, const std::string& text, const Buttons& buttons,
+IInteractive::Result AutobotInteractive::error(const std::string& contentTitle, const std::string& text, const Buttons& buttons,
                                                const Button& def, const Options& options, const std::string& dialogTitle) const
 {
-    return m_real->error(title, text, buttons, def, options, dialogTitle);
+    return m_real->error(contentTitle, text, buttons, def, options, dialogTitle);
 }
 
-IInteractive::Result AutobotInteractive::error(const std::string& title, const Text& text, const ButtonDatas& buttons,
+IInteractive::Result AutobotInteractive::error(const std::string& contentTitle, const Text& text, const ButtonDatas& buttons,
                                                int defBtn, const Options& options, const std::string& dialogTitle) const
 {
-    return m_real->error(title, text, buttons, defBtn, options, dialogTitle);
+    return m_real->error(contentTitle, text, buttons, defBtn, options, dialogTitle);
 }
 
-IInteractive::Result AutobotInteractive::error(const std::string& title, const Text& text, const std::string& detailedText,
+IInteractive::Result AutobotInteractive::error(const std::string& contentTitle, const Text& text, const std::string& detailedText,
                                                const ButtonDatas& buttons, int defBtn, const Options& options,
                                                const std::string& dialogTitle) const
 {
-    return m_real->error(title, text, detailedText, buttons, defBtn, options, dialogTitle);
+    return m_real->error(contentTitle, text, detailedText, buttons, defBtn, options, dialogTitle);
 }
 
 Ret AutobotInteractive::showProgress(const std::string& title, Progress* progress) const

--- a/src/framework/autobot/internal/autobotinteractive.cpp
+++ b/src/framework/autobot/internal/autobotinteractive.cpp
@@ -37,15 +37,16 @@ std::shared_ptr<IInteractive> AutobotInteractive::realInteractive() const
 }
 
 IInteractive::Result AutobotInteractive::question(const std::string& title, const std::string& text, const Buttons& buttons,
-                                                  const Button& def, const Options& options) const
+                                                  const Button& def, const Options& options,
+                                                  const std::string& dialogTitle) const
 {
-    return m_real->question(title, text, buttons, def, options);
+    return m_real->question(title, text, buttons, def, options, dialogTitle);
 }
 
 IInteractive::Result AutobotInteractive::question(const std::string& title, const Text& text, const ButtonDatas& buttons,
-                                                  int defBtn, const Options& options) const
+                                                  int defBtn, const Options& options, const std::string& dialogTitle) const
 {
-    return m_real->question(title, text, buttons, defBtn, options);
+    return m_real->question(title, text, buttons, defBtn, options, dialogTitle);
 }
 
 IInteractive::ButtonData AutobotInteractive::buttonData(Button b) const
@@ -54,52 +55,53 @@ IInteractive::ButtonData AutobotInteractive::buttonData(Button b) const
 }
 
 IInteractive::Result AutobotInteractive::info(const std::string& title, const std::string& text, const Buttons& buttons,
-                                              int defBtn, const Options& options) const
+                                              int defBtn, const Options& options, const std::string& dialogTitle) const
 {
-    return m_real->info(title, text, buttons, defBtn, options);
+    return m_real->info(title, text, buttons, defBtn, options, dialogTitle);
 }
 
 IInteractive::Result AutobotInteractive::info(const std::string& title, const Text& text, const ButtonDatas& buttons, int defBtn,
-                                              const Options& options) const
+                                              const Options& options, const std::string& dialogTitle) const
 {
-    return m_real->info(title, text, buttons, defBtn, options);
+    return m_real->info(title, text, buttons, defBtn, options, dialogTitle);
 }
 
 IInteractive::Result AutobotInteractive::warning(const std::string& title, const std::string& text, const Buttons& buttons,
-                                                 const Button& def, const Options& options) const
+                                                 const Button& def, const Options& options, const std::string& dialogTitle) const
 {
-    return m_real->warning(title, text, buttons, def, options);
+    return m_real->warning(title, text, buttons, def, options, dialogTitle);
 }
 
 IInteractive::Result AutobotInteractive::warning(const std::string& title, const Text& text, const ButtonDatas& buttons,
-                                                 int defBtn, const Options& options) const
+                                                 int defBtn, const Options& options, const std::string& dialogTitle) const
 {
-    return m_real->warning(title, text, buttons, defBtn, options);
+    return m_real->warning(title, text, buttons, defBtn, options, dialogTitle);
 }
 
 IInteractive::Result AutobotInteractive::warning(const std::string& title, const Text& text, const std::string& detailedText,
                                                  const ButtonDatas& buttons, int defBtn,
-                                                 const Options& options) const
+                                                 const Options& options, const std::string& dialogTitle) const
 {
-    return m_real->warning(title, text, detailedText, buttons, defBtn, options);
+    return m_real->warning(title, text, detailedText, buttons, defBtn, options, dialogTitle);
 }
 
 IInteractive::Result AutobotInteractive::error(const std::string& title, const std::string& text, const Buttons& buttons,
-                                               const Button& def, const Options& options) const
+                                               const Button& def, const Options& options, const std::string& dialogTitle) const
 {
-    return m_real->error(title, text, buttons, def, options);
+    return m_real->error(title, text, buttons, def, options, dialogTitle);
 }
 
 IInteractive::Result AutobotInteractive::error(const std::string& title, const Text& text, const ButtonDatas& buttons,
-                                               int defBtn, const Options& options) const
+                                               int defBtn, const Options& options, const std::string& dialogTitle) const
 {
-    return m_real->error(title, text, buttons, defBtn, options);
+    return m_real->error(title, text, buttons, defBtn, options, dialogTitle);
 }
 
 IInteractive::Result AutobotInteractive::error(const std::string& title, const Text& text, const std::string& detailedText,
-                                               const ButtonDatas& buttons, int defBtn, const Options& options) const
+                                               const ButtonDatas& buttons, int defBtn, const Options& options,
+                                               const std::string& dialogTitle) const
 {
-    return m_real->error(title, text, detailedText, buttons, defBtn, options);
+    return m_real->error(title, text, detailedText, buttons, defBtn, options, dialogTitle);
 }
 
 Ret AutobotInteractive::showProgress(const std::string& title, Progress* progress) const

--- a/src/framework/autobot/internal/autobotinteractive.h
+++ b/src/framework/autobot/internal/autobotinteractive.h
@@ -35,39 +35,39 @@ public:
     void setRealInteractive(std::shared_ptr<IInteractive> real);
     std::shared_ptr<IInteractive> realInteractive() const;
 
-    Result question(const std::string& title, const std::string& text, const Buttons& buttons, const Button& def = Button::NoButton,
+    Result question(const std::string& contentTitle, const std::string& text, const Buttons& buttons, const Button& def = Button::NoButton,
                     const Options& options = {}, const std::string& dialogTitle = "") const override;
 
-    Result question(const std::string& title, const Text& text, const ButtonDatas& buttons, int defBtn = int(Button::NoButton),
+    Result question(const std::string& contentTitle, const Text& text, const ButtonDatas& buttons, int defBtn = int(Button::NoButton),
                     const Options& options = {}, const std::string& dialogTitle = "") const override;
 
     ButtonData buttonData(Button b) const override;
 
     // info
-    Result info(const std::string& title, const std::string& text, const Buttons& buttons = {}, int defBtn = int(Button::NoButton),
+    Result info(const std::string& contentTitle, const std::string& text, const Buttons& buttons = {}, int defBtn = int(Button::NoButton),
                 const Options& options = {}, const std::string& dialogTitle = "") const override;
 
-    Result info(const std::string& title, const Text& text, const ButtonDatas& buttons, int defBtn = int(Button::NoButton),
+    Result info(const std::string& contentTitle, const Text& text, const ButtonDatas& buttons, int defBtn = int(Button::NoButton),
                 const Options& options = {}, const std::string& dialogTitle = "") const override;
 
     // warning
-    Result warning(const std::string& title, const std::string& text, const Buttons& buttons = {}, const Button& def = Button::NoButton,
+    Result warning(const std::string& contentTitle, const std::string& text, const Buttons& buttons = {},
+                   const Button& def = Button::NoButton, const Options& options = {}, const std::string& dialogTitle = "") const override;
+
+    Result warning(const std::string& contentTitle, const Text& text, const ButtonDatas& buttons = {}, int defBtn = int(Button::NoButton),
                    const Options& options = {}, const std::string& dialogTitle = "") const override;
 
-    Result warning(const std::string& title, const Text& text, const ButtonDatas& buttons = {}, int defBtn = int(Button::NoButton),
-                   const Options& options = {}, const std::string& dialogTitle = "") const override;
-
-    Result warning(const std::string& title, const Text& text, const std::string& detailedText, const ButtonDatas& buttons = {},
+    Result warning(const std::string& contentTitle, const Text& text, const std::string& detailedText, const ButtonDatas& buttons = {},
                    int defBtn = int(Button::NoButton), const Options& options = {}, const std::string& dialogTitle = "") const override;
 
     // error
-    Result error(const std::string& title, const std::string& text, const Buttons& buttons = {}, const Button& def = Button::NoButton,
+    Result error(const std::string& contentTitle, const std::string& text, const Buttons& buttons = {},
+                 const Button& def = Button::NoButton, const Options& options = {}, const std::string& dialogTitle = "") const override;
+
+    Result error(const std::string& contentTitle, const Text& text, const ButtonDatas& buttons = {}, int defBtn = int(Button::NoButton),
                  const Options& options = {}, const std::string& dialogTitle = "") const override;
 
-    Result error(const std::string& title, const Text& text, const ButtonDatas& buttons = {}, int defBtn = int(Button::NoButton),
-                 const Options& options = {}, const std::string& dialogTitle = "") const override;
-
-    Result error(const std::string& title, const Text& text, const std::string& detailedText, const ButtonDatas& buttons = {},
+    Result error(const std::string& contentTitle, const Text& text, const std::string& detailedText, const ButtonDatas& buttons = {},
                  int defBtn = int(Button::NoButton), const Options& options = {}, const std::string& dialogTitle = "") const override;
 
     // progress

--- a/src/framework/autobot/internal/autobotinteractive.h
+++ b/src/framework/autobot/internal/autobotinteractive.h
@@ -36,39 +36,41 @@ public:
     std::shared_ptr<IInteractive> realInteractive() const;
 
     Result question(const std::string& title, const std::string& text, const Buttons& buttons, const Button& def = Button::NoButton,
-                    const Options& options = {}) const override;
+                    const Options& options = {}, const std::string& dialogTitle = "") const override;
 
     Result question(const std::string& title, const Text& text, const ButtonDatas& buttons, int defBtn = int(Button::NoButton),
-                    const Options& options = {}) const override;
+                    const Options& options = {}, const std::string& dialogTitle = "") const override;
 
     ButtonData buttonData(Button b) const override;
 
     // info
     Result info(const std::string& title, const std::string& text, const Buttons& buttons = {}, int defBtn = int(Button::NoButton),
-                const Options& options = {}) const override;
+                const Options& options = {}, const std::string& dialogTitle = "") const override;
 
     Result info(const std::string& title, const Text& text, const ButtonDatas& buttons, int defBtn = int(Button::NoButton),
-                const Options& options = {}) const override;
+                const Options& options = {}, const std::string& dialogTitle = "") const override;
 
     // warning
     Result warning(const std::string& title, const std::string& text, const Buttons& buttons = {}, const Button& def = Button::NoButton,
-                   const Options& options = {}) const override;
+                   const Options& options = {}, const std::string& dialogTitle = "") const override;
 
     Result warning(const std::string& title, const Text& text, const ButtonDatas& buttons = {}, int defBtn = int(Button::NoButton),
-                   const Options& options = {}) const override;
+                   const Options& options = {}, const std::string& dialogTitle = "") const override;
 
     Result warning(const std::string& title, const Text& text, const std::string& detailedText, const ButtonDatas& buttons = {},
-                   int defBtn = int(Button::NoButton), const Options& options = {}) const override;
+                   int defBtn = int(Button::NoButton), const Options& options = {},
+                   const std::string& dialogTitle = "") const override;
 
     // error
     Result error(const std::string& title, const std::string& text, const Buttons& buttons = {}, const Button& def = Button::NoButton,
-                 const Options& options = {}) const override;
+                 const Options& options = {}, const std::string& dialogTitle = "") const override;
 
     Result error(const std::string& title, const Text& text, const ButtonDatas& buttons = {}, int defBtn = int(Button::NoButton),
-                 const Options& options = {}) const override;
+                 const Options& options = {}, const std::string& dialogTitle = "") const override;
 
     Result error(const std::string& title, const Text& text, const std::string& detailedText, const ButtonDatas& buttons = {},
-                 int defBtn = int(Button::NoButton), const Options& options = {}) const override;
+                 int defBtn = int(Button::NoButton), const Options& options = {},
+                 const std::string& dialogTitle = "") const override;
 
     // progress
     Ret showProgress(const std::string& title, Progress* progress) const override;

--- a/src/framework/autobot/internal/autobotinteractive.h
+++ b/src/framework/autobot/internal/autobotinteractive.h
@@ -58,8 +58,7 @@ public:
                    const Options& options = {}, const std::string& dialogTitle = "") const override;
 
     Result warning(const std::string& title, const Text& text, const std::string& detailedText, const ButtonDatas& buttons = {},
-                   int defBtn = int(Button::NoButton), const Options& options = {},
-                   const std::string& dialogTitle = "") const override;
+                   int defBtn = int(Button::NoButton), const Options& options = {}, const std::string& dialogTitle = "") const override;
 
     // error
     Result error(const std::string& title, const std::string& text, const Buttons& buttons = {}, const Button& def = Button::NoButton,
@@ -69,8 +68,7 @@ public:
                  const Options& options = {}, const std::string& dialogTitle = "") const override;
 
     Result error(const std::string& title, const Text& text, const std::string& detailedText, const ButtonDatas& buttons = {},
-                 int defBtn = int(Button::NoButton), const Options& options = {},
-                 const std::string& dialogTitle = "") const override;
+                 int defBtn = int(Button::NoButton), const Options& options = {}, const std::string& dialogTitle = "") const override;
 
     // progress
     Ret showProgress(const std::string& title, Progress* progress) const override;

--- a/src/framework/extensions/api/v1/messagedialog.cpp
+++ b/src/framework/extensions/api/v1/messagedialog.cpp
@@ -26,7 +26,7 @@ using namespace muse::extensions::apiv1;
 MessageDialog::MessageDialog(QObject* parent)
     : QObject(parent), Injectable(muse::iocCtxForQmlObject(this)) {}
 
-void MessageDialog::doOpen(const QString& title, const QString& text, const QString& detailed, const QVariantList& buttons)
+void MessageDialog::doOpen(const QString& contentTitle, const QString& text, const QString& detailed, const QVariantList& buttons)
 {
     //! NOTE Minimum compatibility for the current ones to work.
     //! It would be nice to change a lot of things.
@@ -38,7 +38,7 @@ void MessageDialog::doOpen(const QString& title, const QString& text, const QStr
 
     // info
     if (btns.size() <= 1) {
-        interactive()->error(title.toStdString(), text.toStdString(), detailed.toStdString());
+        interactive()->error(contentTitle.toStdString(), text.toStdString(), detailed.toStdString());
         emit accepted();
     }
     //
@@ -49,7 +49,7 @@ void MessageDialog::doOpen(const QString& title, const QString& text, const QStr
             txt += detailed.toStdString();
         }
 
-        IInteractive::Result res = interactive()->question(title.toStdString(), txt, btns);
+        IInteractive::Result res = interactive()->question(contentTitle.toStdString(), txt, btns);
 
         if (res.standardButton() == IInteractive::Button::Ok) {
             emit accepted();

--- a/src/framework/extensions/api/v1/messagedialog.h
+++ b/src/framework/extensions/api/v1/messagedialog.h
@@ -85,7 +85,7 @@ signals:
 
 private:
 
-    void doOpen(const QString& title, const QString& text, const QString& detailed, const QVariantList& buttons);
+    void doOpen(const QString& contentTitle, const QString& text, const QString& detailed, const QVariantList& buttons);
 
     QString m_text;
     bool m_visible = false;

--- a/src/framework/global/api/interactiveapi.cpp
+++ b/src/framework/global/api/interactiveapi.cpp
@@ -41,9 +41,9 @@ InteractiveApi::InteractiveApi(IApiEngine* e)
  * @param {String} text Message
  */
 
-void InteractiveApi::info(const QString& title, const QString& text)
+void InteractiveApi::info(const QString& contentTitle, const QString& text)
 {
-    interactive()->info(title.toStdString(), text.toStdString());
+    interactive()->info(contentTitle.toStdString(), text.toStdString());
 }
 
 /** APIDOC method

--- a/src/framework/global/api/interactiveapi.h
+++ b/src/framework/global/api/interactiveapi.h
@@ -37,7 +37,7 @@ class InteractiveApi : public ApiObject
 public:
     explicit InteractiveApi(IApiEngine* e);
 
-    Q_INVOKABLE void info(const QString& title, const QString& text);
+    Q_INVOKABLE void info(const QString& contentTitle, const QString& text);
     Q_INVOKABLE void openUrl(const QString& url);
 };
 }

--- a/src/framework/global/iinteractive.h
+++ b/src/framework/global/iinteractive.h
@@ -145,43 +145,46 @@ public:
     };
     DECLARE_FLAGS(Options, Option)
 
-    virtual Result question(const std::string& title, const std::string& text, const Buttons& buttons, const Button& def = Button::NoButton,
-                            const Options& options = {}, const std::string& dialogTitle = "") const = 0;
+    virtual Result question(const std::string& contentTitle, const std::string& text, const Buttons& buttons,
+                            const Button& def = Button::NoButton, const Options& options = {},
+                            const std::string& dialogTitle = "") const = 0;
 
-    virtual Result question(const std::string& title, const Text& text, const ButtonDatas& buttons, int defBtn = int(Button::NoButton),
-                            const Options& options = {}, const std::string& dialogTitle = "") const = 0;
+    virtual Result question(const std::string& contentTitle, const Text& text, const ButtonDatas& buttons,
+                            int defBtn = int(Button::NoButton), const Options& options = {}, const std::string& dialogTitle = "") const = 0;
 
     virtual ButtonData buttonData(Button b) const = 0;
 
     // info
-    virtual Result info(const std::string& title, const std::string& text, const Buttons& buttons = {}, int defBtn = int(Button::NoButton),
-                        const Options& options = {}, const std::string& dialogTitle = "") const = 0;
+    virtual Result info(const std::string& contentTitle, const std::string& text, const Buttons& buttons = {},
+                        int defBtn = int(Button::NoButton), const Options& options = {}, const std::string& dialogTitle = "") const = 0;
 
-    virtual Result info(const std::string& title, const Text& text, const ButtonDatas& buttons = {}, int defBtn = int(Button::NoButton),
-                        const Options& options = {}, const std::string& dialogTitle = "") const = 0;
+    virtual Result info(const std::string& contentTitle, const Text& text, const ButtonDatas& buttons = {},
+                        int defBtn = int(Button::NoButton), const Options& options = {}, const std::string& dialogTitle = "") const = 0;
 
     // warning
-    virtual Result warning(const std::string& title, const std::string& text, const Buttons& buttons = {},
+    virtual Result warning(const std::string& contentTitle, const std::string& text, const Buttons& buttons = {},
                            const Button& def = Button::NoButton, const Options& options = { WithIcon },
                            const std::string& dialogTitle = "") const = 0;
 
-    virtual Result warning(const std::string& title, const Text& text, const ButtonDatas& buttons = {}, int defBtn = int(Button::NoButton),
-                           const Options& options = { WithIcon }, const std::string& dialogTitle = "") const = 0;
-
-    virtual Result warning(const std::string& title, const Text& text, const std::string& detailedText, const ButtonDatas& buttons = {},
+    virtual Result warning(const std::string& contentTitle, const Text& text, const ButtonDatas& buttons = {},
                            int defBtn = int(Button::NoButton), const Options& options = { WithIcon },
                            const std::string& dialogTitle = "") const = 0;
 
+    virtual Result warning(const std::string& contentTitle, const Text& text, const std::string& detailedText,
+                           const ButtonDatas& buttons = {}, int defBtn = int(Button::NoButton), const Options& options = { WithIcon },
+                           const std::string& dialogTitle = "") const = 0;
+
     // error
-    virtual Result error(const std::string& title, const std::string& text, const Buttons& buttons = {},
+    virtual Result error(const std::string& contentTitle, const std::string& text, const Buttons& buttons = {},
                          const Button& def = Button::NoButton, const Options& options = { WithIcon },
                          const std::string& dialogTitle = "") const = 0;
 
-    virtual Result error(const std::string& title, const Text& text, const ButtonDatas& buttons = {}, int defBtn = int(Button::NoButton),
-                         const Options& options = { WithIcon }, const std::string& dialogTitle = "") const = 0;
-
-    virtual Result error(const std::string& title, const Text& text, const std::string& detailedText, const ButtonDatas& buttons = {},
+    virtual Result error(const std::string& contentTitle, const Text& text, const ButtonDatas& buttons = {},
                          int defBtn = int(Button::NoButton), const Options& options = { WithIcon },
+                         const std::string& dialogTitle = "") const = 0;
+
+    virtual Result error(const std::string& contentTitle, const Text& text, const std::string& detailedText,
+                         const ButtonDatas& buttons = {}, int defBtn = int(Button::NoButton), const Options& options = { WithIcon },
                          const std::string& dialogTitle = "") const = 0;
 
     // progress

--- a/src/framework/global/iinteractive.h
+++ b/src/framework/global/iinteractive.h
@@ -146,39 +146,43 @@ public:
     DECLARE_FLAGS(Options, Option)
 
     virtual Result question(const std::string& title, const std::string& text, const Buttons& buttons, const Button& def = Button::NoButton,
-                            const Options& options = {}) const = 0;
+                            const Options& options = {}, const std::string& dialogTitle = "") const = 0;
 
     virtual Result question(const std::string& title, const Text& text, const ButtonDatas& buttons, int defBtn = int(Button::NoButton),
-                            const Options& options = {}) const = 0;
+                            const Options& options = {}, const std::string& dialogTitle = "") const = 0;
 
     virtual ButtonData buttonData(Button b) const = 0;
 
     // info
     virtual Result info(const std::string& title, const std::string& text, const Buttons& buttons = {}, int defBtn = int(Button::NoButton),
-                        const Options& options = {}) const = 0;
+                        const Options& options = {}, const std::string& dialogTitle = "") const = 0;
 
     virtual Result info(const std::string& title, const Text& text, const ButtonDatas& buttons = {}, int defBtn = int(Button::NoButton),
-                        const Options& options = {}) const = 0;
+                        const Options& options = {}, const std::string& dialogTitle = "") const = 0;
 
     // warning
     virtual Result warning(const std::string& title, const std::string& text, const Buttons& buttons = {},
-                           const Button& def = Button::NoButton, const Options& options = { WithIcon }) const = 0;
+                           const Button& def = Button::NoButton, const Options& options = { WithIcon },
+                           const std::string& dialogTitle = "") const = 0;
 
     virtual Result warning(const std::string& title, const Text& text, const ButtonDatas& buttons = {}, int defBtn = int(Button::NoButton),
-                           const Options& options = { WithIcon }) const = 0;
+                           const Options& options = { WithIcon }, const std::string& dialogTitle = "") const = 0;
 
     virtual Result warning(const std::string& title, const Text& text, const std::string& detailedText, const ButtonDatas& buttons = {},
-                           int defBtn = int(Button::NoButton), const Options& options = { WithIcon }) const = 0;
+                           int defBtn = int(Button::NoButton), const Options& options = { WithIcon },
+                           const std::string& dialogTitle = "") const = 0;
 
     // error
     virtual Result error(const std::string& title, const std::string& text, const Buttons& buttons = {},
-                         const Button& def = Button::NoButton, const Options& options = { WithIcon }) const = 0;
+                         const Button& def = Button::NoButton, const Options& options = { WithIcon },
+                         const std::string& dialogTitle = "") const = 0;
 
     virtual Result error(const std::string& title, const Text& text, const ButtonDatas& buttons = {}, int defBtn = int(Button::NoButton),
-                         const Options& options = { WithIcon }) const = 0;
+                         const Options& options = { WithIcon }, const std::string& dialogTitle = "") const = 0;
 
     virtual Result error(const std::string& title, const Text& text, const std::string& detailedText, const ButtonDatas& buttons = {},
-                         int defBtn = int(Button::NoButton), const Options& options = { WithIcon }) const = 0;
+                         int defBtn = int(Button::NoButton), const Options& options = { WithIcon },
+                         const std::string& dialogTitle = "") const = 0;
 
     // progress
     virtual Ret showProgress(const std::string& title, Progress* progress) const = 0;

--- a/src/framework/global/internal/interactive.cpp
+++ b/src/framework/global/internal/interactive.cpp
@@ -76,15 +76,16 @@ static QString filterToString(const std::vector<std::string>& filter)
 IInteractive::Result Interactive::question(const std::string& title, const std::string& text,
                                            const Buttons& buttons,
                                            const Button& def,
-                                           const Options& options) const
+                                           const Options& options,
+                                           const std::string& dialogTitle) const
 {
-    return question(title, Text(text), buttonDataList(buttons), int(def), options);
+    return question(title, Text(text), buttonDataList(buttons), int(def), options, dialogTitle);
 }
 
 IInteractive::Result Interactive::question(const std::string& title, const Text& text, const ButtonDatas& btns, int defBtn,
-                                           const Options& options) const
+                                           const Options& options, const std::string& dialogTitle) const
 {
-    return standardDialogResult(provider()->question(title, text, btns, defBtn, options));
+    return standardDialogResult(provider()->question(title, text, btns, defBtn, options, dialogTitle));
 }
 
 IInteractive::ButtonData Interactive::buttonData(Button b) const
@@ -126,56 +127,58 @@ IInteractive::ButtonData Interactive::buttonData(Button b) const
 
 IInteractive::Result Interactive::info(const std::string& title, const std::string& text, const Buttons& buttons,
                                        int defBtn,
-                                       const Options& options) const
+                                       const Options& options,
+                                       const std::string& dialogTitle) const
 {
-    return standardDialogResult(provider()->info(title, text, buttonDataList(buttons), defBtn, options));
+    return standardDialogResult(provider()->info(title, text, buttonDataList(buttons), defBtn, options, dialogTitle));
 }
 
 IInteractive::Result Interactive::info(const std::string& title, const Text& text, const ButtonDatas& buttons, int defBtn,
-                                       const Options& options) const
+                                       const Options& options, const std::string& dialogTitle) const
 {
-    return standardDialogResult(provider()->info(title, text, buttons, defBtn, options));
+    return standardDialogResult(provider()->info(title, text, buttons, defBtn, options, dialogTitle));
 }
 
 Interactive::Result Interactive::warning(const std::string& title, const std::string& text, const Buttons& buttons, const Button& defBtn,
-                                         const Options& options) const
+                                         const Options& options, const std::string& dialogTitle) const
 {
-    return standardDialogResult(provider()->warning(title, text, {}, buttonDataList(buttons), int(defBtn), options));
+    return standardDialogResult(provider()->warning(title, text, {}, buttonDataList(buttons), int(defBtn), options, dialogTitle));
 }
 
 IInteractive::Result Interactive::warning(const std::string& title, const Text& text, const ButtonDatas& buttons,
                                           int defBtn,
-                                          const Options& options) const
+                                          const Options& options,
+                                          const std::string& dialogTitle) const
 {
-    return standardDialogResult(provider()->warning(title, text, {}, buttons, defBtn, options));
+    return standardDialogResult(provider()->warning(title, text, {}, buttons, defBtn, options, dialogTitle));
 }
 
 IInteractive::Result Interactive::warning(const std::string& title, const Text& text, const std::string& detailedText,
                                           const ButtonDatas& buttons, int defBtn,
-                                          const Options& options) const
+                                          const Options& options, const std::string& dialogTitle) const
 {
-    return standardDialogResult(provider()->warning(title, text, detailedText, buttons, defBtn, options));
+    return standardDialogResult(provider()->warning(title, text, detailedText, buttons, defBtn, options, dialogTitle));
 }
 
 IInteractive::Result Interactive::error(const std::string& title, const std::string& text,
                                         const Buttons& buttons, const Button& defBtn,
-                                        const Options& options) const
+                                        const Options& options, const std::string& dialogTitle) const
 {
-    return standardDialogResult(provider()->error(title, text, {}, buttonDataList(buttons), int(defBtn), options));
+    return standardDialogResult(provider()->error(title, text, {}, buttonDataList(buttons), int(defBtn), options, dialogTitle));
 }
 
 IInteractive::Result Interactive::error(const std::string& title, const Text& text,
                                         const ButtonDatas& buttons, int defBtn,
-                                        const Options& options) const
+                                        const Options& options, const std::string& dialogTitle) const
 {
-    return standardDialogResult(provider()->error(title, text, {}, buttons, defBtn, options));
+    return standardDialogResult(provider()->error(title, text, {}, buttons, defBtn, options, dialogTitle));
 }
 
 IInteractive::Result Interactive::error(const std::string& title, const Text& text, const std::string& detailedText,
                                         const ButtonDatas& buttons, int defBtn,
-                                        const Options& options) const
+                                        const Options& options, const std::string& dialogTitle) const
 {
-    return standardDialogResult(provider()->error(title, text, detailedText, buttons, defBtn, options));
+    return standardDialogResult(provider()->error(title, text, detailedText, buttons, defBtn, options, dialogTitle));
 }
 
 Ret Interactive::showProgress(const std::string& title, Progress* progress) const

--- a/src/framework/global/internal/interactive.cpp
+++ b/src/framework/global/internal/interactive.cpp
@@ -73,19 +73,19 @@ static QString filterToString(const std::vector<std::string>& filter)
 
 #endif
 
-IInteractive::Result Interactive::question(const std::string& title, const std::string& text,
+IInteractive::Result Interactive::question(const std::string& contentTitle, const std::string& text,
                                            const Buttons& buttons,
                                            const Button& def,
                                            const Options& options,
                                            const std::string& dialogTitle) const
 {
-    return question(title, Text(text), buttonDataList(buttons), int(def), options, dialogTitle);
+    return question(contentTitle, Text(text), buttonDataList(buttons), int(def), options, dialogTitle);
 }
 
-IInteractive::Result Interactive::question(const std::string& title, const Text& text, const ButtonDatas& btns, int defBtn,
+IInteractive::Result Interactive::question(const std::string& contentTitle, const Text& text, const ButtonDatas& btns, int defBtn,
                                            const Options& options, const std::string& dialogTitle) const
 {
-    return standardDialogResult(provider()->question(title, text, btns, defBtn, options, dialogTitle));
+    return standardDialogResult(provider()->question(contentTitle, text, btns, defBtn, options, dialogTitle));
 }
 
 IInteractive::ButtonData Interactive::buttonData(Button b) const
@@ -125,60 +125,60 @@ IInteractive::ButtonData Interactive::buttonData(Button b) const
     return ButtonData(int(b), "");
 }
 
-IInteractive::Result Interactive::info(const std::string& title, const std::string& text, const Buttons& buttons,
+IInteractive::Result Interactive::info(const std::string& contentTitle, const std::string& text, const Buttons& buttons,
                                        int defBtn,
                                        const Options& options,
                                        const std::string& dialogTitle) const
 {
-    return standardDialogResult(provider()->info(title, text, buttonDataList(buttons), defBtn, options, dialogTitle));
+    return standardDialogResult(provider()->info(contentTitle, text, buttonDataList(buttons), defBtn, options, dialogTitle));
 }
 
-IInteractive::Result Interactive::info(const std::string& title, const Text& text, const ButtonDatas& buttons, int defBtn,
+IInteractive::Result Interactive::info(const std::string& contentTitle, const Text& text, const ButtonDatas& buttons, int defBtn,
                                        const Options& options, const std::string& dialogTitle) const
 {
-    return standardDialogResult(provider()->info(title, text, buttons, defBtn, options, dialogTitle));
+    return standardDialogResult(provider()->info(contentTitle, text, buttons, defBtn, options, dialogTitle));
 }
 
-Interactive::Result Interactive::warning(const std::string& title, const std::string& text, const Buttons& buttons, const Button& defBtn,
-                                         const Options& options, const std::string& dialogTitle) const
+Interactive::Result Interactive::warning(const std::string& contentTitle, const std::string& text, const Buttons& buttons,
+                                         const Button& defBtn, const Options& options, const std::string& dialogTitle) const
 {
-    return standardDialogResult(provider()->warning(title, text, {}, buttonDataList(buttons), int(defBtn), options, dialogTitle));
+    return standardDialogResult(provider()->warning(contentTitle, text, {}, buttonDataList(buttons), int(defBtn), options, dialogTitle));
 }
 
-IInteractive::Result Interactive::warning(const std::string& title, const Text& text, const ButtonDatas& buttons,
+IInteractive::Result Interactive::warning(const std::string& contentTitle, const Text& text, const ButtonDatas& buttons,
                                           int defBtn,
                                           const Options& options,
                                           const std::string& dialogTitle) const
 {
-    return standardDialogResult(provider()->warning(title, text, {}, buttons, defBtn, options, dialogTitle));
+    return standardDialogResult(provider()->warning(contentTitle, text, {}, buttons, defBtn, options, dialogTitle));
 }
 
-IInteractive::Result Interactive::warning(const std::string& title, const Text& text, const std::string& detailedText,
+IInteractive::Result Interactive::warning(const std::string& contentTitle, const Text& text, const std::string& detailedText,
                                           const ButtonDatas& buttons, int defBtn,
                                           const Options& options, const std::string& dialogTitle) const
 {
-    return standardDialogResult(provider()->warning(title, text, detailedText, buttons, defBtn, options, dialogTitle));
+    return standardDialogResult(provider()->warning(contentTitle, text, detailedText, buttons, defBtn, options, dialogTitle));
 }
 
-IInteractive::Result Interactive::error(const std::string& title, const std::string& text,
+IInteractive::Result Interactive::error(const std::string& contentTitle, const std::string& text,
                                         const Buttons& buttons, const Button& defBtn,
                                         const Options& options, const std::string& dialogTitle) const
 {
-    return standardDialogResult(provider()->error(title, text, {}, buttonDataList(buttons), int(defBtn), options, dialogTitle));
+    return standardDialogResult(provider()->error(contentTitle, text, {}, buttonDataList(buttons), int(defBtn), options, dialogTitle));
 }
 
-IInteractive::Result Interactive::error(const std::string& title, const Text& text,
+IInteractive::Result Interactive::error(const std::string& contentTitle, const Text& text,
                                         const ButtonDatas& buttons, int defBtn,
                                         const Options& options, const std::string& dialogTitle) const
 {
-    return standardDialogResult(provider()->error(title, text, {}, buttons, defBtn, options, dialogTitle));
+    return standardDialogResult(provider()->error(contentTitle, text, {}, buttons, defBtn, options, dialogTitle));
 }
 
-IInteractive::Result Interactive::error(const std::string& title, const Text& text, const std::string& detailedText,
+IInteractive::Result Interactive::error(const std::string& contentTitle, const Text& text, const std::string& detailedText,
                                         const ButtonDatas& buttons, int defBtn,
                                         const Options& options, const std::string& dialogTitle) const
 {
-    return standardDialogResult(provider()->error(title, text, detailedText, buttons, defBtn, options, dialogTitle));
+    return standardDialogResult(provider()->error(contentTitle, text, detailedText, buttons, defBtn, options, dialogTitle));
 }
 
 Ret Interactive::showProgress(const std::string& title, Progress* progress) const

--- a/src/framework/global/internal/interactive.h
+++ b/src/framework/global/internal/interactive.h
@@ -44,40 +44,40 @@ public:
         : Injectable(ctx) {}
 
     // question
-    Result question(const std::string& title, const std::string& text, const Buttons& buttons, const Button& def = Button::NoButton,
+    Result question(const std::string& contentTitle, const std::string& text, const Buttons& buttons, const Button& def = Button::NoButton,
                     const Options& options = {}, const std::string& dialogTitle = "") const override;
 
-    Result question(const std::string& title, const Text& text, const ButtonDatas& buttons, int defBtn = int(Button::NoButton),
+    Result question(const std::string& contentTitle, const Text& text, const ButtonDatas& buttons, int defBtn = int(Button::NoButton),
                     const Options& options = {}, const std::string& dialogTitle = "") const override;
 
     ButtonData buttonData(Button b) const override;
 
     // info
-    Result info(const std::string& title, const std::string& text, const Buttons& buttons, int defBtn = int(Button::NoButton),
+    Result info(const std::string& contentTitle, const std::string& text, const Buttons& buttons, int defBtn = int(Button::NoButton),
                 const Options& options = {}, const std::string& dialogTitle = "") const override;
 
-    Result info(const std::string& title, const Text& text, const ButtonDatas& buttons, int defBtn = int(Button::NoButton),
+    Result info(const std::string& contentTitle, const Text& text, const ButtonDatas& buttons, int defBtn = int(Button::NoButton),
                 const Options& options = {}, const std::string& dialogTitle = "") const override;
 
     // warning
-    Result warning(const std::string& title, const std::string& text, const Buttons& buttons, const Button& def = Button::NoButton,
+    Result warning(const std::string& contentTitle, const std::string& text, const Buttons& buttons, const Button& def = Button::NoButton,
                    const Options& options = { WithIcon }, const std::string& dialogTitle = "") const override;
 
-    Result warning(const std::string& title, const Text& text, const ButtonDatas& buttons, int defBtn = int(Button::NoButton),
+    Result warning(const std::string& contentTitle, const Text& text, const ButtonDatas& buttons, int defBtn = int(Button::NoButton),
                    const Options& options = { WithIcon }, const std::string& dialogTitle = "") const override;
 
-    Result warning(const std::string& title, const Text& text, const std::string& detailedText, const ButtonDatas& buttons,
+    Result warning(const std::string& contentTitle, const Text& text, const std::string& detailedText, const ButtonDatas& buttons,
                    int defBtn = int(Button::NoButton), const Options& options = { WithIcon },
                    const std::string& dialogTitle = "") const override;
 
     // error
-    Result error(const std::string& title, const std::string& text, const Buttons& buttons, const Button& def = Button::NoButton,
+    Result error(const std::string& contentTitle, const std::string& text, const Buttons& buttons, const Button& def = Button::NoButton,
                  const Options& options = { WithIcon }, const std::string& dialogTitle = "") const override;
 
-    Result error(const std::string& title, const Text& text, const ButtonDatas& buttons, int defBtn = int(Button::NoButton),
+    Result error(const std::string& contentTitle, const Text& text, const ButtonDatas& buttons, int defBtn = int(Button::NoButton),
                  const Options& options = { WithIcon }, const std::string& dialogTitle = "") const override;
 
-    Result error(const std::string& title, const Text& text, const std::string& detailedText, const ButtonDatas& buttons,
+    Result error(const std::string& contentTitle, const Text& text, const std::string& detailedText, const ButtonDatas& buttons,
                  int defBtn = int(Button::NoButton), const Options& options = { WithIcon },
                  const std::string& dialogTitle = "") const override;
 

--- a/src/framework/global/internal/interactive.h
+++ b/src/framework/global/internal/interactive.h
@@ -45,39 +45,41 @@ public:
 
     // question
     Result question(const std::string& title, const std::string& text, const Buttons& buttons, const Button& def = Button::NoButton,
-                    const Options& options = {}) const override;
+                    const Options& options = {}, const std::string& dialogTitle = "") const override;
 
     Result question(const std::string& title, const Text& text, const ButtonDatas& buttons, int defBtn = int(Button::NoButton),
-                    const Options& options = {}) const override;
+                    const Options& options = {}, const std::string& dialogTitle = "") const override;
 
     ButtonData buttonData(Button b) const override;
 
     // info
     Result info(const std::string& title, const std::string& text, const Buttons& buttons, int defBtn = int(Button::NoButton),
-                const Options& options = {}) const override;
+                const Options& options = {}, const std::string& dialogTitle = "") const override;
 
     Result info(const std::string& title, const Text& text, const ButtonDatas& buttons, int defBtn = int(Button::NoButton),
-                const Options& options = {}) const override;
+                const Options& options = {}, const std::string& dialogTitle = "") const override;
 
     // warning
     Result warning(const std::string& title, const std::string& text, const Buttons& buttons, const Button& def = Button::NoButton,
-                   const Options& options = { WithIcon }) const override;
+                   const Options& options = { WithIcon }, const std::string& dialogTitle = "") const override;
 
     Result warning(const std::string& title, const Text& text, const ButtonDatas& buttons, int defBtn = int(Button::NoButton),
-                   const Options& options = { WithIcon }) const override;
+                   const Options& options = { WithIcon }, const std::string& dialogTitle = "") const override;
 
     Result warning(const std::string& title, const Text& text, const std::string& detailedText, const ButtonDatas& buttons,
-                   int defBtn = int(Button::NoButton), const Options& options = { WithIcon }) const override;
+                   int defBtn = int(Button::NoButton), const Options& options = { WithIcon },
+                   const std::string& dialogTitle = "") const override;
 
     // error
     Result error(const std::string& title, const std::string& text, const Buttons& buttons, const Button& def = Button::NoButton,
-                 const Options& options = { WithIcon }) const override;
+                 const Options& options = { WithIcon }, const std::string& dialogTitle = "") const override;
 
     Result error(const std::string& title, const Text& text, const ButtonDatas& buttons, int defBtn = int(Button::NoButton),
-                 const Options& options = { WithIcon }) const override;
+                 const Options& options = { WithIcon }, const std::string& dialogTitle = "") const override;
 
     Result error(const std::string& title, const Text& text, const std::string& detailedText, const ButtonDatas& buttons,
-                 int defBtn = int(Button::NoButton), const Options& options = { WithIcon }) const override;
+                 int defBtn = int(Button::NoButton), const Options& options = { WithIcon },
+                 const std::string& dialogTitle = "") const override;
 
     // progress
     Ret showProgress(const std::string& title, Progress* progress) const override;

--- a/src/framework/global/settings.cpp
+++ b/src/framework/global/settings.cpp
@@ -114,6 +114,10 @@ void Settings::reset(bool keepDefaultSettings, bool notifyAboutChanges)
     }
 
     for (auto it = m_items.begin(); it != m_items.end(); ++it) {
+        if (it->second.value == it->second.defaultValue) {
+            continue;
+        }
+
         it->second.value = it->second.defaultValue;
 
         Channel<Val>& channel = findChannel(it->first);

--- a/src/framework/global/settings.cpp
+++ b/src/framework/global/settings.cpp
@@ -95,6 +95,13 @@ void Settings::reset(bool keepDefaultSettings, bool notifyAboutChanges)
     m_settings->clear();
 
     m_isTransactionStarted = false;
+
+    std::vector<Settings::Key> locallyAddedKeys;
+    for (auto it = m_localSettings.begin(); it != m_localSettings.end(); ++it) {
+        if (m_items.count(it->first) == 0) {
+            locallyAddedKeys.push_back(it->first);
+        }
+    }
     m_localSettings.clear();
 
     if (!keepDefaultSettings) {
@@ -111,6 +118,10 @@ void Settings::reset(bool keepDefaultSettings, bool notifyAboutChanges)
 
         Channel<Val>& channel = findChannel(it->first);
         channel.send(it->second.value);
+    }
+    for (auto it = locallyAddedKeys.cbegin(); it != locallyAddedKeys.cend(); ++it) {
+        Channel<Val>& channel = findChannel(*it);
+        channel.send(Val());
     }
 }
 

--- a/src/framework/global/tests/mocks/interactivemock.h
+++ b/src/framework/global/tests/mocks/interactivemock.h
@@ -30,25 +30,31 @@ namespace muse {
 class InteractiveMock : public IInteractive
 {
 public:
-    MOCK_METHOD(Result, question, (const std::string&, const std::string&, const Buttons&, const Button&, const Options&),
-                (const, override));
-    MOCK_METHOD(Result, question, (const std::string&, const Text&, const ButtonDatas&, int, const Options&), (const, override));
+    MOCK_METHOD(Result, question, (const std::string&, const std::string&, const Buttons&, const Button&, const Options&,
+                const std::string&), (const, override));
+    MOCK_METHOD(Result, question, (const std::string&, const Text&, const ButtonDatas&, int, const Options&,
+                const std::string&), (const, override));
 
     MOCK_METHOD(ButtonData, buttonData, (Button), (const, override));
 
-    MOCK_METHOD(Result, info, (const std::string&, const std::string&, const Buttons&, int, const Options&), (const, override));
-    MOCK_METHOD(Result, info, (const std::string&, const Text&, const ButtonDatas&, int, const Options&), (const, override));
+    MOCK_METHOD(Result, info, (const std::string&, const std::string&, const Buttons&, int, const Options&,
+                const std::string&), (const, override));
+    MOCK_METHOD(Result, info, (const std::string&, const Text&, const ButtonDatas&, int, const Options&,
+                const std::string&), (const, override));
 
-    MOCK_METHOD(Result, warning, (const std::string&, const std::string&, const Buttons&, const Button&, const Options&),
-                (const, override));
-    MOCK_METHOD(Result, warning, (const std::string&, const Text&, const ButtonDatas&, int, const Options&), (const, override));
-    MOCK_METHOD(Result, warning, (const std::string&, const Text&, const std::string&, const ButtonDatas&, int, const Options&),
-                (const, override));
+    MOCK_METHOD(Result, warning, (const std::string&, const std::string&, const Buttons&, const Button&, const Options&,
+                const std::string&), (const, override));
+    MOCK_METHOD(Result, warning, (const std::string&, const Text&, const ButtonDatas&, int, const Options&,
+                const std::string&), (const, override));
+    MOCK_METHOD(Result, warning, (const std::string&, const Text&, const std::string&, const ButtonDatas&, int, const Options&,
+                const std::string&), (const, override));
 
-    MOCK_METHOD(Result, error, (const std::string&, const std::string&, const Buttons&, const Button&, const Options&), (const, override));
-    MOCK_METHOD(Result, error, (const std::string&, const Text&, const ButtonDatas&, int, const Options&), (const, override));
-    MOCK_METHOD(Result, error, (const std::string&, const Text&, const std::string&, const ButtonDatas&, int, const Options&),
-                (const, override));
+    MOCK_METHOD(Result, error, (const std::string&, const std::string&, const Buttons&, const Button&, const Options&,
+                const std::string&), (const, override));
+    MOCK_METHOD(Result, error, (const std::string&, const Text&, const ButtonDatas&, int, const Options&,
+                const std::string&), (const, override));
+    MOCK_METHOD(Result, error, (const std::string&, const Text&, const std::string&, const ButtonDatas&, int, const Options&,
+                const std::string&), (const, override));
 
     MOCK_METHOD(Ret, showProgress, (const std::string&, Progress*), (const, override));
 

--- a/src/framework/global/tests/mocks/interactivemock.h
+++ b/src/framework/global/tests/mocks/interactivemock.h
@@ -31,30 +31,30 @@ class InteractiveMock : public IInteractive
 {
 public:
     MOCK_METHOD(Result, question, (const std::string&, const std::string&, const Buttons&, const Button&, const Options&,
-                const std::string&), (const, override));
+                                   const std::string&), (const, override));
     MOCK_METHOD(Result, question, (const std::string&, const Text&, const ButtonDatas&, int, const Options&,
-                const std::string&), (const, override));
+                                   const std::string&), (const, override));
 
     MOCK_METHOD(ButtonData, buttonData, (Button), (const, override));
 
     MOCK_METHOD(Result, info, (const std::string&, const std::string&, const Buttons&, int, const Options&,
-                const std::string&), (const, override));
+                               const std::string&), (const, override));
     MOCK_METHOD(Result, info, (const std::string&, const Text&, const ButtonDatas&, int, const Options&,
-                const std::string&), (const, override));
+                               const std::string&), (const, override));
 
     MOCK_METHOD(Result, warning, (const std::string&, const std::string&, const Buttons&, const Button&, const Options&,
-                const std::string&), (const, override));
+                                  const std::string&), (const, override));
     MOCK_METHOD(Result, warning, (const std::string&, const Text&, const ButtonDatas&, int, const Options&,
-                const std::string&), (const, override));
+                                  const std::string&), (const, override));
     MOCK_METHOD(Result, warning, (const std::string&, const Text&, const std::string&, const ButtonDatas&, int, const Options&,
-                const std::string&), (const, override));
+                                  const std::string&), (const, override));
 
     MOCK_METHOD(Result, error, (const std::string&, const std::string&, const Buttons&, const Button&, const Options&,
-                const std::string&), (const, override));
+                                const std::string&), (const, override));
     MOCK_METHOD(Result, error, (const std::string&, const Text&, const ButtonDatas&, int, const Options&,
-                const std::string&), (const, override));
+                                const std::string&), (const, override));
     MOCK_METHOD(Result, error, (const std::string&, const Text&, const std::string&, const ButtonDatas&, int, const Options&,
-                const std::string&), (const, override));
+                                const std::string&), (const, override));
 
     MOCK_METHOD(Ret, showProgress, (const std::string&, Progress*), (const, override));
 

--- a/src/framework/languages/internal/languagesservice.cpp
+++ b/src/framework/languages/internal/languagesservice.cpp
@@ -63,11 +63,15 @@ void LanguagesService::init()
 
     ValCh<QString> languageCode = configuration()->currentLanguageCode();
     setCurrentLanguage(languageCode.val);
-    m_activeLanguageCode = languageCode.val;
 
-    languageCode.ch.onReceive(this, [this](const QString& newLanguageCode) {
+    // Remember the active language code so the "Restart required" text can go away if the language
+    // is changed and later reverted in the same session. Cannot use m_currentLanguage.code
+    // because m_currentLanguage holds the effective language: if the language code is "system",
+    // m_currentLanguage will hold "en-us" for example (whatever the system is set to).
+    QString activeLanguageCode = languageCode.val;
+    languageCode.ch.onReceive(this, [this, activeLanguageCode](const QString& newLanguageCode) {
         //! NOTE To change the language at the moment, a restart is required
-        m_needRestartToApplyLanguageChange = newLanguageCode != m_activeLanguageCode;
+        m_needRestartToApplyLanguageChange = newLanguageCode != activeLanguageCode;
         m_needRestartToApplyLanguageChangeChanged.send(m_needRestartToApplyLanguageChange);
     });
 

--- a/src/framework/languages/internal/languagesservice.cpp
+++ b/src/framework/languages/internal/languagesservice.cpp
@@ -63,10 +63,11 @@ void LanguagesService::init()
 
     ValCh<QString> languageCode = configuration()->currentLanguageCode();
     setCurrentLanguage(languageCode.val);
+    m_activeLanguageCode = languageCode.val;
 
-    languageCode.ch.onReceive(this, [this](const QString&) {
+    languageCode.ch.onReceive(this, [this](const QString& newLanguageCode) {
         //! NOTE To change the language at the moment, a restart is required
-        m_needRestartToApplyLanguageChange = true;
+        m_needRestartToApplyLanguageChange = newLanguageCode != m_activeLanguageCode;
         m_needRestartToApplyLanguageChangeChanged.send(m_needRestartToApplyLanguageChange);
     });
 

--- a/src/framework/languages/internal/languagesservice.h
+++ b/src/framework/languages/internal/languagesservice.h
@@ -73,6 +73,7 @@ private:
     RetVal<QString> fileHash(const io::path_t& path);
 
 private:
+    QString m_activeLanguageCode;
     LanguagesHash m_languagesHash;
     Language m_currentLanguage;
     async::Notification m_currentLanguageChanged;

--- a/src/framework/languages/internal/languagesservice.h
+++ b/src/framework/languages/internal/languagesservice.h
@@ -73,7 +73,6 @@ private:
     RetVal<QString> fileHash(const io::path_t& path);
 
 private:
-    QString m_activeLanguageCode;
     LanguagesHash m_languagesHash;
     Language m_currentLanguage;
     async::Notification m_currentLanguageChanged;

--- a/src/framework/midi/imidiconfiguration.h
+++ b/src/framework/midi/imidiconfiguration.h
@@ -53,6 +53,7 @@ public:
 
     virtual bool useMIDI20Output() const = 0;
     virtual void setUseMIDI20Output(bool use) = 0;
+    virtual async::Channel<bool> useMIDI20OutputChanged() const = 0;
 };
 }
 

--- a/src/framework/midi/imidiconfiguration.h
+++ b/src/framework/midi/imidiconfiguration.h
@@ -41,7 +41,7 @@ public:
 
     virtual bool useRemoteControl() const = 0;
     virtual void setUseRemoteControl(bool value) = 0;
-    virtual muse::async::Channel<bool> useRemoteControlChanged() const = 0;
+    virtual async::Channel<bool> useRemoteControlChanged() const = 0;
 
     virtual MidiDeviceID midiInputDeviceId() const = 0;
     virtual void setMidiInputDeviceId(const MidiDeviceID& deviceId) = 0;

--- a/src/framework/midi/imidiconfiguration.h
+++ b/src/framework/midi/imidiconfiguration.h
@@ -41,6 +41,7 @@ public:
 
     virtual bool useRemoteControl() const = 0;
     virtual void setUseRemoteControl(bool value) = 0;
+    virtual muse::async::Channel<bool> useRemoteControlChanged() const = 0;
 
     virtual MidiDeviceID midiInputDeviceId() const = 0;
     virtual void setMidiInputDeviceId(const MidiDeviceID& deviceId) = 0;

--- a/src/framework/midi/internal/midiconfiguration.cpp
+++ b/src/framework/midi/internal/midiconfiguration.cpp
@@ -38,6 +38,9 @@ static const Settings::Key USE_MIDI20_OUTPUT_KEY(module_name, "io/midi/useMIDI20
 void MidiConfiguration::init()
 {
     settings()->setDefaultValue(USE_REMOTE_CONTROL_KEY, Val(true));
+    settings()->valueChanged(USE_REMOTE_CONTROL_KEY).onReceive(this, [this](const Val& val) {
+        m_useRemoteControlChanged.send(val.toBool());
+    });
 
     settings()->setDefaultValue(MIDI_INPUT_DEVICE_ID, Val(""));
     settings()->valueChanged(MIDI_INPUT_DEVICE_ID).onReceive(nullptr, [this](const Val&) {
@@ -65,6 +68,11 @@ bool MidiConfiguration::useRemoteControl() const
 void MidiConfiguration::setUseRemoteControl(bool value)
 {
     settings()->setSharedValue(USE_REMOTE_CONTROL_KEY, Val(value));
+}
+
+async::Channel<bool> MidiConfiguration::useRemoteControlChanged() const
+{
+    return m_useRemoteControlChanged;
 }
 
 MidiDeviceID MidiConfiguration::midiInputDeviceId() const

--- a/src/framework/midi/internal/midiconfiguration.cpp
+++ b/src/framework/midi/internal/midiconfiguration.cpp
@@ -42,7 +42,7 @@ void MidiConfiguration::init()
         m_useRemoteControlChanged.send(val.toBool());
     });
 
-    settings()->setDefaultValue(MIDI_INPUT_DEVICE_ID, Val(""));
+    settings()->setDefaultValue(MIDI_INPUT_DEVICE_ID, Val(NONE_DEVICE_ID));
     settings()->valueChanged(MIDI_INPUT_DEVICE_ID).onReceive(nullptr, [this](const Val&) {
         m_midiInputDeviceIdChanged.notify();
     });
@@ -53,6 +53,9 @@ void MidiConfiguration::init()
     });
 
     settings()->setDefaultValue(USE_MIDI20_OUTPUT_KEY, Val(true));
+    settings()->valueChanged(USE_MIDI20_OUTPUT_KEY).onReceive(this, [this](const Val& val) {
+        m_useMIDI20OutputChanged.send(val.toBool());
+    });
 }
 
 bool MidiConfiguration::midiPortIsAvalaible() const
@@ -113,4 +116,9 @@ bool MidiConfiguration::useMIDI20Output() const
 void MidiConfiguration::setUseMIDI20Output(bool use)
 {
     settings()->setSharedValue(USE_MIDI20_OUTPUT_KEY, Val(use));
+}
+
+async::Channel<bool> MidiConfiguration::useMIDI20OutputChanged() const
+{
+    return m_useMIDI20OutputChanged;
 }

--- a/src/framework/midi/internal/midiconfiguration.h
+++ b/src/framework/midi/internal/midiconfiguration.h
@@ -47,11 +47,13 @@ public:
 
     bool useMIDI20Output() const override;
     void setUseMIDI20Output(bool use) override;
+    async::Channel<bool> useMIDI20OutputChanged() const override;
 
 private:
     async::Notification m_midiInputDeviceIdChanged;
     async::Notification m_midiOutputDeviceIdChanged;
     async::Channel<bool> m_useRemoteControlChanged;
+    async::Channel<bool> m_useMIDI20OutputChanged;
 };
 }
 

--- a/src/framework/midi/internal/midiconfiguration.h
+++ b/src/framework/midi/internal/midiconfiguration.h
@@ -23,9 +23,10 @@
 #define MUSE_MIDI_MIDICONFIGURATION_H
 
 #include "../imidiconfiguration.h"
+#include "async/asyncable.h"
 
 namespace muse::midi {
-class MidiConfiguration : public IMidiConfiguration
+class MidiConfiguration : public IMidiConfiguration, public async::Asyncable
 {
 public:
     void init();
@@ -34,6 +35,7 @@ public:
 
     bool useRemoteControl() const override;
     void setUseRemoteControl(bool value) override;
+    async::Channel<bool> useRemoteControlChanged() const override;
 
     MidiDeviceID midiInputDeviceId() const override;
     void setMidiInputDeviceId(const MidiDeviceID& deviceId) override;
@@ -49,6 +51,7 @@ public:
 private:
     async::Notification m_midiInputDeviceIdChanged;
     async::Notification m_midiOutputDeviceIdChanged;
+    async::Channel<bool> m_useRemoteControlChanged;
 };
 }
 

--- a/src/framework/shortcuts/internal/shortcutsconfiguration.cpp
+++ b/src/framework/shortcuts/internal/shortcutsconfiguration.cpp
@@ -40,6 +40,9 @@ void ShortcutsConfiguration::init()
     m_config = ConfigReader::read(":/configs/shortcuts.cfg");
 
     settings()->setDefaultValue(ADVANCE_TO_NEXT_NOTE_ON_KEY_RELEASE, Val(true));
+    settings()->valueChanged(ADVANCE_TO_NEXT_NOTE_ON_KEY_RELEASE).onReceive(nullptr, [this](const Val& val) {
+        m_advanceToNextNoteOnKeyReleaseChanged.send(val.toBool());
+    });
 }
 
 QString ShortcutsConfiguration::currentKeyboardLayout() const
@@ -82,4 +85,9 @@ bool ShortcutsConfiguration::advanceToNextNoteOnKeyRelease() const
 void ShortcutsConfiguration::setAdvanceToNextNoteOnKeyRelease(bool value)
 {
     settings()->setSharedValue(ADVANCE_TO_NEXT_NOTE_ON_KEY_RELEASE, Val(value));
+}
+
+muse::async::Channel<bool> ShortcutsConfiguration::advanceToNextNoteOnKeyReleaseChanged() const
+{
+    return m_advanceToNextNoteOnKeyReleaseChanged;
 }

--- a/src/framework/shortcuts/internal/shortcutsconfiguration.cpp
+++ b/src/framework/shortcuts/internal/shortcutsconfiguration.cpp
@@ -40,7 +40,7 @@ void ShortcutsConfiguration::init()
     m_config = ConfigReader::read(":/configs/shortcuts.cfg");
 
     settings()->setDefaultValue(ADVANCE_TO_NEXT_NOTE_ON_KEY_RELEASE, Val(true));
-    settings()->valueChanged(ADVANCE_TO_NEXT_NOTE_ON_KEY_RELEASE).onReceive(nullptr, [this](const Val& val) {
+    settings()->valueChanged(ADVANCE_TO_NEXT_NOTE_ON_KEY_RELEASE).onReceive(this, [this](const Val& val) {
         m_advanceToNextNoteOnKeyReleaseChanged.send(val.toBool());
     });
 }

--- a/src/framework/shortcuts/internal/shortcutsconfiguration.h
+++ b/src/framework/shortcuts/internal/shortcutsconfiguration.h
@@ -51,8 +51,11 @@ public:
 
     bool advanceToNextNoteOnKeyRelease() const override;
     void setAdvanceToNextNoteOnKeyRelease(bool value) override;
+    virtual muse::async::Channel<bool> advanceToNextNoteOnKeyReleaseChanged() const override;
 
 private:
     Config m_config;
+
+    muse::async::Channel<bool> m_advanceToNextNoteOnKeyReleaseChanged;
 };
 }

--- a/src/framework/shortcuts/ishortcutsconfiguration.h
+++ b/src/framework/shortcuts/ishortcutsconfiguration.h
@@ -44,6 +44,7 @@ public:
 
     virtual bool advanceToNextNoteOnKeyRelease() const = 0;
     virtual void setAdvanceToNextNoteOnKeyRelease(bool value) = 0;
+    virtual muse::async::Channel<bool> advanceToNextNoteOnKeyReleaseChanged() const = 0;
 };
 }
 

--- a/src/framework/shortcuts/view/mididevicemappingmodel.cpp
+++ b/src/framework/shortcuts/view/mididevicemappingmodel.cpp
@@ -124,6 +124,10 @@ QHash<int, QByteArray> MidiDeviceMappingModel::roleNames() const
 
 void MidiDeviceMappingModel::load()
 {
+    midiConfiguration()->useRemoteControlChanged().onReceive(this, [this](bool val) {
+        emit useRemoteControlChanged(val);
+    });
+
     beginResetModel();
     m_midiMappings.clear();
 

--- a/src/framework/stubs/midi/midiconfigurationstub.cpp
+++ b/src/framework/stubs/midi/midiconfigurationstub.cpp
@@ -40,8 +40,8 @@ void MidiConfigurationStub::setUseRemoteControl(bool)
 
 async::Channel<bool> MidiConfigurationStub::useRemoteControlChanged() const
 {
-    static async::Channel<bool> n;
-    return n;
+    static async::Channel<bool> ch;
+    return ch;
 }
 
 MidiDeviceID MidiConfigurationStub::midiInputDeviceId() const
@@ -55,8 +55,8 @@ void MidiConfigurationStub::setMidiInputDeviceId(const MidiDeviceID&)
 
 async::Notification MidiConfigurationStub::midiInputDeviceIdChanged() const
 {
-    static async::Notification n;
-    return n;
+    static async::Notification ch;
+    return ch;
 }
 
 MidiDeviceID MidiConfigurationStub::midiOutputDeviceId() const

--- a/src/framework/stubs/midi/midiconfigurationstub.cpp
+++ b/src/framework/stubs/midi/midiconfigurationstub.cpp
@@ -55,8 +55,8 @@ void MidiConfigurationStub::setMidiInputDeviceId(const MidiDeviceID&)
 
 async::Notification MidiConfigurationStub::midiInputDeviceIdChanged() const
 {
-    static async::Notification ch;
-    return ch;
+    static async::Notification n;
+    return n;
 }
 
 MidiDeviceID MidiConfigurationStub::midiOutputDeviceId() const
@@ -85,6 +85,6 @@ void MidiConfigurationStub::setUseMIDI20Output(bool)
 
 async::Channel<bool> MidiConfigurationStub::useMIDI20OutputChanged() const
 {
-    static async::Channel<bool> n;
-    return n;
+    static async::Channel<bool> ch;
+    return ch;
 }

--- a/src/framework/stubs/midi/midiconfigurationstub.cpp
+++ b/src/framework/stubs/midi/midiconfigurationstub.cpp
@@ -38,6 +38,12 @@ void MidiConfigurationStub::setUseRemoteControl(bool)
 {
 }
 
+async::Channel<bool> MidiConfigurationStub::useRemoteControlChanged() const
+{
+    static async::Channel<bool> n;
+    return n;
+}
+
 MidiDeviceID MidiConfigurationStub::midiInputDeviceId() const
 {
     return MidiDeviceID();
@@ -75,4 +81,10 @@ bool MidiConfigurationStub::useMIDI20Output() const
 
 void MidiConfigurationStub::setUseMIDI20Output(bool)
 {
+}
+
+async::Channel<bool> MidiConfigurationStub::useMIDI20OutputChanged() const
+{
+    static async::Channel<bool> n;
+    return n;
 }

--- a/src/framework/stubs/midi/midiconfigurationstub.h
+++ b/src/framework/stubs/midi/midiconfigurationstub.h
@@ -34,6 +34,7 @@ public:
 
     bool useRemoteControl() const override;
     void setUseRemoteControl(bool value) override;
+    async::Channel<bool> useRemoteControlChanged() const override;
 
     MidiDeviceID midiInputDeviceId() const override;
     void setMidiInputDeviceId(const MidiDeviceID& deviceId) override;
@@ -45,6 +46,7 @@ public:
 
     bool useMIDI20Output() const override;
     void setUseMIDI20Output(bool use) override;
+    async::Channel<bool> useMIDI20OutputChanged() const override;
 };
 }
 

--- a/src/framework/stubs/shortcuts/shortcutsconfigurationstub.cpp
+++ b/src/framework/stubs/shortcuts/shortcutsconfigurationstub.cpp
@@ -56,3 +56,9 @@ bool ShortcutsConfigurationStub::advanceToNextNoteOnKeyRelease() const
 void ShortcutsConfigurationStub::setAdvanceToNextNoteOnKeyRelease(bool)
 {
 }
+
+async::Channel<bool> ShortcutsConfigurationStub::advanceToNextNoteOnKeyReleaseChanged() const
+{
+    static async::Channel<bool> ch;
+    return ch;
+}

--- a/src/framework/stubs/shortcuts/shortcutsconfigurationstub.h
+++ b/src/framework/stubs/shortcuts/shortcutsconfigurationstub.h
@@ -38,6 +38,7 @@ public:
 
     bool advanceToNextNoteOnKeyRelease() const override;
     void setAdvanceToNextNoteOnKeyRelease(bool value) override;
+    muse::async::Channel<bool> advanceToNextNoteOnKeyReleaseChanged() const override;
 };
 }
 

--- a/src/framework/stubs/update/updateconfigurationstub.cpp
+++ b/src/framework/stubs/update/updateconfigurationstub.cpp
@@ -46,6 +46,12 @@ void UpdateConfigurationStub::setNeedCheckForUpdate(bool)
 {
 }
 
+muse::async::Notification UpdateConfigurationStub::needCheckForUpdateChanged() const
+{
+    static muse::async::Notification n;
+    return n;
+}
+
 std::string UpdateConfigurationStub::skippedReleaseVersion() const
 {
     return "";

--- a/src/framework/stubs/update/updateconfigurationstub.h
+++ b/src/framework/stubs/update/updateconfigurationstub.h
@@ -35,6 +35,7 @@ public:
 
     bool needCheckForUpdate() const override;
     void setNeedCheckForUpdate(bool needCheck) override;
+    muse::async::Notification needCheckForUpdateChanged() const override;
 
     std::string skippedReleaseVersion() const override;
     void setSkippedReleaseVersion(const std::string& version) override;

--- a/src/framework/ui/iinteractiveprovider.h
+++ b/src/framework/ui/iinteractiveprovider.h
@@ -39,18 +39,20 @@ public:
     virtual ~IInteractiveProvider() = default;
 
     virtual RetVal<Val> question(const std::string& title, const IInteractive::Text& text, const IInteractive::ButtonDatas& buttons,
-                                 int defBtn = int(IInteractive::Button::NoButton), const IInteractive::Options& options = {}) = 0;
+                                 int defBtn = int(IInteractive::Button::NoButton), const IInteractive::Options& options = {},
+                                 const std::string& dialogTitle = "") = 0;
 
     virtual RetVal<Val> info(const std::string& title, const IInteractive::Text& text, const IInteractive::ButtonDatas& buttons,
-                             int defBtn = int(IInteractive::Button::NoButton), const IInteractive::Options& options = {}) = 0;
+                             int defBtn = int(IInteractive::Button::NoButton), const IInteractive::Options& options = {},
+                             const std::string& dialogTitle = "") = 0;
 
     virtual RetVal<Val> warning(const std::string& title, const IInteractive::Text& text, const std::string& detailedText = {},
                                 const IInteractive::ButtonDatas& buttons = {}, int defBtn = int(IInteractive::Button::NoButton),
-                                const IInteractive::Options& options = {}) = 0;
+                                const IInteractive::Options& options = {}, const std::string& dialogTitle = "") = 0;
 
     virtual RetVal<Val> error(const std::string& title, const IInteractive::Text& text, const std::string& detailedText = {},
                               const IInteractive::ButtonDatas& buttons = {}, int defBtn = int(IInteractive::Button::NoButton),
-                              const IInteractive::Options& options = {}) = 0;
+                              const IInteractive::Options& options = {}, const std::string& dialogTitle = "") = 0;
 
     virtual Ret showProgress(const std::string& title, Progress* progress) = 0;
 

--- a/src/framework/ui/iinteractiveprovider.h
+++ b/src/framework/ui/iinteractiveprovider.h
@@ -38,19 +38,19 @@ class IInteractiveProvider : MODULE_EXPORT_INTERFACE
 public:
     virtual ~IInteractiveProvider() = default;
 
-    virtual RetVal<Val> question(const std::string& title, const IInteractive::Text& text, const IInteractive::ButtonDatas& buttons,
+    virtual RetVal<Val> question(const std::string& contentTitle, const IInteractive::Text& text, const IInteractive::ButtonDatas& buttons,
                                  int defBtn = int(IInteractive::Button::NoButton), const IInteractive::Options& options = {},
                                  const std::string& dialogTitle = "") = 0;
 
-    virtual RetVal<Val> info(const std::string& title, const IInteractive::Text& text, const IInteractive::ButtonDatas& buttons,
+    virtual RetVal<Val> info(const std::string& contentTitle, const IInteractive::Text& text, const IInteractive::ButtonDatas& buttons,
                              int defBtn = int(IInteractive::Button::NoButton), const IInteractive::Options& options = {},
                              const std::string& dialogTitle = "") = 0;
 
-    virtual RetVal<Val> warning(const std::string& title, const IInteractive::Text& text, const std::string& detailedText = {},
+    virtual RetVal<Val> warning(const std::string& contentTitle, const IInteractive::Text& text, const std::string& detailedText = {},
                                 const IInteractive::ButtonDatas& buttons = {}, int defBtn = int(IInteractive::Button::NoButton),
                                 const IInteractive::Options& options = {}, const std::string& dialogTitle = "") = 0;
 
-    virtual RetVal<Val> error(const std::string& title, const IInteractive::Text& text, const std::string& detailedText = {},
+    virtual RetVal<Val> error(const std::string& contentTitle, const IInteractive::Text& text, const std::string& detailedText = {},
                               const IInteractive::ButtonDatas& buttons = {}, int defBtn = int(IInteractive::Button::NoButton),
                               const IInteractive::Options& options = {}, const std::string& dialogTitle = "") = 0;
 

--- a/src/framework/ui/qml/Muse/Ui/internal/StandardDialog.qml
+++ b/src/framework/ui/qml/Muse/Ui/internal/StandardDialog.qml
@@ -30,6 +30,7 @@ StyledDialogView {
 
     property alias type: mainPanel.type
 
+    property alias dialogTitle: root.title
     property alias title: mainPanel.title
     property alias text: mainPanel.text
     property alias textFormat: mainPanel.textFormat

--- a/src/framework/ui/qml/Muse/Ui/internal/StandardDialog.qml
+++ b/src/framework/ui/qml/Muse/Ui/internal/StandardDialog.qml
@@ -31,7 +31,7 @@ StyledDialogView {
     property alias type: mainPanel.type
 
     property alias dialogTitle: root.title
-    property alias title: mainPanel.title
+    property alias contentTitle: mainPanel.title
     property alias text: mainPanel.text
     property alias textFormat: mainPanel.textFormat
     property string detailedText: ""

--- a/src/framework/ui/view/interactiveprovider.cpp
+++ b/src/framework/ui/view/interactiveprovider.cpp
@@ -100,41 +100,41 @@ void InteractiveProvider::raiseWindowInStack(QObject* newActiveWindow)
     }
 }
 
-RetVal<Val> InteractiveProvider::question(const std::string& title, const IInteractive::Text& text,
+RetVal<Val> InteractiveProvider::question(const std::string& contentTitle, const IInteractive::Text& text,
                                           const IInteractive::ButtonDatas& buttons, int defBtn,
                                           const IInteractive::Options& options,
                                           const std::string& dialogTitle)
 {
-    return openStandardDialog("QUESTION", title, text, {}, buttons, defBtn, options, dialogTitle);
+    return openStandardDialog("QUESTION", contentTitle, text, {}, buttons, defBtn, options, dialogTitle);
 }
 
-RetVal<Val> InteractiveProvider::info(const std::string& title, const IInteractive::Text& text,
+RetVal<Val> InteractiveProvider::info(const std::string& contentTitle, const IInteractive::Text& text,
                                       const IInteractive::ButtonDatas& buttons,
                                       int defBtn,
                                       const IInteractive::Options& options,
                                       const std::string& dialogTitle)
 {
-    return openStandardDialog("INFO", title, text, {}, buttons, defBtn, options, dialogTitle);
+    return openStandardDialog("INFO", contentTitle, text, {}, buttons, defBtn, options, dialogTitle);
 }
 
-RetVal<Val> InteractiveProvider::warning(const std::string& title, const IInteractive::Text& text,
+RetVal<Val> InteractiveProvider::warning(const std::string& contentTitle, const IInteractive::Text& text,
                                          const std::string& detailedText,
                                          const IInteractive::ButtonDatas& buttons,
                                          int defBtn,
                                          const IInteractive::Options& options,
                                          const std::string& dialogTitle)
 {
-    return openStandardDialog("WARNING", title, text, detailedText, buttons, defBtn, options, dialogTitle);
+    return openStandardDialog("WARNING", contentTitle, text, detailedText, buttons, defBtn, options, dialogTitle);
 }
 
-RetVal<Val> InteractiveProvider::error(const std::string& title, const IInteractive::Text& text,
+RetVal<Val> InteractiveProvider::error(const std::string& contentTitle, const IInteractive::Text& text,
                                        const std::string& detailedText,
                                        const IInteractive::ButtonDatas& buttons,
                                        int defBtn,
                                        const IInteractive::Options& options,
                                        const std::string& dialogTitle)
 {
-    return openStandardDialog("ERROR", title, text, detailedText, buttons, defBtn, options, dialogTitle);
+    return openStandardDialog("ERROR", contentTitle, text, detailedText, buttons, defBtn, options, dialogTitle);
 }
 
 Ret InteractiveProvider::showProgress(const std::string& title, Progress* progress)
@@ -427,7 +427,7 @@ void InteractiveProvider::fillData(QObject* object, const UriQuery& q) const
     }
 }
 
-void InteractiveProvider::fillStandardDialogData(QmlLaunchData* data, const QString& type, const std::string& title,
+void InteractiveProvider::fillStandardDialogData(QmlLaunchData* data, const QString& type, const std::string& contentTitle,
                                                  const IInteractive::Text& text, const std::string& detailedText,
                                                  const IInteractive::ButtonDatas& buttons, int defBtn,
                                                  const IInteractive::Options& options,
@@ -444,7 +444,7 @@ void InteractiveProvider::fillStandardDialogData(QmlLaunchData* data, const QStr
 
     QVariantMap params;
     params["type"] = type;
-    params["title"] = QString::fromStdString(title);
+    params["contentTitle"] = QString::fromStdString(contentTitle);
     params["text"] = QString::fromStdString(text.text);
     params["detailedText"] = QString::fromStdString(detailedText);
     params["textFormat"] = format(text.format);
@@ -723,7 +723,7 @@ RetVal<InteractiveProvider::OpenData> InteractiveProvider::openQml(const UriQuer
     return result;
 }
 
-RetVal<Val> InteractiveProvider::openStandardDialog(const QString& type, const std::string& title, const IInteractive::Text& text,
+RetVal<Val> InteractiveProvider::openStandardDialog(const QString& type, const std::string& contentTitle, const IInteractive::Text& text,
                                                     const std::string& detailedText,
                                                     const IInteractive::ButtonDatas& buttons, int defBtn,
                                                     const IInteractive::Options& options,
@@ -732,7 +732,7 @@ RetVal<Val> InteractiveProvider::openStandardDialog(const QString& type, const s
     notifyAboutCurrentUriWillBeChanged();
 
     QmlLaunchData* data = new QmlLaunchData();
-    fillStandardDialogData(data, type, title, text, detailedText, buttons, defBtn, options, dialogTitle);
+    fillStandardDialogData(data, type, contentTitle, text, detailedText, buttons, defBtn, options, dialogTitle);
 
     emit fireOpenStandardDialog(data);
 

--- a/src/framework/ui/view/interactiveprovider.cpp
+++ b/src/framework/ui/view/interactiveprovider.cpp
@@ -102,35 +102,39 @@ void InteractiveProvider::raiseWindowInStack(QObject* newActiveWindow)
 
 RetVal<Val> InteractiveProvider::question(const std::string& title, const IInteractive::Text& text,
                                           const IInteractive::ButtonDatas& buttons, int defBtn,
-                                          const IInteractive::Options& options)
+                                          const IInteractive::Options& options,
+                                          const std::string& dialogTitle)
 {
-    return openStandardDialog("QUESTION", title, text, {}, buttons, defBtn, options);
+    return openStandardDialog("QUESTION", title, text, {}, buttons, defBtn, options, dialogTitle);
 }
 
 RetVal<Val> InteractiveProvider::info(const std::string& title, const IInteractive::Text& text,
                                       const IInteractive::ButtonDatas& buttons,
                                       int defBtn,
-                                      const IInteractive::Options& options)
+                                      const IInteractive::Options& options,
+                                      const std::string& dialogTitle)
 {
-    return openStandardDialog("INFO", title, text, {}, buttons, defBtn, options);
+    return openStandardDialog("INFO", title, text, {}, buttons, defBtn, options, dialogTitle);
 }
 
 RetVal<Val> InteractiveProvider::warning(const std::string& title, const IInteractive::Text& text,
                                          const std::string& detailedText,
                                          const IInteractive::ButtonDatas& buttons,
                                          int defBtn,
-                                         const IInteractive::Options& options)
+                                         const IInteractive::Options& options,
+                                         const std::string& dialogTitle)
 {
-    return openStandardDialog("WARNING", title, text, detailedText, buttons, defBtn, options);
+    return openStandardDialog("WARNING", title, text, detailedText, buttons, defBtn, options, dialogTitle);
 }
 
 RetVal<Val> InteractiveProvider::error(const std::string& title, const IInteractive::Text& text,
                                        const std::string& detailedText,
                                        const IInteractive::ButtonDatas& buttons,
                                        int defBtn,
-                                       const IInteractive::Options& options)
+                                       const IInteractive::Options& options,
+                                       const std::string& dialogTitle)
 {
-    return openStandardDialog("ERROR", title, text, detailedText, buttons, defBtn, options);
+    return openStandardDialog("ERROR", title, text, detailedText, buttons, defBtn, options, dialogTitle);
 }
 
 Ret InteractiveProvider::showProgress(const std::string& title, Progress* progress)
@@ -426,7 +430,8 @@ void InteractiveProvider::fillData(QObject* object, const UriQuery& q) const
 void InteractiveProvider::fillStandardDialogData(QmlLaunchData* data, const QString& type, const std::string& title,
                                                  const IInteractive::Text& text, const std::string& detailedText,
                                                  const IInteractive::ButtonDatas& buttons, int defBtn,
-                                                 const IInteractive::Options& options) const
+                                                 const IInteractive::Options& options,
+                                                 const std::string& dialogTitle) const
 {
     auto format = [](IInteractive::TextFormat f) {
         switch (f) {
@@ -444,6 +449,7 @@ void InteractiveProvider::fillStandardDialogData(QmlLaunchData* data, const QStr
     params["detailedText"] = QString::fromStdString(detailedText);
     params["textFormat"] = format(text.format);
     params["defaultButtonId"] = defBtn;
+    params["dialogTitle"] = QString::fromStdString(dialogTitle);
 
     QVariantList buttonsList;
     QVariantList customButtonsList;
@@ -720,12 +726,13 @@ RetVal<InteractiveProvider::OpenData> InteractiveProvider::openQml(const UriQuer
 RetVal<Val> InteractiveProvider::openStandardDialog(const QString& type, const std::string& title, const IInteractive::Text& text,
                                                     const std::string& detailedText,
                                                     const IInteractive::ButtonDatas& buttons, int defBtn,
-                                                    const IInteractive::Options& options)
+                                                    const IInteractive::Options& options,
+                                                    const std::string& dialogTitle /* the title in the titlebar */)
 {
     notifyAboutCurrentUriWillBeChanged();
 
     QmlLaunchData* data = new QmlLaunchData();
-    fillStandardDialogData(data, type, title, text, detailedText, buttons, defBtn, options);
+    fillStandardDialogData(data, type, title, text, detailedText, buttons, defBtn, options, dialogTitle);
 
     emit fireOpenStandardDialog(data);
 

--- a/src/framework/ui/view/interactiveprovider.h
+++ b/src/framework/ui/view/interactiveprovider.h
@@ -71,7 +71,7 @@ public:
 
     RetVal<Val> warning(const std::string& title, const IInteractive::Text& text, const std::string& detailedText = {},
                         const IInteractive::ButtonDatas& buttons = {}, int defBtn = int(IInteractive::Button::NoButton),
-                        const IInteractive::Options& options = {}, const std::string & dialogTitle = "") override;
+                        const IInteractive::Options& options = {}, const std::string& dialogTitle = "") override;
 
     RetVal<Val> error(const std::string& title, const IInteractive::Text& text, const std::string& detailedText = {},
                       const IInteractive::ButtonDatas& buttons = {}, int defBtn = int(IInteractive::Button::NoButton),

--- a/src/framework/ui/view/interactiveprovider.h
+++ b/src/framework/ui/view/interactiveprovider.h
@@ -61,19 +61,19 @@ class InteractiveProvider : public QObject, public IInteractiveProvider, public 
 public:
     explicit InteractiveProvider(const modularity::ContextPtr& iocCtx);
 
-    RetVal<Val> question(const std::string& title, const IInteractive::Text& text, const IInteractive::ButtonDatas& buttons,
+    RetVal<Val> question(const std::string& contentTitle, const IInteractive::Text& text, const IInteractive::ButtonDatas& buttons,
                          int defBtn = int(IInteractive::Button::NoButton), const IInteractive::Options& options = {},
                          const std::string& dialogTitle = "") override;
 
-    RetVal<Val> info(const std::string& title, const IInteractive::Text& text, const IInteractive::ButtonDatas& buttons,
+    RetVal<Val> info(const std::string& contentTitle, const IInteractive::Text& text, const IInteractive::ButtonDatas& buttons,
                      int defBtn = int(IInteractive::Button::NoButton), const IInteractive::Options& options = {},
                      const std::string& dialogTitle = "") override;
 
-    RetVal<Val> warning(const std::string& title, const IInteractive::Text& text, const std::string& detailedText = {},
+    RetVal<Val> warning(const std::string& contentTitle, const IInteractive::Text& text, const std::string& detailedText = {},
                         const IInteractive::ButtonDatas& buttons = {}, int defBtn = int(IInteractive::Button::NoButton),
                         const IInteractive::Options& options = {}, const std::string& dialogTitle = "") override;
 
-    RetVal<Val> error(const std::string& title, const IInteractive::Text& text, const std::string& detailedText = {},
+    RetVal<Val> error(const std::string& contentTitle, const IInteractive::Text& text, const std::string& detailedText = {},
                       const IInteractive::ButtonDatas& buttons = {}, int defBtn = int(IInteractive::Button::NoButton),
                       const IInteractive::Options& options = {}, const std::string& dialogTitle = "") override;
 
@@ -144,7 +144,7 @@ private:
     void fillExtData(QmlLaunchData* data, const UriQuery& q) const;
     void fillData(QmlLaunchData* data, const UriQuery& q) const;
     void fillData(QObject* object, const UriQuery& q) const;
-    void fillStandardDialogData(QmlLaunchData* data, const QString& type, const std::string& title, const IInteractive::Text& text,
+    void fillStandardDialogData(QmlLaunchData* data, const QString& type, const std::string& contentTitle, const IInteractive::Text& text,
                                 const std::string& detailedText, const IInteractive::ButtonDatas& buttons, int defBtn,
                                 const IInteractive::Options& options, const std::string& dialogTitle) const;
     void fillFileDialogData(QmlLaunchData* data, FileDialogType type, const std::string& title, const io::path_t& path,
@@ -156,7 +156,7 @@ private:
     RetVal<OpenData> openExtensionDialog(const UriQuery& q);
     RetVal<OpenData> openWidgetDialog(const UriQuery& q);
     RetVal<OpenData> openQml(const UriQuery& q);
-    RetVal<Val> openStandardDialog(const QString& type, const std::string& title, const IInteractive::Text& text,
+    RetVal<Val> openStandardDialog(const QString& type, const std::string& contentTitle, const IInteractive::Text& text,
                                    const std::string& detailedText = {}, const IInteractive::ButtonDatas& buttons = {},
                                    int defBtn = int(IInteractive::Button::NoButton), const IInteractive::Options& options = {},
                                    const std::string& dialogTitle = "");

--- a/src/framework/ui/view/interactiveprovider.h
+++ b/src/framework/ui/view/interactiveprovider.h
@@ -62,18 +62,20 @@ public:
     explicit InteractiveProvider(const modularity::ContextPtr& iocCtx);
 
     RetVal<Val> question(const std::string& title, const IInteractive::Text& text, const IInteractive::ButtonDatas& buttons,
-                         int defBtn = int(IInteractive::Button::NoButton), const IInteractive::Options& options = {}) override;
+                         int defBtn = int(IInteractive::Button::NoButton), const IInteractive::Options& options = {},
+                         const std::string& dialogTitle = "") override;
 
     RetVal<Val> info(const std::string& title, const IInteractive::Text& text, const IInteractive::ButtonDatas& buttons,
-                     int defBtn = int(IInteractive::Button::NoButton), const IInteractive::Options& options = {}) override;
+                     int defBtn = int(IInteractive::Button::NoButton), const IInteractive::Options& options = {},
+                     const std::string& dialogTitle = "") override;
 
     RetVal<Val> warning(const std::string& title, const IInteractive::Text& text, const std::string& detailedText = {},
                         const IInteractive::ButtonDatas& buttons = {}, int defBtn = int(IInteractive::Button::NoButton),
-                        const IInteractive::Options& options = {}) override;
+                        const IInteractive::Options& options = {}, const std::string & dialogTitle = "") override;
 
     RetVal<Val> error(const std::string& title, const IInteractive::Text& text, const std::string& detailedText = {},
                       const IInteractive::ButtonDatas& buttons = {}, int defBtn = int(IInteractive::Button::NoButton),
-                      const IInteractive::Options& options = {}) override;
+                      const IInteractive::Options& options = {}, const std::string& dialogTitle = "") override;
 
     Ret showProgress(const std::string& title, Progress* progress) override;
 
@@ -144,7 +146,7 @@ private:
     void fillData(QObject* object, const UriQuery& q) const;
     void fillStandardDialogData(QmlLaunchData* data, const QString& type, const std::string& title, const IInteractive::Text& text,
                                 const std::string& detailedText, const IInteractive::ButtonDatas& buttons, int defBtn,
-                                const IInteractive::Options& options) const;
+                                const IInteractive::Options& options, const std::string& dialogTitle) const;
     void fillFileDialogData(QmlLaunchData* data, FileDialogType type, const std::string& title, const io::path_t& path,
                             const std::vector<std::string>& filter = {}, bool confirmOverwrite = true) const;
 
@@ -156,7 +158,8 @@ private:
     RetVal<OpenData> openQml(const UriQuery& q);
     RetVal<Val> openStandardDialog(const QString& type, const std::string& title, const IInteractive::Text& text,
                                    const std::string& detailedText = {}, const IInteractive::ButtonDatas& buttons = {},
-                                   int defBtn = int(IInteractive::Button::NoButton), const IInteractive::Options& options = {});
+                                   int defBtn = int(IInteractive::Button::NoButton), const IInteractive::Options& options = {},
+                                   const std::string& dialogTitle = "");
 
     RetVal<io::path_t> openFileDialog(FileDialogType type, const std::string& title, const io::path_t& path,
                                       const std::vector<std::string>& filter = {}, bool confirmOverwrite = true);

--- a/src/framework/uicomponents/view/buttonboxmodel.h
+++ b/src/framework/uicomponents/view/buttonboxmodel.h
@@ -165,11 +165,11 @@ private:
                                    RejectRole, HelpRole },
 
         // MacLayout
-        std::vector <ButtonRole> { CustomRole, HelpRole, ResetRole, RetryRole, DestructiveRole, RejectRole, BackRole, AcceptRole,
+        std::vector <ButtonRole> { CustomRole, HelpRole, RetryRole, DestructiveRole, RejectRole, ResetRole, BackRole, AcceptRole,
                                    ApplyRole, ContinueRole },
 
         // LinuxLayout
-        std::vector <ButtonRole> { CustomRole, HelpRole, ResetRole, RetryRole, DestructiveRole, RejectRole, BackRole, AcceptRole,
+        std::vector <ButtonRole> { CustomRole, HelpRole, RetryRole, DestructiveRole, RejectRole, ResetRole, BackRole, AcceptRole,
                                    ApplyRole, ContinueRole }
     };
 

--- a/src/framework/update/internal/updateconfiguration.cpp
+++ b/src/framework/update/internal/updateconfiguration.cpp
@@ -64,6 +64,9 @@ void UpdateConfiguration::init()
     m_config = ConfigReader::read(":/configs/update.cfg");
 
     settings()->setDefaultValue(CHECK_FOR_UPDATE_KEY, Val(isAppUpdatable()));
+    settings()->valueChanged(CHECK_FOR_UPDATE_KEY).onReceive(this, [this](const Val&) {
+        m_needCheckForUpdateChanged.notify();
+    });
 
     bool allowUpdateOnPreRelease = false;
 #ifdef MUSESCORE_ALLOW_UPDATE_ON_PRERELEASE
@@ -97,6 +100,11 @@ bool UpdateConfiguration::needCheckForUpdate() const
 void UpdateConfiguration::setNeedCheckForUpdate(bool needCheck)
 {
     settings()->setSharedValue(CHECK_FOR_UPDATE_KEY, Val(needCheck));
+}
+
+async::Notification UpdateConfiguration::needCheckForUpdateChanged() const
+{
+    return m_needCheckForUpdateChanged;
 }
 
 std::string UpdateConfiguration::skippedReleaseVersion() const

--- a/src/framework/update/internal/updateconfiguration.h
+++ b/src/framework/update/internal/updateconfiguration.h
@@ -48,6 +48,7 @@ public:
 
     bool needCheckForUpdate() const override;
     void setNeedCheckForUpdate(bool needCheck) override;
+    muse::async::Notification needCheckForUpdateChanged() const override;
 
     std::string skippedReleaseVersion() const override;
     void setSkippedReleaseVersion(const std::string& version) override;
@@ -68,6 +69,7 @@ public:
     muse::io::path_t updateRequestHistoryJsonPath() const override;
 
 private:
+    muse::async::Notification m_needCheckForUpdateChanged;
 
     Config m_config;
 };

--- a/src/framework/update/iupdateconfiguration.h
+++ b/src/framework/update/iupdateconfiguration.h
@@ -22,6 +22,7 @@
 #ifndef MUSE_UPDATE_IUPDATECONFIGURATION_H
 #define MUSE_UPDATE_IUPDATECONFIGURATION_H
 
+#include "async/notification.h"
 #include "io/path.h"
 #include "network/networktypes.h"
 
@@ -42,6 +43,7 @@ public:
 
     virtual bool needCheckForUpdate() const = 0;
     virtual void setNeedCheckForUpdate(bool needCheck) = 0;
+    virtual muse::async::Notification needCheckForUpdateChanged() const = 0;
 
     virtual std::string skippedReleaseVersion() const = 0;
     virtual void setSkippedReleaseVersion(const std::string& version) = 0;

--- a/src/framework/update/tests/mocks/updateconfigurationmock.h
+++ b/src/framework/update/tests/mocks/updateconfigurationmock.h
@@ -37,6 +37,7 @@ public:
 
     MOCK_METHOD(bool, needCheckForUpdate, (), (const, override));
     MOCK_METHOD(void, setNeedCheckForUpdate, (bool), (override));
+    MOCK_METHOD(muse::async::Notification, needCheckForUpdateChanged, (), (const, override));
 
     MOCK_METHOD(std::string, skippedReleaseVersion, (), (const, override));
     MOCK_METHOD(void, setSkippedReleaseVersion, (const std::string&), (override));

--- a/src/importexport/mei/imeiconfiguration.h
+++ b/src/importexport/mei/imeiconfiguration.h
@@ -23,6 +23,7 @@
 #define MU_IMPORTEXPORT_IMEICONFIGURATION_H
 
 #include "modularity/imoduleinterface.h"
+#include "async/channel.h"
 
 namespace mu::iex::mei {
 class IMeiConfiguration : MODULE_EXPORT_INTERFACE
@@ -34,6 +35,7 @@ public:
 
     virtual bool meiImportLayout() const = 0;
     virtual void setMeiImportLayout(bool value) = 0;
+    virtual muse::async::Channel<bool> meiImportLayoutChanged() const = 0;
 
     virtual bool meiExportLayout() const = 0;
     virtual void setMeiExportLayout(bool value) = 0;

--- a/src/importexport/mei/internal/meiconfiguration.cpp
+++ b/src/importexport/mei/internal/meiconfiguration.cpp
@@ -36,6 +36,10 @@ static const Settings::Key MEI_USE_MUSESCORE_IDS_KEY(module_name, "export/mei/us
 void MeiConfiguration::init()
 {
     settings()->setDefaultValue(MEI_IMPORT_LAYOUT_KEY, Val(true));
+    settings()->valueChanged(MEI_IMPORT_LAYOUT_KEY).onReceive(this, [this](const Val& val) {
+        m_meiImportLayoutChanged.send(val.toBool());
+    });
+
     settings()->setDefaultValue(MEI_EXPORT_LAYOUT_KEY, Val(true));
     settings()->setDefaultValue(MEI_USE_MUSESCORE_IDS_KEY, Val(false));
 }
@@ -48,6 +52,11 @@ bool MeiConfiguration::meiImportLayout() const
 void MeiConfiguration::setMeiImportLayout(bool value)
 {
     settings()->setSharedValue(MEI_IMPORT_LAYOUT_KEY, Val(value));
+}
+
+async::Channel<bool> MeiConfiguration::meiImportLayoutChanged() const
+{
+    return m_meiImportLayoutChanged;
 }
 
 bool MeiConfiguration::meiExportLayout() const

--- a/src/importexport/mei/internal/meiconfiguration.h
+++ b/src/importexport/mei/internal/meiconfiguration.h
@@ -23,21 +23,26 @@
 #define MU_IMPORTEXPORT_MEICONFIGURATION_H
 
 #include "../imeiconfiguration.h"
+#include "async/asyncable.h"
 
 namespace mu::iex::mei {
-class MeiConfiguration : public IMeiConfiguration
+class MeiConfiguration : public IMeiConfiguration, public muse::async::Asyncable
 {
 public:
     void init();
 
     bool meiImportLayout() const override;
     void setMeiImportLayout(bool value) override;
+    muse::async::Channel<bool> meiImportLayoutChanged() const override;
 
     bool meiExportLayout() const override;
     void setMeiExportLayout(bool value) override;
 
     bool meiUseMuseScoreIds() const override;
     void setMeiUseMuseScoreIds(bool value) override;
+
+private:
+    muse::async::Channel<bool> m_meiImportLayoutChanged;
 };
 }
 

--- a/src/importexport/midi/imidiconfiguration.h
+++ b/src/importexport/midi/imidiconfiguration.h
@@ -25,6 +25,7 @@
 #include <optional>
 
 #include "modularity/imoduleinterface.h"
+#include "async/channel.h"
 #include "io/path.h"
 
 namespace mu::iex::midi {
@@ -38,6 +39,7 @@ public:
     // import
     virtual int midiShortestNote() const = 0; //ticks
     virtual void setMidiShortestNote(int ticks) = 0;
+    virtual muse::async::Channel<int> midiShortestNoteChanged() const = 0;
 
     virtual void setMidiImportOperationsFile(const std::optional<muse::io::path_t>& filePath) const = 0;
 

--- a/src/importexport/midi/internal/midiconfiguration.cpp
+++ b/src/importexport/midi/internal/midiconfiguration.cpp
@@ -38,6 +38,10 @@ static const Settings::Key EXPAND_REPEATS_KEY("iex_midi", "io/midi/expandRepeats
 void MidiConfiguration::init()
 {
     settings()->setDefaultValue(SHORTEST_NOTE_KEY, Val(mu::engraving::Constants::DIVISION / 4));
+    settings()->valueChanged(SHORTEST_NOTE_KEY).onReceive(this, [this](const Val& val) {
+        m_midiShortestNoteChanged.send(val.toInt());
+    });
+
     settings()->setDefaultValue(EXPAND_REPEATS_KEY, Val(true));
     settings()->setDefaultValue(EXPORTRPNS_KEY, Val(true));
 }
@@ -50,6 +54,11 @@ int MidiConfiguration::midiShortestNote() const
 void MidiConfiguration::setMidiShortestNote(int ticks)
 {
     settings()->setSharedValue(SHORTEST_NOTE_KEY, Val(ticks));
+}
+
+async::Channel<int> MidiConfiguration::midiShortestNoteChanged() const
+{
+    return m_midiShortestNoteChanged;
 }
 
 void MidiConfiguration::setMidiImportOperationsFile(const std::optional<muse::io::path_t>& filePath) const

--- a/src/importexport/midi/internal/midiconfiguration.h
+++ b/src/importexport/midi/internal/midiconfiguration.h
@@ -22,11 +22,12 @@
 #ifndef MU_IMPORTEXPORT_MIDICONFIGURATION_H
 #define MU_IMPORTEXPORT_MIDICONFIGURATION_H
 
+#include "async/asyncable.h"
 #include "io/path.h"
 #include "../imidiconfiguration.h"
 
 namespace mu::iex::midi {
-class MidiConfiguration : public IMidiImportExportConfiguration
+class MidiConfiguration : public IMidiImportExportConfiguration, public muse::async::Asyncable
 {
 public:
     void init();
@@ -34,6 +35,7 @@ public:
     // import
     int midiShortestNote() const override; // ticks
     void setMidiShortestNote(int ticks) override;
+    muse::async::Channel<int> midiShortestNoteChanged() const override;
 
     void setMidiImportOperationsFile(const std::optional<muse::io::path_t>& filePath) const override;
 
@@ -43,6 +45,9 @@ public:
 
     bool isMidiExportRpns() const override;
     void setIsMidiExportRpns(bool exportRpns) override;
+
+private:
+    muse::async::Channel<int> m_midiShortestNoteChanged;
 };
 }
 

--- a/src/importexport/musicxml/imusicxmlconfiguration.h
+++ b/src/importexport/musicxml/imusicxmlconfiguration.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "modularity/imoduleinterface.h"
+#include "async/channel.h"
 #include "io/path.h"
 
 namespace mu::iex::musicxml {
@@ -34,9 +35,11 @@ public:
 
     virtual bool importBreaks() const = 0;
     virtual void setImportBreaks(bool value) = 0;
+    virtual muse::async::Channel<bool> importBreaksChanged() const = 0;
 
     virtual bool importLayout() const = 0;
     virtual void setImportLayout(bool value) = 0;
+    virtual muse::async::Channel<bool> importLayoutChanged() const = 0;
 
     virtual bool exportLayout() const = 0;
     virtual void setExportLayout(bool value) = 0;
@@ -56,13 +59,16 @@ public:
 
     virtual bool needUseDefaultFont() const = 0;
     virtual void setNeedUseDefaultFont(bool value) = 0;
+    virtual muse::async::Channel<bool> needUseDefaultFontChanged() const = 0;
     virtual void setNeedUseDefaultFontOverride(std::optional<bool> value) = 0;
 
     virtual bool needAskAboutApplyingNewStyle() const = 0;
     virtual void setNeedAskAboutApplyingNewStyle(bool value) = 0;
+    virtual muse::async::Channel<bool> needAskAboutApplyingNewStyleChanged() const = 0;
 
     virtual bool inferTextType() const = 0;
     virtual void setInferTextType(bool value) = 0;
+    virtual muse::async::Channel<bool> inferTextTypeChanged() const = 0;
     virtual void setInferTextTypeOverride(std::optional<bool> value) = 0;
 };
 }

--- a/src/importexport/musicxml/internal/musicxmlconfiguration.cpp
+++ b/src/importexport/musicxml/internal/musicxmlconfiguration.cpp
@@ -43,7 +43,15 @@ static const Settings::Key MUSICXML_IMPORT_INFER_TEXT_TYPE(module_name, "import/
 void MusicXmlConfiguration::init()
 {
     settings()->setDefaultValue(MUSICXML_IMPORT_BREAKS_KEY, Val(true));
+    settings()->valueChanged(MUSICXML_IMPORT_BREAKS_KEY).onReceive(this, [this](const Val& val) {
+        m_importBreaksChanged.send(val.toBool());
+    });
+
     settings()->setDefaultValue(MUSICXML_IMPORT_LAYOUT_KEY, Val(true));
+    settings()->valueChanged(MUSICXML_IMPORT_LAYOUT_KEY).onReceive(this, [this](const Val& val) {
+        m_importLayoutChanged.send(val.toBool());
+    });
+
     settings()->setDefaultValue(MUSICXML_EXPORT_LAYOUT_KEY, Val(true));
     settings()->setDefaultValue(MUSICXML_EXPORT_MU3_COMPAT_KEY, Val(false));
     settings()->setDescription(MUSICXML_EXPORT_MU3_COMPAT_KEY,
@@ -56,9 +64,21 @@ void MusicXmlConfiguration::init()
     settings()->setDescription(MUSICXML_EXPORT_INVISIBLE_ELEMENTS_KEY,
                                muse::trc("iex_musicxml", "Export invisible elements to MusicXML"));
     settings()->setCanBeManuallyEdited(MUSICXML_EXPORT_INVISIBLE_ELEMENTS_KEY, true);
+
     settings()->setDefaultValue(MIGRATION_APPLY_EDWIN_FOR_XML, Val(false));
+    settings()->valueChanged(MIGRATION_APPLY_EDWIN_FOR_XML).onReceive(this, [this](const Val& val) {
+        m_needUseDefaultFontChanged.send(val.toBool());
+    });
+
     settings()->setDefaultValue(MIGRATION_NOT_ASK_AGAIN_KEY, Val(false));
+    settings()->valueChanged(MIGRATION_NOT_ASK_AGAIN_KEY).onReceive(this, [this](const Val& val) {
+        m_needAskAboutApplyingNewStyleChanged.send(val.toBool());
+    });
+
     settings()->setDefaultValue(MUSICXML_IMPORT_INFER_TEXT_TYPE, Val(false));
+    settings()->valueChanged(MUSICXML_IMPORT_INFER_TEXT_TYPE).onReceive(this, [this](const Val& val) {
+        m_inferTextTypeChanged.send(val.toBool());
+    });
 }
 
 bool MusicXmlConfiguration::importBreaks() const
@@ -71,6 +91,11 @@ void MusicXmlConfiguration::setImportBreaks(bool value)
     settings()->setSharedValue(MUSICXML_IMPORT_BREAKS_KEY, Val(value));
 }
 
+async::Channel<bool> MusicXmlConfiguration::importBreaksChanged() const
+{
+    return m_importBreaksChanged;
+}
+
 bool MusicXmlConfiguration::importLayout() const
 {
     return settings()->value(MUSICXML_IMPORT_LAYOUT_KEY).toBool();
@@ -79,6 +104,11 @@ bool MusicXmlConfiguration::importLayout() const
 void MusicXmlConfiguration::setImportLayout(bool value)
 {
     settings()->setSharedValue(MUSICXML_IMPORT_LAYOUT_KEY, Val(value));
+}
+
+async::Channel<bool> MusicXmlConfiguration::importLayoutChanged() const
+{
+    return m_importLayoutChanged;
 }
 
 bool MusicXmlConfiguration::exportLayout() const
@@ -135,6 +165,11 @@ void MusicXmlConfiguration::setNeedUseDefaultFont(bool value)
     settings()->setSharedValue(MIGRATION_APPLY_EDWIN_FOR_XML, Val(value));
 }
 
+async::Channel<bool> MusicXmlConfiguration::needUseDefaultFontChanged() const
+{
+    return m_needUseDefaultFontChanged;
+}
+
 void MusicXmlConfiguration::setNeedUseDefaultFontOverride(std::optional<bool> value)
 {
     m_needUseDefaultFontOverride = value;
@@ -150,6 +185,11 @@ void MusicXmlConfiguration::setNeedAskAboutApplyingNewStyle(bool value)
     settings()->setSharedValue(MIGRATION_NOT_ASK_AGAIN_KEY, Val(!value));
 }
 
+async::Channel<bool> MusicXmlConfiguration::needAskAboutApplyingNewStyleChanged() const
+{
+    return m_needAskAboutApplyingNewStyleChanged;
+}
+
 bool MusicXmlConfiguration::inferTextType() const
 {
     if (m_inferTextTypeOverride.has_value()) {
@@ -162,6 +202,11 @@ bool MusicXmlConfiguration::inferTextType() const
 void MusicXmlConfiguration::setInferTextType(bool value)
 {
     settings()->setSharedValue(MUSICXML_IMPORT_INFER_TEXT_TYPE, Val(value));
+}
+
+async::Channel<bool> MusicXmlConfiguration::inferTextTypeChanged() const
+{
+    return m_inferTextTypeChanged;
 }
 
 void MusicXmlConfiguration::setInferTextTypeOverride(std::optional<bool> value)

--- a/src/importexport/musicxml/internal/musicxmlconfiguration.h
+++ b/src/importexport/musicxml/internal/musicxmlconfiguration.h
@@ -22,18 +22,21 @@
 #pragma once
 
 #include "../imusicxmlconfiguration.h"
+#include "async/asyncable.h"
 
 namespace mu::iex::musicxml {
-class MusicXmlConfiguration : public IMusicXmlConfiguration
+class MusicXmlConfiguration : public IMusicXmlConfiguration, public muse::async::Asyncable
 {
 public:
     void init();
 
     bool importBreaks() const override;
     void setImportBreaks(bool value) override;
+    muse::async::Channel<bool> importBreaksChanged() const override;
 
     bool importLayout() const override;
     void setImportLayout(bool value) override;
+    muse::async::Channel<bool> importLayoutChanged() const override;
 
     bool exportLayout() const override;
     void setExportLayout(bool value) override;
@@ -49,17 +52,26 @@ public:
 
     bool needUseDefaultFont() const override;
     void setNeedUseDefaultFont(bool value) override;
+    muse::async::Channel<bool> needUseDefaultFontChanged() const override;
     void setNeedUseDefaultFontOverride(std::optional<bool> value) override;
 
     bool needAskAboutApplyingNewStyle() const override;
     void setNeedAskAboutApplyingNewStyle(bool value) override;
+    muse::async::Channel<bool> needAskAboutApplyingNewStyleChanged() const override;
 
     bool inferTextType() const override;
     void setInferTextType(bool value) override;
+    muse::async::Channel<bool> inferTextTypeChanged() const override;
     void setInferTextTypeOverride(std::optional<bool> value) override;
 
 private:
     std::optional<bool> m_needUseDefaultFontOverride;
     std::optional<bool> m_inferTextTypeOverride;
+
+    muse::async::Channel<bool> m_importBreaksChanged;
+    muse::async::Channel<bool> m_importLayoutChanged;
+    muse::async::Channel<bool> m_needUseDefaultFontChanged;
+    muse::async::Channel<bool> m_needAskAboutApplyingNewStyleChanged;
+    muse::async::Channel<bool> m_inferTextTypeChanged;
 };
 }

--- a/src/importexport/ove/internal/oveconfiguration.cpp
+++ b/src/importexport/ove/internal/oveconfiguration.cpp
@@ -32,6 +32,9 @@ static const Settings::Key IMPORT_OVERTURE_CHARSET_KEY("iex_ove", "import/overtu
 void OveConfiguration::init()
 {
     settings()->setDefaultValue(IMPORT_OVERTURE_CHARSET_KEY, Val("GBK"));
+    settings()->valueChanged(IMPORT_OVERTURE_CHARSET_KEY).onReceive(this, [this](const Val& val) {
+        m_importOvertureCharsetChanged.send(val.toString());
+    });
 }
 
 std::string OveConfiguration::importOvertureCharset() const
@@ -42,4 +45,9 @@ std::string OveConfiguration::importOvertureCharset() const
 void OveConfiguration::setImportOvertureCharset(const std::string& charset)
 {
     settings()->setSharedValue(IMPORT_OVERTURE_CHARSET_KEY, Val(charset));
+}
+
+async::Channel<std::string> OveConfiguration::importOvertureCharsetChanged() const
+{
+    return m_importOvertureCharsetChanged;
 }

--- a/src/importexport/ove/internal/oveconfiguration.h
+++ b/src/importexport/ove/internal/oveconfiguration.h
@@ -23,15 +23,20 @@
 #define MU_IMPORTEXPORT_OVECONFIGURATION_H
 
 #include "../ioveconfiguration.h"
+#include "async/asyncable.h"
 
 namespace mu::iex::ove {
-class OveConfiguration : public IOveConfiguration
+class OveConfiguration : public IOveConfiguration, public muse::async::Asyncable
 {
 public:
     void init();
 
     std::string importOvertureCharset() const override;
     void setImportOvertureCharset(const std::string& charset) override;
+    muse::async::Channel<std::string> importOvertureCharsetChanged() const override;
+
+private:
+    muse::async::Channel<std::string> m_importOvertureCharsetChanged;
 };
 }
 

--- a/src/importexport/ove/ioveconfiguration.h
+++ b/src/importexport/ove/ioveconfiguration.h
@@ -24,6 +24,7 @@
 
 #include <string>
 
+#include "async/channel.h"
 #include "modularity/imoduleinterface.h"
 
 namespace mu::iex::ove {
@@ -36,6 +37,7 @@ public:
 
     virtual std::string importOvertureCharset() const = 0;
     virtual void setImportOvertureCharset(const std::string& charset) = 0;
+    virtual muse::async::Channel<std::string> importOvertureCharsetChanged() const = 0;
 };
 }
 

--- a/src/notation/inotationconfiguration.h
+++ b/src/notation/inotationconfiguration.h
@@ -111,9 +111,11 @@ public:
 
     virtual muse::io::path_t defaultStyleFilePath() const = 0;
     virtual void setDefaultStyleFilePath(const muse::io::path_t& path) = 0;
+    virtual muse::async::Channel<muse::io::path_t> defaultStyleFilePathChanged() const = 0;
 
     virtual muse::io::path_t partStyleFilePath() const = 0;
     virtual void setPartStyleFilePath(const muse::io::path_t& path) = 0;
+    virtual muse::async::Channel<muse::io::path_t> partStyleFilePathChanged() const = 0;
 
     virtual bool isMidiInputEnabled() const = 0;
     virtual void setIsMidiInputEnabled(bool enabled) = 0;

--- a/src/notation/inotationconfiguration.h
+++ b/src/notation/inotationconfiguration.h
@@ -90,7 +90,6 @@ public:
 
     virtual int defaultZoom() const = 0;
     virtual void setDefaultZoom(int zoomPercentage) = 0;
-
     virtual muse::async::Notification defaultZoomChanged() const = 0;
 
     virtual QList<int> possibleZoomPercentageList() const = 0;

--- a/src/notation/inotationconfiguration.h
+++ b/src/notation/inotationconfiguration.h
@@ -219,6 +219,7 @@ public:
 
     virtual muse::io::path_t styleFileImportPath() const = 0;
     virtual void setStyleFileImportPath(const muse::io::path_t& path) = 0;
+    virtual muse::async::Channel<std::string> styleFileImportPathChanged() const = 0;
 
     virtual int styleDialogLastPageIndex() const = 0;
     virtual void setStyleDialogLastPageIndex(int value) = 0;

--- a/src/notation/inotationconfiguration.h
+++ b/src/notation/inotationconfiguration.h
@@ -150,15 +150,19 @@ public:
 
     virtual bool colorNotesOutsideOfUsablePitchRange() const = 0;
     virtual void setColorNotesOutsideOfUsablePitchRange(bool value) = 0;
+    virtual muse::async::Channel<bool> colorNotesOutsideOfUsablePitchRangeChanged() const = 0;
 
     virtual bool warnGuitarBends() const = 0;
     virtual void setWarnGuitarBends(bool value) = 0;
+    virtual muse::async::Channel<bool> warnGuitarBendsChanged() const = 0;
 
     virtual int delayBetweenNotesInRealTimeModeMilliseconds() const = 0;
     virtual void setDelayBetweenNotesInRealTimeModeMilliseconds(int delayMs) = 0;
+    virtual muse::async::Channel<int> delayBetweenNotesInRealTimeModeMillisecondsChanged() const = 0;
 
     virtual int notePlayDurationMilliseconds() const = 0;
     virtual void setNotePlayDurationMilliseconds(int durationMs) = 0;
+    virtual muse::async::Channel<int> notePlayDurationMillisecondsChanged() const = 0;
 
     virtual void setTemplateModeEnabled(std::optional<bool> enabled) = 0;
     virtual void setTestModeEnabled(std::optional<bool> enabled) = 0;

--- a/src/notation/inotationconfiguration.h
+++ b/src/notation/inotationconfiguration.h
@@ -83,12 +83,15 @@ public:
 
     virtual int selectionProximity() const = 0;
     virtual void setSelectionProximity(int proximity) = 0;
+    virtual muse::async::Channel<int> selectionProximityChanged() const = 0;
 
     virtual ZoomType defaultZoomType() const = 0;
     virtual void setDefaultZoomType(ZoomType zoomType) = 0;
 
     virtual int defaultZoom() const = 0;
     virtual void setDefaultZoom(int zoomPercentage) = 0;
+
+    virtual muse::async::Notification defaultZoomChanged() const = 0;
 
     virtual QList<int> possibleZoomPercentageList() const = 0;
 
@@ -97,6 +100,7 @@ public:
 
     virtual int mouseZoomPrecision() const = 0;
     virtual void setMouseZoomPrecision(int precision) = 0;
+    virtual muse::async::Notification mouseZoomPrecisionChanged() const = 0;
 
     virtual std::string fontFamily() const = 0;
     virtual int fontSize() const = 0;

--- a/src/notation/internal/notationconfiguration.cpp
+++ b/src/notation/internal/notationconfiguration.cpp
@@ -221,7 +221,6 @@ void NotationConfiguration::init()
         m_notePlayDurationMillisecondsChanged.send(val.toInt());
     });
 
-    settings()->setDefaultValue(STYLE_FILE_IMPORT_PATH_KEY, Val(""));
     settings()->valueChanged(STYLE_FILE_IMPORT_PATH_KEY).onReceive(this, [this](const Val& val) {
         m_styleFileImportPathChanged.send(val.toString());
     });

--- a/src/notation/internal/notationconfiguration.cpp
+++ b/src/notation/internal/notationconfiguration.cpp
@@ -153,16 +153,16 @@ void NotationConfiguration::init()
     });
 
     settings()->setDefaultValue(DEFAULT_ZOOM_TYPE, Val(ZoomType::Percentage));
-    settings()->valueChanged(DEFAULT_ZOOM_TYPE).onReceive(nullptr, [this](const Val&) {
+    settings()->valueChanged(DEFAULT_ZOOM_TYPE).onReceive(this, [this](const Val&) {
         m_defaultZoomChanged.notify();
     });
     settings()->setDefaultValue(DEFAULT_ZOOM, Val(100));
-    settings()->valueChanged(DEFAULT_ZOOM).onReceive(nullptr, [this](const Val&) {
+    settings()->valueChanged(DEFAULT_ZOOM).onReceive(this, [this](const Val&) {
         m_defaultZoomChanged.notify();
     });
     settings()->setDefaultValue(KEYBOARD_ZOOM_PRECISION, Val(2));
     settings()->setDefaultValue(MOUSE_ZOOM_PRECISION, Val(6));
-    settings()->valueChanged(MOUSE_ZOOM_PRECISION).onReceive(nullptr, [this](const Val&) {
+    settings()->valueChanged(MOUSE_ZOOM_PRECISION).onReceive(this, [this](const Val&) {
         m_mouseZoomPrecisionChanged.notify();
     });
 
@@ -176,7 +176,7 @@ void NotationConfiguration::init()
     }
 
     settings()->setDefaultValue(SELECTION_PROXIMITY, Val(2));
-    settings()->valueChanged(SELECTION_PROXIMITY).onReceive(nullptr, [this](const Val& val) {
+    settings()->valueChanged(SELECTION_PROXIMITY).onReceive(this, [this](const Val& val) {
         m_selectionProximityChanged.send(val.toInt());
     });
     settings()->setDefaultValue(IS_MIDI_INPUT_ENABLED, Val(true));

--- a/src/notation/internal/notationconfiguration.cpp
+++ b/src/notation/internal/notationconfiguration.cpp
@@ -153,9 +153,18 @@ void NotationConfiguration::init()
     });
 
     settings()->setDefaultValue(DEFAULT_ZOOM_TYPE, Val(ZoomType::Percentage));
+    settings()->valueChanged(DEFAULT_ZOOM_TYPE).onReceive(nullptr, [this](const Val&) {
+        m_defaultZoomChanged.notify();
+    });
     settings()->setDefaultValue(DEFAULT_ZOOM, Val(100));
+    settings()->valueChanged(DEFAULT_ZOOM).onReceive(nullptr, [this](const Val&) {
+        m_defaultZoomChanged.notify();
+    });
     settings()->setDefaultValue(KEYBOARD_ZOOM_PRECISION, Val(2));
     settings()->setDefaultValue(MOUSE_ZOOM_PRECISION, Val(6));
+    settings()->valueChanged(MOUSE_ZOOM_PRECISION).onReceive(nullptr, [this](const Val&) {
+        m_mouseZoomPrecisionChanged.notify();
+    });
 
     settings()->setDefaultValue(USER_STYLES_PATH, Val(globalConfiguration()->userDataPath() + "/Styles"));
     settings()->valueChanged(USER_STYLES_PATH).onReceive(nullptr, [this](const Val& val) {
@@ -167,6 +176,9 @@ void NotationConfiguration::init()
     }
 
     settings()->setDefaultValue(SELECTION_PROXIMITY, Val(2));
+    settings()->valueChanged(SELECTION_PROXIMITY).onReceive(nullptr, [this](const Val& val) {
+        m_selectionProximityChanged.send(val.toInt());
+    });
     settings()->setDefaultValue(IS_MIDI_INPUT_ENABLED, Val(true));
     settings()->setDefaultValue(IS_AUTOMATICALLY_PAN_ENABLED, Val(true));
     settings()->setDefaultValue(IS_PLAY_REPEATS_ENABLED, Val(true));
@@ -484,6 +496,11 @@ void NotationConfiguration::setSelectionProximity(int proximity)
     settings()->setSharedValue(SELECTION_PROXIMITY, Val(proximity));
 }
 
+Channel<int> NotationConfiguration::selectionProximityChanged() const
+{
+    return m_selectionProximityChanged;
+}
+
 ZoomType NotationConfiguration::defaultZoomType() const
 {
     return settings()->value(DEFAULT_ZOOM_TYPE).toEnum<ZoomType>();
@@ -502,6 +519,11 @@ int NotationConfiguration::defaultZoom() const
 void NotationConfiguration::setDefaultZoom(int zoomPercentage)
 {
     settings()->setSharedValue(DEFAULT_ZOOM, Val(zoomPercentage));
+}
+
+Notification NotationConfiguration::defaultZoomChanged() const
+{
+    return m_defaultZoomChanged;
 }
 
 qreal NotationConfiguration::scalingFromZoomPercentage(int zoomPercentage) const
@@ -529,6 +551,11 @@ int NotationConfiguration::mouseZoomPrecision() const
 void NotationConfiguration::setMouseZoomPrecision(int precision)
 {
     settings()->setSharedValue(MOUSE_ZOOM_PRECISION, Val(precision));
+}
+
+muse::async::Notification NotationConfiguration::mouseZoomPrecisionChanged() const
+{
+    return m_mouseZoomPrecisionChanged;
 }
 
 std::string NotationConfiguration::fontFamily() const

--- a/src/notation/internal/notationconfiguration.cpp
+++ b/src/notation/internal/notationconfiguration.cpp
@@ -221,6 +221,7 @@ void NotationConfiguration::init()
         m_notePlayDurationMillisecondsChanged.send(val.toInt());
     });
 
+    settings()->setDefaultValue(STYLE_FILE_IMPORT_PATH_KEY, Val(""));
     settings()->valueChanged(STYLE_FILE_IMPORT_PATH_KEY).onReceive(this, [this](const Val& val) {
         m_styleFileImportPathChanged.send(val.toString());
     });
@@ -569,7 +570,7 @@ void NotationConfiguration::setMouseZoomPrecision(int precision)
     settings()->setSharedValue(MOUSE_ZOOM_PRECISION, Val(precision));
 }
 
-muse::async::Notification NotationConfiguration::mouseZoomPrecisionChanged() const
+Notification NotationConfiguration::mouseZoomPrecisionChanged() const
 {
     return m_mouseZoomPrecisionChanged;
 }

--- a/src/notation/internal/notationconfiguration.cpp
+++ b/src/notation/internal/notationconfiguration.cpp
@@ -221,6 +221,11 @@ void NotationConfiguration::init()
         m_notePlayDurationMillisecondsChanged.send(val.toInt());
     });
 
+    settings()->setDefaultValue(STYLE_FILE_IMPORT_PATH_KEY, Val(""));
+    settings()->valueChanged(STYLE_FILE_IMPORT_PATH_KEY).onReceive(this, [this](const Val& val) {
+        m_styleFileImportPathChanged.send(val.toString());
+    });
+
     settings()->setDefaultValue(FIRST_SCORE_ORDER_LIST_KEY,
                                 Val(globalConfiguration()->appDataPath().toStdString() + "instruments/orders.xml"));
     settings()->valueChanged(FIRST_SCORE_ORDER_LIST_KEY).onReceive(nullptr, [this](const Val&) {
@@ -1063,6 +1068,11 @@ muse::io::path_t NotationConfiguration::styleFileImportPath() const
 void NotationConfiguration::setStyleFileImportPath(const muse::io::path_t& path)
 {
     settings()->setSharedValue(STYLE_FILE_IMPORT_PATH_KEY, Val(path.toStdString()));
+}
+
+async::Channel<std::string> NotationConfiguration::styleFileImportPathChanged() const
+{
+    return m_styleFileImportPathChanged;
 }
 
 int NotationConfiguration::styleDialogLastPageIndex() const

--- a/src/notation/internal/notationconfiguration.cpp
+++ b/src/notation/internal/notationconfiguration.cpp
@@ -610,6 +610,11 @@ void NotationConfiguration::setDefaultStyleFilePath(const muse::io::path_t& path
     engravingConfiguration()->setDefaultStyleFilePath(path.toQString());
 }
 
+async::Channel<muse::io::path_t> NotationConfiguration::defaultStyleFilePathChanged() const
+{
+    return engravingConfiguration()->defaultStyleFilePathChanged();
+}
+
 muse::io::path_t NotationConfiguration::partStyleFilePath() const
 {
     return engravingConfiguration()->partStyleFilePath();
@@ -618,6 +623,11 @@ muse::io::path_t NotationConfiguration::partStyleFilePath() const
 void NotationConfiguration::setPartStyleFilePath(const muse::io::path_t& path)
 {
     engravingConfiguration()->setPartStyleFilePath(path.toQString());
+}
+
+async::Channel<muse::io::path_t> NotationConfiguration::partStyleFilePathChanged() const
+{
+    return engravingConfiguration()->partStyleFilePathChanged();
 }
 
 bool NotationConfiguration::isMidiInputEnabled() const

--- a/src/notation/internal/notationconfiguration.cpp
+++ b/src/notation/internal/notationconfiguration.cpp
@@ -205,9 +205,21 @@ void NotationConfiguration::init()
     });
 
     settings()->setDefaultValue(COLOR_NOTES_OUTSIDE_OF_USABLE_PITCH_RANGE, Val(true));
+    settings()->valueChanged(COLOR_NOTES_OUTSIDE_OF_USABLE_PITCH_RANGE).onReceive(nullptr, [this](const Val& val) {
+        m_colorNotesOutsideOfUsablePitchRangeChanged.send(val.toBool());
+    });
     settings()->setDefaultValue(WARN_GUITAR_BENDS, Val(true));
+    settings()->valueChanged(WARN_GUITAR_BENDS).onReceive(nullptr, [this](const Val& val) {
+        m_warnGuitarBendsChanged.send(val.toBool());
+    });
     settings()->setDefaultValue(REALTIME_DELAY, Val(750));
+    settings()->valueChanged(REALTIME_DELAY).onReceive(nullptr, [this](const Val& val) {
+        m_delayBetweenNotesInRealTimeModeMillisecondsChanged.send(val.toInt());
+    });
     settings()->setDefaultValue(NOTE_DEFAULT_PLAY_DURATION, Val(500));
+    settings()->valueChanged(NOTE_DEFAULT_PLAY_DURATION).onReceive(nullptr, [this](const Val& val) {
+        m_notePlayDurationMillisecondsChanged.send(val.toInt());
+    });
 
     settings()->setDefaultValue(FIRST_SCORE_ORDER_LIST_KEY,
                                 Val(globalConfiguration()->appDataPath().toStdString() + "instruments/orders.xml"));
@@ -738,6 +750,11 @@ void NotationConfiguration::setColorNotesOutsideOfUsablePitchRange(bool value)
     settings()->setSharedValue(COLOR_NOTES_OUTSIDE_OF_USABLE_PITCH_RANGE, Val(value));
 }
 
+muse::async::Channel<bool> NotationConfiguration::colorNotesOutsideOfUsablePitchRangeChanged() const
+{
+    return m_colorNotesOutsideOfUsablePitchRangeChanged;
+}
+
 bool NotationConfiguration::warnGuitarBends() const
 {
     return settings()->value(WARN_GUITAR_BENDS).toBool();
@@ -747,6 +764,11 @@ void NotationConfiguration::setWarnGuitarBends(bool value)
 {
     mu::engraving::MScore::warnGuitarBends = value;
     settings()->setSharedValue(WARN_GUITAR_BENDS, Val(value));
+}
+
+muse::async::Channel<bool> NotationConfiguration::warnGuitarBendsChanged() const
+{
+    return m_warnGuitarBendsChanged;
 }
 
 int NotationConfiguration::delayBetweenNotesInRealTimeModeMilliseconds() const
@@ -759,6 +781,11 @@ void NotationConfiguration::setDelayBetweenNotesInRealTimeModeMilliseconds(int d
     settings()->setSharedValue(REALTIME_DELAY, Val(delayMs));
 }
 
+muse::async::Channel<int> NotationConfiguration::delayBetweenNotesInRealTimeModeMillisecondsChanged() const
+{
+    return m_delayBetweenNotesInRealTimeModeMillisecondsChanged;
+}
+
 int NotationConfiguration::notePlayDurationMilliseconds() const
 {
     return settings()->value(NOTE_DEFAULT_PLAY_DURATION).toInt();
@@ -768,6 +795,11 @@ void NotationConfiguration::setNotePlayDurationMilliseconds(int durationMs)
 {
     mu::engraving::MScore::defaultPlayDuration = durationMs;
     settings()->setSharedValue(NOTE_DEFAULT_PLAY_DURATION, Val(durationMs));
+}
+
+muse::async::Channel<int> NotationConfiguration::notePlayDurationMillisecondsChanged() const
+{
+    return m_notePlayDurationMillisecondsChanged;
 }
 
 void NotationConfiguration::setTemplateModeEnabled(std::optional<bool> enabled)

--- a/src/notation/internal/notationconfiguration.cpp
+++ b/src/notation/internal/notationconfiguration.cpp
@@ -205,19 +205,19 @@ void NotationConfiguration::init()
     });
 
     settings()->setDefaultValue(COLOR_NOTES_OUTSIDE_OF_USABLE_PITCH_RANGE, Val(true));
-    settings()->valueChanged(COLOR_NOTES_OUTSIDE_OF_USABLE_PITCH_RANGE).onReceive(nullptr, [this](const Val& val) {
+    settings()->valueChanged(COLOR_NOTES_OUTSIDE_OF_USABLE_PITCH_RANGE).onReceive(this, [this](const Val& val) {
         m_colorNotesOutsideOfUsablePitchRangeChanged.send(val.toBool());
     });
     settings()->setDefaultValue(WARN_GUITAR_BENDS, Val(true));
-    settings()->valueChanged(WARN_GUITAR_BENDS).onReceive(nullptr, [this](const Val& val) {
+    settings()->valueChanged(WARN_GUITAR_BENDS).onReceive(this, [this](const Val& val) {
         m_warnGuitarBendsChanged.send(val.toBool());
     });
     settings()->setDefaultValue(REALTIME_DELAY, Val(750));
-    settings()->valueChanged(REALTIME_DELAY).onReceive(nullptr, [this](const Val& val) {
+    settings()->valueChanged(REALTIME_DELAY).onReceive(this, [this](const Val& val) {
         m_delayBetweenNotesInRealTimeModeMillisecondsChanged.send(val.toInt());
     });
     settings()->setDefaultValue(NOTE_DEFAULT_PLAY_DURATION, Val(500));
-    settings()->valueChanged(NOTE_DEFAULT_PLAY_DURATION).onReceive(nullptr, [this](const Val& val) {
+    settings()->valueChanged(NOTE_DEFAULT_PLAY_DURATION).onReceive(this, [this](const Val& val) {
         m_notePlayDurationMillisecondsChanged.send(val.toInt());
     });
 
@@ -765,7 +765,7 @@ void NotationConfiguration::setColorNotesOutsideOfUsablePitchRange(bool value)
     settings()->setSharedValue(COLOR_NOTES_OUTSIDE_OF_USABLE_PITCH_RANGE, Val(value));
 }
 
-muse::async::Channel<bool> NotationConfiguration::colorNotesOutsideOfUsablePitchRangeChanged() const
+async::Channel<bool> NotationConfiguration::colorNotesOutsideOfUsablePitchRangeChanged() const
 {
     return m_colorNotesOutsideOfUsablePitchRangeChanged;
 }
@@ -781,7 +781,7 @@ void NotationConfiguration::setWarnGuitarBends(bool value)
     settings()->setSharedValue(WARN_GUITAR_BENDS, Val(value));
 }
 
-muse::async::Channel<bool> NotationConfiguration::warnGuitarBendsChanged() const
+async::Channel<bool> NotationConfiguration::warnGuitarBendsChanged() const
 {
     return m_warnGuitarBendsChanged;
 }
@@ -796,7 +796,7 @@ void NotationConfiguration::setDelayBetweenNotesInRealTimeModeMilliseconds(int d
     settings()->setSharedValue(REALTIME_DELAY, Val(delayMs));
 }
 
-muse::async::Channel<int> NotationConfiguration::delayBetweenNotesInRealTimeModeMillisecondsChanged() const
+async::Channel<int> NotationConfiguration::delayBetweenNotesInRealTimeModeMillisecondsChanged() const
 {
     return m_delayBetweenNotesInRealTimeModeMillisecondsChanged;
 }
@@ -812,7 +812,7 @@ void NotationConfiguration::setNotePlayDurationMilliseconds(int durationMs)
     settings()->setSharedValue(NOTE_DEFAULT_PLAY_DURATION, Val(durationMs));
 }
 
-muse::async::Channel<int> NotationConfiguration::notePlayDurationMillisecondsChanged() const
+async::Channel<int> NotationConfiguration::notePlayDurationMillisecondsChanged() const
 {
     return m_notePlayDurationMillisecondsChanged;
 }

--- a/src/notation/internal/notationconfiguration.h
+++ b/src/notation/internal/notationconfiguration.h
@@ -88,12 +88,15 @@ public:
 
     int selectionProximity() const override;
     void setSelectionProximity(int proximity) override;
+    muse::async::Channel<int> selectionProximityChanged() const override;
 
     ZoomType defaultZoomType() const override;
     void setDefaultZoomType(ZoomType zoomType) override;
 
     int defaultZoom() const override;
     void setDefaultZoom(int zoomPercentage) override;
+
+    muse::async::Notification defaultZoomChanged() const override;
 
     qreal scalingFromZoomPercentage(int zoomPercentage) const override;
     int zoomPercentageFromScaling(qreal scaling) const override;
@@ -102,6 +105,7 @@ public:
 
     int mouseZoomPrecision() const override;
     void setMouseZoomPrecision(int precision) override;
+    muse::async::Notification mouseZoomPrecisionChanged() const override;
 
     std::string fontFamily() const override;
     int fontSize() const override;
@@ -235,10 +239,13 @@ private:
     muse::async::Notification m_backgroundChanged;
     muse::async::Notification m_foregroundChanged;
 
+    muse::async::Notification m_defaultZoomChanged;
+    muse::async::Notification m_mouseZoomPrecisionChanged;
     muse::async::Channel<muse::Orientation> m_canvasOrientationChanged;
     muse::async::Channel<muse::io::path_t> m_userStylesPathChanged;
     muse::async::Notification m_scoreOrderListPathsChanged;
     muse::async::Notification m_isLimitCanvasScrollAreaChanged;
+    muse::async::Channel<int> m_selectionProximityChanged;
     muse::async::Notification m_isPlayRepeatsChanged;
     muse::async::Notification m_isPlayChordSymbolsChanged;
     muse::ValCh<int> m_pianoKeyboardNumberOfKeys;

--- a/src/notation/internal/notationconfiguration.h
+++ b/src/notation/internal/notationconfiguration.h
@@ -155,15 +155,19 @@ public:
 
     bool colorNotesOutsideOfUsablePitchRange() const override;
     void setColorNotesOutsideOfUsablePitchRange(bool value) override;
+    muse::async::Channel<bool> colorNotesOutsideOfUsablePitchRangeChanged() const override;
 
     bool warnGuitarBends() const override;
     void setWarnGuitarBends(bool value) override;
+    muse::async::Channel<bool> warnGuitarBendsChanged() const override;
 
     int delayBetweenNotesInRealTimeModeMilliseconds() const override;
     void setDelayBetweenNotesInRealTimeModeMilliseconds(int delayMs) override;
+    muse::async::Channel<int> delayBetweenNotesInRealTimeModeMillisecondsChanged() const override;
 
     int notePlayDurationMilliseconds() const override;
     void setNotePlayDurationMilliseconds(int durationMs) override;
+    muse::async::Channel<int> notePlayDurationMillisecondsChanged() const override;
 
     void setTemplateModeEnabled(std::optional<bool> enabled) override;
     void setTestModeEnabled(std::optional<bool> enabled) override;
@@ -246,6 +250,10 @@ private:
     muse::async::Notification m_scoreOrderListPathsChanged;
     muse::async::Notification m_isLimitCanvasScrollAreaChanged;
     muse::async::Channel<int> m_selectionProximityChanged;
+    muse::async::Channel<bool> m_colorNotesOutsideOfUsablePitchRangeChanged;
+    muse::async::Channel<bool> m_warnGuitarBendsChanged;
+    muse::async::Channel<int> m_delayBetweenNotesInRealTimeModeMillisecondsChanged;
+    muse::async::Channel<int> m_notePlayDurationMillisecondsChanged;
     muse::async::Notification m_isPlayRepeatsChanged;
     muse::async::Notification m_isPlayChordSymbolsChanged;
     muse::ValCh<int> m_pianoKeyboardNumberOfKeys;

--- a/src/notation/internal/notationconfiguration.h
+++ b/src/notation/internal/notationconfiguration.h
@@ -116,9 +116,11 @@ public:
 
     muse::io::path_t defaultStyleFilePath() const override;
     void setDefaultStyleFilePath(const muse::io::path_t& path) override;
+    muse::async::Channel<muse::io::path_t> defaultStyleFilePathChanged() const override;
 
     muse::io::path_t partStyleFilePath() const override;
     void setPartStyleFilePath(const muse::io::path_t& path) override;
+    muse::async::Channel<muse::io::path_t> partStyleFilePathChanged() const override;
 
     bool isMidiInputEnabled() const override;
     void setIsMidiInputEnabled(bool enabled) override;

--- a/src/notation/internal/notationconfiguration.h
+++ b/src/notation/internal/notationconfiguration.h
@@ -224,6 +224,7 @@ public:
 
     muse::io::path_t styleFileImportPath() const override;
     void setStyleFileImportPath(const muse::io::path_t& path) override;
+    muse::async::Channel<std::string> styleFileImportPathChanged() const override;
 
     int styleDialogLastPageIndex() const override;
     void setStyleDialogLastPageIndex(int value) override;
@@ -254,6 +255,7 @@ private:
     muse::async::Channel<bool> m_warnGuitarBendsChanged;
     muse::async::Channel<int> m_delayBetweenNotesInRealTimeModeMillisecondsChanged;
     muse::async::Channel<int> m_notePlayDurationMillisecondsChanged;
+    muse::async::Channel<std::string> m_styleFileImportPathChanged;
     muse::async::Notification m_isPlayRepeatsChanged;
     muse::async::Notification m_isPlayChordSymbolsChanged;
     muse::ValCh<int> m_pianoKeyboardNumberOfKeys;

--- a/src/notation/internal/notationconfiguration.h
+++ b/src/notation/internal/notationconfiguration.h
@@ -95,7 +95,6 @@ public:
 
     int defaultZoom() const override;
     void setDefaultZoom(int zoomPercentage) override;
-
     muse::async::Notification defaultZoomChanged() const override;
 
     qreal scalingFromZoomPercentage(int zoomPercentage) const override;

--- a/src/notation/tests/mocks/notationconfigurationmock.h
+++ b/src/notation/tests/mocks/notationconfigurationmock.h
@@ -209,6 +209,7 @@ public:
 
     MOCK_METHOD(muse::io::path_t, styleFileImportPath, (), (const, override));
     MOCK_METHOD(void, setStyleFileImportPath, (const muse::io::path_t&), (override));
+    MOCK_METHOD((muse::async::Channel<std::string>), styleFileImportPathChanged, (), (const, override));
 
     MOCK_METHOD(int, styleDialogLastPageIndex, (), (const, override));
     MOCK_METHOD(void, setStyleDialogLastPageIndex, (int), (override));

--- a/src/notation/tests/mocks/notationconfigurationmock.h
+++ b/src/notation/tests/mocks/notationconfigurationmock.h
@@ -101,9 +101,11 @@ public:
 
     MOCK_METHOD(muse::io::path_t, defaultStyleFilePath, (), (const, override));
     MOCK_METHOD(void, setDefaultStyleFilePath, (const muse::io::path_t&), (override));
+    MOCK_METHOD(muse::async::Channel<muse::io::path_t>, defaultStyleFilePathChanged, (), (const, override));
 
     MOCK_METHOD(muse::io::path_t, partStyleFilePath, (), (const, override));
     MOCK_METHOD(void, setPartStyleFilePath, (const muse::io::path_t&), (override));
+    MOCK_METHOD(muse::async::Channel<muse::io::path_t>, partStyleFilePathChanged, (), (const, override));
 
     MOCK_METHOD(bool, isMidiInputEnabled, (), (const, override));
     MOCK_METHOD(void, setIsMidiInputEnabled, (bool), (override));

--- a/src/notation/tests/mocks/notationconfigurationmock.h
+++ b/src/notation/tests/mocks/notationconfigurationmock.h
@@ -140,15 +140,19 @@ public:
 
     MOCK_METHOD(bool, colorNotesOutsideOfUsablePitchRange, (), (const, override));
     MOCK_METHOD(void, setColorNotesOutsideOfUsablePitchRange, (bool), (override));
+    MOCK_METHOD((muse::async::Channel<bool>), colorNotesOutsideOfUsablePitchRangeChanged, (), (const, override));
 
     MOCK_METHOD(bool, warnGuitarBends, (), (const, override));
     MOCK_METHOD(void, setWarnGuitarBends, (bool), (override));
+    MOCK_METHOD((muse::async::Channel<bool>), warnGuitarBendsChanged, (), (const, override));
 
     MOCK_METHOD(int, delayBetweenNotesInRealTimeModeMilliseconds, (), (const, override));
     MOCK_METHOD(void, setDelayBetweenNotesInRealTimeModeMilliseconds, (int), (override));
+    MOCK_METHOD((muse::async::Channel<int>), delayBetweenNotesInRealTimeModeMillisecondsChanged, (), (const, override));
 
     MOCK_METHOD(int, notePlayDurationMilliseconds, (), (const, override));
     MOCK_METHOD(void, setNotePlayDurationMilliseconds, (int), (override));
+    MOCK_METHOD((muse::async::Channel<int>), notePlayDurationMillisecondsChanged, (), (const, override));
 
     MOCK_METHOD(void, setTemplateModeEnabled, (std::optional<bool>), (override));
     MOCK_METHOD(void, setTestModeEnabled, (std::optional<bool>), (override));

--- a/src/notation/tests/mocks/notationconfigurationmock.h
+++ b/src/notation/tests/mocks/notationconfigurationmock.h
@@ -73,12 +73,15 @@ public:
 
     MOCK_METHOD(int, selectionProximity, (), (const, override));
     MOCK_METHOD(void, setSelectionProximity, (int), (override));
+    MOCK_METHOD(muse::async::Channel<int>, selectionProximityChanged, (), (const, override));
 
     MOCK_METHOD(ZoomType, defaultZoomType, (), (const, override));
     MOCK_METHOD(void, setDefaultZoomType, (ZoomType), (override));
 
     MOCK_METHOD(int, defaultZoom, (), (const, override));
     MOCK_METHOD(void, setDefaultZoom, (int), (override));
+
+    MOCK_METHOD(muse::async::Notification, defaultZoomChanged, (), (const, override));
 
     MOCK_METHOD(QList<int>, possibleZoomPercentageList, (), (const, override));
 
@@ -87,6 +90,7 @@ public:
 
     MOCK_METHOD(int, mouseZoomPrecision, (), (const, override));
     MOCK_METHOD(void, setMouseZoomPrecision, (int), (override));
+    MOCK_METHOD(muse::async::Notification, mouseZoomPrecisionChanged, (), (const, override));
 
     MOCK_METHOD(std::string, fontFamily, (), (const, override));
     MOCK_METHOD(int, fontSize, (), (const, override));

--- a/src/notation/tests/mocks/notationconfigurationmock.h
+++ b/src/notation/tests/mocks/notationconfigurationmock.h
@@ -80,7 +80,6 @@ public:
 
     MOCK_METHOD(int, defaultZoom, (), (const, override));
     MOCK_METHOD(void, setDefaultZoom, (int), (override));
-
     MOCK_METHOD(muse::async::Notification, defaultZoomChanged, (), (const, override));
 
     MOCK_METHOD(QList<int>, possibleZoomPercentageList, (), (const, override));

--- a/src/playback/internal/playbackconfiguration.cpp
+++ b/src/playback/internal/playbackconfiguration.cpp
@@ -96,11 +96,11 @@ void PlaybackConfiguration::init()
         m_playNotesWhenEditingChanged.notify();
     });
     settings()->setDefaultValue(PLAY_CHORD_WHEN_EDITING, Val(true));
-    settings()->valueChanged(PLAY_CHORD_WHEN_EDITING).onReceive(nullptr, [this](const Val& val) {
+    settings()->valueChanged(PLAY_CHORD_WHEN_EDITING).onReceive(this, [this](const Val& val) {
         m_playChordWhenEditingChanged.send(val.toBool());
     });
     settings()->setDefaultValue(PLAY_HARMONY_WHEN_EDITING, Val(true));
-    settings()->valueChanged(PLAY_HARMONY_WHEN_EDITING).onReceive(nullptr, [this](const Val& val) {
+    settings()->valueChanged(PLAY_HARMONY_WHEN_EDITING).onReceive(this, [this](const Val& val) {
         m_playHarmonyWhenEditingChanged.send(val.toBool());
     });
     settings()->setDefaultValue(PLAYBACK_CURSOR_TYPE_KEY, Val(PlaybackCursorType::STEPPED));
@@ -165,7 +165,7 @@ void PlaybackConfiguration::setPlayChordWhenEditing(bool value)
     settings()->setSharedValue(PLAY_CHORD_WHEN_EDITING, Val(value));
 }
 
-muse::async::Channel<bool> PlaybackConfiguration::playChordWhenEditingChanged() const
+async::Channel<bool> PlaybackConfiguration::playChordWhenEditingChanged() const
 {
     return m_playChordWhenEditingChanged;
 }
@@ -180,7 +180,7 @@ void PlaybackConfiguration::setPlayHarmonyWhenEditing(bool value)
     settings()->setSharedValue(PLAY_HARMONY_WHEN_EDITING, Val(value));
 }
 
-muse::async::Channel<bool> PlaybackConfiguration::playHarmonyWhenEditingChanged() const
+async::Channel<bool> PlaybackConfiguration::playHarmonyWhenEditingChanged() const
 {
     return m_playHarmonyWhenEditingChanged;
 }

--- a/src/playback/internal/playbackconfiguration.cpp
+++ b/src/playback/internal/playbackconfiguration.cpp
@@ -96,7 +96,13 @@ void PlaybackConfiguration::init()
         m_playNotesWhenEditingChanged.notify();
     });
     settings()->setDefaultValue(PLAY_CHORD_WHEN_EDITING, Val(true));
+    settings()->valueChanged(PLAY_CHORD_WHEN_EDITING).onReceive(nullptr, [this](const Val& val) {
+        m_playChordWhenEditingChanged.send(val.toBool());
+    });
     settings()->setDefaultValue(PLAY_HARMONY_WHEN_EDITING, Val(true));
+    settings()->valueChanged(PLAY_HARMONY_WHEN_EDITING).onReceive(nullptr, [this](const Val& val) {
+        m_playHarmonyWhenEditingChanged.send(val.toBool());
+    });
     settings()->setDefaultValue(PLAYBACK_CURSOR_TYPE_KEY, Val(PlaybackCursorType::STEPPED));
     settings()->setDefaultValue(SOUND_PRESETS_MULTI_SELECTION_KEY, Val(false));
     settings()->setDefaultValue(MIXER_RESET_SOUND_FLAGS_WHEN_CHANGE_SOUND_WARNING, Val(true));
@@ -159,6 +165,11 @@ void PlaybackConfiguration::setPlayChordWhenEditing(bool value)
     settings()->setSharedValue(PLAY_CHORD_WHEN_EDITING, Val(value));
 }
 
+muse::async::Channel<bool> PlaybackConfiguration::playChordWhenEditingChanged() const
+{
+    return m_playChordWhenEditingChanged;
+}
+
 bool PlaybackConfiguration::playHarmonyWhenEditing() const
 {
     return settings()->value(PLAY_HARMONY_WHEN_EDITING).toBool();
@@ -167,6 +178,11 @@ bool PlaybackConfiguration::playHarmonyWhenEditing() const
 void PlaybackConfiguration::setPlayHarmonyWhenEditing(bool value)
 {
     settings()->setSharedValue(PLAY_HARMONY_WHEN_EDITING, Val(value));
+}
+
+muse::async::Channel<bool> PlaybackConfiguration::playHarmonyWhenEditingChanged() const
+{
+    return m_playHarmonyWhenEditingChanged;
 }
 
 PlaybackCursorType PlaybackConfiguration::cursorType() const

--- a/src/playback/internal/playbackconfiguration.h
+++ b/src/playback/internal/playbackconfiguration.h
@@ -44,9 +44,11 @@ public:
 
     bool playChordWhenEditing() const override;
     void setPlayChordWhenEditing(bool value) override;
+    muse::async::Channel<bool> playChordWhenEditingChanged() const override;
 
     bool playHarmonyWhenEditing() const override;
     void setPlayHarmonyWhenEditing(bool value) override;
+    muse::async::Channel<bool> playHarmonyWhenEditingChanged() const override;
 
     PlaybackCursorType cursorType() const override;
 
@@ -89,7 +91,8 @@ private:
     const SoundProfileName& fallbackSoundProfileStr() const;
 
     muse::async::Notification m_playNotesWhenEditingChanged;
-
+    muse::async::Channel<bool> m_playChordWhenEditingChanged;
+    muse::async::Channel<bool> m_playHarmonyWhenEditingChanged;
     muse::async::Channel<muse::audio::aux_channel_idx_t, bool> m_isAuxSendVisibleChanged;
     muse::async::Channel<muse::audio::aux_channel_idx_t, bool> m_isAuxChannelVisibleChanged;
     muse::async::Channel<MixerSectionType, bool> m_isMixerSectionVisibleChanged;

--- a/src/playback/iplaybackconfiguration.h
+++ b/src/playback/iplaybackconfiguration.h
@@ -40,9 +40,11 @@ public:
 
     virtual bool playChordWhenEditing() const = 0;
     virtual void setPlayChordWhenEditing(bool value) = 0;
+    virtual muse::async::Channel<bool> playChordWhenEditingChanged() const = 0;
 
     virtual bool playHarmonyWhenEditing() const = 0;
     virtual void setPlayHarmonyWhenEditing(bool value) = 0;
+    virtual muse::async::Channel<bool> playHarmonyWhenEditingChanged() const = 0;
 
     virtual PlaybackCursorType cursorType() const = 0;
 

--- a/src/project/internal/projectconfiguration.cpp
+++ b/src/project/internal/projectconfiguration.cpp
@@ -114,7 +114,13 @@ void ProjectConfiguration::init()
     settings()->setDefaultValue(OPEN_DETAILED_PROJECT_UPLOADED_DIALOG, Val(true));
     settings()->setDefaultValue(HAS_ASKED_AUDIO_GENERATION_SETTINGS, Val(false));
     settings()->setDefaultValue(GENERATE_AUDIO_TIME_PERIOD_TYPE_KEY, Val(static_cast<int>(GenerateAudioTimePeriodType::Never)));
+    settings()->valueChanged(GENERATE_AUDIO_TIME_PERIOD_TYPE_KEY).onReceive(nullptr, [this](const Val& val) {
+        m_generateAudioTimePeriodTypeChanged.send(val.toInt());
+    });
     settings()->setDefaultValue(NUMBER_OF_SAVES_TO_GENERATE_AUDIO_KEY, Val(10));
+    settings()->valueChanged(NUMBER_OF_SAVES_TO_GENERATE_AUDIO_KEY).onReceive(nullptr, [this](const Val& val) {
+        m_numberOfSavesToGenerateAudioChanged.send(val.toInt());
+    });
     settings()->setDefaultValue(SHOW_CLOUD_IS_NOT_AVAILABLE_WARNING, Val(true));
 
     settings()->setDefaultValue(DISABLE_VERSION_CHECKING, Val(false));
@@ -645,6 +651,11 @@ void ProjectConfiguration::setGenerateAudioTimePeriodType(GenerateAudioTimePerio
     settings()->setSharedValue(GENERATE_AUDIO_TIME_PERIOD_TYPE_KEY, Val(static_cast<int>(type)));
 }
 
+muse::async::Channel<int> ProjectConfiguration::generateAudioTimePeriodTypeChanged() const
+{
+    return m_generateAudioTimePeriodTypeChanged;
+}
+
 int ProjectConfiguration::numberOfSavesToGenerateAudio() const
 {
     return settings()->value(NUMBER_OF_SAVES_TO_GENERATE_AUDIO_KEY).toInt();
@@ -653,6 +664,11 @@ int ProjectConfiguration::numberOfSavesToGenerateAudio() const
 void ProjectConfiguration::setNumberOfSavesToGenerateAudio(int number)
 {
     settings()->setSharedValue(NUMBER_OF_SAVES_TO_GENERATE_AUDIO_KEY, Val(number));
+}
+
+muse::async::Channel<int> ProjectConfiguration::numberOfSavesToGenerateAudioChanged() const
+{
+    return m_numberOfSavesToGenerateAudioChanged;
 }
 
 muse::io::path_t ProjectConfiguration::temporaryMp3FilePathTemplate() const

--- a/src/project/internal/projectconfiguration.h
+++ b/src/project/internal/projectconfiguration.h
@@ -142,8 +142,11 @@ public:
 
     GenerateAudioTimePeriodType generateAudioTimePeriodType() const override;
     void setGenerateAudioTimePeriodType(GenerateAudioTimePeriodType type) override;
+    muse::async::Channel<int> generateAudioTimePeriodTypeChanged() const override;
+
     int numberOfSavesToGenerateAudio() const override;
     void setNumberOfSavesToGenerateAudio(int number) override;
+    muse::async::Channel<int> numberOfSavesToGenerateAudioChanged() const override;
 
     muse::io::path_t temporaryMp3FilePathTemplate() const override;
 
@@ -171,6 +174,9 @@ private:
 
     muse::async::Channel<bool> m_autoSaveEnabledChanged;
     muse::async::Channel<int> m_autoSaveIntervalChanged;
+
+    muse::async::Channel<int> m_generateAudioTimePeriodTypeChanged;
+    muse::async::Channel<int> m_numberOfSavesToGenerateAudioChanged;
 
     muse::async::Channel<bool> m_alsoShareAudioComChanged;
 

--- a/src/project/iprojectconfiguration.h
+++ b/src/project/iprojectconfiguration.h
@@ -147,9 +147,11 @@ public:
 
     virtual GenerateAudioTimePeriodType generateAudioTimePeriodType() const = 0;
     virtual void setGenerateAudioTimePeriodType(GenerateAudioTimePeriodType type) = 0;
+    virtual muse::async::Channel<int> generateAudioTimePeriodTypeChanged() const = 0;
 
     virtual int numberOfSavesToGenerateAudio() const = 0;
     virtual void setNumberOfSavesToGenerateAudio(int number) = 0;
+    virtual muse::async::Channel<int> numberOfSavesToGenerateAudioChanged() const = 0;
 
     virtual muse::io::path_t temporaryMp3FilePathTemplate() const = 0;
 

--- a/src/project/qml/MuseScore/Project/AudioGenerationSettings.qml
+++ b/src/project/qml/MuseScore/Project/AudioGenerationSettings.qml
@@ -55,6 +55,10 @@ RadioButtonGroup {
         id: settingsModel
     }
 
+    Component.onCompleted: {
+        settingsModel.load()
+    }
+
     model: [
         { text: qsTrc("project/save", "Never"), type: GenerateAudioTimePeriodType.Never },
         { text: qsTrc("project/save", "Always"), type: GenerateAudioTimePeriodType.Always },

--- a/src/project/tests/mocks/projectconfigurationmock.h
+++ b/src/project/tests/mocks/projectconfigurationmock.h
@@ -124,9 +124,11 @@ public:
 
     MOCK_METHOD(GenerateAudioTimePeriodType, generateAudioTimePeriodType, (), (const, override));
     MOCK_METHOD(void, setGenerateAudioTimePeriodType, (GenerateAudioTimePeriodType), (override));
+    MOCK_METHOD(muse::async::Channel<int>, generateAudioTimePeriodTypeChanged, (), (const, override));
 
     MOCK_METHOD(int, numberOfSavesToGenerateAudio, (), (const, override));
     MOCK_METHOD(void, setNumberOfSavesToGenerateAudio, (int), (override));
+    MOCK_METHOD(muse::async::Channel<int>, numberOfSavesToGenerateAudioChanged, (), (const, override));
 
     MOCK_METHOD(muse::io::path_t, temporaryMp3FilePathTemplate, (), (const, override));
 

--- a/src/project/view/audiogenerationsettingsmodel.cpp
+++ b/src/project/view/audiogenerationsettingsmodel.cpp
@@ -29,6 +29,17 @@ AudioGenerationSettingsModel::AudioGenerationSettingsModel(QObject* parent)
 {
 }
 
+void AudioGenerationSettingsModel::load()
+{
+    configuration()->generateAudioTimePeriodTypeChanged().onReceive(this, [this](int) {
+        emit timePeriodTypeChanged();
+    });
+
+    configuration()->numberOfSavesToGenerateAudioChanged().onReceive(this, [this](int) {
+        emit numberOfSavesChanged();
+    });
+}
+
 int AudioGenerationSettingsModel::timePeriodType() const
 {
     return static_cast<int>(configuration()->generateAudioTimePeriodType());

--- a/src/project/view/audiogenerationsettingsmodel.h
+++ b/src/project/view/audiogenerationsettingsmodel.h
@@ -28,7 +28,7 @@
 #include "iprojectconfiguration.h"
 
 namespace mu::project {
-class AudioGenerationSettingsModel : public QObject
+class AudioGenerationSettingsModel : public QObject, public muse::async::Asyncable
 {
     Q_OBJECT
 
@@ -39,6 +39,8 @@ class AudioGenerationSettingsModel : public QObject
 
 public:
     explicit AudioGenerationSettingsModel(QObject* parent = nullptr);
+
+    Q_INVOKABLE void load();
 
     int timePeriodType() const;
     int numberOfSaves() const;

--- a/src/stubs/notation/notationconfigurationstub.cpp
+++ b/src/stubs/notation/notationconfigurationstub.cpp
@@ -164,6 +164,12 @@ void NotationConfigurationStub::setSelectionProximity(int)
 {
 }
 
+muse::async::Channel<int> NotationConfigurationStub::selectionProximityChanged() const
+{
+    static muse::async::Channel<int> ch;
+    return ch;
+}
+
 ZoomType NotationConfigurationStub::defaultZoomType() const
 {
     return ZoomType::PageWidth;
@@ -180,6 +186,12 @@ int NotationConfigurationStub::defaultZoom() const
 
 void NotationConfigurationStub::setDefaultZoom(int)
 {
+}
+
+muse::async::Notification NotationConfigurationStub::defaultZoomChanged() const
+{
+    static muse::async::Notification n;
+    return n;
 }
 
 QList<int> NotationConfigurationStub::possibleZoomPercentageList() const
@@ -204,6 +216,12 @@ int NotationConfigurationStub::mouseZoomPrecision() const
 
 void NotationConfigurationStub::setMouseZoomPrecision(int)
 {
+}
+
+muse::async::Notification NotationConfigurationStub::mouseZoomPrecisionChanged() const
+{
+    static muse::async::Notification n;
+    return n;
 }
 
 std::string NotationConfigurationStub::fontFamily() const
@@ -240,6 +258,12 @@ void NotationConfigurationStub::setDefaultStyleFilePath(const muse::io::path_t&)
 {
 }
 
+muse::async::Channel<muse::io::path_t> NotationConfigurationStub::defaultStyleFilePathChanged() const
+{
+    static muse::async::Channel<muse::io::path_t> ch;
+    return ch;
+}
+
 muse::io::path_t NotationConfigurationStub::partStyleFilePath() const
 {
     return muse::io::path_t();
@@ -247,6 +271,12 @@ muse::io::path_t NotationConfigurationStub::partStyleFilePath() const
 
 void NotationConfigurationStub::setPartStyleFilePath(const muse::io::path_t&)
 {
+}
+
+muse::async::Channel<muse::io::path_t> NotationConfigurationStub::partStyleFilePathChanged() const
+{
+    static muse::async::Channel<muse::io::path_t> ch;
+    return ch;
 }
 
 bool NotationConfigurationStub::isMidiInputEnabled() const
@@ -359,6 +389,12 @@ void NotationConfigurationStub::setColorNotesOutsideOfUsablePitchRange(bool)
 {
 }
 
+muse::async::Channel<bool> NotationConfigurationStub::colorNotesOutsideOfUsablePitchRangeChanged() const
+{
+    static muse::async::Channel<bool> ch;
+    return ch;
+}
+
 int NotationConfigurationStub::delayBetweenNotesInRealTimeModeMilliseconds() const
 {
     return 100;
@@ -368,6 +404,12 @@ void NotationConfigurationStub::setDelayBetweenNotesInRealTimeModeMilliseconds(i
 {
 }
 
+muse::async::Channel<int> NotationConfigurationStub::delayBetweenNotesInRealTimeModeMillisecondsChanged() const
+{
+    static muse::async::Channel<int> ch;
+    return ch;
+}
+
 int NotationConfigurationStub::notePlayDurationMilliseconds() const
 {
     return 100;
@@ -375,6 +417,12 @@ int NotationConfigurationStub::notePlayDurationMilliseconds() const
 
 void NotationConfigurationStub::setNotePlayDurationMilliseconds(int)
 {
+}
+
+muse::async::Channel<int> NotationConfigurationStub::notePlayDurationMillisecondsChanged() const
+{
+    static muse::async::Channel<int> ch;
+    return ch;
 }
 
 void NotationConfigurationStub::setTemplateModeEnabled(std::optional<bool>)
@@ -542,4 +590,10 @@ muse::io::path_t NotationConfigurationStub::styleFileImportPath() const
 
 void NotationConfigurationStub::setStyleFileImportPath(const muse::io::path_t&)
 {
+}
+
+muse::async::Channel<std::string> NotationConfigurationStub::styleFileImportPathChanged() const
+{
+    static muse::async::Channel<std::string> ch;
+    return ch;
 }

--- a/src/stubs/notation/notationconfigurationstub.h
+++ b/src/stubs/notation/notationconfigurationstub.h
@@ -75,12 +75,15 @@ public:
 
     int selectionProximity() const override;
     void setSelectionProximity(int proximity)  override;
+    muse::async::Channel<int> selectionProximityChanged() const override;
 
     ZoomType defaultZoomType() const override;
     void setDefaultZoomType(ZoomType zoomType)  override;
 
     int defaultZoom() const override;
     void setDefaultZoom(int zoomPercentage)  override;
+
+    muse::async::Notification defaultZoomChanged() const override;
 
     QList<int> possibleZoomPercentageList() const override;
 
@@ -89,6 +92,7 @@ public:
 
     int mouseZoomPrecision() const override;
     void setMouseZoomPrecision(int precision)  override;
+    muse::async::Notification mouseZoomPrecisionChanged() const override;
 
     std::string fontFamily() const override;
     int fontSize() const override;
@@ -99,9 +103,11 @@ public:
 
     muse::io::path_t defaultStyleFilePath() const override;
     void setDefaultStyleFilePath(const muse::io::path_t& path)  override;
+    muse::async::Channel<muse::io::path_t> defaultStyleFilePathChanged() const override;
 
     muse::io::path_t partStyleFilePath() const override;
     void setPartStyleFilePath(const muse::io::path_t& path)  override;
+    muse::async::Channel<muse::io::path_t> partStyleFilePathChanged() const override;
 
     bool isMidiInputEnabled() const override;
     void setIsMidiInputEnabled(bool enabled)  override;
@@ -135,12 +141,15 @@ public:
 
     bool colorNotesOutsideOfUsablePitchRange() const override;
     void setColorNotesOutsideOfUsablePitchRange(bool value)  override;
+    muse::async::Channel<bool> colorNotesOutsideOfUsablePitchRangeChanged() const override;
 
     int delayBetweenNotesInRealTimeModeMilliseconds() const override;
     void setDelayBetweenNotesInRealTimeModeMilliseconds(int delayMs)  override;
+    muse::async::Channel<int> delayBetweenNotesInRealTimeModeMillisecondsChanged() const override;
 
     int notePlayDurationMilliseconds() const override;
     void setNotePlayDurationMilliseconds(int durationMs)  override;
+    muse::async::Channel<int> notePlayDurationMillisecondsChanged() const override;
 
     void setTemplateModeEnabled(std::optional<bool> enabled) override;
     void setTestModeEnabled(std::optional<bool> enabled) override;
@@ -192,6 +201,7 @@ public:
 
     muse::io::path_t styleFileImportPath() const override;
     void setStyleFileImportPath(const muse::io::path_t& path)  override;
+    muse::async::Channel<std::string> styleFileImportPathChanged() const override;
 };
 }
 

--- a/src/stubs/playback/playbackconfigurationstub.cpp
+++ b/src/stubs/playback/playbackconfigurationstub.cpp
@@ -47,6 +47,12 @@ void PlaybackConfigurationStub::setPlayChordWhenEditing(bool)
 {
 }
 
+muse::async::Channel<bool> PlaybackConfigurationStub::playChordWhenEditingChanged() const
+{
+    static muse::async::Channel<bool> ch;
+    return ch;
+}
+
 bool PlaybackConfigurationStub::playHarmonyWhenEditing() const
 {
     return false;
@@ -54,6 +60,12 @@ bool PlaybackConfigurationStub::playHarmonyWhenEditing() const
 
 void PlaybackConfigurationStub::setPlayHarmonyWhenEditing(bool)
 {
+}
+
+muse::async::Channel<bool> PlaybackConfigurationStub::playHarmonyWhenEditingChanged() const
+{
+    static muse::async::Channel<bool> ch;
+    return ch;
 }
 
 PlaybackCursorType PlaybackConfigurationStub::cursorType() const

--- a/src/stubs/playback/playbackconfigurationstub.h
+++ b/src/stubs/playback/playbackconfigurationstub.h
@@ -34,9 +34,11 @@ public:
 
     bool playChordWhenEditing() const override;
     void setPlayChordWhenEditing(bool value) override;
+    muse::async::Channel<bool> playChordWhenEditingChanged() const override;
 
     bool playHarmonyWhenEditing() const override;
     void setPlayHarmonyWhenEditing(bool value) override;
+    muse::async::Channel<bool> playHarmonyWhenEditingChanged() const override;
 
     PlaybackCursorType cursorType() const override;
 

--- a/src/stubs/project/projectconfigurationstub.cpp
+++ b/src/stubs/project/projectconfigurationstub.cpp
@@ -296,6 +296,12 @@ void ProjectConfigurationStub::setGenerateAudioTimePeriodType(GenerateAudioTimeP
 {
 }
 
+muse::async::Channel<int> ProjectConfigurationStub::generateAudioTimePeriodTypeChanged() const
+{
+    static muse::async::Channel<int> ch;
+    return ch;
+}
+
 int ProjectConfigurationStub::numberOfSavesToGenerateAudio() const
 {
     return 1;
@@ -303,6 +309,12 @@ int ProjectConfigurationStub::numberOfSavesToGenerateAudio() const
 
 void ProjectConfigurationStub::setNumberOfSavesToGenerateAudio(int)
 {
+}
+
+muse::async::Channel<int> ProjectConfigurationStub::numberOfSavesToGenerateAudioChanged() const
+{
+    static muse::async::Channel<int> ch;
+    return ch;
 }
 
 muse::io::path_t ProjectConfigurationStub::temporaryMp3FilePathTemplate() const

--- a/src/stubs/project/projectconfigurationstub.h
+++ b/src/stubs/project/projectconfigurationstub.h
@@ -115,9 +115,11 @@ public:
 
     GenerateAudioTimePeriodType generateAudioTimePeriodType() const override;
     void setGenerateAudioTimePeriodType(GenerateAudioTimePeriodType type) override;
+    muse::async::Channel<int> generateAudioTimePeriodTypeChanged() const override;
 
     int numberOfSavesToGenerateAudio() const override;
     void setNumberOfSavesToGenerateAudio(int number) override;
+    muse::async::Channel<int> numberOfSavesToGenerateAudioChanged() const override;
 
     muse::io::path_t temporaryMp3FilePathTemplate() const override;
 


### PR DESCRIPTION
Resolves: #11565 

@cbjeukendrup @avvvvve @mathesoncalum 
This PR replaces [PR 25400](https://github.com/musescore/MuseScore/pull/25400) because I was unable to rebase due to my commits starting with "#" (a known issue it turned out) and it was easier to create a new branch and cherry-pick my changes to it. I will close 25400.

The first 24 commits are the same as those in PR 25400. The next address the code review comments left in PR 25400.
NOTES:
- As far as the dialog is concerned: whether the Cancel button will be specified as the default button or not does not make any difference now that the "Reset" button is the accented one. This means that pressing Space or Enter will execute the reset (which I personally am not fond of but at least is consistent behavior).
- The Cancel button should appear to the left of the Reset button on Mac and Linux (I didn't find any other dialog to use the ResetRole so I moved it to the right of RejectedRole)
- I've made the "First-time launch" wizard not appear after the reset which partially fixes [#13299](https://github.com/musescore/MuseScore/issues/13299) too.

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
