### PR TITLE
[MusicXML] Add full support for hand bells

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
@@ -477,7 +477,7 @@ private:
 static std::string fractionToStdString(const Fraction& f)
 {
     if (!f.isValid()) {
-        return "<invalid>";
+        return u"<invalid>";
     }
     String res { f.toString() };
     res += String(u" (%1)").arg(String::number(f.ticks()));
@@ -3331,7 +3331,7 @@ static String symIdToTechn(const SymId sid)
         return u"smear";
         break;
     case SymId::brassMuteOpen:
-        // return "open-string";
+        // return u"open-string";
         return u"open";
         break;
     case SymId::brassMuteHalfClosed:
@@ -3345,6 +3345,42 @@ static String symIdToTechn(const SymId sid)
         break;
     case SymId::guitarGolpe:
         return u"golpe";
+        break;
+    case SymId::handbellsBelltree: 
+        return u"belltree";
+        break;
+    case SymId::handbellsDamp3: 
+        return u"damp";
+        break;
+    case SymId::handbellsEcho1: 
+        return u"echo";
+        break;
+    case SymId::handbellsGyro: 
+        return u"gyro";
+        break;
+    case SymId::handbellsHandMartellato: 
+        return u"hand martellato";
+        break;
+    case SymId::handbellsMalletLft: 
+        return u"mallet lift";
+        break;
+    case SymId::handbellsMalletBellOnTable: 
+        return u"mallet table";
+        break;
+    case SymId::handbellsMartellato: 
+        return u"martellato";
+        break;
+    case SymId::handbellsMartellatoLift: 
+        return u"martellato lift";
+        break;
+    case SymId::handbellsMutedMartellato: 
+        return u"muted martellato";
+        break;
+    case SymId::handbellsPluckLift: 
+        return u"pluck lift";
+        break;
+    case SymId::handbellsSwing: 
+        return u"swing";
         break;
     default:
         ;           // nothing
@@ -3587,6 +3623,14 @@ void ExportMusicXml::chordAttributes(Chord* chord, Notations& notations, Technic
                 m_xml.startElementRaw(mxmlTechn);
                 m_xml.tag("natural");
                 m_xml.endElement();
+            } else if (String::fromAscii(SymNames::nameForSymId(sid).ascii()).startsWith(u"handbells")) {
+                String handbell = u"handbell";
+                handbell += color2xml(a);
+                handbell += ExportMusicXml::positioningAttributes(a);
+                if (!placement.empty()) {
+                    handbell += String(u" placement=\"%1\"").arg(placement);
+                }
+                m_xml.tagRaw(handbell, symIdToTechn(sid));
             } else if (mxmlTechn.startsWith(u"harmon")) {
                 m_xml.startElementRaw(mxmlTechn);
                 XmlWriter::Attributes location = {};

--- a/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
@@ -476,7 +476,7 @@ private:
 static std::string fractionToStdString(const Fraction& f)
 {
     if (!f.isValid()) {
-        return u"<invalid>";
+        return "<invalid>";
     }
     String res { f.toString() };
     res += String(u" (%1)").arg(String::number(f.ticks()));

--- a/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
@@ -404,7 +404,6 @@ public:
     static String fermataPosition(const Fermata* const fermata);
 
 private:
-
     int findBracket(const TextLineBase* tl) const;
     int findDashes(const TextLineBase* tl) const;
     int findHairpin(const Hairpin* tl) const;
@@ -3346,40 +3345,40 @@ static String symIdToTechn(const SymId sid)
     case SymId::guitarGolpe:
         return u"golpe";
         break;
-    case SymId::handbellsBelltree: 
+    case SymId::handbellsBelltree:
         return u"belltree";
         break;
-    case SymId::handbellsDamp3: 
+    case SymId::handbellsDamp3:
         return u"damp";
         break;
-    case SymId::handbellsEcho1: 
+    case SymId::handbellsEcho1:
         return u"echo";
         break;
-    case SymId::handbellsGyro: 
+    case SymId::handbellsGyro:
         return u"gyro";
         break;
-    case SymId::handbellsHandMartellato: 
+    case SymId::handbellsHandMartellato:
         return u"hand martellato";
         break;
-    case SymId::handbellsMalletLft: 
+    case SymId::handbellsMalletLft:
         return u"mallet lift";
         break;
-    case SymId::handbellsMalletBellOnTable: 
+    case SymId::handbellsMalletBellOnTable:
         return u"mallet table";
         break;
-    case SymId::handbellsMartellato: 
+    case SymId::handbellsMartellato:
         return u"martellato";
         break;
-    case SymId::handbellsMartellatoLift: 
+    case SymId::handbellsMartellatoLift:
         return u"martellato lift";
         break;
-    case SymId::handbellsMutedMartellato: 
+    case SymId::handbellsMutedMartellato:
         return u"muted martellato";
         break;
-    case SymId::handbellsPluckLift: 
+    case SymId::handbellsPluckLift:
         return u"pluck lift";
         break;
-    case SymId::handbellsSwing: 
+    case SymId::handbellsSwing:
         return u"swing";
         break;
     default:

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -1361,7 +1361,20 @@ static bool convertArticulationToSymId(const String& mxmlName, SymId& id)
         { u"brass-bend",             SymId::brassBend },
         { u"flip",                   SymId::brassFlip },
         { u"smear",                  SymId::brassSmear },
-        { u"open",                   SymId::brassMuteOpen }
+        { u"open",                   SymId::brassMuteOpen },
+
+        { u"belltree", SymId::handbellsBelltree },
+        { u"damp", SymId::handbellsDamp3 },
+        { u"echo", SymId::handbellsEcho1 },
+        { u"gyro", SymId::handbellsGyro },
+        { u"hand martellato", SymId::handbellsHandMartellato },
+        { u"mallet lift", SymId::handbellsMalletLft },
+        { u"mallet table", SymId::handbellsMalletBellOnTable },
+        { u"martellato", SymId::handbellsMartellato },
+        { u"martellato lift", SymId::handbellsMartellatoLift },
+        { u"muted martellato", SymId::handbellsMutedMartellato },
+        { u"pluck lift", SymId::handbellsPluckLift },
+        { u"swing", SymId::handbellsSwing }
     };
 
     auto it = map.find(mxmlName);
@@ -8149,6 +8162,11 @@ void MusicXmlParserNotations::technical()
             m_notations.push_back(notation);
         } else if (m_e.name() == "harmonic") {
             harmonic();
+        } else if (m_e.name() == "handbell") {
+            const std::vector<XmlStreamReader::Attribute> attributes = m_e.attributes();
+            convertArticulationToSymId(m_e.readText(), id);
+            m_notations.push_back(Notation::notationWithAttributes(String::fromAscii(m_e.name().ascii()),
+                                                                   attributes, u"technical", id));
         } else if (m_e.name() == "harmon-mute") {
             harmonMute();
         } else if (m_e.name() == "other-technical") {

--- a/src/importexport/musicxml/tests/data/testHandbells.xml
+++ b/src/importexport/musicxml/tests/data/testHandbells.xml
@@ -1,0 +1,236 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <work>
+    <work-title>Hand bell symbols test</work-title>
+    </work>
+  <identification>
+    <creator type="composer">Klaus Rettinghaus</creator>
+    <encoding>
+      <software>MuseScore 0.7.0</software>
+      <encoding-date>2007-09-10</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="no"/>
+      <supports element="print" attribute="new-system" type="no"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Hand Bells</part-name>
+      <part-abbreviation>Ha. Be.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Hand Bells</instrument-name>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>2</midi-channel>
+        <midi-program>113</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <staves>2</staves>
+        <clef number="1">
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        <clef number="2">
+          <sign>F</sign>
+          <line>4</line>
+          </clef>
+        <transpose>
+          <diatonic>0</diatonic>
+          <chromatic>0</chromatic>
+          <octave-change>1</octave-change>
+          </transpose>
+        </attributes>
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <note>
+        <pitch>
+          <step>F</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>5</voice>
+        <type>half</type>
+        <stem>down</stem>
+        <staff>2</staff>
+        <notations>
+          <technical>
+            <handbell>belltree</handbell>
+            </technical>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>5</voice>
+        <type>half</type>
+        <stem>down</stem>
+        <staff>2</staff>
+        <notations>
+          <technical>
+            <handbell>damp</handbell>
+            </technical>
+          </notations>
+        </note>
+      </measure>
+    <measure number="2">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <note>
+        <pitch>
+          <step>G</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>5</voice>
+        <type>half</type>
+        <stem>down</stem>
+        <staff>2</staff>
+        <notations>
+          <technical>
+            <handbell placement="below">echo</handbell>
+            </technical>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>5</voice>
+        <type>half</type>
+        <stem>up</stem>
+        <staff>2</staff>
+        <notations>
+          <technical>
+            <handbell color="#FF00FF" placement="below">gyro</handbell>
+            </technical>
+          </notations>
+        </note>
+      </measure>
+    <measure number="3">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>5</voice>
+        <type>half</type>
+        <stem>up</stem>
+        <staff>2</staff>
+        <notations>
+          <technical>
+            <handbell placement="above">hand martellato</handbell>
+            </technical>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>G</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>5</voice>
+        <type>half</type>
+        <stem>down</stem>
+        <staff>2</staff>
+        <notations>
+          <technical>
+            <handbell placement="above">mallet lift</handbell>
+            </technical>
+          </notations>
+        </note>
+      </measure>
+    <measure number="4">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>5</voice>
+        <type>half</type>
+        <stem>down</stem>
+        <staff>2</staff>
+        <notations>
+          <technical>
+            <handbell>mallet table</handbell>
+            </technical>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>F</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>5</voice>
+        <type>half</type>
+        <stem>down</stem>
+        <staff>2</staff>
+        <notations>
+          <technical>
+            <handbell>martellato</handbell>
+            </technical>
+          </notations>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/src/importexport/musicxml/tests/musicxml_tests.cpp
+++ b/src/importexport/musicxml/tests/musicxml_tests.cpp
@@ -667,6 +667,9 @@ TEST_F(MusicXml_Tests, harpPedals) {
 TEST_F(MusicXml_Tests, hairpinDynamics) {
     musicXmlMscxExportTestRef("testHairpinDynamics");
 }
+TEST_F(MusicXml_Tests, handbells) {
+    musicXmlIoTest("testHandbells");
+}
 TEST_F(MusicXml_Tests, harmony1) {
     musicXmlIoTest("testHarmony1");
 }


### PR DESCRIPTION
This PR adds full support for the [technical indication for handbells](https://www.w3.org/2021/06/musicxml40/musicxml-reference/elements/handbell/) to the MusicXML import and export.