### PR TITLE
Fix bug where legacy percussion panel won't appear until close/reopen

### DIFF
--- a/src/appshell/view/notationpagemodel.cpp
+++ b/src/appshell/view/notationpagemodel.cpp
@@ -162,25 +162,14 @@ void NotationPageModel::onNotationChanged()
     }
 
     INotationNoteInputPtr noteInput = notation->interaction()->noteInput();
-    if (!notationConfiguration()->useNewPercussionPanel()) {
-        noteInput->stateChanged().onNotify(this, [this]() {
-            updateDrumsetPanelVisibility();
-            updatePercussionPanelVisibility();
-        });
-        return;
-    }
-
-    INotationInteractionPtr notationInteraction = notation->interaction();
-    notationInteraction->selectionChanged().onNotify(this, [this]() {
+    noteInput->stateChanged().onNotify(this, [this]() {
         updateDrumsetPanelVisibility();
         updatePercussionPanelVisibility();
     });
 
-    noteInput->noteInputStarted().onReceive(this, [this](bool) {
-        updatePercussionPanelVisibility();
-    });
-
-    noteInput->noteInputEnded().onNotify(this, [this]() {
+    INotationInteractionPtr notationInteraction = notation->interaction();
+    notationInteraction->selectionChanged().onNotify(this, [this]() {
+        updateDrumsetPanelVisibility();
         updatePercussionPanelVisibility();
     });
 }


### PR DESCRIPTION
Fixes a bug found by @zacjansheski:

1. Make sure the new panel is active
2. Go to Preferences -> click "Use legacy percussion panel"
3. Legacy panel will not appear when entering note input mode (not until close/reopen)

This fix is a bit of a cleanup - some of the logic here was hanging over from early versions of the new percussion panel. Namely there shouldn't be any need to subscribe to `noteInputStarted` and `noteInputEnded` - `stateChanged` should be enough for what we're trying to do here.