### PR TITLE
Cast to number_t to avoid floating point errors

### DIFF
--- a/src/framework/draw/types/geometry.h
+++ b/src/framework/draw/types/geometry.h
@@ -565,8 +565,8 @@ RectX<T> RectX<T>::united(const RectX<T>& r) const
 template<typename T>
 RectX<T> RectX<T>::intersected(const RectX<T>& r) const
 {
-    T l1 = m_x;
-    T r1 = m_x;
+    number_t<T> l1 = m_x;
+    number_t<T> r1 = m_x;
     if (m_w.is_negative()) {
         l1 += m_w;
     } else {
@@ -575,8 +575,8 @@ RectX<T> RectX<T>::intersected(const RectX<T>& r) const
     if (l1 == r1) {   // null rect
         return RectX<T>();
     }
-    T l2 = r.m_x;
-    T r2 = r.m_x;
+    number_t<T> l2 = r.m_x;
+    number_t<T> r2 = r.m_x;
     if (r.m_w.is_negative()) {
         l2 += r.m_w;
     } else {
@@ -588,8 +588,8 @@ RectX<T> RectX<T>::intersected(const RectX<T>& r) const
     if (l1 >= r2 || l2 >= r1) {
         return RectX<T>();
     }
-    T t1 = m_y;
-    T b1 = m_y;
+    number_t<T> t1 = m_y;
+    number_t<T> b1 = m_y;
     if (m_h.is_negative()) {
         t1 += m_h;
     } else {
@@ -598,8 +598,8 @@ RectX<T> RectX<T>::intersected(const RectX<T>& r) const
     if (t1 == b1) {   // null rect
         return RectX<T>();
     }
-    T t2 = r.m_y;
-    T b2 = r.m_y;
+    number_t<T> t2 = r.m_y;
+    number_t<T> b2 = r.m_y;
     if (r.m_h.is_negative()) {
         t2 += r.m_h;
     } else {
@@ -622,47 +622,47 @@ RectX<T> RectX<T>::intersected(const RectX<T>& r) const
 template<typename T>
 bool RectX<T>::intersects(const RectX<T>& r) const
 {
-    T l1 = m_x;
-    T r1 = m_x;
+    number_t<T> l1 = m_x;
+    number_t<T> r1 = m_x;
     if (m_w.is_negative()) {
         l1 += m_w;
     } else {
         r1 += m_w;
     }
-    if (isEqual(l1, r1)) { // null rect
+    if (l1 == r1) { // null rect
         return false;
     }
-    T l2 = r.m_x;
-    T r2 = r.m_x;
+    number_t<T> l2 = r.m_x;
+    number_t<T> r2 = r.m_x;
     if (r.m_w.is_negative()) {
         l2 += r.m_w;
     } else {
         r2 += r.m_w;
     }
-    if (isEqual(l2, r2)) { // null rect
+    if (l2 == r2) { // null rect
         return false;
     }
     if (l1 >= r2 || l2 >= r1) {
         return false;
     }
-    T t1 = m_y;
-    T b1 = m_y;
+    number_t<T> t1 = m_y;
+    number_t<T> b1 = m_y;
     if (m_h.is_negative()) {
         t1 += m_h;
     } else {
         b1 += m_h;
     }
-    if (isEqual(t1, b1)) { // null rect
+    if (t1 == b1) { // null rect
         return false;
     }
-    T t2 = r.m_y;
-    T b2 = r.m_y;
+    number_t<T> t2 = r.m_y;
+    number_t<T> b2 = r.m_y;
     if (r.m_h.is_negative()) {
         t2 += r.m_h;
     } else {
         b2 += r.m_h;
     }
-    if (isEqual(t2, b2)) { // null rect
+    if (t2 == b2) { // null rect
         return false;
     }
     if (t1 >= b2 || t2 >= b1) {
@@ -674,27 +674,27 @@ bool RectX<T>::intersects(const RectX<T>& r) const
 template<typename T>
 bool RectX<T>::contains(const PointX<T>& p) const
 {
-    T l = m_x;
-    T r = m_x;
+    number_t<T> l = m_x;
+    number_t<T> r = m_x;
     if (m_w.is_negative()) {
         l += m_w;
     } else {
         r += m_w;
     }
-    if (isEqual(l, r)) { // null rect
+    if (l == r) { // null rect
         return false;
     }
     if (p.x() < l || p.x() > r) {
         return false;
     }
-    T t = m_y;
-    T b = m_y;
+    number_t<T> t = m_y;
+    number_t<T> b = m_y;
     if (m_h.is_negative()) {
         t += m_h;
     } else {
         b += m_h;
     }
-    if (isEqual(t, b)) { // null rect
+    if (t == b) { // null rect
         return false;
     }
     if (p.y() < t || p.y() > b) {
@@ -706,47 +706,47 @@ bool RectX<T>::contains(const PointX<T>& p) const
 template<typename T>
 bool RectX<T>::contains(const RectX<T>& r) const
 {
-    T l1 = m_x;
-    T r1 = m_x;
+    number_t<T> l1 = m_x;
+    number_t<T> r1 = m_x;
     if (m_w.is_negative()) {
         l1 += m_w;
     } else {
         r1 += m_w;
     }
-    if (isEqual(l1, r1)) { // null rect
+    if (l1 == r1) { // null rect
         return false;
     }
-    T l2 = r.m_x;
-    T r2 = r.m_x;
+    number_t<T> l2 = r.m_x;
+    number_t<T> r2 = r.m_x;
     if (r.m_w.is_negative()) {
         l2 += r.m_w;
     } else {
         r2 += r.m_w;
     }
-    if (isEqual(l2, r2)) { // null rect
+    if (l2 == r2) { // null rect
         return false;
     }
     if (l2 < l1 || r2 > r1) {
         return false;
     }
-    T t1 = m_y;
-    T b1 = m_y;
+    number_t<T> t1 = m_y;
+    number_t<T> b1 = m_y;
     if (m_h.is_negative()) {
         t1 += m_h;
     } else {
         b1 += m_h;
     }
-    if (isEqual(t1, b1)) { // null rect
+    if (t1 == b1) { // null rect
         return false;
     }
-    T t2 = r.m_y;
-    T b2 = r.m_y;
+    number_t<T> t2 = r.m_y;
+    number_t<T> b2 = r.m_y;
     if (r.m_h.is_negative()) {
         t2 += r.m_h;
     } else {
         b2 += r.m_h;
     }
-    if (isEqual(t2, b2)) { // null rect
+    if (t2 == b2) { // null rect
         return false;
     }
     if (t2 < t1 || b2 > b1) {
@@ -758,8 +758,8 @@ bool RectX<T>::contains(const RectX<T>& r) const
 template<typename T>
 T RectX<T>::distanceTo(const PointX<T>& p) const
 {
-    T dx = std::max({ bottomLeft().x() - p.x(), 0.0, p.x() - bottomRight().x() });
-    T dy = std::max({ bottomLeft().y() - p.y(), 0.0, p.y() - topLeft().y() });
+    number_t<T> dx = std::max({ bottomLeft().x() - p.x(), 0.0, p.x() - bottomRight().x() });
+    number_t<T> dy = std::max({ bottomLeft().y() - p.y(), 0.0, p.y() - topLeft().y() });
     return std::sqrt(dx * dx + dy * dy);
 }
 

--- a/src/framework/global/tests/CMakeLists.txt
+++ b/src/framework/global/tests/CMakeLists.txt
@@ -45,6 +45,7 @@ set(MODULE_TEST_SRC
     ${CMAKE_CURRENT_LIST_DIR}/containers_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/version_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/number_tests.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/geometry_tests.cpp
 )
 
 include(SetupGTest)

--- a/src/framework/global/tests/geometry_tests.cpp
+++ b/src/framework/global/tests/geometry_tests.cpp
@@ -1,0 +1,66 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2025 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include <gtest/gtest.h>
+
+#include "draw/types/geometry.h"
+
+using namespace muse;
+
+class Global_Types_GeometryTests : public ::testing::Test
+{
+public:
+};
+
+TEST_F(Global_Types_GeometryTests, intersects) {
+    RectX<double> r1 { 10.0, 10.0, 10.0, 10.0 };
+
+    // above - no collision
+    RectX<double> r2 { 10.0, 0.0, 5.0, 5.0 };
+    EXPECT_FALSE(r1.intersects(r2));
+    // above - collision
+    r2 = RectX<double>(10.0, 8.0, 5.0, 5.0);
+    EXPECT_TRUE(r1.intersects(r2));
+    // above - touching
+    r2 = RectX<double>(10.0, 0.0, 10.0, 10.0);
+    EXPECT_FALSE(r1.intersects(r2));
+    // above - touching (floating point case)
+    r1 = RectX<double>(10.0, 10.0, 10.0000002, 10.0);
+    r2 = RectX<double>(20.0000001, 10.0, 10.0, 10.0);
+    EXPECT_FALSE(r1.intersects(r2));
+
+    r1 = RectX<double>(10.0, 10.0, 10.0, 10.0);
+    // adjacent - no collision
+    r2 = RectX<double>(25.0, 10.0, 10.0, 10.0);
+    EXPECT_FALSE(r1.intersects(r2));
+    // adjacent - collision
+    r2 = RectX<double>(17.0, 10.0, 10.0, 10.0);
+    EXPECT_TRUE(r1.intersects(r2));
+    // adjacent - touching
+    r2 = RectX<double>(20.0, 10.0, 10.0, 10.0);
+    EXPECT_FALSE(r1.intersects(r2));
+
+    r1 = RectX<double>(10.0, 10.0, 10.0000002, 10.0);
+
+    // adjacent - touching (floating point case)
+    r2 = RectX<double>(20.0000001, 10.0, 10.0, 10.0);
+    EXPECT_FALSE(r1.intersects(r2));
+}


### PR DESCRIPTION
Resolves: #26597 

Floating point values aren't being compared properly in `RectX<T>::intersected`, `RectX<T>::intersects`, or `RectX<T>::contains` as their type needs to be `number_t` to use our overloaded `<=` & `>=` comparisons.

Alternatively, I could add an inline method like the existing `isEqual` for `<=` & `>=` comparisons.