### PR TITLE
Collapse the Accessibility section in the Properties panel

### DIFF
--- a/src/inspector/models/abstractinspectormodel.cpp
+++ b/src/inspector/models/abstractinspectormodel.cpp
@@ -217,6 +217,21 @@ InspectorModelType AbstractInspectorModel::modelType() const
     return m_modelType;
 }
 
+bool AbstractInspectorModel::isExpanded() const
+{
+    return m_isExpanded;
+}
+
+void AbstractInspectorModel::setIsExpanded(bool expanded)
+{
+    if (m_isExpanded == expanded) {
+        return;
+    }
+
+    m_isExpanded = expanded;
+    emit isExpandedChanged();
+}
+
 ElementKey AbstractInspectorModel::makeKey(const EngravingItem* item)
 {
     switch (item->type()) {

--- a/src/inspector/models/abstractinspectormodel.h
+++ b/src/inspector/models/abstractinspectormodel.h
@@ -43,7 +43,7 @@
 #include "types/commontypes.h"
 
 namespace mu::inspector {
-class AbstractInspectorModel : public QObject, public muse::async::Asyncable
+class AbstractInspectorModel : public QObject, public muse::async::Asyncable, public muse::Injectable
 {
     Q_OBJECT
 
@@ -52,11 +52,12 @@ class AbstractInspectorModel : public QObject, public muse::async::Asyncable
     Q_PROPERTY(InspectorSectionType sectionType READ sectionType CONSTANT)
     Q_PROPERTY(InspectorModelType modelType READ modelType CONSTANT)
     Q_PROPERTY(bool isEmpty READ isEmpty NOTIFY isEmptyChanged)
+    Q_PROPERTY(bool isExpanded READ isExpanded WRITE setIsExpanded NOTIFY isExpandedChanged)
 
-public:
-    INJECT(context::IGlobalContext, context)
-    INJECT(muse::actions::IActionsDispatcher, dispatcher)
-    INJECT(muse::ui::IUiActionsRegister, uiActionsRegister)
+protected:
+    muse::Inject<context::IGlobalContext> context = { this };
+    muse::Inject<muse::actions::IActionsDispatcher> dispatcher = { this };
+    muse::Inject<muse::ui::IUiActionsRegister> uiActionsRegister = { this };
 
 public:
     enum class InspectorSectionType {
@@ -153,6 +154,9 @@ public:
     InspectorSectionType sectionType() const;
     InspectorModelType modelType() const;
 
+    bool isExpanded() const;
+    void setIsExpanded(bool expanded);
+
     static ElementKey makeKey(const mu::engraving::EngravingItem* item);
     static InspectorModelType modelTypeByElementKey(const ElementKey& elementKey);
     static std::set<InspectorModelType> modelTypesByElementKeys(const ElementKeySet& elementKeySet);
@@ -181,6 +185,7 @@ signals:
 
     void modelReseted();
     void isEmptyChanged();
+    void isExpandedChanged();
 
     void requestReloadPropertyItems();
 
@@ -249,6 +254,7 @@ private:
     InspectorModelType m_modelType = InspectorModelType::TYPE_UNDEFINED;
     mu::engraving::ElementType m_elementType = mu::engraving::ElementType::INVALID;
     bool m_updatePropertiesAllowed = false;
+    bool m_isExpanded = true;
 };
 
 using InspectorModelType = AbstractInspectorModel::InspectorModelType;

--- a/src/inspector/models/score/scoreaccessibilitysettingsmodel.cpp
+++ b/src/inspector/models/score/scoreaccessibilitysettingsmodel.cpp
@@ -34,6 +34,7 @@ ScoreAccessibilitySettingsModel::ScoreAccessibilitySettingsModel(QObject* parent
 {
     setSectionType(InspectorSectionType::SECTION_SCORE_ACCESSIBILITY);
     setTitle(muse::qtrc("inspector", "Accessibility"));
+    setIsExpanded(projectConfiguration()->inspectorExpandAccessibilitySection());
 
     notationStyle()->styleChanged().onNotify(this, [this]() {
         if (!m_ignoreStyleChanges && !m_currentPresetEdited) {
@@ -42,6 +43,17 @@ ScoreAccessibilitySettingsModel::ScoreAccessibilitySettingsModel(QObject* parent
             emit possibleStylePresetsChanged();
             emit currentStylePresetIndexChanged();
         }
+    });
+
+    connect(this, &ScoreAccessibilitySettingsModel::isExpandedChanged, [this]() {
+        projectConfiguration()->setInspectorExpandAccessibilitySection(isExpanded());
+
+        // if (isExpanded()) {
+        //     QTimer::singleShot(2000, this, [this]() {
+        //         setIsExpanded(false);
+        //         LOGW() << "Accessibility Timer Expired";
+        //     });
+        // }
     });
 }
 

--- a/src/inspector/models/score/scoreaccessibilitysettingsmodel.h
+++ b/src/inspector/models/score/scoreaccessibilitysettingsmodel.h
@@ -24,8 +24,8 @@
 #include <QObject>
 
 #include "models/abstractinspectormodel.h"
-#include "context/iglobalcontext.h"
 #include "global/iglobalconfiguration.h"
+#include "project/iprojectconfiguration.h"
 #include "engraving/iengravingconfiguration.h"
 #include "engraving/types/types.h"
 
@@ -33,9 +33,6 @@ namespace mu::inspector {
 class ScoreAccessibilitySettingsModel : public AbstractInspectorModel
 {
     Q_OBJECT
-    INJECT(mu::context::IGlobalContext, globalContext)
-    INJECT(muse::IGlobalConfiguration, globalConfiguration);
-    INJECT(engraving::IEngravingConfiguration, engravingConfiguration);
 
     Q_PROPERTY(QVariantList possibleStylePresets
                READ possibleStylePresets
@@ -45,6 +42,10 @@ class ScoreAccessibilitySettingsModel : public AbstractInspectorModel
                READ currentStylePresetIndex
                WRITE setCurrentStylePresetIndex
                NOTIFY currentStylePresetIndexChanged);
+
+    muse::Inject<engraving::IEngravingConfiguration> engravingConfiguration = { this };
+    muse::Inject<project::IProjectConfiguration> projectConfiguration = { this };
+    muse::Inject<muse::IGlobalConfiguration> globalConfiguration = { this };
 
 public:
     explicit ScoreAccessibilitySettingsModel(QObject* parent, IElementRepositoryService* repository);

--- a/src/inspector/view/qml/MuseScore/Inspector/InspectorSectionDelegate.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/InspectorSectionDelegate.qml
@@ -55,6 +55,34 @@ ExpandableBlank {
 
     title: root.sectionModel ? root.sectionModel.title : ""
 
+    // Update the QML view when the C++ model is changed
+    Binding on isExpanded {
+        when: sectionModel
+        value: sectionModel.isExpanded
+    }
+
+    // Update the C++ model when the QML view is changed
+    onIsExpandedChanged: {
+        if (sectionModel) {
+            sectionModel.isExpanded = root.isExpanded
+        }
+    }
+
+    // isExpanded: sectionModel && sectionModel.isExpanded // breaks when expanded manually
+
+    // property bool sectionExpanded: sectionModel && sectionModel.isExpanded
+
+    // onSectionExpandedChanged: {
+    //     root.isExpanded = sectionExpanded
+    // }
+
+    // Binding {
+    //     target: sectionModel
+    //     when: sectionModel
+    //     property: "isExpanded"
+    //     value: root.isExpanded
+    // }
+
     contentItemComponent: {
         if (!root.sectionModel) {
             return undefined

--- a/src/project/internal/projectconfiguration.cpp
+++ b/src/project/internal/projectconfiguration.cpp
@@ -50,6 +50,7 @@ static const Settings::Key SHOULD_WARN_BEFORE_PUBLISH(module_name, "project/shou
 static const Settings::Key SHOULD_WARN_BEFORE_SAVING_PUBLICLY_TO_CLOUD(module_name, "project/shouldWarnBeforeSavingPubliclyToCloud");
 static const Settings::Key HOME_SCORES_PAGE_VIEW_TYPE(module_name, "project/homeScoresPageViewType");
 static const Settings::Key PREFERRED_SCORE_CREATION_MODE_KEY(module_name, "project/preferredScoreCreationMode");
+static const Settings::Key INSPECTOR_EXPAND_ACCESSIBILITY_SECTION_KEY(module_name, "project/inspectorExpandAccessibilitySection");
 static const Settings::Key MIGRATION_OPTIONS(module_name, "project/migration");
 static const Settings::Key AUTOSAVE_ENABLED_KEY(module_name, "project/autoSaveEnabled");
 static const Settings::Key AUTOSAVE_INTERVAL_KEY(module_name, "project/autoSaveInterval");
@@ -83,6 +84,8 @@ void ProjectConfiguration::init()
 
     Val preferredScoreCreationMode = Val(PreferredScoreCreationMode::FromInstruments);
     settings()->setDefaultValue(PREFERRED_SCORE_CREATION_MODE_KEY, preferredScoreCreationMode);
+
+    settings()->setDefaultValue(INSPECTOR_EXPAND_ACCESSIBILITY_SECTION_KEY, Val(false));
 
     settings()->setDefaultValue(HOME_SCORES_PAGE_VIEW_TYPE, Val(HomeScoresPageViewType::Grid));
 
@@ -425,6 +428,16 @@ ProjectConfiguration::PreferredScoreCreationMode ProjectConfiguration::preferred
 void ProjectConfiguration::setPreferredScoreCreationMode(PreferredScoreCreationMode mode)
 {
     settings()->setSharedValue(PREFERRED_SCORE_CREATION_MODE_KEY, Val(mode));
+}
+
+bool ProjectConfiguration::inspectorExpandAccessibilitySection() const
+{
+    return settings()->value(INSPECTOR_EXPAND_ACCESSIBILITY_SECTION_KEY).toBool();
+}
+
+void ProjectConfiguration::setInspectorExpandAccessibilitySection(bool expand)
+{
+    settings()->setSharedValue(INSPECTOR_EXPAND_ACCESSIBILITY_SECTION_KEY, Val(expand));
 }
 
 static MigrationType migrationTypeFromString(const QString& str)

--- a/src/project/internal/projectconfiguration.h
+++ b/src/project/internal/projectconfiguration.h
@@ -104,6 +104,9 @@ public:
     PreferredScoreCreationMode preferredScoreCreationMode() const override;
     void setPreferredScoreCreationMode(PreferredScoreCreationMode mode) override;
 
+    bool inspectorExpandAccessibilitySection() const override;
+    void setInspectorExpandAccessibilitySection(bool mode) override;
+
     MigrationOptions migrationOptions(MigrationType type) const override;
     void setMigrationOptions(MigrationType type, const MigrationOptions& opt, bool persistent = true) override;
 

--- a/src/project/iprojectconfiguration.h
+++ b/src/project/iprojectconfiguration.h
@@ -109,6 +109,9 @@ public:
     virtual PreferredScoreCreationMode preferredScoreCreationMode() const = 0;
     virtual void setPreferredScoreCreationMode(PreferredScoreCreationMode mode) = 0;
 
+    virtual bool inspectorExpandAccessibilitySection() const = 0;
+    virtual void setInspectorExpandAccessibilitySection(bool expand) = 0;
+
     virtual MigrationOptions migrationOptions(MigrationType type) const = 0;
     virtual void setMigrationOptions(MigrationType type, const MigrationOptions& opt, bool persistent = true) = 0;
 

--- a/src/project/tests/mocks/projectconfigurationmock.h
+++ b/src/project/tests/mocks/projectconfigurationmock.h
@@ -86,6 +86,9 @@ public:
     MOCK_METHOD(PreferredScoreCreationMode, preferredScoreCreationMode, (), (const, override));
     MOCK_METHOD(void, setPreferredScoreCreationMode, (PreferredScoreCreationMode), (override));
 
+    MOCK_METHOD(bool, inspectorExpandAccessibilitySection, (), (const, override));
+    MOCK_METHOD(void, setInspectorExpandAccessibilitySection, (bool), (override));
+
     MOCK_METHOD(MigrationOptions, migrationOptions, (MigrationType), (const, override));
     MOCK_METHOD(void, setMigrationOptions, (MigrationType, const MigrationOptions&, bool), (override));
 


### PR DESCRIPTION
According to @avvvvve's design, the Accessibility section should start collapsed by default, but if the user expands or collapses it manually then its final state should be remembered when MuseScore is relaunched.

Note: The Accessibility section is shown (collapsed or expanded) in the Properties panel when there is nothing selected in the score. You have to press Esc or click on an empty region of page in order to see it.

### Collapsed

![image](https://github.com/user-attachments/assets/e9b48230-e984-49e9-a400-09b193d19e6a)

### Expanded

![image](https://github.com/user-attachments/assets/0ef4cbba-b6cc-4681-bf15-3ce3de0e3d99)