### PR TITLE
Update translations server URL for 4.5

### DIFF
--- a/src/app/configs/languages.cfg
+++ b/src/app/configs/languages.cfg
@@ -1,3 +1,3 @@
 {
-    "server_url": "http://extensions.musescore.org/4.4/languages/"
+    "server_url": "http://extensions.musescore.org/4.5/languages/"
 }


### PR DESCRIPTION
After this is merged to master, both `s3_packandsend.py` and "Check for language updates" will use the new URL.