### PR TITLE
Fix porting error

### DIFF
--- a/src/engraving/rendering/score/tlayout.cpp
+++ b/src/engraving/rendering/score/tlayout.cpp
@@ -2658,6 +2658,8 @@ void TLayout::layoutFretDiagram(const FretDiagram* item, FretDiagram::LayoutData
         }
     }
 
+    ldata->setPos((noteheadWidth - item->mainWidth()) / 2, -(ldata->shape().bottom() + item->styleP(Sid::fretY)));
+
     Harmony* harmony = item->harmony();
     if (harmony) {
         TLayout::layoutHarmony(harmony, harmony->mutldata(), ctx);


### PR DESCRIPTION
This happened because some code has been merged in master but not in 4.5 related to fret diagrams, which means that [my recent PR](https://github.com/musescore/MuseScore/pull/27276) about this (which worked in master) didn't port properly to 4.5.2 and the vtests failure for 4.5.2 wasn't spotted because they were supposed to fail anyway. @miiizen @oktophonie let's remind ourselves to always re-check the vtests and not take them for granted when porting things between branches.