### PR TITLE
Fix invisible text disappears when resetting part

### DIFF
--- a/src/engraving/dom/excerpt.cpp
+++ b/src/engraving/dom/excerpt.cpp
@@ -1533,7 +1533,8 @@ void Excerpt::cloneStaff2(Staff* srcStaff, Staff* dstStaff, const Fraction& star
                         continue;
                     }
                     bool systemObject = e->systemFlag() && e->track() == 0;
-                    bool alreadyCloned = bool(e->findLinkedInScore(score)) && e->parent() == ns;
+                    EngravingItem* linkedElement = e->findLinkedInScore(score);
+                    bool alreadyCloned = linkedElement && linkedElement->parent() == ns;
                     bool cloneAnnotation = !alreadyCloned && (e->elementAppliesToTrack(srcTrack) || systemObject);
 
                     if (!cloneAnnotation) {

--- a/src/engraving/dom/excerpt.cpp
+++ b/src/engraving/dom/excerpt.cpp
@@ -1533,7 +1533,7 @@ void Excerpt::cloneStaff2(Staff* srcStaff, Staff* dstStaff, const Fraction& star
                         continue;
                     }
                     bool systemObject = e->systemFlag() && e->track() == 0;
-                    bool alreadyCloned = bool(e->findLinkedInScore(score));
+                    bool alreadyCloned = bool(e->findLinkedInScore(score)) && e->parent() == ns;
                     bool cloneAnnotation = !alreadyCloned && (e->elementAppliesToTrack(srcTrack) || systemObject);
 
                     if (!cloneAnnotation) {


### PR DESCRIPTION
Resolves: #25598 

Adding to the issue:

1. Open the default template
2. Insert a staff text on any measure
3. Open part (observe that the staff text breaks the multirest, as expected)
4. Set staff text invisible (observe the multirest merges, as expected)
5. Instrument -> Settings -> Reset all formatting. Observe the invisible text doesn't come back visible.
6. Deactivare multi-rests. Observe the text has disappeared.