### PR TITLE
Use General MIDI Percussion as the standard drumset

### DIFF
--- a/share/instruments/instruments.xml
+++ b/share/instruments/instruments.xml
@@ -7227,7 +7227,13 @@
                   <drumset>1</drumset>
                   <singleNoteDynamics>0</singleNoteDynamics>
                   <Drum pitch="62"> <!--Mute High Conga-->
-                        <head>cross</head>
+                        <head>normal</head>
+                        <noteheads>
+                              <quarter>noteheadXOrnate</quarter>
+                              <half>noteheadXOrnate</half>
+                              <whole>noteheadXOrnate</whole>
+                              <breve>noteheadXOrnate</breve>
+                        </noteheads>
                         <line>-1</line>
                         <voice>0</voice>
                         <name>Mute High Conga</name>
@@ -7308,99 +7314,71 @@
             </Instrument>
             <Instrument id="drumset">
                   <family>drums</family>
-                  <!--Drums are hard-coded in drumset.cpp to initialize MIDI and playback systems at startup before instruments.xml is loaded.-->
-                  <trackName>Large Drum Kit</trackName>
+                  <trackName>Drum Kit (large)</trackName>
                   <longName>Drum Kit</longName>
                   <shortName>D. Kit</shortName>
-                  <description>Drum Kit.</description>
+                  <description>Large drum kit.</description>
                   <musicXMLid>drum.group.set</musicXMLid>
                   <clef>PERC</clef>
                   <stafftype staffTypePreset="perc5Line">percussion</stafftype>
                   <barlineSpan>1</barlineSpan>
                   <drumset>1</drumset>
                   <singleNoteDynamics>0</singleNoteDynamics>
-                  <Channel>
-                        <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
-                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
-                        <program value="0"/> <!--Standard Kit-->
-                  </Channel>
-                  <genre>common</genre>
-                  <genre>popular</genre>
-                  <genre>jazz</genre>
-                  <genre>orchestra</genre>
-                  <genre>concertband</genre>
-                  <genre>marching</genre>
-            </Instrument>
-            <Instrument id="drum-kit-4">
-                  <family>drums</family>
-                  <!--Created as a minimalist version of drumset-->
-                  <trackName>4-Piece Drum Kit</trackName>
-                  <longName>Drum Kit</longName>
-                  <shortName>D. Kit</shortName>
-                  <description>4 piece drum kit.</description>
-                  <musicXMLid>drum.group.set</musicXMLid>
-                  <clef>PERC</clef>
-                  <stafftype staffTypePreset="perc5Line">percussion</stafftype>
-                  <barlineSpan>1</barlineSpan>
-                  <drumset>1</drumset>
-                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Drum pitch="35"> <!--Acoustic Bass Drum-->
+                        <head>normal</head>
+                        <line>8</line>
+                        <voice>1</voice>
+                        <name>Bass Drum 2</name>
+                        <stem>2</stem>
+                        <panelRow>1</panelRow>
+                        <panelColumn>0</panelColumn>
+                  </Drum>
                   <Drum pitch="36"> <!--Electric Bass Drum-->
                         <head>normal</head>
                         <line>7</line>
                         <voice>1</voice>
-                        <name>Bass Drum</name>
+                        <name>Bass Drum 1</name>
                         <stem>2</stem>
                         <shortcut>B</shortcut>
-                        <panelRow>2</panelRow>
-                        <panelColumn>0</panelColumn>
-                  </Drum>
-                  <Drum pitch="38"> <!--Acoustic Snare-->
-                        <head>normal</head>
-                        <line>3</line>
-                        <voice>0</voice>
-                        <name>Snare</name>
-                        <stem>1</stem>
-                        <shortcut>A</shortcut>
-                        <panelRow>1</panelRow>
+                        <panelRow>0</panelRow>
                         <panelColumn>0</panelColumn>
                   </Drum>
                   <Drum pitch="37"> <!--Side Stick-->
                         <head>slashed1</head>
                         <line>3</line>
                         <voice>0</voice>
-                        <name>Cross-stick</name>
+                        <name>Side Stick</name>
                         <stem>1</stem>
                         <panelRow>1</panelRow>
                         <panelColumn>1</panelColumn>
                   </Drum>
-                  <Drum pitch="50"> <!--High Tom-->
+                  <Drum pitch="38"> <!--Acoustic Snare-->
                         <head>normal</head>
-                        <line>1</line>
+                        <line>3</line>
                         <voice>0</voice>
-                        <name>Tom</name>
+                        <name>Acoustic Snare</name>
                         <stem>1</stem>
-                        <shortcut>E</shortcut>
-                        <panelRow>1</panelRow>
-                        <panelColumn>2</panelColumn>
+                        <shortcut>A</shortcut>
+                        <panelRow>0</panelRow>
+                        <panelColumn>1</panelColumn>
+                  </Drum>
+                  <Drum pitch="40"> <!--Electric Snare-->
+                        <head>slash</head>
+                        <line>3</line>
+                        <voice>0</voice>
+                        <name>Electric Snare</name>
+                        <stem>1</stem>
+                        <panelRow>2</panelRow>
+                        <panelColumn>0</panelColumn>
                   </Drum>
                   <Drum pitch="41"> <!--Low Floor Tom-->
                         <head>normal</head>
-                        <line>5</line>
+                        <line>6</line>
                         <voice>0</voice>
-                        <name>Floor Tom</name>
+                        <name>Low Floor Tom</name>
                         <stem>1</stem>
                         <panelRow>1</panelRow>
-                        <panelColumn>3</panelColumn>
-                  </Drum>
-                  <Drum pitch="44"> <!--Pedal Hi-hat-->
-                        <head>cross</head>
-                        <line>9</line>
-                        <voice>1</voice>
-                        <name>Pedal Hi-Hat</name>
-                        <stem>2</stem>
-                        <shortcut>F</shortcut>
-                        <panelRow>2</panelRow>
-                        <panelColumn>1</panelColumn>
+                        <panelColumn>7</panelColumn>
                   </Drum>
                   <Drum pitch="42"> <!--Closed Hi-hat-->
                         <head>cross</head>
@@ -7410,192 +7388,90 @@
                         <stem>1</stem>
                         <shortcut>G</shortcut>
                         <panelRow>0</panelRow>
-                        <panelColumn>0</panelColumn>
+                        <panelColumn>2</panelColumn>
+                  </Drum>
+                  <Drum pitch="43"> <!--High Floor Tom-->
+                        <head>normal</head>
+                        <line>5</line>
+                        <voice>0</voice>
+                        <name>High Floor Tom</name>
+                        <stem>1</stem>
+                        <panelRow>0</panelRow>
+                        <panelColumn>7</panelColumn>
+                  </Drum>
+                  <Drum pitch="44"> <!--Pedal Hi-hat-->
+                        <head>cross</head>
+                        <line>9</line>
+                        <voice>1</voice>
+                        <name>Pedal Hi-Hat</name>
+                        <stem>2</stem>
+                        <shortcut>F</shortcut>
+                        <panelRow>1</panelRow>
+                        <panelColumn>2</panelColumn>
+                  </Drum>
+                  <Drum pitch="45"> <!--Low Tom-->
+                        <head>normal</head>
+                        <line>4</line>
+                        <voice>0</voice>
+                        <name>Low Tom</name>
+                        <stem>1</stem>
+                        <panelRow>1</panelRow>
+                        <panelColumn>6</panelColumn>
                   </Drum>
                   <Drum pitch="46"> <!--Open Hi-hat-->
-                        <head>cross</head>
+                        <head>xcircle</head>
                         <line>-1</line>
                         <voice>0</voice>
                         <name>Open Hi-Hat</name>
                         <stem>1</stem>
                         <panelRow>0</panelRow>
-                        <panelColumn>1</panelColumn>
-                  </Drum>
-                  <Drum pitch="51"> <!--Ride Cymbal 1-->
-                        <head>cross</head>
-                        <line>0</line>
-                        <voice>0</voice>
-                        <name>Ride Cymbal</name>
-                        <stem>1</stem>
-                        <shortcut>D</shortcut>
-                        <panelRow>0</panelRow>
-                        <panelColumn>2</panelColumn>
-                  </Drum>
-                  <Drum pitch="53"> <!--Ride Bell-->
-                        <head>diamond</head>
-                        <line>0</line>
-                        <voice>0</voice>
-                        <name>Ride Bell</name>
-                        <stem>1</stem>
-                        <panelRow>0</panelRow>
                         <panelColumn>3</panelColumn>
-                  </Drum>
-                  <Drum pitch="49"> <!--Crash Cymbal 1-->
-                        <head>cross</head>
-                        <line>-2</line>
-                        <voice>0</voice>
-                        <name>Crash Cymbal</name>
-                        <stem>1</stem>
-                        <shortcut>C</shortcut>
-                        <panelRow>0</panelRow>
-                        <panelColumn>4</panelColumn>
-                  </Drum>
-                  <Channel>
-                        <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
-                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
-                        <program value="0"/> <!--Standard Kit-->
-                  </Channel>
-                  <genre>common</genre>
-                  <genre>popular</genre>
-                  <genre>jazz</genre>
-                  <genre>orchestra</genre>
-                  <genre>concertband</genre>
-                  <genre>marching</genre>
-            </Instrument>
-            <Instrument id="drum-kit-5">
-                  <family>drums</family>
-                  <!--Created as a more conventional version of drumset.-->
-                  <trackName>5-Piece Drum Kit</trackName>
-                  <longName>Drum Kit</longName>
-                  <shortName>D. Kit</shortName>
-                  <description>5 piece drum kit.</description>
-                  <musicXMLid>drum.group.set</musicXMLid>
-                  <clef>PERC</clef>
-                  <stafftype staffTypePreset="perc5Line">percussion</stafftype>
-                  <barlineSpan>1</barlineSpan>
-                  <drumset>1</drumset>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Drum pitch="36"> <!--Electric Bass Drum-->
-                        <head>normal</head>
-                        <line>7</line>
-                        <voice>1</voice>
-                        <name>Bass Drum</name>
-                        <stem>2</stem>
-                        <shortcut>B</shortcut>
-                        <panelRow>2</panelRow>
-                        <panelColumn>0</panelColumn>
-                  </Drum>
-                  <Drum pitch="38"> <!--Acoustic Snare-->
-                        <head>normal</head>
-                        <line>3</line>
-                        <voice>0</voice>
-                        <name>Snare</name>
-                        <stem>1</stem>
-                        <shortcut>A</shortcut>
-                        <panelRow>1</panelRow>
-                        <panelColumn>0</panelColumn>
-                  </Drum>
-                  <Drum pitch="37"> <!--Side Stick-->
-                        <head>slashed1</head>
-                        <line>3</line>
-                        <voice>0</voice>
-                        <name>Cross-stick</name>
-                        <stem>1</stem>
-                        <panelRow>1</panelRow>
-                        <panelColumn>1</panelColumn>
-                  </Drum>
-                  <Drum pitch="50"> <!--High Tom-->
-                        <head>normal</head>
-                        <line>1</line>
-                        <voice>0</voice>
-                        <name>High Tom</name>
-                        <stem>1</stem>
-                        <shortcut>E</shortcut>
-                        <panelRow>1</panelRow>
-                        <panelColumn>2</panelColumn>
                   </Drum>
                   <Drum pitch="47"> <!--Low-Mid Tom-->
                         <head>normal</head>
                         <line>2</line>
                         <voice>0</voice>
-                        <name>Low Tom</name>
+                        <name>Low-Mid Tom</name>
                         <stem>1</stem>
                         <panelRow>1</panelRow>
-                        <panelColumn>3</panelColumn>
+                        <panelColumn>5</panelColumn>
                   </Drum>
-                  <Drum pitch="41"> <!--Low Floor Tom-->
+                  <Drum pitch="48"> <!--Hi-Mid Tom-->
                         <head>normal</head>
-                        <line>5</line>
+                        <line>1</line>
                         <voice>0</voice>
-                        <name>Floor Tom</name>
-                        <stem>1</stem>
-                        <panelRow>1</panelRow>
-                        <panelColumn>4</panelColumn>
-                  </Drum>
-                  <Drum pitch="44"> <!--Pedal Hi-hat-->
-                        <head>cross</head>
-                        <line>9</line>
-                        <voice>1</voice>
-                        <name>Pedal Hi-Hat</name>
-                        <stem>2</stem>
-                        <shortcut>F</shortcut>
-                        <panelRow>2</panelRow>
-                        <panelColumn>1</panelColumn>
-                  </Drum>
-                  <Drum pitch="42"> <!--Closed Hi-hat-->
-                        <head>cross</head>
-                        <line>-1</line>
-                        <voice>0</voice>
-                        <name>Closed Hi-Hat</name>
-                        <stem>1</stem>
-                        <shortcut>G</shortcut>
-                        <panelRow>0</panelRow>
-                        <panelColumn>0</panelColumn>
-                  </Drum>
-                  <Drum pitch="46"> <!--Open Hi-hat-->
-                        <head>cross</head>
-                        <line>-1</line>
-                        <voice>0</voice>
-                        <name>Open Hi-Hat</name>
+                        <name>Hi-Mid Tom</name>
                         <stem>1</stem>
                         <panelRow>0</panelRow>
-                        <panelColumn>1</panelColumn>
-                  </Drum>
-                  <Drum pitch="51"> <!--Ride Cymbal 1-->
-                        <head>cross</head>
-                        <line>0</line>
-                        <voice>0</voice>
-                        <name>Ride Cymbal</name>
-                        <stem>1</stem>
-                        <shortcut>D</shortcut>
-                        <panelRow>0</panelRow>
-                        <panelColumn>2</panelColumn>
-                  </Drum>
-                  <Drum pitch="53"> <!--Ride Bell-->
-                        <head>diamond</head>
-                        <line>0</line>
-                        <voice>0</voice>
-                        <name>Ride Bell</name>
-                        <stem>1</stem>
-                        <panelRow>0</panelRow>
-                        <panelColumn>3</panelColumn>
+                        <panelColumn>6</panelColumn>
                   </Drum>
                   <Drum pitch="49"> <!--Crash Cymbal 1-->
                         <head>cross</head>
                         <line>-2</line>
                         <voice>0</voice>
-                        <name>Crash Cymbal</name>
+                        <name>Crash Cymbal 1</name>
                         <stem>1</stem>
                         <shortcut>C</shortcut>
                         <panelRow>0</panelRow>
                         <panelColumn>4</panelColumn>
                   </Drum>
-                  <Drum pitch="57"> <!--Crash Cymbal 2-->
-                        <head>cross</head>
-                        <line>-3</line>
+                  <Drum pitch="50"> <!--High Tom-->
+                        <head>normal</head>
+                        <line>0</line>
                         <voice>0</voice>
-                        <name>Crash Cymbal 2</name>
+                        <name>High Tom</name>
                         <stem>1</stem>
+                        <shortcut>E</shortcut>
+                        <panelRow>1</panelRow>
+                        <panelColumn>4</panelColumn>
+                  </Drum>
+                  <Drum pitch="51"> <!--Ride Cymbal 1-->
+                        <head>cross</head>
+                        <line>0</line>
+                        <voice>0</voice>
+                        <name>Ride Cymbal 1</name>
+                        <stem>1</stem>
+                        <shortcut>D</shortcut>
                         <panelRow>0</panelRow>
                         <panelColumn>5</panelColumn>
                   </Drum>
@@ -7605,8 +7481,26 @@
                         <voice>0</voice>
                         <name>China Cymbal</name>
                         <stem>1</stem>
-                        <panelRow>0</panelRow>
-                        <panelColumn>6</panelColumn>
+                        <panelRow>2</panelRow>
+                        <panelColumn>3</panelColumn>
+                  </Drum>
+                  <Drum pitch="53"> <!--Ride Bell-->
+                        <head>diamond</head>
+                        <line>0</line>
+                        <voice>0</voice>
+                        <name>Ride Bell</name>
+                        <stem>1</stem>
+                        <panelRow>2</panelRow>
+                        <panelColumn>5</panelColumn>
+                  </Drum>
+                  <Drum pitch="54"> <!--Tambourine-->
+                        <head>diamond</head>
+                        <line>1</line>
+                        <voice>0</voice>
+                        <name>Tambourine</name>
+                        <stem>1</stem>
+                        <panelRow>2</panelRow>
+                        <panelColumn>1</panelColumn>
                   </Drum>
                   <Drum pitch="55"> <!--Splash Cymbal-->
                         <head>cross</head>
@@ -7614,8 +7508,35 @@
                         <voice>0</voice>
                         <name>Splash Cymbal</name>
                         <stem>1</stem>
-                        <panelRow>0</panelRow>
-                        <panelColumn>7</panelColumn>
+                        <panelRow>2</panelRow>
+                        <panelColumn>4</panelColumn>
+                  </Drum>
+                  <Drum pitch="56"> <!--Cowbell-->
+                        <head>triangle-down</head>
+                        <line>1</line>
+                        <voice>0</voice>
+                        <name>Cowbell</name>
+                        <stem>1</stem>
+                        <panelRow>2</panelRow>
+                        <panelColumn>2</panelColumn>
+                  </Drum>
+                  <Drum pitch="57"> <!--Crash Cymbal 2-->
+                        <head>cross</head>
+                        <line>-3</line>
+                        <voice>0</voice>
+                        <name>Crash Cymbal 2</name>
+                        <stem>1</stem>
+                        <panelRow>1</panelRow>
+                        <panelColumn>3</panelColumn>
+                  </Drum>
+                  <Drum pitch="59"> <!--Ride Cymbal 2-->
+                        <head>cross</head>
+                        <line>2</line>
+                        <voice>0</voice>
+                        <name>Ride Cymbal 2</name>
+                        <stem>1</stem>
+                        <panelRow>2</panelRow>
+                        <panelColumn>6</panelColumn>
                   </Drum>
                   <Channel>
                         <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
@@ -7624,7 +7545,317 @@
                   </Channel>
                   <genre>common</genre>
                   <genre>popular</genre>
