### PR TITLE
Fix #25175: Crash when adding any symbol to the bend amount text field

### DIFF
--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -2971,6 +2971,7 @@ void Score::deleteItem(EngravingItem* el)
 
     case ElementType::STEM_SLASH:                   // cannot delete this elements
     case ElementType::HOOK:
+    case ElementType::GUITAR_BEND_TEXT:
         LOGD("cannot remove %s", el->typeName());
         break;
 

--- a/src/engraving/dom/guitarbend.h
+++ b/src/engraving/dom/guitarbend.h
@@ -251,6 +251,8 @@ class GuitarBendText final : public TextBase
 public:
     GuitarBendText(GuitarBendSegment* parent);
     GuitarBendText* clone() const override { return new GuitarBendText(*this); }
+
+    bool isEditable() const override { return false; }
 };
 } // namespace mu::engraving
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/25175