### PR TITLE
Avoid showing anchors in print

### DIFF
--- a/src/engraving/rendering/score/tdraw.cpp
+++ b/src/engraving/rendering/score/tdraw.cpp
@@ -3146,6 +3146,10 @@ void TDraw::draw(const TimeSig* item, Painter* painter)
 
 void TDraw::draw(const TimeTickAnchor* item, Painter* painter)
 {
+    if (item->score()->printing()) {
+        return;
+    }
+
     TimeTickAnchor::DrawRegion drawRegion = item->drawRegion();
 
     if (drawRegion == TimeTickAnchor::DrawRegion::OUT_OF_RANGE) {


### PR DESCRIPTION
This can only happen in edge cases where the event which triggers hiding the anchors is missed and they stay visible. The PR makes sure that, regardless of what's on screen, they never show in print in any case.

Resolves: #27454 