### PR TITLE
[MusicXML] Add glissando line styles

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
@@ -998,15 +998,15 @@ static void glissando(const Glissando* gli, int number, bool start, Notations& n
     String tagName;
     if (gli->glissandoType() == GlissandoType::STRAIGHT) {
         switch (gli->lineStyle()) {
-            case LineType::SOLID:
-                tagName = u"slide line-type=\"solid\"";
-                break;
-            case LineType::DASHED:
-                tagName = u"slide line-type=\"dashed\"";
-                break;
-            case LineType::DOTTED:
-                tagName = u"slide line-type=\"dotted\"";
-                break;
+        case LineType::SOLID:
+            tagName = u"slide line-type=\"solid\"";
+            break;
+        case LineType::DASHED:
+            tagName = u"slide line-type=\"dashed\"";
+            break;
+        case LineType::DOTTED:
+            tagName = u"slide line-type=\"dotted\"";
+            break;
         }
     } else {
         tagName = u"glissando line-type=\"wavy\"";

--- a/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
@@ -995,19 +995,21 @@ void SlurHandler::doSlurStop(const Slur* s, Notations& notations, XmlWriter& xml
 
 static void glissando(const Glissando* gli, int number, bool start, Notations& notations, XmlWriter& xml)
 {
-    GlissandoType st = gli->glissandoType();
     String tagName;
-    switch (st) {
-    case GlissandoType::STRAIGHT:
-        tagName = u"slide line-type=\"solid\"";
-        break;
-    case GlissandoType::WAVY:
+    if (gli->glissandoType() == GlissandoType::STRAIGHT) {
+        switch (gli->lineStyle()) {
+            case LineType::SOLID:
+                tagName = u"slide line-type=\"solid\"";
+                break;
+            case LineType::DASHED:
+                tagName = u"slide line-type=\"dashed\"";
+                break;
+            case LineType::DOTTED:
+                tagName = u"slide line-type=\"dotted\"";
+                break;
+        }
+    } else {
         tagName = u"glissando line-type=\"wavy\"";
-        break;
-    default:
-        LOGD("unknown glissando subtype %d", int(st));
-        return;
-        break;
     }
     tagName += String(u" number=\"%1\" type=\"%2\"").arg(number).arg(start ? u"start" : u"stop");
     if (start) {

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -8527,8 +8527,8 @@ static void addGlissandoSlide(const Notation& notation, Note* note,
         glissandoNumber--;
     }
     const String glissandoType = notation.attribute(u"type");
-    int glissandoTag = notation.name() == u"slide" ? 0 : 1;
-    //                  String lineType  = ee.attribute(String("line-type"), "solid");
+    const bool glissandoTag = notation.name() != u"slide";
+    const String lineType  = notation.attribute(u"line-type");
     Glissando*& gliss = glissandi[glissandoNumber][glissandoTag];
 
     const Fraction tick = note->tick();
@@ -8551,8 +8551,15 @@ static void addGlissandoSlide(const Notation& notation, Note* note,
             if (glissandoColor.isValid()) {
                 gliss->setLineColor(glissandoColor);
             }
+            if (lineType == u"dashed") {
+                gliss->setLineStyle(LineType::DASHED);
+            } else if (lineType == u"dotted") {
+                gliss->setLineStyle(LineType::DOTTED);
+            } else if (lineType == u"solid" || lineType.empty()) {
+                gliss->setLineStyle(LineType::SOLID);
+            }
             gliss->setText(glissandoText);
-            gliss->setGlissandoType(glissandoTag == 0 ? GlissandoType::STRAIGHT : GlissandoType::WAVY);
+            gliss->setGlissandoType(glissandoTag || (lineType == u"wavy") ? GlissandoType::WAVY : GlissandoType::STRAIGHT);
             spanners[gliss] = std::pair<int, int>(tick.ticks(), -1);
             // LOGD("glissando/slide=%p inserted at first tick %d", gliss, tick);
         }

--- a/src/importexport/musicxml/tests/data/testGlissandoLines.xml
+++ b/src/importexport/musicxml/tests/data/testGlissandoLines.xml
@@ -1,0 +1,167 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <work>
+    <work-number>MuseScore testfile</work-number>
+    <work-title>Glissando line types</work-title>
+    </work>
+  <identification>
+    <creator type="composer">Klaus Rettinghaus</creator>
+    <encoding>
+      <software>MuseScore 0.7.0</software>
+      <encoding-date>2007-09-10</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="no"/>
+      <supports element="print" attribute="new-system" type="no"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Piano</part-name>
+      <part-abbreviation>Pno.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Piano</instrument-name>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>1</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <note>
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>up</stem>
+        <notations>
+          <slide line-type="solid" number="1" type="start"/>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>down</stem>
+        <notations>
+          <slide line-type="solid" number="1" type="stop"/>
+          </notations>
+        </note>
+      </measure>
+    <measure number="2">
+      <note>
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>up</stem>
+        <notations>
+          <slide line-type="dashed" number="1" type="start"/>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>down</stem>
+        <notations>
+          <slide line-type="dashed" number="1" type="stop"/>
+          </notations>
+        </note>
+      </measure>
+    <measure number="3">
+      <note>
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>up</stem>
+        <notations>
+          <slide line-type="dotted" number="1" type="start"/>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>down</stem>
+        <notations>
+          <slide line-type="dotted" number="1" type="stop"/>
+          </notations>
+        </note>
+      </measure>
+    <measure number="4">
+      <note>
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>up</stem>
+        <notations>
+          <glissando line-type="wavy" number="1" type="start">gliss.</glissando>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>down</stem>
+        <notations>
+          <glissando line-type="wavy" number="1" type="stop"/>
+          </notations>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/src/importexport/musicxml/tests/musicxml_tests.cpp
+++ b/src/importexport/musicxml/tests/musicxml_tests.cpp
@@ -637,6 +637,9 @@ TEST_F(MusicXml_Tests, fractionPlus) {
 TEST_F(MusicXml_Tests, fractionTicks) {
     musicXmlIoTestRef("testFractionTicks");
 }
+TEST_F(MusicXml_Tests, glissandoLines) {
+    musicXmlIoTest("testGlissandoLines");
+}
 TEST_F(MusicXml_Tests, glissFall) {
     musicXmlImportTestRef("testGlissFall");
 }


### PR DESCRIPTION
This PR adds import and export of `line-type` attributes on `slide` and `glissando` elements to MusicXML support. 