### PR TITLE
Fix #26514: Show normal noteheads first when hovering percussion staves

### DIFF
--- a/src/engraving/dom/drumset.cpp
+++ b/src/engraving/dom/drumset.cpp
@@ -40,6 +40,11 @@ using namespace mu::engraving;
 namespace mu::engraving {
 Drumset* smDrumset = nullptr;           // standard midi drumset
 
+bool Drumset::isValid(int pitch) const
+{
+    return pitch >= 0 && pitch < DRUM_INSTRUMENTS && !m_drums[pitch].name.empty();
+}
+
 String Drumset::translatedName(int pitch) const
 {
     return muse::mtrc("engraving/drumset", name(pitch));
@@ -64,6 +69,26 @@ int Drumset::pitchForShortcut(const String& shortcut) const
     }
 
     return -1;
+}
+
+int Drumset::defaultPitchForLine(int val) const
+{
+    int firstValidPitch = -1;
+    for (int pitch = 0; pitch < DRUM_INSTRUMENTS; ++pitch) {
+        if (!isValid(pitch) || line(pitch) != val) {
+            continue;
+        }
+
+        if (firstValidPitch < 0) {
+            firstValidPitch = pitch;
+        }
+
+        const NoteHeadGroup headGroup = noteHead(pitch);
+        if (headGroup == NoteHeadGroup::HEAD_NORMAL) {
+            return pitch;
+        }
+    }
+    return firstValidPitch;
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/drumset.h
+++ b/src/engraving/dom/drumset.h
@@ -102,7 +102,7 @@ static const int DRUM_INSTRUMENTS = 128;
 class Drumset
 {
 public:
-    bool isValid(int pitch) const { return !m_drums[pitch].name.empty(); }
+    bool isValid(int pitch) const;
     NoteHeadGroup noteHead(int pitch) const { return m_drums[pitch].notehead; }
     SymId noteHeads(int pitch, NoteHeadType t) const { return m_drums[pitch].noteheads[int(t)]; }
     int line(int pitch) const { return m_drums[pitch].line; }
@@ -116,6 +116,10 @@ public:
     int panelColumn(int pitch) const { return m_drums[pitch].panelColumn; }
 
     int pitchForShortcut(const String& shortcut) const;
+
+    // defaultPitchForLine tries to find the pitch of a normal notehead at "line". If a normal notehead can't be found it will
+    // instead return the "first valid pitch" (i.e. the lowest used midi note)
+    int defaultPitchForLine(int line) const;
 
     void save(XmlWriter&) const;
     void load(XmlReader&);

--- a/src/engraving/dom/noteentry.cpp
+++ b/src/engraving/dom/noteentry.cpp
@@ -81,14 +81,11 @@ NoteVal Score::noteValForPosition(Position pos, AccidentalType at, bool& error)
         }
         const Drumset* ds = instr->drumset();
         nval.pitch = m_is.drumNote();
-        if (nval.pitch < 0 || !ds->isValid(nval.pitch) || ds->line(nval.pitch) != line) {
+        if (!ds->isValid(nval.pitch) || ds->line(nval.pitch) != line) {
             // Drum note from input state is not valid - fall back to the first valid pitch for this line...
-            for (int pitch = 0; pitch < mu::engraving::DRUM_INSTRUMENTS; ++pitch) {
-                if (!ds->isValid(pitch) || ds->line(pitch) != line) {
-                    continue;
-                }
-                nval.pitch = pitch;
-                break;
+            const int defaultPitch = ds->defaultPitchForLine(line);
+            if (ds->isValid(defaultPitch)) {
+                nval.pitch = defaultPitch;
             }
         }
         if (nval.pitch < 0) {

--- a/src/importexport/ove/internal/importove.cpp
+++ b/src/importexport/ove/internal/importove.cpp
@@ -1627,7 +1627,7 @@ void OveToMScore::convertNotes(Measure* measure, int part, int staff, int track)
                 if (clefType == ovebase::ClefType::Percussion1 || clefType == ovebase::ClefType::Percussion2) {
                     Drumset* drumset = getDrumset(m_score, part);
                     if (drumset != 0) {
-                        if (!drumset->isValid(pitch) || pitch == -1) {
+                        if (!drumset->isValid(pitch)) {
                             LOGD("unmapped drum note 0x%02x %d", note->pitch(), note->pitch());
                         } else {
                             note->setHeadGroup(drumset->noteHead(pitch));

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -450,18 +450,16 @@ bool NotationInteraction::showShadowNote(ShadowNote& shadowNote, ShadowNoteParam
 
         const int noteInputPitch = inputState.drumNote();
 
-        if (noteInputPitch > 0 && ds->isValid(noteInputPitch) && ds->line(noteInputPitch) == line) {
+        if (ds->isValid(noteInputPitch) && ds->line(noteInputPitch) == line) {
             noteheadGroup = ds->noteHead(noteInputPitch);
             voice = ds->voice(noteInputPitch);
             drumNotePitch = noteInputPitch;
         } else {
-            for (int pitch = 0; pitch < mu::engraving::DRUM_INSTRUMENTS; ++pitch) {
-                if (ds->isValid(pitch) && ds->line(pitch) == line) {
-                    noteheadGroup = ds->noteHead(pitch);
-                    voice = ds->voice(pitch);
-                    drumNotePitch = pitch;
-                    break;
-                }
+            const int pitch = ds->defaultPitchForLine(line);
+            if (ds->isValid(pitch)) {
+                noteheadGroup = ds->noteHead(pitch);
+                voice = ds->voice(pitch);
+                drumNotePitch = pitch;
             }
             if (drumNotePitch < 0) {
                 shadowNote.setVisible(false);

--- a/src/notation/utilities/percussionutilities.cpp
+++ b/src/notation/utilities/percussionutilities.cpp
@@ -121,7 +121,7 @@ void PercussionUtilities::editPercussionShortcut(Drumset& drumset, int originPit
     drumset.drum(originPitch).shortcut = vals.value("newShortcut").toString();
 
     const int conflictShortcutPitch = vals.value("conflictDrumPitch").toInt();
-    if (conflictShortcutPitch > -1 && drumset.isValid(conflictShortcutPitch)) {
+    if (drumset.isValid(conflictShortcutPitch)) {
         drumset.drum(conflictShortcutPitch).shortcut.clear();
     }
 }

--- a/src/notation/view/internal/percussionnotepopupcontentmodel.cpp
+++ b/src/notation/view/internal/percussionnotepopupcontentmodel.cpp
@@ -191,17 +191,9 @@ int PercussionNotePopupContentModel::currentDrumPitch() const
 
     //  First check whether a drum note has been specified in the input state, and whether it's valid...
     const int noteInputPitch = noteInput()->state().drumNote();
-    if (noteInputPitch > 0 && ds->isValid(noteInputPitch) && ds->line(noteInputPitch) == shadowNoteLine) {
+    if (ds->isValid(noteInputPitch) && ds->line(noteInputPitch) == shadowNoteLine) {
         return noteInputPitch;
     }
 
-    // Otherwise just return the first pitch that matches the line that the shadowNote is currently on...
-    for (int pitch = 0; pitch < mu::engraving::DRUM_INSTRUMENTS; ++pitch) {
-        if (!ds->isValid(pitch) || ds->line(pitch) != shadowNoteLine) {
-            continue;
-        }
-        return pitch;
-    }
-
-    return -1;
+    return ds->defaultPitchForLine(shadowNoteLine);
 }


### PR DESCRIPTION
Resolves: #26514