### PR TITLE
Clean up MIDI Event class and its usages

### DIFF
--- a/src/framework/audio/internal/synthesizers/fluidsynth/fluidsequencer.cpp
+++ b/src/framework/audio/internal/synthesizers/fluidsynth/fluidsequencer.cpp
@@ -131,7 +131,7 @@ void FluidSequencer::updatePlaybackEvents(EventSequenceMap& destination, const m
             midi::Event noteOn(Event::Opcode::NoteOn, Event::MessageType::ChannelVoice20);
             noteOn.setChannel(channelIdx);
             noteOn.setNote(noteIdx);
-            noteOn.setVelocity(velocity);
+            noteOn.setVelocity16(velocity);
             noteOn.setPitchNote(noteIdx, tuning);
 
             destination[timestampFrom].emplace(std::move(noteOn));

--- a/src/framework/midi/internal/platform/lin/alsamidiinport.cpp
+++ b/src/framework/midi/internal/platform/lin/alsamidiinport.cpp
@@ -335,7 +335,7 @@ void AlsaMidiInPort::doProcess()
             continue;
         }
 
-        e = Event::fromMIDI10Package(data);
+        e = Event::fromMidi10Package(data);
 
         e = e.toMIDI20();
         if (e) {

--- a/src/framework/midi/internal/platform/lin/alsamidioutport.cpp
+++ b/src/framework/midi/internal/platform/lin/alsamidioutport.cpp
@@ -252,10 +252,10 @@ Ret AlsaMidiOutPort::sendEvent(const Event& e)
 
     switch (e.opcode()) {
     case Event::Opcode::NoteOn:
-        snd_seq_ev_set_noteon(&seqev, e.channel(), e.note(), e.velocity());
+        snd_seq_ev_set_noteon(&seqev, e.channel(), e.note(), e.velocity7());
         break;
     case Event::Opcode::NoteOff:
-        snd_seq_ev_set_noteoff(&seqev, e.channel(), e.note(), e.velocity());
+        snd_seq_ev_set_noteoff(&seqev, e.channel(), e.note(), e.velocity7());
         break;
     case Event::Opcode::ProgramChange:
         snd_seq_ev_set_pgmchange(&seqev, e.channel(), e.program());

--- a/src/framework/midi/internal/platform/osx/coremidiinport.cpp
+++ b/src/framework/midi/internal/platform/osx/coremidiinport.cpp
@@ -25,8 +25,6 @@
 #include <CoreServices/CoreServices.h>
 #include <CoreMIDI/CoreMIDI.h>
 
-#include <algorithm>
-
 #include "translation.h"
 #include "midierrors.h"
 #include "defer.h"
@@ -188,69 +186,38 @@ void CoreMidiInPort::initCore()
         }
     };
 
-    QString name = "MuseScore";
-    result = MIDIClientCreate(name.toCFString(), onCoreMidiNotificationReceived, this, &m_core->client);
+    result = MIDIClientCreate(CFSTR("MuseScore"), onCoreMidiNotificationReceived, this, &m_core->client);
     IF_ASSERT_FAILED(result == noErr) {
         LOGE() << "failed create midi input client";
         return;
     }
 
