### PR TITLE
Fix Bass Viol (tablatur)

### DIFF
--- a/share/instruments/instruments.xml
+++ b/share/instruments/instruments.xml
@@ -14798,9 +14798,6 @@
                   <longName>Bass Viol</longName>
                   <shortName>B. Vl.</shortName>
                   <description>Bass viola da gamba (tablature). Third lowest member of the viol family.</description>
-                  <StringData>
-                        <frets>13</frets>
-                  </StringData>
                   <stafftype staffTypePreset="tab6StrFrench">tablature</stafftype>
                   <genre>earlymusic</genre>
             </Instrument>


### PR DESCRIPTION
See https://musescore.org/en/node/376843.
Seems to have errnously gotten introduced by #23203.

I know this is not the right way to fix this issue, hence submitted as a draft

The real fix is to empty https://docs.google.com/spreadsheets/d/1SwqZb8lq5rfv5regPSA10drWjUAoi65EuMoYtG-4k5s/edit?gid=516529997#gid=516529997&range=BF592
or to fill https://docs.google.com/spreadsheets/d/1SwqZb8lq5rfv5regPSA10drWjUAoi65EuMoYtG-4k5s/edit?gid=516529997#gid=516529997&range=BI592:BJ592 with the content of https://docs.google.com/spreadsheets/d/1SwqZb8lq5rfv5regPSA10drWjUAoi65EuMoYtG-4k5s/edit?gid=516529997#gid=516529997&range=BI591:BJ591
and in either case to build instruments.xml from that.
This PR emulates the former.

Seems an easy enough change to go into 4.5.2 too.