### PR TITLE
Add multiplication sign for time signatures

### DIFF
--- a/src/engraving/dom/utils.cpp
+++ b/src/engraving/dom/utils.cpp
@@ -1206,8 +1206,9 @@ SymIdList timeSigSymIdsFromString(const String& string, TimeSigStyle timeSigStyl
         { 40,    SymId::timeSigParensLeftSmall },       // '('
         { 41,    SymId::timeSigParensRightSmall },      // ')'
         { 162,   SymId::timeSigCutCommon },             // '¢'
-        { 189,   SymId::timeSigFractionHalf },
-        { 188,   SymId::timeSigFractionQuarter },
+        { 189,   SymId::timeSigFractionHalf },          // '½'
+        { 188,   SymId::timeSigFractionQuarter },       // '¼'
+        { 42,    SymId::timeSigMultiply },              // '*'
         { 88,    SymId::timeSigMultiply },              // 'X'
         { 120,   SymId::timeSigMultiply },              // 'x'
         { 215,   SymId::timeSigMultiply },              // '×'
@@ -1240,8 +1241,9 @@ SymIdList timeSigSymIdsFromString(const String& string, TimeSigStyle timeSigStyl
         { 40,    SymId::timeSigParensLeftSmallLarge },       // '('
         { 41,    SymId::timeSigParensRightSmallLarge },      // ')'
         { 162,   SymId::timeSigCutCommonLarge },             // '¢'
-        { 189,   SymId::timeSigFractionHalfLarge },
-        { 189,   SymId::timeSigFractionQuarterLarge },
+        { 189,   SymId::timeSigFractionHalfLarge },          // '½'
+        { 188,   SymId::timeSigFractionQuarterLarge },       // '¼'
+        { 42,    SymId::timeSigMultiplyLarge },              // '*'
         { 88,    SymId::timeSigMultiplyLarge },              // 'X'
         { 120,   SymId::timeSigMultiplyLarge },              // 'x'
         { 215,   SymId::timeSigMultiplyLarge },              // '×'
@@ -1263,8 +1265,9 @@ SymIdList timeSigSymIdsFromString(const String& string, TimeSigStyle timeSigStyl
         { 40,    SymId::timeSigParensLeftSmallNarrow },       // '('
         { 41,    SymId::timeSigParensRightSmallNarrow },      // ')'
         { 162,   SymId::timeSigCutCommonNarrow },             // '¢'
-        { 189,   SymId::timeSigFractionHalfNarrow },
-        { 188,   SymId::timeSigFractionQuarterNarrow },
+        { 189,   SymId::timeSigFractionHalfNarrow },          // '½'
+        { 188,   SymId::timeSigFractionQuarterNarrow },       // '¼'
+        { 42,    SymId::timeSigMultiplyNarrow },              // '*'
         { 88,    SymId::timeSigMultiplyNarrow },              // 'X'
         { 120,   SymId::timeSigMultiplyNarrow },              // 'x'
         { 215,   SymId::timeSigMultiplyNarrow },              // '×'

--- a/src/engraving/dom/utils.cpp
+++ b/src/engraving/dom/utils.cpp
@@ -1208,6 +1208,9 @@ SymIdList timeSigSymIdsFromString(const String& string, TimeSigStyle timeSigStyl
         { 162,   SymId::timeSigCutCommon },             // '¢'
         { 189,   SymId::timeSigFractionHalf },
         { 188,   SymId::timeSigFractionQuarter },
+        { 88,    SymId::timeSigMultiply },              // 'X'
+        { 120,   SymId::timeSigMultiply },              // 'x'
+        { 215,   SymId::timeSigMultiply },              // '×'
         { 59664, SymId::mensuralProlation1 },
         { 79,    SymId::mensuralProlation2 },           // 'O'
         { 59665, SymId::mensuralProlation2 },
@@ -1239,6 +1242,9 @@ SymIdList timeSigSymIdsFromString(const String& string, TimeSigStyle timeSigStyl
         { 162,   SymId::timeSigCutCommonLarge },             // '¢'
         { 189,   SymId::timeSigFractionHalfLarge },
         { 189,   SymId::timeSigFractionQuarterLarge },
+        { 88,    SymId::timeSigMultiplyLarge },              // 'X'
+        { 120,   SymId::timeSigMultiplyLarge },              // 'x'
+        { 215,   SymId::timeSigMultiplyLarge },              // '×'
     };
 
     static const std::map<Char, SymId> dictNarrow = {
@@ -1259,6 +1265,9 @@ SymIdList timeSigSymIdsFromString(const String& string, TimeSigStyle timeSigStyl
         { 162,   SymId::timeSigCutCommonNarrow },             // '¢'
         { 189,   SymId::timeSigFractionHalfNarrow },
         { 188,   SymId::timeSigFractionQuarterNarrow },
+        { 88,    SymId::timeSigMultiplyNarrow },              // 'X'
+        { 120,   SymId::timeSigMultiplyNarrow },              // 'x'
+        { 215,   SymId::timeSigMultiplyNarrow },              // '×'
     };
 
     SymIdList list;

--- a/src/engraving/dom/utils.cpp
+++ b/src/engraving/dom/utils.cpp
@@ -1191,38 +1191,38 @@ Segment* skipTuplet(Tuplet* tuplet)
 SymIdList timeSigSymIdsFromString(const String& string, TimeSigStyle timeSigStyle)
 {
     static const std::map<Char, SymId> dict = {
-        { 43,    SymId::timeSigPlusSmall },             // '+'
-        { 48,    SymId::timeSig0 },                     // '0'
-        { 49,    SymId::timeSig1 },                     // '1'
-        { 50,    SymId::timeSig2 },                     // '2'
-        { 51,    SymId::timeSig3 },                     // '3'
-        { 52,    SymId::timeSig4 },                     // '4'
-        { 53,    SymId::timeSig5 },                     // '5'
-        { 54,    SymId::timeSig6 },                     // '6'
-        { 55,    SymId::timeSig7 },                     // '7'
-        { 56,    SymId::timeSig8 },                     // '8'
-        { 57,    SymId::timeSig9 },                     // '9'
-        { 67,    SymId::timeSigCommon },                // 'C'
-        { 40,    SymId::timeSigParensLeftSmall },       // '('
-        { 41,    SymId::timeSigParensRightSmall },      // ')'
-        { 162,   SymId::timeSigCutCommon },             // '¢'
-        { 189,   SymId::timeSigFractionHalf },          // '½'
-        { 188,   SymId::timeSigFractionQuarter },       // '¼'
-        { 42,    SymId::timeSigMultiply },              // '*'
-        { 88,    SymId::timeSigMultiply },              // 'X'
-        { 120,   SymId::timeSigMultiply },              // 'x'
-        { 215,   SymId::timeSigMultiply },              // '×'
-        { 59664, SymId::mensuralProlation1 },
-        { 79,    SymId::mensuralProlation2 },           // 'O'
-        { 59665, SymId::mensuralProlation2 },
-        { 216,   SymId::mensuralProlation3 },           // 'Ø'
-        { 59666, SymId::mensuralProlation3 },
-        { 59667, SymId::mensuralProlation4 },
-        { 59668, SymId::mensuralProlation5 },
-        { 59670, SymId::mensuralProlation7 },
-        { 59671, SymId::mensuralProlation8 },
-        { 59673, SymId::mensuralProlation10 },
-        { 59674, SymId::mensuralProlation11 },
+        { '+',    SymId::timeSigPlusSmall },
+        { '0',    SymId::timeSig0 },
+        { '1',    SymId::timeSig1 },
+        { '2',    SymId::timeSig2 },
+        { '3',    SymId::timeSig3 },
+        { '4',    SymId::timeSig4 },
+        { '5',    SymId::timeSig5 },
+        { '6',    SymId::timeSig6 },
+        { '7',    SymId::timeSig7 },
+        { '8',    SymId::timeSig8 },
+        { '9',    SymId::timeSig9 },
+        { 'C',    SymId::timeSigCommon },
+        { '(',    SymId::timeSigParensLeftSmall },
+        { ')',    SymId::timeSigParensRightSmall },
+        { u'¢',   SymId::timeSigCutCommon },
+        { u'½',   SymId::timeSigFractionHalf },
+        { u'¼',   SymId::timeSigFractionQuarter },
+        { '*',    SymId::timeSigMultiply },
+        { 'X',    SymId::timeSigMultiply },
+        { 'x',    SymId::timeSigMultiply },
+        { u'×',   SymId::timeSigMultiply },
+        { 59664,  SymId::mensuralProlation1 },
+        { 79,     SymId::mensuralProlation2 },           // 'O'
+        { 59665,  SymId::mensuralProlation2 },
+        { 216,    SymId::mensuralProlation3 },           // 'Ø'
+        { 59666,  SymId::mensuralProlation3 },
+        { 59667,  SymId::mensuralProlation4 },
+        { 59668,  SymId::mensuralProlation5 },
+        { 59670,  SymId::mensuralProlation7 },
+        { 59671,  SymId::mensuralProlation8 },
+        { 59673,  SymId::mensuralProlation10 },
+        { 59674,  SymId::mensuralProlation11 },
     };
 
     static const std::map<Char, SymId> dictLarge = {

--- a/src/palette/view/widgets/timesignaturepropertiesdialog.cpp
+++ b/src/palette/view/widgets/timesignaturepropertiesdialog.cpp
@@ -79,8 +79,8 @@ TimeSignaturePropertiesDialog::TimeSignaturePropertiesDialog(QWidget* parent)
     zText->setText(m_editedTimeSig->numeratorString());
     nText->setText(m_editedTimeSig->denominatorString());
     // set validators for numerator and denominator strings
-    // which only accept '+', '(', ')', digits and some time symb conventional representations
-    QRegularExpression regex("[0-9+CO()\\x00A2\\x00D8\\x00BD\\x00BC]*");
+    // which only accept '+', '*' (or 'x'), '(', ')', digits and some time symb conventional representations
+    QRegularExpression regex("[0-9+COXx()\\*\\x00A2\\x00D7\\x00D8\\x00BD\\x00BC]*");
     QValidator* validator = new QRegularExpressionValidator(regex, this);
     zText->setValidator(validator);
     nText->setValidator(validator);


### PR DESCRIPTION
This PR makes the multiplication sign for time signatures available:
 
<img width="200" alt="grafik" src="https://github.com/user-attachments/assets/435c7a8a-7866-4a06-b7ba-2dd9a8208c0c" />

Upper and lower case X may be used as well as the multiplication character (`&times;`) ×.