### PR TITLE
Fix crash when there is no previous repeat segment

### DIFF
--- a/src/engraving/dom/utils.cpp
+++ b/src/engraving/dom/utils.cpp
@@ -1641,7 +1641,7 @@ std::vector<Measure*> findPreviousRepeatMeasures(const Measure* measure)
 
     std::vector<Measure*> measures;
 
-    for (auto it = repeatList.begin(); it != repeatList.end(); it++) {
+    for (auto it = repeatList.begin() + 1; it != repeatList.end(); it++) {
         const RepeatSegment* rs = *it;
         const auto prevSegIt = std::prev(it);
         if (!rs->startsWithMeasure(masterMeasure) || prevSegIt == repeatList.end()) {


### PR DESCRIPTION
Resolves: #26980 
The method is looking for the previous segment in `repeatList`. We should start the loop at the second item as the first will obviously not have a previous segment. If `repeatList` is only 1 item long, `repeatList.begin() + 1` will be `repeatList.end()`
