### PR TITLE
26583: Percussion Pads context menu refinements

### DIFF
--- a/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPad.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPad.qml
@@ -197,7 +197,7 @@ DropArea {
                     Connections {
                         target: footerNavCtrl
                         function onTriggered() {
-                            padContent.openFooterContextMenu()
+                            padContent.openContextMenu(null)
                         }
                     }
                 }

--- a/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPadContent.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPadContent.qml
@@ -37,11 +37,16 @@ Column {
 
     property bool padSwapActive: false
 
-    function openFooterContextMenu() {
+    function openContextMenu(pos) {
         if (!root.padModel) {
             return
         }
-        menuLoader.toggleOpened(root.padModel.footerContextMenuItems)
+
+        if (!pos) {
+            pos = menuLoader.parent.mapFromItem(root, 0, root.height)
+        }
+
+        menuLoader.show(pos, root.padModel.contextMenuItems)
     }
 
     Item {
@@ -67,7 +72,8 @@ Column {
                 }
 
                 if (event.button === Qt.RightButton) {
-                    root.openFooterContextMenu()
+                    let pos = menuLoader.parent.mapFromItem(mouseArea, event.x, event.y)
+                    root.openContextMenu(pos)
                     return
                 }
 
@@ -177,8 +183,9 @@ Column {
 
             acceptedButtons: Qt.LeftButton | Qt.RightButton
 
-            onClicked: {
-                root.openFooterContextMenu()
+            onPressed: function(event) {
+                let pos = menuLoader.parent.mapFromItem(footerMouseArea, event.x, event.y)
+                root.openContextMenu(pos)
             }
         }
 
@@ -218,13 +225,13 @@ Column {
 
             text: Boolean(root.padModel) ? root.padModel.midiNote : ""
         }
+    }
 
-        StyledMenuLoader {
-            id: menuLoader
+    ContextMenuLoader {
+        id: menuLoader
 
-            onHandleMenuItem: function(itemId) {
-                root.padModel.handleMenuItem(itemId)
-            }
+        onHandleMenuItem: function(itemId) {
+            root.padModel.handleMenuItem(itemId)
         }
     }
 }

--- a/src/notation/view/percussionpanel/percussionpanelpadmodel.cpp
+++ b/src/notation/view/percussionpanel/percussionpanelpadmodel.cpp
@@ -81,21 +81,21 @@ const QVariant PercussionPanelPadModel::notationPreviewItemVariant() const
     return QVariant::fromValue(m_notationPreviewItem);
 }
 
-QList<QVariantMap> PercussionPanelPadModel::footerContextMenuItems() const
+QList<QVariantMap> PercussionPanelPadModel::contextMenuItems() const
 {
     static constexpr int definePadShortcutIcon = static_cast<int>(IconCode::Code::SHORTCUTS);
     // static constexpr int duplicatePadIcon = static_cast<int>(IconCode::Code::COPY);
     static constexpr int deletePadIcon = static_cast<int>(IconCode::Code::DELETE_TANK);
 
     QList<QVariantMap> menuItems = {
-        { { "id", DEFINE_PAD_SHORTCUT_CODE }, { "title", muse::qtrc("shortcuts", "Define keyboard shortcut") },
+        { { "id", DEFINE_PAD_SHORTCUT_CODE }, { "title", muse::qtrc("shortcuts", "Define keyboard shortcut…") },
             { "icon", definePadShortcutIcon }, { "enabled", true } },
 
         //! NOTE: Disabled for now - will be re-introduced with new percussion mapping system...
         // { { "id", DUPLICATE_PAD_CODE }, { "title", muse::qtrc("global", "Duplicate") },
         //     { "icon", duplicatePadIcon }, { "enabled", true } },
 
-        { { "id", DELETE_PAD_CODE }, { "title", muse::qtrc("global", "Delete") },
+        { { "id", DELETE_PAD_CODE }, { "title", muse::qtrc("global", "Delete pad") },
             { "icon", deletePadIcon }, { "enabled", true } },
     };
 

--- a/src/notation/view/percussionpanel/percussionpanelpadmodel.h
+++ b/src/notation/view/percussionpanel/percussionpanelpadmodel.h
@@ -43,7 +43,7 @@ class PercussionPanelPadModel : public QObject, public muse::async::Asyncable
 
     Q_PROPERTY(QVariant notationPreviewItem READ notationPreviewItemVariant NOTIFY notationPreviewItemChanged)
 
-    Q_PROPERTY(QList<QVariantMap> footerContextMenuItems READ footerContextMenuItems CONSTANT)
+    Q_PROPERTY(QList<QVariantMap> contextMenuItems READ contextMenuItems CONSTANT)
 
 public:
     explicit PercussionPanelPadModel(QObject* parent = nullptr);
@@ -64,7 +64,7 @@ public:
 
     const QVariant notationPreviewItemVariant() const;
 
-    QList<QVariantMap> footerContextMenuItems() const;
+    QList<QVariantMap> contextMenuItems() const;
     Q_INVOKABLE void handleMenuItem(const QString& itemId);
 
     Q_INVOKABLE void triggerPad(const Qt::KeyboardModifiers& modifiers);


### PR DESCRIPTION
Resolves: #26583

**Key Points:**
1. Replaced `StyledMenuLoader` with `ContextMenuLoader`.
2. The coordinates of the click are now passed to the loader in the `show()` method.
3. Moved the loader outside of the footer and into the entire pad. Technically this was not needed for things to work but I figured it made sense.

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
