### PR TITLE
23033: Parts are displayed at incorrect zoom level when the Navigator is open

### DIFF
--- a/src/notation/view/notationpaintview.cpp
+++ b/src/notation/view/notationpaintview.cpp
@@ -60,6 +60,7 @@ void NotationPaintView::onMatrixChanged(const Transform& oldMatrix, const Transf
 
     if (!m_isLocalMatrixUpdate && notation()) {
         notation()->viewState()->setMatrix(newMatrix, this);
+        notation()->viewState()->setMatrixInited(true);
 
         if (overrideZoomType) {
             notation()->viewState()->setZoomType(ZoomType::Percentage);

--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -167,8 +167,6 @@ void NotationViewInputController::initZoom()
         doZoomToTwoPages();
         break;
     }
-
-    currentNotation()->viewState()->setMatrixInited(true);
 }
 
 void NotationViewInputController::initCanvasPos()


### PR DESCRIPTION
Resolves: #23033

**KEY POINTS:**
**Overview:**
1. When the Navigator is open, it creates a `NotationNavigator` instance which inherits from `AbstractNotationPaintView`.

2. For the actual notation an instance of `NotationPaintView` is created which also inherits from `AbstractNotationPaintView`.

3. Both of these listen for current notation changes in `AbstractNotationPaintView::onNotationSetup()` (line 622) and call `onCurrentNotationChanged()` (line 623). 

4. `AbstractNotationPaintView::onCurrentNotationChanged()` calls `onLoadNotation` (line 226).

5. `onLoadNotation` is supposed to call `m_inputController->initZoom();` (line 232) where the zoom on the notation should be set (if not previously set) following these calls:
- `NotationViewInputController::initZoom()`
- `NotationViewInputController::setZoom` / `doZoomToPageWidth` / `doZoomToWholePage` etc.
- `AbstractNotationPaintView::setScaling`
- `AbstractNotationPaintView::scale`
- `AbstractNotationPaintView::onMatrixChanged` for the `NotationNavigator` instance or `NotationPaintView::onMatrixChanged` for the `NotationPaintView` instance (an override).

**The problem is in that:**
1. The zoom is actually set in `NotationPaintView::onMatrixChanged` when it calls `notation()->viewState()->setMatrix` (line 62). 

2. The above steps execute first for the `NotationNavigator` instance since it registers to listen for `onCurrentNotationChanged` notification before the `NotationPaintView` instance registers itself.

3. When the steps execute for the `NotationNavigator` instance, the zoom won't be set but `NotationViewInputController::initZoom()` will set `isMatrixInited` on the notation's viewstate to `true` (line 171).

4. When the steps execute the second time for the `NotationPaintView` instance, `onLoadNotation` does not call `m_inputController->initZoom()` (line 232) because the if condition returns `false` due to `isMatrixInited()` being true for the notation.

5.  The zoom of the notation remains unset and defaults to 0.

When the Navigator is not visible, the `NotationNavigator` instance is not created and does not interfere.

**Further observations:**
When the Navigator is active the two `AbstractNotationPaintView` descendants share the same notation. As a result the code in `AbstractNotationPaintView::onLoadNotation` that operates on the notation executes twice, e.g. event listeners are bound twice and the handlers are executed twice. Therefore those pieces of code should probably be moved elsewhere (not as part of this issue though).

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
