### PR TITLE
Fix #26527: Crash with instrument changes and multi-measure rests (plus refactor)

### DIFF
--- a/src/engraving/dom/masterscore.h
+++ b/src/engraving/dom/masterscore.h
@@ -200,7 +200,10 @@ private:
     void reorderMidiMapping();
     void rebuildExcerptsMidiMapping();
     void removeDeletedMidiMapping();
+
     int updateMidiMapping();
+    void doUpdateMidiMapping(int& maxport, std::set<int>& occupiedMidiChannels, unsigned int& searchMidiMappingFrom, Part* part,
+                             InstrChannel* channel, bool useDrumset);
 
     friend class EngravingProject;
     friend class compat::ScoreAccess;

--- a/src/engraving/dom/midimapping.cpp
+++ b/src/engraving/dom/midimapping.cpp
@@ -290,7 +290,8 @@ void MasterScore::doUpdateMidiMapping(int& maxport, std::set<int>& occupiedMidiC
 {
     bool channelExists = false;
     for (const MidiMapping& mapping : m_midiMapping) {
-        if (channel == mapping.m_masterChannel && channel->channel() != -1) {
+        const bool validChannelIndex = channel->channel() >= 0 && channel->channel() < static_cast<int>(m_midiMapping.size());
+        if (channel == mapping.m_masterChannel && validChannelIndex) {
             channelExists = true;
             break;
         }

--- a/src/engraving/dom/midimapping.cpp
+++ b/src/engraving/dom/midimapping.cpp
@@ -190,14 +190,17 @@ void MasterScore::reorderMidiMapping()
         for (const auto& pair : part->instruments()) {
             const Instrument* instr = pair.second;
             for (InstrChannel* channel : instr->channel()) {
-                if (!(m_midiMapping[sequenceNumber].part() == part
-                      && m_midiMapping[sequenceNumber].m_masterChannel == channel)) {
-                    int shouldBe = channel->channel();
-                    swap(m_midiMapping[sequenceNumber], m_midiMapping[shouldBe]);
-                    m_midiMapping[sequenceNumber].articulation()->setChannel(sequenceNumber);
-                    channel->setChannel(sequenceNumber);
-                    m_midiMapping[shouldBe].articulation()->setChannel(shouldBe);
+                if (m_midiMapping[sequenceNumber].part() == part && m_midiMapping[sequenceNumber].m_masterChannel == channel) {
+                    sequenceNumber++;
+                    continue;
                 }
+
+                const int shouldBe = channel->channel();
+                swap(m_midiMapping[sequenceNumber], m_midiMapping[shouldBe]);
+                m_midiMapping[sequenceNumber].articulation()->setChannel(sequenceNumber);
+                channel->setChannel(sequenceNumber);
+                m_midiMapping[shouldBe].articulation()->setChannel(shouldBe);
+
                 sequenceNumber++;
             }
         }


### PR DESCRIPTION
Resolves: #26527

The problem here is that we were only checking `channel->channel() != -1` - looks like we should also check the upper bound. If we don't, the later call to `m_midiMapping[channel->channel()]` will give us garbage data (which eventually causes problems in `reorderMidiMapping`).

The reason why the channel index is invalid in the first place is a little bit unclear to me. It looks like it gets invalidated in `removeDeletedMappings` when `channelExists` evaluates to false (so we pop the mapping from the `m_midiMapping` vector). For the purposes of fixing this crash this shouldn't matter, though. If `channelExists` evaluates to false in `doUpdateMidiMapping` we'll simply assign a new one.

The refactor aims to make things a little more robust & readable (there is a slight tradeoff with some data coupling in `doUpdateMidiMapping`, though).