### PR TITLE
Fix crash when opening MusicXML file with multiple fermatas on grace notes

### DIFF
--- a/src/engraving/dom/factory.cpp
+++ b/src/engraving/dom/factory.cpp
@@ -415,8 +415,8 @@ MAKE_ITEM_IMPL(Clef, Segment)
 CREATE_ITEM_IMPL(DeadSlapped, ElementType::DEAD_SLAPPED, Rest, isAccessibleEnabled)
 COPY_ITEM_IMPL(DeadSlapped)
 
-CREATE_ITEM_IMPL(Fermata, ElementType::FERMATA, EngravingItem, isAccessibleEnabled)
-MAKE_ITEM_IMPL(Fermata, EngravingItem)
+CREATE_ITEM_IMPL(Fermata, ElementType::FERMATA, Segment, isAccessibleEnabled)
+MAKE_ITEM_IMPL(Fermata, Segment)
 
 CREATE_ITEM_IMPL(FiguredBass, ElementType::FIGURED_BASS, Segment, isAccessibleEnabled)
 MAKE_ITEM_IMPL(FiguredBass, Segment)

--- a/src/engraving/dom/factory.h
+++ b/src/engraving/dom/factory.h
@@ -93,8 +93,8 @@ public:
     static Clef* copyClef(const Clef& src);
     static std::shared_ptr<Clef> makeClef(Segment* parent);
 
-    static Fermata* createFermata(EngravingItem* parent, bool isAccessibleEnabled = true);
-    static std::shared_ptr<Fermata> makeFermata(EngravingItem* parent);
+    static Fermata* createFermata(Segment* parent, bool isAccessibleEnabled = true);
+    static std::shared_ptr<Fermata> makeFermata(Segment* parent);
 
     static FiguredBass* createFiguredBass(Segment* parent, bool isAccessibleEnabled = true);
     static std::shared_ptr<FiguredBass> makeFiguredBass(Segment* parent);

--- a/src/engraving/dom/fermata.cpp
+++ b/src/engraving/dom/fermata.cpp
@@ -87,18 +87,6 @@ muse::TranslatableString Fermata::subtypeUserName() const
 }
 
 //---------------------------------------------------------
-//   chordRest
-//---------------------------------------------------------
-
-ChordRest* Fermata::chordRest() const
-{
-    if (explicitParent() && explicitParent()->isChordRest()) {
-        return toChordRest(explicitParent());
-    }
-    return 0;
-}
-
-//---------------------------------------------------------
 //   measure
 //---------------------------------------------------------
 

--- a/src/engraving/dom/fermata.h
+++ b/src/engraving/dom/fermata.h
@@ -67,7 +67,6 @@ public:
     PropertyValue propertyDefault(Pid) const override;
     void resetProperty(Pid id) override;
 
-    ChordRest* chordRest() const;
     Segment* segment() const { return toSegment(explicitParent()); }
     Measure* measure() const;
     System* system() const;

