### PR TITLE
(Optionally) add space to lyrics when exporting MIDI.

### DIFF
--- a/src/importexport/midi/imidiconfiguration.h
+++ b/src/importexport/midi/imidiconfiguration.h
@@ -49,6 +49,9 @@ public:
 
     virtual bool isMidiExportRpns() const = 0;
     virtual void setIsMidiExportRpns(bool exportRpns) = 0;
+
+    virtual bool isMidiSpaceLyrics() const = 0;
+    virtual void setIsMidiSpaceLyrics(bool spaceLyrics) = 0;
 };
 }
 

--- a/src/importexport/midi/internal/midiconfiguration.cpp
+++ b/src/importexport/midi/internal/midiconfiguration.cpp
@@ -34,6 +34,7 @@ using namespace mu::iex::midi;
 static const Settings::Key SHORTEST_NOTE_KEY("iex_midi", "io/midi/shortestNote");
 static const Settings::Key EXPORTRPNS_KEY("iex_midi", "io/midi/exportRPNs");
 static const Settings::Key EXPAND_REPEATS_KEY("iex_midi", "io/midi/expandRepeats");
+static const Settings::Key SPACELYRICS_KEY("iex_midi", "io/midi/spaceLyrics");
 
 void MidiConfiguration::init()
 {
@@ -44,6 +45,7 @@ void MidiConfiguration::init()
 
     settings()->setDefaultValue(EXPAND_REPEATS_KEY, Val(true));
     settings()->setDefaultValue(EXPORTRPNS_KEY, Val(true));
+    settings()->setDefaultValue(SPACELYRICS_KEY, Val(true));
 }
 
 int MidiConfiguration::midiShortestNote() const
@@ -86,4 +88,14 @@ bool MidiConfiguration::isMidiExportRpns() const
 void MidiConfiguration::setIsMidiExportRpns(bool exportRpns)
 {
     settings()->setSharedValue(EXPORTRPNS_KEY, Val(exportRpns));
+}
+
+bool MidiConfiguration::isMidiSpaceLyrics() const
+{
+    return settings()->value(SPACELYRICS_KEY).toBool();
+}
+
+void MidiConfiguration::setIsMidiSpaceLyrics(bool spaceLyrics)
+{
+    settings()->setSharedValue(SPACELYRICS_KEY, Val(spaceLyrics));
 }

--- a/src/importexport/midi/internal/midiconfiguration.h
+++ b/src/importexport/midi/internal/midiconfiguration.h
@@ -46,6 +46,9 @@ public:
     bool isMidiExportRpns() const override;
     void setIsMidiExportRpns(bool exportRpns) override;
 
+    bool isMidiSpaceLyrics() const override;
+    void setIsMidiSpaceLyrics(bool exportRpns) override;
+
 private:
     muse::async::Channel<int> m_midiShortestNoteChanged;
 };

--- a/src/importexport/midi/internal/midiexport/exportmidi.cpp
+++ b/src/importexport/midi/internal/midiexport/exportmidi.cpp
@@ -212,7 +212,7 @@ void ExportMidi::writeHeader(const CompatMidiRendererInternal::Context& context)
 //    from mscore->synthesizerState() as the synthState parameter.
 //---------------------------------------------------------
 
