### PR TITLE
Fix #25299: Allow navigating to grace notes when inputting fingerings

### DIFF
--- a/src/engraving/dom/chord.cpp
+++ b/src/engraving/dom/chord.cpp
@@ -2554,6 +2554,21 @@ Chord* Chord::graceNoteAt(size_t idx) const
 }
 
 //---------------------------------------------------------
+//   allGraceChordsOfMainChord
+//   returns a list containing all grace notes (chords) attached to the main chord and the main chord itself, in order
+//---------------------------------------------------------
+std::vector<Chord*> Chord::allGraceChordsOfMainChord()
+{
+    Chord* mainChord = isGrace() ? toChord(explicitParent()) : this;
+    std::vector<Chord*> chords = { mainChord };
+    GraceNotesGroup gnBefore = mainChord->graceNotesBefore();
+    GraceNotesGroup gnAfter = mainChord->graceNotesAfter();
+    chords.insert(chords.begin(), gnBefore.begin(), gnBefore.end());
+    chords.insert(chords.end(), gnAfter.begin(), gnAfter.end());
+    return chords;
+}
+
+//---------------------------------------------------------
 //   setShowStemSlashInAdvance
 //---------------------------------------------------------
 

--- a/src/engraving/dom/chord.cpp
+++ b/src/engraving/dom/chord.cpp
@@ -2561,8 +2561,8 @@ std::vector<Chord*> Chord::allGraceChordsOfMainChord()
 {
     Chord* mainChord = isGrace() ? toChord(explicitParent()) : this;
     std::vector<Chord*> chords = { mainChord };
-    GraceNotesGroup gnBefore = mainChord->graceNotesBefore();
-    GraceNotesGroup gnAfter = mainChord->graceNotesAfter();
+    const GraceNotesGroup& gnBefore = mainChord->graceNotesBefore();
+    const GraceNotesGroup& gnAfter = mainChord->graceNotesAfter();
     chords.insert(chords.begin(), gnBefore.begin(), gnBefore.end());
     chords.insert(chords.end(), gnAfter.begin(), gnAfter.end());
     return chords;

--- a/src/engraving/dom/chord.h
+++ b/src/engraving/dom/chord.h
@@ -181,6 +181,7 @@ public:
 
     const std::vector<Chord*>& graceNotes() const { return m_graceNotes; }
     std::vector<Chord*>& graceNotes() { return m_graceNotes; }
+    std::vector<Chord*> allGraceChordsOfMainChord();
 
     GraceNotesGroup& graceNotesBefore(bool filterUnplayable = false) const;
     GraceNotesGroup& graceNotesAfter(bool filterUnplayable = false) const;

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -5932,16 +5932,7 @@ void NotationInteraction::navigateToNearText(MoveDirection direction)
         }
 
         // next, try going to next/prev grace note chord in the same group as the current
