### PR TITLE
Fix #25457: Style dialog too big by default

### DIFF
--- a/src/notation/view/widgets/editstyle.cpp
+++ b/src/notation/view/widgets/editstyle.cpp
@@ -228,6 +228,7 @@ EditStyle::EditStyle(QWidget* parent)
 
     setObjectName("EditStyle");
     setupUi(this);
+    resizeDialog();
     setWindowFlag(Qt::WindowContextHelpButtonHint, false);
     setModal(true);
 
@@ -1279,6 +1280,20 @@ void EditStyle::changeEvent(QEvent* event)
     QDialog::changeEvent(event);
     if (event->type() == QEvent::LanguageChange) {
         retranslate();
+    }
+}
+\
+//---------------------------------------------------------
+//   resizeDialog
+//---------------------------------------------------------
+
+void EditStyle::resizeDialog()
+{
+    QScreen *screen = QGuiApplication::primaryScreen();
+    int screenHeight = screen->size().height();
+    int maximumHeight = static_cast<int>(0.9 * screenHeight);
+    if (this->height() > maximumHeight) {
+        this->resize(this->width(), maximumHeight);
     }
 }
 

--- a/src/notation/view/widgets/editstyle.h
+++ b/src/notation/view/widgets/editstyle.h
@@ -79,6 +79,7 @@ private:
     void changeEvent(QEvent*);
     void keyPressEvent(QKeyEvent* event);
 
+    void resizeDialog();
     void retranslate();
     void setHeaderFooterToolTip();
     void adjustPagesStackSize(int currentPageIndex);

--- a/src/notation/view/widgets/editstyle.ui
+++ b/src/notation/view/widgets/editstyle.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>933</width>
-    <height>824</height>
+    <height>752</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -38,7 +38,7 @@
    <item>
     <widget class="QSplitter" name="splitter">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
      <widget class="QListWidget" name="pageList">
       <property name="sizePolicy">
@@ -279,7 +279,7 @@
            <item>
             <widget class="QScrollArea" name="scrollArea_score">
              <property name="frameShape">
-              <enum>QFrame::NoFrame</enum>
+              <enum>QFrame::Shape::NoFrame</enum>
              </property>
              <property name="widgetResizable">
               <bool>true</bool>
@@ -289,8 +289,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>591</width>
-                <height>523</height>
+                <width>613</width>
+                <height>648</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_10">
@@ -372,7 +372,7 @@
                  <item row="0" column="3">
                   <spacer name="horizontalSpacer_2">
                    <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
+                    <enum>Qt::Orientation::Horizontal</enum>
                    </property>
                    <property name="sizeHint" stdset="0">
                     <size>
@@ -537,7 +537,7 @@
                   <item>
                    <spacer name="horizontalSpacer_indentation">
                     <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
+                     <enum>Qt::Orientation::Horizontal</enum>
                     </property>
                     <property name="sizeHint" stdset="0">
                      <size>
@@ -686,7 +686,7 @@
                     <item row="0" column="5">
                      <spacer name="horizontalSpacer_67">
                       <property name="orientation">
-                       <enum>Qt::Horizontal</enum>
+                       <enum>Qt::Orientation::Horizontal</enum>
                       </property>
                       <property name="sizeHint" stdset="0">
                        <size>
@@ -704,10 +704,10 @@
                <item>
                 <spacer name="verticalSpacer_10">
                  <property name="orientation">
-                  <enum>Qt::Vertical</enum>
+                  <enum>Qt::Orientation::Vertical</enum>
                  </property>
                  <property name="sizeType">
-                  <enum>QSizePolicy::Preferred</enum>
+                  <enum>QSizePolicy::Policy::Preferred</enum>
                  </property>
                  <property name="sizeHint" stdset="0">
                   <size>
@@ -759,7 +759,7 @@
                     <item>
                      <spacer name="zontalSpacer_16">
                       <property name="orientation">
-                       <enum>Qt::Horizontal</enum>
+                       <enum>Qt::Orientation::Horizontal</enum>
                       </property>
                       <property name="sizeHint" stdset="0">
                        <size>
@@ -808,7 +808,7 @@
                     <item>
                      <spacer name="horizontalSpacer_16">
                       <property name="orientation">
-                       <enum>Qt::Horizontal</enum>
+                       <enum>Qt::Orientation::Horizontal</enum>
                       </property>
                       <property name="sizeHint" stdset="0">
                        <size>
@@ -870,7 +870,7 @@
                   <item row="0" column="7">
                    <spacer name="horizontalSpacer_23">
                     <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
+                     <enum>Qt::Orientation::Horizontal</enum>
                     </property>
                     <property name="sizeHint" stdset="0">
                      <size>
@@ -919,7 +919,7 @@
                   <item row="0" column="3">
                    <spacer name="horizontalSpacer_51">
                     <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
+                     <enum>Qt::Orientation::Horizontal</enum>
                     </property>
                     <property name="sizeHint" stdset="0">
                      <size>
@@ -935,7 +935,7 @@
                <item>
                 <spacer name="verticalSpacer">
                  <property name="orientation">
-                  <enum>Qt::Vertical</enum>
+                  <enum>Qt::Orientation::Vertical</enum>
                  </property>
                  <property name="sizeHint" stdset="0">
                   <size>
@@ -980,7 +980,7 @@
            <item row="0" column="0" colspan="7">
             <widget class="QScrollArea" name="scrollArea_page">
              <property name="frameShape">
-              <enum>QFrame::NoFrame</enum>
+              <enum>QFrame::Shape::NoFrame</enum>
              </property>
              <property name="widgetResizable">
               <bool>true</bool>
@@ -990,8 +990,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>406</width>
-                <height>374</height>
+                <width>579</width>
+                <height>459</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_4">
@@ -1093,7 +1093,7 @@
                   <item row="0" column="3">
                    <spacer name="horizontalSpacer_15">
                     <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
+                     <enum>Qt::Orientation::Horizontal</enum>
                     </property>
                     <property name="sizeHint" stdset="0">
                      <size>
@@ -1223,7 +1223,7 @@
                   <item row="0" column="7">
                    <spacer name="horizontalSpacer_50">
                     <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
+                     <enum>Qt::Orientation::Horizontal</enum>
                     </property>
                     <property name="sizeHint" stdset="0">
                      <size>
@@ -1303,7 +1303,7 @@
                <item row="1" column="0" colspan="9">
                 <widget class="Line" name="line_8">
                  <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
+                  <enum>Qt::Orientation::Horizontal</enum>
                  </property>
                 </widget>
                </item>
@@ -1363,7 +1363,7 @@
                <item row="7" column="0" colspan="9">
                 <widget class="Line" name="line_6">
                  <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
+                  <enum>Qt::Orientation::Horizontal</enum>
                  </property>
                 </widget>
                </item>
@@ -1416,7 +1416,7 @@
                <item row="4" column="0" colspan="9">
                 <widget class="Line" name="line_7">
                  <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
+                  <enum>Qt::Orientation::Horizontal</enum>
                  </property>
                 </widget>
                </item>
@@ -1445,7 +1445,7 @@
                <item row="0" column="8">
                 <spacer name="horizontalSpacer_44">
                  <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
+                  <enum>Qt::Orientation::Horizontal</enum>
                  </property>
                  <property name="sizeHint" stdset="0">
                   <size>
@@ -1493,7 +1493,7 @@
                <item row="0" column="3">
                 <spacer name="horizontalSpacer_11">
                  <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
+                  <enum>Qt::Orientation::Horizontal</enum>
                  </property>
                  <property name="sizeHint" stdset="0">
                   <size>
@@ -1535,7 +1535,7 @@
                <item row="8" column="0" colspan="8">
                 <spacer name="verticalSpacer_9">
                  <property name="orientation">
