### PR TITLE
Correct accent placement on opening pre 4.1 scores

### DIFF
--- a/src/engraving/data/styles/legacy-style-defaults-v1.mss
+++ b/src/engraving/data/styles/legacy-style-defaults-v1.mss
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.10">
+<museScore version="1.14">
   <Style>
     <pageWidth>8.27</pageWidth>
     <pageHeight>11.69</pageHeight>

--- a/src/engraving/data/styles/legacy-style-defaults-v2.mss
+++ b/src/engraving/data/styles/legacy-style-defaults-v2.mss
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.10">
+<museScore version="2.06">
   <Style>
     <pageWidth>8.27</pageWidth>
     <pageHeight>11.69</pageHeight>

--- a/src/engraving/data/styles/legacy-style-defaults-v3.mss
+++ b/src/engraving/data/styles/legacy-style-defaults-v3.mss
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.10">
+<museScore version="3.01">
   <Style>
     <pageWidth>8.27</pageWidth>
     <pageHeight>11.69</pageHeight>

--- a/src/engraving/data/styles/legacy-style-defaults-v302.mss
+++ b/src/engraving/data/styles/legacy-style-defaults-v302.mss
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.10">
+<museScore version="3.02">
   <Style>
     <pageWidth>8.26772</pageWidth>
     <pageHeight>11.6929</pageHeight>

--- a/src/engraving/data/styles/migration-306-style-Edwin.mss
+++ b/src/engraving/data/styles/migration-306-style-Edwin.mss
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.10">
+<museScore version="3.02">
   <Style>
     <lyricsMinDistance>0.25</lyricsMinDistance>
     <lyricsDashLineThickness>0.1</lyricsDashLineThickness>

--- a/src/engraving/data/styles/migration-306-style-Leland.mss
+++ b/src/engraving/data/styles/migration-306-style-Leland.mss
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.10">
+<museScore version="3.02">
   <Style>
     <musicalSymbolFont>Leland</musicalSymbolFont>
     <musicalTextFont>Leland Text</musicalTextFont>

--- a/src/engraving/style/style.cpp
+++ b/src/engraving/style/style.cpp
@@ -25,6 +25,7 @@
 #include "types/constants.h"
 #include "compat/pageformat.h"
 #include "rw/compat/readchordlisthook.h"
+#include "rw/compat/compatutils.h"
 #include "rw/xmlreader.h"
 #include "rw/xmlwriter.h"
 #include "types/typesconv.h"
@@ -531,6 +532,12 @@ void MStyle::read(XmlReader& e, compat::ReadChordListHook* readChordListHook)
                    || tag == "defaultFontSpatiumDependent"
                    || tag == "usePre_3_6_defaults") {
             e.skipCurrentElement(); // obsolete
+        } else if (tag == "articulationAnchorDefault" && m_version < 410) {
+            set(Sid::articulationAnchorDefault, (int)compat::CompatUtils::translateToNewArticulationAnchor(e.readInt()));
+        } else if (tag == "articulationAnchorLuteFingering" && m_version < 410) {
+            set(Sid::articulationAnchorLuteFingering, (int)compat::CompatUtils::translateToNewArticulationAnchor(e.readInt()));
+        } else if (tag == "articulationAnchorOther" && m_version < 410) {
+            set(Sid::articulationAnchorOther, (int)compat::CompatUtils::translateToNewArticulationAnchor(e.readInt()));
         } else if (tag == "lineEndToSystemEndDistance") { // renamed in 4.5
             set(Sid::lineEndToBarlineDistance, Spatium(e.readDouble()));
         } else if (!readProperties(e)) {

--- a/src/engraving/tests/compat114_data/style-ref.mscx
+++ b/src/engraving/tests/compat114_data/style-ref.mscx
@@ -32,7 +32,9 @@
       <beamMinLen>1.3</beamMinLen>
       <dotNoteDistance>0.45</dotNoteDistance>
       <dotDotDistance>0.6</dotDotDistance>
+      <propertyDistanceHead>0.5</propertyDistanceHead>
       <propertyDistanceStem>0.6</propertyDistanceStem>
+      <propertyDistance>0.5</propertyDistance>
       <lastSystemFillLimit>0.29</lastSystemFillLimit>
       <hairpinHeight>1.3</hairpinHeight>
       <hairpinContHeight>0.6</hairpinContHeight>


### PR DESCRIPTION
Resolves: #25746 
This PR adds the correct version numbers to the default style files.  Previously these were all 4.1, meaning that some compatibility checks using `m_version` in `MStyle::read` weren't being applied.
The PR also adds conversion from the old articulation anchor style setting to the new version (https://github.com/musescore/MuseScore/pull/17640)
