### PR TITLE
Fix MSVC compiler warning

### DIFF
--- a/src/engraving/rendering/score/layoutcontext.cpp
+++ b/src/engraving/rendering/score/layoutcontext.cpp
@@ -151,7 +151,7 @@ const std::vector<Part*>& DomAccessor::parts() const
     return score()->parts();
 }
 
-int DomAccessor::visiblePartCount() const
+size_t DomAccessor::visiblePartCount() const
 {
     IF_ASSERT_FAILED(score()) {
         return 0;

--- a/src/engraving/rendering/score/layoutcontext.h
+++ b/src/engraving/rendering/score/layoutcontext.h
@@ -154,7 +154,7 @@ public:
 
     // Const access
     const std::vector<Part*>& parts() const;
-    int visiblePartCount() const;
+    size_t visiblePartCount() const;
 
     size_t npages() const;
     const std::vector<Page*>& pages() const;


### PR DESCRIPTION
reg.: 'return': conversion from 'size_t' to 'int', possible loss of data (C4267)
Introduced with 1668e1f