-                  <enum>Qt::Vertical</enum>
+                  <enum>Qt::Orientation::Vertical</enum>
                  </property>
                  <property name="sizeHint" stdset="0">
                   <size>
@@ -1691,7 +1691,7 @@
                   <item row="0" column="3">
                    <spacer name="horizontalSpacer_13">
                     <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
+                     <enum>Qt::Orientation::Horizontal</enum>
                     </property>
                     <property name="sizeHint" stdset="0">
                      <size>
@@ -1849,7 +1849,7 @@
                   <item row="4" column="0" colspan="3">
                    <widget class="QLabel" name="label_157">
                     <property name="frameShadow">
-                     <enum>QFrame::Sunken</enum>
+                     <enum>QFrame::Shadow::Sunken</enum>
                     </property>
                     <property name="text">
                      <string>Factor for distance above/below brace:</string>
@@ -1862,7 +1862,7 @@
                   <item row="2" column="0" colspan="3">
                    <widget class="QLabel" name="label_154">
                     <property name="frameShadow">
-                     <enum>QFrame::Sunken</enum>
+                     <enum>QFrame::Shadow::Sunken</enum>
                     </property>
                     <property name="text">
                      <string>Factor for distance above/below bracket:</string>
@@ -1894,7 +1894,7 @@
                   <item row="1" column="2">
                    <spacer name="horizontalSpacer_21">
                     <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
+                     <enum>Qt::Orientation::Horizontal</enum>
                     </property>
                     <property name="sizeHint" stdset="0">
                      <size>
@@ -1987,7 +1987,7 @@
                   <item row="0" column="0" colspan="3">
                    <widget class="QLabel" name="label_153">
                     <property name="frameShadow">
-                     <enum>QFrame::Sunken</enum>
+                     <enum>QFrame::Shadow::Sunken</enum>
                     </property>
                     <property name="text">
                      <string>Factor for distance between systems:</string>
@@ -2000,7 +2000,7 @@
                   <item row="0" column="7">
                    <spacer name="horizontalSpacer_49">
                     <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
+                     <enum>Qt::Orientation::Horizontal</enum>
                     </property>
                     <property name="sizeHint" stdset="0">
                      <size>
@@ -2151,7 +2151,7 @@
            <item row="0" column="4">
             <spacer name="horizontalSpacer_24">
              <property name="orientation">
-              <enum>Qt::Horizontal</enum>
+              <enum>Qt::Orientation::Horizontal</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
@@ -2300,7 +2300,7 @@
         <item>
          <spacer name="verticalSpacer_21">
           <property name="orientation">
-           <enum>Qt::Vertical</enum>
+           <enum>Qt::Orientation::Vertical</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -2329,7 +2329,7 @@
         <item>
          <widget class="QScrollArea" name="scrollArea_headerFooter">
           <property name="frameShape">
-           <enum>QFrame::NoFrame</enum>
+           <enum>QFrame::Shape::NoFrame</enum>
           </property>
           <property name="widgetResizable">
            <bool>true</bool>
@@ -2339,8 +2339,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>685</width>
-             <height>298</height>
+             <width>711</width>
+             <height>354</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_9">
@@ -2368,7 +2368,7 @@
                  <item>
                   <spacer name="horizontalSpacer_52">
                    <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
+                    <enum>Qt::Orientation::Horizontal</enum>
                    </property>
                    <property name="sizeHint" stdset="0">
                     <size>
@@ -2391,7 +2391,7 @@
                  <item>
                   <spacer name="horizontalSpacer_4">
                    <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
+                    <enum>Qt::Orientation::Horizontal</enum>
                    </property>
                    <property name="sizeHint" stdset="0">
                     <size>
@@ -2467,7 +2467,7 @@
                     <string>Left</string>
                    </property>
                    <property name="alignment">
-                    <set>Qt::AlignCenter</set>
+                    <set>Qt::AlignmentFlag::AlignCenter</set>
                    </property>
                   </widget>
                  </item>
@@ -2571,7 +2571,7 @@
                     <string>Middle</string>
                    </property>
                    <property name="alignment">
-                    <set>Qt::AlignCenter</set>
+                    <set>Qt::AlignmentFlag::AlignCenter</set>
                    </property>
                   </widget>
                  </item>
@@ -2638,7 +2638,7 @@
                     <string>Right</string>
                    </property>
                    <property name="alignment">
-                    <set>Qt::AlignCenter</set>
+                    <set>Qt::AlignmentFlag::AlignCenter</set>
                    </property>
                   </widget>
                  </item>
@@ -2671,7 +2671,7 @@
                  <item>
                   <spacer name="horizontalSpacer_53">
                    <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
+                    <enum>Qt::Orientation::Horizontal</enum>
                    </property>
                    <property name="sizeHint" stdset="0">
                     <size>
@@ -2694,7 +2694,7 @@
                  <item>
                   <spacer name="horizontalSpacer_3">
                    <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
+                    <enum>Qt::Orientation::Horizontal</enum>
                    </property>
                    <property name="sizeHint" stdset="0">
                     <size>
@@ -2758,7 +2758,7 @@
                     <string>Middle</string>
                    </property>
                    <property name="alignment">
-                    <set>Qt::AlignCenter</set>
+                    <set>Qt::AlignmentFlag::AlignCenter</set>
                    </property>
                   </widget>
                  </item>
@@ -2837,7 +2837,7 @@
                     <string>Left</string>
                    </property>
                    <property name="alignment">
-                    <set>Qt::AlignCenter</set>
+                    <set>Qt::AlignmentFlag::AlignCenter</set>
                    </property>
                   </widget>
                  </item>
@@ -2941,7 +2941,7 @@
                     <string>Right</string>
                    </property>
                    <property name="alignment">
-                    <set>Qt::AlignCenter</set>
+                    <set>Qt::AlignmentFlag::AlignCenter</set>
                    </property>
                   </widget>
                  </item>
@@ -2953,7 +2953,7 @@
             <item>
              <spacer name="verticalSpacer_33">
               <property name="orientation">
-               <enum>Qt::Vertical</enum>
+               <enum>Qt::Orientation::Vertical</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -2996,7 +2996,7 @@
               <string>Position above:</string>
              </property>
              <property name="alignment">
-              <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+              <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
              </property>
              <property name="buddy">
               <cstring>measureNumberPosAbove</cstring>
@@ -3036,7 +3036,7 @@
               <string>Position below:</string>
              </property>
              <property name="alignment">
-              <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+              <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
              </property>
              <property name="buddy">
               <cstring>measureNumberPosBelow</cstring>
@@ -3092,7 +3092,7 @@
            <item row="2" column="4" rowspan="2" colspan="2">
             <widget class="mu::notation::OffsetSelect" name="measureNumberPosAbove" native="true">
              <property name="focusPolicy">
-              <enum>Qt::StrongFocus</enum>
+              <enum>Qt::FocusPolicy::StrongFocus</enum>
              </property>
             </widget>
            </item>
@@ -3109,7 +3109,7 @@
            <item row="4" column="4" rowspan="2" colspan="2">
             <widget class="mu::notation::OffsetSelect" name="measureNumberPosBelow" native="true">
              <property name="focusPolicy">
-              <enum>Qt::StrongFocus</enum>
+              <enum>Qt::FocusPolicy::StrongFocus</enum>
              </property>
             </widget>
            </item>
@@ -3146,7 +3146,7 @@
            <item row="0" column="2">
             <spacer name="horizontalSpacer_18">
              <property name="orientation">
-              <enum>Qt::Horizontal</enum>
+              <enum>Qt::Orientation::Horizontal</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
@@ -3159,7 +3159,7 @@
            <item row="0" column="7">
             <spacer name="horizontalSpacer_54">
              <property name="orientation">
