### PR TITLE
Fix MSVC Compiler warnings

### DIFF
--- a/src/engraving/playback/playbackmodel.cpp
+++ b/src/engraving/playback/playbackmodel.cpp
@@ -951,9 +951,9 @@ PlaybackContextPtr PlaybackModel::playbackCtx(const InstrumentTrackId& trackId)
 void PlaybackModel::applyTiedNotesTickBoundaries(const Note* note, TickBoundaries& tickBoundaries)
 {
     const Tie* tie;
-    if (tie = note->tieFor()) {
+    if ((tie = note->tieFor())) {
         applyTieTickBoundaries(tie, tickBoundaries);
-    } else if (tie = note->tieBack()) {
+    } else if ((tie = note->tieBack())) {
         applyTieTickBoundaries(tie, tickBoundaries);
     }
 }


### PR DESCRIPTION
silence `-Wparentheses` warning