### PR TITLE
[MusicXML] fix harmonic import

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -8353,6 +8353,7 @@ void MusicXmlParserNotations::harmonic()
             m_e.skipCurrentElement();  // skip but don't log
         } else if (name == "artificial") {   // TODO: add artificial harmonic when supported by MuseScore
             m_logger->logError(String(u"unsupported harmonic type/pitch '%1'").arg(name), &m_e);
+            notation.setSymId(SymId::noSym);
             m_e.skipCurrentElement();
         } else {
             m_e.skipCurrentElement();

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -8351,15 +8351,15 @@ void MusicXmlParserNotations::harmonic()
         if (name == "natural") {
             notation.setSubType(name);
             m_e.skipCurrentElement();  // skip but don't log
-        } else {   // TODO: add artificial harmonic when supported by musescore
+        } else if (name == "artificial") {   // TODO: add artificial harmonic when supported by MuseScore
             m_logger->logError(String(u"unsupported harmonic type/pitch '%1'").arg(name), &m_e);
+            m_e.skipCurrentElement();
+        } else {
             m_e.skipCurrentElement();
         }
     }
 
-    if (notation.subType() != "") {
-        m_notations.push_back(notation);
-    }
+    m_notations.push_back(notation);
 }
 
 //---------------------------------------------------------


### PR DESCRIPTION
This PR fixes a small flaw in importing `technical/harmonic` that may be [empty](https://www.w3.org/2021/06/musicxml40/musicxml-reference/elements/harmonic/) (just for the associated glyph).

Brings import in line with export.