### PR TITLE
Fix #26381: Toolbars not opening

### DIFF
--- a/src/appshell/internal/applicationuiactions.cpp
+++ b/src/appshell/internal/applicationuiactions.cpp
@@ -309,7 +309,7 @@ bool ApplicationUiActions::actionChecked(const UiAction& act) const
     }
 
     const IDockWindow* window = dockWindowProvider()->window();
-    return window ? window->isDockOpen(dockName) : false;
+    return window ? window->isDockOpenAndCurrentInFrame(dockName) : false;
 }
 
 muse::async::Channel<ActionCodeList> ApplicationUiActions::actionEnabledChanged() const

--- a/src/appshell/view/notationpagemodel.cpp
+++ b/src/appshell/view/notationpagemodel.cpp
@@ -198,7 +198,7 @@ void NotationPageModel::updateDrumsetPanelVisibility()
     }
 
     auto setDrumsetPanelOpen = [this, window](bool open) {
-        if (open == window->isDockOpen(DRUMSET_PANEL_NAME)) {
+        if (open == window->isDockOpenAndCurrentInFrame(DRUMSET_PANEL_NAME)) {
             return;
         }
         dispatcher()->dispatch("dock-set-open", ActionData::make_arg2<QString, bool>(DRUMSET_PANEL_NAME, open));
@@ -232,7 +232,7 @@ void NotationPageModel::updatePercussionPanelVisibility()
     }
 
     auto setPercussionPanelOpen = [this, window](bool open) {
-        if (open == window->isDockOpen(PERCUSSION_PANEL_NAME)) {
+        if (open == window->isDockOpenAndCurrentInFrame(PERCUSSION_PANEL_NAME)) {
             return;
         }
         dispatcher()->dispatch("dock-set-open", ActionData::make_arg2<QString, bool>(PERCUSSION_PANEL_NAME, open));

--- a/src/framework/dockwindow/idockwindow.h
+++ b/src/framework/dockwindow/idockwindow.h
@@ -36,7 +36,7 @@ class IDockWindow
 public:
     virtual ~IDockWindow() = default;
 
-    virtual bool isDockOpen(const QString& dockName) const = 0;
+    virtual bool isDockOpenAndCurrentInFrame(const QString& dockName) const = 0;
     virtual void setDockOpen(const QString& dockName, bool open) = 0;
     virtual void toggleDock(const QString& dockName) = 0;
 

--- a/src/framework/dockwindow/view/dockpageview.cpp
+++ b/src/framework/dockwindow/view/dockpageview.cpp
@@ -190,24 +190,26 @@ QList<DockPanelView*> DockPageView::possiblePanelsForTab(const DockPanelView* ta
     return result;
 }
 
-bool DockPageView::isDockOpen(const QString& dockName) const
+bool DockPageView::isDockOpenAndCurrentInFrame(const QString& dockName) const
 {
     const DockBase* dock = dockByName(dockName);
     if (!dock) {
         return false;
     }
 
+    const bool isDockOpen = dock && dock->isOpen();
+
     const DockPanelView* panel = dynamic_cast<const DockPanelView*>(dock);
-    if (!panel) {
-        return false;
+    if (panel) {
+        return isDockOpen && panel->isCurrentTabInFrame();
     }
 
-    return dock ? dock->isOpen() && panel->isCurrentTabInFrame() : false;
+    return isDockOpen;
 }
 
 void DockPageView::toggleDock(const QString& dockName)
 {
-    setDockOpen(dockName, !isDockOpen(dockName));
+    setDockOpen(dockName, !isDockOpenAndCurrentInFrame(dockName));
 }
 
 void DockPageView::setDockOpen(const QString& dockName, bool open)

--- a/src/framework/dockwindow/view/dockpageview.h
+++ b/src/framework/dockwindow/view/dockpageview.h
@@ -89,7 +89,7 @@ public:
     DockingHolderView* holder(DockType type, Location location) const;
     QList<DockPanelView*> possiblePanelsForTab(const DockPanelView* tab) const;
 
-    bool isDockOpen(const QString& dockName) const;
+    bool isDockOpenAndCurrentInFrame(const QString& dockName) const;
     void toggleDock(const QString& dockName);
     void setDockOpen(const QString& dockName, bool open);
 

--- a/src/framework/dockwindow/view/dockwindow.cpp
+++ b/src/framework/dockwindow/view/dockwindow.cpp
@@ -249,9 +249,9 @@ void DockWindow::loadPage(const QString& uri, const QVariantMap& params)
     }
 }
 
-bool DockWindow::isDockOpen(const QString& dockName) const
+bool DockWindow::isDockOpenAndCurrentInFrame(const QString& dockName) const
 {
-    return m_currentPage && m_currentPage->isDockOpen(dockName);
+    return m_currentPage && m_currentPage->isDockOpenAndCurrentInFrame(dockName);
 }
 
 void DockWindow::toggleDock(const QString& dockName)

--- a/src/framework/dockwindow/view/dockwindow.h
+++ b/src/framework/dockwindow/view/dockwindow.h
@@ -78,7 +78,7 @@ public:
     Q_INVOKABLE void loadPage(const QString& uri, const QVariantMap& params);
 
     //! IDockWindow
-    bool isDockOpen(const QString& dockName) const override;
+    bool isDockOpenAndCurrentInFrame(const QString& dockName) const override;
     void toggleDock(const QString& dockName) override;
     void setDockOpen(const QString& dockName, bool open) override;
 


### PR DESCRIPTION
Resolves: #26381

As pointed out [here](https://github.com/musescore/MuseScore/issues/26381#issuecomment-2644399783) by @krasko78, this was broken in 99501cb3de20bc4298f4338c53f53e2c5de29afd due to a failed cast (the toolbars are `DockToolBarViews` as opposed to `DockPanelViews`).