### PR TITLE
Fix #26099: Crash when opening score and pressing direction key

### DIFF
--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -1017,7 +1017,7 @@ void NotationActionController::move(MoveDirection direction, bool quickly)
             interaction->moveLyrics(direction);
         } else if (selectedElement && (selectedElement->isTextBase() || selectedElement->isArticulationFamily())) {
             interaction->nudge(direction, quickly);
-        } else if (selectedElement && selectedElement->hasGrips()) {
+        } else if (selectedElement && selectedElement->hasGrips() && interaction->isGripEditStarted()) {
             interaction->nudgeAnchors(direction);
         } else if (interaction->noteInput()->isNoteInputMode()
                    && interaction->noteInput()->state().staffGroup == mu::engraving::StaffGroup::TAB) {
@@ -1074,7 +1074,7 @@ void NotationActionController::move(MoveDirection direction, bool quickly)
 
         if (selectedElement && selectedElement->isTextBase()) {
             interaction->nudge(direction, quickly);
-        } else if (selectedElement && selectedElement->hasGrips()) {
+        } else if (selectedElement && selectedElement->hasGrips() && interaction->isGripEditStarted()) {
             interaction->nudgeAnchors(direction);
         } else {
             if (interaction->selection()->isNone()) {

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -3271,6 +3271,10 @@ void NotationInteraction::nudge(MoveDirection d, bool quickly)
 
 void NotationInteraction::nudgeAnchors(MoveDirection d)
 {
+    IF_ASSERT_FAILED(m_editData.element) {
+        return;
+    }
+
     startEdit(TranslatableString("undoableAction", "Nudge"));
     qreal vRaster = mu::engraving::MScore::vRaster();
     qreal hRaster = mu::engraving::MScore::hRaster();


### PR DESCRIPTION
Resolves: #26099

Problem is as follows: 
1. When opening a score via keyboard, we select the “first element in the score”. 
2. In scores with more than one staff, the first element in the score is a barline (an element with grips) 
3. We call `NotationInteraction::nudgeAnchors` which causes a crash because `NotationInteraction::startEditGrip` was never called.

The solution I've gone for in this PR is to check whether a grip edit has started before calling `nudgeAnchors`. We could potentially include an additional step where we immediately start editing the barline's grips - but my feeling is that this behaviour is probably undesirable (see video).

https://github.com/user-attachments/assets/1c1d5df4-7497-432b-9b52-728eea0578d3