-              <enum>Qt::Horizontal</enum>
+              <enum>Qt::Orientation::Horizontal</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
@@ -3197,7 +3197,7 @@
            <item row="3" column="1">
             <widget class="mu::notation::OffsetSelect" name="mmRestRangePosAbove" native="true">
              <property name="focusPolicy">
-              <enum>Qt::StrongFocus</enum>
+              <enum>Qt::FocusPolicy::StrongFocus</enum>
              </property>
             </widget>
            </item>
@@ -3242,7 +3242,7 @@
               <string>Position above:</string>
              </property>
              <property name="alignment">
-              <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+              <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
              </property>
              <property name="buddy">
               <cstring>mmRestRangePosAbove</cstring>
@@ -3301,7 +3301,7 @@
               <string>Position below:</string>
              </property>
              <property name="alignment">
-              <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+              <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
              </property>
              <property name="buddy">
               <cstring>mmRestRangePosBelow</cstring>
@@ -3311,7 +3311,7 @@
            <item row="4" column="1">
             <widget class="mu::notation::OffsetSelect" name="mmRestRangePosBelow" native="true">
              <property name="focusPolicy">
-              <enum>Qt::StrongFocus</enum>
+              <enum>Qt::FocusPolicy::StrongFocus</enum>
              </property>
             </widget>
            </item>
@@ -3331,7 +3331,7 @@
            <item row="0" column="3">
             <spacer name="horizontalSpacer_19">
              <property name="orientation">
-              <enum>Qt::Horizontal</enum>
+              <enum>Qt::Orientation::Horizontal</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
@@ -3347,7 +3347,7 @@
         <item>
          <spacer name="verticalSpacer_27">
           <property name="orientation">
-           <enum>Qt::Vertical</enum>
+           <enum>Qt::Orientation::Vertical</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -3556,7 +3556,7 @@
            <item row="0" column="3">
             <spacer name="horizontalSpacer_22">
              <property name="orientation">
-              <enum>Qt::Horizontal</enum>
+              <enum>Qt::Orientation::Horizontal</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
@@ -3569,7 +3569,7 @@
            <item row="0" column="7">
             <spacer name="horizontalSpacer_42">
              <property name="orientation">
-              <enum>Qt::Horizontal</enum>
+              <enum>Qt::Orientation::Horizontal</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
@@ -3677,7 +3677,7 @@
               <item row="0" column="2">
                <spacer name="horizontalSpacer_37">
                 <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
+                 <enum>Qt::Orientation::Horizontal</enum>
                 </property>
                 <property name="sizeHint" stdset="0">
                  <size>
@@ -3690,7 +3690,7 @@
               <item row="0" column="5">
                <spacer name="horizontalSpacer_41">
                 <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
+                 <enum>Qt::Orientation::Horizontal</enum>
                 </property>
                 <property name="sizeHint" stdset="0">
                  <size>
@@ -3792,7 +3792,7 @@
               <item row="0" column="2">
                <spacer name="horizontalSpacer_39">
                 <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
+                 <enum>Qt::Orientation::Horizontal</enum>
                 </property>
                 <property name="sizeHint" stdset="0">
                  <size>
@@ -3805,7 +3805,7 @@
               <item row="0" column="5">
                <spacer name="horizontalSpacer_40">
                 <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
+                 <enum>Qt::Orientation::Horizontal</enum>
                 </property>
                 <property name="sizeHint" stdset="0">
                  <size>
@@ -3824,7 +3824,7 @@
         <item>
          <spacer name="verticalSpacer_20">
           <property name="orientation">
-           <enum>Qt::Vertical</enum>
+           <enum>Qt::Orientation::Vertical</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -3964,10 +3964,10 @@
         <item>
          <spacer name="verticalSpacer_15">
           <property name="orientation">
-           <enum>Qt::Vertical</enum>
+           <enum>Qt::Orientation::Vertical</enum>
           </property>
           <property name="sizeType">
-           <enum>QSizePolicy::Expanding</enum>
+           <enum>QSizePolicy::Policy::Expanding</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -3991,8 +3991,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>383</width>
-             <height>294</height>
+             <width>552</width>
+             <height>382</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_631">
@@ -4068,7 +4068,7 @@
                <item row="0" column="4" rowspan="2">
                 <spacer name="horizontalSpacer_6">
                  <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
+                  <enum>Qt::Orientation::Horizontal</enum>
                  </property>
                  <property name="sizeHint" stdset="0">
                   <size>
@@ -4153,7 +4153,7 @@
             <item>
              <spacer name="verticalSpacer_5">
               <property name="orientation">
-               <enum>Qt::Vertical</enum>
+               <enum>Qt::Orientation::Vertical</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -4178,7 +4178,7 @@
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_4">
         <property name="sizeConstraint">
-         <enum>QLayout::SetMinimumSize</enum>
+         <enum>QLayout::SizeConstraint::SetMinimumSize</enum>
         </property>
         <item>
          <widget class="QGroupBox" name="groupBox_measure">
@@ -4201,7 +4201,7 @@
            <item row="0" column="0" rowspan="2" colspan="2">
             <widget class="QScrollArea" name="scrollArea_measure">
              <property name="frameShape">
-              <enum>QFrame::NoFrame</enum>
+              <enum>QFrame::Shape::NoFrame</enum>
              </property>
              <property name="widgetResizable">
               <bool>true</bool>
@@ -4211,8 +4211,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>239</width>
-                <height>593</height>
+                <width>339</width>
+                <height>726</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_56">
@@ -4290,7 +4290,7 @@
                <item row="28" column="0">
                 <spacer name="horizontalSpacer_62">
                  <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
+                  <enum>Qt::Orientation::Horizontal</enum>
                  </property>
                  <property name="sizeHint" stdset="0">
                   <size>
@@ -4313,10 +4313,10 @@
                <item row="0" column="3">
                 <spacer name="horizontalSpacer_57">
                  <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
+                  <enum>Qt::Orientation::Horizontal</enum>
                  </property>
                  <property name="sizeType">
-                  <enum>QSizePolicy::Expanding</enum>
+                  <enum>QSizePolicy::Policy::Expanding</enum>
                  </property>
                  <property name="sizeHint" stdset="0">
                   <size>
@@ -4371,7 +4371,7 @@
                   <item row="1" column="3">
                    <spacer name="horizontalSpacer_58">
                     <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
+                     <enum>Qt::Orientation::Horizontal</enum>
                     </property>
                     <property name="sizeHint" stdset="0">
                      <size>
@@ -4394,7 +4394,7 @@
                   <item row="9" column="0" colspan="4">
                    <widget class="Line" name="line_15">
                     <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
+                     <enum>Qt::Orientation::Horizontal</enum>
                     </property>
                    </widget>
                   </item>
@@ -4414,7 +4414,7 @@
                   <item row="14" column="0" colspan="4">
                    <widget class="Line" name="line_10">
                     <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
+                     <enum>Qt::Orientation::Horizontal</enum>
                     </property>
                    </widget>
                   </item>
@@ -4473,7 +4473,7 @@
                   <item row="17" column="0" colspan="4">
                    <widget class="Line" name="line_11">
                     <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
+                     <enum>Qt::Orientation::Horizontal</enum>
                     </property>
                    </widget>
                   </item>
@@ -4732,7 +4732,7 @@
                   <item row="20" column="0" colspan="4">
                    <widget class="Line" name="line_12">
                     <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
+                     <enum>Qt::Orientation::Horizontal</enum>
                     </property>
                    </widget>
                   </item>
@@ -4768,7 +4768,7 @@
                      <string>Clef to note:</string>
                     </property>
                     <property name="textFormat">
