### PR TITLE
Improve behaviour when dragging elements between systems

### DIFF
--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -1131,7 +1131,7 @@ std::vector<System*> Score::searchSystem(const PointF& pos, const System* prefer
         }
         if (y < y2) {
             systems.push_back(s);
-            for (size_t iii = i + 1; ii < n; ++iii) {
+            for (size_t iii = i + 1; iii < n; ++iii) {
                 if (sl.at(iii)->y() != s->y()) {
                     break;
                 }

--- a/src/engraving/dom/textbase.cpp
+++ b/src/engraving/dom/textbase.cpp
@@ -3252,8 +3252,7 @@ void TextBase::editDrag(EditData& ed)
     score()->dragPosition(canvasPos(), &si, &newSeg, spacingFactor, allowTimeAnchor());
     if (newSeg && (newSeg != segment || staffIdx() != si)) {
         undoMoveSegment(newSeg, newSeg->tick() - segment->tick());
-        double deltaX = newSeg->pageX() - segment->pageX();
-        PointF offsetShift = PointF(deltaX, 0.0);
+        PointF offsetShift = newSeg->pagePos() - segment->pagePos();
         shiftInitOffset(ed, offsetShift);
     }
 }


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/27101

It improves the situation, but it won't be perfect yet, and I suspect that's because of the `ldata->moveY` in `Autoplace::rebaseOffset`, because we're unable to adjust the `initOffset` accordingly.