### PR TITLE
fix #22615: read GuitarBend color

### DIFF
--- a/src/engraving/rw/read410/tread.cpp
+++ b/src/engraving/rw/read410/tread.cpp
@@ -3098,6 +3098,7 @@ void TRead::read(GuitarBend* g, XmlReader& e, ReadContext& ctx)
             TRead::read(hold, e, ctx);
             hold->setParent(g);
             g->setHoldLine(hold);
+        } else if (TRead::readProperty(g, tag, e, ctx, Pid::COLOR)) {
         } else if (TRead::readProperty(g, tag, e, ctx, Pid::DIRECTION)) {
         } else if (TRead::readProperty(g, tag, e, ctx, Pid::BEND_SHOW_HOLD_LINE)) {
         } else if (TRead::readProperty(g, tag, e, ctx, Pid::BEND_START_TIME_FACTOR)) {


### PR DESCRIPTION
Resolves: #22615

In latest develop simple `GuitarBend` color is written, but never read. This PR fixes this little flaw.