### PR TITLE
Don't allow copy-by-drag onto tuplets

### DIFF
--- a/src/engraving/dom/segment.cpp
+++ b/src/engraving/dom/segment.cpp
@@ -1095,6 +1095,25 @@ void Segment::setXPosInSystemCoords(double x)
     mutldata()->setPosX(x - measure()->x());
 }
 
+bool Segment::isInsideTuplet() const
+{
+    if (!isChordRestType()) {
+        return false;
+    }
+
+    for (EngravingItem* item : m_elist) {
+        if (!item) {
+            continue;
+        }
+        ChordRest* chordRest = toChordRest(item);
+        if (chordRest->tuplet() && chordRest->tick() != chordRest->topTuplet()->tick()) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 //---------------------------------------------------------
 //   swapElements
 //---------------------------------------------------------

--- a/src/engraving/dom/segment.h
+++ b/src/engraving/dom/segment.h
@@ -320,6 +320,8 @@ public:
     double xPosInSystemCoords() const;
     void setXPosInSystemCoords(double x);
 
+    bool isInsideTuplet() const;
+
 private:
 
     friend class Factory;

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -1972,8 +1972,8 @@ bool NotationInteraction::dropRange(const QByteArray& data, const PointF& pos, b
     }
 
     if (segment->isInsideTuplet()) {
-        notifyAboutDropChanged();
         endDrop();
+        notifyAboutDropChanged();
         //MScore::setError(MsError::DEST_TUPLET);
         //MScoreErrorsController(iocContext()).checkAndShowMScoreError();
         // NOTE: if we show the error popup here it seems that the mouse-release event is missed
@@ -2015,8 +2015,8 @@ bool NotationInteraction::dropRange(const QByteArray& data, const PointF& pos, b
     XmlReader e(data);
     score()->pasteStaff(e, segment, staffIdx);
 
-    apply();
     endDrop();
+    apply();
 
     MScoreErrorsController(iocContext()).checkAndShowMScoreError();
 

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -1971,6 +1971,16 @@ bool NotationInteraction::dropRange(const QByteArray& data, const PointF& pos, b
         return false;
     }
 
+    if (segment->isInsideTuplet()) {
+        notifyAboutDropChanged();
+        endDrop();
+        //MScore::setError(MsError::DEST_TUPLET);
+        //MScoreErrorsController(iocContext()).checkAndShowMScoreError();
+        // NOTE: if we show the error popup here it seems that the mouse-release event is missed
+        // so the dragged region stays sticked to the mouse and move around. Don't know how to fix it. [M.S.]
+        return false;
+    }
+
     rdd.targetSegment = segment;
     rdd.targetStaffIdx = staffIdx;
 


### PR DESCRIPTION
Resolves: #27087

Copy-pasting onto a tuplet isn't allowed. Copy-by-dragging shouldn't either. 