### PR TITLE
Fix #27433: Crash on paste

### DIFF
--- a/src/engraving/dom/cmd.cpp
+++ b/src/engraving/dom/cmd.cpp
@@ -1462,7 +1462,7 @@ bool Score::makeGap1(const Fraction& baseTick, staff_idx_t staffIdx, const Fract
             deleteOrShortenOutSpannersFromRange(tick, endTick, track, track + 1, filter);
         }
 
-        seg = m->undoGetSegment(SegmentType::ChordRest, tick);
+        seg = tm->undoGetSegment(SegmentType::ChordRest, tick);
         bool result = makeGapVoice(seg, track, newLen, tick);
         if (track == strack && !result) {   // makeGap failed for first voice
             return false;


### PR DESCRIPTION
Resolves: #27433
Caused by: 00130fc728e326ec4e403b8de5be02703666a2de

When the shadowing variable `m` was renamed to `tm` in the above commit, the call to `m->undoGetSegment(...` should have been updated too (as this was also referencing the inner variable).