### PR TITLE
Remove Millimetre usage

### DIFF
--- a/src/engraving/dom/chord.cpp
+++ b/src/engraving/dom/chord.cpp
@@ -1519,9 +1519,9 @@ void Chord::resizeLedgerLinesTo(size_t newSize)
 void Chord::setBeamExtension(double extension)
 {
     if (m_stem) {
-        double baseLength = m_stem->baseLength().toMM(spatium()).val();
+        double baseLength = m_stem->absoluteFromSpatium(m_stem->baseLength());
         m_stem->setBaseLength(std::max(Spatium::fromMM(baseLength + extension, spatium()), Spatium(0.0)));
-        m_defaultStemLength = std::max(m_defaultStemLength + extension, m_stem->baseLength().toMM(spatium()).val());
+        m_defaultStemLength = std::max(m_defaultStemLength + extension, m_stem->absoluteFromSpatium(m_stem->baseLength()));
     }
 }
 

--- a/src/engraving/dom/chord.cpp
+++ b/src/engraving/dom/chord.cpp
@@ -1519,8 +1519,9 @@ void Chord::resizeLedgerLinesTo(size_t newSize)
 void Chord::setBeamExtension(double extension)
 {
     if (m_stem) {
-        m_stem->setBaseLength(std::max(m_stem->baseLength() + Millimetre(extension), Millimetre { 0.0 }));
-        m_defaultStemLength = std::max(m_defaultStemLength + extension, m_stem->baseLength().val());
+        double baseLength = m_stem->baseLength().toMM(spatium()).val();
+        m_stem->setBaseLength(std::max(Spatium::fromMM(baseLength + extension, spatium()), Spatium(0.0)));
+        m_defaultStemLength = std::max(m_defaultStemLength + extension, m_stem->baseLength().toMM(spatium()).val());
     }
 }
 

--- a/src/engraving/dom/measure.cpp
+++ b/src/engraving/dom/measure.cpp
@@ -1623,7 +1623,7 @@ EngravingItem* Measure::drop(EditData& data)
                 double y2 = s->staffYpage(nextVisStaffIdx);
                 gap = y2 - y1 - score()->staff(staffIdx)->staffHeight();
             }
-            spacer->setGap(Millimetre(gap));
+            spacer->setGap(Spatium::fromMM(gap, spatium()));
         }
         score()->undoAddElement(spacer);
         triggerLayout();

--- a/src/engraving/dom/property.cpp
+++ b/src/engraving/dom/property.cpp
@@ -304,7 +304,7 @@ static constexpr PropertyMetaData propertyList[] = {
     { Pid::STAFF_GEN_TIMESIG,       false, "",                      P_TYPE::BOOL,               PropertyGroup::APPEARANCE,      DUMMY_QT_TR_NOOP("propertyName", "generating time signature") },
     { Pid::STAFF_GEN_KEYSIG,        false, "",                      P_TYPE::BOOL,               PropertyGroup::APPEARANCE,      DUMMY_QT_TR_NOOP("propertyName", "generating key signature") },
     { Pid::STAFF_YOFFSET,           false, "",                      P_TYPE::SPATIUM,            PropertyGroup::APPEARANCE,      DUMMY_QT_TR_NOOP("propertyName", "y-offset") },
-    { Pid::STAFF_USERDIST,          false, "distOffset",            P_TYPE::MILLIMETRE,         PropertyGroup::APPEARANCE,      DUMMY_QT_TR_NOOP("propertyName", "distance offset") },
+    { Pid::STAFF_USERDIST,          false, "distOffset",            P_TYPE::SPATIUM,            PropertyGroup::APPEARANCE,      DUMMY_QT_TR_NOOP("propertyName", "distance offset") },
     { Pid::STAFF_BARLINE_SPAN,      false, "barLineSpan",           P_TYPE::BOOL,               PropertyGroup::APPEARANCE,      DUMMY_QT_TR_NOOP("propertyName", "barline span") },
     { Pid::STAFF_BARLINE_SPAN_FROM, false, "barLineSpanFrom",       P_TYPE::INT,                PropertyGroup::APPEARANCE,      DUMMY_QT_TR_NOOP("propertyName", "barline span from") },
     { Pid::STAFF_BARLINE_SPAN_TO,   false, "barLineSpanTo",         P_TYPE::INT,                PropertyGroup::APPEARANCE,      DUMMY_QT_TR_NOOP("propertyName", "barline span to") },

--- a/src/engraving/dom/property.cpp
+++ b/src/engraving/dom/property.cpp
@@ -155,7 +155,7 @@ static constexpr PropertyMetaData propertyList[] = {
     { Pid::USER_LEN,                false, "userLen",               P_TYPE::SPATIUM,            PropertyGroup::APPEARANCE,      DUMMY_QT_TR_NOOP("propertyName", "length") },
     { Pid::SHOW_STEM_SLASH,         true,  "showStemSlash",         P_TYPE::BOOL,               PropertyGroup::APPEARANCE,      DUMMY_QT_TR_NOOP("propertyName", "show stem slash") },
 
-    { Pid::SPACE,                   false, "space",                 P_TYPE::MILLIMETRE,         PropertyGroup::APPEARANCE,      DUMMY_QT_TR_NOOP("propertyName", "space") },
+    { Pid::SPACE,                   false, "space",                 P_TYPE::SPATIUM,         PropertyGroup::APPEARANCE,      DUMMY_QT_TR_NOOP("propertyName", "space") },
     { Pid::TEMPO,                   true,  "tempo",                 P_TYPE::TEMPO,              PropertyGroup::APPEARANCE,      DUMMY_QT_TR_NOOP("propertyName", "tempo") },
     { Pid::TEMPO_FOLLOW_TEXT,       true,  "followText",            P_TYPE::BOOL,               PropertyGroup::APPEARANCE,      DUMMY_QT_TR_NOOP("propertyName", "following text") },
     { Pid::ACCIDENTAL_BRACKET,      false, "bracket",               P_TYPE::INT,                PropertyGroup::APPEARANCE,      DUMMY_QT_TR_NOOP("propertyName", "bracket") },

--- a/src/engraving/dom/spacer.cpp
+++ b/src/engraving/dom/spacer.cpp
@@ -64,16 +64,6 @@ void Spacer::setGap(Spatium sp)
 }
 
 //---------------------------------------------------------
-//   spatiumChanged
-//---------------------------------------------------------
-
-void Spacer::spatiumChanged(double ov, double nv)
-{
-    m_gap = (m_gap / ov) * nv;
-    renderer()->layoutItem(this);
-}
-
-//---------------------------------------------------------
 //   startEditDrag
 //---------------------------------------------------------
 

--- a/src/engraving/dom/spacer.cpp
+++ b/src/engraving/dom/spacer.cpp
@@ -50,56 +50,7 @@ Spacer::Spacer(const Spacer& s)
     : EngravingItem(s)
 {
     m_gap        = s.m_gap;
-    m_path        = s.m_path;
     m_spacerType = s.m_spacerType;
-}
-
-//---------------------------------------------------------
-//   layout0
-//---------------------------------------------------------
-
-void Spacer::layout0()
-{
-    double _spatium = spatium();
-
-    m_path    = PainterPath();
-    double w = _spatium;
-    double b = w * .5;
-    double h = (explicitParent() ? m_gap.toMM(spatium()) : std::min(m_gap, Spatium(4.0)).toMM(spatium())).val();       // limit length for palette
-
-    switch (spacerType()) {
-    case SpacerType::DOWN:
-        m_path.lineTo(w, 0.0);
-        m_path.moveTo(b, 0.0);
-        m_path.lineTo(b, h);
-        m_path.lineTo(0.0, h - b);
-        m_path.moveTo(b, h);
-        m_path.lineTo(w, h - b);
-        break;
-    case SpacerType::UP:
-        m_path.moveTo(b, 0.0);
-        m_path.lineTo(0.0, b);
-        m_path.moveTo(b, 0.0);
-        m_path.lineTo(w, b);
-        m_path.moveTo(b, 0.0);
-        m_path.lineTo(b, h);
-        m_path.moveTo(0.0, h);
-        m_path.lineTo(w, h);
-        break;
-    case SpacerType::FIXED:
-        m_path.lineTo(w, 0.0);
-        m_path.moveTo(b, 0.0);
-        m_path.lineTo(b, h);
-        m_path.moveTo(0.0, h);
-        m_path.lineTo(w, h);
-        break;
-    }
-    double lw = _spatium * 0.4;
-    RectF bb(0, 0, w, h);
-    bb.adjust(-lw, -lw, lw, lw);
-    setbbox(bb);
-
-    setZ(0.0);
 }
 
 //---------------------------------------------------------
@@ -109,7 +60,7 @@ void Spacer::layout0()
 void Spacer::setGap(Spatium sp)
 {
     m_gap = sp;
-    layout0();
+    renderer()->layoutItem(this);
 }
 
 //---------------------------------------------------------
@@ -119,7 +70,7 @@ void Spacer::setGap(Spatium sp)
 void Spacer::spatiumChanged(double ov, double nv)
 {
     m_gap = (m_gap / ov) * nv;
-    layout0();
+    renderer()->layoutItem(this);
 }
 
 //---------------------------------------------------------
@@ -150,7 +101,7 @@ void Spacer::editDrag(EditData& ed)
         break;
     }
     m_gap = std::max(m_gap, Spatium(2.0));
