### PR TITLE
do not write Staff properties twice

### DIFF
--- a/src/engraving/rw/write/twrite.cpp
+++ b/src/engraving/rw/write/twrite.cpp
@@ -2730,9 +2730,6 @@ void TWrite::write(const Staff* item, XmlWriter& xml, WriteContext& ctx)
         xml.tag("defaultTransposingClef", TConv::toXml(ct.transposingClef));
     }
 
-    if (item->isLinesInvisible(Fraction(0, 1))) {
-        xml.tag("invisible", item->isLinesInvisible(Fraction(0, 1)));
-    }
     if (item->hideWhenEmpty() != Staff::HideMode::AUTO) {
         xml.tag("hideWhenEmpty", int(item->hideWhenEmpty()));
     }
@@ -2766,7 +2763,6 @@ void TWrite::write(const Staff* item, XmlWriter& xml, WriteContext& ctx)
     writeProperty(item, xml, Pid::STAFF_BARLINE_SPAN_FROM);
     writeProperty(item, xml, Pid::STAFF_BARLINE_SPAN_TO);
     writeProperty(item, xml, Pid::STAFF_USERDIST);
-    writeProperty(item, xml, Pid::STAFF_COLOR);
     writeProperty(item, xml, Pid::PLAYBACK_VOICE1);
     writeProperty(item, xml, Pid::PLAYBACK_VOICE2);
     writeProperty(item, xml, Pid::PLAYBACK_VOICE3);

--- a/src/importexport/mei/tests/data/score-03.mscx
+++ b/src/importexport/mei/tests/data/score-03.mscx
@@ -47,7 +47,6 @@
           <name>stdNormal</name>
           <invisible>1</invisible>
           </StaffType>
-        <invisible>1</invisible>
         <bracket type="1" span="2" col="0" visible="1"/>
         <barLineSpan>1</barLineSpan>
         </Staff>
@@ -57,7 +56,6 @@
           <name>stdNormal</name>
           <color r="51" g="255" b="0" a="255"/>
           </StaffType>
-        <color r="51" g="255" b="0" a="255"/>
         </Staff>
       <trackName></trackName>
       <Instrument id="piano">


### PR DESCRIPTION
The staff line visibility and color are hold in `StaffType` and thus written twice, once in `StaffType` and once in `Staff`. This PR cleans this up.

Interestingly all StaffType properties are also being read twice, even things like the "small" flag, that is only written once. Maybe this should also be cleaned up?