### PR TITLE
Tidying up colors and prettify frames

### DIFF
--- a/src/engraving/dom/engravingitem.cpp
+++ b/src/engraving/dom/engravingitem.cpp
@@ -2096,7 +2096,7 @@ void EngravingItem::drawEditMode(Painter* p, EditData& ed, double /*currentViewS
     p->setPen(pen);
     for (int i = 0; i < ed.grips; ++i) {
         if (Grip(i) == ed.curGrip) {
-            p->setBrush(configuration()->formattingColor());
+            p->setBrush(configuration()->scoreGreyColor());
         } else {
             p->setBrush(BrushStyle::NoBrush);
         }

--- a/src/engraving/dom/slurtie.cpp
+++ b/src/engraving/dom/slurtie.cpp
@@ -324,14 +324,14 @@ void SlurTieSegment::drawEditMode(Painter* p, EditData& ed, double /*currentView
     polygon[4] = PointF(ed.grip[int(Grip::END)].center());
     polygon[5] = PointF(ed.grip[int(Grip::DRAG)].center());
     polygon[6] = PointF(ed.grip[int(Grip::START)].center());
-    p->setPen(Pen(configuration()->formattingColor(), 0.0));
+    p->setPen(Pen(configuration()->scoreGreyColor(), 0.0));
     p->drawPolyline(polygon);
 
     p->setPen(Pen(configuration()->defaultColor(), 0.0));
     for (int i = 0; i < ed.grips; ++i) {
         // Can't use ternary operator, because we want different overloads of `setBrush`
         if (Grip(i) == ed.curGrip) {
-            p->setBrush(configuration()->formattingColor());
+            p->setBrush(configuration()->scoreGreyColor());
         } else {
             p->setBrush(BrushStyle::NoBrush);
         }

--- a/src/engraving/iengravingconfiguration.h
+++ b/src/engraving/iengravingconfiguration.h
@@ -92,6 +92,8 @@ public:
     virtual Color frameColor() const = 0;
     virtual muse::async::Channel<Color> frameColorChanged() const = 0;
 
+    virtual Color scoreGreyColor() const = 0;
+
     virtual Color highlightSelectionColor(voice_idx_t voiceIndex = 0) const = 0;
 
     struct DebuggingOptions {

--- a/src/engraving/internal/engravingconfiguration.cpp
+++ b/src/engraving/internal/engravingconfiguration.cpp
@@ -48,6 +48,7 @@ static const Settings::Key INVERT_SCORE_COLOR("engraving", "engraving/scoreColor
 static const Settings::Key ALL_VOICES_COLOR("engraving", "engraving/colors/allVoicesColor");
 static const Settings::Key FORMATTING_COLOR("engraving", "engraving/colors/formattingColor");
 static const Settings::Key FRAME_COLOR("engraving", "engraving/colors/frameColor");
+static const Settings::Key SCORE_GREY_COLOR("engraving", "engraving/color/scoreGreyColor");
 static const Settings::Key INVISIBLE_COLOR("engraving", "engraving/colors/invisibleColor");
 static const Settings::Key UNLINKED_COLOR("engraving", "engraving/colors/unlinkedColor");
 
@@ -128,6 +129,10 @@ void EngravingConfiguration::init()
     settings()->valueChanged(FRAME_COLOR).onReceive(nullptr, [this](const Val& val) {
         m_frameColorChanged.send(Color::fromQColor(val.toQColor()));
     });
+
+    settings()->setDefaultValue(SCORE_GREY_COLOR, Val(Color("#A0A0A4").toQColor()));
+    settings()->setDescription(SCORE_GREY_COLOR, muse::trc("engraving", "Score grey color"));
+    settings()->setCanBeManuallyEdited(SCORE_GREY_COLOR, false);
 
     settings()->setDefaultValue(FORMATTING_COLOR, Val(Color("#C31989").toQColor()));
     settings()->setDescription(FORMATTING_COLOR, muse::trc("engraving", "Formatting color"));
@@ -374,6 +379,11 @@ Color EngravingConfiguration::frameColor() const
 muse::async::Channel<Color> EngravingConfiguration::frameColorChanged() const
 {
     return m_frameColorChanged;
+}
+
+Color EngravingConfiguration::scoreGreyColor() const
+{
+    return Color::fromQColor(settings()->value(SCORE_GREY_COLOR).toQColor());
 }
 
 Color EngravingConfiguration::invisibleColor() const

--- a/src/engraving/internal/engravingconfiguration.h
+++ b/src/engraving/internal/engravingconfiguration.h
@@ -95,6 +95,8 @@ public:
     Color frameColor() const override;
     muse::async::Channel<Color> frameColorChanged() const override;
 
+    Color scoreGreyColor() const override;
+
     Color invisibleColor() const override;
     muse::async::Channel<Color> invisibleColorChanged() const override;
 

--- a/src/engraving/rendering/score/tdraw.cpp
+++ b/src/engraving/rendering/score/tdraw.cpp
@@ -841,7 +841,7 @@ void TDraw::draw(const BarLine* item, Painter* painter)
     if (s && s->isEndBarLineType() && !item->score()->printing()) {
         Measure* m = s->measure();
         if (m->isIrregular() && item->score()->markIrregularMeasures() && !m->isMMRest()) {
-            painter->setPen(item->configuration()->formattingColor());
+            painter->setPen(item->configuration()->invisibleColor());
 
             Font f(u"Edwin", Font::Type::Text);
             f.setPointSizeF(12 * item->spatium() / SPATIUM20);
@@ -1191,7 +1191,7 @@ void TDraw::draw(const FiguredBass* item, Painter* painter)
     if (!item->score()->printing() && item->score()->showUnprintable()) {
         for (double len : ldata->lineLengths) {
             if (len > 0) {
-                painter->setPen(Pen(item->configuration()->frameColor(), 3));
+                painter->setPen(Pen(item->configuration()->invisibleColor(), 3));
                 painter->drawLine(0.0, -2, len, -2);              // -2: 2 rast. un. above digits
             }
         }

--- a/src/engraving/rendering/score/tdraw.cpp
+++ b/src/engraving/rendering/score/tdraw.cpp
@@ -1002,15 +1002,15 @@ void TDraw::draw(const Box* item, Painter* painter)
     const bool showFrame = showHighlightedFrame || (item->score() ? item->score()->showFrames() : false);
 
     if (showFrame) {
-        double lineWidth = item->spatium() * .15;
+        double lineWidth = SPATIUM20 * .10;
         Pen pen;
         pen.setWidthF(lineWidth);
-        pen.setJoinStyle(PenJoinStyle::MiterJoin);
-        pen.setCapStyle(PenCapStyle::SquareCap);
+        pen.setJoinStyle(PenJoinStyle::RoundJoin);
+        pen.setCapStyle(PenCapStyle::RoundCap);
         pen.setColor(showHighlightedFrame
                      ? item->configuration()->selectionColor()
                      : item->configuration()->frameColor());
-        pen.setDashPattern({ 1, 3 });
+        pen.setDashPattern({ 5, 5 });
 
         painter->setBrush(BrushStyle::NoBrush);
         painter->setPen(pen);

--- a/src/engraving/rendering/single/singledraw.cpp
+++ b/src/engraving/rendering/single/singledraw.cpp
@@ -1927,7 +1927,7 @@ void SingleDraw::draw(const KeySig* item, Painter* painter)
 
     if (!item->explicitParent() && (item->isAtonal() || item->isCustom()) && ldata->keySymbols.empty()) {
         // empty custom or atonal key signature - draw something for palette
-        painter->setPen(item->configuration()->formattingColor());
+        painter->setPen(item->configuration()->scoreGreyColor());
         item->drawSymbol(SymId::timeSigX, painter, PointF(item->symWidth(SymId::timeSigX) * -0.5, 2.0 * item->spatium()));
     }
 }

--- a/src/engraving/tests/mocks/engravingconfigurationmock.h
+++ b/src/engraving/tests/mocks/engravingconfigurationmock.h
@@ -76,6 +76,8 @@ public:
     MOCK_METHOD(Color, frameColor, (), (const, override));
     MOCK_METHOD(muse::async::Channel<Color>, frameColorChanged, (), (const, override));
 
+    MOCK_METHOD(Color, scoreGreyColor, (), (const, override));
+
     MOCK_METHOD(Color, invisibleColor, (), (const, override));
     MOCK_METHOD(muse::async::Channel<Color>, invisibleColorChanged, (), (const, override));
 

--- a/src/notation/internal/notationpainting.cpp
+++ b/src/notation/internal/notationpainting.cpp
@@ -170,7 +170,7 @@ void NotationPainting::paintPageSheet(Painter* painter, const Page* page, const 
     RectF pageContentRect = page->ldata()->bbox().adjusted(page->lm(), page->tm(), -page->rm(), -page->bm());
 
     painter->setBrush(BrushStyle::NoBrush);
-    painter->setPen(engravingConfiguration()->formattingColor());
+    painter->setPen(engravingConfiguration()->scoreGreyColor());
     painter->drawRect(pageContentRect);
 
     if (!page->isOdd()) {

--- a/src/notation/view/notationnavigator.cpp
+++ b/src/notation/view/notationnavigator.cpp
@@ -287,7 +287,7 @@ void NotationNavigator::paintPageNumbers(QPainter* painter)
         painter->translate(page->pos().toQPointF());
 
         painter->setFont(font);
-        painter->setPen(engravingConfiguration()->formattingColor().toQColor());
+        painter->setPen(engravingConfiguration()->scoreGreyColor().toQColor());
         painter->drawText(page->ldata()->bbox().toQRectF(), Qt::AlignCenter, QString("%1").arg(page->no() + 1));
 
         painter->translate(-page->pos().toQPointF());


### PR DESCRIPTION
Resolves: #26171

At the moment we have the following color definitions:

- Formatting color (defaults to bright pink)
- Frame color (defaults to grey)
- Invisible color (defaults to another grey)

Some items need a grey color, but that color is not conceptually related to either invisible elements nor frames, and it shouldn't change if users for some reason decide to change frame color or invisible color from the preferences. So I've introduced a further color definition, called

- Score grey color

which defaults to the same grey as the frame color but is not editable (in other words, it's hardcoded).

Here's a summary of the whole thing.

- Selected grip handle: formatting color ❌ ➡️ Changed to score grey
- Slur/tie editing lines: formatting color ❌ ➡️ Changed to score grey
- Irregular measures: formatting color ✅
- Layout breaks / System locks / Spacers: formatting color ✅
- Staff type change: formatting color ✅
- Atonal key signature in palette: formatting color ❌ ➡️ Changed to score grey
- Page margins: formatting color ❌ ➡️ Changed to score grey
- Page number in navigator: formatting color ❌ ➡️ Changed to score grey
- Text editing frame: frame color ✅
- Frames: frame color ✅
- Figured bass extensione lines: frame color ❌ ➡️ Changed to invisible color

While I was at it, I took the opportunity to try to prettify frames by

- Slightly decreasing the line width (now at 0.1 staff spaces)
- Increasing the dash size
- Using round caps and round joins
