### PR TITLE
Fix #26353: Broken layout reset for Muse Sampler drumsets (percussion panel)

### DIFF
--- a/src/notation/utilities/percussionutilities.cpp
+++ b/src/notation/utilities/percussionutilities.cpp
@@ -33,6 +33,23 @@
 using namespace mu::notation;
 using namespace mu::engraving;
 
+void PercussionUtilities::readDrumset(const muse::ByteArray& drumMapping, Drumset& drumset)
+{
+    XmlReader reader(drumMapping);
+
+    while (reader.readNextStartElement()) {
+        if (reader.name() == "museScore") {
+            while (reader.readNextStartElement()) {
+                if (reader.name() == "Drum") {
+                    drumset.load(reader);
+                } else {
+                    reader.unknown();
+                }
+            }
+        }
+    }
+}
+
 /// Returns a drum note prepared for preview.
 std::shared_ptr<Chord> PercussionUtilities::getDrumNoteForPreview(const Drumset* drumset, int pitch)
 {

--- a/src/notation/utilities/percussionutilities.h
+++ b/src/notation/utilities/percussionutilities.h
@@ -28,6 +28,7 @@
 #include "iinteractive.h"
 
 #include "engraving/rendering/isinglerenderer.h"
+#include "engraving/rw/xmlreader.h"
 
 #include "engraving/dom/chord.h"
 #include "engraving/dom/drumset.h"
@@ -45,6 +46,7 @@ class PercussionUtilities
     INJECT_STATIC(mu::engraving::rendering::ISingleRenderer, engravingRender)
 
 public:
+    static void readDrumset(const muse::ByteArray& drumMapping, mu::engraving::Drumset& drumset);
     static std::shared_ptr<mu::engraving::Chord> getDrumNoteForPreview(const mu::engraving::Drumset* drumset, int pitch);
     static void editPercussionShortcut(mu::engraving::Drumset& drumset, int originPitch);
 

--- a/src/notation/view/percussionpanel/percussionpanelmodel.h
+++ b/src/notation/view/percussionpanel/percussionpanelmodel.h
@@ -30,6 +30,7 @@
 #include "context/iglobalcontext.h"
 #include "actions/iactionsdispatcher.h"
 #include "playback/iplaybackcontroller.h"
+#include "musesampler/imusesamplerinfo.h"
 #include "iinstrumentsrepository.h"
 #include "inotationconfiguration.h"
 
@@ -54,6 +55,7 @@ class PercussionPanelModel : public QObject, public muse::Injectable, public mus
     muse::Inject<context::IGlobalContext> globalContext = { this };
     muse::Inject<muse::actions::IActionsDispatcher> dispatcher = { this };
     muse::Inject<playback::IPlaybackController> playbackController = { this };
+    muse::Inject<muse::musesampler::IMuseSamplerInfo> museSampler;
     muse::Inject<IInstrumentsRepository> instrumentsRepository = { this };
     muse::Inject<INotationConfiguration> configuration = { this };
 
@@ -126,6 +128,8 @@ private:
     void playPitch(int pitch);
 
     void resetLayout();
+    Drumset standardDefaultDrumset() const;
+    Drumset museSamplerDefaultDrumset() const;
 
     mu::engraving::InstrumentTrackId currentTrackId() const;
 

--- a/src/notation/view/percussionpanel/percussionpanelpadlistmodel.cpp
+++ b/src/notation/view/percussionpanel/percussionpanelpadlistmodel.cpp
@@ -179,7 +179,7 @@ void PercussionPanelPadListModel::setDrumset(const engraving::Drumset* drumset)
     removeEmptyRows();
 }
 
