### PR TITLE
Unify attribute handling in MusicXML importer

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -3886,7 +3886,7 @@ void MusicXmlParserDirection::directionType(std::vector<MusicXmlSpannerDesc>& st
             }
         }
         String type = m_e.attribute("type");
-        m_color = Color::fromString(m_e.asciiAttribute("color").ascii());
+        m_color = Color::fromString(m_e.attribute("color"));
         if (m_e.name() == "metronome") {
             m_metroText = metronome(m_tpoMetro);
         } else if (m_e.name() == "words") {
@@ -4886,7 +4886,7 @@ void MusicXmlParserDirection::bracket(const String& type, const int number,
             } else if (lineType != "wavy") {
                 m_logger->logError(String(u"unsupported line-type: %1").arg(String::fromAscii(lineType.ascii())), &m_e);
             }
-            const Color color = Color::fromString(m_e.asciiAttribute("color").ascii());
+            const Color color = Color::fromString(m_e.attribute("color"));
             if (color.isValid()) {
                 textLine->setLineColor(color);
             }
@@ -4998,7 +4998,7 @@ void MusicXmlParserDirection::octaveShift(const String& type, const int number,
                 }
             }
 
-            const Color color = Color::fromString(m_e.asciiAttribute("color").ascii());
+            const Color color = Color::fromString(m_e.attribute("color"));
             if (color.isValid()) {
                 o->setLineColor(color);
             }
