### PR TITLE
Fix system locks bug

### DIFF
--- a/src/engraving/rendering/score/systemlayout.cpp
+++ b/src/engraving/rendering/score/systemlayout.cpp
@@ -450,19 +450,16 @@ void SystemLayout::layoutSystemLockIndicators(System* system, LayoutContext& ctx
     const std::vector<SystemLockIndicator*> lockIndicators = system->lockIndicators();
     // In PAGE view, at most ONE lock indicator can exist per system.
     assert(lockIndicators.size() <= 1);
+    system->deleteLockIndicators();
 
     const SystemLock* lock = system->systemLock();
     if (!lock) {
-        system->deleteLockIndicators();
         return;
     }
 
-    SystemLockIndicator* lockIndicator = lockIndicators.empty() ? nullptr : lockIndicators.front();
-    if (!lockIndicator) {
-        lockIndicator = new SystemLockIndicator(system, lock);
-        lockIndicator->setParent(system);
-        system->addLockIndicator(lockIndicator);
-    }
+    SystemLockIndicator* lockIndicator = new SystemLockIndicator(system, lock);
+    lockIndicator->setParent(system);
+    system->addLockIndicator(lockIndicator);
 
     TLayout::layoutSystemLockIndicator(lockIndicator, lockIndicator->mutldata());
 }


### PR DESCRIPTION
This reverts commit 3f3761cab56b10958a46ab2bf30a5b113768ea97.

Note: this commit wasn't strictly necessary to fix the crash of https://github.com/musescore/MuseScore/issues/26901, I just thought it was a good idea (it wasn't). Reverting this commit shouldn't bring back that issue.

Resolves: #27008 