### PR TITLE
[MusicXML] Add full support for holes element

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
@@ -3343,6 +3343,12 @@ static String symIdToTechn(const SymId sid)
     case SymId::brassHarmonMuteStemOpen:
         return u"harmon-mute";
         break;
+    case SymId::windClosedHole:
+    case SymId::windHalfClosedHole1:
+    case SymId::windHalfClosedHole2:
+    case SymId::windHalfClosedHole3:
+    case SymId::windOpenHole:
+        return u"hole";
     case SymId::guitarGolpe:
         return u"golpe";
         break;
@@ -3604,6 +3610,24 @@ void ExportMusicXml::chordAttributes(Chord* chord, Notations& notations, Technic
                     break;
                 }
                 m_xml.tag("harmon-closed", location, harmonClosedValue);
+                m_xml.endElement();
+            } else if (mxmlTechn.startsWith(u"hole")) {
+                m_xml.startElementRaw(mxmlTechn);
+                XmlWriter::Attributes location = {};
+                String holeClosedValue;
+                switch (sid) {
+                case SymId::windClosedHole:
+                    holeClosedValue = u"yes";
+                    break;
+                case SymId::windOpenHole:
+                    holeClosedValue = u"no";
+                    break;
+                default:
+                    holeClosedValue = u"half";
+                    location = { { "location", (sid == SymId::windHalfClosedHole1) ? "right" : "bottom" } };
+                    break;
+                }
+                m_xml.tag("hole-closed", location, holeClosedValue);
                 m_xml.endElement();
             } else {
                 m_xml.tagRaw(mxmlTechn);

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -8151,6 +8151,8 @@ void MusicXmlParserNotations::technical()
             harmonic();
         } else if (m_e.name() == "harmon-mute") {
             harmonMute();
+        } else if (m_e.name() == "hole") {
+            hole();
         } else if (m_e.name() == "other-technical") {
             otherTechnical();
         } else {
@@ -8236,6 +8238,44 @@ void MusicXmlParserNotations::harmonMute()
         }
     }
     m_notations.push_back(Notation::notationWithAttributes(u"harmon-closed", attributes, u"technical", mute));
+}
+
+//---------------------------------------------------------
+//   harmonMute
+//---------------------------------------------------------
+
+/**
+ Parse the /score-partwise/part/measure/note/notations/technical/hole node.
+ */
+
+void MusicXmlParserNotations::hole()
+{
+    engraving::SymId hole = SymId::noSym;
+    const std::vector<XmlStreamReader::Attribute> attributes = m_e.attributes();
+    while (m_e.readNextStartElement()) {
+        String name = String::fromAscii(m_e.name().ascii());
+        if (name == "hole-closed") {
+            const String location = m_e.attribute("location");
+            String value = m_e.readText();
+            if (value == "yes") {
+                hole = SymId::windClosedHole;
+            } else if (value == "no") {
+                hole = SymId::windOpenHole;
+            } else if (value == "half") {
+                if (location == "bottom") {
+                    hole = SymId::windHalfClosedHole2;
+                } else if (location == "right") {
+                    hole = SymId::windHalfClosedHole1;
+                } else {
+                    m_logger->logError(String(u"unsupported hole-closed location '%1'").arg(location), &m_e);
+                    hole = SymId::windHalfClosedHole3;
+                }
+            }
+        } else {
+            m_e.skipCurrentElement();
+        }
+    }
+    m_notations.push_back(Notation::notationWithAttributes(u"hole-closed", attributes, u"technical", hole));
 }
 
 //---------------------------------------------------------

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -8053,6 +8053,16 @@ void MusicXmlParserNotations::articulations()
             artic.setSubType(String::fromAscii(m_e.name().ascii()));
             m_notations.push_back(artic);
             m_e.skipCurrentElement();  // skip but don't log
