### PR TITLE
Fix "ambiguity" with Russian keyboard layout

### DIFF
--- a/src/framework/shortcuts/internal/platform/macos/macosshortcutsinstancemodel.mm
+++ b/src/framework/shortcuts/internal/platform/macos/macosshortcutsinstancemodel.mm
@@ -379,27 +379,29 @@ void MacOSShortcutsInstanceModel::doLoadShortcuts()
 
             // Ensure standard order of modifiers by converting to/from QKeySequence
             QKeySequence untranslatedSequence = QKeySequence::fromString(untranslatedSequenceStr, QKeySequence::PortableText);
-            QString untranslatedSequenceStrNormalised = untranslatedSequence.toString(QKeySequence::PortableText);
-
-            // Always record the untranslated sequence
-            // Map to non-normalised, because that's what ShortcutsInstanceModel::doActivate expects
-            recordMapping(untranslatedSequenceStrNormalised, untranslatedSequenceStr, true);
-            recordAutoRepeat(untranslatedSequenceStrNormalised, sc.autoRepeat);
 
             // Attempt to translate from combination of keys to character, e.g., `Shift+.` becomes `>`, in the case of a QWERTY layout
             QKeySequence translatedSequence
                 = translateToCurrentKeyboardLayout(untranslatedSequence);
-            if (translatedSequence.isEmpty()) {
-                LOGW() << "Failed to translate sequence " << untranslatedSequenceStr;
-                continue;
+            if (translatedSequence.isEmpty() || !(untranslatedSequence[0].key() & 0xff)) {
+                QString untranslatedSequenceStrNormalised = untranslatedSequence.toString(QKeySequence::PortableText);
+
+                // Record the untranslated sequence
+                // Map to non-normalised, because that's what ShortcutsInstanceModel::doActivate expects
+                recordMapping(untranslatedSequenceStrNormalised, untranslatedSequenceStr, true);
+                recordAutoRepeat(untranslatedSequenceStrNormalised, sc.autoRepeat);
             }
 
-            QString translatedSequenceStrNormalised = translatedSequence.toString(QKeySequence::PortableText);
+            if (translatedSequence.isEmpty()) {
+                LOGW() << "Failed to translate sequence " << untranslatedSequenceStr;
+            } else {
+                QString translatedSequenceStrNormalised = translatedSequence.toString(QKeySequence::PortableText);
 
-            // If it was successful, record the translated sequence too, and map it to the untranslated sequence
-            // Again, map to non-normalised
-            recordMapping(translatedSequenceStrNormalised, untranslatedSequenceStr, false);
-            recordAutoRepeat(translatedSequenceStrNormalised, sc.autoRepeat);
+                // If it was successful, record the translated sequence too, and map it to the untranslated sequence
+                // Again, map to non-normalised
+                recordMapping(translatedSequenceStrNormalised, untranslatedSequenceStr, false);
+                recordAutoRepeat(translatedSequenceStrNormalised, sc.autoRepeat);
+            }
         }
     }
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/25824

When using Russian keyboard layout, and when there is a `Z` shortcut and a `Ctrl+Z` shortcut, and you press `Ctrl+Z`, we add four shortcuts:
- `Z` and `Я`
- `Ctrl+Z` and `Ctrl+Я`

When pressing `Ctrl+Z`, Qt thinks there are two possible keys:
```
17:42:43.971 | DEBUG | main_thread     | Qt              | 	- QKeyCombination(ControlModifier, Key(1071)) / QKeySequence("Ctrl+Я") / ⌘Я
17:42:43.971 | DEBUG | main_thread     | Qt              | 	- QKeyCombination(NoModifier, Key_Z) / QKeySequence("Z") / Z
```
(output seen after `QLoggingCategory::setFilterRules("qt.gui.shortcutmap.debug=true\nqt.qpa.keymapper.debug=true\nqt.qpa.keymapper.keys.debug=true");`)

The latter, `Z` with no modifier, makes no sense to me, but whatever; Qt thinks it must be.

As a result, Qt thinks the shortcuts are ambiguous: it doesn't know whether to activate `Z` or `Ctrl+Я`.

The solution is to avoid adding `Z` as a shortcut; it won't be necessary anyway, as `Я` suffices.

Same story goes for other single-letter shortcuts.

Should be tested very carefully, also with other keyboard layouts than Russian (for example, what effect will it have for AZERTY users...)