### PR TITLE
Added support for custom time signature appearance

### DIFF
--- a/src/palette/view/widgets/noteGroups.cpp
+++ b/src/palette/view/widgets/noteGroups.cpp
@@ -52,6 +52,8 @@ Score* NoteGroups::createScore(int n, DurationType t, std::vector<Chord*>* chord
     if (!_n.isEmpty()) {
         nts->setDenominatorString(_n);
     }
+    // Just to display complete and cut time correctly
+    nts->setProperty(mu::engraving::Pid::TIMESIG_TYPE, static_cast<int>(_tst));
     GroupNode node { 0, 0 };
     Groups ng;
     ng.addNode(node);
@@ -109,12 +111,13 @@ NoteGroups::NoteGroups(QWidget* parent)
     connect(view32, &NoteGroupsExampleView::beamPropertyDropped, this, &NoteGroups::beamPropertyDropped);
 }
 
-void NoteGroups::setSig(Fraction sig, const Groups& g, const QString& z, const QString& n)
+void NoteGroups::setSig(Fraction sig, const Groups& g, const QString& z, const QString& n, TimeSigType tst)
 {
     _sig    = sig;
     _z      = z;
     _n      = n;
     _groups = g;
+    _tst    = tst;
     chords8.clear();
     chords16.clear();
     chords32.clear();
@@ -144,7 +147,7 @@ Groups NoteGroups::groups()
 
 void NoteGroups::resetClicked()
 {
-    setSig(_sig, _groups, _z, _n);
+    setSig(_sig, _groups, _z, _n, _tst);
 }
 
 void NoteGroups::noteClicked(Note* note)

--- a/src/palette/view/widgets/noteGroups.h
+++ b/src/palette/view/widgets/noteGroups.h
@@ -26,6 +26,7 @@
 #include "ui_note_groups.h"
 
 #include "engraving/dom/groups.h"
+#include "engraving/dom/timesig.h"
 
 #include "modularity/ioc.h"
 #include "ipaletteconfiguration.h"
@@ -48,6 +49,7 @@ class NoteGroups : public QGroupBox, Ui::NoteGroups, public muse::Injectable
     engraving::Groups _groups;
     engraving::Fraction _sig;
     QString _z, _n;
+    engraving::TimeSigType _tst;
 
     engraving::Score* createScore(int n, engraving::DurationType t, std::vector<engraving::Chord*>* chords);
     void updateBeams(engraving::Chord*, engraving::BeamMode);
@@ -59,7 +61,7 @@ private slots:
 
 public:
     NoteGroups(QWidget* parent);
-    void setSig(engraving::Fraction sig, const engraving::Groups&, const QString& zText, const QString& nText);
+    void setSig(engraving::Fraction sig, const engraving::Groups&, const QString& zText, const QString& nText, engraving::TimeSigType tst);
     engraving::Groups groups();
 };
 }

--- a/src/palette/view/widgets/timedialog.cpp
+++ b/src/palette/view/widgets/timedialog.cpp
@@ -29,13 +29,17 @@
 #include "palettewidget.h"
 #include "internal/palettecreator.h"
 
+#include "engraving/iengravingfont.h"
 #include "engraving/dom/factory.h"
 #include "engraving/dom/masterscore.h"
 #include "engraving/dom/timesig.h"
 #include "engraving/compat/dummyelement.h"
 
+#include "ui/view/musicalsymbolcodes.h"
+
 using namespace mu::palette;
 using namespace mu::engraving;
+using namespace muse::ui;
 
 TimeDialog::TimeDialog(QWidget* parent)
     : QWidget(parent, Qt::WindowFlags(Qt::Dialog | Qt::Window))
@@ -54,6 +58,44 @@ TimeDialog::TimeDialog(QWidget* parent)
     sp->setReadOnly(false);
     sp->setSelectable(true);
 
