### PR TITLE
Rename Muse Sounds profile to MuseSounds (with compat)

### DIFF
--- a/src/playback/internal/playbackconfiguration.cpp
+++ b/src/playback/internal/playbackconfiguration.cpp
@@ -61,7 +61,8 @@ static const Settings::Key MUTE_HIDDEN_INSTRUMENTS(moduleName, "playback/mixer/m
 
 static const Settings::Key DEFAULT_SOUND_PROFILE_FOR_NEW_PROJECTS(moduleName, "playback/profiles/defaultProfileName");
 static const SoundProfileName BASIC_PROFILE_NAME(u"MuseScore Basic");
-static const SoundProfileName MUSE_PROFILE_NAME(u"Muse Sounds");
+static const SoundProfileName MUSESOUNDS_PROFILE_NAME(u"MuseSounds");
+static const SoundProfileName COMPAT_MUSESOUNDS_PROFILE_NAME(u"Muse Sounds");
 
 static Settings::Key mixerSectionVisibleKey(MixerSectionType sectionType)
 {
@@ -294,9 +295,14 @@ const SoundProfileName& PlaybackConfiguration::basicSoundProfileName() const
     return BASIC_PROFILE_NAME;
 }
 
-const SoundProfileName& PlaybackConfiguration::museSoundProfileName() const
+const SoundProfileName& PlaybackConfiguration::museSoundsProfileName() const
 {
-    return MUSE_PROFILE_NAME;
+    return MUSESOUNDS_PROFILE_NAME;
+}
+
+const SoundProfileName& PlaybackConfiguration::compatMuseSoundsProfileName() const
+{
+    return COMPAT_MUSESOUNDS_PROFILE_NAME;
 }
 
 SoundProfileName PlaybackConfiguration::defaultProfileForNewProjects() const
@@ -347,7 +353,7 @@ bool PlaybackConfiguration::shouldMeasureInputLag() const
 const SoundProfileName& PlaybackConfiguration::fallbackSoundProfileStr() const
 {
     if (musesamplerInfo() && musesamplerInfo()->isInstalled()) {
-        return MUSE_PROFILE_NAME;
+        return MUSESOUNDS_PROFILE_NAME;
     }
 
     return BASIC_PROFILE_NAME;

--- a/src/playback/internal/playbackconfiguration.h
+++ b/src/playback/internal/playbackconfiguration.h
@@ -76,7 +76,9 @@ public:
     muse::async::Channel<bool> muteHiddenInstrumentsChanged() const override;
 
     const SoundProfileName& basicSoundProfileName() const override;
-    const SoundProfileName& museSoundProfileName() const override;
+    const SoundProfileName& museSoundsProfileName() const override;
+    const SoundProfileName& compatMuseSoundsProfileName() const override;
+
     SoundProfileName defaultProfileForNewProjects() const override;
     void setDefaultProfileForNewProjects(const SoundProfileName& name) override;
 

--- a/src/playback/internal/soundprofilesrepository.cpp
+++ b/src/playback/internal/soundprofilesrepository.cpp
@@ -38,7 +38,7 @@ void SoundProfilesRepository::init()
 
     SoundProfile museProfile;
     museProfile.type = SoundProfileType::Muse;
-    museProfile.name = config()->museSoundProfileName();
+    museProfile.name = config()->museSoundsProfileName();
     m_profilesMap.emplace(museProfile.name, std::move(museProfile));
 }
 
@@ -47,7 +47,7 @@ void SoundProfilesRepository::refresh()
     playback()->tracks()->availableInputResources()
     .onResolve(this, [this](const AudioResourceMetaList& availableResources) {
         SoundProfile& basicProfile = m_profilesMap.at(config()->basicSoundProfileName());
-        SoundProfile& museProfile = m_profilesMap.at(config()->museSoundProfileName());
+        SoundProfile& museProfile = m_profilesMap.at(config()->museSoundsProfileName());
 
         for (const AudioResourceMeta& resource : availableResources) {
             auto setup = resource.attributes.find(u"playbackSetupData");

--- a/src/playback/iplaybackconfiguration.h
+++ b/src/playback/iplaybackconfiguration.h
@@ -73,7 +73,8 @@ public:
     virtual muse::async::Channel<bool> muteHiddenInstrumentsChanged() const = 0;
 
     virtual const SoundProfileName& basicSoundProfileName() const = 0;
-    virtual const SoundProfileName& museSoundProfileName() const = 0;
+    virtual const SoundProfileName& museSoundsProfileName() const = 0;
+    virtual const SoundProfileName& compatMuseSoundsProfileName() const = 0;
 
     virtual SoundProfileName defaultProfileForNewProjects() const = 0;
     virtual void setDefaultProfileForNewProjects(const SoundProfileName& name) = 0;

--- a/src/playback/view/soundprofilesmodel.cpp
+++ b/src/playback/view/soundprofilesmodel.cpp
@@ -44,7 +44,7 @@ void SoundProfilesModel::init()
 
     std::sort(m_profiles.begin(), m_profiles.end(), [this](const SoundProfile& left, const SoundProfile& right) {
         if (left.name == config()->basicSoundProfileName()
-            && right.name == config()->museSoundProfileName()) {
+            && right.name == config()->museSoundsProfileName()) {
             return true;
         }
 

--- a/src/project/internal/projectaudiosettings.cpp
+++ b/src/project/internal/projectaudiosettings.cpp
@@ -278,6 +278,8 @@ Ret ProjectAudioSettings::read(const engraving::MscReader& reader)
     m_activeSoundProfileName = rootObj.value("activeSoundProfile").toString();
     if (m_activeSoundProfileName.empty()) {
         m_activeSoundProfileName = playbackConfig()->defaultProfileForNewProjects();
+    } else if (m_activeSoundProfileName == playbackConfig()->compatMuseSoundsProfileName()) {
+        m_activeSoundProfileName = playbackConfig()->museSoundsProfileName();
     }
 
     return make_ret(Ret::Code::Ok);

--- a/src/stubs/playback/playbackconfigurationstub.cpp
+++ b/src/stubs/playback/playbackconfigurationstub.cpp
@@ -156,10 +156,16 @@ const SoundProfileName& PlaybackConfigurationStub::basicSoundProfileName() const
     return basic;
 }
 
-const SoundProfileName& PlaybackConfigurationStub::museSoundProfileName() const
+const SoundProfileName& PlaybackConfigurationStub::museSoundsProfileName() const
 {
     static const SoundProfileName museSounds;
     return museSounds;
+}
+
+const SoundProfileName& PlaybackConfigurationStub::compatMuseSoundsProfileName() const
+{
+    static const SoundProfileName compatMuseSounds;
+    return compatMuseSounds;
 }
 
 SoundProfileName PlaybackConfigurationStub::defaultProfileForNewProjects() const

--- a/src/stubs/playback/playbackconfigurationstub.h
+++ b/src/stubs/playback/playbackconfigurationstub.h
@@ -66,7 +66,8 @@ public:
     muse::async::Channel<bool> muteHiddenInstrumentsChanged() const override;
 
     const SoundProfileName& basicSoundProfileName() const override;
-    const SoundProfileName& museSoundProfileName() const override;
+    const SoundProfileName& museSoundsProfileName() const override;
+    const SoundProfileName& compatMuseSoundsProfileName() const override;
 
     SoundProfileName defaultProfileForNewProjects() const override;
     void setDefaultProfileForNewProjects(const SoundProfileName& name) override;


### PR DESCRIPTION
Originally I thought about separating the UI display name from the code that's stored in the file, but that seemed to be more work than the solution of this PR. And since it's still not very clear which way we want to go with these profiles, I'd prefer not spending too much time on a complicated advanced solution that will probably be overhauled again.