### PR TITLE
Fix #27335: VST window doesn't close after replacing with a new one (VSTi and VSTe)

### DIFF
--- a/src/playback/view/internal/abstractaudioresourceitem.cpp
+++ b/src/playback/view/internal/abstractaudioresourceitem.cpp
@@ -20,9 +20,7 @@ AbstractAudioResourceItem::AbstractAudioResourceItem(QObject* parent)
 
 AbstractAudioResourceItem::~AbstractAudioResourceItem()
 {
-    if (m_editorAction.isValid()) {
-        emit nativeEditorViewCloseRequested();
-    }
+    requestToCloseNativeEditorView();
 }
 
 void AbstractAudioResourceItem::requestToLaunchNativeEditorView()
@@ -32,11 +30,9 @@ void AbstractAudioResourceItem::requestToLaunchNativeEditorView()
     }
 }
 
-void AbstractAudioResourceItem::updateNativeEditorView()
+void AbstractAudioResourceItem::requestToCloseNativeEditorView()
 {
-    if (hasNativeEditorSupport()) {
-        doRequestToLaunchNativeEditorView();
-    } else if (m_editorAction.isValid()) {
+    if (m_editorAction.isValid()) {
         emit nativeEditorViewCloseRequested();
     }
 }

--- a/src/playback/view/internal/abstractaudioresourceitem.h
+++ b/src/playback/view/internal/abstractaudioresourceitem.h
@@ -44,8 +44,10 @@ public:
     explicit AbstractAudioResourceItem(QObject* parent);
     ~AbstractAudioResourceItem() override;
 
+    Q_INVOKABLE void requestToLaunchNativeEditorView();
+    void requestToCloseNativeEditorView();
+
     virtual Q_INVOKABLE void requestAvailableResources() {}
-    virtual Q_INVOKABLE void requestToLaunchNativeEditorView();
     virtual Q_INVOKABLE void handleMenuItem(const QString& menuItemId) { Q_UNUSED(menuItemId) }
 
     virtual QString title() const;
@@ -75,8 +77,6 @@ protected:
     QVariantMap buildExternalLinkMenuItem(const QString& menuId, const QString& title) const;
 
     void sortResourcesList(muse::audio::AudioResourceMetaList& list);
-
-    void updateNativeEditorView();
 
 private:
     void doRequestToLaunchNativeEditorView();

--- a/src/playback/view/internal/inputresourceitem.cpp
+++ b/src/playback/view/internal/inputresourceitem.cpp
@@ -147,6 +147,8 @@ void InputResourceItem::setParams(const audio::AudioInputParams& newParams)
 
 void InputResourceItem::setParamsRecourceMeta(const AudioResourceMeta& newMeta)
 {
+    requestToCloseNativeEditorView();
+
     m_currentInputParams.resourceMeta = newMeta;
 
     emit titleChanged();
@@ -154,7 +156,7 @@ void InputResourceItem::setParamsRecourceMeta(const AudioResourceMeta& newMeta)
     emit isActiveChanged();
     emit inputParamsChanged();
 
-    updateNativeEditorView();
+    requestToLaunchNativeEditorView();
 }
 
 QString InputResourceItem::title() const

--- a/src/playback/view/internal/outputresourceitem.cpp
+++ b/src/playback/view/internal/outputresourceitem.cpp
@@ -170,12 +170,14 @@ void OutputResourceItem::updateCurrentFxParams(const AudioResourceMeta& newMeta)
         return;
     }
 
+    requestToCloseNativeEditorView();
+
     audio::AudioFxParams newParams = m_currentFxParams;
     newParams.resourceMeta = newMeta;
     newParams.active = newMeta.isValid();
 
     setParams(newParams);
-    updateNativeEditorView();
+    requestToLaunchNativeEditorView();
 }
 
 void OutputResourceItem::updateAvailableFxVendorsMap(const audio::AudioResourceMetaList& availableFxResources)


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/27335