### PR TITLE
[MusicXML] import shake ornament

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -1391,6 +1391,7 @@ static bool convertArticulationToSymId(const String& mxmlName, SymId& id)
         { u"vertical-turn",          SymId::ornamentTurnUp },
         { u"inverted-vertical-turn", SymId::ornamentTurnUpS },
         { u"turn",                   SymId::ornamentTurn },
+        { u"shake",                  SymId::ornamentTremblementCouperin },
         { u"schleifer",              SymId::ornamentPrecompSlide },
         { u"haydn",                  SymId::ornamentHaydn },
         // articulations


### PR DESCRIPTION
Small PR for importing the [shake element](https://www.w3.org/2021/06/musicxml40/musicxml-reference/elements/shake/).