### PR TITLE
Don't move top system objects when rearranging staves

### DIFF
--- a/src/engraving/dom/engravingitem.cpp
+++ b/src/engraving/dom/engravingitem.cpp
@@ -505,19 +505,7 @@ staff_idx_t EngravingItem::staffIdxOrNextVisible() const
 
 bool EngravingItem::isTopSystemObject() const
 {
-    if (!systemFlag()) {
-        return false; // non system object
-    }
-    if ((isSpanner() || isSpannerSegment() || isTimeSig()) && track() != 0) {
-        return false;
-    }
-    if (!m_links) {
-        return true; // a system object, but not one with any linked clones
-    }
-    // this is part of a link ecosystem, see if we're the main one
-    EngravingObject* mainElement = m_links->mainElement();
-    return track() == 0
-           && (mainElement->score() != score() || !toEngravingItem(mainElement)->enabled());
+    return systemFlag() && track() == 0;
 }
 
 staff_idx_t EngravingItem::vStaffIdx() const

--- a/src/engraving/dom/segment.cpp
+++ b/src/engraving/dom/segment.cpp
@@ -1029,25 +1029,10 @@ void Segment::sortStaves(std::vector<staff_idx_t>& dst)
         map.insert({ dst[k], k });
     }
     for (EngravingItem* e : m_annotations) {
-        ElementType et = e->type();
-        // the set of system objects that are allowed to move staves if they are clones / excerpts
-        static const std::set<ElementType> allowedTypes {
-            ElementType::REHEARSAL_MARK,
-            ElementType::SYSTEM_TEXT,
-            ElementType::TRIPLET_FEEL,
-            ElementType::PLAYTECH_ANNOTATION,
-            ElementType::CAPO,
-            ElementType::STRING_TUNINGS,
-            ElementType::JUMP,
-            ElementType::MARKER,
-            ElementType::TEMPO_TEXT,
-            ElementType::VOLTA,
-            ElementType::GRADUAL_TEMPO_CHANGE,
-            ElementType::TEXTLINE
-        };
-        if (!e->systemFlag() || (e->isLinked() && (allowedTypes.find(et) != allowedTypes.end()))) {
-            e->setTrack(map[e->staffIdx()] * VOICES + e->voice());
+        if (e->isTopSystemObject()) {
+            continue;
         }
+        e->setTrack(map[e->staffIdx()] * VOICES + e->voice());
     }
     fixStaffIdx();
 }


### PR DESCRIPTION
Resolves: #25822

This has always been quite a buggy and confusing area of code. The general principle (as far as I understand) is that the "top" system object should not move when rearranging staves (cause it should just stay at the top of the score), whereas "non-top" system objects follow their stave, which makes sense. 
But I've never understood why the condition of being top system object should be deduced from the linking properties. The fact that top and non-top system objects are linked to each other is a consequence, not a definition. Furthermore, linking has the additional complexity that links can exists within the same score, but also across score and parts (hence why this bug showed up in parts but not in the main score).

It seems quite clear to me that being a "top" system object should just mean being a system object at the top of the score (i.e. at track == 0). If it turns up that other parts of code relied on the previuos strange definition (which is likely), we'll fix those too.
