### PR TITLE
26665: Toolbar buttons do not react to long clicks

### DIFF
--- a/src/framework/uicomponents/qml/Muse/UiComponents/FlatButton.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/FlatButton.qml
@@ -103,8 +103,9 @@ FocusScope {
     }
 
     signal clicked(var mouse)
-    // There are intentionally no "forwarded" signals here from the MouseArea, like `pressAndHold`
-    // See https://github.com/musescore/MuseScore/issues/16012#issuecomment-1399656043
+    // The `pressAndHold` signal is intentionally not "forwarded" here from the MouseArea for performance reasons.
+    // Most buttons don't use it and Qt has optimizations if no signal is attached. If a component needs it,
+    // it can hook to it directly (the mouse area is exposed via the `mouseArea` alias property).
 
     objectName: root.text
 

--- a/src/framework/uicomponents/qml/Muse/UiComponents/StyledToolBarItem.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/StyledToolBarItem.qml
@@ -103,18 +103,13 @@ FlatButton {
         }
     }
 
-    Connections {
-        target: root.mouseArea
-
-        enabled: root.hasMenu && !menuLoader.isMenuOpened
-
-        function onPressAndHold() {
-            if (menuLoader.isMenuOpened || !root.hasMenu) {
-                return
-            }
-
-            root.toggleMenuOpened()
+    mouseArea.onPressAndHold: function(event) {
+        if (menuLoader.isMenuOpened || !root.hasMenu) {
+            event.accepted = false // do not suppress the click event
+            return
         }
+
+        root.toggleMenuOpened()
     }
 
     Canvas {

--- a/src/notation/qml/MuseScore/NotationScene/NoteInputBar.qml
+++ b/src/notation/qml/MuseScore/NotationScene/NoteInputBar.qml
@@ -155,20 +155,13 @@ Item {
                 }
             }
 
-            Connections {
-                target: btn.mouseArea
-
-                // Make sure we only connect to `pressAndHold` if necessary
-                // See https://github.com/musescore/MuseScore/issues/16012
-                enabled: btn.hasMenu && !menuLoader.isMenuOpened
-
-                function onPressAndHold() {
-                    if (menuLoader.isMenuOpened || !btn.hasMenu) {
-                        return
-                    }
-
-                    btn.toggleMenuOpened()
+            mouseArea.onPressAndHold: function(event) {
+                if (menuLoader.isMenuOpened || !btn.hasMenu) {
+                    event.accepted = false // do not suppress the click event
+                    return
                 }
+
+                btn.toggleMenuOpened()
             }
 
             StyledMenuLoader {


### PR DESCRIPTION
Resolves: #26665

This is the same issue as [#16012](https://github.com/musescore/MuseScore/issues/16012). The fix done there appears not to have fixed it. Handling the `pressAndHold` signal, even directly as implemented in the fix, suppresses the `click` signal.

I have found a new fix: when handling the `pressAndHold` signal, if we do not consume it, we should set the `accepted` property of the mouse event to `false`. In this case the `click` event will not be suppressed. Interestingly, for `pressAndHold` the `accepted` property is `true` by default which means the event has to be unaccepted if not consumed. So I am reverting the fix for [#16012](https://github.com/musescore/MuseScore/issues/16012) and am taking care of the `accepted` property: in `FlatButton` I set `accepted` to `false` to not suppress the `click` signal if there are no handlers or none consumes the event. On the other hand, when `pressAndHold` is consumed in `NoteInputBar` and `StyledToolBarItem`, `accepted` will be set to `true`.

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
