### PR TITLE
Allow dock title bar height update

### DIFF
--- a/src/framework/dockwindow/qml/Muse/Dock/DockFrame.qml
+++ b/src/framework/dockwindow/qml/Muse/Dock/DockFrame.qml
@@ -82,7 +82,7 @@ Rectangle {
 
         anchors.top: parent.top
         width: parent.width
-        height: visible ? 34 : 0
+        height: visible ? implicitHeight : 0
 
         visible: root.hasTitleBar
 

--- a/src/framework/dockwindow/qml/Muse/Dock/DockTitleBar.qml
+++ b/src/framework/dockwindow/qml/Muse/Dock/DockTitleBar.qml
@@ -40,7 +40,7 @@ Item {
     signal handleContextMenuItemRequested(string itemId)
 
     width: parent.width
-    height: visible ? heightWhenVisible : 0
+    implicitHeight: titleBarLoader.implicitHeight
 
     visible: Boolean(titleBarCpp)
 
@@ -69,7 +69,7 @@ Item {
 
             anchors.fill: parent
             implicitWidth: rowLayout.implicitWidth
-            implicitHeight: rowLayout.implicitHeight
+            implicitHeight: rowLayout.implicitHeight + rowLayout.anchors.topMargin + rowLayout.anchors.bottomMargin
 
             property NavigationPanel navigationPanel
             property int navigationOrder
@@ -84,6 +84,8 @@ Item {
             RowLayout {
                 id: rowLayout
                 anchors.fill: parent
+                anchors.topMargin: 2
+                anchors.bottomMargin: 2
                 anchors.leftMargin: 12
                 anchors.rightMargin: 12
 


### PR DESCRIPTION
After one of the latest updates the title bar from DockFrame now has a fixed height of 34 pixels.
This PR would allow to overwrite this value on a DockPage component for example.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
