### PR TITLE
Improved checks for paste into tuplets

### DIFF
--- a/src/engraving/dom/segment.h
+++ b/src/engraving/dom/segment.h
@@ -320,7 +320,8 @@ public:
     double xPosInSystemCoords() const;
     void setXPosInSystemCoords(double x);
 
-    bool isInsideTuplet() const;
+    bool isTupletSubdivision() const;
+    bool isInsideTupletOnStaff(staff_idx_t staffIdx) const;
 
 private:
 

--- a/src/engraving/rw/read410/read410.cpp
+++ b/src/engraving/rw/read410/read410.cpp
@@ -376,6 +376,10 @@ bool Read410::pasteStaff(XmlReader& e, Segment* dst, staff_idx_t dstStaff, Fract
                 done = true;
                 break;
             }
+            if (dst->isInsideTupletOnStaff(dstStaffIdx)) {
+                done = true;
+                break;
+            }
 
             while (e.readNextStartElement()) {
                 pasted = true;

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -1971,7 +1971,7 @@ bool NotationInteraction::dropRange(const QByteArray& data, const PointF& pos, b
         return false;
     }
 
-    if (segment->isInsideTuplet()) {
+    if (segment->isTupletSubdivision() || segment->isInsideTupletOnStaff(staffIdx)) {
         endDrop();
         notifyAboutDropChanged();
         //MScore::setError(MsError::DEST_TUPLET);


### PR DESCRIPTION
This is an improved version of #27092, which

Resolves: #27087

including the case described in https://github.com/musescore/MuseScore/issues/27087#issuecomment-2722983723.

Probably too late for 4.5, in which case we'll keep it for the first patch. @bkunda @cbjeukendrup 

Update: maybe also fixes one of the frequent crash reports we got after release @RomanPudashkin @miiizen FYI