### PR TITLE
Create "Built-in styles" shortcut within the user styles folder

### DIFF
--- a/share/styles/MSN/CMakeLists.txt
+++ b/share/styles/MSN/CMakeLists.txt
@@ -4,7 +4,7 @@
 # MuseScore Studio
 # Music Composition & Notation
 #
-# Copyright (C) 2021 MuseScore Limited
+# Copyright (C) 2025 MuseScore Limited
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -19,17 +19,10 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 install(FILES
-      MuseJazz.mss
-      chords_std.xml
-      chords_jazz.xml
-      chords.xml
-      stdchords.xml
-      jazzchords.xml
-      cchords_muse.xml
-      cchords_nrb.xml
-      cchords_rb.xml
-      cchords_sym.xml
-      DESTINATION ${Mscore_SHARE_NAME}${Mscore_INSTALL_NAME}styles
-      )
-
-add_subdirectory(MSN)
+    16mm_MSN.mss
+    18mm_MSN.mss
+    20mm_MSN.mss
+    22mm_MSN.mss
+    25mm_MSN.mss
+    DESTINATION "${Mscore_SHARE_NAME}${Mscore_INSTALL_NAME}styles/Modified Stave Notation"
+)

--- a/src/framework/global/io/ifilesystem.h
+++ b/src/framework/global/io/ifilesystem.h
@@ -45,6 +45,7 @@ public:
     virtual Ret move(const io::path_t& src, const io::path_t& dst, bool replace = false) = 0;
 
     virtual Ret makePath(const io::path_t& path) const = 0;
+    virtual Ret makeLink(const io::path_t& targetPath, const io::path_t& linkPath) const = 0;
 
     virtual EntryType entryType(const io::path_t& path) const = 0;
 

--- a/src/framework/global/io/internal/filesystem.cpp
+++ b/src/framework/global/io/internal/filesystem.cpp
@@ -228,6 +228,23 @@ Ret FileSystem::makePath(const io::path_t& path) const
     return make_ret(Err::NoError);
 }
 
+Ret FileSystem::makeLink(const io::path_t& targetPath, const path_t& linkPath) const
+{
+    // On Windows, if targetPath points to a directory rather than a file, the
+    // path must be normalized otherwise the shortcut file won't work. On other
+    // platforms, normalization makes symlink resolution slightly faster.
+    QString target = QDir::cleanPath(targetPath.toQString());
+    QString link = linkPath.toQString();
+
+#if defined(Q_OS_WIN)
+    // Also required to make the shortcut file valid...
+    target = QDir::toNativeSeparators(target);
+    link += ".lnk";
+#endif
+
+    return QFile().link(target, link) ? make_ret(Err::NoError) : make_ret(Err::FSMakingError);
+}
+
 EntryType FileSystem::entryType(const io::path_t& path) const
 {
     QFileInfo fi(path.toQString());

--- a/src/framework/global/io/internal/filesystem.h
+++ b/src/framework/global/io/internal/filesystem.h
@@ -36,6 +36,7 @@ public:
     Ret move(const io::path_t& src, const io::path_t& dst, bool replace = false) override;
 
     Ret makePath(const io::path_t& path) const override;
+    Ret makeLink(const io::path_t& targetPath, const io::path_t& linkPath) const override;
 
     EntryType entryType(const io::path_t& path) const override;
 

--- a/src/framework/global/tests/mocks/filesystemmock.h
+++ b/src/framework/global/tests/mocks/filesystemmock.h
@@ -45,6 +45,7 @@ public:
     MOCK_METHOD(Ret, writeFile, (const io::path_t& filePath, const ByteArray& data), (const, override));
 
     MOCK_METHOD(Ret, makePath, (const io::path_t&), (const, override));
+    MOCK_METHOD(Ret, makeLink, (const io::path_t& targetPath, const io::path_t& linkPath), (const, override));
 
     MOCK_METHOD(RetVal<io::paths_t>, scanFiles, (const io::path_t&, const std::vector<std::string>&, ScanMode), (const, override));
 

--- a/src/notation/internal/notationconfiguration.cpp
+++ b/src/notation/internal/notationconfiguration.cpp
@@ -214,6 +214,17 @@ void NotationConfiguration::init()
 
     if (!userStylesPath().empty()) {
         fileSystem()->makePath(userStylesPath());
+
+#if !defined(Q_OS_LINUX)
+        // Create shortcut or symlink to global styles folder. Doesn't overwrite an existing file
+        // or link, which means it won't work on Linux because the global styles folder is inside
+        // the AppImage, and the AppImage mountpoint changes on each run. TODO: Check for existing
+        // link, read it, and if necessary update it. This would make it work on Linux too.
+        fileSystem()->makeLink(
+            globalConfiguration()->appDataPath() + "/styles",
+            userStylesPath() + "/Built-in styles"
+            );
+#endif
     }
 
     settings()->setDefaultValue(DEFAULT_NOTE_INPUT_METHOD, Val(BY_NOTE_NAME_INPUT_METHOD));


### PR DESCRIPTION
On Windows and macOS, shortcut is created when MS Studio launches unless there is already a file or another shortcut at that location. The shortcut is available in the location brought up by the **Format > Load style** dialog.

On Linux, we skip creating the shortcut because it would only be valid the first time MS Studio is run. This is because the global styles folder is _inside_ the AppImage, and the AppImage is mounted at a different random location on each run. Solving this is a task for another time.

Resolves: #26884