### PR TITLE
Fix ottava dragging

### DIFF
--- a/src/engraving/dom/line.h
+++ b/src/engraving/dom/line.h
@@ -79,6 +79,9 @@ public:
 
     double absoluteFromSpatium(const Spatium& sp) const override;
 
+protected:
+    virtual void rebaseOffsetsOnAnchorChanged(Grip grip, const PointF& oldPos, System* sys);
+
 private:
     Segment* findNewAnchorSegment(const EditData& ed, const Segment* curSeg);
     void undoMoveStartEndAndSnappedItems(bool moveStart, bool moveEnd, Segment* s1, Segment* s2);
@@ -90,7 +93,6 @@ private:
     static PointF deltaRebaseRight(const Segment* oldSeg, const Segment* newSeg);
     static Fraction lastSegmentEndTick(const Segment* lastSeg, const Spanner* s);
     LineSegment* rebaseAnchor(Grip grip, Segment* newSeg);
-    void rebaseOffsetsOnAnchorChanged(Grip grip, const PointF& oldPos, System* sys);
     void rebaseAnchors(EditData&, Grip);
 };
 

--- a/src/engraving/dom/ottava.cpp
+++ b/src/engraving/dom/ottava.cpp
@@ -394,6 +394,14 @@ muse::TranslatableString OttavaSegment::subtypeUserName() const
     return ottava()->subtypeUserName();
 }
 
+void OttavaSegment::rebaseOffsetsOnAnchorChanged(Grip grip, const PointF& oldPos, System* sys)
+{
+    if (grip == Grip::MIDDLE || grip == Grip::END) {
+        ottava()->computeEndElement();
+    }
+    LineSegment::rebaseOffsetsOnAnchorChanged(grip, oldPos, sys);
+}
+
 int OttavaSegment::subtype() const
 {
     return ottava()->subtype();

--- a/src/engraving/dom/ottava.h
+++ b/src/engraving/dom/ottava.h
@@ -99,6 +99,9 @@ public:
     TranslatableString subtypeUserName() const override;
 
     bool canBeExcludedFromOtherParts() const override { return true; }
+
+private:
+    void rebaseOffsetsOnAnchorChanged(Grip grip, const PointF& oldPos, System* sys) override;
 };
 
 //---------------------------------------------------------


### PR DESCRIPTION
Resolves: #26506 

Ottava lines are different in that their end point isn't calculated just based on the end tick, but depends on the position of the last chord spanned by the line, which is calculated in `computeEndElement`. Therefore we need an additional call to `computeEndElement` when changing the end tick, otherwise the rebasing of the dragging offset will be incorrect.