### PR TITLE
26338: Display the specific layout break subtype name in the statusbar

### DIFF
--- a/src/engraving/dom/layoutbreak.cpp
+++ b/src/engraving/dom/layoutbreak.cpp
@@ -229,6 +229,15 @@ muse::TranslatableString LayoutBreak::subtypeUserName() const
     return TConv::userName(layoutBreakType());
 }
 
+//---------------------------------------------------------
+//   accessibleInfo
+//---------------------------------------------------------
+
+String LayoutBreak::accessibleInfo() const
+{
+    return translatedSubtypeUserName();
+}
+
 void LayoutBreak::added()
 {
     IF_ASSERT_FAILED(score()) {

--- a/src/engraving/dom/layoutbreak.h
+++ b/src/engraving/dom/layoutbreak.h
@@ -73,6 +73,8 @@ public:
     bool setProperty(Pid propertyId, const PropertyValue&) override;
     PropertyValue propertyDefault(Pid) const override;
 
+    String accessibleInfo() const override;
+
     char16_t iconCode() const;
 
     muse::draw::Font font() const;


### PR DESCRIPTION
Resolves: #26338

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
