### PR TITLE
Fix #26387: Style dialog's left sidebar resizes unexpectedly when clicking certain pages

### DIFF
--- a/src/notation/view/widgets/editstyle.cpp
+++ b/src/notation/view/widgets/editstyle.cpp
@@ -1467,14 +1467,6 @@ void EditStyle::adjustPagesStackSize(int currentPageIndex)
 {
     QSize preferredSize = pageStack->widget(currentPageIndex)->sizeHint();
     pageStack->setMinimumSize(preferredSize);
-
-    connect(pageStack, &QStackedWidget::currentChanged, this, [this](int currentIndex) {
-        QWidget* currentPage = pageStack->widget(currentIndex);
-        if (!currentPage) {
-            return;
-        }
-        pageStack->setMinimumSize(currentPage->sizeHint());
-    });
 }
 
 EditStyle::WidgetAndView EditStyle::createQmlWidget(QWidget* parent, const QUrl& source)

--- a/src/notation/view/widgets/editstyle.ui
+++ b/src/notation/view/widgets/editstyle.ui
@@ -10164,31 +10164,74 @@
       <widget class="QWidget" name="PageGlissNoteLines">
        <layout class="QVBoxLayout" name="verticalLayout_691">
         <item>
-         <widget class="QGroupBox" name="groupBox_glissando">
-          <property name="accessibleName">
-           <string>Glissandos</string>
+         <widget class="QScrollArea" name="scrollArea_5">
+          <property name="widgetResizable">
+           <bool>true</bool>
           </property>
-          <property name="title">
-           <string>Glissandos</string>
-          </property>
-          <layout class="QGridLayout" name="gridLayout0_2"/>
-         </widget>
-        </item>
-        <item>
-         <widget class="QGroupBox" name="groupBox_noteline">
-          <property name="accessibleName">
-           <string>Note-anchored lines</string>
-          </property>
-          <property name="title">
-           <string>Note-anchored lines</string>
-          </property>
-          <layout class="QGridLayout" name="gridLayout0_3"/>
+          <widget class="QWidget" name="scrollAreaWidgetContents_6">
+           <property name="geometry">
+            <rect>
+             <x>0</x>
+             <y>0</y>
+             <width>651</width>
+             <height>354</height>
+            </rect>
+           </property>
+           <layout class="QVBoxLayout" name="verticalLayout_59">
+            <item>
+             <widget class="QGroupBox" name="groupBox_glissando">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>627</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="accessibleName">
+               <string>Glissandos</string>
+              </property>
+              <property name="title">
+               <string>Glissandos</string>
+              </property>
+              <layout class="QGridLayout" name="gridLayout0_2"/>
+             </widget>
+            </item>
+            <item>
+             <widget class="QGroupBox" name="groupBox_noteline">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>627</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="accessibleName">
+               <string>Note-anchored lines</string>
+              </property>
+              <property name="title">
+               <string>Note-anchored lines</string>
+              </property>
+              <layout class="QGridLayout" name="gridLayout0_3"/>
+             </widget>
+            </item>
+           </layout>
+          </widget>
          </widget>
         </item>
         <item>
          <spacer name="verticalSpacer_39">
           <property name="orientation">
-           <enum>Qt::Vertical</enum>
+           <enum>Qt::Orientation::Vertical</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -14155,18 +14198,24 @@ first note of the system</string>
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>98</width>
-             <height>28</height>
+             <width>651</width>
+             <height>744</height>
             </rect>
            </property>
-           <layout class="QHBoxLayout" name="horizontalLayout_3">
+           <layout class="QVBoxLayout" name="verticalLayout_60">
             <item>
              <widget class="QWidget" name="fretboardsWidget" native="true">
               <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+               <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
                 <horstretch>0</horstretch>
                 <verstretch>0</verstretch>
                </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>470</width>
+                <height>0</height>
+               </size>
               </property>
               <property name="palette">
                <palette>

--- a/src/notation/view/widgets/editstyle.ui
+++ b/src/notation/view/widgets/editstyle.ui
@@ -14198,15 +14198,15 @@ first note of the system</string>
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>651</width>
-             <height>744</height>
+             <width>98</width>
+             <height>28</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_60">
             <item>
              <widget class="QWidget" name="fretboardsWidget" native="true">
               <property name="sizePolicy">
-               <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+               <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
                 <horstretch>0</horstretch>
                 <verstretch>0</verstretch>
                </sizepolicy>


### PR DESCRIPTION
Resolves: #26387

In the Style Dialog, clicking certain pages caused the left sidebar to resize unexpectedly.
This was due to a `connect` inside `EditStyle::adjustPagesStackSize()` that updated `setMinimumSize()` every time a new page was selected from the pageList, leading to unwanted horizontal shifts.
I removed this `connect`, which stopped the unexpected movement of the scroll bar.

However, I then noticed that some pages became unusable when the vertical scroll bar was dragged too far to the right because their buttons were positioned beyond the visible area of the dialog.
To fix this, I added QScrollAreas to those pages (*Glissandos & note-anchored lines*, *Fretboard diagrams*) to ensure all elements remained accessible.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
