### PR TITLE
Calculate correct stem direction when beam is deleted

### DIFF
--- a/src/engraving/rendering/score/chordlayout.cpp
+++ b/src/engraving/rendering/score/chordlayout.cpp
@@ -1360,6 +1360,9 @@ void ChordLayout::computeUp(const Chord* item, Chord::LayoutData* ldata, const L
 
     assert(!item->notes().empty());
 
+    // Beams with one chord will be removed later, ignore
+    const bool hasBeam = item->beam() && item->beam()->elements().size() > 1;
+
     const StaffType* tab = item->staff() ? item->staff()->staffTypeForElement(item) : 0;
     bool isTabStaff = tab && tab->isTabStaff();
     if (isTabStaff) {
@@ -1380,7 +1383,7 @@ void ChordLayout::computeUp(const Chord* item, Chord::LayoutData* ldata, const L
     }
 
     if (item->stemDirection() != DirectionV::AUTO
-        && !item->beam()
+        && !hasBeam
         && !item->tremoloTwoChord()) {
         ldata->up = item->stemDirection() == DirectionV::UP;
         return;
@@ -1391,7 +1394,7 @@ void ChordLayout::computeUp(const Chord* item, Chord::LayoutData* ldata, const L
         return;
     }
 
-    if (item->beam()) {
+    if (hasBeam) {
         computeUpBeamCase(const_cast<Chord*>(item), item->beam(), ctx);
         return;
     } else if (item->tremoloTwoChord()) {
@@ -1430,7 +1433,9 @@ void ChordLayout::computeUp(ChordRest* item, const LayoutContext& ctx)
         computeUp(ch, ch->mutldata(), ctx);
     } else {
         // base ChordRest
-        if (item->beam()) {
+        // Beams with one chord will be removed later, ignore
+        const bool hasBeam = item->beam() && item->beam()->elements().size() > 1;
+        if (hasBeam) {
             item->mutldata()->up = item->beam()->up();
         } else {
             item->mutldata()->up = true;

--- a/src/engraving/tests/beam_data/deleteBeamStemDirection.mscx
+++ b/src/engraving/tests/beam_data/deleteBeamStemDirection.mscx
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="4.50">
+  <programVersion>4.5.0</programVersion>
+  <programRevision></programRevision>
+  <Score>
+    <Division>480</Division>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <open>1</open>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer">Composer / arranger</metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="creationDate">2025-01-31</metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="platform">Apple Macintosh</metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="subtitle">Subtitle</metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle">Untitled score</metaTag>
+    <Order id="orchestra">
+      <name>Orchestra</name>
+      <instrument id="flute">
+        <family id="flutes">Flutes</family>
+        </instrument>
+      <section id="woodwind" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>flutes</family>
+        <family>oboes</family>
+        <family>clarinets</family>
+        <family>saxophones</family>
+        <family>bassoons</family>
+        <unsorted group="woodwinds"/>
+        </section>
+      <section id="brass" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>horns</family>
+        <family>trumpets</family>
+        <family>cornets</family>
+        <family>flugelhorns</family>
+        <family>trombones</family>
+        <family>tubas</family>
+        <unsorted group="brass"/>
+        </section>
+      <section id="timpani" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>timpani</family>
+        </section>
+      <section id="percussion" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>keyboard-percussion</family>
+        <unsorted group="pitched-percussion"/>
+        <family>drums</family>
+        <family>unpitched-metal-percussion</family>
+        <family>unpitched-wooden-percussion</family>
+        <family>other-percussion</family>
+        <unsorted group="unpitched-percussion"/>
+        </section>
+      <family>keyboards</family>
+      <family>harps</family>
+      <family>organs</family>
+      <family>synths</family>
+      <unsorted/>
+      <soloists/>
+      <section id="voices" brackets="true" barLineSpan="false" thinBrackets="true">
+        <family>voices</family>
+        <family>voice-groups</family>
+        </section>
+      <section id="strings" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>orchestral-strings</family>
+        </section>
+      </Order>
+    <Part id="1">
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        </Staff>
+      <trackName>Flute</trackName>
+      <Instrument id="flute">
+        <longName>Flute</longName>
+        <shortName>Fl.</shortName>
+        <trackName>Flute</trackName>
+        <minPitchP>59</minPitchP>
+        <maxPitchP>98</maxPitchP>
+        <minPitchA>60</minPitchA>
+        <maxPitchA>93</maxPitchA>
+        <instrumentId>wind.flutes.flute</instrumentId>
+        <Channel>
+          <program value="73"/>
+          <synti>Fluid</synti>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <Measure>
+        <voice>
+          <KeySig>
+            <concertKey>0</concertKey>
+            </KeySig>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Chord>
+            <durationType>eighth</durationType>
+            <Note>
+              <pitch>74</pitch>
+              <tpc>16</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>eighth</durationType>
+            <Note>
+              <pitch>71</pitch>
+              <tpc>19</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>eighth</durationType>
+            <Note>
+              <pitch>69</pitch>
+              <tpc>17</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>eighth</durationType>
+            <Note>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          <Rest>
+            <durationType>half</durationType>
+            </Rest>
+          </voice>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/src/engraving/tests/beam_tests.cpp
+++ b/src/engraving/tests/beam_tests.cpp
@@ -263,3 +263,45 @@ TEST_F(Engraving_BeamTests, flipTremoloStemDir)
 
     delete score;
 }
+
+TEST_F(Engraving_BeamTests, deleteBeamStemDirection)
+{
+    MasterScore* score = ScoreRW::readScore(BEAM_DATA_DIR + "deleteBeamStemDirection.mscx");
+    EXPECT_TRUE(score);
+
+    Measure* m1 = score->firstMeasure();
+    ChordRest* cr1 = toChordRest(m1->findSegment(SegmentType::ChordRest, Fraction(0, 8))->element(0));
+    EXPECT_TRUE(cr1);
+    ChordRest* cr2 = toChordRest(m1->findSegment(SegmentType::ChordRest, Fraction(1, 8))->element(0));
+    EXPECT_TRUE(cr2);
+    ChordRest* cr3 = toChordRest(m1->findSegment(SegmentType::ChordRest, Fraction(2, 8))->element(0));
+    EXPECT_TRUE(cr3);
+    ChordRest* cr4 = toChordRest(m1->findSegment(SegmentType::ChordRest, Fraction(3, 8))->element(0));
+    EXPECT_TRUE(cr4);
+
+    for (ChordRest* cr : { cr1, cr2, cr3, cr4 }) {
+        EXPECT_TRUE(cr->ldata()->up);
+    }
+
+    score->startCmd(TranslatableString::untranslatable("Engraving beam tests"));
+    score->select({ cr2, cr3, cr4 }, SelectType::RANGE);
+    score->cmdDeleteSelection();
+    score->endCmd();
+    score->setLayoutAll();
+    score->doLayout();
+
+    EXPECT_FALSE(cr1->ldata()->up);
+
+    score->undoRedo(true, nullptr);
+
+    toChord(cr1)->setStemDirection(DirectionV::UP);
+
+    score->startCmd(TranslatableString::untranslatable("Engraving beam tests"));
+    score->select({ cr2, cr3, cr4 }, SelectType::RANGE);
+    score->cmdDeleteSelection();
+    score->endCmd();
+    score->setLayoutAll();
+    score->doLayout();
+
+    EXPECT_TRUE(cr1->ldata()->up);
+}


### PR DESCRIPTION
Resolves: #25313 

Beams which only have one element are deleted later in layout than direction is calculated. This was causing the stale beam's direction to be used when calculating the remaining chord's direction.