### PR TITLE
Fix #25145: Crash relating to `StaffTypeChange`

### DIFF
--- a/src/engraving/dom/measure.cpp
+++ b/src/engraving/dom/measure.cpp
@@ -1395,6 +1395,9 @@ bool Measure::acceptDrop(EditData& data) const
             viewer->setDropRectangle(canvasBoundingRect());
             return true;
         case ActionIconType::STAFF_TYPE_CHANGE:
+            if (!canAddStaffTypeChange(staffIdx)) {
+                return false;
+            }
             viewer->setDropRectangle(staffRect);
             return true;
         case ActionIconType::SYSTEM_LOCK:
@@ -1736,6 +1739,9 @@ EngravingItem* Measure::drop(EditData& data)
             score()->insertMeasure(ElementType::MEASURE, this);
             break;
         case ActionIconType::STAFF_TYPE_CHANGE: {
+            if (!canAddStaffTypeChange(staffIdx)) {
+                return nullptr;
+            }
             EngravingItem* stc = Factory::createStaffTypeChange(this);
             stc->setParent(this);
             stc->setTrack(staffIdx * VOICES);
@@ -3473,6 +3479,21 @@ bool Measure::canAddStringTunings(staff_idx_t staffIdx) const
     }
 
     return !alreadyHasStringTunings;
+}
+
+bool Measure::canAddStaffTypeChange(staff_idx_t staffIdx) const
+{
+    for (const EngravingObject* child : el()) {
+        if (!child || !child->isStaffTypeChange()) {
+            continue;
+        }
+        const StaffTypeChange* stc = toStaffTypeChange(child);
+        if (stc->staffIdx() == staffIdx) {
+            // Staff already has a StaffTypeChange at this measure...
+            return false;
+        }
+    }
+    return true;
 }
 
 Fraction Measure::maxTicks() const

--- a/src/engraving/dom/measure.h
+++ b/src/engraving/dom/measure.h
@@ -355,6 +355,7 @@ public:
     void respaceSegments();
 
     bool canAddStringTunings(staff_idx_t staffIdx) const;
+    bool canAddStaffTypeChange(staff_idx_t staffIdx) const;
 
 private:
 

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -2516,9 +2516,13 @@ bool NotationInteraction::dragMeasureAnchorElement(const PointF& pos)
         RectF measureRect = targetMeasure->staffPageBoundingRect(staffIdx);
         measureRect.adjust(page->x(), page->y(), page->x(), page->y());
         m_dropData.ed.pos = measureRect.center();
-        setAnchorLines({ LineF(pos, measureRect.topLeft()) });
 
-        return targetMeasure->acceptDrop(m_dropData.ed);
+        const bool dropAccepted = targetMeasure->acceptDrop(m_dropData.ed);
+        if (dropAccepted) {
+            setAnchorLines({ LineF(pos, measureRect.topLeft()) });
+        }
+
+        return dropAccepted;
     }
     dropElem->score()->addRefresh(dropElem->canvasBoundingRect());
     setDropTarget(nullptr);


### PR DESCRIPTION
Resolves (partially): #25145

This is a preventative fix - with these changes it is no longer possible to apply multiple `StaffTypeChanges` to the same measure (see video for updated behaviour). This PR initially included some logic for handling corrupted `StaffTypeChanges` in existing scores (https://github.com/musescore/MuseScore/commit/ae0627c12516ca28934a83bede8153afe4e9bf06) but this ended up causing another type of corruption that is arguably more severe than the crash.

https://github.com/user-attachments/assets/5f0cd5a3-be2a-4816-b03f-4ecf879f8eb0
