### PR TITLE
Remove some redundant code from `cmdAddTimeSig`

### DIFF
--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -1338,20 +1338,9 @@ void Score::cmdAddTimeSig(Measure* fm, staff_idx_t staffIdx, TimeSig* ts, bool l
 
     Fraction ns   = ts->sig();
     Fraction tick = fm->tick();
-    TimeSig* lts  = staff(staffIdx)->timeSig(tick);
     if (local) {
         Fraction stretch = (ns / fm->timesig()).reduced();
         ts->setStretch(stretch);
-    }
-
-    Fraction stretch;
-    Fraction lsig;                  // last signature
-    if (lts) {
-        stretch = lts->stretch();
-        lsig    = lts->sig();
-    } else {
-        stretch.set(1, 1);
-        lsig.set(4, 4);              // set to default
     }
 
     track_idx_t track = staffIdx * VOICES;


### PR DESCRIPTION
Stumbled across this while investigating #26001. Local variables `lsig` and `stretch` are set but never used (and `lts` is solely used to determine these redundant variables).