+        } else if (m_e.name() == "other-articulation") {
+            const String smufl = m_e.attribute("smufl");
+
+            if (!smufl.empty()) {
+                SymId id = SymNames::symIdByName(smufl, SymId::noSym);
+                Notation artic = Notation::notationWithAttributes(String::fromAscii(m_e.name().ascii()),
+                                                                     m_e.attributes(), u"articulations", id);
+                m_notations.push_back(artic);
+            }
+            m_e.skipCurrentElement();  // skip but don't log
         } else {
             skipLogCurrElem();
         }

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -8163,7 +8163,18 @@ void MusicXmlParserNotations::technical()
 
 void MusicXmlParserNotations::otherTechnical()
 {
-    String text = m_e.readText();
+    const String smufl = m_e.attribute("smufl");
+
+    if (!smufl.empty()) {
+        SymId id = SymNames::symIdByName(smufl, SymId::noSym);
+        Notation notation = Notation::notationWithAttributes(String::fromAscii(m_e.name().ascii()),
+                                                             m_e.attributes(), u"technical", id);
+        m_notations.push_back(notation);
+        m_e.skipCurrentElement();
+        return;
+    }
+
+    const String text = m_e.readText();
 
     if (text == u"z") {
         // Buzz roll

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -8241,7 +8241,7 @@ void MusicXmlParserNotations::harmonMute()
 }
 
 //---------------------------------------------------------
-//   harmonMute
+//   hole
 //---------------------------------------------------------
 
 /**
@@ -8253,10 +8253,9 @@ void MusicXmlParserNotations::hole()
     engraving::SymId hole = SymId::noSym;
     const std::vector<XmlStreamReader::Attribute> attributes = m_e.attributes();
     while (m_e.readNextStartElement()) {
-        String name = String::fromAscii(m_e.name().ascii());
-        if (name == "hole-closed") {
+        if (m_e.name() == "hole-closed") {
             const String location = m_e.attribute("location");
-            String value = m_e.readText();
+            const String value = m_e.readText();
             if (value == "yes") {
                 hole = SymId::windClosedHole;
             } else if (value == "no") {

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -1356,7 +1356,7 @@ static bool convertArticulationToSymId(const String& mxmlName, SymId& id)
         { u"stopped",                SymId::brassMuteClosed },
         { u"snap-pizzicato",         SymId::pluckedSnapPizzicatoAbove },
         { u"heel",                   SymId::keyboardPedalHeel1 },
-        { u"toe",                    SymId::keyboardPedalToe1 },
+        { u"toe",                    SymId::keyboardPedalToe2 },
         { u"fingernails",            SymId::pluckedWithFingernails },
         { u"brass-bend",             SymId::brassBend },
         { u"flip",                   SymId::brassFlip },

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -8059,7 +8059,7 @@ void MusicXmlParserNotations::articulations()
             if (!smufl.empty()) {
                 SymId id = SymNames::symIdByName(smufl, SymId::noSym);
                 Notation artic = Notation::notationWithAttributes(String::fromAscii(m_e.name().ascii()),
-                                                                     m_e.attributes(), u"articulations", id);
+                                                                  m_e.attributes(), u"articulations", id);
                 m_notations.push_back(artic);
             }
             m_e.skipCurrentElement();  // skip but don't log

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.h
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.h
@@ -357,6 +357,7 @@ private:
     void arpeggio();
     void harmonic();
     void harmonMute();
+    void hole();
     void articulations();
     void dynamics();
     void fermata();

--- a/src/importexport/musicxml/tests/data/testHoles.xml
+++ b/src/importexport/musicxml/tests/data/testHoles.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <work>
+    <work-title>Holes test</work-title>
+    </work>
+  <identification>
+    <creator type="composer">Klaus Rettinghaus</creator>
+    <encoding>
+      <software>MuseScore 0.7.0</software>
+      <encoding-date>2007-09-10</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="no"/>
+      <supports element="print" attribute="new-system" type="no"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Flute</part-name>
+      <part-abbreviation>Fl.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Flute</instrument-name>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>58</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations>
+          <technical>
+            <hole>
+              <hole-closed>no</hole-closed>
+              </hole>
+            </technical>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations>
+          <technical>
+            <hole>
+              <hole-closed>yes</hole-closed>
+              </hole>
+            </technical>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations>
+          <technical>
+            <hole>
+              <hole-closed location="bottom">half</hole-closed>
+              </hole>
+            </technical>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations>
+          <technical>
+            <hole>
+              <hole-closed location="right">half</hole-closed>
+              </hole>
+            </technical>
+          </notations>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/src/importexport/musicxml/tests/musicxml_tests.cpp
+++ b/src/importexport/musicxml/tests/musicxml_tests.cpp
@@ -706,6 +706,9 @@ TEST_F(MusicXml_Tests, helloReadCompr) {
 TEST_F(MusicXml_Tests, helloReadWriteCompr) {
     musicXmlReadWriteTestCompr("testHello");
 }
+TEST_F(MusicXml_Tests, holes) {
+    musicXmlIoTest("testHoles");
+}
 TEST_F(MusicXml_Tests, implicitMeasure1) {
     musicXmlIoTest("testImplicitMeasure1");
 }


### PR DESCRIPTION
This PR adds full support for the `hole` element to the technical notations in MusicXML import and export.

<img width="174" alt="grafik" src="https://github.com/user-attachments/assets/ab531872-101e-4dc3-9857-7942a387cba4" />

Furthermore it adds import of `other-articulation` and `other-technical` (if they provide a `@smufl` attribute).

Also it changes the glyph for the `toe` import to be more in line with the [MusicXML specification](https://www.w3.org/2021/06/musicxml40/musicxml-reference/elements/toe/).