-                     <enum>Qt::PlainText</enum>
+                     <enum>Qt::TextFormat::PlainText</enum>
                     </property>
                     <property name="buddy">
                      <cstring>clefKeyRightMargin</cstring>
@@ -4909,7 +4909,7 @@
                   <item row="23" column="0">
                    <spacer name="horizontalSpacer_61">
                     <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
+                     <enum>Qt::Orientation::Horizontal</enum>
                     </property>
                     <property name="sizeHint" stdset="0">
                      <size>
@@ -4977,7 +4977,7 @@
                   <item row="1" column="3">
                    <spacer name="horizontalSpacer_59">
                     <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
+                     <enum>Qt::Orientation::Horizontal</enum>
                     </property>
                     <property name="sizeHint" stdset="0">
                      <size>
@@ -5026,7 +5026,7 @@
                   <item row="3" column="0">
                    <spacer name="horizontalSpacer_60">
                     <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
+                     <enum>Qt::Orientation::Horizontal</enum>
                     </property>
                     <property name="sizeHint" stdset="0">
                      <size>
@@ -5042,7 +5042,7 @@
                <item row="29" column="0">
                 <spacer name="verticalSpacer_11">
                  <property name="orientation">
-                  <enum>Qt::Vertical</enum>
+                  <enum>Qt::Orientation::Vertical</enum>
                  </property>
                  <property name="sizeHint" stdset="0">
                   <size>
@@ -5073,8 +5073,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>249</width>
-             <height>485</height>
+             <width>351</width>
+             <height>608</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_38">
@@ -5195,7 +5195,7 @@
                <item row="0" column="3">
                 <spacer name="horizontalSpacer_48">
                  <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
+                  <enum>Qt::Orientation::Horizontal</enum>
                  </property>
                  <property name="sizeHint" stdset="0">
                   <size>
@@ -5462,7 +5462,7 @@
             <item>
              <spacer name="verticalSpacer_12">
               <property name="orientation">
-               <enum>Qt::Vertical</enum>
+               <enum>Qt::Orientation::Vertical</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -5500,7 +5500,7 @@
            <item row="1" column="2">
             <spacer name="horizontalSpacer_20">
              <property name="orientation">
-              <enum>Qt::Horizontal</enum>
+              <enum>Qt::Orientation::Horizontal</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
@@ -5815,7 +5815,7 @@
         <item>
          <spacer name="verticalSpacer_6">
           <property name="orientation">
-           <enum>Qt::Vertical</enum>
+           <enum>Qt::Orientation::Vertical</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -5839,8 +5839,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>405</width>
-             <height>597</height>
+             <width>570</width>
+             <height>738</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_67">
@@ -5945,7 +5945,7 @@
                   <item row="4" column="4">
                    <spacer name="horizontalSpacer_32">
                     <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
+                     <enum>Qt::Orientation::Horizontal</enum>
                     </property>
                     <property name="sizeHint" stdset="0">
                      <size>
@@ -6048,7 +6048,7 @@
                   <item row="0" column="3">
                    <spacer name="horizontalSpacer_70">
                     <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
+                     <enum>Qt::Orientation::Horizontal</enum>
                     </property>
                     <property name="sizeHint" stdset="0">
                      <size>
@@ -6169,7 +6169,7 @@
                   <item row="2" column="3">
                    <spacer name="horizontalSpacer_71">
                     <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
+                     <enum>Qt::Orientation::Horizontal</enum>
                     </property>
                     <property name="sizeHint" stdset="0">
                      <size>
@@ -6200,7 +6200,7 @@
                   <item row="0" column="3">
                    <spacer name="horizontalSpacer_151">
                     <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
+                     <enum>Qt::Orientation::Horizontal</enum>
                     </property>
                     <property name="sizeHint" stdset="0">
                      <size>
@@ -6453,7 +6453,7 @@
             <item>
              <spacer name="verticalSpacer_34">
               <property name="orientation">
-               <enum>Qt::Vertical</enum>
+               <enum>Qt::Orientation::Vertical</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -6487,7 +6487,7 @@
            <item row="1" column="3">
             <spacer name="horizontalSpacer_25">
              <property name="orientation">
-              <enum>Qt::Horizontal</enum>
+              <enum>Qt::Orientation::Horizontal</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
@@ -6539,7 +6539,7 @@
               <item row="0" column="3">
                <spacer name="horizontalSpacer_7">
                 <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
+                 <enum>Qt::Orientation::Horizontal</enum>
                 </property>
                 <property name="sizeHint" stdset="0">
                  <size>
@@ -6639,7 +6639,7 @@
         <item row="1" column="0">
          <spacer name="verticalSpacer_36">
           <property name="orientation">
-           <enum>Qt::Vertical</enum>
+           <enum>Qt::Orientation::Vertical</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -6665,7 +6665,7 @@
            <item>
             <spacer name="horizontalSpacer_14">
              <property name="orientation">
-              <enum>Qt::Horizontal</enum>
+              <enum>Qt::Orientation::Horizontal</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
@@ -6681,7 +6681,7 @@
         <item>
          <spacer name="verticalSpacer_7">
           <property name="orientation">
-           <enum>Qt::Vertical</enum>
+           <enum>Qt::Orientation::Vertical</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -6716,7 +6716,7 @@
            <item row="0" column="0" rowspan="2" colspan="2">
             <widget class="QScrollArea" name="scrollArea_tuplets">
              <property name="frameShape">
-              <enum>QFrame::NoFrame</enum>
+              <enum>QFrame::Shape::NoFrame</enum>
              </property>
              <property name="widgetResizable">
               <bool>true</bool>
@@ -6726,8 +6726,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>363</width>
-                <height>386</height>
+                <width>503</width>
+                <height>472</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_54" rowstretch="0,0,0,2">
@@ -6890,7 +6890,7 @@
                   <item row="0" column="3">
                    <spacer name="horizontalSpacer_28">
                     <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
+                     <enum>Qt::Orientation::Horizontal</enum>
                     </property>
                     <property name="sizeHint" stdset="0">
                      <size>
@@ -7005,7 +7005,7 @@
                   <item row="0" column="9">
                    <spacer name="horizontalSpacer_26">
                     <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
+                     <enum>Qt::Orientation::Horizontal</enum>
                     </property>
                     <property name="sizeHint" stdset="0">
                      <size>
@@ -7187,7 +7187,7 @@
                   <item row="0" column="3">
                    <spacer name="horizontalSpacer_55">
                     <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
+                     <enum>Qt::Orientation::Horizontal</enum>
                     </property>
                     <property name="sizeHint" stdset="0">
                      <size>
@@ -7200,7 +7200,7 @@
                   <item row="2" column="0">
                    <spacer name="verticalSpacer_35">
                     <property name="orientation">
-                     <enum>Qt::Vertical</enum>
+                     <enum>Qt::Orientation::Vertical</enum>
                     </property>
                     <property name="sizeHint" stdset="0">
                      <size>
@@ -7420,7 +7420,7 @@
                   <item row="0" column="3">
                    <spacer name="horizontalSpacer_27">
                     <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
+                     <enum>Qt::Orientation::Horizontal</enum>
                     </property>
                     <property name="sizeHint" stdset="0">
                      <size>
@@ -7436,7 +7436,7 @@
                <item row="3" column="0" colspan="2">
                 <spacer name="verticalSpacer_3">
                  <property name="orientation">
-                  <enum>Qt::Vertical</enum>
+                  <enum>Qt::Orientation::Vertical</enum>
                  </property>
                  <property name="sizeHint" stdset="0">
                   <size>
@@ -7472,7 +7472,7 @@
               <string>Hook length:</string>
              </property>
              <property name="alignment">
-              <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+              <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
              </property>
              <property name="buddy">
               <cstring>arpeggioHookLen</cstring>
