### PR TITLE
Translate the pad names in the drum input panel

### DIFF
--- a/src/notation/view/percussionpanel/percussionpanelpadlistmodel.cpp
+++ b/src/notation/view/percussionpanel/percussionpanelpadlistmodel.cpp
@@ -324,7 +324,7 @@ PercussionPanelPadModel* PercussionPanelPadListModel::createPadModelForPitch(int
 
     PercussionPanelPadModel* model = new PercussionPanelPadModel(this);
 
-    model->setPadName(m_drumset->name(pitch));
+    model->setPadName(m_drumset->translatedName(pitch));
     model->setKeyboardShortcut(m_drumset->shortcut(pitch));
     model->setPitch(pitch);
 


### PR DESCRIPTION
Came up in https://musescore.org/en/node/375408

Now it looks like this (in German):
![image](https://github.com/user-attachments/assets/5dca0cfa-84a9-4350-8ee9-f234303fdb15)
No idea where "Bass Drum 2" or "China Cymbal" come from, they are not in Transifex (there's "Chineese Cymbal", translated to "Chinesisches Becken" though), nor in the sources, as far as I can tell

applies to master and 4.5.0