### PR TITLE
Fix crash when splitting measure near lyrics line and organic system break

### DIFF
--- a/src/engraving/dom/spanner.cpp
+++ b/src/engraving/dom/spanner.cpp
@@ -534,7 +534,7 @@ void Spanner::insertTimeUnmanaged(const Fraction& fromTick, const Fraction& len)
 
     // check spanner start and end point
     if (len > Fraction(0, 1)) {            // adding time
-        if (tick() > fromTick) {          // start after insertion point: shift start to right
+        if (tick() >= fromTick) {          // start after insertion point: shift start to right
             newTick1 += len;
         }
         if (tick2() > fromTick) {         // end after insertion point: shift end to right


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/26369

The crash happens because we're allocating a huge number of `LineF`s for dashes of a LyricsLineSegment, and the reason we're allocating so many is that we're trying to fill a distance of almost DBL_MAX.

This DBL_MAX originates from a `Shape::right()` call on an empty Shape, namely the Shape of that LyricsLineSegment's LyricsLine's Lyrics. The reason that it is empty, is that this Lyric has not been laid out yet.

That is because the Lyric is on the next system, so has not been seen yet.

But why are we seeing the LyricsLine then? That is because its tick gets messed up while splitting the measure (it is not moved forward when inserting time, but it is moved backwards when removing time), causing it to get out of sync with its Lyrics, and causing it to be considered while laying out the previous system.

The solution is to ensure that the tick adjustment when inserting the two measures that result from the splitment is in balance with the tick adjustment when removing the original measure.