### PR TITLE
Fix crash on drop time sig or key sig

### DIFF
--- a/src/engraving/rendering/score/systemlayout.cpp
+++ b/src/engraving/rendering/score/systemlayout.cpp
@@ -332,6 +332,11 @@ System* SystemLayout::collectSystem(LayoutContext& ctx)
         }
     }
 
+    if (system->staves().empty()) {
+        // Edge case. Can only happen if all instruments have been deleted.
+        return system;
+    }
+
     /*************************************************************
      * SYSTEM NOW HAS A COMPLETE SET OF MEASURES
      * Now perform all operation to finalize system.

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -1574,7 +1574,6 @@ bool NotationInteraction::drop(const PointF& pos, Qt::KeyboardModifiers modifier
         break;
     }
 
-    EngravingItem* elementToSelect = m_dropData.ed.dropElement;
     m_dropData.ed.dropElement = nullptr;
     m_dropData.ed.pos = PointF();
     m_dropData.ed.modifiers = {};
@@ -1584,10 +1583,6 @@ bool NotationInteraction::drop(const PointF& pos, Qt::KeyboardModifiers modifier
 
     if (accepted) {
         notifyAboutDropChanged();
-
-        if (elementToSelect) {
-            selectAndStartEditIfNeeded(elementToSelect);
-        }
     }
 
     MScoreErrorsController(iocContext()).checkAndShowMScoreError();

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -1623,7 +1623,7 @@ bool NotationInteraction::doDropStandard()
     score()->addRefresh(el->canvasBoundingRect());
     if (dropElement) {
         if (!score()->noteEntryMode()) {
-            doSelect({ dropElement }, SelectType::SINGLE);
+            selectAndStartEditIfNeeded(dropElement);
         }
         score()->addRefresh(dropElement->canvasBoundingRect());
     }
@@ -1664,7 +1664,7 @@ bool NotationInteraction::doDropTextBaseAndSymbols(const PointF& pos, bool apply
         EngravingItem* dropElement = el->drop(m_dropData.ed);
         score()->addRefresh(el->canvasBoundingRect());
         if (dropElement) {
-            doSelect({ dropElement }, SelectType::SINGLE);
+            selectAndStartEditIfNeeded(dropElement);
             score()->addRefresh(dropElement->canvasBoundingRect());
         }
     }


### PR DESCRIPTION
Resolves: #26423 
Resolves: #26414 
Resolves: #25395 

@cbjeukendrup `EditData::dropElement` can't be used after the drop, because it is often deleted during the drop itself (see for instance `Measure::drop` on the case `ElementType::KEYSIG`). In turn, it's the `drop` method which returns (if possible) the element to be selected after the drop, and the selection is already done in `NotationInteraction::doDropStandard` and `NotationInteraction::doDropTextBaseAndSymbols` so it shouldn't be necessary to do it here too.

The last issue is not a real issue, just an assert failure on an edge case that's only relevant with debug builds, but I've fixed it anyway.