### PR TITLE
fix 26405: export correct tempo

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
@@ -113,6 +113,7 @@
 #include "engraving/dom/stem.h"
 #include "engraving/dom/stringdata.h"
 #include "engraving/dom/system.h"
+#include "engraving/dom/tempo.h"
 #include "engraving/dom/tempotext.h"
 #include "engraving/dom/text.h"
 #include "engraving/dom/textlinebase.h"
@@ -5145,6 +5146,9 @@ void ExportMusicXml::tempoText(TempoText const* const text, staff_idx_t staff)
     // Format tempo with maximum 2 decimal places, because in some MuseScore files tempo is stored
     // imprecisely and this could cause rounding errors (e.g. 92 BPM would be saved as 91.9998).
     BeatsPerMinute bpm = text->tempo().toBPM();
+    if (text->isATempo() || text->isTempoPrimo()) {
+        bpm = m_score->tempomap()->tempo(text->tick().ticks()).toBPM();
+    }
     double bpmRounded = round(bpm.val * 100) / 100;
     m_xml.tag("sound", { { "tempo", bpmRounded } });
     m_xml.endElement();


### PR DESCRIPTION
Resolves: #26405

This PR checks the timemap for "a tempo" and "tempo primo" markings and exports the correct tempo instead of the default 120 to MusicXML.