### PR TITLE
Percussion panel - refinements round 4

### DIFF
--- a/src/engraving/dom/undo.h
+++ b/src/engraving/dom/undo.h
@@ -1505,8 +1505,8 @@ class ChangeDrumset : public UndoCommand
     void flip(EditData*) override;
 
 public:
-    ChangeDrumset(Instrument* i, const Drumset* d, Part* p)
-        : instrument(i), drumset(*d), part(p) {}
+    ChangeDrumset(Instrument* i, const Drumset& d, Part* p)
+        : instrument(i), drumset(d), part(p) {}
 
     UNDO_TYPE(CommandType::ChangeDrumset)
     UNDO_NAME("ChangeDrumset")

--- a/src/notation/internal/notationconfiguration.h
+++ b/src/notation/internal/notationconfiguration.h
@@ -207,11 +207,11 @@ public:
     muse::async::Notification autoShowPercussionPanelChanged() const override;
 
     bool showPercussionPanelPadSwapDialog() const override;
-    void setShowPercussionPanelPadSwapDialog(bool show);
+    void setShowPercussionPanelPadSwapDialog(bool show) override;
     muse::async::Notification showPercussionPanelPadSwapDialogChanged() const override;
 
     bool percussionPanelMoveMidiNotesAndShortcuts() const override;
