### PR TITLE
Fix MSVC linker errors in Debug mode and compiler warnings, in/with opus

### DIFF
--- a/src/framework/audio/thirdparty/opus/opus-1.5.2/CMakeLists.txt
+++ b/src/framework/audio/thirdparty/opus/opus-1.5.2/CMakeLists.txt
@@ -275,7 +275,7 @@ if(MSVC)
   if(OPUS_STATIC_RUNTIME)
     set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
   else()
-    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
   endif()
 endif()
 

--- a/src/framework/audio/thirdparty/opus/opus-1.5.2/cmake/OpusConfig.cmake
+++ b/src/framework/audio/thirdparty/opus/opus-1.5.2/cmake/OpusConfig.cmake
@@ -104,7 +104,7 @@ endif()
 
 if(MSVC)
   # move cosmetic warnings to level 4
-  add_compile_options(/w44244 /w44305 /w44267)
+  add_compile_options(/w44305 /w44267)
 else()
   set(WARNING_LIST -Wall -W -Wstrict-prototypes -Wextra -Wcast-align -Wnested-externs -Wshadow)
   include(CheckCCompilerFlag)


### PR DESCRIPTION
* Fix 130 MSVC compiler warnings C4244 from opus 1.5.2
  Seems moving warning C4244 to warning level 4 renders a `/wd4244` (via src/framework/audio(thirdparty/opusenc/cmake/SetupOpus.cmake and buildscripts/cmake/SeupCompileWarnings.cmake)  ineffective?
* Fix 30 linker errors with opus when building in Debug mode
  (not an issue in RelWithDebug mode)

I didn't find a way to do this without modi´fying third-party code...
