### PR TITLE
Translate the pad names in the drum input panel

### DIFF
--- a/src/notation/view/percussionpanel/percussionpanelpadlistmodel.cpp
+++ b/src/notation/view/percussionpanel/percussionpanelpadlistmodel.cpp
@@ -324,7 +324,7 @@ PercussionPanelPadModel* PercussionPanelPadListModel::createPadModelForPitch(int
 
     PercussionPanelPadModel* model = new PercussionPanelPadModel(this);
 
-    model->setPadName(m_drumset->name(pitch));
+    model->setPadName(m_drumset->translatedName(pitch));
     model->setKeyboardShortcut(m_drumset->shortcut(pitch));
     model->setPitch(pitch);
 


### PR DESCRIPTION
Same as #26661, but for 4.5.0