-                  <genre>jazz</genre>
+                  <genre>orchestra</genre>
+                  <genre>concertband</genre>
+                  <genre>marching</genre>
+            </Instrument>
+            <Instrument id="drum-kit-4">
+                  <family>drums</family>
+                  <!--Created as a minimalist version of drumset-->
+                  <trackName>Drum Kit (minimal)</trackName>
+                  <longName>Drum Kit</longName>
+                  <shortName>D. Kit</shortName>
+                  <description>Minimal drum kit, 4-piece.</description>
+                  <musicXMLid>drum.group.set</musicXMLid>
+                  <clef>PERC</clef>
+                  <stafftype staffTypePreset="perc5Line">percussion</stafftype>
+                  <barlineSpan>1</barlineSpan>
+                  <drumset>1</drumset>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Drum pitch="36"> <!--Electric Bass Drum-->
+                        <head>normal</head>
+                        <line>7</line>
+                        <voice>1</voice>
+                        <name>Bass Drum</name>
+                        <stem>2</stem>
+                        <shortcut>B</shortcut>
+                        <panelRow>0</panelRow>
+                        <panelColumn>0</panelColumn>
+                  </Drum>
+                  <Drum pitch="37"> <!--Side Stick-->
+                        <head>slashed1</head>
+                        <line>3</line>
+                        <voice>0</voice>
+                        <name>Cross-stick</name>
+                        <stem>1</stem>
+                        <panelRow>1</panelRow>
+                        <panelColumn>1</panelColumn>
+                  </Drum>
+                  <Drum pitch="38"> <!--Acoustic Snare-->
+                        <head>normal</head>
+                        <line>3</line>
+                        <voice>0</voice>
+                        <name>Snare</name>
+                        <stem>1</stem>
+                        <shortcut>A</shortcut>
+                        <panelRow>0</panelRow>
+                        <panelColumn>1</panelColumn>
+                  </Drum>
+                  <Drum pitch="41"> <!--Low Floor Tom-->
+                        <head>normal</head>
+                        <line>5</line>
+                        <voice>0</voice>
+                        <name>Floor Tom</name>
+                        <stem>1</stem>
+                        <panelRow>0</panelRow>
+                        <panelColumn>7</panelColumn>
+                  </Drum>
+                  <Drum pitch="42"> <!--Closed Hi-hat-->
+                        <head>cross</head>
+                        <line>-1</line>
+                        <voice>0</voice>
+                        <name>Closed Hi-Hat</name>
+                        <stem>1</stem>
+                        <shortcut>G</shortcut>
+                        <panelRow>0</panelRow>
+                        <panelColumn>2</panelColumn>
+                  </Drum>
+                  <Drum pitch="44"> <!--Pedal Hi-hat-->
+                        <head>cross</head>
+                        <line>9</line>
+                        <voice>1</voice>
+                        <name>Pedal Hi-Hat</name>
+                        <stem>2</stem>
+                        <shortcut>F</shortcut>
+                        <panelRow>1</panelRow>
+                        <panelColumn>0</panelColumn>
+                  </Drum>
+                  <Drum pitch="46"> <!--Open Hi-hat-->
+                        <head>xcircle</head>
+                        <line>-1</line>
+                        <voice>0</voice>
+                        <name>Open Hi-Hat</name>
+                        <stem>1</stem>
+                        <panelRow>0</panelRow>
+                        <panelColumn>3</panelColumn>
+                  </Drum>
+                  <Drum pitch="49"> <!--Crash Cymbal 1-->
+                        <head>cross</head>
+                        <line>-2</line>
+                        <voice>0</voice>
+                        <name>Crash Cymbal</name>
+                        <stem>1</stem>
+                        <shortcut>C</shortcut>
+                        <panelRow>0</panelRow>
+                        <panelColumn>4</panelColumn>
+                  </Drum>
+                  <Drum pitch="50"> <!--High Tom-->
+                        <head>normal</head>
+                        <line>1</line>
+                        <voice>0</voice>
+                        <name>Tom</name>
+                        <stem>1</stem>
+                        <shortcut>E</shortcut>
+                        <panelRow>0</panelRow>
+                        <panelColumn>6</panelColumn>
+                  </Drum>
+                  <Drum pitch="51"> <!--Ride Cymbal 1-->
+                        <head>cross</head>
+                        <line>0</line>
+                        <voice>0</voice>
+                        <name>Ride Cymbal</name>
+                        <stem>1</stem>
+                        <shortcut>D</shortcut>
+                        <panelRow>0</panelRow>
+                        <panelColumn>5</panelColumn>
+                  </Drum>
+                  <Drum pitch="53"> <!--Ride Bell-->
+                        <head>diamond</head>
+                        <line>0</line>
+                        <voice>0</voice>
+                        <name>Ride Bell</name>
+                        <stem>1</stem>
+                        <panelRow>1</panelRow>
+                        <panelColumn>2</panelColumn>
+                  </Drum>
+                  <Channel>
+                        <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
+                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
+                        <program value="0"/> <!--Standard Kit-->
+                  </Channel>
+                  <genre>common</genre>
+                  <genre>popular</genre>
+                  <genre>orchestra</genre>
+                  <genre>concertband</genre>
+                  <genre>marching</genre>
+            </Instrument>
+            <Instrument id="drum-kit-5">
+                  <family>drums</family>
+                  <!--Created as a more conventional version of drumset.-->
+                  <trackName>Drum Kit (common)</trackName>
+                  <longName>Drum Kit</longName>
+                  <shortName>D. Kit</shortName>
+                  <description>Common drum kit, 5-piece.</description>
+                  <musicXMLid>drum.group.set</musicXMLid>
+                  <clef>PERC</clef>
+                  <stafftype staffTypePreset="perc5Line">percussion</stafftype>
+                  <barlineSpan>1</barlineSpan>
+                  <drumset>1</drumset>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Drum pitch="35"> <!--Acoustic Bass Drum-->
+                        <head>normal</head>
+                        <line>8</line>
+                        <voice>1</voice>
+                        <name>Bass Drum 2</name>
+                        <stem>2</stem>
+                        <panelRow>1</panelRow>
+                        <panelColumn>0</panelColumn>
+                  </Drum>
+                  <Drum pitch="36"> <!--Electric Bass Drum-->
+                        <head>normal</head>
+                        <line>7</line>
+                        <voice>1</voice>
+                        <name>Bass Drum</name>
+                        <stem>2</stem>
+                        <shortcut>B</shortcut>
+                        <panelRow>0</panelRow>
+                        <panelColumn>0</panelColumn>
+                  </Drum>
+                  <Drum pitch="37"> <!--Side Stick-->
+                        <head>slashed1</head>
+                        <line>3</line>
+                        <voice>0</voice>
+                        <name>Cross-stick</name>
+                        <stem>1</stem>
+                        <panelRow>1</panelRow>
+                        <panelColumn>1</panelColumn>
+                  </Drum>
+                  <Drum pitch="38"> <!--Acoustic Snare-->
+                        <head>normal</head>
+                        <line>3</line>
+                        <voice>0</voice>
+                        <name>Snare</name>
+                        <stem>1</stem>
+                        <shortcut>A</shortcut>
+                        <panelRow>0</panelRow>
+                        <panelColumn>1</panelColumn>
+                  </Drum>
+                  <Drum pitch="41"> <!--Low Floor Tom-->
+                        <head>normal</head>
+                        <line>5</line>
+                        <voice>0</voice>
+                        <name>Floor Tom</name>
+                        <stem>1</stem>
+                        <panelRow>0</panelRow>
+                        <panelColumn>7</panelColumn>
+                  </Drum>
+                  <Drum pitch="42"> <!--Closed Hi-hat-->
+                        <head>cross</head>
+                        <line>-1</line>
+                        <voice>0</voice>
+                        <name>Closed Hi-Hat</name>
+                        <stem>1</stem>
+                        <shortcut>G</shortcut>
+                        <panelRow>0</panelRow>
+                        <panelColumn>2</panelColumn>
+                  </Drum>
+                  <Drum pitch="44"> <!--Pedal Hi-hat-->
+                        <head>cross</head>
+                        <line>9</line>
+                        <voice>1</voice>
+                        <name>Pedal Hi-Hat</name>
+                        <stem>2</stem>
+                        <shortcut>F</shortcut>
+                        <panelRow>1</panelRow>
+                        <panelColumn>3</panelColumn>
+                  </Drum>
+                  <Drum pitch="46"> <!--Open Hi-hat-->
+                        <head>xcircle</head>
+                        <line>-1</line>
+                        <voice>0</voice>
+                        <name>Open Hi-Hat</name>
+                        <stem>1</stem>
+                        <panelRow>0</panelRow>
+                        <panelColumn>3</panelColumn>
+                  </Drum>
+                  <Drum pitch="47"> <!--Low-Mid Tom-->
+                        <head>normal</head>
+                        <line>2</line>
+                        <voice>0</voice>
+                        <name>Low Tom</name>
+                        <stem>1</stem>
+                        <panelRow>1</panelRow>
+                        <panelColumn>6</panelColumn>
+                  </Drum>
+                  <Drum pitch="49"> <!--Crash Cymbal 1-->
+                        <head>cross</head>
+                        <line>-2</line>
+                        <voice>0</voice>
+                        <name>Crash Cymbal</name>
+                        <stem>1</stem>
+                        <shortcut>C</shortcut>
+                        <panelRow>0</panelRow>
+                        <panelColumn>4</panelColumn>
+                  </Drum>
+                  <Drum pitch="50"> <!--High Tom-->
+                        <head>normal</head>
+                        <line>1</line>
+                        <voice>0</voice>
+                        <name>High Tom</name>
+                        <stem>1</stem>
+                        <shortcut>E</shortcut>
+                        <panelRow>0</panelRow>
+                        <panelColumn>6</panelColumn>
+                  </Drum>
+                  <Drum pitch="51"> <!--Ride Cymbal 1-->
+                        <head>cross</head>
+                        <line>0</line>
+                        <voice>0</voice>
+                        <name>Ride Cymbal</name>
+                        <stem>1</stem>
+                        <shortcut>D</shortcut>
+                        <panelRow>0</panelRow>
+                        <panelColumn>5</panelColumn>
+                  </Drum>
+                  <Drum pitch="52"> <!--Chinese Cymbal-->
+                        <head>normal</head>
+                        <noteheads>
+                              <quarter>noteheadHeavyXHat</quarter>
+                              <half>noteheadHeavyXHat</half>
+                              <whole>noteheadHeavyXHat</whole>
+                              <breve>noteheadHeavyXHat</breve>
+                        </noteheads>
+                        <line>-3</line>
+                        <voice>0</voice>
+                        <name>China Cymbal</name>
+                        <stem>1</stem>
+                        <panelRow>1</panelRow>
+                        <panelColumn>7</panelColumn>
+                  </Drum>
+                  <Drum pitch="53"> <!--Ride Bell-->
+                        <head>diamond</head>
+                        <line>0</line>
+                        <voice>0</voice>
+                        <name>Ride Bell</name>
+                        <stem>1</stem>
+                        <panelRow>1</panelRow>
+                        <panelColumn>5</panelColumn>
+                  </Drum>
+                  <Drum pitch="55"> <!--Splash Cymbal-->
+                        <head>cross</head>
+                        <line>-4</line>
+                        <voice>0</voice>
+                        <name>Splash Cymbal</name>
+                        <stem>1</stem>
+                        <panelRow>1</panelRow>
+                        <panelColumn>2</panelColumn>
+                  </Drum>
+                  <Drum pitch="57"> <!--Crash Cymbal 2-->
+                        <head>cross</head>
+                        <line>-3</line>
+                        <voice>0</voice>
+                        <name>Crash Cymbal 2</name>
+                        <stem>1</stem>
+                        <panelRow>1</panelRow>
+                        <panelColumn>4</panelColumn>
+                  </Drum>
+                  <Channel>
+                        <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
+                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
+                        <program value="0"/> <!--Standard Kit-->
+                  </Channel>
+                  <genre>common</genre>
+                  <genre>popular</genre>
                   <genre>orchestra</genre>
                   <genre>concertband</genre>
                   <genre>marching</genre>
@@ -7854,7 +8085,17 @@
                   <barlineSpan>1</barlineSpan>
                   <drumset>1</drumset>
                   <singleNoteDynamics>0</singleNoteDynamics>
-                  <Drum pitch="36"> <!--Electric Bass Drum-->
+                  <Drum pitch="86"> <!--Mute Surdo-->
+                        <head>cross</head>
+                        <line>0</line>
+                        <voice>0</voice>
+                        <name>Taiko Mute</name>
+                        <stem>1</stem>
+                        <shortcut>B</shortcut>
+                        <panelRow>0</panelRow>
+                        <panelColumn>1</panelColumn>
+                  </Drum>
+                  <Drum pitch="87"> <!--Open Surdo-->
                         <head>normal</head>
                         <line>0</line>
                         <voice>0</voice>
@@ -8029,7 +8270,7 @@
                         <head>normal</head>
                         <line>0</line>
                         <voice>0</voice>
-                        <name>Chinese Cymbal</name>
+                        <name>China Cymbal</name>
                         <stem>1</stem>
                         <shortcut>A</shortcut>
                         <panelRow>0</panelRow>
@@ -8183,7 +8424,7 @@
                         <head>cross</head>
                         <line>0</line>
                         <voice>0</voice>
-                        <name>Closed Hi-hat</name>
+                        <name>Closed Hi-Hat</name>
                         <stem>1</stem>
                         <shortcut>B</shortcut>
                         <panelRow>0</panelRow>
@@ -8640,6 +8881,16 @@
                         <stem>1</stem>
                         <shortcut>A</shortcut>
                         <panelRow>0</panelRow>
+                        <panelColumn>1</panelColumn>
+                  </Drum>
+                  <Drum pitch="74"> <!--Long Guiro-->
+                        <head>normal</head>
+                        <line>0</line>
+                        <voice>0</voice>
+                        <name>Long Güiro</name>
+                        <stem>1</stem>
+                        <shortcut>A</shortcut>
+                        <panelRow>0</panelRow>
                         <panelColumn>0</panelColumn>
                   </Drum>
                   <Channel>
@@ -8851,225 +9102,6 @@
                   <genre>world</genre>
                   <genre>classroom</genre>
             </Instrument>
-            <Instrument id="percussion">
-                  <family>other-percussion</family>
-                  <trackName>Percussion</trackName>
-                  <longName>Percussion</longName>
-                  <shortName>Perc.</shortName>
-                  <description>Orchestral percussion drumset.</description>
-                  <musicXMLid>drum.group.set</musicXMLid>
-                  <clef>PERC</clef>
-                  <stafftype staffTypePreset="perc5Line">percussion</stafftype>
-                  <barlineSpan>1</barlineSpan>
-                  <drumset>1</drumset>
-                  <singleNoteDynamics>0</singleNoteDynamics>
-                  <Drum pitch="27"> <!--High Q-->
-                        <head>cross</head>
-                        <line>-1</line>
-                        <voice>0</voice>
-                        <name>Closed Hi-Hat</name>
-                        <stem>1</stem>
-                        <shortcut>G</shortcut>
-                        <panelRow>0</panelRow>
-                        <panelColumn>2</panelColumn>
-                  </Drum>
-                  <Drum pitch="28"> <!--Slap-->
-                        <head>cross</head>
-                        <line>9</line>
-                        <voice>1</voice>
-                        <name>Pedal Hi-Hat</name>
-                        <stem>2</stem>
-                        <shortcut>F</shortcut>
-                        <panelRow>0</panelRow>
-                        <panelColumn>3</panelColumn>
-                  </Drum>
-                  <Drum pitch="29"> <!--Scratch Push-->
-                        <head>cross</head>
-                        <line>1</line>
-                        <voice>0</voice>
-                        <name>Open Hi-Hat</name>
-                        <stem>1</stem>
-                        <shortcut>E</shortcut>
-                        <panelRow>0</panelRow>
-                        <panelColumn>4</panelColumn>
-                  </Drum>
-                  <Drum pitch="30"> <!--Scratch Pull-->
-                        <head>cross</head>
-                        <line>0</line>
-                        <voice>0</voice>
-                        <name>Ride Cymbal 1</name>
-                        <stem>1</stem>
-                        <panelRow>0</panelRow>
-                        <panelColumn>1</panelColumn>
-                  </Drum>
-                  <Drum pitch="36"> <!--Electric Bass Drum-->
-                        <head>normal</head>
-                        <line>7</line>
-                        <voice>1</voice>
-                        <name>Bass Drum 1</name>
-                        <stem>2</stem>
-                        <shortcut>B</shortcut>
-                        <panelRow>2</panelRow>
-                        <panelColumn>0</panelColumn>
-                  </Drum>
-                  <Drum pitch="37"> <!--Side Stick-->
-                        <head>cross</head>
-                        <line>3</line>
-                        <voice>0</voice>
-                        <name>Side Stick</name>
-                        <stem>1</stem>
-                        <panelRow>1</panelRow>
-                        <panelColumn>1</panelColumn>
-                  </Drum>
-                  <Drum pitch="38"> <!--Acoustic Snare-->
-                        <head>normal</head>
-                        <line>3</line>
-                        <voice>0</voice>
-                        <name>Acoustic Snare</name>
-                        <stem>1</stem>
-                        <shortcut>A</shortcut>
-                        <panelRow>1</panelRow>
-                        <panelColumn>0</panelColumn>
-                  </Drum>
-                  <Drum pitch="54"> <!--Tambourine-->
-                        <head>diamond</head>
-                        <line>2</line>
-                        <voice>0</voice>
-                        <name>Tambourine</name>
-                        <stem>1</stem>
-                        <panelRow>1</panelRow>
-                        <panelColumn>2</panelColumn>
-                  </Drum>
-                  <Drum pitch="55"> <!--Splash Cymbal-->
-                        <head>cross</head>
-                        <line>-3</line>
-                        <voice>0</voice>
-                        <name>Splash Cymbal</name>
-                        <stem>1</stem>
-                        <panelRow>0</panelRow>
-                        <panelColumn>5</panelColumn>
-                  </Drum>
-                  <Drum pitch="56"> <!--Cowbell-->
-                        <head>triangle-down</head>
-                        <line>1</line>
-                        <voice>0</voice>
-                        <name>Cowbell</name>
-                        <stem>1</stem>
-                        <panelRow>1</panelRow>
-                        <panelColumn>3</panelColumn>
-                  </Drum>
-                  <Drum pitch="58"> <!--Vibra Slap-->
-                        <head>diamond</head>
-                        <line>1</line>
-                        <voice>0</voice>
-                        <name>Vibraslap</name>
-                        <stem>1</stem>
-                        <panelRow>1</panelRow>
-                        <panelColumn>6</panelColumn>
-                  </Drum>
-                  <Drum pitch="59"> <!--Ride Cymbal 2-->
-                        <head>cross</head>
-                        <line>-2</line>
-                        <voice>0</voice>
-                        <name>Hand Cymbals</name>
-                        <stem>1</stem>
-                        <shortcut>C</shortcut>
-                        <panelRow>0</panelRow>
-                        <panelColumn>0</panelColumn>
-                  </Drum>
-                  <Drum pitch="62"> <!--Mute High Conga-->
-                        <head>cross</head>
-                        <line>2</line>
-                        <voice>0</voice>
-                        <name>Mute High Conga</name>
-                        <stem>1</stem>
-                        <panelRow>2</panelRow>
-                        <panelColumn>3</panelColumn>
-                  </Drum>
-                  <Drum pitch="63"> <!--Open High Conga-->
-                        <head>cross</head>
-                        <line>4</line>
-                        <voice>0</voice>
-                        <name>Open High Conga</name>
-                        <stem>1</stem>
-                        <panelRow>2</panelRow>
-                        <panelColumn>2</panelColumn>
-                  </Drum>
-                  <Drum pitch="64"> <!--Low Conga-->
-                        <head>cross</head>
-                        <line>6</line>
-                        <voice>0</voice>
-                        <name>Low Conga</name>
-                        <stem>1</stem>
-                        <panelRow>2</panelRow>
-                        <panelColumn>1</panelColumn>
-                  </Drum>
-                  <Drum pitch="70"> <!--Maracas-->
-                        <head>normal</head>
-                        <line>2</line>
-                        <voice>0</voice>
-                        <name>Maracas</name>
-                        <stem>1</stem>
-                        <panelRow>2</panelRow>
-                        <panelColumn>5</panelColumn>
-                  </Drum>
-                  <Drum pitch="75"> <!--Claves-->
-                        <head>normal</head>
-                        <line>0</line>
-                        <voice>0</voice>
-                        <name>Claves</name>
-                        <stem>1</stem>
-                        <panelRow>1</panelRow>
-                        <panelColumn>4</panelColumn>
-                  </Drum>
-                  <Drum pitch="81"> <!--Open Triangle-->
-                        <head>diamond</head>
-                        <line>0</line>
-                        <voice>0</voice>
-                        <name>Open Triangle</name>
-                        <stem>1</stem>
-                        <shortcut>D</shortcut>
-                        <panelRow>0</panelRow>
-                        <panelColumn>6</panelColumn>
-                  </Drum>
-                  <Drum pitch="82"> <!--Shaker-->
-                        <head>normal</head>
-                        <line>4</line>
-                        <voice>0</voice>
-                        <name>Shaker</name>
-                        <stem>1</stem>
-                        <panelRow>2</panelRow>
-                        <panelColumn>4</panelColumn>
-                  </Drum>
-                  <Drum pitch="84"> <!--Belltree-->
-                        <head>cross</head>
-                        <line>2</line>
-                        <voice>0</voice>
-                        <name>Mark Tree</name>
-                        <stem>1</stem>
-                        <panelRow>0</panelRow>
-                        <panelColumn>7</panelColumn>
-                  </Drum>
-                  <Drum pitch="85"> <!--Castanets-->
-                        <head>normal</head>
-                        <line>1</line>
-                        <voice>0</voice>
-                        <name>Castanets</name>
-                        <stem>1</stem>
-                        <panelRow>1</panelRow>
-                        <panelColumn>5</panelColumn>
-                  </Drum>
-                  <Channel>
-                        <!--MIDI: Bank 128, Prog 48; MS General: Orchestra Kit-->
-                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
-                        <program value="48"/> <!--Orchestra Kit-->
-                  </Channel>
-                  <genre>popular</genre>
-                  <genre>choral</genre>
-                  <genre>orchestra</genre>
-                  <genre>concertband</genre>
-                  <genre>marching</genre>
-            </Instrument>
             <Instrument id="quijada">
                   <family>other-percussion</family>
                   <trackName>Quijada</trackName>
@@ -9255,7 +9287,7 @@
                         <line>0</line>
                         <voice>0</voice>
                         <name>Tambourine</name>
-                        <stem>2</stem>
+                        <stem>1</stem>
                         <shortcut>A</shortcut>
                         <panelRow>0</panelRow>
                         <panelColumn>0</panelColumn>
@@ -9381,6 +9413,445 @@
                   <genre>concertband</genre>
                   <genre>classroom</genre>
             </Instrument>
