### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/engraving/dom/measure.cpp
+++ b/src/engraving/dom/measure.cpp
@@ -947,6 +947,7 @@ void Measure::remove(EngravingItem* e)
         if (e->isJump() || (e->isMarker() && toMarker(e)->isRightMarker())) {
             setProperty(Pid::REPEAT_JUMP, false);
         }
+    // FALLTHROUGH
     case ElementType::HBOX:
         if (!el().remove(e)) {
             LOGD("Measure(%p)::remove(%s,%p) not found", this, e->typeName(), e);

--- a/src/framework/global/containers.h
+++ b/src/framework/global/containers.h
@@ -342,7 +342,7 @@ inline bool remove(Map& c, const T& k)
 }
 
 template<typename Map, typename Predicate>
-inline int remove_if(Map& c, Predicate pred)
+inline size_t remove_if(Map& c, Predicate pred)
 {
     auto old_size = c.size();
     for (auto first = c.begin(), last = c.end(); first != last;) {

--- a/src/framework/midi/internal/platform/osx/coremidioutport.cpp
+++ b/src/framework/midi/internal/platform/osx/coremidioutport.cpp
@@ -287,7 +287,7 @@ Ret CoreMidiOutPort::sendEvent(const Event& e)
         return make_ret(Err::MidiNotConnected);
     }
 
-    OSStatus result;
+    OSStatus result = noErr;
     MIDITimeStamp timeStamp = AudioGetCurrentHostTime();
 
     // Note: there could be three cases: MIDI2+MIDIEventList, MIDI1+MIDIEventList, MIDI1+MIDIPacketList.

--- a/src/framework/vst/internal/synth/vstsequencer.cpp
+++ b/src/framework/vst/internal/synth/vstsequencer.cpp
@@ -106,8 +106,8 @@ void VstSequencer::updatePlaybackEvents(EventSequenceMap& destination, const mpe
 {
     SostenutoTimeAndDurations sostenutoTimeAndDurations;
 
-    for (const auto& pair : events) {
-        for (const mpe::PlaybackEvent& event : pair.second) {
+    for (const auto& evPair : events) {
+        for (const mpe::PlaybackEvent& event : evPair.second) {
             if (!std::holds_alternative<mpe::NoteEvent>(event)) {
                 continue;
             }
@@ -124,8 +124,8 @@ void VstSequencer::updatePlaybackEvents(EventSequenceMap& destination, const mpe
             destination[timestampFrom].emplace(buildEvent(VstEvent::kNoteOnEvent, noteId, velocityFraction, tuning));
             destination[timestampTo].emplace(buildEvent(VstEvent::kNoteOffEvent, noteId, velocityFraction, tuning));
 
-            for (const auto& pair : noteEvent.expressionCtx().articulations) {
-                const mpe::ArticulationMeta& meta = pair.second.meta;
+            for (const auto& articPair : noteEvent.expressionCtx().articulations) {
+                const mpe::ArticulationMeta& meta = articPair.second.meta;
 
                 if (muse::contains(BEND_SUPPORTED_TYPES, meta.type)) {
                     appendPitchBend(destination, noteEvent, meta);

--- a/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
@@ -3274,8 +3274,6 @@ static String symIdToOrnam(const SymId sid)
         return String(u"other-ornament smufl=\"%1\"").arg(String::fromAscii(name.ascii()));
         break;
     }
-
-    return String();
 }
 
 //---------------------------------------------------------


### PR DESCRIPTION
* MSVC: reg.: unreachable code (C4702)
* GCC: reg.: this statement may fall through [-Wimplicit-fallthrough=]
* CLANG(?): reg.: variable 'result' is used uninitialized whenever 'if' condition is false [-Wsometimes-uninitialized]
* MSVC: reg.: return: conversion from 'size_t' to 'int', possible loss of data  (C4267)
* MSVC: reg.: declaration of 'pair' hides previous local declaration (C4456)