### PR TITLE
4.5.0: Update all Linux builds to use Ubuntu 22.04

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -107,8 +107,7 @@ jobs:
         # Expose edge cases like different command versions, CRLF line endings, etc.
         # Use same OS versions as used in real build workflows.
         os:
-        - ubuntu-20.04 # linux_x64, backend
-        - ubuntu-22.04 # linux_arm32, linux_arm64
+        - ubuntu-22.04 # linux_x64, backend, linux_arm32, linux_arm64
         - macos-latest
         - windows-2022 # windows_x64, windows_portable
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build_backend.yml
+++ b/.github/workflows/build_backend.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   backend:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: github.event_name != 'schedule' || github.repository == 'musescore/MuseScore'
     steps:
     - name: Cancel Previous Runs

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -36,7 +36,7 @@ on:
 
 jobs:
   linux_x64:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Cancel Previous Runs
       uses: styfle/cancel-workflow-action@0.12.1

--- a/.github/workflows/build_without_qt.yml
+++ b/.github/workflows/build_without_qt.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   run_tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Cancel Previous Runs
       uses: styfle/cancel-workflow-action@0.12.1

--- a/.github/workflows/check_visual_tests.yml
+++ b/.github/workflows/check_visual_tests.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   setup:
     name: "Setup VTests workflow"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       do_run: ${{ steps.output_data.outputs.do_run }}
       reference_sha: ${{ steps.output_data.outputs.reference_sha }}
@@ -59,7 +59,7 @@ jobs:
 
   build_current:
     name: "Build current"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: setup
     if: needs.setup.outputs.do_run == 'true'
     steps:
@@ -95,7 +95,7 @@ jobs:
 
   build_reference:
     name: "Build reference"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: setup
     if: needs.setup.outputs.do_run == 'true'
     steps:
@@ -133,7 +133,7 @@ jobs:
 
   generate_and_compare:
     name: "Generate and Compare"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [setup, build_current, build_reference]
     if: needs.setup.outputs.do_run == 'true'
     steps:

--- a/.github/workflows/update_release_info.yml
+++ b/.github/workflows/update_release_info.yml
@@ -33,7 +33,7 @@ defaults:
 
 jobs:
   update-release-info:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     environment:
       name: ${{ inputs.environment }} # can be empty/blank (if so, URL will not be shown)
       url: ${{ github.server_url }}/${{ github.repository }}/releases/${{ inputs.tag && format('tag/{0}', inputs.tag) || 'latest' }} # show on run page

--- a/.github/workflows/update_release_info_clear.yml
+++ b/.github/workflows/update_release_info_clear.yml
@@ -14,7 +14,7 @@ defaults:
 
 jobs:
   update-release-clear:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Clone repository
         uses: actions/checkout@v4

--- a/buildscripts/ci/vtests/generate_pngs.sh
+++ b/buildscripts/ci/vtests/generate_pngs.sh
@@ -21,7 +21,7 @@
 
 trap 'echo Generate PNGs failed; exit 1' ERR
 
-sudo apt-get install libegl1 -y
+sudo apt-get install libegl1 libfuse2 -y
 export QT_QPA_PLATFORM=offscreen
 
 REF_BIN=./musescore_reference/MuseScore-Studio-vtest.AppImage


### PR DESCRIPTION
as 20.04 will get deprecated on GitHub CI on April 1st, see https://github.com/actions/runner-images/issues/11101

Same as #26827, but for 4.5.0. Before merging see https://github.com/musescore/MuseScore/pull/26827#issuecomment-2691153243  ;-)