+            <Instrument id="percussion-synthesizer">
+                  <family>other-percussion</family>
+                  <!--Drums are hard-coded in drumset.cpp to initialize MIDI and playback systems at startup before instruments.xml is loaded.-->
+                  <trackName>General MIDI Percussion</trackName>
+                  <longName>Percussion</longName>
+                  <shortName>Perc.</shortName>
+                  <description>General MIDI percussion kit with Level 2 extensions.</description>
+                  <musicXMLid>drum.group</musicXMLid>
+                  <clef>PERC</clef>
+                  <stafftype staffTypePreset="perc5Line">percussion</stafftype>
+                  <barlineSpan>1</barlineSpan>
+                  <drumset>1</drumset>
+                  <Channel>
+                        <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
+                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
+                        <program value="0"/> <!--Standard Kit-->
+                  </Channel>
+                  <genre>common</genre>
+                  <genre>popular</genre>
+                  <genre>jazz</genre>
+                  <genre>orchestra</genre>
+                  <genre>concertband</genre>
+                  <genre>marching</genre>
+                  <genre>electronic</genre>
+            </Instrument>
+            <Instrument id="percussion">
+                  <family>other-percussion</family>
+                  <trackName>Mixed Percussion</trackName>
+                  <longName>Percussion</longName>
+                  <shortName>Perc.</shortName>
+                  <description>Orchestral percussion kit.</description>
+                  <musicXMLid>drum.group.set</musicXMLid>
+                  <clef>PERC</clef>
+                  <stafftype staffTypePreset="perc5Line">percussion</stafftype>
+                  <barlineSpan>1</barlineSpan>
+                  <drumset>1</drumset>
+                  <singleNoteDynamics>0</singleNoteDynamics>
+                  <Drum pitch="27"> <!--High Q-->
+                        <head>cross</head>
+                        <line>-1</line>
+                        <voice>0</voice>
+                        <name>Closed Hi-Hat</name>
+                        <stem>1</stem>
+                        <panelRow>4</panelRow>
+                        <panelColumn>5</panelColumn>
+                  </Drum>
+                  <Drum pitch="28"> <!--Slap-->
+                        <head>cross</head>
+                        <line>9</line>
+                        <voice>1</voice>
+                        <name>Pedal Hi-Hat</name>
+                        <stem>2</stem>
+                        <panelRow>4</panelRow>
+                        <panelColumn>7</panelColumn>
+                  </Drum>
+                  <Drum pitch="29"> <!--Scratch Push-->
+                        <head>xcircle</head>
+                        <line>-1</line>
+                        <voice>0</voice>
+                        <name>Open Hi-Hat</name>
+                        <stem>1</stem>
+                        <panelRow>4</panelRow>
+                        <panelColumn>6</panelColumn>
+                  </Drum>
+                  <Drum pitch="30"> <!--Scratch Pull-->
+                        <head>cross</head>
+                        <line>0</line>
+                        <voice>0</voice>
+                        <name>Ride Cymbal</name>
+                        <stem>1</stem>
+                        <panelRow>5</panelRow>
+                        <panelColumn>0</panelColumn>
+                  </Drum>
+                  <Drum pitch="31"> <!--Sticks-->
+                        <head>plus</head>
+                        <line>-1</line>
+                        <voice>0</voice>
+                        <name>Stick Click</name>
+                        <stem>1</stem>
+                        <panelRow>4</panelRow>
+                        <panelColumn>4</panelColumn>
+                  </Drum>
+                  <Drum pitch="36"> <!--Electric Bass Drum-->
+                        <head>normal</head>
+                        <line>7</line>
+                        <voice>1</voice>
+                        <name>Bass Drum</name>
+                        <stem>2</stem>
+                        <panelRow>0</panelRow>
+                        <panelColumn>0</panelColumn>
+                  </Drum>
+                  <Drum pitch="37"> <!--Side Stick-->
+                        <head>slashed1</head>
+                        <line>3</line>
+                        <voice>0</voice>
+                        <name>Side Stick</name>
+                        <stem>1</stem>
+                        <panelRow>1</panelRow>
+                        <panelColumn>1</panelColumn>
+                  </Drum>
+                  <Drum pitch="38"> <!--Acoustic Snare-->
+                        <head>normal</head>
+                        <line>3</line>
+                        <voice>0</voice>
+                        <name>Snare</name>
+                        <stem>1</stem>
+                        <panelRow>0</panelRow>
+                        <panelColumn>1</panelColumn>
+                  </Drum>
+                  <Drum pitch="54"> <!--Tambourine-->
+                        <head>diamond</head>
+                        <line>6</line>
+                        <voice>0</voice>
+                        <name>Tambourine</name>
+                        <stem>1</stem>
+                        <panelRow>0</panelRow>
+                        <panelColumn>6</panelColumn>
+                  </Drum>
+                  <Drum pitch="55"> <!--Splash Cymbal-->
+                        <head>cross</head>
+                        <line>-4</line>
+                        <voice>0</voice>
+                        <name>Splash Cymbal</name>
+                        <stem>1</stem>
+                        <panelRow>5</panelRow>
+                        <panelColumn>1</panelColumn>
+                  </Drum>
+                  <Drum pitch="56"> <!--Cowbell-->
+                        <head>triangle-down</head>
+                        <line>0</line>
+                        <voice>0</voice>
+                        <name>Cowbell</name>
+                        <stem>1</stem>
+                        <panelRow>2</panelRow>
+                        <panelColumn>7</panelColumn>
+                  </Drum>
+                  <Drum pitch="57"> <!--Crash Cymbal 2-->
+                        <head>cross</head>
+                        <line>-2</line>
+                        <voice>0</voice>
+                        <name>Suspended Cymbal</name>
+                        <stem>1</stem>
+                        <panelRow>0</panelRow>
+                        <panelColumn>4</panelColumn>
+                  </Drum>
+                  <Drum pitch="58"> <!--Vibra Slap-->
+                        <head>ti</head>
+                        <line>0</line>
+                        <voice>0</voice>
+                        <name>Vibraslap</name>
+                        <stem>1</stem>
+                        <panelRow>1</panelRow>
+                        <panelColumn>3</panelColumn>
+                  </Drum>
+                  <Drum pitch="59"> <!--Ride Cymbal 2-->
+                        <head>cross</head>
+                        <line>4</line>
+                        <voice>0</voice>
+                        <name>Hand Cymbals</name>
+                        <stem>1</stem>
+                        <panelRow>0</panelRow>
+                        <panelColumn>5</panelColumn>
+                  </Drum>
+                  <Drum pitch="60"> <!--High Bongo-->
+                        <head>normal</head>
+                        <line>-1</line>
+                        <voice>0</voice>
+                        <name>Hi Bongo</name>
+                        <stem>1</stem>
+                        <panelRow>2</panelRow>
+                        <panelColumn>6</panelColumn>
+                  </Drum>
+                  <Drum pitch="61"> <!--Low Bongo-->
+                        <head>normal</head>
+                        <line>0</line>
+                        <voice>0</voice>
+                        <name>Lo Bongo</name>
+                        <stem>1</stem>
+                        <panelRow>2</panelRow>
+                        <panelColumn>5</panelColumn>
+                  </Drum>
+                  <Drum pitch="62"> <!--Mute High Conga-->
+                        <head>normal</head>
+                        <noteheads>
+                              <quarter>noteheadXOrnate</quarter>
+                              <half>noteheadXOrnate</half>
+                              <whole>noteheadXOrnate</whole>
+                              <breve>noteheadXOrnate</breve>
+                        </noteheads>
+                        <line>1</line>
+                        <voice>0</voice>
+                        <name>Mute Hi Conga</name>
+                        <stem>1</stem>
+                        <panelRow>2</panelRow>
+                        <panelColumn>4</panelColumn>
+                  </Drum>
+                  <Drum pitch="63"> <!--Open High Conga-->
+                        <head>normal</head>
+                        <line>1</line>
+                        <voice>0</voice>
+                        <name>Hi Conga</name>
+                        <stem>1</stem>
+                        <panelRow>2</panelRow>
+                        <panelColumn>3</panelColumn>
+                  </Drum>
+                  <Drum pitch="64"> <!--Low Conga-->
+                        <head>normal</head>
+                        <line>2</line>
+                        <voice>0</voice>
+                        <name>Lo Conga</name>
+                        <stem>1</stem>
+                        <panelRow>2</panelRow>
+                        <panelColumn>2</panelColumn>
+                  </Drum>
+                  <Drum pitch="65"> <!--High Timbale-->
+                        <head>normal</head>
+                        <line>5</line>
+                        <voice>0</voice>
+                        <name>Hi Timbale</name>
+                        <stem>1</stem>
+                        <panelRow>2</panelRow>
+                        <panelColumn>1</panelColumn>
+                  </Drum>
+                  <Drum pitch="66"> <!--Low Timbale-->
+                        <head>normal</head>
+                        <line>7</line>
+                        <voice>0</voice>
+                        <name>Lo Timbale</name>
+                        <stem>1</stem>
+                        <panelRow>2</panelRow>
+                        <panelColumn>0</panelColumn>
+                  </Drum>
+                  <Drum pitch="67"> <!--High Agogô-->
+                        <head>triangle-down</head>
+                        <line>-2</line>
+                        <voice>0</voice>
+                        <name>Hi Agogô</name>
+                        <stem>1</stem>
+                        <panelRow>3</panelRow>
+                        <panelColumn>7</panelColumn>
+                  </Drum>
+                  <Drum pitch="68"> <!--Low Agogô-->
+                        <head>triangle-down</head>
+                        <line>-1</line>
+                        <voice>0</voice>
+                        <name>Lo Agogô</name>
+                        <stem>1</stem>
+                        <panelRow>3</panelRow>
+                        <panelColumn>6</panelColumn>
+                  </Drum>
+                  <Drum pitch="69"> <!--Cabasa-->
+                        <head>diamond</head>
+                        <line>2</line>
+                        <voice>0</voice>
+                        <name>Cabasa</name>
+                        <stem>1</stem>
+                        <panelRow>1</panelRow>
+                        <panelColumn>6</panelColumn>
+                  </Drum>
+                  <Drum pitch="70"> <!--Maracas-->
+                        <head>diamond</head>
+                        <line>4</line>
+                        <voice>0</voice>
+                        <name>Maracas</name>
+                        <stem>1</stem>
+                        <panelRow>1</panelRow>
+                        <panelColumn>5</panelColumn>
+                  </Drum>
+                  <Drum pitch="71"> <!--Short Whistle-->
+                        <head>ti</head>
+                        <line>-3</line>
+                        <voice>0</voice>
+                        <name>Long Whistle</name>
+                        <stem>1</stem>
+                        <panelRow>4</panelRow>
+                        <panelColumn>2</panelColumn>
+                  </Drum>
+                  <Drum pitch="72"> <!--Long Whistle-->
+                        <head>cross</head>
+                        <line>-3</line>
+                        <voice>0</voice>
+                        <name>Short Whistle</name>
+                        <stem>1</stem>
+                        <panelRow>4</panelRow>
+                        <panelColumn>3</panelColumn>
+                  </Drum>
+                  <Drum pitch="73"> <!--Short Guiro-->
+                        <head>cross</head>
+                        <line>-1</line>
+                        <voice>0</voice>
+                        <name>Short Güiro</name>
+                        <stem>1</stem>
+                        <panelRow>3</panelRow>
+                        <panelColumn>5</panelColumn>
+                  </Drum>
+                  <Drum pitch="74"> <!--Long Guiro-->
+                        <head>slashed1</head>
+                        <line>-1</line>
+                        <voice>0</voice>
+                        <name>Long Güiro</name>
+                        <stem>1</stem>
+                        <panelRow>3</panelRow>
+                        <panelColumn>4</panelColumn>
+                  </Drum>
+                  <Drum pitch="75"> <!--Claves-->
+                        <head>la</head>
+                        <line>0</line>
+                        <voice>0</voice>
+                        <name>Claves</name>
+                        <stem>1</stem>
+                        <panelRow>0</panelRow>
+                        <panelColumn>7</panelColumn>
+                  </Drum>
+                  <Drum pitch="76"> <!--High Woodblock-->
+                        <head>la</head>
+                        <line>5</line>
+                        <voice>0</voice>
+                        <name>Hi Woodblock</name>
+                        <stem>1</stem>
+                        <panelRow>3</panelRow>
+                        <panelColumn>3</panelColumn>
+                  </Drum>
+                  <Drum pitch="77"> <!--Low Woodblock-->
+                        <head>la</head>
+                        <line>7</line>
+                        <voice>0</voice>
+                        <name>Lo Woodblock</name>
+                        <stem>1</stem>
+                        <panelRow>3</panelRow>
+                        <panelColumn>2</panelColumn>
+                  </Drum>
+                  <Drum pitch="78"> <!--Mute Cuica-->
+                        <head>cross</head>
+                        <line>8</line>
+                        <voice>0</voice>
+                        <name>Mute Cuica</name>
+                        <stem>1</stem>
+                        <panelRow>4</panelRow>
+                        <panelColumn>1</panelColumn>
+                  </Drum>
+                  <Drum pitch="79"> <!--Open Cuica-->
+                        <head>slashed2</head>
+                        <line>8</line>
+                        <voice>0</voice>
+                        <name>Open Cuica</name>
+                        <stem>1</stem>
+                        <panelRow>4</panelRow>
+                        <panelColumn>0</panelColumn>
+                  </Drum>
+                  <Drum pitch="80"> <!--Mute Triangle-->
+                        <head>cross</head>
+                        <line>0</line>
+                        <voice>0</voice>
+                        <name>Mute Triangle</name>
+                        <stem>1</stem>
+                        <panelRow>0</panelRow>
+                        <panelColumn>3</panelColumn>
+                  </Drum>
+                  <Drum pitch="81"> <!--Open Triangle-->
+                        <head>triangle-up</head>
+                        <line>0</line>
+                        <voice>0</voice>
+                        <name>Triangle</name>
+                        <stem>1</stem>
+                        <panelRow>0</panelRow>
+                        <panelColumn>2</panelColumn>
+                  </Drum>
+                  <Drum pitch="82"> <!--Shaker-->
+                        <head>diamond</head>
+                        <line>5</line>
+                        <voice>0</voice>
+                        <name>Shaker</name>
+                        <stem>1</stem>
+                        <panelRow>1</panelRow>
+                        <panelColumn>4</panelColumn>
+                  </Drum>
+                  <Drum pitch="83"> <!--Jingle Bell-->
+                        <head>triangle-down</head>
+                        <line>3</line>
+                        <voice>0</voice>
+                        <name>Sleigh Bells</name>
+                        <stem>1</stem>
+                        <panelRow>1</panelRow>
+                        <panelColumn>2</panelColumn>
+                  </Drum>
+                  <Drum pitch="84"> <!--Belltree-->
+                        <head>ti</head>
+                        <line>2</line>
+                        <voice>0</voice>
+                        <name>Mark Tree</name>
+                        <stem>1</stem>
+                        <panelRow>1</panelRow>
+                        <panelColumn>0</panelColumn>
+                  </Drum>
+                  <Drum pitch="85"> <!--Castanets-->
+                        <head>la</head>
+                        <line>2</line>
+                        <voice>0</voice>
+                        <name>Castanets</name>
+                        <stem>1</stem>
+                        <panelRow>1</panelRow>
+                        <panelColumn>7</panelColumn>
+                  </Drum>
+                  <Drum pitch="86"> <!--Mute Surdo-->
+                        <head>normal</head>
+                        <noteheads>
+                              <quarter>noteheadSlashX</quarter>
+                              <half>noteheadSlashX</half>
+                              <whole>noteheadSlashX</whole>
+                              <breve>noteheadSlashX</breve>
+                        </noteheads>
+                        <line>4</line>
+                        <voice>0</voice>
+                        <name>Mute Surdo</name>
+                        <stem>1</stem>
+                        <panelRow>3</panelRow>
+                        <panelColumn>1</panelColumn>
+                  </Drum>
+                  <Drum pitch="87"> <!--Open Surdo-->
+                        <head>slash</head>
+                        <line>4</line>
+                        <voice>0</voice>
+                        <name>Surdo</name>
+                        <stem>1</stem>
+                        <panelRow>3</panelRow>
+                        <panelColumn>0</panelColumn>
+                  </Drum>
+                  <Channel>
+                        <!--MIDI: Bank 128, Prog 48; MS General: Orchestra Kit-->
+                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
+                        <program value="48"/> <!--Orchestra Kit-->
+                  </Channel>
+                  <genre>common</genre>
+                  <genre>popular</genre>
+                  <genre>jazz</genre>
+                  <genre>orchestra</genre>
+                  <genre>concertband</genre>
+                  <genre>marching</genre>
+            </Instrument>
       </InstrumentGroup>
       <InstrumentGroup id="marching-percussion">
             <name>Percussion - Marching</name>
@@ -9414,7 +9885,13 @@
                         <panelColumn>0</panelColumn>
                   </Drum>
                   <Drum pitch="52"> <!--Chinese Cymbal-->
-                        <head>xcircle</head>
+                        <head>normal</head>
+                        <noteheads>
+                              <quarter>noteheadXOrnate</quarter>
+                              <half>noteheadXOrnate</half>
+                              <whole>noteheadXOrnate</whole>
+                              <breve>noteheadXOrnate</breve>
+                        </noteheads>
                         <line>1</line>
                         <voice>0</voice>
                         <name>Rim Shot</name>
@@ -9462,7 +9939,7 @@
                         <head>ti</head>
                         <line>1</line>
                         <voice>0</voice>
-                        <name>Visual (BS,X-Over,Etc)</name>
+                        <name>Backstick</name>
                         <panelRow>0</panelRow>
                         <panelColumn>5</panelColumn>
                   </Drum>
@@ -9475,7 +9952,7 @@
                         <panelColumn>2</panelColumn>
                   </Drum>
                   <Drum pitch="74"> <!--Long Guiro-->
-                        <head>cross</head>
+                        <head>xcircle</head>
                         <line>-1</line>
                         <voice>0</voice>
                         <name>Open Hi-Hat</name>
@@ -9974,7 +10451,7 @@
                         <panelColumn>6</panelColumn>
                   </Drum>
                   <Drum pitch="84"> <!--Belltree-->
-                        <head>do</head>
+                        <head>diamond</head>
                         <line>0</line>
                         <voice>0</voice>
                         <name>Bell Tap</name>
@@ -9982,7 +10459,7 @@
                         <panelColumn>0</panelColumn>
                   </Drum>
                   <Drum pitch="86"> <!--Mute Surdo-->
-                        <head>do</head>
+                        <head>diamond</head>
                         <line>0</line>
                         <voice>0</voice>
                         <name>Bell Tap-Choke</name>
@@ -9990,7 +10467,7 @@
                         <panelColumn>1</panelColumn>
                   </Drum>
                   <Drum pitch="88">
-                        <head>do</head>
+                        <head>plus</head>
                         <line>0</line>
                         <voice>0</voice>
                         <name>Muted Tap</name>
@@ -9998,7 +10475,13 @@
                         <panelColumn>7</panelColumn>
                   </Drum>
                   <Drum pitch="89">
-                        <head>cross</head>
+                        <head>normal</head>
+                        <noteheads>
+                              <quarter>noteheadXOrnate</quarter>
+                              <half>noteheadXOrnate</half>
+                              <whole>noteheadXOrnate</whole>
+                              <breve>noteheadXOrnate</breve>
+                        </noteheads>
                         <line>0</line>
                         <voice>0</voice>
                         <name>Smash</name>
@@ -10963,26 +11446,6 @@
                   <Channel>
                         <!--MIDI: Bank 0, Prog 79; MS General: Ocarina-->
                         <program value="79"/> <!--Ocarina-->
-                  </Channel>
-                  <genre>popular</genre>
-                  <genre>marching</genre>
-                  <genre>electronic</genre>
-            </Instrument>
-            <Instrument id="percussion-synthesizer">
-                  <family>synths</family>
-                  <trackName>Percussion Synthesizer</trackName>
-                  <longName>Percussion Synthesizer</longName>
-                  <shortName>Perc. Syn.</shortName>
-                  <description>Percussion synthesizer.</description>
-                  <musicXMLid>drum.snare-drum.electric</musicXMLid>
-                  <clef>PERC</clef>
-                  <stafftype staffTypePreset="perc5Line">percussion</stafftype>
-                  <barlineSpan>1</barlineSpan>
-                  <drumset>1</drumset>
-                  <Channel>
-                        <!--MIDI: Bank 128, Prog 0; MS General: Standard-->
-                        <controller ctrl="0" value="1"/> <!--Bank MSB-->
-                        <program value="0"/> <!--Standard Kit-->
                   </Channel>
                   <genre>popular</genre>
                   <genre>marching</genre>

--- a/share/instruments/instrumentsxml.h
+++ b/share/instruments/instrumentsxml.h
@@ -3871,31 +3871,31 @@ QT_TRANSLATE_NOOP3("engraving/instruments", "Cuica", "cuica longName"),
 //: shortName for Cuica; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
 QT_TRANSLATE_NOOP3("engraving/instruments", "Cu.", "cuica shortName"),
 
-//: description for Large Drum Kit; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
-QT_TRANSLATE_NOOP3("engraving/instruments", "Drum Kit.", "drumset description"),
-//: trackName for Large Drum Kit; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
-QT_TRANSLATE_NOOP3("engraving/instruments", "Large Drum Kit", "drumset trackName"),
-//: longName for Large Drum Kit; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
+//: description for Drum Kit (large); Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
+QT_TRANSLATE_NOOP3("engraving/instruments", "Large drum kit.", "drumset description"),
+//: trackName for Drum Kit (large); Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
+QT_TRANSLATE_NOOP3("engraving/instruments", "Drum Kit (large)", "drumset trackName"),
+//: longName for Drum Kit (large); Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
 QT_TRANSLATE_NOOP3("engraving/instruments", "Drum Kit", "drumset longName"),
-//: shortName for Large Drum Kit; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
+//: shortName for Drum Kit (large); Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
 QT_TRANSLATE_NOOP3("engraving/instruments", "D. Kit", "drumset shortName"),
 
-//: description for 4-Piece Drum Kit; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
-QT_TRANSLATE_NOOP3("engraving/instruments", "4 piece drum kit.", "drum-kit-4 description"),
-//: trackName for 4-Piece Drum Kit; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
-QT_TRANSLATE_NOOP3("engraving/instruments", "4-Piece Drum Kit", "drum-kit-4 trackName"),
-//: longName for 4-Piece Drum Kit; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
+//: description for Drum Kit (minimal); Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
+QT_TRANSLATE_NOOP3("engraving/instruments", "Minimal drum kit, 4-piece.", "drum-kit-4 description"),
+//: trackName for Drum Kit (minimal); Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
+QT_TRANSLATE_NOOP3("engraving/instruments", "Drum Kit (minimal)", "drum-kit-4 trackName"),
+//: longName for Drum Kit (minimal); Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
 QT_TRANSLATE_NOOP3("engraving/instruments", "Drum Kit", "drum-kit-4 longName"),
-//: shortName for 4-Piece Drum Kit; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
+//: shortName for Drum Kit (minimal); Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
 QT_TRANSLATE_NOOP3("engraving/instruments", "D. Kit", "drum-kit-4 shortName"),
 
-//: description for 5-Piece Drum Kit; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
-QT_TRANSLATE_NOOP3("engraving/instruments", "5 piece drum kit.", "drum-kit-5 description"),
-//: trackName for 5-Piece Drum Kit; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
-QT_TRANSLATE_NOOP3("engraving/instruments", "5-Piece Drum Kit", "drum-kit-5 trackName"),
-//: longName for 5-Piece Drum Kit; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
+//: description for Drum Kit (common); Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
+QT_TRANSLATE_NOOP3("engraving/instruments", "Common drum kit, 5-piece.", "drum-kit-5 description"),
+//: trackName for Drum Kit (common); Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
+QT_TRANSLATE_NOOP3("engraving/instruments", "Drum Kit (common)", "drum-kit-5 trackName"),
+//: longName for Drum Kit (common); Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
 QT_TRANSLATE_NOOP3("engraving/instruments", "Drum Kit", "drum-kit-5 longName"),
-//: shortName for 5-Piece Drum Kit; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
+//: shortName for Drum Kit (common); Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
 QT_TRANSLATE_NOOP3("engraving/instruments", "D. Kit", "drum-kit-5 shortName"),
 
 //: description for Field Drum; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
@@ -4240,15 +4240,6 @@ QT_TRANSLATE_NOOP3("engraving/instruments", "Maracas", "maracas longName"),
 //: shortName for Maracas; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
 QT_TRANSLATE_NOOP3("engraving/instruments", "Mrcs.", "maracas shortName"),
 
-//: description for Percussion; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
-QT_TRANSLATE_NOOP3("engraving/instruments", "Orchestral percussion drumset.", "percussion description"),
-//: trackName for Percussion; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
-QT_TRANSLATE_NOOP3("engraving/instruments", "Percussion", "percussion trackName"),
-//: longName for Percussion; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
-QT_TRANSLATE_NOOP3("engraving/instruments", "Percussion", "percussion longName"),
-//: shortName for Percussion; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
-QT_TRANSLATE_NOOP3("engraving/instruments", "Perc.", "percussion shortName"),
-
 //: description for Quijada; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
 QT_TRANSLATE_NOOP3("engraving/instruments", "Dried donkey or horse jawbone, traditionally used as a rattle in some Latin American countries.", "quijada description"),
 //: trackName for Quijada; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
@@ -4338,6 +4329,24 @@ QT_TRANSLATE_NOOP3("engraving/instruments", "Whip", "whip trackName"),
 QT_TRANSLATE_NOOP3("engraving/instruments", "Whip", "whip longName"),
 //: shortName for Whip; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
 QT_TRANSLATE_NOOP3("engraving/instruments", "Wh.", "whip shortName"),
+
+//: description for General MIDI Percussion; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
+QT_TRANSLATE_NOOP3("engraving/instruments", "General MIDI percussion kit with Level 2 extensions.", "percussion-synthesizer description"),
+//: trackName for General MIDI Percussion; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
+QT_TRANSLATE_NOOP3("engraving/instruments", "General MIDI Percussion", "percussion-synthesizer trackName"),
+//: longName for General MIDI Percussion; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
+QT_TRANSLATE_NOOP3("engraving/instruments", "Percussion", "percussion-synthesizer longName"),
+//: shortName for General MIDI Percussion; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
+QT_TRANSLATE_NOOP3("engraving/instruments", "Perc.", "percussion-synthesizer shortName"),
+
+//: description for Mixed Percussion; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
+QT_TRANSLATE_NOOP3("engraving/instruments", "Orchestral percussion kit.", "percussion description"),
+//: trackName for Mixed Percussion; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
+QT_TRANSLATE_NOOP3("engraving/instruments", "Mixed Percussion", "percussion trackName"),
+//: longName for Mixed Percussion; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
+QT_TRANSLATE_NOOP3("engraving/instruments", "Percussion", "percussion longName"),
+//: shortName for Mixed Percussion; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
+QT_TRANSLATE_NOOP3("engraving/instruments", "Perc.", "percussion shortName"),
 
 // Percussion - Marching
 QT_TRANSLATE_NOOP("engraving/instruments/group", "Percussion - Marching"),