@@ -7557,7 +7557,7 @@
            <item row="0" column="2">
             <spacer name="horizontalSpacer_35">
              <property name="orientation">
-              <enum>Qt::Horizontal</enum>
+              <enum>Qt::Orientation::Horizontal</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
@@ -7573,7 +7573,7 @@
         <item>
          <spacer name="verticalSpacer_8">
           <property name="orientation">
-           <enum>Qt::Vertical</enum>
+           <enum>Qt::Orientation::Vertical</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -7597,8 +7597,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>416</width>
-             <height>315</height>
+             <width>586</width>
+             <height>421</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_70">
@@ -7812,7 +7812,7 @@
                   <item row="3" column="3">
                    <spacer name="horizontalSpacer">
                     <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
+                     <enum>Qt::Orientation::Horizontal</enum>
                     </property>
                     <property name="sizeHint" stdset="0">
                      <size>
@@ -8014,7 +8014,7 @@
                   <item row="3" column="3">
                    <spacer name="horizontalSpacer_66">
                     <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
+                     <enum>Qt::Orientation::Horizontal</enum>
                     </property>
                     <property name="sizeHint" stdset="0">
                      <size>
@@ -8095,7 +8095,7 @@
                  <item>
                   <spacer name="horizontalSpacer_43">
                    <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
+                    <enum>Qt::Orientation::Horizontal</enum>
                    </property>
                    <property name="sizeHint" stdset="0">
                     <size>
@@ -8166,7 +8166,7 @@
                  <item>
                   <spacer name="horizontalSpacer_73">
                    <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
+                    <enum>Qt::Orientation::Horizontal</enum>
                    </property>
                    <property name="sizeHint" stdset="0">
                     <size>
@@ -8181,7 +8181,7 @@
                <item>
                 <widget class="Line" name="line_16">
                  <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
+                  <enum>Qt::Orientation::Horizontal</enum>
                  </property>
                 </widget>
                </item>
@@ -8253,7 +8253,7 @@
                  <item>
                   <spacer name="horizontalSpacer_72">
                    <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
+                    <enum>Qt::Orientation::Horizontal</enum>
                    </property>
                    <property name="sizeHint" stdset="0">
                     <size>
@@ -8278,7 +8278,7 @@
             <item>
              <spacer name="verticalSpacer_4">
               <property name="orientation">
-               <enum>Qt::Vertical</enum>
+               <enum>Qt::Orientation::Vertical</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -8306,8 +8306,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>471</width>
-             <height>508</height>
+             <width>589</width>
+             <height>629</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_68">
@@ -8349,7 +8349,7 @@
                  <item>
                   <spacer name="horizontalSpacer_69">
                    <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
+                    <enum>Qt::Orientation::Horizontal</enum>
                    </property>
                    <property name="sizeHint" stdset="0">
                     <size>
@@ -8582,7 +8582,7 @@
                <item row="5" column="3">
                 <spacer name="horizontalSpacer_30">
                  <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
+                  <enum>Qt::Orientation::Horizontal</enum>
                  </property>
                  <property name="sizeHint" stdset="0">
                   <size>
@@ -8646,7 +8646,7 @@
                <item row="0" column="1">
                 <widget class="mu::notation::OffsetSelect" name="hairpinPosAbove" native="true">
                  <property name="focusPolicy">
-                  <enum>Qt::StrongFocus</enum>
+                  <enum>Qt::FocusPolicy::StrongFocus</enum>
                  </property>
                 </widget>
                </item>
@@ -8753,7 +8753,7 @@
                <item row="1" column="1">
                 <widget class="mu::notation::OffsetSelect" name="hairpinPosBelow" native="true">
                  <property name="focusPolicy">
-                  <enum>Qt::StrongFocus</enum>
+                  <enum>Qt::FocusPolicy::StrongFocus</enum>
                  </property>
                 </widget>
                </item>
@@ -8844,7 +8844,7 @@
                <item row="0" column="3">
                 <spacer name="horizontalSpacer_671">
                  <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
+                  <enum>Qt::Orientation::Horizontal</enum>
                  </property>
                  <property name="sizeHint" stdset="0">
                   <size>
@@ -8860,7 +8860,7 @@
             <item>
              <spacer name="verticalSpacer_22">
               <property name="orientation">
-               <enum>Qt::Vertical</enum>
+               <enum>Qt::Orientation::Vertical</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -8906,7 +8906,7 @@
            <item row="0" column="1">
             <widget class="mu::notation::OffsetSelect" name="voltaPosAbove" native="true">
              <property name="focusPolicy">
-              <enum>Qt::StrongFocus</enum>
+              <enum>Qt::FocusPolicy::StrongFocus</enum>
              </property>
             </widget>
            </item>
@@ -8932,7 +8932,7 @@
            <item row="1" column="0" colspan="4">
             <widget class="Line" name="line_2">
              <property name="orientation">
-              <enum>Qt::Horizontal</enum>
+              <enum>Qt::Orientation::Horizontal</enum>
              </property>
             </widget>
            </item>
@@ -9085,7 +9085,7 @@
            <item row="0" column="3">
             <spacer name="horizontalSpacer_5">
              <property name="orientation">
-              <enum>Qt::Horizontal</enum>
+              <enum>Qt::Orientation::Horizontal</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
@@ -9175,7 +9175,7 @@
         <item>
          <spacer name="verticalSpacer_13">
           <property name="orientation">
-           <enum>Qt::Vertical</enum>
+           <enum>Qt::Orientation::Vertical</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -9214,7 +9214,7 @@
            <item row="1" column="0" colspan="8">
             <widget class="Line" name="line_5">
              <property name="orientation">
-              <enum>Qt::Horizontal</enum>
+              <enum>Qt::Orientation::Horizontal</enum>
              </property>
             </widget>
            </item>
@@ -9419,7 +9419,7 @@
            <item row="0" column="3">
             <spacer name="horizontalSpacer_29">
              <property name="orientation">
-              <enum>Qt::Horizontal</enum>
+              <enum>Qt::Orientation::Horizontal</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
@@ -9451,14 +9451,14 @@
            <item row="4" column="0" colspan="8">
             <widget class="Line" name="line_4">
              <property name="orientation">
-              <enum>Qt::Horizontal</enum>
+              <enum>Qt::Orientation::Horizontal</enum>
              </property>
             </widget>
            </item>
            <item row="0" column="7">
             <spacer name="horizontalSpacer_56">
              <property name="orientation">
-              <enum>Qt::Horizontal</enum>
+              <enum>Qt::Orientation::Horizontal</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
@@ -9471,7 +9471,7 @@
            <item row="3" column="1">
             <widget class="mu::notation::OffsetSelect" name="ottavaPosBelow" native="true">
              <property name="focusPolicy">
-              <enum>Qt::StrongFocus</enum>
+              <enum>Qt::FocusPolicy::StrongFocus</enum>
              </property>
             </widget>
            </item>
@@ -9539,7 +9539,7 @@
            <item row="2" column="1">
             <widget class="mu::notation::OffsetSelect" name="ottavaPosAbove" native="true">
              <property name="focusPolicy">
-              <enum>Qt::StrongFocus</enum>
+              <enum>Qt::FocusPolicy::StrongFocus</enum>
              </property>
             </widget>
            </item>
@@ -9619,7 +9619,7 @@
         <item>
          <spacer name="verticalSpacer_14">
           <property name="orientation">
-           <enum>Qt::Vertical</enum>
+           <enum>Qt::Orientation::Vertical</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -9748,7 +9748,7 @@
            <item row="2" column="1">
             <widget class="mu::notation::OffsetSelect" name="pedalLinePosBelow" native="true">
              <property name="focusPolicy">
-              <enum>Qt::StrongFocus</enum>
+              <enum>Qt::FocusPolicy::StrongFocus</enum>
              </property>
             </widget>
            </item>
