### PR TITLE
[MusicXML] add support for guitar tap

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
@@ -3314,6 +3314,12 @@ static String symIdToTechn(const SymId sid)
     case SymId::pluckedSnapPizzicatoBelow:
         return u"snap-pizzicato";
         break;
+    case SymId::guitarLeftHandTapping:
+        return u"tap hand=\"left\"";
+        break;
+    case SymId::guitarRightHandTapping:
+        return u"tap hand=\"right\"";
+        break;
     case SymId::keyboardPedalHeel1:
     case SymId::keyboardPedalHeel2:
     case SymId::keyboardPedalHeel3:

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -8304,6 +8304,11 @@ void MusicXmlParserNotations::technical()
             harmonMute();
         } else if (m_e.name() == "hole") {
             hole();
+        } else if (m_e.name() == "tap") {
+            id = (m_e.attribute("hand") == u"left") ? SymId::guitarLeftHandTapping : SymId::guitarRightHandTapping;
+            m_notations.push_back(Notation::notationWithAttributes(String::fromAscii(m_e.name().ascii()),
+                                                                   m_e.attributes(), u"technical", id));
+            m_e.skipCurrentElement();  // skip but don't log
         } else if (m_e.name() == "other-technical") {
             otherTechnical();
         } else {


### PR DESCRIPTION
This PR adds support for [tap](https://www.w3.org/2021/06/musicxml40/musicxml-reference/elements/tap/) elements.