### PR TITLE
Revert "Restore geometry. Enabled for macOS"

### DIFF
--- a/src/framework/dockwindow/view/dockwindow.cpp
+++ b/src/framework/dockwindow/view/dockwindow.cpp
@@ -173,7 +173,14 @@ void DockWindow::init()
 {
     clearRegistry();
 
+#ifdef Q_OS_MACOS
+    /*! TODO: restoring of the window geometry is temporarily disabled for macOS
+     * because it has a problem with saving a normal geometry of main window on KDDockWidgets
+     * see https://github.com/KDAB/KDDockWidgets/pull/273
+    */
+#else
     restoreGeometry();
+#endif
 
     dockWindowProvider()->init(this);
 


### PR DESCRIPTION
Reverts musescore/MuseScore#26475

Should resolve https://github.com/musescore/MuseScore/issues/27256

See also https://github.com/musescore/MuseScore/pull/27262, which might be a more pleasant alternative.

Re. how to test: place the `workspaces/Default.mws` file from https://github.com/musescore/MuseScore/issues/27256#issuecomment-2741272176 in `~/Library/Application Support/MuseScore/MuseScore4Development/workspaces/` to 'simulate' a broken situation (`MuseScore4Development` rather than just `MuseScore4` because we're working with PR builds and nightly builds rather than stable builds); then launch a nightly build to verify that it indeed doesn't start correctly; then run the build from this PR to verify that it hopefully does start correctly.