### PR TITLE
Don't unlink top frame when init parts

### DIFF
--- a/src/notation/internal/excerptnotation.cpp
+++ b/src/notation/internal/excerptnotation.cpp
@@ -50,10 +50,6 @@ void ExcerptNotation::init()
 
     setScore(m_excerpt->excerptScore());
 
-    if (isEmpty()) {
-        fillWithDefaultInfo();
-    }
-
     m_inited = true;
 }
 
@@ -80,34 +76,6 @@ bool ExcerptNotation::isCustom() const
 bool ExcerptNotation::isEmpty() const
 {
     return m_excerpt->parts().empty();
-}
-
-void ExcerptNotation::fillWithDefaultInfo()
-{
-    TRACEFUNC;
-
-    IF_ASSERT_FAILED(m_excerpt || m_excerpt->excerptScore()) {
-        return;
-    }
-
-    mu::engraving::Score* score = m_excerpt->excerptScore();
-    mu::engraving::MeasureBase* topVerticalFrame = score->first();
-
-    if (topVerticalFrame && topVerticalFrame->isVBox()) {
-        topVerticalFrame->undoUnlink();
-    }
-
-    auto unlinkText = [&score](TextStyleType textType) {
-        engraving::Text* textItem = score->getText(textType);
-        if (textItem) {
-            textItem->undoUnlink();
-        }
-    };
-
-    unlinkText(TextStyleType::TITLE);
-    unlinkText(TextStyleType::SUBTITLE);
-    unlinkText(TextStyleType::COMPOSER);
-    unlinkText(TextStyleType::LYRICIST);
 }
 
 mu::engraving::Excerpt* ExcerptNotation::excerpt() const

--- a/src/notation/internal/excerptnotation.h
+++ b/src/notation/internal/excerptnotation.h
@@ -55,7 +55,6 @@ public:
     IExcerptNotationPtr clone() const override;
 
 private:
-    void fillWithDefaultInfo();
 
     mu::engraving::Excerpt* m_excerpt = nullptr;
     bool m_inited = false;


### PR DESCRIPTION
Resolves: #27060

The crash happens because when undoing, the excerpt gets recreated, which calls this method `fillWithDefaultInfo`. 

I'm really not sure that I understand the purpose of this method, but it looks a bit strange cause it isn't actually filling the default information (as the name would suggest) but is just unlinking the top frame and its content. Indeed, when the excerpt gets recreated by undo, one can see by moving the Title text in the part that it isn't linked (it doesn't turn orange), which is undesirable.  

It seems that this additional unlinking is the cause of the crash, and I don't see an immediate reason why we _should_ unlink the top frame, so I've just tried removing the function and it seems to fix the crash. But @cbjeukendrup and @RomanPudashkin I think you should have a look at this too.