### PR TITLE
27414: Fix Reset Preferences issue

### DIFF
--- a/src/framework/global/settings.cpp
+++ b/src/framework/global/settings.cpp
@@ -98,10 +98,15 @@ void Settings::reset(bool keepDefaultSettings, bool notifyAboutChanges, bool not
 
     std::vector<Settings::Key> locallyAddedKeys;
     for (auto it = m_localSettings.begin(); it != m_localSettings.end(); ++it) {
-        if (m_items.count(it->first) == 0) {
+        auto item = m_items.find(it->first);
+        if (item == m_items.end()) {
             locallyAddedKeys.push_back(it->first);
+        } else {
+            // UI currently has the values from m_localSettings but we've turned off the transaction.
+            item->second.value = it->second.value;
         }
     }
+
     m_localSettings.clear();
 
     if (!keepDefaultSettings) {
@@ -123,6 +128,7 @@ void Settings::reset(bool keepDefaultSettings, bool notifyAboutChanges, bool not
         Channel<Val>& channel = findChannel(it->first);
         channel.send(it->second.value);
     }
+
     for (auto it = locallyAddedKeys.cbegin(); it != locallyAddedKeys.cend(); ++it) {
         Channel<Val>& channel = findChannel(*it);
         channel.send(Val());


### PR DESCRIPTION
Resolves: #27414

When I recently made all preferences reset correctly, I introduced an optimization where if a setting had its default value, it would be skipped and its change notification would not be sent out. This was both good performance-wise but also if I remember correctly it was necesitated by the fact that on MacOS users were seeing a [system permissions dialog](https://github.com/musescore/MuseScore/pull/25872) after resetting the preferences due to the sound fonts folder getting re-scanned (even if the sound fonts folder wasn't changing).

This optimization, however, breaks the Reset Preferences dialog for when you open the dialog, change a setting from its default value to a different value and click the Reset Preferences button. The problem is in that the value changes in the transactional setting and the UI but not in the non-transactional setting. When the reset happens, the mentioned optimization skips the setting since it checks the non-transactional values and sees no change from the default value. The onChange notification is not sent out and the UI is not updated.

I am changing the code to copy all the values from the transactional settings (that are also in the UI) into the non-transactional settings beofre the actual reset is done. It is similar to committing the transaction.

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
