### PR TITLE
Check that frames is not empty before trying to access `first()`

### DIFF
--- a/src/framework/dockwindow/thirdparty/KDDockWidgets/src/private/FloatingWindow.cpp
+++ b/src/framework/dockwindow/thirdparty/KDDockWidgets/src/private/FloatingWindow.cpp
@@ -393,14 +393,15 @@ void FloatingWindow::updateTitleBarVisibility()
 
     bool visible = true;
 
-    for (Frame *frame : frames())
+    const Frame::List frames = this->frames();
+    for (Frame *frame : frames)
         frame->updateTitleBarVisibility();
 
     if (KDDockWidgets::usesClientTitleBar()) {
         const auto flags = Config::self().flags();
         if ((flags & Config::Flag_HideTitleBarWhenTabsVisible) && !(flags & Config::Flag_AlwaysTitleBarWhenFloating)) {
-            if (hasSingleFrame()) {
-                visible = !frames().first()->hasTabsVisible();
+            if (!frames.isEmpty() && hasSingleFrame()) {
+                visible = !frames.first()->hasTabsVisible();
             }
         }
 
@@ -422,8 +423,10 @@ void FloatingWindow::updateTitleAndIcon()
 {
     QString title;
     QIcon icon;
-    if (hasSingleFrame()) {
-        const Frame *frame = frames().constFirst();
+
+    const Frame::List frames = this->frames();
+    if (!frames.isEmpty() && hasSingleFrame()) {
+        const Frame *frame = frames.constFirst();
         title = frame->title();
         icon = frame->icon();
     } else {
@@ -498,11 +501,12 @@ LayoutSaver::FloatingWindow FloatingWindow::serialize() const
 QRect FloatingWindow::dragRect() const
 {
     QRect rect;
+    const Frame::List frames = this->frames();
     if (m_titleBar->isVisible()) {
         rect = m_titleBar->rect();
         rect.moveTopLeft(m_titleBar->mapToGlobal(QPoint(0, 0)));
-    } else if (hasSingleFrame()) {
-        rect = frames().constFirst()->dragRect();
+    } else if (!frames.isEmpty() && hasSingleFrame()) {
+        rect = frames.constFirst()->dragRect();
     } else {
         qWarning() << Q_FUNC_INFO << "Expected a title bar";
     }


### PR DESCRIPTION
This PR aims to address a new crash logged in Sentry where `frames().first()` is null in `updateTitleAndIcon`. I wasn't able to repro this crash locally (tried on Windows as this looks like a Windows-only crash), so the root cause of this one isn't exactly clear to me.

One curious thing about this crash is that it seems to occur after a first time setup. Normally this implies that the workspace data should evaluate as empty and early return in `LayoutSaver::restoreLayout`, but that doesn't appear to be the case here because the stack goes to `FloatingWindow::deserialize`.

<details>
<summary> Stacktrace </summary>

```
Thread 2112 Crashed:

0   MuseScore4.exe                  0x7ff642eca469      KDDockWidgets::FloatingWindow::updateTitleAndIcon() (FloatingWindow.cpp:426)

1   MuseScore4.exe                  0x7ff642eca61a      KDDockWidgets::FloatingWindow::updateTitleBarVisibility() (FloatingWindow.cpp:392)

2   MuseScore4.exe                  0x7ff642ec856a      KDDockWidgets::FloatingWindow::deserialize(KDDockWidgets::LayoutSaver::FloatingWindow const &) (FloatingWindow.cpp:462)

3   MuseScore4.exe                  0x7ff642e9accc      KDDockWidgets::LayoutSaver::restoreLayout(QByteArray const &) (LayoutSaver.cpp:273)

4   MuseScore4.exe                  0x7ff642550120      muse::dock::DockWindow::restoreLayout(QByteArray const &,bool) (dockwindow.cpp:579)

5   MuseScore4.exe                  0x7ff64255031f      muse::dock::DockWindow::restorePageState(QString const &) (dockwindow.cpp:552)

6   MuseScore4.exe                  0x7ff642538d79      muse::dock::DockWindow::doLoadPage(QString const &,QMap<QString,QVariant> const &) (dockwindow.cpp:496)

7   MuseScore4.exe                  0x7ff6425410f9      muse::dock::DockWindow::loadPage(QString const &,QMap<QString,QVariant> const &) (dockwindow.cpp:211)

8   MuseScore4.exe                  0x7ff642546e71      muse::dock::DockWindow::qt_metacall(QMetaObject::Call,int,void * *) (moc_dockwindow.cpp:208)

9   Qt6Qml.dll                      0x7ff83467e98e      <unknown>

10  MuseScore4.exe                  0x7ff6423f7571      muse::api::ThemeApi::qt_static_metacall(QObject *,QMetaObject::Call,int,void * *) (moc_themeapi.cpp:221)

11  Qt6Qml.dll                      0x7ff834558a25      <unknown>

12  MuseScore4.exe                  0x7ff64318561f      operator new(unsigned __int64) (new_scalar.cpp:36)

13  <unknown>                       0x17448dd8870       <unknown>

14  MuseScore4.exe                  0x7ff641009ee0      QMap<QString,QVariant>::operator[](QString const &) (qmap.h:410)

15  MuseScore4.exe                  0x7ff640f6c6c6      QtPrivate::QExplicitlySharedDataPointerV2<QMapData<std::map<QString,QVariant,std::less<QString>,std::allocator<std::pair<QString const ,QVariant> > > > >::~QExplicitlySharedDataPointerV2<QMapData<std::map<QString,QVariant,std::less<QString>,std::allocat... (qshareddata_impl.h:103)

16  MuseScore4.exe                  0x7ff642477236      muse::ui::InteractiveProvider::fillData(muse::ui::QmlLaunchData *,muse::UriQuery const &) (interactiveprovider.cpp:411)

17  MuseScore4.exe                  0x7ff642482507      muse::ui::InteractiveProvider::openQml(muse::UriQuery const &) (interactiveprovider.cpp:729)

18  MuseScore4.exe                  0x7ff642481703      muse::ui::InteractiveProvider::open(muse::UriQuery const &) (interactiveprovider.cpp:244)

19  MuseScore4.exe                  0x7ff64101409d      muse::Interactive::open(muse::UriQuery const &) (interactive.cpp:269)

20  MuseScore4.exe                  0x7ff641013dbb      muse::Interactive::open(std::basic_string<char,std::char_traits<char>,std::allocator<char> > const &) (interactive.cpp:254)

21  MuseScore4.exe                  0x7ff642651c17      mu::appshell::FirstLaunchSetupModel::setCurrentPageIndex(int) (firstlaunchsetupmodel.cpp:95)

22  MuseScore4.exe                  0x7ff64260d661      mu::appshell::FirstLaunchSetupModel::qt_metacall(QMetaObject::Call,int,void * *) (moc_firstlaunchsetupmodel.cpp:192)

23  Qt6Core.dll                     0x7ff8332af801      <unknown>
```
</details/>