### PR TITLE
26435: Auto select first MIDI input device after having reset all preferences

### DIFF
--- a/src/framework/midi/internal/midiconfiguration.cpp
+++ b/src/framework/midi/internal/midiconfiguration.cpp
@@ -42,7 +42,7 @@ void MidiConfiguration::init()
         m_useRemoteControlChanged.send(val.toBool());
     });
 
-    settings()->setDefaultValue(MIDI_INPUT_DEVICE_ID, Val(NONE_DEVICE_ID));
+    settings()->setDefaultValue(MIDI_INPUT_DEVICE_ID, Val("")); // "" makes MuseScore select the first available device
     settings()->valueChanged(MIDI_INPUT_DEVICE_ID).onReceive(nullptr, [this](const Val&) {
         m_midiInputDeviceIdChanged.notify();
     });


### PR DESCRIPTION
Resolves: #26435

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
