### PR TITLE
 Fix #27106: New panels appearing undocked [Master]

### DIFF
--- a/src/framework/dockwindow/view/dockwindow.cpp
+++ b/src/framework/dockwindow/view/dockwindow.cpp
@@ -362,9 +362,13 @@ void DockWindow::loadPanels(const DockPageView* page)
     TRACEFUNC;
 
     for (DockPanelView* panel : page->panels()) {
+        if (DockPanelView* destinationPanel = findDestinationForPanel(page, panel)) {
+            addPanelAsTab(panel, destinationPanel);
+            continue;
+        }
         const Location location = panel->location();
         const bool isSideLocation = location == Location::Left || location == Location::Right;
-        addPanel(page, panel, location, isSideLocation ? page->centralDock() : nullptr);
+        addDock(panel, location, isSideLocation ? page->centralDock() : nullptr);
     }
 
     for (Location location : POSSIBLE_LOCATIONS) {
@@ -428,6 +432,16 @@ void DockWindow::alignTopLevelToolBars(const DockPageView* page)
     lastCentralToolBar->setMinimumWidth(lastCentralToolBar->contentWidth() + deltaForLastCentralToolBar);
 }
 
+DockPanelView* DockWindow::findDestinationForPanel(const DockPageView* page, const DockPanelView* panel) const
+{
+    for (DockPanelView* destinationPanel : page->panels()) {
+        if (destinationPanel->isTabAllowed(panel)) {
+            return destinationPanel;
+        }
+    }
+    return nullptr;
+}
+
 void DockWindow::addDock(DockBase* dock, Location location, const DockBase* relativeTo)
 {
     TRACEFUNC;
@@ -444,20 +458,14 @@ void DockWindow::addDock(DockBase* dock, Location location, const DockBase* rela
     m_mainWindow->addDockWidget(dock->dockWidget(), locationToKLocation(location), relativeDock, options);
 }
 
-void DockWindow::addPanel(const DockPageView* page, DockPanelView* panel, Location location, const DockBase* relativeTo)
+void DockWindow::addPanelAsTab(DockPanelView* panel, DockPanelView* destinationPanel)
 {
-    for (DockPanelView* destinationPanel : page->panels()) {
-        if (panel->isVisible() && destinationPanel->isTabAllowed(panel)) {
-            registerDock(panel);
+    registerDock(panel);
 
-            destinationPanel->addPanelAsTab(panel);
-            destinationPanel->setCurrentTabIndex(0);
-
-            return;
-        }
+    if (panel->isVisible()) {
+        destinationPanel->addPanelAsTab(panel);
+        destinationPanel->setCurrentTabIndex(0);
     }
-
-    addDock(panel, location, relativeTo);
 }
 
 void DockWindow::registerDock(DockBase* dock)
@@ -473,6 +481,39 @@ void DockWindow::registerDock(DockBase* dock)
 
     if (!registry->containsDockWidget(dockWidget->uniqueName())) {
         registry->registerDockWidget(dockWidget);
+    }
+}
+
+void DockWindow::handleUnknownDock(const DockPageView* page, DockBase* unknownDock)
+{
+    DockPanelView* unknownPanel = dynamic_cast<DockPanelView*>(unknownDock);
+    if (!unknownPanel) {
+        addDock(unknownDock, unknownDock->location(), page->centralDock());
+        return;
+    }
+
+    if (DockPanelView* destinationPanel = findDestinationForPanel(page, unknownPanel)) {
+        addPanelAsTab(unknownPanel, destinationPanel);
+        return;
+    }
+
+    DockingHolderView* holder = page->holder(DockType::Panel, unknownPanel->location());
+    IF_ASSERT_FAILED(holder) {
+        addDock(unknownDock, unknownDock->location(), page->centralDock());
+        return;
+    }
+
+    registerDock(unknownPanel);
+
+    holder->open(); // init the frame...
+
+    KDDockWidgets::Frame* frame = holder->dockWidget()->frame();
+    frame->addWidget(unknownPanel->dockWidget());
+
+    holder->close();
+
+    if (!unknownPanel->isVisible()) {
+        unknownPanel->close();
     }
 }
 
@@ -571,11 +612,7 @@ void DockWindow::restorePageState(const DockPageView* page)
 
     if (!layoutIsEmpty) {
         for (DockBase* dock : unknownDocks) {
-            if (DockPanelView* panel = dynamic_cast<DockPanelView*>(dock)) {
-                addPanel(page, panel, panel->location(), page->centralDock());
-                continue;
-            }
-            addDock(dock, dock->location(), page->centralDock());
+            handleUnknownDock(page, dock);
         }
     }
 

--- a/src/framework/dockwindow/view/dockwindow.cpp
+++ b/src/framework/dockwindow/view/dockwindow.cpp
@@ -30,7 +30,6 @@
 
 #include "dockcentralview.h"
 #include "dockpageview.h"
-#include "dockpanelview.h"
 #include "dockstatusbarview.h"
 #include "docktoolbarview.h"
 #include "dockingholderview.h"
@@ -362,25 +361,10 @@ void DockWindow::loadPanels(const DockPageView* page)
 {
     TRACEFUNC;
 
-    auto addPanel = [this, page](DockPanelView* panel, Location location) {
-        for (DockPanelView* destinationPanel : page->panels()) {
-            if (panel->isVisible() && destinationPanel->isTabAllowed(panel)) {
-                registerDock(panel);
-
-                destinationPanel->addPanelAsTab(panel);
-                destinationPanel->setCurrentTabIndex(0);
-
-                return;
-            }
-        }
-
-        bool isSideLocation = location == Location::Left || location == Location::Right;
-
-        addDock(panel, location, isSideLocation ? page->centralDock() : nullptr);
-    };
-
     for (DockPanelView* panel : page->panels()) {
-        addPanel(panel, panel->location());
+        const Location location = panel->location();
+        const bool isSideLocation = location == Location::Left || location == Location::Right;
+        addPanel(page, panel, location, isSideLocation ? page->centralDock() : nullptr);
     }
 
     for (Location location : POSSIBLE_LOCATIONS) {
@@ -460,6 +444,22 @@ void DockWindow::addDock(DockBase* dock, Location location, const DockBase* rela
     m_mainWindow->addDockWidget(dock->dockWidget(), locationToKLocation(location), relativeDock, options);
 }
 
+void DockWindow::addPanel(const DockPageView* page, DockPanelView* panel, Location location, const DockBase* relativeTo)
+{
+    for (DockPanelView* destinationPanel : page->panels()) {
+        if (panel->isVisible() && destinationPanel->isTabAllowed(panel)) {
+            registerDock(panel);
+
+            destinationPanel->addPanelAsTab(panel);
+            destinationPanel->setCurrentTabIndex(0);
+
+            return;
+        }
+    }
+
+    addDock(panel, location, relativeTo);
+}
+
 void DockWindow::registerDock(DockBase* dock)
 {
     TRACEFUNC;
@@ -495,7 +495,7 @@ bool DockWindow::doLoadPage(const QString& uri, const QVariantMap& params)
     }
 
     loadPageContent(newPage);
-    restorePageState(newPage->objectName());
+    restorePageState(newPage);
     initDocks(newPage);
 
     newPage->setParams(params);
@@ -544,16 +544,39 @@ void DockWindow::savePageState(const QString& pageName)
     m_reloadCurrentPageAllowed = true;
 }
 
-void DockWindow::restorePageState(const QString& pageName)
+void DockWindow::restorePageState(const DockPageView* page)
 {
     TRACEFUNC;
 
+    const QString& pageName = page->objectName();
+
     ValNt<QByteArray> pageStateValNt = uiConfiguration()->pageState(pageName);
+    const bool layoutIsEmpty = pageStateValNt.val.isEmpty();
+
+    QSet<DockBase*> unknownDocks;
+    if (!layoutIsEmpty) {
+        for (DockBase* dock : page->allDocks()) {
+            const KDDockWidgets::DockWidgetBase* dockWidget = dock->dockWidget();
+            if (!pageStateValNt.val.contains(dockWidget->uniqueName().toLocal8Bit())) {
+                unknownDocks.insert(dock);
+            }
+        }
+    }
 
     /// NOTE: Do not restore geometry
     bool ok = restoreLayout(pageStateValNt.val, true /*restoreRelativeToMainWindow*/);
     if (!ok) {
         LOGE() << "Could not restore the state of " << pageName << "!";
+    }
+
+    if (!layoutIsEmpty) {
+        for (DockBase* dock : unknownDocks) {
+            if (DockPanelView* panel = dynamic_cast<DockPanelView*>(dock)) {
+                addPanel(page, panel, panel->location(), page->centralDock());
+                continue;
+            }
+            addDock(dock, dock->location(), page->centralDock());
+        }
     }
 
     if (!pageStateValNt.notification.isConnected()) {

--- a/src/framework/dockwindow/view/dockwindow.h
+++ b/src/framework/dockwindow/view/dockwindow.h
@@ -115,9 +115,13 @@ private:
     void loadTopLevelToolBars(const DockPageView* page);
     void alignTopLevelToolBars(const DockPageView* page);
 
+    DockPanelView* findDestinationForPanel(const DockPageView* page, const DockPanelView* panel) const;
+
     void addDock(DockBase* dock, Location location = Location::Left, const DockBase* relativeTo = nullptr);
-    void addPanel(const DockPageView* page, DockPanelView* panel, Location location, const DockBase* relativeTo = nullptr);
+    void addPanelAsTab(DockPanelView* panel, DockPanelView* destinationPanel);
     void registerDock(DockBase* dock);
+
+    void handleUnknownDock(const DockPageView* page, DockBase* unknownDock);
 
     void saveGeometry();
     void restoreGeometry();

--- a/src/framework/dockwindow/view/dockwindow.h
+++ b/src/framework/dockwindow/view/dockwindow.h
@@ -48,6 +48,7 @@ namespace muse::dock {
 class DockToolBarView;
 class DockingHolderView;
 class DockPageView;
+class DockPanelView;
 class DockWindow : public QQuickItem, public IDockWindow, public muse::Injectable, public async::Asyncable
 {
     Q_OBJECT
@@ -115,6 +116,7 @@ private:
     void alignTopLevelToolBars(const DockPageView* page);
 
     void addDock(DockBase* dock, Location location = Location::Left, const DockBase* relativeTo = nullptr);
+    void addPanel(const DockPageView* page, DockPanelView* panel, Location location, const DockBase* relativeTo = nullptr);
     void registerDock(DockBase* dock);
 
     void saveGeometry();
@@ -123,7 +125,7 @@ private:
     QByteArray windowState() const;
 
     void savePageState(const QString& pageName);
-    void restorePageState(const QString& pageName);
+    void restorePageState(const DockPageView* page);
 
     void reloadCurrentPage();
     bool restoreLayout(const QByteArray& layout, bool restoreRelativeToMainWindow = false);


### PR DESCRIPTION
Resolves: #27106 (see #27222 for details)

Recent changes (#26643) mean that this bug can't be reproduced in the master branch as described in #27106. The root of the problem still exists though, and would manifest whenever a new panel is added to MuseScore.