### PR TITLE
Fix MSVC compiler warning

### DIFF
--- a/src/engraving/rendering/score/harmonylayout.cpp
+++ b/src/engraving/rendering/score/harmonylayout.cpp
@@ -41,6 +41,7 @@ using namespace mu::engraving::rendering::score;
 
 void HarmonyLayout::autoplaceHarmonies(const std::vector<Segment*>& sl, LayoutContext& ctx)
 {
+    UNUSED(ctx);
     for (const Segment* s : sl) {
         for (EngravingItem* e : s->annotations()) {
             if (e->isHarmony()) {


### PR DESCRIPTION
reg: 'ctx'; unreferenced formal parameter (C4100)