### PR TITLE
Fixing issues in translatable texts

### DIFF
--- a/src/appshell/view/appmenumodel.cpp
+++ b/src/appshell/view/appmenumodel.cpp
@@ -485,7 +485,7 @@ MenuItem* AppMenuModel::makeDiagnosticsMenu()
               << makeMenu(TranslatableString("appshell/menu/diagnostics", "&Engraving"), engravingItems, "menu-engraving")
               << makeMenu(TranslatableString("appshell/menu/diagnostics", "E&xtensions"), extensionsItems, "menu-extensions")
               << makeMenu(TranslatableString("appshell/menu/diagnostics", "Auto&bot"), autobotItems, "menu-autobot")
-              << makeMenu(TranslatableString("appshell/menu/diagnostics", "&Vst"), vstItems, "menu-vst")
+              << makeMenu(TranslatableString("appshell/menu/diagnostics", "&VST"), vstItems, "menu-vst")
               << makeMenuItem("multiinstances-dev-show-info");
     }
 

--- a/src/framework/extensions/internal/extensionsuiactions.cpp
+++ b/src/framework/extensions/internal/extensionsuiactions.cpp
@@ -42,7 +42,7 @@ static const UiActionList STATIC_ACTIONS = {
     UiAction("extensions-show-apidump",
              muse::ui::UiCtxAny,
              muse::shortcuts::CTX_ANY,
-             TranslatableString("action", "Show Api dump")
+             TranslatableString("action", "Show API dump")
              ),
 };
 


### PR DESCRIPTION
* Api > API, being an acronym
* Vst > VST, same