### PR TITLE
26658: Vertically center percussions pads within the panel

### DIFF
--- a/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
+++ b/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
@@ -115,7 +115,7 @@ Item {
         width: Math.min(rowLayout.width, parent.width)
 
         contentWidth: rowLayout.width
-        contentHeight: rowLayout.height
+        contentHeight: rowLayout.height + rowLayout.anchors.topMargin
 
         StyledScrollBar.vertical: verticalScrollBar
 
@@ -152,6 +152,8 @@ Item {
             }
 
             height: padGrid.cellHeight * padGrid.numRows
+            anchors.top: parent.top
+            anchors.topMargin: Math.max((flickable.height - height) / 2, 0)
             spacing: padGrid.spacing / 2
 
             NavigationPanel {
@@ -240,10 +242,8 @@ Item {
                 property Item swapOriginPad: null
                 property bool isKeyboardSwapActive: false
 
-                Layout.alignment: Qt.AlignTop
-                Layout.fillHeight: true
-
                 width: cellWidth * numColumns
+                Layout.fillHeight: true
 
                 interactive: false
 
@@ -433,6 +433,7 @@ Item {
             visible: !percModel.enabled
 
             anchors.centerIn: parent
+            anchors.verticalCenterOffset: rowLayout.anchors.topMargin / 2
 
             font: ui.theme.bodyFont
             text: qsTrc("notation/percussion", "Select an unpitched percussion staff to see available sounds")


### PR DESCRIPTION
Resolves: #26658 

Here is what I came up with. Hope it is usable.

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
