### PR TITLE
Various pad name cleanup

### DIFF
--- a/share/instruments/instruments.xml
+++ b/share/instruments/instruments.xml
@@ -10056,8 +10056,8 @@
                         <voice>0</voice>
                         <name>Drum 4 Shell</name>
                         <stem>1</stem>
-                        <panelRow>4</panelRow>
-                        <panelColumn>1</panelColumn>
+                        <panelRow>3</panelRow>
+                        <panelColumn>4</panelColumn>
                   </Drum>
                   <Drum pitch="43"> <!--High Floor Tom-->
                         <head>plus</head>
@@ -10065,8 +10065,8 @@
                         <voice>0</voice>
                         <name>Stick Click</name>
                         <stem>1</stem>
-                        <panelRow>4</panelRow>
-                        <panelColumn>0</panelColumn>
+                        <panelRow>3</panelRow>
+                        <panelColumn>6</panelColumn>
                   </Drum>
                   <Drum pitch="48"> <!--Hi-Mid Tom-->
                         <head>normal</head>
@@ -10111,8 +10111,8 @@
                         <voice>0</voice>
                         <name>Drum 3 Shell</name>
                         <stem>1</stem>
-                        <panelRow>4</panelRow>
-                        <panelColumn>2</panelColumn>
+                        <panelRow>3</panelRow>
+                        <panelColumn>5</panelColumn>
                   </Drum>
                   <Drum pitch="60"> <!--High Bongo-->
                         <head>normal</head>
@@ -10407,7 +10407,7 @@
                   <singleNoteDynamics>0</singleNoteDynamics>
                   <Drum pitch="72"> <!--Long Whistle-->
                         <head>normal</head>
-                        <line>0</line>
+                        <line>1</line>
                         <voice>0</voice>
                         <name>Full Crash</name>
                         <shortcut>A</shortcut>
@@ -10416,7 +10416,7 @@
                   </Drum>
                   <Drum pitch="74"> <!--Long Guiro-->
                         <head>normal</head>
-                        <line>0</line>
+                        <line>1</line>
                         <voice>0</voice>
                         <name>Half Crash</name>
                         <shortcut>B</shortcut>
@@ -10425,7 +10425,7 @@
                   </Drum>
                   <Drum pitch="76"> <!--High Woodblock-->
                         <head>cross</head>
-                        <line>0</line>
+                        <line>1</line>
                         <voice>0</voice>
                         <name>Hi-Hat</name>
                         <shortcut>C</shortcut>
@@ -10434,7 +10434,7 @@
                   </Drum>
                   <Drum pitch="77"> <!--Low Woodblock-->
                         <head>normal</head>
-                        <line>0</line>
+                        <line>1</line>
                         <voice>0</voice>
                         <name>Sizzle</name>
                         <shortcut>D</shortcut>
@@ -10443,7 +10443,7 @@
                   </Drum>
                   <Drum pitch="79"> <!--Open Cuica-->
                         <head>normal</head>
-                        <line>0</line>
+                        <line>1</line>
                         <voice>0</voice>
                         <name>Crash-Choke</name>
                         <shortcut>E</shortcut>
@@ -10452,7 +10452,7 @@
                   </Drum>
                   <Drum pitch="81"> <!--Open Triangle-->
                         <head>do</head>
-                        <line>0</line>
+                        <line>1</line>
                         <voice>0</voice>
                         <name>Tap</name>
                         <shortcut>F</shortcut>
@@ -10461,7 +10461,7 @@
                   </Drum>
                   <Drum pitch="83"> <!--Jingle Bell-->
                         <head>do</head>
-                        <line>0</line>
+                        <line>1</line>
                         <voice>0</voice>
                         <name>Tap-Choke</name>
                         <shortcut>G</shortcut>
@@ -10470,7 +10470,7 @@
                   </Drum>
                   <Drum pitch="84"> <!--Belltree-->
                         <head>diamond</head>
-                        <line>0</line>
+                        <line>1</line>
                         <voice>0</voice>
                         <name>Bell Tap</name>
                         <panelRow>1</panelRow>
@@ -10478,7 +10478,7 @@
                   </Drum>
                   <Drum pitch="86"> <!--Mute Surdo-->
                         <head>diamond</head>
-                        <line>0</line>
+                        <line>1</line>
                         <voice>0</voice>
                         <name>Bell Tap-Choke</name>
                         <panelRow>1</panelRow>
@@ -10486,7 +10486,7 @@
                   </Drum>
                   <Drum pitch="88">
                         <head>plus</head>
-                        <line>0</line>
+                        <line>1</line>
                         <voice>0</voice>
                         <name>Muted Tap</name>
                         <shortcut>H</shortcut>
@@ -10501,7 +10501,7 @@
                               <whole>noteheadXOrnate</whole>
                               <breve>noteheadXOrnate</breve>
                         </noteheads>
-                        <line>0</line>
+                        <line>1</line>
                         <voice>0</voice>
                         <name>Smash</name>
                         <panelRow>1</panelRow>
@@ -10509,7 +10509,7 @@
                   </Drum>
                   <Drum pitch="91">
                         <head>slashed1</head>
-                        <line>0</line>
+                        <line>1</line>
                         <voice>0</voice>
                         <name>Zing</name>
                         <panelRow>1</panelRow>
@@ -10517,7 +10517,7 @@
                   </Drum>
                   <Drum pitch="93">
                         <head>normal</head>
-                        <line>0</line>
+                        <line>1</line>
                         <voice>0</voice>
                         <name>Roll</name>
                         <panelRow>1</panelRow>

