### PR TITLE
System lock improvements

### DIFF
--- a/src/engraving/dom/cmd.cpp
+++ b/src/engraving/dom/cmd.cpp
@@ -4829,7 +4829,10 @@ void Score::cmdApplyLockToSelection()
         return;
     }
 
-    if (first != last) {
+    const SystemLock* lockOnLast = systemLocks()->lockContaining(last);
+    if (lockOnLast && lockOnLast->endMB() == last) {
+        undoRemoveSystemLock(lockOnLast);
+    } else if (first != last) {
         makeIntoSystem(first, last);
     } else {
         makeIntoSystem(first->system()->first(), last);

--- a/src/engraving/dom/cmd.cpp
+++ b/src/engraving/dom/cmd.cpp
@@ -4812,6 +4812,12 @@ void Score::cmdApplyLockToSelection()
         last = selection().endMeasureBase();
     } else {
         for (EngravingItem* el : selection().elements()) {
+            if (el->isSystemLockIndicator()) {
+                const SystemLock* lock = toSystemLockIndicator(el)->systemLock();
+                first = lock->startMB();
+                last = lock->endMB();
+                break;
+            }
             MeasureBase* mb = el->findMeasureBase();
             if (!mb) {
                 continue;

--- a/src/engraving/dom/navigate.cpp
+++ b/src/engraving/dom/navigate.cpp
@@ -850,6 +850,12 @@ EngravingItem* Score::nextElement()
             staffId = 0;             // otherwise it will equal -1, which breaks the navigation
             break;
         }
+        case ElementType::SYSTEM_LOCK_INDICATOR:
+        {
+            staffId = 0;
+            e = toSystemLockIndicator(e)->systemLock()->endMB();
+            continue;
+        }
         case ElementType::SOUND_FLAG:
             if (EngravingItem* parent = toSoundFlag(e)->parentItem()) {
                 return parent;
@@ -1040,6 +1046,12 @@ EngravingItem* Score::prevElement()
         case ElementType::LAYOUT_BREAK: {
             staffId = 0;             // otherwise it will equal -1, which breaks the navigation
             break;
+        }
+        case ElementType::SYSTEM_LOCK_INDICATOR:
+        {
+            staffId = 0;
+            e = toSystemLockIndicator(e)->systemLock()->endMB();
+            continue;
         }
         default:
             break;

--- a/src/engraving/dom/segment.cpp
+++ b/src/engraving/dom/segment.cpp
@@ -2089,6 +2089,12 @@ EngravingItem* Segment::nextElement(staff_idx_t activeStaff)
                 return nme;
             } else if (nme && nme->isLayoutBreak() && e->staffIdx() == 0) {
                 return nme;
+            } else if (nmb->isEndOfSystemLock()) {
+                System* system = nmb->system();
+                SystemLockIndicator* lockInd = system ? system->lockIndicators().front() : nullptr;
+                if (lockInd) {
+                    return lockInd;
+                }
             }
         }
 
@@ -2263,6 +2269,12 @@ EngravingItem* Segment::prevElement(staff_idx_t activeStaff)
                 return me;
             } else if (me && me->isLayoutBreak() && e->staffIdx() == 0) {
                 return me;
+            } else if (measure()->isEndOfSystemLock()) {
+                System* system = measure()->system();
+                SystemLockIndicator* lockInd = system ? system->lockIndicators().front() : nullptr;
+                if (lockInd) {
+                    return lockInd;
+                }
             } else if (psm != pmb) {
                 return pmb;
             }

--- a/src/engraving/dom/select.cpp
+++ b/src/engraving/dom/select.cpp
@@ -420,6 +420,10 @@ MeasureBase* Selection::startMeasureBase() const
         }
     }
 
+    if (tickStart().negative()) { // Tick is not set
+        return nullptr;
+    }
+
     bool mmrests = m_score->style().styleB(Sid::createMultiMeasureRests);
     Fraction refTick = tickStart();
 
@@ -437,6 +441,10 @@ MeasureBase* Selection::endMeasureBase() const
         if (mb) {
             return mb;
         }
+    }
+
+    if (tickEnd().negative()) { // Tick is not set
+        return nullptr;
     }
 
     bool mmrests = m_score->style().styleB(Sid::createMultiMeasureRests);

