### PR TITLE
Percussion panel - adjustments to screen reader behaviour

### DIFF
--- a/src/framework/accessibility/iaccessible.h
+++ b/src/framework/accessibility/iaccessible.h
@@ -48,6 +48,7 @@ public:
         Panel,
         StaticText,
         EditableText,
+        SilentRole, // avoids reading "button", "text", etc. after item name
         Button,
         CheckBox,
         RadioButton,

--- a/src/framework/accessibility/internal/accessibleiteminterface.cpp
+++ b/src/framework/accessibility/internal/accessibleiteminterface.cpp
@@ -156,6 +156,10 @@ QAccessible::State AccessibleItemInterface::state() const
         state.focusable = true;
         state.focused = item->accessibleState(IAccessible::State::Focused);
     } break;
+    case IAccessible::Role::SilentRole: {
+        state.focusable = true;
+        state.focused = item->accessibleState(IAccessible::State::Focused);
+    } break;
     case IAccessible::Role::List: {
         state.active = item->accessibleState(IAccessible::State::Active);
     } break;
@@ -217,6 +221,23 @@ QAccessible::Role AccessibleItemInterface::role() const
     case IAccessible::Role::Dialog: return QAccessible::Dialog;
     case IAccessible::Role::Panel: return QAccessible::Pane;
     case IAccessible::Role::StaticText: return QAccessible::StaticText;
+    case IAccessible::Role::SilentRole: {
+        // See https://doc.qt.io/qt-5/qaccessible.html#Role-enum
+        // We want the screen reader to say the name of the current item and
+        // nothing else (i.e. not the name followed by "button" or "text").
+#if defined(Q_OS_MACOS)
+        // Good on macOS with VoiceOver.
+        return QAccessible::StaticText;
+        // VoiceOver gives unwanted additional output if ListItem is used, and it
+        // doesn't work at all if the role is TreeItem or Cell.
+#else
+        // Good on Windows with Narrator, NVDA, or JAWS; and on Linux with Orca.
+        return QAccessible::ListItem;
+        // Orca is equally happy with the roles TreeItem or Cell, but these cause
+        // unwanted additional ouput on Windows. StaticText causes unwanted
+        // additional output on both Linux and Windows.
+#endif
+    }
     case IAccessible::Role::EditableText: return QAccessible::EditableText;
     case IAccessible::Role::Button: return QAccessible::Button;
     case IAccessible::Role::CheckBox: return QAccessible::CheckBox;

--- a/src/framework/ui/view/qmlaccessible.h
+++ b/src/framework/ui/view/qmlaccessible.h
@@ -52,6 +52,7 @@ public:
         Panel,
         StaticText,
         EditableText,
+        SilentRole,
         Button,
         CheckBox,
         RadioButton,

--- a/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPad.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPad.qml
@@ -65,15 +65,38 @@ DropArea {
         readonly property color enabledBackgroundColor: Utils.colorWithAlpha(ui.theme.buttonColor, ui.theme.buttonOpacityNormal)
         readonly property color disabledBackgroundColor: Utils.colorWithAlpha(ui.theme.buttonColor, ui.theme.itemOpacityDisabled)
         readonly property real footerHeight: 24
-        readonly property string accessibleDescription: {
+
+        readonly property string accessibleDetailsString: {
+            if (!Boolean(root.padModel)) {
+                return ""
+            }
+
+            //: %1 will be the MIDI note for a drum (displayed in the percussion panel)
+            let line1 = qsTrc("notation/percussion", "MIDI %1").arg(root.padModel.midiNote)
+
+            let shortcut = root.padModel.keyboardShortcut
+            if (shortcut === "") {
+                return line1
+            }
+
+
+            //: %1 will be the shortcut for a drum (displayed in the percussion panel)
+            let line2 = qsTrc("notation/percussion", "Shortcut %1").arg(shortcut)
+
+            return line2 + ", " + line1
+        }
+
+        readonly property string accessibleRowColumnString: {
             //: %1 will be the row number of a percussion panel pad
-            let line1 = qsTrc("notation/percussion", "Row: %1").arg(root.navigationRow + 1)
+            let line1 = qsTrc("notation/percussion", "Row %1").arg(root.navigationRow + 1)
 
             //: %1 will be the column number of a percussion panel pad
-            let line2 = qsTrc("notation/percussion", "Column: %1").arg(root.navigationColumn + 1)
+            let line2 = qsTrc("notation/percussion", "Column %1").arg(root.navigationColumn + 1)
 
-            return line1 + ", " + line2
+            return line1 + " " + line2
         }
+
+        readonly property string fullAccessibleString: prv.accessibleDetailsString + ", " + prv.accessibleRowColumnString
     }
 
     NavigationControl {
@@ -90,7 +113,7 @@ DropArea {
         accessible.role: MUAccessible.Button
         accessible.name: Boolean(root.padModel) ? root.padModel.padName : qsTrc("notation/percussion", "Empty pad")
 
-        accessible.description: prv.accessibleDescription
+        accessible.description: Boolean(root.padModel) ? prv.fullAccessibleString : prv.accessibleRowColumnString
 
         accessible.visualItem: padFocusBorder
         accessible.enabled: padNavCtrl.enabled
@@ -115,9 +138,7 @@ DropArea {
         enabled: Boolean(root.padModel)
 
         accessible.role: MUAccessible.Button
-        accessible.name: Boolean(root.padModel) ? root.padModel.padName + " " + qsTrc("notation/percussion", "footer") : ""
-
-        accessible.description: prv.accessibleDescription
+        accessible.name: Boolean(root.padModel) ? root.padModel.padName + " " + qsTrc("notation/percussion", "options") : ""
 
         accessible.visualItem: footerFocusBorder
         accessible.enabled: footerNavCtrl.enabled

--- a/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPad.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPad.qml
@@ -110,7 +110,7 @@ DropArea {
         // Only navigate to empty slots when we're in edit mode
         enabled: Boolean(root.padModel) || root.panelMode === PanelMode.EDIT_LAYOUT
 
-        accessible.role: MUAccessible.Button
+        accessible.role: MUAccessible.SilentRole
         accessible.name: Boolean(root.padModel) ? root.padModel.padName : qsTrc("notation/percussion", "Empty pad")
 
         accessible.description: Boolean(root.padModel) ? prv.fullAccessibleString : prv.accessibleRowColumnString
@@ -137,7 +137,7 @@ DropArea {
 
         enabled: Boolean(root.padModel)
 
-        accessible.role: MUAccessible.Button
+        accessible.role: MUAccessible.SilentRole
         accessible.name: Boolean(root.padModel) ? root.padModel.padName + " " + qsTrc("notation/percussion", "options") : ""
 
         accessible.visualItem: footerFocusBorder


### PR DESCRIPTION
Addresses point 3 from: #26352

The screen reader will now behave as specified in [this comment](https://github.com/musescore/MuseScore/issues/26352#issuecomment-2638226070) (minor difference to the comment -  we decided to drop "pad button" from the "Pad speech").