### PR TITLE
Percussion panel - fix triggering pads with keyboard

### DIFF
--- a/src/notation/view/percussionpanel/percussionpanelpadmodel.h
+++ b/src/notation/view/percussionpanel/percussionpanelpadmodel.h
@@ -67,7 +67,7 @@ public:
     QList<QVariantMap> footerContextMenuItems() const;
     Q_INVOKABLE void handleMenuItem(const QString& itemId);
 
-    Q_INVOKABLE void triggerPad(const Qt::KeyboardModifiers& modifiers);
+    Q_INVOKABLE void triggerPad(const Qt::KeyboardModifiers& modifiers = Qt::KeyboardModifier::NoModifier);
 
     enum class PadAction {
         TRIGGER_STANDARD,


### PR DESCRIPTION
Fixes a regression where navigating to a pad with the keyboard and pressing space no longer triggers the pad. This bug was introduced with da116bc1848dbc9372f86e2b50fb206a8a79d2b2 where I added a keyboard modifier argument to the `triggerPad` method - `Qt::NoModifier` should have been included as a default argument here.

_Thanks to @avvvvve for catching this one!_