### PR TITLE
Fix crash on cross-staff slurs with TAB staves

### DIFF
--- a/src/engraving/dom/slur.cpp
+++ b/src/engraving/dom/slur.cpp
@@ -151,6 +151,12 @@ bool SlurSegment::edit(EditData& ed)
         return false;
     }
     if (cr && cr != e1) {
+        if (cr->staff() != e->staff() && (cr->staffType()->isTabStaff() || e->staffType()->isTabStaff())) {
+            return false; // Cross-staff slurs don't make sense for TAB staves
+        }
+        if (cr->staff()->isLinked(e->staff())) {
+            return false; // Don't allow slur to cross into staff that's linked to this
+        }
         changeAnchor(ed, cr);
     }
     return true;
@@ -224,8 +230,10 @@ void SlurSegment::changeAnchor(EditData& ed, EngravingItem* element)
                     }
                 }
             }
-            score()->undo(new ChangeStartEndSpanner(sp, se, ee));
-            renderer()->layoutItem(sp);
+            if (se && ee) {
+                score()->undo(new ChangeStartEndSpanner(sp, se, ee));
+                renderer()->layoutItem(sp);
+            }
         }
     }
 

--- a/src/engraving/rendering/score/slurtielayout.cpp
+++ b/src/engraving/rendering/score/slurtielayout.cpp
@@ -1582,6 +1582,8 @@ void SlurTieLayout::createSlurSegments(Slur* item, LayoutContext& ctx)
 {
     const ChordRest* startCR = item->startCR();
     const ChordRest* endCR = item->endCR();
+    assert(startCR && endCR);
+
     const System* startSys = startCR->measure()->system();
     const System* endSys = endCR->measure()->system();
 


### PR DESCRIPTION
Resolves: #25901 

The shift+up/down operation can create cross-staff slurs, but that shouldn't be allowed when one of them is a TAB staff (makes no sense for slurs to cross in or out of TABs), or when the destination stave is linked to the origin stave (makes no sense to slur to cross between linked staves). Additionally, it's theoretically possible (though meaningless notation-wise) for a linked slur to not find a suitable start/end chord even if the main edited slur could. That case should be null-checked _before_ we set the slur start/end element.
