### PR TITLE
Fix MSVC compiler warnings

### DIFF
--- a/src/engraving/tests/timesig_tests.cpp
+++ b/src/engraving/tests/timesig_tests.cpp
@@ -313,8 +313,8 @@ TEST_F(Engraving_TimesigTests, timesig_11)
     EXPECT_TRUE(score);
     score->doLayout();
 
-    TimeSig* timeSig = Factory::createTimeSig(score->dummy()->segment());
-    timeSig->setSig(Fraction(5, 4));
+    TimeSig* timeSig1 = Factory::createTimeSig(score->dummy()->segment());
+    timeSig1->setSig(Fraction(5, 4));
 
     TimeSig* timeSig2 = Factory::createTimeSig(score->dummy()->segment());
     timeSig2->setSig(Fraction(7, 8));
@@ -329,7 +329,7 @@ TEST_F(Engraving_TimesigTests, timesig_11)
 
     // Add local timeSig to Clarinet staff at meas 3
     score->startCmd(TranslatableString::untranslatable("Engraving time signature tests"));
-    score->cmdAddTimeSig(thirdMeas, clarinetStaff, timeSig, true);
+    score->cmdAddTimeSig(thirdMeas, clarinetStaff, timeSig1, true);
     score->endCmd();
     // Check timeSig exist at meas 3 and is only on Clarinet
     Segment* timeSigSegment = thirdMeas->findSegmentR(SegmentType::TimeSig, Fraction(0, 1));

--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -521,7 +521,7 @@ void GPConverter::convertVoices(const std::vector<std::unique_ptr<GPVoice> >& vo
         fillUncompletedMeasure(ctx);
     }
 
-    int currentTrackFirstVoice = ctx.curTrack;
+    track_idx_t currentTrackFirstVoice = ctx.curTrack;
     for (const auto& voice : voices) {
         ctx.curTrack = currentTrackFirstVoice + voice->position();
         convertVoice(voice.get(), ctx);


### PR DESCRIPTION
* reg.: conversion from 'size_t' to 'int', possible loss of data (C4267)
* reg.: declaration of 'timeSig' hides previous local declaration (C4456)