### PR TITLE
Fix probable bug in BWW lexer

### DIFF
--- a/src/importexport/bww/internal/bww/lexer.cpp
+++ b/src/importexport/bww/internal/bww/lexer.cpp
@@ -40,9 +40,7 @@ namespace Bww {
    */
 
 Lexer::Lexer(QIODevice* inDevice)
-    : in(inDevice),
-    lineNumber(-1),
-    value(QChar(NONE))
+    : in(inDevice)
 {
     LOGD() << "Lexer::Lexer() begin";
 

--- a/src/importexport/bww/internal/bww/lexer.h
+++ b/src/importexport/bww/internal/bww/lexer.h
@@ -19,9 +19,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
-#ifndef LEXER_H
-#define LEXER_H
+#pragma once
 
 /**
  \file
@@ -54,12 +52,10 @@ private:
     void categorizeWord(QString word);
     QTextStream in;                     ///< Input stream
     QString line;                       ///< The current line
-    int lineNumber;                     ///< The current line number (zero-based)
+    int lineNumber = -1;                ///< The current line number (zero-based)
     QStringList list;                   ///< Unprocessed words
-    Symbol type;                        ///< Last symbol type
+    Symbol type = NONE;                 ///< Last symbol type
     QString value;                      ///< Last symbol value
     QMap<QString, QString> graceMap;    ///< Map bww embellishments to separate grace notes
 };
-} // namespace Bww
-
-#endif // LEXER_H
+}

--- a/src/importexport/bww/internal/bww/symbols.cpp
+++ b/src/importexport/bww/internal/bww/symbols.cpp
@@ -29,7 +29,7 @@
 #include "symbols.h"
 
 namespace Bww {
-static const char* symTable[] =
+static constexpr const char* symTable[] =
 {
     "COMMENT",
     "HEADER",
@@ -51,13 +51,10 @@ static const char* symTable[] =
 
 QString symbolToString(Symbol s)
 {
-    if (s < 0) {
+    if (static_cast<size_t>(s) >= sizeof symTable) {
         return "INVALID";
     }
-    if (static_cast<unsigned>(s) > sizeof symTable) {
-        return "INVALID";
-    } else {
-        return symTable[s];
-    }
+
+    return symTable[s];
 }
 } // namespace Bww

--- a/src/importexport/bww/internal/bww/symbols.h
+++ b/src/importexport/bww/internal/bww/symbols.h
@@ -19,9 +19,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
-#ifndef SYMBOLS_H
-#define SYMBOLS_H
+#pragma once
 
 /**
  \file
@@ -29,7 +27,7 @@
  */
 
 namespace Bww {
-enum Symbol
+enum Symbol : unsigned char
 {
     COMMENT,
     HEADER,
@@ -49,7 +47,7 @@ enum Symbol
     NONE
 };
 
-enum class StartStop
+enum class StartStop : unsigned char
 {
     ST_NONE,
     ST_START,
@@ -58,6 +56,4 @@ enum class StartStop
 };
 
 extern QString symbolToString(Symbol s);
-} // namespace Bww
-
-#endif // SYMBOLS_H
+}


### PR DESCRIPTION
Was trying to intialise the `QString value` member with `NONE`, which is an enum case / integer. Initialising a QString with an integer has become more and more difficult over the Qt versions, and when updating to Qt 6.2, we fixed it by casting to QChar first. But with Qt 6.9, even that causes compile errors, so I took another look at it. That revealed that it is much more likely that the intention was to initialise not `QString value`, but `Symbol type`.