### PR TITLE
Fix memory leak in MIDI export #26415

### DIFF
--- a/src/importexport/midi/internal/midiexport/exportmidi.cpp
+++ b/src/importexport/midi/internal/midiexport/exportmidi.cpp
@@ -68,7 +68,7 @@ void ExportMidi::writeHeader(const CompatMidiRendererInternal::Context& context)
         MidiEvent ev;
         ev.setType(ME_META);
         ev.setMetaType(META_TRACK_NAME);
-        ev.setEData(data);
+        ev.setEData(std::move(data));
         ev.setLen(static_cast<int>(len));
 
         track1.insert(0, ev);
@@ -121,7 +121,7 @@ void ExportMidi::writeHeader(const CompatMidiRendererInternal::Context& context)
             MidiEvent ev;
             ev.setType(ME_META);
             ev.setMetaType(META_TIME_SIGNATURE);
-            ev.setEData(data);
+            ev.setEData(std::move(data));
             ev.setLen(4);
             track.insert(CompatMidiRender::tick(context, is->first + tickOffset), ev);
         }
@@ -153,7 +153,7 @@ void ExportMidi::writeHeader(const CompatMidiRendererInternal::Context& context)
                 ev.setMetaType(META_KEY_SIGNATURE);
                 ev.setLen(2);
                 std::vector<unsigned char> data { static_cast<unsigned char>(key), 0 /* major */ };
-                ev.setEData(data);
+                ev.setEData(std::move(data));
                 int tick = ik->first + tickOffset;
                 track1.insert(CompatMidiRender::tick(context, tick), ev);
                 if (tick == 0) {
@@ -169,7 +169,7 @@ void ExportMidi::writeHeader(const CompatMidiRendererInternal::Context& context)
             ev.setMetaType(META_KEY_SIGNATURE);
             ev.setLen(2);
             std::vector<unsigned char> data { 0 /* key */, 0 /* major */ };
-            ev.setEData(data);
+            ev.setEData(std::move(data));
             track1.insert(0, ev);
         }
 
@@ -200,7 +200,7 @@ void ExportMidi::writeHeader(const CompatMidiRendererInternal::Context& context)
         std::vector<unsigned char> data { static_cast<unsigned char>(tempo >> 16),
                                           static_cast<unsigned char>(tempo >> 8),
                                           static_cast<unsigned char>(tempo) };
-        ev.setEData(data);
+        ev.setEData(std::move(data));
         track.insert(it->first, ev);
     }
 }
@@ -295,7 +295,7 @@ bool ExportMidi::write(QIODevice* device, bool midiExpandRepeats, bool exportRPN
                     ev.setMetaType(META_PORT_CHANGE);
                     ev.setLen(1);
                     std::vector<unsigned char> data { static_cast<unsigned char>(track.outPort()) };
-                    ev.setEData(data);
+                    ev.setEData(std::move(data));
                     track.insert(0, ev);
                 }
 
