### PR TITLE
Ensure layout range includes ticks notation is moved from

### DIFF
--- a/src/engraving/rw/read400/read400.cpp
+++ b/src/engraving/rw/read400/read400.cpp
@@ -711,7 +711,6 @@ bool Read400::pasteStaff(XmlReader& e, Segment* dst, staff_idx_t dstStaff, Fract
         }
 
         if (score->cmdState().layoutRange()) {
-            score->cmdState().reset();
             score->setLayout(dstTick, dstTick + tickLen, dstStaff, endStaff, dst);
         }
 

--- a/src/engraving/rw/read410/read410.cpp
+++ b/src/engraving/rw/read410/read410.cpp
@@ -748,7 +748,6 @@ bool Read410::pasteStaff(XmlReader& e, Segment* dst, staff_idx_t dstStaff, Fract
         }
 
         if (score->cmdState().layoutRange()) {
-            score->cmdState().reset();
             score->setLayout(dstTick, dstTick + tickLen, dstStaff, endStaff, dst);
         }
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/26883
Resolves: https://github.com/musescore/MuseScore/issues/26882

The layout range is cleared on pasting notation. This means that the area cut from is not laid out, leaving unwanted elements. 
I'm not sure of the implication on playback of removing this line - it doesn't seem to cause a regression of the issues fixed in https://github.com/musescore/MuseScore/issues/26883 for me, but this should be double checked. Hopefully expanding the layout range to the pasted area is sufficient. 