-    layout0();
+    renderer()->layoutItem(this);
     triggerLayout();
 }
 
@@ -165,7 +116,7 @@ std::vector<PointF> Spacer::gripsPositions(const EditData&) const
     switch (spacerType()) {
     case SpacerType::DOWN:
     case SpacerType::FIXED:
-        p = PointF(_spatium * .5, m_gap.toMM(_spatium).val());
+        p = PointF(_spatium * .5, absoluteGap());
         break;
     case SpacerType::UP:
         p = PointF(_spatium * .5, 0.0);
@@ -204,7 +155,7 @@ bool Spacer::setProperty(Pid propertyId, const PropertyValue& v)
         }
         break;
     }
-    layout0();
+    renderer()->layoutItem(this);
     triggerLayout();
     setGenerated(false);
     return true;

--- a/src/engraving/dom/spacer.h
+++ b/src/engraving/dom/spacer.h
@@ -63,8 +63,10 @@ public:
     void editDrag(EditData&) override;
     void spatiumChanged(double, double) override;
 
-    void setGap(Millimetre sp);
-    Millimetre gap() const { return m_gap; }
+    void setGap(Spatium sp);
+    Spatium gap() const { return m_gap; }
+
+    double absoluteGap() const { return m_gap.toMM(spatium()).val(); }
 
     const muse::draw::PainterPath& path() const { return m_path; }
 
@@ -87,7 +89,7 @@ private:
     Spacer(const Spacer&);
 
     SpacerType m_spacerType = SpacerType::UP;
-    Millimetre m_gap;
+    Spatium m_gap;
     muse::draw::PainterPath m_path;
 };
 } // namespace mu::engraving

--- a/src/engraving/dom/spacer.h
+++ b/src/engraving/dom/spacer.h
@@ -68,8 +68,6 @@ public:
 
     double absoluteGap() const { return m_gap.toMM(spatium()).val(); }
 
-    const muse::draw::PainterPath& path() const { return m_path; }
-
     bool needStartEditingAfterSelecting() const override { return true; }
     int gripsCount() const override { return 1; }
     Grip initialEditModeGrip() const override { return Grip::START; }
@@ -80,7 +78,10 @@ public:
     bool setProperty(Pid propertyId, const PropertyValue&) override;
     PropertyValue propertyDefault(Pid id) const override;
 
-    void layout0();
+    struct LayoutData : public EngravingItem::LayoutData {
+        PainterPath path;
+    };
+    DECLARE_LAYOUTDATA_METHODS(Spacer)
 
 private:
 
@@ -90,7 +91,6 @@ private:
 
     SpacerType m_spacerType = SpacerType::UP;
     Spatium m_gap;
-    muse::draw::PainterPath m_path;
 };
 } // namespace mu::engraving
 #endif

--- a/src/engraving/dom/spacer.h
+++ b/src/engraving/dom/spacer.h
@@ -61,7 +61,6 @@ public:
     bool isEditable() const override { return true; }
     void startEditDrag(EditData&) override;
     void editDrag(EditData&) override;
-    void spatiumChanged(double, double) override;
 
     void setGap(Spatium sp);
     Spatium gap() const { return m_gap; }

--- a/src/engraving/dom/spacer.h
+++ b/src/engraving/dom/spacer.h
@@ -65,7 +65,7 @@ public:
     void setGap(Spatium sp);
     Spatium gap() const { return m_gap; }
 
-    double absoluteGap() const { return m_gap.toMM(spatium()).val(); }
+    double absoluteGap() const { return absoluteFromSpatium(m_gap); }
 
     bool needStartEditingAfterSelecting() const override { return true; }
     int gripsCount() const override { return 1; }

--- a/src/engraving/dom/staff.cpp
+++ b/src/engraving/dom/staff.cpp
@@ -1117,11 +1117,6 @@ bool Staff::isPrimaryStaff() const
     return linkedStavesInThisScore.front() == this;
 }
 
