### PR TITLE
24724 - Increased MAX_PACKAGE_SIZE so the UI_THEMES_KEY setting can be synced

### DIFF
--- a/src/framework/multiinstances/internal/ipc/ipc.h
+++ b/src/framework/multiinstances/internal/ipc/ipc.h
@@ -55,6 +55,8 @@ static const QString IPC_WHOIS("ipc_whois");
 static const QString IPC_METAINFO("ipc_metainfo");
 static const QString IPC_PING("ipc_ping");
 
+static constexpr uint32_t MAX_PACKAGE_SIZE = 4096;
+
 enum class Code {
     Undefined = -1,
     Success = 0,


### PR DESCRIPTION
Resolves: #24724
Resolves: #25323

I've bumped up MAX_PACKAGE_SIZE from 2048 to 4096 so that the UI_THEMES_KEY setting can be synced between all open instances when the current theme or any of its properties change. The size of the UI_THEMES_KEY setting on my machine is 3531 bytes (holds 4 themes). Also added a size check for when sending a package.

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
