### PR TITLE
Fix #15726 (Voltas): Some elements are lost when changing time signature

### DIFF
--- a/src/engraving/dom/range.cpp
+++ b/src/engraving/dom/range.cpp
@@ -36,6 +36,7 @@
 #include "slur.h"
 #include "staff.h"
 #include "tie.h"
+#include "volta.h"
 
 #include "tremolosinglechord.h"
 #include "tremolotwochord.h"
@@ -714,6 +715,62 @@ void ScoreRange::read(Segment* first, Segment* last, bool readSpanner)
 }
 
 //---------------------------------------------------------
+//   restoreVolta
+//---------------------------------------------------------
+
+void ScoreRange::restoreVolta(Score* score, const Fraction& tick, Volta* v) const
+{
+    bool voltaStartOK = false;
+    bool voltaEndOK = false;
+    Fraction measureSize;
+
+    if (v->voltaType() == Volta::Type::OPEN) {
+        voltaEndOK = true;
+    }
+
+    // Check if we should keep this volta
+    for (Measure* m = score->tick2measure(tick); m; m = m->nextMeasure()) {
+        if (m->tick() == (v->tick() + tick)) {
+            voltaStartOK = true;
+            measureSize = m->endTick() - m->tick();
+        }
+        if (m->endTick() == (v->tick2() + tick)) {
+            voltaEndOK = true;
+            // No need to continue looking for
+            break;
+        }
+        // Last Measure
+        if (m->sectionBreak() || (m->nextMeasure() && (m->nextMeasure()->first(SegmentType::TimeSig)))) {
+            break;
+        }
+    }
+    bool shouldKeepVolta = voltaStartOK && voltaEndOK;
+
+    if (shouldKeepVolta) {
+        // Volta start
+        v->setTick(v->tick() + tick);
+
+        // Review Volta endings with open Voltas
+        if (v->voltaType() == Volta::Type::OPEN) {
+            Fraction voltaFormerTicks = v->ticks();
+            Fraction voltaNewTicks = voltaFormerTicks;
+
+            if (voltaFormerTicks < measureSize) {
+                voltaNewTicks = measureSize;
+            } else if (voltaFormerTicks > measureSize) {
+                if ((voltaFormerTicks / measureSize).reduced().denominator() != 1) {
+                    voltaNewTicks = (std::floor((voltaFormerTicks / measureSize).toDouble()) + 1) * measureSize;
+                }
+            }
+            if (voltaFormerTicks != voltaNewTicks) {
+                v->setTicks(voltaNewTicks);
+            }
+        }
+        score->undoAddElement(v);
+    }
+}
+
+//---------------------------------------------------------
 //   write
 //---------------------------------------------------------
 
@@ -742,23 +799,27 @@ bool ScoreRange::write(Score* score, const Fraction& tick) const
         ++track;
     }
     for (Spanner* s : m_spanner) {
-        s->setTick(s->tick() + tick);
-        if (s->isSlur()) {
-            Slur* slur = toSlur(s);
-            if (slur->startCR() && slur->startCR()->isGrace()) {
-                Chord* sc = slur->startChord();
-                size_t idx = sc->graceIndex();
-                Chord* dc = toChord(score->findCR(s->tick(), s->track()));
-                s->setStartElement(dc->graceNotes()[idx]);
+        if (s->isVolta()) {
+            restoreVolta(score, tick, toVolta(s));
+        } else {
+            s->setTick(s->tick() + tick);
+            if (s->isSlur()) {
+                Slur* slur = toSlur(s);
+                if (slur->startCR() && slur->startCR()->isGrace()) {
+                    Chord* sc = slur->startChord();
+                    size_t idx = sc->graceIndex();
+                    Chord* dc = toChord(score->findCR(s->tick(), s->track()));
+                    s->setStartElement(dc->graceNotes()[idx]);
+                }
+                if (slur->endCR() && slur->endCR()->isGrace()) {
+                    Chord* sc = slur->endChord();
+                    size_t idx = sc->graceIndex();
+                    Chord* dc = toChord(score->findCR(s->tick2(), s->track2()));
+                    s->setEndElement(dc->graceNotes()[idx]);
+                }
             }
-            if (slur->endCR() && slur->endCR()->isGrace()) {
-                Chord* sc = slur->endChord();
-                size_t idx = sc->graceIndex();
-                Chord* dc = toChord(score->findCR(s->tick2(), s->track2()));
-                s->setEndElement(dc->graceNotes()[idx]);
-            }
+            score->undoAddElement(s);
         }
-        score->undoAddElement(s);
     }
     for (const Annotation& a : m_annotations) {
         Measure* tm = score->tick2measure(a.tick);

--- a/src/engraving/dom/range.h
+++ b/src/engraving/dom/range.h
@@ -40,6 +40,7 @@ class Spanner;
 class ScoreRange;
 class ChordRest;
 class Score;
+class Volta;
 
 //---------------------------------------------------------
 //   TrackList
@@ -109,6 +110,7 @@ protected:
     std::list<Annotation> m_annotations;
 
 private:
+    void restoreVolta(Score* score, const Fraction& tick, Volta* v) const;
 
     friend class TrackList;
 


### PR DESCRIPTION
Resolves: #15726 (Voltas) <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
This PR:
- Avoid restoring Voltas that doesn't fit with new measure size after changing time signature
- Changes Voltas length to adapt to new measure size when necessary

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
