### PR TITLE
Fix freeze on specific file

### DIFF
--- a/src/engraving/dom/engravingitem.cpp
+++ b/src/engraving/dom/engravingitem.cpp
@@ -2658,7 +2658,8 @@ void EngravingItem::LayoutData::setBbox(const RectF& r)
 
 void EngravingItem::LayoutData::connectItemSnappedBefore(EngravingItem* itemBefore)
 {
-    IF_ASSERT_FAILED(itemBefore && itemBefore != m_item && itemBefore != m_itemSnappedAfter) {
+    IF_ASSERT_FAILED(itemBefore && itemBefore != m_item && itemBefore != m_itemSnappedAfter
+                     && itemBefore->ldata()->itemSnappedBefore() != m_item) {
         return;
     }
     m_itemSnappedBefore = itemBefore;
@@ -2676,7 +2677,8 @@ void EngravingItem::LayoutData::disconnectItemSnappedBefore()
 
 void EngravingItem::LayoutData::connectItemSnappedAfter(EngravingItem* itemAfter)
 {
-    IF_ASSERT_FAILED(itemAfter && itemAfter != m_item && itemAfter != m_itemSnappedBefore) {
+    IF_ASSERT_FAILED(itemAfter && itemAfter != m_item && itemAfter != m_itemSnappedBefore
+                     && itemAfter->ldata()->itemSnappedAfter() != m_item) {
         return;
     }
     m_itemSnappedAfter = itemAfter;

--- a/src/engraving/rendering/score/tlayout.cpp
+++ b/src/engraving/rendering/score/tlayout.cpp
@@ -3138,7 +3138,8 @@ void TLayout::manageHairpinSnapping(HairpinSegment* item, LayoutContext& ctx)
 
     bool doSnapBefore = possibleSnapBeforeElement && item->hairpin()->snapToItemBefore();
     if (doSnapBefore && possibleSnapBeforeElement->isHairpinSegment()) {
-        doSnapBefore = doSnapBefore && toHairpinSegment(possibleSnapBeforeElement)->hairpin()->snapToItemAfter();
+        doSnapBefore = doSnapBefore && toHairpinSegment(possibleSnapBeforeElement)->hairpin()->snapToItemAfter()
+                       && possibleSnapBeforeElement->ldata()->itemSnappedBefore() != item;
     }
 
     if (doSnapBefore) {
@@ -3147,7 +3148,8 @@ void TLayout::manageHairpinSnapping(HairpinSegment* item, LayoutContext& ctx)
 
     bool doSnapAfter = possibleSnapAfterElement && item->hairpin()->snapToItemAfter();
     if (doSnapAfter && possibleSnapAfterElement->isHairpinSegment()) {
-        doSnapAfter = doSnapAfter && toHairpinSegment(possibleSnapAfterElement)->hairpin()->snapToItemBefore();
+        doSnapAfter = doSnapAfter && toHairpinSegment(possibleSnapAfterElement)->hairpin()->snapToItemBefore()
+                      && possibleSnapAfterElement->ldata()->itemSnappedAfter() != item;
     }
 
     if (doSnapAfter) {


### PR DESCRIPTION
Resolves: #25774

The freeze was due to an infinite loop in a snapping chain of hairpins. This is an edge case that wasn't detected neither during layout nor at the assertion check. Now it's included in both.
