### PR TITLE
Avoid crash when string is empty

### DIFF
--- a/src/framework/uicomponents/tests/doubleinputvalidator_tests.cpp
+++ b/src/framework/uicomponents/tests/doubleinputvalidator_tests.cpp
@@ -70,7 +70,8 @@ TEST_F(DoubleInputValidatorTests, Validate) {
         { "-100.1", QValidator::Intermediate, "-100" },
         { "100.1", QValidator::Intermediate, "100" },
         { "1.123", QValidator::Invalid }, // more than 2 decimal
-        { "abc", QValidator::Invalid }
+        { "abc", QValidator::Invalid },
+        { "", QValidator::Intermediate, "0" }
     };
 
     int pos = 0;

--- a/src/framework/uicomponents/view/validators/doubleinputvalidator.cpp
+++ b/src/framework/uicomponents/view/validators/doubleinputvalidator.cpp
@@ -53,6 +53,10 @@ void DoubleInputValidator::fixup(QString& string) const
         }
     };
 
+    if (string.isEmpty()) {
+        string.append("0");
+    }
+
     if (string.startsWith(".")) {
         string.prepend("0");
     }


### PR DESCRIPTION
<!-- Add a short description of and motivation for the changes here -->

I have seen some crashs due the validator trying to process an empty string.  
This will fix it setting a default value.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
