### PR TITLE
Fix MSVC compiler warning

### DIFF
--- a/src/engraving/rendering/score/tlayout.cpp
+++ b/src/engraving/rendering/score/tlayout.cpp
@@ -1460,11 +1460,11 @@ void TLayout::layoutFBox(const FBox* item, FBox::LayoutData* ldata, const Layout
 
     //! NOTE: layout fret diagrams and calculate sizes
 
-    const int totalDiagrams = fretDiagrams.size();
+    const size_t totalDiagrams = fretDiagrams.size();
     double maxFretDiagramHeight = 0.0;
     double maxFretDiagramWidth = 0.0;
 
-    for (int i = 0; i < totalDiagrams; ++i) {
+    for (size_t i = 0; i < totalDiagrams; ++i) {
         FretDiagram* fretDiagram = fretDiagrams[i];
         if (!fretDiagram) {
             continue;
@@ -1496,12 +1496,12 @@ void TLayout::layoutFBox(const FBox* item, FBox::LayoutData* ldata, const Layout
 
     const double spatium = item->spatium();
 
-    const int chordsPerRow = item->chordsPerRow();
+    const size_t chordsPerRow = item->chordsPerRow();
     const double rowGap = item->rowGap().val() * spatium;
     const double columnGap = item->columnGap().val() * spatium;
 
-    const int rows = std::ceil(double(totalDiagrams) / double(chordsPerRow));
-    const int columns = std::min(totalDiagrams, chordsPerRow);
+    const size_t rows = std::ceil(double(totalDiagrams) / double(chordsPerRow));
+    const size_t columns = std::min(totalDiagrams, chordsPerRow);
 
     static constexpr double MARGINS = 8.0;
     const double totalTableHeight = rows * cellHeight + (rows - 1) * rowGap + MARGINS;
@@ -1531,16 +1531,16 @@ void TLayout::layoutFBox(const FBox* item, FBox::LayoutData* ldata, const Layout
                           : alignH == AlignH::RIGHT ? item->width() - totalTableWidth : 0.0;
     const double startY = !muse::RealIsNull(topMargin) ? topMargin : -bottomMargin;
 
-    for (int i = 0; i < totalDiagrams; ++i) {
+    for (size_t i = 0; i < totalDiagrams; ++i) {
         FretDiagram* fretDiagram = fretDiagrams[i];
         if (!fretDiagram) {
             continue;
         }
 
-        int row = i / chordsPerRow;
-        int col = i % chordsPerRow;
+        size_t row = i / chordsPerRow;
+        size_t col = i % chordsPerRow;
 
-        int itemsInRow = std::min(chordsPerRow, totalDiagrams - row * chordsPerRow);
+        size_t itemsInRow = std::min(chordsPerRow, totalDiagrams - row * chordsPerRow);
         double rowOffsetX = alignH == AlignH::HCENTER
                             ? (totalTableWidth - (itemsInRow * cellWidth + (itemsInRow - 1) * columnGap)) / 2
                             : alignH == AlignH::RIGHT

--- a/src/importexport/guitarpro/internal/importgtp-gp5.cpp
+++ b/src/importexport/guitarpro/internal/importgtp-gp5.cpp
@@ -937,7 +937,7 @@ bool GuitarPro5::read(IODevice* io)
                 bar.volta.voltaInfo.push_back(voltaNumber & 1);
                 voltaNumber >>= 1;
             }
-            bar.repeats = bar.volta.voltaInfo.size() + 1;
+            bar.repeats = static_cast<int>(bar.volta.voltaInfo.size()) + 1;
         }
         if (barBits & SCORE_KEYSIG) {
             int currentKey = readUInt8();

--- a/src/instrumentsscene/view/systemobjectslayertreeitem.cpp
+++ b/src/instrumentsscene/view/systemobjectslayertreeitem.cpp
@@ -68,17 +68,6 @@ static QString formatLayerTitle(const SystemObjectGroups& groups)
     return title;
 }
 
-static bool isLayerVisible(const SystemObjectGroups& groups)
-{
-    for (const SystemObjectsGroup& group : groups) {
-        if (isSystemObjectsGroupVisible(group)) {
-            return true;
-        }
-    }
-
-    return false;
-}
-
 SystemObjectsLayerTreeItem::SystemObjectsLayerTreeItem(IMasterNotationPtr masterNotation, INotationPtr notation, QObject* parent)
     : AbstractLayoutPanelTreeItem(LayoutPanelItemType::SYSTEM_OBJECTS_LAYER, masterNotation, notation, parent)
 {

--- a/src/notation/view/abstractnotationpaintview.cpp
+++ b/src/notation/view/abstractnotationpaintview.cpp
@@ -629,8 +629,8 @@ void AbstractNotationPaintView::paint(QPainter* qp)
     bool isPrinting = publishMode() || m_inputController->readonly();
     notation()->painting()->paintView(painter, toLogical(rect), isPrinting);
 
-    const ui::UiContext ctx = uiContextResolver()->currentUiContext();
-    const bool isOnNotationPage = ctx == ui::UiCtxProjectOpened || ctx == ui::UiCtxProjectFocused;
+    const ui::UiContext uiCtx = uiContextResolver()->currentUiContext();
+    const bool isOnNotationPage = uiCtx == ui::UiCtxProjectOpened || uiCtx == ui::UiCtxProjectFocused;
 
     const INotationNoteInputPtr noteInput = notationNoteInput();
     if (noteInput->isNoteInputMode() && isOnNotationPage) {
@@ -646,12 +646,12 @@ void AbstractNotationPaintView::paint(QPainter* qp)
     m_loopOutMarker->paint(painter);
 
     if (notation()->viewMode() == engraving::LayoutMode::LINE) {
-        ContinuousPanel::NotationViewContext ctx;
-        ctx.xOffset = m_matrix.dx();
-        ctx.yOffset = m_matrix.dy();
-        ctx.scaling = currentScaling();
-        ctx.fromLogical = [this](const PointF& pos) -> PointF { return fromLogical(pos); };
-        m_continuousPanel->paint(*painter, ctx);
+        ContinuousPanel::NotationViewContext nvCtx;
+        nvCtx.xOffset = m_matrix.dx();
+        nvCtx.yOffset = m_matrix.dy();
+        nvCtx.scaling = currentScaling();
+        nvCtx.fromLogical = [this](const PointF& pos) -> PointF { return fromLogical(pos); };
+        m_continuousPanel->paint(*painter, nvCtx);
     }
 }
 

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -830,9 +830,9 @@ void PlaybackController::toggleHearPlaybackWhenEditing()
 
 void PlaybackController::reloadPlaybackCache()
 {
-    INotationPlaybackPtr playback = notationPlayback();
-    if (playback) {
-        playback->reload();
+    INotationPlaybackPtr nPlayback = notationPlayback();
+    if (nPlayback) {
+        nPlayback->reload();
     }
 }
 


### PR DESCRIPTION
* reg.: conversion from 'size_t' to 'int', possible loss of data (C4267) (so far) master only
* reg.: declaration of 'playback' hides class member (C4458) master and 4.5.0 (merged in 4.5.0 already, see #26763)
* reg.: 'isLayerVisible': unreferenced function with internal linkage has been removed (C4505) master and 4.5.0
* reg.: declaration of 'ctx' hides previous local declaration master and 4.5.0