### PR TITLE
Fix #15726 (Marks & Jumps): Some elements are lost when changing time signature

### DIFF
--- a/src/engraving/dom/range.h
+++ b/src/engraving/dom/range.h
@@ -40,6 +40,8 @@ class Spanner;
 class ScoreRange;
 class ChordRest;
 class Score;
+class Marker;
+class Jump;
 
 //---------------------------------------------------------
 //   TrackList
@@ -110,9 +112,20 @@ protected:
 
 private:
 
+    bool endOfMeasure(EngravingItem* e) const;
+    void backupJumpsAndMarkers(Segment* first, Segment* last);
+    void restoreJumpsAndMarkers(Score* score, const Fraction& tick) const;
+    void deleteJumpsAndMarkers();
     friend class TrackList;
 
+    struct JumpsMarkersBackup
+    {
+        Fraction sPosition;
+        EngravingItem* e = nullptr;
+    };
+
     std::list<TrackList*> m_tracks;
+    std::list<JumpsMarkersBackup> m_jumpsMarkers;
     Segment* m_first = nullptr;
     Segment* m_last = nullptr;
 };


### PR DESCRIPTION
Resolves: #15726 (Jumps & Marks) <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
This PR keeps as much Marks and Jumps as possible when changing time signature

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