@@ -4775,15 +4784,6 @@ QT_TRANSLATE_NOOP3("engraving/instruments", "Ondes Martenot", "ondes-martenot tr
 QT_TRANSLATE_NOOP3("engraving/instruments", "Ondes Martenot", "ondes-martenot longName"),
 //: shortName for Ondes Martenot; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
 QT_TRANSLATE_NOOP3("engraving/instruments", "O.M.", "ondes-martenot shortName"),
-
-//: description for Percussion Synthesizer; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
-QT_TRANSLATE_NOOP3("engraving/instruments", "Percussion synthesizer.", "percussion-synthesizer description"),
-//: trackName for Percussion Synthesizer; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
-QT_TRANSLATE_NOOP3("engraving/instruments", "Percussion Synthesizer", "percussion-synthesizer trackName"),
-//: longName for Percussion Synthesizer; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
-QT_TRANSLATE_NOOP3("engraving/instruments", "Percussion Synthesizer", "percussion-synthesizer longName"),
-//: shortName for Percussion Synthesizer; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
-QT_TRANSLATE_NOOP3("engraving/instruments", "Perc. Syn.", "percussion-synthesizer shortName"),
 
 //: description for Atmosphere Synthesizer; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
 QT_TRANSLATE_NOOP3("engraving/instruments", "Atmosphere synth effect (General MIDI program 100).", "atmosphere-synth description"),

--- a/share/instruments/update_instruments_xml.py
+++ b/share/instruments/update_instruments_xml.py
@@ -55,7 +55,7 @@ sheet_ids = {
     'GM+GS_Percussion':         '1216482735',
 }
 
-standard_drumset_id = 'drumset'
+standard_drumset_id = 'percussion-synthesizer' # General MIDI Percussion (most generic kit)
 
 parser = argparse.ArgumentParser(description='Fetch the latest spreadsheet and generate instruments.xml.')
 parser.add_argument('-c', '--cached', action='store_true', help='Use cached version instead of downloading')
@@ -304,6 +304,15 @@ for group in groups.values():
                 if pitch in gmgs_percussion:
                     to_comment(d_el, gmgs_percussion[pitch], 'name')
                 to_subelement(d_el, drum, 'head')
+
+                noteheads_el = ET.Element('noteheads')
+                to_subelement(noteheads_el, drum, 'quarter')
+                to_subelement(noteheads_el, drum, 'half')
+                to_subelement(noteheads_el, drum, 'whole')
+                to_subelement(noteheads_el, drum, 'breve')
+                if noteheads_el.find('*') is not None:
+                    d_el.append(noteheads_el)
+
                 to_subelement(d_el, drum, 'line')
                 to_subelement(d_el, drum, 'voice')
                 to_subelement(d_el, drum, 'drum', 'name')
@@ -516,6 +525,11 @@ def noteheadgroup(tag):
 
     return 'HEAD_' + tag.upper().replace('-', '_')
 
+def noteheadtype(tag):
+    if tag == 'breve':
+        return 'HEAD_BREVIS'
+    return 'HEAD_' + tag.upper()
+
 def shortcut(tag):
     if tag == null or not tag:
         return '0'
@@ -530,11 +544,25 @@ gen_code = ''
 for drum in drumsets[standard_drumset_id].values():
     pitch = drum['pitch']
 
+    custom_noteheads_code = ''
+
+    for duration in ['whole', 'half', 'quarter', 'breve']:
+        notehead = drum[duration]
+
+        if not notehead or notehead is null:
+            continue
+
+        type = noteheadtype(duration)
+
+        custom_noteheads_code += f"""\
+    smDrumset->drum({pitch}).noteheads[static_cast<int>(NoteHeadType::{type})] = SymNames::symIdByName("{notehead}");
+"""
+
     gen_code += f"""
     // {drum['drum']}
     smDrumset->drum({pitch}) = DrumInstrument(
         TConv::userName(DrumNum({pitch})),
-        NoteHeadGroup::{noteheadgroup(drum['head'])},
+        NoteHeadGroup::{noteheadgroup('custom' if custom_noteheads_code else drum['head'])},
         /*line*/ {drum['line']},
         DirectionV::{direction(drum['stem'])},
         /*panelRow*/ {drum['row']},
@@ -542,6 +570,9 @@ for drum in drumsets[standard_drumset_id].values():
         /*voice*/ {drum['voice']},
         /*shortcut*/ {shortcut(drum['shortcut'])});
 """
+
+    if custom_noteheads_code:
+        gen_code += '\n' + custom_noteheads_code
 
 with open(standard_drumset_cpp_path, newline='\n', encoding='utf-8') as file:
     old_code = file.read()

--- a/src/engraving/dom/drumset.cpp
+++ b/src/engraving/dom/drumset.cpp
@@ -302,27 +302,120 @@ void Drumset::initDrumset()
 
     // BEGIN GENERATED CODE
 
+    // Laser (High Q)
+    smDrumset->drum(27) = DrumInstrument(
+        TConv::userName(DrumNum(27)),
+        NoteHeadGroup::HEAD_SLASH,
+        /*line*/ 8,
+        DirectionV::UP,
+        /*panelRow*/ 0,
+        /*panelColumn*/ 0,
+        /*voice*/ 0,
+        /*shortcut*/ 0);
+
+    // Slap
+    smDrumset->drum(28) = DrumInstrument(
+        TConv::userName(DrumNum(28)),
+        NoteHeadGroup::HEAD_CUSTOM,
+        /*line*/ 4,
+        DirectionV::UP,
+        /*panelRow*/ 0,
+        /*panelColumn*/ 1,
+        /*voice*/ 0,
+        /*shortcut*/ 0);
+
+    smDrumset->drum(28).noteheads[static_cast<int>(NoteHeadType::HEAD_WHOLE)] = SymNames::symIdByName("noteheadSlashX");
+    smDrumset->drum(28).noteheads[static_cast<int>(NoteHeadType::HEAD_HALF)] = SymNames::symIdByName("noteheadSlashX");
+    smDrumset->drum(28).noteheads[static_cast<int>(NoteHeadType::HEAD_QUARTER)] = SymNames::symIdByName("noteheadSlashX");
+    smDrumset->drum(28).noteheads[static_cast<int>(NoteHeadType::HEAD_BREVIS)] = SymNames::symIdByName("noteheadSlashX");
+
+    // Scratch Push
+    smDrumset->drum(29) = DrumInstrument(
+        TConv::userName(DrumNum(29)),
+        NoteHeadGroup::HEAD_SLASH,
+        /*line*/ 6,
+        DirectionV::UP,
+        /*panelRow*/ 0,
+        /*panelColumn*/ 2,
+        /*voice*/ 0,
+        /*shortcut*/ 0);
+
+    // Scratch Pull
+    smDrumset->drum(30) = DrumInstrument(
+        TConv::userName(DrumNum(30)),
+        NoteHeadGroup::HEAD_SLASH,
+        /*line*/ 6,
+        DirectionV::UP,
+        /*panelRow*/ 0,
+        /*panelColumn*/ 3,
+        /*voice*/ 0,
+        /*shortcut*/ 0);
+
+    // Sticks
+    smDrumset->drum(31) = DrumInstrument(
+        TConv::userName(DrumNum(31)),
+        NoteHeadGroup::HEAD_PLUS,
+        /*line*/ -1,
+        DirectionV::UP,
+        /*panelRow*/ 0,
+        /*panelColumn*/ 4,
+        /*voice*/ 0,
+        /*shortcut*/ 0);
+
+    // Square Click
+    smDrumset->drum(32) = DrumInstrument(
+        TConv::userName(DrumNum(32)),
+        NoteHeadGroup::HEAD_PLUS,
+        /*line*/ 10,
+        DirectionV::UP,
+        /*panelRow*/ 0,
+        /*panelColumn*/ 5,
+        /*voice*/ 0,
+        /*shortcut*/ 0);
+
+    // Metronome Click
+    smDrumset->drum(33) = DrumInstrument(
+        TConv::userName(DrumNum(33)),
+        NoteHeadGroup::HEAD_CROSS,
+        /*line*/ 10,
+        DirectionV::UP,
+        /*panelRow*/ 0,
+        /*panelColumn*/ 6,
+        /*voice*/ 0,
+        /*shortcut*/ 0);
+
+    // Metronome Bell
+    smDrumset->drum(34) = DrumInstrument(
+        TConv::userName(DrumNum(34)),
+        NoteHeadGroup::HEAD_TRIANGLE_UP,
+        /*line*/ 10,
+        DirectionV::UP,
+        /*panelRow*/ 0,
+        /*panelColumn*/ 7,
+        /*voice*/ 0,
+        /*shortcut*/ 0);
+
     // Acoustic Bass Drum
     smDrumset->drum(35) = DrumInstrument(
         TConv::userName(DrumNum(35)),
         NoteHeadGroup::HEAD_NORMAL,
         /*line*/ 8,
-        DirectionV::DOWN,
-        /*panelRow*/ 2,
-        /*panelColumn*/ 1,
-        /*voice*/ 1,
+        DirectionV::UP,
+        /*panelRow*/ 1,
+        /*panelColumn*/ 0,
+        /*voice*/ 0,
         /*shortcut*/ 0);
 
-    // Bass Drum 1
+    // Electric Bass Drum
     smDrumset->drum(36) = DrumInstrument(
         TConv::userName(DrumNum(36)),
         NoteHeadGroup::HEAD_NORMAL,
         /*line*/ 7,
         DirectionV::DOWN,
-        /*panelRow*/ 2,
-        /*panelColumn*/ 0,
+        /*panelRow*/ 1,
+        /*panelColumn*/ 1,
         /*voice*/ 1,
-        /*shortcut*/ Key_B);
+        /*shortcut*/ 0);
 
     // Side Stick
     smDrumset->drum(37) = DrumInstrument(
@@ -331,7 +424,7 @@ void Drumset::initDrumset()
         /*line*/ 3,
         DirectionV::UP,
         /*panelRow*/ 1,
-        /*panelColumn*/ 1,
+        /*panelColumn*/ 2,
         /*voice*/ 0,
         /*shortcut*/ 0);
 
@@ -342,9 +435,20 @@ void Drumset::initDrumset()
         /*line*/ 3,
         DirectionV::UP,
         /*panelRow*/ 1,
-        /*panelColumn*/ 0,
+        /*panelColumn*/ 3,
         /*voice*/ 0,
-        /*shortcut*/ Key_A);
+        /*shortcut*/ 0);
+
+    // Hand Clap
+    smDrumset->drum(39) = DrumInstrument(
+        TConv::userName(DrumNum(39)),
+        NoteHeadGroup::HEAD_PLUS,
+        /*line*/ -2,
+        DirectionV::UP,
+        /*panelRow*/ 1,
+        /*panelColumn*/ 4,
+        /*voice*/ 0,
+        /*shortcut*/ 0);
 
     // Electric Snare
     smDrumset->drum(40) = DrumInstrument(
@@ -352,36 +456,14 @@ void Drumset::initDrumset()
         NoteHeadGroup::HEAD_SLASH,
         /*line*/ 3,
         DirectionV::UP,
-        /*panelRow*/ 2,
-        /*panelColumn*/ 6,
+        /*panelRow*/ 1,
+        /*panelColumn*/ 5,
         /*voice*/ 0,
         /*shortcut*/ 0);
 
     // Low Floor Tom
     smDrumset->drum(41) = DrumInstrument(
         TConv::userName(DrumNum(41)),
-        NoteHeadGroup::HEAD_NORMAL,
-        /*line*/ 6,
-        DirectionV::UP,
-        /*panelRow*/ 1,
-        /*panelColumn*/ 7,
-        /*voice*/ 0,
-        /*shortcut*/ 0);
-
-    // Closed Hi-Hat
-    smDrumset->drum(42) = DrumInstrument(
-        TConv::userName(DrumNum(42)),
-        NoteHeadGroup::HEAD_CROSS,
-        /*line*/ -1,
-        DirectionV::UP,
-        /*panelRow*/ 0,
-        /*panelColumn*/ 0,
-        /*voice*/ 0,
-        /*shortcut*/ Key_G);
-
-    // High Floor Tom
-    smDrumset->drum(43) = DrumInstrument(
-        TConv::userName(DrumNum(43)),
         NoteHeadGroup::HEAD_NORMAL,
         /*line*/ 5,
         DirectionV::UP,
@@ -390,16 +472,38 @@ void Drumset::initDrumset()
         /*voice*/ 0,
         /*shortcut*/ 0);
 
-    // Pedal Hi-Hat
+    // Closed Hi-hat
+    smDrumset->drum(42) = DrumInstrument(
+        TConv::userName(DrumNum(42)),
+        NoteHeadGroup::HEAD_CROSS,
+        /*line*/ -1,
+        DirectionV::UP,
+        /*panelRow*/ 1,
+        /*panelColumn*/ 7,
+        /*voice*/ 0,
+        /*shortcut*/ 0);
+
+    // High Floor Tom
+    smDrumset->drum(43) = DrumInstrument(
+        TConv::userName(DrumNum(43)),
+        NoteHeadGroup::HEAD_NORMAL,
+        /*line*/ 6,
+        DirectionV::UP,
+        /*panelRow*/ 2,
+        /*panelColumn*/ 0,
+        /*voice*/ 0,
+        /*shortcut*/ 0);
+
+    // Pedal Hi-hat
     smDrumset->drum(44) = DrumInstrument(
         TConv::userName(DrumNum(44)),
         NoteHeadGroup::HEAD_CROSS,
         /*line*/ 9,
-        DirectionV::DOWN,
+        DirectionV::UP,
         /*panelRow*/ 2,
-        /*panelColumn*/ 2,
+        /*panelColumn*/ 1,
         /*voice*/ 1,
-        /*shortcut*/ Key_F);
+        /*shortcut*/ 0);
 
     // Low Tom
     smDrumset->drum(45) = DrumInstrument(
@@ -407,19 +511,19 @@ void Drumset::initDrumset()
         NoteHeadGroup::HEAD_NORMAL,
         /*line*/ 4,
         DirectionV::UP,
-        /*panelRow*/ 1,
-        /*panelColumn*/ 5,
+        /*panelRow*/ 2,
+        /*panelColumn*/ 2,
         /*voice*/ 0,
         /*shortcut*/ 0);
 
-    // Open Hi-Hat
+    // Open Hi-hat
     smDrumset->drum(46) = DrumInstrument(
         TConv::userName(DrumNum(46)),
         NoteHeadGroup::HEAD_XCIRCLE,
         /*line*/ -1,
         DirectionV::UP,
-        /*panelRow*/ 0,
-        /*panelColumn*/ 1,
+        /*panelRow*/ 2,
+        /*panelColumn*/ 3,
         /*voice*/ 0,
         /*shortcut*/ 0);
 
@@ -429,7 +533,7 @@ void Drumset::initDrumset()
         NoteHeadGroup::HEAD_NORMAL,
         /*line*/ 2,
         DirectionV::UP,
-        /*panelRow*/ 1,
+        /*panelRow*/ 2,
         /*panelColumn*/ 4,
         /*voice*/ 0,
         /*shortcut*/ 0);
@@ -440,8 +544,8 @@ void Drumset::initDrumset()
         NoteHeadGroup::HEAD_NORMAL,
         /*line*/ 1,
         DirectionV::UP,
-        /*panelRow*/ 1,
-        /*panelColumn*/ 3,
+        /*panelRow*/ 2,
+        /*panelColumn*/ 5,
         /*voice*/ 0,
         /*shortcut*/ 0);
 
@@ -451,10 +555,10 @@ void Drumset::initDrumset()
         NoteHeadGroup::HEAD_CROSS,
         /*line*/ -2,
         DirectionV::UP,
-        /*panelRow*/ 0,
-        /*panelColumn*/ 4,
+        /*panelRow*/ 2,
+        /*panelColumn*/ 6,
         /*voice*/ 0,
-        /*shortcut*/ Key_C);
+        /*shortcut*/ 0);
 
     // High Tom
     smDrumset->drum(50) = DrumInstrument(
@@ -462,10 +566,10 @@ void Drumset::initDrumset()
         NoteHeadGroup::HEAD_NORMAL,
         /*line*/ 0,
         DirectionV::UP,
-        /*panelRow*/ 1,
-        /*panelColumn*/ 2,
+        /*panelRow*/ 2,
+        /*panelColumn*/ 7,
         /*voice*/ 0,
-        /*shortcut*/ Key_E);
+        /*shortcut*/ 0);
 
     // Ride Cymbal 1
     smDrumset->drum(51) = DrumInstrument(
@@ -473,21 +577,26 @@ void Drumset::initDrumset()
         NoteHeadGroup::HEAD_CROSS,
         /*line*/ 0,
         DirectionV::UP,
-        /*panelRow*/ 0,
-        /*panelColumn*/ 2,
-        /*voice*/ 0,
-        /*shortcut*/ Key_D);
-
-    // Chinese Cymbal
-    smDrumset->drum(52) = DrumInstrument(
-        TConv::userName(DrumNum(52)),
-        NoteHeadGroup::HEAD_CROSS,
-        /*line*/ -4,
-        DirectionV::UP,
-        /*panelRow*/ 0,
-        /*panelColumn*/ 6,
+        /*panelRow*/ 3,
+        /*panelColumn*/ 0,
         /*voice*/ 0,
         /*shortcut*/ 0);
+
+    // China Cymbal
+    smDrumset->drum(52) = DrumInstrument(
+        TConv::userName(DrumNum(52)),
+        NoteHeadGroup::HEAD_CUSTOM,
+        /*line*/ -3,
+        DirectionV::UP,
+        /*panelRow*/ 3,
+        /*panelColumn*/ 1,
+        /*voice*/ 0,
+        /*shortcut*/ 0);
+
+    smDrumset->drum(52).noteheads[static_cast<int>(NoteHeadType::HEAD_WHOLE)] = SymNames::symIdByName("noteheadHeavyXHat");
+    smDrumset->drum(52).noteheads[static_cast<int>(NoteHeadType::HEAD_HALF)] = SymNames::symIdByName("noteheadHeavyXHat");
+    smDrumset->drum(52).noteheads[static_cast<int>(NoteHeadType::HEAD_QUARTER)] = SymNames::symIdByName("noteheadHeavyXHat");
+    smDrumset->drum(52).noteheads[static_cast<int>(NoteHeadType::HEAD_BREVIS)] = SymNames::symIdByName("noteheadHeavyXHat");
 
     // Ride Bell
     smDrumset->drum(53) = DrumInstrument(
@@ -495,8 +604,8 @@ void Drumset::initDrumset()
         NoteHeadGroup::HEAD_DIAMOND,
         /*line*/ 0,
         DirectionV::UP,
-        /*panelRow*/ 0,
-        /*panelColumn*/ 3,
+        /*panelRow*/ 3,
+        /*panelColumn*/ 2,
         /*voice*/ 0,
         /*shortcut*/ 0);
 
@@ -504,10 +613,10 @@ void Drumset::initDrumset()
     smDrumset->drum(54) = DrumInstrument(
         TConv::userName(DrumNum(54)),
         NoteHeadGroup::HEAD_DIAMOND,
-        /*line*/ 1,
+        /*line*/ 6,
         DirectionV::UP,
-        /*panelRow*/ 2,
-        /*panelColumn*/ 4,
+        /*panelRow*/ 3,
+        /*panelColumn*/ 3,
         /*voice*/ 0,
         /*shortcut*/ 0);
 
@@ -515,10 +624,10 @@ void Drumset::initDrumset()
     smDrumset->drum(55) = DrumInstrument(
         TConv::userName(DrumNum(55)),
         NoteHeadGroup::HEAD_CROSS,
-        /*line*/ -5,
+        /*line*/ -4,
         DirectionV::UP,
-        /*panelRow*/ 0,
-        /*panelColumn*/ 7,
+        /*panelRow*/ 3,
+        /*panelColumn*/ 4,
         /*voice*/ 0,
         /*shortcut*/ 0);
 
@@ -526,10 +635,10 @@ void Drumset::initDrumset()
     smDrumset->drum(56) = DrumInstrument(
         TConv::userName(DrumNum(56)),
         NoteHeadGroup::HEAD_TRIANGLE_DOWN,
-        /*line*/ 1,
+        /*line*/ 0,
         DirectionV::UP,
-        /*panelRow*/ 2,
-        /*panelColumn*/ 3,
+        /*panelRow*/ 3,
+        /*panelColumn*/ 5,
         /*voice*/ 0,
         /*shortcut*/ 0);
 
@@ -539,8 +648,19 @@ void Drumset::initDrumset()
         NoteHeadGroup::HEAD_CROSS,
         /*line*/ -3,
         DirectionV::UP,
-        /*panelRow*/ 0,
-        /*panelColumn*/ 5,
+        /*panelRow*/ 3,
+        /*panelColumn*/ 6,
+        /*voice*/ 0,
+        /*shortcut*/ 0);
+
+    // Vibraslap
+    smDrumset->drum(58) = DrumInstrument(
+        TConv::userName(DrumNum(58)),
+        NoteHeadGroup::HEAD_TI,
+        /*line*/ 0,
+        DirectionV::UP,
+        /*panelRow*/ 3,
+        /*panelColumn*/ 7,
         /*voice*/ 0,
         /*shortcut*/ 0);
 
@@ -550,8 +670,326 @@ void Drumset::initDrumset()
         NoteHeadGroup::HEAD_CROSS,
         /*line*/ 2,
         DirectionV::UP,
