### PR TITLE
Fix #27204, adding Spanner properties to SpannerSegment

### DIFF
--- a/src/engraving/dom/spanner.cpp
+++ b/src/engraving/dom/spanner.cpp
@@ -143,6 +143,9 @@ EngravingItem* SpannerSegment::propertyDelegate(Pid pid)
     case Pid::EXCLUDE_FROM_OTHER_PARTS:
     case Pid::POSITION_LINKED_TO_MASTER:
     case Pid::APPEARANCE_LINKED_TO_MASTER:
+    case Pid::SPANNER_TICK:
+    case Pid::SPANNER_TICKS:
+    case Pid::SPANNER_TRACK2:
         return spanner();
     default: break;
     }


### PR DESCRIPTION
Adds spannerTick, spannerTicks and spannerTrack2 properties to spannerSegment to enable plugins to access these properties of any 'spannerSegment' object (e.g. SLUR_SEGMENT, OTTAVA_SEGMENT, HAIRPIN_SEGMENT, etc.)

Resolves: #27204 

<!-- Add a short description of and motivation for the changes here -->

MuseScore 4.5 changed the spanner objects exposed to the plugin API from (e.g.) Element.SLUR to Element.SLUR_SEGMENT. Unfortunately, the 'Segment' objects returned 'undefined' for the properties of 'spannerTick', 'spannerTicks' and 'spannerTrack2' to plugins. This change fixes the problem.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
