### PR TITLE
Don't duplicate linked spanners on rewrite measures

### DIFF
--- a/src/engraving/dom/range.cpp
+++ b/src/engraving/dom/range.cpp
@@ -297,6 +297,10 @@ void TrackList::read(const Segment* fs, const Segment* es)
         EngravingItem* e = s->element(m_track);
         if (!e || e->generated()) {
             for (EngravingItem* ee : s->annotations()) {
+                if (ee->systemFlag() && ee->track() != 0) {
+                    // Only process the top system object
+                    continue;
+                }
                 if (ee->track() == m_track) {
                     m_range->m_annotations.push_back({ s->tick(), ee->clone() });
                 }

--- a/src/engraving/dom/range.cpp
+++ b/src/engraving/dom/range.cpp
@@ -691,6 +691,11 @@ void ScoreRange::read(Segment* first, Segment* last, bool readSpanner)
         Fraction etick = last->tick();
         for (auto i : first->score()->spanner()) {
             Spanner* s = i.second;
+            if (s->systemFlag() && s->track() != 0) {
+                // Only process the top system object
+                continue;
+            }
+
             if (s->tick() >= stick && s->tick() < etick && s->track() >= startTrack && s->track() < endTrack) {
                 Spanner* ns = toSpanner(s->clone());
                 ns->resetExplicitParent();


### PR DESCRIPTION
Resolves: #27228 
Resolves: #27400 

When a time signature is changed, we effectively delete and recreate the affected part of the score to create the new measure subdivision. This is already quite strange to me, cause I don't see why we couldn't work with the existing list of segments and just rearrange it.

As part of this rewriting process, all the affected spanners are removed and readded to score. This makes even less sense to me, given that spanners are defined by a starting tick and a duration which are independent from the underlying notation. Specifically, the duplication happenes because we are readding all the copies of the system object lines, but the score already takes care of making those copies (as it should) via the linking infrastructure, so we end up with more copies than needed.

~~This PR avoids removing/readding the spanners, and just performs the change of `tick` and `ticks` property, which anyway seemed to be the only relevant change made to the spanners themselves.~~

EDIT: That made sense, but of course it doesn't seem to work in some cases (hence the failing unit tests) because there are 20 separate bits of code making changes to these spanners which I'm currently unable to untangle (and would be likely too big of a work for a patch anyway). So I've tried the simpler solution of just keeping track of the linked spanners to avoid duplications. Hope this works.