### PR TITLE
[MusicXML] full support for Harmon mutes

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
@@ -3591,16 +3591,15 @@ void ExportMusicXml::chordAttributes(Chord* chord, Notations& notations, Technic
                 m_xml.startElementRaw(mxmlTechn);
                 XmlWriter::Attributes location = {};
                 String harmonClosedValue;
-                switch (sid)
-                {
+                switch (sid) {
                 case SymId::brassHarmonMuteClosed:
-                    harmonClosedValue = "yes";
+                    harmonClosedValue = u"yes";
                     break;
                 case SymId::brassHarmonMuteStemOpen:
-                    harmonClosedValue = "no";
-                    break;                
+                    harmonClosedValue = u"no";
+                    break;
                 default:
-                    harmonClosedValue = "half";
+                    harmonClosedValue = u"half";
                     location = { { "location", (sid == SymId::brassHarmonMuteStemHalfLeft) ? "left" : "right" } };
                     break;
                 }

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -8227,7 +8227,7 @@ void MusicXmlParserNotations::harmonMute()
             m_e.skipCurrentElement();
         }
     }
-    m_notations.push_back(Notation::notationWithAttributes(u"harmon-closed", attributes, u"articulations", mute));
+    m_notations.push_back(Notation::notationWithAttributes(u"harmon-closed", attributes, u"technical", mute));
 }
 
 //---------------------------------------------------------

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -8141,6 +8141,8 @@ void MusicXmlParserNotations::technical()
             m_notations.push_back(notation);
         } else if (m_e.name() == "harmonic") {
             harmonic();
+        } else if (m_e.name() == "harmon-mute") {
+            harmonMute();
         } else if (m_e.name() == "other-technical") {
             otherTechnical();
         } else {
@@ -8188,6 +8190,44 @@ void MusicXmlParserNotations::harmonic()
     if (notation.subType() != "") {
         m_notations.push_back(notation);
     }
+}
+
+//---------------------------------------------------------
+//   harmonMute
+//---------------------------------------------------------
+
+/**
+ Parse the /score-partwise/part/measure/note/notations/technical/harmon-mute node.
+ */
+
+void MusicXmlParserNotations::harmonMute()
+{
+    engraving::SymId mute = SymId::brassHarmonMuteClosed;
+    const std::vector<XmlStreamReader::Attribute> attributes = m_e.attributes();
+    while (m_e.readNextStartElement()) {
+        String name = String::fromAscii(m_e.name().ascii());
+        if (name == "harmon-closed") {
+            const String location = m_e.attribute("location");
+            String value = m_e.readText();
+            if (value == "yes") {
+                mute = SymId::brassHarmonMuteClosed;
+            } else if (value == "no") {
+                mute = SymId::brassHarmonMuteStemOpen;
+            } else if (value == "half") {
+                if (location == "left") {
+                    mute = SymId::brassHarmonMuteStemHalfLeft;
+                } else if (location == "right") {
+                    mute = SymId::brassHarmonMuteStemHalfRight;
+                } else {
+                    m_logger->logError(String(u"unsupported harmon-closed location '%1'").arg(location), &m_e);
+                    mute = SymId::brassHarmonMuteStemHalfLeft;
+                }
+            }
+        } else {
+            m_e.skipCurrentElement();
+        }
+    }
+    m_notations.push_back(Notation::notationWithAttributes(u"harmon-closed", attributes, u"articulations", mute));
 }
 
 //---------------------------------------------------------

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.h
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.h
@@ -356,6 +356,7 @@ private:
     void addTechnical(const Notation& notation, engraving::Note* note);
     void arpeggio();
     void harmonic();
+    void harmonMute();
     void articulations();
     void dynamics();
     void fermata();

--- a/src/importexport/musicxml/tests/data/testHarmonMutes.xml
+++ b/src/importexport/musicxml/tests/data/testHarmonMutes.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <work>
+    <work-title>Harmon mute test</work-title>
+    </work>
+  <identification>
+    <creator type="composer">Klaus Rettinghaus</creator>
+    <encoding>
+      <software>MuseScore 0.7.0</software>
+      <encoding-date>2007-09-10</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="no"/>
+      <supports element="print" attribute="new-system" type="no"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Trombone</part-name>
+      <part-abbreviation>Tbn.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Trombone</instrument-name>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>58</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>F</sign>
+          <line>4</line>
+          </clef>
+        </attributes>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>up</stem>
+        <notations>
+          <technical>
+            <harmon-mute>
+              <harmon-closed>yes</harmon-closed>
+              </harmon-mute>
+            </technical>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>up</stem>
+        <notations>
+          <technical>
+            <harmon-mute color="#FF0000" placement="below">
+              <harmon-closed>no</harmon-closed>
+              </harmon-mute>
+            </technical>
+          </notations>
+        </note>
+      </measure>
+    <measure number="2">
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>up</stem>
+        <notations>
+          <technical>
+            <harmon-mute placement="above">
+              <harmon-closed location="left">half</harmon-closed>
+              </harmon-mute>
+            </technical>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>up</stem>
+        <notations>
+          <technical>
+            <harmon-mute color="#0000FF">
+              <harmon-closed location="right">half</harmon-closed>
+              </harmon-mute>
+            </technical>
+          </notations>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/src/importexport/musicxml/tests/musicxml_tests.cpp
+++ b/src/importexport/musicxml/tests/musicxml_tests.cpp
@@ -694,6 +694,9 @@ TEST_F(MusicXml_Tests, harmony8) {
 TEST_F(MusicXml_Tests, harmony9) {
     musicXmlIoTest("testHarmony9");
 }                                                                      // chordnames without chordrest
+TEST_F(MusicXml_Tests, harmonMutes) {
+    musicXmlIoTest("testHarmonMutes");
+}
 TEST_F(MusicXml_Tests, hello) {
     musicXmlIoTest("testHello");
 }


### PR DESCRIPTION
This PR fixes the export of [Harmon mutes](https://www.w3.org/2021/06/musicxml40/musicxml-reference/elements/harmon-mute/), which produced invalid MusicXML. 
It adds also complete import of these symbols.