### PR TITLE
Don't translate "%", "/" and "°"

### DIFF
--- a/src/inspector/view/qml/MuseScore/Inspector/notation/dynamics/DynamicsSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/dynamics/DynamicsSettings.qml
@@ -55,7 +55,7 @@ Column {
         navigationRowStart: root.navigationRowStart + 1
 
         titleText: qsTrc("inspector", "Scale")
-        measureUnitsSymbol: qsTrc("global", "%")
+        measureUnitsSymbol: "%"
         propertyItem: root.model ? root.model.dynamicSize : null
 
         decimals: 0

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/symbols/SymbolSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/symbols/SymbolSettings.qml
@@ -60,7 +60,7 @@ Column {
             navigationRowStart: root.navigationRowStart
 
             titleText: qsTrc("inspector", "Scale")
-            measureUnitsSymbol: qsTrc("global", "%")
+            measureUnitsSymbol: "%"
             propertyItem: root.model ? root.model.symbolSize : null
 
             decimals: 0

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/symbols/SymbolSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/symbols/SymbolSettings.qml
@@ -80,7 +80,7 @@ Column {
             navigationRowStart: root.navigationRowStart + 1
 
             titleText: qsTrc("inspector", "Rotation")
-            measureUnitsSymbol: qsTrc("global", "°")
+            measureUnitsSymbol: "°"
             propertyItem: root.model ? root.model.symAngle : null
 
             decimals: 0

--- a/src/notation/view/widgets/editstaff.ui
+++ b/src/notation/view/widgets/editstaff.ui
@@ -151,7 +151,7 @@
           <item row="5" column="1">
            <widget class="QDoubleSpinBox" name="mag">
             <property name="suffix">
-             <string>%</string>
+             <string notr="true">%</string>
             </property>
             <property name="decimals">
              <number>1</number>

--- a/src/notation/view/widgets/editstyle.ui
+++ b/src/notation/view/widgets/editstyle.ui
@@ -795,7 +795,7 @@
                        <bool>false</bool>
                       </property>
                       <property name="suffix">
-                       <string>%</string>
+                       <string notr="true">%</string>
                       </property>
                       <property name="minimum">
                        <number>25</number>
@@ -8362,7 +8362,7 @@
                   <bool>false</bool>
                  </property>
                  <property name="suffix">
-                  <string>%</string>
+                  <string notr="true">%</string>
                  </property>
                  <property name="decimals">
                   <number>0</number>
@@ -11820,7 +11820,7 @@
                     <bool>false</bool>
                    </property>
                    <property name="suffix">
-                    <string>%</string>
+                    <string notr="true">%</string>
                    </property>
                    <property name="minimum">
                     <double>50.000000000000000</double>
@@ -14903,7 +14903,7 @@ first note of the system</string>
                 <bool>false</bool>
                </property>
                <property name="suffix">
-                <string>%</string>
+                <string notr="true">%</string>
                </property>
                <property name="decimals">
                 <number>0</number>

--- a/src/notation/view/widgets/measureproperties.ui
+++ b/src/notation/view/widgets/measureproperties.ui
@@ -115,7 +115,7 @@
           <item row="0" column="3">
            <widget class="QLabel" name="label_3">
             <property name="text">
-             <string>/</string>
+             <string notr="true">/</string>
             </property>
             <property name="alignment">
              <set>Qt::AlignCenter</set>
@@ -151,7 +151,7 @@
           <item row="1" column="3">
            <widget class="QLabel" name="label_4">
             <property name="text">
-             <string>/</string>
+             <string notr="true">/</string>
             </property>
             <property name="alignment">
              <set>Qt::AlignCenter</set>

--- a/src/notation/view/widgets/stafftextpropertiesdialog.ui
+++ b/src/notation/view/widgets/stafftextpropertiesdialog.ui
@@ -122,7 +122,7 @@
               <bool>true</bool>
              </property>
              <property name="suffix">
-              <string>%</string>
+              <string notr="true">%</string>
              </property>
              <property name="minimum">
               <number>25</number>

--- a/src/notation/view/widgets/tupletdialog.ui
+++ b/src/notation/view/widgets/tupletdialog.ui
@@ -68,7 +68,7 @@
           <item>
            <widget class="QLabel" name="label_2">
             <property name="text">
-             <string>/</string>
+             <string notr="true">/</string>
             </property>
             <property name="buddy">
              <cstring>normalNotes</cstring>

--- a/src/palette/view/widgets/timedialog.ui
+++ b/src/palette/view/widgets/timedialog.ui
@@ -95,7 +95,7 @@
               </sizepolicy>
              </property>
              <property name="text">
-              <string>/</string>
+              <string notr="true">/</string>
              </property>
              <property name="buddy">
               <cstring>nNominal</cstring>
@@ -197,7 +197,7 @@
               </sizepolicy>
              </property>
              <property name="text">
-              <string>/</string>
+              <string notr="true">/</string>
              </property>
              <property name="buddy">
               <cstring>nText</cstring>

--- a/src/palette/view/widgets/timesignaturepropertiesdialog.ui
+++ b/src/palette/view/widgets/timesignaturepropertiesdialog.ui
@@ -98,7 +98,7 @@
              <item>
               <widget class="QLabel" name="label">
                <property name="text">
-                <string>/</string>
+                <string notr="true">/</string>
                </property>
               </widget>
              </item>


### PR DESCRIPTION
As discussed on Discord
Don't translate the standalone "%" at all, alternative to #26382
Also don't translate "/" and "°"