### PR TITLE
Revert "fixed #25098: correct pitchbend midi export in chords"

### DIFF
--- a/src/importexport/midi/internal/midiexport/exportmidi.cpp
+++ b/src/importexport/midi/internal/midiexport/exportmidi.cpp
@@ -236,7 +236,7 @@ bool ExportMidi::write(QIODevice* device, bool midiExpandRepeats, bool exportRPN
 
     EventsHolder events;
     CompatMidiRendererInternal::Context context;
-    context.eachStringHasChannel = true;
+    context.eachStringHasChannel = false;
     context.instrumentsHaveEffects = false;
     context.harmonyChannelSetting = CompatMidiRendererInternal::HarmonyChannelSetting::DEFAULT;
     context.sndController = CompatMidiRender::getControllerForSnd(m_score, synthState.ccToUse());


### PR DESCRIPTION
Reverts musescore/MuseScore#25443

Resolves: https://github.com/musescore/MuseScore/issues/26603