### PR TITLE
Improve performance of identifying jump items

### DIFF
--- a/src/engraving/dom/chordrest.cpp
+++ b/src/engraving/dom/chordrest.cpp
@@ -1303,7 +1303,7 @@ bool ChordRest::hasFollowingJumpItem() const
         return false;
     }
 
-    if (measure->lastChordRest(track()) != this) {
+    if (endTick() != measure->endTick()) {
         return false;
     }
 
@@ -1318,7 +1318,7 @@ bool ChordRest::hasPrecedingJumpItem() const
     const Segment* seg = segment();
     const Measure* measure = seg->measure();
 
-    if (measure->firstChordRest(track()) != this) {
+    if (tick() != measure->tick()) {
         return false;
     }
 

--- a/src/engraving/dom/chordrest.cpp
+++ b/src/engraving/dom/chordrest.cpp
@@ -1302,62 +1302,19 @@ bool ChordRest::hasFollowingJumpItem() const
     if (!measure) {
         return false;
     }
-    const Fraction nextTick = seg->tick() + actualTicks();
 
     if (measure->lastChordRest(track()) != this) {
         return false;
     }
 
-    // Jumps & markers
-    for (const EngravingItem* e : measure->el()) {
-        if (!e->isJump() && !e->isMarker()) {
-            continue;
-        }
+    std::vector<Measure*> followingRepeatMeasures = findFollowingRepeatMeasures(measure);
 
-        if (e->isJump()) {
-            return true;
-        }
-
-        const Marker* marker = toMarker(e);
-
-        if (marker->isRightMarker()) {
-            return true;
-        }
-    }
-
-    // Voltas
-    auto spanners = score()->spannerMap().findOverlapping(measure->endTick().ticks(), measure->endTick().ticks());
-    for (auto& spanner : spanners) {
-        if (!spanner.value->isVolta() || Fraction::fromTicks(spanner.start) != nextTick) {
-            continue;
-        }
-
-        return true;
-    }
-
-    // Repeats
-    if (measure->repeatEnd()) {
-        return true;
-    }
-
-    for (Segment* nextSeg = seg->next(SegmentType::BarLineType); nextSeg && nextSeg->tick() == nextTick;
-         nextSeg = nextSeg->next(SegmentType::BarLineType)) {
-        const EngravingItem* el = nextSeg->element(track());
-        if (!el || !el->isBarLine()) {
-            continue;
-        }
-        const BarLine* bl = toBarLine(el);
-
-        if (bl->barLineType() & (BarLineType::END_REPEAT | BarLineType::END_START_REPEAT)) {
-            return true;
-        }
-    }
-
-    return false;
+    return !followingRepeatMeasures.empty();
 }
 
 bool ChordRest::hasPrecedingJumpItem() const
 {
+    TRACEFUNC;
     const Segment* seg = segment();
     const Measure* measure = seg->measure();
 
@@ -1365,52 +1322,8 @@ bool ChordRest::hasPrecedingJumpItem() const
         return false;
     }
 
-    if (seg->score()->firstSegment(SegmentType::ChordRest) == seg) {
-        return true;
-    }
+    std::vector<Measure*> precedingRepeatMeasures = findPreviousRepeatMeasures(measure);
 
-    // Markers
-    for (const EngravingItem* e : measure->el()) {
-        if (!e->isMarker()) {
-            continue;
-        }
-
-        const Marker* marker = toMarker(e);
-        if (marker->isRightMarker()) {
-            continue;
-        }
-
-        return true;
-    }
-
-    // Voltas
-    auto spanners = score()->spannerMap().findOverlapping(measure->tick().ticks(), measure->tick().ticks());
-    for (auto& spanner : spanners) {
-        if (!spanner.value->isVolta() || Fraction::fromTicks(spanner.start) != tick() || toVolta(spanner.value)->isFirstVolta()) {
-            continue;
-        }
-
-        return true;
-    }
-
-    // Repeat barlines
-    if (measure->repeatStart()) {
-        return true;
-    }
-
-    for (Segment* prevSeg = seg->prev(SegmentType::BarLineType); prevSeg && prevSeg->tick() == seg->tick();
-         prevSeg = prevSeg->prev(SegmentType::BarLineType)) {
-        EngravingItem* el = prevSeg->element(track());
-        if (!el || !el->isBarLine()) {
-            continue;
-        }
-
-        BarLine* bl = toBarLine(el);
-        if (bl->barLineType() & (BarLineType::START_REPEAT | BarLineType::END_START_REPEAT)) {
-            return true;
-        }
-    }
-
-    return false;
+    return !precedingRepeatMeasures.empty();
 }
 }

--- a/src/engraving/dom/utils.h
+++ b/src/engraving/dom/utils.h
@@ -73,7 +73,6 @@ extern Note* prevChordNote(Note* note);
 extern Segment* nextSeg1(Segment* s);
 extern Segment* prevSeg1(Segment* seg);
 
-extern Volta* findVolta(const Segment* seg, const Score* score);
 extern Note* searchTieNote(const Note* note, const Segment* nextSegment = nullptr, const bool disableOverRepeats = true);
 extern Note* searchTieNote114(Note* note);
 


### PR DESCRIPTION
This PR replaces a more complex set of checks to see if a `ChordRest` is followed by a repeat item with simply checking against the score's repeat structure.
I was trying to avoid forcing the score to update its repeat structure more often than was necessary. What I hadn't factored in was updating the score's spanner map. Calls to `SpannerMap::findOverlapping` were updating the whole spanner map very frequently, leading to a large impact in performance. 
While the new solution does regenerate the score's repeat structure more often than before, this is a much faster operation - there will usually be fewer repeat sections than spanners in a score. Testing on the Beethoven 9 score in release mode:

|   | NotationProject::load(ms) | Score::doLayoutRange(ms) | hasFollowingJumpItem(ms) | hasPrecedingJumpItem(ms) |
| ------------- | ------------- | ------------- | ------------- | ------------- | 
| Before PR 1  | 40990.274 | 28402.757 | 7253.991 | 366.372 |
| Before PR 2 | 40205.233  | 28287.846 | 6874.989 | 370.329 | 
| After PR 1 | 36470.430 | 28058.989 | 1851.505 | 14.313 | 
| After PR 2 | 36806.955 | 28424.238 | 1815.317 | 16.000 | 


The second commit makes similar changes to `segmentsAreAdjacentInRepeatStructure`. The performance improvements for this measure are as follows:
`Before PR 1   0.769 ms    5491    4220.364 ms`
`Before PR 2   0.795 ms    5491    4367.959 ms`
`After PR  1   0.001 ms    5491    2.873 ms`
`After PR  2   0.002 ms    5491    10.280 ms`

Also:
Resolves: #27303
