### PR TITLE
Fix time sig interactions with timesigs at the end of measures

### DIFF
--- a/src/engraving/dom/timesig.cpp
+++ b/src/engraving/dom/timesig.cpp
@@ -109,11 +109,28 @@ EngravingItem* TimeSig::drop(EditData& data)
         // change timesig applies to all staves, can't simply set subtype
         // for this one only
         // ownership of e is transferred to cmdAddTimeSig
-        score()->cmdAddTimeSig(measure(), staffIdx(), toTimeSig(e), false);
-        return 0;
+
+        if (tick() != measure()->endTick()) {
+            score()->cmdAddTimeSig(measure(), staffIdx(), toTimeSig(e), false);
+            return nullptr;
+        }
+
+        // This is a timesig at the end of a measure.
+        if (*toTimeSig(e) == *this) {
+            delete e;
+            return nullptr;
+        }
+
+        if (!measure()->nextMeasure()) {
+            return nullptr;
+        }
+
+        // Apply change to next measure
+        score()->cmdAddTimeSig(measure()->nextMeasure(), staffIdx(), toTimeSig(e), false);
+        return nullptr;
     }
     delete e;
-    return 0;
+    return nullptr;
 }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Resolves: Interaction issues with end of measure time signatures eg.
![Screenshot 2025-03-03 at 12 00 27](https://github.com/user-attachments/assets/ffc09ad9-20ac-4a92-82a1-dcafb5431be9)

This PR ensures time signatures added to the following measure (b.4 above), the end of measure time signature itself, or anywhere before an end of measure time signature behave correctly.

When a measure containing an end of measure time signature is rewritten, we need to remove the end of measure timesig segments as the repeat will be removed. 
We also need to reinstate the time signature at the same tick position bit in the following measure.