### PR TITLE
[MusicXML] invisible notations

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -1340,8 +1340,8 @@ static void addMordentToChord(const Notation& notation, ChordRest* cr)
         } else {
             mordent->setAnchor(ArticulationAnchor::AUTO);
         }
-        colorItem(mordent, Color::fromString(notation.attribute(u"color")));
         mordent->setVisible(notation.visible());
+        colorItem(mordent, Color::fromString(notation.attribute(u"color")));
         cr->add(mordent);
     } else {
         LOGD("unknown ornament: name '%s' long '%s' approach '%s' departure '%s'",

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -8460,6 +8460,7 @@ void MusicXmlParserNotations::ornaments()
     // so don't add an additional one
     if (trillMark && m_wavyLineType != "start" && m_wavyLineType != "startstop") {
         Notation ornament = Notation::notationWithAttributes(u"trill-mark", m_e.attributes(), u"ornaments", SymId::ornamentTrill);
+        ornament.setVisible(m_visible);
         m_notations.push_back(ornament);
     }
 }

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -1569,7 +1569,7 @@ static NoteHeadGroup convertNotehead(String mxmlName)
  */
 
 static void addTextToNote(int64_t byteOffset, String txt, String placement, String fontWeight,
-                          double fontSize, String fontStyle, String fontFamily, Color color,
+                          double fontSize, String fontStyle, String fontFamily, bool visible, Color color,
                           TextStyleType subType, const Score*, Note* note)
 {
     if (note) {
@@ -1598,6 +1598,7 @@ static void addTextToNote(int64_t byteOffset, String txt, String placement, Stri
                 t->setPropertyFlags(Pid::PLACEMENT, PropertyFlags::UNSTYLED);
                 t->resetProperty(Pid::OFFSET);
             }
+            t->setVisible(visible);
             colorItem(t, color);
             note->add(t);
         }
@@ -4418,7 +4419,7 @@ void MusicXmlInferredFingering::addToNotes(std::vector<Note*>& notes) const
         // Fingerings in reverse order
         addTextToNote(-1,
                       m_fingerings[m_fingerings.size() - 1 - i], m_placement, u"", -1, u"", u"",
-                      Color::BLACK, TextStyleType::FINGERING,
+                      true, Color::BLACK, TextStyleType::FINGERING,
                       notes[i]->score(),
                       notes[i]);
     }
@@ -8664,7 +8665,7 @@ void MusicXmlParserNotations::addTechnical(const Notation& notation, Note* note)
         // TODO: distinguish between keyboards (style TextStyleName::FINGERING)
         // and (plucked) strings (style TextStyleName::LH_GUITAR_FINGERING)
         addTextToNote(m_e.byteOffset(), notation.text(), placement, fontWeight, fontSize, fontStyle, fontFamily,
-                      color, TextStyleType::FINGERING, m_score, note);
+                      notation.visible(), color, TextStyleType::FINGERING, m_score, note);
     } else if (notation.name() == u"fret") {
         int fret = notation.text().toInt();
         if (note) {
@@ -8676,14 +8677,14 @@ void MusicXmlParserNotations::addTechnical(const Notation& notation, Note* note)
         }
     } else if (notation.name() == "pluck") {
         addTextToNote(m_e.byteOffset(), notation.text(), placement, fontWeight, fontSize, fontStyle, fontFamily,
-                      color, TextStyleType::RH_GUITAR_FINGERING, m_score, note);
+                      notation.visible(), color, TextStyleType::RH_GUITAR_FINGERING, m_score, note);
     } else if (notation.name() == "string") {
         if (note) {
             if (note->staff()->isTabStaff(Fraction(0, 1))) {
                 note->setString(notation.text().toInt() - 1);
             } else {
                 addTextToNote(m_e.byteOffset(), notation.text(), placement, fontWeight, fontSize, fontStyle, fontFamily,
-                              color, TextStyleType::STRING_NUMBER, m_score, note);
+                              notation.visible(), color, TextStyleType::STRING_NUMBER, m_score, note);
             }
         } else {
             m_logger->logError(u"no note for string", &m_e);

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.h
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.h
@@ -279,6 +279,8 @@ public:
     muse::String print() const;
     void setText(const muse::String& text) { m_text = text; }
     muse::String text() const { return m_text; }
+    void setVisible(const bool visible) { m_visible = visible; }
+    bool visible() const { return m_visible; }
     static Notation notationWithAttributes(const muse::String& name, const std::vector<muse::XmlStreamReader::Attribute>& attributes,
                                            const muse::String& parent = {}, const engraving::SymId& symId = engraving::SymId::noSym);
 private:
@@ -288,6 +290,7 @@ private:
     muse::String m_subType;
     muse::String m_text;
     std::map<muse::String, muse::String> m_attributes;
+    bool m_visible = true;
 };
 
 //---------------------------------------------------------
@@ -396,6 +399,7 @@ private:
     bool m_slurStop = false;
     bool m_slurStart = false;
     bool m_wavyLineStop = false;
+    bool m_visible = true;
 };
 
 //---------------------------------------------------------

--- a/src/importexport/musicxml/tests/data/testExcludeInvisibleElements_noinvisible_ref.xml
+++ b/src/importexport/musicxml/tests/data/testExcludeInvisibleElements_noinvisible_ref.xml
@@ -69,6 +69,9 @@
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
+        <notations print-object="no">
+          <fermata type="upright"/>
+          </notations>
         </note>
       <note>
         <pitch>
