### PR TITLE
Cache ignore-for-spacing property

### DIFF
--- a/src/engraving/rendering/score/horizontalspacing.cpp
+++ b/src/engraving/rendering/score/horizontalspacing.cpp
@@ -45,6 +45,8 @@ using namespace mu::engraving::rendering::score;
 double HorizontalSpacing::computeSpacingForFullSystem(System* system, double stretchReduction, double squeezeFactor,
                                                       bool overrideMinMeasureWidth)
 {
+    TRACEFUNC;
+
     HorizontalSpacingContext ctx;
     ctx.system = system;
     ctx.spatium = system->spatium();
@@ -80,6 +82,8 @@ double HorizontalSpacing::computeSpacingForFullSystem(System* system, double str
 
 double HorizontalSpacing::updateSpacingForLastAddedMeasure(System* system, bool startOfContinuousLayoutRegion)
 {
+    TRACEFUNC;
+
     HorizontalSpacingContext ctx;
     ctx.system = system;
     ctx.spatium = system->spatium();
@@ -118,6 +122,8 @@ double HorizontalSpacing::updateSpacingForLastAddedMeasure(System* system, bool 
 
 void HorizontalSpacing::squeezeSystemToFit(System* system, double& curSysWidth, double targetSysWidth)
 {
+    TRACEFUNC;
+
     Measure* firstMeasure = system->firstMeasure();
     if (!firstMeasure) {
         return;

--- a/src/engraving/rendering/score/horizontalspacing.cpp
+++ b/src/engraving/rendering/score/horizontalspacing.cpp
@@ -256,7 +256,7 @@ std::vector<HorizontalSpacing::SegmentPosition> HorizontalSpacing::spaceSegments
     for (size_t i = 0; i < segList.size(); ++i) {
         Segment* curSeg = segList[i];
         if (ignoreSegmentForSpacing(curSeg)) {
-            placedSegments.emplace_back(curSeg, ctx.xCur);
+            placedSegments.emplace_back(curSeg, ctx.xCur, /*ignoreForSpacing*/ true);
             continue;
         }
 
@@ -314,7 +314,7 @@ bool HorizontalSpacing::ignoreSegmentForSpacing(const Segment* segment)
 bool HorizontalSpacing::ignoreAllSegmentsForSpacing(const std::vector<SegmentPosition>& segmentPositions)
 {
     for (const SegmentPosition& segPos : segmentPositions) {
-        if (!ignoreSegmentForSpacing(segPos.segment)) {
+        if (!segPos.ignoreForSpacing) {
             return false;
         }
     }
@@ -336,12 +336,12 @@ void HorizontalSpacing::spaceAgainstPreviousSegments(Segment* segment, std::vect
 
     for (size_t i = prevSegPositions.size(); i > 0; --i) {
         const SegmentPosition& prevSegPos = prevSegPositions[i - 1];
-        Segment* prevSeg = prevSegPos.segment;
-        double xPrevSeg = prevSegPos.xPosInSystemCoords;
-
-        if (ignoreSegmentForSpacing(prevSeg)) {
+        if (prevSegPos.ignoreForSpacing) {
             continue;
         }
+
+        Segment* prevSeg = prevSegPos.segment;
+        double xPrevSeg = prevSegPos.xPosInSystemCoords;
 
         if (prevSeg->isChordRestType()) {
             ++prevCRSegmentsCount;
@@ -372,7 +372,7 @@ void HorizontalSpacing::spaceAgainstPreviousSegments(Segment* segment, std::vect
                 double xMovement = spaceIncrease;
                 for (size_t j = i; j < prevSegPositions.size(); ++j) {
                     SegmentPosition& segPos = prevSegPositions[j];
-                    if (ignoreSegmentForSpacing(segPos.segment)) {
+                    if (segPos.ignoreForSpacing) {
                         continue;
                     }
                     segPos.xPosInSystemCoords += xMovement;
@@ -607,14 +607,19 @@ void HorizontalSpacing::moveRightAlignedSegments(std::vector<SegmentPosition>& p
         double x = DBL_MAX;
 
         for (size_t j = i + 1; j < placedSegments.size(); ++j) {
-            Segment* followingSeg = placedSegments[j].segment;
-            if (followingSeg->isRightAligned() || ignoreSegmentForSpacing(followingSeg) || followingSeg->hasTimeSigAboveStaves()) {
+            SegmentPosition& segPos = placedSegments[j];
+            if (segPos.ignoreForSpacing) {
+                continue;
+            }
+
+            Segment* followingSeg = segPos.segment;
+            if (followingSeg->isRightAligned() || followingSeg->hasTimeSigAboveStaves()) {
                 continue;
             }
             if (followingSeg->measure() != segment->measure()) {
                 break;
             }
-            double followingSegX = placedSegments[j].xPosInSystemCoords;
+            double followingSegX = segPos.xPosInSystemCoords;
             double minDist = minHorizontalDistance(segment, followingSeg, ctx.squeezeFactor);
             x = std::min(x, followingSegX - minDist);
         }
@@ -1026,10 +1031,11 @@ void HorizontalSpacing::setPositionsAndWidths(const std::vector<SegmentPosition>
 {
     size_t segmentsSize = segmentPositions.size();
     for (size_t i = 0; i < segmentsSize; ++i) {
-        Segment* curSeg = segmentPositions[i].segment;
-        double curX = segmentPositions[i].xPosInSystemCoords;
+        const SegmentPosition& segPos = segmentPositions[i];
+        Segment* curSeg = segPos.segment;
+        double curX = segPos.xPosInSystemCoords;
 
-        if (ignoreSegmentForSpacing(curSeg)) {
+        if (segPos.ignoreForSpacing) {
             curSeg->setWidth(0.0);
             continue;
         }
@@ -1037,9 +1043,10 @@ void HorizontalSpacing::setPositionsAndWidths(const std::vector<SegmentPosition>
         Segment* nextSeg = curSeg;
         double nextX = curX;
         for (size_t j = i + 1; j < segmentsSize; ++j) {
-            if (!ignoreSegmentForSpacing(segmentPositions[j].segment)) {
-                nextSeg = segmentPositions[j].segment;
-                nextX = segmentPositions[j].xPosInSystemCoords;
+            const SegmentPosition& nextSegPos = segmentPositions[j];
+            if (!nextSegPos.ignoreForSpacing) {
+                nextSeg = nextSegPos.segment;
+                nextX = nextSegPos.xPosInSystemCoords;
                 break;
             }
         }

--- a/src/engraving/rendering/score/horizontalspacing.h
+++ b/src/engraving/rendering/score/horizontalspacing.h
@@ -78,8 +78,9 @@ private:
     struct SegmentPosition {
         Segment* segment;
         double xPosInSystemCoords;
-        SegmentPosition(Segment* s, double x)
-            : segment(s), xPosInSystemCoords(x) {}
+        bool ignoreForSpacing;
+        SegmentPosition(Segment* s, double x, bool ignoreForSpacing = false)
+            : segment(s), xPosInSystemCoords(x), ignoreForSpacing(ignoreForSpacing) {}
     };
 
     struct CrossBeamSpacing

--- a/src/engraving/rendering/score/systemlayout.cpp
+++ b/src/engraving/rendering/score/systemlayout.cpp
@@ -165,7 +165,7 @@ System* SystemLayout::collectSystem(LayoutContext& ctx)
 
             MeasureLayout::createEndBarLines(m, true, ctx);
 
-            if (m->noBreak()) {
+            if (m->noBreak() || systemLock) {
                 MeasureLayout::removeSystemTrailer(m);
             } else {
                 MeasureLayout::addSystemTrailer(m, m->nextMeasure(), ctx);
@@ -175,9 +175,13 @@ System* SystemLayout::collectSystem(LayoutContext& ctx)
 
             MeasureLayout::updateGraceNotes(m, ctx);
 
-            curSysWidth = HorizontalSpacing::updateSpacingForLastAddedMeasure(system);
+            if (!systemLock) {
+                curSysWidth = HorizontalSpacing::updateSpacingForLastAddedMeasure(system);
+            }
         } else if (ctx.state().curMeasure()->isHBox()) {
-            curSysWidth = HorizontalSpacing::updateSpacingForLastAddedMeasure(system);
+            if (!systemLock) {
+                curSysWidth = HorizontalSpacing::updateSpacingForLastAddedMeasure(system);
+            }
         } else {
             // vbox:
             MeasureLayout::getNextMeasure(ctx);
@@ -223,7 +227,9 @@ System* SystemLayout::collectSystem(LayoutContext& ctx)
 
             MeasureLayout::updateGraceNotes(m, ctx);
 
-            curSysWidth = HorizontalSpacing::updateSpacingForLastAddedMeasure(system);
+            if (!systemLock) {
+                curSysWidth = HorizontalSpacing::updateSpacingForLastAddedMeasure(system);
+            }
         }
 
         const MeasureBase* mb = ctx.state().curMeasure();


### PR DESCRIPTION
This is a follow up to #27247 so that should be merged first. **Not** intended for 4.5.1.

As I was working on the related PR I realized that during horizontal spacing calculations we're making _a lot_ of calls to `ignoreSegmentForSpacing()`, which involves checking things on all staves all the time, which makes it quite expensive. With this PR we compute it only once and cache it for all subsequent uses. 
