### PR TITLE
Fix #17549: Prevent MIDI KeyUp-event from executing mapped command

### DIFF
--- a/src/framework/shortcuts/internal/midiremote.cpp
+++ b/src/framework/shortcuts/internal/midiremote.cpp
@@ -218,7 +218,9 @@ bool MidiRemote::needIgnoreEvent(const Event& event) const
         Event::Opcode::NoteOff
     };
 
-    bool release = releaseOps.contains(event.opcode());
+    bool release = releaseOps.contains(event.opcode())
+                   || (event.opcode() == Event::Opcode::ControlChange && event.data() == 0);
+
     if (release) {
         bool advanceToNextNoteOnKeyRelease = configuration()->advanceToNextNoteOnKeyRelease();
         if (!advanceToNextNoteOnKeyRelease) {


### PR DESCRIPTION
Resolves: #17549 

When mapping a command to a MIDI button, the command is executed both for press and release. This PR fixes the issue by checking the velocity of the button press.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
