### PR TITLE
Add missing forward declarations and #includes

### DIFF
--- a/src/engraving/engravingmodule.cpp
+++ b/src/engraving/engravingmodule.cpp
@@ -41,6 +41,7 @@
 
 #include "engraving/style/defaultstyle.h"
 
+#include "engraving/dom/stafftype.h"
 #include "engraving/dom/mscore.h"
 #include "engraving/dom/masterscore.h"
 #include "engraving/dom/drumset.h"

--- a/src/framework/ui/inavigation.h
+++ b/src/framework/ui/inavigation.h
@@ -33,6 +33,7 @@
 #include "async/notification.h"
 
 class QWindow;
+class QQuickItem;
 
 namespace muse::ui {
 class INavigationSection;

--- a/src/notation/view/paintedengravingitem.cpp
+++ b/src/notation/view/paintedengravingitem.cpp
@@ -20,6 +20,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+#include <QPainter>
 #include "paintedengravingitem.h"
 
 #include "notation/utilities/engravingitempreviewpainter.h"


### PR DESCRIPTION
When building a non-standard build, certain files are missing type definitions. This PR adds the missing includes and forward declarations to allow building these files, even if they're built under different circumstances.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] ~I created a unit test or vtest to verify the changes I made (if applicable)~