-bool ExportMidi::write(QIODevice* device, bool midiExpandRepeats, bool exportRPNs, const SynthesizerState& synthState)
+bool ExportMidi::write(QIODevice* device, bool midiExpandRepeats, bool exportRPNs, const SynthesizerState& synthState, bool spaceLyrics)
 {
     m_midiFile.setDivision(Constants::DIVISION);
     m_midiFile.setFormat(1);
@@ -371,7 +371,13 @@ bool ExportMidi::write(QIODevice* device, bool midiExpandRepeats, bool exportRPN
                     ChordRest* cr = toChordRest(seg->element(i));
                     if (cr) {
                         for (const auto& lyric : cr->lyrics()) {
+                            LyricsSyllabic syllabic = lyric->syllabic();
                             muse::ByteArray lyricText = lyric->plainText().toUtf8();
+                            if (spaceLyrics) {
+                                if (syllabic == LyricsSyllabic::SINGLE || syllabic == LyricsSyllabic::END) {
+                                    lyricText.push_back(' ');
+                             }
+                        }
                             size_t len = lyricText.size() + 1;
                             std::vector<unsigned char> data(lyricText.constData(), lyricText.constData() + len);
 
@@ -418,24 +424,24 @@ bool ExportMidi::write(QIODevice* device, bool midiExpandRepeats, bool exportRPN
     return !m_midiFile.write(device);
 }
 
-bool ExportMidi::write(const QString& name, bool midiExpandRepeats, bool exportRPNs, const SynthesizerState& synthState)
+bool ExportMidi::write(const QString& name, bool midiExpandRepeats, bool exportRPNs, const SynthesizerState& synthState, bool spaceLyrics)
 {
     m_file.setFileName(name);
     if (!m_file.open(QIODevice::WriteOnly)) {
         return false;
     }
-    return write(&m_file, midiExpandRepeats, exportRPNs, synthState);
+    return write(&m_file, midiExpandRepeats, exportRPNs, synthState, spaceLyrics);
 }
 
-bool ExportMidi::write(QIODevice* device, bool midiExpandRepeats, bool exportRPNs)
+bool ExportMidi::write(QIODevice* device, bool midiExpandRepeats, bool exportRPNs, bool spaceLyrics)
 {
     SynthesizerState ss;
-    return write(device, midiExpandRepeats, exportRPNs, ss);
+    return write(device, midiExpandRepeats, exportRPNs, ss, spaceLyrics);
 }
 
-bool ExportMidi::write(const QString& name, bool midiExpandRepeats, bool exportRPNs)
+bool ExportMidi::write(const QString& name, bool midiExpandRepeats, bool exportRPNs, bool spaceLyrics)
 {
     SynthesizerState ss;
-    return write(name, midiExpandRepeats, exportRPNs, ss);
+    return write(name, midiExpandRepeats, exportRPNs, ss, spaceLyrics);
 }
 }

--- a/src/importexport/midi/internal/midiexport/exportmidi.h
+++ b/src/importexport/midi/internal/midiexport/exportmidi.h
@@ -44,10 +44,10 @@ class ExportMidi
 {
 public:
     ExportMidi(engraving::Score* s) { m_score = s; }
-    bool write(const QString& name, bool midiExpandRepeats, bool exportRPNs);
-    bool write(QIODevice* device, bool midiExpandRepeats, bool exportRPNs);
-    bool write(const QString& name, bool midiExpandRepeats, bool exportRPNs, const engraving::SynthesizerState& synthState);
-    bool write(QIODevice* device, bool midiExpandRepeats, bool exportRPNs, const engraving::SynthesizerState& synthState);
+    bool write(const QString& name, bool midiExpandRepeats, bool exportRPNs, bool spaceLyrics);
+    bool write(QIODevice* device, bool midiExpandRepeats, bool exportRPNs, bool spaceLyrics);
+    bool write(const QString& name, bool midiExpandRepeats, bool exportRPNs, const engraving::SynthesizerState& synthState, bool spaceLyrics);
+    bool write(QIODevice* device, bool midiExpandRepeats, bool exportRPNs, const engraving::SynthesizerState& synthState, bool spaceLyrics);
 
 private:
     void writeHeader(const engraving::CompatMidiRendererInternal::Context& context);

--- a/src/importexport/midi/internal/midiimport/importmidi_lyrics.cpp
+++ b/src/importexport/midi/internal/midiimport/importmidi_lyrics.cpp
@@ -68,6 +68,7 @@ extractLyricsFromTrack(const MidiTrack& track, int division, bool isDivisionInTp
         if (isLyricEvent(e)) {
             const uchar* data = (uchar*)e.edata();
             std::string text = MidiCharset::fromUchar(data);
+            text.erase(text.find_last_not_of(' ')+1);
             if (isLyricText(text)) {
                 const auto tick = toMuseScoreTicks(i.first, division, isDivisionInTps);
                 // no charset handling here

--- a/src/importexport/midi/internal/notationmidiwriter.cpp
+++ b/src/importexport/midi/internal/notationmidiwriter.cpp
@@ -62,13 +62,14 @@ Ret NotationMidiWriter::write(INotationPtr notation, io::IODevice& destinationDe
 
     bool isPlayRepeatsEnabled = midiImportExportConfiguration()->isExpandRepeats();
     bool isMidiExportRpns = midiImportExportConfiguration()->isMidiExportRpns();
+    bool isMidiSpaceLyrics = midiImportExportConfiguration()->isMidiSpaceLyrics();
     SynthesizerState synthesizerState = score->synthesizerState();
 
     QByteArray qdata;
     QBuffer buf(&qdata);
     buf.open(QIODevice::WriteOnly);
 
-    bool ok = exportMidi.write(&buf, isPlayRepeatsEnabled, isMidiExportRpns, synthesizerState);
+    bool ok = exportMidi.write(&buf, isPlayRepeatsEnabled, isMidiExportRpns, synthesizerState, isMidiSpaceLyrics);
     if (ok) {
         ByteArray data = ByteArray::fromQByteArrayNoCopy(qdata);
         destinationDevice.write(data);

--- a/src/project/qml/MuseScore/Project/internal/Export/MidiSettingsPage.qml
+++ b/src/project/qml/MuseScore/Project/internal/Export/MidiSettingsPage.qml
@@ -54,6 +54,21 @@ ExportSettingsPage {
         }
     }
 
+    CheckBox {
+        width: parent.width
+        text: qsTrc("project/export", "Add spacing to lyrics")
+
+        navigation.name: "SpaceLyricsCheckbox"
+        navigation.panel: root.navigationPanel
+        navigation.row: root.navigationOrder + 2
+
+        checked: root.model.midiSpaceLyrics
+        onClicked: {
+            root.model.midiSpaceLyrics = !checked
+        }
+    }
+
+
     StyledTextLabel {
         width: parent.width
         text: qsTrc("project/export", "Each selected part will be exported as a separate MIDI file.")

--- a/src/project/view/exportdialogmodel.cpp
+++ b/src/project/view/exportdialogmodel.cpp
@@ -553,6 +553,21 @@ void ExportDialogModel::setMidiExportRpns(bool exportRpns)
     emit midiExportRpnsChanged(exportRpns);
 }
 
+bool ExportDialogModel::midiSpaceLyrics() const
+{
+    return midiImportExportConfiguration()->isMidiSpaceLyrics();
+}
+
+void ExportDialogModel::setMidiSpaceLyrics(bool spaceLyrics)
+{
+    if (spaceLyrics == midiSpaceLyrics()) {
+        return;
+    }
+
+    midiImportExportConfiguration()->setIsMidiSpaceLyrics(spaceLyrics);
+    emit midiSpaceLyricsChanged(spaceLyrics);
+}
+
 bool ExportDialogModel::meiExportLayout() const
 {
     return meiConfiguration()->meiExportLayout();

--- a/src/project/view/exportdialogmodel.h
+++ b/src/project/view/exportdialogmodel.h
@@ -83,6 +83,7 @@ class ExportDialogModel : public QAbstractListModel, public muse::async::Asyncab
 
     Q_PROPERTY(bool midiExpandRepeats READ midiExpandRepeats WRITE setMidiExpandRepeats NOTIFY midiExpandRepeatsChanged)
     Q_PROPERTY(bool midiExportRpns READ midiExportRpns WRITE setMidiExportRpns NOTIFY midiExportRpnsChanged)
+    Q_PROPERTY(bool midiSpaceLyrics READ midiSpaceLyrics WRITE setMidiSpaceLyrics NOTIFY midiSpaceLyricsChanged)
 
     Q_PROPERTY(MusicXmlLayoutType musicXmlLayoutType READ musicXmlLayoutType WRITE setMusicXmlLayoutType NOTIFY musicXmlLayoutTypeChanged)
 
@@ -151,6 +152,10 @@ public:
     bool midiExportRpns() const;
     void setMidiExportRpns(bool exportRpns);
 
+    bool midiSpaceLyrics() const;
+    void setMidiSpaceLyrics(bool spaceLyrics);
+
+
     bool meiExportLayout() const;
     void setMeiExportLayout(bool exportLayout);
 
@@ -196,6 +201,7 @@ signals:
 
     void midiExpandRepeatsChanged(bool expandRepeats);
     void midiExportRpnsChanged(bool exportRpns);
+    void midiSpaceLyricsChanged(bool spaceLyrics);
 
     void musicXmlLayoutTypeChanged(MusicXmlLayoutType layoutType);
 


### PR DESCRIPTION
When working with other MIDI software, and trying to open a MIDI exported from MuseScore, the lyrics were squished together, while other MIDI files didn't have squished lyrics. By looking into the files that weren't squished, there was a space character at the end of the final syllable (or the syllable if there's only one).

An example of this is in midiis2jam2:

Before this PR (or with the spacing option disabled):
![image](https://github.com/user-attachments/assets/0a791f8d-3747-47bc-a54a-05833ea38e57)

With this PR (and the spacing option enabled):
![image](https://github.com/user-attachments/assets/f160c3bc-a32c-4ba2-8415-24d23e1c9e84)

Here is what the sheet music looks like:
![image](https://github.com/user-attachments/assets/4dad9584-c22c-45fd-8b6e-418f51cc3737)

And here is the new option in the MIDI export menu:
![image](https://github.com/user-attachments/assets/b48ffc7a-569f-40ec-b563-12b2467f7e72)

I know this use case scenario might be a little niche, but it's the little things that count, and hey, I already did the work.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
