### PR TITLE
Exclude some barline properties from linking in the same score

### DIFF
--- a/src/engraving/dom/engravingitem.cpp
+++ b/src/engraving/dom/engravingitem.cpp
@@ -1451,7 +1451,10 @@ PropertyPropagation EngravingItem::propertyPropagation(const EngravingItem* dest
     const Staff* destinationStaff = destinationItem->staff();
 
     if (sourceScore == destinationScore) {
-        if (sourceStaff != destinationStaff && (propertyId == Pid::VISIBLE || propertyGroup(propertyId) == PropertyGroup::POSITION)) {
+        const bool diffStaff = sourceStaff != destinationStaff;
+        const bool visibleOrPosition = propertyId == Pid::VISIBLE || propertyGroup(propertyId) == PropertyGroup::POSITION;
+        const bool linkSameScore = propertyLinkSameScore(propertyId);
+        if ((diffStaff && visibleOrPosition) || !linkSameScore) {
             // Allow visibility and position to stay independent
             return PropertyPropagation::NONE;
         }

--- a/src/engraving/dom/property.cpp
+++ b/src/engraving/dom/property.cpp
@@ -502,6 +502,23 @@ bool propertyLink(Pid id)
 }
 
 //---------------------------------------------------------
+//   propertyLinkSameScore
+//---------------------------------------------------------
+
+bool propertyLinkSameScore(Pid id)
+{
+    assert(id < Pid::END);
+    switch (id) {
+    case Pid::STAFF_BARLINE_SPAN:
+    case Pid::STAFF_BARLINE_SPAN_FROM:
+    case Pid::STAFF_BARLINE_SPAN_TO:
+        return false;
+    default:
+        return true;
+    }
+}
+
+//---------------------------------------------------------
 //   propertyName
 //---------------------------------------------------------
 

--- a/src/engraving/dom/property.h
+++ b/src/engraving/dom/property.h
@@ -491,6 +491,7 @@ extern String propertyToString(Pid, const PropertyValue& value, bool mscx);
 extern P_TYPE propertyType(Pid);
 extern const char* propertyName(Pid);
 extern bool propertyLink(Pid id);
+extern bool propertyLinkSameScore(Pid id);
 extern PropertyGroup propertyGroup(Pid id);
 extern Pid propertyId(const muse::AsciiStringView& name);
 extern String propertyUserName(Pid);


### PR DESCRIPTION
Resolves: #27455 
This PR adds a field to `PropertyMetaData` which allows some properties to be excluded from linking within the same score. All properties between linked staves were synced in https://github.com/musescore/MuseScore/pull/26279.
