### PR TITLE
Fixes for plugins shortcuts in Home > Plugins

### DIFF
--- a/src/framework/extensions/extensionstypes.h
+++ b/src/framework/extensions/extensionstypes.h
@@ -150,25 +150,35 @@ struct Action {
 
     struct Config {
         ExecPointName execPoint = EXEC_DISABLED;
-        std::string shortcut;
     };
 
     bool isValid() const { return type != Type::Undefined && !code.empty(); }
 };
 
-inline actions::ActionQuery makeActionQuery(const Uri& uri, const std::string& actionCode)
+inline actions::ActionQuery makeActionQueryBase(const Uri& uri)
 {
     UriQuery q(uri);
     q.setScheme("action");
+    return q;
+}
+
+inline actions::ActionQuery makeActionQuery(const Uri& uri, const std::string& actionCode)
+{
+    UriQuery q = makeActionQueryBase(uri);
     q.addParam("action", Val(actionCode));
     return q;
 }
 
 inline UriQuery uriQueryFromActionQuery(const actions::ActionQuery& a)
 {
-    UriQuery q(a.toString());
+    UriQuery q(a);
     q.setScheme("musescore");
     return q;
+}
+
+inline actions::ActionCode makeActionCodeBase(const Uri& uri)
+{
+    return makeActionQueryBase(uri).toString();
 }
 
 inline actions::ActionCode makeActionCode(const Uri& uri, const std::string& extActionCode)
