### PR TITLE
Fix crash because of data race in `AsyncImpl::onCall`

### DIFF
--- a/src/framework/global/thirdparty/kors_async/async/internal/asyncimpl.cpp
+++ b/src/framework/global/thirdparty/kors_async/async/internal/asyncimpl.cpp
@@ -36,17 +36,12 @@ AsyncImpl* AsyncImpl::instance()
 void AsyncImpl::disconnectAsync(Asyncable* caller)
 {
     std::lock_guard locker(m_mutex);
-    uint64_t key = 0;
-    std::map<uint64_t, Call>::const_iterator it = m_calls.cbegin(), end = m_calls.cend();
-    for (; it != end; ++it) {
+
+    for (auto it = m_calls.cbegin(), end = m_calls.cend(); it != end; ++it) {
         if (it->second.caller == caller) {
-            key = it->first;
+            m_calls.erase(it);
             break;
         }
-    }
-
-    if (key) {
-        m_calls.erase(key);
     }
 }
 

--- a/src/framework/global/thirdparty/kors_async/async/internal/asyncimpl.cpp
+++ b/src/framework/global/thirdparty/kors_async/async/internal/asyncimpl.cpp
@@ -79,14 +79,15 @@ void AsyncImpl::onCall(uint64_t key)
         }
 
         c = it->second;
+
         m_calls.erase(it);
+
+        if (c.caller) {
+            c.caller->disconnectAsync(this);
+        }
     }
 
     c.f->call();
-
-    if (c.caller) {
-        c.caller->disconnectAsync(this);
-    }
 
     delete c.f;
 }


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/25884

We were calling `c.caller->disconnectAsync` after `c.f->call()`, not protected by any mutex. The problem is that `c.caller` is deleted by another thread, between the mutex-protected section and the `disconnectAsync` call.

A solution is to move the `disconnectAsync` call inside the mutex-protected section. It does not really matter that it happens before `c.f->call()` this way; one could even argue it's better this way, because it belongs together with `m_calls.erase(it)`. This way, we can be certain that `c.caller` has not been deleted by another thread iff it is found in `m_calls`: when `c.caller` is being deleted (see `~Asyncable`), it calls its `disconnectAll()` method, which calls `AsyncImpl::disconnectAsync`, which uses the mutex and removes the `Asyncable` from `m_calls`.

A remaining potential problem now, is that `c.caller` may be deleted during `c.f->call()`, which may be problematic inside `c.f->call()`. I'm not sure if it is the responsibility of `AsyncImpl` to mitigate that. If it is, that will either be challenging, or require the use of `recursive_mutex`.