### PR TITLE
Make all % signs in editstyle.ui translatable, not just 4

### DIFF
--- a/src/notation/view/widgets/editstyle.ui
+++ b/src/notation/view/widgets/editstyle.ui
@@ -1432,7 +1432,7 @@
                   <bool>false</bool>
                  </property>
                  <property name="suffix">
-                  <string notr="true">%</string>
+                  <string>%</string>
                  </property>
                  <property name="maximum">
                   <number>100</number>
@@ -2103,7 +2103,7 @@
               <bool>false</bool>
              </property>
              <property name="suffix">
-              <string notr="true">%</string>
+              <string>%</string>
              </property>
              <property name="minimum">
               <number>10</number>
@@ -2186,7 +2186,7 @@
               <bool>false</bool>
              </property>
              <property name="suffix">
-              <string notr="true">%</string>
+              <string>%</string>
              </property>
              <property name="minimum">
               <number>10</number>
@@ -2211,7 +2211,7 @@
               <bool>false</bool>
              </property>
              <property name="suffix">
-              <string notr="true">%</string>
+              <string>%</string>
              </property>
              <property name="minimum">
               <number>10</number>
@@ -2268,7 +2268,7 @@
               <bool>false</bool>
              </property>
              <property name="suffix">
-              <string notr="true">%</string>
+              <string>%</string>
              </property>
              <property name="minimum">
               <number>10</number>
@@ -5602,7 +5602,7 @@
               <bool>false</bool>
              </property>
              <property name="suffix">
-              <string notr="true">%</string>
+              <string>%</string>
              </property>
              <property name="minimum">
               <number>50</number>
@@ -10768,7 +10768,7 @@
               <bool>false</bool>
              </property>
              <property name="suffix">
-              <string notr="true">%</string>
+              <string>%</string>
              </property>
              <property name="maximum">
               <number>300</number>
@@ -12923,7 +12923,7 @@ first note of the system</string>
                 <bool>false</bool>
                </property>
                <property name="suffix">
-                <string notr="true">%</string>
+                <string>%</string>
                </property>
                <property name="minimum">
                 <number>1</number>


### PR DESCRIPTION
As discussed on Discord.
There are 4 strings "%"on Transifex, affecting 8 locations, with this change it'd be 16 locations and at no extra cost (for the translators, alternative to #26383