-        auto graceChordList = [](Chord* ch) {
-            Chord* parentChord = ch->isGrace() ? toChord(ch->explicitParent()) : ch;
-            std::vector<Chord*> chords = { parentChord };
-            GraceNotesGroup gnBefore = parentChord->graceNotesBefore();
-            GraceNotesGroup gnAfter = parentChord->graceNotesAfter();
-            chords.insert(chords.begin(), gnBefore.begin(), gnBefore.end());
-            chords.insert(chords.end(), gnAfter.begin(), gnAfter.end());
-            return chords;
-        };
-        std::vector<Chord*> chordList = graceChordList(ch);
+        std::vector<Chord*> chordList = ch->allGraceChordsOfMainChord();
 
         if (!el && ch != (back ? chordList.front() : chordList.back())) {
             for (auto it = chordList.begin(); it != chordList.end(); ++it) {
@@ -5966,7 +5957,7 @@ void NotationInteraction::navigateToNearText(MoveDirection direction)
             for (int track = sTrack; back ? (track >= eTrack) : (track <= eTrack); track += inc) {
                 EngravingItem* e = seg->element(track);
                 if (e && e->isChord()) {
-                    std::vector<Chord*> targetChordList = graceChordList(toChord(e));
+                    std::vector<Chord*> targetChordList = toChord(e)->allGraceChordsOfMainChord();
                     Chord* targetChord = back ? targetChordList.back() : targetChordList.front();
                     el = back ? targetChord->notes().front() : targetChord->notes().back();
                     break;
@@ -5985,7 +5976,7 @@ void NotationInteraction::navigateToNearText(MoveDirection direction)
                 for (int track = sTrack; back ? (track >= eTrack) : (track <= eTrack); track += inc) {
                     EngravingItem* e = seg->element(track);
                     if (e && e->isChord()) {
-                        std::vector<Chord*> targetChordList = graceChordList(toChord(e));
+                        std::vector<Chord*> targetChordList = toChord(e)->allGraceChordsOfMainChord();
                         Chord* targetChord = back ? targetChordList.back() : targetChordList.front();
                         el = back ? targetChord->notes().front() : targetChord->notes().back();
                         break;

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -5923,23 +5923,24 @@ void NotationInteraction::navigateToNearText(MoveDirection direction)
 
         // first, try going to prev/next note in the current chord
         if (origNote != (back ? notes.back() : notes.front())) {
-            for (auto it = notes.cbegin(); it != notes.cend(); ++it) {
-                if (*it == origNote) {
-                    el = back ? *(it + 1) : *(it - 1);
-                    break;
-                }
+            auto it = std::find(notes.begin(), notes.end(), origNote);
+            if (it != notes.end()) {
+                el = back ? *std::next(it) : *std::prev(it);
             }
         }
 
         // next, try going to next/prev grace note chord in the same group as the current
-        std::vector<Chord*> chordList = ch->allGraceChordsOfMainChord();
+        const std::vector<Chord*> chordList = ch->allGraceChordsOfMainChord();
 
         if (!el && ch != (back ? chordList.front() : chordList.back())) {
-            for (auto it = chordList.begin(); it != chordList.end(); ++it) {
-                if (*it == ch) {
-                    Chord* targetChord = back ? *(it - 1) : *(it + 1);
-                    el = back ? targetChord->notes().front() : targetChord->notes().back();
-                    break;
+            auto it = std::find(chordList.begin(), chordList.end(), ch);
+            if (it != chordList.end()) {
+                if (back) {
+                    const Chord* targetChord = *std::prev(it);
+                    el = targetChord->notes().front();
+                } else {
+                    const Chord* targetChord = *std::next(it);
+                    el = targetChord->notes().back();
                 }
             }
         }
@@ -5957,9 +5958,14 @@ void NotationInteraction::navigateToNearText(MoveDirection direction)
             for (int track = sTrack; back ? (track >= eTrack) : (track <= eTrack); track += inc) {
                 EngravingItem* e = seg->element(track);
                 if (e && e->isChord()) {
-                    std::vector<Chord*> targetChordList = toChord(e)->allGraceChordsOfMainChord();
-                    Chord* targetChord = back ? targetChordList.back() : targetChordList.front();
-                    el = back ? targetChord->notes().front() : targetChord->notes().back();
+                    const std::vector<Chord*> targetChordList = toChord(e)->allGraceChordsOfMainChord();
+                    if (back) {
+                        Chord* targetChord = targetChordList.back();
+                        el = targetChord->notes().front();
+                    } else {
+                        Chord* targetChord = targetChordList.front();
+                        el = targetChord->notes().back();
+                    }
                     break;
                 }
             }
@@ -5976,9 +5982,14 @@ void NotationInteraction::navigateToNearText(MoveDirection direction)
                 for (int track = sTrack; back ? (track >= eTrack) : (track <= eTrack); track += inc) {
                     EngravingItem* e = seg->element(track);
                     if (e && e->isChord()) {
-                        std::vector<Chord*> targetChordList = toChord(e)->allGraceChordsOfMainChord();
-                        Chord* targetChord = back ? targetChordList.back() : targetChordList.front();
-                        el = back ? targetChord->notes().front() : targetChord->notes().back();
+                        const std::vector<Chord*> targetChordList = toChord(e)->allGraceChordsOfMainChord();
+                        if (back) {
+                            Chord* targetChord = targetChordList.back();
+                            el = targetChord->notes().front();
+                        } else {
+                            Chord* targetChord = targetChordList.front();
+                            el = targetChord->notes().back();
+                        }
                         break;
                     }
                 }


### PR DESCRIPTION
Resolves: #25299 

If there are other grace notes (`Chord`s) in the current group, navigate to those first before going to other non-grace chords.

Also restructured some of the other logic to make it more readable.

Added `Chord::allGraceChordsOfMainChord()` to return the list of grace and non-grace Chords in the current group. I'm also working on fixing grace note navigation using Alt-arrow keys, so this function will come in useful later.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
