### PR TITLE
Added ability to reload playback cache

### DIFF
--- a/src/appshell/view/appmenumodel.cpp
+++ b/src/appshell/view/appmenumodel.cpp
@@ -436,6 +436,7 @@ MenuItem* AppMenuModel::makeDiagnosticsMenu()
 
     MenuItemList items {
         makeMenuItem("diagnostic-save-diagnostic-files"),
+        makeMenuItem("playback-reload-cache"),
         makeMenu(TranslatableString("appshell/menu/diagnostics", "&System"), systemItems, "menu-system")
     };
 

--- a/src/notation/inotationplayback.h
+++ b/src/notation/inotationplayback.h
@@ -38,6 +38,7 @@ public:
     virtual ~INotationPlayback() = default;
 
     virtual void init() = 0;
+    virtual void reload() = 0;
 
     virtual const engraving::InstrumentTrackId& metronomeTrackId() const = 0;
     virtual engraving::InstrumentTrackId chordSymbolsTrackId(const muse::ID& partId) const = 0;

--- a/src/notation/internal/notationplayback.cpp
+++ b/src/notation/internal/notationplayback.cpp
@@ -105,6 +105,11 @@ void NotationPlayback::init()
     });
 }
 
+void NotationPlayback::reload()
+{
+    m_playbackModel.reload();
+}
+
 const engraving::InstrumentTrackId& NotationPlayback::metronomeTrackId() const
 {
     return m_playbackModel.metronomeTrackId();

--- a/src/notation/internal/notationplayback.h
+++ b/src/notation/internal/notationplayback.h
@@ -43,6 +43,7 @@ public:
     NotationPlayback(IGetScore* getScore, muse::async::Notification notationChanged, const muse::modularity::ContextPtr& iocCtx);
 
     void init() override;
+    void reload() override;
 
     const engraving::InstrumentTrackId& metronomeTrackId() const override;
     engraving::InstrumentTrackId chordSymbolsTrackId(const muse::ID& partId) const override;

--- a/src/notation/internal/notationplaybackstub.cpp
+++ b/src/notation/internal/notationplaybackstub.cpp
@@ -36,6 +36,10 @@ void NotationPlaybackStub::init()
 {
 }
 
+void NotationPlaybackStub::reload()
+{
+}
+
 const engraving::InstrumentTrackId& NotationPlaybackStub::metronomeTrackId() const
 {
     static const engraving::InstrumentTrackId dummy;

--- a/src/notation/internal/notationplaybackstub.h
+++ b/src/notation/internal/notationplaybackstub.h
@@ -30,6 +30,7 @@ public:
     NotationPlaybackStub();
 
     void init() override;
+    void reload() override;
 
     const engraving::InstrumentTrackId& metronomeTrackId() const override;
     engraving::InstrumentTrackId chordSymbolsTrackId(const muse::ID& partId) const override;

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -107,6 +107,7 @@ void PlaybackController::init()
     dispatcher()->reg(this, COUNT_IN_CODE, this, &PlaybackController::toggleCountIn);
     dispatcher()->reg(this, PLAYBACK_SETUP, this, &PlaybackController::openPlaybackSetupDialog);
     dispatcher()->reg(this, TOGGLE_HEAR_PLAYBACK_WHEN_EDITING_CODE, this, &PlaybackController::toggleHearPlaybackWhenEditing);
+    dispatcher()->reg(this, "playback-reload-cache", this, &PlaybackController::reloadPlaybackCache);
 
     globalContext()->currentNotationChanged().onNotify(this, [this]() {
         onNotationChanged();
@@ -822,6 +823,14 @@ void PlaybackController::toggleHearPlaybackWhenEditing()
 {
     bool wasPlayNotesWhenEditing = configuration()->playNotesWhenEditing();
     configuration()->setPlayNotesWhenEditing(!wasPlayNotesWhenEditing);
+}
+
+void PlaybackController::reloadPlaybackCache()
+{
+    INotationPlaybackPtr playback = notationPlayback();
+    if (playback) {
+        playback->reload();
+    }
 }
 
 void PlaybackController::openPlaybackSetupDialog()

--- a/src/playback/internal/playbackcontroller.h
+++ b/src/playback/internal/playbackcontroller.h
@@ -174,6 +174,8 @@ private:
     void toggleLoopPlayback();
     void toggleHearPlaybackWhenEditing();
 
+    void reloadPlaybackCache();
+
     void openPlaybackSetupDialog();
 
     void addLoopBoundary(notation::LoopBoundaryType type);

--- a/src/playback/internal/playbackuiactions.cpp
+++ b/src/playback/internal/playbackuiactions.cpp
@@ -168,6 +168,14 @@ const UiActionList PlaybackUiActions::m_loopBoundaryActions = {
              ),
 };
 
+const UiActionList PlaybackUiActions::m_diagnosticActions = {
+    UiAction("playback-reload-cache",
+             mu::context::UiCtxAny,
+             mu::context::CTX_ANY,
+             TranslatableString("action", "Reload playback cache")
+             )
+};
+
 PlaybackUiActions::PlaybackUiActions(std::shared_ptr<PlaybackController> controller)
     : m_controller(controller)
 {
@@ -199,6 +207,7 @@ const UiActionList& PlaybackUiActions::actionsList() const
         alist.insert(alist.end(), m_midiInputPitchActions.cbegin(), m_midiInputPitchActions.cend());
         alist.insert(alist.end(), m_settingsActions.cbegin(), m_settingsActions.cend());
         alist.insert(alist.end(), m_loopBoundaryActions.cbegin(), m_loopBoundaryActions.cend());
+        alist.insert(alist.end(), m_diagnosticActions.cbegin(), m_diagnosticActions.cend());
     }
     return alist;
 }

--- a/src/playback/internal/playbackuiactions.h
+++ b/src/playback/internal/playbackuiactions.h
@@ -60,6 +60,7 @@ private:
     static const muse::ui::UiActionList m_midiInputPitchActions;
     static const muse::ui::UiActionList m_settingsActions;
     static const muse::ui::UiActionList m_loopBoundaryActions;
+    static const muse::ui::UiActionList m_diagnosticActions;
 
     std::shared_ptr<PlaybackController> m_controller;
     muse::async::Channel<muse::actions::ActionCodeList> m_actionEnabledChanged;


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/25885

New option: Diagnostics -> Reload playback cache. It can either be used to diagnose problems with the playback cache or as a workaround to quickly fix playback without having to reopen the score