### PR TITLE
Enable dock frame title bar height update

### DIFF
--- a/src/framework/dockwindow/internal/dockbase.cpp
+++ b/src/framework/dockwindow/internal/dockbase.cpp
@@ -546,7 +546,7 @@ void DockBase::setTitleBarHeight(int height)
         return;
     }
 
-    frameVisualItem->setProperty("titleBarDefaultHeight", height);
+    frameVisualItem->setProperty("titleBarHeight", height);
 }
 
 void DockBase::resetToDefault()

--- a/src/framework/dockwindow/internal/dockbase.cpp
+++ b/src/framework/dockwindow/internal/dockbase.cpp
@@ -530,6 +530,25 @@ void DockBase::setFramePanelOrder(int order)
     frameVisualItem->setProperty("titleBarNavigationPanelOrder", order);
 }
 
+void DockBase::setTitleBarHeight(int height)
+{
+    if (!m_dockWidget) {
+        return;
+    }
+
+    auto frame = static_cast<const KDDockWidgets::FrameQuick*>(m_dockWidget->frame());
+    if (!frame) {
+        return;
+    }
+
+    QQuickItem* frameVisualItem = frame->visualItem();
+    if (!frameVisualItem) {
+        return;
+    }
+
+    frameVisualItem->setProperty("titleBarDefaultHeight", height);
+}
+
 void DockBase::resetToDefault()
 {
     setVisible(m_defaultVisibility);

--- a/src/framework/dockwindow/internal/dockbase.h
+++ b/src/framework/dockwindow/internal/dockbase.h
@@ -115,6 +115,7 @@ public:
     bool isInSameFrame(const DockBase* other) const;
     void setFramePanelOrder(int order);
 
+    Q_INVOKABLE void setTitleBarHeight(int height);
     Q_INVOKABLE bool isOpen() const;
     Q_INVOKABLE void open();
     Q_INVOKABLE void close();

--- a/src/framework/dockwindow/qml/Muse/Dock/DockFrame.qml
+++ b/src/framework/dockwindow/qml/Muse/Dock/DockFrame.qml
@@ -36,13 +36,12 @@ Rectangle {
     readonly property QtObject titleBarCpp: Boolean(frameCpp) ? frameCpp.actualTitleBar : null
     readonly property int nonContentsHeight: titleBar.height + tabBar.height + stackLayout.anchors.topMargin
     property int titleBarNavigationPanelOrder: 1
+    property int titleBarHeight: 34
     //! ---
 
     readonly property bool hasTitleBar: frameModel.titleBarAllowed && !(frameModel.tabs.length > 1 || frameModel.isHorizontalPanel)
     readonly property bool hasSingleTab: frameModel.titleBarAllowed && frameModel.tabs.length === 1 && frameModel.isHorizontalPanel
     readonly property bool hasTabBar: frameModel.titleBarAllowed && (frameModel.tabs.length > 1 || frameModel.isHorizontalPanel)
-
-    property int titleBarDefaultHeight: 34
 
     anchors.fill: parent
     color: ui.theme.backgroundPrimaryColor
@@ -84,7 +83,7 @@ Rectangle {
 
         anchors.top: parent.top
         width: parent.width
-        height: visible ? titleBarDefaultHeight : 0
+        height: visible ? titleBarHeight : 0
 
         visible: root.hasTitleBar
 

--- a/src/framework/dockwindow/qml/Muse/Dock/DockFrame.qml
+++ b/src/framework/dockwindow/qml/Muse/Dock/DockFrame.qml
@@ -42,6 +42,8 @@ Rectangle {
     readonly property bool hasSingleTab: frameModel.titleBarAllowed && frameModel.tabs.length === 1 && frameModel.isHorizontalPanel
     readonly property bool hasTabBar: frameModel.titleBarAllowed && (frameModel.tabs.length > 1 || frameModel.isHorizontalPanel)
 
+    property int titleBarDefaultHeight: 34
+
     anchors.fill: parent
     color: ui.theme.backgroundPrimaryColor
 
@@ -82,7 +84,7 @@ Rectangle {
 
         anchors.top: parent.top
         width: parent.width
-        height: visible ? 34 : 0
+        height: visible ? titleBarDefaultHeight : 0
 
         visible: root.hasTitleBar
 


### PR DESCRIPTION
After one of the latest updates the title bar from DockFrame now has a fixed height of 34 pixels.
This PR would allow to overwrite this value on a DockPage component for example.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
