### PR TITLE
4.5.0: Keep URLs out of translatable strings

### DIFF
--- a/src/engraving/engravingerrors.h
+++ b/src/engraving/engravingerrors.h
@@ -86,7 +86,8 @@ inline muse::Ret make_ret(Err err, const muse::io::path_t& filePath = {})
         break;
     case Err::FileTooNew:
         text = muse::mtrc("engraving", "This file was saved using a newer version of MuseScore Studio. "
-                                       "Please visit <a href=\"https://musescore.org\">MuseScore.org</a> to obtain the latest version.");
+                                       "Please visit <a href=\"%1\">MuseScore.org</a> to obtain the latest version.")
+               .arg(u"https://musescore.org");
         break;
     case Err::FileOld300Format:
         text = muse::mtrc("engraving", "This file was last saved in a development version of 3.0.");

--- a/src/framework/cloud/qml/Muse/Cloud/CloudScoresView.qml
+++ b/src/framework/cloud/qml/Muse/Cloud/CloudScoresView.qml
@@ -128,7 +128,7 @@ ScoresView {
                 anchors.rightMargin: root.sideMargin
 
                 title: qsTrc("project", "You don’t have any online scores yet")
-                body: qsTrc("project", "Scores will appear here when you save a file to the cloud, or publish a score on <a href=\"https://musescore.com\">MuseScore.com</a>.")
+                body: qsTrc("project", "Scores will appear here when you save a file to the cloud, or publish a score on <a href=\"%1\">MuseScore.com</a>.").arg("https://musescore.com")
             }
         }
     }
@@ -153,7 +153,7 @@ ScoresView {
                     width: parent.width
 
                     title: qsTrc("project", "You are not signed in")
-                    body: qsTrc("project", "Log in or create a new account on <a href=\"https://musescore.com\">MuseScore.com</a> to view online scores.")
+                    body: qsTrc("project", "Log in or create a new account on <a href=\"%1\">MuseScore.com</a> to view online scores.").arg("https://musescore.com")
                 }
 
                 Row {

--- a/src/project/internal/opensaveprojectscenario.cpp
+++ b/src/project/internal/opensaveprojectscenario.cpp
@@ -505,8 +505,9 @@ void OpenSaveProjectScenario::showCloudOpenError(const Ret& ret) const
         break;
 
     case int(cloud::Err::NetworkError):
-        message = muse::trc("project/cloud", "Could not connect to <a href=\"https://musescore.com\">MuseScore.com</a>. "
-                                             "Please check your internet connection or try again later.");
+        message = muse::mtrc("project/cloud", "Could not connect to <a href=\"%1\">MuseScore.com</a>. "
+                                              "Please check your internet connection or try again later.")
+                  .arg(u"https://musescore.com").toStdString();
         break;
     default:
         message = muse::trc("project/cloud", "Please try again later.");
@@ -591,8 +592,9 @@ Ret OpenSaveProjectScenario::showCloudSaveError(const Ret& ret, const CloudProje
         break;
 
     case int(cloud::Err::NetworkError):
-        msg = muse::trc("project/cloud", "Could not connect to <a href=\"https://musescore.com\">MuseScore.com</a>. "
-                                         "Please check your internet connection or try again later.");
+        msg = muse::mtrc("project/cloud", "Could not connect to <a href=\"%1\">MuseScore.com</a>. "
+                                          "Please check your internet connection or try again later.")
+              .arg(u"https://musescore.com").toStdString();
         break;
     default:
         msg = muse::trc("project/cloud", "Please try again later, or get help for this problem on MuseScore.org.");

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -1741,8 +1741,9 @@ bool ProjectActionsController::askIfUserAgreesToOpenProjectWithIncompatibleVersi
 void ProjectActionsController::warnFileTooNew(const muse::io::path_t& filepath)
 {
     interactive()->error(muse::qtrc("project", "Cannot read file %1").arg(io::toNativeSeparators(filepath).toQString()).toStdString(),
-                         muse::trc("project", "This file was saved using a newer version of MuseScore Studio. "
-                                              "Please visit <a href=\"https://musescore.org\">MuseScore.org</a> to obtain the latest version."));
+                         muse::mtrc("project", "This file was saved using a newer version of MuseScore Studio. "
+                                               "Please visit <a href=\"%1\">MuseScore.org</a> to obtain the latest version.")
+                         .arg(u"https://musescore.org").toStdString());
 }
 
 bool ProjectActionsController::askIfUserAgreesToOpenCorruptedProject(const String& projectName, const std::string& errorText)


### PR DESCRIPTION
to minimize the chances of translators removing or replacing them, by accident or malice

Same as #26947

Updates 5 strings for translators