### PR TITLE
26645: Undo/redo buttons' hovered state and of disabled controls

### DIFF
--- a/src/appshell/qml/platform/AppButtonBackground.qml
+++ b/src/appshell/qml/platform/AppButtonBackground.qml
@@ -53,7 +53,7 @@ Rectangle {
     states: [
         State {
             name: "PRESSED"
-            when: root.mouseArea.pressed
+            when: root.mouseArea.pressed && root.enabled
 
             PropertyChanges {
                 target: root
@@ -64,7 +64,7 @@ Rectangle {
 
         State {
             name: "HOVERED"
-            when: root.mouseArea.containsMouse && !root.mouseArea.pressed
+            when: root.mouseArea.containsMouse && !root.mouseArea.pressed && root.enabled
 
             PropertyChanges {
                 target: root

--- a/src/appshell/qml/platform/AppMenuBar.qml
+++ b/src/appshell/qml/platform/AppMenuBar.qml
@@ -190,7 +190,7 @@ ListView {
         }
 
         mouseArea.onHoveredChanged: {
-            if (!mouseArea.containsMouse) {
+            if (!mouseArea.containsMouse || !radioButtonDelegate.enabled) {
                 return
             }
 

--- a/src/appshell/qml/shared/internal/ThemeSample.qml
+++ b/src/appshell/qml/shared/internal/ThemeSample.qml
@@ -129,14 +129,13 @@ Rectangle {
         color: "transparent"
         radius: 4
         border.width: 1
-        border.color: mouseArea.containsMouse ? root.theme.accentColor : root.theme.strokeColor
+        border.color: mouseArea.containsMouse && root.enabled ? root.theme.accentColor : root.theme.strokeColor
     }
 
     MouseArea {
         id: mouseArea
         anchors.fill: parent
 
-        enabled: root.enabled
         hoverEnabled: true
 
         onClicked: root.clicked()

--- a/src/framework/diagnostics/qml/Muse/Diagnostics/DiagnosticNavigationPanel.qml
+++ b/src/framework/diagnostics/qml/Muse/Diagnostics/DiagnosticNavigationPanel.qml
@@ -210,8 +210,8 @@ Rectangle {
                             MouseArea {
                                 anchors.fill: parent
 
-                                enabled: gridItem.enabled
                                 hoverEnabled: true
+
                                 onContainsMouseChanged: {
                                     if (containsMouse) {
                                         var info = control.name + "\n"

--- a/src/framework/dockwindow/qml/Muse/Dock/DockPanelTab.qml
+++ b/src/framework/dockwindow/qml/Muse/Dock/DockPanelTab.qml
@@ -106,7 +106,7 @@ StyledTabButton {
         states: [
             State {
                 name: "HOVERED"
-                when: root.hovered && !root.isCurrent
+                when: root.hovered && root.enabled && !root.isCurrent
 
                 PropertyChanges {
                     target: backgroundRect

--- a/src/framework/extensions/qml/Muse/Extensions/internal/ExtensionItem.qml
+++ b/src/framework/extensions/qml/Muse/Extensions/internal/ExtensionItem.qml
@@ -112,7 +112,7 @@ Item {
     states: [
         State {
             name: "HOVERED"
-            when: mouseArea.containsMouse && !mouseArea.pressed
+            when: mouseArea.containsMouse && !mouseArea.pressed && root.enabled
 
             PropertyChanges {
                 target: thumbnail
@@ -122,7 +122,7 @@ Item {
 
         State {
             name: "PRESSED"
-            when: mouseArea.pressed
+            when: mouseArea.pressed && root.enabled
 
             PropertyChanges {
                 target: thumbnail
@@ -135,7 +135,6 @@ Item {
         id: mouseArea
         anchors.fill: parent
 
-        enabled: root.enabled
         hoverEnabled: true
 
         onClicked: {

--- a/src/framework/learn/qml/Muse/Learn/internal/PlaylistItem.qml
+++ b/src/framework/learn/qml/Muse/Learn/internal/PlaylistItem.qml
@@ -96,7 +96,7 @@ FocusScope {
             states: [
                 State {
                     name: "HOVERED"
-                    when: mouseArea.containsMouse && !mouseArea.pressed
+                    when: mouseArea.containsMouse && !mouseArea.pressed && root.enabled
 
                     PropertyChanges {
                         target: thumbnailRect
@@ -107,7 +107,7 @@ FocusScope {
 
                 State {
                     name: "PRESSED"
-                    when: mouseArea.pressed
+                    when: mouseArea.pressed && root.enabled
 
                     PropertyChanges {
                         target: thumbnailRect
@@ -170,7 +170,6 @@ FocusScope {
         id: mouseArea
         anchors.fill: parent
 
-        enabled: root.enabled
         hoverEnabled: true
 
         onClicked: {

--- a/src/framework/mpe/qml/Muse/Mpe/ArticulationPatternSegmentsList.qml
+++ b/src/framework/mpe/qml/Muse/Mpe/ArticulationPatternSegmentsList.qml
@@ -59,7 +59,6 @@ ListView {
                 id: thumbnailMouseArea
 
                 anchors.fill: parent
-                enabled: thumbnailPlot.enabled
                 hoverEnabled: true
 
                 onClicked: {
@@ -77,7 +76,7 @@ ListView {
 
             mouseArea.anchors.margins: -4
             enabled: root.model.isAbleToRemoveCurrentSegment()
-            visible: thumbnailMouseArea.containsMouse || deleteButton.mouseArea.containsMouse
+            visible: (thumbnailMouseArea.containsMouse && thumbnailPlot.enabled) || (deleteButton.mouseArea.containsMouse && deleteButton.enabled)
 
             transparent: true
 
@@ -98,7 +97,7 @@ ListView {
             anchors.leftMargin: 4
 
             mouseArea.anchors.margins: -4
-            visible: thumbnailMouseArea.containsMouse || createButton.mouseArea.containsMouse
+            visible: (thumbnailMouseArea.containsMouse && thumbnailPlot.enabled) || (createButton.mouseArea.containsMouse && createButton.enabled)
 
             transparent: true
 
@@ -112,7 +111,10 @@ ListView {
         states: [
             State {
                 name: "HOVERED"
-                when: (thumbnailMouseArea.containsMouse || createButton.mouseArea.containsMouse || deleteButton.mouseArea.containsMouse || delegateItem.isSelected)
+                when: ((thumbnailMouseArea.containsMouse && thumbnailPlot.enabled)
+                            || (createButton.mouseArea.containsMouse && createButton.enabled)
+                            || (deleteButton.mouseArea.containsMouse && deleteButton.enabled)
+                            || delegateItem.isSelected)
                       && !thumbnailMouseArea.containsPress
 
                 PropertyChanges {
@@ -123,7 +125,7 @@ ListView {
 
             State {
                 name: "SELECTED"
-                when: thumbnailMouseArea.containsPress
+                when: thumbnailMouseArea.containsPress && thumbnailPlot.enabled
 
                 PropertyChanges {
                     target: thumbnailPlot

--- a/src/framework/mpe/qml/Muse/Mpe/ArticulationPatternsList.qml
+++ b/src/framework/mpe/qml/Muse/Mpe/ArticulationPatternsList.qml
@@ -84,7 +84,6 @@ ListView {
                     anchors.fill: label
 
                     acceptedButtons: Qt.LeftButton | Qt.RightButton
-                    enabled: label.enabled
                     hoverEnabled: true
 
                     onClicked: function(mouse) {
@@ -142,7 +141,7 @@ ListView {
 
             State {
                 name: "HOVERED"
-                when: (mouseArea.containsMouse || checkBox.hovered) && !modelData.isSelected && !mouseArea.containsPress
+                when: (mouseArea.containsMouse || checkBox.hovered) && !modelData.isSelected && !mouseArea.containsPress && label.enabled
 
                 PropertyChanges {
                     target: backgroundRect
@@ -153,7 +152,7 @@ ListView {
 
             State {
                 name: "PRESSED"
-                when: (mouseArea.containsPress || checkBox.pressed) && !modelData.isSelected
+                when: (mouseArea.containsPress || checkBox.pressed) && !modelData.isSelected && label.enabled
 
                 PropertyChanges {
                     target: backgroundRect

--- a/src/framework/uicomponents/qml/Muse/UiComponents/CheckBox.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/CheckBox.qml
@@ -28,8 +28,8 @@ FocusScope {
     id: root
 
     property bool checked: false
-    property alias pressed: clickableArea.containsPress
-    property alias hovered: clickableArea.containsMouse
+    readonly property bool pressed: clickableArea.containsPress && root.enabled
+    readonly property bool hovered: clickableArea.containsMouse && root.enabled
     property bool isIndeterminate: false
 
     property alias text: label.text
@@ -131,7 +131,7 @@ FocusScope {
     states: [
         State {
             name: "HOVERED"
-            when: clickableArea.containsMouse && !clickableArea.pressed
+            when: clickableArea.containsMouse && !clickableArea.pressed && root.enabled
 
             PropertyChanges {
                 target: box
@@ -141,7 +141,7 @@ FocusScope {
 
         State {
             name: "PRESSED"
-            when: clickableArea.containsMouse && clickableArea.pressed
+            when: clickableArea.containsMouse && clickableArea.pressed && root.enabled
 
             PropertyChanges {
                 target: box

--- a/src/framework/uicomponents/qml/Muse/UiComponents/ColorPicker.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/ColorPicker.qml
@@ -83,7 +83,6 @@ Rectangle {
         id: clickableArea
         anchors.fill: parent
 
-        enabled: root.enabled
         hoverEnabled: true
 
         onClicked: {
@@ -96,14 +95,14 @@ Rectangle {
     states: [
         State {
             name: "HOVERED"
-            when: clickableArea.containsMouse && !clickableArea.pressed
+            when: clickableArea.containsMouse && !clickableArea.pressed && root.enabled
 
             PropertyChanges { target: root; border.color: ui.theme.accentColor }
         },
 
         State {
             name: "PRESSED"
-            when: clickableArea.pressed
+            when: clickableArea.pressed && root.enabled
 
             PropertyChanges { target: root; border.color: ui.theme.fontPrimaryColor }
         }

--- a/src/framework/uicomponents/qml/Muse/UiComponents/ExpandableBlankSection.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/ExpandableBlankSection.qml
@@ -107,7 +107,6 @@ FocusScope {
         id: mouseArea
         anchors.fill: expandSectionRow
 
-        enabled: root.enabled
         hoverEnabled: true
 
         onClicked: {
@@ -120,7 +119,7 @@ FocusScope {
     Loader {
         id: menuLoader
 
-        property bool isMenuButtonVisible: root.isExpanded || mouseArea.containsMouse
+        property bool isMenuButtonVisible: root.isExpanded || (mouseArea.containsMouse && root.enabled)
 
         anchors {
             right: root.right

--- a/src/framework/uicomponents/qml/Muse/UiComponents/FlatButton.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/FlatButton.qml
@@ -160,7 +160,7 @@ FocusScope {
             states: [
                 State {
                     name: "PRESSED"
-                    when: mouseArea.pressed
+                    when: mouseArea.pressed && root.enabled
 
                     PropertyChanges {
                         target: background
@@ -171,7 +171,7 @@ FocusScope {
 
                 State {
                     name: "HOVERED"
-                    when: mouseArea.containsMouse && !mouseArea.pressed
+                    when: mouseArea.containsMouse && !mouseArea.pressed && root.enabled
 
                     PropertyChanges {
                         target: background
@@ -300,7 +300,6 @@ FocusScope {
         id: mouseArea
         anchors.fill: parent
 
-        enabled: root.enabled
         hoverEnabled: true
 
         onClicked: function(mouse) {

--- a/src/framework/uicomponents/qml/Muse/UiComponents/FlatRadioButton.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/FlatRadioButton.qml
@@ -56,7 +56,7 @@ RadioDelegate {
     implicitWidth: ListView.view ? (ListView.view.width - (ListView.view.spacing * (ListView.view.count - 1))) / ListView.view.count
                                  : ui.theme.defaultButtonSize
 
-    hoverEnabled: root.enabled
+    hoverEnabled: true
 
     onClicked: {
         navigation.requestActiveByInteraction()
@@ -109,7 +109,7 @@ RadioDelegate {
         states: [
             State {
                 name: "HOVERED"
-                when: root.hovered && !root.pressed
+                when: root.hovered && !root.pressed && root.enabled
 
                 PropertyChanges {
                     target: backgroundRect
@@ -120,7 +120,7 @@ RadioDelegate {
 
             State {
                 name: "PRESSED"
-                when: root.pressed
+                when: root.pressed && root.enabled
 
                 PropertyChanges {
                     target: backgroundRect

--- a/src/framework/uicomponents/qml/Muse/UiComponents/FlatToggleButton.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/FlatToggleButton.qml
@@ -82,7 +82,6 @@ FocusScope {
         id: mouseArea
         anchors.fill: parent
 
-        enabled: root.enabled
         hoverEnabled: true
 
         onClicked: {
@@ -110,7 +109,7 @@ FocusScope {
     states: [
         State {
             name: "HOVERED"
-            when: mouseArea.containsMouse && !mouseArea.pressed
+            when: mouseArea.containsMouse && !mouseArea.pressed && root.enabled
 
             PropertyChanges {
                 target: backgroundRect
@@ -121,7 +120,7 @@ FocusScope {
 
         State {
             name: "PRESSED"
-            when: mouseArea.pressed
+            when: mouseArea.pressed && root.enabled
 
             PropertyChanges {
                 target: backgroundRect

--- a/src/framework/uicomponents/qml/Muse/UiComponents/IncrementalPropertyControl.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/IncrementalPropertyControl.qml
@@ -176,7 +176,7 @@ Item {
 
         validator: !prv.isCustom ? (root.decimals > 0 ? doubleInputValidator : intInputValidator) : null
 
-        containsMouse: mouseArea.containsMouse || valueAdjustControl.containsMouse
+        containsMouse: (mouseArea.containsMouse && textInputField.enabled) || valueAdjustControl.containsMouse
 
         ValueAdjustControl {
             id: valueAdjustControl

--- a/src/framework/uicomponents/qml/Muse/UiComponents/ListItemBlank.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/ListItemBlank.qml
@@ -59,9 +59,8 @@ FocusableControl {
 
     focusBorder.drawOutsideParent: false
 
-    mouseArea.enabled: root.visible && root.enabled
-    mouseArea.hoverEnabled: true
-    mouseArea.onHoveredChanged: root.hovered(mouseArea.containsMouse, mouseArea.mouseX, mouseArea.mouseY)
+    mouseArea.hoverEnabled: root.visible
+    mouseArea.onHoveredChanged: root.hovered(mouseArea.containsMouse && root.enabled, mouseArea.mouseX, mouseArea.mouseY)
 
     mouseArea.onClicked: function(mouse) {
         navigation.requestActiveByInteraction()
@@ -103,7 +102,7 @@ FocusableControl {
     states: [
         State {
             name: "HOVERED"
-            when: mouseArea.containsMouse && !mouseArea.pressed && !root.isSelected
+            when: mouseArea.containsMouse && !mouseArea.pressed && root.enabled && !root.isSelected
 
             PropertyChanges {
                 target: root.background
@@ -114,7 +113,7 @@ FocusableControl {
 
         State {
             name: "PRESSED"
-            when: mouseArea.pressed && !root.isSelected
+            when: mouseArea.pressed && root.enabled && !root.isSelected
 
             PropertyChanges {
                 target: root.background
@@ -125,7 +124,7 @@ FocusableControl {
 
         State {
             name: "SELECTED"
-            when: !mouseArea.containsMouse && !mouseArea.pressed && root.isSelected
+            when: ((!mouseArea.containsMouse && !mouseArea.pressed) || !root.enabled) && root.isSelected
 
             PropertyChanges {
                 target: root.background
@@ -136,7 +135,7 @@ FocusableControl {
 
         State {
             name: "SELECTED_HOVERED"
-            when: mouseArea.containsMouse && !mouseArea.pressed && root.isSelected
+            when: mouseArea.containsMouse && !mouseArea.pressed && root.enabled && root.isSelected
 
             PropertyChanges {
                 target: root.background
@@ -147,7 +146,7 @@ FocusableControl {
 
         State {
             name: "SELECTED_PRESSED"
-            when: mouseArea.pressed && root.isSelected
+            when: mouseArea.pressed && root.enabled && root.isSelected
 
             PropertyChanges {
                 target: root.background

--- a/src/framework/uicomponents/qml/Muse/UiComponents/NumberInputField.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/NumberInputField.qml
@@ -200,7 +200,7 @@ FocusScope {
     states: [
         State {
             name: "HOVERED"
-            when: mouseArea.containsMouse && !mouseArea.pressed && !textField.activeFocus
+            when: mouseArea.containsMouse && !mouseArea.pressed && root.enabled && !textField.activeFocus
 
             PropertyChanges {
                 target: textFieldBackground
@@ -211,7 +211,7 @@ FocusScope {
 
         State {
             name: "PRESSED"
-            when: mouseArea.pressed && !textField.activeFocus
+            when: mouseArea.pressed && root.enabled && !textField.activeFocus
 
             PropertyChanges {
                 target: textFieldBackground

--- a/src/framework/uicomponents/qml/Muse/UiComponents/PageTabButton.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/PageTabButton.qml
@@ -173,7 +173,7 @@ RadioDelegate {
     states: [
         State {
             name: "HOVERED"
-            when: root.hovered && !root.checked && !root.pressed
+            when: root.hovered && root.enabled && !root.checked && !root.pressed
 
             PropertyChanges {
                 target: backgroundRect
@@ -184,7 +184,7 @@ RadioDelegate {
 
         State {
             name: "PRESSED"
-            when: root.pressed && !root.checked
+            when: root.pressed && root.enabled && !root.checked
 
             PropertyChanges {
                 target: backgroundRect

--- a/src/framework/uicomponents/qml/Muse/UiComponents/RoundedRadioButton.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/RoundedRadioButton.qml
@@ -42,7 +42,7 @@ RadioDelegate {
 
     font: ui.theme.bodyFont
 
-    hoverEnabled: root.enabled
+    hoverEnabled: true
 
     onToggled: {
         navigation.requestActiveByInteraction()
@@ -135,7 +135,7 @@ RadioDelegate {
     states: [
         State {
             name: "PRESSED"
-            when: root.pressed
+            when: root.pressed && root.enabled
 
             PropertyChanges {
                 target: backgroundRect
@@ -150,7 +150,7 @@ RadioDelegate {
 
         State {
             name: "SELECTED"
-            when: root.checked && !root.hovered
+            when: root.checked && (!root.hovered || !root.enabled)
 
             PropertyChanges {
                 target: backgroundRect
@@ -165,7 +165,7 @@ RadioDelegate {
 
         State {
             name: "HOVERED"
-            when: root.hovered && !root.checked && !root.pressed
+            when: root.hovered && !root.checked && !root.pressed && root.enabled
 
             PropertyChanges {
                 target: backgroundRect
@@ -175,7 +175,7 @@ RadioDelegate {
 
         State {
             name: "SELECTED_HOVERED"
-            when: root.hovered && root.checked
+            when: root.hovered && root.checked && root.enabled
 
             PropertyChanges {
                 target: backgroundRect

--- a/src/framework/uicomponents/qml/Muse/UiComponents/StyledDropdown.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/StyledDropdown.qml
@@ -172,7 +172,6 @@ Item {
             id: mouseAreaItem
             anchors.fill: parent
 
-            enabled: mainItem.enabled
             hoverEnabled: true
 
             onClicked: mainItem.clicked()
@@ -225,7 +224,7 @@ Item {
 
             State {
                 name: "HOVERED"
-                when: mouseAreaItem.containsMouse && !mouseAreaItem.pressed
+                when: mouseAreaItem.containsMouse && !mouseAreaItem.pressed && mainItem.enabled
 
                 PropertyChanges {
                     target: backgroundItem
@@ -236,7 +235,7 @@ Item {
 
             State {
                 name: "PRESSED"
-                when: mouseAreaItem.pressed
+                when: mouseAreaItem.pressed && mainItem.enabled
 
                 PropertyChanges {
                     target: backgroundItem

--- a/src/framework/uicomponents/qml/Muse/UiComponents/StyledSlider.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/StyledSlider.qml
@@ -32,7 +32,7 @@ Slider {
     implicitWidth: vertical ? prv.handleSize : prv.defaultLength
     implicitHeight: vertical ? prv.defaultLength : prv.handleSize
 
-    hoverEnabled: root.enabled
+    hoverEnabled: true
     wheelEnabled: true
 
     QtObject {
@@ -105,7 +105,7 @@ Slider {
             states: [
                 State {
                     name: "HOVERED"
-                    when: root.hovered && !root.pressed
+                    when: root.hovered && !root.pressed && root.enabled
 
                     PropertyChanges {
                         target: handleBorder
@@ -115,7 +115,7 @@ Slider {
 
                 State {
                     name: "PRESSED"
-                    when: root.pressed
+                    when: root.pressed && root.enabled
 
                     PropertyChanges {
                         target: handleBorder

--- a/src/framework/uicomponents/qml/Muse/UiComponents/StyledTabButton.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/StyledTabButton.qml
@@ -110,7 +110,7 @@ TabButton {
     states: [
         State {
             name: "HOVERED"
-            when: root.hovered && !root.isCurrent
+            when: root.hovered && root.enabled && !root.isCurrent
 
             PropertyChanges {
                 target: contentItem

--- a/src/framework/uicomponents/qml/Muse/UiComponents/TextInputArea.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/TextInputArea.qml
@@ -42,7 +42,7 @@ FocusScope {
     readonly property alias background: background
 
     readonly property alias mouseArea: clickableArea
-    property bool containsMouse: clickableArea.containsMouse
+    property bool containsMouse: clickableArea.containsMouse && root.enabled
 
     readonly property alias navigation: navCtrl
     readonly property alias accessible: navCtrl.accessible
@@ -228,7 +228,6 @@ FocusScope {
         id: clickableArea
         anchors.fill: parent
 
-        enabled: root.enabled
         propagateComposedEvents: true
         hoverEnabled: true
         cursorShape: Qt.IBeamCursor

--- a/src/framework/uicomponents/qml/Muse/UiComponents/TextInputField.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/TextInputField.qml
@@ -52,7 +52,7 @@ FocusScope {
     readonly property alias background: background
 
     readonly property alias mouseArea: clickableArea
-    property bool containsMouse: clickableArea.containsMouse
+    property bool containsMouse: clickableArea.containsMouse && root.enabled
 
     readonly property alias navigation: navCtrl
     readonly property alias accessible: navCtrl.accessible
@@ -319,7 +319,6 @@ FocusScope {
         height: parent.height
         width: clearTextButtonItem.visible ? parent.width - clearTextButtonItem.width : parent.width
 
-        enabled: root.enabled
         propagateComposedEvents: true
         hoverEnabled: true
         cursorShape: root.readOnly ? Qt.ArrowCursor : Qt.IBeamCursor

--- a/src/framework/uicomponents/qml/Muse/UiComponents/ToggleButton.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/ToggleButton.qml
@@ -100,7 +100,6 @@ FocusScope {
         id: mouseArea
         anchors.fill: parent
 
-        enabled: root.enabled
         hoverEnabled: true
         onClicked: {
             navigation.requestActiveByInteraction()

--- a/src/framework/uicomponents/qml/Muse/UiComponents/ValueAdjustControl.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/ValueAdjustControl.qml
@@ -27,7 +27,8 @@ import Muse.UiComponents 1.0
 Column {
     id: root
 
-    readonly property bool containsMouse: increaseMouseArea.containsMouse || decreaseMouseArea.containsMouse
+    readonly property bool containsMouse: (increaseMouseArea.containsMouse && increaseButton.enabled)
+                                          || (decreaseMouseArea.containsMouse && decreaseButton.enabled)
 
     property alias canIncrease: increaseButton.enabled
     property alias canDecrease: decreaseButton.enabled
@@ -65,7 +66,6 @@ Column {
             id: increaseMouseArea
             anchors.fill: parent
 
-            enabled: increaseButton.enabled
             hoverEnabled: true
             preventStealing: true
 
@@ -86,7 +86,7 @@ Column {
         states: [
             State {
                 name: "hovered"
-                when: increaseMouseArea.containsMouse && !increaseMouseArea.pressed
+                when: increaseMouseArea.containsMouse && !increaseMouseArea.pressed && increaseButton.enabled
 
                 PropertyChanges {
                     target: increaseButton
@@ -96,7 +96,7 @@ Column {
 
             State {
                 name: "pressed"
-                when: increaseMouseArea.pressed
+                when: increaseMouseArea.pressed && increaseButton.enabled
 
                 PropertyChanges {
                     target: increaseButton
@@ -131,7 +131,6 @@ Column {
             id: decreaseMouseArea
             anchors.fill: parent
 
-            enabled: decreaseButton.enabled
             hoverEnabled: true
             preventStealing: true
 
@@ -152,7 +151,7 @@ Column {
         states: [
             State {
                 name: "hovered"
-                when: decreaseMouseArea.containsMouse && !decreaseMouseArea.pressed
+                when: decreaseMouseArea.containsMouse && !decreaseMouseArea.pressed && decreaseButton.enabled
 
                 PropertyChanges {
                     target: decreaseButton
@@ -162,7 +161,7 @@ Column {
 
             State {
                 name: "pressed"
-                when: decreaseMouseArea.pressed
+                when: decreaseMouseArea.pressed && decreaseButton.enabled
 
                 PropertyChanges {
                     target: decreaseButton

--- a/src/framework/uicomponents/qml/Muse/UiComponents/internal/ArrowScrollButton.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/internal/ArrowScrollButton.qml
@@ -56,7 +56,7 @@ FlatButton {
         states: [
             State {
                 name: "HOVERED"
-                when: root.mouseArea.containsMouse && !root.mouseArea.pressed
+                when: root.mouseArea.containsMouse && !root.mouseArea.pressed && root.enabled
 
                 PropertyChanges {
                     target: background

--- a/src/framework/uicomponents/qml/Muse/UiComponents/internal/StyledMenuItem.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/internal/StyledMenuItem.qml
@@ -235,7 +235,7 @@ ListItemBlank {
     }
 
     onHovered: function(isHovered, mouseX, mouseY) {
-        if (isHovered) {
+        if (isHovered && root.enabled) {
             root.openSubMenuRequested(true)
         }
     }

--- a/src/framework/uicomponents/qml/Muse/UiComponents/internal/ValueListHeaderItem.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/internal/ValueListHeaderItem.qml
@@ -103,7 +103,6 @@ Item {
         id: mouseArea
         anchors.fill: parent
 
-        enabled: root.enabled
         hoverEnabled: true
 
         onClicked: {
@@ -114,7 +113,7 @@ Item {
     states: [
         State {
             name: "HOVERED"
-            when: mouseArea.containsMouse && !mouseArea.pressed
+            when: mouseArea.containsMouse && !mouseArea.pressed && root.enabled
 
             PropertyChanges {
                 target: titleLabel

--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/LayoutPanelItemDelegate.qml
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/LayoutPanelItemDelegate.qml
@@ -375,7 +375,7 @@ FocusableControl {
     background.states: [
         State {
             name: "HOVERED"
-            when: root.mouseArea.containsMouse && !root.mouseArea.pressed && !root.isSelected && !prv.dragged
+            when: root.mouseArea.containsMouse && !root.mouseArea.pressed && root.enabled && !root.isSelected && !prv.dragged
 
             PropertyChanges {
                 target: root.background
@@ -386,7 +386,7 @@ FocusableControl {
 
         State {
             name: "PRESSED"
-            when: root.mouseArea.pressed && !root.isSelected && !prv.dragged
+            when: root.mouseArea.pressed && root.enabled && !root.isSelected && !prv.dragged
 
             PropertyChanges {
                 target: root.background
@@ -397,7 +397,7 @@ FocusableControl {
 
         State {
             name: "SELECTED"
-            when: root.isSelected && !root.mouseArea.containsMouse && !root.mouseArea.pressed
+            when: root.isSelected && ((!root.mouseArea.containsMouse && !root.mouseArea.pressed) || !root.enabled)
 
             PropertyChanges {
                 target: root.background
@@ -408,7 +408,7 @@ FocusableControl {
 
         State {
             name: "SELECTED_HOVERED"
-            when: root.isSelected && root.mouseArea.containsMouse && !root.mouseArea.pressed
+            when: root.isSelected && root.mouseArea.containsMouse && !root.mouseArea.pressed && root.enabled
 
             PropertyChanges {
                 target: root.background
@@ -419,7 +419,7 @@ FocusableControl {
 
         State {
             name: "SELECTED_PRESSED"
-            when: root.isSelected && root.mouseArea.pressed
+            when: root.isSelected && root.mouseArea.pressed && root.enabled
 
             PropertyChanges {
                 target: root.background

--- a/src/notation/qml/MuseScore/NotationScene/internal/NotationSwitchButton.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/NotationSwitchButton.qml
@@ -147,7 +147,7 @@ FlatRadioButton {
 
             State {
                 name: "HOVERED"
-                when: root.hovered && !root.pressed
+                when: root.hovered && !root.pressed && root.enabled
 
                 PropertyChanges {
                     target: background
@@ -157,7 +157,7 @@ FlatRadioButton {
 
             State {
                 name: "PRESSED"
-                when: root.pressed
+                when: root.pressed && root.enabled
 
                 PropertyChanges {
                     target: background

--- a/src/notation/qml/MuseScore/NotationScene/internal/NotationSwitchScrollArrowButton.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/NotationSwitchScrollArrowButton.qml
@@ -40,7 +40,7 @@ FlatButton {
         states: [
             State {
                 name: "pressed"
-                when: root.mouseArea.pressed
+                when: root.mouseArea.pressed && root.enabled
 
                 PropertyChanges {
                     target: background
@@ -51,7 +51,7 @@ FlatButton {
 
             State {
                 name: "hovered"
-                when: root.mouseArea.containsMouse
+                when: root.mouseArea.containsMouse && root.enabled
 
                 PropertyChanges {
                     target: background

--- a/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPadContent.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPadContent.qml
@@ -60,7 +60,6 @@ Column {
             id: mouseArea
             anchors.fill: parent
 
-            enabled: mainContentArea.enabled
             hoverEnabled: true
 
             acceptedButtons: Qt.LeftButton | Qt.RightButton
@@ -135,7 +134,7 @@ Column {
         states: [
             State {
                 name: "MOUSE_HOVERED"
-                when: mouseArea.containsMouse && !mouseArea.pressed && !root.padSwapActive
+                when: mouseArea.containsMouse && !mouseArea.pressed && mainContentArea.enabled && !root.padSwapActive
                 PropertyChanges {
                     target: padNameBackground
                     color: Utils.colorWithAlpha(ui.theme.accentColor, ui.theme.buttonOpacityHover)
@@ -147,7 +146,7 @@ Column {
             },
             State {
                 name: "MOUSE_HIT"
-                when: mouseArea.pressed || root.padSwapActive
+                when: (mouseArea.pressed && mainContentArea.enabled) || root.padSwapActive
                 PropertyChanges {
                     target: padNameBackground
                     color: Utils.colorWithAlpha(ui.theme.accentColor, ui.theme.buttonOpacityHit)

--- a/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelToolBar.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelToolBar.qml
@@ -96,7 +96,7 @@ Item {
                 states: [
                     State {
                         name: "PRESSED"
-                        when: writeButton.mouseArea.pressed
+                        when: writeButton.mouseArea.pressed && writeButton.enabled
 
                         PropertyChanges {
                             target: writeButtonBackground
@@ -106,7 +106,7 @@ Item {
 
                     State {
                         name: "HOVERED"
-                        when: !writeButton.mouseArea.pressed && writeButton.mouseArea.containsMouse
+                        when: !writeButton.mouseArea.pressed && writeButton.mouseArea.containsMouse && writeButton.enabled
 
                         PropertyChanges {
                             target: writeButtonBackground
@@ -163,7 +163,7 @@ Item {
                 states: [
                     State {
                         name: "PRESSED"
-                        when: previewButton.mouseArea.pressed
+                        when: previewButton.mouseArea.pressed && previewButton.enabled
 
                         PropertyChanges {
                             target: previewButtonBackground
@@ -173,7 +173,7 @@ Item {
 
                     State {
                         name: "HOVERED"
-                        when: !previewButton.mouseArea.pressed && previewButton.mouseArea.containsMouse
+                        when: !previewButton.mouseArea.pressed && previewButton.mouseArea.containsMouse && previewButton.enabled
 
                         PropertyChanges {
                             target: previewButtonBackground

--- a/src/palette/qml/MuseScore/Palette/internal/PaletteTree.qml
+++ b/src/palette/qml/MuseScore/Palette/internal/PaletteTree.qml
@@ -632,7 +632,7 @@ StyledListView {
                     width: parent.width
                     opacity: enabled ? 1 : ui.theme.itemOpacityDisabled
                     expanded: control.expanded
-                    hovered: control.hovered
+                    hovered: control.hovered && control.enabled
                     text: model.display
 
                     isInVisibleArea: control.y >= paletteTree.contentY && control.y < (paletteTree.contentY + paletteTree.height)

--- a/src/playback/qml/MuseScore/Playback/internal/AudioResourceControl.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/AudioResourceControl.qml
@@ -45,7 +45,7 @@ Item {
 
     property bool resourcePickingActive: false
 
-    readonly property bool showAdditionalButtons: rootMouseArea.containsMouse || (navigationPanel ? navigationPanel.highlight : false) || resourcePickingActive
+    readonly property bool showAdditionalButtons: (rootMouseArea.containsMouse && root.enabled) || (navigationPanel ? navigationPanel.highlight : false) || resourcePickingActive
 
     property NavigationPanel navigationPanel: null
     property int navigationRowStart: 0
@@ -68,9 +68,9 @@ Item {
 
         // We can't just check the containsMouse property of the mouseAreas of the buttons themselves,
         // because that property will always be false because this MouseArea is (and must be) on top
-        readonly property bool isActivityButtonHovered: rootMouseArea.containsMouse && activityLoader.visible && rootMouseArea.mouseX < root.height // activityLoader.visible && activityLoader.contains(rootMouseArea.mapToItem(activityLoader, rootMouseArea.mouseX, rootMouseArea.mouseY))
-        readonly property bool isTitleButtonHovered: rootMouseArea.containsMouse && titleLoader.visible && titleLoader.contains(rootMouseArea.mapToItem(titleLoader, rootMouseArea.mouseX, rootMouseArea.mouseY))
-        readonly property bool isSelectorButtonHovered: rootMouseArea.containsMouse && selectorLoader.visible && selectorLoader.contains(rootMouseArea.mapToItem(selectorLoader, rootMouseArea.mouseX, rootMouseArea.mouseY))
+        readonly property bool isActivityButtonHovered: rootMouseArea.containsMouse && root.enabled && activityLoader.visible && rootMouseArea.mouseX < root.height // activityLoader.visible && activityLoader.contains(rootMouseArea.mapToItem(activityLoader, rootMouseArea.mouseX, rootMouseArea.mouseY))
+        readonly property bool isTitleButtonHovered: rootMouseArea.containsMouse && root.enabled && titleLoader.visible && titleLoader.contains(rootMouseArea.mapToItem(titleLoader, rootMouseArea.mouseX, rootMouseArea.mouseY))
+        readonly property bool isSelectorButtonHovered: rootMouseArea.containsMouse && root.enabled && selectorLoader.visible && selectorLoader.contains(rootMouseArea.mapToItem(selectorLoader, rootMouseArea.mouseX, rootMouseArea.mouseY))
     }
 
     RowLayout {
@@ -121,7 +121,7 @@ Item {
                     states: [
                         State {
                             name: "PRESSED"
-                            when: activityButton.mouseArea.pressed
+                            when: activityButton.mouseArea.pressed && activityButton.enabled
 
                             PropertyChanges {
                                 target: activityButtonBackground
@@ -131,7 +131,7 @@ Item {
 
                         State {
                             name: "HOVERED"
-                            when: !activityButton.mouseArea.pressed && prv.isActivityButtonHovered
+                            when: !activityButton.mouseArea.pressed && activityButton.enabled && prv.isActivityButtonHovered
 
                             PropertyChanges {
                                 target: activityButtonBackground
@@ -208,7 +208,7 @@ Item {
 
                         State {
                             name: "PRESSED"
-                            when: titleButton.mouseArea.pressed
+                            when: titleButton.mouseArea.pressed && titleButton.enabled
 
                             PropertyChanges {
                                 target: titleButtonBackground
@@ -218,7 +218,7 @@ Item {
 
                         State {
                             name: "HOVERED"
-                            when: !titleButton.mouseArea.pressed && prv.isTitleButtonHovered
+                            when: !titleButton.mouseArea.pressed && titleButton.enabled && prv.isTitleButtonHovered
 
                             PropertyChanges {
                                 target: titleButtonBackground
@@ -295,7 +295,7 @@ Item {
                     states: [
                         State {
                             name: "PRESSED"
-                            when: menuButton.mouseArea.pressed || menuLoader.isMenuOpened
+                            when: (menuButton.mouseArea.pressed && menuButton.enabled) || menuLoader.isMenuOpened
 
                             PropertyChanges {
                                 target: menuButtonBackground
@@ -305,7 +305,7 @@ Item {
 
                         State {
                             name: "HOVERED"
-                            when: !menuButton.mouseArea.pressed && prv.isSelectorButtonHovered
+                            when: !menuButton.mouseArea.pressed && menuButton.enabled && prv.isSelectorButtonHovered
 
                             PropertyChanges {
                                 target: menuButtonBackground
@@ -368,7 +368,6 @@ Item {
         id: rootMouseArea
         anchors.fill: parent
 
-        enabled: parent.enabled
         acceptedButtons: Qt.NoButton
         hoverEnabled: true
     }

--- a/src/playback/qml/MuseScore/Playback/internal/AuxSendControl.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/AuxSendControl.qml
@@ -80,7 +80,7 @@ Item {
         FlatButton {
             id: bypassBtn
 
-            readonly property bool isHovering: bypassBtn.mouseArea.containsMouse
+            readonly property bool isHovering: bypassBtn.mouseArea.containsMouse && bypassBtn.enabled
 
             Layout.fillWidth: true
             Layout.preferredHeight: audioSignalAmountKnob.backgroundHeight
@@ -96,7 +96,7 @@ Item {
             }
 
             text: {
-                if (audioSignalAmountKnob.mouseArea.pressed) {
+                if (audioSignalAmountKnob.mouseArea.pressed && audioSignalAmountKnob.enabled) {
                     return audioSignalAmountKnob.value + "%"
                 }
 

--- a/src/playback/qml/MuseScore/Playback/internal/MixerTitleSection.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/MixerTitleSection.qml
@@ -79,7 +79,6 @@ MixerPanelSection {
             id: mouseArea
             anchors.fill: parent
 
-            enabled: parent.enabled
             hoverEnabled: true
 
             onContainsMouseChanged: {

--- a/src/project/qml/MuseScore/Project/internal/ScoresPage/CloudScoreIndicatorButton.qml
+++ b/src/project/qml/MuseScore/Project/internal/ScoresPage/CloudScoreIndicatorButton.qml
@@ -95,7 +95,7 @@ Item {
 
         State {
             name: "pressed"
-            when: mouseArea.pressed
+            when: mouseArea.pressed && root.enabled
 
             PropertyChanges {
                 target: foreground
@@ -107,7 +107,7 @@ Item {
 
         State {
             name: "hovered"
-            when: mouseArea.containsMouse && !mouseArea.pressed
+            when: mouseArea.containsMouse && !mouseArea.pressed && root.enabled
 
             PropertyChanges {
                 target: foreground
@@ -154,7 +154,6 @@ Item {
         id: mouseArea
         anchors.fill: root
 
-        enabled: root.enabled
         hoverEnabled: true
 
         onContainsMouseChanged: {

--- a/src/project/qml/MuseScore/Project/internal/ScoresPage/ScoreGridItem.qml
+++ b/src/project/qml/MuseScore/Project/internal/ScoresPage/ScoreGridItem.qml
@@ -65,7 +65,6 @@ FocusScope {
         id: mouseArea
         anchors.fill: parent
 
-        enabled: root.enabled
         hoverEnabled: true
 
         onClicked: {
@@ -137,7 +136,7 @@ FocusScope {
                 states: [
                     State {
                         name: "NORMAL"
-                        when: !mouseArea.containsMouse && !mouseArea.pressed
+                        when: (!mouseArea.containsMouse && !mouseArea.pressed) || !root.enabled
 
                         PropertyChanges {
                             target: thumbnail
@@ -147,7 +146,7 @@ FocusScope {
 
                     State {
                         name: "HOVERED"
-                        when: mouseArea.containsMouse && !mouseArea.pressed
+                        when: mouseArea.containsMouse && !mouseArea.pressed && root.enabled
 
                         PropertyChanges {
                             target: thumbnail
@@ -158,7 +157,7 @@ FocusScope {
 
                     State {
                         name: "PRESSED"
-                        when: mouseArea.pressed
+                        when: mouseArea.pressed && root.enabled
 
                         PropertyChanges {
                             target: thumbnail


### PR DESCRIPTION
Resolves: #26645
Partially resolves #26232: tooltips on disabled controls will appear when those are hovered.

Supersedes [PR#26671](https://github.com/musescore/MuseScore/pull/26671) which became a mess after rebasing.

**Key points:**

1. Added `&& root.enabled` to the condition for the "HOVERED" and "PRESSED" states.
2. Removed `enabled: root.enabled` from the MouseArea-s since it has side effects. See below.
3. For [#26232](https://github.com/musescore/MuseScore/issues/26232) we want shortcuts on disabled controls to work again so I didn't add `&& root.enabled` in the various `onContainsMouseChanged` handlers.

Disabling the MouseArea together with a button has side effects when the button is disabled upon its own click. This is the case with the Undo and Redo buttons when there are no more actions to undo/redo. In particular `containsMouse` and `pressed` of the MouseArea remain `true` when the button and its MouseArea get disabled. This means that the "HOVERED" state will remain active. This could be worked around by adding `&& mouseArea.enabled` to the condition of the "HOVERED" state.

However, there is more: `containsMouse` will continue to be `true` even if the mouse then leaves the now disabled button. Let's say this is the Undo button and it becomes disabled on click since there are no more actions to undo. The user moves the mouse away from it and over the Redo button. `containsMouse` of the Undo button's MouseArea continues to be `true` since both the button and the MouseArea are now disabled and the MouseArea does not react to any mouse events any more. If the Redo button is now clicked, this will re-enable the Undo button and its MouseArea. The Undo button's "HOVERED" state will fire even though the mouse is hovering the Redo button.

The conclusion we (Casper and I) came to is we should not be disabling the MouseArea. Instead we should be checking root.Enabled where necessary. This also mkes tooltips on disabled controls appear again on hover: [#26232](https://github.com/musescore/MuseScore/issues/26232).

The disabling of the MouseArea-s was done for #25697.

Commit 1 fixes the hover state specifically for the Undo/Redo buttons (this story).
Commit 2 takes care of the other controls.

I have tested what I could.
**QA: #25697 will have to be retested.**

TBH, I find it a bit clumsy having to check `root.enabled` every time but adding a new property to the MouseArea-s - something like `isHovered: containsMouse && parent.enabled` - isn't good enough either because I am sure everyone is used to the traditional properties of the MouseArea...

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
