### PR TITLE
Fix system-text line visible when all staves hidden and code improvement

### DIFF
--- a/src/engraving/dom/engravingitem.h
+++ b/src/engraving/dom/engravingitem.h
@@ -328,7 +328,7 @@ public:
 
     staff_idx_t staffIdx() const;
     void setStaffIdx(staff_idx_t val);
-    staff_idx_t staffIdxOrNextVisible() const; // for system objects migrating
+    staff_idx_t effectiveStaffIdx() const; // for system objects migrating
     bool isTopSystemObject() const;
     virtual staff_idx_t vStaffIdx() const;
     voice_idx_t voice() const;

--- a/src/engraving/dom/volta.cpp
+++ b/src/engraving/dom/volta.cpp
@@ -360,7 +360,7 @@ PointF Volta::linePos(Grip grip, System** system) const
         x += (isAtSystemStart ? 0.5 : -0.5) * absoluteFromSpatium(lineWidth());
     } else {
         if ((*system) && segment->tick() == (*system)->endTick()) {
-            x += segment->staffShape(staffIdxOrNextVisible()).right();
+            x += segment->staffShape(backSegment()->effectiveStaffIdx()).right();
             x -= 0.5 * absoluteFromSpatium(lineWidth());
         } else if (segment->segmentType() & SegmentType::BarLineType) {
             BarLine* barLine = toBarLine(segment->elementAt(track()));

--- a/src/engraving/rendering/score/autoplace.cpp
+++ b/src/engraving/rendering/score/autoplace.cpp
@@ -54,7 +54,7 @@ void Autoplace::autoplaceSegmentElement(const EngravingItem* item, EngravingItem
         LD_CONDITION(s->ldata()->isSetPos());
 
         double sp = item->style().spatium();
-        staff_idx_t si = item->staffIdxOrNextVisible();
+        staff_idx_t si = item->effectiveStaffIdx();
 
         // if there's no good staff for this object, obliterate it
         ldata->setIsSkipDraw(si == muse::nidx);
@@ -130,7 +130,7 @@ void Autoplace::autoplaceMeasureElement(const EngravingItem* item, EngravingItem
         LD_CONDITION(ldata->isSetBbox());
         LD_CONDITION(m->ldata()->isSetPos());
 
-        staff_idx_t si = item->staffIdxOrNextVisible();
+        staff_idx_t si = item->effectiveStaffIdx();
 
         // if there's no good staff for this object, obliterate it
         ldata->setIsSkipDraw(si == muse::nidx);
@@ -215,7 +215,7 @@ void Autoplace::autoplaceSpannerSegment(const SpannerSegment* item, EngravingIte
         Shape sh = item->shape();
         sl.add(sh.translate(item->pos()));
         double yd = 0.0;
-        staff_idx_t stfIdx = item->systemFlag() ? item->staffIdxOrNextVisible() : item->staffIdx();
+        staff_idx_t stfIdx = item->effectiveStaffIdx();
         if (stfIdx == muse::nidx) {
             ldata->setIsSkipDraw(true);
             return;

--- a/src/engraving/rendering/score/systemlayout.cpp
+++ b/src/engraving/rendering/score/systemlayout.cpp
@@ -998,9 +998,6 @@ void SystemLayout::layoutSystemElements(System* system, LayoutContext& ctx)
         if (!sp->systemFlag() && sp->staff() && !sp->staff()->show()) {
             continue;
         }
-        if (sp->systemFlag() && sp->staffIdxOrNextVisible() == muse::nidx) {
-            continue;
-        }
 
         const Measure* startMeas = sp->findStartMeasure();
         const Measure* endMeas = sp->findEndMeasure();
@@ -1542,7 +1539,7 @@ void SystemLayout::processLines(System* system, LayoutContext& ctx, std::vector<
     //
     for (SpannerSegment* ss : segments) {
         if (ss->addToSkyline()) {
-            staff_idx_t stfIdx = ss->systemFlag() ? ss->staffIdxOrNextVisible() : ss->staffIdx();
+            staff_idx_t stfIdx = ss->effectiveStaffIdx();
             if (stfIdx == muse::nidx) {
                 continue;
             }
@@ -2680,12 +2677,12 @@ void SystemLayout::centerBigTimeSigsAcrossStaves(const System* system)
                 if (!timeSig || !timeSig->ldata()->isValid()) {
                     continue;
                 }
-                staff_idx_t thisStaffIdx = timeSig->staffIdxOrNextVisible();
+                staff_idx_t thisStaffIdx = timeSig->effectiveStaffIdx();
                 staff_idx_t nextStaffIdx = thisStaffIdx;
                 for (staff_idx_t idx = thisStaffIdx + 1; idx < nstaves; ++idx) {
                     EngravingItem* nextTimeSig = segment.element(staff2track(idx));
                     if (nextTimeSig && nextTimeSig->ldata()->isValid()) {
-                        staff_idx_t nextTimeSigStave = nextTimeSig->staffIdxOrNextVisible();
+                        staff_idx_t nextTimeSigStave = nextTimeSig->effectiveStaffIdx();
                         nextStaffIdx = system->prevVisibleStaff(nextTimeSigStave);
                         break;
                     }


### PR DESCRIPTION
Resolves: #25123

The fix in itself was one LOC, but as I looked into it I realized that this function was unnecessarily complex and expensive. Even though for the vast majority of items (which are not system-objects) the function exits at the first check, this is a function that gets called at every frame refresh for every item on screen, so it's still important to avoid stuff like
- calls to Score::tick2measure()
- unnecessary (and I guess unintentional) copies of Score::systemObjectStaves
- unnecessary nested loops.

The name was also misleading, so I've changed it to `effectiveStaffIdx`.