### PR TITLE
Fix partial tie crash on changing voice

### DIFF
--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -7073,6 +7073,10 @@ void Score::undoChangeSpannerElements(Spanner* spanner, EngravingItem* startElem
             newEndElement = endElement;
         }
         sp->score()->undo(new ChangeSpannerElements(sp, newStartElement, newEndElement));
+
+        if (sp->isTie()) {
+            toTie(sp)->updatePossibleJumpPoints();
+        }
     }
 }
 
@@ -7404,6 +7408,9 @@ void Score::undoChangeMeasureRepeatCount(Measure* m, int newCount, staff_idx_t s
 void Score::doUndoRemoveStaleTieJumpPoints(Tie* tie)
 {
     std::vector<Tie*> oldTies;
+    if (!tie->tieJumpPoints()) {
+        return;
+    }
     for (TieJumpPoint* jumpPoint : *tie->tieJumpPoints()) {
         if (jumpPoint->followingNote()) {
             continue;
@@ -7423,6 +7430,9 @@ void Score::doUndoRemoveStaleTieJumpPoints(Tie* tie)
         auto findEndTie = [&oldTie](const TieJumpPoint* jumpPoint) {
             return jumpPoint->endTie() == oldTie;
         };
+        if (!oldTie) {
+            continue;
+        }
 
         if (std::find_if((*tie->tieJumpPoints()).begin(), (*tie->tieJumpPoints()).end(),
                          findEndTie) != (*tie->tieJumpPoints()).end()) {

--- a/src/engraving/dom/laissezvib.cpp
+++ b/src/engraving/dom/laissezvib.cpp
@@ -78,6 +78,13 @@ SymId LaissezVib::symId() const
     return up() ? SymId::articLaissezVibrerAbove : SymId::articLaissezVibrerBelow;
 }
 
+SlurTieSegment* LaissezVib::newSlurTieSegment(System* parent)
+{
+    LaissezVibSegment* seg =  new LaissezVibSegment(parent);
+    seg->setTrack(track());
+    return seg;
+}
+
 void LaissezVib::setEndNote(Note* note)
 {
     setEndElement(note);
@@ -86,7 +93,6 @@ void LaissezVib::setEndNote(Note* note)
 void LaissezVib::setEndElement(EngravingItem* e)
 {
     UNUSED(e);
-    LOGI() << "nope";
     ASSERT_X("Laissez vibrer ties do not have an end note");
 }
 

--- a/src/engraving/dom/laissezvib.h
+++ b/src/engraving/dom/laissezvib.h
@@ -70,7 +70,7 @@ public:
 
     SymId symId() const;
 
-    SlurTieSegment* newSlurTieSegment(System* parent) override { return new LaissezVibSegment(parent); }
+    SlurTieSegment* newSlurTieSegment(System* parent) override;
 
     void setEndNote(Note* note) override;
     void setEndElement(EngravingItem*) override;

--- a/src/engraving/dom/partialtie.cpp
+++ b/src/engraving/dom/partialtie.cpp
@@ -44,6 +44,13 @@ bool PartialTie::setProperty(Pid propertyId, const PropertyValue& v)
     return true;
 }
 
+SlurTieSegment* PartialTie::newSlurTieSegment(System* parent)
+{
+    PartialTieSegment* seg = new PartialTieSegment(parent);
+    seg->setTrack(track());
+    return seg;
+}
+
 void PartialTie::setStartNote(Note* note)
 {
     setPartialSpannerDirection(PartialSpannerDirection::OUTGOING);

--- a/src/engraving/dom/partialtie.h
+++ b/src/engraving/dom/partialtie.h
@@ -62,7 +62,7 @@ public:
     PropertyValue propertyDefault(Pid propertyId) const override;
     bool setProperty(Pid propertyId, const PropertyValue& v) override;
 
-    SlurTieSegment* newSlurTieSegment(System* parent) override { return new PartialTieSegment(parent); }
+    SlurTieSegment* newSlurTieSegment(System* parent) override;
 
     Note* note() const { return isOutgoing() ? startNote() : endNote(); }
     void setStartNote(Note* note) override;

--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -5576,6 +5576,7 @@ void Score::changeSelectedElementsVoice(voice_idx_t voice)
                 Lyrics* newLyric = Factory::copyLyrics(*lyric);
                 newLyric->setParent(dstChord);
                 newLyric->setSelected(false);
+                newLyric->setTrack(dstTrack);
                 score->undoAddElement(newLyric);
                 newElements.push_back(newLyric);
 

--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -73,6 +73,7 @@
 #include "page.h"
 #include "palmmute.h"
 #include "part.h"
+#include "partialtie.h"
 #include "pitchspelling.h"
 #include "rehearsalmark.h"
 #include "repeatlist.h"
@@ -5497,7 +5498,8 @@ void Score::changeSelectedElementsVoice(voice_idx_t voice)
                 // reconnect the tie to this note, if any
                 Tie* tie = linkedNote->tieBack();
                 if (tie) {
-                    score->undoChangeSpannerElements(tie, tie->startNote(), linkedNewNote);
+                    Note* startNote = tie->isPartialTie() && !toPartialTie(tie)->isOutgoing() ? nullptr : tie->startNote();
+                    score->undoChangeSpannerElements(tie, startNote, linkedNewNote);
                 }
                 // reconnect the tie from this note, if any
                 tie = linkedNote->tieFor();

--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -5537,7 +5537,10 @@ void Score::changeSelectedElementsVoice(voice_idx_t voice)
                         continue;
                     }
                     Slur* slur = toSlur(spanner);
-                    if (slur->startElement() == chord) {
+                    if (slur->startElement() == chord && slur->endElement() == chord) {
+                        score->undoChangeSpannerElements(slur, dstChord, dstChord);
+                        slur->undoChangeProperty(Pid::VOICE, voice);
+                    } else if (slur->startElement() == chord) {
                         score->undoChangeSpannerElements(slur, dstChord, slur->endElement());
                     } else if (slur->endElement() == chord) {
                         score->undoChangeSpannerElements(slur, slur->startElement(), dstChord);
@@ -5578,7 +5581,7 @@ void Score::changeSelectedElementsVoice(voice_idx_t voice)
 
                 score->undoRemoveElement(lyric);
             }
-        } else {
+        } else if (e->hasVoiceAssignmentProperties()) {
             if (e->isSpannerSegment()) {
                 e = toSpannerSegment(e)->spanner();
             }
@@ -5589,9 +5592,7 @@ void Score::changeSelectedElementsVoice(voice_idx_t voice)
             }
 
             e->undoChangeProperty(Pid::VOICE, voice);
-            if (e->hasVoiceAssignmentProperties()) {
-                e->undoChangeProperty(Pid::VOICE_ASSIGNMENT, VoiceAssignment::CURRENT_VOICE_ONLY);
-            }
+            e->undoChangeProperty(Pid::VOICE_ASSIGNMENT, VoiceAssignment::CURRENT_VOICE_ONLY);
             newElements.push_back(e);
         }
     }

--- a/src/engraving/dom/spanner.cpp
+++ b/src/engraving/dom/spanner.cpp
@@ -949,14 +949,21 @@ void Spanner::setNoteSpan(Note* startNote, Note* endNote)
         return;
     }
 
-    setScore(startNote->score());
-    setParent(startNote);
+    Score* score = startNote ? startNote->score() : endNote->score();
+    Note* parent = startNote ? startNote : endNote;
+    Fraction tick = startNote ? startNote->tick() : endNote->tick();
+    Fraction endTick = endNote ? endNote->tick() : startNote->tick();
+    track_idx_t track = startNote ? startNote->track() : endNote->track();
+    track_idx_t endTrack = endNote ? endNote->track() : startNote->track();
+
+    setScore(score);
+    setParent(parent);
     setStartElement(startNote);
     setEndElement(endNote);
-    setTick(startNote->chord()->tick());
-    setTick2(endNote->chord()->tick());
-    setTrack(startNote->track());
-    setTrack2(endNote->track());
+    setTick(tick);
+    setTick2(endTick);
+    setTrack(track);
+    setTrack2(endTrack);
 }
 
 //---------------------------------------------------------

