### PR TITLE
Fix build with clang where build fails because the virtual table of StubPlatformTheme isn't found

### DIFF
--- a/src/framework/ui/internal/platform/stub/stubplatformtheme.cpp
+++ b/src/framework/ui/internal/platform/stub/stubplatformtheme.cpp
@@ -25,6 +25,8 @@
 using namespace muse::ui;
 using namespace muse::async;
 
+StubPlatformTheme::~StubPlatformTheme() = default;
+
 void StubPlatformTheme::startListening()
 {
 }

--- a/src/framework/ui/internal/platform/stub/stubplatformtheme.h
+++ b/src/framework/ui/internal/platform/stub/stubplatformtheme.h
@@ -29,6 +29,8 @@ namespace muse::ui {
 class StubPlatformTheme : public IPlatformTheme
 {
 public:
+    ~StubPlatformTheme() override;
+
     void startListening() override;
     void stopListening() override;
 


### PR DESCRIPTION

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
