### PR TITLE
[MusicXML] minor refactor

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
@@ -736,7 +736,7 @@ static String color2xml(const EngravingItem* el)
 static void addColorAttr(const EngravingItem* el, XmlWriter::Attributes& attrs)
 {
     if (el->color() != engravingConfiguration()->defaultColor()) {
-        attrs.push_back({ "color", String::fromStdString(el->color().toString()) });
+        attrs.emplace_back(std::make_pair("color", String::fromStdString(el->color().toString())));
     }
 }
 
@@ -2190,7 +2190,7 @@ void ExportMusicXml::timesig(const TimeSig* tsig)
         attrs = { { "symbol", "single-number" } };
     }
     if (!tsig->visible()) {
-        attrs.push_back({ "print-object", "no" });
+        attrs.emplace_back(std::make_pair("print-object", "no"));
     }
 
     addColorAttr(tsig, attrs);
@@ -2425,10 +2425,10 @@ void ExportMusicXml::keysig(const KeySig* ks, ClefType ct, staff_idx_t staff, bo
 
     XmlWriter::Attributes attrs;
     if (staff) {
-        attrs.push_back({ "number", staff });
+        attrs.emplace_back(std::make_pair("number", staff));
     }
     if (!visible) {
-        attrs.push_back({ "print-object", "no" });
+        attrs.emplace_back(std::make_pair("print-object", "no"));
     }
     addColorAttr(ks, attrs);
 
@@ -2793,7 +2793,7 @@ static void tupletStop(const Tuplet* const t, const int number, Notations& notat
     notations.tag(xml, t);
     XmlWriter::Attributes tupletAttrs = { { "type", "stop" } };
     if (!isSimpleTuplet(t)) {
-        tupletAttrs.push_back({ "number", number });
+        tupletAttrs.emplace_back(std::make_pair("number", number));
     }
     xml.tag("tuplet", tupletAttrs);
 }
@@ -5038,7 +5038,7 @@ void ExportMusicXml::tempoText(TempoText const* const text, staff_idx_t staff)
     XmlWriter::Attributes tempoAttrs;
     tempoAttrs = { { "placement", (text->placement() == PlacementV::BELOW) ? "below" : "above" } };
     if (text->systemFlag()) {
-        tempoAttrs.push_back({ "system", text->isLinked() ? "also-top" : "only-top" });
+        tempoAttrs.emplace_back(std::make_pair("system", text->isLinked() ? "also-top" : "only-top"));
     }
 
     m_xml.startElement("direction", tempoAttrs);
@@ -6407,7 +6407,7 @@ static void measureRepeat(XmlWriter& xml, Attributes& attr, const Measure* const
         staff_idx_t staffIdx = scoreRelStaff + i;
         XmlWriter::Attributes styleAttrs;
         if (part->nstaves() > 1) {
-            styleAttrs.push_back({ "number", i + 1 });
+            styleAttrs.emplace_back(std::make_pair("number", i + 1));
         }
         if (m->isMeasureRepeatGroup(staffIdx)
             && (!m->prevMeasure() || !m->prevMeasure()->isMeasureRepeatGroup(staffIdx)
@@ -7650,7 +7650,7 @@ static void partList(XmlWriter& xml, Score* score, MusicXmlInstrumentMap& instrM
         if (partName.empty()) {
             partName = part->partName();
             if (!partName.empty()) {
-                attributes.push_back({ "print-object", "no" });
+                attributes.emplace_back(std::make_pair("print-object", "no"));
             }
         }
         xml.tag("part-name", attributes, MScoreTextToMusicXml::toPlainText(partName).replace(u"♭", u"b").replace(u"♯", u"#"));
@@ -8827,11 +8827,11 @@ void ExportMusicXml::harmony(Harmony const* const h, FretDiagram const* const fd
     int rootTpc = h->rootTpc();
     XmlWriter::Attributes harmonyAttrs;
     if (!h->isStyled(Pid::PLACEMENT)) {
-        harmonyAttrs.push_back({ "placement", (h->placement() == PlacementV::BELOW) ? "below" : "above" });
+        harmonyAttrs.emplace_back(std::make_pair("placement", (h->placement() == PlacementV::BELOW) ? "below" : "above"));
     }
-    harmonyAttrs.push_back({ "print-frame", h->hasFrame() ? "yes" : "no" });     // .append(relative));
+    harmonyAttrs.emplace_back(std::make_pair("print-frame", h->hasFrame() ? "yes" : "no"));     // .append(relative));
     if (!h->visible()) {
-        harmonyAttrs.push_back({ "print-object", "no" });
+        harmonyAttrs.emplace_back(std::make_pair("print-object", "no"));
     }
     addColorAttr(h, harmonyAttrs);
     m_xml.startElement("harmony", harmonyAttrs);


### PR DESCRIPTION
This PR adds export of frames on dynamics to the MusicXML support. 

Small refactorig:

- code for adding "enlcosure" attributes has been moved into a function
- it now prefers `emplace_back` for adding up attributes, which is faster than `push_back`
