### PR TITLE
Percussion panel - add `useNotationPreview` to notation configuration

### DIFF
--- a/src/notation/inotationconfiguration.h
+++ b/src/notation/inotationconfiguration.h
@@ -231,6 +231,10 @@ public:
     virtual void setUseNewPercussionPanel(bool use) = 0;
     virtual muse::async::Notification useNewPercussionPanelChanged() const = 0;
 
+    virtual bool percussionPanelUseNotationPreview() const = 0;
+    virtual void setPercussionPanelUseNotationPreview(bool use) = 0;
+    virtual muse::async::Notification percussionPanelUseNotationPreviewChanged() const = 0;
+
     virtual PercussionPanelAutoShowMode percussionPanelAutoShowMode() const = 0;
     virtual void setPercussionPanelAutoShowMode(PercussionPanelAutoShowMode autoShowMode) = 0;
     virtual muse::async::Notification percussionPanelAutoShowModeChanged() const = 0;

--- a/src/notation/internal/notationconfiguration.cpp
+++ b/src/notation/internal/notationconfiguration.cpp
@@ -108,6 +108,7 @@ static const Settings::Key NEED_TO_SHOW_ADD_GUITAR_BEND_ERROR_MESSAGE_KEY(module
 static const Settings::Key PIANO_KEYBOARD_NUMBER_OF_KEYS(module_name,  "pianoKeyboard/numberOfKeys");
 
 static const Settings::Key USE_NEW_PERCUSSION_PANEL_KEY(module_name,  "ui/useNewPercussionPanel");
+static const Settings::Key PERCUSSION_PANEL_USE_NOTATION_PREVIEW_KEY(module_name,  "ui/percussionPanelUseNotationPreview");
 static const Settings::Key PERCUSSION_PANEL_AUTO_SHOW_MODE_KEY(module_name,  "ui/percussionPanelAutoShowMode");
 static const Settings::Key AUTO_CLOSE_PERCUSSION_PANEL_KEY(module_name, "ui/autoClosePercussionPanel");
 static const Settings::Key SHOW_PERCUSSION_PANEL_SWAP_DIALOG(module_name,  "ui/showPercussionPanelPadSwapDialog");
@@ -324,6 +325,11 @@ void NotationConfiguration::init()
     settings()->setDefaultValue(USE_NEW_PERCUSSION_PANEL_KEY, Val(true));
     settings()->valueChanged(USE_NEW_PERCUSSION_PANEL_KEY).onReceive(this, [this](const Val&) {
         m_useNewPercussionPanelChanged.notify();
+    });
+
+    settings()->setDefaultValue(PERCUSSION_PANEL_USE_NOTATION_PREVIEW_KEY, Val(false));
+    settings()->valueChanged(PERCUSSION_PANEL_USE_NOTATION_PREVIEW_KEY).onReceive(this, [this](const Val&) {
+        m_percussionPanelUseNotationPreviewChanged.notify();
     });
 
     settings()->setDefaultValue(PERCUSSION_PANEL_AUTO_SHOW_MODE_KEY, Val(PercussionPanelAutoShowMode::UNPITCHED_STAFF));
@@ -1150,6 +1156,21 @@ void NotationConfiguration::setUseNewPercussionPanel(bool use)
 Notification NotationConfiguration::useNewPercussionPanelChanged() const
 {
     return m_useNewPercussionPanelChanged;
+}
+
+bool NotationConfiguration::percussionPanelUseNotationPreview() const
+{
+    return settings()->value(PERCUSSION_PANEL_USE_NOTATION_PREVIEW_KEY).toBool();
+}
+
+void NotationConfiguration::setPercussionPanelUseNotationPreview(bool use)
+{
+    settings()->setSharedValue(PERCUSSION_PANEL_USE_NOTATION_PREVIEW_KEY, Val(use));
+}
+
+Notification NotationConfiguration::percussionPanelUseNotationPreviewChanged() const
+{
+    return m_percussionPanelUseNotationPreviewChanged;
 }
 
 PercussionPanelAutoShowMode NotationConfiguration::percussionPanelAutoShowMode() const

--- a/src/notation/internal/notationconfiguration.h
+++ b/src/notation/internal/notationconfiguration.h
@@ -236,6 +236,10 @@ public:
     void setUseNewPercussionPanel(bool use) override;
     muse::async::Notification useNewPercussionPanelChanged() const override;
 
+    bool percussionPanelUseNotationPreview() const override;
+    void setPercussionPanelUseNotationPreview(bool use) override;
+    muse::async::Notification percussionPanelUseNotationPreviewChanged() const override;
+
     PercussionPanelAutoShowMode percussionPanelAutoShowMode() const override;
     void setPercussionPanelAutoShowMode(PercussionPanelAutoShowMode percussionPanelAutoShowMode) override;
     muse::async::Notification percussionPanelAutoShowModeChanged() const override;
@@ -299,6 +303,7 @@ private:
     muse::ValCh<bool> m_midiInputUseWrittenPitch;
     muse::async::Channel<QColor> m_anchorColorChanged;
     muse::async::Notification m_useNewPercussionPanelChanged;
+    muse::async::Notification m_percussionPanelUseNotationPreviewChanged;
     muse::async::Notification m_percussionPanelAutoShowModeChanged;
     muse::async::Notification m_autoClosePercussionPanelChanged;
     muse::async::Notification m_showPercussionPanelPadSwapDialogChanged;

--- a/src/notation/tests/mocks/notationconfigurationmock.h
+++ b/src/notation/tests/mocks/notationconfigurationmock.h
@@ -221,6 +221,10 @@ public:
     MOCK_METHOD(void, setUseNewPercussionPanel, (bool), (override));
     MOCK_METHOD(muse::async::Notification, useNewPercussionPanelChanged, (), (const, override));
 
+    MOCK_METHOD(bool, percussionPanelUseNotationPreview, (), (const, override));
+    MOCK_METHOD(void, setPercussionPanelUseNotationPreview, (bool), (override));
+    MOCK_METHOD(muse::async::Notification, percussionPanelUseNotationPreviewChanged, (), (const, override));
+
     MOCK_METHOD(PercussionPanelAutoShowMode, percussionPanelAutoShowMode, (), (const, override));
     MOCK_METHOD(void, setPercussionPanelAutoShowMode, (PercussionPanelAutoShowMode), (override));
     MOCK_METHOD(muse::async::Notification, percussionPanelAutoShowModeChanged, (), (const, override));

--- a/src/notation/view/percussionpanel/percussionpanelmodel.h
+++ b/src/notation/view/percussionpanel/percussionpanelmodel.h
@@ -148,7 +148,6 @@ private:
 
     PanelMode::Mode m_currentPanelMode = PanelMode::Mode::WRITE;
     PanelMode::Mode m_panelModeToRestore = PanelMode::Mode::WRITE;
-    bool m_useNotationPreview = false;
 
     PercussionPanelPadListModel* m_padListModel = nullptr;
 };

