### PR TITLE
Added ability to change context menu icon color

### DIFF
--- a/src/framework/ui/uiaction.h
+++ b/src/framework/ui/uiaction.h
@@ -54,6 +54,7 @@ struct UiAction
     MnemonicString title;
     TranslatableString description;
     IconCode::Code iconCode = IconCode::Code::NONE;
+    QString iconColor;
     Checkable checkable = Checkable::No;
     std::vector<std::string> shortcuts;
 
@@ -73,6 +74,10 @@ struct UiAction
              const TranslatableString& desc, IconCode::Code icon, Checkable ch = Checkable::No)
         : code(code), uiCtx(ctx), scCtx(scCtx), title(title), description(desc), iconCode(icon), checkable(ch) {}
 
+    UiAction(const actions::ActionCode& code, UiContext ctx, std::string scCtx, const MnemonicString& title,
+             const TranslatableString& desc, IconCode::Code icon, QString iconColor, Checkable ch = Checkable::No)
+        : code(code), uiCtx(ctx), scCtx(scCtx), title(title), description(desc), iconCode(icon), iconColor(iconColor), checkable(ch) {}
+
     UiAction(const actions::ActionCode& code, UiContext ctx, std::string scCtx, const MnemonicString& title, IconCode::Code icon,
              Checkable ch = Checkable::No)
         : code(code), uiCtx(ctx), scCtx(scCtx), title(title), iconCode(icon), checkable(ch) {}
@@ -90,6 +95,7 @@ struct UiAction
                && title == other.title
                && description == other.description
                && iconCode == other.iconCode
+               && iconColor == other.iconColor
                && checkable == other.checkable
                && shortcuts == other.shortcuts;
     }

--- a/src/framework/uicomponents/qml/Muse/UiComponents/internal/StyledMenuItem.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/internal/StyledMenuItem.qml
@@ -202,6 +202,7 @@ ListItemBlank {
             id: secondaryIconLabel
             Layout.alignment: Qt.AlignLeft
             Layout.preferredWidth: 16
+            color: root.modelData.iconColor ? root.modelData.iconColor : ui.theme.fontPrimaryColor
             iconCode: root.modelData?.icon ?? IconCode.NONE
             visible: root.iconAndCheckMarkMode === StyledMenuItem.ShowBoth
         }

--- a/src/framework/uicomponents/view/menuitem.cpp
+++ b/src/framework/uicomponents/view/menuitem.cpp
@@ -221,6 +221,11 @@ int MenuItem::icon_property() const
     return static_cast<int>(m_action.iconCode);
 }
 
+QString MenuItem::iconColor_property() const
+{
+    return m_action.iconColor;
+}
+
 bool MenuItem::enabled_property() const
 {
     return m_state.enabled;

--- a/src/framework/uicomponents/view/menuitem.h
+++ b/src/framework/uicomponents/view/menuitem.h
@@ -57,6 +57,7 @@ class MenuItem : public QObject, public async::Asyncable
     Q_PROPERTY(QString section READ section NOTIFY sectionChanged)
 
     Q_PROPERTY(int icon READ icon_property NOTIFY actionChanged)
+    Q_PROPERTY(QString iconColor READ iconColor_property NOTIFY actionChanged)
 
     Q_PROPERTY(bool enabled READ enabled_property NOTIFY stateChanged)
 
@@ -124,6 +125,7 @@ private:
     QString description_property() const;
 
     int icon_property() const;
+    QString iconColor_property() const;
 
     bool enabled_property() const;
 


### PR DESCRIPTION
Adds possibility to change context menu icon color like this:
<img width="542" alt="screenshot" src="https://github.com/user-attachments/assets/6ffa649d-cd60-4fb8-9dda-668cb8821b24" />

Used QString instead of QColor as the latter loses "invalid" property once converted to color property in QML - QML then treats it as a perfectly valid black color. 
That way, in case of not providing a custom color, icon will stay as it was assuming fontPrimaryColor.

QA note:
Result should not impact MuseScore's context menu icons (or top bar menu)