+    QString musicalFontFamily = QString::fromStdString(uiConfiguration()->musicalFontFamily());
+    int musicalFontSize = uiConfiguration()->musicalFontSize();
+
+    QString radioButtonStyle = QString("QRadioButton { font-family: %1; font-size: %2px }")
+                               .arg(musicalFontFamily)
+                               .arg(musicalFontSize);
+
+    fourfourButton->setStyleSheet(radioButtonStyle);
+    fourfourButton->setText(musicalSymbolToString(MusicalSymbolCodes::Code::TIMESIG_COMMON));
+    fourfourButton->setMaximumHeight(30);
+    allaBreveButton->setStyleSheet(radioButtonStyle);
+    allaBreveButton->setText(musicalSymbolToString(MusicalSymbolCodes::Code::TIMESIG_CUT));
+    allaBreveButton->setMaximumHeight(30);
+
+    static const SymIdList prolatioList = {
+        SymId::mensuralProlation1,  // tempus perfectum, prol. perfecta
+        SymId::mensuralProlation2,  // tempus perfectum, prol. imperfecta
+        SymId::mensuralProlation3,  // tempus perfectum, prol. imperfecta, dimin.
+        SymId::mensuralProlation4,  // tempus perfectum, prol. perfecta, dimin.
+        SymId::mensuralProlation5,  // tempus imperf. prol. perfecta
+        SymId::mensuralProlation7,  // tempus imperf., prol. imperfecta, reversed
+        SymId::mensuralProlation8,  // tempus imperf., prol. perfecta, dimin.
+        SymId::mensuralProlation10, // tempus imperf., prol imperfecta, dimin., reversed
+        SymId::mensuralProlation11, // tempus inperf., prol. perfecta, reversed
+    };
+
+    IEngravingFontPtr symbolFont = gpaletteScore->engravingFont();
+
+    otherCombo->clear();
+    otherCombo->setStyleSheet(QString("QComboBox { font-family: \"%1 Text\"; font-size: %2px; max-height: 30px } ")
+                              .arg(QString::fromStdString(symbolFont->family())).arg(musicalFontSize));
+
+    for (SymId prolatio : prolatioList) {
+        const QString& str = symbolFont->toString(prolatio);
+        if (str.size() > 0) {
+            otherCombo->addItem(str, int(prolatio));
+        }
+    }
     connect(zNominal, &QSpinBox::editingFinished, this, &TimeDialog::zChanged);
     connect(nNominal, &QComboBox::currentIndexChanged, this, &TimeDialog::nChanged);
     connect(sp, &PaletteWidget::boxClicked, this, &TimeDialog::paletteChanged);
@@ -61,6 +103,11 @@ TimeDialog::TimeDialog(QWidget* parent)
     connect(addButton, &QPushButton::clicked, this, &TimeDialog::addClicked);
     connect(zText, &QLineEdit::textChanged, this, &TimeDialog::textChanged);
     connect(nText, &QLineEdit::textChanged, this, &TimeDialog::textChanged);
+    connect(textButton, &QRadioButton::toggled, this, &TimeDialog::textToggled);
+    connect(fourfourButton, &QRadioButton::toggled, this, &TimeDialog::fourfourToggled);
+    connect(allaBreveButton, &QRadioButton::toggled, this, &TimeDialog::allaBreveToggled);
+    connect(otherButton, &QRadioButton::toggled, this, &TimeDialog::otherToggled);
+    connect(otherCombo, &QComboBox::currentIndexChanged, this, &TimeDialog::otherChanged);
 
     _timePalette = new PaletteScrollArea(sp);
     QSizePolicy policy(QSizePolicy::Expanding, QSizePolicy::Expanding);
