### PR TITLE
27138: Allow more special characters to be entered with AltGr and Ctrl+Alt on Windows

### DIFF
--- a/src/engraving/dom/textedit.cpp
+++ b/src/engraving/dom/textedit.cpp
@@ -395,8 +395,8 @@ bool TextBase::isTextualEditAllowed(EditData& ed) const
         }
 
 #if defined(Q_OS_WIN)
-        // Allow accented characters to be input with AltGr and Ctrl+Alt (both are treated the same in Windows)
-        if (ed.key >= Key_nobreakspace && ed.key <= Key_ydiaeresis) {
+        // Allow special characters to be typed with AltGr / Ctrl+Alt (they are the same in Windows)
+        if (!ed.s.empty() && (ed.key < Key_A || ed.key > Key_Z) && (ed.key < Key_0 || ed.key > Key_9)) {
             return true;
         }
 #endif


### PR DESCRIPTION
Resolves: #27138 (or at least tries to resolve it)

We are starting to get reports that many AltGr / Ctrl+Alt characters cannot be typed on Windows in MuseScore v.4.5. Users say it worked before. I was not able to find out why it used to work. In `TextBase::isTextualEditAllowed(EditData& ed)` we were only allowing CTRL+ALT+minus and rejecting everything else. In January I created this [PR#25957](https://github.com/musescore/MuseScore/pull/25957) to allow many accented characters to be entered. Interestingly now we are seeing the opposite effect where most AltGr characters are broken for some users, in particular Italian and Polish users, and possibly more.

I am proposing the following fix: in `TextBase::isTextualEditAllowed(EditData& ed)` let's allow any CTRL+ALT+n key combination that produces a character except if the character is an english letter A-Z or a digit 0-9. This is to still allow potencial CTRL+ALT+English letter/digit shortcuts to fire off while editing text (provided CTRL+ALT+English letter/digit does not produce a special character). One consequence of this change is that pressing CTRL+ALT + , for example (or AltGr + ,) will cause a comma to be typed into the text object. I believe this is a minor thing we can live with and not very like to happen or to be an issue.

For Italian users: they are unable to use AltGr to type characters such as #, [, ], {, }, etc., i.e. characters that do not fall within the range of accented characters that I allowed in my PR#25957 (these are ordinary characters and not accented). Polish users on the other hand, cannot type ś (AltGr + s) which gave me key ID = 346. This value is not even in the [Qt docs](https://doc.qt.io/qt-6/qt.html#Key-enum).

I've installed Italian and Polish (Programmers) layouts on my machine and have been able to enter all of those plus many more with the proposed change. My idea is to get this PR reviewed, QA-ed, merged and then tested by one or more affected users in the next nightly build after the merge.

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
