### PR TITLE
Don't add multiple incorrect system markings from finale files

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass1.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass1.cpp
@@ -1402,15 +1402,17 @@ void MusicXmlParserPass1::scorePartwise()
             Part* spannedPart = il.at(pg->start + j);
             stavesSpan += spannedPart->nstaves();
 
-            if (pg->barlineSpan) {
-                for (Staff* spannedStaff : spannedPart->staves()) {
-                    if ((j == pg->span - 1) && (spannedStaff == spannedPart->staves().back())) {
-                        // Very last staff of group,
-                        continue;
-                    } else {
-                        spannedStaff->setBarLineSpan(true);
-                    }
+            if (!pg->barlineSpan) {
+                continue;
+            }
+
+            for (Staff* spannedStaff : spannedPart->staves()) {
+                if ((j == pg->span - 1) && (spannedStaff == spannedPart->staves().back())) {
+                    // Very last staff of group,
+                    continue;
                 }
+
+                spannedStaff->setBarLineSpan(true);
             }
         }
         // add bracket and set the span
@@ -1427,6 +1429,12 @@ void MusicXmlParserPass1::scorePartwise()
             if (pg->span == 1) {
                 partSet.insert(il.at(pg->start));
             }
+        }
+
+        Score* score = staff->score();
+        if (!score->isSystemObjectStaff(staff) && exporterSoftware() == MusicXmlExporterSoftware::FINALE
+            && configuration()->inferTextType()) {
+            score->addSystemObjectStaff(staff);
         }
     }
 

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -944,8 +944,8 @@ static void addInferredStickings(ChordRest* cr, const std::vector<Sticking*>& nu
 //   addElemOffset
 //---------------------------------------------------------
 
-static void addElemOffset(EngravingItem* el, track_idx_t track, const String& placement, Measure* measure, const Fraction& tick,
-                          MusicXmlParserPass2& _pass2)
+void MusicXmlParserPass2::addElemOffset(engraving::EngravingItem* el, engraving::track_idx_t track, const muse::String& placement,
+                                        engraving::Measure* measure, const engraving::Fraction& tick)
 {
     if (!measure) {
         return;
@@ -985,13 +985,20 @@ static void addElemOffset(EngravingItem* el, track_idx_t track, const String& pl
     }
 
     if (el->systemFlag()) {
+        const bool finale = m_pass1.exporterSoftware() == MusicXmlExporterSoftware::FINALE;
         Score* score = measure->score();
         Staff* st = score->staff(track2staff(track));
+
         if (!score->isSystemObjectStaff(st) && st->idx() != 0) {
+            if (finale) {
+                delete el;
+                return;
+            }
             score->addSystemObjectStaff(st);
         }
+
         bool found = false;
-        for (EngravingItem* existingEl : muse::values(_pass2.systemElements(), elTick.ticks())) {
+        for (EngravingItem* existingEl : muse::values(systemElements(), elTick.ticks())) {
             if (el->type() == existingEl->type()) {
                 if (el->isTextBase()) {
                     TextBase* elText = toTextBase(el);
@@ -1009,7 +1016,7 @@ static void addElemOffset(EngravingItem* el, track_idx_t track, const String& pl
         }
         if (!found) {
             el->setParent(s);
-            _pass2.addSystemElement(el, elTick);
+            addSystemElement(el, elTick);
         }
     } else {
         s->add(el);
@@ -2048,7 +2055,8 @@ void MusicXmlParserPass2::scorePartwise()
                     = existingEl->isTextBase() ? toTextBase(existingEl)->plainText() : toTextLineBase(existingEl)->beginText();
                 const bool textMatches = existingText == sysElText;
                 const bool placementMatches = existingEl->placement() == sysEl->placement();
-                if (textMatches && !existingEl->systemFlag() && placementMatches) {
+                const bool staffMatches = existingEl->staffIdx() == sysEl->staffIdx();
+                if (textMatches && (!existingEl->systemFlag() || staffMatches) && placementMatches) {
                     m_score->removeElement(existingEl);
                 }
             }
@@ -2768,7 +2776,7 @@ void MusicXmlParserPass2::measure(const String& partId, const Fraction time)
 
                     m_score->setTempo(tick, tpo);
 
-                    addElemOffset(t, m_pass1.trackForPart(partId), u"above", measure, tick, *this);
+                    addElemOffset(t, m_pass1.trackForPart(partId), u"above", measure, tick);
                 }
             }
             m_e.skipCurrentElement();
@@ -2866,8 +2874,7 @@ void MusicXmlParserPass2::measure(const String& partId, const Fraction time)
     }
               );
     for (MusicXmlDelayedDirectionElement* direction : delayedDirections) {
-        direction->addElem(*this);
-        delete direction;
+        addElemOffset(direction->element(), direction->track(), direction->placement(), direction->measure(), direction->tick());
     }
 
     // TODO:
@@ -3240,11 +3247,6 @@ static void preventNegativeTick(const Fraction& tick, Fraction& offset, MusicXml
     }
 }
 
-void MusicXmlDelayedDirectionElement::addElem(MusicXmlParserPass2& _pass2)
-{
-    addElemOffset(m_element, m_track, m_placement, m_measure, m_tick, _pass2);
-}
-
 String MusicXmlParserDirection::placement() const
 {
     if (m_placement.empty() && hasTotalY()) {
@@ -3410,7 +3412,7 @@ void MusicXmlParserDirection::direction(const String& partId,
         }
         tt->setVisible(m_visible);
 
-        addElemOffset(tt, m_track, placement(), measure, tick + m_offset, m_pass2);
+        m_pass2.addElemOffset(tt, m_track, placement(), measure, tick + m_offset);
         tempoTextAdded = true;
     } else if (isLikelyTempoLine(m_track)) {
         String simplifiedText = MScoreTextToMusicXml::toPlainText(m_wordsText).simplified();
@@ -3440,7 +3442,7 @@ void MusicXmlParserDirection::direction(const String& partId,
                 totalY(), sticking, m_track, placement(), measure, tick + m_offset);
             delayedDirections.push_back(delayedDirection);
         } else {
-            addElemOffset(sticking, m_track, placement(), measure, tick + m_offset, m_pass2);
+            m_pass2.addElemOffset(sticking, m_track, placement(), measure, tick + m_offset);
         }
     } else if (isLikelyDynamicRange()) {
         isDynamicRange = true;
@@ -3539,7 +3541,7 @@ void MusicXmlParserDirection::direction(const String& partId,
                         totalY(), t, m_track, placement(), measure, tick + m_offset);
                     delayedDirections.push_back(delayedDirection);
                 } else {
-                    addElemOffset(t, m_track, placement(), measure, tick + m_offset, m_pass2);
+                    m_pass2.addElemOffset(t, m_track, placement(), measure, tick + m_offset);
                 }
             }
         }
@@ -3559,7 +3561,7 @@ void MusicXmlParserDirection::direction(const String& partId,
             // TBD may want ro use tick + _offset if sound is affected
             m_score->setTempo(tick, tpo);
 
-            addElemOffset(t, m_track, placement(), measure, tick + m_offset, m_pass2);
+            m_pass2.addElemOffset(t, m_track, placement(), measure, tick + m_offset);
             tempoTextAdded = true;
         }
     }
