### PR TITLE
Percussion panel - refinements round 7

### DIFF
--- a/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPadContent.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPadContent.qml
@@ -57,10 +57,17 @@ Column {
             enabled: mainContentArea.enabled
             hoverEnabled: true
 
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
+
             onPressed: function(event) {
                 ui.tooltip.hide(root)
 
                 if (!Boolean(root.padModel)) {
+                    return
+                }
+
+                if (event.button === Qt.RightButton) {
+                    root.openFooterContextMenu()
                     return
                 }
 
@@ -167,6 +174,8 @@ Column {
 
             anchors.fill: parent
             enabled: root.panelMode !== PanelMode.EDIT_LAYOUT
+
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
 
             onClicked: {
                 root.openFooterContextMenu()

--- a/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPadContent.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPadContent.qml
@@ -57,14 +57,14 @@ Column {
             enabled: mainContentArea.enabled
             hoverEnabled: true
 
-            onPressed: {
+            onPressed: function(event) {
                 ui.tooltip.hide(root)
 
                 if (!Boolean(root.padModel)) {
                     return
                 }
 
-                root.padModel.triggerPad()
+                root.padModel.triggerPad(event.modifiers)
             }
 
             onContainsMouseChanged: {

--- a/src/notation/view/percussionpanel/percussionpanelmodel.cpp
+++ b/src/notation/view/percussionpanel/percussionpanelmodel.cpp
@@ -372,9 +372,12 @@ bool PercussionPanelModel::eventFilter(QObject* watched, QEvent* event)
 void PercussionPanelModel::onPadTriggered(int pitch, const PercussionPanelPadModel::PadAction& action)
 {
     switch (currentPanelMode()) {
-    case PanelMode::Mode::EDIT_LAYOUT: return;
-    case PanelMode::Mode::WRITE: writePitch(pitch, WRITE_ACTION_MAP.at(action)); // fall through
-    case PanelMode::Mode::SOUND_PREVIEW: playPitch(pitch);
+    case PanelMode::Mode::WRITE:
+        writePitch(pitch, WRITE_ACTION_MAP.at(action));
+        break;
+    case PanelMode::Mode::SOUND_PREVIEW:
+        playPitch(pitch);
+        break;
     default: break;
     }
 }

--- a/src/notation/view/percussionpanel/percussionpanelmodel.cpp
+++ b/src/notation/view/percussionpanel/percussionpanelmodel.cpp
@@ -452,17 +452,13 @@ void PercussionPanelModel::writePitch(int pitch)
         return;
     }
 
-    undoStack->prepareChanges(muse::TranslatableString("undoableAction", "Enter percussion note"));
-
     interaction()->noteInput()->startNoteInput(configuration()->defaultNoteInputMethod(), /*focusNotation*/ false);
 
-    score()->addMidiPitch(pitch, false, /*transpose*/ false);
-    undoStack->commitChanges();
+    NoteInputParams params;
+    params.drumPitch = pitch;
 
-    const mu::engraving::InputState& inputState = score()->inputState();
-    if (inputState.cr()) {
-        interaction()->showItem(inputState.cr());
-    }
+    const ActionData args = ActionData::make_arg2<NoteInputParams, NoteAddingMode>(params, NoteAddingMode::NextChord);
+    dispatcher()->dispatch("note-action", args);
 }
 
 void PercussionPanelModel::playPitch(int pitch)

--- a/src/notation/view/percussionpanel/percussionpanelmodel.cpp
+++ b/src/notation/view/percussionpanel/percussionpanelmodel.cpp
@@ -39,7 +39,8 @@ static const QString EDIT_LAYOUT_CODE("percussion-edit-layout");
 static const QString RESET_LAYOUT_CODE("percussion-reset-layout");
 
 using namespace muse;
-using namespace ui;
+using namespace muse::actions;
+using namespace muse::ui;
 using namespace mu::notation;
 
 static const std::unordered_map<PercussionPanelPadModel::PadAction, NoteAddingMode> WRITE_ACTION_MAP = {

--- a/src/notation/view/percussionpanel/percussionpanelmodel.h
+++ b/src/notation/view/percussionpanel/percussionpanelmodel.h
@@ -109,8 +109,6 @@ signals:
     void padListModelChanged();
 
 private:
-    using ActionData = muse::actions::ActionData;
-
     void setUpConnections();
 
     void setDrumset(mu::engraving::Drumset* drumset);

--- a/src/notation/view/percussionpanel/percussionpanelmodel.h
+++ b/src/notation/view/percussionpanel/percussionpanelmodel.h
@@ -109,6 +109,8 @@ signals:
     void padListModelChanged();
 
 private:
+    using ActionData = muse::actions::ActionData;
+
     void setUpConnections();
 
     void setDrumset(mu::engraving::Drumset* drumset);

--- a/src/notation/view/percussionpanel/percussionpanelmodel.h
+++ b/src/notation/view/percussionpanel/percussionpanelmodel.h
@@ -119,12 +119,12 @@ private:
 
     bool eventFilter(QObject* watched, QEvent* event) override;
 
-    void onPadTriggered(int pitch);
+    void onPadTriggered(int pitch, const PercussionPanelPadModel::PadAction& action);
     void onDuplicatePadRequested(int pitch);
     void onDeletePadRequested(int pitch);
     void onDefinePadShortcutRequested(int pitch);
 
-    void writePitch(int pitch);
+    void writePitch(int pitch, const NoteAddingMode& addingMode);
     void playPitch(int pitch);
 
     void resetLayout();

--- a/src/notation/view/percussionpanel/percussionpanelpadmodel.cpp
+++ b/src/notation/view/percussionpanel/percussionpanelpadmodel.cpp
@@ -115,7 +115,15 @@ void PercussionPanelPadModel::handleMenuItem(const QString& itemId)
     }
 }
 
-void PercussionPanelPadModel::triggerPad()
+void PercussionPanelPadModel::triggerPad(const Qt::KeyboardModifiers& mods)
 {
-    m_padActionTriggered.send(PadAction::TRIGGER);
+    PadAction action = PadAction::TRIGGER_STANDARD;
+
+    if (mods & Qt::ShiftModifier && (mods & Qt::ControlModifier || mods & Qt::MetaModifier)) {
+        action = PadAction::TRIGGER_INSERT;
+    } else if (mods & Qt::ShiftModifier) {
+        action = PadAction::TRIGGER_ADD;
+    }
+
+    m_padActionTriggered.send(action);
 }

--- a/src/notation/view/percussionpanel/percussionpanelpadmodel.cpp
+++ b/src/notation/view/percussionpanel/percussionpanelpadmodel.cpp
@@ -83,22 +83,20 @@ const QVariant PercussionPanelPadModel::notationPreviewItemVariant() const
 
 QList<QVariantMap> PercussionPanelPadModel::footerContextMenuItems() const
 {
+    static constexpr int definePadShortcutIcon = static_cast<int>(IconCode::Code::SHORTCUTS);
     // static constexpr int duplicatePadIcon = static_cast<int>(IconCode::Code::COPY);
     static constexpr int deletePadIcon = static_cast<int>(IconCode::Code::DELETE_TANK);
-    static constexpr int definePadShortcutIcon = static_cast<int>(IconCode::Code::SHORTCUTS);
 
     QList<QVariantMap> menuItems = {
+        { { "id", DEFINE_PAD_SHORTCUT_CODE }, { "title", muse::qtrc("shortcuts", "Define keyboard shortcut") },
+            { "icon", definePadShortcutIcon }, { "enabled", true } },
+
         //! NOTE: Disabled for now - will be re-introduced with new percussion mapping system...
         // { { "id", DUPLICATE_PAD_CODE }, { "title", muse::qtrc("global", "Duplicate") },
         //     { "icon", duplicatePadIcon }, { "enabled", true } },
 
         { { "id", DELETE_PAD_CODE }, { "title", muse::qtrc("global", "Delete") },
             { "icon", deletePadIcon }, { "enabled", true } },
-
-        { }, // separator
-
-        { { "id", DEFINE_PAD_SHORTCUT_CODE }, { "title", muse::qtrc("shortcuts", "Define keyboard shortcut") },
-            { "icon", definePadShortcutIcon }, { "enabled", true } },
     };
 
     return menuItems;

--- a/src/notation/view/percussionpanel/percussionpanelpadmodel.h
+++ b/src/notation/view/percussionpanel/percussionpanelpadmodel.h
@@ -67,10 +67,12 @@ public:
     QList<QVariantMap> footerContextMenuItems() const;
     Q_INVOKABLE void handleMenuItem(const QString& itemId);
 
-    Q_INVOKABLE void triggerPad();
+    Q_INVOKABLE void triggerPad(const Qt::KeyboardModifiers& modifiers);
 
     enum class PadAction {
-        TRIGGER,
+        TRIGGER_STANDARD,
+        TRIGGER_ADD,
+        TRIGGER_INSERT,
         DUPLICATE,
         DELETE,
         DEFINE_SHORTCUT,


### PR DESCRIPTION
Small refinements PR this time:

Commits b3227815332e72f06e34e9f4d69c213ac9f4546c and da116bc1848dbc9372f86e2b50fb206a8a79d2b2 resolve the first point mentioned in #26490 (shift-clicking pads to make chords, shift-ctrl/cmd-clicking to insert)

Commit 29fecd5461eeda69b923cb6dc42fc0a2dfff081b resolves a bug where the sound preview was incorrect when adding notes over an instrument change (the fall-through is no longer needed after the first two commits in this PR).

Commit 4ede47b49cd7875ecfbaa9c7d766959f15159fa4 resolves #26361