### PR TITLE
Fix #25647: Bug when switching back and forth to unpitched percussion sound

### DIFF
--- a/src/playback/internal/playbackcontroller.h
+++ b/src/playback/internal/playbackcontroller.h
@@ -145,6 +145,9 @@ private:
     void onAudioResourceChanged(const mu::engraving::InstrumentTrackId& trackId, const muse::audio::AudioResourceMeta& oldMeta,
                                 const muse::audio::AudioResourceMeta& newMeta);
 
+    bool shouldLoadDrumset(const engraving::InstrumentTrackId& trackId, const muse::audio::AudioResourceMeta& oldMeta,
+                           const muse::audio::AudioResourceMeta& newMeta) const;
+
     void addSoundFlagsIfNeed(const std::vector<engraving::EngravingItem*>& selection);
 
     void togglePlay();


### PR DESCRIPTION
Resolves: #25647

As highlighted [here](https://github.com/musescore/MuseScore/issues/25647#issuecomment-2511491759) by @zacjansheski, we shouldn't try to load `Drumsets` on tonal instruments when choosing an unpitched percussion sound in the mixer.