### PR TITLE
Partial ties refinements

### DIFF
--- a/src/engraving/dom/dom.cmake
+++ b/src/engraving/dom/dom.cmake
@@ -343,6 +343,8 @@ set(DOM_SRC
     ${CMAKE_CURRENT_LIST_DIR}/textlinebase.h
     ${CMAKE_CURRENT_LIST_DIR}/tie.cpp
     ${CMAKE_CURRENT_LIST_DIR}/tie.h
+    ${CMAKE_CURRENT_LIST_DIR}/tiejumppointlist.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/tiejumppointlist.h
     ${CMAKE_CURRENT_LIST_DIR}/tiemap.h
     ${CMAKE_CURRENT_LIST_DIR}/timesig.cpp
     ${CMAKE_CURRENT_LIST_DIR}/timesig.h

--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -1900,6 +1900,9 @@ static Tie* createAndAddTie(Note* startNote, Note* endNote)
     tie->setTrack(startNote->track());
     tie->setTick(startNote->chord()->segment()->tick());
     if (endNote) {
+        if (endNote->tieBack()) {
+            score->undoRemoveElement(endNote->tieBack());
+        }
         tie->setEndNote(endNote);
         tie->setTicks(endNote->chord()->segment()->tick() - startNote->chord()->segment()->tick());
     }

--- a/src/engraving/dom/note.cpp
+++ b/src/engraving/dom/note.cpp
@@ -2515,6 +2515,7 @@ void Note::setTieBack(Tie* t)
 {
     if (m_tieBack && t && m_tieBack->jumpPoint()) {
         t->setJumpPoint(m_tieBack->jumpPoint());
+        m_tieBack->setJumpPoint(nullptr);
     }
     m_tieBack = t;
 }

--- a/src/engraving/dom/note.cpp
+++ b/src/engraving/dom/note.cpp
@@ -549,7 +549,7 @@ NoteHeadGroup NoteHead::headGroup() const
 //---------------------------------------------------------
 
 Note::Note(Chord* ch)
-    : EngravingItem(ElementType::NOTE, ch, ElementFlag::MOVABLE), m_jumpPoints(this)
+    : EngravingItem(ElementType::NOTE, ch, ElementFlag::MOVABLE)
 {
     m_playEvents.push_back(NoteEvent());      // add default play event
 }
@@ -599,7 +599,7 @@ std::vector<const Note*> Note::compoundNotes() const
 }
 
 Note::Note(const Note& n, bool link)
