### PR TITLE
Fix attach dynamic to end of duration

### DIFF
--- a/src/engraving/dom/segment.cpp
+++ b/src/engraving/dom/segment.cpp
@@ -1699,6 +1699,10 @@ EngravingItem* Segment::firstInNextSegments(staff_idx_t activeStaff) const
 
 EngravingItem* Segment::firstElementOfSegment(staff_idx_t activeStaff) const
 {
+    if (isTimeTickType()) {
+        return nullptr;
+    }
+
     for (auto i: m_elist) {
         if (i && i->staffIdx() == activeStaff) {
             if (i->isDurationElement()) {
@@ -1853,6 +1857,10 @@ EngravingItem* Segment::prevElementOfSegment(EngravingItem* e, staff_idx_t activ
 
 EngravingItem* Segment::lastElementOfSegment(staff_idx_t activeStaff) const
 {
+    if (isTimeTickType()) {
+        return nullptr;
+    }
+
     const std::vector<EngravingItem*>& elements = m_elist;
     for (auto it = elements.rbegin(); it != elements.rend(); ++it) {
         EngravingItem* item = *it;
@@ -2172,6 +2180,10 @@ EngravingItem* Segment::prevElement(staff_idx_t activeStaff)
             if (lastEl) {
                 return lastEl;
             }
+        }
+        if (isTimeTickType()) {
+            Segment* prevSeg = prev1MMenabled();
+            return prevSeg ? prevSeg->lastElementOfSegment(activeStaff) : nullptr;
         }
         track_idx_t track = score()->nstaves() * VOICES - 1;
         Segment* s = this;

--- a/src/engraving/dom/textbase.cpp
+++ b/src/engraving/dom/textbase.cpp
@@ -3364,7 +3364,9 @@ bool TextBase::isNonTextualEditAllowed(EditData& ed) const
         Key_Down
     };
 
-    return muse::contains(ARROW_KEYS, static_cast<KeyboardKey>(ed.key)) && !(ed.modifiers & AltModifier);
+    bool altKeyWithoutShift = (ed.modifiers & AltModifier) && !(ed.modifiers & ShiftModifier);
+
+    return muse::contains(ARROW_KEYS, static_cast<KeyboardKey>(ed.key)) && !altKeyWithoutShift;
 }
 
 void TextBase::checkMeasureBoundariesAndMoveIfNeed()


### PR DESCRIPTION
Resolves: can't attach dynamics to end of durations anymore. 
<img width="410" alt="image" src="https://github.com/user-attachments/assets/77c7ceee-a8e7-40c6-b3be-e8b29cf7a50d" />


This was caused by #26848. That PR reserves the alt modifier for the accessible navigation using alt+arrows, but there must be an exception when the shift modifier is also pressed. Shift+alt+arrow is the command for attaching dynamics to end of durations.