@@ -9820,7 +9820,7 @@
            <item row="1" column="4">
             <spacer name="horizontalSpacer_8">
              <property name="orientation">
-              <enum>Qt::Horizontal</enum>
+              <enum>Qt::Orientation::Horizontal</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
@@ -9836,7 +9836,7 @@
               <number>0</number>
              </property>
              <property name="orientation">
-              <enum>Qt::Horizontal</enum>
+              <enum>Qt::Orientation::Horizontal</enum>
              </property>
             </widget>
            </item>
@@ -9853,7 +9853,7 @@
            <item row="1" column="1">
             <widget class="mu::notation::OffsetSelect" name="pedalLinePosAbove" native="true">
              <property name="focusPolicy">
-              <enum>Qt::StrongFocus</enum>
+              <enum>Qt::FocusPolicy::StrongFocus</enum>
              </property>
             </widget>
            </item>
@@ -9943,7 +9943,7 @@
         <item>
          <spacer name="verticalSpacer_19">
           <property name="orientation">
-           <enum>Qt::Vertical</enum>
+           <enum>Qt::Orientation::Vertical</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -9976,7 +9976,7 @@
            <item row="1" column="3">
             <spacer name="horizontalSpacer_10">
              <property name="orientation">
-              <enum>Qt::Horizontal</enum>
+              <enum>Qt::Orientation::Horizontal</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
@@ -10062,14 +10062,14 @@
            <item row="1" column="1">
             <widget class="mu::notation::OffsetSelect" name="trillLinePosAbove" native="true">
              <property name="focusPolicy">
-              <enum>Qt::StrongFocus</enum>
+              <enum>Qt::FocusPolicy::StrongFocus</enum>
              </property>
             </widget>
            </item>
            <item row="2" column="1">
             <widget class="mu::notation::OffsetSelect" name="trillLinePosBelow" native="true">
              <property name="focusPolicy">
-              <enum>Qt::StrongFocus</enum>
+              <enum>Qt::FocusPolicy::StrongFocus</enum>
              </property>
             </widget>
            </item>
@@ -10079,7 +10079,7 @@
         <item>
          <spacer name="verticalSpacer_18">
           <property name="orientation">
-           <enum>Qt::Vertical</enum>
+           <enum>Qt::Orientation::Vertical</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -10112,7 +10112,7 @@
            <item row="1" column="3">
             <spacer name="horizontalSpacer_101">
              <property name="orientation">
-              <enum>Qt::Horizontal</enum>
+              <enum>Qt::Orientation::Horizontal</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
@@ -10198,14 +10198,14 @@
            <item row="1" column="1">
             <widget class="mu::notation::OffsetSelect" name="vibratoLinePosAbove" native="true">
              <property name="focusPolicy">
-              <enum>Qt::StrongFocus</enum>
+              <enum>Qt::FocusPolicy::StrongFocus</enum>
              </property>
             </widget>
            </item>
            <item row="2" column="1">
             <widget class="mu::notation::OffsetSelect" name="vibratoLinePosBelow" native="true">
              <property name="focusPolicy">
-              <enum>Qt::StrongFocus</enum>
+              <enum>Qt::FocusPolicy::StrongFocus</enum>
              </property>
             </widget>
            </item>
@@ -10215,7 +10215,7 @@
         <item>
          <spacer name="verticalSpacer_181">
           <property name="orientation">
-           <enum>Qt::Vertical</enum>
+           <enum>Qt::Orientation::Vertical</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -10254,7 +10254,7 @@
         <item>
          <spacer name="verticalSpacer_39">
           <property name="orientation">
-           <enum>Qt::Vertical</enum>
+           <enum>Qt::Orientation::Vertical</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -10294,7 +10294,7 @@
               <item row="0" column="3">
                <spacer name="horizontalSpacer_64">
                 <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
+                 <enum>Qt::Orientation::Horizontal</enum>
                 </property>
                 <property name="sizeHint" stdset="0">
                  <size>
@@ -10427,7 +10427,7 @@
               <item row="1" column="6">
                <spacer name="horizontalSpacer_46">
                 <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
+                 <enum>Qt::Orientation::Horizontal</enum>
                 </property>
                 <property name="sizeHint" stdset="0">
                  <size>
@@ -10494,7 +10494,7 @@
         <item row="3" column="0">
          <spacer name="verticalSpacer_31">
           <property name="orientation">
-           <enum>Qt::Vertical</enum>
+           <enum>Qt::Orientation::Vertical</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -10628,7 +10628,7 @@
            <item row="1" column="3">
             <spacer name="horizontalSpacer_33">
              <property name="orientation">
-              <enum>Qt::Horizontal</enum>
+              <enum>Qt::Orientation::Horizontal</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
@@ -10641,14 +10641,14 @@
            <item row="1" column="1">
             <widget class="mu::notation::OffsetSelect" name="textLinePosAbove" native="true">
              <property name="focusPolicy">
-              <enum>Qt::StrongFocus</enum>
+              <enum>Qt::FocusPolicy::StrongFocus</enum>
              </property>
             </widget>
            </item>
            <item row="2" column="1">
             <widget class="mu::notation::OffsetSelect" name="textLinePosBelow" native="true">
              <property name="focusPolicy">
-              <enum>Qt::StrongFocus</enum>
+              <enum>Qt::FocusPolicy::StrongFocus</enum>
              </property>
             </widget>
            </item>
@@ -10658,7 +10658,7 @@
         <item>
          <spacer name="verticalSpacer_24">
           <property name="orientation">
-           <enum>Qt::Vertical</enum>
+           <enum>Qt::Orientation::Vertical</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -10776,7 +10776,7 @@
            <item row="1" column="3">
             <spacer name="horizontalSpacer_47">
              <property name="orientation">
-              <enum>Qt::Horizontal</enum>
+              <enum>Qt::Orientation::Horizontal</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
@@ -10789,14 +10789,14 @@
            <item row="1" column="1">
             <widget class="mu::notation::OffsetSelect" name="systemTextLinePosAbove" native="true">
              <property name="focusPolicy">
-              <enum>Qt::StrongFocus</enum>
+              <enum>Qt::FocusPolicy::StrongFocus</enum>
              </property>
             </widget>
            </item>
            <item row="2" column="1">
             <widget class="mu::notation::OffsetSelect" name="systemTextLinePosBelow" native="true">
              <property name="focusPolicy">
-              <enum>Qt::StrongFocus</enum>
+              <enum>Qt::FocusPolicy::StrongFocus</enum>
              </property>
             </widget>
            </item>
@@ -10806,7 +10806,7 @@
         <item>
          <spacer name="verticalSpacer_341">
           <property name="orientation">
-           <enum>Qt::Vertical</enum>
+           <enum>Qt::Orientation::Vertical</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -10938,7 +10938,7 @@
            <item row="1" column="3">
             <spacer name="horizontalSpacer_31">
              <property name="orientation">
-              <enum>Qt::Horizontal</enum>
+              <enum>Qt::Orientation::Horizontal</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
@@ -10998,10 +10998,10 @@
         <item>
          <spacer name="verticalSpacer_38">
           <property name="orientation">
-           <enum>Qt::Vertical</enum>
+           <enum>Qt::Orientation::Vertical</enum>
           </property>
           <property name="sizeType">
-           <enum>QSizePolicy::Fixed</enum>
+           <enum>QSizePolicy::Policy::Fixed</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -11044,10 +11044,10 @@
         <item>
          <spacer name="verticalSpacer_41">
           <property name="orientation">
-           <enum>Qt::Vertical</enum>
+           <enum>Qt::Orientation::Vertical</enum>
           </property>
           <property name="sizeType">