-    QString portName = "MuseScore MIDI input port";
+    CFStringRef portName = CFSTR("MuseScore MIDI input port");
     if (__builtin_available(macOS 11.0, *)) {
         MIDIReceiveBlock receiveBlock = ^ (const MIDIEventList* eventList, void* /*srcConnRefCon*/) {
-            // For reference have a look at Table 4 on page 22f in
-            // Universal MIDI Packet (UMP) Format
-            // and MIDI 2.0 Protocol
-            // With MIDI 1.0 Protocol in UMP Format
-            //
-            // MIDI Association Document: M2-104-UM
-            // Document Version 1.1.2
-            // Draft Date 2023-10-27
-            // Published 2023-11-10
-            // Section 2.1.4
-            const uint32_t message_type_to_size_in_words[] = {
-                1,  // 0x0 Utility
-                1,  // 0x1 SystemRealTime
-                1,  // 0x2 ChannelVoice10
-                2,  // 0x3 SystemExclusiveData
-                2,  // 0x4 ChannelVoice20
-                4,  // 0x5 Data
-                1,  // 0x6 Reserved
-                1,  // 0x7 Reserved
-                2,  // 0x8 Reserved
-                2,  // 0x9 Reserved
-                2,  // 0xA Reserved
-                3,  // 0xB Reserved
-                3,  // 0xC Reserved
-                4,  // 0xD Reserved
-                4,  // 0xE Reserved
-                4   // 0xF Reserved
-            };
-
             const MIDIEventPacket* packet = eventList->packet;
             for (UInt32 index = 0; index < eventList->numPackets; index++) {
                 LOG_MIDI_D() << "Receiving MIDIEventPacket with " << packet->wordCount << " words";
                 // Handle packet
                 uint32_t pos = 0;
                 while (pos < packet->wordCount) {
-                    uint32_t most_significant_4_bit = packet->words[pos] >> 28;
-                    assert(most_significant_4_bit < 6);
+                    uint32_t messageType = packet->words[pos] >> 28;
+                    size_t messageWordCount = Event::wordCountForMessageType(static_cast<Event::MessageType>(messageType));
 
-                    uint32_t message_size = message_type_to_size_in_words[most_significant_4_bit];
-                    LOG_MIDI_D() << "Receiving midi message with " << message_size << " words";
-                    Event e = Event::fromRawData(&packet->words[pos], message_size);
+                    LOG_MIDI_D() << "Receiving midi message with " << messageWordCount << " words";
+                    Event e = Event::fromMidi20Words(&packet->words[pos], messageWordCount);
                     if (e) {
-                        LOG_MIDI_D() << "Received midi message:" << e.to_string();
+                        LOG_MIDI_D() << "Received midi message: " << e.to_string();
                         m_eventReceived.send((tick_t)packet->timeStamp, e);
                     }
-                    pos += message_size;
+                    pos += messageWordCount;
                 }
                 packet = MIDIEventPacketNext(packet);
             }
         };
 
         result
-            = MIDIInputPortCreateWithProtocol(m_core->client, portName.toCFString(), kMIDIProtocol_2_0, &m_core->inputPort, receiveBlock);
+            = MIDIInputPortCreateWithProtocol(m_core->client, portName, kMIDIProtocol_2_0, &m_core->inputPort, receiveBlock);
     } else {
         MIDIReadBlock readBlock = ^ (const MIDIPacketList* packetList, void* /*srcConnRefCon*/)
         {
@@ -262,20 +229,20 @@ void CoreMidiInPort::initCore()
                 while (pos < len) {
                     Byte status = pointer[pos] >> 4;
                     if (status < 8 || status >= 15) {
-                        LOG_MIDI_W() << "Unhandled status byte:" << status;
+                        LOG_MIDI_W() << "Unhandled status byte: " << status;
                         return;
                     }
                     Event::Opcode opcode = static_cast<Event::Opcode>(status);
-                    int msgLen = Event::midi10ByteCountForOpcode(opcode);
+                    size_t msgLen = Event::midi10ByteCountForOpcode(opcode);
                     if (msgLen == 0) {
                         LOG_MIDI_W() << "Unhandled opcode:" << status;
                         return;
                     }
-                    Event e = Event::fromMIDI10BytePackage(pointer + pos, msgLen);
-                    LOG_MIDI_D() << "Received midi 1.0 message:" << e.to_string();
+                    Event e = Event::fromMidi10Bytes(pointer + pos, msgLen);
+                    LOG_MIDI_D() << "Received midi 1.0 message: " << e.to_string();
                     e = e.toMIDI20();
                     if (e) {
-                        LOG_MIDI_D() << "Converted to midi 2.0 midi message:" << e.to_string();
+                        LOG_MIDI_D() << "Converted to midi 2.0 midi message: " << e.to_string();
                         m_eventReceived.send((tick_t)packet->timeStamp, e);
                     }
                     pos += msgLen;
@@ -284,7 +251,7 @@ void CoreMidiInPort::initCore()
             }
         };
 
-        result = MIDIInputPortCreateWithBlock(m_core->client, portName.toCFString(), &m_core->inputPort, readBlock);
+        result = MIDIInputPortCreateWithBlock(m_core->client, portName, &m_core->inputPort, readBlock);
     }
 
     IF_ASSERT_FAILED(result == noErr) {

--- a/src/framework/midi/internal/platform/osx/coremidioutport.cpp
+++ b/src/framework/midi/internal/platform/osx/coremidioutport.cpp
@@ -21,8 +21,6 @@
  */
 #include "coremidioutport.h"
 
-#include <QString>
-
 #include <CoreAudio/HostTime.h>
 #include <CoreServices/CoreServices.h>
 #include <CoreMIDI/CoreMIDI.h>
@@ -145,15 +143,13 @@ void CoreMidiOutPort::initCore()
         }
     };
 
-    QString name = "MuseScore";
-    result = MIDIClientCreate(name.toCFString(), onCoreMidiNotificationReceived, this, &m_core->client);
+    result = MIDIClientCreate(CFSTR("MuseScore"), onCoreMidiNotificationReceived, this, &m_core->client);
     IF_ASSERT_FAILED(result == noErr) {
         LOGE() << "failed create midi output client";
         return;
     }
 
-    QString portName = "MuseScore output port";
-    result = MIDIOutputPortCreate(m_core->client, portName.toCFString(), &m_core->outputPort);
+    result = MIDIOutputPortCreate(m_core->client, CFSTR("MuseScore output port"), &m_core->outputPort);
     IF_ASSERT_FAILED(result == noErr) {
         LOGE() << "failed create midi output port";
     }
@@ -307,12 +303,7 @@ Ret CoreMidiOutPort::sendEvent(const Event& e)
             MIDIEventList eventList;
             MIDIEventPacket* packet = MIDIEventListInit(&eventList, protocolId);
 
