### PR TITLE
Drop "pad swap options" from percussion panel & percussion preferences tweaks (#26432)

### DIFF
--- a/src/appshell/qml/Preferences/PercussionPreferencesPage.qml
+++ b/src/appshell/qml/Preferences/PercussionPreferencesPage.qml
@@ -66,103 +66,14 @@ PreferencesPage {
             }
         }
 
-        Column {
-            id: swappingOptionsColumn
+        //! NOTE: "Pad swap options" and the associated dialog were dropped from percussion panel MVP (version 4.5).
+        //! See PR #25810 when re-implementing...
+        // Column {
+        //     id: swappingOptionsColumn
+        //     ...
+        // }
 
-            width: parent.width
-            spacing: 12
-
-            StyledTextLabel {
-                id: padSwapInfo
-
-                enabled: percussionPreferencesModel.useNewPercussionPanel
-                width: parent.width
-
-                horizontalAlignment: Text.AlignLeft
-                wrapMode: Text.Wrap
-                text: qsTrc("notation/percussion", "When swapping the positions of two drum pads:")
-            }
-
-            RadioButtonGroup {
-                id: radioButtons
-
-                property int navigationRowStart: unpitchedSelectedCheckbox.navigation.row + 1
-                property int navigationRowEnd: radioButtons.navigationRowStart + model.length
-
-                enabled: percussionPreferencesModel.useNewPercussionPanel
-
-                width: parent.width
-                spacing: swappingOptionsColumn.spacing
-
-                orientation: ListView.Vertical
-
-                model: [
-                    { text: qsTrc("notation/percussion", "Move MIDI notes and keyboard shortcuts with their sounds"), value: true },
-                    { text: qsTrc("notation/percussion", "Leave MIDI notes and keyboard shortcuts fixed to original pad positions"), value: false }
-                ]
-
-                delegate: Row {
-                    width: parent.width
-                    spacing: 6
-
-                    RoundedRadioButton {
-                        id: radioButton
-
-                        anchors.verticalCenter: parent.verticalCenter
-
-                        navigation.name: modelData.text
-                        navigation.panel: percussionPanelPreferences.navigation
-                        navigation.row: radioButtons.navigationRowStart + model.index
-
-                        checked: modelData.value === percussionPreferencesModel.percussionPanelMoveMidiNotesAndShortcuts
-
-                        onToggled: {
-                            percussionPreferencesModel.percussionPanelMoveMidiNotesAndShortcuts = modelData.value
-                        }
-                    }
-
-                    //! NOTE: Can't use radioButton.text because it won't wrap
-                    StyledTextLabel {
-                        width: parent.width - parent.spacing - radioButton.width
-
-                        anchors.verticalCenter: parent.verticalCenter
-
-                        horizontalAlignment: Text.AlignLeft
-                        wrapMode: Text.Wrap
-                        text: modelData.text
-
-                        MouseArea {
-                            id: mouseArea
-
-                            anchors.fill: parent
-
-                            onClicked: {
-                                percussionPreferencesModel.percussionPanelMoveMidiNotesAndShortcuts = modelData.value
-                            }
-                        }
-                    }
-                }
-            }
-
-            CheckBox {
-                id: alwaysAsk
-
-                enabled: percussionPreferencesModel.useNewPercussionPanel
-                width: parent.width
-
-                text: qsTrc("global", "Always ask")
-
-                navigation.name: "AlwaysAskCheckBox"
-                navigation.panel: percussionPanelPreferences.navigation
-                navigation.row: radioButtons.navigationRowEnd
-
-                checked: percussionPreferencesModel.showPercussionPanelPadSwapDialog
-
-                onClicked:  {
-                    percussionPreferencesModel.showPercussionPanelPadSwapDialog = !alwaysAsk.checked
-                }
-            }
-        }
+        SeparatorLine {}
 
         Row {
             id: useLegacyToggleRow

--- a/src/appshell/qml/Preferences/PercussionPreferencesPage.qml
+++ b/src/appshell/qml/Preferences/PercussionPreferencesPage.qml
@@ -47,25 +47,6 @@ PreferencesPage {
 
         navigation.section: root.navigationSection
 
-        CheckBox {
-            id: unpitchedSelectedCheckbox
-
-            enabled: percussionPreferencesModel.useNewPercussionPanel
-            width: parent.width
-
-            text: qsTrc("appshell/preferences", "Open the percussion panel when an unpitched staff is selected")
-
-            navigation.name: "UnpitchedSelectedCheckbox"
-            navigation.panel: percussionPanelPreferences.navigation
-            navigation.row: 0
-
-            checked: percussionPreferencesModel.autoShowPercussionPanel
-
-            onClicked:  {
-                percussionPreferencesModel.autoShowPercussionPanel = !unpitchedSelectedCheckbox.checked
-            }
-        }
-
         //! NOTE: "Pad swap options" and the associated dialog were dropped from percussion panel MVP (version 4.5).
         //! See PR #25810 when re-implementing...
         // Column {

--- a/src/appshell/qml/Preferences/PercussionPreferencesPage.qml
+++ b/src/appshell/qml/Preferences/PercussionPreferencesPage.qml
@@ -39,55 +39,117 @@ PreferencesPage {
         percussionPreferencesModel.init()
     }
 
-    BaseSection {
-        id: percussionPanelPreferences
+    Column {
+        id: contentColumn
 
-        title: qsTrc("appshell/preferences", "Percussion")
-        rowSpacing: 20
+        width: root.width
+        spacing: root.sectionsSpacing
 
-        navigation.section: root.navigationSection
+        BaseSection {
+            id: autoShowSection
 
-        //! NOTE: "Pad swap options" and the associated dialog were dropped from percussion panel MVP (version 4.5).
-        //! See PR #25810 when re-implementing...
-        // Column {
-        //     id: swappingOptionsColumn
-        //     ...
-        // }
+            enabled: percussionPreferencesModel.useNewPercussionPanel
+
+            width: parent.width
+            rowSpacing: 16
+
+            title: qsTrc("notation/percussion", "Triggering the panel")
+
+            navigation.section: root.navigationSection
+            navigation.order: root.navigationOrderStart + 1
+
+            StyledTextLabel {
+                id: autoShowLabel
+
+                width: parent.width
+
+                horizontalAlignment: Text.AlignLeft
+                wrapMode: Text.Wrap
+                text: qsTrc("notation/percussion", "Open the percussion panel automatically:")
+            }
+
+            RadioButtonGroup {
+                id: autoShowModesBox
+
+                spacing: 12
+                orientation: Qt.Vertical
+
+                width: parent.width
+
+                model: percussionPreferencesModel.autoShowModes
+
+                delegate: RoundedRadioButton {
+                    width: parent.width
+
+                    checked: modelData.checked
+                    text: modelData.title
+
+                    navigation.name: modelData.title
+                    navigation.panel: autoShowSection.navigation
+                    navigation.row: model.index
+                    navigation.column: 0
+
+                    onToggled: {
+                        percussionPreferencesModel.setAutoShowMode(model.index)
+                    }
+                }
+            }
+        }
 
         SeparatorLine {}
 
-        Row {
-            id: useLegacyToggleRow
+        //! NOTE: "Pad swap options" and the associated dialog were dropped from percussion panel MVP (version 4.5).
+        //! See PR #25810 when re-implementing...
+        // BaseSection {
+        //     id: padSwappingOptionsSection
+        //     ...
+        // }
 
-            height: useLegacyToggle.height
+        // SeparatorLine {}
+
+        BaseSection {
+            id: legacyToggleSection
+
             width: parent.width
+            rowSpacing: 20
 
-            spacing: 6
+            title: qsTrc("appshell/preferences", "Legacy panel")
 
-            ToggleButton {
-                id: useLegacyToggle
+            navigation.section: root.navigationSection
+            navigation.order: autoShowSection.navigation.order + 1
 
-                checked: !percussionPreferencesModel.useNewPercussionPanel
+            Row {
+                id: useLegacyToggleRow
 
-                navigation.name: "UseLegacyPercussionPanel"
-                navigation.panel: percussionPanelPreferences.navigation
-                navigation.row: alwaysAsk.navigation.row + 1
+                height: useLegacyToggle.height
+                width: parent.width
 
-                onToggled: {
-                    percussionPreferencesModel.useNewPercussionPanel = !percussionPreferencesModel.useNewPercussionPanel
+                spacing: 6
+
+                ToggleButton {
+                    id: useLegacyToggle
+
+                    checked: !percussionPreferencesModel.useNewPercussionPanel
+
+                    navigation.name: "UseLegacyPercussionPanel"
+                    navigation.panel: legacyToggleSection.navigation
+
+                    onToggled: {
+                        percussionPreferencesModel.useNewPercussionPanel = !percussionPreferencesModel.useNewPercussionPanel
+                    }
                 }
-            }
 
-            StyledTextLabel {
-                id: legacyToggleInfo
+                StyledTextLabel {
+                    id: legacyToggleInfo
 
-                height: parent.height
+                    height: parent.height
 
-                horizontalAlignment: Text.AlignLeft
-                verticalAlignment: Text.AlignVCenter
+                    horizontalAlignment: Text.AlignLeft
+                    verticalAlignment: Text.AlignVCenter
 
-                wrapMode: Text.Wrap
-                text: qsTrc("notation/percussion", "Use legacy percussion panel")
+                    wrapMode: Text.Wrap
+                    text: qsTrc("notation/percussion", "Use legacy percussion panel")
+                }
             }
         }
     }

--- a/src/appshell/view/notationpagemodel.cpp
+++ b/src/appshell/view/notationpagemodel.cpp
@@ -155,8 +155,8 @@ void NotationPageModel::onNotationChanged()
         return;
     }
 
+    INotationNoteInputPtr noteInput = notation->interaction()->noteInput();
     if (!notationConfiguration()->useNewPercussionPanel()) {
-        INotationNoteInputPtr noteInput = notation->interaction()->noteInput();
         noteInput->stateChanged().onNotify(this, [this]() {
             updateDrumsetPanelVisibility();
             updatePercussionPanelVisibility();
@@ -167,6 +167,10 @@ void NotationPageModel::onNotationChanged()
     INotationInteractionPtr notationInteraction = notation->interaction();
     notationInteraction->selectionChanged().onNotify(this, [this]() {
         updateDrumsetPanelVisibility();
+        updatePercussionPanelVisibility();
+    });
+
+    noteInput->noteInputStarted().onReceive(this, [this](bool) {
         updatePercussionPanelVisibility();
     });
 }

--- a/src/appshell/view/notationpagemodel.cpp
+++ b/src/appshell/view/notationpagemodel.cpp
@@ -245,7 +245,13 @@ void NotationPageModel::updatePercussionPanelVisibility()
     }
 
     const INotationPtr notation = globalContext()->currentNotation();
-    if (!notation || !notation->elements() || !notationConfiguration()->autoShowPercussionPanel()) {
+    const PercussionPanelAutoShowMode autoShowMode = notationConfiguration()->percussionPanelAutoShowMode();
+    if (!notation || !notation->elements() || autoShowMode == PercussionPanelAutoShowMode::NEVER) {
+        return;
+    }
+
+    const INotationNoteInputPtr noteInput = notation->interaction()->noteInput();
+    if (noteInput && !noteInput->isNoteInputMode() && autoShowMode == PercussionPanelAutoShowMode::UNPITCHED_STAFF_NOTE_INPUT) {
         return;
     }
 

--- a/src/appshell/view/preferences/percussionpreferencesmodel.cpp
+++ b/src/appshell/view/preferences/percussionpreferencesmodel.cpp
@@ -33,8 +33,8 @@ void PercussionPreferencesModel::init()
         emit useNewPercussionPanelChanged();
     });
 
-    configuration()->autoShowPercussionPanelChanged().onNotify(this, [this]() {
-        emit autoShowPercussionPanelChanged();
+    configuration()->percussionPanelAutoShowModeChanged().onNotify(this, [this]() {
+        emit percussionPanelAutoShowModeChanged();
     });
 
     configuration()->showPercussionPanelPadSwapDialogChanged().onNotify(this, [this]() {
@@ -56,14 +56,14 @@ void PercussionPreferencesModel::setUseNewPercussionPanel(bool use)
     configuration()->setUseNewPercussionPanel(use);
 }
 
-bool PercussionPreferencesModel::autoShowPercussionPanel() const
+mu::notation::PercussionPanelAutoShowMode PercussionPreferencesModel::percussionPanelAutoShowMode() const
 {
-    return configuration()->autoShowPercussionPanel();
+    return configuration()->percussionPanelAutoShowMode();
 }
 
-void PercussionPreferencesModel::setAutoShowPercussionPanel(bool autoShow)
+void PercussionPreferencesModel::setPercussionPanelAutoShowMode(mu::notation::PercussionPanelAutoShowMode autoShowMode)
 {
-    configuration()->setAutoShowPercussionPanel(autoShow);
+    configuration()->setPercussionPanelAutoShowMode(autoShowMode);
 }
 
 bool PercussionPreferencesModel::showPercussionPanelPadSwapDialog() const

--- a/src/appshell/view/preferences/percussionpreferencesmodel.cpp
+++ b/src/appshell/view/preferences/percussionpreferencesmodel.cpp
@@ -22,6 +22,8 @@
 
 #include "percussionpreferencesmodel.h"
 
+using namespace mu::notation;
+
 PercussionPreferencesModel::PercussionPreferencesModel(QObject* parent)
     : QObject(parent), muse::Injectable(muse::iocCtxForQmlObject(this))
 {
@@ -46,6 +48,38 @@ void PercussionPreferencesModel::init()
     });
 }
 
+QVariantList PercussionPreferencesModel::autoShowModes() const
+{
+    QVariantList result;
+
+    for (const AutoShowMode& mode: allAutoShowModes()) {
+        QVariantMap obj;
+        obj["title"] = mode.title;
+        obj["checked"] = mode.checked;
+
+        result << obj;
+    }
+
+    return result;
+}
+
+void PercussionPreferencesModel::setAutoShowMode(int modeIndex)
+{
+    QList<AutoShowMode> modes = allAutoShowModes();
+
+    if (modeIndex < 0 || modeIndex >= modes.size()) {
+        return;
+    }
+
+    const PercussionPanelAutoShowMode selectedMode = modes[modeIndex].type;
+    if (selectedMode == configuration()->percussionPanelAutoShowMode()) {
+        return;
+    }
+
+    configuration()->setPercussionPanelAutoShowMode(selectedMode);
+    emit percussionPanelAutoShowModeChanged();
+}
+
 bool PercussionPreferencesModel::useNewPercussionPanel() const
 {
     return configuration()->useNewPercussionPanel();
@@ -54,16 +88,6 @@ bool PercussionPreferencesModel::useNewPercussionPanel() const
 void PercussionPreferencesModel::setUseNewPercussionPanel(bool use)
 {
     configuration()->setUseNewPercussionPanel(use);
-}
-
-mu::notation::PercussionPanelAutoShowMode PercussionPreferencesModel::percussionPanelAutoShowMode() const
-{
-    return configuration()->percussionPanelAutoShowMode();
-}
-
-void PercussionPreferencesModel::setPercussionPanelAutoShowMode(mu::notation::PercussionPanelAutoShowMode autoShowMode)
-{
-    configuration()->setPercussionPanelAutoShowMode(autoShowMode);
 }
 
 bool PercussionPreferencesModel::showPercussionPanelPadSwapDialog() const
@@ -84,4 +108,31 @@ bool PercussionPreferencesModel::percussionPanelMoveMidiNotesAndShortcuts() cons
 void PercussionPreferencesModel::setPercussionPanelMoveMidiNotesAndShortcuts(bool move)
 {
     configuration()->setPercussionPanelMoveMidiNotesAndShortcuts(move);
+}
+
+QList<PercussionPreferencesModel::AutoShowMode> PercussionPreferencesModel::allAutoShowModes() const
+{
+    static const QMap<PercussionPanelAutoShowMode, QString> modeTitles {
+        { PercussionPanelAutoShowMode::UNPITCHED_STAFF,
+          muse::qtrc("notation/percussion", "When selecting an unpitched percussion staff") },
+
+        { PercussionPanelAutoShowMode::UNPITCHED_STAFF_NOTE_INPUT,
+          muse::qtrc("notation/percussion", "When in note input mode on an unpitched percussion staff") },
+
+        { PercussionPanelAutoShowMode::NEVER,
+          muse::qtrc("notation/percussion", "Never") },
+    };
+
+    QList<AutoShowMode> modes;
+
+    for (PercussionPanelAutoShowMode type : modeTitles.keys()) {
+        AutoShowMode mode;
+        mode.type = type;
+        mode.title = modeTitles[type];
+        mode.checked = configuration()->percussionPanelAutoShowMode() == type;
+
+        modes << mode;
+    }
+
+    return modes;
 }

--- a/src/appshell/view/preferences/percussionpreferencesmodel.h
+++ b/src/appshell/view/preferences/percussionpreferencesmodel.h
@@ -35,8 +35,8 @@ class PercussionPreferencesModel : public QObject, public muse::Injectable, publ
 
     Q_PROPERTY(bool useNewPercussionPanel READ useNewPercussionPanel WRITE setUseNewPercussionPanel NOTIFY useNewPercussionPanelChanged)
 
-    Q_PROPERTY(bool autoShowPercussionPanel READ autoShowPercussionPanel
-               WRITE setAutoShowPercussionPanel NOTIFY autoShowPercussionPanelChanged)
+    Q_PROPERTY(mu::notation::PercussionPanelAutoShowMode percussionPanelAutoShowMode READ percussionPanelAutoShowMode
+               WRITE setPercussionPanelAutoShowMode NOTIFY percussionPanelAutoShowModeChanged)
 
     Q_PROPERTY(bool showPercussionPanelPadSwapDialog READ showPercussionPanelPadSwapDialog
                WRITE setShowPercussionPanelPadSwapDialog NOTIFY showPercussionPanelPadSwapDialogChanged)
@@ -54,8 +54,8 @@ public:
     bool useNewPercussionPanel() const;
     void setUseNewPercussionPanel(bool use);
 
-    bool autoShowPercussionPanel() const;
-    void setAutoShowPercussionPanel(bool autoShow);
+    mu::notation::PercussionPanelAutoShowMode percussionPanelAutoShowMode() const;
+    void setPercussionPanelAutoShowMode(mu::notation::PercussionPanelAutoShowMode autoShowMode);
 
     bool showPercussionPanelPadSwapDialog() const;
     void setShowPercussionPanelPadSwapDialog(bool show);
@@ -65,7 +65,7 @@ public:
 
 signals:
     void useNewPercussionPanelChanged();
-    void autoShowPercussionPanelChanged();
+    void percussionPanelAutoShowModeChanged();
     void showPercussionPanelPadSwapDialogChanged();
     void percussionPanelMoveMidiNotesAndShortcutsChanged();
 };

--- a/src/appshell/view/preferences/percussionpreferencesmodel.h
+++ b/src/appshell/view/preferences/percussionpreferencesmodel.h
@@ -33,10 +33,9 @@ class PercussionPreferencesModel : public QObject, public muse::Injectable, publ
 {
     Q_OBJECT
 
-    Q_PROPERTY(bool useNewPercussionPanel READ useNewPercussionPanel WRITE setUseNewPercussionPanel NOTIFY useNewPercussionPanelChanged)
+    Q_PROPERTY(QVariantList autoShowModes READ autoShowModes NOTIFY percussionPanelAutoShowModeChanged)
 
-    Q_PROPERTY(mu::notation::PercussionPanelAutoShowMode percussionPanelAutoShowMode READ percussionPanelAutoShowMode
-               WRITE setPercussionPanelAutoShowMode NOTIFY percussionPanelAutoShowModeChanged)
+    Q_PROPERTY(bool useNewPercussionPanel READ useNewPercussionPanel WRITE setUseNewPercussionPanel NOTIFY useNewPercussionPanelChanged)
 
     Q_PROPERTY(bool showPercussionPanelPadSwapDialog READ showPercussionPanelPadSwapDialog
                WRITE setShowPercussionPanelPadSwapDialog NOTIFY showPercussionPanelPadSwapDialogChanged)
@@ -51,11 +50,11 @@ public:
 
     Q_INVOKABLE void init();
 
+    QVariantList autoShowModes() const;
+    Q_INVOKABLE void setAutoShowMode(int modeIndex);
+
     bool useNewPercussionPanel() const;
     void setUseNewPercussionPanel(bool use);
-
-    mu::notation::PercussionPanelAutoShowMode percussionPanelAutoShowMode() const;
-    void setPercussionPanelAutoShowMode(mu::notation::PercussionPanelAutoShowMode autoShowMode);
 
     bool showPercussionPanelPadSwapDialog() const;
     void setShowPercussionPanelPadSwapDialog(bool show);
@@ -68,4 +67,14 @@ signals:
     void percussionPanelAutoShowModeChanged();
     void showPercussionPanelPadSwapDialogChanged();
     void percussionPanelMoveMidiNotesAndShortcutsChanged();
+
+private:
+    struct AutoShowMode
+    {
+        mu::notation::PercussionPanelAutoShowMode type = mu::notation::PercussionPanelAutoShowMode::UNPITCHED_STAFF;
+        QString title;
+        bool checked = false;
+    };
+
+    QList<AutoShowMode> allAutoShowModes() const;
 };

--- a/src/notation/inotationconfiguration.h
+++ b/src/notation/inotationconfiguration.h
@@ -231,9 +231,9 @@ public:
     virtual void setUseNewPercussionPanel(bool use) = 0;
     virtual muse::async::Notification useNewPercussionPanelChanged() const = 0;
 
-    virtual bool autoShowPercussionPanel() const = 0;
-    virtual void setAutoShowPercussionPanel(bool autoShow) = 0;
-    virtual muse::async::Notification autoShowPercussionPanelChanged() const = 0;
+    virtual PercussionPanelAutoShowMode percussionPanelAutoShowMode() const = 0;
+    virtual void setPercussionPanelAutoShowMode(PercussionPanelAutoShowMode autoShowMode) = 0;
+    virtual muse::async::Notification percussionPanelAutoShowModeChanged() const = 0;
 
     virtual bool showPercussionPanelPadSwapDialog() const = 0;
     virtual void setShowPercussionPanelPadSwapDialog(bool show) = 0;

--- a/src/notation/internal/notationconfiguration.cpp
+++ b/src/notation/internal/notationconfiguration.cpp
@@ -108,7 +108,7 @@ static const Settings::Key NEED_TO_SHOW_ADD_GUITAR_BEND_ERROR_MESSAGE_KEY(module
 static const Settings::Key PIANO_KEYBOARD_NUMBER_OF_KEYS(module_name,  "pianoKeyboard/numberOfKeys");
 
 static const Settings::Key USE_NEW_PERCUSSION_PANEL_KEY(module_name,  "ui/useNewPercussionPanel");
-static const Settings::Key AUTO_SHOW_PERCUSSION_PANEL_KEY(module_name,  "ui/autoShowPercussionPanel");
+static const Settings::Key PERCUSSION_PANEL_AUTO_SHOW_MODE_KEY(module_name,  "ui/percussionPanelAutoShowMode");
 static const Settings::Key SHOW_PERCUSSION_PANEL_SWAP_DIALOG(module_name,  "ui/showPercussionPanelPadSwapDialog");
 static const Settings::Key PERCUSSION_PANEL_MOVE_MIDI_NOTES_AND_SHORTCUTS(module_name,  "ui/percussionPanelMoveMidiNotesAndShortcuts");
 
@@ -325,9 +325,9 @@ void NotationConfiguration::init()
         m_useNewPercussionPanelChanged.notify();
     });
 
-    settings()->setDefaultValue(AUTO_SHOW_PERCUSSION_PANEL_KEY, Val(true));
-    settings()->valueChanged(AUTO_SHOW_PERCUSSION_PANEL_KEY).onReceive(this, [this](const Val&) {
-        m_autoShowPercussionPanelChanged.notify();
+    settings()->setDefaultValue(PERCUSSION_PANEL_AUTO_SHOW_MODE_KEY, Val(PercussionPanelAutoShowMode::UNPITCHED_STAFF));
+    settings()->valueChanged(PERCUSSION_PANEL_AUTO_SHOW_MODE_KEY).onReceive(this, [this](const Val&) {
+        m_percussionPanelAutoShowModeChanged.notify();
     });
 
     settings()->setDefaultValue(SHOW_PERCUSSION_PANEL_SWAP_DIALOG, Val(true));
@@ -1146,19 +1146,19 @@ Notification NotationConfiguration::useNewPercussionPanelChanged() const
     return m_useNewPercussionPanelChanged;
 }
 
-bool NotationConfiguration::autoShowPercussionPanel() const
+PercussionPanelAutoShowMode NotationConfiguration::percussionPanelAutoShowMode() const
 {
-    return settings()->value(AUTO_SHOW_PERCUSSION_PANEL_KEY).toBool();
+    return settings()->value(PERCUSSION_PANEL_AUTO_SHOW_MODE_KEY).toEnum<PercussionPanelAutoShowMode>();
 }
 
-void NotationConfiguration::setAutoShowPercussionPanel(bool autoShow)
+void NotationConfiguration::setPercussionPanelAutoShowMode(PercussionPanelAutoShowMode autoShowMode)
 {
-    settings()->setSharedValue(AUTO_SHOW_PERCUSSION_PANEL_KEY, Val(autoShow));
+    settings()->setSharedValue(PERCUSSION_PANEL_AUTO_SHOW_MODE_KEY, Val(autoShowMode));
 }
 
-Notification NotationConfiguration::autoShowPercussionPanelChanged() const
+Notification NotationConfiguration::percussionPanelAutoShowModeChanged() const
 {
-    return m_autoShowPercussionPanelChanged;
+    return m_percussionPanelAutoShowModeChanged;
 }
 
 bool NotationConfiguration::showPercussionPanelPadSwapDialog() const

--- a/src/notation/internal/notationconfiguration.h
+++ b/src/notation/internal/notationconfiguration.h
@@ -236,9 +236,9 @@ public:
     void setUseNewPercussionPanel(bool use) override;
     muse::async::Notification useNewPercussionPanelChanged() const override;
 
-    bool autoShowPercussionPanel() const override;
-    void setAutoShowPercussionPanel(bool autoShow) override;
-    muse::async::Notification autoShowPercussionPanelChanged() const override;
+    PercussionPanelAutoShowMode percussionPanelAutoShowMode() const override;
+    void setPercussionPanelAutoShowMode(PercussionPanelAutoShowMode percussionPanelAutoShowMode) override;
+    muse::async::Notification percussionPanelAutoShowModeChanged() const override;
 
     bool showPercussionPanelPadSwapDialog() const override;
     void setShowPercussionPanelPadSwapDialog(bool show) override;
@@ -295,7 +295,7 @@ private:
     muse::ValCh<bool> m_midiInputUseWrittenPitch;
     muse::async::Channel<QColor> m_anchorColorChanged;
     muse::async::Notification m_useNewPercussionPanelChanged;
-    muse::async::Notification m_autoShowPercussionPanelChanged;
+    muse::async::Notification m_percussionPanelAutoShowModeChanged;
     muse::async::Notification m_showPercussionPanelPadSwapDialogChanged;
     muse::async::Notification m_percussionPanelMoveMidiNotesAndShortcutsChanged;
 

--- a/src/notation/notationtypes.h
+++ b/src/notation/notationtypes.h
@@ -617,9 +617,9 @@ struct StringTuningsInfo
 using InstrumentStringTuningsMap = std::map<std::string, std::vector<StringTuningsInfo> >;
 
 enum class PercussionPanelAutoShowMode {
-    NEVER,
     UNPITCHED_STAFF,
     UNPITCHED_STAFF_NOTE_INPUT,
+    NEVER,
 };
 }
 

--- a/src/notation/notationtypes.h
+++ b/src/notation/notationtypes.h
@@ -615,6 +615,12 @@ struct StringTuningsInfo
 };
 
 using InstrumentStringTuningsMap = std::map<std::string, std::vector<StringTuningsInfo> >;
+
+enum class PercussionPanelAutoShowMode {
+    NEVER,
+    UNPITCHED_STAFF,
+    UNPITCHED_STAFF_NOTE_INPUT,
+};
 }
 
 #endif // MU_NOTATION_NOTATIONTYPES_H

--- a/src/notation/tests/mocks/notationconfigurationmock.h
+++ b/src/notation/tests/mocks/notationconfigurationmock.h
@@ -221,9 +221,9 @@ public:
     MOCK_METHOD(void, setUseNewPercussionPanel, (bool), (override));
     MOCK_METHOD(muse::async::Notification, useNewPercussionPanelChanged, (), (const, override));
 
-    MOCK_METHOD(bool, autoShowPercussionPanel, (), (const, override));
-    MOCK_METHOD(void, setAutoShowPercussionPanel, (bool), (override));
-    MOCK_METHOD(muse::async::Notification, autoShowPercussionPanelChanged, (), (const, override));
+    MOCK_METHOD(PercussionPanelAutoShowMode, percussionPanelAutoShowMode, (), (const, override));
+    MOCK_METHOD(void, setPercussionPanelAutoShowMode, (PercussionPanelAutoShowMode), (override));
+    MOCK_METHOD(muse::async::Notification, percussionPanelAutoShowModeChanged, (), (const, override));
 
     MOCK_METHOD(bool, showPercussionPanelPadSwapDialog, (), (const, override));
     MOCK_METHOD(void, setShowPercussionPanelPadSwapDialog, (bool), (override));

--- a/src/notation/view/percussionpanel/percussionpanelpadlistmodel.cpp
+++ b/src/notation/view/percussionpanel/percussionpanelpadlistmodel.cpp
@@ -130,38 +130,9 @@ void PercussionPanelPadListModel::endPadSwap(int endIndex)
 
     movePad(m_padSwapStartIndex, endIndex);
 
-    if (!m_padModels.at(m_padSwapStartIndex) || !m_padModels.at(endIndex)) {
-        // Swapping with an empty pad - no extra options...
-        endSwap();
-        return;
-    }
-
-    // Give Qt a chance to process pending UI updates before opening the options dialog...
-    QMetaObject::invokeMethod(this, [this, endSwap, endIndex]() {
-        bool moveMidiNotesAndShortcuts = configuration()->percussionPanelMoveMidiNotesAndShortcuts();
-
-        if (configuration()->showPercussionPanelPadSwapDialog()) {
-            const muse::RetVal<muse::Val> rv = openPadSwapDialog();
-            if (!rv.ret) {
-                // Cancelled, revert the swap...
-                movePad(m_padSwapStartIndex, endIndex);
-                endSwap();
-                return;
-            }
-
-            const QVariantMap vals = rv.val.toQVariant().toMap();
-            moveMidiNotesAndShortcuts = vals["moveMidiNotesAndShortcuts"].toBool();
-        }
-
-        if (moveMidiNotesAndShortcuts) {
-            // MIDI notes and shortcuts were moved with the pad itself, so we can return...
-            endSwap();
-            return;
-        }
-
-        swapMidiNotesAndShortcuts(m_padSwapStartIndex, endIndex);
-        endSwap();
-    }, Qt::QueuedConnection);
+    //! NOTE: "Pad swap options" and the associated dialog were dropped from percussion panel MVP (version 4.5).
+    //! See PR #25810 when re-implementing...
+    endSwap();
 }
 
 void PercussionPanelPadListModel::setDrumset(const engraving::Drumset* drumset)

--- a/src/stubs/notation/notationconfigurationstub.h
+++ b/src/stubs/notation/notationconfigurationstub.h
@@ -212,9 +212,9 @@ public:
     void setUseNewPercussionPanel(bool use) override;
     muse::async::Notification useNewPercussionPanelChanged() const override;
 
-    bool autoShowPercussionPanel() const override;
-    void setAutoShowPercussionPanel(bool autoShow) override;
-    muse::async::Notification autoShowPercussionPanelChanged() const override;
+    PercussionPanelAutoShowMode percussionPanelAutoShowMode() const override;
+    void setPercussionPanelAutoShowMode(PercussionPanelAutoShowMode autoShowMode) override;
+    muse::async::Notification percussionPanelAutoShowModeChanged() const override;
 
     bool showPercussionPanelPadSwapDialog() const override;
     void setShowPercussionPanelPadSwapDialog(bool show);


### PR DESCRIPTION
Resolves: #26432

We have decided to drop "pad swap options" (and the associated dialog) from the percussion panel for MVP. Most of the behind-the-scenes implementation remains, but everything is now unreachable outside of DevTools.

Percussion preferences have been adjusted in accordance with this, and we've also added some more granular options for triggering the percussion panel.