@@ -94,6 +97,11 @@
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
+        <notations print-object="no">
+          <articulations>
+            <staccato/>
+            </articulations>
+          </notations>
         </note>
       </measure>
     <measure number="2">
@@ -427,6 +435,9 @@
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
+        <notations print-object="no">
+          <slur type="start" number="1"/>
+          </notations>
         </note>
       <note>
         <pitch>
@@ -457,6 +468,9 @@
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
+        <notations print-object="no">
+          <slur type="stop" number="1"/>
+          </notations>
         </note>
       </measure>
     <measure number="9">
@@ -590,6 +604,9 @@
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
+        <notations print-object="no">
+          <glissando line-type="wavy" number="1" type="start">gliss.</glissando>
+          </notations>
         </note>
       <note>
         <pitch>
@@ -600,6 +617,9 @@
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
+        <notations print-object="no">
+          <glissando line-type="wavy" number="1" type="stop"/>
+          </notations>
         </note>
       </measure>
     <measure number="12">
@@ -653,6 +673,9 @@
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
+        <notations print-object="no">
+          <arpeggiate number="1"/>
+          </notations>
         </note>
       <note>
         <chord/>
@@ -664,6 +687,9 @@
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
+        <notations print-object="no">
+          <arpeggiate number="1"/>
+          </notations>
         </note>
       <note>
         <chord/>
@@ -675,6 +701,9 @@
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
+        <notations print-object="no">
+          <arpeggiate number="1"/>
+          </notations>
         </note>
       <note>
         <rest/>
@@ -737,6 +766,12 @@
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
+        <notations print-object="no">
+          <tied type="start"/>
+          <technical>
+            <fingering>4</fingering>
+            </technical>
+          </notations>
         </note>
       </measure>
     <measure number="14">
@@ -750,6 +785,9 @@
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
+        <notations print-object="no">
+          <tied type="stop"/>
+          </notations>
         </note>
       <note>
         <rest/>
@@ -773,6 +811,9 @@
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
+        <notations print-object="no">
+          <tied type="start"/>
+          </notations>
         <notations>
           <technical>
             <fingering>4</fingering>
@@ -791,6 +832,9 @@
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
+        <notations print-object="no">
+          <tied type="stop"/>
+          </notations>
         </note>
       <note>
         <rest/>

--- a/src/importexport/musicxml/tests/data/testInvisibleNotations.xml
+++ b/src/importexport/musicxml/tests/data/testInvisibleNotations.xml
@@ -1,0 +1,226 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <work>
+    <work-title>invisible notations</work-title>
+    </work>
+  <identification>
+    <encoding>
+      <software>MuseScore 0.7.0</software>
+      <encoding-date>2007-09-10</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="no"/>
+      <supports element="print" attribute="new-system" type="no"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <part-list>
+    <score-part id="P1">
+      <part-name></part-name>
+      <score-instrument id="P1-I1">
+        <instrument-name></instrument-name>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>1</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <note>
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        <notations print-object="no">
+          <slur type="start" number="1"/>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations print-object="no">
+          <slur type="stop" number="1"/>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations print-object="no">
+          <articulations>
+            <accent/>
+            </articulations>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations print-object="no">
+          <technical>
+            <down-bow/>
+            </technical>
+          </notations>
+        </note>
+      </measure>
+    <measure number="2">
+      <note>
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations print-object="no">
+          <articulations>
+            <breath-mark>comma</breath-mark>
+            </articulations>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations print-object="no">
+          <articulations>
+            <caesura/>
+            </articulations>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        <notations print-object="no">
+          <technical>
+            <string>1</string>
+            </technical>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <tie type="start"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        <notations print-object="no">
+          <tied type="start"/>
+          </notations>
+        </note>
+      </measure>
+    <measure number="3">
+      <note>
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <tie type="stop"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        <notations print-object="no">
+          <tied type="stop"/>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations print-object="no">
+          <ornaments>
+            <turn/>
+            </ornaments>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations print-object="no">
+          <ornaments>
+            <mordent/>
+            </ornaments>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <notations print-object="no">
+          <fermata type="upright"/>
+          </notations>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/src/importexport/musicxml/tests/musicxml_tests.cpp
+++ b/src/importexport/musicxml/tests/musicxml_tests.cpp
@@ -751,7 +751,9 @@ TEST_F(MusicXml_Tests, incompleteTuplet) {
 TEST_F(MusicXml_Tests, incorrectMidiProgram) {
     musicXmlIoTestRef("testIncorrectMidiProgram");
 }
-
+TEST_F(MusicXml_Tests, invisibleNotations) {
+    musicXmlIoTest("testInvisibleNotations");
+}
 TEST_F(MusicXml_Tests, incorrectStaffNumber1) {
     musicXmlIoTestRef("testIncorrectStaffNumber1");
 }


### PR DESCRIPTION
This adds proper import and export for invisible `notations` from MusicXML.

NB: I think the original intention of `exportInvisibleElements` was to allow exporting invisible elements that can not be marked as invisible in MusicXML. However the current solution showed weird inconsitencies when making all elements in a measure invisible. With this approach invisble notations are correctly exported and imported.
