### PR TITLE
Added scroll deceleration to all flickables for better user experience during scrolling

### DIFF
--- a/src/appshell/qml/DevTools/Gallery/GeneralComponentsGallery.qml
+++ b/src/appshell/qml/DevTools/Gallery/GeneralComponentsGallery.qml
@@ -39,7 +39,7 @@ Rectangle {
         order: 4
     }
 
-    Flickable {
+    StyledFlickable {
         id: flickableWrapper
 
         anchors.fill: parent

--- a/src/framework/ui/api/themeapi.cpp
+++ b/src/framework/ui/api/themeapi.cpp
@@ -344,6 +344,11 @@ int ThemeApi::flickableMaxVelocity() const
     return configuration()->flickableMaxVelocity();
 }
 
+int ThemeApi::flickableDeceleration() const
+{
+    return configuration()->flickableDeceleration();
+}
+
 int ThemeApi::tooltipDelay() const
 {
     return configuration()->tooltipDelay();

--- a/src/framework/ui/api/themeapi.h
+++ b/src/framework/ui/api/themeapi.h
@@ -87,6 +87,7 @@ class ThemeApi : public api::ApiObject, public async::Asyncable
     Q_PROPERTY(qreal defaultButtonSize READ defaultButtonSize NOTIFY themeChanged)
 
     Q_PROPERTY(int flickableMaxVelocity READ flickableMaxVelocity CONSTANT)
+    Q_PROPERTY(int flickableDeceleration READ flickableDeceleration CONSTANT)
 
     Q_PROPERTY(int tooltipDelay READ tooltipDelay CONSTANT)
 
@@ -147,6 +148,7 @@ public:
     qreal itemOpacityDisabled() const;
 
     int flickableMaxVelocity() const;
+    int flickableDeceleration() const;
 
     int tooltipDelay() const;
 

--- a/src/framework/ui/internal/uiconfiguration.cpp
+++ b/src/framework/ui/internal/uiconfiguration.cpp
@@ -54,6 +54,7 @@ static const Settings::Key UI_MUSICAL_FONT_SIZE_KEY("ui", "ui/theme/musicalFontS
 static const QString WINDOW_GEOMETRY_KEY("window");
 
 static const int FLICKABLE_MAX_VELOCITY = 1500;
+static const int FLICKABLE_DECELERATION = 5000;
 
 static const int TOOLTIP_DELAY = 500;
 
@@ -822,6 +823,11 @@ void UiConfiguration::updateToolConfig(const QString& toolName, ToolConfig& user
 int UiConfiguration::flickableMaxVelocity() const
 {
     return FLICKABLE_MAX_VELOCITY;
+}
+
+int UiConfiguration::flickableDeceleration() const
+{
+    return FLICKABLE_DECELERATION;
 }
 
 int UiConfiguration::tooltipDelay() const

--- a/src/framework/ui/internal/uiconfiguration.h
+++ b/src/framework/ui/internal/uiconfiguration.h
@@ -122,6 +122,7 @@ public:
     async::Notification toolConfigChanged(const QString& toolName) const override;
 
     int flickableMaxVelocity() const override;
+    int flickableDeceleration() const override;
 
     int tooltipDelay() const override;
 

--- a/src/framework/ui/iuiconfiguration.h
+++ b/src/framework/ui/iuiconfiguration.h
@@ -117,6 +117,7 @@ public:
     virtual async::Notification toolConfigChanged(const QString& toolName) const = 0;
 
     virtual int flickableMaxVelocity() const = 0;
+    virtual int flickableDeceleration() const = 0;
 
     virtual int tooltipDelay() const = 0;
 };

--- a/src/framework/ui/tests/mocks/uiconfigurationmock.h
+++ b/src/framework/ui/tests/mocks/uiconfigurationmock.h
@@ -101,6 +101,7 @@ public:
     MOCK_METHOD(async::Notification, toolConfigChanged, (const QString&), (const, override));
 
     MOCK_METHOD(int, flickableMaxVelocity, (), (const, override));
+    MOCK_METHOD(int, flickableDeceleration, (), (const, override));
 
     MOCK_METHOD(int, tooltipDelay, (), (const, override));
 };

--- a/src/framework/uicomponents/qml/Muse/UiComponents/StyledFlickable.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/StyledFlickable.qml
@@ -26,6 +26,7 @@ Flickable {
     clip: true
     boundsBehavior: Flickable.StopAtBounds
     maximumFlickVelocity: ui.theme.flickableMaxVelocity
+    flickDeceleration: ui.theme.flickableDeceleration
 
     ScrollBar.vertical: StyledScrollBar {}
     ScrollBar.horizontal: StyledScrollBar {}

--- a/src/framework/uicomponents/qml/Muse/UiComponents/StyledGridView.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/StyledGridView.qml
@@ -26,6 +26,7 @@ GridView {
     clip: true
     boundsBehavior: Flickable.StopAtBounds
     maximumFlickVelocity: ui.theme.flickableMaxVelocity
+    flickDeceleration: ui.theme.flickableDeceleration
 
     ScrollBar.vertical: StyledScrollBar {}
     ScrollBar.horizontal: StyledScrollBar {}

--- a/src/framework/uicomponents/qml/Muse/UiComponents/StyledListView.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/StyledListView.qml
@@ -39,6 +39,7 @@ ListView {
     clip: true
     boundsBehavior: Flickable.StopAtBounds
     maximumFlickVelocity: ui.theme.flickableMaxVelocity
+    flickDeceleration: ui.theme.flickableDeceleration
 
     ScrollBar.vertical: root.arrowControlsAvailable ? null : scrollBarComp.createObject(root)
     ScrollBar.horizontal: root.arrowControlsAvailable ? null : scrollBarComp.createObject(root)


### PR DESCRIPTION
Resolves: #24963

This PR changes the scroll deceleration of all flickables from whatever default value they have (around 1500 I believe) to a higher value. This noticeably decreases the scrolling inertia, i.e. when you stop scrolling, scrolling won't continue much longer any more. Thus hitting your scroll target is much easier now and the user experience while scrolling is improved.

I've not slowed down the scrolling too much as it could become annoying. Let me know what you think. There are two parameters - the aforementioned deceleration as well as the maximum scroll speed - with which we can play further to refine the scrolling experience. I am not changing the maximum scroll speed for now. 

Here are the most important panels/lists that are affected (not an exhaustive list) IMO:
* palettes
* DevTools tab -> Settings list
* DevTools tab -> Extensions list
* Dev Tools -> UI gallery
* All drop-down lists (e.g. Font in the Properties panel)
* Home tab -> MuseSounds list
* Home tab -> Learn -> Get started tab -> video list
* Home tab -> Plugins list
* Home tab -> score list (both "New & recent" and "My online scores" tabs)
* Panels: Properties, Layout (expanding all instruments helps), Percussion, Mixer, Undo/Redo History, Selection Filter, Parts
* Style dialog: "Beams" page, "Clefs, key and time signatures" page
* Notehead type in the Properties panel when a note is selected (this one is small so is a good test for small scrollable content)
* All of the Preference pages (some are easily scrollable, others not)
* Advanced preferences list, MIDI mappings list, Shortcuts list in preferences
* Project properties dialog
* Scrollable menus ("File -> Open recent" for example when long enough)

I think the first 5-6 of the above are a good test and give a good idea of the new scrolling experience. The rest are identical so no need to go through all of them unless one wants to. :)

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
