### PR TITLE
New percussion mouse input interaction & popup

### DIFF
--- a/src/engraving/dom/engravingobject.h
+++ b/src/engraving/dom/engravingobject.h
@@ -190,6 +190,7 @@ class VoltaSegment;
 class WhammyBar;
 class WhammyBarSegment;
 class FretCircle;
+class ShadowNote;
 
 class LinkedObjects;
 
@@ -456,6 +457,7 @@ public:
     CONVERT(StringTunings, STRING_TUNINGS)
     CONVERT(TimeTickAnchor, TIME_TICK_ANCHOR)
     CONVERT(Parenthesis, PARENTHESIS)
+    CONVERT(ShadowNote, SHADOW_NOTE)
 #undef CONVERT
 
     virtual bool isEngravingItem() const { return false; }   // overridden in element.h
@@ -871,5 +873,6 @@ CONVERT(PartialTie)
 CONVERT(PartialLyricsLine)
 CONVERT(PartialLyricsLineSegment)
 CONVERT(Parenthesis)
+CONVERT(ShadowNote)
 #undef CONVERT
 }

--- a/src/engraving/dom/noteentry.cpp
+++ b/src/engraving/dom/noteentry.cpp
@@ -461,12 +461,12 @@ Ret Score::putNote(const Position& p, bool replace)
 
     expandVoice();
 
-    ChordRest* cr = m_is.cr();
-
     // If there's an overlapping ChordRest at the current input position, shorten it...
