### PR TITLE
Allow adding clef before first beat, after timesig even on non-first measure.

### DIFF
--- a/src/engraving/dom/chordrest.cpp
+++ b/src/engraving/dom/chordrest.cpp
@@ -205,7 +205,7 @@ EngravingItem* ChordRest::drop(EditData& data)
         return 0;
 
     case ElementType::CLEF:
-        score()->cmdInsertClef(toClef(e), this);
+        score()->cmdInsertClef(toClef(e), this, data.modifiers & ControlModifier);
         break;
 
     case ElementType::TIMESIG:

--- a/src/engraving/dom/cmd.cpp
+++ b/src/engraving/dom/cmd.cpp
@@ -3451,9 +3451,9 @@ void Score::cmdInsertClef(ClefType type)
 //    insert clef before cr
 //---------------------------------------------------------
 
-void Score::cmdInsertClef(Clef* clef, ChordRest* cr)
+void Score::cmdInsertClef(Clef* clef, ChordRest* cr, bool ctrlModifier)
 {
-    undoChangeClef(cr->staff(), cr, clef->clefType());
+    undoChangeClef(cr->staff(), cr, clef->clefType(), /*instrumentChange*/ false, /*clefToRelink*/ nullptr, ctrlModifier);
     delete clef;
 }
 

--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -5300,7 +5300,7 @@ void Score::updateInstrumentChangeTranspositions(KeySigEvent& key, Staff* staff,
 //    create a clef before element e
 //---------------------------------------------------------
 
-void Score::undoChangeClef(Staff* ostaff, EngravingItem* e, ClefType ct, bool forInstrumentChange, Clef* clefToRelink)
+void Score::undoChangeClef(Staff* ostaff, EngravingItem* e, ClefType ct, bool forInstrumentChange, Clef* clefToRelink, bool ctrlModifier)
 {
     IF_ASSERT_FAILED(ostaff && e) {
         return;
@@ -5328,7 +5328,7 @@ void Score::undoChangeClef(Staff* ostaff, EngravingItem* e, ClefType ct, bool fo
     } else if (e->rtick() == Fraction(0, 1)) {
         Measure* curMeasure = e->findMeasure();
         Measure* prevMeasure = curMeasure ? curMeasure->prevMeasure() : nullptr;
-        if (prevMeasure && !prevMeasure->sectionBreak()) {
+        if (!ctrlModifier && prevMeasure && !prevMeasure->sectionBreak()) {
             moveClef = true;
         }
     }

--- a/src/engraving/dom/score.h
+++ b/src/engraving/dom/score.h
@@ -441,7 +441,7 @@ public:
     void undoChangeTuning(Note*, double);
     void undoChangeUserMirror(Note*, DirectionH);
     void undoChangeKeySig(Staff* ostaff, const Fraction& tick, KeySigEvent);
-    void undoChangeClef(Staff* ostaff, EngravingItem*, ClefType st, bool forInstrumentChange = false, Clef* clefToRelink = nullptr);
+    void undoChangeClef(Staff* ostaff, EngravingItem*, ClefType st, bool forInstrumentChange = false, Clef* clefToRelink = nullptr, bool ctrlModifier = false);
     bool undoPropertyChanged(EngravingItem* item, Pid propId, const PropertyValue& propValue,
                              PropertyFlags propFlags = PropertyFlags::NOSTYLE);
     void undoPropertyChanged(EngravingObject*, Pid, const PropertyValue& v, PropertyFlags ps = PropertyFlags::NOSTYLE);
@@ -956,7 +956,7 @@ public:
     int duration();
     int durationWithoutRepeats();
 
-    void cmdInsertClef(Clef* clef, ChordRest* cr);
+    void cmdInsertClef(Clef* clef, ChordRest* cr, bool ctrlModifier = false);
 
     void cmdExplode();
     void cmdImplode();


### PR DESCRIPTION
Resolves: #25946 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
With Ctrl pressed, now it is possible to place clef before first note (after time sig) in non-first measure.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