-    : EngravingItem(n), m_jumpPoints(this)
+    : EngravingItem(n)
 {
     if (link) {
         score()->undo(new Link(this, const_cast<Note*>(&n)));

--- a/src/engraving/dom/note.cpp
+++ b/src/engraving/dom/note.cpp
@@ -549,7 +549,7 @@ NoteHeadGroup NoteHead::headGroup() const
 //---------------------------------------------------------
 
 Note::Note(Chord* ch)
-    : EngravingItem(ElementType::NOTE, ch, ElementFlag::MOVABLE)
+    : EngravingItem(ElementType::NOTE, ch, ElementFlag::MOVABLE), m_jumpPoints(this)
 {
     m_playEvents.push_back(NoteEvent());      // add default play event
 }
@@ -599,7 +599,7 @@ std::vector<const Note*> Note::compoundNotes() const
 }
 
 Note::Note(const Note& n, bool link)
-    : EngravingItem(n)
+    : EngravingItem(n), m_jumpPoints(this)
 {
     if (link) {
         score()->undo(new Link(this, const_cast<Note*>(&n)));
@@ -2509,7 +2509,6 @@ PartialTie* Note::outgoingPartialTie() const
 void Note::setTieFor(Tie* t)
 {
     m_tieFor = t;
-    m_jumpPoints.setStartTie(m_tieFor);
 }
 
 void Note::setTieBack(Tie* t)

--- a/src/engraving/dom/note.h
+++ b/src/engraving/dom/note.h
@@ -575,6 +575,6 @@ private:
     String m_fretString;
 
     std::vector<LineAttachPoint> m_lineAttachPoints;
-    TieJumpPointList m_jumpPoints;
+    TieJumpPointList m_jumpPoints { this };
 };
 } // namespace mu::engraving

--- a/src/engraving/dom/note.h
+++ b/src/engraving/dom/note.h
@@ -36,6 +36,7 @@
 #include "pitchspelling.h"
 #include "symbol.h"
 #include "tie.h"
+#include "tiejumppointlist.h"
 #include "types.h"
 
 namespace mu::engraving {

--- a/src/engraving/dom/tie.cpp
+++ b/src/engraving/dom/tie.cpp
@@ -31,7 +31,6 @@
 #include "factory.h"
 #include "hook.h"
 #include "ledgerline.h"
-#include "marker.h"
 #include "masterscore.h"
 #include "measure.h"
 #include "mscoreview.h"
@@ -45,7 +44,7 @@
 #include "stafftype.h"
 #include "stem.h"
 #include "system.h"
-#include "types/typesconv.h"
+#include "tiejumppointlist.h"
 #include "undo.h"
 #include "utils.h"
 #include "volta.h"
@@ -213,6 +212,11 @@ Tie::Tie(const ElementType& type, EngravingItem* parent)
     : SlurTie(type, parent)
 {
     setAnchor(Anchor::NOTE);
+}
+
+TieJumpPointList* Tie::startTieJumpPoints() const
+{
+    return m_jumpPoint ? m_jumpPoint->jumpPointList() : nullptr;
 }
 
 void Tie::updatePossibleJumpPoints()
@@ -453,250 +457,6 @@ bool Tie::isCrossStaff() const
            || (endChord && (endChord->staffMove() != 0 || endChord->vStaffIdx() != staff));
 }
 
-//---------------------------------------------------------
-//   PartialTieJumpPoint
-//---------------------------------------------------------
-
-TieJumpPoint::TieJumpPoint(Note* note, bool active, int idx, bool followingNote)
-    : m_note(note), m_active(active), m_followingNote(followingNote)
-{
-    m_id = u"jumpPoint" + String::fromStdString(std::to_string(idx));
-    if (active && endTie()) {
-        endTie()->setJumpPoint(this);
-    }
-}
-
-Tie* TieJumpPoint::endTie() const
-{
-    return m_note ? m_note->tieBack() : nullptr;
-}
-
-void TieJumpPoint::undoSetActive(bool v)
-{
-    Score* score = m_note ? m_note->score() : nullptr;
-    if (!score || m_active == v) {
-        return;
-    }
-    score->undo(new ChangeTieJumpPointActive(m_jumpPointList, m_id, v));
-}
-
-const String TieJumpPoint::menuTitle() const
-{
-    const Measure* measure = m_note->findMeasure();
-    const int measureNo = measure ? measure->no() + 1 : 0;
-    const String measureStr = String::fromStdString(std::to_string(measureNo));
-
-    //: %1 represents the preceding jump item eg. coda. %2 represents the measure number
-    return muse::mtrc("engraving", "Tie to %1 (m. %2)").arg(precedingJumpItemName(), measureStr);
-}
-
-String TieJumpPoint::precedingJumpItemName() const
-{
-    const Chord* startChord = m_note->chord();
-    const Segment* seg = startChord->segment();
-    const Measure* measure = seg->measure();
-
-    if (seg->score()->firstSegment(SegmentType::ChordRest) == seg) {
-        //: Used at %1 in the string "Tie to %1 (m. %2)"
-        return muse::mtrc("engraving", "start of score", "partial tie menu");
-    }
-
-    // Markers
-    for (const EngravingItem* e : measure->el()) {
-        if (!e->isMarker()) {
-            continue;
-        }
-
-        const Marker* marker = toMarker(e);
-        if (muse::contains(Marker::RIGHT_MARKERS, marker->markerType())) {
-            continue;
-        }
-
-        if (marker->markerType() == MarkerType::CODA || marker->markerType() == MarkerType::VARCODA) {
-            //: Used at %1 in the string "Tie to %1 (m. %2)"
-            return muse::mtrc("engraving", "coda", "partial tie menu");
-        } else {
-            //: Used at %1 in the string "Tie to %1 (m. %2)"
-            return muse::mtrc("engraving", "segno", "partial tie menu");
-        }
-    }
-
-    // Voltas
-    auto spanners = m_note->score()->spannerMap().findOverlapping(measure->tick().ticks(), measure->tick().ticks());
-    for (auto& spanner : spanners) {
-        if (!spanner.value->isVolta() || Fraction::fromTicks(spanner.start) != startChord->tick()) {
-            continue;
-        }
-
-        Volta* volta = toVolta(spanner.value);
-
-        //: Used at %1 in the string "Tie to %1 (m. %2)". %1 in this string represents the volta's text set by the user
-        return muse::mtrc("engraving", "“%1” volta", "partial tie menu").arg(volta->beginText());
-    }
-
-    // Repeat barlines
-    if (measure->repeatStart()) {
-        //: Used at %1 in the string "Tie to %1 (m. %2)"
-        return muse::mtrc("engraving", "start repeat", "partial tie menu");
-    }
-
-    for (Segment* prevSeg = seg->prev(SegmentType::BarLineType); prevSeg && prevSeg->tick() == seg->tick();
-         prevSeg = prevSeg->prev(SegmentType::BarLineType)) {
-        EngravingItem* el = prevSeg->element(startChord->track());
-        if (!el || !el->isBarLine()) {
-            continue;
-        }
-
-        BarLine* bl = toBarLine(el);
-        if (bl->barLineType() & (BarLineType::START_REPEAT | BarLineType::END_START_REPEAT)) {
-            //: Used at %1 in the string "Tie to %1 (m. %2)"
-            return muse::mtrc("engraving", "start repeat", "partial tie menu");
-        }
-    }
-
-    if (m_note->tieBack() && m_note->tieBack()->startNote()) {
-        //: Used at %1 in the string "Tie to %1 (m. %2)"
-        return muse::mtrc("engraving", "next note", "partial tie menu");
-    }
-
-    //: Used at %1 in the string "Tie to %1 (m. %2)"
-    return muse::mtrc("engraving", "invalid", "partial tie menu");
-}
-
-//---------------------------------------------------------
-//   PartialTieJumpPointList
-//---------------------------------------------------------
-
-TieJumpPointList::~TieJumpPointList()
-{
-    muse::DeleteAll(m_jumpPoints);
-    m_jumpPoints.clear();
-}
-
-void TieJumpPointList::add(TieJumpPoint* item)
-{
-    item->setJumpPointList(this);
-    m_jumpPoints.push_back(item);
-}
-
-void TieJumpPointList::clear()
-{
-    for (const TieJumpPoint* jumpPoint : m_jumpPoints) {
-        Tie* endTie = jumpPoint->endTie();
-        if (!endTie) {
-            continue;
-        }
-        endTie->setJumpPoint(nullptr);
-    }
-    muse::DeleteAll(m_jumpPoints);
-    m_jumpPoints.clear();
-}
-
-TieJumpPoint* TieJumpPointList::findJumpPoint(const String& id)
-{
-    for (TieJumpPoint* jumpPoint : m_jumpPoints) {
-        if (jumpPoint->id() != id) {
-            continue;
-        }
-
-        return jumpPoint;
-    }
-    return nullptr;
-}
-
-void TieJumpPointList::toggleJumpPoint(const String& id)
-{
-    TieJumpPoint* end = findJumpPoint(id);
-
-    if (!end) {
-        LOGE() << "No partial tie end point found with id: " << id;
-        return;
-    }
-
-    Score* score = end->note() ? end->note()->score() : nullptr;
-    if (!score) {
-        return;
-    }
-
-    score->startCmd(TranslatableString("engraving", "Toggle partial tie"));
-    const bool checked = end->active();
-    if (checked) {
-        undoRemoveTieFromScore(end);
-    } else {
-        undoAddTieToScore(end);
-    }
-    score->endCmd();
-}
-
-void TieJumpPointList::undoAddTieToScore(TieJumpPoint* jumpPoint)
-{
-    Note* note = jumpPoint->note();
-    Score* score = note ? note->score() : nullptr;
-    if (!m_startTie || !score) {
-        return;
-    }
-
-    if (jumpPoint->followingNote()) {
-        // Remove partial tie and add full tie
-        if (!m_startTie->isPartialTie() || !toPartialTie(m_startTie)->isOutgoing()) {
-            return;
-        }
-        jumpPoint->undoSetActive(true);
-        m_startTie = Tie::changeTieType(m_startTie, note);
-        return;
-    }
-
-    jumpPoint->undoSetActive(true);
-
-    // Check if there is already a tie.  If so, add partial tie info to it
-    Tie* tieBack = note->tieBack();
-    if (tieBack && !tieBack->isPartialTie()) {
-        tieBack->setJumpPoint(jumpPoint);
-        return;
-    }
-    // Otherwise create incoming partial tie on note
-    PartialTie* pt = Factory::createPartialTie(note);
-    pt->setParent(note);
-    pt->setEndNote(note);
-    pt->setJumpPoint(jumpPoint);
-    score->undoAddElement(pt);
-}
-
-void TieJumpPointList::undoRemoveTieFromScore(TieJumpPoint* jumpPoint)
-{
-    Note* note = jumpPoint->note();
-    Score* score = note ? note->score() : nullptr;
-    if (!m_startTie || !score) {
-        return;
-    }
-
-    if (jumpPoint->followingNote()) {
-        // Remove full tie and add partial tie
-        if (m_startTie->isPartialTie()) {
-            return;
-        }
-        jumpPoint->undoSetActive(false);
-
-        m_startTie = Tie::changeTieType(m_startTie);
-        return;
-    }
-
-    jumpPoint->undoSetActive(false);
-
-    // Check if there is a full tie. If so, remove partial tie info from it
-    Tie* tieBack = note->tieBack();
-    if (tieBack && !tieBack->isPartialTie()) {
-        tieBack->setJumpPoint(nullptr);
-        return;
-    }
-    // Otherwise remove incoming partial tie on note
-    PartialTie* pt = note->incomingPartialTie();
-    if (!pt) {
-        return;
-    }
-    score->undoRemoveElement(pt);
-}
-
 Tie* Tie::changeTieType(Tie* oldTie, Note* endNote)
 {
     // Replaces oldTie with an outgoing partial tie if no endNote is specified.  Otherwise replaces oldTie with a regular tie
@@ -748,5 +508,10 @@ void Tie::updateStartTieOnRemoval()
     if (startTieJumpPoints()->size() <= 1 || _startTie->allJumpPointsInactive()) {
         score()->undoRemoveElement(_startTie);
     }
+}
+
+Tie* Tie::startTie() const
+{
+    return startTieJumpPoints() ? startTieJumpPoints()->startTie() : nullptr;
 }
 }

