### PR TITLE
Fix crash on adding multiple guitar pre-bends or grace-note-bends

### DIFF
--- a/src/engraving/dom/note.cpp
+++ b/src/engraving/dom/note.cpp
@@ -1924,15 +1924,16 @@ EngravingItem* Note::drop(EditData& data)
             GuitarBendType type = (toActionIcon(e)->actionType() == ActionIconType::PRE_BEND)
                                   ? GuitarBendType::PRE_BEND : GuitarBendType::GRACE_NOTE_BEND;
             GuitarBend* guitarBend = score()->addGuitarBend(type, this);
-            if (guitarBend) {
-                Note* note = guitarBend->startNote();
-                IF_ASSERT_FAILED(note) {
-                    LOGE() << "not valid start note of the bend";
-                    break;
-                }
-
-                score()->select(note, SelectType::SINGLE, 0);
+            if (!guitarBend) {
+                break;
             }
+            Note* note = guitarBend->startNote();
+            IF_ASSERT_FAILED(note) {
+                LOGE() << "not valid start note of the bend";
+                break;
+            }
+
+            score()->select(note, SelectType::SINGLE, 0);
             break;
         }
         case ActionIconType::SLIGHT_BEND:

--- a/src/engraving/dom/note.cpp
+++ b/src/engraving/dom/note.cpp
@@ -1924,13 +1924,15 @@ EngravingItem* Note::drop(EditData& data)
             GuitarBendType type = (toActionIcon(e)->actionType() == ActionIconType::PRE_BEND)
                                   ? GuitarBendType::PRE_BEND : GuitarBendType::GRACE_NOTE_BEND;
             GuitarBend* guitarBend = score()->addGuitarBend(type, this);
-            Note* note = guitarBend->startNote();
-            IF_ASSERT_FAILED(note) {
-                LOGE() << "not valid start note of the bend";
-                break;
-            }
+            if (guitarBend) {
+                Note* note = guitarBend->startNote();
+                IF_ASSERT_FAILED(note) {
+                    LOGE() << "not valid start note of the bend";
+                    break;
+                }
 
-            score()->select(note, SelectType::SINGLE, 0);
+                score()->select(note, SelectType::SINGLE, 0);
+            }
             break;
         }
         case ActionIconType::SLIGHT_BEND:


### PR DESCRIPTION
Resolves: #25817 

`addGuitarBend` is expected to return null if the start note isn't suitable to add the required type of bend, so it's output must be null-checked.


