### PR TITLE
27297: Stop false error in the logs about not being able to check for an update

### DIFF
--- a/src/framework/update/internal/updatescenario.cpp
+++ b/src/framework/update/internal/updatescenario.cpp
@@ -73,18 +73,18 @@ void UpdateScenario::doCheckForUpdate(bool manual)
             m_checkProgress = false;
         };
 
-        if (!res.ret) {
+        bool noUpdate = res.ret.code() == static_cast<int>(Err::NoUpdate);
+        if (!noUpdate && !res.ret) {
             LOGE() << "Unable to check for update, error: " << res.ret.toString();
 
             if (manual) {
-                processUpdateResult(res.ret.code());
+                showServerErrorMsg();
             }
 
             return;
         }
 
         ReleaseInfo info = releaseInfoFromValMap(res.val.toMap());
-        bool noUpdate = res.ret.code() == static_cast<int>(Err::NoUpdate);
         if (!manual) {
             bool shouldIgnoreUpdate = info.version == configuration()->skippedReleaseVersion();
             if (noUpdate || shouldIgnoreUpdate) {


### PR DESCRIPTION
Resolves: #27297 

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
