### PR TITLE
Fix #26907: Avoid capturing notation in selectionChanged()

### DIFF
--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -2398,9 +2398,9 @@ void NotationActionController::registerAction(const ActionCode& code,
 {
     registerAction(code, [this, handler, playMode]()
     {
-        auto interaction = currentNotationInteraction().get();
-        if (interaction) {
-            (interaction->*handler)();
+        INotationPtr notation = currentNotation();
+        if (notation) {
+            (notation->interaction().get()->*handler)();
             if (playMode != PlayMode::NoPlay) {
                 playSelectedElement(playMode == PlayMode::PlayChord);
             }
@@ -2428,9 +2428,9 @@ void NotationActionController::registerAction(const ActionCode& code, void (INot
 {
     registerAction(code, [this, handler, param1, playMode]()
     {
-        auto interaction = currentNotationInteraction().get();
-        if (interaction) {
-            (interaction->*handler)(param1);
+        INotationPtr notation = currentNotation();
+        if (notation) {
+            (notation->interaction().get()->*handler)(param1);
             if (playMode != PlayMode::NoPlay) {
                 playSelectedElement(playMode == PlayMode::PlayChord);
             }
@@ -2452,9 +2452,9 @@ void NotationActionController::registerAction(const ActionCode& code, void (INot
 {
     registerAction(code, [this, handler, param1, param2, playMode]()
     {
-        auto interaction = currentNotationInteraction().get();
-        if (interaction) {
-            (interaction->*handler)(param1, param2);
+        INotationPtr notation = currentNotation();
+        if (notation) {
+            (notation->interaction().get()->*handler)(param1, param2);
             if (playMode != PlayMode::NoPlay) {
                 playSelectedElement(playMode == PlayMode::PlayChord);
             }

--- a/src/notation/view/abstractnotationpaintview.cpp
+++ b/src/notation/view/abstractnotationpaintview.cpp
@@ -239,10 +239,10 @@ void AbstractNotationPaintView::onLoadNotation(INotationPtr)
         m_notation->painting()->setViewMode(m_notation->viewState()->viewMode());
     }
 
-    INotationInteractionPtr interaction = notationInteraction();
-
-    m_notation->notationChanged().onNotify(this, [this, interaction]() {
-        interaction->hideShadowNote();
+    m_notation->notationChanged().onNotify(this, [this]() {
+        if (INotationInteractionPtr interaction = notationInteraction()) {
+            interaction->hideShadowNote();
+        }
         m_shadowNoteRect = RectF();
         scheduleRedraw();
     });
@@ -251,6 +251,8 @@ void AbstractNotationPaintView::onLoadNotation(INotationPtr)
     if (isNoteEnterMode()) {
         emit activeFocusRequested();
     }
+
+    INotationInteractionPtr interaction = notationInteraction();
 
     interaction->noteInput()->stateChanged().onNotify(this, [this]() {
         onNoteInputStateChanged();

--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -121,13 +121,18 @@ void NotationViewInputController::init()
 
 void NotationViewInputController::onNotationChanged()
 {
-    INotationPtr notation = currentNotation();
-    if (!notation) {
+    INotationPtr currNotation = currentNotation();
+    if (!currNotation) {
         return;
     }
 
-    notation->interaction()->selectionChanged().onNotify(this, [this, notation]() {
-        EngravingItem* selectedItem = notation->interaction()->selection()->element();
+    currNotation->interaction()->selectionChanged().onNotify(this, [this]() {
+        const INotationPtr notation = currentNotation();
+        if (!notation) {
+            return;
+        }
+
+        const EngravingItem* selectedItem = notation->interaction()->selection()->element();
         ElementType type = selectedItem ? selectedItem->type() : ElementType::INVALID;
 
         bool noChanges = selectedItem && m_prevSelectedElement == selectedItem;

--- a/src/notation/view/notationviewinputcontroller.h
+++ b/src/notation/view/notationviewinputcontroller.h
@@ -212,8 +212,8 @@ private:
         muse::PointF logicalBeginPoint;
     } m_mouseDownInfo;
 
-    mu::engraving::EngravingItem* m_prevHitElement = nullptr;
-    mu::engraving::EngravingItem* m_prevSelectedElement = nullptr;
+    const mu::engraving::EngravingItem* m_prevHitElement = nullptr;
+    const mu::engraving::EngravingItem* m_prevSelectedElement = nullptr;
 
     bool m_shouldStartEditOnLeftClickRelease = false;
     bool m_shouldTogglePopupOnLeftClickRelease = false;


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/26907
Resolves: https://github.com/musescore/MuseScore/issues/26932