### PR TITLE
Added Qt multimedia (optional)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,6 +158,10 @@ if (MUSE_MODULE_NETWORK_WEBSOCKET)
     set(QT_ADD_WEBSOCKET ON)
 endif()
 
+# It is used to develop new functionality that is not ready and released yet.
+# It should be enabled only for separate build (not master)  used for testing.
+set(QT_ADD_MULTIMEDIA OFF)
+
 include(SetupQt6)
 
 if (MUE_DOWNLOAD_SOUNDFONT)

--- a/buildscripts/ci/linux/setup.sh
+++ b/buildscripts/ci/linux/setup.sh
@@ -130,7 +130,8 @@ sudo apt-get install -y --no-install-recommends \
 
 # Get newer Qt (only used cached version if it is the same)
 qt_version="624"
-qt_revision="r2" # added websocket module
+#qt_revision="r2" # added websocket module
+qt_revision="r3" # added multimedia module
 qt_dir="$BUILD_TOOLS/Qt/${qt_version}"
 if [[ ! -d "${qt_dir}" ]]; then
   mkdir -p "${qt_dir}"

--- a/buildscripts/cmake/SetupQt6.cmake
+++ b/buildscripts/cmake/SetupQt6.cmake
@@ -56,6 +56,12 @@ if (QT_ADD_WEBSOCKET)
     )
 endif()
 
+if (QT_ADD_MULTIMEDIA)
+    set(_components ${_components}
+        Multimedia
+    )
+endif()
+
 foreach(_component ${_components})
     find_package(Qt6${_component} REQUIRED)
     list(APPEND QT_LIBRARIES ${Qt6${_component}_LIBRARIES})


### PR DESCRIPTION
see https://github.com/musescore/MuseScore/pull/27552 

This allows us to build assemblies on CI with multimedia support to test the functions that use it. 
Need to switch on the option: `QT_ADD_MULTIMEDIA` 

But it won't affect other developers. We can turn on multimedia support by default when we get ready-made functionality that can be provided to users.