-double Staff::absoluteUserDist() const
-{
-    return m_userDist.toMM(style().spatium()).val();
-}
-
 //---------------------------------------------------------
 //   staffType
 //---------------------------------------------------------

--- a/src/engraving/dom/staff.cpp
+++ b/src/engraving/dom/staff.cpp
@@ -1117,6 +1117,11 @@ bool Staff::isPrimaryStaff() const
     return linkedStavesInThisScore.front() == this;
 }
 
+double Staff::absoluteUserDist() const
+{
+    return m_userDist.toMM(style().spatium()).val();
+}
+
 //---------------------------------------------------------
 //   staffType
 //---------------------------------------------------------
@@ -1289,15 +1294,6 @@ void Staff::initFromStaffType(const StaffType* staffType)
 
     // use selected staff type
     setStaffType(Fraction(0, 1), *staffType);
-}
-
-//---------------------------------------------------------
-//   spatiumChanged
-//---------------------------------------------------------
-
-void Staff::spatiumChanged(double oldValue, double newValue)
-{
-    m_userDist = (m_userDist / oldValue) * newValue;
 }
 
 //---------------------------------------------------------
@@ -1602,7 +1598,7 @@ bool Staff::setProperty(Pid id, const PropertyValue& v)
         setBarLineTo(v.toInt());
         break;
     case Pid::STAFF_USERDIST:
-        setUserDist(v.value<Millimetre>());
+        setUserDist(v.value<Spatium>());
         break;
     default:
         LOGD("unhandled id <%s>", propertyName(id));
@@ -1636,7 +1632,7 @@ PropertyValue Staff::propertyDefault(Pid id) const
     case Pid::STAFF_BARLINE_SPAN_TO:
         return 0;
     case Pid::STAFF_USERDIST:
-        return Millimetre(0.0);
+        return Spatium(0.0);
     default:
         LOGD("unhandled id <%s>", propertyName(id));
         return PropertyValue();

--- a/src/engraving/dom/staff.h
+++ b/src/engraving/dom/staff.h
@@ -217,7 +217,6 @@ public:
     bool isPrimaryStaff() const;
 
     Spatium userDist() const { return m_userDist; }
-    double absoluteUserDist() const;
     void setUserDist(Spatium val) { m_userDist = val; }
 
     void setLocalSpatium(double oldVal, double newVal, Fraction tick);

--- a/src/engraving/dom/staff.h
+++ b/src/engraving/dom/staff.h
@@ -216,10 +216,10 @@ public:
     Staff* primaryStaff() const;
     bool isPrimaryStaff() const;
 
-    Millimetre userDist() const { return m_userDist; }
-    void setUserDist(Millimetre val) { m_userDist = val; }
+    Spatium userDist() const { return m_userDist; }
+    double absoluteUserDist() const;
+    void setUserDist(Spatium val) { m_userDist = val; }
 
-    void spatiumChanged(double /*oldValue*/, double /*newValue*/) override;
     void setLocalSpatium(double oldVal, double newVal, Fraction tick);
     bool genKeySig();
     bool showLedgerLines(const Fraction&) const;
@@ -301,7 +301,7 @@ private:
     HideMode m_hideWhenEmpty = HideMode::AUTO;      // hide empty staves
 
     Color m_color;
-    Millimetre m_userDist     { Millimetre(0.0) };           ///< user edited extra distance
+    Spatium m_userDist     { Spatium(0.0) };           ///< user edited extra distance
 
     StaffTypeList m_staffTypeList;
 

--- a/src/engraving/dom/stem.cpp
+++ b/src/engraving/dom/stem.cpp
@@ -60,9 +60,9 @@ bool Stem::up() const
     return chord() ? chord()->up() : true;
 }
 
-void Stem::setBaseLength(Millimetre baseLength)
+void Stem::setBaseLength(Spatium baseLength)
 {
-    m_baseLength = Millimetre(std::abs(baseLength.val()));
+    m_baseLength = Spatium(std::abs(baseLength.val()));
 }
 
 double Stem::lineWidthMag() const
@@ -73,6 +73,8 @@ double Stem::lineWidthMag() const
 void Stem::spatiumChanged(double oldValue, double newValue)
 {
     m_userLength = (m_userLength / oldValue) * newValue;
+    m_baseLength = (m_baseLength / oldValue) * newValue;
+    m_lineWidth = (m_lineWidth / oldValue) * newValue;
     renderer()->layoutItem(this);
 }
 
@@ -114,7 +116,7 @@ void Stem::editDrag(EditData& ed)
 
 void Stem::reset()
 {
-    undoChangeProperty(Pid::USER_LEN, Millimetre(0.0));
+    undoChangeProperty(Pid::USER_LEN, Spatium(0.0));
     EngravingItem::reset();
 }
 

--- a/src/engraving/dom/stem.cpp
+++ b/src/engraving/dom/stem.cpp
@@ -70,14 +70,6 @@ double Stem::lineWidthMag() const
     return absoluteFromSpatium(m_lineWidth) * chord()->intrinsicMag();
 }
 