--- a/src/stubs/notation/notationconfigurationstub.cpp
+++ b/src/stubs/notation/notationconfigurationstub.cpp
@@ -629,6 +629,21 @@ muse::async::Notification NotationConfigurationStub::useNewPercussionPanelChange
     return n;
 }
 
+bool NotationConfigurationStub::percussionPanelUseNotationPreview() const
+{
+    return false;
+}
+
+void NotationConfigurationStub::setPercussionPanelUseNotationPreview(bool)
+{
+}
+
+muse::async::Notification NotationConfigurationStub::percussionPanelUseNotationPreviewChanged() const
+{
+    static muse::async::Notification n;
+    return n;
+}
+
 bool NotationConfigurationStub::autoShowPercussionPanel() const
 {
     return true;

--- a/src/stubs/notation/notationconfigurationstub.h
+++ b/src/stubs/notation/notationconfigurationstub.h
@@ -212,6 +212,10 @@ public:
     void setUseNewPercussionPanel(bool use) override;
     muse::async::Notification useNewPercussionPanelChanged() const override;
 
+    bool percussionPanelUseNotationPreview() const override;
+    void setPercussionPanelUseNotationPreview(bool use);
+    muse::async::Notification percussionPanelUseNotationPreviewChanged() const override;
+
     PercussionPanelAutoShowMode percussionPanelAutoShowMode() const override;
     void setPercussionPanelAutoShowMode(PercussionPanelAutoShowMode autoShowMode) override;
     muse::async::Notification percussionPanelAutoShowModeChanged() const override;


### PR DESCRIPTION
When switching the percussion panel to notation preview mode, we want this state to persist after closing/reopening the panel (and between sessions). To do this, `useNotationPreview` has been removed as a private member of `PercussionPanelModel` and added to our notation configuration.