@@ -73,7 +120,7 @@ TimeDialog::TimeDialog(QWidget* parent)
 
     if (configuration()->useFactorySettings() || !sp->readFromFile(configuration()->timeSignaturesDirPath().toQString())) {
         Fraction sig(4, 4);
-        groups->setSig(sig, Groups::endings(sig), zText->text(), nText->text());
+        groups->setSig(sig, Groups::endings(sig), zText->text(), nText->text(),TimeSigType::NORMAL);
     }
     for (int i = 0; i < sp->actualCellCount(); ++i) { // cells can be changed
         sp->setCellReadOnly(i, false);
@@ -106,15 +153,33 @@ bool TimeDialog::showTimePalette() const
 
 void TimeDialog::addClicked()
 {
+    TimeSigType tst = TimeSigType::NORMAL;
+    if (textButton->isChecked() || otherButton->isChecked()) {
+        tst = TimeSigType::NORMAL;
+    } else if (fourfourButton->isChecked()) {
+        tst = TimeSigType::FOUR_FOUR;
+    } else if (allaBreveButton->isChecked()) {
+        tst = TimeSigType::ALLA_BREVE;
+    }
+
     auto ts = mu::engraving::Factory::makeTimeSig(gpaletteScore->dummy()->segment());
-    ts->setSig(Fraction(zNominal->value(), denominator()));
+    ts->setSig(Fraction(zNominal->value(), denominator()),tst);
     ts->setGroups(groups->groups());
 
-    // check for special text
-    if ((QString("%1").arg(zNominal->value()) != zText->text())
-        || (QString("%1").arg(denominator()) != nText->text())) {
-        ts->setNumeratorString(zText->text());
-        ts->setDenominatorString(nText->text());
+    if (otherButton->isChecked()){
+        IEngravingFontPtr symbolFont = gpaletteScore->engravingFont();
+        SymId symId = (SymId)(otherCombo->itemData(otherCombo->currentIndex()).toInt());
+        // ...and set numerator to font string for symbol and denominator to empty string
+        ts->setNumeratorString(symbolFont->toString(symId));
+        ts->setDenominatorString(QString());
+    }
+    if(textButton->isChecked()){
+        // check for special text
+        if ((QString("%1").arg(zNominal->value()) != zText->text())
+            || (QString("%1").arg(denominator()) != nText->text())) {
+            ts->setNumeratorString(zText->text());
+            ts->setDenominatorString(nText->text());
+        }
     }
     // extend palette:
     sp->appendElement(ts, "");
@@ -150,13 +215,15 @@ void TimeDialog::save()
 
 void TimeDialog::zChanged()
 {
-    int numerator = zNominal->value();
-    int denominator = this->denominator();
+    if(textButton->isChecked()){
+        int numerator = zNominal->value();
+        int denominator = this->denominator();
 
-    Fraction sig(numerator, denominator);
+        Fraction sig(numerator, denominator);
 
-    // Update beam groups view
-    groups->setSig(sig, Groups::endings(sig), zText->text(), nText->text());
+        // Update beam groups view
+        groups->setSig(sig, Groups::endings(sig), zText->text(), nText->text(),TimeSigType::NORMAL);
+    }
 }
 
 //---------------------------------------------------------
@@ -165,9 +232,11 @@ void TimeDialog::zChanged()
 
 void TimeDialog::nChanged(int val)
 {
-    Q_UNUSED(val);
-    Fraction sig(zNominal->value(), denominator());
-    groups->setSig(sig, Groups::endings(sig), zText->text(), nText->text());
+    if(textButton->isChecked()){
+        Q_UNUSED(val);
+        Fraction sig(zNominal->value(), denominator());
+        groups->setSig(sig, Groups::endings(sig), zText->text(), nText->text(),TimeSigType::NORMAL);
+    }
 }
 
 //---------------------------------------------------------
@@ -242,6 +311,11 @@ void TimeDialog::paletteChanged(int idx)
         nText->setEnabled(false);
         groups->setEnabled(false);
         addButton->setEnabled(false);
+        textButton->setEnabled(false);
+        fourfourButton->setEnabled(false);
+        allaBreveButton->setEnabled(false);
+        otherCombo->setEnabled(false);
+        otherButton->setEnabled(false);
         return;
     }
 
@@ -251,6 +325,11 @@ void TimeDialog::paletteChanged(int idx)
     nText->setEnabled(true);
     groups->setEnabled(true);
     addButton->setEnabled(true);
+    textButton->setEnabled(true);
+    fourfourButton->setEnabled(true);
+    allaBreveButton->setEnabled(true);
+    otherCombo->setEnabled(true);
+    otherButton->setEnabled(true);
 
     Fraction sig(timeSig->sig());
     Groups g = timeSig->groups();
@@ -262,7 +341,8 @@ void TimeDialog::paletteChanged(int idx)
     nNominal->setCurrentIndex(denominator2Idx(sig.denominator()));
     zText->setText(timeSig->numeratorString());
     nText->setText(timeSig->denominatorString());
-    groups->setSig(sig, g, zText->text(), nText->text());
+    textButton->setChecked(true);
+    groups->setSig(sig, g, zText->text(), nText->text(),TimeSigType::NORMAL);
 }
 
 //---------------------------------------------------------
@@ -271,8 +351,57 @@ void TimeDialog::paletteChanged(int idx)
 
 void TimeDialog::textChanged()
 {
-    Fraction sig(zNominal->value(), denominator());
-    groups->setSig(sig, Groups::endings(sig), zText->text(), nText->text());
+    if(textButton->isChecked()){
+        Fraction sig(zNominal->value(), denominator());
+        groups->setSig(sig, Groups::endings(sig), zText->text(), nText->text(),TimeSigType::NORMAL);
+    }
+}
+
+void TimeDialog::textToggled()
+{
+    if(textButton->isChecked()){
+        this->textChanged();
+    }
+}
+
+void TimeDialog::fourfourToggled()
+{
+    if(fourfourButton->isChecked()){
+        Fraction sig(zNominal->value(), denominator());
+        groups->setSig(sig, Groups::endings(sig), QString(), QString(),TimeSigType::FOUR_FOUR);
+    }
+
+}
+
+void TimeDialog::allaBreveToggled()
+{
+    if(allaBreveButton->isChecked()){
+        Fraction sig(zNominal->value(), denominator());
+        groups->setSig(sig, Groups::endings(sig), QString(), QString(),TimeSigType::ALLA_BREVE);
+    }
+
+}
+
+void TimeDialog::otherToggled()
+{
+    if (otherButton->isChecked()) {
+        Fraction sig(zNominal->value(), denominator());
+        IEngravingFontPtr symbolFont = gpaletteScore->engravingFont(); 
+        SymId symId = (SymId)(otherCombo->itemData(otherCombo->currentIndex()).toInt());
+        groups->setSig(sig, Groups::endings(sig), symbolFont->toString(symId), QString(),TimeSigType::NORMAL);
+    }
+    
+}
+
+void TimeDialog::otherChanged(int idx)
+{
+    if (otherButton->isChecked()) {
+        Fraction sig(zNominal->value(), denominator());
+        IEngravingFontPtr symbolFont = gpaletteScore->engravingFont(); 
+        SymId symId = (SymId)(otherCombo->itemData(idx).toInt());
+        groups->setSig(sig, Groups::endings(sig), symbolFont->toString(symId), QString(),TimeSigType::NORMAL);
+    }
+    
 }
 
 void TimeDialog::setDirty()

--- a/src/palette/view/widgets/timedialog.cpp
+++ b/src/palette/view/widgets/timedialog.cpp
@@ -120,7 +120,7 @@ TimeDialog::TimeDialog(QWidget* parent)
 
     if (configuration()->useFactorySettings() || !sp->readFromFile(configuration()->timeSignaturesDirPath().toQString())) {
         Fraction sig(4, 4);
-        groups->setSig(sig, Groups::endings(sig), zText->text(), nText->text(),TimeSigType::NORMAL);
+        groups->setSig(sig, Groups::endings(sig), zText->text(), nText->text(), TimeSigType::NORMAL);
     }
     for (int i = 0; i < sp->actualCellCount(); ++i) { // cells can be changed
         sp->setCellReadOnly(i, false);
@@ -163,17 +163,17 @@ void TimeDialog::addClicked()
     }
 
     auto ts = mu::engraving::Factory::makeTimeSig(gpaletteScore->dummy()->segment());
-    ts->setSig(Fraction(zNominal->value(), denominator()),tst);
+    ts->setSig(Fraction(zNominal->value(), denominator()), tst);
     ts->setGroups(groups->groups());
 
-    if (otherButton->isChecked()){
+    if (otherButton->isChecked()) {
         IEngravingFontPtr symbolFont = gpaletteScore->engravingFont();
         SymId symId = (SymId)(otherCombo->itemData(otherCombo->currentIndex()).toInt());
         // ...and set numerator to font string for symbol and denominator to empty string
         ts->setNumeratorString(symbolFont->toString(symId));
         ts->setDenominatorString(QString());
     }
-    if(textButton->isChecked()){
+    if (textButton->isChecked()) {
         // check for special text
         if ((QString("%1").arg(zNominal->value()) != zText->text())
             || (QString("%1").arg(denominator()) != nText->text())) {
@@ -215,14 +215,14 @@ void TimeDialog::save()
 
 void TimeDialog::zChanged()
 {
-    if(textButton->isChecked()){
+    if (textButton->isChecked()) {
         int numerator = zNominal->value();
         int denominator = this->denominator();
 
         Fraction sig(numerator, denominator);
 
         // Update beam groups view
-        groups->setSig(sig, Groups::endings(sig), zText->text(), nText->text(),TimeSigType::NORMAL);
+        groups->setSig(sig, Groups::endings(sig), zText->text(), nText->text(), TimeSigType::NORMAL);
     }
 }
 
@@ -232,10 +232,10 @@ void TimeDialog::zChanged()
 
 void TimeDialog::nChanged(int val)
 {
-    if(textButton->isChecked()){
+    if (textButton->isChecked()) {
         Q_UNUSED(val);
         Fraction sig(zNominal->value(), denominator());
-        groups->setSig(sig, Groups::endings(sig), zText->text(), nText->text(),TimeSigType::NORMAL);
+        groups->setSig(sig, Groups::endings(sig), zText->text(), nText->text(), TimeSigType::NORMAL);
     }
 }
 
@@ -342,7 +342,7 @@ void TimeDialog::paletteChanged(int idx)
     zText->setText(timeSig->numeratorString());
     nText->setText(timeSig->denominatorString());
     textButton->setChecked(true);
-    groups->setSig(sig, g, zText->text(), nText->text(),TimeSigType::NORMAL);
+    groups->setSig(sig, g, zText->text(), nText->text(), TimeSigType::NORMAL);
 }
 
 //---------------------------------------------------------
@@ -351,57 +351,53 @@ void TimeDialog::paletteChanged(int idx)
 
 void TimeDialog::textChanged()
 {
-    if(textButton->isChecked()){
+    if (textButton->isChecked()) {
         Fraction sig(zNominal->value(), denominator());
-        groups->setSig(sig, Groups::endings(sig), zText->text(), nText->text(),TimeSigType::NORMAL);
+        groups->setSig(sig, Groups::endings(sig), zText->text(), nText->text(), TimeSigType::NORMAL);
     }
 }
 
 void TimeDialog::textToggled()
 {
-    if(textButton->isChecked()){
+    if (textButton->isChecked()) {
         this->textChanged();
     }
 }
 
 void TimeDialog::fourfourToggled()
 {
-    if(fourfourButton->isChecked()){
+    if (fourfourButton->isChecked()) {
         Fraction sig(zNominal->value(), denominator());
-        groups->setSig(sig, Groups::endings(sig), QString(), QString(),TimeSigType::FOUR_FOUR);
+        groups->setSig(sig, Groups::endings(sig), QString(), QString(), TimeSigType::FOUR_FOUR);
     }
-
 }
 
 void TimeDialog::allaBreveToggled()
 {
-    if(allaBreveButton->isChecked()){
+    if (allaBreveButton->isChecked()) {
         Fraction sig(zNominal->value(), denominator());
-        groups->setSig(sig, Groups::endings(sig), QString(), QString(),TimeSigType::ALLA_BREVE);
+        groups->setSig(sig, Groups::endings(sig), QString(), QString(), TimeSigType::ALLA_BREVE);
     }
-
 }
 
 void TimeDialog::otherToggled()
 {
     if (otherButton->isChecked()) {
         Fraction sig(zNominal->value(), denominator());
-        IEngravingFontPtr symbolFont = gpaletteScore->engravingFont(); 
+        IEngravingFontPtr symbolFont = gpaletteScore->engravingFont();
         SymId symId = (SymId)(otherCombo->itemData(otherCombo->currentIndex()).toInt());
-        groups->setSig(sig, Groups::endings(sig), symbolFont->toString(symId), QString(),TimeSigType::NORMAL);
+        groups->setSig(sig, Groups::endings(sig), symbolFont->toString(symId), QString(), TimeSigType::NORMAL);
     }
-    
 }
 
 void TimeDialog::otherChanged(int idx)
 {
     if (otherButton->isChecked()) {
         Fraction sig(zNominal->value(), denominator());
-        IEngravingFontPtr symbolFont = gpaletteScore->engravingFont(); 
+        IEngravingFontPtr symbolFont = gpaletteScore->engravingFont();
         SymId symId = (SymId)(otherCombo->itemData(idx).toInt());
-        groups->setSig(sig, Groups::endings(sig), symbolFont->toString(symId), QString(),TimeSigType::NORMAL);
+        groups->setSig(sig, Groups::endings(sig), symbolFont->toString(symId), QString(), TimeSigType::NORMAL);
     }
-    
 }
 
 void TimeDialog::setDirty()

--- a/src/palette/view/widgets/timedialog.h
+++ b/src/palette/view/widgets/timedialog.h
@@ -29,6 +29,7 @@
 #include "ipaletteconfiguration.h"
 #include "internal/ipaletteprovider.h"
 #include "engraving/rendering/isinglerenderer.h"
+#include "ui/iuiconfiguration.h"
 
 namespace mu::palette {
 class PaletteWidget;
@@ -43,6 +44,7 @@ class TimeDialog : public QWidget, Ui::TimeDialogBase
     INJECT(IPaletteConfiguration, configuration)
     INJECT(IPaletteProvider, paletteProvider)
     INJECT(engraving::rendering::ISingleRenderer, engravingRender)
+    INJECT(muse::ui::IUiConfiguration, uiConfiguration)
 
 public:
     TimeDialog(QWidget* parent = 0);
@@ -57,6 +59,11 @@ private slots:
     void nChanged(int);
     void paletteChanged(int idx);
     void textChanged();
+    void textToggled();
+    void fourfourToggled();
+    void allaBreveToggled();
+    void otherToggled();
+    void otherChanged(int idx);
     void setDirty();
     void setShowTimePalette(bool val);
 

--- a/src/palette/view/widgets/timedialog.ui
+++ b/src/palette/view/widgets/timedialog.ui
@@ -152,91 +152,104 @@
           </layout>
          </item>
          <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_2">
-           <item>
-            <widget class="QLabel" name="label_3">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
+          <widget class="QGroupBox" name="groupBox_3">
+          <property name="title">
+           <string>Appearance (visual only; will not affect actual measure duration)</string>
+          </property>
+          <layout class="QGridLayout" name="gridLayout_3">
+           <property name="verticalSpacing">
+            <number>0</number>
+           </property>
+           <item row="3" column="0">
+            <widget class="QRadioButton" name="otherButton">
+             <property name="text">
+              <string>Other:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="0">
+            <widget class="QRadioButton" name="textButton">
+             <property name="layoutDirection">
+              <enum>Qt::LeftToRight</enum>
              </property>
              <property name="text">
               <string>Text:</string>
              </property>
-             <property name="buddy">
-              <cstring>zText</cstring>
-             </property>
             </widget>
            </item>
-           <item>
-            <widget class="QLineEdit" name="zText">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="maximumSize">
-              <size>
-               <width>60</width>
-               <height>16777215</height>
-              </size>
-             </property>
+           <item row="2" column="0">
+            <widget class="QRadioButton" name="allaBreveButton">
              <property name="text">
-              <string>4</string>
+              <string notr="true"/>
              </property>
             </widget>
            </item>
-           <item>
-            <widget class="QLabel" name="label_8">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
+           <item row="1" column="0">
+            <widget class="QRadioButton" name="fourfourButton">
              <property name="text">
-              <string>/</string>
-             </property>
-             <property name="buddy">
-              <cstring>nText</cstring>
+              <string notr="true"/>
              </property>
             </widget>
            </item>
-           <item>
-            <widget class="QLineEdit" name="nText">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="maximumSize">
-              <size>
-               <width>60</width>
-               <height>16777215</height>
-              </size>
-             </property>
-             <property name="text">
-              <string>4</string>
-             </property>
-            </widget>
+           <item row="0" column="1">
+            <layout class="QHBoxLayout" name="horizontalLayout1">
+             <item>
+              <widget class="QLineEdit" name="zText"/>
+             </item>
+             <item>
+              <widget class="QLabel" name="label">
+               <property name="text">
+                <string>/</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLineEdit" name="nText"/>
+             </item>
+             <item>
+              <spacer name="horizontalSpacer_21">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+            </layout>
            </item>
-           <item>
-            <spacer name="horizontalSpacer">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>40</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
+           <item row="3" column="1">
+            <layout class="QHBoxLayout" name="horizontalLayout_41">
+             <item>
+              <widget class="QComboBox" name="otherCombo">
+               <property name="maxVisibleItems">
+                <number>12</number>
+               </property>
+               <property name="maxCount">
+                <number>24</number>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <spacer name="horizontalSpacer">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+            </layout>
            </item>
           </layout>
+         </widget>
          </item>
         </layout>
        </item>

--- a/src/palette/view/widgets/timesignaturepropertiesdialog.cpp
+++ b/src/palette/view/widgets/timesignaturepropertiesdialog.cpp
@@ -153,7 +153,7 @@ TimeSignaturePropertiesDialog::TimeSignaturePropertiesDialog(QWidget* parent)
     if (g.empty()) {
         g = Groups::endings(m_editedTimeSig->sig()); // initialize with default
     }
-    groups->setSig(m_editedTimeSig->sig(), g, m_editedTimeSig->numeratorString(), m_editedTimeSig->denominatorString());
+    groups->setSig(m_editedTimeSig->sig(), g, m_editedTimeSig->numeratorString(), m_editedTimeSig->denominatorString(), m_editedTimeSig->timeSigType());
 
     WidgetStateStore::restoreGeometry(this);
 }

--- a/src/palette/view/widgets/timesignaturepropertiesdialog.cpp
+++ b/src/palette/view/widgets/timesignaturepropertiesdialog.cpp
@@ -153,7 +153,8 @@ TimeSignaturePropertiesDialog::TimeSignaturePropertiesDialog(QWidget* parent)
     if (g.empty()) {
         g = Groups::endings(m_editedTimeSig->sig()); // initialize with default
     }
-    groups->setSig(m_editedTimeSig->sig(), g, m_editedTimeSig->numeratorString(), m_editedTimeSig->denominatorString(), m_editedTimeSig->timeSigType());
+    groups->setSig(m_editedTimeSig->sig(), g, m_editedTimeSig->numeratorString(), m_editedTimeSig->denominatorString(),
+                   m_editedTimeSig->timeSigType());
 
     WidgetStateStore::restoreGeometry(this);
 }


### PR DESCRIPTION
Resolves: #25704 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

UI of time signature dialog updated with a new section that changes the appearance of the time signature when adding a new one to the palette. (similar to the time signature properties dialog)  

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
