### PR TITLE
Let the dynamics popup remove hairpins

### DIFF
--- a/src/notation/view/internal/dynamicpopupmodel.cpp
+++ b/src/notation/view/internal/dynamicpopupmodel.cpp
@@ -187,10 +187,12 @@ void DynamicPopupModel::addHairpinToDynamic(ItemType itemType)
 
     if (Hairpin* existingHairpin = dynamic->rightHairpin()) {
         if (existingHairpin->hairpinType() == hairpinType) {
-            return;
+            beginCommand(TranslatableString("undoableAction", "Remove hairpin"));
+            m_item->score()->undoRemoveElement(existingHairpin);
+        } else {
+            beginCommand(TranslatableString("undoableAction", "Change hairpin type"));
+            existingHairpin->undoChangeProperty(Pid::HAIRPIN_TYPE, int(hairpinType));
         }
-        beginCommand(TranslatableString("undoableAction", "Change hairpin type"));
-        existingHairpin->undoChangeProperty(Pid::HAIRPIN_TYPE, int(hairpinType));
         endCommand();
         updateNotation();
         return;


### PR DESCRIPTION
Pressing the same hairpin button again will remove the hairpin.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
