### PR TITLE
4.5.0: Fix MSVC compiler warning

### DIFF
--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -827,9 +827,9 @@ void PlaybackController::toggleHearPlaybackWhenEditing()
 
 void PlaybackController::reloadPlaybackCache()
 {
-    INotationPlaybackPtr playback = notationPlayback();
-    if (playback) {
-        playback->reload();
+    INotationPlaybackPtr nPlayback = notationPlayback();
+    if (nPlayback) {
+        nPlayback->reload();
     }
 }
 


### PR DESCRIPTION
reg.: declaration of 'playback' hides class member (C4458)