-    if (!cr) {
+    if (!m_is.cr()) {
         handleOverlappingChordRest(m_is);
     }
+
+    ChordRest* cr = m_is.cr();
 
     auto checkTied = [&]() {
         if (!cr || !cr->isChord()) {

--- a/src/engraving/dom/noteentry.cpp
+++ b/src/engraving/dom/noteentry.cpp
@@ -80,7 +80,17 @@ NoteVal Score::noteValForPosition(Position pos, AccidentalType at, bool& error)
             break;
         }
         const Drumset* ds = instr->drumset();
-        nval.pitch        = m_is.drumNote();
+        nval.pitch = m_is.drumNote();
+        if (nval.pitch < 0 || !ds->isValid(nval.pitch) || ds->line(nval.pitch) != line) {
+            // Drum note from input state is not valid - fall back to the first valid pitch for this line...
+            for (int pitch = 0; pitch < mu::engraving::DRUM_INSTRUMENTS; ++pitch) {
+                if (!ds->isValid(pitch) || ds->line(pitch) != line) {
+                    continue;
+                }
+                nval.pitch = pitch;
+                break;
+            }
+        }
         if (nval.pitch < 0) {
             error = true;
             return nval;
@@ -447,6 +457,7 @@ Ret Score::putNote(const Position& p, bool replace)
 
         if (ds) {
             stemDirection = ds->stemDirection(nval.pitch);
+            m_is.setVoice(ds->voice(nval.pitch));
         }
         break;
     }

--- a/src/engraving/dom/shadownote.h
+++ b/src/engraving/dom/shadownote.h
@@ -73,6 +73,7 @@ public:
     SymId flagSym() const;
     AccidentalType accidentalType() const;
     const std::set<SymId>& articulationIds() const;
+
     double segmentSkylineBottomY() const;
     double segmentSkylineTopY() const;
 

--- a/src/framework/uicomponents/qml/Muse/UiComponents/StyledPopupView.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/StyledPopupView.qml
@@ -44,6 +44,8 @@ PopupView {
     property alias closeOnEscape: content.closeOnEscape
     property alias navigationSection: content.navigationSection
 
+    property alias useDropShadow: content.useDropShadow
+
     contentWidth: 240
     contentHeight: content.contentBodyHeight
 

--- a/src/framework/uicomponents/qml/Muse/UiComponents/internal/PopupContent.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/internal/PopupContent.qml
@@ -43,6 +43,7 @@ FocusScope {
     property int arrowX: 0
     property bool opensUpward: false
     property bool isOpened: false
+    property bool useDropShadow: true
 
     property bool animationEnabled: false
 
@@ -95,6 +96,8 @@ FocusScope {
         ItemWithDropShadow {
             anchors.fill: parent
             shadow.radius: root.padding
+
+            shadow.visible: root.useDropShadow
 
             Rectangle {
                 id: contentBackground

--- a/src/framework/uicomponents/view/popupview.cpp
+++ b/src/framework/uicomponents/view/popupview.cpp
@@ -136,6 +136,7 @@ void PopupView::init()
     m_window->init(engine, isDialog(), frameless());
     m_window->setOnHidden([this]() { onHidden(); });
     m_window->setContent(m_component, m_contentItem);
+    m_window->setTakeFocusOnClick(m_takeFocusOnClick);
 
     // TODO: Can't use new `connect` syntax because the IPopupWindow::aboutToClose
     // has a parameter of type QQuickCloseEvent, which is not public, so we
@@ -352,6 +353,11 @@ PopupView::Placement PopupView::placement() const
 bool PopupView::activateParentOnClose() const
 {
     return m_activateParentOnClose;
+}
+
+bool PopupView::takeFocusOnClick() const
+{
+    return m_takeFocusOnClick;
 }
 
 muse::ui::INavigationControl* PopupView::navigationParentControl() const
@@ -674,6 +680,15 @@ void PopupView::setActivateParentOnClose(bool activateParentOnClose)
 
     m_activateParentOnClose = activateParentOnClose;
     emit activateParentOnCloseChanged(m_activateParentOnClose);
+}
+
+void PopupView::setTakeFocusOnClick(bool takeFocusOnClick)
+{
+    if (m_takeFocusOnClick == takeFocusOnClick) {
+        return;
+    }
+    m_takeFocusOnClick = takeFocusOnClick;
+    emit takeFocusOnClickChanged(takeFocusOnClick);
 }
 
 QVariantMap PopupView::ret() const

--- a/src/framework/uicomponents/view/popupview.h
+++ b/src/framework/uicomponents/view/popupview.h
@@ -81,6 +81,8 @@ class PopupView : public QObject, public QQmlParserStatus, public Injectable, pu
     Q_PROPERTY(
         bool activateParentOnClose READ activateParentOnClose WRITE setActivateParentOnClose NOTIFY activateParentOnCloseChanged)
 
+    Q_PROPERTY(bool takeFocusOnClick READ takeFocusOnClick WRITE setTakeFocusOnClick NOTIFY takeFocusOnClickChanged)
+
     //! NOTE Used for dialogs, but be here so that dialogs and just popups have one api
     Q_PROPERTY(QString title READ title WRITE setTitle NOTIFY titleChanged)
     Q_PROPERTY(QString objectId READ objectId WRITE setObjectId NOTIFY objectIdChanged)
@@ -151,6 +153,7 @@ public:
     Placement placement() const;
 
     bool activateParentOnClose() const;
+    bool takeFocusOnClick() const;
 
     ui::INavigationControl* navigationParentControl() const;
 
@@ -201,6 +204,7 @@ public slots:
     void setAnchorItem(QQuickItem* anchorItem);
 
     void setActivateParentOnClose(bool activateParentOnClose);
+    void setTakeFocusOnClick(bool takeFocusOnClick);
 
 signals:
     void parentItemChanged();
@@ -234,6 +238,7 @@ signals:
     void anchorItemChanged(QQuickItem* anchorItem);
 
     void activateParentOnCloseChanged(bool activateParentOnClose);
+    void takeFocusOnClickChanged(bool takeFocusOnClick);
 
     void isContentReadyChanged();
 
@@ -295,6 +300,7 @@ protected:
     Placement m_placement = { Placement::Default };
 
     bool m_activateParentOnClose = true;
+    bool m_takeFocusOnClick = true;
     ui::INavigationControl* m_navigationParentControl = nullptr;
     QString m_objectId;
     QString m_title;

--- a/src/framework/uicomponents/view/popupwindow/ipopupwindow.h
+++ b/src/framework/uicomponents/view/popupwindow/ipopupwindow.h
@@ -65,6 +65,7 @@ public:
     virtual void forceActiveFocus() = 0;
 
     virtual void setOnHidden(const std::function<void()>& callback) = 0;
+    virtual void setTakeFocusOnClick(bool takeFocusOnClick) = 0;
 
 signals:
     void aboutToClose(QQuickCloseEvent* event);

--- a/src/framework/uicomponents/view/popupwindow/popupwindow_qquickview.cpp
+++ b/src/framework/uicomponents/view/popupwindow/popupwindow_qquickview.cpp
@@ -259,6 +259,11 @@ void PopupWindow_QQuickView::setOnHidden(const std::function<void()>& callback)
     m_onHidden = callback;
 }
 
+void PopupWindow_QQuickView::setTakeFocusOnClick(bool takeFocusOnClick)
+{
+    m_takeFocusOnClick = takeFocusOnClick;
+}
+
 bool PopupWindow_QQuickView::eventFilter(QObject* watched, QEvent* event)
 {
     if (watched == m_view) {
@@ -272,7 +277,7 @@ bool PopupWindow_QQuickView::eventFilter(QObject* watched, QEvent* event)
             m_view->rootObject()->forceActiveFocus();
         }
 
-        if (event->type() == QEvent::MouseButtonPress) {
+        if (m_takeFocusOnClick && event->type() == QEvent::MouseButtonPress) {
             forceActiveFocus();
         }
     }

--- a/src/framework/uicomponents/view/popupwindow/popupwindow_qquickview.h
+++ b/src/framework/uicomponents/view/popupwindow/popupwindow_qquickview.h
@@ -72,6 +72,7 @@ public:
     void forceActiveFocus() override;
 
     void setOnHidden(const std::function<void()>& callback) override;
+    void setTakeFocusOnClick(bool takeFocusOnClick) override;
 
 private:
     bool eventFilter(QObject* watched, QEvent* event) override;
@@ -82,6 +83,7 @@ private:
     bool m_resizable = false;
     std::function<void()> m_onHidden;
     bool m_activeFocusOnParentOnClose = false;
+    bool m_takeFocusOnClick = true;
 
     QWindow* m_parentWindow = nullptr;
 };

--- a/src/notation/CMakeLists.txt
+++ b/src/notation/CMakeLists.txt
@@ -176,8 +176,12 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/view/internal/dynamicpopupmodel.h
     ${CMAKE_CURRENT_LIST_DIR}/view/internal/partialtiepopupmodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/internal/partialtiepopupmodel.h
+
     ${CMAKE_CURRENT_LIST_DIR}/view/internal/shadownotepopupmodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/internal/shadownotepopupmodel.h
+    ${CMAKE_CURRENT_LIST_DIR}/view/internal/percussionnotepopupcontentmodel.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/view/internal/percussionnotepopupcontentmodel.h
+
     ${CMAKE_CURRENT_LIST_DIR}/view/selectionfiltermodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/selectionfiltermodel.h
     ${CMAKE_CURRENT_LIST_DIR}/view/editgridsizedialogmodel.cpp

--- a/src/notation/CMakeLists.txt
+++ b/src/notation/CMakeLists.txt
@@ -176,6 +176,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/view/internal/dynamicpopupmodel.h
     ${CMAKE_CURRENT_LIST_DIR}/view/internal/partialtiepopupmodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/internal/partialtiepopupmodel.h
+    ${CMAKE_CURRENT_LIST_DIR}/view/internal/shadownotepopupmodel.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/view/internal/shadownotepopupmodel.h
     ${CMAKE_CURRENT_LIST_DIR}/view/selectionfiltermodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/selectionfiltermodel.h
     ${CMAKE_CURRENT_LIST_DIR}/view/editgridsizedialogmodel.cpp

--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -42,9 +42,11 @@ public:
     virtual INotationNoteInputPtr noteInput() const = 0;
 
     // Shadow note
+    virtual mu::engraving::ShadowNote* shadowNote() const = 0;
     virtual bool showShadowNote(const muse::PointF& pos) = 0;
     virtual void hideShadowNote() = 0;
     virtual muse::RectF shadowNoteRect() const = 0;
+    virtual muse::async::Notification shadowNoteChanged() const = 0;
 
     // Visibility
     virtual void toggleVisible() = 0;

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -358,6 +358,11 @@ INotationNoteInputPtr NotationInteraction::noteInput() const
     return m_noteInput;
 }
 
+mu::engraving::ShadowNote* NotationInteraction::shadowNote() const
+{
+    return score()->shadowNote();
+}
+
 bool NotationInteraction::showShadowNote(const PointF& pos)
 {
     const mu::engraving::InputState& inputState = score()->inputState();
@@ -366,6 +371,7 @@ bool NotationInteraction::showShadowNote(const PointF& pos)
     ShadowNoteParams params;
     if (!score()->getPosition(&params.position, pos, inputState.voice())) {
         shadowNote.setVisible(false);
+        m_shadowNoteChanged.notify();
         return false;
     }
 
@@ -462,6 +468,8 @@ void NotationInteraction::showShadowNote(ShadowNote& shadowNote, ShadowNoteParam
     score()->renderer()->layoutItem(&shadowNote);
 
     shadowNote.setPos(position.pos);
+
+    m_shadowNoteChanged.notify();
 }
 
 void NotationInteraction::hideShadowNote()
@@ -488,6 +496,11 @@ RectF NotationInteraction::shadowNoteRect() const
     rect.adjust(-penWidth, -penWidth, penWidth, penWidth);
 
     return rect;
+}
+
+muse::async::Notification NotationInteraction::shadowNoteChanged() const
+{
+    return m_shadowNoteChanged;
 }
 
 void NotationInteraction::toggleVisible()

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -379,11 +379,13 @@ bool NotationInteraction::showShadowNote(const PointF& pos)
     params.accidentalType = inputState.accidentalType();
     params.articulationIds = inputState.articulationIds();
 
-    showShadowNote(shadowNote, params);
-    return true;
+    const bool show = showShadowNote(shadowNote, params);
+    m_shadowNoteChanged.notify();
+
+    return show;
 }
 
-void NotationInteraction::showShadowNote(ShadowNote& shadowNote, ShadowNoteParams& params)
+bool NotationInteraction::showShadowNote(ShadowNote& shadowNote, ShadowNoteParams& params)
 {
     Position& position = params.position;
 
@@ -412,20 +414,34 @@ void NotationInteraction::showShadowNote(ShadowNote& shadowNote, ShadowNoteParam
 
     mu::engraving::NoteHeadGroup noteheadGroup = mu::engraving::NoteHeadGroup::HEAD_NORMAL;
     mu::engraving::NoteHeadType noteHead = params.duration.headType();
+
     int line = position.line;
+    voice_idx_t voice = 0;
+    int drumNotePitch = -1;
 
     if (instr->useDrumset()) {
-        const mu::engraving::Drumset* ds  = instr->drumset();
-        int pitch = inputState.drumNote();
-        if (pitch >= 0 && ds->isValid(pitch)) {
-            line = ds->line(pitch);
-            noteheadGroup = ds->noteHead(pitch);
-        }
-    }
+        const Drumset* ds = instr->drumset();
 
-    voice_idx_t voice = 0;
-    if (inputState.drumNote() != -1 && inputState.drumset() && inputState.drumset()->isValid(inputState.drumNote())) {
-        voice = inputState.drumset()->voice(inputState.drumNote());
+        const int noteInputPitch = inputState.drumNote();
+
+        if (noteInputPitch > 0 && ds->isValid(noteInputPitch) && ds->line(noteInputPitch) == line) {
+            noteheadGroup = ds->noteHead(noteInputPitch);
+            voice = ds->voice(noteInputPitch);
+            drumNotePitch = noteInputPitch;
+        } else {
+            for (int pitch = 0; pitch < mu::engraving::DRUM_INSTRUMENTS; ++pitch) {
+                if (ds->isValid(pitch) && ds->line(pitch) == line) {
+                    noteheadGroup = ds->noteHead(pitch);
+                    voice = ds->voice(pitch);
+                    drumNotePitch = pitch;
+                    break;
+                }
+            }
+            if (drumNotePitch < 0) {
+                shadowNote.setVisible(false);
+                return false;
+            }
+        }
     } else {
         voice = inputState.voice();
     }
@@ -456,7 +472,7 @@ void NotationInteraction::showShadowNote(ShadowNote& shadowNote, ShadowNoteParam
         delete rest;
     } else {
         if (mu::engraving::NoteHeadGroup::HEAD_CUSTOM == noteheadGroup) {
-            symNotehead = instr->drumset()->noteHeads(inputState.drumNote(), noteHead);
+            symNotehead = instr->drumset()->noteHeads(drumNotePitch, noteHead);
         } else {
             symNotehead = Note::noteHead(0, noteheadGroup, noteHead);
         }
@@ -469,7 +485,7 @@ void NotationInteraction::showShadowNote(ShadowNote& shadowNote, ShadowNoteParam
 
     shadowNote.setPos(position.pos);
 
-    m_shadowNoteChanged.notify();
+    return true;
 }
 
 void NotationInteraction::hideShadowNote()

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -329,7 +329,7 @@ private:
         mu::engraving::Position position;
     };
 
-    void showShadowNote(mu::engraving::ShadowNote& note, ShadowNoteParams& params);
+    bool showShadowNote(mu::engraving::ShadowNote& note, ShadowNoteParams& params);
 
     bool needStartEditGrip(QKeyEvent* event) const;
     bool handleKeyPress(QKeyEvent* event);

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -63,9 +63,11 @@ public:
     INotationNoteInputPtr noteInput() const override;
 
     // Shadow note
+    mu::engraving::ShadowNote* shadowNote() const override;
     bool showShadowNote(const muse::PointF& pos) override;
     void hideShadowNote() override;
     muse::RectF shadowNoteRect() const override;
+    muse::async::Notification shadowNoteChanged() const override;
 
     // Visibility
     void toggleVisible() override;
@@ -480,6 +482,8 @@ private:
     INotationUndoStackPtr m_undoStack;
 
     INotationNoteInputPtr m_noteInput = nullptr;
+
+    muse::async::Notification m_shadowNoteChanged;
 
     std::shared_ptr<NotationSelection> m_selection = nullptr;
     muse::async::Notification m_selectionChanged;

--- a/src/notation/notationmodule.cpp
+++ b/src/notation/notationmodule.cpp
@@ -77,7 +77,9 @@
 #include "view/internal/stringtuningssettingsmodel.h"
 #include "view/internal/dynamicpopupmodel.h"
 #include "view/internal/partialtiepopupmodel.h"
+
 #include "view/internal/shadownotepopupmodel.h"
+#include "view/internal/percussionnotepopupcontentmodel.h"
 
 #include "view/percussionpanel/percussionpanelmodel.h"
 
@@ -201,6 +203,7 @@ void NotationModule::registerUiTypes()
 
     qmlRegisterUncreatableType<ShadowNotePopupContent>("MuseScore.NotationScene", 1, 0, "ShadowNotePopupContent", "Cannot create");
     qmlRegisterType<ShadowNotePopupModel>("MuseScore.NotationScene", 1, 0, "ShadowNotePopupModel");
+    qmlRegisterType<PercussionNotePopupContentModel>("MuseScore.NotationScene", 1, 0, "PercussionNotePopupContentModel");
 
     qmlRegisterType<PaintedEngravingItem>("MuseScore.NotationScene", 1, 0, "PaintedEngravingItem");
 

--- a/src/notation/notationmodule.cpp
+++ b/src/notation/notationmodule.cpp
@@ -77,6 +77,7 @@
 #include "view/internal/stringtuningssettingsmodel.h"
 #include "view/internal/dynamicpopupmodel.h"
 #include "view/internal/partialtiepopupmodel.h"
+#include "view/internal/shadownotepopupmodel.h"
 
 #include "view/percussionpanel/percussionpanelmodel.h"
 
@@ -197,6 +198,9 @@ void NotationModule::registerUiTypes()
     qmlRegisterType<StringTuningsSettingsModel>("MuseScore.NotationScene", 1, 0, "StringTuningsSettingsModel");
     qmlRegisterType<DynamicPopupModel>("MuseScore.NotationScene", 1, 0, "DynamicPopupModel");
     qmlRegisterType<PartialTiePopupModel>("MuseScore.NotationScene", 1, 0, "PartialTiePopupModel");
+
+    qmlRegisterUncreatableType<ShadowNotePopupContent>("MuseScore.NotationScene", 1, 0, "ShadowNotePopupContent", "Cannot create");
+    qmlRegisterType<ShadowNotePopupModel>("MuseScore.NotationScene", 1, 0, "ShadowNotePopupModel");
 
     qmlRegisterType<PaintedEngravingItem>("MuseScore.NotationScene", 1, 0, "PaintedEngravingItem");
 

--- a/src/notation/notationscene.qrc
+++ b/src/notation/notationscene.qrc
@@ -97,5 +97,6 @@
         <file>qml/MuseScore/NotationScene/internal/EditStyle/courtesyImages/other-jump-2.png</file>
         <file>qml/MuseScore/NotationScene/internal/EditStyle/courtesyImages/other-jump-1.png</file>
         <file>qml/MuseScore/NotationScene/internal/ShadowNotePopup.qml</file>
+        <file>qml/MuseScore/NotationScene/internal/PercussionNotePopupContent.qml</file>
     </qresource>
 </RCC>

--- a/src/notation/notationscene.qrc
+++ b/src/notation/notationscene.qrc
@@ -96,5 +96,6 @@
         <file>qml/MuseScore/NotationScene/internal/EditStyle/courtesyImages/other-jump-3.png</file>
         <file>qml/MuseScore/NotationScene/internal/EditStyle/courtesyImages/other-jump-2.png</file>
         <file>qml/MuseScore/NotationScene/internal/EditStyle/courtesyImages/other-jump-1.png</file>
+        <file>qml/MuseScore/NotationScene/internal/ShadowNotePopup.qml</file>
     </qresource>
 </RCC>

--- a/src/notation/qml/MuseScore/NotationScene/NotationView.qml
+++ b/src/notation/qml/MuseScore/NotationScene/NotationView.qml
@@ -186,8 +186,11 @@ FocusScope {
                         notationViewNavigationSection: navSec
                         navigationOrderStart: notationView.navigationPanel.order + 1
 
-                        onOpened: paintView.onElementPopupIsOpenChanged(true)
-                        onClosed: paintView.onElementPopupIsOpenChanged(false)
+                        onOpened: function(popupType) {
+                            paintView.onElementPopupIsOpenChanged(popupType)
+                        }
+
+                        onClosed: paintView.onElementPopupIsOpenChanged()
                     }
                 }
 

--- a/src/notation/qml/MuseScore/NotationScene/internal/ElementPopupLoader.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/ElementPopupLoader.qml
@@ -41,7 +41,7 @@ Item {
                                         ? loader.item.navigationOrderEnd
                                         : navigationOrderStart
 
-    signal opened()
+    signal opened(var popupType)
     signal closed()
 
     QtObject {
@@ -55,6 +55,7 @@ Item {
             case Notation.TYPE_SOUND_FLAG: return soundFlagComp
             case Notation.TYPE_DYNAMIC: return dynamicComp
             case Notation.TYPE_PARTIAL_TIE: return partialTieComp
+            case Notation.TYPE_SHADOW_NOTE: return shadowNoteComp
             }
 
             return null
@@ -70,12 +71,10 @@ Item {
         }
     }
 
-    function show(elementType, elementRect) {
+    function show(popupType, elementRect) {
         close()
 
-        var component = prv.componentByType(elementType)
-
-        var popup = loader.loadPopup(component, elementRect)
+        var popup = loader.loadPopup(popupType, elementRect)
         popup.open()
     }
 
@@ -91,8 +90,8 @@ Item {
         anchors.fill: parent
         active: false
 
-        function loadPopup(comp, elementRect) {
-            loader.sourceComponent = comp
+        function loadPopup(popupType, elementRect) {
+            loader.sourceComponent = prv.componentByType(popupType)
             loader.active = true
 
             const popup = loader.item
@@ -101,7 +100,7 @@ Item {
             popup.parent = container
 
             popup.opened.connect(function() {
-                container.opened()
+                container.opened(popupType)
             })
 
             popup.closed.connect(function() {
@@ -165,6 +164,12 @@ Item {
     Component {
         id: partialTieComp
         PartialTiePopup {
+        }
+    }
+
+    Component {
+        id: shadowNoteComp
+        ShadowNotePopup {
         }
     }
 }

--- a/src/notation/qml/MuseScore/NotationScene/internal/PercussionNotePopupContent.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/PercussionNotePopupContent.qml
@@ -79,10 +79,10 @@ Row {
         id: labelRow
 
         height: root.height
-        spacing: 4
+        spacing: 6
 
-        rightPadding: 4
-        leftPadding: 4
+        leftPadding: 6
+        rightPadding: 6
 
         StyledTextLabel {
             id: percussionNoteName

--- a/src/notation/qml/MuseScore/NotationScene/internal/PercussionNotePopupContent.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/PercussionNotePopupContent.qml
@@ -1,0 +1,109 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2025 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import QtQuick 2.15
+
+import Muse.Ui 1.0
+import Muse.UiComponents 1.0
+import MuseScore.NotationScene 1.0
+
+Row {
+    id: root
+
+    height: 24
+    spacing: 2
+
+    PercussionNotePopupContentModel {
+        id: contentModel
+
+        Component.onCompleted: {
+            contentModel.init()
+        }
+    }
+
+    Row {
+        id: buttonRow
+
+        visible: contentModel.shouldShowButtons
+
+        height: root.height
+        spacing: 2
+
+        FlatButton {
+            id: prevButton
+
+            height: buttonRow.height
+            width: 16
+
+            icon: IconCode.CHEVRON_LEFT
+
+            onClicked: {
+                contentModel.prevDrumNote()
+            }
+        }
+
+        FlatButton {
+            id: nextButton
+
+            height: buttonRow.height
+            width: 16
+
+            icon: IconCode.CHEVRON_RIGHT
+
+            onClicked: {
+                contentModel.nextDrumNote()
+            }
+        }
+    }
+
+    Row {
+        id: labelRow
+
+        height: root.height
+        spacing: 4
+
+        rightPadding: 4
+        leftPadding: 4
+
+        StyledTextLabel {
+            id: percussionNoteName
+
+            height: labelRow.height
+            verticalAlignment: Text.AlignVCenter
+
+            text: contentModel.percussionNoteName
+            font: ui.theme.bodyBoldFont
+        }
+
+        StyledTextLabel {
+            id: keyboardShortcut
+
+            height: labelRow.height
+            verticalAlignment: Text.AlignVCenter
+
+            text: contentModel.keyboardShortcut
+            font: ui.theme.bodyFont
+            opacity: 0.8
+        }
+    }
+}
+

--- a/src/notation/qml/MuseScore/NotationScene/internal/ShadowNotePopup.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/ShadowNotePopup.qml
@@ -38,6 +38,7 @@ StyledPopupView {
 
     showArrow: false
     openPolicies: PopupView.NoActivateFocus
+    takeFocusOnClick: false
 
     padding: 0 // The popup will "steal" mouse events if the padding overlaps with the shadow note area
     margins: 0

--- a/src/notation/qml/MuseScore/NotationScene/internal/ShadowNotePopup.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/ShadowNotePopup.qml
@@ -36,6 +36,7 @@ StyledPopupView {
     contentWidth: contentLoader.width
     contentHeight: contentLoader.height
 
+    useDropShadow: false
     showArrow: false
     openPolicies: PopupView.NoActivateFocus
     takeFocusOnClick: false

--- a/src/notation/qml/MuseScore/NotationScene/internal/ShadowNotePopup.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/ShadowNotePopup.qml
@@ -41,7 +41,7 @@ StyledPopupView {
     takeFocusOnClick: false
 
     padding: 0 // The popup will "steal" mouse events if the padding overlaps with the shadow note area
-    margins: 0
+    margins: 3
 
     signal elementRectChanged(var elementRect)
 
@@ -75,11 +75,7 @@ StyledPopupView {
 
         Component {
             id: percussionContent
-
-            Rectangle { // Placeholder...
-                color: "red"
-                width: 200
-                height: 50
+            PercussionNotePopupContent {
             }
         }
     }

--- a/src/notation/qml/MuseScore/NotationScene/internal/ShadowNotePopup.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/ShadowNotePopup.qml
@@ -1,0 +1,85 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2025 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import QtQuick 2.15
+
+import Muse.Ui 1.0
+import Muse.UiComponents 1.0
+import MuseScore.NotationScene 1.0
+
+StyledPopupView {
+    id: root
+
+    property NavigationSection notationViewNavigationSection: null
+    property int navigationOrderStart: 0
+    property int navigationOrderEnd: 0
+
+    contentWidth: contentLoader.width
+    contentHeight: contentLoader.height
+
+    showArrow: false
+    openPolicies: PopupView.NoActivateFocus
+
+    padding: 0 // The popup will "steal" mouse events if the padding overlaps with the shadow note area
+    margins: 0
+
+    signal elementRectChanged(var elementRect)
+
+    function updatePosition() {
+        root.x = root.parent.width * 1.5
+        root.y = (root.parent.height / 2) - (root.height / 2)
+    }
+
+    Loader {
+        id: contentLoader
+
+        function contentByType(type) {
+            switch (type) {
+            case ShadowNotePopupContent.PERCUSSION_CONTENT: return percussionContent
+            }
+            return null
+        }
+
+        ShadowNotePopupModel {
+            id: shadowNotePopupModel
+
+            onItemRectChanged: function(rect) {
+                root.elementRectChanged(rect)
+            }
+        }
+
+        Component.onCompleted: {
+            shadowNotePopupModel.init()
+            contentLoader.sourceComponent = contentLoader.contentByType(shadowNotePopupModel.currentPopupType)
+        }
+
+        Component {
+            id: percussionContent
+
+            Rectangle { // Placeholder...
+                color: "red"
+                width: 200
+                height: 50
+            }
+        }
+    }
+}

--- a/src/notation/tests/mocks/controlledviewmock.h
+++ b/src/notation/tests/mocks/controlledviewmock.h
@@ -56,8 +56,10 @@ public:
     MOCK_METHOD(void, hideContextMenu, (), (override));
 
     MOCK_METHOD(void, showElementPopup, (const ElementType&, const muse::RectF&), (override));
-    MOCK_METHOD(void, hideElementPopup, (), (override));
+    MOCK_METHOD(void, hideElementPopup, (const ElementType& elementType), (override));
     MOCK_METHOD(void, toggleElementPopup, (const ElementType&, const muse::RectF&), (override));
+
+    MOCK_METHOD(bool, elementPopupIsOpen, (const ElementType&), (const, override));
 
     MOCK_METHOD(INotationInteractionPtr, notationInteraction, (), (const, override));
     MOCK_METHOD(INotationPlaybackPtr, notationPlayback, (), (const, override));

--- a/src/notation/tests/mocks/notationinteractionmock.h
+++ b/src/notation/tests/mocks/notationinteractionmock.h
@@ -31,9 +31,11 @@ class NotationInteractionMock : public INotationInteraction
 public:
     MOCK_METHOD(INotationNoteInputPtr, noteInput, (), (const, override));
 
+    MOCK_METHOD(mu::engraving::ShadowNote*, shadowNote, (), (const, override));
     MOCK_METHOD(bool, showShadowNote, (const muse::PointF&), (override));
     MOCK_METHOD(void, hideShadowNote, (), (override));
     MOCK_METHOD(muse::RectF, shadowNoteRect, (), (const, override));
+    MOCK_METHOD(muse::async::Notification, shadowNoteChanged, (), (const, override));
 
     MOCK_METHOD(void, toggleVisible, (), (override));
 

--- a/src/notation/view/abstractelementpopupmodel.cpp
+++ b/src/notation/view/abstractelementpopupmodel.cpp
@@ -22,6 +22,7 @@
 
 #include "abstractelementpopupmodel.h"
 #include "internal/partialtiepopupmodel.h"
+#include "internal/shadownotepopupmodel.h"
 #include "log.h"
 
 using namespace mu::notation;
@@ -33,7 +34,8 @@ static const QMap<mu::engraving::ElementType, PopupModelType> ELEMENT_POPUP_TYPE
     { mu::engraving::ElementType::SOUND_FLAG, PopupModelType::TYPE_SOUND_FLAG },
     { mu::engraving::ElementType::DYNAMIC, PopupModelType::TYPE_DYNAMIC },
     { mu::engraving::ElementType::TIE_SEGMENT, PopupModelType::TYPE_PARTIAL_TIE },
-    { mu::engraving::ElementType::PARTIAL_TIE_SEGMENT, PopupModelType::TYPE_PARTIAL_TIE }
+    { mu::engraving::ElementType::PARTIAL_TIE_SEGMENT, PopupModelType::TYPE_PARTIAL_TIE },
+    { mu::engraving::ElementType::SHADOW_NOTE, PopupModelType::TYPE_SHADOW_NOTE }
 };
 
 static const QHash<PopupModelType, mu::engraving::ElementTypeSet> POPUP_DEPENDENT_ELEMENT_TYPES = {
@@ -74,6 +76,8 @@ bool AbstractElementPopupModel::supportsPopup(const EngravingItem* element)
     switch (modelType) {
     case PopupModelType::TYPE_PARTIAL_TIE:
         return PartialTiePopupModel::canOpen(element);
+    case PopupModelType::TYPE_SHADOW_NOTE:
+        return ShadowNotePopupModel::canOpen(element);
     default:
         return true;
     }
@@ -232,7 +236,7 @@ const mu::engraving::ElementTypeSet& AbstractElementPopupModel::dependentElement
 
 void AbstractElementPopupModel::updateItemRect()
 {
-    QRect rect = m_item ? fromLogical(m_item->canvasBoundingRect()).toQRect() : QRect();
+    const QRect rect = m_item ? fromLogical(m_item->canvasBoundingRect()).toQRect() : QRect();
 
     if (m_itemRect != rect) {
         m_itemRect = rect;

--- a/src/notation/view/abstractelementpopupmodel.h
+++ b/src/notation/view/abstractelementpopupmodel.h
@@ -51,7 +51,8 @@ public:
         TYPE_STRING_TUNINGS,
         TYPE_SOUND_FLAG,
         TYPE_DYNAMIC,
-        TYPE_PARTIAL_TIE
+        TYPE_PARTIAL_TIE,
+        TYPE_SHADOW_NOTE
     };
     Q_ENUM(PopupModelType)
 
@@ -70,6 +71,8 @@ signals:
     void itemRectChanged(QRect rect);
 
 protected:
+    virtual void updateItemRect();
+
     muse::PointF fromLogical(muse::PointF point) const;
     muse::RectF fromLogical(muse::RectF rect) const;
 
@@ -86,6 +89,7 @@ protected:
     void changeItemProperty(mu::engraving::Pid id, const PropertyValue& value, engraving::PropertyFlags flags);
 
     EngravingItem* m_item = nullptr;
+    QRect m_itemRect;
 
 private:
     INotationSelectionPtr selection() const;
@@ -93,10 +97,7 @@ private:
     engraving::ElementType elementType() const;
     const engraving::ElementTypeSet& dependentElementTypes() const;
 
-    void updateItemRect();
-
     PopupModelType m_modelType = PopupModelType::TYPE_UNDEFINED;
-    QRect m_itemRect;
 };
 
 using PopupModelType = AbstractElementPopupModel::PopupModelType;

--- a/src/notation/view/abstractnotationpaintview.h
+++ b/src/notation/view/abstractnotationpaintview.h
@@ -92,7 +92,7 @@ public:
     Q_INVOKABLE void forceFocusIn();
 
     Q_INVOKABLE void onContextMenuIsOpenChanged(bool open);
-    Q_INVOKABLE void onElementPopupIsOpenChanged(bool open);
+    Q_INVOKABLE void onElementPopupIsOpenChanged(const PopupModelType& popupType = PopupModelType::TYPE_UNDEFINED);
 
     Q_INVOKABLE void setPlaybackCursorItem(QQuickItem* cursor);
 
@@ -123,8 +123,10 @@ public:
     void hideContextMenu() override;
 
     void showElementPopup(const ElementType& elementType, const muse::RectF& elementRect) override;
-    void hideElementPopup() override;
+    void hideElementPopup(const ElementType& elementType = ElementType::INVALID) override;
     void toggleElementPopup(const ElementType& elementType, const muse::RectF& elementRect) override;
+
+    bool elementPopupIsOpen(const ElementType& elementType) const override;
 
     INotationInteractionPtr notationInteraction() const override;
     INotationPlaybackPtr notationPlayback() const override;
@@ -283,7 +285,7 @@ private:
     bool m_autoScrollEnabled = true;
     QTimer m_enableAutoScrollTimer;
 
-    bool m_isPopupOpen = false;
+    PopupModelType m_currentElementPopupType = PopupModelType::TYPE_UNDEFINED;
     bool m_isContextMenuOpen = false;
 
     muse::RectF m_shadowNoteRect;

--- a/src/notation/view/internal/percussionnotepopupcontentmodel.cpp
+++ b/src/notation/view/internal/percussionnotepopupcontentmodel.cpp
@@ -1,0 +1,207 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2025 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "percussionnotepopupcontentmodel.h"
+
+#include "engraving/dom/drumset.h"
+#include "engraving/dom/shadownote.h"
+
+using namespace mu::notation;
+
+PercussionNotePopupContentModel::PercussionNotePopupContentModel(QObject* parent)
+    : QObject{parent}
+{
+}
+
+void PercussionNotePopupContentModel::init()
+{
+    interaction()->shadowNoteChanged().onNotify(this, [this]() {
+        emit shouldShowButtonsChanged();
+        emit percussionNoteNameChanged();
+        emit keyboardShortcutChanged();
+    });
+}
+
+void PercussionNotePopupContentModel::prevDrumNote()
+{
+    const Drumset* ds = currentDrumset();
+    const mu::engraving::ShadowNote* shadowNote = currentShadowNote();
+    IF_ASSERT_FAILED(ds && shadowNote) {
+        return;
+    }
+
+    const int currNote = currentDrumPitch();
+    const int currLine = ds->line(currNote);
+
+    int pitch = currNote - 1;
+    while (pitch != currNote) {
+        if (pitch < 0) {
+            // Wrap around
+            pitch = mu::engraving::DRUM_INSTRUMENTS - 1;
+        }
+        if (ds->isValid(pitch) && ds->line(pitch) == currLine) {
+            noteInput()->setDrumNote(pitch);
+            interaction()->showShadowNote(shadowNote->pos());
+            emit percussionNoteNameChanged();
+            emit keyboardShortcutChanged();
+            return;
+        }
+        --pitch;
+    }
+
+    UNREACHABLE;
+}
+
+void PercussionNotePopupContentModel::nextDrumNote()
+{
+    const Drumset* ds = currentDrumset();
+    const mu::engraving::ShadowNote* shadowNote = currentShadowNote();
+    IF_ASSERT_FAILED(ds && shadowNote) {
+        return;
+    }
+
+    const int currNote = currentDrumPitch();
+    const int currLine = ds->line(currNote);
+
+    int pitch = currNote + 1;
+    while (pitch != currNote) {
+        if (pitch == mu::engraving::DRUM_INSTRUMENTS) {
+            // Wrap around
+            pitch = 0;
+        }
+        if (ds->isValid(pitch) && ds->line(pitch) == currLine) {
+            noteInput()->setDrumNote(pitch);
+            interaction()->showShadowNote(shadowNote->pos());
+            emit percussionNoteNameChanged();
+            emit keyboardShortcutChanged();
+            return;
+        }
+        ++pitch;
+    }
+
+    UNREACHABLE;
+}
+
+bool PercussionNotePopupContentModel::shouldShowButtons() const
+{
+    const Drumset* ds = currentDrumset();
+    const int drumPitch = currentDrumPitch();
+    if (!ds || drumPitch < 0) {
+        return false;
+    }
+
+    const int line = ds->line(drumPitch);
+
+    int drumsOnSameLine = 0;
+    for (int pitch = 0; pitch < mu::engraving::DRUM_INSTRUMENTS; ++pitch) {
+        if (ds->isValid(pitch) && ds->line(pitch) == line) {
+            ++drumsOnSameLine;
+        }
+        if (drumsOnSameLine > 1) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+QString PercussionNotePopupContentModel::percussionNoteName() const
+{
+    const Drumset* ds = currentDrumset();
+    const int drumPitch = currentDrumPitch();
+    if (!ds || drumPitch < 0) {
+        return QString();
+    }
+
+    return ds->name(drumPitch);
+}
+
+QString PercussionNotePopupContentModel::keyboardShortcut() const
+{
+    const Drumset* ds = currentDrumset();
+    const int drumPitch = currentDrumPitch();
+    if (!ds || drumPitch < 0) {
+        return QString();
+    }
+
+    const muse::String shortcut = ds->shortcut(drumPitch);
+    return !shortcut.isEmpty() ? QString("(%1)").arg(shortcut) : QString();
+}
+
+INotationInteractionPtr PercussionNotePopupContentModel::interaction() const
+{
+    INotationPtr notation = globalContext()->currentNotation();
+    return notation ? notation->interaction() : nullptr;
+}
+
+INotationNoteInputPtr PercussionNotePopupContentModel::noteInput() const
+{
+    return interaction() ? interaction()->noteInput() : nullptr;
+}
+
+const mu::engraving::ShadowNote* PercussionNotePopupContentModel::currentShadowNote() const
+{
+    return interaction() ? interaction()->shadowNote() : nullptr;
+}
+
+const Drumset* PercussionNotePopupContentModel::currentDrumset() const
+{
+    const mu::engraving::ShadowNote* shadowNote = currentShadowNote();
+    if (!shadowNote) {
+        return nullptr;
+    }
+
+    const Part* part = shadowNote->part();
+    if (!part) {
+        return nullptr;
+    }
+
+    const Instrument* inst = part->instrument(shadowNote->tick());
+    return inst ? inst->drumset() : nullptr;
+}
+
+int PercussionNotePopupContentModel::currentDrumPitch() const
+{
+    const Drumset* ds = currentDrumset();
+    const mu::engraving::ShadowNote* shadowNote = currentShadowNote();
+    if (!noteInput() || !ds || !shadowNote) {
+        return -1;
+    }
+
+    const int shadowNoteLine = shadowNote->lineIndex();
+
+    //  First check whether a drum note has been specified in the input state, and whether it's valid...
+    const int noteInputPitch = noteInput()->state().drumNote();
+    if (noteInputPitch > 0 && ds->isValid(noteInputPitch) && ds->line(noteInputPitch) == shadowNoteLine) {
+        return noteInputPitch;
+    }
+
+    // Otherwise just return the first pitch that matches the line that the shadowNote is currently on...
+    for (int pitch = 0; pitch < mu::engraving::DRUM_INSTRUMENTS; ++pitch) {
+        if (!ds->isValid(pitch) || ds->line(pitch) != shadowNoteLine) {
+            continue;
+        }
+        return pitch;
+    }
+
+    return -1;
+}

--- a/src/notation/view/internal/percussionnotepopupcontentmodel.h
+++ b/src/notation/view/internal/percussionnotepopupcontentmodel.h
@@ -1,0 +1,69 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2025 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QObject>
+
+#include "modularity/ioc.h"
+#include "context/iglobalcontext.h"
+
+#include "async/asyncable.h"
+
+namespace mu::notation {
+class PercussionNotePopupContentModel : public QObject, public muse::Injectable, public muse::async::Asyncable
+{
+    Q_OBJECT
+
+    Q_PROPERTY(bool shouldShowButtons READ shouldShowButtons NOTIFY shouldShowButtonsChanged)
+    Q_PROPERTY(QString percussionNoteName READ percussionNoteName NOTIFY percussionNoteNameChanged)
+    Q_PROPERTY(QString keyboardShortcut READ keyboardShortcut NOTIFY keyboardShortcutChanged)
+
+    muse::Inject<mu::context::IGlobalContext> globalContext = { this };
+
+public:
+    explicit PercussionNotePopupContentModel(QObject* parent = nullptr);
+
+    Q_INVOKABLE void init();
+
+    Q_INVOKABLE void prevDrumNote();
+    Q_INVOKABLE void nextDrumNote();
+
+    bool shouldShowButtons() const;
+    QString percussionNoteName() const;
+    QString keyboardShortcut() const;
+
+signals:
+    void shouldShowButtonsChanged();
+    void percussionNoteNameChanged();
+    void keyboardShortcutChanged();
+
+private:
+    INotationInteractionPtr interaction() const;
+    INotationNoteInputPtr noteInput() const;
+
+    const mu::engraving::ShadowNote* currentShadowNote() const;
+    const Drumset* currentDrumset() const;
+
+    int currentDrumPitch() const;
+};
+}

--- a/src/notation/view/internal/shadownotepopupmodel.cpp
+++ b/src/notation/view/internal/shadownotepopupmodel.cpp
@@ -32,7 +32,15 @@ ShadowNotePopupModel::ShadowNotePopupModel(QObject* parent)
 
 bool ShadowNotePopupModel::canOpen(const EngravingItem* element)
 {
-    // TODO: Determine based on context
+    if (!element || !element->isShadowNote() || !element->visible()) {
+        return false;
+    }
+
+    if (element->staff() && element->staff()->isDrumStaff(element->tick())) {
+        // Can open with PERCUSSON_CONTENT type
+        return true;
+    }
+
     return false;
 }
 
@@ -51,7 +59,15 @@ void ShadowNotePopupModel::init()
 
 ShadowNotePopupContent::ContentType ShadowNotePopupModel::currentPopupType() const
 {
-    // TODO: Determine based on context
+    const mu::engraving::ShadowNote* shadowNote = interaction()->shadowNote();
+    if (!shadowNote || !shadowNote->visible()) {
+        return ShadowNotePopupContent::ContentType::NONE;
+    }
+
+    if (shadowNote->staff() && shadowNote->staff()->isDrumStaff(shadowNote->tick())) {
+        return ShadowNotePopupContent::ContentType::PERCUSSION_CONTENT;
+    }
+
     return ShadowNotePopupContent::ContentType::NONE;
 }
 

--- a/src/notation/view/internal/shadownotepopupmodel.cpp
+++ b/src/notation/view/internal/shadownotepopupmodel.cpp
@@ -1,0 +1,70 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2025 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "shadownotepopupmodel.h"
+#include "engraving/dom/shadownote.h"
+
+using namespace mu::notation;
+
+ShadowNotePopupModel::ShadowNotePopupModel(QObject* parent)
+    : AbstractElementPopupModel(PopupModelType::TYPE_HARP_DIAGRAM, parent)
+{
+}
+
+bool ShadowNotePopupModel::canOpen(const EngravingItem* element)
+{
+    // TODO: Determine based on context
+    return false;
+}
+
+void ShadowNotePopupModel::init()
+{
+    AbstractElementPopupModel::init();
+
+    m_item = interaction()->shadowNote();
+
+    interaction()->shadowNoteChanged().onNotify(this, [this]() {
+        updateItemRect();
+    });
+
+    emit currentPopupTypeChanged();
+}
+
+ShadowNotePopupContent::ContentType ShadowNotePopupModel::currentPopupType() const
+{
+    // TODO: Determine based on context
+    return ShadowNotePopupContent::ContentType::NONE;
+}
+
+void ShadowNotePopupModel::updateItemRect()
+{
+    const mu::engraving::ShadowNote* shadowNote = interaction()->shadowNote();
+    if (!shadowNote || !shadowNote->visible()) {
+        m_itemRect = QRect();
+        emit itemRectChanged(m_itemRect);
+    }
+
+    muse::RectF noteHeadRect = shadowNote->symBbox(shadowNote->noteheadSymbol());
+    noteHeadRect.translate(shadowNote->canvasPos().x(), shadowNote->canvasPos().y());
+    m_itemRect = fromLogical(noteHeadRect).toQRect();
+    emit itemRectChanged(m_itemRect);
+}

--- a/src/notation/view/internal/shadownotepopupmodel.h
+++ b/src/notation/view/internal/shadownotepopupmodel.h
@@ -1,0 +1,63 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2025 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QObject>
+
+#include "view/abstractelementpopupmodel.h"
+
+namespace mu::notation {
+class ShadowNotePopupContent
+{
+    Q_GADGET
+public:
+    enum ContentType
+    {
+        NONE = -1,
+        PERCUSSION_CONTENT
+    };
+    Q_ENUM(ContentType)
+};
+
+class ShadowNotePopupModel : public AbstractElementPopupModel
+{
+    Q_OBJECT
+    Q_PROPERTY(ShadowNotePopupContent::ContentType currentPopupType
+               READ currentPopupType NOTIFY currentPopupTypeChanged)
+
+public:
+    explicit ShadowNotePopupModel(QObject* parent = nullptr);
+
+    static bool canOpen(const EngravingItem* shadowNote);
+
+    Q_INVOKABLE void init() override;
+
+    ShadowNotePopupContent::ContentType currentPopupType() const;
+
+signals:
+    void currentPopupTypeChanged();
+
+protected:
+    void updateItemRect() override;
+};
+} // namespace mu::notation

--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -1120,13 +1120,17 @@ void NotationViewInputController::keyPressEvent(QKeyEvent* event)
     } else if (event->key() == Qt::Key_Shift) {
         updateShadowNotePopupVisibility();
     }
+
+    updateShadowNotePopupVisibility();
 }
 
 void NotationViewInputController::keyReleaseEvent(QKeyEvent* event)
 {
-    if (event->key() == Qt::Key_Shift) {
-        viewInteraction()->editElement(event);
+    if (event->key() != Qt::Key_Shift) {
+        return;
     }
+
+    viewInteraction()->editElement(event);
     updateShadowNotePopupVisibility(/*forceHide*/ true);
 }
 

--- a/src/notation/view/notationviewinputcontroller.h
+++ b/src/notation/view/notationviewinputcontroller.h
@@ -74,8 +74,10 @@ public:
     virtual void hideContextMenu() = 0;
 
     virtual void showElementPopup(const ElementType& elementType, const muse::RectF& elementRect) = 0;
-    virtual void hideElementPopup() = 0;
+    virtual void hideElementPopup(const ElementType& elementType = ElementType::INVALID) = 0;
     virtual void toggleElementPopup(const ElementType& elementType, const muse::RectF& elementRect) = 0;
+
+    virtual bool elementPopupIsOpen(const ElementType& elementType) const = 0;
 
     virtual INotationInteractionPtr notationInteraction() const = 0;
     virtual INotationPlaybackPtr notationPlayback() const = 0;
@@ -166,6 +168,7 @@ private:
     void startDragElements(ElementType elementsType, const muse::PointF& elementsOffset);
 
     void togglePopupForItemIfSupports(const EngravingItem* item);
+    void updateShadowNotePopupVisibility(bool forceHide = false);
 
     float hitWidth() const;
 


### PR DESCRIPTION
This PR implements the new percussion mouse input interaction and associated popup. 

### Part 1 - `ShadowNotePopup` groundwork (eb6c14109bd0d5934b6157561291ad79c2a6c7e5 & 21cb8ed5f6cb3cfb1705b8430f5e7444d463d4d2)
  Two of the main goals in this PR were to: 
1.   Avoid coupling to percussion-specific logic. 
2.  Reuse (and adapt) as much of our existing `ElementPopup` logic as possible.

    With this in mind, the idea with this commit was to provide a generalised shadow-note popup which will determine its “content” based on the context (`ShadowNotePopupModel::currentPopupType`). This should help with future flexibility, for example if we wish to implement other shadow-note-based popups.  
    
    A couple of optimisations were made to our existing `ElementPopup` logic. Firstly, we no longer attempt to show a popup if it is already showing - this is essential for `ShadowNotePopups` as we should try to update the visibility on every `hoverMoveEvent`. Second, the option to close a _specific_ element popup is also included here - we need this because we don't want to close _all_ element popups when shift is released, only the shadow-note popup.
    ...
###   Part 2 - Percussion shadow-note popup   (c015a98fe0beaa5692a1d3334a78779cd6b2bfe3)
    The content of this commit is fairly self-explanatory. It implements the “percussion note content” UI and outlines the circumstances where `ShadowNotePopup` should load this content.  
    
    This commit also contains logic for evaluating which percussion note should be inputted on click (see `Score::noteValForPosition`)