### PR TITLE
Zip read/write fix

### DIFF
--- a/src/framework/global/tests/CMakeLists.txt
+++ b/src/framework/global/tests/CMakeLists.txt
@@ -45,6 +45,7 @@ set(MODULE_TEST_SRC
     ${CMAKE_CURRENT_LIST_DIR}/containers_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/version_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/number_tests.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/ziprw_tests.cpp
 )
 
 include(SetupGTest)

--- a/src/framework/global/tests/ziprw_tests.cpp
+++ b/src/framework/global/tests/ziprw_tests.cpp
@@ -1,0 +1,57 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2025 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include <gtest/gtest.h>
+
+#include "io/file.h"
+
+#include "global/serialization/zipwriter.h"
+#include "global/serialization/zipreader.h"
+
+using namespace muse;
+
+class Zip_RW_Tests : public ::testing::Test
+{
+public:
+};
+
+TEST_F(Zip_RW_Tests, Write_And_Read)
+{
+    //! [GIVEN] A zip file
+    io::IODevice* device = new io::File("test.zip");
+    ZipWriter writer(device);
+
+    //! [WHEN] Writing data to the zip file
+    writer.addFile("file1.txt", "Hello World!");
+    writer.addFile("folder/file2.txt", "Hello World 2!");
+
+    writer.close();
+
+    //! [THEN] The data can be read back
+    ZipReader reader(device);
+    auto data = reader.fileData("file1.txt");
+    EXPECT_EQ(data, "Hello World!");
+
+    auto data2 = reader.fileData("folder/file2.txt");
+    EXPECT_EQ(data2, "Hello World 2!");
+
+    reader.close();
+}

--- a/tools/ziprw/CMakeLists.txt
+++ b/tools/ziprw/CMakeLists.txt
@@ -1,0 +1,61 @@
+cmake_minimum_required(VERSION 3.16)
+
+project(ziprw LANGUAGES CXX)
+
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(MU_ROOT ${CMAKE_CURRENT_LIST_DIR}/../..)
+set(MUSE_FRAMEWORK_PATH ${MU_ROOT})
+
+set(CMAKE_MODULE_PATH
+        ${MU_ROOT}/buildscripts
+        ${MU_ROOT}/buildscripts/cmake
+        ${CMAKE_MODULE_PATH}
+)
+
+include(SetupBuildEnvironment)
+include(GetPlatformInfo)
+
+set(QT_MIN_VERSION "6.2.4")
+include(SetupQt6)
+
+include_directories(
+    ${CMAKE_CURRENT_LIST_DIR}
+    ${MU_ROOT}/src/framework
+)
+
+add_compile_definitions(
+    GLOBAL_NO_INTERNAL
+)
+
+configure_file(${MU_ROOT}/src/framework/cmake/muse_framework_config.h.in muse_framework_config.h )
+
+include(DeclareModuleSetup)
+
+set(GLOBAL_NO_INTERNAL ON)
+add_subdirectory(${MU_ROOT}/src/framework/global global)
+
+set(ENGRAVING_NO_INTERNAL ON)
+set(ENGRAVING_NO_ACCESSIBILITY ON)
+
+add_executable(ziprw
+    ${MU_ROOT}/src/framework/global/io/internal/filesystem.cpp
+    ${MU_ROOT}/src/framework/global/io/internal/filesystem.h
+    main.cpp
+)
+
+set_target_properties(muse_global PROPERTIES COMPILE_FLAGS "-fPIC")
+set_target_properties(ziprw PROPERTIES COMPILE_FLAGS "-fPIC")
+
+target_include_directories(ziprw PUBLIC
+    ${MU_ROOT}/src/framework
+    ${MU_ROOT}/src
+)
+
+target_link_libraries(ziprw PRIVATE
+    ${QT_LIBRARIES}
+    muse_global
+)

--- a/tools/ziprw/main.cpp
+++ b/tools/ziprw/main.cpp
@@ -1,0 +1,89 @@
+#include "modularity/ioc.h"
+
+#include "global/serialization/zipreader.h"
+#include "global/serialization/zipwriter.h"
+
+#include "global/io/internal/filesystem.h"
+
+#include "log.h"
+
+using namespace muse;
+
+void unzip(const std::string& zip_path, const std::string& extract_path)
+{
+    ZipReader zip(zip_path);
+    if (!zip.exists() || zip.hasError()) {
+        LOGE() << "Failed to open zip file: " << zip_path;
+        return;
+    }
+
+    std::shared_ptr<io::IFileSystem> fileSystem = modularity::globalIoc()->resolve<io::IFileSystem>("ziprw");
+
+    for (const auto& info : zip.fileInfoList()) {
+        if (info.isDir) {
+            fileSystem->makePath(extract_path + "/" + info.filePath.toStdString());
+        } else if (info.isFile) {
+            io::path_t out_path = extract_path + "/" + info.filePath.toStdString();
+            fileSystem->makePath(io::dirpath(out_path));
+
+            fileSystem->writeFile(out_path, zip.fileData(info.filePath.toStdString()));
+        }
+    }
+
+    zip.close();
+}
+
+void zip(const std::string& dir_path, const std::string& zip_path)
+{
+    ZipWriter zip(zip_path);
+    if (zip.hasError()) {
+        LOGE() << "Failed to create zip writer for file: " << zip_path;
+        return;
+    }
+
+    std::shared_ptr<io::IFileSystem> fileSystem = modularity::globalIoc()->resolve<io::IFileSystem>("ziprw");
+
+    RetVal<io::paths_t> files = fileSystem->scanFiles(dir_path, { "*" });
+    if (!files.ret) {
+        LOGE() << "Failed to scan files in directory: " << dir_path;
+        return;
+    }
+
+    for (const io::path_t& file : files.val) {
+        RetVal<ByteArray> data = fileSystem->readFile(file);
+        if (!data.ret) {
+            LOGE() << "Failed to read file: " << file.toStdString();
+            continue;
+        }
+
+        zip.addFile(file.toString().replace(String::fromStdString(dir_path + "/"), u"").toStdString(), data.val);
+    }
+
+    zip.close();
+}
+
+int main(int argc, char* argv[])
+{
+    if (argc < 4) {
+        LOGE() << "Usage: " << argv[0] << " <action> <source> <destination>";
+        LOGE() << "Actions: unzip, zip";
+        return 1;
+    }
+
+    muse::modularity::globalIoc()->registerExport<muse::io::IFileSystem>("ziprw", new muse::io::FileSystem());
+
+    std::string action = argv[1];
+    std::string source = argv[2];
+    std::string destination = argv[3];
+
+    if (action == "unzip") {
+        unzip(source, destination);
+    } else if (action == "zip") {
+        zip(source, destination);
+    } else {
+        LOGE() << "Unknown action: " << action;
+        return 1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
Main problem: 
`fileInfoList` returns a list of files without a `/` at the beginning of the path, while `fileHeaders` in `file_name` still contains a `/` at the beginning.
If the container returns to the user paths without a `/`, then it should be able to handle files without a `/`