### PR TITLE
4.5.0: Fix untranslatable string

### DIFF
--- a/src/notation/view/internal/dynamicpopupmodel.cpp
+++ b/src/notation/view/internal/dynamicpopupmodel.cpp
@@ -156,7 +156,7 @@ void DynamicPopupModel::addOrChangeDynamic(int page, int index)
         return;
     }
 
-    beginCommand(TranslatableString::untranslatable("Add dynamic"));
+    beginCommand(TranslatableString("undoableAction", "Add dynamic"));
     m_item->undoChangeProperty(Pid::TEXT, Dynamic::dynamicText(DYN_POPUP_PAGES[page][index].dynType));
     m_item->undoChangeProperty(Pid::DYNAMIC_TYPE, DYN_POPUP_PAGES[page][index].dynType);
     endCommand();


### PR DESCRIPTION
Same as #26903, but for 4.5.0
As a same string in the same context exists already, no work needed to by done by the translators