--- a/src/engraving/dom/tie.cpp
+++ b/src/engraving/dom/tie.cpp
@@ -229,12 +229,11 @@ void Tie::updatePossibleJumpPoints()
 
     const Note* note = toNote(parentItem());
     const Chord* chord = note->chord();
+    const Measure* measure = chord->measure();
 
     if (!chord->hasFollowingJumpItem()) {
         return;
     }
-
-    const Measure* measure = chord->measure();
 
     int jumpPointIdx = 0;
 

--- a/src/engraving/dom/tie.cpp
+++ b/src/engraving/dom/tie.cpp
@@ -457,14 +457,14 @@ bool Tie::isCrossStaff() const
            || (endChord && (endChord->staffMove() != 0 || endChord->vStaffIdx() != staff));
 }
 
-Tie* Tie::changeTieType(Tie* oldTie, Note* endNote)
+void Tie::changeTieType(Tie* oldTie, Note* endNote)
 {
     // Replaces oldTie with an outgoing partial tie if no endNote is specified.  Otherwise replaces oldTie with a regular tie
     Note* startNote = oldTie->startNote();
     bool addPartialTie = !endNote;
     Score* score = startNote ? startNote->score() : nullptr;
     if (!score) {
-        return nullptr;
+        return;
     }
 
     TranslatableString undoCmd = addPartialTie ? TranslatableString("engraving", "Replace full tie with partial tie")
@@ -494,8 +494,6 @@ Tie* Tie::changeTieType(Tie* oldTie, Note* endNote)
     score->undoAddElement(newTie);
 
     score->endCmd();
-
-    return newTie;
 }
 
 void Tie::updateStartTieOnRemoval()

--- a/src/engraving/dom/tie.h
+++ b/src/engraving/dom/tie.h
@@ -26,63 +26,7 @@
 
 namespace mu::engraving {
 class TieJumpPointList;
-class TieJumpPoint
-{
-public:
-    TieJumpPoint(Note* note, bool active, int idx, bool followingNote);
-    TieJumpPoint() {}
-
-    Note* note() const { return m_note; }
-    Tie* endTie() const;
-    bool followingNote() const { return m_followingNote; }
-    const String& id() const { return m_id; }
-    bool active() const { return m_active; }
-    void setActive(bool v) { m_active = v; }
-    void undoSetActive(bool v);
-    void setJumpPointList(TieJumpPointList* jumpPointList) { m_jumpPointList = jumpPointList; }
-    TieJumpPointList* jumpPointList() { return m_jumpPointList; }
-
-    const String menuTitle() const;
-
-private:
-    String precedingJumpItemName() const;
-    Note* m_note = nullptr;
-    bool m_active = false;
-    String m_id;
-    TieJumpPointList* m_jumpPointList = nullptr;
-    bool m_followingNote = false;
-};
-
-class TieJumpPointList
-{
-public:
-    TieJumpPointList() = default;
-    ~TieJumpPointList();
-
-    void add(TieJumpPoint* item);
-    void clear();
-    size_t size() const { return m_jumpPoints.size(); }
-    bool empty() const { return m_jumpPoints.empty(); }
-
-    void setStartTie(Tie* startTie) { m_startTie = startTie; }
-    Tie* startTie() const { return m_startTie; }
-
-    TieJumpPoint* findJumpPoint(const String& id);
-    void toggleJumpPoint(const String& id);
-
-    void undoAddTieToScore(TieJumpPoint* jumpPoint);
-    void undoRemoveTieFromScore(TieJumpPoint* jumpPoint);
-
-    std::vector<TieJumpPoint*>::iterator begin() { return m_jumpPoints.begin(); }
-    std::vector<TieJumpPoint*>::const_iterator begin() const { return m_jumpPoints.begin(); }
-    std::vector<TieJumpPoint*>::iterator end() { return m_jumpPoints.end(); }
-    std::vector<TieJumpPoint*>::const_iterator end() const { return m_jumpPoints.end(); }
-
-private:
-    std::vector<TieJumpPoint*> m_jumpPoints;
-    Tie* m_startTie = nullptr;
-};
-
+class TieJumpPoint;
 //---------------------------------------------------------
 //   @@ TieSegment
 ///    a single segment of a tie
@@ -189,7 +133,7 @@ public:
     void setJumpPoint(TieJumpPoint* jumpPoint) { m_jumpPoint = jumpPoint; }
     void updateStartTieOnRemoval();
     TieJumpPoint* jumpPoint() const { return m_jumpPoint; }
-    Tie* startTie() const { return startTieJumpPoints() ? startTieJumpPoints()->startTie() : nullptr; }
+    Tie* startTie() const;
 
     static Tie* changeTieType(Tie* oldTie, Note* endNote = nullptr);
 
@@ -201,6 +145,6 @@ protected:
 
     // Jump point information for incoming ties after repeats
     TieJumpPoint* m_jumpPoint = nullptr;
-    TieJumpPointList* startTieJumpPoints() const { return m_jumpPoint ? m_jumpPoint->jumpPointList() : nullptr; }
+    TieJumpPointList* startTieJumpPoints() const;
 };
 } // namespace mu::engraving

--- a/src/engraving/dom/tie.h
+++ b/src/engraving/dom/tie.h
@@ -135,7 +135,7 @@ public:
     TieJumpPoint* jumpPoint() const { return m_jumpPoint; }
     Tie* startTie() const;
 
-    static Tie* changeTieType(Tie* oldTie, Note* endNote = nullptr);
+    static void changeTieType(Tie* oldTie, Note* endNote = nullptr);
 
 protected:
     Tie(const ElementType& type, EngravingItem* parent = nullptr);

--- a/src/engraving/dom/tie.h
+++ b/src/engraving/dom/tie.h
@@ -70,7 +70,7 @@ public:
     TieJumpPoint* findJumpPoint(const String& id);
     void toggleJumpPoint(const String& id);
 
-    void addTieToScore(TieJumpPoint* jumpPoint);
+    void undoAddTieToScore(TieJumpPoint* jumpPoint);
     void undoRemoveTieFromScore(TieJumpPoint* jumpPoint);
 
     std::vector<TieJumpPoint*>::iterator begin() { return m_jumpPoints.begin(); }

