### PR TITLE
Fix crash on opening specific file

### DIFF
--- a/src/engraving/dom/stringdata.cpp
+++ b/src/engraving/dom/stringdata.cpp
@@ -364,9 +364,7 @@ bool StringData::convertPitch(int pitch, int pitchOffset, int* string, int* fret
         for (int i = strings - 1; i >= 0; i--) {
             instrString strg = m_stringTable.at(i);
             if (pitch >= strg.pitch) {
-                if (pitch == strg.pitch || !strg.open) {
-                    *string = strings - i - 1;
-                }
+                *string = strings - i - 1;
                 *fret = pitch - strg.pitch;
                 return true;
             }

--- a/src/engraving/dom/volta.cpp
+++ b/src/engraving/dom/volta.cpp
@@ -360,7 +360,11 @@ PointF Volta::linePos(Grip grip, System** system) const
         x += (isAtSystemStart ? 0.5 : -0.5) * absoluteFromSpatium(lineWidth());
     } else {
         if ((*system) && segment->tick() == (*system)->endTick()) {
-            x += segment->staffShape(backSegment()->effectiveStaffIdx()).right();
+            staff_idx_t si = backSegment()->effectiveStaffIdx();
+            if (si == muse::nidx) {
+                return PointF(x, 0.0);
+            }
+            x += segment->staffShape(si).right();
             x -= 0.5 * absoluteFromSpatium(lineWidth());
         } else if (segment->segmentType() & SegmentType::BarLineType) {
             BarLine* barLine = toBarLine(segment->elementAt(track()));


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/26696

There were two different problems, fixed in two different commits, and I'm not very confident about both of them. 

For the Volta one, I'd think that code should not even be called at all when `effectiveStaffIdx` is muse::nidx, but I found it difficult to figure out where to put such a check. 

For the StringData one, I have no idea why that `if` condition was there, and I'm also not very certain about the consequences of this change, but at least it fixes this particular crash...