### PR TITLE
[MusicXML] add forgotten technical indications

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -1414,6 +1414,8 @@ static bool convertArticulationToSymId(const String& mxmlName, SymId& id)
         { u"flip",                   SymId::brassFlip },
         { u"smear",                  SymId::brassSmear },
         { u"open",                   SymId::brassMuteOpen },
+        { u"half-muted",             SymId::brassMuteHalfClosed }, // ignoring the smufl attribute
+        { u"golpe",                  SymId::guitarGolpe },
 
         { u"belltree", SymId::handbellsBelltree },
         { u"damp", SymId::handbellsDamp3 },


### PR DESCRIPTION
This PR adds two previously forgotten technical indications on import side (export already supports these).