-            if (e.messageType() == Event::MessageType::ChannelVoice20 && e.opcode() == muse::midi::Event::Opcode::NoteOn
-                && e.velocity() < 128) {
-                LOG_MIDI_W() << "Detected low MIDI 2.0 ChannelVoiceMessage velocity.";
-            }
-
-            MIDIEventListAdd(&eventList, sizeof(eventList), packet, timeStamp, wordCount, e.rawData());
+            MIDIEventListAdd(&eventList, sizeof(eventList), packet, timeStamp, wordCount, e.midi20Words());
 
             result = MIDISendEventList(m_core->outputPort, m_core->destinationId, &eventList);
         } else {
@@ -332,7 +323,7 @@ Ret CoreMidiOutPort::sendEvent(const Event& e)
         Byte bytesPackage[4];
 
         for (const Event& event : events) {
-            int length = event.to_MIDI10BytesPackage(bytesPackage);
+            int length = event.toMidi10Bytes(bytesPackage);
             assert(length <= 3);
             if (length == 0) {
                 LOG_MIDI_W() << "Failed Sending MIDIPacketList event: " << event.to_string();

--- a/src/framework/midi/internal/platform/win/winmidiinport.cpp
+++ b/src/framework/midi/internal/platform/win/winmidiinport.cpp
@@ -142,7 +142,7 @@ static void CALLBACK process(HMIDIIN hMidiIn, UINT wMsg, DWORD_PTR dwInstance, D
 
 void WinMidiInPort::doProcess(uint32_t message, tick_t timing)
 {
-    auto e = Event::fromMIDI10Package(message).toMIDI20();
+    auto e = Event::fromMidi10Package(message).toMIDI20();
     if (e) {
         m_eventReceived.send(timing, e);
     }

--- a/src/framework/midi/internal/platform/win/winmidioutport.cpp
+++ b/src/framework/midi/internal/platform/win/winmidioutport.cpp
@@ -192,7 +192,7 @@ Ret WinMidiOutPort::sendEvent(const Event& e)
 
     auto events = e.toMIDI10();
     for (auto& event : events) {
-        uint32_t msg = event.to_MIDI10Package();
+        uint32_t msg = event.toMidi10Package();
         MMRESULT ret = midiOutShortMsg(m_win->midiOut, (DWORD)msg);
         if (ret != MMSYSERR_NOERROR) {
             return make_ret(Err::MidiFailedConnect, "failed send event, error: " + errorString(ret));

--- a/src/framework/midi/view/devtools/midiportdevmodel.cpp
+++ b/src/framework/midi/view/devtools/midiportdevmodel.cpp
@@ -159,7 +159,7 @@ void MidiPortDevModel::generateMIDI20()
         case Event::Opcode::NoteOff:
         case Event::Opcode::NoteOn:
             e.setNote(++note);
-            e.setVelocity(++velocity);
+            e.setVelocity7(++velocity);
             e.setPitchNote(note + 12, 0.5);
             break;
         case Event::Opcode::PolyPressure:

--- a/src/notation/internal/notationmidiinput.cpp
+++ b/src/notation/internal/notationmidiinput.cpp
@@ -218,7 +218,7 @@ Note* NotationMidiInput::addNoteToScore(const muse::midi::Event& e)
 
     mu::engraving::MidiInputEvent inputEv;
     inputEv.pitch = e.note();
-    inputEv.velocity = e.velocity();
+    inputEv.velocity = e.velocity7();
 
     sc->activeMidiPitches().remove_if([&inputEv](const mu::engraving::MidiInputEvent& val) {
         return inputEv.pitch == val.pitch;
@@ -285,7 +285,7 @@ Note* NotationMidiInput::addNoteToScore(const muse::midi::Event& e)
 
 Note* NotationMidiInput::makePreviewNote(const muse::midi::Event& e)
 {
-    if (e.opcode() == muse::midi::Event::Opcode::NoteOff || e.velocity() == 0) {
+    if (e.opcode() == muse::midi::Event::Opcode::NoteOff || e.velocity7() == 0) {
         return nullptr;
     }
 

--- a/src/notation/view/pianokeyboard/pianokeyboardcontroller.cpp
+++ b/src/notation/view/pianokeyboard/pianokeyboardcontroller.cpp
@@ -153,7 +153,7 @@ void PianoKeyboardController::sendNoteOn(piano_key_t key)
     ev.setMessageType(muse::midi::Event::MessageType::ChannelVoice10);
     ev.setOpcode(muse::midi::Event::Opcode::NoteOn);
     ev.setNote(key);
-    ev.setVelocity(80);
+    ev.setVelocity7(80);
 
     notation->midiInput()->onMidiEventReceived(ev);
 }


### PR DESCRIPTION
Related to #26800

The idea is: with the old `velocity()` method, you never know whether you get something on a 7-bit scale or a 16-bit scale. So I'm removing that method, so that you _have_ to choose `velocity7()` or `velocity16()`. 