### PR TITLE
Fix GH#27069: Crash when deleting multimeasure rest at end of part

### DIFF
--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -4596,18 +4596,21 @@ void Score::cmdTimeDelete()
         startSegment = selection().startSegment();
         endSegment   = selection().endSegment();
     }
-
     if (!isMaster() && masterScore()) {
-        Measure* masterStartMeas = masterScore()->tick2measure(startSegment->tick());
-        Measure* masterEndMeas = masterScore()->tick2measure(endSegment->tick());
-        if (endSegment->isEndBarLineType()) {
-            Measure* prevEndMeasure = masterEndMeas->prevMeasure();
-            masterEndMeas = prevEndMeasure ? prevEndMeasure : masterEndMeas;
+        if (!endSegment) {
+            masterScore()->doTimeDelete(startSegment, endSegment);
+        } else {
+            Measure* masterStartMeas = masterScore()->tick2measure(startSegment->tick());
+            Measure* masterEndMeas = masterScore()->tick2measure(endSegment->tick());
+            if (endSegment->isEndBarLineType()) {
+                Measure* prevEndMeasure = masterEndMeas->prevMeasure();
+                masterEndMeas = prevEndMeasure ? prevEndMeasure : masterEndMeas;
+            }
+            Segment* masterStartSeg
+                = masterStartMeas ? masterStartMeas->findSegment(startSegment->segmentType(), startSegment->tick()) : startSegment;
+            Segment* masterEndSeg = masterEndMeas ? masterEndMeas->findSegment(endSegment->segmentType(), endSegment->tick()) : endSegment;
+            masterScore()->doTimeDelete(masterStartSeg, masterEndSeg);
         }
-        Segment* masterStartSeg
-            = masterStartMeas ? masterStartMeas->findSegment(startSegment->segmentType(), startSegment->tick()) : startSegment;
-        Segment* masterEndSeg = masterEndMeas ? masterEndMeas->findSegment(endSegment->segmentType(), endSegment->tick()) : endSegment;
-        masterScore()->doTimeDelete(masterStartSeg, masterEndSeg);
     } else {
         doTimeDelete(startSegment, endSegment);
     }


### PR DESCRIPTION
Resolves: #27069

Sort of partly reverts the change from 28fb252c, but only in case of `endSegment` being a `nullptr`