### PR TITLE
Fix crash when reading slur on trill cue note

### DIFF
--- a/src/engraving/rw/read410/connectorinforeader.cpp
+++ b/src/engraving/rw/read410/connectorinforeader.cpp
@@ -131,6 +131,11 @@ void ConnectorInfoReader::readEndpointLocation(Location& l)
     }
 }
 
+Fraction ConnectorInfoReader::curTick() const
+{
+    return m_ctx->tick();
+}
+
 //---------------------------------------------------------
 //   ConnectorInfoReader::update
 //---------------------------------------------------------
@@ -257,7 +262,9 @@ void ConnectorInfoReader::readAddConnector(ChordRest* item, ConnectorInfoReader*
 
         if (info->isStart()) {
             spanner->setTrack(l.track());
-            spanner->setTick(item->tick());
+            // trillCueNotes have unreliable tick() while reading so use instead tick from readContext
+            Fraction startTick = item->isChord() && toChord(item)->isTrillCueNote() ? info->curTick() : item->tick();
+            spanner->setTick(startTick);
             spanner->setStartElement(item);
             if (pasteMode) {
                 item->score()->undoAddElement(spanner);

--- a/src/engraving/rw/read410/connectorinforeader.h
+++ b/src/engraving/rw/read410/connectorinforeader.h
@@ -67,6 +67,7 @@ public:
 
 private:
     void readEndpointLocation(Location& l);
+    Fraction curTick() const;
 
     XmlReader* m_reader = nullptr;
     ReadContext* m_ctx = nullptr;

--- a/src/engraving/rw/read410/tread.cpp
+++ b/src/engraving/rw/read410/tread.cpp
@@ -2084,6 +2084,7 @@ bool TRead::readProperties(Ornament* o, XmlReader& xml, ReadContext& ctx)
         Chord* chord = Factory::createChord(ctx.score()->dummy()->segment());
         TRead::read(chord, xml, ctx);
         chord->setTrack(ctx.track());
+        chord->setIsTrillCueNote(true);
         o->setCueNoteChord(chord);
         o->setNoteAbove(chord->notes().front());
     } else {


### PR DESCRIPTION
Resolves: #25003

This is, once again, a result of the [insane way we read/write spanners to our files](https://github.com/musescore/MuseScore/issues/23688#:~:text=Score/part%20links-,Spanners,else%20had%20already%20stored%20references%20to%20them%2C%20which%20then%20become%20invalidated.,-Score/parts). 

The trill cue note has unreliable `tick` while reading (which can't be fixed with the current spanner read/write system). This was causing the slur starting on the cue note to be read with a wrong starting tick (specifically `Fraction(0, 1)`) which was causing it to be laid out before the cue note itself and hence the crash. The only thing we can do at this moment is to get the tick from a different source.
