### PR TITLE
Menu mnemonics and keyboard issues

### DIFF
--- a/src/appshell/qml/platform/AppMenuBar.qml
+++ b/src/appshell/qml/platform/AppMenuBar.qml
@@ -61,6 +61,12 @@ ListView {
         onCloseOpenedMenuRequested: {
             menuLoader.close()
         }
+
+        onNavigateWithSymbolRequested: function(symbol) {
+            if (menuLoader.isMenuOpened) {
+                menuLoader.menu.navigateWithSymbolRequested(symbol, appMenuModel)
+            }
+        }
     }
 
     AccessibleItem {

--- a/src/appshell/view/appmenumodel.cpp
+++ b/src/appshell/view/appmenumodel.cpp
@@ -311,7 +311,7 @@ MenuItem* AppMenuModel::makeAddMenu()
         makeSeparator(),
         makeMenu(TranslatableString("appshell/menu/add", "&Measures"), makeMeasuresItems(), "menu-measures"),
         makeMenu(TranslatableString("appshell/menu/add", "&Frames"), makeFramesItems(), "menu-frames"),
-        makeMenu(TranslatableString("appshell/menu/add", "&Text"), makeTextItems(), "menu-notes"),
+        makeMenu(TranslatableString("appshell/menu/add", "&Text"), makeTextItems(), "menu-text"),
         makeMenu(TranslatableString("appshell/menu/add", "&Lines"), makeLinesItems(), "menu-lines"),
         makeMenu(TranslatableString("appshell/menu/add", "&Chords and fretboard diagrams"),
                  makeChordAndFretboardDiagramsItems(), "menu-chord-and-frets"),

--- a/src/appshell/view/navigableappmenumodel.cpp
+++ b/src/appshell/view/navigableappmenumodel.cpp
@@ -438,6 +438,10 @@ QRect NavigableAppMenuModel::openedMenuAreaRect() const
 
 void NavigableAppMenuModel::saveMUNavigationSystemState()
 {
+    if (m_lastActiveMUNavigationState.has_value()) {
+        return;
+    }
+
     bool muNavigationIsHighlight = navigationController()->isHighlight();
     m_needActivateLastMUNavigationControl = muNavigationIsHighlight;
 

--- a/src/appshell/view/navigableappmenumodel.cpp
+++ b/src/appshell/view/navigableappmenumodel.cpp
@@ -362,7 +362,8 @@ bool NavigableAppMenuModel::isNavigateKey(int key) const
         Qt::Key_Down,
         Qt::Key_Space,
         Qt::Key_Escape,
-        Qt::Key_Return
+        Qt::Key_Return,
+        Qt::Key_Enter
     };
 
     return keys.contains(static_cast<Qt::Key>(key));
@@ -393,6 +394,7 @@ void NavigableAppMenuModel::navigate(int scanCode)
     case Qt::Key_Down:
     case Qt::Key_Space:
     case Qt::Key_Return:
+    case Qt::Key_Enter:
         activateHighlightedMenu();
         break;
     case Qt::Key_Escape:

--- a/src/appshell/view/navigableappmenumodel.h
+++ b/src/appshell/view/navigableappmenumodel.h
@@ -52,6 +52,7 @@ public:
     Q_INVOKABLE void openMenu(const QString& menuId, bool byHover);
     Q_INVOKABLE void openPrevMenu();
     Q_INVOKABLE void openNextMenu();
+    Q_INVOKABLE bool menuItemMatchesSymbol(muse::uicomponents::MenuItem* menuItem, const QChar& symbol);
 
     bool isNavigationStarted() const;
     bool isMenuOpened() const;
@@ -75,6 +76,7 @@ signals:
     void openedMenuIdChanged(QString openedMenuId);
     void appMenuAreaRectChanged(QRect appMenuAreaRect);
     void openedMenuAreaRectChanged(QRect openedMenuAreaRect);
+    void navigateWithSymbolRequested(const QChar& symbol);
 
 private:
     bool eventFilter(QObject* watched, QEvent* event) override;
@@ -83,10 +85,8 @@ private:
 
     bool isNavigateKey(int key) const;
     void navigate(const QSet<int>& activatePossibleKeys);
-    void navigateToSubItem(const QString& menuId, const QSet<int>& activatePossibleKeys);
 
     bool hasItem(const QSet<int>& activatePossibleKeys);
-    bool hasSubItem(const QString& menuId, const QSet<int>& activatePossibleKeys);
     void navigate(int scanCode);
 
     void resetNavigation();

--- a/src/framework/uicomponents/qml/Muse/UiComponents/internal/StyledMenu.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/internal/StyledMenu.qml
@@ -187,7 +187,6 @@ MenuView {
                 } else {
                     root.close()
                 }
-                event.accepted = true
             }
         }
 

--- a/src/framework/uicomponents/qml/Muse/UiComponents/internal/StyledMenu.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/internal/StyledMenu.qml
@@ -89,6 +89,55 @@ MenuView {
         y = parent.height
     }
 
