### PR TITLE
Fix crash when adding augmentation dot to list selection

### DIFF
--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -3343,7 +3343,9 @@ void Score::padToggle(Pad p, bool toggleForSelectionOnly)
         m_is.setDuration(oldDuration);
         m_is.setRest(oldRest);
         m_is.setAccidentalType(oldAccidentalType);
-        m_is.moveToNextInputPos();
+        if (noteEntryMode()) {
+            m_is.moveToNextInputPos();
+        }
     }
 }
 


### PR DESCRIPTION
Crashed inside `moveToNextInputPos` because the InputState's `m_segment` is nullptr (and the reason that it's nullptr, is that `selection.startSegment()` is nullptr in `InputState::update`, because the selection is not a range selection). Solution: simply don't call `moveToNextInputPos`, as that doesn't really make sense anyway when not in note input mode.

Resolves: https://github.com/musescore/MuseScore/issues/26724