### PR TITLE
Prevent crash on system with no measures

### DIFF
--- a/src/engraving/rendering/score/pagelayout.cpp
+++ b/src/engraving/rendering/score/pagelayout.cpp
@@ -82,7 +82,7 @@ void PageLayout::getNextPage(LayoutContext& ctx)
     } else {
         state.setPage(dom.pages()[state.pageIdx()]);
         std::vector<System*>& systems = state.page()->systems();
-        state.setPageOldMeasure(systems.empty() ? nullptr : systems.back()->measures().back());
+        state.setPageOldMeasure(systems.empty() || systems.back()->measures().empty() ? nullptr : systems.back()->measures().back());
         const system_idx_t i = muse::indexOf(systems, state.curSystem());
         if ((i < systems.size()) && i > 0 && systems[i - 1]->page() == state.page()) {
             // Current and previous systems are on the current page.


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/24705
Resolves: https://github.com/musescore/MuseScore/issues/24648

Crash on layout change which results in a system with a single measure being removed. This crash does not happen when deleting the measure.

https://github.com/user-attachments/assets/71ae2579-3407-4bdf-a854-6560b312c9f1

