### PR TITLE
Focus and accessibility improvements of Spin edit controls

### DIFF
--- a/src/framework/accessibility/iaccessible.h
+++ b/src/framework/accessibility/iaccessible.h
@@ -56,6 +56,7 @@ public:
         List,
         ListItem,
         MenuItem,
+        SpinBox,
         Range,
         Group,
 

--- a/src/framework/accessibility/internal/accessibleiteminterface.cpp
+++ b/src/framework/accessibility/internal/accessibleiteminterface.cpp
@@ -196,6 +196,10 @@ QAccessible::State AccessibleItemInterface::state() const
         state.focusable = true;
         state.focused = item->accessibleState(IAccessible::State::Focused);
     } break;
+    case IAccessible::Role::SpinBox: {
+        state.focusable = true;
+        state.focused = item->accessibleState(IAccessible::State::Focused);
+    } break;
     case IAccessible::Role::Range: {
         state.focusable = true;
         state.focused = item->accessibleState(IAccessible::State::Focused);
@@ -246,6 +250,7 @@ QAccessible::Role AccessibleItemInterface::role() const
     case IAccessible::Role::List: return QAccessible::List;
     case IAccessible::Role::ListItem: return QAccessible::ListItem;
     case IAccessible::Role::MenuItem: return QAccessible::MenuItem;
+    case IAccessible::Role::SpinBox: return QAccessible::SpinBox;
     case IAccessible::Role::Range: return QAccessible::Slider;
     case IAccessible::Role::Group:
     case IAccessible::Role::Information:

--- a/src/framework/ui/view/qmlaccessible.h
+++ b/src/framework/ui/view/qmlaccessible.h
@@ -60,8 +60,11 @@ public:
         List,
         ListItem,
         MenuItem,
+        SpinBox,
         Range,
-        Information
+        Group,
+        Information,
+        ElementOnScore
     };
     Q_ENUM(Role)
 };

--- a/src/framework/uicomponents/qml/Muse/UiComponents/IncrementalPropertyControl.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/IncrementalPropertyControl.qml
@@ -150,14 +150,22 @@ Item {
         anchors.top: parent.top
         anchors.bottom: parent.bottom
 
+        navigation.accessible.role: MUAccessible.SpinBox
+        navigation.accessible.value: currentValue + (measureUnitsSymbol !== "" ? " " + measureUnitsSymbol : "")
         navigation.onNavigationEvent: function(event) {
+            if (!textInputField.activeFocus) {
+                return
+            }
+
             switch (event.type) {
             case NavigationEvent.Up:
                 root.increment()
+                selectAll()
                 event.accepted = true
                 break
             case NavigationEvent.Down:
                 root.decrement()
+                selectAll()
                 event.accepted = true
                 break
             }
@@ -193,8 +201,8 @@ Item {
             canIncrease: root.canIncrease
             canDecrease: root.canDecrease
 
-            onIncreaseButtonClicked: { root.increment() }
-            onDecreaseButtonClicked: { root.decrement() }
+            onIncreaseButtonClicked: { root.increment(); textInputField.selectAll() }
+            onDecreaseButtonClicked: { root.decrement(); textInputField.selectAll() }
         }
 
         mouseArea.onWheel: function(wheel) {

--- a/src/framework/uicomponents/qml/Muse/UiComponents/TextInputField.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/TextInputField.qml
@@ -117,6 +117,9 @@ FocusScope {
                 root.ensureActiveFocus()
             }
         }
+
+        // Focus the text input field with Enter/Space when it is the navigation-active control.
+        onTriggered: root.ensureActiveFocus()
     }
 
     Rectangle {
@@ -189,6 +192,12 @@ FocusScope {
                         || event.key === Qt.Key_Escape) {
                     event.accepted = true
                     return
+                }
+
+                // Pass the UP/DOWN arrow keys on without defocusing the text input field
+                // to allow the containing control (e.g. IncrementalPropertyControl) to react to them.
+                if (event.key === Qt.Key_Up || event.key === Qt.Key_Down) {
+                    return;
                 }
 
                 if (textInputModel.isShortcutAllowedOverride(event.key, event.modifiers)) {

--- a/src/inspector/view/qml/MuseScore/Inspector/common/SpinBoxPropertyView.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/common/SpinBoxPropertyView.qml
@@ -52,7 +52,7 @@ InspectorPropertyView {
         navigation.name: root.navigationName + " Spinbox"
         navigation.panel: root.navigationPanel
         navigation.row: root.navigationRowStart + 1
-        navigation.accessible.name: root.titleText + " " + currentValue
+        navigation.accessible.name: root.titleText
 
         isIndeterminate: root.propertyItem ? root.propertyItem.isUndefined : true
         currentValue: root.propertyItem ? root.propertyItem.value : 0


### PR DESCRIPTION
Resolves: #13679

**Key points:**
1. I changed the accessibility role to SpinBox. My NVDA on Windows now says "Spin button" instead of "Edit".
2. NVDA does read out the new value on change. Since the issue is more than two years old, it will be good to retest it in other screen readers and confirm if they still do not read out the new value.
3. When the value is changed with the arrow buttons or the up/down arrow keys, the spin control will now _not_ lose the focus and will select all the text.
4. If ESC is pressed, the control will lose the focus as before. But if you then try to increase or decrease the value with the up/down arrow keys it won't work. You can however press Space or Enter to focus the control again and change the value further as much as you want.

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
