### PR TITLE
DrumInstrument constructor: take name as String instead of const char*

### DIFF
--- a/src/engraving/dom/drumset.h
+++ b/src/engraving/dom/drumset.h
@@ -20,14 +20,10 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef MU_ENGRAVING_DRUMSET_H
-#define MU_ENGRAVING_DRUMSET_H
+#pragma once
 
-#include "mscore.h"
 #include "pitchspelling.h"
 #include "../types/types.h"
-
-#include "editdata.h"
 
 namespace mu::engraving {
 class XmlWriter;
@@ -70,9 +66,9 @@ struct DrumInstrument {
     std::list<DrumInstrumentVariant> variants;
 
     DrumInstrument() {}
-    DrumInstrument(const char* s, NoteHeadGroup nh, int l, DirectionV d,
+    DrumInstrument(const String& n, NoteHeadGroup nh, int l, DirectionV d,
                    int pr = -1, int pc = -1, int v = 0, String sc = String())
-        : name(String::fromUtf8(s)), notehead(nh), line(l), stemDirection(d), panelRow(pr), panelColumn(pc), voice(v), shortcut(sc) {}
+        : name(n), notehead(nh), line(l), stemDirection(d), panelRow(pr), panelColumn(pc), voice(v), shortcut(sc) {}
 
     void addVariant(DrumInstrumentVariant v) { variants.push_back(v); }
 
@@ -152,4 +148,3 @@ private:
 
 extern Drumset* smDrumset;
 } // namespace mu::engraving
-#endif

--- a/src/engraving/types/typesconv.cpp
+++ b/src/engraving/types/typesconv.cpp
@@ -2433,96 +2433,96 @@ ChordLineType TConv::fromXml(const AsciiStringView& tag, ChordLineType def)
 
 struct DrumPitchItem {
     DrumNum num = DrumNum(0);
-    const char* userName;
+    String userName;
 };
 
 // TODO: Can't use TranslatableString, because Drumset uses these strings and doesn't support TranslatableString
 static const std::vector<DrumPitchItem> DRUMPITCHS = {
-    { DrumNum(27),       QT_TRANSLATE_NOOP("engraving/drumset", "High Q") },
-    { DrumNum(28),       QT_TRANSLATE_NOOP("engraving/drumset", "Slap") },
-    { DrumNum(29),       QT_TRANSLATE_NOOP("engraving/drumset", "Scratch Push") },
+    { DrumNum(27),       QT_TRANSLATE_NOOP("engraving/drumset", u"High Q") },
+    { DrumNum(28),       QT_TRANSLATE_NOOP("engraving/drumset", u"Slap") },
+    { DrumNum(29),       QT_TRANSLATE_NOOP("engraving/drumset", u"Scratch Push") },
 
-    { DrumNum(30),       QT_TRANSLATE_NOOP("engraving/drumset", "Scratch Pull") },
-    { DrumNum(31),       QT_TRANSLATE_NOOP("engraving/drumset", "Sticks") },
-    { DrumNum(32),       QT_TRANSLATE_NOOP("engraving/drumset", "Square Click") },
-    { DrumNum(33),       QT_TRANSLATE_NOOP("engraving/drumset", "Metronome Click") },
-    { DrumNum(34),       QT_TRANSLATE_NOOP("engraving/drumset", "Metronome Bell") },
-    { DrumNum(35),       QT_TRANSLATE_NOOP("engraving/drumset", "Acoustic Bass Drum") },
-    { DrumNum(36),       QT_TRANSLATE_NOOP("engraving/drumset", "Bass Drum 1") },
-    { DrumNum(37),       QT_TRANSLATE_NOOP("engraving/drumset", "Side Stick") },
-    { DrumNum(38),       QT_TRANSLATE_NOOP("engraving/drumset", "Acoustic Snare") },
-    { DrumNum(39),       QT_TRANSLATE_NOOP("engraving/drumset", "Hand Clap") },
+    { DrumNum(30),       QT_TRANSLATE_NOOP("engraving/drumset", u"Scratch Pull") },
+    { DrumNum(31),       QT_TRANSLATE_NOOP("engraving/drumset", u"Sticks") },
+    { DrumNum(32),       QT_TRANSLATE_NOOP("engraving/drumset", u"Square Click") },
+    { DrumNum(33),       QT_TRANSLATE_NOOP("engraving/drumset", u"Metronome Click") },
+    { DrumNum(34),       QT_TRANSLATE_NOOP("engraving/drumset", u"Metronome Bell") },
+    { DrumNum(35),       QT_TRANSLATE_NOOP("engraving/drumset", u"Acoustic Bass Drum") },
+    { DrumNum(36),       QT_TRANSLATE_NOOP("engraving/drumset", u"Bass Drum 1") },
+    { DrumNum(37),       QT_TRANSLATE_NOOP("engraving/drumset", u"Side Stick") },
+    { DrumNum(38),       QT_TRANSLATE_NOOP("engraving/drumset", u"Acoustic Snare") },
+    { DrumNum(39),       QT_TRANSLATE_NOOP("engraving/drumset", u"Hand Clap") },
 
-    { DrumNum(40),       QT_TRANSLATE_NOOP("engraving/drumset", "Electric Snare") },
-    { DrumNum(41),       QT_TRANSLATE_NOOP("engraving/drumset", "Low Floor Tom") },
-    { DrumNum(42),       QT_TRANSLATE_NOOP("engraving/drumset", "Closed Hi-Hat") },
-    { DrumNum(43),       QT_TRANSLATE_NOOP("engraving/drumset", "High Floor Tom") },
-    { DrumNum(44),       QT_TRANSLATE_NOOP("engraving/drumset", "Pedal Hi-Hat") },
-    { DrumNum(45),       QT_TRANSLATE_NOOP("engraving/drumset", "Low Tom") },
-    { DrumNum(46),       QT_TRANSLATE_NOOP("engraving/drumset", "Open Hi-Hat") },
-    { DrumNum(47),       QT_TRANSLATE_NOOP("engraving/drumset", "Low-Mid Tom") },
-    { DrumNum(48),       QT_TRANSLATE_NOOP("engraving/drumset", "Hi-Mid Tom") },
-    { DrumNum(49),       QT_TRANSLATE_NOOP("engraving/drumset", "Crash Cymbal 1") },
+    { DrumNum(40),       QT_TRANSLATE_NOOP("engraving/drumset", u"Electric Snare") },
+    { DrumNum(41),       QT_TRANSLATE_NOOP("engraving/drumset", u"Low Floor Tom") },
+    { DrumNum(42),       QT_TRANSLATE_NOOP("engraving/drumset", u"Closed Hi-Hat") },
+    { DrumNum(43),       QT_TRANSLATE_NOOP("engraving/drumset", u"High Floor Tom") },
+    { DrumNum(44),       QT_TRANSLATE_NOOP("engraving/drumset", u"Pedal Hi-Hat") },
+    { DrumNum(45),       QT_TRANSLATE_NOOP("engraving/drumset", u"Low Tom") },
+    { DrumNum(46),       QT_TRANSLATE_NOOP("engraving/drumset", u"Open Hi-Hat") },
+    { DrumNum(47),       QT_TRANSLATE_NOOP("engraving/drumset", u"Low-Mid Tom") },
+    { DrumNum(48),       QT_TRANSLATE_NOOP("engraving/drumset", u"Hi-Mid Tom") },
+    { DrumNum(49),       QT_TRANSLATE_NOOP("engraving/drumset", u"Crash Cymbal 1") },
 
-    { DrumNum(50),       QT_TRANSLATE_NOOP("engraving/drumset", "High Tom") },
-    { DrumNum(51),       QT_TRANSLATE_NOOP("engraving/drumset", "Ride Cymbal 1") },
-    { DrumNum(52),       QT_TRANSLATE_NOOP("engraving/drumset", "Chinese Cymbal") },
-    { DrumNum(53),       QT_TRANSLATE_NOOP("engraving/drumset", "Ride Bell") },
-    { DrumNum(54),       QT_TRANSLATE_NOOP("engraving/drumset", "Tambourine") },
-    { DrumNum(55),       QT_TRANSLATE_NOOP("engraving/drumset", "Splash Cymbal") },
-    { DrumNum(56),       QT_TRANSLATE_NOOP("engraving/drumset", "Cowbell") },
-    { DrumNum(57),       QT_TRANSLATE_NOOP("engraving/drumset", "Crash Cymbal 2") },
-    { DrumNum(58),       QT_TRANSLATE_NOOP("engraving/drumset", "Vibraslap") },
-    { DrumNum(59),       QT_TRANSLATE_NOOP("engraving/drumset", "Ride Cymbal 2") },
+    { DrumNum(50),       QT_TRANSLATE_NOOP("engraving/drumset", u"High Tom") },
+    { DrumNum(51),       QT_TRANSLATE_NOOP("engraving/drumset", u"Ride Cymbal 1") },
+    { DrumNum(52),       QT_TRANSLATE_NOOP("engraving/drumset", u"Chinese Cymbal") },
+    { DrumNum(53),       QT_TRANSLATE_NOOP("engraving/drumset", u"Ride Bell") },
+    { DrumNum(54),       QT_TRANSLATE_NOOP("engraving/drumset", u"Tambourine") },
+    { DrumNum(55),       QT_TRANSLATE_NOOP("engraving/drumset", u"Splash Cymbal") },
+    { DrumNum(56),       QT_TRANSLATE_NOOP("engraving/drumset", u"Cowbell") },
+    { DrumNum(57),       QT_TRANSLATE_NOOP("engraving/drumset", u"Crash Cymbal 2") },
+    { DrumNum(58),       QT_TRANSLATE_NOOP("engraving/drumset", u"Vibraslap") },
+    { DrumNum(59),       QT_TRANSLATE_NOOP("engraving/drumset", u"Ride Cymbal 2") },
 
-    { DrumNum(60),       QT_TRANSLATE_NOOP("engraving/drumset", "Hi Bongo") },
-    { DrumNum(61),       QT_TRANSLATE_NOOP("engraving/drumset", "Low Bongo") },
-    { DrumNum(62),       QT_TRANSLATE_NOOP("engraving/drumset", "Mute Hi Conga") },
-    { DrumNum(63),       QT_TRANSLATE_NOOP("engraving/drumset", "Open Hi Conga") },
-    { DrumNum(64),       QT_TRANSLATE_NOOP("engraving/drumset", "Low Conga") },
-    { DrumNum(65),       QT_TRANSLATE_NOOP("engraving/drumset", "High Timbale") },
-    { DrumNum(66),       QT_TRANSLATE_NOOP("engraving/drumset", "Low Timbale") },
-    { DrumNum(67),       QT_TRANSLATE_NOOP("engraving/drumset", "High Agogo") },
-    { DrumNum(68),       QT_TRANSLATE_NOOP("engraving/drumset", "Low Agogo") },
-    { DrumNum(69),       QT_TRANSLATE_NOOP("engraving/drumset", "Cabasa") },
+    { DrumNum(60),       QT_TRANSLATE_NOOP("engraving/drumset", u"Hi Bongo") },
+    { DrumNum(61),       QT_TRANSLATE_NOOP("engraving/drumset", u"Low Bongo") },
+    { DrumNum(62),       QT_TRANSLATE_NOOP("engraving/drumset", u"Mute Hi Conga") },
+    { DrumNum(63),       QT_TRANSLATE_NOOP("engraving/drumset", u"Open Hi Conga") },
+    { DrumNum(64),       QT_TRANSLATE_NOOP("engraving/drumset", u"Low Conga") },
+    { DrumNum(65),       QT_TRANSLATE_NOOP("engraving/drumset", u"High Timbale") },
+    { DrumNum(66),       QT_TRANSLATE_NOOP("engraving/drumset", u"Low Timbale") },
+    { DrumNum(67),       QT_TRANSLATE_NOOP("engraving/drumset", u"High Agogo") },
+    { DrumNum(68),       QT_TRANSLATE_NOOP("engraving/drumset", u"Low Agogo") },
+    { DrumNum(69),       QT_TRANSLATE_NOOP("engraving/drumset", u"Cabasa") },
 
-    { DrumNum(70),       QT_TRANSLATE_NOOP("engraving/drumset", "Maracas") },
-    { DrumNum(71),       QT_TRANSLATE_NOOP("engraving/drumset", "Short Whistle") },
-    { DrumNum(72),       QT_TRANSLATE_NOOP("engraving/drumset", "Long Whistle") },
-    { DrumNum(73),       QT_TRANSLATE_NOOP("engraving/drumset", "Short Güiro") },
-    { DrumNum(74),       QT_TRANSLATE_NOOP("engraving/drumset", "Long Güiro") },
-    { DrumNum(75),       QT_TRANSLATE_NOOP("engraving/drumset", "Claves") },
-    { DrumNum(76),       QT_TRANSLATE_NOOP("engraving/drumset", "Hi Wood Block") },
-    { DrumNum(77),       QT_TRANSLATE_NOOP("engraving/drumset", "Low Wood Block") },
-    { DrumNum(78),       QT_TRANSLATE_NOOP("engraving/drumset", "Mute Cuica") },
-    { DrumNum(79),       QT_TRANSLATE_NOOP("engraving/drumset", "Open Cuica") },
+    { DrumNum(70),       QT_TRANSLATE_NOOP("engraving/drumset", u"Maracas") },
+    { DrumNum(71),       QT_TRANSLATE_NOOP("engraving/drumset", u"Short Whistle") },
+    { DrumNum(72),       QT_TRANSLATE_NOOP("engraving/drumset", u"Long Whistle") },
+    { DrumNum(73),       QT_TRANSLATE_NOOP("engraving/drumset", u"Short Güiro") },
+    { DrumNum(74),       QT_TRANSLATE_NOOP("engraving/drumset", u"Long Güiro") },
+    { DrumNum(75),       QT_TRANSLATE_NOOP("engraving/drumset", u"Claves") },
+    { DrumNum(76),       QT_TRANSLATE_NOOP("engraving/drumset", u"Hi Wood Block") },
+    { DrumNum(77),       QT_TRANSLATE_NOOP("engraving/drumset", u"Low Wood Block") },
+    { DrumNum(78),       QT_TRANSLATE_NOOP("engraving/drumset", u"Mute Cuica") },
+    { DrumNum(79),       QT_TRANSLATE_NOOP("engraving/drumset", u"Open Cuica") },
 
-    { DrumNum(80),       QT_TRANSLATE_NOOP("engraving/drumset", "Mute Triangle") },
-    { DrumNum(81),       QT_TRANSLATE_NOOP("engraving/drumset", "Open Triangle") },
-    { DrumNum(82),       QT_TRANSLATE_NOOP("engraving/drumset", "Shaker") },
-    { DrumNum(83),       QT_TRANSLATE_NOOP("engraving/drumset", "Sleigh Bell") },
-    { DrumNum(84),       QT_TRANSLATE_NOOP("engraving/drumset", "Mark Tree") },
-    { DrumNum(85),       QT_TRANSLATE_NOOP("engraving/drumset", "Castanets") },
-    { DrumNum(86),       QT_TRANSLATE_NOOP("engraving/drumset", "Mute Surdo") },
-    { DrumNum(87),       QT_TRANSLATE_NOOP("engraving/drumset", "Open Surdo") },
+    { DrumNum(80),       QT_TRANSLATE_NOOP("engraving/drumset", u"Mute Triangle") },
+    { DrumNum(81),       QT_TRANSLATE_NOOP("engraving/drumset", u"Open Triangle") },
+    { DrumNum(82),       QT_TRANSLATE_NOOP("engraving/drumset", u"Shaker") },
+    { DrumNum(83),       QT_TRANSLATE_NOOP("engraving/drumset", u"Sleigh Bell") },
+    { DrumNum(84),       QT_TRANSLATE_NOOP("engraving/drumset", u"Mark Tree") },
+    { DrumNum(85),       QT_TRANSLATE_NOOP("engraving/drumset", u"Castanets") },
+    { DrumNum(86),       QT_TRANSLATE_NOOP("engraving/drumset", u"Mute Surdo") },
+    { DrumNum(87),       QT_TRANSLATE_NOOP("engraving/drumset", u"Open Surdo") },
 
-    { DrumNum(91),       QT_TRANSLATE_NOOP("engraving/drumset", "Snare (Rim shot)") },
+    { DrumNum(91),       QT_TRANSLATE_NOOP("engraving/drumset", u"Snare (Rim shot)") },
 
-    { DrumNum(93),       QT_TRANSLATE_NOOP("engraving/drumset", "Ride (Edge)") },
+    { DrumNum(93),       QT_TRANSLATE_NOOP("engraving/drumset", u"Ride (Edge)") },
 
-    { DrumNum(99),       QT_TRANSLATE_NOOP("engraving/drumset", "Cowbell Low") },
+    { DrumNum(99),       QT_TRANSLATE_NOOP("engraving/drumset", u"Cowbell Low") },
 
-    { DrumNum(102),      QT_TRANSLATE_NOOP("engraving/drumset", "Cowbell High") },
+    { DrumNum(102),      QT_TRANSLATE_NOOP("engraving/drumset", u"Cowbell High") },
 };
 
-const char* TConv::userName(DrumNum v)
+const String& TConv::userName(DrumNum v)
 {
     auto it = std::find_if(DRUMPITCHS.cbegin(), DRUMPITCHS.cend(), [v](const DrumPitchItem& i) {
         return i.num == v;
     });
 
     IF_ASSERT_FAILED(it != DRUMPITCHS.cend()) {
-        static const char* dummy = "";
+        static const String dummy;
         return dummy;
     }
     return it->userName;

--- a/src/engraving/types/typesconv.h
+++ b/src/engraving/types/typesconv.h
@@ -191,7 +191,7 @@ public:
     static AsciiStringView toXml(ChordLineType v);
     static ChordLineType fromXml(const AsciiStringView& tag, ChordLineType def);
 
-    static const char* userName(DrumNum v);
+    static const String& userName(DrumNum v);
 
     static const TranslatableString& userName(GlissandoType v);
     static AsciiStringView toXml(GlissandoType v);

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -460,9 +460,8 @@ static void initDrumset(Drumset* drumset, const MusicXmlInstruments& instruments
         //LOGD("initDrumset: instrument: %s %s", muPrintable(ii.key()), muPrintable(ii.value().toString()));
         int unpitched = ii.second.unpitched;
         if (0 <= unpitched && unpitched <= 127) {
-            ByteArray name = ii.second.name.toAscii();
             drumset->drum(ii.second.unpitched)
-                = DrumInstrument(name.constChar(), ii.second.notehead, ii.second.line, ii.second.stemDirection);
+                = DrumInstrument(ii.second.name, ii.second.notehead, ii.second.line, ii.second.stemDirection);
         }
     }
 }
@@ -6612,7 +6611,7 @@ void MusicXmlParserPass2::xmlSetDrumsetPitch(Note* note, const Chord* chord, con
 
             newPitch = instr.pitch;
             ds->drum(newPitch) = ds->drum(newPitch) = DrumInstrument(
-                instr.name.toStdString().c_str(), headGroup, line, stemDir, static_cast<int>(chord->voice()));
+                instr.name, headGroup, line, stemDir, static_cast<int>(chord->voice()));
         }
     }
 
@@ -6627,7 +6626,7 @@ void MusicXmlParserPass2::xmlSetDrumsetPitch(Note* note, const Chord* chord, con
             }
         }
 
-        ds->drum(newPitch) = DrumInstrument("drum", headGroup, line, stemDir, static_cast<int>(chord->voice()));
+        ds->drum(newPitch) = DrumInstrument(u"drum", headGroup, line, stemDir, static_cast<int>(chord->voice()));
     } else if (stemDir == DirectionV::AUTO) {
         stemDir = ds->stemDirection(newPitch);
     }


### PR DESCRIPTION
Simplification that avoids some back-and-forth conversions