### PR TITLE
Fix #25851: Crash when deleting multiple staves

### DIFF
--- a/src/notation/internal/notationparts.cpp
+++ b/src/notation/internal/notationparts.cpp
@@ -204,24 +204,6 @@ std::vector<Staff*> NotationParts::staves(const IDList& stavesIds) const
     return staves;
 }
 
-std::vector<staff_idx_t> NotationParts::staffIndices(const muse::IDList& stavesIds) const
-{
-    std::vector<staff_idx_t> staffIndices;
-
-    if (stavesIds.empty()) {
-        return staffIndices;
-    }
-
-    const auto& staves = score()->staves();
-    for (staff_idx_t staffIdx = 0; staffIdx < staves.size(); ++staffIdx) {
-        if (muse::contains(stavesIds, staves.at(staffIdx)->id())) {
-            staffIndices.push_back(staffIdx);
-        }
-    }
-
-    return staffIndices;
-}
-
 std::vector<Part*> NotationParts::parts(const IDList& partsIds) const
 {
     std::vector<Part*> parts;
@@ -834,21 +816,24 @@ void NotationParts::removeStaves(const IDList& stavesIds)
 {
     TRACEFUNC;
 
-    std::vector<staff_idx_t> staffIndicesToRemove = staffIndices(stavesIds);
+    std::vector<Staff*> stavesToRemove = staves(stavesIds);
+    if (stavesToRemove.empty()) {
+        return;
+    }
 
     endInteractionWithScore();
     startEdit(TranslatableString("undoableAction", "Remove staves"));
 
-    for (staff_idx_t staffIdx: staffIndicesToRemove) {
-        score()->cmdRemoveStaff(staffIdx);
+    for (Staff* staff: stavesToRemove) {
+        score()->cmdRemoveStaff(staff->idx());
     }
 
     setBracketsAndBarlines();
 
     apply();
 
-    for (staff_idx_t staffIdx: staffIndicesToRemove) {
-        notifyAboutStaffRemoved(score()->staff(staffIdx));
+    for (const Staff* staff : stavesToRemove) {
+        notifyAboutStaffRemoved(staff);
     }
 }
 

--- a/src/notation/internal/notationparts.h
+++ b/src/notation/internal/notationparts.h
@@ -102,7 +102,6 @@ private:
     Staff* staffModifiable(const muse::ID& staffId) const;
 
     std::vector<Staff*> staves(const muse::IDList& stavesIds) const;
-    std::vector<engraving::staff_idx_t> staffIndices(const muse::IDList& stavesIds) const;
     std::vector<Part*> parts(const muse::IDList& partsIds) const;
 
     mu::engraving::InstrumentChange* findInstrumentChange(const Part* part, const Fraction& tick) const;


### PR DESCRIPTION
Resolves: #25851

Problem number 1 - using `cmdRemoveStaff` causes our staff indexes to update. This means that the indexes stored in `staffIndicesToRemove` become outdated, and we crash the next time we call `cmdRemoveStaff` with an invalid index.

Problem number 2 - `Staff` objects are deleted/nullified when we call `cmdRemoveStaff` & `apply`. This leads to a crash when we call `notifyAboutStaffRemoved` with a null pointer.

It's worth noting that #24207 has re-emerged, and problem number 2 seems to be the cause (re-resolved in this PR).

Once again, as mentioned [here](https://github.com/musescore/MuseScore/pull/24221#issue-2488908541), when testing this PR we should check that the requirements of #10526 haven't been broken by these changes.