### PR TITLE
Continuous view fixes

### DIFF
--- a/src/engraving/rendering/score/horizontalspacing.cpp
+++ b/src/engraving/rendering/score/horizontalspacing.cpp
@@ -78,7 +78,7 @@ double HorizontalSpacing::computeSpacingForFullSystem(System* system, double str
     return ctx.xCur;
 }
 
-double HorizontalSpacing::updateSpacingForLastAddedMeasure(System* system)
+double HorizontalSpacing::updateSpacingForLastAddedMeasure(System* system, bool startOfContinuousLayoutRegion)
 {
     HorizontalSpacingContext ctx;
     ctx.system = system;
@@ -95,7 +95,7 @@ double HorizontalSpacing::updateSpacingForLastAddedMeasure(System* system)
 
     if (secondToLast) {
         ctx.xCur = secondToLast->x();
-        if (secondToLast->isHBox() || last->isHBox()) {
+        if (secondToLast->isHBox() || last->isHBox() || startOfContinuousLayoutRegion) {
             ctx.xCur += secondToLast->width();
         }
     } else {
@@ -106,7 +106,7 @@ double HorizontalSpacing::updateSpacingForLastAddedMeasure(System* system)
         last->mutldata()->setPosX(ctx.xCur);
         last->computeMinWidth();
         ctx.xCur += last->width();
-    } else if (!secondToLast || secondToLast->isHBox()) {
+    } else if (!secondToLast || secondToLast->isHBox() || startOfContinuousLayoutRegion) {
         spaceMeasureGroup({ toMeasure(last) }, ctx);
     } else {
         ctx.startMeas = toMeasure(last);

--- a/src/engraving/rendering/score/horizontalspacing.h
+++ b/src/engraving/rendering/score/horizontalspacing.h
@@ -47,7 +47,7 @@ public:
 
     static double computeSpacingForFullSystem(System* system, double stretchReduction = 1.0, double squeezeFactor = 1.0,
                                               bool overrideMinMeasureWidth = false);
-    static double updateSpacingForLastAddedMeasure(System* system);
+    static double updateSpacingForLastAddedMeasure(System* system, bool startOfContinuousLayoutRegion = false);
     static void squeezeSystemToFit(System* system, double& curSysWidth, double targetSysWidth);
     static void justifySystem(System* system, double curSysWidth, double targetSystemWidth);
 

--- a/src/engraving/rendering/score/layoutcontext.cpp
+++ b/src/engraving/rendering/score/layoutcontext.cpp
@@ -236,6 +236,14 @@ size_t DomAccessor::ntracks() const
     return score()->ntracks();
 }
 
+size_t DomAccessor::nmeasures() const
+{
+    IF_ASSERT_FAILED(score()) {
+        return 0;
+    }
+    return score()->nmeasures();
+}
+
 const Measure* DomAccessor::tick2measure(const Fraction& tick) const
 {
     IF_ASSERT_FAILED(score()) {

--- a/src/engraving/rendering/score/layoutcontext.h
+++ b/src/engraving/rendering/score/layoutcontext.h
@@ -167,6 +167,8 @@ public:
 
     size_t ntracks() const;
 
+    size_t nmeasures() const;
+
     const Measure* tick2measure(const Fraction& tick) const;
     const Measure* firstMeasure() const;
     const Measure* lastMeasure() const;


### PR DESCRIPTION
Resolves: #26890 
Resolves: #25561
Resolves: Courtesy repeat clef, key & time signatures in continuous view

The spacing issue was due to the running system width being updated with the current measure's stale width before updating its spacing.  We should use the value returned by `HorizontalSpacing::updateSpacingForLastAddedMeasure` as we do in all other layout modes.