@@ -3627,7 +3629,7 @@ void MusicXmlParserDirection::direction(const String& partId,
                 totalY(), elem, m_track, placement(), measure, tick + m_offset);
             delayedDirections.push_back(delayedDirection);
         } else {
-            addElemOffset(elem, m_track, placement(), measure, tick + m_offset, m_pass2);
+            m_pass2.addElemOffset(elem, m_track, placement(), measure, tick + m_offset);
         }
     }
 
@@ -9055,7 +9057,7 @@ void MusicXmlParserNotations::addToScore(ChordRest* const cr, Note* const note, 
     for (const String& d : std::as_const(m_dynamicsList)) {
         Dynamic* dynamic = Factory::createDynamic(m_score->dummy()->segment());
         dynamic->setDynamicType(d);
-        addElemOffset(dynamic, cr->track(), m_dynamicsPlacement, cr->measure(), Fraction::fromTicks(tick), m_pass2);
+        m_pass2.addElemOffset(dynamic, cr->track(), m_dynamicsPlacement, cr->measure(), Fraction::fromTicks(tick));
     }
 }
 

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.h
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.h
@@ -429,6 +429,9 @@ public:
         m_inferredPerc.push_back(instr);
     }
 
+    void addElemOffset(engraving::EngravingItem* el, engraving::track_idx_t track, const muse::String& placement,
+                       engraving::Measure* measure, const engraving::Fraction& tick);
+
 private:
     void addError(const muse::String& error);      // Add an error to be shown in the GUI
     void initPartState(const muse::String& partId);
@@ -655,12 +658,12 @@ public:
                                     muse::String placement, engraving::Measure* measure, engraving::Fraction tick)
         : m_totalY(totalY),  m_element(element), m_track(track), m_placement(placement),
         m_measure(measure), m_tick(tick) {}
-    void addElem(MusicXmlParserPass2& _pass2);
     double totalY() const { return m_totalY; }
-    const engraving::EngravingItem* element() const { return m_element; }
+    engraving::EngravingItem* element() const { return m_element; }
     engraving::track_idx_t track() const { return m_track; }
     const engraving::Fraction& tick() const { return m_tick; }
     const muse::String& placement() const { return m_placement; }
+    engraving::Measure* measure() const { return m_measure; }
 
 private:
     double m_totalY = 0.0;

--- a/src/importexport/musicxml/tests/data/testFinaleInstr2_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testFinaleInstr2_ref.mscx
@@ -143,6 +143,12 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
+    <SystemObjects>
+      <Instance staffId="1" barNumbers="false"/>
+      <Instance staffId="3" barNumbers="false"/>
+      <Instance staffId="5" barNumbers="false"/>
+      <Instance staffId="8" barNumbers="false"/>
+      </SystemObjects>
     <Part id="1">
       <Staff id="1">
         <StaffType group="pitched">

--- a/src/importexport/musicxml/tests/data/testFinaleInstr_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testFinaleInstr_ref.mscx
@@ -143,6 +143,14 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
+    <SystemObjects>
+      <Instance staffId="1" barNumbers="false"/>
+      <Instance staffId="4" barNumbers="false"/>
+      <Instance staffId="8" barNumbers="false"/>
+      <Instance staffId="11" barNumbers="false"/>
+      <Instance staffId="14" barNumbers="false"/>
+      <Instance staffId="17" barNumbers="false"/>
+      </SystemObjects>
     <Part id="1">
       <Staff id="1">
         <StaffType group="pitched">

