### PR TITLE
Fix crash on drag text line

### DIFF
--- a/src/engraving/dom/line.cpp
+++ b/src/engraving/dom/line.cpp
@@ -586,9 +586,9 @@ LineSegment* LineSegment::rebaseAnchor(Grip grip, Segment* newSeg)
     const Segment* newTickSeg = left ? l->startSegment() : l->endSegment();
     const System* newSpannerSystem = newTickSeg->measure()->system();
 
-    if (newSeg->system() != oldLineSegSystem || oldSpannerSystem != newSpannerSystem) {
+    if ((oldLineSegSystem && newSeg->system() != oldLineSegSystem) || oldSpannerSystem != newSpannerSystem) {
         renderer()->layoutItem(l);
-        return left ? l->frontSegment() : l->backSegment();
+        return l->segmentsEmpty() ? nullptr : left ? l->frontSegment() : l->backSegment();
     } else if (anchorChanged) {
         rebaseOffsetsOnAnchorChanged(grip, oldPos, oldLineSegSystem);
     }


### PR DESCRIPTION
Resolves: #26690 

There is still some weirdness with the grips positions, due to the fact that the line segment currently being edited gets invalidated when dragging beyond the start of the system. That will need a separate refinement. At this stage, the only thing I'm doing is avoiding the crash.