### PR TITLE
Fix #15761: Change Behaviour when clicking "Apply to style" property with different selected elements

### DIFF
--- a/src/inspector/models/abstractinspectormodel.cpp
+++ b/src/inspector/models/abstractinspectormodel.cpp
@@ -646,6 +646,7 @@ void AbstractInspectorModel::loadPropertyItem(PropertyItem* propertyItem, const 
     QVariant defaultPropertyValue;
 
     bool isUndefined = false;
+    bool isEnabled = true;
 
     for (const mu::engraving::EngravingItem* element : elements) {
         IF_ASSERT_FAILED(element) {
@@ -654,6 +655,7 @@ void AbstractInspectorModel::loadPropertyItem(PropertyItem* propertyItem, const 
 
         QVariant elementCurrentValue = valueFromElementUnits(pid, element->getProperty(pid), element);
         QVariant elementDefaultValue = valueFromElementUnits(pid, element->propertyDefault(pid), element);
+        mu::engraving::Sid elementStyleId = element->getPropertyStyle(pid);
 
         bool isPropertySupportedByElement = elementCurrentValue.isValid();
 
@@ -672,8 +674,9 @@ void AbstractInspectorModel::loadPropertyItem(PropertyItem* propertyItem, const 
         }
 
         isUndefined = propertyValue != elementCurrentValue;
+        isEnabled = !((styleId != elementStyleId) || (propertyValue != elementCurrentValue));
 
-        if (isUndefined) {
+        if ((isUndefined) || (!isEnabled)) {
             break;
         }
     }
@@ -683,6 +686,8 @@ void AbstractInspectorModel::loadPropertyItem(PropertyItem* propertyItem, const 
     propertyItem->setIsEnabled(propertyValue.isValid());
 
     if (isUndefined) {
+        propertyValue = QVariant();
+    } else if (!isEnabled) {
         propertyValue = QVariant();
     }
 


### PR DESCRIPTION
Resolves: #15761 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
Change behaviour when applying to style. "Save as default style for this score" is only active when selecting several elements if:
- Property style is the same 
- Property value is the same

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