-void Stem::spatiumChanged(double oldValue, double newValue)
-{
-    m_userLength = (m_userLength / oldValue) * newValue;
-    m_baseLength = (m_baseLength / oldValue) * newValue;
-    m_lineWidth = (m_lineWidth / oldValue) * newValue;
-    renderer()->layoutItem(this);
-}
-
 //! In chord coordinates
 PointF Stem::flagPosition() const
 {

--- a/src/engraving/dom/stem.h
+++ b/src/engraving/dom/stem.h
@@ -71,7 +71,7 @@ public:
     void setLineWidth(Spatium lineWidth) { m_lineWidth = lineWidth; }
 
     PointF flagPosition() const;
-    double length() const { return (m_baseLength + m_userLength).toMM(spatium()); }
+    double length() const { return absoluteFromSpatium(m_baseLength + m_userLength); }
 
     bool needStartEditingAfterSelecting() const override { return true; }
     int gripsCount() const override { return 1; }

--- a/src/engraving/dom/stem.h
+++ b/src/engraving/dom/stem.h
@@ -40,7 +40,6 @@ public:
 
     Stem* clone() const override { return new Stem(*this); }
 
-    void spatiumChanged(double oldValue, double newValue) override;
     EngravingItem* elementBase() const override;
 
     bool isEditable() const override { return true; }

--- a/src/engraving/dom/stem.h
+++ b/src/engraving/dom/stem.h
@@ -61,8 +61,8 @@ public:
     Chord* chord() const { return toChord(explicitParent()); }
     bool up() const;
 
-    Millimetre baseLength() const { return m_baseLength; }
-    void setBaseLength(Millimetre baseLength);
+    Spatium baseLength() const { return m_baseLength; }
+    void setBaseLength(Spatium baseLength);
 
     Spatium userLength() const { return m_userLength; }
     void setUserLength(Spatium userLength) { m_userLength = userLength; }
@@ -72,7 +72,7 @@ public:
     void setLineWidth(Spatium lineWidth) { m_lineWidth = lineWidth; }
 
     PointF flagPosition() const;
-    double length() const { return m_baseLength + m_userLength.toMM(spatium()); }
+    double length() const { return (m_baseLength + m_userLength).toMM(spatium()); }
 
     bool needStartEditingAfterSelecting() const override { return true; }
     int gripsCount() const override { return 1; }
@@ -90,7 +90,7 @@ private:
     friend class Factory;
     Stem(Chord* parent = 0);
 
-    Millimetre m_baseLength = Millimetre(0.0);
+    Spatium m_baseLength = Spatium(0.0);
 
     Spatium m_userLength = Spatium(0.0);
     Spatium m_lineWidth = Spatium(0.0);

--- a/src/engraving/dom/system.cpp
+++ b/src/engraving/dom/system.cpp
@@ -913,10 +913,10 @@ double System::spacerDistance(bool up) const
             Spacer* sp = up ? m->vspacerUp(staff) : m->vspacerDown(staff);
             if (sp) {
                 if (sp->spacerType() == SpacerType::FIXED) {
-                    dist = sp->gap();
+                    dist = sp->absoluteGap();
                     break;
                 } else {
-                    dist = std::max(dist, sp->gap().val());
+                    dist = std::max(dist, sp->absoluteGap());
                 }
             }
         }

--- a/src/engraving/dom/undo.cpp
+++ b/src/engraving/dom/undo.cpp
@@ -1911,7 +1911,7 @@ ChangeStaff::ChangeStaff(Staff* _staff)
 }
 
 ChangeStaff::ChangeStaff(Staff* _staff, bool _visible, ClefTypeList _clefType,
-                         double _userDist, Staff::HideMode _hideMode, bool _showIfEmpty, bool _cutaway,
+                         Spatium _userDist, Staff::HideMode _hideMode, bool _showIfEmpty, bool _cutaway,
                          bool _hideSystemBarLine, AutoOnOff _mergeMatchingRests, bool _reflectTranspositionInLinkedTab)
 {
     staff       = _staff;
@@ -1934,7 +1934,7 @@ void ChangeStaff::flip(EditData*)
 {
     bool oldVisible = staff->visible();
     ClefTypeList oldClefType = staff->defaultClefType();
-    double oldUserDist   = staff->userDist();
+    Spatium oldUserDist   = staff->userDist();
     Staff::HideMode oldHideMode    = staff->hideWhenEmpty();
     bool oldShowIfEmpty = staff->showIfEmpty();
     bool oldCutaway     = staff->cutaway();
@@ -1944,7 +1944,7 @@ void ChangeStaff::flip(EditData*)
 
     staff->setVisible(visible);
     staff->setDefaultClefType(clefType);
-    staff->setUserDist(Millimetre(userDist));
+    staff->setUserDist(userDist);
     staff->setHideWhenEmpty(hideMode);
     staff->setShowIfEmpty(showIfEmpty);
     staff->setCutaway(cutaway);

--- a/src/engraving/dom/undo.h
+++ b/src/engraving/dom/undo.h
@@ -796,7 +796,7 @@ class ChangeStaff : public UndoCommand
 
     bool visible = false;
     ClefTypeList clefType;
-    double userDist = 0.0;
+    Spatium userDist = Spatium(0.0);
     Staff::HideMode hideMode = Staff::HideMode::AUTO;
     bool showIfEmpty = false;
     bool cutaway = false;
@@ -809,8 +809,8 @@ class ChangeStaff : public UndoCommand
 public:
     ChangeStaff(Staff*);
 
-    ChangeStaff(Staff*, bool _visible, ClefTypeList _clefType, double userDist, Staff::HideMode _hideMode, bool _showIfEmpty, bool _cutaway,
-                bool _hideSystemBarLine, AutoOnOff _mergeRests, bool _reflectTranspositionInLinkedTab);
+    ChangeStaff(Staff*, bool _visible, ClefTypeList _clefType, Spatium userDist, Staff::HideMode _hideMode, bool _showIfEmpty,
+                bool _cutaway, bool _hideSystemBarLine, AutoOnOff _mergeRests, bool _reflectTranspositionInLinkedTab);
 
     UNDO_TYPE(CommandType::ChangeStaff)
     UNDO_NAME("ChangeStaff")

--- a/src/engraving/rendering/iscorerenderer.h
+++ b/src/engraving/rendering/iscorerenderer.h
@@ -80,6 +80,7 @@ class Spanner;
 class Slur;
 class SlurSegment;
 class SlurTie;
+class Spacer;
 class StaffText;
 class Stem;
 class SystemLockIndicator;
@@ -151,6 +152,7 @@ public:
                                    Spanner*,
                                    Slur*,
                                    SlurTie*,
+                                   Spacer*,
                                    StaffText*,
                                    Stem*,
                                    SystemLockIndicator*,

--- a/src/engraving/rendering/score/chordlayout.cpp
+++ b/src/engraving/rendering/score/chordlayout.cpp
@@ -1233,7 +1233,7 @@ void ChordLayout::layoutStem(Chord* item, const LayoutContext& ctx)
 
     item->stem()->mutldata()->setPosX(item->stemPosX());
 
-    item->stem()->setBaseLength(Millimetre(item->defaultStemLength()));
+    item->stem()->setBaseLength(Spatium::fromMM(item->defaultStemLength(), item->spatium()));
     TLayout::layoutStem(item->stem(), item->stem()->mutldata(), ctx.conf());
 
     // And now we need to set the position of the flag.

--- a/src/engraving/rendering/score/measurelayout.cpp
+++ b/src/engraving/rendering/score/measurelayout.cpp
@@ -96,7 +96,7 @@ void MeasureLayout::layout2(Measure* item, LayoutContext& ctx)
         if (sp) {
             TLayout::layoutSpacer(sp, ctx);
             double y = item->system()->staff(staffIdx)->y();
-            sp->setPos(_spatium * .5, y - sp->gap());
+            sp->setPos(_spatium * .5, y - sp->absoluteGap());
         }
     }
 

--- a/src/engraving/rendering/score/pagelayout.cpp
+++ b/src/engraving/rendering/score/pagelayout.cpp
@@ -178,11 +178,11 @@ void PageLayout::collectPage(LayoutContext& ctx)
                         Spacer* sp = m->vspacerUp(0);
                         if (sp) {
                             if (sp->spacerType() == SpacerType::FIXED) {
-                                distance = sp->gap();
+                                distance = sp->absoluteGap();
                                 fixedDistance = true;
                                 break;
                             } else {
-                                distance = std::max(distance, sp->gap().val());
+                                distance = std::max(distance, sp->absoluteGap());
                             }
                         }
                     }