--- a/share/instruments/instruments.xml
+++ b/share/instruments/instruments.xml
@@ -10060,11 +10060,11 @@
                         <panelColumn>1</panelColumn>
                   </Drum>
                   <Drum pitch="43"> <!--High Floor Tom-->
-                        <head>diamond</head>
+                        <head>plus</head>
                         <line>-1</line>
                         <voice>0</voice>
-                        <name>sticks</name>
-                        <stem>2</stem>
+                        <name>Stick Click</name>
+                        <stem>1</stem>
                         <panelRow>4</panelRow>
                         <panelColumn>0</panelColumn>
                   </Drum>
@@ -10276,7 +10276,7 @@
                         <head>normal</head>
                         <line>7</line>
                         <voice>0</voice>
-                        <name>Bass Drum 5</name>
+                        <name>Drum 5</name>
                         <stem>1</stem>
                         <shortcut>A</shortcut>
                         <panelRow>0</panelRow>
@@ -10286,7 +10286,7 @@
                         <head>cross</head>
                         <line>7</line>
                         <voice>0</voice>
-                        <name>Bass Drum 5 Rim Knock</name>
+                        <name>Drum 5 Rim</name>
                         <stem>1</stem>
                         <panelRow>1</panelRow>
                         <panelColumn>0</panelColumn>
@@ -10295,7 +10295,7 @@
                         <head>normal</head>
                         <line>5</line>
                         <voice>0</voice>
-                        <name>Bass Drum 4</name>
+                        <name>Drum 4</name>
                         <stem>1</stem>
                         <shortcut>B</shortcut>
                         <panelRow>0</panelRow>
@@ -10305,7 +10305,7 @@
                         <head>cross</head>
                         <line>5</line>
                         <voice>0</voice>
-                        <name>Bass Drum 4 Rim Knock</name>
+                        <name>Drum 4 Rim</name>
                         <stem>1</stem>
                         <panelRow>1</panelRow>
                         <panelColumn>1</panelColumn>
@@ -10314,7 +10314,7 @@
                         <head>normal</head>
                         <line>3</line>
                         <voice>0</voice>
-                        <name>Bass Drum 3</name>
+                        <name>Drum 3</name>
                         <stem>1</stem>
                         <shortcut>C</shortcut>
                         <panelRow>0</panelRow>
@@ -10324,7 +10324,7 @@
                         <head>cross</head>
                         <line>3</line>
                         <voice>0</voice>
-                        <name>Bass Drum 3 Rim Knock</name>
+                        <name>Drum 3 Rim</name>
                         <stem>1</stem>
                         <panelRow>1</panelRow>
                         <panelColumn>2</panelColumn>
@@ -10333,7 +10333,7 @@
                         <head>normal</head>
                         <line>1</line>
                         <voice>0</voice>
-                        <name>Bass Drum 2</name>
+                        <name>Drum 2</name>
                         <stem>1</stem>
                         <shortcut>D</shortcut>
                         <panelRow>0</panelRow>
@@ -10343,7 +10343,7 @@
                         <head>cross</head>
                         <line>1</line>
                         <voice>0</voice>
-                        <name>Bass Drum 2 Rim Knock</name>
+                        <name>Drum 2 Rim</name>
                         <stem>1</stem>
                         <panelRow>1</panelRow>
                         <panelColumn>3</panelColumn>
@@ -10352,7 +10352,7 @@
                         <head>normal</head>
                         <line>-1</line>
                         <voice>0</voice>
-                        <name>Bass Drum 1</name>
+                        <name>Drum 1</name>
                         <stem>1</stem>
                         <shortcut>E</shortcut>
                         <panelRow>0</panelRow>
@@ -10362,7 +10362,7 @@
                         <head>cross</head>
                         <line>-1</line>
                         <voice>0</voice>
-                        <name>Bass Drum 1 Rim Knock</name>
+                        <name>Drum 1 Rim</name>
                         <stem>1</stem>
                         <panelRow>1</panelRow>
                         <panelColumn>4</panelColumn>
@@ -10371,7 +10371,7 @@
                         <head>slash</head>
                         <line>4</line>
                         <voice>0</voice>
-                        <name>Simultaneous Hit</name>
+                        <name>Unison</name>
                         <stem>1</stem>
                         <shortcut>F</shortcut>
                         <panelRow>0</panelRow>
@@ -10427,7 +10427,7 @@
                         <head>cross</head>
                         <line>0</line>
                         <voice>0</voice>
-                        <name>High Hat</name>
+                        <name>Hi-Hat</name>
                         <shortcut>C</shortcut>
                         <panelRow>0</panelRow>
                         <panelColumn>2</panelColumn>
@@ -10454,7 +10454,7 @@
                         <head>do</head>
                         <line>0</line>
                         <voice>0</voice>
-                        <name>Normal Tap</name>
+                        <name>Tap</name>
                         <shortcut>F</shortcut>
                         <panelRow>0</panelRow>
                         <panelColumn>5</panelColumn>
@@ -10463,7 +10463,7 @@
                         <head>do</head>
                         <line>0</line>
                         <voice>0</voice>
-                        <name>Normal Tap-Choke</name>
+                        <name>Tap-Choke</name>
                         <shortcut>G</shortcut>
                         <panelRow>0</panelRow>
                         <panelColumn>6</panelColumn>


### PR DESCRIPTION
Marching Cymbals:
"Normal" is unnecessary, can just say Tap
High Hat is wrong, Hi-Hat is correct

Bass Drums:
Match tenor convention and just say "Drum 1,2,3,4 etc

Marching tenors
Use same notion and name for Stick Click as snares

Update in spreadsheet, run Python script
