### PR TITLE
Fix #26523: Crash on deleting instrument if last staff contains fretboard diagram 

### DIFF
--- a/src/engraving/dom/fret.cpp
+++ b/src/engraving/dom/fret.cpp
@@ -896,6 +896,15 @@ PropertyValue FretDiagram::propertyDefault(Pid pid) const
     return EngravingItem::propertyDefault(pid);
 }
 
+void FretDiagram::setTrack(track_idx_t val)
+{
+    EngravingItem::setTrack(val);
+
+    if (m_harmony) {
+        m_harmony->setTrack(val);
+    }
+}
+
 //---------------------------------------------------------
 //   endEditDrag
 //---------------------------------------------------------

--- a/src/engraving/dom/fret.h
+++ b/src/engraving/dom/fret.h
@@ -235,6 +235,8 @@ public:
     bool setProperty(Pid propertyId, const PropertyValue&) override;
     PropertyValue propertyDefault(Pid) const override;
 
+    void setTrack(track_idx_t val) override;
+
     String accessibleInfo() const override;
     String screenReaderInfo() const override;
 

--- a/src/engraving/dom/harmony.cpp
+++ b/src/engraving/dom/harmony.cpp
@@ -1073,9 +1073,12 @@ const ChordDescription* Harmony::getDescription(const String& name, const Parsed
 
 const RealizedHarmony& Harmony::getRealizedHarmony() const
 {
-    Fraction tick = this->tick();
     const Staff* st = staff();
+    IF_ASSERT_FAILED(st) {
+        return m_realizedHarmony;
+    }
 
+    const Fraction tick = this->tick();
     const CapoParams& capo = st->capo(tick);
 
     int offset = 0;
@@ -1091,7 +1094,7 @@ const RealizedHarmony& Harmony::getRealizedHarmony() const
     //Adjust for Nashville Notation, might be temporary
     // TODO: set dirty on add/remove of keysig
     if (m_harmonyType == HarmonyType::NASHVILLE && !m_realizedHarmony.valid()) {
-        Key key = staff()->key(tick);
+        Key key = st->key(tick);
 
         //parse root
         int rootTpc = function2Tpc(m_function, key);

--- a/src/engraving/playback/playbackeventsrenderer.cpp
+++ b/src/engraving/playback/playbackeventsrenderer.cpp
@@ -116,6 +116,11 @@ void PlaybackEventsRenderer::renderChordSymbol(const Harmony* chordSymbol,
         return;
     }
 
+    const Staff* staff = chordSymbol->staff();
+    IF_ASSERT_FAILED(staff) {
+        return;
+    }
+
     const RealizedHarmony& realized = chordSymbol->getRealizedHarmony();
     const RealizedHarmony::PitchMap& notes = realized.notes();
 
@@ -130,7 +135,7 @@ void PlaybackEventsRenderer::renderChordSymbol(const Harmony* chordSymbol,
 
     voice_layer_idx_t voiceIdx = static_cast<voice_layer_idx_t>(chordSymbol->voice());
     staff_layer_idx_t staffIdx = static_cast<staff_layer_idx_t>(chordSymbol->staffIdx());
-    Key key = chordSymbol->staff()->key(chordSymbol->tick());
+    Key key = staff->key(chordSymbol->tick());
 
     ArticulationMap articulations = makeStandardArticulationMap(profile, eventTimestamp, duration);
 
@@ -161,6 +166,11 @@ void PlaybackEventsRenderer::renderChordSymbol(const Harmony* chordSymbol, const
         return;
     }
 
+    const Staff* staff = chordSymbol->staff();
+    IF_ASSERT_FAILED(staff) {
+        return;
+    }
+
     const RealizedHarmony& realized = chordSymbol->getRealizedHarmony();
     const RealizedHarmony::PitchMap& notes = realized.notes();
 
@@ -168,8 +178,7 @@ void PlaybackEventsRenderer::renderChordSymbol(const Harmony* chordSymbol, const
 
     voice_layer_idx_t voiceIdx = static_cast<voice_layer_idx_t>(chordSymbol->voice());
     staff_layer_idx_t staffIdx = static_cast<staff_layer_idx_t>(chordSymbol->staffIdx());
-
-    Key key = chordSymbol->staff()->key(chordSymbol->tick());
+    Key key = staff->key(chordSymbol->tick());
 
     ArticulationMap articulations = makeStandardArticulationMap(profile, actualTimestamp, actualDuration);
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/26523