### PR TITLE
Percussion panel - refinements round 6

### DIFF
--- a/src/appshell/qml/Preferences/PercussionPreferencesPage.qml
+++ b/src/appshell/qml/Preferences/PercussionPreferencesPage.qml
@@ -189,8 +189,6 @@ PreferencesPage {
             StyledTextLabel {
                 id: legacyToggleInfo
 
-                enabled: percussionPreferencesModel.useNewPercussionPanel
-
                 height: parent.height
 
                 horizontalAlignment: Text.AlignLeft

--- a/src/engraving/dom/drumset.h
+++ b/src/engraving/dom/drumset.h
@@ -136,6 +136,11 @@ public:
         return true;
     }
 
+    bool operator!=(const Drumset& other) const
+    {
+        return !(*this == other);
+    }
+
 private:
     DrumInstrument m_drums[DRUM_INSTRUMENTS];
 };

--- a/src/framework/dockwindow/internal/dockbase.cpp
+++ b/src/framework/dockwindow/internal/dockbase.cpp
@@ -548,7 +548,7 @@ void DockBase::resize(int width, int height)
     }
 
     auto frame = static_cast<const KDDockWidgets::FrameQuick*>(m_dockWidget->frame());
-    if (!frame) {
+    if (!frame || m_dockWidget != frame->currentDockWidget()) {
         return;
     }
 

--- a/src/framework/dockwindow/view/dockpageview.cpp
+++ b/src/framework/dockwindow/view/dockpageview.cpp
@@ -193,7 +193,16 @@ QList<DockPanelView*> DockPageView::possiblePanelsForTab(const DockPanelView* ta
 bool DockPageView::isDockOpen(const QString& dockName) const
 {
     const DockBase* dock = dockByName(dockName);
-    return dock ? dock->isOpen() : false;
+    if (!dock) {
+        return false;
+    }
+
+    const DockPanelView* panel = dynamic_cast<const DockPanelView*>(dock);
+    if (!panel) {
+        return false;
+    }
+
+    return dock ? dock->isOpen() && panel->isCurrentTabInFrame() : false;
 }
 
 void DockPageView::toggleDock(const QString& dockName)
@@ -222,6 +231,7 @@ void DockPageView::setDockOpen(const QString& dockName, bool open)
     DockPanelView* destinationPanel = findPanelForTab(panel);
     if (destinationPanel) {
         destinationPanel->addPanelAsTab(panel);
+        panel->makeCurrentTabInFrame();
     } else {
         panel->open();
     }

--- a/src/framework/dockwindow/view/dockpanelview.cpp
+++ b/src/framework/dockwindow/view/dockpanelview.cpp
@@ -308,3 +308,27 @@ void DockPanelView::setCurrentTabIndex(int index)
         frame->setCurrentTabIndex(index);
     }
 }
+
+bool DockPanelView::isCurrentTabInFrame() const
+{
+    if (!dockWidget()) {
+        return false;
+    }
+
+    KDDockWidgets::Frame* frame = dockWidget()->frame();
+    return frame && frame->currentDockWidget() == dockWidget();
+}
+
+void DockPanelView::makeCurrentTabInFrame()
+{
+    IF_ASSERT_FAILED(dockWidget()) {
+        return;
+    }
+
+    KDDockWidgets::Frame* frame = dockWidget()->frame();
+    if (!frame) {
+        return;
+    }
+
+    frame->setCurrentDockWidget(dockWidget());
+}

--- a/src/framework/dockwindow/view/dockpanelview.h
+++ b/src/framework/dockwindow/view/dockpanelview.h
@@ -58,6 +58,9 @@ public:
     void addPanelAsTab(DockPanelView* tab);
     void setCurrentTabIndex(int index);
 
+    bool isCurrentTabInFrame() const;
+    void makeCurrentTabInFrame();
+
 public slots:
     void setGroupName(const QString& name);
     void setContextMenuModel(uicomponents::AbstractMenuModel* model);

--- a/src/notation/view/percussionpanel/percussionpanelmodel.h
+++ b/src/notation/view/percussionpanel/percussionpanelmodel.h
@@ -109,6 +109,8 @@ signals:
 private:
     void setUpConnections();
 
+    void setDrumset(mu::engraving::Drumset* drumset);
+
     void updateSoundTitle(const InstrumentTrackId& trackId);
 
     bool eventFilter(QObject* watched, QEvent* event) override;


### PR DESCRIPTION
Just a small round of refinements this time:

1. When tabbing in an empty row in edit layout mode, we now tab to the associated delete button (45a51983ceb8398115890bb49713dce502c2045b)
2. Fixed a bug where horizontal panels were resizing unexpectedly when the percussion panel was open in another tab. The proposed solution is to only handle resize calls coming from the currently active tab (a718180ce34cb137334ab61fbb21df8c14f306bb)
3. Fixed some bugs caused by a discrepancy between the panel's drumset, and the associated drumset in the score. The comment in `PercussionPanelModel::setDrumset` gives more details (7572404f7bc03e3ccb2f0f943639c3c7c5670aad)
4. Fixed bug a relating to dock panels and tabs (321dd5456e5f6c6adef4607bf2327216c5d8f22b)

Resolves #26009 