### PR TITLE
More system object refinements

### DIFF
--- a/src/engraving/dom/timesig.cpp
+++ b/src/engraving/dom/timesig.cpp
@@ -72,7 +72,7 @@ void TimeSig::setParent(Segment* parent)
 
 double TimeSig::mag() const
 {
-    return staff() ? staff()->staffMag(tick()) : 1.0;
+    return timeSigPlacement() == TimeSigPlacement::NORMAL && staff() ? staff()->staffMag(tick()) : 1.0;
 }
 
 //---------------------------------------------------------

--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/LayoutPanel.qml
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/LayoutPanel.qml
@@ -98,6 +98,7 @@ Item {
             isMovingUpAvailable: treeModel.isMovingUpAvailable
             isMovingDownAvailable: treeModel.isMovingDownAvailable
             isAddingAvailable: treeModel.isAddingAvailable
+            isAddingSystemMarkingsAvailable: treeModel.isAddingSystemMarkingsAvailable
             isRemovingAvailable: treeModel.isRemovingAvailable
             selectedItemsType: treeModel.selectedItemsType
 

--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/LayoutControlPanel.qml
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/LayoutControlPanel.qml
@@ -34,6 +34,7 @@ RowLayout {
     property bool isMovingDownAvailable: false
     property bool isRemovingAvailable: false
     property bool isAddingAvailable: value
+    property bool isAddingSystemMarkingsAvailable: value
 
     property int selectedItemsType: LayoutPanelItemType.UNDEFINED
 
@@ -68,6 +69,7 @@ RowLayout {
         navigation.order: 1
 
         enabled: root.isAddingAvailable
+        addSystemMarkingsAvailable: root.isAddingSystemMarkingsAvailable
 
         onAddInstrumentRequested: {
             root.addInstrumentRequested()

--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/LayoutPanelAddButton.qml
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/LayoutPanelAddButton.qml
@@ -31,6 +31,8 @@ MenuButton {
     signal addInstrumentRequested()
     signal addSystemMarkingsRequested()
 
+    property bool addSystemMarkingsAvailable: true
+
     //: Keep in sync with the message that appears if there are no instruments in the score (LayoutPanel.qml)
     text: qsTrc("layoutpanel", "Add")
 
@@ -44,7 +46,7 @@ MenuButton {
     menuModel: [
         { id: "ADD_INSTRUMENT", title: qsTrc("layoutpanel", "New instrument")  },
         {},
-        { id: "ADD_SYSTEM_MARKINGS", title: qsTrc("layoutpanel", "System markings (tempo, rehearsal marks, etc.)") },
+        { id: "ADD_SYSTEM_MARKINGS", title: qsTrc("layoutpanel", "System markings (tempo, rehearsal marks, etc.)"), enabled: root.addSystemMarkingsAvailable },
     ]
 
     onHandleMenuItem: function(itemId) {

--- a/src/instrumentsscene/view/layoutpaneltreemodel.cpp
+++ b/src/instrumentsscene/view/layoutpaneltreemodel.cpp
@@ -344,9 +344,13 @@ void LayoutPanelTreeModel::load()
     SystemObjectGroupsByStaff systemObjects = collectSystemObjectGroups(systemObjectStaves);
 
     for (const Part* part : masterParts) {
-        for (Staff* staff : part->staves()) {
-            if (muse::contains(systemObjectStaves, staff)) {
-                m_rootItem->appendChild(buildSystemObjectsLayerItem(staff, systemObjects[staff]));
+        if (m_notation->isMaster()) {
+            // Only show system object staves in master score
+            // TODO: extend system object staves logic to parts
+            for (Staff* staff : part->staves()) {
+                if (muse::contains(systemObjectStaves, staff)) {
+                    m_rootItem->appendChild(buildSystemObjectsLayerItem(staff, systemObjects[staff]));
+                }
             }
         }
 
@@ -360,6 +364,7 @@ void LayoutPanelTreeModel::load()
 
     emit isEmptyChanged();
     emit isAddingAvailableChanged(true);
+    emit isAddingSystemMarkingsAvailableChanged(isAddingSystemMarkingsAvailable());
 }
 
 void LayoutPanelTreeModel::sortParts(notation::PartList& parts)
@@ -683,6 +688,11 @@ bool LayoutPanelTreeModel::isRemovingAvailable() const
 bool LayoutPanelTreeModel::isAddingAvailable() const
 {
     return m_notation != nullptr;
+}
+
+bool LayoutPanelTreeModel::isAddingSystemMarkingsAvailable() const
+{
+    return isAddingAvailable() && m_notation->isMaster();
 }
 
 bool LayoutPanelTreeModel::isEmpty() const

--- a/src/instrumentsscene/view/layoutpaneltreemodel.h
+++ b/src/instrumentsscene/view/layoutpaneltreemodel.h
@@ -60,6 +60,7 @@ class LayoutPanelTreeModel : public QAbstractItemModel, public muse::async::Asyn
     Q_PROPERTY(bool isMovingDownAvailable READ isMovingDownAvailable NOTIFY isMovingDownAvailableChanged)
     Q_PROPERTY(bool isRemovingAvailable READ isRemovingAvailable NOTIFY isRemovingAvailableChanged)
     Q_PROPERTY(bool isAddingAvailable READ isAddingAvailable NOTIFY isAddingAvailableChanged)
+    Q_PROPERTY(bool isAddingSystemMarkingsAvailable READ isAddingSystemMarkingsAvailable NOTIFY isAddingSystemMarkingsAvailableChanged)
     Q_PROPERTY(bool isEmpty READ isEmpty NOTIFY isEmptyChanged)
     Q_PROPERTY(QString addInstrumentsKeyboardShortcut READ addInstrumentsKeyboardShortcut NOTIFY addInstrumentsKeyboardShortcutChanged)
     Q_PROPERTY(int selectedItemsType READ selectedItemsType NOTIFY selectedItemsTypeChanged)
@@ -79,6 +80,7 @@ public:
     bool isMovingDownAvailable() const;
     bool isRemovingAvailable() const;
     bool isAddingAvailable() const;
+    bool isAddingSystemMarkingsAvailable() const;
     bool isEmpty() const;
     QString addInstrumentsKeyboardShortcut() const;
     int selectedItemsType() const;
@@ -107,6 +109,7 @@ signals:
     void isMovingUpAvailableChanged(bool isMovingUpAvailable);
     void isMovingDownAvailableChanged(bool isMovingDownAvailable);
     void isAddingAvailableChanged(bool isAddingAvailable);
+    void isAddingSystemMarkingsAvailableChanged(bool isAddingSystemMarkingsAvailable);
     void isRemovingAvailableChanged(bool isRemovingAvailable);
     void isEmptyChanged();
     void addInstrumentsKeyboardShortcutChanged();

--- a/src/instrumentsscene/view/systemobjectslayertreeitem.cpp
+++ b/src/instrumentsscene/view/systemobjectslayertreeitem.cpp
@@ -164,7 +164,7 @@ void SystemObjectsLayerTreeItem::onUndoStackChanged(const mu::engraving::ScoreCh
             isSystemObj = toTimeSig(item)->timeSigPlacement() != TimeSigPlacement::NORMAL;
         }
 
-        if (!isSystemObj || item->staffIdx() != m_staffIdx) {
+        if (!isSystemObj || item->staffIdx() != m_staffIdx || item->isLayoutBreak()) {
             continue;
         }
 

--- a/src/notation/inotation.h
+++ b/src/notation/inotation.h
@@ -69,6 +69,8 @@ public:
 
     virtual bool hasVisibleParts() const = 0;
 
+    virtual bool isMaster() const = 0;
+
     // draw
     virtual ViewMode viewMode() const = 0;
     virtual void setViewMode(const ViewMode& viewMode) = 0;

--- a/src/notation/internal/notation.cpp
+++ b/src/notation/internal/notation.cpp
@@ -238,6 +238,11 @@ bool Notation::hasVisibleParts() const
     return false;
 }
 
+bool Notation::isMaster() const
+{
+    return m_score->isMaster();
+}
+
 void Notation::notifyAboutNotationChanged()
 {
     m_notationChanged.notify();

--- a/src/notation/internal/notation.h
+++ b/src/notation/internal/notation.h
@@ -60,6 +60,8 @@ public:
 
     bool hasVisibleParts() const override;
 
+    bool isMaster() const override;
+
     ViewMode viewMode() const override;
     void setViewMode(const ViewMode& viewMode) override;
     muse::async::Notification viewModeChanged() const override;


### PR DESCRIPTION
Resolves: 

- Layout breaks still showing in the system markings list.
- When staves are hidden, system objects should fold downwards (i.e. the upper ones should replace the lower ones), but they were currently doing the opposite
- Remove the system object UI from part scores. At the moment the UI doesn't work for part scores because the whole tree model that makes up the instrument panel referes to the master score (cause that's where the full list of instrument and staves is) but this doesn't really work for system objects. It's not hard to fix, but we'll do it later. @RomanPudashkin 