-           <enum>QSizePolicy::Fixed</enum>
+           <enum>QSizePolicy::Policy::Fixed</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -11083,10 +11083,10 @@
         <item>
          <spacer name="verticalSpacer_391">
           <property name="orientation">
-           <enum>Qt::Vertical</enum>
+           <enum>Qt::Orientation::Vertical</enum>
           </property>
           <property name="sizeType">
-           <enum>QSizePolicy::Fixed</enum>
+           <enum>QSizePolicy::Policy::Fixed</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -11122,7 +11122,7 @@
         <item>
          <spacer name="verticalSpacer_25">
           <property name="orientation">
-           <enum>Qt::Vertical</enum>
+           <enum>Qt::Orientation::Vertical</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -11177,7 +11177,7 @@
            <item row="1" column="1">
             <widget class="mu::notation::OffsetSelect" name="fermataPosBelow" native="true">
              <property name="focusPolicy">
-              <enum>Qt::StrongFocus</enum>
+              <enum>Qt::FocusPolicy::StrongFocus</enum>
              </property>
             </widget>
            </item>
@@ -11207,7 +11207,7 @@
            <item row="0" column="1">
             <widget class="mu::notation::OffsetSelect" name="fermataPosAbove" native="true">
              <property name="focusPolicy">
-              <enum>Qt::StrongFocus</enum>
+              <enum>Qt::FocusPolicy::StrongFocus</enum>
              </property>
             </widget>
            </item>
@@ -11250,7 +11250,7 @@
            <item row="0" column="3">
             <spacer name="horizontalSpacer_38">
              <property name="orientation">
-              <enum>Qt::Horizontal</enum>
+              <enum>Qt::Orientation::Horizontal</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
@@ -11266,7 +11266,7 @@
         <item>
          <spacer name="verticalSpacer_23">
           <property name="orientation">
-           <enum>Qt::Vertical</enum>
+           <enum>Qt::Orientation::Vertical</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -11289,7 +11289,7 @@
            <item row="1" column="3">
             <spacer name="horizontalSpacer_45">
              <property name="orientation">
-              <enum>Qt::Horizontal</enum>
+              <enum>Qt::Orientation::Horizontal</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
@@ -11373,7 +11373,7 @@
            <item row="1" column="1">
             <widget class="mu::notation::OffsetSelect" name="staffTextPosAbove" native="true">
              <property name="focusPolicy">
-              <enum>Qt::StrongFocus</enum>
+              <enum>Qt::FocusPolicy::StrongFocus</enum>
              </property>
             </widget>
            </item>
@@ -11393,7 +11393,7 @@
            <item row="2" column="1">
             <widget class="mu::notation::OffsetSelect" name="staffTextPosBelow" native="true">
              <property name="focusPolicy">
-              <enum>Qt::StrongFocus</enum>
+              <enum>Qt::FocusPolicy::StrongFocus</enum>
              </property>
             </widget>
            </item>
@@ -11462,7 +11462,7 @@
         <item row="1" column="0">
          <spacer name="verticalSpacer_30">
           <property name="orientation">
-           <enum>Qt::Vertical</enum>
+           <enum>Qt::Orientation::Vertical</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -11590,7 +11590,7 @@
            <item row="1" column="3">
             <spacer name="horizontalSpacer_34">
              <property name="orientation">
-              <enum>Qt::Horizontal</enum>
+              <enum>Qt::Orientation::Horizontal</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
@@ -11641,14 +11641,14 @@
            <item row="1" column="1">
             <widget class="mu::notation::OffsetSelect" name="tempoTextPosAbove" native="true">
              <property name="focusPolicy">
-              <enum>Qt::StrongFocus</enum>
+              <enum>Qt::FocusPolicy::StrongFocus</enum>
              </property>
             </widget>
            </item>
            <item row="2" column="1">
             <widget class="mu::notation::OffsetSelect" name="tempoTextPosBelow" native="true">
              <property name="focusPolicy">
-              <enum>Qt::StrongFocus</enum>
+              <enum>Qt::FocusPolicy::StrongFocus</enum>
              </property>
             </widget>
            </item>
@@ -11658,7 +11658,7 @@
         <item>
          <spacer name="verticalSpacer_26">
           <property name="orientation">
-           <enum>Qt::Vertical</enum>
+           <enum>Qt::Orientation::Vertical</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -11693,7 +11693,7 @@
         <item row="0" column="0">
          <widget class="QScrollArea" name="scrollArea_lyrics">
           <property name="frameShape">
-           <enum>QFrame::NoFrame</enum>
+           <enum>QFrame::Shape::NoFrame</enum>
           </property>
           <property name="widgetResizable">
            <bool>true</bool>
@@ -11703,8 +11703,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>469</width>
-             <height>461</height>
+             <width>644</width>
+             <height>573</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_64" stretch="0,0,2">
@@ -12036,10 +12036,10 @@
                  <item row="3" column="3">
                   <spacer name="horizontalSpacer_672">
                    <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
+                    <enum>Qt::Orientation::Horizontal</enum>
                    </property>
                    <property name="sizeType">
-                    <enum>QSizePolicy::Minimum</enum>
+                    <enum>QSizePolicy::Policy::Minimum</enum>
                    </property>
                    <property name="sizeHint" stdset="0">
                     <size>
@@ -12633,7 +12633,7 @@ first note of the system</string>
                  <item>
                   <spacer name="verticalSpacer_2">
                    <property name="orientation">
-                    <enum>Qt::Vertical</enum>
+                    <enum>Qt::Orientation::Vertical</enum>
                    </property>
                    <property name="sizeHint" stdset="0">
                     <size>
@@ -12651,7 +12651,7 @@ first note of the system</string>
             <item>
              <spacer name="verticalSpacer_17">
               <property name="orientation">
-               <enum>Qt::Vertical</enum>
+               <enum>Qt::Orientation::Vertical</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -12685,7 +12685,7 @@ first note of the system</string>
            <item row="0" column="2">
             <spacer name="horizontalSpacer_65">
              <property name="orientation">
-              <enum>Qt::Horizontal</enum>
+              <enum>Qt::Orientation::Horizontal</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
@@ -12714,7 +12714,7 @@ first note of the system</string>
         <item>
          <spacer name="verticalSpacer_40">
           <property name="orientation">
-           <enum>Qt::Vertical</enum>
+           <enum>Qt::Orientation::Vertical</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -12868,21 +12868,21 @@ first note of the system</string>
            <item row="1" column="1">
             <widget class="mu::notation::OffsetSelect" name="rehearsalMarkPosAbove" native="true">
              <property name="focusPolicy">
-              <enum>Qt::StrongFocus</enum>
+              <enum>Qt::FocusPolicy::StrongFocus</enum>
              </property>
             </widget>
            </item>
            <item row="2" column="1">
             <widget class="mu::notation::OffsetSelect" name="rehearsalMarkPosBelow" native="true">
              <property name="focusPolicy">
-              <enum>Qt::StrongFocus</enum>
+              <enum>Qt::FocusPolicy::StrongFocus</enum>
              </property>
             </widget>
            </item>
            <item row="0" column="3">
             <spacer name="horizontalSpacer_36">
              <property name="orientation">
-              <enum>Qt::Horizontal</enum>
+              <enum>Qt::Orientation::Horizontal</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
@@ -12898,7 +12898,7 @@ first note of the system</string>
         <item>
          <spacer name="verticalSpacer_28">
           <property name="orientation">
-           <enum>Qt::Vertical</enum>
+           <enum>Qt::Orientation::Vertical</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -12926,7 +12926,7 @@ first note of the system</string>
                 <string>Size:</string>
                </property>
                <property name="textFormat">
-                <enum>Qt::PlainText</enum>
+                <enum>Qt::TextFormat::PlainText</enum>
                </property>
                <property name="buddy">
                 <cstring>doubleSpinFBSize</cstring>
