### PR TITLE
add option to unhide courtesy clefs and signatures in section break

### DIFF
--- a/src/engraving/dom/layoutbreak.cpp
+++ b/src/engraving/dom/layoutbreak.cpp
@@ -52,6 +52,7 @@ LayoutBreak::LayoutBreak(MeasureBase* parent)
     m_startWithLongNames = false;
     m_startWithMeasureOne = false;
     m_firstSystemIndentation = false;
+    m_showCourtesy = false;
     m_layoutBreakType = LayoutBreakType(propertyDefault(Pid::LAYOUT_BREAK).toInt());
 
     initElementStyle(&sectionBreakStyle);
@@ -60,6 +61,7 @@ LayoutBreak::LayoutBreak(MeasureBase* parent)
     resetProperty(Pid::START_WITH_LONG_NAMES);
     resetProperty(Pid::START_WITH_MEASURE_ONE);
     resetProperty(Pid::FIRST_SYSTEM_INDENTATION);
+    resetProperty(Pid::SHOW_COURTESY);
 }
 
 LayoutBreak::LayoutBreak(const LayoutBreak& lb)
@@ -70,6 +72,7 @@ LayoutBreak::LayoutBreak(const LayoutBreak& lb)
     m_startWithLongNames     = lb.m_startWithLongNames;
     m_startWithMeasureOne    = lb.m_startWithMeasureOne;
     m_firstSystemIndentation = lb.m_firstSystemIndentation;
+    m_showCourtesy           = lb.m_showCourtesy;
 }
 
 void LayoutBreak::setParent(MeasureBase* parent)
@@ -140,6 +143,8 @@ PropertyValue LayoutBreak::getProperty(Pid propertyId) const
         return m_startWithMeasureOne;
     case Pid::FIRST_SYSTEM_INDENTATION:
         return m_firstSystemIndentation;
+    case Pid::SHOW_COURTESY:
+        return m_showCourtesy;
     default:
         return EngravingItem::getProperty(propertyId);
     }
@@ -167,6 +172,9 @@ bool LayoutBreak::setProperty(Pid propertyId, const PropertyValue& v)
         break;
     case Pid::FIRST_SYSTEM_INDENTATION:
         setFirstSystemIndentation(v.toBool());
+        break;
+    case Pid::SHOW_COURTESY:
+        setShowCourtesy(v.toBool());
         break;
     default:
         if (!EngravingItem::setProperty(propertyId, v)) {
@@ -205,6 +213,8 @@ PropertyValue LayoutBreak::propertyDefault(Pid id) const
         return true;
     case Pid::FIRST_SYSTEM_INDENTATION:
         return true;
+    case Pid::SHOW_COURTESY:
+        return false;
     default:
         return EngravingItem::propertyDefault(id);
     }

--- a/src/engraving/dom/layoutbreak.h
+++ b/src/engraving/dom/layoutbreak.h
@@ -61,6 +61,8 @@ public:
     void setStartWithMeasureOne(bool v) { m_startWithMeasureOne = v; }
     bool firstSystemIndentation() const { return m_firstSystemIndentation; }
     void setFirstSystemIndentation(bool v) { m_firstSystemIndentation = v; }
+    bool showCourtesy() const { return m_showCourtesy; }
+    void setShowCourtesy(bool v) { m_showCourtesy = v; }
 
     bool isPageBreak() const { return m_layoutBreakType == LayoutBreakType::PAGE; }
     bool isLineBreak() const { return m_layoutBreakType == LayoutBreakType::LINE; }
@@ -88,6 +90,7 @@ private:
     bool m_startWithLongNames = false;
     bool m_startWithMeasureOne = false;
     bool m_firstSystemIndentation = false;
+    bool m_showCourtesy = false;
     LayoutBreakType m_layoutBreakType = LayoutBreakType::NOBREAK;
 };
 } // namespace mu::engraving

--- a/src/engraving/dom/measure.cpp
+++ b/src/engraving/dom/measure.cpp
@@ -1970,7 +1970,7 @@ bool Measure::isFinalMeasureOfSection() const
     return false;
 }
 
-LayoutBreak* Measure::isFinalMeasureOfSection()
+LayoutBreak* Measure::sectionBreakElement(bool includeNextFrames)
 {
     const MeasureBase* mb = static_cast<const MeasureBase*>(this);
 
@@ -1980,7 +1980,7 @@ LayoutBreak* Measure::isFinalMeasureOfSection()
         }
 
         mb = mb->next();
-    } while (mb && !mb->isMeasure());           // loop until reach next actual measure or end of score
+    } while (includeNextFrames && mb && !mb->isMeasure());           // loop until reach next actual measure or end of score
 
     return nullptr;
 }

