### PR TITLE
4.5.2: Fix GH#27418: "px" is not translatable in Transifex

### DIFF
--- a/src/appshell/qml/Preferences/internal/MiscellaneousSection.qml
+++ b/src/appshell/qml/Preferences/internal/MiscellaneousSection.qml
@@ -44,7 +44,7 @@ BaseSection {
 
         minValue: 1
         maxValue: 99
-        measureUnitsSymbol: "px"
+        measureUnitsSymbol: qsTrc("global", "px", /*disambiguation*/ "abbreviation of pixels")
 
         navigation.name: "SelectionProximityControl"
         navigation.panel: root.navigation

--- a/src/notation/view/widgets/pagesettings.cpp
+++ b/src/notation/view/widgets/pagesettings.cpp
@@ -159,15 +159,15 @@ void PageSettings::updateValues()
 
     blockSignals(true);
 
-    const char* suffix;
+    QString suffix;
     double singleStepSize;
     double singleStepScale;
     if (mm) {
-        suffix = "mm";
+        suffix = muse::qtrc("global", "mm");
         singleStepSize = 1.0;
         singleStepScale = 0.05;
     } else {
-        suffix = "in";
+        suffix = muse::qtrc("global", "in", /*disambiguation*/ "abbreviation of inch");
         singleStepSize = 0.05;
         singleStepScale = 0.002;
     }


### PR DESCRIPTION
and while at it fix a similar issue for "mm" and "in" in the page settings dialog ("mm" is translatable in other places, like the Edit Style dialog, "in" doesn't exist anywhere else as far as I can tell)

Resolves: #27418, same for 4.5.2 as #27420 was for master