### PR TITLE
Fix continuation courtesy layout

### DIFF
--- a/src/engraving/dom/measure.cpp
+++ b/src/engraving/dom/measure.cpp
@@ -842,7 +842,7 @@ void Measure::add(EngravingItem* e)
     case ElementType::MARKER:
         if (e && (e->isJump() || muse::contains(Marker::RIGHT_MARKERS, toMarker(e)->markerType()))) {
             // "To coda" markings act like jumps
-            setRepeatJump(true);
+            setProperty(Pid::REPEAT_JUMP, true);
         }
         el().push_back(e);
         break;
@@ -943,7 +943,7 @@ void Measure::remove(EngravingItem* e)
         break;
 
     case ElementType::JUMP:
-        setRepeatJump(false);
+        setProperty(Pid::REPEAT_JUMP, false);
     // fall through
     case ElementType::MARKER:
     case ElementType::HBOX:

--- a/src/engraving/rendering/score/measurelayout.cpp
+++ b/src/engraving/rendering/score/measurelayout.cpp
@@ -2057,7 +2057,7 @@ void MeasureLayout::addRepeatCourtesyParentheses(Measure* m, const bool continua
     const SegmentType ksSegType = continuation ? SegmentType::KeySigStartRepeatAnnounce : SegmentType::KeySigRepeatAnnounce;
     const SegmentType clefSegType = continuation ? SegmentType::ClefStartRepeatAnnounce : SegmentType::ClefRepeatAnnounce;
 
-    const Fraction sigTick = continuation ? Fraction(0, 0) : m->ticks();
+    const Fraction sigTick = continuation ? Fraction(0, 1) : m->ticks();
 
     auto segShouldHaveParenthesis = [&](const Segment* seg, const track_idx_t track) -> bool {
         const EngravingItem* el = seg ? seg->element(track) : nullptr;
@@ -2188,7 +2188,7 @@ void MeasureLayout::removeRepeatCourtesyParenthesesMeasure(Measure* m, const boo
     const SegmentType ksSegType = continuation ? SegmentType::KeySigStartRepeatAnnounce : SegmentType::KeySigRepeatAnnounce;
     const SegmentType clefSegType = continuation ? SegmentType::ClefStartRepeatAnnounce : SegmentType::ClefRepeatAnnounce;
 
-    const Fraction sigTick = continuation ? Fraction(0, 0) : m->ticks();
+    const Fraction sigTick = continuation ? Fraction(0, 1) : m->ticks();
 
     Segment* clefSeg = m->findSegmentR(clefSegType, sigTick);
     Segment* ksSeg = m->findSegmentR(ksSegType, sigTick);
@@ -2477,7 +2477,7 @@ void MeasureLayout::addSystemHeader(Measure* m, bool isFirstSystem, LayoutContex
                 const System* sys = searchMeasure->system();
                 if (isFirstClef && searchMeasure->tick() >= clefTick) {
                     // Need to check previous measure for clef change if one not found in this measure
-                    Segment* clefSeg = searchMeasure->findFirstR(SegmentType::Clef | SegmentType::HeaderClef, Fraction(0, 0));
+                    Segment* clefSeg = searchMeasure->findFirstR(SegmentType::Clef | SegmentType::HeaderClef, Fraction(0, 1));
                     Measure* prevMeas = searchMeasure->prevMeasure();
                     if (prevMeas && !clefSeg) {
                         clefSeg = prevMeas->findSegment(SegmentType::Clef, m->tick());

--- a/src/engraving/rendering/score/measurelayout.cpp
+++ b/src/engraving/rendering/score/measurelayout.cpp
@@ -2034,15 +2034,21 @@ Parenthesis* MeasureLayout::findOrCreateParenthesis(Segment* segment, const Dire
     return paren;
 }
 
-static void calcParenTopBottom(Parenthesis* item, double& top, double& bottom)
+static void calcParenTopBottom(Parenthesis* item, double& top, double& bottom, LayoutContext& ctx)
 {
     Segment* seg = item->segment();
     EngravingItem* el = seg->element(item->track());
     const double spatium = item->spatium();
-    if (el) {
-        top = std::min(top, el->shape().top() + el->pos().y() + spatium / 4);
-        bottom = std::max(bottom, el->shape().bottom() + el->pos().y() - spatium / 4);
+    if (!el) {
+        return;
     }
+
+    if (!el->ldata()->isValid()) {
+        TLayout::layoutItem(el, ctx);
+    }
+
+    top = std::min(top, el->shape().top() + el->pos().y() + spatium / 4);
+    bottom = std::max(bottom, el->shape().bottom() + el->pos().y() - spatium / 4);
 }
 
 void MeasureLayout::addRepeatCourtesyParentheses(Measure* m, const bool continuation, LayoutContext& ctx)
@@ -2081,8 +2087,8 @@ void MeasureLayout::addRepeatCourtesyParentheses(Measure* m, const bool continua
                                      != TimeSigPlacement::NORMAL;
         if ((ctx.conf().styleB(Sid::smallParens) || needsBigTimeSigAdjust) && leftParen && rightParen) {
             const double spatium = leftParen->spatium();
-            calcParenTopBottom(leftParen, top, bottom);
-            calcParenTopBottom(rightParen, top, bottom);
+            calcParenTopBottom(leftParen, top, bottom, ctx);
+            calcParenTopBottom(rightParen, top, bottom, ctx);
 
             double height = bottom - top;
 

--- a/src/engraving/rendering/score/tlayout.cpp
+++ b/src/engraving/rendering/score/tlayout.cpp
@@ -4514,7 +4514,7 @@ void TLayout::layoutParenthesis(Parenthesis* item, LayoutContext& ctx)
 
     Parenthesis::LayoutData* ldata = item->mutldata();
     ldata->setPos(PointF());
-    ldata->clearShape();
+    ldata->reset();
     ldata->path.reset();
 
     const Staff* staff = item->staff();


### PR DESCRIPTION
Resolves: #26549

When deleting jumps, their measure needs to be added to the layout range.  This is done by seting the `REPEAT_JUMP` flag via `setProperty`, not directly.
I've also laid out the segment's element when calculating parenthesis height if its layout data is invalid.