-mu::engraving::Drumset PercussionPanelPadListModel::constructDefaultLayout(const engraving::Drumset* defaultDrumset) const
+mu::engraving::Drumset PercussionPanelPadListModel::constructDefaultLayout(const engraving::Drumset& defaultDrumset) const
 {
     //! NOTE: The idea of this method is take a "default" (template) drumset, find matching drums in the current drumset, and evaluate/return
     //! the default panel layout based on this information. The reason we can't simply revert to the default drumset in its entirety is that
@@ -192,20 +192,20 @@ mu::engraving::Drumset PercussionPanelPadListModel::constructDefaultLayout(const
     QList<int /*pitch*/> noTemplateFound;
 
     for (int pitch = 0; pitch < mu::engraving::DRUM_INSTRUMENTS; ++pitch) {
-        if (defaultDrumset->isValid(pitch) && !defaultLayout.isValid(pitch)) {
+        if (defaultDrumset.isValid(pitch) && !defaultLayout.isValid(pitch)) {
             // Pitch was deleted - restore it...
-            defaultLayout.drum(pitch) = defaultDrumset->drum(pitch);
+            defaultLayout.drum(pitch) = defaultDrumset.drum(pitch);
             continue;
         }
         //! NOTE: Pitch + drum name isn't exactly the most robust identifier, but this will probably change with the new percussion ID system
-        if (!defaultDrumset->isValid(pitch) || defaultLayout.name(pitch) != defaultDrumset->name(pitch)) {
+        if (!defaultDrumset.isValid(pitch) || defaultLayout.name(pitch) != defaultDrumset.name(pitch)) {
             // Drum is valid, but we can't find a template for it. Set the position chromatically later...
             noTemplateFound.emplaceBack(pitch);
             continue;
         }
 
-        const int templateRow = defaultDrumset->drum(pitch).panelRow;
-        const int templateColumn = defaultDrumset->drum(pitch).panelColumn;
+        const int templateRow = defaultDrumset.drum(pitch).panelRow;
+        const int templateColumn = defaultDrumset.drum(pitch).panelColumn;
 
         defaultLayout.drum(pitch).panelRow = templateRow;
         defaultLayout.drum(pitch).panelColumn = templateColumn;

--- a/src/notation/view/percussionpanel/percussionpanelpadlistmodel.h
+++ b/src/notation/view/percussionpanel/percussionpanelpadlistmodel.h
@@ -77,7 +77,7 @@ public:
 
     QList<PercussionPanelPadModel*> padList() const { return m_padModels; }
 
-    mu::engraving::Drumset constructDefaultLayout(const engraving::Drumset* templateDrumset) const;
+    mu::engraving::Drumset constructDefaultLayout(const engraving::Drumset& templateDrumset) const;
     int nextAvailableIndex(int pitch) const; //! NOTE: This may be equal to m_padModels.size()
     int nextAvailablePitch(int pitch) const;
 

--- a/src/playback/internal/drumsetloader.cpp
+++ b/src/playback/internal/drumsetloader.cpp
@@ -23,8 +23,7 @@
 #include "drumsetloader.h"
 
 #include "notation/notationtypes.h"
-
-#include "engraving/rw/xmlreader.h"
+#include "notation/utilities/percussionutilities.h"
 
 #include "global/types/bytearray.h"
 
@@ -32,23 +31,6 @@ using namespace mu::playback;
 using namespace muse::audio;
 using namespace mu::notation;
 using namespace mu::engraving;
-
-static void readDrumset(const muse::ByteArray& drumMapping, Drumset& drumset)
-{
-    XmlReader reader(drumMapping);
-
-    while (reader.readNextStartElement()) {
-        if (reader.name() == "museScore") {
-            while (reader.readNextStartElement()) {
-                if (reader.name() == "Drum") {
-                    drumset.load(reader);
-                } else {
-                    reader.unknown();
-                }
-            }
-        }
-    }
-}
 
 void DrumsetLoader::loadDrumset(INotationPtr notation, const InstrumentTrackId& trackId, const AudioResourceMeta& resourceMeta)
 {
@@ -93,7 +75,7 @@ void DrumsetLoader::loadDrumset(INotationPtr notation, const InstrumentTrackId& 
     }
 
     Drumset drumset;
-    readDrumset(drumMapping, drumset);
+    PercussionUtilities::readDrumset(drumMapping, drumset);
     replaceDrumset(notation, trackId, drumset);
 
     m_drumsetCache.emplace(instrumentId, std::move(drumset));


### PR DESCRIPTION
Resolves: #26353

Slightly different approaches are required for "basic" and Muse Sampler drumsets when resolving the default layout.