@@ -12962,7 +12962,7 @@ first note of the system</string>
              <item row="0" column="2">
               <spacer name="horizontalSpacer_9">
                <property name="orientation">
-                <enum>Qt::Horizontal</enum>
+                <enum>Qt::Orientation::Horizontal</enum>
                </property>
                <property name="sizeHint" stdset="0">
                 <size>
@@ -13007,7 +13007,7 @@ first note of the system</string>
                 <string>Line height:</string>
                </property>
                <property name="textFormat">
-                <enum>Qt::PlainText</enum>
+                <enum>Qt::TextFormat::PlainText</enum>
                </property>
                <property name="buddy">
                 <cstring>spinFBLineHeight</cstring>
@@ -13042,7 +13042,7 @@ first note of the system</string>
                 <string>Font:</string>
                </property>
                <property name="textFormat">
-                <enum>Qt::PlainText</enum>
+                <enum>Qt::TextFormat::PlainText</enum>
                </property>
                <property name="buddy">
                 <cstring>comboFBFont</cstring>
@@ -13052,7 +13052,7 @@ first note of the system</string>
              <item row="0" column="1">
               <widget class="QComboBox" name="comboFBFont">
                <property name="sizeAdjustPolicy">
-                <enum>QComboBox::AdjustToContents</enum>
+                <enum>QComboBox::SizeAdjustPolicy::AdjustToContents</enum>
                </property>
               </widget>
              </item>
@@ -13062,7 +13062,7 @@ first note of the system</string>
                 <string>Vertical position:</string>
                </property>
                <property name="textFormat">
-                <enum>Qt::PlainText</enum>
+                <enum>Qt::TextFormat::PlainText</enum>
                </property>
                <property name="buddy">
                 <cstring>doubleSpinFBVertPos</cstring>
@@ -13129,7 +13129,7 @@ first note of the system</string>
         <item>
          <spacer name="verticalSpacer_16">
           <property name="orientation">
-           <enum>Qt::Vertical</enum>
+           <enum>Qt::Orientation::Vertical</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -13164,7 +13164,7 @@ first note of the system</string>
            <item row="0" column="0" colspan="4">
             <widget class="QScrollArea" name="scrollArea_chordSymbols">
              <property name="frameShape">
-              <enum>QFrame::NoFrame</enum>
+              <enum>QFrame::Shape::NoFrame</enum>
              </property>
              <property name="widgetResizable">
               <bool>true</bool>
@@ -13174,8 +13174,8 @@ first note of the system</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>384</width>
-                <height>422</height>
+                <width>546</width>
+                <height>523</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_55" rowstretch="0,0,0,0,1">
@@ -13388,7 +13388,7 @@ first note of the system</string>
                      <item>
                       <spacer name="horizontalSpacer_17">
                        <property name="orientation">
-                        <enum>Qt::Horizontal</enum>
+                        <enum>Qt::Orientation::Horizontal</enum>
                        </property>
                        <property name="sizeHint" stdset="0">
                         <size>
@@ -13466,7 +13466,7 @@ first note of the system</string>
                      <item>
                       <spacer name="horizontalSpacer_12">
                        <property name="orientation">
-                        <enum>Qt::Horizontal</enum>
+                        <enum>Qt::Orientation::Horizontal</enum>
                        </property>
                        <property name="sizeHint" stdset="0">
                         <size>
@@ -13727,7 +13727,7 @@ first note of the system</string>
                <item row="4" column="0" colspan="3">
                 <spacer name="verticalSpacer_61">
                  <property name="orientation">
-                  <enum>Qt::Vertical</enum>
+                  <enum>Qt::Orientation::Vertical</enum>
                  </property>
                  <property name="sizeHint" stdset="0">
                   <size>
@@ -13740,7 +13740,7 @@ first note of the system</string>
                <item row="3" column="1" colspan="2">
                 <spacer name="verticalSpacer_3411">
                  <property name="orientation">
-                  <enum>Qt::Vertical</enum>
+                  <enum>Qt::Orientation::Vertical</enum>
                  </property>
                  <property name="sizeHint" stdset="0">
                   <size>
@@ -13819,8 +13819,8 @@ first note of the system</string>
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>701</width>
-             <height>744</height>
+             <width>98</width>
+             <height>28</height>
             </rect>
            </property>
            <layout class="QHBoxLayout" name="horizontalLayout_3">
@@ -13926,8 +13926,8 @@ first note of the system</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>363</width>
-                <height>550</height>
+                <width>517</width>
+                <height>677</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_40">
@@ -14053,10 +14053,10 @@ first note of the system</string>
                  <item row="1" column="1">
                   <spacer name="horizontalSpacer_63">
                    <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
+                    <enum>Qt::Orientation::Horizontal</enum>
                    </property>
                    <property name="sizeType">
-                    <enum>QSizePolicy::Minimum</enum>
+                    <enum>QSizePolicy::Policy::Minimum</enum>
                    </property>
                    <property name="sizeHint" stdset="0">
                     <size>
@@ -14210,10 +14210,10 @@ first note of the system</string>
                  <item row="1" column="3">
                   <spacer name="horizontalSpacer_661">
                    <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
+                    <enum>Qt::Orientation::Horizontal</enum>
                    </property>
                    <property name="sizeType">
-                    <enum>QSizePolicy::Minimum</enum>
+                    <enum>QSizePolicy::Policy::Minimum</enum>
                    </property>
                    <property name="sizeHint" stdset="0">
                     <size>
@@ -14267,10 +14267,10 @@ first note of the system</string>
                  <item row="2" column="2">
                   <spacer name="verticalSpacer_37">
                    <property name="orientation">
-                    <enum>Qt::Vertical</enum>
+                    <enum>Qt::Orientation::Vertical</enum>
                    </property>
                    <property name="sizeType">
-                    <enum>QSizePolicy::Fixed</enum>
+                    <enum>QSizePolicy::Policy::Fixed</enum>
                    </property>
                    <property name="sizeHint" stdset="0">
                     <size>
@@ -14371,7 +14371,7 @@ first note of the system</string>
                  <item row="1" column="5">
                   <spacer name="horizontalSpacer_68">
                    <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
+                    <enum>Qt::Orientation::Horizontal</enum>
                    </property>
                    <property name="sizeHint" stdset="0">
                     <size>
@@ -14453,7 +14453,7 @@ first note of the system</string>
                <item>
                 <spacer name="verticalSpacer_29">
                  <property name="orientation">
-                  <enum>Qt::Vertical</enum>
+                  <enum>Qt::Orientation::Vertical</enum>
                  </property>
                  <property name="sizeHint" stdset="0">
                   <size>
@@ -14703,7 +14703,7 @@ first note of the system</string>
            <item row="12" column="1">
             <widget class="mu::notation::OffsetSelect" name="textStyleOffset" native="true">
              <property name="focusPolicy">
-              <enum>Qt::StrongFocus</enum>
+              <enum>Qt::FocusPolicy::StrongFocus</enum>
              </property>
             </widget>
            </item>
@@ -15031,7 +15031,7 @@ first note of the system</string>
         <item row="1" column="1">
          <spacer name="verticalSpacer_32">
           <property name="orientation">
-           <enum>Qt::Vertical</enum>
+           <enum>Qt::Orientation::Vertical</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -15092,7 +15092,7 @@ first note of the system</string>
      <item>
       <widget class="QDialogButtonBox" name="buttonBox">
        <property name="standardButtons">
-        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+        <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Ok</set>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
Resolves: #25457 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
Reduces the default dialog height, and adds a detection function which automatically resize the dialog if it's too big to display.
According to the discussion, changing only the default height is not enough, so I added adjustment to the device's screen resolution.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
