### PR TITLE
[MusicXML] Export harp pedal texts

### DIFF
--- a/src/engraving/dom/harppedaldiagram.h
+++ b/src/engraving/dom/harppedaldiagram.h
@@ -69,7 +69,7 @@ public:
     String screenReaderInfo() const override;
 
     void setIsDiagram(bool diagram);
-    bool isDiagram() { return m_isDiagram; }
+    bool isDiagram() const { return m_isDiagram; }
 
     std::array<PedalPosition, HARP_STRING_NO> getPedalState() const { return m_pedalState; }
     void setPedalState(std::array<PedalPosition, HARP_STRING_NO> state);

--- a/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
@@ -5248,10 +5248,6 @@ void ExportMusicXml::rehearsal(RehearsalMark const* const rmk, staff_idx_t staff
 
 void ExportMusicXml::harpPedals(HarpPedalDiagram const* const hpd, staff_idx_t staff)
 {
-    if (hpd->textStyleType() != TextStyleType::HARP_PEDAL_DIAGRAM) {
-        return;
-    }
-
     directionTag(m_xml, m_attr, hpd);
     m_xml.startElement("direction-type");
     XmlWriter::Attributes harpPedalAttrs;

--- a/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
@@ -5252,7 +5252,7 @@ void ExportMusicXml::harpPedals(HarpPedalDiagram const* const hpd, staff_idx_t s
     m_xml.startElement("direction-type");
     XmlWriter::Attributes harpPedalAttrs;
     addColorAttr(hpd, harpPedalAttrs);
-    if (!hpd->isDiagram()) {
+    if (hpd->isDiagram()) {
         m_xml.startElement("harp-pedals", harpPedalAttrs);
         const std::vector <String> pedalSteps = { u"D", u"C", u"B", u"E", u"F", u"G", u"A" };
         for (size_t idx = 0; idx < pedalSteps.size(); idx++) {

--- a/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
@@ -5251,9 +5251,6 @@ void ExportMusicXml::harpPedals(HarpPedalDiagram const* const hpd, staff_idx_t s
     directionTag(m_xml, m_attr, hpd);
     m_xml.startElement("direction-type");
     XmlWriter::Attributes harpPedalAttrs;
-    if (!hpd->isStyled(Pid::PLACEMENT)) {
-        harpPedalAttrs.push_back({ "placement", (hpd->placement() == PlacementV::BELOW) ? "below" : "above" });
-    }
     addColorAttr(hpd, harpPedalAttrs);
     if (!hpd->isDiagram()) {
         m_xml.startElement("harp-pedals", harpPedalAttrs);

--- a/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
@@ -5255,16 +5255,20 @@ void ExportMusicXml::harpPedals(HarpPedalDiagram const* const hpd, staff_idx_t s
         harpPedalAttrs.push_back({ "placement", (hpd->placement() == PlacementV::BELOW) ? "below" : "above" });
     }
     addColorAttr(hpd, harpPedalAttrs);
-    m_xml.startElement("harp-pedals", harpPedalAttrs);
-    const std::vector <String> pedalSteps = { u"D", u"C", u"B", u"E", u"F", u"G", u"A" };
-    for (size_t idx = 0; idx < pedalSteps.size(); idx++) {
-        m_xml.startElement("pedal-tuning");
-        m_xml.tag("pedal-step", pedalSteps.at(idx));
-        m_xml.tag("pedal-alter", static_cast<int>(hpd->getPedalState().at(idx)) - 1);
+    if (!hpd->isDiagram()) {
+        m_xml.startElement("harp-pedals", harpPedalAttrs);
+        const std::vector <String> pedalSteps = { u"D", u"C", u"B", u"E", u"F", u"G", u"A" };
+        for (size_t idx = 0; idx < pedalSteps.size(); idx++) {
+            m_xml.startElement("pedal-tuning");
+            m_xml.tag("pedal-step", pedalSteps.at(idx));
+            m_xml.tag("pedal-alter", static_cast<int>(hpd->getPedalState().at(idx)) - 1);
+            m_xml.endElement();
+        }
         m_xml.endElement();
+        m_xml.endElement();
+    } else {
+        m_xml.tag("words", harpPedalAttrs, hpd->plainText());
     }
-    m_xml.endElement();
-    m_xml.endElement();
     const int offset = calculateTimeDeltaInDivisions(hpd->tick(), tick(), m_div);
     if (offset) {
         m_xml.tag("offset", offset);

--- a/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
@@ -5262,10 +5262,10 @@ void ExportMusicXml::harpPedals(HarpPedalDiagram const* const hpd, staff_idx_t s
             m_xml.endElement();
         }
         m_xml.endElement();
-        m_xml.endElement();
     } else {
         m_xml.tag("words", harpPedalAttrs, hpd->plainText());
     }
+    m_xml.endElement();
     const int offset = calculateTimeDeltaInDivisions(hpd->tick(), tick(), m_div);
     if (offset) {
         m_xml.tag("offset", offset);

--- a/src/importexport/musicxml/tests/data/testHarpPedals.mscx
+++ b/src/importexport/musicxml/tests/data/testHarpPedals.mscx
@@ -176,8 +176,9 @@
       <Measure>
         <voice>
           <HarpPedalDiagram>
+            <isDiagram>0</isDiagram>
             <pedalState>
-              <string name="0">1</string>
+              <string name="0">0</string>
               <string name="1">2</string>
               <string name="2">1</string>
               <string name="3">1</string>
@@ -185,7 +186,9 @@
               <string name="5">2</string>
               <string name="6">1</string>
               </pedalState>
-            <text><sym>harpPedalCentered</sym><sym>harpPedalLowered</sym><sym>harpPedalCentered</sym><sym>harpPedalDivider</sym><sym>harpPedalCentered</sym><sym>harpPedalLowered</sym><sym>harpPedalLowered</sym><sym>harpPedalCentered</sym></text>
+            <style>harp_pedal_text_diagram</style>
+            <text>G<sym>csymAccidentalSharp</sym> 
+D<sym>csymAccidentalFlat</sym> </text>
             </HarpPedalDiagram>
           <Rest>
             <durationType>measure</durationType>

--- a/src/importexport/musicxml/tests/data/testHarpPedals_ref.xml
+++ b/src/importexport/musicxml/tests/data/testHarpPedals_ref.xml
@@ -55,7 +55,7 @@
         </attributes>
       <direction placement="below">
         <direction-type>
-          <harp-pedals placement="below" color="#0096FF">
+          <harp-pedals color="#0096FF">
             <pedal-tuning>
               <pedal-step>D</pedal-step>
               <pedal-alter>-1</pedal-alter>

--- a/src/importexport/musicxml/tests/data/testHarpPedals_ref.xml
+++ b/src/importexport/musicxml/tests/data/testHarpPedals_ref.xml
@@ -209,38 +209,10 @@
         </note>
       </measure>
     <measure number="4">
-      <direction placement="above">
+      <direction placement="below">
         <direction-type>
-          <harp-pedals>
-            <pedal-tuning>
-              <pedal-step>D</pedal-step>
-              <pedal-alter>0</pedal-alter>
-              </pedal-tuning>
-            <pedal-tuning>
-              <pedal-step>C</pedal-step>
-              <pedal-alter>1</pedal-alter>
-              </pedal-tuning>
-            <pedal-tuning>
-              <pedal-step>B</pedal-step>
-              <pedal-alter>0</pedal-alter>
-              </pedal-tuning>
-            <pedal-tuning>
-              <pedal-step>E</pedal-step>
-              <pedal-alter>0</pedal-alter>
-              </pedal-tuning>
-            <pedal-tuning>
-              <pedal-step>F</pedal-step>
-              <pedal-alter>1</pedal-alter>
-              </pedal-tuning>
-            <pedal-tuning>
-              <pedal-step>G</pedal-step>
-              <pedal-alter>1</pedal-alter>
-              </pedal-tuning>
-            <pedal-tuning>
-              <pedal-step>A</pedal-step>
-              <pedal-alter>0</pedal-alter>
-              </pedal-tuning>
-            </harp-pedals>
+          <words>G 
+D </words>
           </direction-type>
         <staff>1</staff>
         </direction>


### PR DESCRIPTION
This PR adds export of harp pedal indications that are not diagrams.
Fixes also a problem with invalid attribute output.