+    function navigateWithSymbolRequested(symbol, requestingMenuModel) {
+        // If this menu does not have the focus, pass on to the next open menu.
+        if (!content.navigationSection.active) {
+            if (root.subMenuLoader.isMenuOpened) {
+                root.subMenuLoader.menu.navigateWithSymbolRequested(symbol, requestingMenuModel)
+            }
+            return
+        }
+
+        // Find the currently active item (if any). The search will start from the item
+        // following it and will wrap from the beginning once the last item is reached.
+        let startingIndex = 0;
+        for (let i = 0; i < view.count; ++i) {
+            let loader = view.itemAtIndex(i)
+            if (loader && !loader.isSeparator && loader.item && loader.item.navigation.active) {
+                startingIndex = i + 1
+                break
+            }
+        }
+
+        // Find the first menu item that matches the given underlined symbol (letter).
+        let firstMatchingIndex = -1;
+        for (let j = 0; j < view.count; ++j) {
+            let index = startingIndex + j;
+            if (index >= view.count) {
+                index -= view.count
+            }
+
+            let item = Boolean(model.get) ? model.get(index).itemRole : model[index]
+            if (item && item.enabled && requestingMenuModel.menuItemMatchesSymbol(item, symbol)) {
+                firstMatchingIndex = index
+                break;
+            }
+        }
+
+        // Focus the first matching menu item and click it.
+        if (firstMatchingIndex !== -1) {
+            let loader = view.itemAtIndex(firstMatchingIndex)
+            if (loader) {
+                if (root.subMenuLoader.isMenuOpened && root.subMenuLoader.parent !== loader.item) {
+                    root.subMenuLoader.close();
+                }
+
+                loader.item.navigation.requestActive()
+                Qt.callLater(loader.item.clicked, null)
+            }
+        }
+    }
+
     onAboutToClose: function(closeEvent) {
         closeSubMenu()
     }

--- a/src/framework/uicomponents/qml/Muse/UiComponents/internal/StyledMenu.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/internal/StyledMenu.qml
@@ -100,7 +100,7 @@ MenuView {
 
         // Find the currently active item (if any). The search will start from the item
         // following it and will wrap from the beginning once the last item is reached.
-        let startingIndex = 0;
+        let startingIndex = 0
         for (let i = 0; i < view.count; ++i) {
             let loader = view.itemAtIndex(i)
             if (loader && !loader.isSeparator && loader.item && loader.item.navigation.active) {
@@ -110,30 +110,39 @@ MenuView {
         }
 
         // Find the first menu item that matches the given underlined symbol (letter).
-        let firstMatchingIndex = -1;
+        let firstMatchingIndex = -1
+        let isSingleMatch = true
         for (let j = 0; j < view.count; ++j) {
-            let index = startingIndex + j;
+            let index = startingIndex + j
             if (index >= view.count) {
                 index -= view.count
             }
 
             let item = Boolean(model.get) ? model.get(index).itemRole : model[index]
             if (item && item.enabled && requestingMenuModel.menuItemMatchesSymbol(item, symbol)) {
-                firstMatchingIndex = index
-                break;
+                if (firstMatchingIndex === -1) {
+                    firstMatchingIndex = index
+                } else {
+                    isSingleMatch = false
+                    break
+                }
             }
         }
 
-        // Focus the first matching menu item and click it.
+        // Highlight the first matching menu item. If it is the only match, click it.
+        // Otheriwise do nothing and give the user a chance to navigate to the other matches.
         if (firstMatchingIndex !== -1) {
             let loader = view.itemAtIndex(firstMatchingIndex)
             if (loader) {
                 if (root.subMenuLoader.isMenuOpened && root.subMenuLoader.parent !== loader.item) {
-                    root.subMenuLoader.close();
+                    root.subMenuLoader.close()
                 }
 
                 loader.item.navigation.requestActive()
-                Qt.callLater(loader.item.clicked, null)
+
+                if (isSingleMatch) {
+                    Qt.callLater(loader.item.clicked, null)
+                }
             }
         }
     }

--- a/src/framework/uicomponents/qml/Muse/UiComponents/internal/StyledMenu.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/internal/StyledMenu.qml
@@ -129,6 +129,7 @@ MenuView {
                 } else {
                     root.close()
                 }
+                event.accepted = true
             }
         }
 


### PR DESCRIPTION
Resolves: #17009
Resolves: #18832 (I assume)

**Key Points:**
Commit 1 fixes the "Notes submenu opening instead of Text submenu" issue.

Commit 2 fixes an issue where a main menu won't open with the Enter key on the numeric pad.

Commit 3 makes the main menu swallow the ESC key since it handles it. Further processing should not happen as it sometimes leads to the focus returning to the main score. E.g. in MuseScore 4.4.4: Press Alt, A, U (menu Add -> Tuplets opens), then ESC.

Commit 4 makes the navigation with an underlined letter work in submenus. I explored the possibility to do it in the model since a lot of logic was already there but in the end this looked more complicated to me: any open menu had to notify the model that it got open + which item was selected. Also in the end the model was not able to activate the target menu item because all submenus used the same name for their navigation panel: "StyledMenu" and the model was attempting to activate by names (section, panel, control). Not impossible to fix but seemed more effort than what I came up with: the model will delegate the navigation with symbol to the open menus themselves. I like it overall except one slight inconvenience: the menus have to ask the model if their items match the pressed symbol because the model uses `QKeyMapper::possibleKeys`. I have no idea what it does but should be there with a purpose.

Also I am handling the situation where there's more than one menu item in the same menu with the same underlined letter. Normally in this case pressing the underlined letter should cycle through those items highlighting them without triggering their actions until the user explicitly does so when they reach the desired menu item. Could be a bit confusing to see pressing an underlined letter only highlight a menu item but this is the behavior I've known for years in case of conflicting underlined letters. And we do have many conflicts, for example I switched to Spanish temporarily and found many. We can mitigate this by ensuring our menus contains as few conflicts as possible.

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
