### PR TITLE
Fix Spanner::track2 issues

### DIFF
--- a/src/engraving/dom/spanner.cpp
+++ b/src/engraving/dom/spanner.cpp
@@ -846,6 +846,20 @@ void Spanner::doComputeEndElement()
     }
 }
 
+bool Spanner::canBeCrossStaff() const
+{
+    switch (type()) {
+    case ElementType::SLUR:
+    case ElementType::TIE:
+    case ElementType::ARPEGGIO:
+    case ElementType::GLISSANDO:
+    case ElementType::NOTELINE:
+        return true;
+    default:
+        return false;
+    }
+}
+
 //---------------------------------------------------------
 //   startElementFromSpanner
 //
@@ -1405,6 +1419,25 @@ bool Spanner::isVoiceSpecific() const
     };
 
     return VOICE_SPECIFIC_SPANNERS.find(type()) != VOICE_SPECIFIC_SPANNERS.end();
+}
+
+track_idx_t Spanner::track2() const
+{
+    return canBeCrossStaff() ? m_track2 : m_track;
+}
+
+void Spanner::setTrack2(track_idx_t v)
+{
+    if (!canBeCrossStaff()) {
+        return;
+    }
+
+    m_track2 = v;
+}
+
+track_idx_t Spanner::effectiveTrack2() const
+{
+    return canBeCrossStaff() && m_track2 != muse::nidx ? m_track2 : m_track;
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/spanner.h
+++ b/src/engraving/dom/spanner.h
@@ -173,9 +173,9 @@ public:
     void setTicks(const Fraction&);
 
     bool isVoiceSpecific() const;
-    track_idx_t track2() const { return m_track2; }
-    void setTrack2(track_idx_t v) { m_track2 = v; }
-    track_idx_t effectiveTrack2() const { return m_track2 == muse::nidx ? track() : m_track2; }
+    track_idx_t track2() const;
+    void setTrack2(track_idx_t v);
+    track_idx_t effectiveTrack2() const;
 
     bool broken() const { return m_broken; }
     void setBroken(bool v) { m_broken = v; }
@@ -279,6 +279,7 @@ protected:
     virtual void doComputeEndElement();
 
 private:
+    bool canBeCrossStaff() const;
 
     friend class SpannerSegment;
 

--- a/src/notation/internal/notationparts.cpp
+++ b/src/notation/internal/notationparts.cpp
@@ -824,14 +824,8 @@ void NotationParts::moveSystemObjects(const ID& sourceStaffId, const ID& destina
             item->triggerLayout();
             continue;
         }
-
         if (item->staff() == srcStaff) {
-            const track_idx_t trackIdx = staff2track(dstStaffIdx, item->voice());
-
-            item->undoChangeProperty(Pid::TRACK, trackIdx);
-            if (item->isSpanner()) {
-                item->undoChangeProperty(Pid::SPANNER_TRACK2, trackIdx);
-            }
+            item->undoChangeProperty(Pid::TRACK, staff2track(dstStaffIdx, item->voice()));
         } else {
             item->undoUnlink();
             score()->undoRemoveElement(item, false /*removeLinked*/);


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/27104

m_track2 is only relevant for Spanners that can be cross staff. This PR make sure that only those can use it, which should fix a long-standing ambiguity causing all sorts of problems.
