### PR TITLE
Fix hiding anchor lines on end drag

### DIFF
--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -1296,12 +1296,13 @@ void NotationInteraction::startOutgoingDragElement(const EngravingItem* element,
         endOutgoingDrag();
     }
 
-    if (element->isSpannerSegment()) {
-        element = toSpannerSegment(element)->spanner();
-    }
-
     QMimeData* mimeData = new QMimeData();
-    mimeData->setData(mu::engraving::mimeSymbolFormat, element->mimeData().toQByteArray());
+    if (element->isSpannerSegment()) {
+        Spanner* s = toSpannerSegment(element)->spanner();
+        mimeData->setData(mu::engraving::mimeSymbolFormat, s->mimeData().toQByteArray());
+    } else {
+        mimeData->setData(mu::engraving::mimeSymbolFormat, element->mimeData().toQByteArray());
+    }
 
     m_outgoingDrag = new QDrag(dragSource);
     m_outgoingDrag->setMimeData(mimeData);

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -1237,7 +1237,12 @@ void NotationInteraction::doEndDrag()
     }
 
     m_dragData.reset();
-    setDropTarget(nullptr, false);
+
+    if (m_dropData.elementDropData.has_value()) {
+        setDropTarget(nullptr, false);
+    } else {
+        resetAnchorLines();
+    }
 }
 
 void NotationInteraction::endDrag()


### PR DESCRIPTION
The `resetAnchorLines()` call inside `setDropTarget` was not reached anymore, because that method returns early when there is no drop session active.

Resolves: https://github.com/musescore/MuseScore/issues/26550