### PR TITLE
Percussion panel - move toolbar into dock frame

### DIFF
--- a/src/appshell/qml/NotationPage/NotationPage.qml
+++ b/src/appshell/qml/NotationPage/NotationPage.qml
@@ -547,19 +547,13 @@ DockPage {
                 navigationSection: percussionPanel.navigationSection
                 contentNavigationPanelOrderStart: percussionPanel.contentNavigationPanelOrderStart
 
-                // TODO: #22050 needed for this
-                /*
-
                 Component.onCompleted: {
-                    percussionPanel.contextMenuModel = contextMenuModel
                     percussionPanel.toolbarComponent = toolbarComponent
                 }
 
                 Component.onDestruction: {
-                    percussionPanel.contextMenuModel = null
                     percussionPanel.toolbarComponent = null
                 }
-                */
             }
         }
     ]

--- a/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
+++ b/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
@@ -36,17 +36,14 @@ Item {
 
     anchors.fill: parent
 
-    //TODO: #22050 needed for this
-    /*
     property Component toolbarComponent: PercussionPanelToolBar {
-        navigation.section: root.navigationSection
-        navigation.order: root.contentNavigationPanelOrderStart
+        navigationSection: root.navigationSection
+        navigationOrderStart: root.contentNavigationPanelOrderStart
 
-        model: percussionPanelModel
+        model: percModel
 
         panelWidth: root.width
     }
-    */
 
     Component.onCompleted: {
         padGrid.model.init()
@@ -69,23 +66,6 @@ Item {
         }
     }
 
-    // TODO: Will live inside percussion panel until #22050 is implemented
-    PercussionPanelToolBar {
-        id: toolbar
-
-        anchors.top: parent.top
-
-        width: parent.width
-        height: 36
-
-        navigationSection: root.navigationSection
-        navigationOrderStart: root.contentNavigationPanelOrderStart
-
-        model: percModel
-
-        panelWidth: root.width
-    }
-
     StyledIconLabel {
         id: soundTitleIcon
 
@@ -105,10 +85,9 @@ Item {
         id: soundTitleLabel
 
         anchors {
-            top: toolbar.bottom
-            right: parent.right
+            top: root.top
+            right: root.right
 
-            topMargin: 8
             bottomMargin: 8
             rightMargin: 16
         }
@@ -151,7 +130,7 @@ Item {
 
                 name: "PercussionPanelDeleteRowButtons"
                 section: root.navigationSection
-                order: toolbar.navigationOrderEnd + 3
+                order: padFootersNavPanel.order + 1
 
                 enabled: deleteButtonsColumn.visible
             }
@@ -258,7 +237,7 @@ Item {
 
                     name: "PercussionPanelPads"
                     section: root.navigationSection
-                    order: toolbar.navigationOrderEnd + 1
+                    order: root.contentNavigationPanelOrderStart + 2 // +2 for toolbar
 
                     onNavigationEvent: function(event) {
                         gridPrv.onNavigationEvent(event)
@@ -270,7 +249,7 @@ Item {
 
                     name: "PercussionPanelFooters"
                     section: root.navigationSection
-                    order: toolbar.navigationOrderEnd + 2
+                    order: padsNavPanel.order + 1
 
                     enabled: percModel.currentPanelMode !== PanelMode.EDIT_LAYOUT
 
@@ -395,7 +374,7 @@ Item {
 
                 name: "PercussionPanelAddRowButton"
                 section: root.navigationSection
-                order: toolbar.navigationOrderEnd + 4
+                order: deleteButtonsPanel.order + 1
 
                 enabled: addRowButton.visible
             }

--- a/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelToolBar.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelToolBar.qml
@@ -34,7 +34,6 @@ Item {
 
     property NavigationSection navigationSection: null
     property int navigationOrderStart: 1
-    readonly property int navigationOrderEnd: rightSideNavPanel.order
 
     QtObject {
         id: prv
@@ -49,7 +48,7 @@ Item {
         id: centralNavPanel
         name: "PercussionPanelToolBarCentral"
         section: root.navigationSection
-        order: root.navigationOrderStart + 1
+        order: root.navigationOrderStart
     }
 
     Row {


### PR DESCRIPTION
With the merging of #22050 we can now move the percussion panel toolbar into the dock frame.