--- a/src/engraving/dom/tiejumppointlist.cpp
+++ b/src/engraving/dom/tiejumppointlist.cpp
@@ -1,0 +1,260 @@
+#include "tiejumppointlist.h"
+
+#include "barline.h"
+#include "chord.h"
+#include "factory.h"
+#include "marker.h"
+#include "measure.h"
+#include "note.h"
+#include "partialtie.h"
+#include "score.h"
+#include "segment.h"
+#include "tie.h"
+#include "undo.h"
+#include "volta.h"
+
+using namespace mu::engraving;
+
+//---------------------------------------------------------
+//   TieJumpPoint
+//---------------------------------------------------------
+
+TieJumpPoint::TieJumpPoint(Note* note, bool active, int idx, bool followingNote)
+    : m_note(note), m_active(active), m_followingNote(followingNote)
+{
+    m_id = u"jumpPoint" + String::fromStdString(std::to_string(idx));
+    if (active && endTie()) {
+        endTie()->setJumpPoint(this);
+    }
+}
+
+Tie* TieJumpPoint::endTie() const
+{
+    return m_note ? m_note->tieBack() : nullptr;
+}
+
+void TieJumpPoint::undoSetActive(bool v)
+{
+    Score* score = m_note ? m_note->score() : nullptr;
+    if (!score || m_active == v) {
+        return;
+    }
+    score->undo(new ChangeTieJumpPointActive(m_jumpPointList, m_id, v));
+}
+
+const String TieJumpPoint::menuTitle() const
+{
+    const Measure* measure = m_note->findMeasure();
+    const int measureNo = measure ? measure->no() + 1 : 0;
+    const String measureStr = String::fromStdString(std::to_string(measureNo));
+
+    //: %1 represents the preceding jump item eg. coda. %2 represents the measure number
+    return muse::mtrc("engraving", "Tie to %1 (m. %2)").arg(precedingJumpItemName(), measureStr);
+}
+
+String TieJumpPoint::precedingJumpItemName() const
+{
+    const Chord* startChord = m_note->chord();
+    const Segment* seg = startChord->segment();
+    const Measure* measure = seg->measure();
+
+    if (seg->score()->firstSegment(SegmentType::ChordRest) == seg) {
+        //: Used at %1 in the string "Tie to %1 (m. %2)"
+        return muse::mtrc("engraving", "start of score", "partial tie menu");
+    }
+
+    // Markers
+    for (const EngravingItem* e : measure->el()) {
+        if (!e->isMarker()) {
+            continue;
+        }
+
+        const Marker* marker = toMarker(e);
+        if (muse::contains(Marker::RIGHT_MARKERS, marker->markerType())) {
+            continue;
+        }
+
+        if (marker->markerType() == MarkerType::CODA || marker->markerType() == MarkerType::VARCODA) {
+            //: Used at %1 in the string "Tie to %1 (m. %2)"
+            return muse::mtrc("engraving", "coda", "partial tie menu");
+        } else {
+            //: Used at %1 in the string "Tie to %1 (m. %2)"
+            return muse::mtrc("engraving", "segno", "partial tie menu");
+        }
+    }
+
+    // Voltas
+    auto spanners = m_note->score()->spannerMap().findOverlapping(measure->tick().ticks(), measure->tick().ticks());
+    for (auto& spanner : spanners) {
+        if (!spanner.value->isVolta() || Fraction::fromTicks(spanner.start) != startChord->tick()) {
+            continue;
+        }
+
+        Volta* volta = toVolta(spanner.value);
+
+        //: Used at %1 in the string "Tie to %1 (m. %2)". %1 in this string represents the volta's text set by the user
+        return muse::mtrc("engraving", "“%1” volta", "partial tie menu").arg(volta->beginText());
+    }
+
+    // Repeat barlines
+    if (measure->repeatStart()) {
+        //: Used at %1 in the string "Tie to %1 (m. %2)"
+        return muse::mtrc("engraving", "start repeat", "partial tie menu");
+    }
+
+    for (Segment* prevSeg = seg->prev(SegmentType::BarLineType); prevSeg && prevSeg->tick() == seg->tick();
+         prevSeg = prevSeg->prev(SegmentType::BarLineType)) {
+        EngravingItem* el = prevSeg->element(startChord->track());
+        if (!el || !el->isBarLine()) {
+            continue;
+        }
+
+        BarLine* bl = toBarLine(el);
+        if (bl->barLineType() & (BarLineType::START_REPEAT | BarLineType::END_START_REPEAT)) {
+            //: Used at %1 in the string "Tie to %1 (m. %2)"
+            return muse::mtrc("engraving", "start repeat", "partial tie menu");
+        }
+    }
+
+    if (m_note->tieBack() && m_note->tieBack()->startNote()) {
+        //: Used at %1 in the string "Tie to %1 (m. %2)"
+        return muse::mtrc("engraving", "next note", "partial tie menu");
+    }
+
+    //: Used at %1 in the string "Tie to %1 (m. %2)"
+    return muse::mtrc("engraving", "invalid", "partial tie menu");
+}
+
+//---------------------------------------------------------
+//   TieJumpPointList
+//---------------------------------------------------------
+
+TieJumpPointList::~TieJumpPointList()
+{
+    muse::DeleteAll(m_jumpPoints);
+    m_jumpPoints.clear();
+}
+
+void TieJumpPointList::add(TieJumpPoint* item)
+{
+    item->setJumpPointList(this);
+    m_jumpPoints.push_back(item);
+}
+
+void TieJumpPointList::clear()
+{
+    for (const TieJumpPoint* jumpPoint : m_jumpPoints) {
+        Tie* endTie = jumpPoint->endTie();
+        if (!endTie) {
+            continue;
+        }
+        endTie->setJumpPoint(nullptr);
+    }
+    muse::DeleteAll(m_jumpPoints);
+    m_jumpPoints.clear();
+}
+
+TieJumpPoint* TieJumpPointList::findJumpPoint(const String& id)
+{
+    for (TieJumpPoint* jumpPoint : m_jumpPoints) {
+        if (jumpPoint->id() != id) {
+            continue;
+        }
+
+        return jumpPoint;
+    }
+    return nullptr;
+}
+
+void TieJumpPointList::toggleJumpPoint(const String& id)
+{
+    TieJumpPoint* end = findJumpPoint(id);
+
+    if (!end) {
+        LOGE() << "No partial tie end point found with id: " << id;
+        return;
+    }
+
+    Score* score = end->note() ? end->note()->score() : nullptr;
+    if (!score) {
+        return;
+    }
+
+    score->startCmd(TranslatableString("engraving", "Toggle partial tie"));
+    const bool checked = end->active();
+    if (checked) {
+        undoRemoveTieFromScore(end);
+    } else {
+        undoAddTieToScore(end);
+    }
+    score->endCmd();
+}
+
+void TieJumpPointList::undoAddTieToScore(TieJumpPoint* jumpPoint)
+{
+    Note* note = jumpPoint->note();
+    Score* score = note ? note->score() : nullptr;
+    if (!m_startTie || !score) {
+        return;
+    }
+
+    if (jumpPoint->followingNote()) {
+        // Remove partial tie and add full tie
+        if (!m_startTie->isPartialTie() || !toPartialTie(m_startTie)->isOutgoing()) {
+            return;
+        }
+        jumpPoint->undoSetActive(true);
+        m_startTie = Tie::changeTieType(m_startTie, note);
+        return;
+    }
+
+    jumpPoint->undoSetActive(true);
+
+    // Check if there is already a tie.  If so, add partial tie info to it
+    Tie* tieBack = note->tieBack();
+    if (tieBack && !tieBack->isPartialTie()) {
+        tieBack->setJumpPoint(jumpPoint);
+        return;
+    }
+    // Otherwise create incoming partial tie on note
+    PartialTie* pt = Factory::createPartialTie(note);
+    pt->setParent(note);
+    pt->setEndNote(note);
+    pt->setJumpPoint(jumpPoint);
+    score->undoAddElement(pt);
+}
+
+void TieJumpPointList::undoRemoveTieFromScore(TieJumpPoint* jumpPoint)
+{
+    Note* note = jumpPoint->note();
+    Score* score = note ? note->score() : nullptr;
+    if (!m_startTie || !score) {
+        return;
+    }
+
+    if (jumpPoint->followingNote()) {
+        // Remove full tie and add partial tie
+        if (m_startTie->isPartialTie()) {
+            return;
+        }
+        jumpPoint->undoSetActive(false);
+
+        m_startTie = Tie::changeTieType(m_startTie);
+        return;
+    }
+
+    jumpPoint->undoSetActive(false);
+
+    // Check if there is a full tie. If so, remove partial tie info from it
+    Tie* tieBack = note->tieBack();
+    if (tieBack && !tieBack->isPartialTie()) {
+        tieBack->setJumpPoint(nullptr);
+        return;
+    }
+    // Otherwise remove incoming partial tie on note
+    PartialTie* pt = note->incomingPartialTie();
+    if (!pt) {
+        return;
+    }
+    score->undoRemoveElement(pt);
+}

