### PR TITLE
Added RehearsalMark to midi export as Markers

### DIFF
--- a/src/importexport/midi/internal/midiexport/exportmidi.cpp
+++ b/src/importexport/midi/internal/midiexport/exportmidi.cpp
@@ -24,6 +24,7 @@
 
 #include "engraving/dom/key.h"
 #include "engraving/dom/lyrics.h"
+#include "engraving/dom/rehearsalmark.h"
 #include "engraving/dom/masterscore.h"
 #include "engraving/dom/note.h"
 #include "engraving/dom/part.h"
@@ -400,6 +401,35 @@ bool ExportMidi::write(QIODevice* device, bool midiExpandRepeats, bool exportRPN
                             track.insert(CompatMidiRender::tick(context, tick), ev);
                         }
                     }
+                }
+            }
+        }
+        
+        // Export RehearsalMarks as Markers
+        for (const RepeatSegment *rs : m_score->repeatList()) {
+            int startTick = rs->tick;
+            int endTick = startTick + rs->len();
+            int tickOffset = rs->utick - rs->tick;
+
+            for (Segment* seg = rs->firstMeasure()->first(); seg && seg->tick().ticks() < endTick; seg = seg->next1()) {
+                for (EngravingItem* e : seg->annotations()) {
+                    if (e->type() == ElementType::REHEARSAL_MARK) {
+                        RehearsalMark* r = toRehearsalMark(e);
+                        muse::ByteArray rText = r->plainText().toUtf8();
+                        size_t len = rText.size() + 1;
+                        unsigned char *data = new unsigned char[len];
+
+                        memcpy(data, rText.constData(), len);
+
+                        MidiEvent ev;
+                        ev.setType(ME_META);
+                        ev.setMetaType(META_MARKER);
+                        ev.setEData(data);
+                        ev.setLen(static_cast<int>(len));
+
+                        int tick = r->segment()->tick().ticks() + tickOffset;
+                        track.insert(CompatMidiRender::tick(context, tick), ev);
+                    }                        
                 }
             }
         }


### PR DESCRIPTION
Resolves: [Add Marker meta events to MIDI export](https://musescore.org/en/node/298601) and [Exporting Rehearsal Markers to MIDI files](https://musescore.org/en/node/363262)
<!-- Add a short description of and motivation for the changes here -->
I want to export Rehearsal Marks to Midi Markers.
I export my sheetmusic as midi into a DAW, where Midi meta events such as Markers are supported.
Usually the sheetmusic contains Rehearsal Marks and I want the same structure to appear in my DAW.
![image](https://github.com/user-attachments/assets/97aa4ee6-c580-4c19-9860-efdc539cdd44)

This PR only adds export functionality. Import of Midi Markers to Rehearsal Marks is still missing.

I did not unit test the implementation but it works for the few examples I have on my machine.
I was also able to check it with python:
```
from miditoolkit import MidiFile
midFile = r"path\to\midi.mid"
midi_obj = MidiFile(midFile)
```
```
print(midi_obj)
```
```
ticks per beat: 480
max tick: 226561
tempo changes: 1
time sig: 1
key sig: 13
markers: 182
lyrics: True
instruments: 13
```
```
print(midi_obj.markers)
```
```
[Marker(text="A", time=7680), Marker(text="B", time=53760), ...
```

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
