### PR TITLE
Shortcuts reading: ignore shortcuts for invalid actions

### DIFF
--- a/src/framework/shortcuts/internal/shortcutsregister.cpp
+++ b/src/framework/shortcuts/internal/shortcutsregister.cpp
@@ -291,7 +291,13 @@ Shortcut ShortcutsRegister::readShortcut(deprecated::XmlReader& reader) const
         }
     }
 
-    shortcut.context = uiactionsRegister()->action(shortcut.action).scCtx;
+    auto action = uiactionsRegister()->action(shortcut.action);
+    if (!action.isValid()) {
+        LOGW() << "ignoring shortcut for invalid action: " << shortcut.action;
+        return Shortcut();
+    }
+
+    shortcut.context = action.scCtx;
 
     return shortcut;
 }


### PR DESCRIPTION
Solves a problem that has not yet been exposed to end users, but see https://github.com/musescore/MuseScore/issues/26249#issuecomment-2690868880