### PR TITLE
Percussion panel - refinements round 8

### DIFF
--- a/src/app/configs/data/shortcuts.xml
+++ b/src/app/configs/data/shortcuts.xml
@@ -899,6 +899,10 @@
     <seq>P</seq>
     </SC>
   <SC>
+    <key>toggle-percussion-panel</key>
+    <seq>O</seq>
+    </SC>
+  <SC>
     <key>next-score</key>
     <std>20</std>
     </SC>

--- a/src/app/configs/data/shortcuts_azerty.xml
+++ b/src/app/configs/data/shortcuts_azerty.xml
@@ -925,6 +925,10 @@
     <seq>P</seq>
     </SC>
   <SC>
+    <key>toggle-percussion-panel</key>
+    <seq>O</seq>
+    </SC>
+  <SC>
     <key>next-score</key>
     <std>20</std>
     </SC>

--- a/src/app/configs/data/shortcuts_mac.xml
+++ b/src/app/configs/data/shortcuts_mac.xml
@@ -900,6 +900,10 @@
     <seq>P</seq>
     </SC>
   <SC>
+    <key>toggle-percussion-panel</key>
+    <seq>O</seq>
+    </SC>
+  <SC>
     <key>next-score</key>
     <std>20</std>
     </SC>

--- a/src/appshell/internal/applicationuiactions.cpp
+++ b/src/appshell/internal/applicationuiactions.cpp
@@ -39,6 +39,7 @@ using namespace muse::dock;
 static const ActionCode FULL_SCREEN_CODE("fullscreen");
 static const ActionCode TOGGLE_NAVIGATOR_ACTION_CODE("toggle-navigator");
 static const ActionCode TOGGLE_BRAILLE_ACTION_CODE("toggle-braille-panel");
