### PR TITLE
17207: Alt+F4 to close a dialog should not activate the top menu

### DIFF
--- a/src/appshell/view/navigableappmenumodel.cpp
+++ b/src/appshell/view/navigableappmenumodel.cpp
@@ -306,9 +306,10 @@ bool NavigableAppMenuModel::processEventForAppMenu(QEvent* event)
             break;
         }
 
+        m_needActivateHighlight = false;
+
         if (isNavigationStarted && isNavigateKey(key)) {
             navigate(key);
-            m_needActivateHighlight = false;
 
             event->accept();
             return true;
@@ -316,14 +317,11 @@ bool NavigableAppMenuModel::processEventForAppMenu(QEvent* event)
             QSet<int> activatePossibleKeys = possibleKeys(keyEvent);
             if (hasItem(activatePossibleKeys)) {
                 navigate(activatePossibleKeys);
-                m_needActivateHighlight = true;
 
                 event->accept();
                 return true;
             }
         }
-
-        m_needActivateHighlight = false;
 
         break;
     }
@@ -337,10 +335,9 @@ bool NavigableAppMenuModel::processEventForAppMenu(QEvent* event)
             restoreMUNavigationSystemState();
         } else {
             if (m_needActivateHighlight) {
+                m_needActivateHighlight = false;
                 saveMUNavigationSystemState();
                 navigateToFirstMenu();
-            } else {
-                m_needActivateHighlight = true;
             }
         }
 
@@ -465,6 +462,7 @@ void NavigableAppMenuModel::navigateToSubItem(const QString& menuId, const QSet<
 void NavigableAppMenuModel::resetNavigation()
 {
     setHighlightedMenuId("");
+    m_needActivateHighlight = false;
 }
 
 void NavigableAppMenuModel::navigateToFirstMenu()

--- a/src/appshell/view/navigableappmenumodel.h
+++ b/src/appshell/view/navigableappmenumodel.h
@@ -111,7 +111,7 @@ private:
     QString m_highlightedMenuId;
     QString m_openedMenuId;
 
-    bool m_needActivateHighlight = true;
+    bool m_needActivateHighlight = false;
     std::optional<MUNavigationSystemState> m_lastActiveMUNavigationState;
     bool m_needActivateLastMUNavigationControl = false;
 


### PR DESCRIPTION
Resolves: #17207

The main menu is activated on the release of the Alt key when `m_needActivateHighlight` is `true`. `m_needActivateHighlight` should become `true` only when the Alt key is previously pressed alone and not in any other case. On the other hand, it should be set to `false` as soon as a menu is highlighted, navigation started, another key is pressed and when the menu is closed.

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