@@ -195,9 +205,6 @@ manifest.json
 struct Manifest {
     struct Config {
         std::map<std::string /*action*/, Action::Config> actions;
-
-        //! TODO remove
-        std::string shortcuts;
 
         const Action::Config& aconfig(const std::string& code) const
         {

--- a/src/framework/extensions/internal/extensionsconfiguration.cpp
+++ b/src/framework/extensions/internal/extensionsconfiguration.cpp
@@ -94,7 +94,6 @@ Ret ExtensionsConfiguration::setManifestConfigs(const std::map<Uri, Manifest::Co
             JsonObject act;
             act["code"] = a.first;
             act["exec_point"] = a.second.execPoint;
-            act["shortcut"] = a.second.shortcut;
             acts.append(act);
         }
         obj["actions"] = acts;
@@ -163,7 +162,6 @@ std::map<muse::Uri, Manifest::Config> ExtensionsConfiguration::manifestConfigs()
                 std::string code = ao.value("code").toStdString();
                 Action::Config ac;
                 ac.execPoint = ao.value("exec_point").toStdString();
-                ac.shortcut = ao.value("shortcut").toStdString();
 
                 c.actions[code] = ac;
             }
@@ -217,7 +215,6 @@ std::map<muse::Uri, Manifest::Config> ExtensionsConfiguration::manifestConfigs()
             bool enabled = obj.value("enabled").toBool();
             Action::Config ac;
             ac.execPoint = enabled ? EXEC_MANUALLY : EXEC_DISABLED;
-            ac.shortcut = obj.value("shortcut").toStdString();
 
             //! NOTE Special case
             if (codeKey == "addCourtesyAccidentals") {

--- a/src/framework/extensions/internal/extensionsloader.cpp
+++ b/src/framework/extensions/internal/extensionsloader.cpp
@@ -124,6 +124,7 @@ Manifest ExtensionsLoader::parseManifest(const ByteArray& data) const
     m.description = obj.value("description").toString();
     m.category = obj.value("category").toString();
     m.thumbnail = obj.value("thumbnail").toStdString();
+    m.version = obj.value("version").toString();
     m.apiversion = obj.value("apiversion", DEFAULT_API_VERSION).toInt();
 
     String uiCtx = obj.value("ui_context", String(DEFAULT_UI_CONTEXT)).toString();

--- a/src/framework/extensions/internal/legacy/extpluginsloader.cpp
+++ b/src/framework/extensions/internal/legacy/extpluginsloader.cpp
@@ -173,7 +173,7 @@ Manifest ExtPluginsLoader::parseManifest(const io::path_t& rootPath, const io::p
     };
 
     String uiCtx = DEFAULT_UI_CONTEXT;
-    int needProperties = 6; // title, description, pluginType, category, thumbnail, requiresScore
+    int needProperties = 7; // title, description, pluginType, category, thumbnail, requiresScore, version
     int propertiesFound = 0;
     bool insideMuseScoreItem = false;
     size_t current, previous = 0;
@@ -242,6 +242,9 @@ Manifest ExtPluginsLoader::parseManifest(const io::path_t& rootPath, const io::p
             if (requiresScore == u"false") {
                 uiCtx = "Any";
             }
+            ++propertiesFound;
+        } else if (line.startsWith(u"version:")) {
+            m.version = dropQuotes(line.mid(8).trimmed());
             ++propertiesFound;
         }
 

--- a/src/framework/extensions/qml/Muse/Extensions/ExtensionsListPanel.qml
+++ b/src/framework/extensions/qml/Muse/Extensions/ExtensionsListPanel.qml
@@ -119,7 +119,7 @@ Item {
                 search: root.search
                 pluginIsEnabled: true
                 selectedCategory: root.selectedCategory
-                selectedPluginCodeKey: prv.selectedPlugin ? prv.selectedPlugin.codeKey : ""
+                selectedPluginUri: prv.selectedPlugin?.uri ?? ""
 
                 model: extensionsModel
 
@@ -148,7 +148,7 @@ Item {
                 search: root.search
                 pluginIsEnabled: false
                 selectedCategory: root.selectedCategory
-                selectedPluginCodeKey: prv.selectedPlugin ? prv.selectedPlugin.codeKey : ""
+                selectedPluginUri: prv.selectedPlugin?.uri ?? ""
 
                 model: extensionsModel
 
@@ -171,8 +171,8 @@ Item {
 
     function openInfoPanel(plugin, navigationControl) {
         prv.selectedPlugin = Object.assign({}, plugin)
-        panel.currentExecPointIndex = extensionsModel.currentExecPointIndex(prv.selectedPlugin.codeKey)
-        panel.execPointsModel = extensionsModel.execPointsModel(prv.selectedPlugin.codeKey)
+        panel.currentExecPointIndex = extensionsModel.currentExecPointIndex(prv.selectedPlugin.uri)
+        panel.execPointsModel = extensionsModel.execPointsModel(prv.selectedPlugin.uri)
         panel.open()
         prv.lastNavigatedExtension = navigationControl
     }
@@ -195,11 +195,11 @@ Item {
         ]
 
         onExecPointSelected: function(index) {
-            extensionsModel.selectExecPoint(selectedPlugin.codeKey, index)
+            extensionsModel.selectExecPoint(selectedPlugin.uri, index)
         }
 
         onEditShortcutRequested: {
-            Qt.callLater(extensionsModel.editShortcut, selectedPlugin.codeKey)
+            Qt.callLater(extensionsModel.editShortcut, selectedPlugin.uri)
             panel.close()
         }
 

--- a/src/framework/extensions/qml/Muse/Extensions/internal/ExtensionsListView.qml
+++ b/src/framework/extensions/qml/Muse/Extensions/internal/ExtensionsListView.qml
@@ -36,7 +36,7 @@ Column {
     property string search: ""
     property string selectedCategory: ""
     property bool pluginIsEnabled: false
-    property string selectedPluginCodeKey: ""
+    property string selectedPluginUri: ""
 
     property var flickableItem: null
     property int headerHeight: titleLabel.height + spacing
@@ -137,7 +137,7 @@ Column {
 
                 name: model.name
                 thumbnailUrl: model.thumbnailUrl
-                selected: model.codeKey === root.selectedPluginCodeKey
+                selected: model.uri === root.selectedPluginUri
 
                 navigation.panel: root.navigationPanel
                 navigation.row: view.columns === 0 ? 0 : Math.floor(model.index / view.columns)

--- a/src/framework/extensions/view/extensionslistmodel.cpp
+++ b/src/framework/extensions/view/extensionslistmodel.cpp
@@ -100,6 +100,10 @@ QVariant ExtensionsListModel::data(const QModelIndex& index, int role) const
     case rCategory:
         return plugin.category.toQString();
     case rVersion:
+        if (plugin.version.empty()) {
+            //: No version is specified for this plugin.
+            return muse::qtrc("extensions", "Not specified");
+        }
         return plugin.version.toQString();
     case rShortcuts: {
         std::vector<std::string> shortcuts;

--- a/src/framework/extensions/view/extensionslistmodel.cpp
+++ b/src/framework/extensions/view/extensionslistmodel.cpp
@@ -35,14 +35,16 @@ static constexpr int INVALID_INDEX = -1;
 ExtensionsListModel::ExtensionsListModel(QObject* parent)
     : QAbstractListModel(parent), Injectable(muse::iocCtxForQmlObject(this))
 {
-    m_roles.insert(rCode, "codeKey");
-    m_roles.insert(rName, "name");
-    m_roles.insert(rDescription, "description");
-    m_roles.insert(rThumbnailUrl, "thumbnailUrl");
-    m_roles.insert(rEnabled, "enabled");
-    m_roles.insert(rCategory, "category");
-    m_roles.insert(rVersion, "version");
-    m_roles.insert(rShortcuts, "shortcuts");
+    m_roles = {
+        { rUri, "uri" },
+        { rName, "name" },
+        { rDescription, "description" },
+        { rThumbnailUrl, "thumbnailUrl" },
+        { rEnabled, "enabled" },
+        { rCategory, "category" },
+        { rVersion, "version" },
+        { rShortcuts, "shortcuts" },
+    };
 }
 
 void ExtensionsListModel::load()
@@ -81,7 +83,7 @@ QVariant ExtensionsListModel::data(const QModelIndex& index, int role) const
     Manifest plugin = m_plugins.at(index.row());
 
     switch (role) {
-    case rCode:
+    case rUri:
         return QString::fromStdString(plugin.uri.toString());
     case rName:
         return plugin.title.toQString();
@@ -99,13 +101,21 @@ QVariant ExtensionsListModel::data(const QModelIndex& index, int role) const
         return plugin.category.toQString();
     case rVersion:
         return plugin.version.toQString();
-    case rShortcuts:
-        if (!plugin.config.shortcuts.empty()) {
-            return shortcuts::sequencesToNativeText(shortcuts::Shortcut::sequencesFromString(plugin.config.shortcuts));
+    case rShortcuts: {
+        std::vector<std::string> shortcuts;
+        for (const auto& action : plugin.actions) {
+            actions::ActionCode code = makeActionCode(plugin.uri, action.code);
+            shortcuts::Shortcut shortcut = shortcutsRegister()->shortcut(code);
+            shortcuts.insert(shortcuts.end(), shortcut.sequences.cbegin(), shortcut.sequences.cend());
+        }
+
+        if (!shortcuts.empty()) {
+            return shortcuts::sequencesToNativeText(shortcuts);
         }
 
         //: No keyboard shortcut is assigned to this plugin.
         return muse::qtrc("extensions", "Not defined");
+    }
     }
 
     return QVariant();
@@ -176,21 +186,24 @@ void ExtensionsListModel::selectExecPoint(const QString& uri, int index)
     emit finished();
 }
 
-void ExtensionsListModel::editShortcut(QString codeKey)
+void ExtensionsListModel::editShortcut(const QString& extensionUri)
 {
-    int index = itemIndexByCodeKey(codeKey);
+    int index = itemIndexByUri(extensionUri);
     if (index == INVALID_INDEX) {
         return;
     }
 
-    UriQuery uri("muse://preferences");
-    uri.addParam("currentPageId", Val("shortcuts"));
+    QString actionCodeBase
+        = QString::fromStdString(makeActionCodeBase(Uri(extensionUri.toStdString())));
+
+    UriQuery preferencesUri("muse://preferences");
+    preferencesUri.addParam("currentPageId", Val("shortcuts"));
 
     QVariantMap params;
-    params["shortcutCodeKey"] = codeKey;
-    uri.addParam("params", Val::fromQVariant(params));
+    params["shortcutCodeKey"] = actionCodeBase;
+    preferencesUri.addParam("params", Val::fromQVariant(params));
 
-    RetVal<Val> retVal = interactive()->open(uri);
+    RetVal<Val> retVal = interactive()->open(preferencesUri);
 
     if (!retVal.ret) {
         LOGE() << retVal.ret.toString();
@@ -232,7 +245,7 @@ void ExtensionsListModel::updatePlugin(const Manifest& plugin)
     }
 }
 
-int ExtensionsListModel::itemIndexByCodeKey(const QString& uri_) const
+int ExtensionsListModel::itemIndexByUri(const QString& uri_) const
 {
     Uri uri(uri_.toStdString());
     for (size_t i = 0; i < m_plugins.size(); ++i) {

--- a/src/framework/extensions/view/extensionslistmodel.h
+++ b/src/framework/extensions/view/extensionslistmodel.h
@@ -31,6 +31,7 @@
 #include "iinteractive.h"
 #include "extensions/iextensionsconfiguration.h"
 #include "extensions/iextensionsprovider.h"
+#include "shortcuts/ishortcutsregister.h"
 
 namespace muse::extensions {
 class ExtensionsListModel : public QAbstractListModel, public Injectable, public async::Asyncable
@@ -40,6 +41,7 @@ class ExtensionsListModel : public QAbstractListModel, public Injectable, public
     Inject<IInteractive> interactive = { this };
     Inject<IExtensionsProvider> provider = { this };
     Inject<IExtensionsConfiguration> configuration = { this };
+    Inject<shortcuts::IShortcutsRegister> shortcutsRegister = { this };
 
 public:
     explicit ExtensionsListModel(QObject* parent = nullptr);
@@ -54,7 +56,7 @@ public:
     Q_INVOKABLE QVariantList execPointsModel(const QString& uri) const;
     Q_INVOKABLE void selectExecPoint(const QString& uri, int index);
 
-    Q_INVOKABLE void editShortcut(QString codeKey);
+    Q_INVOKABLE void editShortcut(const QString& uri);
     Q_INVOKABLE void reloadPlugins();
 
     Q_INVOKABLE QVariantList categories() const;
@@ -64,7 +66,7 @@ signals:
 
 private:
     enum Roles {
-        rCode = Qt::UserRole + 1,
+        rUri = Qt::UserRole + 1,
         rName,
         rDescription,
         rThumbnailUrl,
@@ -80,7 +82,7 @@ private:
     };
 
     void updatePlugin(const Manifest& plugin);
-    int itemIndexByCodeKey(const QString& uri) const;
+    int itemIndexByUri(const QString& uri) const;
 
     const std::vector<ExecPoint>& execPoints(const QString& uri) const;
 

--- a/src/framework/uicomponents/qml/Muse/UiComponents/InfoPanel.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/InfoPanel.qml
@@ -113,54 +113,31 @@ PopupPanel {
         }
 
         Column {
-            width: 585
-
+            width: Math.min(585, parent.width)
             spacing: 8
 
             StyledTextLabel {
                 id: titleLabel
-
+                width: parent.width
+                horizontalAlignment: Text.AlignLeft
                 text: Boolean(root.title) ? root.title : ""
                 font: ui.theme.headerBoldFont
             }
 
-            Row {
-                anchors.left: parent.left
-                anchors.right: parent.right
-
-                spacing: 4
-
+            StyledTextLabel {
                 visible: Boolean(root.additionalInfoModel)
+                width: parent.width
+                horizontalAlignment: Text.AlignLeft
+                font: ui.theme.largeBodyFont
 
-                Repeater {
-                    model: root.additionalInfoModel
-                    Row {
-                        spacing: 4
-                        Rectangle {
-                            width: 2
-                            height: parent.height - 4
-                            anchors.verticalCenter: parent.verticalCenter
-                            color: ui.theme.fontPrimaryColor
-
-                            visible: index !== 0
-                        }
-
-                        StyledTextLabel {
-                            font: ui.theme.largeBodyFont
-                            text: modelData.title
-                        }
-
-                        StyledTextLabel {
-                            font: ui.theme.largeBodyBoldFont
-                            text: modelData.value
-                        }
-                    }
-                }
+                text: root.additionalInfoModel
+                      ?.map(pair => `${pair.title} <b>${pair.value}</b>`)
+                      ?.join(" | ")
             }
         }
 
         StyledTextLabel {
-            width: 585
+            width: Math.min(585, parent.width)
             height: 88
 
             opacity: 0.75


### PR DESCRIPTION
Now, the shortcuts register is the single source of truth.

Resolves: https://github.com/musescore/MuseScore/issues/24906
Resolves: https://github.com/musescore/MuseScore/issues/26872
Resolves: version numbers were missing too