### PR TITLE
fix #17398: mark hidden staves in MusicXML export

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
@@ -7428,11 +7428,7 @@ void ExportMusicXml::print(const Measure* const m, const int partNr, const int f
                     m_xml.tag("staff-distance", String::number(getTenthsFromDots(staffDist), 2));
                     m_xml.endElement();
                 } else {
-                    m_xml.startElement("staff-details", { { "number", staffIdx + 1 }, { "print-object", "no" } });
-                    Part* part = m_score->parts().at(partNr);
-                    Staff* staff = part->staff(staffIdx);
-                    m_xml.tag("staff-lines", staff->lines(m->tick()));
-                    m_xml.endElement();
+                    m_xml.tag("staff-details", { { "number", staffIdx + 1 }, { "print-object", "no" } });
                 }
             }
 

--- a/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
@@ -7427,6 +7427,12 @@ void ExportMusicXml::print(const Measure* const m, const int partNr, const int f
                     m_xml.startElement("staff-layout", { { "number", staffIdx + 1 } });
                     m_xml.tag("staff-distance", String::number(getTenthsFromDots(staffDist), 2));
                     m_xml.endElement();
+                } else {
+                    m_xml.startElement("staff-details", { { "number", staffIdx + 1 }, { "print-object", "no" } });
+                    Part* part = m_score->parts().at(partNr);
+                    Staff* staff = part->staff(staffIdx);
+                    m_xml.tag("staff-lines", staff->lines(m->tick()));
+                    m_xml.endElement();
                 }
             }
 


### PR DESCRIPTION
Resolves: #17398 

In addition to #25960 this now adds a `<staff-details print-object="no" />` to every new system if the actual staff is hidden. 
