### PR TITLE
Add property to disable cursor change on FlatButton

### DIFF
--- a/src/framework/uicomponents/qml/Muse/UiComponents/FlatButton.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/FlatButton.qml
@@ -69,6 +69,7 @@ FocusScope {
     property alias navigation: navCtrl
     property alias accessible: navCtrl.accessible
 
+    property bool userInteraction: true
     property alias mouseArea: mouseArea
 
     property bool isClickOnKeyNavTriggered: true
@@ -299,6 +300,8 @@ FocusScope {
     MouseArea {
         id: mouseArea
         anchors.fill: parent
+
+        visible: root.userInteraction
 
         enabled: root.enabled
         hoverEnabled: true


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/8146

We have some situations where we want the button to be unresponsive.
We cannot use the enabled the functionality once this has other side effects like changing the opacity.
Apart from that, even if the enabled on the mouseArea is false we still can see the cursor shape to change once within the mouse area.

This PR is only a suggestion on how this could be achieved.


<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
