### PR TITLE
Fix #27168: Crash after note input from MIDI keyboard on deleted staff

### DIFF
--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -1638,10 +1638,14 @@ Note* Score::addTiedMidiPitch(int pitch, bool addFlag, Chord* prevChord, bool al
     return n;
 }
 
-NoteVal Score::noteVal(int pitch, bool allowTransposition) const
+NoteVal Score::noteVal(int pitch, staff_idx_t staffIdx, bool allowTransposition) const
 {
     NoteVal nval(pitch);
-    Staff* st = staff(inputState().track() / VOICES);
+
+    const Staff* st = staff(staffIdx);
+    if (!st) {
+        return nval;
+    }
 
     // if transposing, interpret MIDI pitch as representing desired written pitch
     // set pitch based on corresponding sounding pitch
@@ -1661,7 +1665,7 @@ NoteVal Score::noteVal(int pitch, bool allowTransposition) const
 
 Note* Score::addMidiPitch(int pitch, bool addFlag, bool allowTransposition)
 {
-    NoteVal nval = noteVal(pitch, allowTransposition);
+    NoteVal nval = noteVal(pitch, m_is.staffIdx(), allowTransposition);
     return addPitch(nval, addFlag);
 }
 

--- a/src/engraving/dom/score.h
+++ b/src/engraving/dom/score.h
@@ -520,7 +520,7 @@ public:
     Note* addNote(Chord*, const NoteVal& noteVal, bool forceAccidental = false, const std::set<SymId>& articulationIds = {},
                   InputState* externalInputState = nullptr);
 
-    NoteVal noteVal(int pitch, bool allowTransposition) const;
+    NoteVal noteVal(int pitch, staff_idx_t staffIdx, bool allowTransposition) const;
     NoteVal noteValForPosition(Position pos, AccidentalType at, bool& error);
 
     Slur* addSlur(ChordRest* firstChordRest, ChordRest* secondChordRest, const Slur* slurTemplate);

--- a/src/notation/internal/notationmidiinput.cpp
+++ b/src/notation/internal/notationmidiinput.cpp
@@ -112,8 +112,17 @@ mu::engraving::Score* NotationMidiInput::score() const
 
 void NotationMidiInput::doProcessEvents()
 {
-    if (m_eventsQueue.empty()) {
+    DEFER {
+        m_eventsQueue.clear();
         m_processTimer.stop();
+    };
+
+    if (m_eventsQueue.empty()) {
+        return;
+    }
+
+    const mu::engraving::Score* sc = score();
+    if (!sc || sc->noStaves()) {
         return;
     }
 
@@ -152,9 +161,6 @@ void NotationMidiInput::doProcessEvents()
         playbackController()->playElements(notesItems, true);
         m_notesReceivedChannel.send(notes);
     }
-
-    m_eventsQueue.clear();
-    m_processTimer.stop();
 }
 
 void NotationMidiInput::startNoteInputIfNeed()
@@ -173,35 +179,31 @@ void NotationMidiInput::startNoteInputIfNeed()
 void NotationMidiInput::addNoteEventsToInputState()
 {
     NoteValList notes;
-    bool useWrittenPitch = configuration()->midiUseWrittenPitch().val;
+
+    INotationNoteInputPtr noteInput = m_notationInteraction->noteInput();
+    const NoteInputState& state = noteInput->state();
+    const staff_idx_t staffIdx = state.staffIdx();
+    const bool useWrittenPitch = configuration()->midiUseWrittenPitch().val;
 
     for (const muse::midi::Event& event : m_eventsQueue) {
         if (event.opcode() == muse::midi::Event::Opcode::NoteOn) {
-            notes.push_back(score()->noteVal(event.note(), useWrittenPitch));
+            notes.push_back(score()->noteVal(event.note(), staffIdx, useWrittenPitch));
         }
     }
 
     if (!notes.empty()) {
-        INotationNoteInputPtr noteInput = m_notationInteraction->noteInput();
         noteInput->setRestMode(false);
         noteInput->setInputNotes(notes);
 
         if (configuration()->isPlayPreviewNotesInInputByDuration()) {
-            const NoteInputState& state = noteInput->state();
-            playbackController()->playNotes(notes, state.staffIdx(), state.segment());
+            playbackController()->playNotes(notes, staffIdx, state.segment());
         }
     }
-
-    m_eventsQueue.clear();
-    m_processTimer.stop();
 }
 
 Note* NotationMidiInput::addNoteToScore(const muse::midi::Event& e)
 {
     mu::engraving::Score* sc = score();
-    if (!sc) {
-        return nullptr;
-    }
 
     mu::engraving::MidiInputEvent inputEv;
     inputEv.pitch = e.note();
@@ -277,10 +279,6 @@ Note* NotationMidiInput::makePreviewNote(const muse::midi::Event& e)
     }
 
     mu::engraving::Score* score = this->score();
-    if (!score) {
-        return nullptr;
-    }
-
     const mu::engraving::InputState& inputState = score->inputState();
     Segment* seg = inputState.lastSegment() ? inputState.lastSegment() : score->dummy()->segment();
 
@@ -294,7 +292,7 @@ Note* NotationMidiInput::makePreviewNote(const muse::midi::Event& e)
     note->setParent(chord);
     note->setStaffIdx(staffIdx);
 
-    engraving::NoteVal nval = score->noteVal(e.note(), configuration()->midiUseWrittenPitch().val);
+    engraving::NoteVal nval = score->noteVal(e.note(), staffIdx, configuration()->midiUseWrittenPitch().val);
     note->setNval(nval);
 
     return note;


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/27168