### PR TITLE
Keyboard Does Not Show Selected Note When First Opened #26274

### DIFF
--- a/src/notation/view/pianokeyboard/pianokeyboardcontroller.cpp
+++ b/src/notation/view/pianokeyboard/pianokeyboardcontroller.cpp
@@ -119,7 +119,6 @@ void PianoKeyboardController::onNotationChanged()
             updateNotesKeys(notes);
         }
 
-
         notation->midiInput()->notesReceived().onReceive(this, [this](const std::vector<const Note*>& notes) {
             m_isFromMidi = true;
             updateNotesKeys(notes);

--- a/src/notation/view/pianokeyboard/pianokeyboardcontroller.cpp
+++ b/src/notation/view/pianokeyboard/pianokeyboardcontroller.cpp
@@ -90,30 +90,40 @@ void PianoKeyboardController::setPressedKey(std::optional<piano_key_t> key)
 void PianoKeyboardController::onNotationChanged()
 {
     if (auto notation = currentNotation()) {
-        notation->interaction()->selectionChanged().onNotify(this, [this]() {
-            auto notation = currentNotation();
-            if (!notation) {
-                return;
-            }
+    notation->interaction()->selectionChanged().onNotify(this, [this]() {
+        auto notation = currentNotation();
+        if (!notation) {
+            return;
+        }
 
-            auto selection = notation->interaction()->selection();
-            if (selection->isNone()) {
-                return;
-            }
+        auto selection = notation->interaction()->selection();
+        if (selection->isNone()) {
+            return;
+        }
 
-            std::vector<const Note*> notes;
-            for (const mu::engraving::Note* note : selection->notes()) {
-                notes.push_back(note);
-            }
+        std::vector<const Note*> notes;
+        for (const mu::engraving::Note* note : selection->notes()) {
+            notes.push_back(note);
+        }
 
-            m_isFromMidi = false;
-            updateNotesKeys(notes);
-        });
+        m_isFromMidi = false;
+        updateNotesKeys(notes);
+    });
 
-        notation->midiInput()->notesReceived().onReceive(this, [this](const std::vector<const Note*>& notes) {
-            m_isFromMidi = true;
-            updateNotesKeys(notes);
-        });
+    auto selection = notation->interaction()->selection();
+    if (!selection->isNone()) {
+        std::vector<const Note*> notes;
+        for (const mu::engraving::Note* note : selection->notes()) {
+            notes.push_back(note);
+        }
+        updateNotesKeys(notes);
+    }
+
+
+    notation->midiInput()->notesReceived().onReceive(this, [this](const std::vector<const Note*>& notes) {
+        m_isFromMidi = true;
+        updateNotesKeys(notes);
+    });
     }
 }
 

--- a/src/notation/view/pianokeyboard/pianokeyboardcontroller.cpp
+++ b/src/notation/view/pianokeyboard/pianokeyboardcontroller.cpp
@@ -90,40 +90,40 @@ void PianoKeyboardController::setPressedKey(std::optional<piano_key_t> key)
 void PianoKeyboardController::onNotationChanged()
 {
     if (auto notation = currentNotation()) {
-    notation->interaction()->selectionChanged().onNotify(this, [this]() {
-        auto notation = currentNotation();
-        if (!notation) {
-            return;
-        }
+        notation->interaction()->selectionChanged().onNotify(this, [this]() {
+            auto notation = currentNotation();
+            if (!notation) {
+                return;
+            }
+
+            auto selection = notation->interaction()->selection();
+            if (selection->isNone()) {
+                return;
+            }
+
+            std::vector<const Note*> notes;
+            for (const mu::engraving::Note* note : selection->notes()) {
+                notes.push_back(note);
+            }
+
+            m_isFromMidi = false;
+            updateNotesKeys(notes);
+        });
 
         auto selection = notation->interaction()->selection();
-        if (selection->isNone()) {
-            return;
+        if (!selection->isNone()) {
+            std::vector<const Note*> notes;
+            for (const mu::engraving::Note* note : selection->notes()) {
+                notes.push_back(note);
+            }
+            updateNotesKeys(notes);
         }
 
-        std::vector<const Note*> notes;
-        for (const mu::engraving::Note* note : selection->notes()) {
-            notes.push_back(note);
-        }
 
-        m_isFromMidi = false;
-        updateNotesKeys(notes);
-    });
-
-    auto selection = notation->interaction()->selection();
-    if (!selection->isNone()) {
-        std::vector<const Note*> notes;
-        for (const mu::engraving::Note* note : selection->notes()) {
-            notes.push_back(note);
-        }
-        updateNotesKeys(notes);
-    }
-
-
-    notation->midiInput()->notesReceived().onReceive(this, [this](const std::vector<const Note*>& notes) {
-        m_isFromMidi = true;
-        updateNotesKeys(notes);
-    });
+        notation->midiInput()->notesReceived().onReceive(this, [this](const std::vector<const Note*>& notes) {
+            m_isFromMidi = true;
+            updateNotesKeys(notes);
+        });
     }
 }
 


### PR DESCRIPTION
Resolves: #26274 

Fixed an issue where the corresponding piano key was not highlighted when a note in the score was selected before opening the piano keyboard. The fix ensures that the selected note is correctly highlighted when the piano keyboard is displayed.


https://github.com/user-attachments/assets/dc116e92-eef9-4906-af98-b76c71709b8b


- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
