### PR TITLE
Don't clone markers twice

### DIFF
--- a/src/engraving/dom/excerpt.cpp
+++ b/src/engraving/dom/excerpt.cpp
@@ -1501,6 +1501,10 @@ void Excerpt::cloneStaff2(Staff* srcStaff, Staff* dstStaff, const Fraction& star
             if (oldEl->systemFlag() && dstStaffIdx != 0) {
                 continue;
             }
+            bool alreadyCloned = oldEl->systemFlag() && oldEl->findLinkedInScore(score);
+            if (alreadyCloned) {
+                continue;
+            }
             EngravingItem* newEl = oldEl->linkedClone();
             newEl->setParent(nm);
             newEl->setTrack(0);


### PR DESCRIPTION
Resolves: #27080

(Edit: I'd initially linked the wrong issue)

We already run this check for the other system elements because they are attached to Segments. Markers are attached to Measures instead, but the principle is the same.