+static const ActionCode TOGGLE_PERCUSSION_PANEL_ACTION_CODE("toggle-percussion-panel");
 
 const UiActionList ApplicationUiActions::m_actions = {
     UiAction("quit",
@@ -194,14 +195,13 @@ const UiActionList ApplicationUiActions::m_actions = {
              TranslatableString("action", "Show/hide piano keyboard"),
              Checkable::Yes
              ),
-    // still in development
-    // UiAction("toggle-percussion-panel",
-    //          mu::context::UiCtxNotationOpened,
-    //          mu::context::CTX_ANY,
-    //          TranslatableString("action", "Percussion"),
-    //          TranslatableString("action", "Show/hide percussion panel"),
-    //          Checkable::Yes
-    //          ),
+    UiAction(TOGGLE_PERCUSSION_PANEL_ACTION_CODE,
+             mu::context::UiCtxProjectOpened,
+             mu::context::CTX_NOTATION_OPENED,
+             TranslatableString("action", "Percussion"),
+             TranslatableString("action", "Show/hide percussion panel"),
+             Checkable::Yes
+             ),
     UiAction("toggle-scorecmp-tool",
              mu::context::UiCtxProjectOpened,
              mu::context::CTX_NOTATION_OPENED,
@@ -248,6 +248,10 @@ void ApplicationUiActions::init()
     dockWindowProvider()->windowChanged().onNotify(this, [this]() {
         listenOpenedDocksChanged(dockWindowProvider()->window());
     });
+
+    notationConfiguration()->useNewPercussionPanelChanged().onNotify(this, [this]() {
+        m_actionEnabledChanged.send({ TOGGLE_PERCUSSION_PANEL_ACTION_CODE });
+    });
 }
 
 void ApplicationUiActions::listenOpenedDocksChanged(IDockWindow* window)
@@ -280,11 +284,11 @@ const muse::ui::UiActionList& ApplicationUiActions::actionsList() const
 
 bool ApplicationUiActions::actionEnabled(const UiAction& act) const
 {
-    if (!m_controller->canReceiveAction(act.code)) {
-        return false;
+    if (act.code == TOGGLE_PERCUSSION_PANEL_ACTION_CODE) {
+        return notationConfiguration()->useNewPercussionPanel();
     }
 
-    return true;
+    return m_controller->canReceiveAction(act.code);
 }
 
 bool ApplicationUiActions::actionChecked(const UiAction& act) const
@@ -340,7 +344,7 @@ const QMap<ActionCode, DockName>& ApplicationUiActions::toggleDockActions()
         { "toggle-timeline", TIMELINE_PANEL_NAME },
         { "toggle-mixer", MIXER_PANEL_NAME },
         { "toggle-piano-keyboard", PIANO_KEYBOARD_PANEL_NAME },
-        { "toggle-percussion-panel", PERCUSSION_PANEL_NAME },
+        { TOGGLE_PERCUSSION_PANEL_ACTION_CODE, PERCUSSION_PANEL_NAME },
 
         { "toggle-statusbar", NOTATION_STATUSBAR_NAME },
     };

--- a/src/appshell/internal/applicationuiactions.h
+++ b/src/appshell/internal/applicationuiactions.h
@@ -29,6 +29,7 @@
 #include "async/asyncable.h"
 #include "ui/imainwindow.h"
 #include "view/preferences/braillepreferencesmodel.h"
+#include "notation/inotationconfiguration.h"
 
 #include "dockwindow/idockwindowprovider.h"
 
@@ -39,6 +40,7 @@ class ApplicationUiActions : public muse::ui::IUiActionsModule, public muse::Inj
     muse::Inject<muse::dock::IDockWindowProvider> dockWindowProvider = { this };
     muse::Inject<IAppShellConfiguration> configuration = { this };
     muse::Inject<braille::IBrailleConfiguration> brailleConfiguration = { this };
+    muse::Inject<mu::notation::INotationConfiguration> notationConfiguration = { this };
 
 public:
     ApplicationUiActions(std::shared_ptr<ApplicationActionController> controller, const muse::modularity::ContextPtr& iocCtx);

--- a/src/appshell/view/appmenumodel.cpp
+++ b/src/appshell/view/appmenumodel.cpp
@@ -260,7 +260,7 @@ MenuItem* AppMenuModel::makeViewMenu()
         makeMenuItem("toggle-timeline"),
         makeMenuItem("toggle-mixer"),
         makeMenuItem("toggle-piano-keyboard"),
-        // makeMenuItem("toggle-percussion-panel"), // still in development
+        makeMenuItem("toggle-percussion-panel"),
         makeMenuItem("playback-setup"),
         //makeMenuItem("toggle-scorecmp-tool"), // not implemented
         makeSeparator(),

--- a/src/framework/shortcuts/qml/Muse/Shortcuts/EditShortcutDialogContent.qml
+++ b/src/framework/shortcuts/qml/Muse/Shortcuts/EditShortcutDialogContent.qml
@@ -44,6 +44,7 @@ Item {
 
     signal saveRequested()
     signal cancelRequested()
+    signal clearRequested()
     signal keyPressed(var event)
 
     anchors.fill: parent
@@ -137,6 +138,17 @@ Item {
 
             navigationPanel.section: root.navigationSection
             navigationPanel.order: 2
+
+            FlatButton {
+                text: qsTrc("global", "Clear")
+                buttonRole: ButtonBoxModel.CustomRole
+                buttonId: ButtonBoxModel.Clear
+                isLeftSide: true
+
+                onClicked: {
+                    root.clearRequested()
+                }
+            }
 
             onStandardButtonClicked: function(buttonId) {
                 if (buttonId === ButtonBoxModel.Cancel) {

--- a/src/framework/shortcuts/qml/Muse/Shortcuts/StandardEditShortcutDialog.qml
+++ b/src/framework/shortcuts/qml/Muse/Shortcuts/StandardEditShortcutDialog.qml
@@ -63,7 +63,8 @@ StyledDialogView {
 
         headerText: qsTrc("shortcuts", "Define keyboard shortcut")
 
-        originShortcutText: editShortcutModel.originSequence
+        //! NOTE: There's no need to actually clear the origin shortcut, we can simply hide it for aesthetic purposes...
+        originShortcutText: !editShortcutModel.cleared ? editShortcutModel.originSequence : ""
         newShortcutText: editShortcutModel.newSequence
         informationText: editShortcutModel.conflictWarning
 
@@ -74,6 +75,10 @@ StyledDialogView {
 
         onCancelRequested: {
             root.reject()
+        }
+
+        onClearRequested: {
+            editShortcutModel.clear()
         }
 
         onKeyPressed: function(event) {

--- a/src/framework/shortcuts/view/editshortcutmodel.cpp
+++ b/src/framework/shortcuts/view/editshortcutmodel.cpp
@@ -63,7 +63,10 @@ void EditShortcutModel::load(const QVariant& originShortcut, const QVariantList&
     m_originSequence = originShortcutMap.value("sequence").toString();
     m_originShortcutTitle = originShortcutMap.value("title").toString();
 
+    m_cleared = false;
+
     emit originSequenceChanged();
+    emit clearedChanged();
 }
 
 void EditShortcutModel::clearNewSequence()
@@ -108,6 +111,14 @@ void EditShortcutModel::inputKey(Qt::Key key, Qt::KeyboardModifiers modifiers)
     checkNewSequenceForConflicts();
 
     emit newSequenceChanged();
+}
+
+void EditShortcutModel::clear()
+{
+    clearNewSequence();
+    m_cleared = true;
+    emit originSequenceChanged();
+    emit clearedChanged();
 }
 
 bool EditShortcutModel::isShiftAllowed(Qt::Key key)
@@ -215,8 +226,8 @@ QString EditShortcutModel::conflictWarning() const
 void EditShortcutModel::trySave()
 {
     QString newSequence = this->newSequence();
-
-    if (m_originSequence == newSequence) {
+    const bool alreadyEmpty = originSequenceInNativeFormat().isEmpty() && m_cleared;
+    if (alreadyEmpty || m_originSequence == newSequence) {
         return;
     }
 

--- a/src/framework/shortcuts/view/editshortcutmodel.h
+++ b/src/framework/shortcuts/view/editshortcutmodel.h
@@ -39,6 +39,8 @@ class EditShortcutModel : public QObject, public Injectable
     Q_PROPERTY(QString newSequence READ newSequenceInNativeFormat NOTIFY newSequenceChanged)
     Q_PROPERTY(QString conflictWarning READ conflictWarning NOTIFY newSequenceChanged)
 
+    Q_PROPERTY(bool cleared READ cleared NOTIFY clearedChanged)
+
     Inject<IInteractive> interactive = { this };
 
 public:
@@ -47,15 +49,18 @@ public:
     QString originSequenceInNativeFormat() const;
     QString newSequenceInNativeFormat() const;
     QString conflictWarning() const;
+    bool cleared() const { return m_cleared; }
     bool isShiftAllowed(Qt::Key key);
 
     Q_INVOKABLE void load(const QVariant& shortcut, const QVariantList& allShortcuts);
     Q_INVOKABLE void inputKey(Qt::Key key, Qt::KeyboardModifiers modifiers);
+    Q_INVOKABLE void clear();
     Q_INVOKABLE void trySave();
 
 signals:
     void originSequenceChanged();
     void newSequenceChanged();
+    void clearedChanged();
 
     void applyNewSequenceRequested(const QString& newSequence, int conflictShortcutIndex = -1);
 
@@ -74,6 +79,8 @@ private:
     QVariantMap m_conflictShortcut;
 
     QKeySequence m_newSequence;
+
+    bool m_cleared = false;
 };
 }
 

--- a/src/notation/qml/MuseScore/NotationScene/EditPercussionShortcutDialog.qml
+++ b/src/notation/qml/MuseScore/NotationScene/EditPercussionShortcutDialog.qml
@@ -70,7 +70,8 @@ StyledDialogView {
 
         headerText: qsTrc("shortcuts", "Define percussion keyboard shortcut")
 
-        originShortcutText: model.originShortcutText
+        //! NOTE: There's no need to actually clear the origin shortcut, we can simply hide it for aesthetic purposes...
+        originShortcutText: !model.cleared ? model.originShortcutText : ""
         newShortcutText: model.newShortcutText
         informationText: model.informationText
 
@@ -84,6 +85,10 @@ StyledDialogView {
 
         onCancelRequested: {
             root.reject()
+        }
+
+        onClearRequested: {
+            model.clear()
         }
 
         onKeyPressed: function(event) {

--- a/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
+++ b/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
@@ -166,7 +166,7 @@ Item {
                 onNavigationEvent: {
                     // Use the last known "pad navigation row" and tab to the associated delete button if it exists
                     var padNavigationRow = navigationPrv.currentPadNavigationIndex[0]
-                    if (padGrid.model.rowIsEmpty(padNavigationRow)) {
+                    if (padGrid.numRows > 1) {
                         event.setData("controlIndex", [padNavigationRow, 0])
                     }
                 }
@@ -200,7 +200,7 @@ Item {
                             anchors.verticalCenter: parent.verticalCenter
                             anchors.right: parent.right
 
-                            visible: padGrid.numRows > 1 && padGrid.model.rowIsEmpty(model.index)
+                            visible: padGrid.numRows > 1
 
                             icon: IconCode.DELETE_TANK
                             backgroundRadius: deleteButton.width / 2
@@ -213,17 +213,6 @@ Item {
 
                             onClicked: {
                                 padGrid.model.deleteRow(model.index)
-                            }
-
-                            Connections {
-                                target: padGrid.model
-
-                                function onRowIsEmptyChanged(row, isEmpty) {
-                                    if (row !== model.index) {
-                                        return
-                                    }
-                                    deleteButton.visible = padGrid.numRows > 1 && isEmpty
-                                }
                             }
                         }
                     }

--- a/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPadContent.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPadContent.qml
@@ -174,6 +174,7 @@ Column {
 
             anchors.fill: parent
             enabled: root.panelMode !== PanelMode.EDIT_LAYOUT
+            hoverEnabled: true
 
             acceptedButtons: Qt.LeftButton | Qt.RightButton
 
@@ -226,5 +227,24 @@ Column {
                 root.padModel.handleMenuItem(itemId)
             }
         }
+
+        states: [
+            State {
+                name: "MOUSE_HOVERED"
+                when: footerMouseArea.containsMouse && !footerMouseArea.pressed
+                PropertyChanges {
+                    target: footerArea
+                    color: Utils.colorWithAlpha(ui.theme.buttonColor, ui.theme.buttonOpacityHover)
+                }
+            },
+            State {
+                name: "MOUSE_HIT"
+                when: footerMouseArea.pressed
+                PropertyChanges {
+                    target: footerArea
+                    color: Utils.colorWithAlpha(ui.theme.buttonColor, ui.theme.buttonOpacityHit)
+                }
+            }
+        ]
     }
 }

--- a/src/notation/utilities/percussionutilities.cpp
+++ b/src/notation/utilities/percussionutilities.cpp
@@ -105,15 +105,15 @@ std::shared_ptr<Chord> PercussionUtilities::getDrumNoteForPreview(const Drumset*
 }
 
 /// Opens the percussion shortcut dialog, modifies drumset with user input
-void PercussionUtilities::editPercussionShortcut(Drumset& drumset, int originPitch)
+bool PercussionUtilities::editPercussionShortcut(Drumset& drumset, int originPitch)
 {
     IF_ASSERT_FAILED(drumset.isValid(originPitch)) {
-        return;
+        return false;
     }
 
     const muse::RetVal<muse::Val> rv = openPercussionShortcutDialog(drumset, originPitch);
     if (!rv.ret) {
-        return;
+        return false;
     }
 
     const QVariantMap vals = rv.val.toQVariant().toMap();
@@ -124,6 +124,8 @@ void PercussionUtilities::editPercussionShortcut(Drumset& drumset, int originPit
     if (conflictShortcutPitch > -1 && drumset.isValid(conflictShortcutPitch)) {
         drumset.drum(conflictShortcutPitch).shortcut.clear();
     }
+
+    return true;
 }
 
 muse::RetVal<muse::Val> PercussionUtilities::openPercussionShortcutDialog(const Drumset& drumset, int originPitch)

--- a/src/notation/utilities/percussionutilities.h
+++ b/src/notation/utilities/percussionutilities.h
@@ -48,7 +48,7 @@ class PercussionUtilities
 public:
     static void readDrumset(const muse::ByteArray& drumMapping, mu::engraving::Drumset& drumset);
     static std::shared_ptr<mu::engraving::Chord> getDrumNoteForPreview(const mu::engraving::Drumset* drumset, int pitch);
-    static void editPercussionShortcut(mu::engraving::Drumset& drumset, int originPitch);
+    static bool editPercussionShortcut(mu::engraving::Drumset& drumset, int originPitch);
 
 private:
     static muse::RetVal<muse::Val> openPercussionShortcutDialog(const mu::engraving::Drumset& drumset, int originPitch);

--- a/src/notation/view/editpercussionshortcutmodel.cpp
+++ b/src/notation/view/editpercussionshortcutmodel.cpp
@@ -44,7 +44,10 @@ void EditPercussionShortcutModel::load(const QVariant& originDrum, const QVarian
         m_drumsWithShortcut << drum;
     }
 
+    m_cleared = false;
+
     emit originShortcutTextChanged();
+    emit clearedChanged();
 }
 
 void EditPercussionShortcutModel::inputKey(Qt::Key key)
@@ -70,9 +73,22 @@ void EditPercussionShortcutModel::inputKey(Qt::Key key)
     emit newShortcutTextChanged();
 }
 
+void EditPercussionShortcutModel::clear()
+{
+    m_newShortcut = QKeySequence();
+    m_conflictShortcut.clear();
+
+    m_cleared = true;
+
+    emit newShortcutTextChanged();
+    emit clearedChanged();
+}
+
 bool EditPercussionShortcutModel::trySave()
 {
-    if (originShortcutText() == m_newShortcut.toString()) {
+    const QString newShortcut = m_newShortcut.toString();
+    const bool alreadyEmpty = originShortcutText().isEmpty() && m_cleared;
+    if (alreadyEmpty || originShortcutText() == newShortcut) {
         return false;
     }
 

--- a/src/notation/view/editpercussionshortcutmodel.h
+++ b/src/notation/view/editpercussionshortcutmodel.h
@@ -37,6 +37,8 @@ class EditPercussionShortcutModel : public QObject, public muse::Injectable
     Q_PROPERTY(QString newShortcutText READ newShortcutText NOTIFY newShortcutTextChanged)
     Q_PROPERTY(QString informationText READ informationText NOTIFY newShortcutTextChanged)
 
+    Q_PROPERTY(bool cleared READ cleared NOTIFY clearedChanged)
+
     Inject<muse::IInteractive> interactive = { this };
 
 public:
@@ -44,6 +46,7 @@ public:
 
     Q_INVOKABLE void load(const QVariant& originDrum, const QVariantList& drumsWithShortcut, const QVariantList& applicationShortcuts);
     Q_INVOKABLE void inputKey(Qt::Key key);
+    Q_INVOKABLE void clear();
     Q_INVOKABLE bool trySave();
 
     Q_INVOKABLE int conflictDrumPitch() const;
@@ -52,9 +55,12 @@ public:
     QString newShortcutText() const;
     QString informationText() const;
 
+    bool cleared() const { return m_cleared; }
+
 signals:
     void originShortcutTextChanged();
     void newShortcutTextChanged();
+    void clearedChanged();
 
 private:
     bool checkDrumShortcutsForConflict();
@@ -71,5 +77,6 @@ private:
     QVariantList m_applicationShortcuts;
 
     bool m_conflictInAppShortcuts = false;
+    bool m_cleared = false;
 };
 }

--- a/src/notation/view/percussionpanel/percussionpanelmodel.cpp
+++ b/src/notation/view/percussionpanel/percussionpanelmodel.cpp
@@ -448,7 +448,9 @@ void PercussionPanelModel::onDefinePadShortcutRequested(int pitch)
     }
 
     Drumset updatedDrumset = *m_padListModel->drumset();
-    PercussionUtilities::editPercussionShortcut(updatedDrumset, pitch);
+    if (!PercussionUtilities::editPercussionShortcut(updatedDrumset, pitch)) {
+        return;
+    }
 
     INotationUndoStackPtr undoStack = notation()->undoStack();
 

--- a/src/notation/view/percussionpanel/percussionpanelpadlistmodel.h
+++ b/src/notation/view/percussionpanel/percussionpanelpadlistmodel.h
@@ -61,8 +61,6 @@ public:
 
     void removeEmptyRows();
 
-    Q_INVOKABLE bool rowIsEmpty(int row) const;
-
     Q_INVOKABLE void startPadSwap(int startIndex);
     Q_INVOKABLE void endPadSwap(int endIndex);
     bool swapInProgress() const { return indexIsValid(m_padSwapStartIndex); }
@@ -89,7 +87,6 @@ public:
 
 signals:
     void numPadsChanged();
-    void rowIsEmptyChanged(int row, bool empty);
     void padFocusRequested(int padIndex); //! NOTE: This won't work if it is called immediately before a layoutChange
 
 private:

--- a/src/palette/view/widgets/customizekitdialog.cpp
+++ b/src/palette/view/widgets/customizekitdialog.cpp
@@ -666,7 +666,9 @@ void CustomizeKitDialog::defineShortcut()
     }
 
     const int originPitch = item->data(Column::PITCH, Qt::UserRole).toInt();
-    PercussionUtilities::editPercussionShortcut(m_editedDrumset, originPitch);
+    if (!PercussionUtilities::editPercussionShortcut(m_editedDrumset, originPitch)) {
+        return;
+    }
 
     const QString editedShortcutText = m_editedDrumset.shortcut(originPitch);
     shortcut->setText(!editedShortcutText.isEmpty() ? editedShortcutText : muse::qtrc("shortcuts", "None"));


### PR DESCRIPTION
fbe040c60882785b527786c705ddb25ff42c98dd resolves #26575
0587b0a6b01ec2eb87bd8d3537daf9def7d2747f resolves #26450
3b87493fabd38b6b0723848e8aee968a7f17c808 resolves #26452

Commit c9daabbc6cb1bdbd758815f6a856d8bd58638b97 provides functionality for opening the percussion panel with shortcuts and via the "View" app menu (greyed-out when the legacy panel is in use). The default shortcut for the percussion panel is "O".