### PR TITLE
Fix #27106: New panels appearing undocked [4.5.2 port]

### DIFF
--- a/src/framework/dockwindow/view/dockwindow.cpp
+++ b/src/framework/dockwindow/view/dockwindow.cpp
@@ -30,7 +30,6 @@
 
 #include "dockcentralview.h"
 #include "dockpageview.h"
-#include "dockpanelview.h"
 #include "dockstatusbarview.h"
 #include "docktoolbarview.h"
 #include "dockingholderview.h"
@@ -367,23 +366,8 @@ void DockWindow::loadPanels(const DockPageView* page)
 {
     TRACEFUNC;
 
-    auto addPanel = [this, page](DockPanelView* panel, Location location) {
-        for (DockPanelView* destinationPanel : page->panels()) {
-            if (panel->isVisible() && destinationPanel->isTabAllowed(panel)) {
-                registerDock(panel);
-
-                destinationPanel->addPanelAsTab(panel);
-                destinationPanel->setCurrentTabIndex(0);
-
-                return;
-            }
-        }
-
-        addDock(panel, location);
-    };
-
     for (DockPanelView* panel : page->panels()) {
-        addPanel(panel, panel->location());
+        addPanel(page, panel, panel->location());
     }
 
     for (Location location : POSSIBLE_LOCATIONS) {
@@ -463,6 +447,21 @@ void DockWindow::addDock(DockBase* dock, Location location, const DockBase* rela
     m_mainWindow->addDockWidget(dock->dockWidget(), locationToKLocation(location), relativeDock, options);
 }
 
+void DockWindow::addPanel(const DockPageView* page, DockPanelView* panel, Location location, const DockBase* relativeTo)
+{
+    for (DockPanelView* destinationPanel : page->panels()) {
+        if (panel->isVisible() && destinationPanel->isTabAllowed(panel)) {
+            registerDock(panel);
+
+            destinationPanel->addPanelAsTab(panel);
+            destinationPanel->setCurrentTabIndex(0);
+
+            return;
+        }
+    }
+    addDock(panel, location, relativeTo);
+}
+
 void DockWindow::registerDock(DockBase* dock)
 {
     TRACEFUNC;
@@ -498,7 +497,7 @@ bool DockWindow::doLoadPage(const QString& uri, const QVariantMap& params)
     }
 
     loadPageContent(newPage);
-    restorePageState(newPage->objectName());
+    restorePageState(newPage);
     initDocks(newPage);
 
     newPage->setParams(params);
@@ -547,16 +546,39 @@ void DockWindow::savePageState(const QString& pageName)
     m_reloadCurrentPageAllowed = true;
 }
 
-void DockWindow::restorePageState(const QString& pageName)
+void DockWindow::restorePageState(const DockPageView* page)
 {
     TRACEFUNC;
 
+    const QString& pageName = page->objectName();
+
     ValNt<QByteArray> pageStateValNt = uiConfiguration()->pageState(pageName);
+    const bool layoutIsEmpty = pageStateValNt.val.isEmpty();
+
+    QSet<DockBase*> unknownDocks;
+    if (!layoutIsEmpty) {
+        for (DockBase* dock : page->allDocks()) {
+            const KDDockWidgets::DockWidgetBase* dockWidget = dock->dockWidget();
+            if (!pageStateValNt.val.contains(dockWidget->uniqueName().toLocal8Bit())) {
+                unknownDocks.insert(dock);
+            }
+        }
+    }
 
     /// NOTE: Do not restore geometry
     bool ok = restoreLayout(pageStateValNt.val, true /*restoreRelativeToMainWindow*/);
     if (!ok) {
         LOGE() << "Could not restore the state of " << pageName << "!";
+    }
+
+    if (!layoutIsEmpty) {
+        for (DockBase* dock : unknownDocks) {
+            if (DockPanelView* panel = dynamic_cast<DockPanelView*>(dock)) {
+                addPanel(page, panel, panel->location(), page->centralDock());
+                continue;
+            }
+            addDock(dock, dock->location(), page->centralDock());
+        }
     }
 
     if (!pageStateValNt.notification.isConnected()) {

--- a/src/framework/dockwindow/view/dockwindow.h
+++ b/src/framework/dockwindow/view/dockwindow.h
@@ -117,9 +117,13 @@ private:
     void loadTopLevelToolBars(const DockPageView* page);
     void alignTopLevelToolBars(const DockPageView* page);
 
+    DockPanelView* findDestinationForPanel(const DockPageView* page, const DockPanelView* panel) const;
+
     void addDock(DockBase* dock, Location location = Location::Left, const DockBase* relativeTo = nullptr);
-    void addPanel(const DockPageView* page, DockPanelView* panel, Location location, const DockBase* relativeTo = nullptr);
+    void addPanelAsTab(DockPanelView* panel, DockPanelView* destinationPanel);
     void registerDock(DockBase* dock);
+
+    void handleUnknownDock(const DockPageView* page, DockBase* unknownDock);
 
     void saveGeometry();
     void restoreGeometry();

--- a/src/framework/dockwindow/view/dockwindow.h
+++ b/src/framework/dockwindow/view/dockwindow.h
@@ -49,6 +49,7 @@ namespace muse::dock {
 class DockToolBarView;
 class DockingHolderView;
 class DockPageView;
+class DockPanelView;
 class DockWindow : public QQuickItem, public IDockWindow, public muse::Injectable, public async::Asyncable
 {
     Q_OBJECT
@@ -117,6 +118,7 @@ private:
     void alignTopLevelToolBars(const DockPageView* page);
 
     void addDock(DockBase* dock, Location location = Location::Left, const DockBase* relativeTo = nullptr);
+    void addPanel(const DockPageView* page, DockPanelView* panel, Location location, const DockBase* relativeTo = nullptr);
     void registerDock(DockBase* dock);
 
     void saveGeometry();
@@ -125,7 +127,7 @@ private:
     QByteArray windowState() const;
 
     void savePageState(const QString& pageName);
-    void restorePageState(const QString& pageName);
+    void restorePageState(const DockPageView* page);
 
     void reloadCurrentPage();
     bool restoreLayout(const QByteArray& layout, bool restoreRelativeToMainWindow = false);


### PR DESCRIPTION
Resolves: #27106

(Originally posted [here](https://github.com/musescore/MuseScore/pull/27222), bumped into 4.5.2)

After some investigation, it turns out this is an issue for all "new" panels, i.e. panels that the saved workspace JSON doesn't know about (the percussion panel and the undo history panel in this case). My feeling is that this behaviour is somewhat by-design in the KDDockWidgets system (floatUnknownWidgets hints at this, though that isn't actually the cause of the problem here).

Using the percussion panel as an example, the problem goes something like this:
1. Starting in `doLoadPage`, the `percussionPanel` `DockWidgetBase` will have a valid "layout item" in `lastPositions`.
2. `restorePageState` is called, which eventually leads to a `d->m_dockRegistry->clear(...` call. This clears the layout item for the main window (the layout item that the percussion panel is currently using).
3. All docks that the `LayoutSaver` knows about are restored accordingly.
4. When we eventually call `DockWidgetBase::show`, `d->m_lastPositions.isValid()` will be false because of the missing layout item and the widget will `morphIntoFloatingWindow`.