### PR TITLE
19239: Allow accented characters to be typed in text objects with the AltGr / Ctrl+Alt keys

### DIFF
--- a/src/engraving/dom/editdata.h
+++ b/src/engraving/dom/editdata.h
@@ -192,7 +192,9 @@ enum KeyboardKey {
     Key_BraceRight = 0x7d,
     Key_AsciiTilde = 0x7e,
 
+    Key_nobreakspace = 0x0a0,
     Key_periodcentered = 0x0b7,
+    Key_ydiaeresis = 0x0ff,
 };
 
 enum MouseButton {

--- a/src/engraving/dom/textedit.cpp
+++ b/src/engraving/dom/textedit.cpp
@@ -392,6 +392,13 @@ bool TextBase::isEditAllowed(EditData& ed) const
         if (ed.key == Key_Minus) {
             return true;
         }
+
+#if defined(Q_OS_WIN)
+        // Allow accented characters to be input with AltGr and Ctrl+Alt (both are treated the same in Windows)
+        if (ed.key >= Key_nobreakspace && ed.key <= Key_ydiaeresis) {
+            return true;
+        }
+#endif
     }
 
     // At least on non-macOS, sometimes ed.s is not empty even if Ctrl is pressed


### PR DESCRIPTION
Resolves: #19239 (along with another PR)

Although the author of #19239 says he is able to press ESC and repeat the AltGr + letter combination and it works the second time, it does not work for me and I believe we need the changes I am proposing so that we can enter accented characters with AltGr or Ctrl+Alt (which Windows treats the same).

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
