### PR TITLE
26599: Previous and Next buttons in Measure properties will be the same width

### DIFF
--- a/src/inspector/view/qml/MuseScore/Inspector/measures/MeasuresInspectorView.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/measures/MeasuresInspectorView.qml
@@ -95,16 +95,18 @@ InspectorSectionView {
         }
 
         RowLayout {
+            id: moveSystemLayout
+
             Layout.topMargin: 8
             visible: model.scoreIsInPageView
 
-            Layout.fillWidth: true
+            width: parent.width
             spacing: 4
 
             FlatButton {
                 id: upSystem
 
-                Layout.fillWidth: true
+                Layout.preferredWidth: (moveSystemLayout.width - moveSystemLayout.spacing) / 2
 
                 navigation.panel: root.navigationPanel
                 navigation.name: "SystemUp"
@@ -123,7 +125,7 @@ InspectorSectionView {
             FlatButton {
                 id: downSystem
 
-                Layout.fillWidth: true
+                Layout.preferredWidth: (moveSystemLayout.width - moveSystemLayout.spacing) / 2
 
                 navigation.panel: root.navigationPanel
                 navigation.name: "SystemDown"


### PR DESCRIPTION
Resolves: #26599

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
