### PR TITLE
Fix hang on entering tie

### DIFF
--- a/src/engraving/rendering/score/slurtielayout.cpp
+++ b/src/engraving/rendering/score/slurtielayout.cpp
@@ -1860,7 +1860,7 @@ void SlurTieLayout::setPartialTieEndPos(PartialTie* item, SlurTiePos& sPos)
 
     const Segment* adjSeg = outgoing ? seg->next1() : seg->prev1();
     while (adjSeg && (!adjSeg->isActive() || !adjSeg->enabled())) {
-        adjSeg = outgoing ? seg->next1() : seg->prev1();
+        adjSeg = outgoing ? adjSeg->next1() : adjSeg->prev1();
     }
 
     double widthToSegment = 0.0;


### PR DESCRIPTION
Resolves: Hang on trying to enter the tie marked in red. This only happens in a new file, not when adding the tie after loading a saved file.
![image](https://github.com/user-attachments/assets/263e9b8b-7605-484c-b596-d1c1849e2aad)
