### PR TITLE
Fix #26466: Note input add button not working

### DIFF
--- a/src/notation/qml/MuseScore/NotationScene/NoteInputBar.qml
+++ b/src/notation/qml/MuseScore/NotationScene/NoteInputBar.qml
@@ -132,16 +132,12 @@ Item {
             navigation.order: Boolean(itemModel) ? itemModel.order : 0
             isClickOnKeyNavTriggered: false
             navigation.onTriggered: {
-                if (menuLoader.isMenuOpened || btn.hasMenu) {
+                if (btn.hasMenu) {
                     toggleMenuOpened()
                 } else {
                     handleMenuItem()
                 }
             }
-
-            mouseArea.acceptedButtons: btn.hasMenu
-                                       ? Qt.LeftButton | Qt.RightButton
-                                       : Qt.LeftButton
 
             function toggleMenuOpened() {
                 menuLoader.toggleOpened(item.subitems)
@@ -151,15 +147,10 @@ Item {
                 Qt.callLater(noteInputModel.handleMenuItem, item.id)
             }
 
-            onClicked: function(mouse) {
-                if (menuLoader.isMenuOpened // If already menu open, close it
-                        || (btn.hasMenu // Or if can open menu
-                            && mouse.button === Qt.RightButton)) {
+            onClicked: {
+                if (btn.hasMenu) {
                     toggleMenuOpened()
-                    return
-                }
-
-                if (mouse.button === Qt.LeftButton) {
+                } else {
                     handleMenuItem()
                 }
             }


### PR DESCRIPTION
Resolves: #26466

Some logic was hanging over from the left/right click handling of the old "note input menu" (see old `isMenuSecondary` logic). This PR removes handling of right clicks for these buttons and simplifies the logic:

- If a button has a menu, toggle the menu (no need to check whether it's open or closed)
- If a button doesn't have a menu, trigger the action for that button