### PR TITLE
fix: gtp import steel guitar

### DIFF
--- a/src/importexport/guitarpro/internal/importgtp.cpp
+++ b/src/importexport/guitarpro/internal/importgtp.cpp
@@ -2847,9 +2847,10 @@ static void createLinkedTabs(MasterScore* score)
                 StaffTypes::TAB_7SIMPLE,
                 StaffTypes::TAB_8SIMPLE,
                 StaffTypes::TAB_9SIMPLE,
+                StaffTypes::TAB_10SIMPLE,
             };
 
-            size_t index = (lines >= 4 && lines <= 9) ? lines - 4 : 2;
+            size_t index = (lines >= 4 && lines <= 10) ? lines - 4 : 2;
 
             dstStaff->setStaffType(fr, *StaffType::preset(types.at(index)));
             dstStaff->setLines(fr, static_cast<int>(lines));


### PR DESCRIPTION
steel guitar uses 10 strings, but during import we've set 6 strings tab