--- a/src/engraving/dom/select.cpp
+++ b/src/engraving/dom/select.cpp
@@ -455,6 +455,11 @@ MeasureBase* Selection::endMeasureBase() const
 
 std::vector<System*> Selection::selectedSystems() const
 {
+    EngravingItem* el = element();
+    if (el && el->isSystemLockIndicator()) {
+        return { const_cast<System*>(toSystemLockIndicator(el)->system()) };
+    }
+
     const MeasureBase* startMB = startMeasureBase();
     const MeasureBase* endMB = endMeasureBase();
     if (!startMB || !endMB) {

--- a/src/engraving/dom/systemlock.cpp
+++ b/src/engraving/dom/systemlock.cpp
@@ -161,4 +161,11 @@ char16_t SystemLockIndicator::iconCode() const
 {
     return 0xF487;
 }
+
+String SystemLockIndicator::formatBarsAndBeats() const
+{
+    int startMeas = systemLock()->startMB()->no() + 1;
+    int endMeas = systemLock()->endMB()->no() + 1;
+    return muse::mtrc("engraving", "Start measure: %1; End measure: %2").arg(startMeas).arg(endMeas);
+}
 } // namespace mu::engraving

--- a/src/engraving/dom/systemlock.h
+++ b/src/engraving/dom/systemlock.h
@@ -102,6 +102,8 @@ public:
 
     char16_t iconCode() const;
 
+    String formatBarsAndBeats() const override;
+
 private:
     const SystemLock* m_systemLock = nullptr;
 };

--- a/src/inspector/models/measures/measuressettingsmodel.cpp
+++ b/src/inspector/models/measures/measuressettingsmodel.cpp
@@ -42,6 +42,7 @@ void MeasuresSettingsModel::loadProperties()
     updateAllSystemsAreLocked();
     updateScoreIsInPageView();
     updateIsMakeIntoSystemAvailable();
+    updateSystemCount();
 }
 
 void MeasuresSettingsModel::onCurrentNotationChanged()
@@ -174,6 +175,11 @@ bool MeasuresSettingsModel::isMakeIntoSystemAvailable() const
     return m_isMakeIntoSystemAvailable;
 }
 
+int MeasuresSettingsModel::systemCount() const
+{
+    return m_systemCount;
+}
+
 void MeasuresSettingsModel::updateScoreIsInPageView()
 {
     const Score* score = currentNotation()->elements()->msScore();
@@ -202,6 +208,15 @@ void MeasuresSettingsModel::updateIsMakeIntoSystemAvailable()
     if (m_isMakeIntoSystemAvailable != available) {
         m_isMakeIntoSystemAvailable = available;
         emit isMakeIntoSystemAvailableChanged(m_isMakeIntoSystemAvailable);
+    }
+}
+
+void MeasuresSettingsModel::updateSystemCount()
+{
+    int count = currentNotation()->elements()->msScore()->selection().selectedSystems().size();
+    if (count != m_systemCount) {
+        m_systemCount = count;
+        emit systemCountChanged(count);
     }
 }
 

--- a/src/inspector/models/measures/measuressettingsmodel.h
+++ b/src/inspector/models/measures/measuressettingsmodel.h
@@ -39,6 +39,7 @@ class MeasuresSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(bool allSystemsAreLocked READ allSystemsAreLocked NOTIFY allSystemsAreLockedChanged)
     Q_PROPERTY(bool scoreIsInPageView READ scoreIsInPageView NOTIFY scoreIsInPageViewChanged)
     Q_PROPERTY(bool isMakeIntoSystemAvailable READ isMakeIntoSystemAvailable NOTIFY isMakeIntoSystemAvailableChanged)
+    Q_PROPERTY(int systemCount READ systemCount NOTIFY systemCountChanged)
 
 public:
     explicit MeasuresSettingsModel(QObject* parent, IElementRepositoryService* repository);
@@ -78,6 +79,8 @@ public:
     bool scoreIsInPageView() const;
     bool isMakeIntoSystemAvailable() const;
 
+    int systemCount() const;
+
 protected:
     void onNotationChanged(const mu::engraving::PropertyIdSet&, const mu::engraving::StyleIdSet&) override;
 
@@ -85,16 +88,19 @@ private:
     void updateAllSystemsAreLocked();
     void updateScoreIsInPageView();
     void updateIsMakeIntoSystemAvailable();
+    void updateSystemCount();
 
 signals:
     void allSystemsAreLockedChanged(bool allLocked);
     void scoreIsInPageViewChanged(bool isInPageView);
     void isMakeIntoSystemAvailableChanged(bool isMakeIntoSystemAvailable);
+    void systemCountChanged(int count);
 
 private:
     bool m_allSystemsAreLocked = false;
     bool m_scoreIsInPageView = false;
     bool m_isMakeIntoSystemAvailable = false;
+    int m_systemCount = 0;
 };
 }
 

