### PR TITLE
Remove superfluous %n from translatable strings

### DIFF
--- a/src/instrumentsscene/view/layoutpaneltreemodel.cpp
+++ b/src/instrumentsscene/view/layoutpaneltreemodel.cpp
@@ -980,17 +980,10 @@ bool LayoutPanelTreeModel::warnAboutRemovingInstrumentsIfNecessary(int count)
     }
 
     return interactive()->warning(
-        //: Please omit `%n` in the translation in this case; it's only there so that you
-        //: have the possibility to provide translations with the correct numerus form,
-        //: i.e. to show "instrument" or "instruments" as appropriate.
-        muse::trc("layoutpanel", "Are you sure you want to delete the selected %n instrument(s)?", nullptr, count),
-
-        //: Please omit `%n` in the translation in this case; it's only there so that you
-        //: have the possibility to provide translations with the correct numerus form,
-        //: i.e. to show "instrument" or "instruments" as appropriate.
-        muse::trc("layoutpanel", "This will remove the %n instrument(s) from the full score and all part scores.", nullptr, count),
-
-        { IInteractive::Button::No, IInteractive::Button::Yes })
+        muse::trc("layoutpanel", "Are you sure you want to delete the selected instrument(s)?", nullptr, count),
+        muse::trc("layoutpanel", "This will remove the instrument(s) from the full score and all part scores.", nullptr, count),
+        { IInteractive::Button::No, IInteractive::Button::Yes }
+        )
            .standardButton() == IInteractive::Button::Yes;
 }
 


### PR DESCRIPTION
It was there only to ensure that the strings would correctly be picked up as "numerus" strings (i.e. with separate cases for singular, plural, etc.), but as proven in https://github.com/musescore/MuseScore/pull/27236, that is not necessary (anymore).