### PR TITLE
Fix #26208 (Dynamics): [Musicxml Export] - End-bar items lost

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
@@ -8247,6 +8247,14 @@ void ExportMusicXml::writeMeasureTracks(const Measure* const m,
                 const track_idx_t endtrack = staff2track(spannerStaff + 1);
                 spannerStop(this, starttrack, endtrack, seg->tick(), partRelStaffNo, spannersStopped);
 
+                // We check if there are additional annotations
+                for (EngravingItem* annotation : seg->annotations()) {
+                    if (annotation->track() != track || !annotation->isTextBase()) {
+                        continue;
+                    }
+                    // Just to include them
+                    annotations(this, strack, etrack, track, partRelStaffNo, seg);
+                }
                 continue;
             }
             EngravingItem* const el = seg->element(track);


### PR DESCRIPTION
Resolves: #26208 (Dynamics) <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
This PR exports dynamic elements (_p, pp, fff_...) when they are linked to a TimeTickType segment 

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->
- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
