### PR TITLE
correct barline on oneline to hidden staff

### DIFF
--- a/src/engraving/dom/barline.cpp
+++ b/src/engraving/dom/barline.cpp
@@ -501,7 +501,7 @@ void BarLine::calcY()
     bool oneLine = staffType1->lines() <= 1;
     if (oneLine && m_spanFrom == 0) {
         from = BARLINE_SPAN_1LINESTAFF_FROM;
-        if (!m_spanStaff || (staffIdx1 == nstaves - 1)) {
+        if (!m_spanStaff || (staffIdx1 == nstaves - 1) || (staffIdx2 == staffIdx1)) {
             to = BARLINE_SPAN_1LINESTAFF_TO;
         }
     }


### PR DESCRIPTION
Resolves main issue of #26675 (missing bottom half of single line staff barline) <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