-        /*panelRow*/ 2,
+        /*panelRow*/ 4,
+        /*panelColumn*/ 0,
+        /*voice*/ 0,
+        /*shortcut*/ 0);
+
+    // High Bongo
+    smDrumset->drum(60) = DrumInstrument(
+        TConv::userName(DrumNum(60)),
+        NoteHeadGroup::HEAD_NORMAL,
+        /*line*/ -1,
+        DirectionV::UP,
+        /*panelRow*/ 4,
+        /*panelColumn*/ 1,
+        /*voice*/ 0,
+        /*shortcut*/ 0);
+
+    // Low Bongo
+    smDrumset->drum(61) = DrumInstrument(
+        TConv::userName(DrumNum(61)),
+        NoteHeadGroup::HEAD_NORMAL,
+        /*line*/ 0,
+        DirectionV::UP,
+        /*panelRow*/ 4,
+        /*panelColumn*/ 2,
+        /*voice*/ 0,
+        /*shortcut*/ 0);
+
+    // Mute High Conga
+    smDrumset->drum(62) = DrumInstrument(
+        TConv::userName(DrumNum(62)),
+        NoteHeadGroup::HEAD_CUSTOM,
+        /*line*/ 1,
+        DirectionV::UP,
+        /*panelRow*/ 4,
+        /*panelColumn*/ 3,
+        /*voice*/ 0,
+        /*shortcut*/ 0);
+
+    smDrumset->drum(62).noteheads[static_cast<int>(NoteHeadType::HEAD_WHOLE)] = SymNames::symIdByName("noteheadXOrnate");
+    smDrumset->drum(62).noteheads[static_cast<int>(NoteHeadType::HEAD_HALF)] = SymNames::symIdByName("noteheadXOrnate");
+    smDrumset->drum(62).noteheads[static_cast<int>(NoteHeadType::HEAD_QUARTER)] = SymNames::symIdByName("noteheadXOrnate");
+    smDrumset->drum(62).noteheads[static_cast<int>(NoteHeadType::HEAD_BREVIS)] = SymNames::symIdByName("noteheadXOrnate");
+
+    // Open High Conga
+    smDrumset->drum(63) = DrumInstrument(
+        TConv::userName(DrumNum(63)),
+        NoteHeadGroup::HEAD_NORMAL,
+        /*line*/ 1,
+        DirectionV::UP,
+        /*panelRow*/ 4,
+        /*panelColumn*/ 4,
+        /*voice*/ 0,
+        /*shortcut*/ 0);
+
+    // Low Conga
+    smDrumset->drum(64) = DrumInstrument(
+        TConv::userName(DrumNum(64)),
+        NoteHeadGroup::HEAD_NORMAL,
+        /*line*/ 2,
+        DirectionV::UP,
+        /*panelRow*/ 4,
         /*panelColumn*/ 5,
+        /*voice*/ 0,
+        /*shortcut*/ 0);
+
+    // High Timbale
+    smDrumset->drum(65) = DrumInstrument(
+        TConv::userName(DrumNum(65)),
+        NoteHeadGroup::HEAD_NORMAL,
+        /*line*/ 5,
+        DirectionV::UP,
+        /*panelRow*/ 4,
+        /*panelColumn*/ 6,
+        /*voice*/ 0,
+        /*shortcut*/ 0);
+
+    // Low Timbale
+    smDrumset->drum(66) = DrumInstrument(
+        TConv::userName(DrumNum(66)),
+        NoteHeadGroup::HEAD_NORMAL,
+        /*line*/ 7,
+        DirectionV::UP,
+        /*panelRow*/ 4,
+        /*panelColumn*/ 7,
+        /*voice*/ 0,
+        /*shortcut*/ 0);
+
+    // High Agogô
+    smDrumset->drum(67) = DrumInstrument(
+        TConv::userName(DrumNum(67)),
+        NoteHeadGroup::HEAD_TRIANGLE_DOWN,
+        /*line*/ -2,
+        DirectionV::UP,
+        /*panelRow*/ 5,
+        /*panelColumn*/ 0,
+        /*voice*/ 0,
+        /*shortcut*/ 0);
+
+    // Low Agogô
+    smDrumset->drum(68) = DrumInstrument(
+        TConv::userName(DrumNum(68)),
+        NoteHeadGroup::HEAD_TRIANGLE_DOWN,
+        /*line*/ -1,
+        DirectionV::UP,
+        /*panelRow*/ 5,
+        /*panelColumn*/ 1,
+        /*voice*/ 0,
+        /*shortcut*/ 0);
+
+    // Cabasa
+    smDrumset->drum(69) = DrumInstrument(
+        TConv::userName(DrumNum(69)),
+        NoteHeadGroup::HEAD_DIAMOND,
+        /*line*/ 2,
+        DirectionV::UP,
+        /*panelRow*/ 5,
+        /*panelColumn*/ 2,
+        /*voice*/ 0,
+        /*shortcut*/ 0);
+
+    // Maracas
+    smDrumset->drum(70) = DrumInstrument(
+        TConv::userName(DrumNum(70)),
+        NoteHeadGroup::HEAD_DIAMOND,
+        /*line*/ 4,
+        DirectionV::UP,
+        /*panelRow*/ 5,
+        /*panelColumn*/ 3,
+        /*voice*/ 0,
+        /*shortcut*/ 0);
+
+    // Short Whistle
+    smDrumset->drum(71) = DrumInstrument(
+        TConv::userName(DrumNum(71)),
+        NoteHeadGroup::HEAD_CROSS,
+        /*line*/ -3,
+        DirectionV::UP,
+        /*panelRow*/ 5,
+        /*panelColumn*/ 4,
+        /*voice*/ 0,
+        /*shortcut*/ 0);
+
+    // Long Whistle
+    smDrumset->drum(72) = DrumInstrument(
+        TConv::userName(DrumNum(72)),
+        NoteHeadGroup::HEAD_TI,
+        /*line*/ -3,
+        DirectionV::UP,
+        /*panelRow*/ 5,
+        /*panelColumn*/ 5,
+        /*voice*/ 0,
+        /*shortcut*/ 0);
+
+    // Short Güiro
+    smDrumset->drum(73) = DrumInstrument(
+        TConv::userName(DrumNum(73)),
+        NoteHeadGroup::HEAD_CROSS,
+        /*line*/ -1,
+        DirectionV::UP,
+        /*panelRow*/ 5,
+        /*panelColumn*/ 6,
+        /*voice*/ 0,
+        /*shortcut*/ 0);
+
+    // Long Güiro
+    smDrumset->drum(74) = DrumInstrument(
+        TConv::userName(DrumNum(74)),
+        NoteHeadGroup::HEAD_SLASHED1,
+        /*line*/ -1,
+        DirectionV::UP,
+        /*panelRow*/ 5,
+        /*panelColumn*/ 7,
+        /*voice*/ 0,
+        /*shortcut*/ 0);
+
+    // Claves
+    smDrumset->drum(75) = DrumInstrument(
+        TConv::userName(DrumNum(75)),
+        NoteHeadGroup::HEAD_LA,
+        /*line*/ 0,
+        DirectionV::UP,
+        /*panelRow*/ 6,
+        /*panelColumn*/ 0,
+        /*voice*/ 0,
+        /*shortcut*/ 0);
+
+    // High Woodblock
+    smDrumset->drum(76) = DrumInstrument(
+        TConv::userName(DrumNum(76)),
+        NoteHeadGroup::HEAD_LA,
+        /*line*/ 5,
+        DirectionV::UP,
+        /*panelRow*/ 6,
+        /*panelColumn*/ 1,
+        /*voice*/ 0,
+        /*shortcut*/ 0);
+
+    // Low Woodblock
+    smDrumset->drum(77) = DrumInstrument(
+        TConv::userName(DrumNum(77)),
+        NoteHeadGroup::HEAD_LA,
+        /*line*/ 7,
+        DirectionV::UP,
+        /*panelRow*/ 6,
+        /*panelColumn*/ 2,
+        /*voice*/ 0,
+        /*shortcut*/ 0);
+
+    // Mute Cuica
+    smDrumset->drum(78) = DrumInstrument(
+        TConv::userName(DrumNum(78)),
+        NoteHeadGroup::HEAD_CROSS,
+        /*line*/ 8,
+        DirectionV::UP,
+        /*panelRow*/ 6,
+        /*panelColumn*/ 3,
+        /*voice*/ 0,
+        /*shortcut*/ 0);
+
+    // Open Cuica
+    smDrumset->drum(79) = DrumInstrument(
+        TConv::userName(DrumNum(79)),
+        NoteHeadGroup::HEAD_SLASHED2,
+        /*line*/ 8,
+        DirectionV::UP,
+        /*panelRow*/ 6,
+        /*panelColumn*/ 4,
+        /*voice*/ 0,
+        /*shortcut*/ 0);
+
+    // Mute Triangle
+    smDrumset->drum(80) = DrumInstrument(
+        TConv::userName(DrumNum(80)),
+        NoteHeadGroup::HEAD_CROSS,
+        /*line*/ 0,
+        DirectionV::UP,
+        /*panelRow*/ 6,
+        /*panelColumn*/ 5,
+        /*voice*/ 0,
+        /*shortcut*/ 0);
+
+    // Open Triangle
+    smDrumset->drum(81) = DrumInstrument(
+        TConv::userName(DrumNum(81)),
+        NoteHeadGroup::HEAD_TRIANGLE_UP,
+        /*line*/ 0,
+        DirectionV::UP,
+        /*panelRow*/ 6,
+        /*panelColumn*/ 6,
+        /*voice*/ 0,
+        /*shortcut*/ 0);
+
+    // Shaker
+    smDrumset->drum(82) = DrumInstrument(
+        TConv::userName(DrumNum(82)),
+        NoteHeadGroup::HEAD_DIAMOND,
+        /*line*/ 5,
+        DirectionV::UP,
+        /*panelRow*/ 6,
+        /*panelColumn*/ 7,
+        /*voice*/ 0,
+        /*shortcut*/ 0);
+
+    // Jingle Bell
+    smDrumset->drum(83) = DrumInstrument(
+        TConv::userName(DrumNum(83)),
+        NoteHeadGroup::HEAD_TRIANGLE_DOWN,
+        /*line*/ 3,
+        DirectionV::UP,
+        /*panelRow*/ 7,
+        /*panelColumn*/ 0,
+        /*voice*/ 0,
+        /*shortcut*/ 0);
+
+    // Belltree
+    smDrumset->drum(84) = DrumInstrument(
+        TConv::userName(DrumNum(84)),
+        NoteHeadGroup::HEAD_TI,
+        /*line*/ 2,
+        DirectionV::UP,
+        /*panelRow*/ 7,
+        /*panelColumn*/ 1,
+        /*voice*/ 0,
+        /*shortcut*/ 0);
+
+    // Castanets
+    smDrumset->drum(85) = DrumInstrument(
+        TConv::userName(DrumNum(85)),
+        NoteHeadGroup::HEAD_LA,
+        /*line*/ 2,
+        DirectionV::UP,
+        /*panelRow*/ 7,
+        /*panelColumn*/ 2,
+        /*voice*/ 0,
+        /*shortcut*/ 0);
+
+    // Mute Surdo
+    smDrumset->drum(86) = DrumInstrument(
+        TConv::userName(DrumNum(86)),
+        NoteHeadGroup::HEAD_CUSTOM,
+        /*line*/ 4,
+        DirectionV::UP,
+        /*panelRow*/ 7,
+        /*panelColumn*/ 3,
+        /*voice*/ 0,
+        /*shortcut*/ 0);
+
+    smDrumset->drum(86).noteheads[static_cast<int>(NoteHeadType::HEAD_WHOLE)] = SymNames::symIdByName("noteheadSlashX");
+    smDrumset->drum(86).noteheads[static_cast<int>(NoteHeadType::HEAD_HALF)] = SymNames::symIdByName("noteheadSlashX");
+    smDrumset->drum(86).noteheads[static_cast<int>(NoteHeadType::HEAD_QUARTER)] = SymNames::symIdByName("noteheadSlashX");
+    smDrumset->drum(86).noteheads[static_cast<int>(NoteHeadType::HEAD_BREVIS)] = SymNames::symIdByName("noteheadSlashX");
+
+    // Open Surdo
+    smDrumset->drum(87) = DrumInstrument(
+        TConv::userName(DrumNum(87)),
+        NoteHeadGroup::HEAD_SLASH,
+        /*line*/ 4,
+        DirectionV::UP,
+        /*panelRow*/ 7,
+        /*panelColumn*/ 4,
         /*voice*/ 0,
         /*shortcut*/ 0);
 

