### PR TITLE
Percussion panel - refinements round 5

### DIFF
--- a/src/appshell/qml/NotationPage/NotationPage.qml
+++ b/src/appshell/qml/NotationPage/NotationPage.qml
@@ -554,6 +554,10 @@ DockPage {
                 Component.onDestruction: {
                     percussionPanel.toolbarComponent = null
                 }
+
+                onResizeRequested: function(newWidth, newHeight) {
+                    percussionPanel.resize(newWidth, newHeight)
+                }
             }
         }
     ]

--- a/src/appshell/qml/Preferences/PercussionPreferencesPage.qml
+++ b/src/appshell/qml/Preferences/PercussionPreferencesPage.qml
@@ -43,13 +43,14 @@ PreferencesPage {
         id: percussionPanelPreferences
 
         title: qsTrc("appshell/preferences", "Percussion")
+        rowSpacing: 20
 
         navigation.section: root.navigationSection
 
         CheckBox {
             id: unpitchedSelectedCheckbox
 
-            visible: percussionPreferencesModel.useNewPercussionPanel
+            enabled: percussionPreferencesModel.useNewPercussionPanel
             width: parent.width
 
             text: qsTrc("appshell/preferences", "Open the percussion panel when an unpitched staff is selected")
@@ -65,109 +66,138 @@ PreferencesPage {
             }
         }
 
-        StyledTextLabel {
-            id: padSwapInfo
-
-            visible: percussionPreferencesModel.useNewPercussionPanel
-            width: parent.width
-
-            horizontalAlignment: Text.AlignLeft
-            wrapMode: Text.Wrap
-            text: qsTrc("notation/percussion", "When swapping the positions of two drum pads:")
-        }
-
-        RadioButtonGroup {
-            id: radioButtons
-
-            property int navigationRowStart: unpitchedSelectedCheckbox.navigation.row + 1
-            property int navigationRowEnd: radioButtons.navigationRowStart + model.length
-
-            visible: percussionPreferencesModel.useNewPercussionPanel
+        Column {
+            id: swappingOptionsColumn
 
             width: parent.width
-            spacing: percussionPanelPreferences.spacing
+            spacing: 12
 
-            orientation: ListView.Vertical
+            StyledTextLabel {
+                id: padSwapInfo
 
-            model: [
-                { text: qsTrc("notation/percussion", "Move MIDI notes and keyboard shortcuts with their sounds"), value: true },
-                { text: qsTrc("notation/percussion", "Leave MIDI notes and keyboard shortcuts fixed to original pad positions"), value: false }
-            ]
-
-            delegate: Row {
+                enabled: percussionPreferencesModel.useNewPercussionPanel
                 width: parent.width
-                spacing: 6
 
-                RoundedRadioButton {
-                    id: radioButton
+                horizontalAlignment: Text.AlignLeft
+                wrapMode: Text.Wrap
+                text: qsTrc("notation/percussion", "When swapping the positions of two drum pads:")
+            }
 
-                    anchors.verticalCenter: parent.verticalCenter
+            RadioButtonGroup {
+                id: radioButtons
 
-                    navigation.name: modelData.text
-                    navigation.panel: percussionPanelPreferences.navigation
-                    navigation.row: radioButtons.navigationRowStart + model.index
+                property int navigationRowStart: unpitchedSelectedCheckbox.navigation.row + 1
+                property int navigationRowEnd: radioButtons.navigationRowStart + model.length
 
-                    checked: modelData.value === percussionPreferencesModel.percussionPanelMoveMidiNotesAndShortcuts
+                enabled: percussionPreferencesModel.useNewPercussionPanel
 
-                    onToggled: {
-                        percussionPreferencesModel.percussionPanelMoveMidiNotesAndShortcuts = modelData.value
-                    }
-                }
+                width: parent.width
+                spacing: swappingOptionsColumn.spacing
 
-                //! NOTE: Can't use radioButton.text because it won't wrap
-                StyledTextLabel {
-                    width: parent.width - parent.spacing - radioButton.width
+                orientation: ListView.Vertical
 
-                    anchors.verticalCenter: parent.verticalCenter
+                model: [
+                    { text: qsTrc("notation/percussion", "Move MIDI notes and keyboard shortcuts with their sounds"), value: true },
+                    { text: qsTrc("notation/percussion", "Leave MIDI notes and keyboard shortcuts fixed to original pad positions"), value: false }
+                ]
 
-                    horizontalAlignment: Text.AlignLeft
-                    wrapMode: Text.Wrap
-                    text: modelData.text
+                delegate: Row {
+                    width: parent.width
+                    spacing: 6
 
-                    MouseArea {
-                        id: mouseArea
+                    RoundedRadioButton {
+                        id: radioButton
 
-                        anchors.fill: parent
+                        anchors.verticalCenter: parent.verticalCenter
 
-                        onClicked: {
+                        navigation.name: modelData.text
+                        navigation.panel: percussionPanelPreferences.navigation
+                        navigation.row: radioButtons.navigationRowStart + model.index
+
+                        checked: modelData.value === percussionPreferencesModel.percussionPanelMoveMidiNotesAndShortcuts
+
+                        onToggled: {
                             percussionPreferencesModel.percussionPanelMoveMidiNotesAndShortcuts = modelData.value
+                        }
+                    }
+
+                    //! NOTE: Can't use radioButton.text because it won't wrap
+                    StyledTextLabel {
+                        width: parent.width - parent.spacing - radioButton.width
+
+                        anchors.verticalCenter: parent.verticalCenter
+
+                        horizontalAlignment: Text.AlignLeft
+                        wrapMode: Text.Wrap
+                        text: modelData.text
+
+                        MouseArea {
+                            id: mouseArea
+
+                            anchors.fill: parent
+
+                            onClicked: {
+                                percussionPreferencesModel.percussionPanelMoveMidiNotesAndShortcuts = modelData.value
+                            }
                         }
                     }
                 }
             }
-        }
 
-        CheckBox {
-            id: alwaysAsk
+            CheckBox {
+                id: alwaysAsk
 
-            visible: percussionPreferencesModel.useNewPercussionPanel
-            width: parent.width
+                enabled: percussionPreferencesModel.useNewPercussionPanel
+                width: parent.width
 
-            text: qsTrc("global", "Always ask")
+                text: qsTrc("global", "Always ask")
 
-            navigation.name: "AlwaysAskCheckBox"
-            navigation.panel: percussionPanelPreferences.navigation
-            navigation.row: radioButtons.navigationRowEnd
+                navigation.name: "AlwaysAskCheckBox"
+                navigation.panel: percussionPanelPreferences.navigation
+                navigation.row: radioButtons.navigationRowEnd
 
-            checked: percussionPreferencesModel.showPercussionPanelPadSwapDialog
+                checked: percussionPreferencesModel.showPercussionPanelPadSwapDialog
 
-            onClicked:  {
-                percussionPreferencesModel.showPercussionPanelPadSwapDialog = !alwaysAsk.checked
+                onClicked:  {
+                    percussionPreferencesModel.showPercussionPanelPadSwapDialog = !alwaysAsk.checked
+                }
             }
         }
 
-        FlatButton {
-            id: useNewPercussionPanel
+        Row {
+            id: useLegacyToggleRow
 
-            text: percussionPreferencesModel.useNewPercussionPanel ? qsTrc("notation/percussion", "Switch to old percussion panel")
-                                                                   : qsTrc("notation/percussion", "Switch to new percussion panel")
+            height: useLegacyToggle.height
+            width: parent.width
 
-            navigation.name: "SwitchPercussionPanels"
-            navigation.panel: percussionPanelPreferences.navigation
-            navigation.row: alwaysAsk.navigation.row + 1
+            spacing: 6
 
-            onClicked: {
-                percussionPreferencesModel.useNewPercussionPanel = !percussionPreferencesModel.useNewPercussionPanel
+            ToggleButton {
+                id: useLegacyToggle
+
+                checked: !percussionPreferencesModel.useNewPercussionPanel
+
+                navigation.name: "UseLegacyPercussionPanel"
+                navigation.panel: percussionPanelPreferences.navigation
+                navigation.row: alwaysAsk.navigation.row + 1
+
+                onToggled: {
+                    percussionPreferencesModel.useNewPercussionPanel = !percussionPreferencesModel.useNewPercussionPanel
+                }
+            }
+
+            StyledTextLabel {
+                id: legacyToggleInfo
+
+                enabled: percussionPreferencesModel.useNewPercussionPanel
+
+                height: parent.height
+
+                horizontalAlignment: Text.AlignLeft
+                verticalAlignment: Text.AlignVCenter
+
+                wrapMode: Text.Wrap
+                text: qsTrc("notation/percussion", "Use legacy percussion panel")
             }
         }
     }

--- a/src/engraving/dom/score.h
+++ b/src/engraving/dom/score.h
@@ -1074,6 +1074,7 @@ private:
     void selectRange(EngravingItem* e, staff_idx_t staffIdx);
 
     muse::Ret putNote(const Position&, bool replace);
+    void handleOverlappingChordRest(InputState& inputState);
 
     void resetTempo();
     void resetTempoRange(const Fraction& tick1, const Fraction& tick2);

--- a/src/engraving/dom/select.cpp
+++ b/src/engraving/dom/select.cpp
@@ -817,10 +817,11 @@ void Selection::setRange(Segment* startSegment, Segment* endSegment, staff_idx_t
     assert(!(endSegment && !startSegment));
 
     m_startSegment  = startSegment;
-    m_endSegment    = endSegment;
+    m_endSegment = endSegment;
     m_activeSegment = endSegment;
-    m_staffStart    = staffStart;
-    m_staffEnd      = staffEnd;
+    m_staffStart = staffStart;
+    m_staffEnd = staffEnd;
+    m_activeTrack = staff2track(staffStart);
 
     if (m_state == SelState::RANGE) {
         m_score->setSelectionChanged(true);
@@ -844,8 +845,9 @@ void Selection::setRangeTicks(const Fraction& tick1, const Fraction& tick2, staf
     m_plannedTick1 = tick1;
     m_plannedTick2 = tick2;
     m_startSegment = m_endSegment = m_activeSegment = nullptr;
-    m_staffStart    = staffStart;
-    m_staffEnd      = staffEnd;
+    m_staffStart = staffStart;
+    m_staffEnd = staffEnd;
+    m_activeTrack = staff2track(staffStart);
 
     if (m_state == SelState::RANGE) {
         m_score->setSelectionChanged(true);

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -194,11 +194,11 @@ NotationInteraction::NotationInteraction(Notation* notation, INotationUndoStackP
 
     m_undoStack->undoRedoNotification().onNotify(this, [this]() {
         endEditElement();
-        notifyAboutNoteInputStateChanged();
     });
 
     m_undoStack->stackChanged().onNotify(this, [this]() {
         notifyAboutSelectionChangedIfNeed();
+        notifyAboutNoteInputStateChanged();
     });
 
     m_dragData.ed = mu::engraving::EditData(&m_scoreCallbacks);

--- a/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
+++ b/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
@@ -34,6 +34,8 @@ Item {
     property NavigationSection navigationSection: null
     property int contentNavigationPanelOrderStart: 1
 
+    signal resizeRequested(var newWidth, var newHeight)
+
     anchors.fill: parent
 
     property Component toolbarComponent: PercussionPanelToolBar {
@@ -47,6 +49,8 @@ Item {
 
     Component.onCompleted: {
         padGrid.model.init()
+        var newHeight = (padGrid.numRows * padGrid.cellHeight) + (soundTitleLabel.height * 2)
+        root.resizeRequested(root.width, newHeight)
     }
 
     PercussionPanelModel {
@@ -324,6 +328,11 @@ Item {
                                     return
                                 }
                                 pad.padNavigation.requestActive()
+                            }
+
+                            function onNumPadsChanged() {
+                                var newHeight = (padGrid.numRows * padGrid.cellHeight) + (soundTitleLabel.height * 2)
+                                root.resizeRequested(root.width, newHeight)
                             }
                         }
                     }

--- a/src/notation/view/percussionpanel/percussionpanelpadlistmodel.cpp
+++ b/src/notation/view/percussionpanel/percussionpanelpadlistmodel.cpp
@@ -192,8 +192,9 @@ mu::engraving::Drumset PercussionPanelPadListModel::constructDefaultLayout(const
     QList<int /*pitch*/> noTemplateFound;
 
     for (int pitch = 0; pitch < mu::engraving::DRUM_INSTRUMENTS; ++pitch) {
-        if (!defaultLayout.isValid(pitch)) {
-            // We aren't currently using this pitch, doesn't matter if it's valid in the template..
+        if (defaultDrumset->isValid(pitch) && !defaultLayout.isValid(pitch)) {
+            // Pitch was deleted - restore it...
+            defaultLayout.drum(pitch) = defaultDrumset->drum(pitch);
             continue;
         }
         //! NOTE: Pitch + drum name isn't exactly the most robust identifier, but this will probably change with the new percussion ID system
@@ -351,7 +352,7 @@ PercussionPanelPadModel* PercussionPanelPadListModel::createPadModelForPitch(int
     PercussionPanelPadModel* model = new PercussionPanelPadModel(this);
     model->setPadName(m_drumset->name(pitch));
 
-    const QString shortcut = m_drumset->shortcut(pitch) ? QChar(m_drumset->shortcut(pitch)) : QString("-");
+    const QString shortcut = m_drumset->shortcut(pitch) ? QChar(m_drumset->shortcut(pitch)) : QChar('\0');
     model->setKeyboardShortcut(shortcut);
 
     model->setPitch(pitch);

--- a/src/notation/view/percussionpanel/percussionpanelpadmodel.cpp
+++ b/src/notation/view/percussionpanel/percussionpanelpadmodel.cpp
@@ -83,13 +83,14 @@ const QVariant PercussionPanelPadModel::notationPreviewItemVariant() const
 
 QList<QVariantMap> PercussionPanelPadModel::footerContextMenuItems() const
 {
-    static constexpr int duplicatePadIcon = static_cast<int>(IconCode::Code::COPY);
+    // static constexpr int duplicatePadIcon = static_cast<int>(IconCode::Code::COPY);
     static constexpr int deletePadIcon = static_cast<int>(IconCode::Code::DELETE_TANK);
     static constexpr int definePadShortcutIcon = static_cast<int>(IconCode::Code::SHORTCUTS);
 
     QList<QVariantMap> menuItems = {
-        { { "id", DUPLICATE_PAD_CODE }, { "title", muse::qtrc("global", "Duplicate") },
-            { "icon", duplicatePadIcon }, { "enabled", true } },
+        //! NOTE: Disabled for now - will be re-introduced with new percussion mapping system...
+        // { { "id", DUPLICATE_PAD_CODE }, { "title", muse::qtrc("global", "Duplicate") },
+        //     { "icon", duplicatePadIcon }, { "enabled", true } },
 
         { { "id", DELETE_PAD_CODE }, { "title", muse::qtrc("global", "Delete") },
             { "icon", deletePadIcon }, { "enabled", true } },


### PR DESCRIPTION
In this round of refinements:

### Assorted small fixes (746919172049649689d6502085b153fd7460dd74)

1. The panel now automatically resizes to fit the number of pads (see `PercussionPanel.qml`). Unfortunately we have some technical limitations relating to `DockBase::resize` meaning the panel will only _increase_ in size to fit the pads and can't shrink.
2. The duplicate pad action has been disabled for now (see `percussionpanelpadmodel.cpp`)
3. Fixed a bug where the panel wasn't always updating when deleting pads (see `notationinteraction.cpp`)
4. Fixed panel switching to first staff on copy/paste (see `select.cpp`)
5. Pad shortcut labels should be empty instead of showing a dash when no shortcut has been specified (see `percussionpanelpadlistmodel.cpp`). This also fixes a bug where the undo stack was being altered unnecessarily.
6. Deleted pads are now restored on reset layout (see `percussionpanelpadlistmodel.cpp`)

### Percussion preferences tweaks (68e434e1081f09ca4ae6fedb74d70a49654940a6)

Implemented small UI changes to percussion preferences per designers' request. Choosing the legacy panel option now disables new panel options instead of hiding them.

### Fixed bug when switching voices while entering notes (9dcbfac97cf0b33c404753bd4ad062831848fd25)

Resolves: #22741

This was a general limitation of our note input logic. While adding notes to "overlapping `ChordRests`" was made possible in other contexts after #23911, the logic was still missing from `Score::addPitch` (the method used by the percussion panel and piano keyboard).