### PR TITLE
Preserve hairpin/dyn. connection when Shift+Right

### DIFF
--- a/src/engraving/dom/textbase.cpp
+++ b/src/engraving/dom/textbase.cpp
@@ -3457,7 +3457,7 @@ void TextBase::moveSnappedItems(Segment* newSeg, Fraction tickDiff) const
         if (itemBefore->isTextBase() && itemBefore->parent() != newSeg) {
             score()->undoChangeParent(itemBefore, newSeg, itemBefore->staffIdx());
             toTextBase(itemBefore)->moveSnappedItems(newSeg, tickDiff);
-        } else if (itemBefore->isTextLineSegment()) {
+        } else if (itemBefore->isTextLineBaseSegment()) {
             TextLineBase* textLine = ((TextLineBaseSegment*)itemBefore)->textLineBase();
             if (textLine->tick2() != newSeg->tick()) {
                 textLine->undoMoveEnd(tickDiff);


### PR DESCRIPTION
The logic was correct, but there was a typo (see also a few lines above the changed line)

Resolves: https://github.com/musescore/MuseScore/pull/24152#issuecomment-2663065684