### PR TITLE
Fix GH#26523: Crash on deleting instrument if last staff contains fretboard diagram

### DIFF
--- a/src/engraving/dom/harmony.cpp
+++ b/src/engraving/dom/harmony.cpp
@@ -1064,6 +1064,9 @@ const RealizedHarmony& Harmony::getRealizedHarmony() const
 {
     Fraction tick = this->tick();
     const Staff* st = staff();
+    IF_ASSERT_FAILED(st) {
+        return m_realizedHarmony;
+    }
 
     const CapoParams& capo = st->capo(tick);
 

--- a/src/engraving/playback/playbackeventsrenderer.cpp
+++ b/src/engraving/playback/playbackeventsrenderer.cpp
@@ -130,7 +130,11 @@ void PlaybackEventsRenderer::renderChordSymbol(const Harmony* chordSymbol,
 
     voice_layer_idx_t voiceIdx = static_cast<voice_layer_idx_t>(chordSymbol->voice());
     staff_layer_idx_t staffIdx = static_cast<staff_layer_idx_t>(chordSymbol->staffIdx());
-    Key key = chordSymbol->staff()->key(chordSymbol->tick());
+    Staff* staff = chordSymbol->staff();
+    IF_ASSERT_FAILED(staff) {
+        return;
+    }
+    Key key = staff->key(chordSymbol->tick());
 
     ArticulationMap articulations = makeStandardArticulationMap(profile, eventTimestamp, duration);
 


### PR DESCRIPTION
Resolves: #26523

applies to master and 4.5.0