### PR TITLE
Const methods

### DIFF
--- a/src/engraving/dom/editdata.h
+++ b/src/engraving/dom/editdata.h
@@ -271,7 +271,7 @@ public:
     bool control(bool textEditing = false) const;
     bool shift() const { return modifiers & ShiftModifier; }
     bool isStartEndGrip() const { return curGrip == Grip::START || curGrip == Grip::END; }
-    bool hasCurrentGrip() { return curGrip != Grip::NO_GRIP; }
+    bool hasCurrentGrip() const { return curGrip != Grip::NO_GRIP; }
 
 private:
     std::list<std::shared_ptr<ElementEditData> > m_data;

--- a/src/engraving/dom/editdata.h
+++ b/src/engraving/dom/editdata.h
@@ -270,7 +270,7 @@ public:
     void addData(std::shared_ptr<ElementEditData>);
     bool control(bool textEditing = false) const;
     bool shift() const { return modifiers & ShiftModifier; }
-    bool isStartEndGrip() { return curGrip == Grip::START || curGrip == Grip::END; }
+    bool isStartEndGrip() const { return curGrip == Grip::START || curGrip == Grip::END; }
     bool hasCurrentGrip() { return curGrip != Grip::NO_GRIP; }
 
 private:

--- a/src/engraving/dom/tempotext.h
+++ b/src/engraving/dom/tempotext.h
@@ -61,7 +61,7 @@ public:
     BeatsPerSecond tempo() const { return m_tempo; }
     double tempoBpm() const;
     void setTempo(BeatsPerSecond v);
-    bool isRelative() { return m_isRelative; }
+    bool isRelative() const { return m_isRelative; }
     void setRelative(double v) { m_isRelative = true; m_relative = v; }
 
     bool isNormal() const { return m_tempoTextType == TempoTextType::NORMAL; }

--- a/src/notation/view/widgets/timeline.h
+++ b/src/notation/view/widgets/timeline.h
@@ -262,7 +262,7 @@ private:
 
     unsigned nmetas() const;
 
-    bool collapsed() { return _collapsedMeta; }
+    bool collapsed() const { return _collapsedMeta; }
     void setCollapsed(bool st) { _collapsedMeta = st; }
 
     engraving::Staff* numToStaff(int staff);


### PR DESCRIPTION
Basically all `is*` and `has*` methods are not changing their object and should be marked const. There were a few without.