### PR TITLE
Fix GH#26525: Crash when using shortcut 6 on a measure followed by shortcut 7

### DIFF
--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -5527,7 +5527,7 @@ static Chord* findLinkedChord(Chord* c, Staff* nstaff)
     }
     Measure* nm = nstaff->score()->tick2measure(s->tick());
     Segment* ns = nm->findSegment(s->segmentType(), s->tick());
-    EngravingItem* ne = ns->element(dtrack);
+    EngravingItem* ne = ns ? ns->element(dtrack) : nullptr;
     if (!ne || !ne->isChord()) {
         return 0;
     }


### PR DESCRIPTION
see https://musescore.org/en/node/375178

Resolves: #26525

applies to master and 4.5.0