### PR TITLE
Fix #27089: While in Input by duration mode, pressing a note should turn 'Toggle rest' off

### DIFF
--- a/src/notation/inotationnoteinput.h
+++ b/src/notation/inotationnoteinput.h
@@ -68,6 +68,7 @@ public:
     virtual void setInputNotes(const NoteValList& notes) = 0;
     virtual void moveInputNotes(bool up, PitchMode mode) = 0;
 
+    virtual void setRestMode(bool rest) = 0;
     virtual void setAccidental(AccidentalType accidentalType) = 0;
     virtual void setArticulation(SymbolId articulationSymbolId) = 0;
     virtual void setDrumNote(int note) = 0;

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -796,6 +796,7 @@ void NotationActionController::handleNoteAction(const muse::actions::ActionData&
 
     if (addingMode == NoteAddingMode::NextChord) {
         if (noteInput->usingNoteInputMethod(NoteInputMethod::BY_DURATION)) {
+            noteInput->setRestMode(false);
             noteInput->setInputNote(params);
 
             if (configuration()->isPlayPreviewNotesInInputByDuration()) {

--- a/src/notation/internal/notationmidiinput.cpp
+++ b/src/notation/internal/notationmidiinput.cpp
@@ -183,6 +183,7 @@ void NotationMidiInput::addNoteEventsToInputState()
 
     if (!notes.empty()) {
         INotationNoteInputPtr noteInput = m_notationInteraction->noteInput();
+        noteInput->setRestMode(false);
         noteInput->setInputNotes(notes);
 
         if (configuration()->isPlayPreviewNotesInInputByDuration()) {

--- a/src/notation/internal/notationnoteinput.cpp
+++ b/src/notation/internal/notationnoteinput.cpp
@@ -602,6 +602,17 @@ void NotationNoteInput::moveInputNotes(bool up, PitchMode mode)
     setInputNotes(notes);
 }
 
+void NotationNoteInput::setRestMode(bool rest)
+{
+    mu::engraving::InputState& is = score()->inputState();
+    if (is.rest() == rest) {
+        return;
+    }
+
+    is.setRest(rest);
+    notifyAboutStateChanged();
+}
+
 void NotationNoteInput::setAccidental(AccidentalType accidentalType)
 {
     TRACEFUNC;

--- a/src/notation/internal/notationnoteinput.h
+++ b/src/notation/internal/notationnoteinput.h
@@ -78,6 +78,7 @@ public:
     void setInputNotes(const NoteValList& notes) override;
     void moveInputNotes(bool up, PitchMode mode) override;
 
+    void setRestMode(bool rest) override;
     void setAccidental(AccidentalType accidentalType) override;
     void setArticulation(SymbolId articulationSymbolId) override;
     void setDrumNote(int note) override;


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/27089