### PR TITLE
Percussion panel - notation preview now reflects number of staff lines at input position (#26347)

### DIFF
--- a/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
+++ b/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
@@ -285,6 +285,7 @@ Item {
                         panelEnabled: percModel.enabled
                         panelMode: percModel.currentPanelMode
                         useNotationPreview: percModel.useNotationPreview
+                        notationPreviewNumStaffLines: percModel.notationPreviewNumStaffLines
 
                         // When swapping, only show the outline for the swap origin  and the swap target...
                         showEditOutline: percModel.currentPanelMode === PanelMode.EDIT_LAYOUT

--- a/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPad.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPad.qml
@@ -35,6 +35,7 @@ DropArea {
 
     property int panelMode: -1
     property bool useNotationPreview: false
+    property int notationPreviewNumStaffLines: 0
     property bool showEditOutline: false
 
     property alias totalBorderWidth: padLoader.anchors.margins
@@ -210,6 +211,7 @@ DropArea {
                     padModel: root.padModel
                     panelMode: root.panelMode
                     useNotationPreview: root.useNotationPreview
+                    notationPreviewNumStaffLines: root.notationPreviewNumStaffLines
 
                     footerHeight: prv.footerHeight
 

--- a/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPadContent.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPadContent.qml
@@ -32,6 +32,7 @@ Column {
 
     property int panelMode: -1
     property bool useNotationPreview: false
+    property alias notationPreviewNumStaffLines: notationPreview.numStaffLines
 
     property alias footerHeight: footerArea.height
 

--- a/src/notation/utilities/engravingitempreviewpainter.cpp
+++ b/src/notation/utilities/engravingitempreviewpainter.cpp
@@ -46,7 +46,7 @@ void EngravingItemPreviewPainter::paintPreview(mu::engraving::EngravingItem* ele
     }
 
     PointF origin = params.rect.center(); // draw element at center of cell by default
-    if (params.drawStaff) {
+    if (params.numStaffLines > 0) {
         const double topLinePos = paintStaff(params); // draw dummy staff lines onto rect.
         origin.setY(topLinePos); // vertical position relative to staff instead of cell center.
     }
@@ -118,7 +118,7 @@ void EngravingItemPreviewPainter::paintPreviewForActionIcon(mu::engraving::Engra
     painter->restore();
 }
 
-/// Paint a 5 line staff centered within a QRect and return the distance from the
+/// Paint a staff centered within a QRect and return the distance from the
 /// top of the QRect to the uppermost staff line.
 double EngravingItemPreviewPainter::paintStaff(PaintParams& params)
 {
@@ -135,8 +135,7 @@ double EngravingItemPreviewPainter::paintStaff(PaintParams& params)
     pen.setWidthF(engraving::DefaultStyle::defaultStyle().styleS(Sid::staffLineWidth).val() * params.spatium);
     painter->setPen(pen);
 
-    constexpr int numStaffLines = 5;
-    const double staffHeight = params.spatium * (numStaffLines - 1);
+    const double staffHeight = params.spatium * (params.numStaffLines - 1);
     const double topLineDist = params.rect.center().y() - (staffHeight / 2.0);
 
     // lines bounded horizontally by edge of target (with small margin)
@@ -146,7 +145,7 @@ double EngravingItemPreviewPainter::paintStaff(PaintParams& params)
 
     // draw staff lines with middle line centered vertically on target
     double y = topLineDist;
-    for (int i = 0; i < numStaffLines; ++i) {
+    for (int i = 0; i < params.numStaffLines; ++i) {
         painter->drawLine(LineF(x1, y, x2, y));
         y += params.spatium;
     }
@@ -178,7 +177,7 @@ void EngravingItemPreviewPainter::paintPreviewForItem(mu::engraving::EngravingIt
 
     PointF origin = element->ldata()->bbox().center();
 
-    if (params.drawStaff) {
+    if (params.numStaffLines > 0) {
         // y = 0 is position of the element's parent.
         // If the parent is the staff (or a segment on the staff) then
         // y = 0 corresponds to the position of the top staff line.

--- a/src/notation/utilities/engravingitempreviewpainter.h
+++ b/src/notation/utilities/engravingitempreviewpainter.h
@@ -48,7 +48,7 @@ public:
 
         bool useElementColors = false;
         bool colorsInversionEnabled = false;
-        bool drawStaff = false;
+        int numStaffLines = 0;
     };
 
     static void paintPreview(mu::engraving::EngravingItem* element, PaintParams& params);

--- a/src/notation/view/paintedengravingitem.cpp
+++ b/src/notation/view/paintedengravingitem.cpp
@@ -44,7 +44,25 @@ void PaintedEngravingItem::setEngravingItemVariant(QVariant engravingItemVariant
         return;
     }
     m_item = item;
+
+    update();
     emit engravingItemVariantChanged();
+}
+
+int PaintedEngravingItem::numStaffLines() const
+{
+    return m_numStaffLines;
+}
+
+void PaintedEngravingItem::setNumStaffLines(int numStaffLines)
+{
+    if (m_numStaffLines == numStaffLines) {
+        return;
+    }
+    m_numStaffLines = numStaffLines;
+
+    update();
+    emit numStaffLinesChanged();
 }
 
 double PaintedEngravingItem::spatium() const
@@ -58,6 +76,8 @@ void PaintedEngravingItem::setSpatium(double spatium)
         return;
     }
     m_spatium = spatium;
+
+    update();
     emit spatiumChanged();
 }
 
@@ -87,7 +107,7 @@ void PaintedEngravingItem::paintNotationPreview(muse::draw::Painter& painter, qr
 
     params.spatium = m_spatium;
 
-    params.drawStaff = true;
+    params.numStaffLines = m_numStaffLines;
 
     painter.fillRect(params.rect, configuration()->noteBackgroundColor());
 

--- a/src/notation/view/paintedengravingitem.h
+++ b/src/notation/view/paintedengravingitem.h
@@ -39,6 +39,8 @@ class PaintedEngravingItem : public QQuickPaintedItem
     Q_OBJECT
 
     Q_PROPERTY(QVariant engravingItem READ engravingItemVariant WRITE setEngravingItemVariant NOTIFY engravingItemVariantChanged)
+    Q_PROPERTY(int numStaffLines READ numStaffLines WRITE setNumStaffLines NOTIFY numStaffLinesChanged)
+
     Q_PROPERTY(double spatium READ spatium WRITE setSpatium NOTIFY spatiumChanged)
 
 public:
@@ -47,6 +49,9 @@ public:
     QVariant engravingItemVariant() const;
     void setEngravingItemVariant(QVariant engravingItemVariant);
 
+    int numStaffLines() const;
+    void setNumStaffLines(int numStaffLines);
+
     double spatium() const;
     void setSpatium(double spatium);
 
@@ -54,12 +59,15 @@ public:
 
 signals:
     void engravingItemVariantChanged();
+    void numStaffLinesChanged();
     void spatiumChanged();
 
 private:
     void paintNotationPreview(muse::draw::Painter& painter, qreal dpi) const;
 
     mu::engraving::ElementPtr m_item;
+    int m_numStaffLines = 0;
+
     double m_spatium = 1.0;
 };
 }

--- a/src/notation/view/percussionpanel/percussionpanelmodel.cpp
+++ b/src/notation/view/percussionpanel/percussionpanelmodel.cpp
@@ -119,6 +119,18 @@ void PercussionPanelModel::setUseNotationPreview(bool useNotationPreview)
     emit useNotationPreviewChanged(m_useNotationPreview);
 }
 
+int PercussionPanelModel::notationPreviewNumStaffLines() const
+{
+    if (!interaction()) {
+        return 0;
+    }
+
+    const NoteInputState& inputState = interaction()->noteInput()->state();
+    const Staff* staff = inputState.staff();
+
+    return staff ? staff->lines(inputState.tick()) : 0;
+}
+
 PercussionPanelPadListModel* PercussionPanelModel::padListModel() const
 {
     return m_padListModel;
@@ -245,6 +257,8 @@ void PercussionPanelModel::customizeKit()
 void PercussionPanelModel::setUpConnections()
 {
     const auto updatePadModels = [this](Drumset* drumset) {
+        emit notationPreviewNumStaffLinesChanged();
+
         if (drumset && m_padListModel->drumset() && *drumset == *m_padListModel->drumset()) {
             return;
         }

--- a/src/notation/view/percussionpanel/percussionpanelmodel.h
+++ b/src/notation/view/percussionpanel/percussionpanelmodel.h
@@ -67,6 +67,7 @@ class PercussionPanelModel : public QObject, public muse::Injectable, public mus
 
     Q_PROPERTY(PanelMode::Mode currentPanelMode READ currentPanelMode WRITE setCurrentPanelMode NOTIFY currentPanelModeChanged)
     Q_PROPERTY(bool useNotationPreview READ useNotationPreview WRITE setUseNotationPreview NOTIFY useNotationPreviewChanged)
+    Q_PROPERTY(int notationPreviewNumStaffLines READ notationPreviewNumStaffLines NOTIFY notationPreviewNumStaffLinesChanged)
 
     Q_PROPERTY(PercussionPanelPadListModel * padListModel READ padListModel NOTIFY padListModelChanged)
 
@@ -86,6 +87,8 @@ public:
 
     bool useNotationPreview() const;
     void setUseNotationPreview(bool useNotationPreview);
+
+    int notationPreviewNumStaffLines() const;
 
     PercussionPanelPadListModel* padListModel() const;
 
@@ -107,6 +110,7 @@ signals:
 
     void currentPanelModeChanged(const PanelMode::Mode& panelMode);
     void useNotationPreviewChanged(bool useNotationPreview);
+    void notationPreviewNumStaffLinesChanged();
 
     void padListModelChanged();
 

--- a/src/palette/internal/palettecelliconengine.cpp
+++ b/src/palette/internal/palettecelliconengine.cpp
@@ -85,7 +85,8 @@ void PaletteCellIconEngine::paintCell(Painter& painter, const RectF& rect, bool 
     params.dpi = dpi;
     params.spatium = configuration()->paletteSpatium() * params.mag;
 
-    params.drawStaff = m_cell->drawStaff;
+    //! NOTE: Slight hack - we can now specify exactly now many staff lines we want...
+    params.numStaffLines = m_cell->drawStaff ? 5 : 0;
 
     notation::EngravingItemPreviewPainter::paintPreview(element, params);
 }


### PR DESCRIPTION
Addresses the third point of #26347

Worth noting that these changes also theoretically allow us to modify the number of staff lines displayed in palettes...