### PR TITLE
Correct measure rest placement with courtesy time signature above stave

### DIFF
--- a/src/engraving/rendering/score/measurelayout.cpp
+++ b/src/engraving/rendering/score/measurelayout.cpp
@@ -1252,8 +1252,9 @@ MeasureLayout::MeasureStartEndPos MeasureLayout::getMeasureStartEndPos(const Mea
             break;
         }
 
-        if (!modernMMRest && (s2->isClefRepeatAnnounceType() || s2->isTimeSigRepeatAnnounceType() || s2->isKeySigRepeatAnnounceType()
-                              || s2->isEndBarLineType()) && s2->element(staffIdx * VOICES)) {
+        if (!modernMMRest
+            && (s2->isClefRepeatAnnounceType() || (s2->isTimeSigRepeatAnnounceType() && !s2->hasTimeSigAboveStaves())
+                || s2->isKeySigRepeatAnnounceType() || s2->isEndBarLineType()) && s2->element(staffIdx * VOICES)) {
             break;
         }
     }


### PR DESCRIPTION
Resolves: first issue of https://github.com/musescore/MuseScore/issues/26548
