### PR TITLE
4.5.0: AppImage: default to `xcb`

### DIFF
--- a/buildscripts/packaging/Linux+BSD/portable/AppRun.in
+++ b/buildscripts/packaging/Linux+BSD/portable/AppRun.in
@@ -22,6 +22,9 @@ done
 # directory because linuxdeploy sets RUNPATH to point to it anyway.
 export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}${fallback_libs}"
 
+# Default to `xcb`, because `wayland` support is still experimental
+[[ "${QT_QPA_PLATFORM}" ]] || export QT_QPA_PLATFORM=xcb
+
 # Launch MuseScore or an accompanying script
 case "$1" in
   -h|--help|install|update|upgrade|uninstall|remove|man|manual|manpage|check-depends|check-dependencies )


### PR DESCRIPTION
Ports from 4.4 to 4.5: https://github.com/musescore/MuseScore/pull/24131

At first, we made only 4.4 default to xcb, in the hope that Wayland would prove stable enough to become the default in 4.5. But it didn't, so the default should stay xcb in 4.5. When we switch to Qt 6.8, we can try again. 