--- a/src/inspector/view/qml/MuseScore/Inspector/measures/MeasuresInspectorView.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/measures/MeasuresInspectorView.qml
@@ -156,10 +156,13 @@ InspectorSectionView {
 
             orientation: Qt.Horizontal
             icon: Boolean(model.allSystemsAreLocked) ? IconCode.LOCK_CLOSED : IconCode.LOCK_OPEN
-            text: qsTrc("inspector", "Lock current system")
+            text: Boolean(model.allSystemsAreLocked) ? model.systemCount > 1 ? qsTrc("inspector", "Unlock selected systems")
+                                                                             : qsTrc("inspector", "Unlock selected system")
+                                                     : model.systemCount > 1 ? qsTrc("inspector", "Lock selected systems")
+                                                                             : qsTrc("inspector", "Lock selected system")
 
-            toolTipTitle: qsTrc("inspector", "Lock current system(s)")
-            toolTipDescription: qsTrc("inspector", "Keep these measures together and prevent them from reflowing to the next system")
+            toolTipTitle: qsTrc("inspector", "Lock/unlock selected system(s)")
+            toolTipDescription: qsTrc("inspector", "Keep measures on the selected system(s) together and prevent them from reflowing to the next system")
             toolTipShortcut: model.shortcutToggleSystemLock
 
             accentButton: Boolean(model.allSystemsAreLocked)
@@ -180,9 +183,9 @@ InspectorSectionView {
 
             orientation: Qt.Horizontal
             //icon: TODO maybe
-            text: qsTrc("inspector", "Make into one system")
+            text: qsTrc("inspector", "Create system from selection")
 
-            toolTipTitle: qsTrc("inspector", "Make measure(s) into one system")
+            toolTipTitle: qsTrc("inspector", "Create system from selection")
             toolTipDescription: qsTrc("inspector", "Create a system containing only the selected measure(s)")
             toolTipShortcut: model.shortcutMakeIntoSystem
 

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -4767,21 +4767,21 @@ void NotationInteraction::moveMeasureToNextSystem()
 
 void NotationInteraction::toggleSystemLock()
 {
-    startEdit(TranslatableString("undoableAction", "Toggle system lock"));
+    startEdit(TranslatableString("undoableAction", "Lock/unlock selected system(s)"));
     score()->cmdToggleSystemLock();
     apply();
 }
 
 void NotationInteraction::toggleScoreLock()
 {
-    startEdit(TranslatableString("undoableAction", "Toggle score lock"));
+    startEdit(TranslatableString("undoableAction", "Lock/unlock all systems"));
     score()->cmdToggleScoreLock();
     apply();
 }
 
 void NotationInteraction::makeIntoSystem()
 {
-    startEdit(TranslatableString("undoableAction", "Make measure(s) into one system"));
+    startEdit(TranslatableString("undoableAction", "Create system from selection"));
     score()->cmdMakeIntoSystem();
     apply();
 }

--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -654,8 +654,8 @@ const UiActionList NotationUiActions::m_actions = {
     UiAction("make-into-system",
              mu::context::UiCtxProjectOpened,
              mu::context::CTX_NOTATION_FOCUSED,
-             TranslatableString("action", "Make measure(s) into one system"),
-             TranslatableString("action", "Make measure(s) into one system")
+             TranslatableString("action", "Create system from selection"),
+             TranslatableString("action", "Create system from selection")
              ),
     UiAction("section-break",
              mu::context::UiCtxProjectOpened,
@@ -1611,14 +1611,14 @@ const UiActionList NotationUiActions::m_actions = {
     UiAction("toggle-score-lock",
              mu::context::UiCtxProjectOpened,
              mu::context::CTX_ANY,
-             TranslatableString("action", "Toggle score lock"),
-             TranslatableString("action", "Toggle score lock")
+             TranslatableString("action", "Lock/unlock all systems"),
+             TranslatableString("action", "Lock/unlock all systems")
              ),
     UiAction("toggle-system-lock",
              mu::context::UiCtxProjectOpened,
              mu::context::CTX_ANY,
-             TranslatableString("action", "Toggle system lock"),
-             TranslatableString("action", "Toggle system lock"),
+             TranslatableString("action", "Lock/unlock selected system(s)"),
+             TranslatableString("action", "Lock/unlock selected system(s)"),
              IconCode::Code::SYSTEM_LOCK
              ),
     UiAction("enh-both",


### PR DESCRIPTION
Resolves: #26278 
Resolves: #26273 
Resolves: #25806 
Resolves: #26336 
Resolves: #26337 

@avvvvve regarding this request 
> @mike-spa Also, the tooltip width should match the width of the buttons.

I don't think we do that anywhere else. In fact, I don't even know if it's _possible_ to do that, given that tooltips by definition pop up _above_ the UI and are not bound to it, see e.g. 
![image](https://github.com/user-attachments/assets/96fc1aaf-75e3-416f-88a7-13686c86964b)
 But I'm also deeply QML-ignorant, so I may well be talking BS (@cbjeukendrup is the expert here).

