### PR TITLE
Fix #25032: Don't allow notes to be written in the publish page

### DIFF
--- a/src/context/internal/uicontextresolver.cpp
+++ b/src/context/internal/uicontextresolver.cpp
@@ -35,6 +35,8 @@ using namespace muse::ui;
 
 static const muse::Uri HOME_PAGE_URI("musescore://home");
 static const muse::Uri NOTATION_PAGE_URI("musescore://notation");
+static const muse::Uri PUBLISH_PAGE_URI("musescore://publish");
+static const muse::Uri DEVTOOLS_PAGE_URI("musescore://devtools");
 
 static const QString NOTATION_NAVIGATION_PANEL("ScoreView");
 
@@ -119,6 +121,14 @@ UiContext UiContextResolver::currentUiContext() const
         return context::UiCtxProjectOpened;
     }
 
+    if (currentUri == PUBLISH_PAGE_URI) {
+        return context::UiCtxPublishOpened;
+    }
+
+    if (currentUri == DEVTOOLS_PAGE_URI) {
+        return context::UiCtxDevToolsOpened;
+    }
+
     return context::UiCtxUnknown;
 }
 
@@ -128,7 +138,10 @@ bool UiContextResolver::match(const muse::ui::UiContext& currentCtx, const muse:
         return true;
     }
 
-    if (actCtx == context::UiCtxProjectOpened && globalContext()->currentNotation()) {
+    //! NOTE: Context could be unknown if a plugin is currently open, in which case we should return true under
+    //! the following circumstances (see issue #24673)...
+    if ((currentCtx == context::UiCtxProjectFocused || currentCtx == context::UiCtxUnknown)
+        && actCtx == context::UiCtxProjectOpened && globalContext()->currentNotation()) {
         return true;
     }
 

--- a/src/context/uicontext.h
+++ b/src/context/uicontext.h
@@ -34,6 +34,10 @@ static constexpr muse::ui::UiContext UiCtxAny = muse::ui::UiCtxAny;
 static constexpr muse::ui::UiContext UiCtxHomeOpened = muse::ui::UiCtxHomeOpened;
 static constexpr muse::ui::UiContext UiCtxProjectOpened = muse::ui::UiCtxProjectOpened;
 static constexpr muse::ui::UiContext UiCtxProjectFocused = muse::ui::UiCtxProjectFocused;
+
+// application-specific contexts
+static constexpr muse::ui::UiContext UiCtxPublishOpened = "UiCtxPublishOpened";
+static constexpr muse::ui::UiContext UiCtxDevToolsOpened = "UiCtxDevToolsOpened";
 }
 
 #endif // MU_CONTEXT_UICONTEXT_H

--- a/src/notation/view/abstractnotationpaintview.cpp
+++ b/src/notation/view/abstractnotationpaintview.cpp
@@ -629,9 +629,11 @@ void AbstractNotationPaintView::paint(QPainter* qp)
     bool isPrinting = publishMode() || m_inputController->readonly();
     notation()->painting()->paintView(painter, toLogical(rect), isPrinting);
 
-    INotationNoteInputPtr noteInput = notationNoteInput();
+    const ui::UiContext ctx = uiContextResolver()->currentUiContext();
+    const bool isOnNotationPage = ctx == ui::UiCtxProjectOpened || ctx == ui::UiCtxProjectFocused;
 
-    if (noteInput->isNoteInputMode()) {
+    const INotationNoteInputPtr noteInput = notationNoteInput();
+    if (noteInput->isNoteInputMode() && isOnNotationPage) {
         if (noteInput->usingNoteInputMethod(NoteInputMethod::BY_DURATION)
             && !configuration()->useNoteInputCursorInInputByDuration()) {
             m_ruler->paint(painter, noteInput->state());


### PR DESCRIPTION
Resolves: #25032

This bug was introduced with #24887 which always allowed all `UiCtxProjectOpened` actions as long as `globalContext()->currentNotation()` was valid.

This PR does a tiny partial revert of #24887 and introduces new contexts for the Publish and DevTools pages. So that we don't re-introduce #24673, we will allow `UiCtxProjectOpened` actions when the context is `UiCtxUnknown` so long as `globalContext()->currentNotation()` is valid.

An additional commit has been included in this PR to solve an older, unrelated bug where the note input cursor is visible in the publish tab.