### PR TITLE
Fix #25973 reset page number when resetting page settings

### DIFF
--- a/src/notation/view/widgets/pagesettings.cpp
+++ b/src/notation/view/widgets/pagesettings.cpp
@@ -265,6 +265,8 @@ void PageSettings::on_resetPageStyleButton_clicked()
         globalContext()->currentNotation()->style()->resetStyleValue(styleId);
     }
 
+    pageOffsetEntry->setValue(1);
+
     updateValues();
 }
 


### PR DESCRIPTION
Resetting all page settings to default wasn't resetting the first page number. Fixed this issue by setting the index of the first page to 1 when resetting a page to default.

Resolves: #25973 

When resetting all page settings to default, it was only resetting the values of the buttons in inches and nowhere in the code did it reset the page index number. I added the code that resets the page number to 1 when clicking the "reset all page settings to default" to fix this issue.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
