### PR TITLE
Fix crash with page break on vertical frame

### DIFF
--- a/src/engraving/dom/engravingitem.cpp
+++ b/src/engraving/dom/engravingitem.cpp
@@ -441,7 +441,7 @@ staff_idx_t EngravingItem::effectiveStaffIdx() const
     }
 
     const System* system = toSystem(findAncestor(ElementType::SYSTEM));
-    if (!system) {
+    if (!system || system->vbox()) {
         return vStaffIdx();
     }
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/26672

The problem is that on a VBox system, `system->staff(originalStaffIdx)` will return nullptr because for such a system `m_staves` is empty. Not very sure if this is the right solution though.