### PR TITLE
Restore geometry. Enabled for macOS

### DIFF
--- a/src/framework/dockwindow/view/dockwindow.cpp
+++ b/src/framework/dockwindow/view/dockwindow.cpp
@@ -173,14 +173,7 @@ void DockWindow::init()
 {
     clearRegistry();
 
-#ifdef Q_OS_MACOS
-    /*! TODO: restoring of the window geometry is temporarily disabled for macOS
-     * because it has a problem with saving a normal geometry of main window on KDDockWidgets
-     * see https://github.com/KDAB/KDDockWidgets/pull/273
-    */
-#else
     restoreGeometry();
-#endif
 
     dockWindowProvider()->init(this);
 


### PR DESCRIPTION
it looks like the problem was fixed in qt 6