### PR TITLE
Remove `DEFAULT_DEVICE_ID` from `OSXAudioDriver`

### DIFF
--- a/src/framework/audio/internal/platform/osx/osxaudiodriver.mm
+++ b/src/framework/audio/internal/platform/osx/osxaudiodriver.mm
@@ -33,7 +33,6 @@ typedef AudioDeviceID OSXAudioDeviceID;
 
 using namespace muse;
 using namespace muse::audio;
-static constexpr char DEFAULT_DEVICE_ID[] = "Systems default";
 
 struct OSXAudioDriver::Data {
     Spec format;


### PR DESCRIPTION
Looks like this was forgotten in a35362f6ca02faba7e3afbc65a527fe8282ae8e2 (slipped past me while reviewing).