### PR TITLE
4.5.0: Ensure we always select MMRest measures, not underlying ones

### DIFF
--- a/src/engraving/dom/measure.cpp
+++ b/src/engraving/dom/measure.cpp
@@ -2908,7 +2908,7 @@ Measure* Measure::mmRestLast() const
 //    otherwise, return the measure itself.
 //---------------------------------------------------------
 
-const Measure* Measure::coveringMMRestOrThis() const
+Measure* Measure::coveringMMRestOrThis()
 {
     if (!style().styleB(Sid::createMultiMeasureRests)) {
         return this;
@@ -2932,6 +2932,11 @@ const Measure* Measure::coveringMMRestOrThis() const
     }
 
     return 0;
+}
+
+const Measure* Measure::coveringMMRestOrThis() const
+{
+    return const_cast<Measure*>(this)->coveringMMRestOrThis();
 }
 
 int Measure::measureRepeatCount(staff_idx_t staffIdx) const

--- a/src/engraving/dom/measure.h
+++ b/src/engraving/dom/measure.h
@@ -303,6 +303,7 @@ public:
     bool hasMMRest() const { return m_mmRest != 0; }
     bool isMMRest() const { return m_mmRestCount > 0; }
     Measure* mmRest() const { return m_mmRest; }
+    Measure* coveringMMRestOrThis();
     const Measure* coveringMMRestOrThis() const;
     void setMMRest(Measure* m) { m_mmRest = m; }
     int mmRestCount() const { return m_mmRestCount; }            // number of measures m_mmRest spans

--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -3492,7 +3492,7 @@ void Score::selectSingle(EngravingItem* e, staff_idx_t staffIdx)
         setUpdateAll();
     } else {
         if (e->isMeasure()) {
-            doSelect(e, SelectType::RANGE, staffIdx);
+            doSelect(toMeasure(e)->coveringMMRestOrThis(), SelectType::RANGE, staffIdx);
             return;
         }
         addRefresh(e->pageBoundingRect());
@@ -3539,11 +3539,11 @@ void Score::selectAdd(EngravingItem* e)
     }
 
     if (e->isMeasure()) {
-        Measure* m = toMeasure(e);
+        Measure* m = toMeasure(e)->coveringMMRestOrThis();
         Fraction tick  = m->tick();
         if (m_selection.isNone()) {
             m_selection.setRange(m->tick2segment(tick),
-                                 m == lastMeasure() ? 0 : m->last(),
+                                 m == lastMeasureMM() ? 0 : m->last(),
                                  0,
                                  nstaves());
             setUpdateAll();
@@ -3637,9 +3637,9 @@ void Score::selectRange(EngravingItem* e, staff_idx_t staffIdx)
     }
 
     if (e->isMeasure()) {
-        Measure* m = toMeasure(e);
+        Measure* m = toMeasure(e)->coveringMMRestOrThis();
         Segment* startSegment = m->first(SegmentType::ChordRest);
-        Segment* endSegment = m == lastMeasure() ? nullptr : m->last();
+        Segment* endSegment = m == lastMeasureMM() ? nullptr : m->last();
         Fraction tick = m->tick();
         Fraction etick = tick + m->ticks();
 
@@ -3773,14 +3773,14 @@ bool Score::tryExtendSingleSelectionToRange(EngravingItem* newElement, staff_idx
     bool activeSegmentIsStart = false;
 
     if (newElement->isMeasure()) {
-        Measure* m = toMeasure(newElement);
+        Measure* m = toMeasure(newElement)->coveringMMRestOrThis();
         const Fraction tick = m->tick();
 
         if (tick < startSegment->tick()) {
             startSegment = m->first(SegmentType::ChordRest);
             activeSegmentIsStart = true;
         }
-        if (m == lastMeasure()) {
+        if (m == lastMeasureMM()) {
             endSegment = nullptr;
         } else if (endSegment && tick + m->ticks() > endSegment->tick()) {
             endSegment = m->last();


### PR DESCRIPTION
Because underlying ones are possibly not considered during layout, and thus may not have a `system()` which can cause crashes.

(all of this only applies when MMRests are actually enabled, but that is checked for by `coveringMMRestOrThis`.)

Resolves: #23878