@@ -5027,7 +5027,7 @@ void MusicXmlParserDirection::pedal(const String& type, const int /* number */,
     const int number { 0 };
     AsciiStringView line = m_e.asciiAttribute("line");
     String sign = m_e.attribute("sign");
-    const Color color = Color::fromString(m_e.asciiAttribute("color").ascii());
+    const Color color = Color::fromString(m_e.attribute("color"));
 
     // We have found that many exporters omit "sign" even when one is originally present,
     // therefore we will default to "yes", even though this is technically against the spec.
@@ -5169,7 +5169,7 @@ void MusicXmlParserDirection::wedge(const String& type, const int number,
         if (niente == "yes") {
             h->setHairpinCircledTip(true);
         }
-        const Color color = Color::fromString(m_e.asciiAttribute("color").ascii());
+        const Color color = Color::fromString(m_e.attribute("color"));
         if (color.isValid()) {
             h->setLineColor(color);
         }
@@ -5450,16 +5450,16 @@ void MusicXmlParserPass2::barline(const String& partId, Measure* measure, const 
 
     while (m_e.readNextStartElement()) {
         if (m_e.name() == "bar-style") {
-            barlineColor = Color::fromString(m_e.asciiAttribute("color").ascii());
+            barlineColor = Color::fromString(m_e.attribute("color"));
             barStyle = m_e.readText();
         } else if (m_e.name() == "ending") {
             endingNumber = m_e.attribute("number");
             endingType   = m_e.attribute("type");
-            endingColor = Color::fromString(m_e.asciiAttribute("color").ascii());
+            endingColor = Color::fromString(m_e.attribute("color"));
             printEnding = m_e.asciiAttribute("print-object") != "no";
             endingText = m_e.readText();
         } else if (m_e.name() == "fermata") {
-            const Color fermataColor = Color::fromString(m_e.asciiAttribute("color").ascii());
+            const Color fermataColor = Color::fromString(m_e.attribute("color"));
             const String fermataType = m_e.attribute("type");
             Segment* const segment = measure->getSegment(SegmentType::EndBarLine, locTick);
             const track_idx_t track = m_pass1.trackForPart(partId);
@@ -5744,7 +5744,7 @@ void MusicXmlParserPass2::key(const String& partId, Measure* measure, const Frac
         }
     }
     const bool printObject = m_e.asciiAttribute("print-object") != "no";
-    const Color keyColor = Color::fromString(m_e.asciiAttribute("color").ascii());
+    const Color keyColor = Color::fromString(m_e.attribute("color"));
 
     // for custom keys, a single altered tone is described by
     // key-step (required),  key-alter (required) and key-accidental (optional)
@@ -5845,7 +5845,7 @@ void MusicXmlParserPass2::clef(const String& partId, Measure* measure, const Fra
     const String strClefno = m_e.attribute("number");
     const bool afterBarline = m_e.asciiAttribute("after-barline") == "yes";
     const bool printObject = m_e.asciiAttribute("print-object") != "no";
-    const Color clefColor = Color::fromString(m_e.asciiAttribute("color").ascii());
+    const Color clefColor = Color::fromString(m_e.attribute("color"));
 
     while (m_e.readNextStartElement()) {
         if (m_e.name() == "sign") {
@@ -6044,7 +6044,7 @@ void MusicXmlParserPass2::time(const String& partId, Measure* measure, const Fra
     String beatType;
     String timeSymbol = m_e.attribute("symbol");
     bool printObject = m_e.asciiAttribute("print-object") != "no";
-    const Color timeColor = Color::fromString(m_e.asciiAttribute("color").ascii());
+    const Color timeColor = Color::fromString(m_e.attribute("color"));
 
     while (m_e.readNextStartElement()) {
         if (m_e.name() == "beats") {
@@ -6654,7 +6654,7 @@ Note* MusicXmlParserPass2::note(const String& partId,
     bool hasHead = true;
     NoteHeadGroup headGroup = NoteHeadGroup::HEAD_NORMAL;
     NoteHeadScheme headScheme = NoteHeadScheme::HEAD_AUTO;
-    const Color noteColor = Color::fromString(m_e.asciiAttribute("color").ascii());
+    const Color noteColor = Color::fromString(m_e.attribute("color"));
     Color noteheadColor;
     Color stemColor;
     bool noteheadParentheses = false;
@@ -6702,7 +6702,7 @@ Note* MusicXmlParserPass2::note(const String& partId,
             notations.parse();
             addError(notations.errors());
         } else if (m_e.name() == "notehead") {
-            noteheadColor = Color::fromString(m_e.asciiAttribute("color").ascii());
+            noteheadColor = Color::fromString(m_e.attribute("color"));
             noteheadParentheses = m_e.asciiAttribute("parentheses") == "yes";
             noteheadFilled = m_e.attribute("filled");
             String noteheadValue = m_e.readText();
@@ -6743,7 +6743,7 @@ Note* MusicXmlParserPass2::note(const String& partId,
                 staff = -1;
             }
         } else if (m_e.name() == "stem") {
-            stemColor = Color::fromString(m_e.asciiAttribute("color").ascii());
+            stemColor = Color::fromString(m_e.attribute("color"));
             stem(stemDir, noStem);
         } else if (m_e.name() == "tie") {
             tieType = m_e.attribute("type");
@@ -7238,7 +7238,7 @@ FiguredBassItem* MusicXmlParserPass2::figure(const int idx, const bool paren, Fi
             }
             m_e.skipCurrentElement();
         } else if (m_e.name() == "figure-number") {
-            const Color color = Color::fromString(m_e.asciiAttribute("color").ascii());
+            const Color color = Color::fromString(m_e.attribute("color"));
             String val = m_e.readText();
             int iVal = val.toInt();
             // MusicXML spec states figure-number is a number
@@ -7303,7 +7303,7 @@ FiguredBass* MusicXmlParserPass2::figuredBass()
     const bool parentheses = m_e.asciiAttribute("parentheses") == "yes";
     const bool printObject = m_e.asciiAttribute("print-object") != "no";
     const String placement = m_e.attribute("placement");
-    const Color color = Color::fromString(m_e.asciiAttribute("color").ascii());
+    const Color color = Color::fromString(m_e.attribute("color"));
 
     fb->setVisible(printObject);
     if (color.isValid()) {
@@ -7474,7 +7474,7 @@ void MusicXmlParserPass2::harmony(const String& partId, Measure* measure, const 
     UNUSED(measure);
     track_idx_t track = m_pass1.trackForPart(partId);
 
-    const Color color = Color::fromString(m_e.asciiAttribute("color").ascii());
+    const Color color = Color::fromString(m_e.attribute("color"));
     const String placement = m_e.attribute("placement");
     const bool printObject = m_e.asciiAttribute("print-object") != "no";
 
@@ -7801,7 +7801,7 @@ void MusicXmlParserLyric::parse()
 {
     bool hasExtend = false;
     const String lyricNumber = m_e.attribute("number");
-    const Color lyricColor = Color::fromString(m_e.asciiAttribute("color").ascii());
+    const Color lyricColor = Color::fromString(m_e.attribute("color"));
     const bool printLyric = m_e.asciiAttribute("print-object") != "no";
     m_placement = m_e.attribute("placement");
     double relX = m_e.doubleAttribute("relative-x") * 0.1 * DPMM;

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -8859,7 +8859,7 @@ void Notation::addAttribute(const String& name, const String& value)
 
 String Notation::attribute(const char* name) const
 {
-    const auto it = m_attributes.find(String(name));
+    const auto it = m_attributes.find(String(*name));
     return (it != m_attributes.end()) ? it->second : String();
 }
 

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -1153,9 +1153,9 @@ static void setElementPropertyFlags(EngravingObject* element, const Pid property
 static void addArticulationToChord(const Notation& notation, ChordRest* cr)
 {
     const SymId articSym = notation.symId();
-    const String dir = notation.attribute(u"type");
-    const String place = notation.attribute(u"placement");
-    const Color color = Color::fromString(notation.attribute(u"color"));
+    const String dir = notation.attribute("type");
+    const String place = notation.attribute("placement");
+    const Color color = Color::fromString(notation.attribute("color"));
     Articulation* na = Factory::createArticulation(cr);
     na->setSymId(articSym);
     if (color.isValid()) {
@@ -1196,8 +1196,8 @@ static void addArticulationToChord(const Notation& notation, ChordRest* cr)
 static void addFermataToChord(const Notation& notation, ChordRest* cr)
 {
     const SymId articSym = notation.symId();
-    const String direction = notation.attribute(u"type");
-    const Color color = Color::fromString(notation.attribute(u"color"));
+    const String direction = notation.attribute("type");
+    const Color color = Color::fromString(notation.attribute("color"));
     Fermata* na = Factory::createFermata(cr);
     na->setSymIdAndTimeStretch(articSym);
     na->setTrack(cr->track());
@@ -1229,9 +1229,9 @@ static void addFermataToChord(const Notation& notation, ChordRest* cr)
 static void addMordentToChord(const Notation& notation, ChordRest* cr)
 {
     const String name = notation.name();
-    const String attrLong = notation.attribute(u"long");
-    const String attrAppr = notation.attribute(u"approach");
-    const String attrDep = notation.attribute(u"departure");
+    const String attrLong = notation.attribute("long");
+    const String attrAppr = notation.attribute("approach");
+    const String attrDep = notation.attribute("departure");
     SymId articSym = SymId::noSym;   // legal but impossible ArticulationType value here indicating "not found"
     if (name == "inverted-mordent") {
         if ((attrLong.empty() || attrLong == "no") && attrAppr.empty() && attrDep.empty()) {
@@ -1259,8 +1259,8 @@ static void addMordentToChord(const Notation& notation, ChordRest* cr)
         }
     }
     if (articSym != SymId::noSym) {
-        const Color color = Color::fromString(notation.attribute(u"color"));
-        const String place = notation.attribute(u"placement");
+        const Color color = Color::fromString(notation.attribute("color"));
+        const String place = notation.attribute("placement");
         Ornament* mordent = Factory::createOrnament(cr);
         mordent->setSymId(articSym);
         if (place == u"above") {
@@ -1291,8 +1291,8 @@ static void addMordentToChord(const Notation& notation, ChordRest* cr)
 static void addTurnToChord(const Notation& notation, ChordRest* cr)
 {
     const SymId turnSym = notation.symId();
-    const Color color = Color::fromString(notation.attribute(u"color"));
-    const String place = notation.attribute(u"placement");
+    const Color color = Color::fromString(notation.attribute("color"));
+    const String place = notation.attribute("placement");
     Ornament* turn = Factory::createOrnament(cr);
     turn->setSymId(turnSym);
     if (place == u"above") {
@@ -1319,12 +1319,12 @@ static void addTurnToChord(const Notation& notation, ChordRest* cr)
 static void addOtherOrnamentToChord(const Notation& notation, ChordRest* cr)
 {
     const String name = notation.name();
-    const String symname = notation.attribute(u"smufl");
+    const String symname = notation.attribute("smufl");
     SymId sym = SymId::noSym;   // legal but impossible ArticulationType value here indicating "not found"
     sym = SymNames::symIdByName(symname);
 
     if (sym != SymId::noSym) {
-        const Color color = Color::fromString(notation.attribute(u"color"));
+        const Color color = Color::fromString(notation.attribute("color"));
         Ornament* ornam = Factory::createOrnament(cr);
         ornam->setSymId(sym);
         if (color.isValid()) {
@@ -7936,9 +7936,9 @@ void MusicXmlParserNotations::slur()
     // any grace note containing a slur stop means
     // last note of a grace after set has been found
     // -> remember slur stop
-    if (notation.attribute(u"type") == u"stop") {
+    if (notation.attribute("type") == u"stop") {
         m_slurStop = true;
-    } else if (notation.attribute(u"type") == u"start") {
+    } else if (notation.attribute("type") == u"start") {
         m_slurStart = true;
     }
 
@@ -7952,11 +7952,11 @@ void MusicXmlParserNotations::slur()
 static void addSlur(const Notation& notation, SlurStack& slurs, ChordRest* cr, const int tick,
                     MusicXmlLogger* logger, const XmlStreamReader* const xmlreader)
 {
-    int slurNo = notation.attribute(u"number").toInt();
+    int slurNo = notation.attribute("number").toInt();
     if (slurNo > 0) {
         slurNo--;
     }
-    const String slurType = notation.attribute(u"type");
+    const String slurType = notation.attribute("type");
 
     const track_idx_t track = cr->track();
     Score* score = cr->score();
@@ -7983,7 +7983,7 @@ static void addSlur(const Notation& notation, SlurStack& slurs, ChordRest* cr, c
             if (cr->isGrace()) {
                 newSlur->setAnchor(Spanner::Anchor::CHORD);
             }
-            const String lineType = notation.attribute(u"line-type");
+            const String lineType = notation.attribute("line-type");
             if (lineType == u"dashed") {
                 newSlur->setStyleType(SlurStyleType::Dashed);
             } else if (lineType == u"dotted") {
@@ -7991,15 +7991,15 @@ static void addSlur(const Notation& notation, SlurStack& slurs, ChordRest* cr, c
             } else if (lineType == u"solid" || lineType.empty()) {
                 newSlur->setStyleType(SlurStyleType::Solid);
             }
-            const Color color = Color::fromString(notation.attribute(u"color"));
+            const Color color = Color::fromString(notation.attribute("color"));
             if (color.isValid()) {
                 newSlur->setColor(color);
             }
             newSlur->setTick(Fraction::fromTicks(tick));
             newSlur->setStartElement(cr);
             if (configuration()->importLayout()) {
-                const String orientation = notation.attribute(u"orientation");
-                const String placement = notation.attribute(u"placement");
+                const String orientation = notation.attribute("orientation");
+                const String placement = notation.attribute("placement");
                 if (orientation == u"over" || placement == u"above") {
                     newSlur->setSlurDirection(DirectionV::UP);
                 } else if (orientation == u"under" || placement == u"below") {
@@ -8057,12 +8057,12 @@ void MusicXmlParserNotations::tied()
 {
     Notation notation = Notation::notationWithAttributes(String::fromAscii(m_e.name().ascii()), m_e.attributes(), u"notations");
     // Make sure "stops" get processed before "starts"
-    if (notation.attribute(u"type") == u"stop") {
+    if (notation.attribute("type") == u"stop") {
         m_notations.insert(m_notations.begin(), notation);
     } else {
         m_notations.push_back(notation);
     }
-    String tiedType = notation.attribute(u"type");
+    String tiedType = notation.attribute("type");
     if (tiedType != u"start" && tiedType != u"stop" && tiedType != u"let-ring") {
         m_logger->logError(String(u"unknown tied type %1").arg(tiedType), &m_e);
     }
@@ -8417,12 +8417,12 @@ void MusicXmlParserNotations::hole()
 
 void MusicXmlParserNotations::addTechnical(const Notation& notation, Note* note)
 {
-    const String placement = notation.attribute(u"placement");
-    const String fontWeight = notation.attribute(u"font-weight");
-    const double fontSize = notation.attribute(u"font-size").toDouble();
-    const String fontStyle = notation.attribute(u"font-style");
-    const String fontFamily = notation.attribute(u"font-family");
-    const Color color = Color::fromString(notation.attribute(u"color"));
+    const String placement = notation.attribute("placement");
+    const String fontWeight = notation.attribute("font-weight");
+    const double fontSize = notation.attribute("font-size").toDouble();
+    const String fontStyle = notation.attribute("font-style");
+    const String fontFamily = notation.attribute("font-family");
+    const Color color = Color::fromString(notation.attribute("color"));
     if (notation.name() == u"fingering") {
         // TODO: distinguish between keyboards (style TextStyleName::FINGERING)
         // and (plucked) strings (style TextStyleName::LH_GUITAR_FINGERING)
@@ -8507,11 +8507,11 @@ static void addGlissandoSlide(const Notation& notation, Note* note,
                               Glissando* glissandi[MAX_NUMBER_LEVEL][2], MusicXmlSpannerMap& spanners,
                               MusicXmlLogger* logger, const XmlStreamReader* const xmlreader)
 {
-    int glissandoNumber = notation.attribute(u"number").toInt();
+    int glissandoNumber = notation.attribute("number").toInt();
     if (glissandoNumber > 0) {
         glissandoNumber--;
     }
-    const String glissandoType = notation.attribute(u"type");
+    const String glissandoType = notation.attribute("type");
     int glissandoTag = notation.name() == u"slide" ? 0 : 1;
     //                  String lineType  = ee.attribute(String("line-type"), "solid");
     Glissando*& gliss = glissandi[glissandoNumber][glissandoTag];
@@ -8520,7 +8520,7 @@ static void addGlissandoSlide(const Notation& notation, Note* note,
     const track_idx_t track = note->track();
 
     if (glissandoType == u"start") {
-        const Color glissandoColor = Color::fromString(notation.attribute(u"color"));
+        const Color glissandoColor = Color::fromString(notation.attribute("color"));
         const String glissandoText = notation.text();
         if (gliss) {
             logger->logError(String(u"overlapping glissando/slide number %1").arg(glissandoNumber + 1), xmlreader);
@@ -8652,10 +8652,10 @@ static void addTie(const Notation& notation, Note* note, const track_idx_t track
         return;
     }
 
-    const String type = notation.attribute(u"type");
-    const String orientation = notation.attribute(u"orientation");
-    const String placement = notation.attribute(u"placement");
-    const String lineType = notation.attribute(u"line-type");
+    const String type = notation.attribute("type");
+    const String orientation = notation.attribute("orientation");
+    const String placement = notation.attribute("placement");
+    const String lineType = notation.attribute("line-type");
 
     TieLocation loc = TieLocation(note->pitch(), note->track());
 
@@ -8673,7 +8673,7 @@ static void addTie(const Notation& notation, Note* note, const track_idx_t track
         currTie->setStartNote(note);
         currTie->setTrack(track);
 
-        const Color color = Color::fromString(notation.attribute(u"color"));
+        const Color color = Color::fromString(notation.attribute("color"));
         if (color.isValid()) {
             currTie->setColor(color);
         }
@@ -8779,8 +8779,8 @@ static void addWavyLine(ChordRest* cr, const Fraction& tick,
 static void addBreath(const Notation& notation, ChordRest* cr)
 {
     const SymId breath = notation.symId();
-    const Color color = Color::fromString(notation.attribute(u"color"));
-    const String placement = notation.attribute(u"placement");
+    const Color color = Color::fromString(notation.attribute("color"));
+    const String placement = notation.attribute("placement");
 
     Segment* const seg = cr->measure()->getSegment(SegmentType::Breath, cr->tick() + cr->ticks());
     Breath* const b = Factory::createBreath(seg);
@@ -8803,7 +8803,7 @@ static void addChordLine(const Notation& notation, Note* note,
                          MusicXmlLogger* logger, const XmlStreamReader* const xmlreader)
 {
     const String chordLineType = notation.subType();
-    const Color color = Color::fromString(notation.attribute(u"color"));
+    const Color color = Color::fromString(notation.attribute("color"));
     if (!chordLineType.empty()) {
         if (note) {
             ChordLine* const chordline = Factory::createChordLine(note->chord());
@@ -8857,9 +8857,9 @@ void Notation::addAttribute(const String& name, const String& value)
 //   attribute
 //---------------------------------------------------------
 
-String Notation::attribute(const String& name) const
+String Notation::attribute(const char* name) const
 {
-    const auto it = m_attributes.find(name);
+    const auto it = m_attributes.find(String(name));
     return (it != m_attributes.end()) ? it->second : String();
 }
 

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.h
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.h
@@ -266,7 +266,7 @@ public:
     Notation(const muse::String& name, const muse::String& parent = {},
              const engraving::SymId& symId = engraving::SymId::noSym) { m_name = name; m_parent = parent; m_symId = symId; }
     void addAttribute(const muse::String& name, const muse::String& value);
-    muse::String attribute(const muse::String& name) const;
+    muse::String attribute(const char* name) const;
     const std::map<muse::String, muse::String>& attributes() const { return m_attributes; }
     muse::String name() const { return m_name; }
     muse::String parent() const { return m_parent; }


### PR DESCRIPTION
Little clean-up PR to unify the attribute handling in the MusicXML importer. The `attribute` method in the `Notation` class worked differently than the one from the XmlStreamReader, which was annoying me.