### PR TITLE
Update SetupQt6.cmake to include Multimedia

### DIFF
--- a/buildscripts/cmake/SetupQt6.cmake
+++ b/buildscripts/cmake/SetupQt6.cmake
@@ -19,6 +19,7 @@ set(_components
     QuickControls2
     QuickTemplates2
     QuickWidgets
+    Multimedia
     Xml
     Svg
     PrintSupport


### PR DESCRIPTION

Adds QT Multimedia to list of modules for the sake of video player addition.

I've already got a build-in video player QML plugin working based on this change, so it should be possible to do the same in the app.



- [ ] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
