### PR TITLE
MenuItem API exposes checkable property directly

### DIFF
--- a/src/framework/uicomponents/view/menuitem.cpp
+++ b/src/framework/uicomponents/view/menuitem.cpp
@@ -181,6 +181,26 @@ void MenuItem::setSelected(bool selected)
     emit selectedChanged(m_selected);
 }
 
+void MenuItem::setCheckable(bool checkable)
+{
+    const Checkable actionCeckable = checkable ? Checkable::Yes : Checkable::No;
+    if (m_action.checkable == actionCeckable) {
+        return;
+    }
+
+    m_action.checkable = actionCeckable;
+}
+
+void MenuItem::setChecked(bool checked)
+{
+    if (m_state.checked == checked) {
+        return;
+    }
+
+    m_state.checked = checked;
+    emit stateChanged();
+}
+
 void MenuItem::setRole(MenuItemRole role)
 {
     if (m_role == role) {

--- a/src/framework/uicomponents/view/menuitem.h
+++ b/src/framework/uicomponents/view/menuitem.h
@@ -104,6 +104,8 @@ public slots:
     void setState(const ui::UiActionState& state);
     void setSelectable(bool selectable);
     void setSelected(bool selected);
+    void setCheckable(bool checkable);
+    void setChecked(bool checked);
     void setRole(muse::uicomponents::MenuItemRole role);
     void setSubitems(const QList<uicomponents::MenuItem*>& subitems);
     void setAction(const ui::UiAction& action);


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/pull/8268

The AbstractMenuModel implements its entire tree with `MenuItem`s, which only allow setting the checkmark via an Action.
While it makes some sense that menu leaves are associated with actions, it does not for their parents, and hence `MenuItem`s should give access to their checked state without having to modify the action (at least not at API level).

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