@@ -746,7 +746,7 @@ void PageLayout::distributeStaves(LayoutContext& ctx, Page* page, double footerP
     double spaceRemaining{ std::min(page->height() - combinedBottomMargin - yBottom, page->height() - marginToStaff - prevYBottom) };
 
     if (nextSpacer) {
-        spaceRemaining -= std::max(0.0, nextSpacer->gap() - spacerOffset - staffLowerBorder);
+        spaceRemaining -= std::max(0.0, nextSpacer->absoluteGap() - spacerOffset - staffLowerBorder);
     }
     if (spaceRemaining <= 0.0) {
         return;

--- a/src/engraving/rendering/score/systemlayout.cpp
+++ b/src/engraving/rendering/score/systemlayout.cpp
@@ -2360,7 +2360,7 @@ void SystemLayout::layout2(System* system, LayoutContext& ctx)
         } else {
             dist += staffDistance;
         }
-        dist += staff2->userDist();
+        dist += staff2->absoluteUserDist();
         bool fixedSpace = false;
         for (const MeasureBase* mb : system->measures()) {
             if (!mb->isMeasure()) {
@@ -2767,7 +2767,7 @@ double SystemLayout::minDistance(const System* top, const System* bottom, const 
     }
 
     const Staff* staff = dom.staff(firstStaff);
-    double userDist = staff ? staff->userDist() : 0.0;
+    double userDist = staff ? staff->absoluteUserDist() : 0.0;
     dist = std::max(dist, userDist);
     top->setFixedDownDistance(false);
 

--- a/src/engraving/rendering/score/systemlayout.cpp
+++ b/src/engraving/rendering/score/systemlayout.cpp
@@ -2360,7 +2360,7 @@ void SystemLayout::layout2(System* system, LayoutContext& ctx)
         } else {
             dist += staffDistance;
         }
-        dist += staff2->absoluteUserDist();
+        dist += staff2->absoluteFromSpatium(staff2->userDist());
         bool fixedSpace = false;
         for (const MeasureBase* mb : system->measures()) {
             if (!mb->isMeasure()) {
@@ -2767,7 +2767,7 @@ double SystemLayout::minDistance(const System* top, const System* bottom, const 
     }
 
     const Staff* staff = dom.staff(firstStaff);
-    double userDist = staff ? staff->absoluteUserDist() : 0.0;
+    double userDist = staff ? staff->absoluteFromSpatium(staff->userDist()) : 0.0;
     dist = std::max(dist, userDist);
     top->setFixedDownDistance(false);
 

--- a/src/engraving/rendering/score/systemlayout.cpp
+++ b/src/engraving/rendering/score/systemlayout.cpp
@@ -2370,16 +2370,16 @@ void SystemLayout::layout2(System* system, LayoutContext& ctx)
             Spacer* sp = m->vspacerDown(si1);
             if (sp) {
                 if (sp->spacerType() == SpacerType::FIXED) {
-                    dist = staff->staffHeight() + sp->gap();
+                    dist = staff->staffHeight() + sp->absoluteGap();
                     fixedSpace = true;
                     break;
                 } else {
-                    dist = std::max(dist, staff->staffHeight() + sp->gap());
+                    dist = std::max(dist, staff->staffHeight() + sp->absoluteGap());
                 }
             }
             sp = m->vspacerUp(si2);
             if (sp) {
-                dist = std::max(dist, sp->gap() + staff->staffHeight());
+                dist = std::max(dist, sp->absoluteGap() + staff->staffHeight());
             }
         }
         if (!fixedSpace) {
@@ -2786,11 +2786,11 @@ double SystemLayout::minDistance(const System* top, const System* bottom, const 
             const Spacer* sp = m->vspacerDown(lastStaff);
             if (sp) {
                 if (sp->spacerType() == SpacerType::FIXED) {
-                    dist = sp->gap();
+                    dist = sp->absoluteGap();
                     top->setFixedDownDistance(true);
                     break;
                 } else {
-                    dist = std::max(dist, sp->gap().val());
+                    dist = std::max(dist, sp->absoluteGap());
                 }
             }
         }
@@ -2801,7 +2801,7 @@ double SystemLayout::minDistance(const System* top, const System* bottom, const 
                 const Measure* m = toMeasure(mb2);
                 const Spacer* sp = m->vspacerUp(firstStaff);
                 if (sp) {
-                    dist = std::max(dist, sp->gap().val());
+                    dist = std::max(dist, sp->absoluteGap());
                 }
             }
         }

--- a/src/engraving/rendering/score/tdraw.cpp
+++ b/src/engraving/rendering/score/tdraw.cpp
@@ -2665,7 +2665,7 @@ void TDraw::draw(const Spacer* item, Painter* painter)
 
     painter->setPen(pen);
     painter->setBrush(BrushStyle::NoBrush);
-    painter->drawPath(item->path());
+    painter->drawPath(item->ldata()->path);
 }
 
 void TDraw::draw(const StaffLines* item, Painter* painter)

--- a/src/engraving/rendering/score/tlayout.cpp
+++ b/src/engraving/rendering/score/tlayout.cpp
@@ -5364,7 +5364,49 @@ void TLayout::layoutSlur(Slur* item, LayoutContext& ctx)
 void TLayout::layoutSpacer(Spacer* item, LayoutContext&)
 {
     LAYOUT_CALL_ITEM(item);
-    item->layout0();
+    Spacer::LayoutData* ldata = item->mutldata();
+
+    double spatium = item->spatium();
+
+    PainterPath path = PainterPath();
+    double w = spatium;
+    double b = w * .5;
+    double h = item->explicitParent() ? item->absoluteGap() : std::min(item->gap(), Spatium(4.0)).toMM(spatium).val();       // limit length for palette
+
+    switch (item->spacerType()) {
+    case SpacerType::DOWN:
+        path.lineTo(w, 0.0);
+        path.moveTo(b, 0.0);
+        path.lineTo(b, h);
+        path.lineTo(0.0, h - b);
+        path.moveTo(b, h);
+        path.lineTo(w, h - b);
+        break;
+    case SpacerType::UP:
+        path.moveTo(b, 0.0);
+        path.lineTo(0.0, b);
+        path.moveTo(b, 0.0);
+        path.lineTo(w, b);
+        path.moveTo(b, 0.0);
+        path.lineTo(b, h);
+        path.moveTo(0.0, h);
+        path.lineTo(w, h);
+        break;
+    case SpacerType::FIXED:
+        path.lineTo(w, 0.0);
+        path.moveTo(b, 0.0);
+        path.lineTo(b, h);
+        path.moveTo(0.0, h);
+        path.lineTo(w, h);
+        break;
+    }
+    ldata->path = path;
+    double lw = spatium * 0.4;
+    RectF bb(0, 0, w, h);
+    bb.adjust(-lw, -lw, lw, lw);
+    ldata->setBbox(bb);
+
+    item->setZ(0.0);
 }
 
 void TLayout::layoutSpanner(Spanner* item, LayoutContext& ctx)

--- a/src/engraving/rendering/score/verticalgapdata.cpp
+++ b/src/engraving/rendering/score/verticalgapdata.cpp
@@ -46,7 +46,7 @@ VerticalGapData::VerticalGapData(const MStyle* style, bool first, System* sys, c
 
         if (spacer) {
             m_fixedSpacer = spacer->spacerType() == SpacerType::FIXED;
-            m_normalisedSpacing = std::max(m_normalisedSpacing, spacer->gap().val());
+            m_normalisedSpacing = std::max(m_normalisedSpacing, spacer->absoluteGap());
             if (m_fixedSpacer) {
                 m_maxActualSpacing = m_normalisedSpacing;
             }

--- a/src/engraving/rendering/single/singledraw.cpp
+++ b/src/engraving/rendering/single/singledraw.cpp
@@ -2195,7 +2195,7 @@ void SingleDraw::draw(const Spacer* item, Painter* painter)
 
     painter->setPen(pen);
     painter->setBrush(BrushStyle::NoBrush);
-    painter->drawPath(item->path());
+    painter->drawPath(item->ldata()->path);
 }
 
 void SingleDraw::draw(const StaffLines* item, Painter* painter)

--- a/src/engraving/rw/read114/read114.cpp
+++ b/src/engraving/rw/read114/read114.cpp
@@ -1492,7 +1492,6 @@ static void readHarmony114(XmlReader& e, ReadContext& ctx, Harmony* h)
 static void readMeasure(Measure* m, int staffIdx, XmlReader& e, ReadContext& ctx)
 {
     Segment* segment = 0;
-    double _spatium = m->spatium();
 
     std::vector<Chord*> graceNotes;
 
@@ -2080,7 +2079,7 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e, ReadContext& ctx
                 spacer->setTrack(staffIdx * VOICES);
                 m->add(spacer);
             }
-            m->vspacerDown(staffIdx)->setGap(Millimetre(e.readDouble() * _spatium));
+            m->vspacerDown(staffIdx)->setGap(Spatium(e.readDouble()));
         } else if (tag == "vspacer" || tag == "vspacerUp") {
             if (!m->vspacerUp(staffIdx)) {
                 Spacer* spacer = Factory::createSpacer(m);
@@ -2088,7 +2087,7 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e, ReadContext& ctx
                 spacer->setTrack(staffIdx * VOICES);
                 m->add(spacer);
             }
-            m->vspacerUp(staffIdx)->setGap(Millimetre(e.readDouble() * _spatium));
+            m->vspacerUp(staffIdx)->setGap(Spatium(e.readDouble()));
         } else if (tag == "visible") {
             m->setStaffVisible(staffIdx, e.readInt());
         } else if (tag == "slashStyle") {

--- a/src/engraving/rw/read206/read206.cpp
+++ b/src/engraving/rw/read206/read206.cpp
@@ -2474,7 +2474,6 @@ void Read206::readTie206(XmlReader& e, ReadContext& ctx, Tie* t)
 static void readMeasure206(Measure* m, int staffIdx, XmlReader& e, ReadContext& ctx)
 {
     Segment* segment = 0;
-    double _spatium = m->spatium();
 
     std::vector<Chord*> graceNotes;
     ctx.tuplets().clear();
@@ -2977,7 +2976,7 @@ static void readMeasure206(Measure* m, int staffIdx, XmlReader& e, ReadContext& 
                 spacer->setTrack(staffIdx * VOICES);
                 m->add(spacer);
             }
-            m->vspacerDown(staffIdx)->setGap(Millimetre(e.readDouble() * _spatium));
+            m->vspacerDown(staffIdx)->setGap(Spatium(e.readDouble()));
         } else if (tag == "vspacer" || tag == "vspacerUp") {
             if (!m->vspacerUp(staffIdx)) {
                 Spacer* spacer = Factory::createSpacer(m);
@@ -2985,7 +2984,7 @@ static void readMeasure206(Measure* m, int staffIdx, XmlReader& e, ReadContext& 
                 spacer->setTrack(staffIdx * VOICES);
                 m->add(spacer);
             }
-            m->vspacerUp(staffIdx)->setGap(Millimetre(e.readDouble() * _spatium));
+            m->vspacerUp(staffIdx)->setGap(Spatium(e.readDouble()));
         } else if (tag == "visible") {
             m->setStaffVisible(staffIdx, e.readInt());
         } else if (tag == "slashStyle") {

--- a/src/engraving/rw/read400/measurerw.cpp
+++ b/src/engraving/rw/read400/measurerw.cpp
@@ -71,7 +71,6 @@ void MeasureRead::readMeasure(Measure* measure, XmlReader& e, ReadContext& ctx, 
         return;
     }
 
-    double _spatium = measure->spatium();
     ctx.setCurrentMeasure(measure);
     int nextTrack = staffIdx * VOICES;
     ctx.setTrack(nextTrack);
@@ -147,7 +146,7 @@ void MeasureRead::readMeasure(Measure* measure, XmlReader& e, ReadContext& ctx, 
                 spacer->setTrack(staffIdx * VOICES);
                 measure->add(spacer);
             }
-            measure->m_mstaves[staffIdx]->vspacerDown()->setGap(Millimetre(e.readDouble() * _spatium));
+            measure->m_mstaves[staffIdx]->vspacerDown()->setGap(Spatium(e.readDouble()));
         } else if (tag == "vspacerFixed") {
             if (!measure->m_mstaves[staffIdx]->vspacerDown()) {
                 Spacer* spacer = Factory::createSpacer(measure);
@@ -155,7 +154,7 @@ void MeasureRead::readMeasure(Measure* measure, XmlReader& e, ReadContext& ctx, 
                 spacer->setTrack(staffIdx * VOICES);
                 measure->add(spacer);
             }
-            measure->m_mstaves[staffIdx]->vspacerDown()->setGap(Millimetre(e.readDouble() * _spatium));
+            measure->m_mstaves[staffIdx]->vspacerDown()->setGap(Spatium(e.readDouble()));
         } else if (tag == "vspacerUp") {
             if (!measure->m_mstaves[staffIdx]->vspacerUp()) {
                 Spacer* spacer = Factory::createSpacer(measure);
@@ -163,7 +162,7 @@ void MeasureRead::readMeasure(Measure* measure, XmlReader& e, ReadContext& ctx, 
                 spacer->setTrack(staffIdx * VOICES);
                 measure->add(spacer);
             }
-            measure->m_mstaves[staffIdx]->vspacerUp()->setGap(Millimetre(e.readDouble() * _spatium));
+            measure->m_mstaves[staffIdx]->vspacerUp()->setGap(Spatium(e.readDouble()));
         } else if (tag == "visible") {
             measure->m_mstaves[staffIdx]->setVisible(e.readInt());
         } else if ((tag == "slashStyle") || (tag == "stemless")) {

--- a/src/engraving/rw/read400/tread.cpp
+++ b/src/engraving/rw/read400/tread.cpp
@@ -3635,7 +3635,6 @@ void TRead::read(Spacer* s, XmlReader& e, ReadContext& ctx)
             e.unknown();
         }
     }
-    s->layout0();
 }
 
 void TRead::read(StaffType* t, XmlReader& e, ReadContext&)

--- a/src/engraving/rw/read400/tread.cpp
+++ b/src/engraving/rw/read400/tread.cpp
@@ -3796,7 +3796,7 @@ bool TRead::readProperties(Staff* s, XmlReader& e, ReadContext& ctx)
     } else if (tag == "barLineSpanTo") {
         s->setBarLineTo(e.readInt());
     } else if (tag == "distOffset") {
-        s->setUserDist(Millimetre(e.readDouble() * s->style().spatium()));
+        s->setUserDist(Spatium(e.readDouble()));
     } else if (tag == "mag") {
         /*_userMag =*/
         e.readDouble(0.1, 10.0);

--- a/src/engraving/rw/read400/tread.cpp
+++ b/src/engraving/rw/read400/tread.cpp
@@ -3630,7 +3630,7 @@ void TRead::read(Spacer* s, XmlReader& e, ReadContext& ctx)
         if (tag == "subtype") {
             s->setSpacerType(SpacerType(e.readInt()));
         } else if (tag == "space") {
-            s->setGap(Millimetre(e.readDouble() * s->spatium()));
+            s->setGap(Spatium(e.readDouble()));
         } else if (!readItemProperties(s, e, ctx)) {
             e.unknown();
         }

--- a/src/engraving/rw/read410/measureread.cpp
+++ b/src/engraving/rw/read410/measureread.cpp
@@ -69,7 +69,6 @@ void MeasureRead::readMeasure(Measure* measure, XmlReader& e, ReadContext& ctx, 
         return;
     }
 
-    double _spatium = measure->spatium();
     ctx.setCurrentMeasure(measure);
     int nextTrack = staffIdx * VOICES;
     ctx.setTrack(nextTrack);
@@ -140,7 +139,7 @@ void MeasureRead::readMeasure(Measure* measure, XmlReader& e, ReadContext& ctx, 
                 spacer->setTrack(staffIdx * VOICES);
                 measure->add(spacer);
             }
-            measure->m_mstaves[staffIdx]->vspacerDown()->setGap(Millimetre(e.readDouble() * _spatium));
+            measure->m_mstaves[staffIdx]->vspacerDown()->setGap(Spatium(e.readDouble()));
         } else if (tag == "vspacerFixed") {
             if (!measure->m_mstaves[staffIdx]->vspacerDown()) {
                 Spacer* spacer = Factory::createSpacer(measure);
@@ -148,7 +147,7 @@ void MeasureRead::readMeasure(Measure* measure, XmlReader& e, ReadContext& ctx, 
                 spacer->setTrack(staffIdx * VOICES);
                 measure->add(spacer);
             }
-            measure->m_mstaves[staffIdx]->vspacerDown()->setGap(Millimetre(e.readDouble() * _spatium));
+            measure->m_mstaves[staffIdx]->vspacerDown()->setGap(Spatium(e.readDouble()));
         } else if (tag == "vspacerUp") {
             if (!measure->m_mstaves[staffIdx]->vspacerUp()) {
                 Spacer* spacer = Factory::createSpacer(measure);
@@ -156,7 +155,7 @@ void MeasureRead::readMeasure(Measure* measure, XmlReader& e, ReadContext& ctx, 
                 spacer->setTrack(staffIdx * VOICES);
                 measure->add(spacer);
             }
-            measure->m_mstaves[staffIdx]->vspacerUp()->setGap(Millimetre(e.readDouble() * _spatium));
+            measure->m_mstaves[staffIdx]->vspacerUp()->setGap(Spatium(e.readDouble()));
         } else if (tag == "visible") {
             measure->m_mstaves[staffIdx]->setVisible(e.readInt());
         } else if ((tag == "slashStyle") || (tag == "stemless")) {

--- a/src/engraving/rw/read410/tread.cpp
+++ b/src/engraving/rw/read410/tread.cpp
@@ -4133,7 +4133,6 @@ void TRead::read(Spacer* s, XmlReader& e, ReadContext& ctx)
             e.unknown();
         }
     }
-    s->layout0();
 }
 
 void TRead::read(StaffType* t, XmlReader& e, ReadContext&)

--- a/src/engraving/rw/read410/tread.cpp
+++ b/src/engraving/rw/read410/tread.cpp
@@ -4128,7 +4128,7 @@ void TRead::read(Spacer* s, XmlReader& e, ReadContext& ctx)
         if (tag == "subtype") {
             s->setSpacerType(SpacerType(e.readInt()));
         } else if (tag == "space") {
-            s->setGap(Millimetre(e.readDouble() * s->spatium()));
+            s->setGap(Spatium(e.readDouble()));
         } else if (!readItemProperties(s, e, ctx)) {
             e.unknown();
         }

--- a/src/engraving/rw/read410/tread.cpp
+++ b/src/engraving/rw/read410/tread.cpp
@@ -4298,7 +4298,7 @@ bool TRead::readProperties(Staff* s, XmlReader& e, ReadContext& ctx)
     } else if (tag == "barLineSpanTo") {
         s->setBarLineTo(e.readInt());
     } else if (tag == "distOffset") {
-        s->setUserDist(Millimetre(e.readDouble() * s->style().spatium()));
+        s->setUserDist(Spatium(e.readDouble()));
     } else if (tag == "mag") {
         /*_userMag =*/
         e.readDouble(0.1, 10.0);

--- a/src/engraving/rw/write/measurewrite.cpp
+++ b/src/engraving/rw/write/measurewrite.cpp
@@ -68,7 +68,6 @@ void MeasureWrite::writeMeasure(const Measure* measure, XmlWriter& xml, WriteCon
         TWrite::writeProperty(measure, xml, Pid::NO_OFFSET);
         TWrite::writeProperty(measure, xml, Pid::MEASURE_NUMBER_MODE);
     }
-    double _spatium = measure->spatium();
     MStaff* mstaff = measure->m_mstaves[staff];
     if (mstaff->noText() && !mstaff->noText()->generated()) {
         TWrite::write(mstaff->noText(), xml, ctx);
@@ -79,13 +78,13 @@ void MeasureWrite::writeMeasure(const Measure* measure, XmlWriter& xml, WriteCon
     }
 
     if (mstaff->vspacerUp()) {
-        xml.tag("vspacerUp", mstaff->vspacerUp()->gap().val() / _spatium);
+        xml.tag("vspacerUp", mstaff->vspacerUp()->gap().val());
     }
     if (mstaff->vspacerDown()) {
         if (mstaff->vspacerDown()->spacerType() == SpacerType::FIXED) {
-            xml.tag("vspacerFixed", mstaff->vspacerDown()->gap().val() / _spatium);
+            xml.tag("vspacerFixed", mstaff->vspacerDown()->gap().val());
         } else {
-            xml.tag("vspacerDown", mstaff->vspacerDown()->gap().val() / _spatium);
+            xml.tag("vspacerDown", mstaff->vspacerDown()->gap().val());
         }
     }
     if (!mstaff->visible()) {

--- a/src/engraving/rw/write/twrite.cpp
+++ b/src/engraving/rw/write/twrite.cpp
@@ -2656,7 +2656,7 @@ void TWrite::write(const Spacer* item, XmlWriter& xml, WriteContext& ctx)
     xml.startElement(item);
     xml.tag("subtype", int(item->spacerType()));
     writeItemProperties(item, xml, ctx);
-    xml.tag("space", item->gap().val() / item->spatium());
+    xml.tag("space", item->gap().val());
     xml.endElement();
 }
 

--- a/src/notation/notationtypes.h
+++ b/src/notation/notationtypes.h
@@ -412,7 +412,7 @@ struct FilterNotesOptions : FilterElementsOptions
 struct StaffConfig
 {
     bool visible = false;
-    qreal userDistance = 0.0;
+    engraving::Spatium userDistance = engraving::Spatium(0.0);
     bool cutaway = false;
     bool showIfEmpty = false;
     bool hideSystemBarline = false;
@@ -425,7 +425,7 @@ struct StaffConfig
     bool operator==(const StaffConfig& conf) const
     {
         bool equal = visible == conf.visible;
-        equal &= muse::RealIsEqual(userDistance, conf.userDistance);
+        equal &= userDistance == conf.userDistance;
         equal &= cutaway == conf.cutaway;
         equal &= showIfEmpty == conf.showIfEmpty;
         equal &= hideSystemBarline == conf.hideSystemBarline;

--- a/src/notation/utilities/percussionutilities.cpp
+++ b/src/notation/utilities/percussionutilities.cpp
@@ -97,7 +97,7 @@ std::shared_ptr<Chord> PercussionUtilities::getDrumNoteForPreview(const Drumset*
 
     Stem* stem = Factory::createStem(chord.get());
     stem->setParent(chord.get());
-    stem->setBaseLength(Millimetre((up ? -3.0 : 3.0) * _spatium));
+    stem->setBaseLength(Spatium(up ? -3.0 : 3.0));
     engravingRender()->layoutItem(stem);
     chord->add(stem);
 

--- a/src/notation/view/widgets/editstaff.cpp
+++ b/src/notation/view/widgets/editstaff.cpp
@@ -160,7 +160,7 @@ void EditStaff::setStaff(Staff* s, const Fraction& tick)
     }
 
     // set dlg controls
-    spinExtraDistance->setValue(s->userDist() / score->style().spatium());
+    spinExtraDistance->setValue(s->userDist().val());
     invisible->setChecked(stt->invisible());
     isSmallCheckbox->setChecked(stt->isSmall());
     color->setColor(stt->color().toQColor());
@@ -502,7 +502,7 @@ void EditStaff::applyStaffProperties()
     StaffConfig config;
     config.visible = m_orgStaff->visible();
 
-    config.userDistance = spinExtraDistance->value() * m_orgStaff->style().spatium();
+    config.userDistance = Spatium(spinExtraDistance->value());
     config.cutaway = cutaway->isChecked();
     config.showIfEmpty = showIfEmpty->isChecked();
     config.hideSystemBarline = hideSystemBarLine->isChecked();

--- a/src/palette/internal/palettecreator.cpp
+++ b/src/palette/internal/palettecreator.cpp
@@ -558,7 +558,7 @@ PalettePtr PaletteCreator::newLayoutPalette(bool defaultPalette)
     for (SpacerType spacerType : spacers) {
         auto spacer = Factory::makeSpacer(gpaletteScore->dummy()->measure());
         spacer->setSpacerType(spacerType);
-        spacer->setGap(Millimetre(3 * gpaletteScore->style().spatium()));
+        spacer->setGap(Spatium(3));
         PaletteCellPtr cell = sp->appendElement(spacer, spacer->subtypeUserName());
         cell->mag = .7;
     }

--- a/src/palette/view/widgets/customizekitdialog.cpp
+++ b/src/palette/view/widgets/customizekitdialog.cpp
@@ -563,7 +563,7 @@ void CustomizeKitDialog::updateExample()
     chord->add(note);
     Stem* stem = Factory::createStem(chord.get());
     stem->setParent(chord.get());
-    stem->setBaseLength(Millimetre((up ? -3.0 : 3.0) * gpaletteScore->style().spatium()));
+    stem->setBaseLength(Spatium(up ? -3.0 : 3.0));
     engravingRenderer()->layoutItem(stem);
     chord->add(stem);
     drumNote->appendElement(chord, m_editedDrumset.translatedName(pitch));


### PR DESCRIPTION
This PR changes the following values to `Spatium` from `Millimetre`:
- Stem base length - keeps unit consistent with user length and line width
- Spacer gap - this was in Spatium already, but was being stored in a `Millimetre` type.
- Staff distance - same situation as above

This removes the need to rescale these values when changing spatium size, as the values are scaled when they are used rather than being stored after being scaled.

I have also moved the spacer layout code from its DOM class to `TLayout`. 