### PR TITLE
27219: Some text objects cannot be moved immediately after editing

### DIFF
--- a/src/engraving/dom/textbase.cpp
+++ b/src/engraving/dom/textbase.cpp
@@ -3290,6 +3290,11 @@ void TextBase::shiftInitOffset(EditData& ed, const PointF& offsetShift)
     }
 }
 
+bool TextBase::supportsNonTextualEdit() const
+{
+    return hasParentSegment();
+}
+
 void TextBase::startEditNonTextual(EditData& ed)
 {
     EngravingItem::startEdit(ed);

--- a/src/engraving/dom/textbase.h
+++ b/src/engraving/dom/textbase.h
@@ -345,6 +345,7 @@ public:
     virtual bool allowTimeAnchor() const override { return hasParentSegment(); }
     virtual void startEdit(EditData&) override;
     virtual bool isEditAllowed(EditData&) const override;
+    virtual bool supportsNonTextualEdit() const;
     virtual bool edit(EditData&) override;
     virtual void editCut(EditData&) override;
     virtual void editCopy(EditData&) override;

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -4113,7 +4113,9 @@ void NotationInteraction::endEditText()
     if (editedElement) {
         notifyAboutTextEditingEnded(toTextBase(editedElement));
         // When textual edit is finished, non-textual edit can still happen, so we need to start the non-textual edit mode here
-        startEditElement(editedElement, false);
+        if (editedElement->isTextBase() && toTextBase(editedElement)->supportsNonTextualEdit()) {
+            startEditElement(editedElement, false);
+        }
     }
 
     notifyAboutTextEditingChanged();


### PR DESCRIPTION
Resolves: #27219 

`NotationInteraction::endEditText` now puts a text object into _non-textual_ edit mode after ending _textual_ editing. This disables some UI actions and makes them non-functional since they are enabled only when no element is being edited. Some text objects, like fingering for example, do nothing when in non-textual edit mode because `TextBase::editNonTextual` requires the text object to have a parent segment which is not always the case. This, together with the disabled UI actions, makes the text object non-movable immediately after editing.

I am proposing to put a text object in non-textual edit mode only if it has a parent segment. This works but may not be the proper solution. I am going to request a review from mike-spa who should be familiar with this functionality.

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
