### PR TITLE
Renaming: Input pitch -> MIDI input pitch

### DIFF
--- a/src/playback/view/playbacktoolbarmodel.cpp
+++ b/src/playback/view/playbacktoolbarmodel.cpp
@@ -146,7 +146,7 @@ MenuItem* PlaybackToolBarModel::makeInputPitchMenu()
         items << makeMenuItem(action.code);
     }
 
-    MenuItem* menu = makeMenu(muse::TranslatableString("notation", "Input pitch"), items);
+    MenuItem* menu = makeMenu(muse::TranslatableString("notation", "MIDI input pitch"), items);
     UiAction action = menu->action();
     action.iconCode = IconCode::Code::MUSIC_NOTES;
     menu->setAction(action);


### PR DESCRIPTION
Quick fix for: https://github.com/musescore/MuseScore/issues/26493