### PR TITLE
Fix Clang warning and potential bug

### DIFF
--- a/src/notation/internal/notationnoteinput.cpp
+++ b/src/notation/internal/notationnoteinput.cpp
@@ -591,7 +591,7 @@ void NotationNoteInput::moveInputNotes(bool up, PitchMode mode)
 
         switch (mode) {
         case PitchMode::CHROMATIC:
-            newVal.pitch = val.pitch + up ? 1 : -1;
+            newVal.pitch = val.pitch + (up ? 1 : -1);
             break;
         case PitchMode::DIATONIC: {
             const int oldLine = mu::engraving::noteValToLine(val, is.staff(), is.tick());


### PR DESCRIPTION
"Operator '?:' has lower precedence than '+'; '+' will be evaluated first"

Introduced by 6205752864d772a03f591c525c9d749534746624