--- a/src/engraving/dom/measure.cpp
+++ b/src/engraving/dom/measure.cpp
@@ -1970,6 +1970,21 @@ bool Measure::isFinalMeasureOfSection() const
     return false;
 }
 
+LayoutBreak* Measure::isFinalMeasureOfSection()
+{
+    const MeasureBase* mb = static_cast<const MeasureBase*>(this);
+
+    do {
+        if (LayoutBreak* sectionBreak = mb->sectionBreakElement()) {
+            return sectionBreak;
+        }
+
+        mb = mb->next();
+    } while (mb && !mb->isMeasure());           // loop until reach next actual measure or end of score
+
+    return nullptr;
+}
+
 //---------------------------------------------------------
 //   isAnacrusis
 //---------------------------------------------------------

--- a/src/engraving/dom/measure.h
+++ b/src/engraving/dom/measure.h
@@ -282,7 +282,7 @@ public:
     bool visible(staff_idx_t staffIdx) const;
     bool stemless(staff_idx_t staffIdx) const;
     bool isFinalMeasureOfSection() const;
-    LayoutBreak* isFinalMeasureOfSection();
+    LayoutBreak* sectionBreakElement(bool includeNextFrames = true);
     bool isAnacrusis() const;
     bool isFirstInSystem() const;
     bool isLastInSystem() const;

--- a/src/engraving/dom/measure.h
+++ b/src/engraving/dom/measure.h
@@ -282,6 +282,7 @@ public:
     bool visible(staff_idx_t staffIdx) const;
     bool stemless(staff_idx_t staffIdx) const;
     bool isFinalMeasureOfSection() const;
+    LayoutBreak* isFinalMeasureOfSection();
     bool isAnacrusis() const;
     bool isFirstInSystem() const;
     bool isLastInSystem() const;