--- a/src/engraving/dom/instrtemplate.cpp
+++ b/src/engraving/dom/instrtemplate.cpp
@@ -902,9 +902,15 @@ const InstrumentTemplate* searchTemplateForInstrNameList(const std::list<String>
     }
 
     if (!bestMatch) {
+        static const std::wregex drumsetRegex(L"drum ?(set|kit)", std::regex_constants::icase);
+
         for (const String& name : nameList) {
-            if (name.contains(u"drum", muse::CaseInsensitive)) {
-                return searchTemplate(u"drumset");
+            if (name.contains(drumsetRegex)) {
+                return searchTemplate(u"drumset"); // Large Drum Kit
+            }
+
+            if (name.contains(u"drum", muse::CaseInsensitive) || name.contains(u"percussion", muse::CaseInsensitive)) {
+                return searchTemplate(u"percussion-synthesizer"); // General MIDI percussion
             }
 
             if (name.contains(u"piano", muse::CaseInsensitive)) {

--- a/src/importexport/guitarpro/tests/data/all-percussion.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/all-percussion.gp-ref.mscx
@@ -25,11 +25,11 @@
         <defaultClef>PERC</defaultClef>
         </Staff>
       <trackName>Percussions</trackName>
-      <Instrument id="automobile-brake-drums">
+      <Instrument id="percussion-synthesizer">
         <longName>Percussions</longName>
         <shortName>drm.</shortName>
         <trackName></trackName>
-        <instrumentId>metal.brake-drums</instrumentId>
+        <instrumentId>drum.group</instrumentId>
         <useDrumset>1</useDrumset>
         <Drum pitch="27">
           <head>normal</head>

--- a/src/importexport/guitarpro/tests/data/all-percussion.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/all-percussion.gp5-ref.mscx
@@ -25,10 +25,10 @@
         <defaultClef>PERC</defaultClef>
         </Staff>
       <trackName>Percussions</trackName>
-      <Instrument id="automobile-brake-drums">
+      <Instrument id="percussion-synthesizer">
         <longName>Percussions</longName>
         <trackName></trackName>
-        <instrumentId>metal.brake-drums</instrumentId>
+        <instrumentId>drum.group</instrumentId>
         <useDrumset>1</useDrumset>
         <Drum pitch="27">
           <head>normal</head>

--- a/src/importexport/guitarpro/tests/data/all-percussion.gpx-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/all-percussion.gpx-ref.mscx
@@ -1049,7 +1049,7 @@
         <longName>Timbale</longName>
         <shortName>tmblKit</shortName>
         <trackName></trackName>
-        <instrumentId>drumset</instrumentId>
+        <instrumentId>drum.group</instrumentId>
         <useDrumset>1</useDrumset>
         <Drum pitch="27">
           <head>normal</head>
@@ -1559,7 +1559,7 @@
         <longName>Agogo</longName>
         <shortName>agogoKit</shortName>
         <trackName></trackName>
-        <instrumentId>drumset</instrumentId>
+        <instrumentId>drum.group</instrumentId>
         <useDrumset>1</useDrumset>
         <Drum pitch="27">
           <head>normal</head>
@@ -3089,7 +3089,7 @@
         <longName>Whistle</longName>
         <shortName>whstlKit</shortName>
         <trackName></trackName>
-        <instrumentId>drumset</instrumentId>
+        <instrumentId>drum.group</instrumentId>
         <useDrumset>1</useDrumset>
         <Drum pitch="27">
           <head>normal</head>
@@ -6659,7 +6659,7 @@
         <longName>Shaker</longName>
         <shortName>shkr</shortName>
         <trackName></trackName>
-        <instrumentId>drumset</instrumentId>
+        <instrumentId>drum.group</instrumentId>
         <useDrumset>1</useDrumset>
         <Drum pitch="27">
           <head>normal</head>
@@ -7169,7 +7169,7 @@
         <longName>Jingle Bell</longName>
         <shortName>jngl-bell</shortName>
         <trackName></trackName>
-        <instrumentId>drumset</instrumentId>
+        <instrumentId>drum.group</instrumentId>
         <useDrumset>1</useDrumset>
         <Drum pitch="27">
           <head>normal</head>
@@ -8189,7 +8189,7 @@
         <longName>Woodblock</longName>
         <shortName>wdblckKit</shortName>
         <trackName></trackName>
-        <instrumentId>drumset</instrumentId>
+        <instrumentId>drum.group</instrumentId>
         <useDrumset>1</useDrumset>
         <Drum pitch="27">
           <head>normal</head>
@@ -8699,7 +8699,7 @@
         <longName>Guiro</longName>
         <shortName>guiro</shortName>
         <trackName></trackName>
-        <instrumentId>drumset</instrumentId>
+        <instrumentId>drum.group</instrumentId>
         <useDrumset>1</useDrumset>
         <Drum pitch="27">
           <head>normal</head>
@@ -9719,7 +9719,7 @@
         <longName>Surdo</longName>
         <shortName>surdo</shortName>
         <trackName></trackName>
-        <instrumentId>drumset</instrumentId>
+        <instrumentId>drum.group</instrumentId>
         <useDrumset>1</useDrumset>
         <Drum pitch="27">
           <head>normal</head>

--- a/src/importexport/guitarpro/tests/data/percussion-beams.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/percussion-beams.gp-ref.mscx
@@ -25,11 +25,11 @@
         <defaultClef>PERC</defaultClef>
         </Staff>
       <trackName>Drums</trackName>
-      <Instrument id="drumset">
+      <Instrument id="percussion-synthesizer">
         <longName>Drums</longName>
         <shortName>Drums</shortName>
         <trackName></trackName>
-        <instrumentId>drum.group.set</instrumentId>
+        <instrumentId>drum.group</instrumentId>
         <useDrumset>1</useDrumset>
         <Drum pitch="27">
           <head>normal</head>

--- a/src/importexport/guitarpro/tests/data/tuplet-empty-measure.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/tuplet-empty-measure.gp-ref.mscx
@@ -25,11 +25,11 @@
         <defaultClef>PERC</defaultClef>
         </Staff>
       <trackName>Drums</trackName>
-      <Instrument id="drumset">
+      <Instrument id="percussion-synthesizer">
         <longName>Drums</longName>
         <shortName>Drums</shortName>
         <trackName></trackName>
-        <instrumentId>drum.group.set</instrumentId>
+        <instrumentId>drum.group</instrumentId>
         <useDrumset>1</useDrumset>
         <Drum pitch="27">
           <head>normal</head>

--- a/src/importexport/musicxml/tests/data/testFinaleInstr_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testFinaleInstr_ref.mscx
@@ -1258,50 +1258,98 @@
         <barLineSpan>1</barLineSpan>
         </Staff>
       <trackName>Percussion 1</trackName>
-      <Instrument id="percussion">
+      <Instrument id="percussion-synthesizer">
         <longName>Percussion 1</longName>
         <shortName>Perc. 1</shortName>
         <trackName>Percussion 1</trackName>
-        <instrumentId>drum.group.set</instrumentId>
+        <instrumentId>drum.group</instrumentId>
         <useDrumset>1</useDrumset>
         <Drum pitch="27">
-          <head>cross</head>
-          <line>-1</line>
+          <head>slash</head>
+          <line>8</line>
           <voice>0</voice>
-          <name>Closed Hi-Hat</name>
+          <name>High Q</name>
           <stem>1</stem>
-          <shortcut>G</shortcut>
           <panelRow>0</panelRow>
-          <panelColumn>2</panelColumn>
+          <panelColumn>0</panelColumn>
           </Drum>
         <Drum pitch="28">
-          <head>cross</head>
-          <line>9</line>
-          <voice>1</voice>
-          <name>Pedal Hi-Hat</name>
-          <stem>2</stem>
-          <shortcut>F</shortcut>
-          <panelRow>0</panelRow>
-          <panelColumn>3</panelColumn>
-          </Drum>
-        <Drum pitch="29">
-          <head>cross</head>
-          <line>1</line>
+          <head>normal</head>
+          <noteheads>
+            <whole>noteheadSlashX</whole>
+            <half>noteheadSlashX</half>
+            <quarter>noteheadSlashX</quarter>
+            <breve>noteheadSlashX</breve>
+            </noteheads>
+          <line>4</line>
           <voice>0</voice>
-          <name>Open Hi-Hat</name>
-          <stem>1</stem>
-          <shortcut>E</shortcut>
-          <panelRow>0</panelRow>
-          <panelColumn>4</panelColumn>
-          </Drum>
-        <Drum pitch="30">
-          <head>cross</head>
-          <line>0</line>
-          <voice>0</voice>
-          <name>Ride Cymbal 1</name>
+          <name>Slap</name>
           <stem>1</stem>
           <panelRow>0</panelRow>
           <panelColumn>1</panelColumn>
+          </Drum>
+        <Drum pitch="29">
+          <head>slash</head>
+          <line>6</line>
+          <voice>0</voice>
+          <name>Scratch Push</name>
+          <stem>1</stem>
+          <panelRow>0</panelRow>
+          <panelColumn>2</panelColumn>
+          </Drum>
+        <Drum pitch="30">
+          <head>slash</head>
+          <line>6</line>
+          <voice>0</voice>
+          <name>Scratch Pull</name>
+          <stem>1</stem>
+          <panelRow>0</panelRow>
+          <panelColumn>3</panelColumn>
+          </Drum>
+        <Drum pitch="31">
+          <head>plus</head>
+          <line>-1</line>
+          <voice>0</voice>
+          <name>Sticks</name>
+          <stem>1</stem>
+          <panelRow>0</panelRow>
+          <panelColumn>4</panelColumn>
+          </Drum>
+        <Drum pitch="32">
+          <head>plus</head>
+          <line>10</line>
+          <voice>0</voice>
+          <name>Square Click</name>
+          <stem>1</stem>
+          <panelRow>0</panelRow>
+          <panelColumn>5</panelColumn>
+          </Drum>
+        <Drum pitch="33">
+          <head>cross</head>
+          <line>10</line>
+          <voice>0</voice>
+          <name>Metronome Click</name>
+          <stem>1</stem>
+          <panelRow>0</panelRow>
+          <panelColumn>6</panelColumn>
+          </Drum>
+        <Drum pitch="34">
+          <head>triangle-up</head>
+          <line>10</line>
+          <voice>0</voice>
+          <name>Metronome Bell</name>
+          <stem>1</stem>
+          <panelRow>0</panelRow>
+          <panelColumn>7</panelColumn>
+          </Drum>
+        <Drum pitch="35">
+          <head>normal</head>
+          <line>8</line>
+          <voice>0</voice>
+          <name>Acoustic Bass Drum</name>
+          <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>0</panelColumn>
           </Drum>
         <Drum pitch="36">
           <head>normal</head>
@@ -1309,18 +1357,17 @@
           <voice>1</voice>
           <name>Bass Drum 1</name>
           <stem>2</stem>
-          <shortcut>B</shortcut>
-          <panelRow>2</panelRow>
-          <panelColumn>0</panelColumn>
+          <panelRow>1</panelRow>
+          <panelColumn>1</panelColumn>
           </Drum>
         <Drum pitch="37">
-          <head>cross</head>
+          <head>slashed1</head>
           <line>3</line>
           <voice>0</voice>
           <name>Side Stick</name>
           <stem>1</stem>
           <panelRow>1</panelRow>
-          <panelColumn>1</panelColumn>
+          <panelColumn>2</panelColumn>
           </Drum>
         <Drum pitch="38">
           <head>normal</head>
@@ -1328,140 +1375,469 @@
           <voice>0</voice>
           <name>Acoustic Snare</name>
           <stem>1</stem>
-          <shortcut>A</shortcut>
-          <panelRow>1</panelRow>
-          <panelColumn>0</panelColumn>
-          </Drum>
-        <Drum pitch="54">
-          <head>diamond</head>
-          <line>2</line>
-          <voice>0</voice>
-          <name>Tambourine</name>
-          <stem>1</stem>
-          <panelRow>1</panelRow>
-          <panelColumn>2</panelColumn>
-          </Drum>
-        <Drum pitch="55">
-          <head>cross</head>
-          <line>-3</line>
-          <voice>0</voice>
-          <name>Splash Cymbal</name>
-          <stem>1</stem>
-          <panelRow>0</panelRow>
-          <panelColumn>5</panelColumn>
-          </Drum>
-        <Drum pitch="56">
-          <head>triangle-down</head>
-          <line>1</line>
-          <voice>0</voice>
-          <name>Cowbell</name>
-          <stem>1</stem>
           <panelRow>1</panelRow>
           <panelColumn>3</panelColumn>
           </Drum>
-        <Drum pitch="58">
-          <head>diamond</head>
-          <line>1</line>
+        <Drum pitch="39">
+          <head>plus</head>
+          <line>-2</line>
           <voice>0</voice>
-          <name>Vibraslap</name>
+          <name>Hand Clap</name>
+          <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>4</panelColumn>
+          </Drum>
+        <Drum pitch="40">
+          <head>slash</head>
+          <line>3</line>
+          <voice>0</voice>
+          <name>Electric Snare</name>
+          <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>5</panelColumn>
+          </Drum>
+        <Drum pitch="41">
+          <head>normal</head>
+          <line>5</line>
+          <voice>0</voice>
+          <name>Low Floor Tom</name>
           <stem>1</stem>
           <panelRow>1</panelRow>
           <panelColumn>6</panelColumn>
           </Drum>
-        <Drum pitch="59">
+        <Drum pitch="42">
           <head>cross</head>
-          <line>-2</line>
+          <line>-1</line>
           <voice>0</voice>
-          <name>Hand Cymbals</name>
+          <name>Closed Hi-Hat</name>
           <stem>1</stem>
-          <shortcut>C</shortcut>
-          <panelRow>0</panelRow>
-          <panelColumn>0</panelColumn>
+          <panelRow>1</panelRow>
+          <panelColumn>7</panelColumn>
           </Drum>
-        <Drum pitch="62">
-          <head>cross</head>
-          <line>2</line>
-          <voice>0</voice>
-          <name>Mute High Conga</name>
-          <stem>1</stem>
-          <panelRow>2</panelRow>
-          <panelColumn>3</panelColumn>
-          </Drum>
-        <Drum pitch="63">
-          <head>cross</head>
-          <line>4</line>
-          <voice>0</voice>
-          <name>Open High Conga</name>
-          <stem>1</stem>
-          <panelRow>2</panelRow>
-          <panelColumn>2</panelColumn>
-          </Drum>
-        <Drum pitch="64">
-          <head>cross</head>
+        <Drum pitch="43">
+          <head>normal</head>
           <line>6</line>
           <voice>0</voice>
-          <name>Low Conga</name>
+          <name>High Floor Tom</name>
+          <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>0</panelColumn>
+          </Drum>
+        <Drum pitch="44">
+          <head>cross</head>
+          <line>9</line>
+          <voice>1</voice>
+          <name>Pedal Hi-Hat</name>
           <stem>1</stem>
           <panelRow>2</panelRow>
           <panelColumn>1</panelColumn>
           </Drum>
-        <Drum pitch="70">
+        <Drum pitch="45">
+          <head>normal</head>
+          <line>4</line>
+          <voice>0</voice>
+          <name>Low Tom</name>
+          <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>2</panelColumn>
+          </Drum>
+        <Drum pitch="46">
+          <head>xcircle</head>
+          <line>-1</line>
+          <voice>0</voice>
+          <name>Open Hi-Hat</name>
+          <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>3</panelColumn>
+          </Drum>
+        <Drum pitch="47">
           <head>normal</head>
           <line>2</line>
           <voice>0</voice>
-          <name>Maracas</name>
+          <name>Low-Mid Tom</name>
+          <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>4</panelColumn>
+          </Drum>
+        <Drum pitch="48">
+          <head>normal</head>
+          <line>1</line>
+          <voice>0</voice>
+          <name>Hi-Mid Tom</name>
           <stem>1</stem>
           <panelRow>2</panelRow>
           <panelColumn>5</panelColumn>
           </Drum>
-        <Drum pitch="75">
+        <Drum pitch="49">
+          <head>cross</head>
+          <line>-2</line>
+          <voice>0</voice>
+          <name>Crash Cymbal 1</name>
+          <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>6</panelColumn>
+          </Drum>
+        <Drum pitch="50">
           <head>normal</head>
+          <line>0</line>
+          <voice>0</voice>
+          <name>High Tom</name>
+          <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>7</panelColumn>
+          </Drum>
+        <Drum pitch="51">
+          <head>cross</head>
+          <line>0</line>
+          <voice>0</voice>
+          <name>Ride Cymbal 1</name>
+          <stem>1</stem>
+          <panelRow>3</panelRow>
+          <panelColumn>0</panelColumn>
+          </Drum>
+        <Drum pitch="52">
+          <head>normal</head>
+          <noteheads>
+            <whole>noteheadHeavyXHat</whole>
+            <half>noteheadHeavyXHat</half>
+            <quarter>noteheadHeavyXHat</quarter>
+            <breve>noteheadHeavyXHat</breve>
+            </noteheads>
+          <line>-3</line>
+          <voice>0</voice>
+          <name>Chinese Cymbal</name>
+          <stem>1</stem>
+          <panelRow>3</panelRow>
+          <panelColumn>1</panelColumn>
+          </Drum>
+        <Drum pitch="53">
+          <head>diamond</head>
+          <line>0</line>
+          <voice>0</voice>
+          <name>Ride Bell</name>
+          <stem>1</stem>
+          <panelRow>3</panelRow>
+          <panelColumn>2</panelColumn>
+          </Drum>
+        <Drum pitch="54">
+          <head>diamond</head>
+          <line>6</line>
+          <voice>0</voice>
+          <name>Tambourine</name>
+          <stem>1</stem>
+          <panelRow>3</panelRow>
+          <panelColumn>3</panelColumn>
+          </Drum>
+        <Drum pitch="55">
+          <head>cross</head>
+          <line>-4</line>
+          <voice>0</voice>
+          <name>Splash Cymbal</name>
+          <stem>1</stem>
+          <panelRow>3</panelRow>
+          <panelColumn>4</panelColumn>
+          </Drum>
+        <Drum pitch="56">
+          <head>triangle-down</head>
+          <line>0</line>
+          <voice>0</voice>
+          <name>Cowbell</name>
+          <stem>1</stem>
+          <panelRow>3</panelRow>
+          <panelColumn>5</panelColumn>
+          </Drum>
+        <Drum pitch="57">
+          <head>cross</head>
+          <line>-3</line>
+          <voice>0</voice>
+          <name>Crash Cymbal 2</name>
+          <stem>1</stem>
+          <panelRow>3</panelRow>
+          <panelColumn>6</panelColumn>
+          </Drum>
+        <Drum pitch="58">
+          <head>ti</head>
+          <line>0</line>
+          <voice>0</voice>
+          <name>Vibraslap</name>
+          <stem>1</stem>
+          <panelRow>3</panelRow>
+          <panelColumn>7</panelColumn>
+          </Drum>
+        <Drum pitch="59">
+          <head>cross</head>
+          <line>2</line>
+          <voice>0</voice>
+          <name>Ride Cymbal 2</name>
+          <stem>1</stem>
+          <panelRow>4</panelRow>
+          <panelColumn>0</panelColumn>
+          </Drum>
+        <Drum pitch="60">
+          <head>normal</head>
+          <line>-1</line>
+          <voice>0</voice>
+          <name>Hi Bongo</name>
+          <stem>1</stem>
+          <panelRow>4</panelRow>
+          <panelColumn>1</panelColumn>
+          </Drum>
+        <Drum pitch="61">
+          <head>normal</head>
+          <line>0</line>
+          <voice>0</voice>
+          <name>Low Bongo</name>
+          <stem>1</stem>
+          <panelRow>4</panelRow>
+          <panelColumn>2</panelColumn>
+          </Drum>
+        <Drum pitch="62">
+          <head>normal</head>
+          <noteheads>
+            <whole>noteheadXOrnate</whole>
+            <half>noteheadXOrnate</half>
+            <quarter>noteheadXOrnate</quarter>
+            <breve>noteheadXOrnate</breve>
+            </noteheads>
+          <line>1</line>
+          <voice>0</voice>
+          <name>Mute Hi Conga</name>
+          <stem>1</stem>
+          <panelRow>4</panelRow>
+          <panelColumn>3</panelColumn>
+          </Drum>
+        <Drum pitch="63">
+          <head>normal</head>
+          <line>1</line>
+          <voice>0</voice>
+          <name>Open Hi Conga</name>
+          <stem>1</stem>
+          <panelRow>4</panelRow>
+          <panelColumn>4</panelColumn>
+          </Drum>
+        <Drum pitch="64">
+          <head>normal</head>
+          <line>2</line>
+          <voice>0</voice>
+          <name>Low Conga</name>
+          <stem>1</stem>
+          <panelRow>4</panelRow>
+          <panelColumn>5</panelColumn>
+          </Drum>
+        <Drum pitch="65">
+          <head>normal</head>
+          <line>5</line>
+          <voice>0</voice>
+          <name>High Timbale</name>
+          <stem>1</stem>
+          <panelRow>4</panelRow>
+          <panelColumn>6</panelColumn>
+          </Drum>
+        <Drum pitch="66">
+          <head>normal</head>
+          <line>7</line>
+          <voice>0</voice>
+          <name>Low Timbale</name>
+          <stem>1</stem>
+          <panelRow>4</panelRow>
+          <panelColumn>7</panelColumn>
+          </Drum>
+        <Drum pitch="67">
+          <head>triangle-down</head>
+          <line>-2</line>
+          <voice>0</voice>
+          <name>High Agogo</name>
+          <stem>1</stem>
+          <panelRow>5</panelRow>
+          <panelColumn>0</panelColumn>
+          </Drum>
+        <Drum pitch="68">
+          <head>triangle-down</head>
+          <line>-1</line>
+          <voice>0</voice>
+          <name>Low Agogo</name>
+          <stem>1</stem>
+          <panelRow>5</panelRow>
+          <panelColumn>1</panelColumn>
+          </Drum>
+        <Drum pitch="69">
+          <head>diamond</head>
+          <line>2</line>
+          <voice>0</voice>
+          <name>Cabasa</name>
+          <stem>1</stem>
+          <panelRow>5</panelRow>
+          <panelColumn>2</panelColumn>
+          </Drum>
+        <Drum pitch="70">
+          <head>diamond</head>
+          <line>4</line>
+          <voice>0</voice>
+          <name>Maracas</name>
+          <stem>1</stem>
+          <panelRow>5</panelRow>
+          <panelColumn>3</panelColumn>
+          </Drum>
+        <Drum pitch="71">
+          <head>cross</head>
+          <line>-3</line>
+          <voice>0</voice>
+          <name>Short Whistle</name>
+          <stem>1</stem>
+          <panelRow>5</panelRow>
+          <panelColumn>4</panelColumn>
+          </Drum>
+        <Drum pitch="72">
+          <head>ti</head>
+          <line>-3</line>
+          <voice>0</voice>
+          <name>Long Whistle</name>
+          <stem>1</stem>
+          <panelRow>5</panelRow>
+          <panelColumn>5</panelColumn>
+          </Drum>
+        <Drum pitch="73">
+          <head>cross</head>
+          <line>-1</line>
+          <voice>0</voice>
+          <name>Short Güiro</name>
+          <stem>1</stem>
+          <panelRow>5</panelRow>
+          <panelColumn>6</panelColumn>
+          </Drum>
+        <Drum pitch="74">
+          <head>slashed1</head>
+          <line>-1</line>
+          <voice>0</voice>
+          <name>Long Güiro</name>
+          <stem>1</stem>
+          <panelRow>5</panelRow>
+          <panelColumn>7</panelColumn>
+          </Drum>
+        <Drum pitch="75">
+          <head>la</head>
           <line>0</line>
           <voice>0</voice>
           <name>Claves</name>
           <stem>1</stem>
-          <panelRow>1</panelRow>
+          <panelRow>6</panelRow>
+          <panelColumn>0</panelColumn>
+          </Drum>
+        <Drum pitch="76">
+          <head>la</head>
+          <line>5</line>
+          <voice>0</voice>
+          <name>Hi Wood Block</name>
+          <stem>1</stem>
+          <panelRow>6</panelRow>
+          <panelColumn>1</panelColumn>
+          </Drum>
+        <Drum pitch="77">
+          <head>la</head>
+          <line>7</line>
+          <voice>0</voice>
+          <name>Low Wood Block</name>
+          <stem>1</stem>
+          <panelRow>6</panelRow>
+          <panelColumn>2</panelColumn>
+          </Drum>
+        <Drum pitch="78">
+          <head>cross</head>
+          <line>8</line>
+          <voice>0</voice>
+          <name>Mute Cuica</name>
+          <stem>1</stem>
+          <panelRow>6</panelRow>
+          <panelColumn>3</panelColumn>
+          </Drum>
+        <Drum pitch="79">
+          <head>slashed2</head>
+          <line>8</line>
+          <voice>0</voice>
+          <name>Open Cuica</name>
+          <stem>1</stem>
+          <panelRow>6</panelRow>
           <panelColumn>4</panelColumn>
           </Drum>
+        <Drum pitch="80">
+          <head>cross</head>
+          <line>0</line>
+          <voice>0</voice>
+          <name>Mute Triangle</name>
+          <stem>1</stem>
+          <panelRow>6</panelRow>
+          <panelColumn>5</panelColumn>
+          </Drum>
         <Drum pitch="81">
-          <head>diamond</head>
+          <head>triangle-up</head>
           <line>0</line>
           <voice>0</voice>
           <name>Open Triangle</name>
           <stem>1</stem>
-          <shortcut>D</shortcut>
-          <panelRow>0</panelRow>
+          <panelRow>6</panelRow>
           <panelColumn>6</panelColumn>
           </Drum>
         <Drum pitch="82">
-          <head>normal</head>
-          <line>4</line>
+          <head>diamond</head>
+          <line>5</line>
           <voice>0</voice>
           <name>Shaker</name>
           <stem>1</stem>
-          <panelRow>2</panelRow>
-          <panelColumn>4</panelColumn>
+          <panelRow>6</panelRow>
+          <panelColumn>7</panelColumn>
+          </Drum>
+        <Drum pitch="83">
+          <head>triangle-down</head>
+          <line>3</line>
+          <voice>0</voice>
+          <name>Sleigh Bell</name>
+          <stem>1</stem>
+          <panelRow>7</panelRow>
+          <panelColumn>0</panelColumn>
           </Drum>
         <Drum pitch="84">
-          <head>cross</head>
+          <head>ti</head>
           <line>2</line>
           <voice>0</voice>
           <name>Mark Tree</name>
           <stem>1</stem>
-          <panelRow>0</panelRow>
-          <panelColumn>7</panelColumn>
+          <panelRow>7</panelRow>
+          <panelColumn>1</panelColumn>
           </Drum>
         <Drum pitch="85">
-          <head>normal</head>
-          <line>1</line>
+          <head>la</head>
+          <line>2</line>
           <voice>0</voice>
           <name>Castanets</name>
           <stem>1</stem>
-          <panelRow>1</panelRow>
-          <panelColumn>5</panelColumn>
+          <panelRow>7</panelRow>
+          <panelColumn>2</panelColumn>
+          </Drum>
+        <Drum pitch="86">
+          <head>normal</head>
+          <noteheads>
+            <whole>noteheadSlashX</whole>
+            <half>noteheadSlashX</half>
+            <quarter>noteheadSlashX</quarter>
+            <breve>noteheadSlashX</breve>
+            </noteheads>
+          <line>4</line>
+          <voice>0</voice>
+          <name>Mute Surdo</name>
+          <stem>1</stem>
+          <panelRow>7</panelRow>
+          <panelColumn>3</panelColumn>
+          </Drum>
+        <Drum pitch="87">
+          <head>slash</head>
+          <line>4</line>
+          <voice>0</voice>
+          <name>Open Surdo</name>
+          <stem>1</stem>
+          <panelRow>7</panelRow>
+          <panelColumn>4</panelColumn>
           </Drum>
         <clef>PERC</clef>
-        <singleNoteDynamics>0</singleNoteDynamics>
         <Articulation>
           <velocity>100</velocity>
           <gateTime>100</gateTime>
@@ -1522,50 +1898,98 @@
         <barLineSpan>1</barLineSpan>
         </Staff>
       <trackName>Percussion 2</trackName>
-      <Instrument id="percussion">
+      <Instrument id="percussion-synthesizer">
         <longName>Percussion 2</longName>
         <shortName>Perc. 2</shortName>
         <trackName>Percussion 2</trackName>
-        <instrumentId>drum.group.set</instrumentId>
+        <instrumentId>drum.group</instrumentId>
         <useDrumset>1</useDrumset>
         <Drum pitch="27">
-          <head>cross</head>
-          <line>-1</line>
+          <head>slash</head>
+          <line>8</line>
           <voice>0</voice>
-          <name>Closed Hi-Hat</name>
+          <name>High Q</name>
           <stem>1</stem>
-          <shortcut>G</shortcut>
           <panelRow>0</panelRow>
-          <panelColumn>2</panelColumn>
+          <panelColumn>0</panelColumn>
           </Drum>
         <Drum pitch="28">
-          <head>cross</head>
-          <line>9</line>
-          <voice>1</voice>
-          <name>Pedal Hi-Hat</name>
-          <stem>2</stem>
-          <shortcut>F</shortcut>
-          <panelRow>0</panelRow>
-          <panelColumn>3</panelColumn>
-          </Drum>
-        <Drum pitch="29">
-          <head>cross</head>
-          <line>1</line>
+          <head>normal</head>
+          <noteheads>
+            <whole>noteheadSlashX</whole>
+            <half>noteheadSlashX</half>
+            <quarter>noteheadSlashX</quarter>
+            <breve>noteheadSlashX</breve>
+            </noteheads>
+          <line>4</line>
           <voice>0</voice>
-          <name>Open Hi-Hat</name>
-          <stem>1</stem>
-          <shortcut>E</shortcut>
-          <panelRow>0</panelRow>
-          <panelColumn>4</panelColumn>
-          </Drum>
-        <Drum pitch="30">
-          <head>cross</head>
-          <line>0</line>
-          <voice>0</voice>
-          <name>Ride Cymbal 1</name>
+          <name>Slap</name>
           <stem>1</stem>
           <panelRow>0</panelRow>
           <panelColumn>1</panelColumn>
+          </Drum>
+        <Drum pitch="29">
+          <head>slash</head>
+          <line>6</line>
+          <voice>0</voice>
+          <name>Scratch Push</name>
+          <stem>1</stem>
+          <panelRow>0</panelRow>
+          <panelColumn>2</panelColumn>
+          </Drum>
+        <Drum pitch="30">
+          <head>slash</head>
+          <line>6</line>
+          <voice>0</voice>
+          <name>Scratch Pull</name>
+          <stem>1</stem>
+          <panelRow>0</panelRow>
+          <panelColumn>3</panelColumn>
+          </Drum>
+        <Drum pitch="31">
+          <head>plus</head>
+          <line>-1</line>
+          <voice>0</voice>
+          <name>Sticks</name>
+          <stem>1</stem>
+          <panelRow>0</panelRow>
+          <panelColumn>4</panelColumn>
+          </Drum>
+        <Drum pitch="32">
+          <head>plus</head>
+          <line>10</line>
+          <voice>0</voice>
+          <name>Square Click</name>
+          <stem>1</stem>
+          <panelRow>0</panelRow>
+          <panelColumn>5</panelColumn>
+          </Drum>
+        <Drum pitch="33">
+          <head>cross</head>
+          <line>10</line>
+          <voice>0</voice>
+          <name>Metronome Click</name>
+          <stem>1</stem>
+          <panelRow>0</panelRow>
+          <panelColumn>6</panelColumn>
+          </Drum>
+        <Drum pitch="34">
+          <head>triangle-up</head>
+          <line>10</line>
+          <voice>0</voice>
+          <name>Metronome Bell</name>
+          <stem>1</stem>
+          <panelRow>0</panelRow>
+          <panelColumn>7</panelColumn>
+          </Drum>
+        <Drum pitch="35">
+          <head>normal</head>
+          <line>8</line>
+          <voice>0</voice>
+          <name>Acoustic Bass Drum</name>
+          <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>0</panelColumn>
           </Drum>
         <Drum pitch="36">
           <head>normal</head>
@@ -1573,18 +1997,17 @@
           <voice>1</voice>
           <name>Bass Drum 1</name>
           <stem>2</stem>
-          <shortcut>B</shortcut>
-          <panelRow>2</panelRow>
-          <panelColumn>0</panelColumn>
+          <panelRow>1</panelRow>
+          <panelColumn>1</panelColumn>
           </Drum>
         <Drum pitch="37">
-          <head>cross</head>
+          <head>slashed1</head>
           <line>3</line>
           <voice>0</voice>
           <name>Side Stick</name>
           <stem>1</stem>
           <panelRow>1</panelRow>
-          <panelColumn>1</panelColumn>
+          <panelColumn>2</panelColumn>
           </Drum>
         <Drum pitch="38">
           <head>normal</head>
@@ -1592,140 +2015,469 @@
           <voice>0</voice>
           <name>Acoustic Snare</name>
           <stem>1</stem>
-          <shortcut>A</shortcut>
-          <panelRow>1</panelRow>
-          <panelColumn>0</panelColumn>
-          </Drum>
-        <Drum pitch="54">
-          <head>diamond</head>
-          <line>2</line>
-          <voice>0</voice>
-          <name>Tambourine</name>
-          <stem>1</stem>
-          <panelRow>1</panelRow>
-          <panelColumn>2</panelColumn>
-          </Drum>
-        <Drum pitch="55">
-          <head>cross</head>
-          <line>-3</line>
-          <voice>0</voice>
-          <name>Splash Cymbal</name>
-          <stem>1</stem>
-          <panelRow>0</panelRow>
-          <panelColumn>5</panelColumn>
-          </Drum>
-        <Drum pitch="56">
-          <head>triangle-down</head>
-          <line>1</line>
-          <voice>0</voice>
-          <name>Cowbell</name>
-          <stem>1</stem>
           <panelRow>1</panelRow>
           <panelColumn>3</panelColumn>
           </Drum>
-        <Drum pitch="58">
-          <head>diamond</head>
-          <line>1</line>
+        <Drum pitch="39">
+          <head>plus</head>
+          <line>-2</line>
           <voice>0</voice>
-          <name>Vibraslap</name>
+          <name>Hand Clap</name>
+          <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>4</panelColumn>
+          </Drum>
+        <Drum pitch="40">
+          <head>slash</head>
+          <line>3</line>
+          <voice>0</voice>
+          <name>Electric Snare</name>
+          <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>5</panelColumn>
+          </Drum>
+        <Drum pitch="41">
+          <head>normal</head>
+          <line>5</line>
+          <voice>0</voice>
+          <name>Low Floor Tom</name>
           <stem>1</stem>
           <panelRow>1</panelRow>
           <panelColumn>6</panelColumn>
           </Drum>
-        <Drum pitch="59">
+        <Drum pitch="42">
           <head>cross</head>
-          <line>-2</line>
+          <line>-1</line>
           <voice>0</voice>
-          <name>Hand Cymbals</name>
+          <name>Closed Hi-Hat</name>
           <stem>1</stem>
-          <shortcut>C</shortcut>
-          <panelRow>0</panelRow>
-          <panelColumn>0</panelColumn>
+          <panelRow>1</panelRow>
+          <panelColumn>7</panelColumn>
           </Drum>
-        <Drum pitch="62">
-          <head>cross</head>
-          <line>2</line>
-          <voice>0</voice>
-          <name>Mute High Conga</name>
-          <stem>1</stem>
-          <panelRow>2</panelRow>
-          <panelColumn>3</panelColumn>
-          </Drum>
-        <Drum pitch="63">
-          <head>cross</head>
-          <line>4</line>
-          <voice>0</voice>
-          <name>Open High Conga</name>
-          <stem>1</stem>
-          <panelRow>2</panelRow>
-          <panelColumn>2</panelColumn>
-          </Drum>
-        <Drum pitch="64">
-          <head>cross</head>
+        <Drum pitch="43">
+          <head>normal</head>
           <line>6</line>
           <voice>0</voice>
-          <name>Low Conga</name>
+          <name>High Floor Tom</name>
+          <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>0</panelColumn>
+          </Drum>
+        <Drum pitch="44">
+          <head>cross</head>
+          <line>9</line>
+          <voice>1</voice>
+          <name>Pedal Hi-Hat</name>
           <stem>1</stem>
           <panelRow>2</panelRow>
           <panelColumn>1</panelColumn>
           </Drum>
-        <Drum pitch="70">
+        <Drum pitch="45">
+          <head>normal</head>
+          <line>4</line>
+          <voice>0</voice>
+          <name>Low Tom</name>
+          <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>2</panelColumn>
+          </Drum>
+        <Drum pitch="46">
+          <head>xcircle</head>
+          <line>-1</line>
+          <voice>0</voice>
+          <name>Open Hi-Hat</name>
+          <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>3</panelColumn>
+          </Drum>
+        <Drum pitch="47">
           <head>normal</head>
           <line>2</line>
           <voice>0</voice>
-          <name>Maracas</name>
+          <name>Low-Mid Tom</name>
+          <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>4</panelColumn>
+          </Drum>
+        <Drum pitch="48">
+          <head>normal</head>
+          <line>1</line>
+          <voice>0</voice>
+          <name>Hi-Mid Tom</name>
           <stem>1</stem>
           <panelRow>2</panelRow>
           <panelColumn>5</panelColumn>
           </Drum>
-        <Drum pitch="75">
+        <Drum pitch="49">
+          <head>cross</head>
+          <line>-2</line>
+          <voice>0</voice>
+          <name>Crash Cymbal 1</name>
+          <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>6</panelColumn>
+          </Drum>
+        <Drum pitch="50">
           <head>normal</head>
+          <line>0</line>
+          <voice>0</voice>
+          <name>High Tom</name>
+          <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>7</panelColumn>
+          </Drum>
+        <Drum pitch="51">
+          <head>cross</head>
+          <line>0</line>
+          <voice>0</voice>
+          <name>Ride Cymbal 1</name>
+          <stem>1</stem>
+          <panelRow>3</panelRow>
+          <panelColumn>0</panelColumn>
+          </Drum>
+        <Drum pitch="52">
+          <head>normal</head>
+          <noteheads>
+            <whole>noteheadHeavyXHat</whole>
+            <half>noteheadHeavyXHat</half>
+            <quarter>noteheadHeavyXHat</quarter>
+            <breve>noteheadHeavyXHat</breve>
+            </noteheads>
+          <line>-3</line>
+          <voice>0</voice>
+          <name>Chinese Cymbal</name>
+          <stem>1</stem>
+          <panelRow>3</panelRow>
+          <panelColumn>1</panelColumn>
+          </Drum>
+        <Drum pitch="53">
+          <head>diamond</head>
+          <line>0</line>
+          <voice>0</voice>
+          <name>Ride Bell</name>
+          <stem>1</stem>
+          <panelRow>3</panelRow>
+          <panelColumn>2</panelColumn>
+          </Drum>
+        <Drum pitch="54">
+          <head>diamond</head>
+          <line>6</line>
+          <voice>0</voice>
+          <name>Tambourine</name>
+          <stem>1</stem>
+          <panelRow>3</panelRow>
+          <panelColumn>3</panelColumn>
+          </Drum>
+        <Drum pitch="55">
+          <head>cross</head>
+          <line>-4</line>
+          <voice>0</voice>
+          <name>Splash Cymbal</name>
+          <stem>1</stem>
+          <panelRow>3</panelRow>
+          <panelColumn>4</panelColumn>
+          </Drum>
+        <Drum pitch="56">
+          <head>triangle-down</head>
+          <line>0</line>
+          <voice>0</voice>
+          <name>Cowbell</name>
+          <stem>1</stem>
+          <panelRow>3</panelRow>
+          <panelColumn>5</panelColumn>
+          </Drum>
+        <Drum pitch="57">
+          <head>cross</head>
+          <line>-3</line>
+          <voice>0</voice>
+          <name>Crash Cymbal 2</name>
+          <stem>1</stem>
+          <panelRow>3</panelRow>
+          <panelColumn>6</panelColumn>
+          </Drum>
+        <Drum pitch="58">
+          <head>ti</head>
+          <line>0</line>
+          <voice>0</voice>
+          <name>Vibraslap</name>
+          <stem>1</stem>
+          <panelRow>3</panelRow>
+          <panelColumn>7</panelColumn>
+          </Drum>
+        <Drum pitch="59">
+          <head>cross</head>
+          <line>2</line>
+          <voice>0</voice>
+          <name>Ride Cymbal 2</name>
+          <stem>1</stem>
+          <panelRow>4</panelRow>
+          <panelColumn>0</panelColumn>
+          </Drum>
+        <Drum pitch="60">
+          <head>normal</head>
+          <line>-1</line>
+          <voice>0</voice>
+          <name>Hi Bongo</name>
+          <stem>1</stem>
+          <panelRow>4</panelRow>
+          <panelColumn>1</panelColumn>
+          </Drum>
+        <Drum pitch="61">
+          <head>normal</head>
+          <line>0</line>
+          <voice>0</voice>
+          <name>Low Bongo</name>
+          <stem>1</stem>
+          <panelRow>4</panelRow>
+          <panelColumn>2</panelColumn>
+          </Drum>
+        <Drum pitch="62">
+          <head>normal</head>
+          <noteheads>
+            <whole>noteheadXOrnate</whole>
+            <half>noteheadXOrnate</half>
+            <quarter>noteheadXOrnate</quarter>
+            <breve>noteheadXOrnate</breve>
+            </noteheads>
+          <line>1</line>
+          <voice>0</voice>
+          <name>Mute Hi Conga</name>
+          <stem>1</stem>
+          <panelRow>4</panelRow>
+          <panelColumn>3</panelColumn>
+          </Drum>
+        <Drum pitch="63">
+          <head>normal</head>
+          <line>1</line>
+          <voice>0</voice>
+          <name>Open Hi Conga</name>
+          <stem>1</stem>
+          <panelRow>4</panelRow>
+          <panelColumn>4</panelColumn>
+          </Drum>
+        <Drum pitch="64">
+          <head>normal</head>
+          <line>2</line>
+          <voice>0</voice>
+          <name>Low Conga</name>
+          <stem>1</stem>
+          <panelRow>4</panelRow>
+          <panelColumn>5</panelColumn>
+          </Drum>
+        <Drum pitch="65">
+          <head>normal</head>
+          <line>5</line>
+          <voice>0</voice>
+          <name>High Timbale</name>
+          <stem>1</stem>
+          <panelRow>4</panelRow>
+          <panelColumn>6</panelColumn>
+          </Drum>
+        <Drum pitch="66">
+          <head>normal</head>
+          <line>7</line>
+          <voice>0</voice>
+          <name>Low Timbale</name>
+          <stem>1</stem>
+          <panelRow>4</panelRow>
+          <panelColumn>7</panelColumn>
+          </Drum>
+        <Drum pitch="67">
+          <head>triangle-down</head>
+          <line>-2</line>
+          <voice>0</voice>
+          <name>High Agogo</name>
+          <stem>1</stem>
+          <panelRow>5</panelRow>
+          <panelColumn>0</panelColumn>
+          </Drum>
+        <Drum pitch="68">
+          <head>triangle-down</head>
+          <line>-1</line>
+          <voice>0</voice>
+          <name>Low Agogo</name>
+          <stem>1</stem>
+          <panelRow>5</panelRow>
+          <panelColumn>1</panelColumn>
+          </Drum>
+        <Drum pitch="69">
+          <head>diamond</head>
+          <line>2</line>
+          <voice>0</voice>
+          <name>Cabasa</name>
+          <stem>1</stem>
+          <panelRow>5</panelRow>
+          <panelColumn>2</panelColumn>
+          </Drum>
+        <Drum pitch="70">
+          <head>diamond</head>
+          <line>4</line>
+          <voice>0</voice>
+          <name>Maracas</name>
+          <stem>1</stem>
+          <panelRow>5</panelRow>
+          <panelColumn>3</panelColumn>
+          </Drum>
+        <Drum pitch="71">
+          <head>cross</head>
+          <line>-3</line>
+          <voice>0</voice>
+          <name>Short Whistle</name>
+          <stem>1</stem>
+          <panelRow>5</panelRow>
+          <panelColumn>4</panelColumn>
+          </Drum>
+        <Drum pitch="72">
+          <head>ti</head>
+          <line>-3</line>
+          <voice>0</voice>
+          <name>Long Whistle</name>
+          <stem>1</stem>
+          <panelRow>5</panelRow>
+          <panelColumn>5</panelColumn>
+          </Drum>
+        <Drum pitch="73">
+          <head>cross</head>
+          <line>-1</line>
+          <voice>0</voice>
+          <name>Short Güiro</name>
+          <stem>1</stem>
+          <panelRow>5</panelRow>
+          <panelColumn>6</panelColumn>
+          </Drum>
+        <Drum pitch="74">
+          <head>slashed1</head>
+          <line>-1</line>
+          <voice>0</voice>
+          <name>Long Güiro</name>
+          <stem>1</stem>
+          <panelRow>5</panelRow>
+          <panelColumn>7</panelColumn>
+          </Drum>
+        <Drum pitch="75">
+          <head>la</head>
           <line>0</line>
           <voice>0</voice>
           <name>Claves</name>
           <stem>1</stem>
-          <panelRow>1</panelRow>
+          <panelRow>6</panelRow>
+          <panelColumn>0</panelColumn>
+          </Drum>
+        <Drum pitch="76">
+          <head>la</head>
+          <line>5</line>
+          <voice>0</voice>
+          <name>Hi Wood Block</name>
+          <stem>1</stem>
+          <panelRow>6</panelRow>
+          <panelColumn>1</panelColumn>
+          </Drum>
+        <Drum pitch="77">
+          <head>la</head>
+          <line>7</line>
+          <voice>0</voice>
+          <name>Low Wood Block</name>
+          <stem>1</stem>
+          <panelRow>6</panelRow>
+          <panelColumn>2</panelColumn>
+          </Drum>
+        <Drum pitch="78">
+          <head>cross</head>
+          <line>8</line>
+          <voice>0</voice>
+          <name>Mute Cuica</name>
+          <stem>1</stem>
+          <panelRow>6</panelRow>
+          <panelColumn>3</panelColumn>
+          </Drum>
+        <Drum pitch="79">
+          <head>slashed2</head>
+          <line>8</line>
+          <voice>0</voice>
+          <name>Open Cuica</name>
+          <stem>1</stem>
+          <panelRow>6</panelRow>
           <panelColumn>4</panelColumn>
           </Drum>
+        <Drum pitch="80">
+          <head>cross</head>
+          <line>0</line>
+          <voice>0</voice>
+          <name>Mute Triangle</name>
+          <stem>1</stem>
+          <panelRow>6</panelRow>
+          <panelColumn>5</panelColumn>
+          </Drum>
         <Drum pitch="81">
-          <head>diamond</head>
+          <head>triangle-up</head>
           <line>0</line>
           <voice>0</voice>
           <name>Open Triangle</name>
           <stem>1</stem>
-          <shortcut>D</shortcut>
-          <panelRow>0</panelRow>
+          <panelRow>6</panelRow>
           <panelColumn>6</panelColumn>
           </Drum>
         <Drum pitch="82">
-          <head>normal</head>
-          <line>4</line>
+          <head>diamond</head>
+          <line>5</line>
           <voice>0</voice>
           <name>Shaker</name>
           <stem>1</stem>
-          <panelRow>2</panelRow>
-          <panelColumn>4</panelColumn>
+          <panelRow>6</panelRow>
+          <panelColumn>7</panelColumn>
+          </Drum>
+        <Drum pitch="83">
+          <head>triangle-down</head>
+          <line>3</line>
+          <voice>0</voice>
+          <name>Sleigh Bell</name>
+          <stem>1</stem>
+          <panelRow>7</panelRow>
+          <panelColumn>0</panelColumn>
           </Drum>
         <Drum pitch="84">
-          <head>cross</head>
+          <head>ti</head>
           <line>2</line>
           <voice>0</voice>
           <name>Mark Tree</name>
           <stem>1</stem>
-          <panelRow>0</panelRow>
-          <panelColumn>7</panelColumn>
+          <panelRow>7</panelRow>
+          <panelColumn>1</panelColumn>
           </Drum>
         <Drum pitch="85">
-          <head>normal</head>
-          <line>1</line>
+          <head>la</head>
+          <line>2</line>
           <voice>0</voice>
           <name>Castanets</name>
           <stem>1</stem>
-          <panelRow>1</panelRow>
-          <panelColumn>5</panelColumn>
+          <panelRow>7</panelRow>
+          <panelColumn>2</panelColumn>
+          </Drum>
+        <Drum pitch="86">
+          <head>normal</head>
+          <noteheads>
+            <whole>noteheadSlashX</whole>
+            <half>noteheadSlashX</half>
+            <quarter>noteheadSlashX</quarter>
+            <breve>noteheadSlashX</breve>
+            </noteheads>
+          <line>4</line>
+          <voice>0</voice>
+          <name>Mute Surdo</name>
+          <stem>1</stem>
+          <panelRow>7</panelRow>
+          <panelColumn>3</panelColumn>
+          </Drum>
+        <Drum pitch="87">
+          <head>slash</head>
+          <line>4</line>
+          <voice>0</voice>
+          <name>Open Surdo</name>
+          <stem>1</stem>
+          <panelRow>7</panelRow>
+          <panelColumn>4</panelColumn>
           </Drum>
         <clef>PERC</clef>
-        <singleNoteDynamics>0</singleNoteDynamics>
         <Articulation>
           <velocity>100</velocity>
           <gateTime>100</gateTime>

--- a/src/importexport/musicxml/tests/data/testImportDrums2_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testImportDrums2_ref.mscx
@@ -61,10 +61,10 @@
           <head>normal</head>
           <line>8</line>
           <voice>1</voice>
-          <name>Acoustic Bass Drum</name>
+          <name>Bass Drum 2</name>
           <stem>2</stem>
-          <panelRow>2</panelRow>
-          <panelColumn>1</panelColumn>
+          <panelRow>1</panelRow>
+          <panelColumn>0</panelColumn>
           </Drum>
         <Drum pitch="36">
           <head>normal</head>
@@ -73,7 +73,7 @@
           <name>Bass Drum 1</name>
           <stem>2</stem>
           <shortcut>B</shortcut>
-          <panelRow>2</panelRow>
+          <panelRow>0</panelRow>
           <panelColumn>0</panelColumn>
           </Drum>
         <Drum pitch="37">
@@ -92,8 +92,8 @@
           <name>Acoustic Snare</name>
           <stem>1</stem>
           <shortcut>A</shortcut>
-          <panelRow>1</panelRow>
-          <panelColumn>0</panelColumn>
+          <panelRow>0</panelRow>
+          <panelColumn>1</panelColumn>
           </Drum>
         <Drum pitch="40">
           <head>slash</head>
@@ -102,7 +102,7 @@
           <name>Electric Snare</name>
           <stem>1</stem>
           <panelRow>2</panelRow>
-          <panelColumn>6</panelColumn>
+          <panelColumn>0</panelColumn>
           </Drum>
         <Drum pitch="41">
           <head>normal</head>
@@ -121,7 +121,7 @@
           <stem>1</stem>
           <shortcut>G</shortcut>
           <panelRow>0</panelRow>
-          <panelColumn>0</panelColumn>
+          <panelColumn>2</panelColumn>
           </Drum>
         <Drum pitch="43">
           <head>normal</head>
@@ -129,8 +129,8 @@
           <voice>0</voice>
           <name>High Floor Tom</name>
           <stem>1</stem>
-          <panelRow>1</panelRow>
-          <panelColumn>6</panelColumn>
+          <panelRow>0</panelRow>
+          <panelColumn>7</panelColumn>
           </Drum>
         <Drum pitch="44">
           <head>cross</head>
@@ -139,7 +139,7 @@
           <name>Pedal Hi-Hat</name>
           <stem>2</stem>
           <shortcut>F</shortcut>
-          <panelRow>2</panelRow>
+          <panelRow>1</panelRow>
           <panelColumn>2</panelColumn>
           </Drum>
         <Drum pitch="45">
@@ -149,7 +149,7 @@
           <name>Low Tom</name>
           <stem>1</stem>
           <panelRow>1</panelRow>
-          <panelColumn>5</panelColumn>
+          <panelColumn>6</panelColumn>
           </Drum>
         <Drum pitch="46">
           <head>xcircle</head>
@@ -158,7 +158,7 @@
           <name>Open Hi-Hat</name>
           <stem>1</stem>
           <panelRow>0</panelRow>
-          <panelColumn>1</panelColumn>
+          <panelColumn>3</panelColumn>
           </Drum>
         <Drum pitch="47">
           <head>normal</head>
@@ -167,7 +167,7 @@
           <name>Low-Mid Tom</name>
           <stem>1</stem>
           <panelRow>1</panelRow>
-          <panelColumn>4</panelColumn>
+          <panelColumn>5</panelColumn>
           </Drum>
         <Drum pitch="48">
           <head>normal</head>
@@ -175,8 +175,8 @@
           <voice>0</voice>
           <name>Hi-Mid Tom</name>
           <stem>1</stem>
-          <panelRow>1</panelRow>
-          <panelColumn>3</panelColumn>
+          <panelRow>0</panelRow>
+          <panelColumn>6</panelColumn>
           </Drum>
         <Drum pitch="49">
           <head>cross</head>
@@ -196,7 +196,7 @@
           <stem>1</stem>
           <shortcut>E</shortcut>
           <panelRow>1</panelRow>
-          <panelColumn>2</panelColumn>
+          <panelColumn>4</panelColumn>
           </Drum>
         <Drum pitch="51">
           <head>cross</head>
@@ -206,16 +206,16 @@
           <stem>1</stem>
           <shortcut>D</shortcut>
           <panelRow>0</panelRow>
-          <panelColumn>2</panelColumn>
+          <panelColumn>5</panelColumn>
           </Drum>
         <Drum pitch="52">
           <head>cross</head>
           <line>-4</line>
           <voice>0</voice>
-          <name>Chinese Cymbal</name>
+          <name>China Cymbal</name>
           <stem>1</stem>
-          <panelRow>0</panelRow>
-          <panelColumn>6</panelColumn>
+          <panelRow>2</panelRow>
+          <panelColumn>3</panelColumn>
           </Drum>
         <Drum pitch="53">
           <head>diamond</head>
@@ -223,8 +223,8 @@
           <voice>0</voice>
           <name>Ride Bell</name>
           <stem>1</stem>
-          <panelRow>0</panelRow>
-          <panelColumn>3</panelColumn>
+          <panelRow>2</panelRow>
+          <panelColumn>5</panelColumn>
           </Drum>
         <Drum pitch="54">
           <head>diamond</head>
@@ -233,7 +233,7 @@
           <name>Tambourine</name>
           <stem>1</stem>
           <panelRow>2</panelRow>
-          <panelColumn>4</panelColumn>
+          <panelColumn>1</panelColumn>
           </Drum>
         <Drum pitch="55">
           <head>cross</head>
@@ -241,8 +241,8 @@
           <voice>0</voice>
           <name>Splash Cymbal</name>
           <stem>1</stem>
-          <panelRow>0</panelRow>
-          <panelColumn>7</panelColumn>
+          <panelRow>2</panelRow>
+          <panelColumn>4</panelColumn>
           </Drum>
         <Drum pitch="56">
           <head>triangle-down</head>
@@ -251,7 +251,7 @@
           <name>Cowbell</name>
           <stem>1</stem>
           <panelRow>2</panelRow>
-          <panelColumn>3</panelColumn>
+          <panelColumn>2</panelColumn>
           </Drum>
         <Drum pitch="57">
           <head>cross</head>
@@ -259,8 +259,8 @@
           <voice>0</voice>
           <name>Crash Cymbal 2</name>
           <stem>1</stem>
-          <panelRow>0</panelRow>
-          <panelColumn>5</panelColumn>
+          <panelRow>1</panelRow>
+          <panelColumn>3</panelColumn>
           </Drum>
         <Drum pitch="59">
           <head>cross</head>
@@ -269,7 +269,7 @@
           <name>Ride Cymbal 2</name>
           <stem>1</stem>
           <panelRow>2</panelRow>
-          <panelColumn>5</panelColumn>
+          <panelColumn>6</panelColumn>
           </Drum>
         <Drum pitch="81">
           <head>normal</head>

--- a/src/importexport/musicxml/tests/data/testImportDrums_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testImportDrums_ref.mscx
@@ -50,10 +50,10 @@
           <head>normal</head>
           <line>8</line>
           <voice>1</voice>
-          <name>Acoustic Bass Drum</name>
+          <name>Bass Drum 2</name>
           <stem>2</stem>
-          <panelRow>2</panelRow>
-          <panelColumn>1</panelColumn>
+          <panelRow>1</panelRow>
+          <panelColumn>0</panelColumn>
           </Drum>
         <Drum pitch="36">
           <head>normal</head>
@@ -62,7 +62,7 @@
           <name>Bass Drum 1</name>
           <stem>2</stem>
           <shortcut>B</shortcut>
-          <panelRow>2</panelRow>
+          <panelRow>0</panelRow>
           <panelColumn>0</panelColumn>
           </Drum>
         <Drum pitch="37">
@@ -81,8 +81,8 @@
           <name>Acoustic Snare</name>
           <stem>1</stem>
           <shortcut>A</shortcut>
-          <panelRow>1</panelRow>
-          <panelColumn>0</panelColumn>
+          <panelRow>0</panelRow>
+          <panelColumn>1</panelColumn>
           </Drum>
         <Drum pitch="40">
           <head>slash</head>
@@ -91,7 +91,7 @@
           <name>Electric Snare</name>
           <stem>1</stem>
           <panelRow>2</panelRow>
-          <panelColumn>6</panelColumn>
+          <panelColumn>0</panelColumn>
           </Drum>
         <Drum pitch="41">
           <head>normal</head>
@@ -110,7 +110,7 @@
           <stem>1</stem>
           <shortcut>G</shortcut>
           <panelRow>0</panelRow>
-          <panelColumn>0</panelColumn>
+          <panelColumn>2</panelColumn>
           </Drum>
         <Drum pitch="43">
           <head>normal</head>
@@ -118,8 +118,8 @@
           <voice>0</voice>
           <name>High Floor Tom</name>
           <stem>1</stem>
-          <panelRow>1</panelRow>
-          <panelColumn>6</panelColumn>
+          <panelRow>0</panelRow>
+          <panelColumn>7</panelColumn>
           </Drum>
         <Drum pitch="44">
           <head>cross</head>
@@ -128,7 +128,7 @@
           <name>Pedal Hi-Hat</name>
           <stem>2</stem>
           <shortcut>F</shortcut>
-          <panelRow>2</panelRow>
+          <panelRow>1</panelRow>
           <panelColumn>2</panelColumn>
           </Drum>
         <Drum pitch="45">
@@ -138,7 +138,7 @@
           <name>Low Tom</name>
           <stem>1</stem>
           <panelRow>1</panelRow>
-          <panelColumn>5</panelColumn>
+          <panelColumn>6</panelColumn>
           </Drum>
         <Drum pitch="46">
           <head>xcircle</head>
@@ -147,7 +147,7 @@
           <name>Open Hi-Hat</name>
           <stem>1</stem>
           <panelRow>0</panelRow>
-          <panelColumn>1</panelColumn>
+          <panelColumn>3</panelColumn>
           </Drum>
         <Drum pitch="47">
           <head>normal</head>
@@ -156,7 +156,7 @@
           <name>Low-Mid Tom</name>
           <stem>1</stem>
           <panelRow>1</panelRow>
-          <panelColumn>4</panelColumn>
+          <panelColumn>5</panelColumn>
           </Drum>
         <Drum pitch="48">
           <head>normal</head>
@@ -164,8 +164,8 @@
           <voice>0</voice>
           <name>Hi-Mid Tom</name>
           <stem>1</stem>
-          <panelRow>1</panelRow>
-          <panelColumn>3</panelColumn>
+          <panelRow>0</panelRow>
+          <panelColumn>6</panelColumn>
           </Drum>
         <Drum pitch="49">
           <head>cross</head>
@@ -185,7 +185,7 @@
           <stem>1</stem>
           <shortcut>E</shortcut>
           <panelRow>1</panelRow>
-          <panelColumn>2</panelColumn>
+          <panelColumn>4</panelColumn>
           </Drum>
         <Drum pitch="51">
           <head>cross</head>
@@ -195,16 +195,16 @@
           <stem>1</stem>
           <shortcut>D</shortcut>
           <panelRow>0</panelRow>
-          <panelColumn>2</panelColumn>
+          <panelColumn>5</panelColumn>
           </Drum>
         <Drum pitch="52">
           <head>cross</head>
           <line>-4</line>
           <voice>0</voice>
-          <name>Chinese Cymbal</name>
+          <name>China Cymbal</name>
           <stem>1</stem>
-          <panelRow>0</panelRow>
-          <panelColumn>6</panelColumn>
+          <panelRow>2</panelRow>
+          <panelColumn>3</panelColumn>
           </Drum>
         <Drum pitch="53">
           <head>diamond</head>
@@ -212,8 +212,8 @@
           <voice>0</voice>
           <name>Ride Bell</name>
           <stem>1</stem>
-          <panelRow>0</panelRow>
-          <panelColumn>3</panelColumn>
+          <panelRow>2</panelRow>
+          <panelColumn>5</panelColumn>
           </Drum>
         <Drum pitch="54">
           <head>diamond</head>
@@ -222,7 +222,7 @@
           <name>Tambourine</name>
           <stem>1</stem>
           <panelRow>2</panelRow>
-          <panelColumn>4</panelColumn>
+          <panelColumn>1</panelColumn>
           </Drum>
         <Drum pitch="55">
           <head>cross</head>
@@ -230,8 +230,8 @@
           <voice>0</voice>
           <name>Splash Cymbal</name>
           <stem>1</stem>
-          <panelRow>0</panelRow>
-          <panelColumn>7</panelColumn>
+          <panelRow>2</panelRow>
+          <panelColumn>4</panelColumn>
           </Drum>
         <Drum pitch="56">
           <head>triangle-down</head>
@@ -240,7 +240,7 @@
           <name>Cowbell</name>
           <stem>1</stem>
           <panelRow>2</panelRow>
-          <panelColumn>3</panelColumn>
+          <panelColumn>2</panelColumn>
           </Drum>
         <Drum pitch="57">
           <head>cross</head>
@@ -248,8 +248,8 @@
           <voice>0</voice>
           <name>Crash Cymbal 2</name>
           <stem>1</stem>
-          <panelRow>0</panelRow>
-          <panelColumn>5</panelColumn>
+          <panelRow>1</panelRow>
+          <panelColumn>3</panelColumn>
           </Drum>
         <Drum pitch="59">
           <head>cross</head>
@@ -258,7 +258,7 @@
           <name>Ride Cymbal 2</name>
           <stem>1</stem>
           <panelRow>2</panelRow>
-          <panelColumn>5</panelColumn>
+          <panelColumn>6</panelColumn>
           </Drum>
         <Drum pitch="81">
           <head>normal</head>

--- a/src/importexport/musicxml/tests/data/testInstrImport_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testInstrImport_ref.mscx
@@ -1145,9 +1145,8 @@
           <voice>0</voice>
           <name>Closed Hi-Hat</name>
           <stem>1</stem>
-          <shortcut>G</shortcut>
-          <panelRow>0</panelRow>
-          <panelColumn>2</panelColumn>
+          <panelRow>4</panelRow>
+          <panelColumn>5</panelColumn>
           </Drum>
         <Drum pitch="28">
           <head>cross</head>
@@ -1155,41 +1154,47 @@
           <voice>1</voice>
           <name>Pedal Hi-Hat</name>
           <stem>2</stem>
-          <shortcut>F</shortcut>
-          <panelRow>0</panelRow>
-          <panelColumn>3</panelColumn>
+          <panelRow>4</panelRow>
+          <panelColumn>7</panelColumn>
           </Drum>
         <Drum pitch="29">
-          <head>cross</head>
-          <line>1</line>
+          <head>xcircle</head>
+          <line>-1</line>
           <voice>0</voice>
           <name>Open Hi-Hat</name>
           <stem>1</stem>
-          <shortcut>E</shortcut>
-          <panelRow>0</panelRow>
-          <panelColumn>4</panelColumn>
+          <panelRow>4</panelRow>
+          <panelColumn>6</panelColumn>
           </Drum>
         <Drum pitch="30">
           <head>cross</head>
           <line>0</line>
           <voice>0</voice>
-          <name>Ride Cymbal 1</name>
+          <name>Ride Cymbal</name>
           <stem>1</stem>
-          <panelRow>0</panelRow>
-          <panelColumn>1</panelColumn>
+          <panelRow>5</panelRow>
+          <panelColumn>0</panelColumn>
+          </Drum>
+        <Drum pitch="31">
+          <head>plus</head>
+          <line>-1</line>
+          <voice>0</voice>
+          <name>Stick Click</name>
+          <stem>1</stem>
+          <panelRow>4</panelRow>
+          <panelColumn>4</panelColumn>
           </Drum>
         <Drum pitch="36">
           <head>normal</head>
           <line>7</line>
           <voice>1</voice>
-          <name>Bass Drum 1</name>
+          <name>Bass Drum</name>
           <stem>2</stem>
-          <shortcut>B</shortcut>
-          <panelRow>2</panelRow>
+          <panelRow>0</panelRow>
           <panelColumn>0</panelColumn>
           </Drum>
         <Drum pitch="37">
-          <head>cross</head>
+          <head>slashed1</head>
           <line>3</line>
           <voice>0</voice>
           <name>Side Stick</name>
@@ -1201,139 +1206,328 @@
           <head>normal</head>
           <line>3</line>
           <voice>0</voice>
-          <name>Acoustic Snare</name>
+          <name>Snare</name>
           <stem>1</stem>
-          <shortcut>A</shortcut>
-          <panelRow>1</panelRow>
-          <panelColumn>0</panelColumn>
+          <panelRow>0</panelRow>
+          <panelColumn>1</panelColumn>
           </Drum>
         <Drum pitch="54">
           <head>diamond</head>
-          <line>2</line>
+          <line>6</line>
           <voice>0</voice>
           <name>Tambourine</name>
           <stem>1</stem>
-          <panelRow>1</panelRow>
-          <panelColumn>2</panelColumn>
+          <panelRow>0</panelRow>
+          <panelColumn>6</panelColumn>
           </Drum>
         <Drum pitch="55">
           <head>cross</head>
-          <line>-3</line>
+          <line>-4</line>
           <voice>0</voice>
           <name>Splash Cymbal</name>
           <stem>1</stem>
-          <panelRow>0</panelRow>
-          <panelColumn>5</panelColumn>
+          <panelRow>5</panelRow>
+          <panelColumn>1</panelColumn>
           </Drum>
         <Drum pitch="56">
           <head>triangle-down</head>
-          <line>1</line>
+          <line>0</line>
           <voice>0</voice>
           <name>Cowbell</name>
           <stem>1</stem>
-          <panelRow>1</panelRow>
-          <panelColumn>3</panelColumn>
+          <panelRow>2</panelRow>
+          <panelColumn>7</panelColumn>
+          </Drum>
+        <Drum pitch="57">
+          <head>cross</head>
+          <line>-2</line>
+          <voice>0</voice>
+          <name>Suspended Cymbal</name>
+          <stem>1</stem>
+          <panelRow>0</panelRow>
+          <panelColumn>4</panelColumn>
           </Drum>
         <Drum pitch="58">
-          <head>diamond</head>
-          <line>1</line>
+          <head>ti</head>
+          <line>0</line>
           <voice>0</voice>
           <name>Vibraslap</name>
           <stem>1</stem>
           <panelRow>1</panelRow>
-          <panelColumn>6</panelColumn>
+          <panelColumn>3</panelColumn>
           </Drum>
         <Drum pitch="59">
           <head>cross</head>
-          <line>-2</line>
+          <line>4</line>
           <voice>0</voice>
           <name>Hand Cymbals</name>
           <stem>1</stem>
-          <shortcut>C</shortcut>
           <panelRow>0</panelRow>
-          <panelColumn>0</panelColumn>
+          <panelColumn>5</panelColumn>
+          </Drum>
+        <Drum pitch="60">
+          <head>normal</head>
+          <line>-1</line>
+          <voice>0</voice>
+          <name>Hi Bongo</name>
+          <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>6</panelColumn>
+          </Drum>
+        <Drum pitch="61">
+          <head>normal</head>
+          <line>0</line>
+          <voice>0</voice>
+          <name>Lo Bongo</name>
+          <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>5</panelColumn>
           </Drum>
         <Drum pitch="62">
-          <head>cross</head>
-          <line>2</line>
+          <head>normal</head>
+          <noteheads>
+            <whole>noteheadXOrnate</whole>
+            <half>noteheadXOrnate</half>
+            <quarter>noteheadXOrnate</quarter>
+            <breve>noteheadXOrnate</breve>
+            </noteheads>
+          <line>1</line>
           <voice>0</voice>
-          <name>Mute High Conga</name>
+          <name>Mute Hi Conga</name>
+          <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>4</panelColumn>
+          </Drum>
+        <Drum pitch="63">
+          <head>normal</head>
+          <line>1</line>
+          <voice>0</voice>
+          <name>Hi Conga</name>
           <stem>1</stem>
           <panelRow>2</panelRow>
           <panelColumn>3</panelColumn>
           </Drum>
-        <Drum pitch="63">
-          <head>cross</head>
-          <line>4</line>
+        <Drum pitch="64">
+          <head>normal</head>
+          <line>2</line>
           <voice>0</voice>
-          <name>Open High Conga</name>
+          <name>Lo Conga</name>
           <stem>1</stem>
           <panelRow>2</panelRow>
           <panelColumn>2</panelColumn>
           </Drum>
-        <Drum pitch="64">
-          <head>cross</head>
-          <line>6</line>
+        <Drum pitch="65">
+          <head>normal</head>
+          <line>5</line>
           <voice>0</voice>
-          <name>Low Conga</name>
+          <name>Hi Timbale</name>
           <stem>1</stem>
           <panelRow>2</panelRow>
           <panelColumn>1</panelColumn>
           </Drum>
-        <Drum pitch="70">
+        <Drum pitch="66">
           <head>normal</head>
+          <line>7</line>
+          <voice>0</voice>
+          <name>Lo Timbale</name>
+          <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>0</panelColumn>
+          </Drum>
+        <Drum pitch="67">
+          <head>triangle-down</head>
+          <line>-2</line>
+          <voice>0</voice>
+          <name>Hi Agogô</name>
+          <stem>1</stem>
+          <panelRow>3</panelRow>
+          <panelColumn>7</panelColumn>
+          </Drum>
+        <Drum pitch="68">
+          <head>triangle-down</head>
+          <line>-1</line>
+          <voice>0</voice>
+          <name>Lo Agogô</name>
+          <stem>1</stem>
+          <panelRow>3</panelRow>
+          <panelColumn>6</panelColumn>
+          </Drum>
+        <Drum pitch="69">
+          <head>diamond</head>
           <line>2</line>
+          <voice>0</voice>
+          <name>Cabasa</name>
+          <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>6</panelColumn>
+          </Drum>
+        <Drum pitch="70">
+          <head>diamond</head>
+          <line>4</line>
           <voice>0</voice>
           <name>Maracas</name>
           <stem>1</stem>
-          <panelRow>2</panelRow>
+          <panelRow>1</panelRow>
           <panelColumn>5</panelColumn>
           </Drum>
+        <Drum pitch="71">
+          <head>ti</head>
+          <line>-3</line>
+          <voice>0</voice>
+          <name>Long Whistle</name>
+          <stem>1</stem>
+          <panelRow>4</panelRow>
+          <panelColumn>2</panelColumn>
+          </Drum>
+        <Drum pitch="72">
+          <head>cross</head>
+          <line>-3</line>
+          <voice>0</voice>
+          <name>Short Whistle</name>
+          <stem>1</stem>
+          <panelRow>4</panelRow>
+          <panelColumn>3</panelColumn>
+          </Drum>
+        <Drum pitch="73">
+          <head>cross</head>
+          <line>-1</line>
+          <voice>0</voice>
+          <name>Short Güiro</name>
+          <stem>1</stem>
+          <panelRow>3</panelRow>
+          <panelColumn>5</panelColumn>
+          </Drum>
+        <Drum pitch="74">
+          <head>slashed1</head>
+          <line>-1</line>
+          <voice>0</voice>
+          <name>Long Güiro</name>
+          <stem>1</stem>
+          <panelRow>3</panelRow>
+          <panelColumn>4</panelColumn>
+          </Drum>
         <Drum pitch="75">
-          <head>normal</head>
+          <head>la</head>
           <line>0</line>
           <voice>0</voice>
           <name>Claves</name>
           <stem>1</stem>
-          <panelRow>1</panelRow>
-          <panelColumn>4</panelColumn>
+          <panelRow>0</panelRow>
+          <panelColumn>7</panelColumn>
           </Drum>
-        <Drum pitch="81">
-          <head>diamond</head>
+        <Drum pitch="76">
+          <head>la</head>
+          <line>5</line>
+          <voice>0</voice>
+          <name>Hi Woodblock</name>
+          <stem>1</stem>
+          <panelRow>3</panelRow>
+          <panelColumn>3</panelColumn>
+          </Drum>
+        <Drum pitch="77">
+          <head>la</head>
+          <line>7</line>
+          <voice>0</voice>
+          <name>Lo Woodblock</name>
+          <stem>1</stem>
+          <panelRow>3</panelRow>
+          <panelColumn>2</panelColumn>
+          </Drum>
+        <Drum pitch="78">
+          <head>cross</head>
+          <line>8</line>
+          <voice>0</voice>
+          <name>Mute Cuica</name>
+          <stem>1</stem>
+          <panelRow>4</panelRow>
+          <panelColumn>1</panelColumn>
+          </Drum>
+        <Drum pitch="79">
+          <head>slashed2</head>
+          <line>8</line>
+          <voice>0</voice>
+          <name>Open Cuica</name>
+          <stem>1</stem>
+          <panelRow>4</panelRow>
+          <panelColumn>0</panelColumn>
+          </Drum>
+        <Drum pitch="80">
+          <head>cross</head>
           <line>0</line>
           <voice>0</voice>
-          <name>Open Triangle</name>
+          <name>Mute Triangle</name>
           <stem>1</stem>
-          <shortcut>D</shortcut>
           <panelRow>0</panelRow>
-          <panelColumn>6</panelColumn>
+          <panelColumn>3</panelColumn>
+          </Drum>
+        <Drum pitch="81">
+          <head>triangle-up</head>
+          <line>0</line>
+          <voice>0</voice>
+          <name>Triangle</name>
+          <stem>1</stem>
+          <panelRow>0</panelRow>
+          <panelColumn>2</panelColumn>
           </Drum>
         <Drum pitch="82">
-          <head>normal</head>
-          <line>4</line>
+          <head>diamond</head>
+          <line>5</line>
           <voice>0</voice>
           <name>Shaker</name>
           <stem>1</stem>
-          <panelRow>2</panelRow>
+          <panelRow>1</panelRow>
           <panelColumn>4</panelColumn>
           </Drum>
+        <Drum pitch="83">
+          <head>triangle-down</head>
+          <line>3</line>
+          <voice>0</voice>
+          <name>Sleigh Bells</name>
+          <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>2</panelColumn>
+          </Drum>
         <Drum pitch="84">
-          <head>cross</head>
+          <head>ti</head>
           <line>2</line>
           <voice>0</voice>
           <name>Mark Tree</name>
           <stem>1</stem>
-          <panelRow>0</panelRow>
-          <panelColumn>7</panelColumn>
+          <panelRow>1</panelRow>
+          <panelColumn>0</panelColumn>
           </Drum>
         <Drum pitch="85">
-          <head>normal</head>
-          <line>1</line>
+          <head>la</head>
+          <line>2</line>
           <voice>0</voice>
           <name>Castanets</name>
           <stem>1</stem>
           <panelRow>1</panelRow>
-          <panelColumn>5</panelColumn>
+          <panelColumn>7</panelColumn>
+          </Drum>
+        <Drum pitch="86">
+          <head>normal</head>
+          <noteheads>
+            <whole>noteheadSlashX</whole>
+            <half>noteheadSlashX</half>
+            <quarter>noteheadSlashX</quarter>
+            <breve>noteheadSlashX</breve>
+            </noteheads>
+          <line>4</line>
+          <voice>0</voice>
+          <name>Mute Surdo</name>
+          <stem>1</stem>
+          <panelRow>3</panelRow>
+          <panelColumn>1</panelColumn>
+          </Drum>
+        <Drum pitch="87">
+          <head>slash</head>
+          <line>4</line>
+          <voice>0</voice>
+          <name>Surdo</name>
+          <stem>1</stem>
+          <panelRow>3</panelRow>
+          <panelColumn>0</panelColumn>
           </Drum>
         <clef>PERC</clef>
         <Articulation>

--- a/src/importexport/musicxml/tests/data/testStickingLyrics_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testStickingLyrics_ref.mscx
@@ -61,10 +61,10 @@
           <head>normal</head>
           <line>8</line>
           <voice>1</voice>
-          <name>Acoustic Bass Drum</name>
+          <name>Bass Drum 2</name>
           <stem>2</stem>
-          <panelRow>2</panelRow>
-          <panelColumn>1</panelColumn>
+          <panelRow>1</panelRow>
+          <panelColumn>0</panelColumn>
           </Drum>
         <Drum pitch="36">
           <head>normal</head>
@@ -73,7 +73,7 @@
           <name>Bass Drum 1</name>
           <stem>2</stem>
           <shortcut>B</shortcut>
-          <panelRow>2</panelRow>
+          <panelRow>0</panelRow>
           <panelColumn>0</panelColumn>
           </Drum>
         <Drum pitch="37">
@@ -92,8 +92,8 @@
           <name>Acoustic Snare</name>
           <stem>1</stem>
           <shortcut>A</shortcut>
-          <panelRow>1</panelRow>
-          <panelColumn>0</panelColumn>
+          <panelRow>0</panelRow>
+          <panelColumn>1</panelColumn>
           </Drum>
         <Drum pitch="40">
           <head>slash</head>
@@ -102,7 +102,7 @@
           <name>Electric Snare</name>
           <stem>1</stem>
           <panelRow>2</panelRow>
-          <panelColumn>6</panelColumn>
+          <panelColumn>0</panelColumn>
           </Drum>
         <Drum pitch="41">
           <head>normal</head>
@@ -121,7 +121,7 @@
           <stem>1</stem>
           <shortcut>G</shortcut>
           <panelRow>0</panelRow>
-          <panelColumn>0</panelColumn>
+          <panelColumn>2</panelColumn>
           </Drum>
         <Drum pitch="43">
           <head>normal</head>
@@ -129,8 +129,8 @@
           <voice>0</voice>
           <name>High Floor Tom</name>
           <stem>1</stem>
-          <panelRow>1</panelRow>
-          <panelColumn>6</panelColumn>
+          <panelRow>0</panelRow>
+          <panelColumn>7</panelColumn>
           </Drum>
         <Drum pitch="44">
           <head>cross</head>
@@ -139,7 +139,7 @@
           <name>Pedal Hi-Hat</name>
           <stem>2</stem>
           <shortcut>F</shortcut>
-          <panelRow>2</panelRow>
+          <panelRow>1</panelRow>
           <panelColumn>2</panelColumn>
           </Drum>
         <Drum pitch="45">
@@ -149,7 +149,7 @@
           <name>Low Tom</name>
           <stem>1</stem>
           <panelRow>1</panelRow>
-          <panelColumn>5</panelColumn>
+          <panelColumn>6</panelColumn>
           </Drum>
         <Drum pitch="46">
           <head>xcircle</head>
@@ -158,7 +158,7 @@
           <name>Open Hi-Hat</name>
           <stem>1</stem>
           <panelRow>0</panelRow>
-          <panelColumn>1</panelColumn>
+          <panelColumn>3</panelColumn>
           </Drum>
         <Drum pitch="47">
           <head>normal</head>
@@ -167,7 +167,7 @@
           <name>Low-Mid Tom</name>
           <stem>1</stem>
           <panelRow>1</panelRow>
-          <panelColumn>4</panelColumn>
+          <panelColumn>5</panelColumn>
           </Drum>
         <Drum pitch="48">
           <head>normal</head>
@@ -175,8 +175,8 @@
           <voice>0</voice>
           <name>Hi-Mid Tom</name>
           <stem>1</stem>
-          <panelRow>1</panelRow>
-          <panelColumn>3</panelColumn>
+          <panelRow>0</panelRow>
+          <panelColumn>6</panelColumn>
           </Drum>
         <Drum pitch="49">
           <head>cross</head>
@@ -196,7 +196,7 @@
           <stem>1</stem>
           <shortcut>E</shortcut>
           <panelRow>1</panelRow>
-          <panelColumn>2</panelColumn>
+          <panelColumn>4</panelColumn>
           </Drum>
         <Drum pitch="51">
           <head>cross</head>
@@ -206,16 +206,16 @@
           <stem>1</stem>
           <shortcut>D</shortcut>
           <panelRow>0</panelRow>
-          <panelColumn>2</panelColumn>
+          <panelColumn>5</panelColumn>
           </Drum>
         <Drum pitch="52">
           <head>cross</head>
           <line>-4</line>
           <voice>0</voice>
-          <name>Chinese Cymbal</name>
+          <name>China Cymbal</name>
           <stem>1</stem>
-          <panelRow>0</panelRow>
-          <panelColumn>6</panelColumn>
+          <panelRow>2</panelRow>
+          <panelColumn>3</panelColumn>
           </Drum>
         <Drum pitch="53">
           <head>diamond</head>
@@ -223,8 +223,8 @@
           <voice>0</voice>
           <name>Ride Bell</name>
           <stem>1</stem>
-          <panelRow>0</panelRow>
-          <panelColumn>3</panelColumn>
+          <panelRow>2</panelRow>
+          <panelColumn>5</panelColumn>
           </Drum>
         <Drum pitch="54">
           <head>diamond</head>
@@ -233,7 +233,7 @@
           <name>Tambourine</name>
           <stem>1</stem>
           <panelRow>2</panelRow>
-          <panelColumn>4</panelColumn>
+          <panelColumn>1</panelColumn>
           </Drum>
         <Drum pitch="55">
           <head>cross</head>
@@ -241,8 +241,8 @@
           <voice>0</voice>
           <name>Splash Cymbal</name>
           <stem>1</stem>
-          <panelRow>0</panelRow>
-          <panelColumn>7</panelColumn>
+          <panelRow>2</panelRow>
+          <panelColumn>4</panelColumn>
           </Drum>
         <Drum pitch="56">
           <head>triangle-down</head>
@@ -251,7 +251,7 @@
           <name>Cowbell</name>
           <stem>1</stem>
           <panelRow>2</panelRow>
-          <panelColumn>3</panelColumn>
+          <panelColumn>2</panelColumn>
           </Drum>
         <Drum pitch="57">
           <head>cross</head>
@@ -259,8 +259,8 @@
           <voice>0</voice>
           <name>Crash Cymbal 2</name>
           <stem>1</stem>
-          <panelRow>0</panelRow>
-          <panelColumn>5</panelColumn>
+          <panelRow>1</panelRow>
+          <panelColumn>3</panelColumn>
           </Drum>
         <Drum pitch="59">
           <head>cross</head>
@@ -269,7 +269,7 @@
           <name>Ride Cymbal 2</name>
           <stem>1</stem>
           <panelRow>2</panelRow>
-          <panelColumn>5</panelColumn>
+          <panelColumn>6</panelColumn>
           </Drum>
         <clef>PERC</clef>
         <singleNoteDynamics>0</singleNoteDynamics>

--- a/src/importexport/musicxml/tests/data/testVirtualInstruments_ref.xml
+++ b/src/importexport/musicxml/tests/data/testVirtualInstruments_ref.xml
@@ -49,7 +49,7 @@
       <part-name>Drumset</part-name>
       <part-abbreviation>Drs.</part-abbreviation>
       <score-instrument id="P3-I36">
-        <instrument-name>Acoustic Bass Drum</instrument-name>
+        <instrument-name>Bass Drum 2</instrument-name>
         </score-instrument>
       <score-instrument id="P3-I37">
         <instrument-name>Bass Drum 1</instrument-name>
@@ -97,7 +97,7 @@
         <instrument-name>Ride Cymbal 1</instrument-name>
         </score-instrument>
       <score-instrument id="P3-I53">
-        <instrument-name>Chinese Cymbal</instrument-name>
+        <instrument-name>China Cymbal</instrument-name>
         </score-instrument>
       <score-instrument id="P3-I54">
         <instrument-name>Ride Bell</instrument-name>


### PR DESCRIPTION
As a result of this change, unrecognized percussion instruments in:

- MIDI files are now imported with the General MIDI (GM) Percussion instrument instead of the Large Drum Kit, so have more drum pads available. This means that more percussion notes will be recognized.

- Pre-3.6 MuseScore files are imported as Large Drum Kit if the instrument name includes "drum kit" or "drum set" (with or without spaces), otherwise as GM Percussion. No new pads are available in these files. That's because the pads are taken from the imported file rather than from `instruments.xml`. (Presumably these files already contain all the pads they need.)
 
- MusicXML was previously imported as Mixed/Orchestral Percussion, possibly due to a bug in [combinedTemplateSearch()](https://github.com/musescore/MuseScore/blob/39cd0b949f1ee8673b3bba9a470ff75836fdc659/src/engraving/dom/instrtemplate.cpp#L722-L838), and that is unchanged by this PR.

Requested by @zacjansheski.