### PR TITLE
Fix #27106: New panels appearing undocked [4.5.1 port]

### DIFF
--- a/src/framework/dockwindow/view/dockwindow.h
+++ b/src/framework/dockwindow/view/dockwindow.h
@@ -48,6 +48,7 @@ namespace muse::dock {
 class DockToolBarView;
 class DockingHolderView;
 class DockPageView;
+class DockPanelView;
 class DockWindow : public QQuickItem, public IDockWindow, public muse::Injectable, public async::Asyncable
 {
     Q_OBJECT
@@ -115,6 +116,7 @@ private:
     void alignTopLevelToolBars(const DockPageView* page);
 
     void addDock(DockBase* dock, Location location = Location::Left, const DockBase* relativeTo = nullptr);
+    void addPanel(const DockPageView* page, DockPanelView* panel, Location location, const DockBase* relativeTo = nullptr);
     void registerDock(DockBase* dock);
 
     void saveGeometry();
@@ -123,7 +125,7 @@ private:
     QByteArray windowState() const;
 
     void savePageState(const QString& pageName);
-    void restorePageState(const QString& pageName);
+    void restorePageState(const DockPageView* page);
 
     void reloadCurrentPage();
     bool restoreLayout(const QByteArray& layout, bool restoreRelativeToMainWindow = false);


### PR DESCRIPTION
Resolves: #27106

After some investigation, it turns out this is an issue for all "new" panels, i.e. panels that the saved workspace JSON doesn't know about (the percussion panel and the undo history panel in this case). My feeling is that this behaviour is somewhat by-design in the KDDockWidgets system (`floatUnknownWidgets` hints at this, though that isn't actually the cause of the problem here).

Using the percussion panel as an example, the problem goes something like this:
1. Starting in `doLoadPage`, the `percussionPanel` `DockWidgetBase` will have a valid "layout item" in `lastPositions`.
2. `restorePageState` is called, which eventually leads to a `d->m_dockRegistry->clear(...` call. This clears the layout item for the main window (the layout item that the percussion panel is currently using).
3. All docks that the `LayoutSaver` knows about are restored accordingly.
4. When we eventually call `DockWidgetBase::show`, `d->m_lastPositions.isValid()` will be false because of the missing layout item and the widget will `morphIntoFloatingWindow`.