@@ -384,7 +384,7 @@ bool ExportMidi::write(QIODevice* device, bool midiExpandRepeats, bool exportRPN
                             MidiEvent ev;
                             ev.setType(ME_META);
                             ev.setMetaType(META_LYRIC);
-                            ev.setEData(data);
+                            ev.setEData(std::move(data));
                             ev.setLen(static_cast<int>(len));
 
                             int tick = cr->tick().ticks() + tickOffset;
@@ -409,7 +409,7 @@ bool ExportMidi::write(QIODevice* device, bool midiExpandRepeats, bool exportRPN
                             MidiEvent ev;
                             ev.setType(ME_META);
                             ev.setMetaType(META_MARKER);
-                            ev.setEData(data);
+                            ev.setEData(std::move(data));
                             ev.setLen(static_cast<int>(len));
 
                             int tick = r->segment()->tick().ticks() + tickOffset;

--- a/src/importexport/midi/internal/midishared/midievent.h
+++ b/src/importexport/midi/internal/midishared/midievent.h
@@ -29,7 +29,7 @@ namespace mu::iex::midi {
 class MidiEvent : public engraving::MidiCoreEvent
 {
 protected:
-    uchar* _edata { nullptr }; // always zero terminated (_data[_len] == 0; )
+    std::vector<uchar> _edata;
     int _len { 0 };
     int _metaType { 0 };
 
@@ -38,8 +38,8 @@ public:
     MidiEvent(uchar t, uchar c, uchar a, uchar b)
         : MidiCoreEvent(t, c, a, b), _edata(0), _len(0) {}
 
-    const uchar* edata() const { return _edata; }
-    void setEData(uchar* d) { _edata = d; }
+    const uchar* edata() const { return _edata.data(); }
+    void setEData(std::vector<uchar>& d) { _edata = d; }
     int len() const { return _len; }
     void setLen(int l) { _len = l; }
     int metaType() const { return _metaType; }

--- a/src/importexport/midi/internal/midishared/midievent.h
+++ b/src/importexport/midi/internal/midishared/midievent.h
@@ -39,7 +39,7 @@ public:
         : MidiCoreEvent(t, c, a, b), _edata(0), _len(0) {}
 
     const uchar* edata() const { return _edata.data(); }
-    void setEData(std::vector<uchar>& d) { _edata = d; }
+    void setEData(std::vector<uchar>&& d) { _edata = d; }
     int len() const { return _len; }
     void setLen(int l) { _len = l; }
     int metaType() const { return _metaType; }

--- a/src/importexport/midi/internal/midishared/midifile.cpp
+++ b/src/importexport/midi/internal/midishared/midifile.cpp
@@ -552,7 +552,6 @@ bool MidiFile::readEvent(MidiEvent* event)
         }
     }
 
-    std::vector<unsigned char> data;
     int dataLen;
 
     if (me == 0xf0 || me == 0xf7) {
@@ -563,7 +562,7 @@ bool MidiFile::readEvent(MidiEvent* event)
             return false;
         }
         dataLen = len;
-        data.resize(len + 1);
+        std::vector<unsigned char> data(len + 1);
         read(data.data(), len);
         if (data[len - 1] != 0xf7) {
             LOGD("SYSEX does not end with 0xf7!");
@@ -586,7 +585,7 @@ bool MidiFile::readEvent(MidiEvent* event)
             LOGD("readEvent: error 6");
             return false;
         }
-        data.resize(dataLen + 1);
+        std::vector<unsigned char> data(dataLen + 1);
         if (dataLen) {
             read(data.data(), dataLen);
         }

--- a/src/importexport/midi/internal/midishared/midifile.cpp
+++ b/src/importexport/midi/internal/midishared/midifile.cpp
@@ -586,8 +586,8 @@ bool MidiFile::readEvent(MidiEvent* event)
             LOGD("readEvent: error 6");
             return false;
         }
+        data.resize(dataLen + 1);
         if (dataLen) {
-            data.resize(dataLen + 1);
             read(data.data(), dataLen);
         }
 

--- a/src/importexport/midi/internal/midishared/midifile.cpp
+++ b/src/importexport/midi/internal/midishared/midifile.cpp
@@ -552,7 +552,7 @@ bool MidiFile::readEvent(MidiEvent* event)
         }
     }
 
-    unsigned char* data;
+    std::vector<unsigned char> data;
     int dataLen;
 
     if (me == 0xf0 || me == 0xf7) {
@@ -562,9 +562,8 @@ bool MidiFile::readEvent(MidiEvent* event)
             LOGD("readEvent: error 3");
             return false;
         }
-        data    = new unsigned char[len + 1];
         dataLen = len;
-        read(data, len);
+        read(data.data(), len);
         data[dataLen] = 0;        // always terminate with zero
         if (data[len - 1] != 0xf7) {
             LOGD("SYSEX does not end with 0xf7!");
@@ -587,9 +586,8 @@ bool MidiFile::readEvent(MidiEvent* event)
             LOGD("readEvent: error 6");
             return false;
         }
-        data = new unsigned char[dataLen + 1];
         if (dataLen) {
-            read(data, dataLen);
+            read(data.data(), dataLen);
         }
         data[dataLen] = 0;          // always terminate with zero so we get valid C++ strings
 

--- a/src/importexport/midi/internal/midishared/midifile.cpp
+++ b/src/importexport/midi/internal/midishared/midifile.cpp
@@ -563,8 +563,8 @@ bool MidiFile::readEvent(MidiEvent* event)
             return false;
         }
         dataLen = len;
+        data.resize(len + 1);
         read(data.data(), len);
-        data[dataLen] = 0;        // always terminate with zero
         if (data[len - 1] != 0xf7) {
             LOGD("SYSEX does not end with 0xf7!");
             // more to come?
@@ -572,7 +572,7 @@ bool MidiFile::readEvent(MidiEvent* event)
             dataLen--;            // don't count 0xf7
         }
         event->setType(ME_SYSEX);
-        event->setEData(data);
+        event->setEData(std::move(data));
         event->setLen(dataLen);
         return true;
     }
@@ -587,14 +587,14 @@ bool MidiFile::readEvent(MidiEvent* event)
             return false;
         }
         if (dataLen) {
+            data.resize(dataLen + 1);
             read(data.data(), dataLen);
         }
-        data[dataLen] = 0;          // always terminate with zero so we get valid C++ strings
 
         event->setType(ME_META);
         event->setMetaType(type);
         event->setLen(dataLen);
-        event->setEData(data);
+        event->setEData(std::move(data));
         return true;
     }
 


### PR DESCRIPTION
Replace new unsigned char allocations with std::vector<unsigned char> and make sure that MidiEvent::setEData takes vector reference rather than raw pointer.

Resolves: #26415