--- a/src/engraving/rendering/score/slurtielayout.cpp
+++ b/src/engraving/rendering/score/slurtielayout.cpp
@@ -1743,6 +1743,7 @@ LaissezVibSegment* SlurTieLayout::createLaissezVibSegment(LaissezVib* item)
     item->fixupSegments(1);
     LaissezVibSegment* segment = item->segmentAt(0);
     segment->setSpannerSegmentType(SpannerSegmentType::SINGLE);
+    segment->setTrack(item->track());
     segment->setSystem(item->startNote()->chord()->segment()->measure()->system());
     segment->resetAdjustmentOffset();
 
@@ -1802,6 +1803,7 @@ PartialTieSegment* SlurTieLayout::createPartialTieSegment(PartialTie* item)
     PartialTieSegment* segment = item->segmentAt(0);
     segment->setSpannerSegmentType(SpannerSegmentType::SINGLE);
     segment->setSystem(chord->segment()->measure()->system());
+    segment->setTrack(item->track());
     segment->resetAdjustmentOffset();
     segment->mutldata()->allJumpPointsInactive = item->allJumpPointsInactive();
 

--- a/src/engraving/tests/exchangevoices_data/exchangevoices-range-ref.mscx
+++ b/src/engraving/tests/exchangevoices_data/exchangevoices-range-ref.mscx
@@ -1,0 +1,316 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="4.50">
+  <Score>
+    <Division>480</Division>
+    <Style>
+      <spatium>1.74978</spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <open>1</open>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="audioComUrl"></metaTag>
+    <metaTag name="composer">Composer / arranger</metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="sourceRevisionId"></metaTag>
+    <metaTag name="subtitle">Subtitle</metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle">Untitled score</metaTag>
+    <Order id="orchestra">
+      <name>Orchestra</name>
+      <instrument id="oboe">
+        <family id="oboes">Oboes</family>
+        </instrument>
+      <section id="woodwind" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>flutes</family>
+        <family>oboes</family>
+        <family>clarinets</family>
+        <family>saxophones</family>
+        <family>bassoons</family>
+        <unsorted group="woodwinds"/>
+        </section>
+      <section id="brass" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>horns</family>
+        <family>trumpets</family>
+        <family>cornets</family>
+        <family>flugelhorns</family>
+        <family>trombones</family>
+        <family>tubas</family>
+        <unsorted group="brass"/>
+        </section>
+      <section id="timpani" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>timpani</family>
+        </section>
+      <section id="percussion" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>keyboard-percussion</family>
+        <unsorted group="pitched-percussion"/>
+        <family>drums</family>
+        <family>unpitched-metal-percussion</family>
+        <family>unpitched-wooden-percussion</family>
+        <family>other-percussion</family>
+        <unsorted group="unpitched-percussion"/>
+        </section>
+      <family>keyboards</family>
+      <family>harps</family>
+      <family>organs</family>
+      <family>synths</family>
+      <unsorted/>
+      <soloists/>
+      <section id="voices" brackets="true" barLineSpan="false" thinBrackets="true">
+        <family>voices</family>
+        <family>voice-groups</family>
+        </section>
+      <section id="strings" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>orchestral-strings</family>
+        </section>
+      </Order>
+    <Part id="1">
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        </Staff>
+      <trackName>Oboe</trackName>
+      <Instrument id="oboe">
+        <longName>Oboe</longName>
+        <shortName>Ob.</shortName>
+        <trackName>Oboe</trackName>
+        <minPitchP>58</minPitchP>
+        <maxPitchP>96</maxPitchP>
+        <minPitchA>58</minPitchA>
+        <maxPitchA>87</maxPitchA>
+        <instrumentId>wind.reed.oboe</instrumentId>
+        <Channel>
+          <program value="68"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <VBox>
+        <height>10</height>
+        <Text>
+          <style>title</style>
+          <text>Untitled score</text>
+          </Text>
+        <Text>
+          <style>subtitle</style>
+          <text>Subtitle</text>
+          </Text>
+        <Text>
+          <style>composer</style>
+          <text>Composer / arranger</text>
+          </Text>
+        </VBox>
+      <Measure>
+        <voice>
+          <KeySig>
+            <concertKey>0</concertKey>
+            </KeySig>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          </voice>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <startRepeat/>
+        <endRepeat>2</endRepeat>
+        <voice>
+          <Spanner type="PartialLyricsLine">
+            <PartialLyricsLine>
+              <isEndMelisma>1</isEndMelisma>
+              </PartialLyricsLine>
+            <next>
+              <location>
+                <fractions>1/4</fractions>
+                </location>
+              </next>
+            </Spanner>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          <location>
+            <fractions>-3/4</fractions>
+            </location>
+          <Spanner type="PartialLyricsLine">
+            <prev>
+              <location>
+                <fractions>-1/4</fractions>
+                </location>
+              </prev>
+            </Spanner>
+          <location>
+            <fractions>1/4</fractions>
+            </location>
+          <Dynamic>
+            <subtype>pp</subtype>
+            <velocity>33</velocity>
+            <voiceAssignment>currentVoiceOnly</voiceAssignment>
+            <direction>up</direction>
+            </Dynamic>
+          </voice>
+        <voice>
+          <Chord>
+            <durationType>quarter</durationType>
+            <Spanner type="Slur">
+              <Slur>
+                <partialSpannerDirection>incoming</partialSpannerDirection>
+                </Slur>
+              <next>
+                <location>
+                  <fractions>1/4</fractions>
+                  </location>
+                </next>
+              </Spanner>
+            <Note>
+              <PartialTie>
+                <partialSpannerDirection>incoming</partialSpannerDirection>
+                </PartialTie>
+              <pitch>71</pitch>
+              <tpc>19</tpc>
+              <Spanner type="NoteLine">
+                <NoteLine>
+                  <diagonal>1</diagonal>
+                  </NoteLine>
+                <next>
+                  <location>
+                    <fractions>1/4</fractions>
+                    </location>
+                  </next>
+                </Spanner>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>quarter</durationType>
+            <Lyrics>
+              <syllabic>begin</syllabic>
+              <text>oo</text>
+              </Lyrics>
+            <Spanner type="Slur">
+              <prev>
+                <location>
+                  <fractions>-1/4</fractions>
+                  </location>
+                </prev>
+              </Spanner>
+            <Note>
+              <pitch>69</pitch>
+              <tpc>17</tpc>
+              <Spanner type="Glissando">
+                <Glissando>
+                  <diagonal>1</diagonal>
+                  </Glissando>
+                <next>
+                  <location>
+                    <fractions>1/4</fractions>
+                    </location>
+                  </next>
+                </Spanner>
+              <Spanner type="NoteLine">
+                <prev>
+                  <location>
+                    <fractions>-1/4</fractions>
+                    </location>
+                  </prev>
+                </Spanner>
+              </Note>
+            </Chord>
+          <Beam>
+            <l1>44</l1>
+            <l2>44</l2>
+            </Beam>
+          <Chord>
+            <durationType>eighth</durationType>
+            <Lyrics>
+              <syllabic>middle</syllabic>
+              <text>oo</text>
+              </Lyrics>
+            <Note>
+              <Spanner type="Tie">
+                <Tie>
+                  </Tie>
+                <next>
+                  <location>
+                    <fractions>1/8</fractions>
+                    </location>
+                  </next>
+                </Spanner>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              <Spanner type="Glissando">
+                <prev>
+                  <location>
+                    <fractions>-1/4</fractions>
+                    </location>
+                  </prev>
+                </Spanner>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>eighth</durationType>
+            <Note>
+              <LaissezVib>
+                </LaissezVib>
+              <Spanner type="Tie">
+                <prev>
+                  <location>
+                    <fractions>-1/8</fractions>
+                    </location>
+                  </prev>
+                </Spanner>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>quarter</durationType>
+            <Lyrics>
+              <syllabic>end</syllabic>
+              <ticks>1</ticks>
+              <ticks_f>1/1920</ticks_f>
+              <text>oo</text>
+              </Lyrics>
+            <Note>
+              <PartialTie>
+                </PartialTie>
+              <pitch>71</pitch>
+              <tpc>19</tpc>
+              </Note>
+            </Chord>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          </voice>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/src/engraving/tests/exchangevoices_data/exchangevoices-range.mscx
+++ b/src/engraving/tests/exchangevoices_data/exchangevoices-range.mscx
@@ -1,0 +1,292 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="4.50">
+  <Score>
+    <Division>480</Division>
+    <Style>
+      <spatium>1.74978</spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <open>1</open>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="audioComUrl"></metaTag>
+    <metaTag name="composer">Composer / arranger</metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="sourceRevisionId"></metaTag>
+    <metaTag name="subtitle">Subtitle</metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle">Untitled score</metaTag>
+    <Order id="orchestra">
+      <name>Orchestra</name>
+      <instrument id="oboe">
+        <family id="oboes">Oboes</family>
+        </instrument>
+      <section id="woodwind" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>flutes</family>
+        <family>oboes</family>
+        <family>clarinets</family>
+        <family>saxophones</family>
+        <family>bassoons</family>
+        <unsorted group="woodwinds"/>
+        </section>
+      <section id="brass" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>horns</family>
+        <family>trumpets</family>
+        <family>cornets</family>
+        <family>flugelhorns</family>
+        <family>trombones</family>
+        <family>tubas</family>
+        <unsorted group="brass"/>
+        </section>
+      <section id="timpani" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>timpani</family>
+        </section>
+      <section id="percussion" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>keyboard-percussion</family>
+        <unsorted group="pitched-percussion"/>
+        <family>drums</family>
+        <family>unpitched-metal-percussion</family>
+        <family>unpitched-wooden-percussion</family>
+        <family>other-percussion</family>
+        <unsorted group="unpitched-percussion"/>
+        </section>
+      <family>keyboards</family>
+      <family>harps</family>
+      <family>organs</family>
+      <family>synths</family>
+      <unsorted/>
+      <soloists/>
+      <section id="voices" brackets="true" barLineSpan="false" thinBrackets="true">
+        <family>voices</family>
+        <family>voice-groups</family>
+        </section>
+      <section id="strings" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>orchestral-strings</family>
+        </section>
+      </Order>
+    <Part id="1">
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        </Staff>
+      <trackName>Oboe</trackName>
+      <Instrument id="oboe">
+        <longName>Oboe</longName>
+        <shortName>Ob.</shortName>
+        <trackName>Oboe</trackName>
+        <minPitchP>58</minPitchP>
+        <maxPitchP>96</maxPitchP>
+        <minPitchA>58</minPitchA>
+        <maxPitchA>87</maxPitchA>
+        <instrumentId>wind.reed.oboe</instrumentId>
+        <Channel>
+          <program value="68"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <VBox>
+        <height>10</height>
+        <Text>
+          <style>title</style>
+          <text>Untitled score</text>
+          </Text>
+        <Text>
+          <style>subtitle</style>
+          <text>Subtitle</text>
+          </Text>
+        <Text>
+          <style>composer</style>
+          <text>Composer / arranger</text>
+          </Text>
+        </VBox>
+      <Measure>
+        <voice>
+          <KeySig>
+            <concertKey>0</concertKey>
+            </KeySig>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <startRepeat/>
+        <endRepeat>2</endRepeat>
+        <voice>
+          <Spanner type="PartialLyricsLine">
+            <PartialLyricsLine>
+              <isEndMelisma>1</isEndMelisma>
+              </PartialLyricsLine>
+            <next>
+              <location>
+                <fractions>1/4</fractions>
+                </location>
+              </next>
+            </Spanner>
+          <Chord>
+            <durationType>quarter</durationType>
+            <Spanner type="Slur">
+              <Slur>
+                <partialSpannerDirection>incoming</partialSpannerDirection>
+                </Slur>
+              <next>
+                <location>
+                  <fractions>1/4</fractions>
+                  </location>
+                </next>
+              </Spanner>
+            <Note>
+              <PartialTie>
+                <partialSpannerDirection>incoming</partialSpannerDirection>
+                </PartialTie>
+              <pitch>71</pitch>
+              <tpc>19</tpc>
+              <Spanner type="NoteLine">
+                <NoteLine>
+                  <diagonal>1</diagonal>
+                  </NoteLine>
+                <next>
+                  <location>
+                    <fractions>1/4</fractions>
+                    </location>
+                  </next>
+                </Spanner>
+              </Note>
+            </Chord>
+          <Spanner type="PartialLyricsLine">
+            <prev>
+              <location>
+                <fractions>-1/4</fractions>
+                </location>
+              </prev>
+            </Spanner>
+          <Chord>
+            <durationType>quarter</durationType>
+            <Lyrics>
+              <syllabic>begin</syllabic>
+              <text>oo</text>
+              </Lyrics>
+            <Spanner type="Slur">
+              <prev>
+                <location>
+                  <fractions>-1/4</fractions>
+                  </location>
+                </prev>
+              </Spanner>
+            <Note>
+              <pitch>69</pitch>
+              <tpc>17</tpc>
+              <Spanner type="Glissando">
+                <Glissando>
+                  <diagonal>1</diagonal>
+                  </Glissando>
+                <next>
+                  <location>
+                    <fractions>1/4</fractions>
+                    </location>
+                  </next>
+                </Spanner>
+              <Spanner type="NoteLine">
+                <prev>
+                  <location>
+                    <fractions>-1/4</fractions>
+                    </location>
+                  </prev>
+                </Spanner>
+              </Note>
+            </Chord>
+          <Dynamic>
+            <subtype>pp</subtype>
+            <velocity>33</velocity>
+            <voiceAssignment>currentVoiceOnly</voiceAssignment>
+            <direction>up</direction>
+            </Dynamic>
+          <Beam>
+            <l1>44</l1>
+            <l2>44</l2>
+            </Beam>
+          <Chord>
+            <durationType>eighth</durationType>
+            <Lyrics>
+              <syllabic>middle</syllabic>
+              <text>oo</text>
+              </Lyrics>
+            <Note>
+              <Spanner type="Tie">
+                <Tie>
+                  </Tie>
+                <next>
+                  <location>
+                    <fractions>1/8</fractions>
+                    </location>
+                  </next>
+                </Spanner>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              <Spanner type="Glissando">
+                <prev>
+                  <location>
+                    <fractions>-1/4</fractions>
+                    </location>
+                  </prev>
+                </Spanner>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>eighth</durationType>
+            <Note>
+              <LaissezVib>
+                </LaissezVib>
+              <Spanner type="Tie">
+                <prev>
+                  <location>
+                    <fractions>-1/8</fractions>
+                    </location>
+                  </prev>
+                </Spanner>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>quarter</durationType>
+            <Lyrics>
+              <syllabic>end</syllabic>
+              <ticks>1</ticks>
+              <ticks_f>1/1920</ticks_f>
+              <text>oo</text>
+              </Lyrics>
+            <Note>
+              <PartialTie>
+                </PartialTie>
+              <pitch>71</pitch>
+              <tpc>19</tpc>
+              </Note>
+            </Chord>
+          </voice>
+        </Measure>
+      <Measure>
+        <voice>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/src/engraving/tests/exchangevoices_tests.cpp
+++ b/src/engraving/tests/exchangevoices_tests.cpp
@@ -79,6 +79,36 @@ TEST_F(Engraving_ExchangevoicesTests, glissandi)
     EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"exchangevoices-gliss.mscx", EXCHVOICES_DATA_DIR + u"exchangevoices-gliss-ref.mscx"));
 }
 