--- a/src/importexport/musicxml/tests/data/testFinaleSystemObjects.xml
+++ b/src/importexport/musicxml/tests/data/testFinaleSystemObjects.xml
@@ -1,0 +1,730 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <work>
+    <work-title>Untitled score</work-title>
+    </work>
+  <identification>
+    <creator type="composer">Composer / arranger</creator>
+    <encoding>
+      <software>Finale v27.2 for Mac</software>
+      <encoding-date>2022-11-10</encoding-date>
+      <supports attribute="new-system" element="print" type="yes" value="yes"/>
+      <supports attribute="new-page" element="print" type="yes" value="yes"/>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="stem" type="yes"/>
+    </encoding>
+    </identification>
+  <defaults>
+    <scaling>
+      <millimeters>6.99911</millimeters>
+      <tenths>40</tenths>
+      </scaling>
+    <page-layout>
+      <page-height>1696.94</page-height>
+      <page-width>1200.48</page-width>
+      <page-margins type="even">
+        <left-margin>85.7252</left-margin>
+        <right-margin>85.7252</right-margin>
+        <top-margin>85.7252</top-margin>
+        <bottom-margin>85.7252</bottom-margin>
+        </page-margins>
+      <page-margins type="odd">
+        <left-margin>85.7252</left-margin>
+        <right-margin>85.7252</right-margin>
+        <top-margin>85.7252</top-margin>
+        <bottom-margin>85.7252</bottom-margin>
+        </page-margins>
+      </page-layout>
+    <appearance>
+      <line-width type="light barline">1.8</line-width>
+      <line-width type="heavy barline">5.5</line-width>
+      <line-width type="beam">5</line-width>
+      <line-width type="bracket">4.5</line-width>
+      <line-width type="dashes">1</line-width>
+      <line-width type="enclosure">1</line-width>
+      <line-width type="ending">1.1</line-width>
+      <line-width type="extend">1</line-width>
+      <line-width type="leger">1.6</line-width>
+      <line-width type="pedal">1.1</line-width>
+      <line-width type="octave shift">1.1</line-width>
+      <line-width type="slur middle">2.1</line-width>
+      <line-width type="slur tip">0.5</line-width>
+      <line-width type="staff">1.1</line-width>
+      <line-width type="stem">1</line-width>
+      <line-width type="tie middle">2.1</line-width>
+      <line-width type="tie tip">0.5</line-width>
+      <line-width type="tuplet bracket">1</line-width>
+      <line-width type="wedge">1.2</line-width>
+      <note-size type="cue">70</note-size>
+      <note-size type="grace">70</note-size>
+      <note-size type="grace-cue">49</note-size>
+      </appearance>
+    <music-font font-family="Leland"/>
+    <word-font font-family="Edwin" font-size="10"/>
+    <lyric-font font-family="Edwin" font-size="10"/>
+    </defaults>
+  <part-list>
+    <part-group type="start" number="1">
+      <group-symbol>bracket</group-symbol>
+      <group-barline>yes</group-barline>
+      </part-group>
+    <score-part id="P1">
+      <part-name>Flute</part-name>
+      <part-abbreviation>Fl.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Flute</instrument-name>
+        <instrument-sound>wind.flutes.flute</instrument-sound>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>74</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <score-part id="P2">
+      <part-name>Oboe</part-name>
+      <part-abbreviation>Ob.</part-abbreviation>
+      <score-instrument id="P2-I1">
+        <instrument-name>Oboe</instrument-name>
+        <instrument-sound>wind.reed.oboe</instrument-sound>
+        </score-instrument>
+      <midi-device id="P2-I1" port="1"></midi-device>
+      <midi-instrument id="P2-I1">
+        <midi-channel>2</midi-channel>
+        <midi-program>69</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <part-group type="stop" number="1"/>
+    <part-group type="start" number="1">
+      <group-symbol>bracket</group-symbol>
+      <group-barline>yes</group-barline>
+      </part-group>
+    <score-part id="P3">
+      <part-name>Horn in F</part-name>
+      <part-abbreviation>Hn. in F</part-abbreviation>
+      <score-instrument id="P3-I1">
+        <instrument-name>Horn</instrument-name>
+        <instrument-sound>brass.french-horn</instrument-sound>
+        </score-instrument>
+      <midi-device id="P3-I1" port="1"></midi-device>
+      <midi-instrument id="P3-I1">
+        <midi-channel>3</midi-channel>
+        <midi-program>61</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <score-part id="P4">
+      <part-name>Trombone</part-name>
+      <part-abbreviation>Tbn.</part-abbreviation>
+      <score-instrument id="P4-I1">
+        <instrument-name>Trombone</instrument-name>
+        <instrument-sound>brass.trombone</instrument-sound>
+        </score-instrument>
+      <midi-device id="P4-I1" port="1"></midi-device>
+      <midi-instrument id="P4-I1">
+        <midi-channel>5</midi-channel>
+        <midi-program>58</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <part-group type="stop" number="1"/>
+    <score-part id="P5">
+      <part-name>Piano</part-name>
+      <part-abbreviation>Pno.</part-abbreviation>
+      <score-instrument id="P5-I1">
+        <instrument-name>Piano</instrument-name>
+        <instrument-sound>keyboard.piano</instrument-sound>
+        </score-instrument>
+      <midi-device id="P5-I1" port="1"></midi-device>
+      <midi-instrument id="P5-I1">
+        <midi-channel>7</midi-channel>
+        <midi-program>1</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <part-group type="start" number="1">
+      <group-symbol>bracket</group-symbol>
+      <group-barline>yes</group-barline>
+      </part-group>
+    <score-part id="P6">
+      <part-name>Violin</part-name>
+      <part-abbreviation>Vln.</part-abbreviation>
+      <score-instrument id="P6-I1">
+        <instrument-name>Violin</instrument-name>
+        <instrument-sound>strings.violin</instrument-sound>
+        </score-instrument>
+      <midi-device id="P6-I1" port="1"></midi-device>
+      <midi-instrument id="P6-I1">
+        <midi-channel>8</midi-channel>
+        <midi-program>41</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <score-part id="P7">
+      <part-name>Viola</part-name>
+      <part-abbreviation>Vla.</part-abbreviation>
+      <score-instrument id="P7-I1">
+        <instrument-name>Viola</instrument-name>
+        <instrument-sound>strings.viola</instrument-sound>
+        </score-instrument>
+      <midi-device id="P7-I1" port="1"></midi-device>
+      <midi-instrument id="P7-I1">
+        <midi-channel>12</midi-channel>
+        <midi-program>42</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <part-group type="stop" number="1"/>
+    </part-list>
+  <part id="P1">
+    <measure number="1" width="495.49">
+      <print>
+        <system-layout>
+          <system-margins>
+            <left-margin>115.62</left-margin>
+            <right-margin>0</right-margin>
+            </system-margins>
+          <top-system-distance>70</top-system-distance>
+          </system-layout>
+        </print>
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+        <direction placement="above">
+          <direction-type>
+            <rehearsal default-x="-5" default-y="40" font-size="12" font-weight="bold">A</rehearsal>
+          </direction-type>
+        </direction>
+        <direction directive="yes" placement="above">
+          <direction-type>
+            <words default-y="40" font-size="12" font-weight="bold" xml:space="preserve">Adagio  </words>
+          </direction-type>
+          <direction-type>
+            <metronome font-family="EngraverTextT" font-size="10.25" font-weight="normal">
+              <beat-unit>quarter</beat-unit>
+              <per-minute>40</per-minute>
+            </metronome>
+          </direction-type>
+          <sound tempo="40"/>
+        </direction>
+        <direction placement="above">
+          <direction-type>
+            <rehearsal default-x="-5" default-y="40" font-size="12" font-weight="bold">A</rehearsal>
+          </direction-type>
+        </direction>
+        <direction directive="yes" placement="above">
+          <direction-type>
+            <words default-y="40" font-size="12" font-weight="bold" xml:space="preserve">Adagio  </words>
+          </direction-type>
+          <direction-type>
+            <metronome font-family="EngraverTextT" font-size="10.25" font-weight="normal">
+              <beat-unit>quarter</beat-unit>
+              <per-minute>40</per-minute>
+            </metronome>
+          </direction-type>
+          <sound tempo="40"/>
+        </direction>
+      <note default-x="279.98" default-y="-10">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="2" width="417.92">
+      <note default-x="196.96" default-y="-10">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  <part id="P2">
+    <measure number="1" width="495.49">
+      <print>
+        <staff-layout number="1">
+          <staff-distance>96.08</staff-distance>
+          </staff-layout>
+        </print>
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+        <direction placement="above">
+          <direction-type>
+            <rehearsal default-x="-5" default-y="40" font-size="12" font-weight="bold">A</rehearsal>
+          </direction-type>
+        </direction>
+        <direction directive="yes" placement="above">
+          <direction-type>
+            <words default-y="40" font-size="12" font-weight="bold" xml:space="preserve">Adagio  </words>
+          </direction-type>
+          <direction-type>
+            <metronome font-family="EngraverTextT" font-size="10.25" font-weight="normal">
+              <beat-unit>quarter</beat-unit>
+              <per-minute>40</per-minute>
+            </metronome>
+          </direction-type>
+          <sound tempo="40"/>
+        </direction>
+        <direction placement="above">
+          <direction-type>
+            <rehearsal default-x="-5" default-y="40" font-size="12" font-weight="bold">A</rehearsal>
+          </direction-type>
+        </direction>
+        <direction directive="yes" placement="above">
+          <direction-type>
+            <words default-y="40" font-size="12" font-weight="bold" xml:space="preserve">Adagio  </words>
+          </direction-type>
+          <direction-type>
+            <metronome font-family="EngraverTextT" font-size="10.25" font-weight="normal">
+              <beat-unit>quarter</beat-unit>
+              <per-minute>40</per-minute>
+            </metronome>
+          </direction-type>
+          <sound tempo="40"/>
+        </direction>
+      <note default-x="279.98" default-y="-146.08">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="2" width="417.92">
+      <note default-x="196.96" default-y="-146.08">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  <part id="P3">
+    <measure number="1" width="495.49">
+      <print>
+        <staff-layout number="1">
+          <staff-distance>115.29</staff-distance>
+          </staff-layout>
+        </print>
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>1</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        <transpose>
+          <diatonic>-4</diatonic>
+          <chromatic>-7</chromatic>
+          </transpose>
+        </attributes>
+        <direction placement="above">
+          <direction-type>
+            <rehearsal default-x="-5" default-y="40" font-size="12" font-weight="bold">A</rehearsal>
+          </direction-type>
+        </direction>
+        <direction directive="yes" placement="above">
+          <direction-type>
+            <words default-y="40" font-size="12" font-weight="bold" xml:space="preserve">Adagio  </words>
+          </direction-type>
+          <direction-type>
+            <metronome font-family="EngraverTextT" font-size="10.25" font-weight="normal">
+              <beat-unit>quarter</beat-unit>
+              <per-minute>40</per-minute>
+            </metronome>
+          </direction-type>
+          <sound tempo="40"/>
+        </direction>
+        <direction placement="above">
+          <direction-type>
+            <rehearsal default-x="-5" default-y="40" font-size="12" font-weight="bold">A</rehearsal>
+          </direction-type>
+        </direction>
+        <direction directive="yes" placement="above">
+          <direction-type>
+            <words default-y="40" font-size="12" font-weight="bold" xml:space="preserve">Adagio  </words>
+          </direction-type>
+          <direction-type>
+            <metronome font-family="EngraverTextT" font-size="10.25" font-weight="normal">
+              <beat-unit>quarter</beat-unit>
+              <per-minute>40</per-minute>
+            </metronome>
+          </direction-type>
+          <sound tempo="40"/>
+        </direction>
+      <note default-x="279.98" default-y="-301.37">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="2" width="417.92">
+      <note default-x="196.96" default-y="-301.37">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  <part id="P4">
+    <measure number="1" width="495.49">
+      <print>
+        <staff-layout number="1">
+          <staff-distance>96.08</staff-distance>
+          </staff-layout>
+        </print>
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>F</sign>
+          <line>4</line>
+          </clef>
+        </attributes>
+        <direction placement="above">
+          <direction-type>
+            <rehearsal default-x="-5" default-y="40" font-size="12" font-weight="bold">A</rehearsal>
+          </direction-type>
+        </direction>
+        <direction directive="yes" placement="above">
+          <direction-type>
+            <words default-y="40" font-size="12" font-weight="bold" xml:space="preserve">Adagio  </words>
+          </direction-type>
+          <direction-type>
+            <metronome font-family="EngraverTextT" font-size="10.25" font-weight="normal">
+              <beat-unit>quarter</beat-unit>
+              <per-minute>40</per-minute>
+            </metronome>
+          </direction-type>
+          <sound tempo="40"/>
+        </direction>
+        <direction placement="above">
+          <direction-type>
+            <rehearsal default-x="-5" default-y="40" font-size="12" font-weight="bold">A</rehearsal>
+          </direction-type>
+        </direction>
+        <direction directive="yes" placement="above">
+          <direction-type>
+            <words default-y="40" font-size="12" font-weight="bold" xml:space="preserve">Adagio  </words>
+          </direction-type>
+          <direction-type>
+            <metronome font-family="EngraverTextT" font-size="10.25" font-weight="normal">
+              <beat-unit>quarter</beat-unit>
+              <per-minute>40</per-minute>
+            </metronome>
+          </direction-type>
+          <sound tempo="40"/>
+        </direction>
+      <note default-x="279.98" default-y="-437.44">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="2" width="417.92">
+      <note default-x="196.96" default-y="-437.44">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  <part id="P5">
+    <measure number="1" width="495.49">
+      <print>
+        <staff-layout number="1">
+          <staff-distance>115.29</staff-distance>
+          </staff-layout>
+        <staff-layout number="2">
+          <staff-distance>65</staff-distance>
+          </staff-layout>
+        </print>
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <staves>2</staves>
+        <clef number="1">
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        <clef number="2">
+          <sign>F</sign>
+          <line>4</line>
+          </clef>
+        </attributes>
+        <direction placement="above">
+          <direction-type>
+            <rehearsal default-x="-5" default-y="40" font-size="12" font-weight="bold">A</rehearsal>
+          </direction-type>
+        </direction>
+        <direction directive="yes" placement="above">
+          <direction-type>
+            <words default-y="40" font-size="12" font-weight="bold" xml:space="preserve">Adagio  </words>
+          </direction-type>
+          <direction-type>
+            <metronome font-family="EngraverTextT" font-size="10.25" font-weight="normal">
+              <beat-unit>quarter</beat-unit>
+              <per-minute>40</per-minute>
+            </metronome>
+          </direction-type>
+          <sound tempo="40"/>
+        </direction>
+        <direction placement="above">
+          <direction-type>
+            <rehearsal default-x="-5" default-y="40" font-size="12" font-weight="bold">A</rehearsal>
+          </direction-type>
+        </direction>
+        <direction directive="yes" placement="above">
+          <direction-type>
+            <words default-y="40" font-size="12" font-weight="bold" xml:space="preserve">Adagio  </words>
+          </direction-type>
+          <direction-type>
+            <metronome font-family="EngraverTextT" font-size="10.25" font-weight="normal">
+              <beat-unit>quarter</beat-unit>
+              <per-minute>40</per-minute>
+            </metronome>
+          </direction-type>
+          <sound tempo="40"/>
+        </direction>
+      <note default-x="279.98" default-y="-592.73">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <note default-x="279.98" default-y="-697.73">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>5</voice>
+        <staff>2</staff>
+        </note>
+      </measure>
+    <measure number="2" width="417.92">
+      <note default-x="196.96" default-y="-592.73">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <note default-x="196.96" default-y="-697.73">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>5</voice>
+        <staff>2</staff>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  <part id="P6">
+    <measure number="1" width="495.49">
+      <print>
+        <staff-layout number="1">
+          <staff-distance>115.29</staff-distance>
+          </staff-layout>
+        </print>
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+        <direction placement="above">
+          <direction-type>
+            <rehearsal default-x="-5" default-y="40" font-size="12" font-weight="bold">A</rehearsal>
+          </direction-type>
+        </direction>
+        <direction directive="yes" placement="above">
+          <direction-type>
+            <words default-y="40" font-size="12" font-weight="bold" xml:space="preserve">Adagio  </words>
+          </direction-type>
+          <direction-type>
+            <metronome font-family="EngraverTextT" font-size="10.25" font-weight="normal">
+              <beat-unit>quarter</beat-unit>
+              <per-minute>40</per-minute>
+            </metronome>
+          </direction-type>
+          <sound tempo="40"/>
+        </direction>
+        <direction placement="above">
+          <direction-type>
+            <rehearsal default-x="-5" default-y="40" font-size="12" font-weight="bold">A</rehearsal>
+          </direction-type>
+        </direction>
+        <direction directive="yes" placement="above">
+          <direction-type>
+            <words default-y="40" font-size="12" font-weight="bold" xml:space="preserve">Adagio  </words>
+          </direction-type>
+          <direction-type>
+            <metronome font-family="EngraverTextT" font-size="10.25" font-weight="normal">
+              <beat-unit>quarter</beat-unit>
+              <per-minute>40</per-minute>
+            </metronome>
+          </direction-type>
+          <sound tempo="40"/>
+        </direction>
+      <note default-x="279.98" default-y="-853.02">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="2" width="417.92">
+      <note default-x="196.96" default-y="-853.02">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  <part id="P7">
+    <measure number="1" width="495.49">
+      <print>
+        <staff-layout number="1">
+          <staff-distance>96.07</staff-distance>
+          </staff-layout>
+        </print>
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>C</sign>
+          <line>3</line>
+          </clef>
+        </attributes>
+        <direction placement="above">
+          <direction-type>
+            <rehearsal default-x="-5" default-y="40" font-size="12" font-weight="bold">A</rehearsal>
+          </direction-type>
+        </direction>
+        <direction directive="yes" placement="above">
+          <direction-type>
+            <words default-y="40" font-size="12" font-weight="bold" xml:space="preserve">Adagio  </words>
+          </direction-type>
+          <direction-type>
+            <metronome font-family="EngraverTextT" font-size="10.25" font-weight="normal">
+              <beat-unit>quarter</beat-unit>
+              <per-minute>40</per-minute>
+            </metronome>
+          </direction-type>
+          <sound tempo="40"/>
+        </direction>
+        <direction placement="above">
+          <direction-type>
+            <rehearsal default-x="-5" default-y="40" font-size="12" font-weight="bold">A</rehearsal>
+          </direction-type>
+        </direction>
+        <direction directive="yes" placement="above">
+          <direction-type>
+            <words default-y="40" font-size="12" font-weight="bold" xml:space="preserve">Adagio  </words>
+          </direction-type>
+          <direction-type>
+            <metronome font-family="EngraverTextT" font-size="10.25" font-weight="normal">
+              <beat-unit>quarter</beat-unit>
+              <per-minute>40</per-minute>
+            </metronome>
+          </direction-type>
+          <sound tempo="40"/>
+        </direction>
+      <note default-x="279.98" default-y="-989.1">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="2" width="417.92">
+      <note default-x="196.96" default-y="-989.1">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/src/importexport/musicxml/tests/data/testFinaleSystemObjects_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testFinaleSystemObjects_ref.mscx
@@ -1,0 +1,843 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="4.50">
+  <Score>
+    <Division>480</Division>
+    <Style>
+      <pageWidth>8.26997</pageWidth>
+      <pageHeight>11.69</pageHeight>
+      <pagePrintableWidth>7.08887</pagePrintableWidth>
+      <pageEvenLeftMargin>0.590551</pageEvenLeftMargin>
+      <pageOddLeftMargin>0.590551</pageOddLeftMargin>
+      <pageEvenTopMargin>0.590551</pageEvenTopMargin>
+      <pageEvenBottomMargin>0.590551</pageEvenBottomMargin>
+      <pageOddTopMargin>0.590551</pageOddTopMargin>
+      <pageOddBottomMargin>0.590551</pageOddBottomMargin>
+      <romanNumeralFontFace>Edwin</romanNumeralFontFace>
+      <nashvilleNumberFontSize>10</nashvilleNumberFontSize>
+      <tupletFontSize>10</tupletFontSize>
+      <fingeringFontSize>10</fingeringFontSize>
+      <lhGuitarFingeringFontSize>10</lhGuitarFingeringFontSize>
+      <rhGuitarFingeringFontSize>10</rhGuitarFingeringFontSize>
+      <stringNumberFontSize>10</stringNumberFontSize>
+      <stringTuningsFontSize>10</stringTuningsFontSize>
+      <partInstrumentFontSize>10</partInstrumentFontSize>
+      <tempoFontSize>10</tempoFontSize>
+      <tempoChangeFontSize>10</tempoChangeFontSize>
+      <metronomeFontSize>10</metronomeFontSize>
+      <measureNumberFontSize>10</measureNumberFontSize>
+      <mmRestRangeFontSize>10</mmRestRangeFontSize>
+      <rehearsalMarkFontSize>10</rehearsalMarkFontSize>
+      <repeatLeftFontSize>10</repeatLeftFontSize>
+      <repeatRightFontSize>10</repeatRightFontSize>
+      <glissandoFontSize>10</glissandoFontSize>
+      <bendFontSize>10</bendFontSize>
+      <headerFontSize>10</headerFontSize>
+      <footerFontSize>10</footerFontSize>
+      <copyrightFontSize>10</copyrightFontSize>
+      <pageNumberFontSize>10</pageNumberFontSize>
+      <spatium>1.74978</spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer">Composer / arranger</metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle">Untitled score</metaTag>
+    <SystemObjects>
+      <Instance staffId="1" barNumbers="false"/>
+      <Instance staffId="3" barNumbers="false"/>
+      <Instance staffId="7" barNumbers="false"/>
+      </SystemObjects>
+    <Part id="1">
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <hideWhenEmpty>3</hideWhenEmpty>
+        <bracket type="0" span="2" col="0" visible="1"/>
+        <barLineSpan>1</barLineSpan>
+        </Staff>
+      <trackName>Flute</trackName>
+      <Instrument id="flute">
+        <longName>Flute</longName>
+        <shortName>Fl.</shortName>
+        <trackName>Flute</trackName>
+        <minPitchP>59</minPitchP>
+        <maxPitchP>98</maxPitchP>
+        <minPitchA>60</minPitchA>
+        <maxPitchA>93</maxPitchA>
+        <instrumentId>wind.flutes.flute</instrumentId>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>95</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>150</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="sforzatoStaccato">
+          <velocity>150</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoStaccato">
+          <velocity>120</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoTenuto">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="73"/>
+          <controller ctrl="10" value="63"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Part id="2">
+      <Staff id="2">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <hideWhenEmpty>3</hideWhenEmpty>
+        </Staff>
+      <trackName>Oboe</trackName>
+      <Instrument id="oboe">
+        <longName>Oboe</longName>
+        <shortName>Ob.</shortName>
+        <trackName>Oboe</trackName>
+        <minPitchP>58</minPitchP>
+        <maxPitchP>96</maxPitchP>
+        <minPitchA>58</minPitchA>
+        <maxPitchA>87</maxPitchA>
+        <instrumentId>wind.reed.oboe</instrumentId>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>150</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="sforzatoStaccato">
+          <velocity>150</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoStaccato">
+          <velocity>120</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoTenuto">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="68"/>
+          <controller ctrl="10" value="63"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Part id="3">
+      <Staff id="3">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <hideWhenEmpty>3</hideWhenEmpty>
+        <bracket type="0" span="2" col="0" visible="1"/>
+        <barLineSpan>1</barLineSpan>
+        </Staff>
+      <trackName>Horn in F</trackName>
+      <Instrument id="horn">
+        <longName>Horn in F</longName>
+        <shortName>Hn. in F</shortName>
+        <trackName>Horn in F</trackName>
+        <minPitchP>31</minPitchP>
+        <maxPitchP>77</maxPitchP>
+        <minPitchA>41</minPitchA>
+        <maxPitchA>69</maxPitchA>
+        <transposeDiatonic>-4</transposeDiatonic>
+        <transposeChromatic>-7</transposeChromatic>
+        <instrumentId>brass.french-horn</instrumentId>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>150</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="sforzatoStaccato">
+          <velocity>150</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoStaccato">
+          <velocity>120</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoTenuto">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel name="open">
+          <program value="60"/>
+          <controller ctrl="10" value="63"/>
+          </Channel>
+        <Channel name="mute">
+          <program value="59"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Part id="4">
+      <Staff id="4">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <hideWhenEmpty>3</hideWhenEmpty>
+        </Staff>
+      <trackName>Trombone</trackName>
+      <Instrument id="trombone">
+        <longName>Trombone</longName>
+        <shortName>Tbn.</shortName>
+        <trackName>Trombone</trackName>
+        <minPitchP>36</minPitchP>
+        <maxPitchP>74</maxPitchP>
+        <minPitchA>40</minPitchA>
+        <maxPitchA>71</maxPitchA>
+        <instrumentId>brass.trombone</instrumentId>
+        <clef>F</clef>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>150</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="sforzatoStaccato">
+          <velocity>150</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoStaccato">
+          <velocity>120</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoTenuto">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel name="open">
+          <program value="57"/>
+          <controller ctrl="10" value="63"/>
+          </Channel>
+        <Channel name="mute">
+          <program value="59"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Part id="5">
+      <Staff id="5">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <hideWhenEmpty>3</hideWhenEmpty>
+        <bracket type="1" span="2" col="1" visible="1"/>
+        <barLineSpan>1</barLineSpan>
+        </Staff>
+      <Staff id="6">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <hideWhenEmpty>3</hideWhenEmpty>
+        </Staff>
+      <trackName>Piano</trackName>
+      <Instrument id="piano">
+        <longName>Piano</longName>
+        <shortName>Pno.</shortName>
+        <trackName>Piano</trackName>
+        <minPitchP>21</minPitchP>
+        <maxPitchP>108</maxPitchP>
+        <minPitchA>21</minPitchA>
+        <maxPitchA>108</maxPitchA>
+        <instrumentId>keyboard.piano</instrumentId>
+        <clef staff="2">F</clef>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>95</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>150</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="sforzatoStaccato">
+          <velocity>150</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoStaccato">
+          <velocity>120</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoTenuto">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="0"/>
+          <controller ctrl="10" value="63"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Part id="6">
+      <Staff id="7">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <hideWhenEmpty>3</hideWhenEmpty>
+        <bracket type="0" span="2" col="0" visible="1"/>
+        <barLineSpan>1</barLineSpan>
+        </Staff>
+      <trackName>Violin</trackName>
+      <Instrument id="violin">
+        <longName>Violin</longName>
+        <shortName>Vln.</shortName>
+        <trackName>Violin</trackName>
+        <minPitchP>55</minPitchP>
+        <maxPitchP>103</maxPitchP>
+        <minPitchA>55</minPitchA>
+        <maxPitchA>88</maxPitchA>
+        <instrumentId>strings.violin</instrumentId>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>150</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="sforzatoStaccato">
+          <velocity>150</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoStaccato">
+          <velocity>120</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoTenuto">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel name="arco">
+          <program value="40"/>
+          <controller ctrl="10" value="63"/>
+          </Channel>
+        <Channel name="pizzicato">
+          <program value="45"/>
+          </Channel>
+        <Channel name="tremolo">
+          <program value="44"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Part id="7">
+      <Staff id="8">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <hideWhenEmpty>3</hideWhenEmpty>
+        </Staff>
+      <trackName>Viola</trackName>
+      <Instrument id="viola">
+        <longName>Viola</longName>
+        <shortName>Vla.</shortName>
+        <trackName>Viola</trackName>
+        <minPitchP>48</minPitchP>
+        <maxPitchP>93</maxPitchP>
+        <minPitchA>48</minPitchA>
+        <maxPitchA>79</maxPitchA>
+        <instrumentId>strings.viola</instrumentId>
+        <clef>C3</clef>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>150</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="sforzatoStaccato">
+          <velocity>150</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoStaccato">
+          <velocity>120</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoTenuto">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel name="arco">
+          <program value="41"/>
+          <controller ctrl="10" value="63"/>
+          </Channel>
+        <Channel name="pizzicato">
+          <program value="45"/>
+          </Channel>
+        <Channel name="tremolo">
+          <program value="44"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <VBox>
+        <height>10</height>
+        <Text>
+          <style>title</style>
+          <text>Untitled score</text>
+          </Text>
+        <Text>
+          <style>composer</style>
+          <text>Composer / arranger</text>
+          </Text>
+        </VBox>
+      <Measure>
+        <voice>
+          <Clef>
+            <concertClefType>G</concertClefType>
+            <transposingClefType>G</transposingClefType>
+            <isHeader>1</isHeader>
+            </Clef>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Tempo>
+            <tempo>0.666667</tempo>
+            <followText>1</followText>
+            <linkedMain/>
+            <text><font size="12"/><b>Adagio  </b><sym>metNoteQuarterUp</sym> = 40</text>
+            </Tempo>
+          <RehearsalMark>
+            <linkedMain/>
+            <text><font size="12"/><b>A</b></text>
+            </RehearsalMark>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          <BarLine>
+            <subtype>end</subtype>
+            </BarLine>
+          </voice>
+        </Measure>
+      </Staff>
+    <Staff id="2">
+      <Measure>
+        <voice>
+          <Clef>
+            <concertClefType>G</concertClefType>
+            <transposingClefType>G</transposingClefType>
+            <isHeader>1</isHeader>
+            </Clef>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          <BarLine>
+            <subtype>end</subtype>
+            </BarLine>
+          </voice>
+        </Measure>
+      </Staff>
+    <Staff id="3">
+      <Measure>
+        <voice>
+          <Clef>
+            <concertClefType>G</concertClefType>
+            <transposingClefType>G</transposingClefType>
+            <isHeader>1</isHeader>
+            </Clef>
+          <KeySig>
+            <concertKey>0</concertKey>
+            <actualKey>1</actualKey>
+            </KeySig>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Tempo>
+            <tempo>0.666667</tempo>
+            <followText>1</followText>
+            <linked>
+              <location>
+                <staves>-2</staves>
+                </location>
+              <indexDiff>-2</indexDiff>
+              </linked>
+            <text><font size="12"/><b>Adagio  </b><sym>metNoteQuarterUp</sym> = 40</text>
+            </Tempo>
+          <RehearsalMark>
+            <linked>
+              <location>
+                <staves>-2</staves>
+                </location>
+              <indexDiff>-2</indexDiff>
+              </linked>
+            <text><font size="12"/><b>A</b></text>
+            </RehearsalMark>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          <BarLine>
+            <subtype>end</subtype>
+            </BarLine>
+          </voice>
+        </Measure>
+      </Staff>
+    <Staff id="4">
+      <Measure>
+        <voice>
+          <Clef>
+            <concertClefType>F</concertClefType>
+            <transposingClefType>F</transposingClefType>
+            <isHeader>1</isHeader>
+            </Clef>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          <BarLine>
+            <subtype>end</subtype>
+            </BarLine>
+          </voice>
+        </Measure>
+      </Staff>
+    <Staff id="5">
+      <Measure>
+        <voice>
+          <Clef>
+            <concertClefType>G</concertClefType>
+            <transposingClefType>G</transposingClefType>
+            <isHeader>1</isHeader>
+            </Clef>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          <BarLine>
+            <subtype>end</subtype>
+            </BarLine>
+          </voice>
+        </Measure>
+      </Staff>
+    <Staff id="6">
+      <Measure>
+        <voice>
+          <Clef>
+            <concertClefType>F</concertClefType>
+            <transposingClefType>F</transposingClefType>
+            <isHeader>1</isHeader>
+            </Clef>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          <BarLine>
+            <subtype>end</subtype>
+            </BarLine>
+          </voice>
+        </Measure>
+      </Staff>
+    <Staff id="7">
+      <Measure>
+        <voice>
+          <Clef>
+            <concertClefType>G</concertClefType>
+            <transposingClefType>G</transposingClefType>
+            <isHeader>1</isHeader>
+            </Clef>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Tempo>
+            <tempo>0.666667</tempo>
+            <followText>1</followText>
+            <linked>
+              <location>
+                <staves>-6</staves>
+                </location>
+              <indexDiff>-4</indexDiff>
+              </linked>
+            <text><font size="12"/><b>Adagio  </b><sym>metNoteQuarterUp</sym> = 40</text>
+            </Tempo>
+          <RehearsalMark>
+            <linked>
+              <location>
+                <staves>-6</staves>
+                </location>
+              <indexDiff>-4</indexDiff>
+              </linked>
+            <text><font size="12"/><b>A</b></text>
+            </RehearsalMark>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          <BarLine>
+            <subtype>end</subtype>
+            </BarLine>
+          </voice>
+        </Measure>
+      </Staff>
+    <Staff id="8">
+      <Measure>
+        <voice>
+          <Clef>
+            <concertClefType>C3</concertClefType>
+            <transposingClefType>C3</transposingClefType>
+            <isHeader>1</isHeader>
+            </Clef>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>1/1</duration>
+            </Rest>
+          <BarLine>
+            <subtype>end</subtype>
+            </BarLine>
+          </voice>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/src/importexport/musicxml/tests/musicxml_tests.cpp
+++ b/src/importexport/musicxml/tests/musicxml_tests.cpp
@@ -622,6 +622,9 @@ TEST_F(MusicXml_Tests, finaleInstr) {
 TEST_F(MusicXml_Tests, finaleInstr2) {
     musicXmlImportTestRef("testFinaleInstr2");
 }
+TEST_F(MusicXml_Tests, finaleSystemObjects) {
+    musicXmlImportTestRef("testFinaleSystemObjects");
+}
 TEST_F(MusicXml_Tests, formattedThings) {
     musicXmlIoTest("testFormattedThings");
 }


### PR DESCRIPTION
Resolves: #25232 
This PR creates system object staves based on the `part-group` tag for Finale files as Finale incorrectly exports some system markings to all staves. System markings are added if they appear on these staves and discarded if not.
