### PR TITLE
Set a default file extension when saving files without an extension.

### DIFF
--- a/src/framework/ui/qml/Muse/Ui/internal/FileDialog.qml
+++ b/src/framework/ui/qml/Muse/Ui/internal/FileDialog.qml
@@ -31,6 +31,10 @@ QtPlatform.FileDialog {
     signal opened()
     signal closed()
 
+    function hasFileExtension(filePath) {
+        return filePath.indexOf('.', filePath.lastIndexOf('/')) !== -1
+    }
+
     onVisibleChanged: {
         if (visible) {
             root.opened()
@@ -38,7 +42,13 @@ QtPlatform.FileDialog {
     }
 
     onAccepted: {
-        root.ret = { "errcode": 0, "value":  root.currentFile.toString() }
+        var filename = root.currentFile.toString();
+        if (root.defaultSuffix && !hasFileExtension(filename))
+        {
+            filename += "." + root.defaultSuffix;
+        }
+
+        root.ret = { "errcode": 0, "value":  filename }
         root.close()
         root.closed()
     }

--- a/src/framework/ui/view/interactiveprovider.cpp
+++ b/src/framework/ui/view/interactiveprovider.cpp
@@ -26,7 +26,7 @@
 #include <QDialog>
 #include <QFileDialog>
 #include <QColorDialog>
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QGuiApplication>
 #include <QWindow>
 
@@ -497,9 +497,10 @@ void InteractiveProvider::fillFileDialogData(QmlLaunchData* data, FileDialogType
         // Extract default suffix from first filter if available
         if (!filter.empty() && (type == FileDialogType::SelectSavingFile)) {
             QString firstFilter = QString::fromStdString(filter[0]);
-            QRegExp rx("\\*\\.(\\w+)");
-            if (rx.indexIn(firstFilter) != -1) {
-                params["defaultSuffix"] = rx.cap(1);
+            QRegularExpression re("\\*\\.(\\w+)");
+            QRegularExpressionMatch match = re.match(firstFilter);
+            if (match.hasMatch()) {
+                params["defaultSuffix"] = match.captured(1);
             }
         }
 

--- a/src/framework/ui/view/interactiveprovider.cpp
+++ b/src/framework/ui/view/interactiveprovider.cpp
@@ -26,6 +26,7 @@
 #include <QDialog>
 #include <QFileDialog>
 #include <QColorDialog>
+#include <QRegExp>
 #include <QGuiApplication>
 #include <QWindow>
 
@@ -491,6 +492,15 @@ void InteractiveProvider::fillFileDialogData(QmlLaunchData* data, FileDialogType
         QStringList filterList;
         for (const std::string& nameFilter : filter) {
             filterList << QString::fromStdString(nameFilter);
+        }
+
+        // Extract default suffix from first filter if available
+        if (!filter.empty() && (type == FileDialogType::SelectSavingFile)) {
+            QString firstFilter = QString::fromStdString(filter[0]);
+            QRegExp rx("\\*\\.(\\w+)");
+            if (rx.indexIn(firstFilter) != -1) {
+                params["defaultSuffix"] = rx.cap(1);
+            }
         }
 
         params["nameFilters"] = filterList;


### PR DESCRIPTION
Resolves: [Audacity 8166](https://github.com/audacity/audacity/issues/8166)

On Linux if you try to save a preset using some filename without extension a default one is not added.
The proposed modification just retrieves the "default" file extension from the first item on the file dialog filter list and append it to the filename if no extension was previously added.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
