### PR TITLE
Fix #22435: Update beam height property boxes when moving cross-staff beam

### DIFF
--- a/src/inspector/models/notation/notes/beams/beamsettingsmodel.cpp
+++ b/src/inspector/models/notation/notes/beams/beamsettingsmodel.cpp
@@ -83,6 +83,7 @@ void BeamSettingsModel::createProperties()
                                          [this](const mu::engraving::Pid pid, const QVariant& newValue) {
         onPropertyValueChanged(pid, newValue);
         loadPropertyItem(m_crossStaffMove);
+        loadBeamHeightProperties();
     });
 }
 


### PR DESCRIPTION
Resolves: #22435

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
