### PR TITLE
KDDW patch: more carefully check if layout is valid before restoring it

### DIFF
--- a/src/framework/dockwindow/thirdparty/KDDockWidgets/src/LayoutSaver.cpp
+++ b/src/framework/dockwindow/thirdparty/KDDockWidgets/src/LayoutSaver.cpp
@@ -834,6 +834,14 @@ void LayoutSaver::FloatingWindow::fromVariantMap(const QVariantMap &map)
 
 bool LayoutSaver::MainWindow::isValid() const
 {
+    if (!geometry.isValid() || geometry.isNull()) {
+        return false;
+    }
+
+    if (!normalGeometry.isValid() || normalGeometry.isNull()) {
+        return false;
+    }
+
     if (!multiSplitterLayout.isValid())
         return false;
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/27256

Alternative to #27261 

Re. how to test: place the `workspaces/Default.mws` file from https://github.com/musescore/MuseScore/issues/27256#issuecomment-2741272176 in `~/Library/Application Support/MuseScore/MuseScore4Development/workspaces/` to 'simulate' a broken situation (`MuseScore4Development` rather than just `MuseScore4` because we're working with PR builds and nightly builds rather than stable builds); then launch a nightly build to verify that it indeed doesn't start correctly; then run the build from this PR to verify that it hopefully does start correctly.