### PR TITLE
Fix detection of Bluetooth MIDI devices

### DIFF
--- a/src/framework/midi/internal/platform/lin/alsamidiinport.cpp
+++ b/src/framework/midi/internal/platform/lin/alsamidiinport.cpp
@@ -77,7 +77,7 @@ MidiDeviceList AlsaMidiInPort::availableDevices() const
 
     int streams = SND_SEQ_OPEN_INPUT;
     const unsigned int cap = SND_SEQ_PORT_CAP_SUBS_READ | SND_SEQ_PORT_CAP_READ;
-    const unsigned int type_hw = SND_SEQ_PORT_TYPE_PORT | SND_SEQ_PORT_TYPE_HARDWARE;
+    const unsigned int type_hw = SND_SEQ_PORT_TYPE_HARDWARE;
     const unsigned int type_sw = SND_SEQ_PORT_TYPE_PORT | SND_SEQ_PORT_TYPE_SOFTWARE;
 
     MidiDeviceList ret;

--- a/src/framework/midi/internal/platform/lin/alsamidioutport.cpp
+++ b/src/framework/midi/internal/platform/lin/alsamidioutport.cpp
@@ -76,7 +76,7 @@ std::vector<MidiDevice> AlsaMidiOutPort::availableDevices() const
 
     int streams = SND_SEQ_OPEN_OUTPUT;
     const unsigned int cap = SND_SEQ_PORT_CAP_SUBS_WRITE | SND_SEQ_PORT_CAP_WRITE;
-    const unsigned int type_hw = SND_SEQ_PORT_TYPE_PORT | SND_SEQ_PORT_TYPE_HARDWARE;
+    const unsigned int type_hw = SND_SEQ_PORT_TYPE_HARDWARE;
     const unsigned int type_sw = SND_SEQ_PORT_TYPE_PORT | SND_SEQ_PORT_TYPE_SOFTWARE;
 
     std::vector<MidiDevice> ret;


### PR DESCRIPTION
This relaxes constraints on MIDI hardware, added in edd6bb10033864c107d84ea085495c995a6e8bc4

My Bluetooth MIDI device has type 0x10002, ie
SND_SEQ_PORT_TYPE_MIDI_GENERIC | SND_SEQ_PORT_TYPE_HARDWARE, which doesn't contain the SND_SEQ_PORT_TYPE_PORT flag.

Resolves: #19747