### PR TITLE
Percussion panel - fix drum note input when switching voices

### DIFF
--- a/src/engraving/dom/cmd.cpp
+++ b/src/engraving/dom/cmd.cpp
@@ -5023,21 +5023,6 @@ void Score::cmdAddPitch(const EditData& ed, const NoteInputParams& params, bool 
     if (ds) {
         is.setDrumNote(params.drumPitch);
         is.setVoice(ds->voice(params.drumPitch));
-
-        if (is.segment()) {
-            Segment* seg = is.segment();
-            while (seg) {
-                if (seg->element(is.track())) {
-                    break;
-                }
-                seg = seg->prev(SegmentType::ChordRest);
-            }
-            if (seg) {
-                is.setSegment(seg);
-            } else {
-                is.setSegment(is.segment()->measure()->first(SegmentType::ChordRest));
-            }
-        }
     }
 
     cmdAddPitch(params.step, addFlag, insert);

--- a/src/engraving/dom/input.cpp
+++ b/src/engraving/dom/input.cpp
@@ -141,7 +141,7 @@ void InputState::setVoice(voice_idx_t v)
 {
     const Score* score = m_segment ? m_segment->score() : nullptr;
 
-    if (!score || v >= VOICES || m_track == muse::nidx) {
+    if (!score || v >= VOICES || v == voice() || m_track == muse::nidx) {
         return;
     }
 

--- a/src/engraving/dom/input.cpp
+++ b/src/engraving/dom/input.cpp
@@ -35,6 +35,7 @@
 #include "select.h"
 #include "staff.h"
 #include "stem.h"
+#include "tuplet.h"
 
 using namespace mu;
 
@@ -138,8 +139,23 @@ void InputState::setDots(int n)
 
 void InputState::setVoice(voice_idx_t v)
 {
-    if (v >= VOICES || m_track == muse::nidx) {
+    const Score* score = m_segment ? m_segment->score() : nullptr;
+
+    if (!score || v >= VOICES || m_track == muse::nidx) {
         return;
+    }
+
+    // TODO: Inserting notes to a new voice in the middle of a tuplet is not yet supported. In this case
+    // we'll move the input to the start of the tuplet...
+    if (const Segment* prevSeg = segment()) {
+        const ChordRest* prevCr = prevSeg->cr(track());
+        //! NOTE: if there's an existing ChordRest at the new voiceIndex, we don't need to move the cursor
+        if (prevCr && prevCr->topTuplet() && !prevSeg->cr(v)) {
+            Segment* newSeg = score->tick2segment(prevCr->topTuplet()->tick());
+            if (newSeg) {
+                setSegment(newSeg);
+            }
+        }
     }
 
     setTrack((m_track / VOICES) * VOICES + v);

--- a/src/notation/internal/notationnoteinput.cpp
+++ b/src/notation/internal/notationnoteinput.cpp
@@ -663,21 +663,8 @@ void NotationNoteInput::setCurrentVoice(voice_idx_t voiceIndex)
     }
 
     mu::engraving::InputState& inputState = score()->inputState();
-
-    // TODO: Inserting notes to a new voice in the middle of a tuplet is not yet supported. In this case
-    // we'll move the input to the start of the tuplet...
-    if (const Segment* prevSeg = inputState.segment()) {
-        const ChordRest* prevCr = prevSeg->cr(inputState.track());
-        //! NOTE: if there's an existing ChordRest at the new voiceIndex, we don't need to move the cursor
-        if (prevCr && prevCr->topTuplet() && !prevSeg->cr(voiceIndex)) {
-            Segment* newSeg = score()->tick2segment(prevCr->topTuplet()->tick());
-            if (newSeg) {
-                inputState.setSegment(newSeg);
-            }
-        }
-    }
-
     inputState.setVoice(voiceIndex);
+
     notifyAboutStateChanged();
 }
 

--- a/src/notation/internal/notationnoteinput.cpp
+++ b/src/notation/internal/notationnoteinput.cpp
@@ -658,13 +658,12 @@ void NotationNoteInput::setCurrentVoice(voice_idx_t voiceIndex)
 {
     TRACEFUNC;
 
-    if (!isVoiceIndexValid(voiceIndex)) {
+    mu::engraving::InputState& inputState = score()->inputState();
+    if (!isVoiceIndexValid(voiceIndex) || voiceIndex == inputState.voice()) {
         return;
     }
 
-    mu::engraving::InputState& inputState = score()->inputState();
     inputState.setVoice(voiceIndex);
-
     notifyAboutStateChanged();
 }
 


### PR DESCRIPTION
The change to the percussion panel's `writePitch` method introduced with b3227815332e72f06e34e9f4d69c213ac9f4546c means that we now go through `cmdAddPitch` when writing notes. This method contains some old logic for evaluating segments on percussion staves which is now redundant after 9dcbfac97cf0b33c404753bd4ad062831848fd25 (see `handleOverlappingChordRest`).