### PR TITLE
20998: Added a midi mapping for 'Enter rest'; improved rest entry in 'Re-pitch existing notes' mode

### DIFF
--- a/src/framework/shortcuts/view/mididevicemappingmodel.cpp
+++ b/src/framework/shortcuts/view/mididevicemappingmodel.cpp
@@ -56,6 +56,7 @@ inline ActionCodeList allMidiActions()
         "pad-note-32",
         "pad-note-64",
         "undo",
+        "rest",
         "pad-rest",
         "tie",
         "pad-dot",

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -5058,6 +5058,18 @@ void NotationInteraction::putRestToSelection()
 
     if (is.usingNoteEntryMethod(NoteEntryMethod::BY_DURATION) || is.usingNoteEntryMethod(NoteEntryMethod::RHYTHM)) {
         m_noteInput->padNote(Pad::REST);
+    } else if (is.usingNoteEntryMethod(NoteEntryMethod::REPITCH)) {
+        ChordRest* cr = is.cr();
+        if (cr) {
+            TDuration duration = cr->durationType();
+            if (duration.isValid() && !duration.isZero()) {
+                if (duration.isMeasure()) {
+                    is.moveToNextInputPos();
+                } else {
+                    putRest(duration);
+                }
+            }
+        }
     } else {
         putRest(is.duration());
     }

--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -1116,7 +1116,8 @@ const UiActionList NotationUiActions::m_actions = {
              mu::context::UiCtxProjectOpened,
              mu::context::CTX_NOTATION_NOT_NOTE_INPUT_STAFF_TAB,
              TranslatableString("action", "Rest"),
-             TranslatableString("action", "Enter rest")
+             TranslatableString("action", "Enter rest"),
+             IconCode::Code::REST
              ),
     UiAction("rest-TAB",
              mu::context::UiCtxProjectOpened,


### PR DESCRIPTION
Resolves: #20998

Adds a midi mapping for the "Enter rest" ui action which is also tied to the "Enter rest" shortcut (normally 0 and Num 0).

I think I am seeing a couple of issues with the "Enter rest" action in general:
- In Rhythm only input mode, "Enter rest" acts as "Toggle rest". Is this expected? Does "Enter rest" make any sense in this mode at all?
- More importantly, in Re-pitch only mode "Enter rest" enters a rest but changes the duration to the currently selected duration instead of retaining the whatever duration the underlying note has (similar to "Input by note name" mode). I don't think this is correct. Personally I enter my scores in Rhythm only mode, then Re-pitch only mode. During the first phase, I'd enter a rest as a note being interested only in its duration, and then during the second phase I'd change the note to a rest but I'd not expect the duration to change.

Thoughts?

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
