### PR TITLE
Fix showing help when calling ninja_build.sh -h

### DIFF
--- a/ninja_build.sh
+++ b/ninja_build.sh
@@ -55,7 +55,7 @@ while [[ "$#" -gt 0 ]]; do
     case $1 in
         -t|--target) TARGET="$2"; shift;;
         -j|--jobs) JOBS="$2"; shift;;
-        -h|--help) SHOW_HELP=1; shift;;
+        -h|--help) SHOW_HELP=1;;
         *) echo "Unknown parameter passed: $1"; exit 1 ;;
     esac
     shift


### PR DESCRIPTION
Calling ./ninja_build.sh -h or ./ninja_build.sh --help does not work because in -h, --help no argument is provided and thus no argument shift is required.
