### PR TITLE
Fix #27073: Crash on MIDI export with score containing partial ties (4.5.0)

### DIFF
--- a/src/engraving/compat/midi/compatmidirenderinternal.cpp
+++ b/src/engraving/compat/midi/compatmidirenderinternal.cpp
@@ -631,8 +631,8 @@ static int calculateTieLength(const Note* note)
     const Note* n = note;
     while (n) {
         // Process ties or bends
-        Tie* tieFor = n->tieFor();
-        GuitarBend* bendFor = n->bendFor();
+        const Tie* tieFor = n->tieForNonPartial();
+        const GuitarBend* bendFor = n->bendFor();
 
         if (tieFor && tieFor->endNote() != n) {
             n = tieFor->endNote();
@@ -642,10 +642,14 @@ static int calculateTieLength(const Note* note)
             break;
         }
 
-        NoteEventList nel = n->playEvents();
+        IF_ASSERT_FAILED(n) {
+            break;
+        }
+
+        const NoteEventList& nel = n->playEvents();
 
         if (!nel.empty()) {
-            tieLen += n->playEvents()[0].len() * n->chord()->actualTicks().ticks() / NoteEvent::NOTE_LENGTH;
+            tieLen += nel[0].len() * n->chord()->actualTicks().ticks() / NoteEvent::NOTE_LENGTH;
         }
     }
 


### PR DESCRIPTION
See: https://github.com/musescore/MuseScore/pull/27074