### PR TITLE
[4.5.2] Patch GTest and Opus to fix build with CMake 4.0.0

### DIFF
--- a/src/framework/audio/thirdparty/opus/opus-1.4/CMakeLists.txt
+++ b/src/framework/audio/thirdparty/opus/opus-1.4/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.16)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 include(OpusPackageVersion)

--- a/src/framework/testing/thirdparty/googletest/CMakeLists.txt
+++ b/src/framework/testing/thirdparty/googletest/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Note: CMake support is community-based. The maintainers do not use CMake
 # internally.
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 
 if (POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)

--- a/src/framework/testing/thirdparty/googletest/googlemock/CMakeLists.txt
+++ b/src/framework/testing/thirdparty/googletest/googlemock/CMakeLists.txt
@@ -36,7 +36,7 @@ endif()
 # as ${gmock_SOURCE_DIR} and to the root binary directory as
 # ${gmock_BINARY_DIR}.
 # Language "C" is required for find_package(Threads).
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 cmake_policy(SET CMP0048 NEW)
 project(gmock VERSION ${GOOGLETEST_VERSION} LANGUAGES CXX C)
 

--- a/src/framework/testing/thirdparty/googletest/googletest/CMakeLists.txt
+++ b/src/framework/testing/thirdparty/googletest/googletest/CMakeLists.txt
@@ -46,7 +46,7 @@ endif()
 
 # Project version:
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 cmake_policy(SET CMP0048 NEW)
 project(gtest VERSION ${GOOGLETEST_VERSION} LANGUAGES CXX C)
 


### PR DESCRIPTION
Compatibility with CMake versions < 3.5 has been removed