### PR TITLE
do not run coverage on forks

### DIFF
--- a/.github/workflows/check_unit_tests.yml
+++ b/.github/workflows/check_unit_tests.yml
@@ -81,6 +81,9 @@ jobs:
 
         python3 buildscripts/ci/linux/tools/lcov_badger.py filtered_coverage.info coverage_badge.svg
 
+    - name: Push to S3
+      if: github.repository == 'musescore/MuseScore'
+      run: |
         S3_URL='s3://extensions.musescore.org/test/code_coverage/coverage_badge.svg'
 
         bash ./buildscripts/ci/tools/s3_push_file.sh \

--- a/.github/workflows/check_unit_tests.yml
+++ b/.github/workflows/check_unit_tests.yml
@@ -82,7 +82,7 @@ jobs:
         python3 buildscripts/ci/linux/tools/lcov_badger.py filtered_coverage.info coverage_badge.svg
 
     - name: Push to S3
-      if: github.repository == 'musescore/MuseScore'
+      if: ( github.event_name == 'schedule' || inputs.code_coverage == 'true' ) && github.repository == 'musescore/MuseScore'
       run: |
         S3_URL='s3://extensions.musescore.org/test/code_coverage/coverage_badge.svg'
 


### PR DESCRIPTION
This limits <s>the code coverage step</s> the push to S3 to the main repo, i.e. do not run it on forks, as scheduled runs always fail there due to the disallowed upload to S3. 