### PR TITLE
Extended dock resizing functionality

### DIFF
--- a/src/appshell/qml/NotationPage/NotationPage.qml
+++ b/src/appshell/qml/NotationPage/NotationPage.qml
@@ -419,6 +419,8 @@ DockPage {
             navigationSection: root.navigationPanelSec(mixerPanel.location)
 
             MixerPanel {
+                id: mixerPanelComponent
+
                 navigationSection: mixerPanel.navigationSection
                 contentNavigationPanelOrderStart: mixerPanel.contentNavigationPanelOrderStart
 
@@ -434,6 +436,13 @@ DockPage {
 
                 onResizeRequested: function(newWidth, newHeight) {
                     mixerPanel.resize(newWidth, newHeight)
+                }
+
+                Connections {
+                    target: mixerPanel
+                    function onPanelShown() {
+                        mixerPanelComponent.resizePanelToContentHeight()
+                    }
                 }
             }
         },
@@ -544,6 +553,8 @@ DockPage {
             navigationSection: root.navigationPanelSec(percussionPanel.location)
 
             PercussionPanel {
+                id: percussionComponent
+
                 navigationSection: percussionPanel.navigationSection
                 contentNavigationPanelOrderStart: percussionPanel.contentNavigationPanelOrderStart
 
@@ -557,6 +568,13 @@ DockPage {
 
                 onResizeRequested: function(newWidth, newHeight) {
                     percussionPanel.resize(newWidth, newHeight)
+                }
+
+                Connections {
+                    target: percussionPanel
+                    function onPanelShown() {
+                        percussionComponent.resizePanelToContentHeight()
+                    }
                 }
             }
         }

--- a/src/framework/dockwindow/internal/dockbase.cpp
+++ b/src/framework/dockwindow/internal/dockbase.cpp
@@ -624,7 +624,7 @@ void DockBase::componentComplete()
     m_dockWidget->setTitle(m_title);
 
     writeProperties();
-    listenFloatingChanges();
+    setUpFrameConnections();
 
     connect(m_dockWidget, &KDDockWidgets::DockWidgetQuick::widthChanged, this, [this]() {
         if (m_dockWidget) {
@@ -717,18 +717,25 @@ void DockBase::applySizeConstraints()
     }
 }
 
-void DockBase::listenFloatingChanges()
+void DockBase::setUpFrameConnections()
 {
     IF_ASSERT_FAILED(m_dockWidget) {
         return;
     }
 
-    auto frameConn = std::make_shared<QMetaObject::Connection>();
+    auto floatingChangedConnection = std::make_shared<QMetaObject::Connection>();
+    auto widgetChangedConnection = std::make_shared<QMetaObject::Connection>();
 
-    connect(m_dockWidget, &KDDockWidgets::DockWidgetQuick::parentChanged, this, [this, frameConn]() {
-        if (frameConn) {
-            disconnect(*frameConn);
+    connect(m_dockWidget, &KDDockWidgets::DockWidgetQuick::parentChanged, this,
+            [this, floatingChangedConnection, widgetChangedConnection]()
+    {
+        if (floatingChangedConnection) {
+            disconnect(*floatingChangedConnection);
             doSetFloating(false);
+        }
+
+        if (widgetChangedConnection) {
+            disconnect(*widgetChangedConnection);
         }
 
         if (!m_dockWidget || !m_dockWidget->parentItem()) {
@@ -751,8 +758,11 @@ void DockBase::listenFloatingChanges()
             }
         });
 
-        *frameConn = connect(frame, &KDDockWidgets::Frame::isInMainWindowChanged,
-                             this, &DockBase::onIsInMainWindowChanged, Qt::UniqueConnection);
+        *floatingChangedConnection = connect(frame, &KDDockWidgets::Frame::isInMainWindowChanged,
+                                             this, &DockBase::onIsInMainWindowChanged, Qt::UniqueConnection);
+
+        *widgetChangedConnection = connect(frame, &KDDockWidgets::Frame::currentDockWidgetChanged,
+                                           this, &DockBase::frameCurrentWidgetChanged, Qt::UniqueConnection);
     });
 
     connect(m_dockWidget->toggleAction(), &QAction::toggled, this, [this]() {

--- a/src/framework/dockwindow/internal/dockbase.h
+++ b/src/framework/dockwindow/internal/dockbase.h
@@ -168,6 +168,7 @@ signals:
     void compactPriorityOrderChanged();
 
     void floatingChanged();
+    void frameCurrentWidgetChanged();
 
     void initedChanged();
 
@@ -191,7 +192,7 @@ private slots:
     void onIsInMainWindowChanged();
 
 private:
-    void listenFloatingChanges();
+    void setUpFrameConnections();
     void doSetFloating(bool floating);
 
     void writeProperties();

--- a/src/framework/dockwindow/view/dockpanelview.cpp
+++ b/src/framework/dockwindow/view/dockpanelview.cpp
@@ -210,6 +210,13 @@ void DockPanelView::componentComplete()
             dockWidget->setProperty(TOOLBAR_COMPONENT_PROPERTY, QVariant::fromValue(m_toolbarComponent));
         }
     });
+
+    connect(this, &DockBase::frameCurrentWidgetChanged, this, [this, dockWidget](){
+        const KDDockWidgets::Frame* frame = dockWidget ? dockWidget->frame() : nullptr;
+        if (frame && frame->currentDockWidget() == dockWidget) {
+            emit panelShown();
+        }
+    });
 }
 
 AbstractMenuModel* DockPanelView::contextMenuModel() const

--- a/src/framework/dockwindow/view/dockpanelview.h
+++ b/src/framework/dockwindow/view/dockpanelview.h
@@ -73,6 +73,8 @@ signals:
     void titleBarChanged();
     void toolbarComponentChanged();
 
+    void panelShown();
+
 private:
     void componentComplete() override;
 

--- a/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
+++ b/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
@@ -47,10 +47,14 @@ Item {
         panelWidth: root.width
     }
 
-    Component.onCompleted: {
-        padGrid.model.init()
+    function resizePanelToContentHeight() {
         var newHeight = (padGrid.numRows * padGrid.cellHeight) + (soundTitleLabel.height * 2)
         root.resizeRequested(root.width, newHeight)
+    }
+
+    Component.onCompleted: {
+        padGrid.model.init()
+        root.resizePanelToContentHeight()
     }
 
     PercussionPanelModel {
@@ -343,8 +347,7 @@ Item {
                             }
 
                             function onNumPadsChanged() {
-                                var newHeight = (padGrid.numRows * padGrid.cellHeight) + (soundTitleLabel.height * 2)
-                                root.resizeRequested(root.width, newHeight)
+                                root.resizePanelToContentHeight()
                             }
                         }
                     }

--- a/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
+++ b/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
@@ -48,7 +48,7 @@ Item {
     }
 
     function resizePanelToContentHeight() {
-        var newHeight = (padGrid.numRows * padGrid.cellHeight) + (soundTitleLabel.height * 2)
+        var newHeight = (Math.min(padGrid.numRows, 2) * padGrid.cellHeight) + (soundTitleLabel.height * 2)
         root.resizeRequested(root.width, newHeight)
     }
 

--- a/src/playback/qml/MuseScore/Playback/MixerPanel.qml
+++ b/src/playback/qml/MuseScore/Playback/MixerPanel.qml
@@ -46,10 +46,14 @@ ColumnLayout {
 
     spacing: 0
 
-    onImplicitHeightChanged: {
+    function resizePanelToContentHeight() {
         if (contentColumn.completed) {
-            resizeRequested(width, implicitHeight)
+            root.resizeRequested(width, implicitHeight)
         }
+    }
+
+    onImplicitHeightChanged: {
+        root.resizePanelToContentHeight()
     }
 
     QtObject {


### PR DESCRIPTION
Some dock panels such as the mixer panel and percussion panel should "auto resize" to fit their content when they become the active tab. This PR implements this functionality using the `Frame::currentDockWidgetChanged` signal.