### PR TITLE
27544 - Fix QML error in logs NotationStatusBar.qml:107:9: QML FlatButton: Binding loop detected for property "text"

### DIFF
--- a/src/appshell/qml/NotationPage/NotationStatusBar.qml
+++ b/src/appshell/qml/NotationPage/NotationStatusBar.qml
@@ -52,10 +52,6 @@ Item {
         section: navSec
     }
 
-    Component.onCompleted: {
-        model.load()
-    }
-
     RowLayout {
         id: statusBarRow
 
@@ -237,7 +233,7 @@ Item {
                     model.handleAction(model.concertPitchItem.code)
                     break
                 case model.currentWorkspaceItem.id:
-                    model.handleAction(model.concertPitchItem.code)
+                    model.handleAction(model.currentWorkspaceItem.code)
                     break
                 }
             }

--- a/src/appshell/view/notationstatusbarmodel.h
+++ b/src/appshell/view/notationstatusbarmodel.h
@@ -24,6 +24,7 @@
 #define MU_NOTATION_NOTATIONSTATUSBARMODEL_H
 
 #include <QObject>
+#include <QQmlParserStatus>
 
 #include "async/asyncable.h"
 #include "actions/actionable.h"
@@ -43,13 +44,15 @@
 #include "global/iglobalconfiguration.h"
 
 namespace mu::appshell {
-class NotationStatusBarModel : public QObject, public muse::Injectable, public muse::async::Asyncable, public muse::actions::Actionable
+class NotationStatusBarModel : public QObject, public QQmlParserStatus, public muse::Injectable, public muse::async::Asyncable,
+    public muse::actions::Actionable
 {
     Q_OBJECT
+    Q_INTERFACES(QQmlParserStatus)
 
     Q_PROPERTY(QString accessibilityInfo READ accessibilityInfo NOTIFY accessibilityInfoChanged)
-    Q_PROPERTY(QVariant currentWorkspaceItem READ currentWorkspaceItem NOTIFY currentWorkspaceActionChanged)
-    Q_PROPERTY(QVariant concertPitchItem READ concertPitchItem NOTIFY concertPitchActionChanged)
+    Q_PROPERTY(QVariant currentWorkspaceItem READ currentWorkspaceItem CONSTANT)
+    Q_PROPERTY(QVariant concertPitchItem READ concertPitchItem CONSTANT)
     Q_PROPERTY(QVariant currentViewMode READ currentViewMode NOTIFY currentViewModeChanged)
     Q_PROPERTY(bool zoomEnabled READ zoomEnabled NOTIFY zoomEnabledChanged)
     Q_PROPERTY(QVariantList availableViewModeList READ availableViewModeList_property NOTIFY availableViewModeListChanged)
@@ -72,8 +75,6 @@ public:
     QVariant currentViewMode();
     bool zoomEnabled() const;
     int currentZoomPercentage() const;
-
-    Q_INVOKABLE void load();
 
     Q_INVOKABLE void toggleConcertPitch();
     Q_INVOKABLE void setCurrentViewMode(const QString& modeCode);
@@ -101,6 +102,9 @@ signals:
     void currentZoomPercentageChanged();
 
 private:
+    void classBegin() override;
+    void componentComplete() override {}
+
     notation::INotationPtr notation() const;
     notation::INotationAccessibilityPtr accessibility() const;
 
@@ -108,6 +112,9 @@ private:
     void initAvailableZoomList();
 
     muse::uicomponents::MenuItem* makeMenuItem(const muse::actions::ActionCode& actionCode);
+
+    void updateConcertPitchItem();
+    void updateCurrentWorkspaceItem();
 
     void dispatch(const muse::actions::ActionCode& code, const muse::actions::ActionData& args = muse::actions::ActionData());
 


### PR DESCRIPTION
Resolves: #27544 

**Key points:**
The problem here is in that `currentWorkspaceItem` is created upon its first use. This first use happens to be 

    `text: model.currentWorkspaceItem.title`

in `NotationStatusBar.qml:112` for the `text` property. When `currentWorkspaceItem` is getting created for this binding, an action is set on it which triggers the `actionChanged` signal to which a bunch of properties are bound including `text` (see `menuitem.h`). Hence the binding loop.

I'm moving the creation of `currentWorkspaceItem` into the `load` method and am adding an `updateCurrentWorkspaceItem` method for updating `currentWorkspaceItem` initially (on load) and when needed (when dependencies change).

I am doing the same for `concertPitchItem` since it follows the same pattern. It does not produce an error currently because although its first use is also in the `text` property, it does not have an _action_ set on it. Instead a _state_ is set on it, and the _state_ affects the `checked` and `enabled` properties only. If you move the `checked` and/or `enabled` property binding before the `text` property binding in `NotationStatusBar.qml`, the same binding loop error will result since in that case the getter of the first of them will cause `concertPitchItem` to be instantiated.

These changes also now require multiple `null`-guards in `NotationStatusBar.qml`.  This is something we have in many QML files since the model could load after property bindings where it is used.

I hope I am not overly complicating this but I can't figure out another way of doing it. If someone has a better suggestion, please let me know.

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