--- a/src/engraving/rw/read206/read206.cpp
+++ b/src/engraving/rw/read206/read206.cpp
@@ -2343,7 +2343,7 @@ EngravingItem* Read206::readArticulation(EngravingItem* parent, XmlReader& e, Re
             case SymId::fermataLongBelow:
             case SymId::fermataVeryLongAbove:
             case SymId::fermataVeryLongBelow: {
-                Fermata* fe = Factory::createFermata(ctx.dummy());
+                Fermata* fe = Factory::createFermata(ctx.dummy()->segment());
                 fe->setSymIdAndTimeStretch(sym);
                 el = fe;
             } break;
@@ -2381,7 +2381,7 @@ EngravingItem* Read206::readArticulation(EngravingItem* parent, XmlReader& e, Re
     }
     // Special case for "no type" = ufermata, with missing subtype tag
     if (!el) {
-        Fermata* f = Factory::createFermata(ctx.dummy());
+        Fermata* f = Factory::createFermata(ctx.dummy()->segment());
         f->setSymIdAndTimeStretch(sym);
         el = f;
     }

--- a/src/engraving/rw/read400/measurerw.cpp
+++ b/src/engraving/rw/read400/measurerw.cpp
@@ -565,7 +565,7 @@ void MeasureRead::readVoice(Measure* measure, XmlReader& e, ReadContext& ctx, in
                 }
             }
         } else if (tag == "Fermata") {
-            fermata = Factory::createFermata(ctx.dummy());
+            fermata = Factory::createFermata(ctx.dummy()->segment());
             fermata->setTrack(ctx.track());
             fermata->setPlacement(fermata->track() & 1 ? PlacementV::BELOW : PlacementV::ABOVE);
             TRead::read(fermata, e, ctx);

--- a/src/engraving/rw/read410/measureread.cpp
+++ b/src/engraving/rw/read410/measureread.cpp
@@ -560,7 +560,7 @@ void MeasureRead::readVoice(Measure* measure, XmlReader& e, ReadContext& ctx, in
             }
             segment->add(el);
         } else if (tag == "Fermata") {
-            fermata = Factory::createFermata(ctx.dummy());
+            fermata = Factory::createFermata(ctx.dummy()->segment());
             fermata->setTrack(ctx.track());
             fermata->setPlacement(fermata->track() & 1 ? PlacementV::BELOW : PlacementV::ABOVE);
             TRead::read(fermata, e, ctx);

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -2596,14 +2596,14 @@ static void addGraceChordsBefore(Chord* c, GraceChordList& gcl)
 {
     for (int i = static_cast<int>(gcl.size()) - 1; i >= 0; i--) {
         Chord* gc = gcl.at(i);
-        for (EngravingItem* e : gc->el()) {
+        std::vector<EngravingItem*> el = gc->el(); // copy, because modified during loop
+        for (EngravingItem* e : el) {
             if (e->isFermata()) {
                 c->segment()->add(e);
                 gc->removeFermata(toFermata(e));
-                break;                          // out of the door, line on the left, one cross each
             }
         }
-        c->add(gc);            // TODO check if same voice ?
+        c->add(gc); // TODO check if same voice ?
         coerceGraceCue(c, gc);
     }
     gcl.clear();

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -1223,23 +1223,25 @@ static void addFermataToChord(const Notation& notation, ChordRest* cr)
     const SymId articSym = notation.symId();
     const String direction = notation.attribute(u"type");
     const Color color = Color::fromString(notation.attribute(u"color"));
-    Fermata* na = Factory::createFermata(cr);
-    na->setSymIdAndTimeStretch(articSym);
-    na->setTrack(cr->track());
+    Segment* seg = cr->segment();
+    Fermata* fermata = Factory::createFermata(seg ? seg : cr->score()->dummy()->segment());
+    fermata->setSymIdAndTimeStretch(articSym);
+    fermata->setTrack(cr->track());
     if (color.isValid()) {
-        na->setColor(color);
+        fermata->setColor(color);
     }
     if (!direction.empty()) {
-        na->setPlacement(direction == "inverted" ? PlacementV::BELOW : PlacementV::ABOVE);
-        na->resetProperty(Pid::OFFSET);
+        fermata->setPlacement(direction == "inverted" ? PlacementV::BELOW : PlacementV::ABOVE);
+        fermata->resetProperty(Pid::OFFSET);
     } else {
-        na->setPlacement(na->propertyDefault(Pid::PLACEMENT).value<PlacementV>());
+        fermata->setPlacement(fermata->propertyDefault(Pid::PLACEMENT).value<PlacementV>());
     }
-    setElementPropertyFlags(na, Pid::PLACEMENT, direction);
-    if (cr->segment() == nullptr && cr->isGrace()) {
-        cr->addFermata(na);           // store for later move to segment
+    setElementPropertyFlags(fermata, Pid::PLACEMENT, direction);
+    if (!seg) {
+        assert(cr->isGrace());
+        cr->addFermata(fermata); // store for later move to segment
     } else {
-        cr->segment()->add(na);
+        cr->segment()->add(fermata);
     }
 }
 

--- a/src/importexport/musicxml/tests/data/testDuplicateFermataOnGraceNote.xml
+++ b/src/importexport/musicxml/tests/data/testDuplicateFermataOnGraceNote.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.1">
+  <identification>
+    <encoding>
+      <software>MuseScore 3.4.2</software>
+      <encoding-date>2020-05-08</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="yes" value="yes"/>
+      <supports element="print" attribute="new-system" type="yes" value="yes"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    <source>http://musescore.com/score/658031</source>
+    </identification>
+  <defaults>
+    <scaling>
+      <millimeters>7.056</millimeters>
+      <tenths>40</tenths>
+      </scaling>
+    <page-layout>
+      <page-height>1683.67</page-height>
+      <page-width>1190.48</page-width>
+      <page-margins type="even">
+        <left-margin>56.6893</left-margin>
+        <right-margin>56.6893</right-margin>
+        <top-margin>56.6893</top-margin>
+        <bottom-margin>113.379</bottom-margin>
+        </page-margins>
+      <page-margins type="odd">
+        <left-margin>56.6893</left-margin>
+        <right-margin>56.6893</right-margin>
+        <top-margin>56.6893</top-margin>
+        <bottom-margin>113.379</bottom-margin>
+        </page-margins>
+      </page-layout>
+    <word-font font-family="FreeSerif" font-size="10"/>
+    <lyric-font font-family="FreeSerif" font-size="11"/>
+    </defaults>
+  <credit page="1">
+    <credit-words default-x="1133.79" default-y="1449.99" justify="right" valign="bottom" font-family="Times New Roman" font-size="12">Franz Liszt
+</credit-words>
+    <credit-words>(1811 - 1886)</credit-words>
+    </credit>
+  <credit page="1">
+    <credit-words default-x="595.238" default-y="1626.98" justify="center" valign="top" font-family="Times New Roman" font-size="24">Mephisto Waltz No. 1</credit-words>
+    </credit>
+  <credit page="1">
+    <credit-words default-x="595.238" default-y="1570.3" justify="center" valign="top" font-family="Times New Roman" font-size="14">S. 514</credit-words>
+    </credit>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Piano</part-name>
+      <score-instrument id="P1-I1">
+        <instrument-name>Piano</instrument-name>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>1</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1" width="166.78">
+      <print>
+        <system-layout>
+          <system-margins>
+            <left-margin>21.00</left-margin>
+            <right-margin>0.00</right-margin>
+            </system-margins>
+          <top-system-distance>246.99</top-system-distance>
+          </system-layout>
+        <staff-layout number="2">
+          <staff-distance>65.00</staff-distance>
+          </staff-layout>
+        </print>
+      <attributes>
+        <divisions>480</divisions>
+        <key>
+          <fifths>1</fifths>
+          </key>
+        <time>
+          <beats>3</beats>
+          <beat-type>8</beat-type>
+          </time>
+        <staves>2</staves>
+        <clef number="1">
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        <clef number="2">
+          <sign>F</sign>
+          <line>4</line>
+          </clef>
+        </attributes>
+      <direction placement="above">
+        <direction-type>
+          <words default-x="-34.94" relative-y="20.00" font-weight="bold" font-family="Times New Roman" font-size="12">Allegro vivace (quasi presto)</words>
+          </direction-type>
+        <staff>1</staff>
+        <sound tempo="194"/>
+        </direction>
+      <note default-x="367.51" default-y="15.00">
+        <grace/>
+        <pitch>
+          <step>B</step>
+          <octave>5</octave>
+          </pitch>
+        <voice>1</voice>
+        <type>16th</type>
+        <stem>up</stem>
+        <staff>1</staff>
+        <beam number="1">begin</beam>
+        <beam number="2">begin</beam>
+        <notations>
+          <fermata type="upright"/>
+          <fermata type="upright"/>
+          </notations>
+        </note>
+      <note default-x="401.16" default-y="20.00">
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>960</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>down</stem>
+        <staff>1</staff>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/src/importexport/musicxml/tests/data/testDuplicateFermataOnGraceNoteAndMainNote.xml
+++ b/src/importexport/musicxml/tests/data/testDuplicateFermataOnGraceNoteAndMainNote.xml
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.1">
+  <identification>
+    <encoding>
+      <software>MuseScore 3.4.2</software>
+      <encoding-date>2020-05-08</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="yes" value="yes"/>
+      <supports element="print" attribute="new-system" type="yes" value="yes"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    <source>http://musescore.com/score/658031</source>
+    </identification>
+  <defaults>
+    <scaling>
+      <millimeters>7.056</millimeters>
+      <tenths>40</tenths>
+      </scaling>
+    <page-layout>
+      <page-height>1683.67</page-height>
+      <page-width>1190.48</page-width>
+      <page-margins type="even">
+        <left-margin>56.6893</left-margin>
+        <right-margin>56.6893</right-margin>
+        <top-margin>56.6893</top-margin>
+        <bottom-margin>113.379</bottom-margin>
+        </page-margins>
+      <page-margins type="odd">
+        <left-margin>56.6893</left-margin>
+        <right-margin>56.6893</right-margin>
+        <top-margin>56.6893</top-margin>
+        <bottom-margin>113.379</bottom-margin>
+        </page-margins>
+      </page-layout>
+    <word-font font-family="FreeSerif" font-size="10"/>
+    <lyric-font font-family="FreeSerif" font-size="11"/>
+    </defaults>
+  <credit page="1">
+    <credit-words default-x="1133.79" default-y="1449.99" justify="right" valign="bottom" font-family="Times New Roman" font-size="12">Franz Liszt
+</credit-words>
+    <credit-words>(1811 - 1886)</credit-words>
+    </credit>
+  <credit page="1">
+    <credit-words default-x="595.238" default-y="1626.98" justify="center" valign="top" font-family="Times New Roman" font-size="24">Mephisto Waltz No. 1</credit-words>
+    </credit>
+  <credit page="1">
+    <credit-words default-x="595.238" default-y="1570.3" justify="center" valign="top" font-family="Times New Roman" font-size="14">S. 514</credit-words>
+    </credit>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Piano</part-name>
+      <score-instrument id="P1-I1">
+        <instrument-name>Piano</instrument-name>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>1</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1" width="166.78">
+      <print>
+        <system-layout>
+          <system-margins>
+            <left-margin>21.00</left-margin>
+            <right-margin>0.00</right-margin>
+            </system-margins>
+          <top-system-distance>246.99</top-system-distance>
+          </system-layout>
+        <staff-layout number="2">
+          <staff-distance>65.00</staff-distance>
+          </staff-layout>
+        </print>
+      <attributes>
+        <divisions>480</divisions>
+        <key>
+          <fifths>1</fifths>
+          </key>
+        <time>
+          <beats>3</beats>
+          <beat-type>8</beat-type>
+          </time>
+        <staves>2</staves>
+        <clef number="1">
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        <clef number="2">
+          <sign>F</sign>
+          <line>4</line>
+          </clef>
+        </attributes>
+      <direction placement="above">
+        <direction-type>
+          <words default-x="-34.94" relative-y="20.00" font-weight="bold" font-family="Times New Roman" font-size="12">Allegro vivace (quasi presto)</words>
+          </direction-type>
+        <staff>1</staff>
+        <sound tempo="194"/>
+        </direction>
+      <note default-x="367.51" default-y="15.00">
+        <grace/>
+        <pitch>
+          <step>B</step>
+          <octave>5</octave>
+          </pitch>
+        <voice>1</voice>
+        <type>16th</type>
+        <stem>up</stem>
+        <staff>1</staff>
+        <beam number="1">begin</beam>
+        <beam number="2">begin</beam>
+        <notations>
+          <fermata type="upright"/>
+          <fermata type="upright"/>
+          </notations>
+        </note>
+      <note default-x="401.16" default-y="20.00">
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>960</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>down</stem>
+        <staff>1</staff>
+        <notations>
+          <fermata type="upright"/>
+          <fermata type="upright"/>
+          </notations>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/src/importexport/musicxml/tests/data/testDuplicateFermataOnGraceNoteAndMainNote_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testDuplicateFermataOnGraceNoteAndMainNote_ref.mscx
@@ -1,0 +1,285 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="4.50">
+  <Score>
+    <Division>480</Division>
+    <Style>
+      <pageWidth>8.26774</pageWidth>
+      <pageHeight>11.6929</pageHeight>
+      <pagePrintableWidth>7.48034</pagePrintableWidth>
+      <pageEvenLeftMargin>0.3937</pageEvenLeftMargin>
+      <pageOddLeftMargin>0.3937</pageOddLeftMargin>
+      <pageEvenTopMargin>0.3937</pageEvenTopMargin>
+      <pageEvenBottomMargin>0.787404</pageEvenBottomMargin>
+      <pageOddTopMargin>0.3937</pageOddTopMargin>
+      <pageOddBottomMargin>0.787404</pageOddBottomMargin>
+      <lyricsOddFontFace>FreeSerif</lyricsOddFontFace>
+      <lyricsOddFontSize>11</lyricsOddFontSize>
+      <lyricsEvenFontFace>FreeSerif</lyricsEvenFontFace>
+      <lyricsEvenFontSize>11</lyricsEvenFontSize>
+      <chordSymbolAFontFace>FreeSerif</chordSymbolAFontFace>
+      <chordSymbolBFontFace>FreeSerif</chordSymbolBFontFace>
+      <romanNumeralFontFace>FreeSerif</romanNumeralFontFace>
+      <nashvilleNumberFontFace>FreeSerif</nashvilleNumberFontFace>
+      <nashvilleNumberFontSize>10</nashvilleNumberFontSize>
+      <tupletFontFace>FreeSerif</tupletFontFace>
+      <tupletFontSize>10</tupletFontSize>
+      <titleFontFace>FreeSerif</titleFontFace>
+      <subTitleFontFace>FreeSerif</subTitleFontFace>
+      <composerFontFace>FreeSerif</composerFontFace>
+      <lyricistFontFace>FreeSerif</lyricistFontFace>
+      <fingeringFontFace>FreeSerif</fingeringFontFace>
+      <fingeringFontSize>10</fingeringFontSize>
+      <lhGuitarFingeringFontFace>FreeSerif</lhGuitarFingeringFontFace>
+      <lhGuitarFingeringFontSize>10</lhGuitarFingeringFontSize>
+      <rhGuitarFingeringFontFace>FreeSerif</rhGuitarFingeringFontFace>
+      <rhGuitarFingeringFontSize>10</rhGuitarFingeringFontSize>
+      <stringNumberFontFace>FreeSerif</stringNumberFontFace>
+      <stringNumberFontSize>10</stringNumberFontSize>
+      <stringTuningsFontSize>10</stringTuningsFontSize>
+      <harpPedalDiagramFontFace>FreeSerif</harpPedalDiagramFontFace>
+      <harpPedalTextDiagramFontFace>FreeSerif</harpPedalTextDiagramFontFace>
+      <longInstrumentFontFace>FreeSerif</longInstrumentFontFace>
+      <shortInstrumentFontFace>FreeSerif</shortInstrumentFontFace>
+      <partInstrumentFontFace>FreeSerif</partInstrumentFontFace>
+      <partInstrumentFontSize>10</partInstrumentFontSize>
+      <expressionFontFace>FreeSerif</expressionFontFace>
+      <tempoFontFace>FreeSerif</tempoFontFace>
+      <tempoFontSize>10</tempoFontSize>
+      <tempoChangeFontFace>FreeSerif</tempoChangeFontFace>
+      <tempoChangeFontSize>10</tempoChangeFontSize>
+      <metronomeFontFace>FreeSerif</metronomeFontFace>
+      <metronomeFontSize>10</metronomeFontSize>
+      <measureNumberFontFace>FreeSerif</measureNumberFontFace>
+      <measureNumberFontSize>10</measureNumberFontSize>
+      <mmRestRangeFontFace>FreeSerif</mmRestRangeFontFace>
+      <mmRestRangeFontSize>10</mmRestRangeFontSize>
+      <translatorFontFace>FreeSerif</translatorFontFace>
+      <systemTextFontFace>FreeSerif</systemTextFontFace>
+      <staffTextFontFace>FreeSerif</staffTextFontFace>
+      <rehearsalMarkFontFace>FreeSerif</rehearsalMarkFontFace>
+      <rehearsalMarkFontSize>10</rehearsalMarkFontSize>
+      <repeatLeftFontFace>FreeSerif</repeatLeftFontFace>
+      <repeatLeftFontSize>10</repeatLeftFontSize>
+      <repeatRightFontFace>FreeSerif</repeatRightFontFace>
+      <repeatRightFontSize>10</repeatRightFontSize>
+      <frameFontFace>FreeSerif</frameFontFace>
+      <noteLineFontFace>FreeSerif</noteLineFontFace>
+      <glissandoFontFace>FreeSerif</glissandoFontFace>
+      <glissandoFontSize>10</glissandoFontSize>
+      <bendFontFace>FreeSerif</bendFontFace>
+      <bendFontSize>10</bendFontSize>
+      <headerFontFace>FreeSerif</headerFontFace>
+      <headerFontSize>10</headerFontSize>
+      <footerFontFace>FreeSerif</footerFontFace>
+      <footerFontSize>10</footerFontSize>
+      <copyrightFontFace>FreeSerif</copyrightFontFace>
+      <copyrightFontSize>10</copyrightFontSize>
+      <pageNumberFontFace>FreeSerif</pageNumberFontFace>
+      <pageNumberFontSize>10</pageNumberFontSize>
+      <instrumentChangeFontFace>FreeSerif</instrumentChangeFontFace>
+      <stickingFontFace>FreeSerif</stickingFontFace>
+      <user1FontFace>FreeSerif</user1FontFace>
+      <user2FontFace>FreeSerif</user2FontFace>
+      <user3FontFace>FreeSerif</user3FontFace>
+      <user4FontFace>FreeSerif</user4FontFace>
+      <user5FontFace>FreeSerif</user5FontFace>
+      <user6FontFace>FreeSerif</user6FontFace>
+      <user7FontFace>FreeSerif</user7FontFace>
+      <user8FontFace>FreeSerif</user8FontFace>
+      <user9FontFace>FreeSerif</user9FontFace>
+      <user10FontFace>FreeSerif</user10FontFace>
+      <user11FontFace>FreeSerif</user11FontFace>
+      <user12FontFace>FreeSerif</user12FontFace>
+      <spatium>1.764</spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer"></metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="source">http://musescore.com/score/658031</metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle"></metaTag>
+    <Part id="1">
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <bracket type="1" span="2" col="1" visible="1"/>
+        <barLineSpan>1</barLineSpan>
+        </Staff>
+      <Staff id="2">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        </Staff>
+      <trackName>Piano</trackName>
+      <Instrument id="piano">
+        <longName>Piano</longName>
+        <trackName>Piano</trackName>
+        <minPitchP>21</minPitchP>
+        <maxPitchP>108</maxPitchP>
+        <minPitchA>21</minPitchA>
+        <maxPitchA>108</maxPitchA>
+        <instrumentId>keyboard.piano</instrumentId>
+        <clef staff="2">F</clef>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>95</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>150</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="sforzatoStaccato">
+          <velocity>150</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoStaccato">
+          <velocity>120</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoTenuto">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="0"/>
+          <controller ctrl="10" value="63"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <VBox>
+        <height>10</height>
+        <Text>
+          <style>composer</style>
+          <family>Times New Roman</family>
+          <text><font size="12"/><font face="Times New Roman"/>Franz Liszt
+(1811 - 1886)</text>
+          </Text>
+        <Text>
+          <style>title</style>
+          <family>Times New Roman</family>
+          <offset x="0" y="-0.172872"/>
+          <text><font size="24"/><font face="Times New Roman"/>Mephisto Waltz No. 1</text>
+          </Text>
+        <Text>
+          <style>subtitle</style>
+          <family>Times New Roman</family>
+          <offset x="0" y="9.82548"/>
+          <text><font size="14"/><font face="Times New Roman"/>S. 514</text>
+          </Text>
+        </VBox>
+      <Measure len="4/8">
+        <voice>
+          <Clef>
+            <concertClefType>G</concertClefType>
+            <transposingClefType>G</transposingClefType>
+            <isHeader>1</isHeader>
+            </Clef>
+          <KeySig>
+            <concertKey>1</concertKey>
+            </KeySig>
+          <TimeSig>
+            <sigN>3</sigN>
+            <sigD>8</sigD>
+            </TimeSig>
+          <Fermata>
+            <subtype>fermataAbove</subtype>
+            </Fermata>
+          <Fermata>
+            <subtype>fermataAbove</subtype>
+            </Fermata>
+          <Fermata>
+            <subtype>fermataAbove</subtype>
+            </Fermata>
+          <Fermata>
+            <subtype>fermataAbove</subtype>
+            </Fermata>
+          <Tempo>
+            <tempo>3.233333</tempo>
+            <family>Times New Roman</family>
+            <text><font size="12"/><font face="Times New Roman"/><b>Allegro vivace (quasi presto)</b></text>
+            </Tempo>
+          <Chord>
+            <durationType>16th</durationType>
+            <grace16/>
+            <Note>
+              <Events>
+                <Event>
+                  <len>0</len>
+                  </Event>
+                </Events>
+              <pitch>83</pitch>
+              <tpc>19</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>half</durationType>
+            <StemDirection>down</StemDirection>
+            <Note>
+              <pitch>72</pitch>
+              <tpc>14</tpc>
+              </Note>
+            </Chord>
+          <BarLine>
+            <subtype>end</subtype>
+            </BarLine>
+          </voice>
+        </Measure>
+      </Staff>
+    <Staff id="2">
+      <Measure len="4/8">
+        <voice>
+          <Clef>
+            <concertClefType>F</concertClefType>
+            <transposingClefType>F</transposingClefType>
+            <isHeader>1</isHeader>
+            </Clef>
+          <KeySig>
+            <concertKey>1</concertKey>
+            </KeySig>
+          <TimeSig>
+            <sigN>3</sigN>
+            <sigD>8</sigD>
+            </TimeSig>
+          <Rest>
+            <visible>0</visible>
+            <durationType>measure</durationType>
+            <duration>4/8</duration>
+            </Rest>
+          <BarLine>
+            <subtype>end</subtype>
+            </BarLine>
+          </voice>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/src/importexport/musicxml/tests/data/testDuplicateFermataOnGraceNote_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testDuplicateFermataOnGraceNote_ref.mscx
@@ -1,0 +1,279 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="4.50">
+  <Score>
+    <Division>480</Division>
+    <Style>
+      <pageWidth>8.26774</pageWidth>
+      <pageHeight>11.6929</pageHeight>
+      <pagePrintableWidth>7.48034</pagePrintableWidth>
+      <pageEvenLeftMargin>0.3937</pageEvenLeftMargin>
+      <pageOddLeftMargin>0.3937</pageOddLeftMargin>
+      <pageEvenTopMargin>0.3937</pageEvenTopMargin>
+      <pageEvenBottomMargin>0.787404</pageEvenBottomMargin>
+      <pageOddTopMargin>0.3937</pageOddTopMargin>
+      <pageOddBottomMargin>0.787404</pageOddBottomMargin>
+      <lyricsOddFontFace>FreeSerif</lyricsOddFontFace>
+      <lyricsOddFontSize>11</lyricsOddFontSize>
+      <lyricsEvenFontFace>FreeSerif</lyricsEvenFontFace>
+      <lyricsEvenFontSize>11</lyricsEvenFontSize>
+      <chordSymbolAFontFace>FreeSerif</chordSymbolAFontFace>
+      <chordSymbolBFontFace>FreeSerif</chordSymbolBFontFace>
+      <romanNumeralFontFace>FreeSerif</romanNumeralFontFace>
+      <nashvilleNumberFontFace>FreeSerif</nashvilleNumberFontFace>
+      <nashvilleNumberFontSize>10</nashvilleNumberFontSize>
+      <tupletFontFace>FreeSerif</tupletFontFace>
+      <tupletFontSize>10</tupletFontSize>
+      <titleFontFace>FreeSerif</titleFontFace>
+      <subTitleFontFace>FreeSerif</subTitleFontFace>
+      <composerFontFace>FreeSerif</composerFontFace>
+      <lyricistFontFace>FreeSerif</lyricistFontFace>
+      <fingeringFontFace>FreeSerif</fingeringFontFace>
+      <fingeringFontSize>10</fingeringFontSize>
+      <lhGuitarFingeringFontFace>FreeSerif</lhGuitarFingeringFontFace>
+      <lhGuitarFingeringFontSize>10</lhGuitarFingeringFontSize>
+      <rhGuitarFingeringFontFace>FreeSerif</rhGuitarFingeringFontFace>
+      <rhGuitarFingeringFontSize>10</rhGuitarFingeringFontSize>
+      <stringNumberFontFace>FreeSerif</stringNumberFontFace>
+      <stringNumberFontSize>10</stringNumberFontSize>
+      <stringTuningsFontSize>10</stringTuningsFontSize>
+      <harpPedalDiagramFontFace>FreeSerif</harpPedalDiagramFontFace>
+      <harpPedalTextDiagramFontFace>FreeSerif</harpPedalTextDiagramFontFace>
+      <longInstrumentFontFace>FreeSerif</longInstrumentFontFace>
+      <shortInstrumentFontFace>FreeSerif</shortInstrumentFontFace>
+      <partInstrumentFontFace>FreeSerif</partInstrumentFontFace>
+      <partInstrumentFontSize>10</partInstrumentFontSize>
+      <expressionFontFace>FreeSerif</expressionFontFace>
+      <tempoFontFace>FreeSerif</tempoFontFace>
+      <tempoFontSize>10</tempoFontSize>
+      <tempoChangeFontFace>FreeSerif</tempoChangeFontFace>
+      <tempoChangeFontSize>10</tempoChangeFontSize>
+      <metronomeFontFace>FreeSerif</metronomeFontFace>
+      <metronomeFontSize>10</metronomeFontSize>
+      <measureNumberFontFace>FreeSerif</measureNumberFontFace>
+      <measureNumberFontSize>10</measureNumberFontSize>
+      <mmRestRangeFontFace>FreeSerif</mmRestRangeFontFace>
+      <mmRestRangeFontSize>10</mmRestRangeFontSize>
+      <translatorFontFace>FreeSerif</translatorFontFace>
+      <systemTextFontFace>FreeSerif</systemTextFontFace>
+      <staffTextFontFace>FreeSerif</staffTextFontFace>
+      <rehearsalMarkFontFace>FreeSerif</rehearsalMarkFontFace>
+      <rehearsalMarkFontSize>10</rehearsalMarkFontSize>
+      <repeatLeftFontFace>FreeSerif</repeatLeftFontFace>
+      <repeatLeftFontSize>10</repeatLeftFontSize>
+      <repeatRightFontFace>FreeSerif</repeatRightFontFace>
+      <repeatRightFontSize>10</repeatRightFontSize>
+      <frameFontFace>FreeSerif</frameFontFace>
+      <noteLineFontFace>FreeSerif</noteLineFontFace>
+      <glissandoFontFace>FreeSerif</glissandoFontFace>
+      <glissandoFontSize>10</glissandoFontSize>
+      <bendFontFace>FreeSerif</bendFontFace>
+      <bendFontSize>10</bendFontSize>
+      <headerFontFace>FreeSerif</headerFontFace>
+      <headerFontSize>10</headerFontSize>
+      <footerFontFace>FreeSerif</footerFontFace>
+      <footerFontSize>10</footerFontSize>
+      <copyrightFontFace>FreeSerif</copyrightFontFace>
+      <copyrightFontSize>10</copyrightFontSize>
+      <pageNumberFontFace>FreeSerif</pageNumberFontFace>
+      <pageNumberFontSize>10</pageNumberFontSize>
+      <instrumentChangeFontFace>FreeSerif</instrumentChangeFontFace>
+      <stickingFontFace>FreeSerif</stickingFontFace>
+      <user1FontFace>FreeSerif</user1FontFace>
+      <user2FontFace>FreeSerif</user2FontFace>
+      <user3FontFace>FreeSerif</user3FontFace>
+      <user4FontFace>FreeSerif</user4FontFace>
+      <user5FontFace>FreeSerif</user5FontFace>
+      <user6FontFace>FreeSerif</user6FontFace>
+      <user7FontFace>FreeSerif</user7FontFace>
+      <user8FontFace>FreeSerif</user8FontFace>
+      <user9FontFace>FreeSerif</user9FontFace>
+      <user10FontFace>FreeSerif</user10FontFace>
+      <user11FontFace>FreeSerif</user11FontFace>
+      <user12FontFace>FreeSerif</user12FontFace>
+      <spatium>1.764</spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer"></metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="source">http://musescore.com/score/658031</metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle"></metaTag>
+    <Part id="1">
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <bracket type="1" span="2" col="1" visible="1"/>
+        <barLineSpan>1</barLineSpan>
+        </Staff>
+      <Staff id="2">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        </Staff>
+      <trackName>Piano</trackName>
+      <Instrument id="piano">
+        <longName>Piano</longName>
+        <trackName>Piano</trackName>
+        <minPitchP>21</minPitchP>
+        <maxPitchP>108</maxPitchP>
+        <minPitchA>21</minPitchA>
+        <maxPitchA>108</maxPitchA>
+        <instrumentId>keyboard.piano</instrumentId>
+        <clef staff="2">F</clef>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>95</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>150</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="sforzatoStaccato">
+          <velocity>150</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoStaccato">
+          <velocity>120</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoTenuto">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="0"/>
+          <controller ctrl="10" value="63"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <VBox>
+        <height>10</height>
+        <Text>
+          <style>composer</style>
+          <family>Times New Roman</family>
+          <text><font size="12"/><font face="Times New Roman"/>Franz Liszt
+(1811 - 1886)</text>
+          </Text>
+        <Text>
+          <style>title</style>
+          <family>Times New Roman</family>
+          <offset x="0" y="-0.172872"/>
+          <text><font size="24"/><font face="Times New Roman"/>Mephisto Waltz No. 1</text>
+          </Text>
+        <Text>
+          <style>subtitle</style>
+          <family>Times New Roman</family>
+          <offset x="0" y="9.82548"/>
+          <text><font size="14"/><font face="Times New Roman"/>S. 514</text>
+          </Text>
+        </VBox>
+      <Measure len="4/8">
+        <voice>
+          <Clef>
+            <concertClefType>G</concertClefType>
+            <transposingClefType>G</transposingClefType>
+            <isHeader>1</isHeader>
+            </Clef>
+          <KeySig>
+            <concertKey>1</concertKey>
+            </KeySig>
+          <TimeSig>
+            <sigN>3</sigN>
+            <sigD>8</sigD>
+            </TimeSig>
+          <Fermata>
+            <subtype>fermataAbove</subtype>
+            </Fermata>
+          <Fermata>
+            <subtype>fermataAbove</subtype>
+            </Fermata>
+          <Tempo>
+            <tempo>3.233333</tempo>
+            <family>Times New Roman</family>
+            <text><font size="12"/><font face="Times New Roman"/><b>Allegro vivace (quasi presto)</b></text>
+            </Tempo>
+          <Chord>
+            <durationType>16th</durationType>
+            <grace16/>
+            <Note>
+              <Events>
+                <Event>
+                  <len>0</len>
+                  </Event>
+                </Events>
+              <pitch>83</pitch>
+              <tpc>19</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>half</durationType>
+            <StemDirection>down</StemDirection>
+            <Note>
+              <pitch>72</pitch>
+              <tpc>14</tpc>
+              </Note>
+            </Chord>
+          <BarLine>
+            <subtype>end</subtype>
+            </BarLine>
+          </voice>
+        </Measure>
+      </Staff>
+    <Staff id="2">
+      <Measure len="4/8">
+        <voice>
+          <Clef>
+            <concertClefType>F</concertClefType>
+            <transposingClefType>F</transposingClefType>
+            <isHeader>1</isHeader>
+            </Clef>
+          <KeySig>
+            <concertKey>1</concertKey>
+            </KeySig>
+          <TimeSig>
+            <sigN>3</sigN>
+            <sigD>8</sigD>
+            </TimeSig>
+          <Rest>
+            <visible>0</visible>
+            <durationType>measure</durationType>
+            <duration>4/8</duration>
+            </Rest>
+          <BarLine>
+            <subtype>end</subtype>
+            </BarLine>
+          </voice>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/src/importexport/musicxml/tests/musicxml_tests.cpp
+++ b/src/importexport/musicxml/tests/musicxml_tests.cpp
@@ -562,6 +562,12 @@ TEST_F(MusicXml_Tests, dsalCodaMisplaced) {
 TEST_F(MusicXml_Tests, durationLargeErrorMscx) {
     musicXmlImportTestRef("testDurationLargeError");
 }
+TEST_F(MusicXml_Tests, duplicateFermataOnGraceNote) {
+    musicXmlImportTestRef("testDuplicateFermataOnGraceNote");
+}
+TEST_F(MusicXml_Tests, duplicateFermataOnGraceNoteAndMainNote) {
+    musicXmlImportTestRef("testDuplicateFermataOnGraceNoteAndMainNote");
+}
 TEST_F(MusicXml_Tests, duplicateInstrChange) {
     musicXmlImportTestRef("testDuplicateInstrChange");
 }

--- a/src/palette/internal/palettecreator.cpp
+++ b/src/palette/internal/palettecreator.cpp
@@ -984,7 +984,7 @@ PalettePtr PaletteCreator::newBreathPalette(bool defaultPalette)
     // Breaths
 
     for (auto i : defaultPalette ? defaultFermatas : masterFermatas) {
-        auto f = Factory::makeFermata(gpaletteScore->dummy());
+        auto f = Factory::makeFermata(gpaletteScore->dummy()->segment());
         f->setSymIdAndTimeStretch(i);
         sp->appendElement(f, f->subtypeUserName());
     }


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/26593

See ChordRest::add/removeFermata and their usages: when reading a MusicXML file where there is a fermata on a grace note, the fermata is temporarily added to the grace chord, because there is no segment yet, and then later it is moved to the segment, which becomes the definitive parent of the fermata. If a MusicXML file contains _multiple_ fermatas on one grace note, then those fermatas except the first would _not_ be moved from the grace chord to the segment. This means that there are fermatas with no segment encountered during layout when going through that grace chord's `el()`, which causes a crash. The solution for now is to ensure that all fermatas are moved. A more definitive solution in the future might be to refactor out the `add/removeFermata` methods, because as the comment at their declaration already says, they really look like a hack. 

Inspired by the investigation at https://github.com/musescore/MuseScore/pull/26602.