### PR TITLE
[MusicXML] Add support for accidental size

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
@@ -2871,6 +2871,11 @@ static void writeAccidental(XmlWriter& xml, const String& tagName, const Acciden
                     attrs.emplace_back(std::make_pair("placement", "below"));
                 }
             }
+            if (acc->isSmall()) {
+                // only set if the accidental is smaller than the notehead
+                const bool tiny = acc->note()->isSmall() || acc->note()->chord()->isSmall();
+                attrs.emplace_back(std::make_pair("size", tiny ? "grace-cue" : "cue"));
+            }
             addColorAttr(acc, attrs);
             xml.tag(AsciiStringView(tag.toStdString()), attrs, s);
         }

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlnotepitch.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlnotepitch.cpp
@@ -54,6 +54,7 @@ static Accidental* accidental(muse::XmlStreamReader& e, Score* score)
     const bool noParentheses = e.asciiAttribute("parentheses") == "no";
     const bool brackets = e.asciiAttribute("bracket") == "yes";
     const bool noBrackets = e.asciiAttribute("bracket") == "no";
+    const bool smallAccid = e.asciiAttribute("size") == "cue" || e.asciiAttribute("size") == "grace-cue";
     const Color accColor = Color(e.asciiAttribute("color").ascii());
     const String smufl = e.attribute("smufl");
 
@@ -75,6 +76,7 @@ static Accidental* accidental(muse::XmlStreamReader& e, Score* score)
         if (accColor.isValid()) {
             a->setColor(accColor);
         }
+        a->setSmall(smallAccid);
         return a;
     }
 

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -6741,6 +6741,8 @@ Note* MusicXmlParserPass2::note(const String& partId,
             // element handled
         } else if (mnd.readProperties(m_e)) {
             // element handled
+        } else if (m_e.name() == "accidental") {
+            m_e.skipCurrentElement();  // skip but don't log
         } else if (m_e.name() == "beam") {
             beamColor = Color::fromString(m_e.asciiAttribute("color").ascii());
             beamFan = m_e.attribute("fan");

--- a/src/importexport/musicxml/tests/data/testLayout.xml
+++ b/src/importexport/musicxml/tests/data/testLayout.xml
@@ -78,7 +78,7 @@
       </score-part>
     </part-list>
   <part id="P1">
-    <measure number="1" width="224.87">
+    <measure number="1" width="218.46">
       <print>
         <system-layout>
           <system-margins>
@@ -110,7 +110,7 @@
           <line>4</line>
           </clef>
         </attributes>
-      <note default-x="129.67" default-y="-10">
+      <note default-x="126.47" default-y="-10">
         <rest measure="yes"/>
         <duration>4</duration>
         <voice>1</voice>
@@ -142,7 +142,7 @@
           </direction-type>
         <staff>2</staff>
         </direction>
-      <note default-x="107.07" default-y="-115">
+      <note default-x="100.67" default-y="-115">
         <grace slash="yes"/>
         <pitch>
           <step>F</step>
@@ -151,11 +151,11 @@
           </pitch>
         <voice>5</voice>
         <type>eighth</type>
-        <accidental>sharp</accidental>
+        <accidental size="cue">sharp</accidental>
         <stem>up</stem>
         <staff>2</staff>
         </note>
-      <note default-x="127.2" default-y="-110">
+      <note default-x="120.79" default-y="-110">
         <pitch>
           <step>G</step>
           <octave>4</octave>
@@ -166,7 +166,7 @@
         <stem>down</stem>
         <staff>2</staff>
         </note>
-      <note default-x="154.19" default-y="-135">
+      <note default-x="147.78" default-y="-135">
         <pitch>
           <step>B</step>
           <octave>3</octave>
@@ -183,7 +183,7 @@
           </direction-type>
         <staff>2</staff>
         </direction>
-      <note default-x="181.18" default-y="-125">
+      <note default-x="174.77" default-y="-125">
         <pitch>
           <step>D</step>
           <octave>3</octave>


### PR DESCRIPTION
This PR adds import/export of accidental size to the MusicXML support. 

NB: `size` is only written, if the accidental is _smaller_ than its respective notehead.