### PR TITLE
27446: Fix "Binding loop detected for property ItemImplicitWidth" in FlatButton.qml

### DIFF
--- a/src/appshell/qml/platform/AppMenuBar.qml
+++ b/src/appshell/qml/platform/AppMenuBar.qml
@@ -167,18 +167,9 @@ ListView {
         contentItem: StyledTextLabel {
             id: textLabel
 
-            width: textMetrics.width
-
             text: appMenuModel.isNavigationStarted ? radioButtonDelegate.titleWithMnemonicUnderline : radioButtonDelegate.title
             textFormat: Text.RichText
             font: ui.theme.defaultFont
-
-            TextMetrics {
-                id: textMetrics
-
-                font: textLabel.font
-                text: radioButtonDelegate.title
-            }
         }
 
         backgroundItem: AppButtonBackground {


### PR DESCRIPTION
Resolves: #27446

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