--- a/src/engraving/rendering/score/measurelayout.cpp
+++ b/src/engraving/rendering/score/measurelayout.cpp
@@ -1423,7 +1423,7 @@ void MeasureLayout::createEndBarLines(Measure* m, bool isLastMeasureInSystem, La
     Measure* nm  = m->nextMeasure();
     double blw    = 0.0;
     bool hideCourtesy = false;
-    if (LayoutBreak* sectionBreakElement = m->isFinalMeasureOfSection()) {
+    if (LayoutBreak* sectionBreakElement = m->sectionBreakElement()) {
         hideCourtesy = !sectionBreakElement->showCourtesy();
     }
 
@@ -1862,7 +1862,7 @@ void MeasureLayout::addSystemTrailer(Measure* m, Measure* nm, LayoutContext& ctx
 {
     Fraction _rtick = m->ticks();
     bool hideCourtesy = false;
-    if (LayoutBreak* sectionBreakElement = m->isFinalMeasureOfSection()) {
+    if (LayoutBreak* sectionBreakElement = m->sectionBreakElement()) {
         hideCourtesy = !sectionBreakElement->showCourtesy();
     }
 

--- a/src/engraving/rendering/score/measurelayout.cpp
+++ b/src/engraving/rendering/score/measurelayout.cpp
@@ -1422,6 +1422,10 @@ void MeasureLayout::createEndBarLines(Measure* m, bool isLastMeasureInSystem, La
     Segment* seg = m->findSegmentR(SegmentType::EndBarLine, m->ticks());
     Measure* nm  = m->nextMeasure();
     double blw    = 0.0;
+    bool hideCourtesy = false;
+    if (LayoutBreak* sectionBreakElement = m->isFinalMeasureOfSection()) {
+        hideCourtesy = !sectionBreakElement->showCourtesy();
+    }
 
     if (nm && nm->repeatStart() && !m->repeatEnd() && !isLastMeasureInSystem && m->next() == nm) {
         // we may skip barline at end of a measure immediately before a start repeat:
@@ -1443,7 +1447,7 @@ void MeasureLayout::createEndBarLines(Measure* m, bool isLastMeasureInSystem, La
         //  This flag is later used to set a double end bar line and to actually
         //  create the courtesy key sig.
 
-        if (nm && !m->sectionBreak()) {
+        if (nm && !hideCourtesy) {
             //  Don't change barlines at the end of a section break,
             //  and don't create courtesy key/time signatures.
             bool hasKeySig = false;
@@ -1583,8 +1587,9 @@ void MeasureLayout::createEndBarLines(Measure* m, bool isLastMeasureInSystem, La
                 bool showCourtesy = ctx.conf().styleB(Sid::genCourtesyClef) && clef->showCourtesy();         // normally show a courtesy clef
                 // check if the measure is the last measure of the system or the last measure before a frame
                 bool lastMeasure = isLastMeasureInSystem || (nm ? !(m->next() == nm) : true);
-                if (!nm || m->isFinalMeasureOfSection() || (lastMeasure && !showCourtesy)) {
-                    // hide the courtesy clef in the final measure of a section, or if the measure is the final measure of a system
+                if (!nm || hideCourtesy || (lastMeasure && !showCourtesy)) {
+                    // hide the courtesy clef in the final measure of a section,
+                    // or if the measure is the final measure of a system
                     // and the score style or the clef style is set to "not show courtesy clef",
                     // or if the clef is at the end of the very last measure of the score
                     clef->clear();
@@ -1856,7 +1861,11 @@ void MeasureLayout::removeSystemHeader(Measure* m)
 void MeasureLayout::addSystemTrailer(Measure* m, Measure* nm, LayoutContext& ctx)
 {
     Fraction _rtick = m->ticks();
-    bool isFinalMeasure = m->isFinalMeasureOfSection();
+    bool hideCourtesy = false;
+    if (LayoutBreak* sectionBreakElement = m->isFinalMeasureOfSection()) {
+        hideCourtesy = !sectionBreakElement->showCourtesy();
+    }
+
 
     // locate a time sig. in the next measure and, if found,
     // check if it has court. sig. turned off
@@ -1866,7 +1875,7 @@ void MeasureLayout::addSystemTrailer(Measure* m, Measure* nm, LayoutContext& ctx
     if (s) {
         s->setTrailer(true);
     }
-    if (nm && ctx.conf().styleB(Sid::genCourtesyTimesig) && !isFinalMeasure && !ctx.conf().isFloatMode()) {
+    if (nm && ctx.conf().styleB(Sid::genCourtesyTimesig) && !hideCourtesy && !ctx.conf().isFloatMode()) {
         Segment* tss = nm->findSegmentR(SegmentType::TimeSig, Fraction(0, 1));
         if (tss) {
             size_t nstaves = ctx.dom().nstaves();

--- a/src/engraving/rendering/score/measurelayout.cpp
+++ b/src/engraving/rendering/score/measurelayout.cpp
@@ -1866,7 +1866,6 @@ void MeasureLayout::addSystemTrailer(Measure* m, Measure* nm, LayoutContext& ctx
         hideCourtesy = !sectionBreakElement->showCourtesy();
     }
 
-
     // locate a time sig. in the next measure and, if found,
     // check if it has court. sig. turned off
     TimeSig* ts = nullptr;

--- a/src/engraving/rw/read410/tread.cpp
+++ b/src/engraving/rw/read410/tread.cpp
@@ -3304,6 +3304,8 @@ void TRead::read(LayoutBreak* b, XmlReader& e, ReadContext& ctx)
             TRead::readProperty(b, e, ctx, Pid::START_WITH_MEASURE_ONE);
         } else if (tag == "firstSystemIndentation") {
             TRead::readProperty(b, e, ctx, Pid::FIRST_SYSTEM_INDENTATION);
+        } else if (tag == "showCourtesySig") {
+            TRead::readProperty(b, e, ctx, Pid::SHOW_COURTESY);
         } else if (!readItemProperties(b, e, ctx)) {
             e.unknown();
         }

--- a/src/engraving/rw/write/twrite.cpp
+++ b/src/engraving/rw/write/twrite.cpp
@@ -2138,7 +2138,7 @@ void TWrite::write(const LayoutBreak* item, XmlWriter& xml, WriteContext& ctx)
     writeItemProperties(item, xml, ctx);
 
     for (auto id :
-         { Pid::LAYOUT_BREAK, Pid::PAUSE, Pid::START_WITH_LONG_NAMES, Pid::START_WITH_MEASURE_ONE, Pid::FIRST_SYSTEM_INDENTATION }) {
+         { Pid::LAYOUT_BREAK, Pid::PAUSE, Pid::START_WITH_LONG_NAMES, Pid::START_WITH_MEASURE_ONE, Pid::FIRST_SYSTEM_INDENTATION, Pid::SHOW_COURTESY }) {
         writeProperty(item, xml, id);
     }
 

--- a/src/engraving/rw/write/twrite.cpp
+++ b/src/engraving/rw/write/twrite.cpp
@@ -2138,7 +2138,8 @@ void TWrite::write(const LayoutBreak* item, XmlWriter& xml, WriteContext& ctx)
     writeItemProperties(item, xml, ctx);
 
     for (auto id :
-         { Pid::LAYOUT_BREAK, Pid::PAUSE, Pid::START_WITH_LONG_NAMES, Pid::START_WITH_MEASURE_ONE, Pid::FIRST_SYSTEM_INDENTATION, Pid::SHOW_COURTESY }) {
+         { Pid::LAYOUT_BREAK, Pid::PAUSE, Pid::START_WITH_LONG_NAMES, Pid::START_WITH_MEASURE_ONE, Pid::FIRST_SYSTEM_INDENTATION,
+           Pid::SHOW_COURTESY }) {
         writeProperty(item, xml, id);
     }
 

--- a/src/inspector/models/notation/sectionbreaks/sectionbreaksettingsmodel.cpp
+++ b/src/inspector/models/notation/sectionbreaks/sectionbreaksettingsmodel.cpp
@@ -41,6 +41,7 @@ void SectionBreakSettingsModel::createProperties()
     m_shouldResetBarNums = buildPropertyItem(mu::engraving::Pid::START_WITH_MEASURE_ONE);
     m_pauseDuration = buildPropertyItem(mu::engraving::Pid::PAUSE);
     m_firstSystemIndent = buildPropertyItem(mu::engraving::Pid::FIRST_SYSTEM_INDENTATION);
+    m_showCourtesySignatures = buildPropertyItem(mu::engraving::Pid::SHOW_COURTESY);
 }
 
 void SectionBreakSettingsModel::requestElements()
@@ -54,6 +55,7 @@ void SectionBreakSettingsModel::loadProperties()
     loadPropertyItem(m_shouldResetBarNums);
     loadPropertyItem(m_pauseDuration, formatDoubleFunc);
     loadPropertyItem(m_firstSystemIndent);
+    loadPropertyItem(m_showCourtesySignatures);
 }
 
 void SectionBreakSettingsModel::resetProperties()
@@ -62,6 +64,7 @@ void SectionBreakSettingsModel::resetProperties()
     m_shouldResetBarNums->resetToDefault();
     m_pauseDuration->resetToDefault();
     m_firstSystemIndent->resetToDefault();
+    m_showCourtesySignatures->resetToDefault();
 }
 
 PropertyItem* SectionBreakSettingsModel::shouldStartWithLongInstrNames() const
@@ -82,4 +85,9 @@ PropertyItem* SectionBreakSettingsModel::pauseDuration() const
 PropertyItem* SectionBreakSettingsModel::firstSystemIndent() const
 {
     return m_firstSystemIndent;
+}
+
+PropertyItem* SectionBreakSettingsModel::showCourtesySignatures() const
+{
+    return m_showCourtesySignatures;
 }

--- a/src/inspector/models/notation/sectionbreaks/sectionbreaksettingsmodel.h
+++ b/src/inspector/models/notation/sectionbreaks/sectionbreaksettingsmodel.h
@@ -33,6 +33,7 @@ class SectionBreakSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(PropertyItem * shouldResetBarNums READ shouldResetBarNums CONSTANT)
     Q_PROPERTY(PropertyItem * pauseDuration READ pauseDuration CONSTANT)
     Q_PROPERTY(PropertyItem * firstSystemIndent READ firstSystemIndent CONSTANT)
+    Q_PROPERTY(PropertyItem * showCourtesySignatures READ showCourtesySignatures CONSTANT)
 
 public:
     explicit SectionBreakSettingsModel(QObject* parent, IElementRepositoryService* repository);
@@ -46,12 +47,14 @@ public:
     PropertyItem* shouldResetBarNums() const;
     PropertyItem* pauseDuration() const;
     PropertyItem* firstSystemIndent() const;
+    PropertyItem* showCourtesySignatures() const;
 
 private:
     PropertyItem* m_shouldStartWithLongInstrNames = nullptr;
     PropertyItem* m_shouldResetBarNums = nullptr;
     PropertyItem* m_pauseDuration = nullptr;
     PropertyItem* m_firstSystemIndent = nullptr;
+    PropertyItem* m_showCourtesySignatures = nullptr;
 };
 }
 

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/sectionbreaks/SectionBreakSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/sectionbreaks/SectionBreakSettings.qml
@@ -89,4 +89,21 @@ Column {
         navigation.panel: root.navigationPanel
         navigation.row: shouldResetBarNums.navigation.row + 1
     }
+
+    PropertyCheckBox {
+        id: showCourtesySignatures
+        text: qsTrc("inspector", "Hide courtesy clefs and signatures")
+        propertyItem: root.model ? root.model.showCourtesySignatures : null
+
+        checked: propertyItem && !Boolean(propertyItem.value)
+        onClicked: {
+            if (propertyItem) {
+                propertyItem.value = checked
+            }
+        }
+
+        navigation.name: "ShowCourtesySignatures"
+        navigation.panel: root.navigationPanel
+        navigation.row: startWithfirstSystemIndented.navigation.row + 1
+    }
 }


### PR DESCRIPTION
Resolves: #24842 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->
Closes: #25865

<!-- Add a short description of and motivation for the changes here -->

https://github.com/user-attachments/assets/f824e19a-bfca-452e-b79e-8eed3a1d7500



<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
