### PR TITLE
26351: Fixed the need to press ESC twice on Percussion panel in order to quit note input mode

### DIFF
--- a/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
+++ b/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
@@ -314,7 +314,9 @@ Item {
                             padGrid.swapOriginPad = pad
                             padGrid.isKeyboardSwapActive = isKeyboardSwap
                             padGrid.model.startPadSwap(index)
-                            pad.padNavigation.requestActive()
+                            if (isKeyboardSwap) {
+                                pad.padNavigation.requestActive()
+                            }
                         }
 
                         onEndPadSwapRequested: {
@@ -343,7 +345,11 @@ Item {
                                 if (index !== padIndex) {
                                     return
                                 }
-                                pad.padNavigation.requestActive()
+
+                                // Focus pad only if keyboard navigation has started
+                                if (root.navigationSection.active) {
+                                    pad.padNavigation.requestActive()
+                                }
                             }
 
                             function onNumPadsChanged() {


### PR DESCRIPTION
Resolves: #26351

**Key points:**
We we focusing some pads upon various actions: start edit layout mode, finish layout mode as well as starting a pad swap. Thus the focus resulted in the Percussion panel so one ESC was needed to return the focus to the notation and then another one to exit note input mode. 

When the user interacts with the Percussion panel entirely with the mouse, I don't see a need to focus a pad ever. So:
1. I've put the focusing of the current pad on start pad swap under a condition: only if it is activated via the keyboard.
2. I've put the focusing of the first/last pad on edit layout start/end under a condition too: only if keyboard navigation in the section has started. I was tempted to rename the `PadFocusRequested` signal to `PadFocusIfKeyboardNavigationStartedRequested` (which is technically more correct) but the long name put me off. Let me know if you me to rename it to that or something else.

**Other observations:**
On a side note: I am not very knowledgable of how these pads work but I noticed something weird: I have two rows of pads. I start a keybaord swap of the pad above the blank pad (the blank pad is on the second row). I press the DOWN arrow. The pad correctly goes into the place of the blank and the blank moves up. But then if I press the RIGHT arrow to swap the pad with the one to the right (both on the second row), somehow the blank from the upper row goes down and one of the pads I am expecting to swap places, goes up into where the blank was. Is it a bug?

Cheers!

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
