### PR TITLE
27534: Fix black backgrounds on QGroupBoxes

### DIFF
--- a/src/framework/ui/api/themeapi.cpp
+++ b/src/framework/ui/api/themeapi.cpp
@@ -625,7 +625,7 @@ void ProxyStyle::drawPrimitive(QStyle::PrimitiveElement element, const QStyleOpt
 
     // GroupBox
     case QStyle::PE_FrameGroupBox: {
-        drawRoundedRect(painter, option->rect, DEFAULT_RADIUS, QBrush(0x03000000),
+        drawRoundedRect(painter, option->rect, DEFAULT_RADIUS, QBrush(QColor::fromRgba(0x03000000)),
                         QPen(m_theme->strokeColor(), fmax(m_theme->borderWidth(), 1.0)));
     } break;
 


### PR DESCRIPTION
Resolves: #27534 

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