--- a/src/engraving/dom/tiejumppointlist.cpp
+++ b/src/engraving/dom/tiejumppointlist.cpp
@@ -1,3 +1,25 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2025 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include "tiejumppointlist.h"
 
 #include "barline.h"
@@ -154,6 +176,11 @@ void TieJumpPointList::clear()
     m_jumpPoints.clear();
 }
 
+Tie* TieJumpPointList::startTie() const
+{
+    return m_note ? m_note->tieFor() : nullptr;
+}
+
 TieJumpPoint* TieJumpPointList::findJumpPoint(const String& id)
 {
     for (TieJumpPoint* jumpPoint : m_jumpPoints) {
@@ -194,17 +221,18 @@ void TieJumpPointList::undoAddTieToScore(TieJumpPoint* jumpPoint)
 {
     Note* note = jumpPoint->note();
     Score* score = note ? note->score() : nullptr;
-    if (!m_startTie || !score) {
+    Tie* tie = startTie();
+    if (!tie || !score) {
         return;
     }
 
     if (jumpPoint->followingNote()) {
         // Remove partial tie and add full tie
-        if (!m_startTie->isPartialTie() || !toPartialTie(m_startTie)->isOutgoing()) {
+        if (!tie->isPartialTie() || !toPartialTie(tie)->isOutgoing()) {
             return;
         }
         jumpPoint->undoSetActive(true);
-        m_startTie = Tie::changeTieType(m_startTie, note);
+        Tie::changeTieType(tie, note);
         return;
     }
 
@@ -228,18 +256,19 @@ void TieJumpPointList::undoRemoveTieFromScore(TieJumpPoint* jumpPoint)
 {
     Note* note = jumpPoint->note();
     Score* score = note ? note->score() : nullptr;
-    if (!m_startTie || !score) {
+    Tie* tie = startTie();
+    if (!tie || !score) {
         return;
     }
 
     if (jumpPoint->followingNote()) {
         // Remove full tie and add partial tie
-        if (m_startTie->isPartialTie()) {
+        if (tie->isPartialTie()) {
             return;
         }
         jumpPoint->undoSetActive(false);
 
-        m_startTie = Tie::changeTieType(m_startTie);
+        Tie::changeTieType(tie);
         return;
     }
 

--- a/src/engraving/dom/tiejumppointlist.cpp
+++ b/src/engraving/dom/tiejumppointlist.cpp
@@ -138,7 +138,7 @@ String TieJumpPoint::precedingJumpItemName() const
         }
     }
 
-    if (m_note->tieBack() && m_note->tieBack()->startNote()) {
+    if (m_followingNote) {
         //: Used at %1 in the string "Tie to %1 (m. %2)"
         return muse::mtrc("engraving", "next note", "partial tie menu");
     }

--- a/src/engraving/dom/tiejumppointlist.cpp
+++ b/src/engraving/dom/tiejumppointlist.cpp
@@ -68,10 +68,9 @@ const String TieJumpPoint::menuTitle() const
 {
     const Measure* measure = m_note->findMeasure();
     const int measureNo = measure ? measure->no() + 1 : 0;
-    const String measureStr = String::fromStdString(std::to_string(measureNo));
 
     //: %1 represents the preceding jump item eg. coda. %2 represents the measure number
-    return muse::mtrc("engraving", "Tie to %1 (m. %2)").arg(precedingJumpItemName(), measureStr);
+    return muse::mtrc("engraving", "Tie to %1 (m. %2)").arg(precedingJumpItemName(), String::number(measureNo));
 }
 
 String TieJumpPoint::precedingJumpItemName() const

--- a/src/engraving/dom/tiejumppointlist.h
+++ b/src/engraving/dom/tiejumppointlist.h
@@ -23,7 +23,6 @@
 #pragma once
 #include "global/types/string.h"
 
-using muse::String;
 namespace mu::engraving {
 class Note;
 class Tie;
@@ -40,7 +39,7 @@ public:
     Note* note() const { return m_note; }
     Tie* endTie() const;
     bool followingNote() const { return m_followingNote; }
-    const String& id() const { return m_id; }
+    const muse::String& id() const { return m_id; }
     bool active() const { return m_active; }
     void setActive(bool v) { m_active = v; }
     void undoSetActive(bool v);
@@ -49,13 +48,13 @@ public:
     void setJumpPointList(TieJumpPointList* jumpPointList) { m_jumpPointList = jumpPointList; }
     TieJumpPointList* jumpPointList() { return m_jumpPointList; }
 
-    const String menuTitle() const;
+    const muse::String menuTitle() const;
 
 private:
-    String precedingJumpItemName() const;
+    muse::String precedingJumpItemName() const;
     Note* m_note = nullptr;
     bool m_active = false;
-    String m_id;
+    muse::String m_id;
     TieJumpPointList* m_jumpPointList = nullptr;
     bool m_followingNote = false;
 };
@@ -76,8 +75,8 @@ public:
 
     Tie* startTie() const;
 
-    TieJumpPoint* findJumpPoint(const String& id);
-    void toggleJumpPoint(const String& id);
+    TieJumpPoint* findJumpPoint(const muse::String& id);
+    void toggleJumpPoint(const muse::String& id);
 
     void undoAddTieToScore(TieJumpPoint* jumpPoint);
     void undoRemoveTieFromScore(TieJumpPoint* jumpPoint);

--- a/src/engraving/dom/tiejumppointlist.h
+++ b/src/engraving/dom/tiejumppointlist.h
@@ -1,3 +1,25 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2025 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 #include "global/types/string.h"
 
@@ -22,6 +44,8 @@ public:
     bool active() const { return m_active; }
     void setActive(bool v) { m_active = v; }
     void undoSetActive(bool v);
+
+    // Stores the list that this end point belongs to. This is needed to find the start tie from an endpoint
     void setJumpPointList(TieJumpPointList* jumpPointList) { m_jumpPointList = jumpPointList; }
     TieJumpPointList* jumpPointList() { return m_jumpPointList; }
 
@@ -41,7 +65,8 @@ private:
 class TieJumpPointList
 {
 public:
-    TieJumpPointList() = default;
+    TieJumpPointList(Note* note)
+        : m_note(note) {}
     ~TieJumpPointList();
 
     void add(TieJumpPoint* item);
@@ -49,8 +74,7 @@ public:
     size_t size() const { return m_jumpPoints.size(); }
     bool empty() const { return m_jumpPoints.empty(); }
 
-    void setStartTie(Tie* startTie) { m_startTie = startTie; }
-    Tie* startTie() const { return m_startTie; }
+    Tie* startTie() const;
 
     TieJumpPoint* findJumpPoint(const String& id);
     void toggleJumpPoint(const String& id);
@@ -65,6 +89,6 @@ public:
 
 private:
     std::vector<TieJumpPoint*> m_jumpPoints;
-    Tie* m_startTie = nullptr;
+    Note* m_note = nullptr;
 };
 }

--- a/src/engraving/dom/tiejumppointlist.h
+++ b/src/engraving/dom/tiejumppointlist.h
@@ -1,0 +1,70 @@
+#pragma once
+#include "global/types/string.h"
+
+using muse::String;
+namespace mu::engraving {
+class Note;
+class Tie;
+class TieJumpPointList;
+
+// Items of TieJumpPointList
+// Stores information about an endpoint
+class TieJumpPoint
+{
+public:
+    TieJumpPoint(Note* note, bool active, int idx, bool followingNote);
+    TieJumpPoint() {}
+
+    Note* note() const { return m_note; }
+    Tie* endTie() const;
+    bool followingNote() const { return m_followingNote; }
+    const String& id() const { return m_id; }
+    bool active() const { return m_active; }
+    void setActive(bool v) { m_active = v; }
+    void undoSetActive(bool v);
+    void setJumpPointList(TieJumpPointList* jumpPointList) { m_jumpPointList = jumpPointList; }
+    TieJumpPointList* jumpPointList() { return m_jumpPointList; }
+
+    const String menuTitle() const;
+
+private:
+    String precedingJumpItemName() const;
+    Note* m_note = nullptr;
+    bool m_active = false;
+    String m_id;
+    TieJumpPointList* m_jumpPointList = nullptr;
+    bool m_followingNote = false;
+};
+
+// Created & deleted by Note
+// Manages adding and removing ties from endpoints
+class TieJumpPointList
+{
+public:
+    TieJumpPointList() = default;
+    ~TieJumpPointList();
+
+    void add(TieJumpPoint* item);
+    void clear();
+    size_t size() const { return m_jumpPoints.size(); }
+    bool empty() const { return m_jumpPoints.empty(); }
+
+    void setStartTie(Tie* startTie) { m_startTie = startTie; }
+    Tie* startTie() const { return m_startTie; }
+
+    TieJumpPoint* findJumpPoint(const String& id);
+    void toggleJumpPoint(const String& id);
+
+    void undoAddTieToScore(TieJumpPoint* jumpPoint);
+    void undoRemoveTieFromScore(TieJumpPoint* jumpPoint);
+
+    std::vector<TieJumpPoint*>::iterator begin() { return m_jumpPoints.begin(); }
+    std::vector<TieJumpPoint*>::const_iterator begin() const { return m_jumpPoints.begin(); }
+    std::vector<TieJumpPoint*>::iterator end() { return m_jumpPoints.end(); }
+    std::vector<TieJumpPoint*>::const_iterator end() const { return m_jumpPoints.end(); }
+
+private:
+    std::vector<TieJumpPoint*> m_jumpPoints;
+    Tie* m_startTie = nullptr;
+};
+}

--- a/src/engraving/style/styledef.cpp
+++ b/src/engraving/style/styledef.cpp
@@ -538,7 +538,7 @@ const std::array<StyleDef::StyleValue, size_t(Sid::STYLES)> StyleDef::styleValue
     styleDef(tieMidWidth,                                Spatium(.21)),
     styleDef(tieDottedWidth,                             Spatium(.10)),
     styleDef(minTieLength,                               Spatium(1.0)),
-    styleDef(minHangingTieLength,                        Spatium(1.0)),
+    styleDef(minHangingTieLength,                        Spatium(1.5)),
     styleDef(minStraightGlissandoLength,                 Spatium(1.2)),
     styleDef(minWigglyGlissandoLength,                   Spatium(2.0)),
     styleDef(slurMinDistance,                            Spatium(0.5)),

--- a/src/framework/uicomponents/qml/Muse/UiComponents/ContextMenuLoader.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/ContextMenuLoader.qml
@@ -21,22 +21,11 @@
  */
 import QtQuick 2.15
 
-import Muse.Ui 1.0
-
 Item {
     id: container
 
     // Useful for static context menus
     property var items: []
-
-
-    property NavigationSection notationViewNavigationSection: null
-    property int navigationOrderStart: 0
-
-    property alias closeMenuOnSelection: contextMenuLoader.closeMenuOnSelection
-    property alias opensUpward: contextMenuLoader.opensUpward
-    property alias focusOnOpened: contextMenuLoader.focusOnOpened
-    property alias item: contextMenuLoader.item
 
     signal handleMenuItem(string itemId)
     signal opened()
@@ -46,13 +35,6 @@ Item {
     //  next(depending on the limitation) to the pressed position.
     width: 0
     height: 0
-
-    onNotationViewNavigationSectionChanged: function() {
-        contextMenuLoader.item.navigationSectionOverride = container.notationViewNavigationSection
-    }
-    onNavigationOrderStartChanged: function() {
-        contextMenuLoader.item.navigationOrderStart = container.navigationOrderStart
-    }
 
     function show(position: point, items) {
         if (!items) {

--- a/src/framework/uicomponents/qml/Muse/UiComponents/StyledMenuLoader.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/StyledMenuLoader.qml
@@ -21,7 +21,6 @@
  */
 import QtQuick 2.15
 
-import Muse.Ui 1.0
 import Muse.UiComponents 1.0
 
 import "internal"
@@ -38,13 +37,6 @@ Loader {
     property StyledMenu menu: loader.item as StyledMenu
     property Item menuAnchorItem: null
     property bool hasSiblingMenus: false
-    property bool closeMenuOnSelection: true
-    property bool focusOnOpened: true
-
-    property NavigationSection notationViewNavigationSection: null
-    property int navigationOrderStart: 0
-
-    property bool opensUpward: false
 
     property alias isMenuOpened: loader.active
 
@@ -73,9 +65,7 @@ Loader {
         accessibleName: loader.accessibleName
 
         onHandleMenuItem: function(itemId) {
-            if (loader.closeMenuOnSelection) {
-                itemMenu.close()
-            }
+            itemMenu.close()
             Qt.callLater(loader.handleMenuItem, itemId)
         }
 
@@ -92,9 +82,7 @@ Loader {
         }
 
         onOpened: {
-            if (focusOnOpened) {
-                focusOnOpenedMenuTimer.start()
-            }
+            focusOnOpenedMenuTimer.start()
         }
     }
 
@@ -144,8 +132,6 @@ Loader {
         }
 
         menu.closeSubMenu()
-
-        menu.setOpensUpward(loader.opensUpward)
 
         if (x !== -1) {
             menu.x = x

--- a/src/framework/uicomponents/qml/Muse/UiComponents/internal/StyledMenu.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/internal/StyledMenu.qml
@@ -32,9 +32,6 @@ MenuView {
 
     property alias model: view.model
 
-    property NavigationSection navigationSectionOverride: null
-    property int navigationOrderStart: 0
-
     property int preferredAlign: Qt.AlignRight // Left, HCenter, Right
     property bool hasSiblingMenus: loader.hasSiblingMenus
 
@@ -137,9 +134,9 @@ MenuView {
 
         property NavigationPanel navigationPanel: NavigationPanel {
             name: "StyledMenu"
+            section: content.navigationSection
             direction: NavigationPanel.Vertical
-            section: root.navigationSectionOverride ?? content.navigationSection
-            order: root.navigationOrderStart
+            order: 1
 
             accessible.name: root.accessibleName
 

--- a/src/notation/notationscene.qrc
+++ b/src/notation/notationscene.qrc
@@ -76,5 +76,6 @@
         <file>qml/MuseScore/NotationScene/internal/EditStyle/timeSigImages/timesig-on_all_staves.png</file>
         <file>qml/MuseScore/NotationScene/internal/EditStyle/timeSigImages/timesig-courtesy-create_space.png</file>
         <file>qml/MuseScore/NotationScene/internal/EditStyle/StyledImage.qml</file>
+        <file>qml/MuseScore/NotationScene/internal/PartialTieMenuRowItem.qml</file>
     </qresource>
 </RCC>

--- a/src/notation/qml/MuseScore/NotationScene/internal/CapoPopup.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/CapoPopup.qml
@@ -33,8 +33,6 @@ StyledPopupView {
     property alias navigationOrderStart: capoSettingsNavPanel.order
     readonly property alias navigationOrderEnd: capoSettingsNavPanel.order
 
-    readonly property alias model: capoModel
-
 
     contentWidth: content.width
     contentHeight: content.height

--- a/src/notation/qml/MuseScore/NotationScene/internal/CapoPopup.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/CapoPopup.qml
@@ -33,7 +33,7 @@ StyledPopupView {
     property alias navigationOrderStart: capoSettingsNavPanel.order
     readonly property alias navigationOrderEnd: capoSettingsNavPanel.order
 
-    property QtObject model: capoModel
+    readonly property alias model: capoModel
 
 
     contentWidth: content.width

--- a/src/notation/qml/MuseScore/NotationScene/internal/HarpPedalPopup.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/HarpPedalPopup.qml
@@ -30,7 +30,7 @@ import MuseScore.NotationScene 1.0
 StyledPopupView {
     id: root
 
-    property QtObject model: harpModel
+    readonly property alias model: harpModel
 
     property variant pedalState: harpModel.pedalState
 

--- a/src/notation/qml/MuseScore/NotationScene/internal/HarpPedalPopup.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/HarpPedalPopup.qml
@@ -29,9 +29,6 @@ import MuseScore.NotationScene 1.0
 
 StyledPopupView {
     id: root
-
-    readonly property alias model: harpModel
-
     property variant pedalState: harpModel.pedalState
 
     property alias notationViewNavigationSection: pedalSettingsNavPanel.section
@@ -279,7 +276,7 @@ StyledPopupView {
             Layout.leftMargin: 30
             Layout.fillWidth: true
 
-            checked: model.isDiagram
+            checked: harpModel.isDiagram
             text: qsTrc("notation", "Diagram")
 
             navigation.name: "diagramButton"
@@ -288,7 +285,7 @@ StyledPopupView {
             navigation.accessible.name: qsTrc("notation", "Diagram")
 
             onToggled: {
-                model.setIsDiagram(true)
+                harpModel.setIsDiagram(true)
             }
         }
 
@@ -302,7 +299,7 @@ StyledPopupView {
             Layout.bottomMargin: 15
             Layout.fillWidth: true
 
-            checked: !model.isDiagram
+            checked: !harpModel.isDiagram
             text: qsTrc("notation", "Text")
 
             navigation.name: "textButton"
@@ -311,7 +308,7 @@ StyledPopupView {
             navigation.accessible.name: qsTrc("notation", "Text")
 
             onToggled: {
-                model.setIsDiagram(false)
+                harpModel.setIsDiagram(false)
             }
         }
     }

--- a/src/notation/qml/MuseScore/NotationScene/internal/PartialTieMenuRowItem.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/PartialTieMenuRowItem.qml
@@ -1,0 +1,75 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2025 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import QtQuick.Window 2.15
+
+import Muse.Ui 1.0
+import Muse.UiComponents 1.0
+import MuseScore.NotationScene 1.0
+
+ListItemBlank {
+    function calculateWidth() {
+        let result = 0
+
+        result += rowLayout.anchors.leftMargin
+
+        result += Math.ceil(checkIcon.Layout.preferredWidth)
+        result += rowLayout.spacing
+
+        result += Math.ceil(titleLabel.implicitWidth)
+        result += rowLayout.spacing
+        result += rowLayout.anchors.rightMargin
+
+        return result
+    }
+
+    RowLayout {
+        id: rowLayout
+
+        anchors.verticalCenter: parent.verticalCenter
+        anchors.left: parent.left
+        anchors.leftMargin: 12
+        anchors.right: parent.right
+        anchors.rightMargin: 12
+
+        spacing: 12
+
+        StyledIconLabel {
+            id: checkIcon
+            Layout.alignment: Qt.AlignLeft
+            Layout.preferredWidth: 16
+            iconCode: modelData.checked ? IconCode.TICK_RIGHT_ANGLE : IconCode.NONE
+        }
+
+        StyledTextLabel {
+            id: titleLabel
+            Layout.fillWidth: true
+            horizontalAlignment: Text.AlignLeft
+
+            text: modelData.title
+
+            textFormat: Text.RichText
+        }
+    }
+}

--- a/src/notation/qml/MuseScore/NotationScene/internal/PartialTieMenuRowItem.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/PartialTieMenuRowItem.qml
@@ -44,6 +44,11 @@ ListItemBlank {
         return result
     }
 
+    id: rowDelegate
+
+    required property var modelData
+    required property var model
+
     RowLayout {
         id: rowLayout
 
@@ -59,7 +64,7 @@ ListItemBlank {
             id: checkIcon
             Layout.alignment: Qt.AlignLeft
             Layout.preferredWidth: 16
-            iconCode: modelData.checked ? IconCode.TICK_RIGHT_ANGLE : IconCode.NONE
+            iconCode: rowDelegate.modelData.checked ? IconCode.TICK_RIGHT_ANGLE : IconCode.NONE
         }
 
         StyledTextLabel {
@@ -67,7 +72,7 @@ ListItemBlank {
             Layout.fillWidth: true
             horizontalAlignment: Text.AlignLeft
 
-            text: modelData.title
+            text: rowDelegate.modelData.title
 
             textFormat: Text.RichText
         }

--- a/src/notation/qml/MuseScore/NotationScene/internal/PartialTiePopup.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/PartialTiePopup.qml
@@ -5,7 +5,7 @@
  * MuseScore
  * Music Composition & Notation
  *
- * Copyright (C) 2022 MuseScore BVBA and others
+ * Copyright (C) 2025 MuseScore BVBA and others
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -32,6 +32,9 @@ StyledPopupView {
     id: root
     margins: 0
 
+    contentWidth: content.width
+    contentHeight: content.height
+
     property alias notationViewNavigationSection: partialTieNavPanel.section
     property alias navigationOrderStart: partialTieNavPanel.order
     readonly property alias navigationOrderEnd: partialTieNavPanel.order
@@ -40,12 +43,7 @@ StyledPopupView {
 
     showArrow: false
 
-    onOpened: {
-        tieMenuLoader.show(Qt.point(0, 0))
-    }
-
     onClosed: {
-        tieMenuLoader.close()
         partialTiePopupModel.onClosed()
     }
 
@@ -53,26 +51,23 @@ StyledPopupView {
 
     function updatePosition() {
         const opensUp = partialTiePopupModel.tieDirection
-        const popupHeight = tieMenuLoader.item.height + root.margins * 2 + root.padding * 2
+        const popupHeight = content.height + root.margins * 2 + root.padding * 2
         root.x = partialTiePopupModel.dialogPosition.x - root.parent.x
         root.y = partialTiePopupModel.dialogPosition.y - root.parent.y - (opensUp ? popupHeight : 0)
         root.setOpensUpward(opensUp)
+
+        tieMenuList.calculateWidth()
     }
 
-    contentWidth: tieMenuLoader.width
-    contentHeight: tieMenuLoader.childrenRect.height
+    Component.onCompleted: {
+        partialTiePopupModel.init()
+    }
 
-    ContextMenuLoader {
-        id: tieMenuLoader
-        closeMenuOnSelection: false
-        focusOnOpened: false
-        opensUpward: root.opensUpward
-
-        items: partialTiePopupModel.items
-
-        onHandleMenuItem: function(itemId) {
-            partialTiePopupModel.toggleItemChecked(itemId)
-        }
+    Column {
+        id: content
+        width: tieMenuList.width
+        height: tieMenuList.height
+        spacing: 0
 
         PartialTiePopupModel {
             id: partialTiePopupModel
@@ -82,12 +77,8 @@ StyledPopupView {
             }
 
             onItemsChanged: function() {
-                tieMenuLoader.show(Qt.point(0, 0))
+                tieMenuList.model = partialTiePopupModel.items
             }
-        }
-
-        Component.onCompleted: {
-            partialTiePopupModel.init()
         }
 
         NavigationPanel {
@@ -95,13 +86,45 @@ StyledPopupView {
             name: "PartialTieMenu"
             direction: NavigationPanel.Vertical
             accessible.name: qsTrc("notation", "Partial tie menu items")
+        }
 
-            onSectionChanged: function() {
-                tieMenuLoader.notationViewNavigationSection = section
+        StyledListView {
+            id: tieMenuList
+
+            property int itemHeight: 32
+
+            implicitWidth: contentItem.childrenRect.width
+            height: itemHeight * count
+
+            spacing: 0
+            arrowControlsAvailable: false
+
+            model: partialTiePopupModel.items
+
+            visible: true
+
+            function calculateWidth() {
+                var result = 0
+                for (var item in tieMenuList.contentItem.children) {
+                    var row = tieMenuList.contentItem.children[item];
+                    if (!(row instanceof ListItemBlank)) {
+                        continue
+                    }
+                    result = Math.max(result, tieMenuList.contentItem.children[item].calculateWidth())
+                }
+
+                tieMenuList.width = result
             }
 
-            onOrderChanged: function() {
-                tieMenuLoader.navigationOrderStart = order
+            delegate: PartialTieMenuRowItem {
+                implicitHeight: tieMenuList.itemHeight
+                hoverHitColor: ui.theme.accentColor
+                anchors.left: parent ? parent.left : undefined
+                anchors.right: parent ? parent.right : undefined
+
+                onClicked: {
+                    partialTiePopupModel.toggleItemChecked(modelData.id)
+                }
             }
         }
     }

--- a/src/notation/qml/MuseScore/NotationScene/internal/PartialTiePopup.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/PartialTiePopup.qml
@@ -35,11 +35,9 @@ StyledPopupView {
     contentWidth: content.width
     contentHeight: content.height
 
-    property alias notationViewNavigationSection: partialTieNavPanel.section
-    property alias navigationOrderStart: partialTieNavPanel.order
-    readonly property alias navigationOrderEnd: partialTieNavPanel.order
-
-    readonly property alias model: partialTiePopupModel
+    property NavigationSection notationViewNavigationSection: null
+    property int navigationOrderStart: 0
+    property int navigationOrderEnd: tieMenuList.navigation.order
 
     showArrow: false
 
@@ -81,13 +79,6 @@ StyledPopupView {
             }
         }
 
-        NavigationPanel {
-            id: partialTieNavPanel
-            name: "PartialTieMenu"
-            direction: NavigationPanel.Vertical
-            accessible.name: qsTrc("notation", "Partial tie menu items")
-        }
-
         StyledListView {
             id: tieMenuList
 
@@ -100,6 +91,9 @@ StyledPopupView {
             arrowControlsAvailable: false
 
             model: partialTiePopupModel.items
+
+            navigation.section: notationViewNavigationSection
+            navigation.order: navigationOrderStart
 
             visible: true
 
@@ -121,6 +115,9 @@ StyledPopupView {
                 hoverHitColor: ui.theme.accentColor
                 anchors.left: parent ? parent.left : undefined
                 anchors.right: parent ? parent.right : undefined
+
+                navigation.panel: tieMenuList.navigation
+                navigation.row: model.index
 
                 onClicked: {
                     partialTiePopupModel.toggleItemChecked(modelData.id)

--- a/src/notation/qml/MuseScore/NotationScene/internal/PartialTiePopup.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/PartialTiePopup.qml
@@ -36,7 +36,7 @@ StyledPopupView {
     property alias navigationOrderStart: partialTieNavPanel.order
     readonly property alias navigationOrderEnd: partialTieNavPanel.order
 
-    property QtObject model: partialTiePopupModel
+    readonly property alias model: partialTiePopupModel
 
     showArrow: false
 

--- a/src/notation/qml/MuseScore/NotationScene/internal/StringTuningsPopup.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/StringTuningsPopup.qml
@@ -33,7 +33,7 @@ StyledPopupView {
     property alias navigationOrderStart: navPanel.order
     readonly property alias navigationOrderEnd: navPanel.order
 
-    property QtObject model: stringTuningsModel
+    readonly property alias model: stringTuningsModel
 
 
     contentWidth: content.width

--- a/src/notation/qml/MuseScore/NotationScene/internal/StringTuningsPopup.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/StringTuningsPopup.qml
@@ -33,9 +33,6 @@ StyledPopupView {
     property alias navigationOrderStart: navPanel.order
     readonly property alias navigationOrderEnd: navPanel.order
 
-    readonly property alias model: stringTuningsModel
-
-
     contentWidth: content.width
     contentHeight: content.height
 

--- a/src/playback/qml/MuseScore/Playback/SoundFlagPopup.qml
+++ b/src/playback/qml/MuseScore/Playback/SoundFlagPopup.qml
@@ -36,7 +36,7 @@ StyledPopupView {
     property alias navigationOrderStart: navPanel.order
     readonly property alias navigationOrderEnd: museSoundsParams.navigationPanelOrderEnd
 
-    property QtObject model: soundFlagModel
+    readonly property alias model: soundFlagModel
 
     contentWidth: content.width
     contentHeight: content.childrenRect.height

--- a/src/playback/qml/MuseScore/Playback/SoundFlagPopup.qml
+++ b/src/playback/qml/MuseScore/Playback/SoundFlagPopup.qml
@@ -36,8 +36,6 @@ StyledPopupView {
     property alias navigationOrderStart: navPanel.order
     readonly property alias navigationOrderEnd: museSoundsParams.navigationPanelOrderEnd
 
-    readonly property alias model: soundFlagModel
-
     contentWidth: content.width
     contentHeight: content.childrenRect.height
     onContentHeightChanged: {


### PR DESCRIPTION
This PR contains:
 - The last few fixes from Casper's review of the first PR
 - Moves `TieJumpPoint` related code to its own file
 - Simplify the relationship between `TieJumpPoint` and `Note`
 - Updates the minimum hanging tie length to 1.5sp
 - Fixes the following crash
https://github.com/user-attachments/assets/a59055ff-bfe8-41c3-9649-bedaec01e235
 - Fixes ties to next notes being named "invalid"
 - Refactors the tie popup. This never needed to use the whole `StyledMenu` implementation and definitely didn't need a loader.  I've recreated the popup in a more straightforward way.
 - Fixed accessibility & navigation in the popup

