### PR TITLE
Remove superfluous ampersand

### DIFF
--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -737,7 +737,7 @@ const UiActionList NotationUiActions::m_actions = {
              mu::context::UiCtxProjectOpened,
              mu::context::CTX_NOTATION_OPENED,
              TranslatableString("action", "Insert &fretboard diagram legend"),
-             TranslatableString("action", "Insert &fretboard diagram legend"),
+             TranslatableString("action", "Insert fretboard diagram legend"),
              IconCode::Code::FRET_FRAME
              ),
     UiAction("append-hbox",


### PR DESCRIPTION
Resolves:
<img width="992" alt="Scherm­afbeelding 2025-03-01 om 17 59 42" src="https://github.com/user-attachments/assets/01a21e03-e4c4-45cf-a36b-c96fbd29cda1" />
