### PR TITLE
Reduce the step width of the scaling value in Page settings dialog

### DIFF
--- a/src/notation/view/widgets/pagesettings.cpp
+++ b/src/notation/view/widgets/pagesettings.cpp
@@ -165,11 +165,11 @@ void PageSettings::updateValues()
     if (mm) {
         suffix = "mm";
         singleStepSize = 1.0;
-        singleStepScale = 0.2;
+        singleStepScale = 0.05;
     } else {
         suffix = "in";
         singleStepSize = 0.05;
-        singleStepScale = 0.005;
+        singleStepScale = 0.002;
     }
     for (auto w : { oddPageTopMargin, oddPageBottomMargin, oddPageLeftMargin, oddPageRightMargin, evenPageTopMargin,
                     evenPageBottomMargin, evenPageLeftMargin, evenPageRightMargin, spatiumEntry, pageWidth, pageHeight }) {


### PR DESCRIPTION
the current value of 0.2 mm seems to be too large, so changing to 0.05 mm and 0.002 inch, which is almost the same.