+TEST_F(Engraving_ExchangevoicesTests, rangeSelection)
+{
+    // Change voice of range selection including lyrics, lyrics lines, partial ties, slur, glissando, note anchored line, dynamics
+    bool use302 = MScore::useRead302InTestMode;
+    MScore::useRead302InTestMode = false;
+
+    Score* score = ScoreRW::readScore(EXCHVOICES_DATA_DIR + u"exchangevoices-range.mscx");
+    EXPECT_TRUE(score);
+    score->doLayout();
+
+    score->startCmd(TranslatableString::untranslatable("Exchange voices select all"));
+    score->cmdSelectAll();
+    score->endCmd();
+
+    score->startCmd(TranslatableString::untranslatable("Exchange voices tests"));
+    score->cmdExchangeVoice(0, 1);
+    score->endCmd();
+
+    EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"exchangevoices-range.mscx",
+                                            EXCHVOICES_DATA_DIR + u"exchangevoices-range-ref.mscx"));
+
+    EditData ed;
+    score->undoStack()->undo(&ed);
+
+    EXPECT_TRUE(ScoreComp::saveCompareScore(score, u"exchangevoices-range.mscx",
+                                            EXCHVOICES_DATA_DIR + u"exchangevoices-range.mscx"));
+
+    MScore::useRead302InTestMode = use302;
+}
+
 TEST_F(Engraving_ExchangevoicesTests, undoChangeVoice)
 {
     String readFile(EXCHVOICES_DATA_DIR + u"undoChangeVoice.mscx");


### PR DESCRIPTION
Resolves: #27252 

This PR also allows all selected elements to have their voice changed. Previously many were missing - eg. glissandos, note anchored lines, slurs, lyrics, lyrics lines etc.