### PR TITLE
Fix #17599: Gradual tempo changes skipped by Alt+Left and Alt+Right

### DIFF
--- a/src/engraving/dom/navigate.cpp
+++ b/src/engraving/dom/navigate.cpp
@@ -948,6 +948,7 @@ EngravingItem* Score::prevElement()
         case ElementType::OTTAVA_SEGMENT:
         case ElementType::TRILL_SEGMENT:
         case ElementType::VIBRATO_SEGMENT:
+        case ElementType::GRADUAL_TEMPO_CHANGE_SEGMENT:
         case ElementType::PEDAL_SEGMENT: {
             SpannerSegment* s = toSpannerSegment(e);
             Spanner* sp = s->spanner();

--- a/src/engraving/dom/segment.cpp
+++ b/src/engraving/dom/segment.cpp
@@ -1930,7 +1930,7 @@ Spanner* Segment::firstSpanner(staff_idx_t activeStaff) const
                 continue;
             }
             if (s->startSegment() == this) {
-                if (e->staffIdx() == activeStaff || (e->isMeasure() && activeStaff == 0)) {
+                if (e->staffIdx() == activeStaff || (e->isMeasure() && activeStaff == 0) || (e->isSegment() && s->isGradualTempoChange())) {
                     return s;
                 }
             }
@@ -1959,7 +1959,7 @@ Spanner* Segment::lastSpanner(staff_idx_t activeStaff) const
                 continue;
             }
             if (s->startSegment() == this) {
-                if (e->staffIdx() == activeStaff || (e->isMeasure() && activeStaff == 0)) {
+                if (e->staffIdx() == activeStaff || (e->isMeasure() && activeStaff == 0) || (e->isSegment() && s->isGradualTempoChange())) {
                     return s;
                 }
             }

--- a/src/engraving/dom/spanner.cpp
+++ b/src/engraving/dom/spanner.cpp
@@ -1295,7 +1295,7 @@ Spanner* Spanner::nextSpanner(EngravingItem* e, staff_idx_t activeStaff)
                     if (s->startSegment() == toSpanner(e)->startSegment()) {
                         if (st->staffIdx() == activeStaff) {
                             return s;
-                        } else if (st->isMeasure() && activeStaff == 0) {
+                        } else if ((st->isMeasure() && activeStaff == 0) || (st->isSegment() && s->isGradualTempoChange())) {
                             return s;
                         }
                     }
@@ -1328,7 +1328,7 @@ Spanner* Spanner::prevSpanner(EngravingItem* e, staff_idx_t activeStaff)
                     if (s->startSegment() == toSpanner(e)->startSegment()) {
                         if (st->staffIdx() == activeStaff) {
                             return s;
-                        } else if (st->isMeasure() && activeStaff == 0) {
+                        } else if ((st->isMeasure() && activeStaff == 0) || (st->isSegment() && s->isGradualTempoChange())) {
                             return s;
                         }
                     }


### PR DESCRIPTION
Added conditions in some functions in spanner.cpp and segment.cpp so that the gradual tempo change would be returned, when it was the next or previous element,
before there was no case for this.

Resolves: #17599 

When navigating with alt+left or alt+right the gradual tempo change was not accessible through any other element, also when starting from a gradual tempo change the alt+right would work as intended but the alt+left would not, it would instead go to the first element the title. I believe I fixed the problem, but I think that the solution is too specific in the spanner.cpp and segment.cpp. 

- [ x] I signed the [CLA](https://musescore.org/en/cla)
- [ x] The title of the PR describes the problem it addresses
- [ x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [ x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [ x] There are no unnecessary changes
- [ x]The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
