### PR TITLE
System object correction

### DIFF
--- a/src/engraving/dom/engravingitem.cpp
+++ b/src/engraving/dom/engravingitem.cpp
@@ -457,7 +457,7 @@ staff_idx_t EngravingItem::effectiveStaffIdx() const
 
     staff_idx_t nextSystemObjectStaff = muse::nidx;
     const std::vector<Staff*>& systemObjectStaves = m_score->systemObjectStaves();
-    for (size_t i = 1; i < systemObjectStaves.size(); ++i) {
+    for (size_t i = 0; i < systemObjectStaves.size(); ++i) {
         staff_idx_t idx = systemObjectStaves[i]->idx();
         if (idx > originalStaffIdx) {
             nextSystemObjectStaff = idx;

--- a/src/engraving/dom/utils.cpp
+++ b/src/engraving/dom/utils.cpp
@@ -1470,7 +1470,7 @@ std::vector<EngravingItem*> collectSystemObjects(const Score* score, const std::
 
     for (const Measure* measure = score->firstMeasure(); measure; measure = measure->nextMeasure()) {
         for (EngravingItem* measureElement : measure->el()) {
-            if (!measureElement || !measureElement->systemFlag()) {
+            if (!measureElement || !measureElement->systemFlag() || measureElement->isLayoutBreak()) {
                 continue;
             }
             if (!staves.empty()) {

--- a/src/instrumentsscene/view/systemobjectslayertreeitem.cpp
+++ b/src/instrumentsscene/view/systemobjectslayertreeitem.cpp
@@ -76,7 +76,7 @@ static bool isLayerVisible(const SystemObjectGroups& groups)
         }
     }
 
-    return true;
+    return false;
 }
 
 SystemObjectsLayerTreeItem::SystemObjectsLayerTreeItem(IMasterNotationPtr masterNotation, INotationPtr notation, QObject* parent)


### PR DESCRIPTION
Resolves: #26540

Also resolves: system objects should be omitted when all the staves in between are hidden.

![image](https://github.com/user-attachments/assets/2b88c411-6651-4af4-bbfe-d0563c07b26c)