-    void setPercussionPanelMoveMidiNotesAndShortcuts(bool move);
+    void setPercussionPanelMoveMidiNotesAndShortcuts(bool move) override;
     muse::async::Notification percussionPanelMoveMidiNotesAndShortcutsChanged() const override;
 
     muse::io::path_t styleFileImportPath() const override;

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -194,6 +194,7 @@ NotationInteraction::NotationInteraction(Notation* notation, INotationUndoStackP
 
     m_undoStack->undoRedoNotification().onNotify(this, [this]() {
         endEditElement();
+        notifyAboutNoteInputStateChanged();
     });
 
     m_undoStack->stackChanged().onNotify(this, [this]() {

--- a/src/notation/internal/notationparts.cpp
+++ b/src/notation/internal/notationparts.cpp
@@ -640,7 +640,7 @@ void NotationParts::replaceDrumset(const InstrumentKey& instrumentKey, const Dru
 
     if (undoable) {
         startEdit(TranslatableString("undoableAction", "Edit drumset"));
-        score()->undo(new mu::engraving::ChangeDrumset(instrument, &newDrumset, part));
+        score()->undo(new mu::engraving::ChangeDrumset(instrument, newDrumset, part));
         apply();
     } else {
         instrument->setDrumset(&newDrumset);

--- a/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
+++ b/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
@@ -415,6 +415,7 @@ Item {
                 orientation: Qt.Horizontal
 
                 navigation.panel: addRowButtonPanel
+                drawFocusBorderInsideRect: true
 
                 onClicked: {
                     padGrid.model.addEmptyRow()
@@ -428,9 +429,7 @@ Item {
 
             visible: !percModel.enabled
 
-            anchors.top: parent.top
-            anchors.horizontalCenter: parent.horizontalCenter
-            anchors.topMargin: (padGrid.cellHeight / 2) - (panelDisabledLabel.height / 2)
+            anchors.centerIn: parent
 
             font: ui.theme.bodyFont
             text: qsTrc("notation/percussion", "Select an unpitched percussion staff to see available sounds")

--- a/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPad.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPad.qml
@@ -121,10 +121,6 @@ DropArea {
 
         accessible.visualItem: footerFocusBorder
         accessible.enabled: footerNavCtrl.enabled
-
-        onTriggered: {
-            // TODO: trigger context menu (not yet implemented)
-        }
     }
 
     Rectangle {
@@ -188,6 +184,8 @@ DropArea {
                 id: padContentComponent
 
                 PercussionPanelPadContent {
+                    id: padContent
+
                     padModel: root.padModel
                     panelMode: root.panelMode
                     useNotationPreview: root.useNotationPreview
@@ -195,6 +193,13 @@ DropArea {
                     footerHeight: prv.footerHeight
 
                     padSwapActive: dragHandler.active
+
+                    Connections {
+                        target: footerNavCtrl
+                        function onTriggered() {
+                            padContent.openFooterContextMenu()
+                        }
+                    }
                 }
             }
 

--- a/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPadContent.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPadContent.qml
@@ -37,6 +37,13 @@ Column {
 
     property bool padSwapActive: false
 
+    function openFooterContextMenu() {
+        if (!root.padModel) {
+            return
+        }
+        menuLoader.toggleOpened(root.padModel.footerContextMenuItems)
+    }
+
     Item {
         id: mainContentArea
 
@@ -154,6 +161,17 @@ Column {
 
         color: Utils.colorWithAlpha(ui.theme.buttonColor, ui.theme.buttonOpacityNormal)
 
+        MouseArea {
+            id: footerMouseArea
+
+            anchors.fill: parent
+            enabled: root.panelMode !== PanelMode.EDIT_LAYOUT
+
+            onClicked: {
+                root.openFooterContextMenu()
+            }
+        }
+
         StyledTextLabel {
             id: shortcutLabel
 
@@ -189,6 +207,14 @@ Column {
             color: ui.theme.fontPrimaryColor
 
             text: Boolean(root.padModel) ? root.padModel.midiNote : ""
+        }
+
+        StyledMenuLoader {
+            id: menuLoader
+
+            onHandleMenuItem: function(itemId) {
+                root.padModel.handleMenuItem(itemId)
+            }
         }
     }
 }

--- a/src/notation/view/paintedengravingitem.cpp
+++ b/src/notation/view/paintedengravingitem.cpp
@@ -88,7 +88,7 @@ void PaintedEngravingItem::paintNotationPreview(muse::draw::Painter& painter, qr
 
     params.drawStaff = true;
 
-    painter.fillRect(params.rect, configuration()->scoreInversionColor());
+    painter.fillRect(params.rect, configuration()->noteBackgroundColor());
 
     EngravingItemPreviewPainter::paintPreview(m_item.get(), params);
 }

--- a/src/notation/view/percussionpanel/percussionpanelmodel.cpp
+++ b/src/notation/view/percussionpanel/percussionpanelmodel.cpp
@@ -125,36 +125,27 @@ void PercussionPanelModel::init()
 
 QList<QVariantMap> PercussionPanelModel::layoutMenuItems() const
 {
-    const TranslatableString padNamesTitle("notation/percussion", "Pad names");
-    // Using IconCode for this instead of "checked" because we want the tick to display on the left
-    const int padNamesIcon = static_cast<int>(m_useNotationPreview ? IconCode::Code::NONE : IconCode::Code::TICK_RIGHT_ANGLE);
+    const auto editLayoutTitle = m_currentPanelMode == PanelMode::Mode::EDIT_LAYOUT
+                                 ? muse::qtrc("notation/percussion", "Finish editing")
+                                 : muse::qtrc("notation/percussion", "Edit layout");
 
-    const TranslatableString notationPreviewTitle("notation/percussion", "Notation preview");
-    // Using IconCode for this instead of "checked" because we want the tick to display on the left
-    const int notationPreviewIcon = static_cast<int>(m_useNotationPreview ? IconCode::Code::TICK_RIGHT_ANGLE : IconCode::Code::NONE);
-
-    const TranslatableString editLayoutTitle = m_currentPanelMode == PanelMode::Mode::EDIT_LAYOUT
-                                               ? TranslatableString("notation/percussion", "Finish editing")
-                                               : TranslatableString("notation/percussion", "Edit layout");
-    const int editLayoutIcon = static_cast<int>(IconCode::Code::CONFIGURE);
-
-    const TranslatableString resetLayoutTitle("notation/percussion", "Reset layout");
-    const int resetLayoutIcon = static_cast<int>(IconCode::Code::UNDO);
+    static constexpr int editLayoutIcon = static_cast<int>(IconCode::Code::CONFIGURE);
+    static constexpr int resetLayoutIcon = static_cast<int>(IconCode::Code::UNDO);
 
     QList<QVariantMap> menuItems = {
-        { { "id", PAD_NAMES_CODE },
-            { "title", padNamesTitle.qTranslated() }, { "icon", padNamesIcon }, { "enabled", true } },
+        { { "id", PAD_NAMES_CODE }, { "title", muse::qtrc("notation/percussion", "Pad names") },
+            { "checkable", true }, { "checked", !m_useNotationPreview }, { "enabled", true } },
 
-        { { "id", NOTATION_PREVIEW_CODE },
-            { "title", notationPreviewTitle.qTranslated() }, { "icon", notationPreviewIcon }, { "enabled", true } },
+        { { "id", NOTATION_PREVIEW_CODE }, { "title", muse::qtrc("notation/percussion", "Notation preview") },
+            { "checkable", true }, { "checked", m_useNotationPreview }, { "enabled", true } },
 
         { }, // separator
 
         { { "id", EDIT_LAYOUT_CODE },
-            { "title", editLayoutTitle.qTranslated() }, { "icon", editLayoutIcon }, { "enabled", true } },
+            { "title", editLayoutTitle }, { "icon", editLayoutIcon }, { "enabled", true } },
 
         { { "id", RESET_LAYOUT_CODE },
-            { "title", resetLayoutTitle.qTranslated() }, { "icon", resetLayoutIcon }, { "enabled", true } },
+            { "title", muse::qtrc("notation/percussion", "Reset layout") }, { "icon", resetLayoutIcon }, { "enabled", true } },
     };
 
     return menuItems;
@@ -185,16 +176,11 @@ void PercussionPanelModel::finishEditing(bool discardChanges)
 
     m_padListModel->removeEmptyRows();
 
-    NoteInputState inputState = interaction()->noteInput()->state();
-    const Staff* staff = inputState.staff;
+    const std::pair<Instrument*, Part*> instAndPart = getCurrentInstrumentAndPart();
+    Instrument* inst = instAndPart.first;
+    Part* part = instAndPart.second;
 
-    IF_ASSERT_FAILED(staff && staff->part()) {
-        return;
-    }
-
-    Instrument* inst = staff->part()->instrument(inputState.segment->tick());
-
-    IF_ASSERT_FAILED(inst && inst->drumset()) {
+    IF_ASSERT_FAILED(inst && inst->drumset() && part) {
         return;
     }
 
@@ -234,7 +220,7 @@ void PercussionPanelModel::finishEditing(bool discardChanges)
     INotationUndoStackPtr undoStack = notation()->undoStack();
 
     undoStack->prepareChanges(muse::TranslatableString("undoableAction", "Edit percussion panel layout"));
-    score()->undo(new engraving::ChangeDrumset(inst, &updatedDrumset, staff->part()));
+    score()->undo(new engraving::ChangeDrumset(inst, &updatedDrumset, part));
     undoStack->commitChanges();
 
     setCurrentPanelMode(m_panelModeToRestore);
@@ -283,11 +269,22 @@ void PercussionPanelModel::setUpConnections()
         setEnabled(m_padListModel->hasActivePads());
     });
 
-    m_padListModel->padTriggered().onReceive(this, [this](int pitch) {
-        switch (currentPanelMode()) {
-        case PanelMode::Mode::EDIT_LAYOUT: return;
-        case PanelMode::Mode::WRITE: writePitch(pitch); // fall through
-        case PanelMode::Mode::SOUND_PREVIEW: playPitch(pitch);
+    m_padListModel->padActionRequested().onReceive(this, [this](PercussionPanelPadModel::PadAction action, int pitch) {
+        switch (action) {
+        case PercussionPanelPadModel::PadAction::TRIGGER:
+            onPadTriggered(pitch);
+            break;
+        case PercussionPanelPadModel::PadAction::DUPLICATE:
+            onDuplicatePadRequested(pitch);
+            break;
+        case PercussionPanelPadModel::PadAction::DELETE:
+            onDeletePadRequested(pitch);
+            break;
+        case PercussionPanelPadModel::PadAction::DEFINE_SHORTCUT:
+            onDefinePadShortcutRequested(pitch);
+            break;
+        default:
+            break;
         }
     });
 
@@ -336,6 +333,76 @@ bool PercussionPanelModel::eventFilter(QObject* watched, QEvent* event)
     finishEditing();
     event->setAccepted(true);
     return true;
+}
+
+void PercussionPanelModel::onPadTriggered(int pitch)
+{
+    switch (currentPanelMode()) {
+    case PanelMode::Mode::EDIT_LAYOUT: return;
+    case PanelMode::Mode::WRITE: writePitch(pitch); // fall through
+    case PanelMode::Mode::SOUND_PREVIEW: playPitch(pitch);
+    default: break;
+    }
+}
+
+void PercussionPanelModel::onDuplicatePadRequested(int pitch)
+{
+    const std::pair<Instrument*, Part*> instAndPart = getCurrentInstrumentAndPart();
+    Instrument* inst = instAndPart.first;
+    Part* part = instAndPart.second;
+
+    IF_ASSERT_FAILED(inst && part) {
+        return;
+    }
+
+    const int nextAvailablePitch = m_padListModel->nextAvailablePitch(pitch);
+    if (nextAvailablePitch < 0) {
+        // TODO: Show some sort of warning dialog?
+        LOGE() << "No space to duplicate drum pad";
+        return;
+    }
+    const int nextAvailableIndex = m_padListModel->nextAvailableIndex(pitch);
+
+    Drumset updatedDrumset = *m_padListModel->drumset();
+
+    engraving::DrumInstrument duplicateDrum = updatedDrumset.drum(pitch);
+
+    duplicateDrum.shortcut = '\0'; // Don't steal the shortcut
+    duplicateDrum.panelRow = nextAvailableIndex / m_padListModel->numColumns();
+    duplicateDrum.panelColumn = nextAvailableIndex % m_padListModel->numColumns();
+
+    updatedDrumset.setDrum(nextAvailablePitch, duplicateDrum);
+
+    INotationUndoStackPtr undoStack = notation()->undoStack();
+
+    undoStack->prepareChanges(muse::TranslatableString("undoableAction", "Duplicate percussion panel pad"));
+    score()->undo(new engraving::ChangeDrumset(inst, &updatedDrumset, part));
+    undoStack->commitChanges();
+}
+
+void PercussionPanelModel::onDeletePadRequested(int pitch)
+{
+    const std::pair<Instrument*, Part*> instAndPart = getCurrentInstrumentAndPart();
+    Instrument* inst = instAndPart.first;
+    Part* part = instAndPart.second;
+
+    IF_ASSERT_FAILED(inst && part) {
+        return;
+    }
+
+    Drumset updatedDrumset = *m_padListModel->drumset();
+    updatedDrumset.setDrum(pitch, engraving::DrumInstrument());
+
+    INotationUndoStackPtr undoStack = notation()->undoStack();
+
+    undoStack->prepareChanges(muse::TranslatableString("undoableAction", "Delete percussion panel pad"));
+    score()->undo(new engraving::ChangeDrumset(inst, &updatedDrumset, part));
+    undoStack->commitChanges();
+}
+
+void PercussionPanelModel::onDefinePadShortcutRequested(int)
+{
+    // TODO: Design in progress...
 }
 
 void PercussionPanelModel::writePitch(int pitch)
@@ -388,16 +455,11 @@ void PercussionPanelModel::resetLayout()
         finishEditing(/*discardChanges*/ true);
     }
 
-    NoteInputState inputState = interaction()->noteInput()->state();
-    const Staff* staff = inputState.staff;
+    const std::pair<Instrument*, Part*> instAndPart = getCurrentInstrumentAndPart();
+    Instrument* inst = instAndPart.first;
+    Part* part = instAndPart.second;
 
-    IF_ASSERT_FAILED(staff && staff->part()) {
-        return;
-    }
-
-    Instrument* inst = staff->part()->instrument(inputState.segment->tick());
-
-    IF_ASSERT_FAILED(inst) {
+    IF_ASSERT_FAILED(inst && inst->drumset() && part) {
         return;
     }
 
@@ -417,7 +479,7 @@ void PercussionPanelModel::resetLayout()
     INotationUndoStackPtr undoStack = notation()->undoStack();
 
     undoStack->prepareChanges(muse::TranslatableString("undoableAction", "Reset percussion panel layout"));
-    score()->undo(new engraving::ChangeDrumset(inst, &defaultLayout, staff->part()));
+    score()->undo(new engraving::ChangeDrumset(inst, &defaultLayout, part));
     undoStack->commitChanges();
 }
 
@@ -435,6 +497,23 @@ InstrumentTrackId PercussionPanelModel::currentTrackId() const
     }
 
     return { staff->part()->id(), staff->part()->instrumentId(inputState.segment->tick()) };
+}
+
+std::pair<mu::engraving::Instrument*, mu::engraving::Part*> PercussionPanelModel::getCurrentInstrumentAndPart() const
+{
+    if (!interaction()) {
+        return { nullptr, nullptr };
+    }
+
+    NoteInputState inputState = interaction()->noteInput()->state();
+
+    const Staff* staff = inputState.staff;
+
+    Part* part = staff ? staff->part() : nullptr;
+
+    Instrument* inst = part ? part->instrument(inputState.segment->tick()) : nullptr;
+
+    return { inst, part };
 }
 
 const project::IProjectAudioSettingsPtr PercussionPanelModel::audioSettings() const

--- a/src/notation/view/percussionpanel/percussionpanelmodel.cpp
+++ b/src/notation/view/percussionpanel/percussionpanelmodel.cpp
@@ -183,7 +183,6 @@ void PercussionPanelModel::finishEditing(bool discardChanges)
         return;
     }
 
-    Drumset* updatedDrumset = m_padListModel->drumset();
     m_padListModel->removeEmptyRows();
 
     NoteInputState inputState = interaction()->noteInput()->state();
@@ -205,6 +204,8 @@ void PercussionPanelModel::finishEditing(bool discardChanges)
         return;
     }
 
+    Drumset updatedDrumset = *m_padListModel->drumset();
+
     for (int i = 0; i < m_padListModel->padList().size(); ++i) {
         const PercussionPanelPadModel* model = m_padListModel->padList().at(i);
         if (!model) {
@@ -214,7 +215,7 @@ void PercussionPanelModel::finishEditing(bool discardChanges)
         const int row = i / m_padListModel->numColumns();
         const int column = i % m_padListModel->numColumns();
 
-        engraving::DrumInstrument& drum = updatedDrumset->drum(model->pitch());
+        engraving::DrumInstrument& drum = updatedDrumset.drum(model->pitch());
 
         drum.panelRow = row;
         drum.panelColumn = column;
@@ -224,8 +225,7 @@ void PercussionPanelModel::finishEditing(bool discardChanges)
     }
 
     // Return if nothing changed after edit...
-    if (inst->drumset() && updatedDrumset
-        && *inst->drumset() == *updatedDrumset) {
+    if (inst->drumset() && *inst->drumset() == updatedDrumset) {
         setCurrentPanelMode(m_panelModeToRestore);
         m_padListModel->focusLastActivePad();
         return;
@@ -234,7 +234,7 @@ void PercussionPanelModel::finishEditing(bool discardChanges)
     INotationUndoStackPtr undoStack = notation()->undoStack();
 
     undoStack->prepareChanges(muse::TranslatableString("undoableAction", "Edit percussion panel layout"));
-    score()->undo(new engraving::ChangeDrumset(inst, updatedDrumset, staff->part()));
+    score()->undo(new engraving::ChangeDrumset(inst, &updatedDrumset, staff->part()));
     undoStack->commitChanges();
 
     setCurrentPanelMode(m_panelModeToRestore);

--- a/src/notation/view/percussionpanel/percussionpanelmodel.h
+++ b/src/notation/view/percussionpanel/percussionpanelmodel.h
@@ -113,6 +113,11 @@ private:
 
     bool eventFilter(QObject* watched, QEvent* event) override;
 
+    void onPadTriggered(int pitch);
+    void onDuplicatePadRequested(int pitch);
+    void onDeletePadRequested(int pitch);
+    void onDefinePadShortcutRequested(int pitch);
+
     void writePitch(int pitch);
     void playPitch(int pitch);
 
@@ -121,6 +126,9 @@ private:
     mu::engraving::InstrumentTrackId currentTrackId() const;
 
     const project::IProjectAudioSettingsPtr audioSettings() const;
+
+    std::pair<mu::engraving::Instrument*, mu::engraving::Part*> getCurrentInstrumentAndPart() const;
+
     const mu::notation::INotationPtr notation() const;
     const mu::notation::INotationInteractionPtr interaction() const;
 

--- a/src/notation/view/percussionpanel/percussionpanelpadlistmodel.cpp
+++ b/src/notation/view/percussionpanel/percussionpanelpadlistmodel.cpp
@@ -225,6 +225,16 @@ mu::engraving::Drumset PercussionPanelPadListModel::constructDefaultLayout(const
     return defaultLayout;
 }
 
+void PercussionPanelPadListModel::focusFirstActivePad()
+{
+    for (int i = 0; i < m_padModels.size(); i++) {
+        if (m_padModels.at(i)) {
+            emit padFocusRequested(i);
+            return;
+        }
+    }
+}
+
 void PercussionPanelPadListModel::focusLastActivePad()
 {
     for (int i = m_padModels.size() - 1; i >= 0; --i) {

--- a/src/notation/view/percussionpanel/percussionpanelpadlistmodel.h
+++ b/src/notation/view/percussionpanel/percussionpanelpadlistmodel.h
@@ -78,11 +78,13 @@ public:
     QList<PercussionPanelPadModel*> padList() const { return m_padModels; }
 
     mu::engraving::Drumset constructDefaultLayout(const engraving::Drumset* templateDrumset) const;
+    int nextAvailableIndex(int pitch) const; //! NOTE: This may be equal to m_padModels.size()
+    int nextAvailablePitch(int pitch) const;
 
     void focusLastActivePad();
 
     muse::async::Notification hasActivePadsChanged() const { return m_hasActivePadsChanged; }
-    muse::async::Channel<int /*pitch*/> padTriggered() const { return m_triggeredChannel; }
+    muse::async::Channel<PercussionPanelPadModel::PadAction, int /*pitch*/> padActionRequested() const { return m_padActionRequestChannel; }
 
 signals:
     void numPadsChanged();
@@ -103,6 +105,8 @@ private:
     PercussionPanelPadModel* createPadModelForPitch(int pitch);
     int createModelIndexForPitch(int pitch) const;
 
+    int getModelIndexForPitch(int pitch) const;
+
     void movePad(int fromIndex, int toIndex);
 
     muse::RetVal<muse::Val> openPadSwapDialog();
@@ -116,6 +120,6 @@ private:
     int m_padSwapStartIndex = -1;
 
     muse::async::Notification m_hasActivePadsChanged;
-    muse::async::Channel<int /*pitch*/> m_triggeredChannel;
+    muse::async::Channel<PercussionPanelPadModel::PadAction, int /*pitch*/> m_padActionRequestChannel;
 };
 }

--- a/src/notation/view/percussionpanel/percussionpanelpadlistmodel.h
+++ b/src/notation/view/percussionpanel/percussionpanelpadlistmodel.h
@@ -81,6 +81,7 @@ public:
     int nextAvailableIndex(int pitch) const; //! NOTE: This may be equal to m_padModels.size()
     int nextAvailablePitch(int pitch) const;
 
+    void focusFirstActivePad();
     void focusLastActivePad();
 
     muse::async::Notification hasActivePadsChanged() const { return m_hasActivePadsChanged; }

--- a/src/notation/view/percussionpanel/percussionpanelpadlistmodel.h
+++ b/src/notation/view/percussionpanel/percussionpanelpadlistmodel.h
@@ -73,7 +73,7 @@ public:
     int numPads() const { return m_padModels.count(); }
 
     void setDrumset(const engraving::Drumset* drumset);
-    engraving::Drumset* drumset() const { return m_drumset; }
+    const engraving::Drumset* drumset() const { return m_drumset; }
 
     QList<PercussionPanelPadModel*> padList() const { return m_padModels; }
 

--- a/src/notation/view/percussionpanel/percussionpanelpadmodel.cpp
+++ b/src/notation/view/percussionpanel/percussionpanelpadmodel.cpp
@@ -22,7 +22,14 @@
 
 #include "percussionpanelpadmodel.h"
 
+#include "ui/view/iconcodes.h"
+
+static const QString DUPLICATE_PAD_CODE("duplicate-pad");
+static const QString DELETE_PAD_CODE("delete-pad");
+static const QString DEFINE_PAD_SHORTCUT_CODE("define-pad-shortcut");
+
 using namespace mu::notation;
+using namespace muse::ui;
 
 PercussionPanelPadModel::PercussionPanelPadModel(QObject* parent)
     : QObject(parent)
@@ -74,7 +81,40 @@ const QVariant PercussionPanelPadModel::notationPreviewItemVariant() const
     return QVariant::fromValue(m_notationPreviewItem);
 }
 
+QList<QVariantMap> PercussionPanelPadModel::footerContextMenuItems() const
+{
+    static constexpr int duplicatePadIcon = static_cast<int>(IconCode::Code::COPY);
+    static constexpr int deletePadIcon = static_cast<int>(IconCode::Code::DELETE_TANK);
+    static constexpr int definePadShortcutIcon = static_cast<int>(IconCode::Code::SHORTCUTS);
+
+    QList<QVariantMap> menuItems = {
+        { { "id", DUPLICATE_PAD_CODE }, { "title", muse::qtrc("global", "Duplicate") },
+            { "icon", duplicatePadIcon }, { "enabled", true } },
+
+        { { "id", DELETE_PAD_CODE }, { "title", muse::qtrc("global", "Delete") },
+            { "icon", deletePadIcon }, { "enabled", true } },
+
+        { }, // separator
+
+        { { "id", DEFINE_PAD_SHORTCUT_CODE }, { "title", muse::qtrc("shortcuts", "Define keyboard shortcut") },
+            { "icon", definePadShortcutIcon }, { "enabled", true } },
+    };
+
+    return menuItems;
+}
+
+void PercussionPanelPadModel::handleMenuItem(const QString& itemId)
+{
+    if (itemId == DUPLICATE_PAD_CODE) {
+        m_padActionTriggered.send(PadAction::DUPLICATE);
+    } else if (itemId == DELETE_PAD_CODE) {
+        m_padActionTriggered.send(PadAction::DELETE);
+    } else if (itemId == DEFINE_PAD_SHORTCUT_CODE) {
+        m_padActionTriggered.send(PadAction::DEFINE_SHORTCUT);
+    }
+}
+
 void PercussionPanelPadModel::triggerPad()
 {
-    m_triggeredNotification.notify();
+    m_padActionTriggered.send(PadAction::TRIGGER);
 }

--- a/src/notation/view/percussionpanel/percussionpanelpadmodel.h
+++ b/src/notation/view/percussionpanel/percussionpanelpadmodel.h
@@ -43,6 +43,8 @@ class PercussionPanelPadModel : public QObject, public muse::async::Asyncable
 
     Q_PROPERTY(QVariant notationPreviewItem READ notationPreviewItemVariant NOTIFY notationPreviewItemChanged)
 
+    Q_PROPERTY(QList<QVariantMap> footerContextMenuItems READ footerContextMenuItems CONSTANT)
+
 public:
     explicit PercussionPanelPadModel(QObject* parent = nullptr);
 
@@ -62,8 +64,19 @@ public:
 
     const QVariant notationPreviewItemVariant() const;
 
+    QList<QVariantMap> footerContextMenuItems() const;
+    Q_INVOKABLE void handleMenuItem(const QString& itemId);
+
     Q_INVOKABLE void triggerPad();
-    muse::async::Notification padTriggered() const { return m_triggeredNotification; }
+
+    enum class PadAction {
+        TRIGGER,
+        DUPLICATE,
+        DELETE,
+        DEFINE_SHORTCUT,
+    };
+
+    muse::async::Channel<PadAction> padActionTriggered() const { return m_padActionTriggered; }
 
 signals:
     void padNameChanged();
@@ -81,6 +94,6 @@ private:
 
     mu::engraving::ElementPtr m_notationPreviewItem;
 
-    muse::async::Notification m_triggeredNotification;
+    muse::async::Channel<PadAction> m_padActionTriggered;
 };
 }


### PR DESCRIPTION
This PR contains an assortment of small fixes for the percussion panel, alongside two more substantial changes.

### Small Fixes

The small fixes (ce1702242d001f23d3bfc5af3381e15fe31df004) are as follows:

1. Corrected the background colour for notation preview (`paintNotationPreview`)
2. Fixed the vertical alignment of the "disabled state" text (`PercussionPanel.qml`)
3. Fixed a bug (and assertion failure) when selecting an unpitched staff during layout edit (`finishEditing`)
4. Keyboard focus now moves to pads when starting layout edit (`handleMenuItem`)
5. Fixed clipped navigation border on "add row" button (`PercussionPanel.qml`)
6. Fixed sounds not previewing properly (this was a placeholder before, we simply need to use `getDrumNoteForPreview` so that the playback controller receives the correct noteheads, etc.)
7. Added forgotten `overrides` from recent refinements PR (`notationconfiguration.h`)
8. Tweaked `ChangeDrumset` (see [comment](https://github.com/musescore/MuseScore/pull/25958#discussion_r1900254844))

### Footer Context Menus

One of the "substantial changes" (89156ff14b7c0ed6c191c48c2984855b0a4fb200) was to implement "footer context menus" for the pads (see image), with associated "duplicate" and "delete" actions. A menu option for assigning keyboard shortcuts to the pads has also been included, but the logic for this action does not exist yet (will be included in a future PR).

<img width="635" alt="Screenshot 2024-12-31 at 09 21 24" src="https://github.com/user-attachments/assets/9e3bc712-ad4b-4fe0-af1c-a6651958ef0c" />

This commit also includes a quick refactor to `PercussionPanelModel::layoutMenuItems`. The "checkable" logic has been simplified, and the definition of translatable strings has been corrected (per [this comment](https://github.com/musescore/MuseScore/pull/25958#discussion_r1900269366)).

### Fixing undo, redo, and reset

The other substantial change (7335c37e8e6ca6c0503c4bc301b83d354f7ca93d) isn't substantial LOC-wise, but has implications beyond the new percussion panel and requires some explanation. This seeks to resolve a bug where the panel doesn't always update visually on undo, redo, and reset layout.

The underlying cause was that `NotationNoteInput::stateChanged` (the main notification that the percussion panel uses to update) was not being triggered on undo/redo. To my eye, this seems incorrect as `NotationInteraction::undo` does eventually lead to a `Score::setInputState` call (inside `UndoMacro::undo`).

The second part of this commit (the changes the `finishEditing`) are mostly academic. The idea is to make `PercussionPanelPadListModel::drumset` const so that the drumset can only be modified through the sanctioned setter.