### PR TITLE
Improve MeasureBaseList lookup performance

### DIFF
--- a/src/engraving/dom/excerpt.cpp
+++ b/src/engraving/dom/excerpt.cpp
@@ -1153,8 +1153,6 @@ void Excerpt::cloneStaves(Score* sourceScore, Score* dstScore, const std::vector
         measures->add(newMeasure);
     }
 
-    measures->updateTickIndex();
-
     size_t n = sourceStavesIndexes.size();
     for (staff_idx_t dstStaffIdx = 0; dstStaffIdx < n; ++dstStaffIdx) {
         Staff* srcStaff = sourceScore->staff(sourceStavesIndexes[dstStaffIdx]);
@@ -1219,8 +1217,6 @@ void Excerpt::cloneMeasures(Score* oscore, Score* score)
         MeasureBase* newMeasure = cloneMeasure(mb, score, oscore, {}, {}, tieMap);
         measures->add(newMeasure);
     }
-
-    measures->updateTickIndex();
 
     collectTieEndPoints(tieMap);
 }

--- a/src/engraving/dom/excerpt.cpp
+++ b/src/engraving/dom/excerpt.cpp
@@ -1153,6 +1153,8 @@ void Excerpt::cloneStaves(Score* sourceScore, Score* dstScore, const std::vector
         measures->add(newMeasure);
     }
 
+    measures->updateTickIndex();
+
     size_t n = sourceStavesIndexes.size();
     for (staff_idx_t dstStaffIdx = 0; dstStaffIdx < n; ++dstStaffIdx) {
         Staff* srcStaff = sourceScore->staff(sourceStavesIndexes[dstStaffIdx]);
@@ -1217,6 +1219,8 @@ void Excerpt::cloneMeasures(Score* oscore, Score* score)
         MeasureBase* newMeasure = cloneMeasure(mb, score, oscore, {}, {}, tieMap);
         measures->add(newMeasure);
     }
+
+    measures->updateTickIndex();
 
     collectTieEndPoints(tieMap);
 }

--- a/src/engraving/dom/excerpt.cpp
+++ b/src/engraving/dom/excerpt.cpp
@@ -1156,7 +1156,7 @@ void Excerpt::cloneStaves(Score* sourceScore, Score* dstScore, const std::vector
             continue;
         }
         MeasureBase* newMeasure = cloneMeasure(mb, dstScore, sourceScore, sourceStavesIndexes, trackList, tieMap);
-        measures->add(newMeasure);
+        measures->append(newMeasure);
     }
 
     size_t n = sourceStavesIndexes.size();
@@ -1221,7 +1221,7 @@ void Excerpt::cloneMeasures(Score* oscore, Score* score)
 
     for (MeasureBase* mb = oscore->firstMeasure(); mb; mb = mb->next()) {
         MeasureBase* newMeasure = cloneMeasure(mb, score, oscore, {}, {}, tieMap);
-        measures->add(newMeasure);
+        measures->append(newMeasure);
     }
 
     collectTieEndPoints(tieMap);

--- a/src/engraving/dom/excerpt.cpp
+++ b/src/engraving/dom/excerpt.cpp
@@ -854,14 +854,20 @@ static MeasureBase* cloneMeasure(MeasureBase* mb, Score* score, const Score* osc
 
     if (mb->isHBox()) {
         nmb = Factory::createHBox(score->dummy()->system());
+        nmb->setTick(mb->tick());
+        nmb->setTicks(mb->ticks());
     } else if (mb->isVBox()) {
         if (toBox(mb)->isTitleFrame()) {
             nmb = Factory::createTitleVBox(score->dummy()->system());
         } else {
             nmb = Factory::createVBox(score->dummy()->system());
         }
+        nmb->setTick(mb->tick());
+        nmb->setTicks(mb->ticks());
     } else if (mb->isTBox()) {
         nmb = Factory::createTBox(score->dummy()->system());
+        nmb->setTick(mb->tick());
+        nmb->setTicks(mb->ticks());
         Text* text = toTBox(mb)->text();
         EngravingItem* ne = text->linkedClone();
         ne->setScore(score);

--- a/src/engraving/dom/mcursor.cpp
+++ b/src/engraving/dom/mcursor.cpp
@@ -74,7 +74,7 @@ void MCursor::createMeasures()
         measure->setTick(tick);
         measure->setTimesig(m_sig);
         measure->setTicks(m_sig);
-        m_score->measures()->add(measure);
+        m_score->measures()->append(measure);
     }
 }
 

--- a/src/engraving/dom/measurebase.cpp
+++ b/src/engraving/dom/measurebase.cpp
@@ -869,9 +869,9 @@ void MeasureBaseList::remove(MeasureBase* m)
     }
 
     auto mbIt = findMeasureBaseIterator(m);
-    if (mbIt != m_tickIndex.end()) {
-        m_tickIndex.erase(mbIt);
-    }
+    assert(mbIt != m_tickIndex.end());
+
+    m_tickIndex.erase(mbIt);
 }
 
 //---------------------------------------------------------
@@ -908,16 +908,16 @@ void MeasureBaseList::remove(MeasureBase* fm, MeasureBase* lm)
 {
     for (MeasureBase* m = fm; m != lm; m = m->next()) {
         auto mbIt = findMeasureBaseIterator(m);
-        if (mbIt != m_tickIndex.end()) {
-            m_tickIndex.erase(mbIt);
-        }
+        assert(mbIt != m_tickIndex.end());
+
+        m_tickIndex.erase(mbIt);
         --m_size;
     }
     --m_size;
     auto mbIt = findMeasureBaseIterator(lm);
-    if (mbIt != m_tickIndex.end()) {
-        m_tickIndex.erase(mbIt);
-    }
+    assert(mbIt != m_tickIndex.end());
+
+    m_tickIndex.erase(mbIt);
     MeasureBase* pm = fm->prev();
     MeasureBase* nm = lm->next();
     if (pm) {
@@ -961,9 +961,9 @@ void MeasureBaseList::change(MeasureBase* ob, MeasureBase* nb)
     }
 
     auto mbIt = findMeasureBaseIterator(ob);
-    if (mbIt != m_tickIndex.end()) {
-        mbIt->second = nb;
-    }
+    assert(mbIt != m_tickIndex.end());
+
+    mbIt->second = nb;
 }
 
 Measure* MeasureBaseList::measureByTick(int tick) const

--- a/src/engraving/dom/measurebase.h
+++ b/src/engraving/dom/measurebase.h
@@ -238,6 +238,8 @@ public:
     int size() const { return m_size; }
     bool empty() const { return m_size == 0; }
 
+    void append(MeasureBase*);
+
     void updateTickIndex();
 
     Measure* measureByTick(int tick) const;
@@ -246,8 +248,6 @@ public:
 private:
     void push_back(MeasureBase* m);
     void push_front(MeasureBase* m);
-
-    std::multimap<int, MeasureBase*>::iterator findMeasureBaseIterator(MeasureBase* m);
 
     int m_size = 0;
     MeasureBase* m_first = nullptr;

--- a/src/engraving/dom/measurebase.h
+++ b/src/engraving/dom/measurebase.h
@@ -229,7 +229,7 @@ public:
     MeasureBaseList();
     MeasureBase* first() const { return m_first; }
     MeasureBase* last()  const { return m_last; }
-    void clear() { m_first = m_last = 0; m_size = 0; }
+    void clear();
     void add(MeasureBase*);
     void remove(MeasureBase*);
     void insert(MeasureBase*, MeasureBase*);
@@ -238,13 +238,25 @@ public:
     int size() const { return m_size; }
     bool empty() const { return m_size == 0; }
 
+    void updateTickIndex();
+
+    Measure* measureByTick(int tick) const;
+    std::vector<MeasureBase*> measureBasesAtTick(int tick) const;
+
 private:
-    void push_back(MeasureBase* e);
-    void push_front(MeasureBase* e);
+    void push_back(MeasureBase* m);
+    void push_front(MeasureBase* m);
+
+    std::multimap<int, MeasureBase*>::iterator findMeasureBaseIterator(MeasureBase* m);
 
     int m_size = 0;
     MeasureBase* m_first = nullptr;
     MeasureBase* m_last = nullptr;
+
+    // At a tick there can be any number of MeasureBases
+    // There can only be one Measure
+    // There can be any number of Boxes
+    std::multimap<int, MeasureBase*> m_tickIndex;
 };
 } // namespace mu::engraving
 #endif

--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -1474,7 +1474,7 @@ Measure* Score::getCreateMeasure(const Fraction& tick)
             m->setTick(lastTick);
             m->setTimesig(ts);
             m->setTicks(ts);
-            measures()->add(toMeasureBase(m));
+            measures()->append(toMeasureBase(m));
             lastTick += Fraction::fromTicks(ts.ticks());
         }
     }
@@ -2176,7 +2176,6 @@ bool Score::appendScore(Score* score, bool addPageBreak, bool addSectionBreak)
 bool Score::appendMeasuresFromScore(Score* score, const Fraction& startTick, const Fraction& endTick)
 {
     Fraction tickOfAppend = last()->endTick();
-    MeasureBase* pmb = last();
     TieMap tieMap;
 
     MeasureBase* fmb = score->tick2measureBase(startTick);
@@ -2192,13 +2191,8 @@ bool Score::appendMeasuresFromScore(Score* score, const Fraction& startTick, con
             nmb = static_cast<MeasureBase*>(cmb->clone());
         }
 
-        addMeasure(nmb, 0);
-        nmb->setNext(0);
-        nmb->setPrev(pmb);
         nmb->setScore(this);
-
-        pmb->setNext(nmb);
-        pmb = nmb;
+        measures()->append(nmb);
     }
 
     Measure* firstAppendedMeasure = tick2measure(tickOfAppend);

--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -450,6 +450,8 @@ void Score::setUpTempoMap()
         tick += measureTicks;
     }
 
+    m_measures.updateTickIndex();
+
     if (isMaster()) {
         for (const auto& pair : spanner()) {
             const Spanner* spannerItem = pair.second;

--- a/src/engraving/dom/utils.cpp
+++ b/src/engraving/dom/utils.cpp
@@ -31,7 +31,6 @@
 #include "chord.h"
 #include "chordrest.h"
 #include "clef.h"
-#include "measurebase.h"
 #include "marker.h"
 #include "masterscore.h"
 #include "repeatlist.h"
@@ -106,8 +105,6 @@ Measure* Score::tick2measureMM(const Fraction& t) const
     }
 
     return measure;
-
-    return 0;
 }
 
 //---------------------------------------------------------

--- a/src/engraving/rendering/score/measurelayout.cpp
+++ b/src/engraving/rendering/score/measurelayout.cpp
@@ -872,7 +872,7 @@ void MeasureLayout::layoutMeasure(MeasureBase* currentMB, LayoutContext& ctx)
     currentMB = ctx.mutState().curMeasure();
 
     if (!currentMB->isMeasure()) {
-        currentMB->setTick(ctx.state().tick());
+        assert(currentMB->tick() == ctx.state().tick());
         return;
     }
 

--- a/src/engraving/rw/read114/read114.cpp
+++ b/src/engraving/rw/read114/read114.cpp
@@ -2303,7 +2303,7 @@ static void readStaffContent(Score* score, XmlReader& e, ReadContext& ctx)
                 measure->checkMeasure(staff);
 
                 if (!measure->isMMRest()) {
-                    score->measures()->add(measure);
+                    score->measures()->append(measure);
                     ctx.setLastMeasure(measure);
                     ctx.setTick(measure->tick() + measure->ticks());
                 } else {
@@ -2321,7 +2321,7 @@ static void readStaffContent(Score* score, XmlReader& e, ReadContext& ctx)
                     LOGD("Score::readStaff(): missing measure!");
                     measure = Factory::createMeasure(score->dummy()->system());
                     measure->setTick(ctx.tick());
-                    score->measures()->add(measure);
+                    score->measures()->append(measure);
                 }
                 ctx.setTick(measure->tick());
 
@@ -2343,7 +2343,7 @@ static void readStaffContent(Score* score, XmlReader& e, ReadContext& ctx)
             Box* mb = toBox(Factory::createItemByName(tag, score->dummy()));
             readBox(e, ctx, mb);
             mb->setTick(ctx.tick());
-            score->measures()->add(mb);
+            score->measures()->append(mb);
         } else if (tag == "tick") {
             ctx.setTick(Fraction::fromTicks(score->fileDivision(e.readInt())));
         } else {

--- a/src/engraving/rw/read206/read206.cpp
+++ b/src/engraving/rw/read206/read206.cpp
@@ -3111,7 +3111,7 @@ static void readStaffContent206(Score* score, XmlReader& e, ReadContext& ctx)
                 readMeasure206(measure, staff, e, ctx);
                 measure->checkMeasure(staff);
                 if (!measure->isMMRest()) {
-                    score->measures()->add(measure);
+                    score->measures()->append(measure);
                     if (m && m->mmRest()) {
                         m->mmRest()->setNext(measure);
                     }
@@ -3132,7 +3132,7 @@ static void readStaffContent206(Score* score, XmlReader& e, ReadContext& ctx)
                 Box* b = toBox(Factory::createItemByName(tag, score->dummy()));
                 readBox(b, e, ctx);
                 b->setTick(ctx.tick());
-                score->measures()->add(b);
+                score->measures()->append(b);
 
                 // If it's the first box, and comes before any measures, reset to
                 // 301 default.
@@ -3161,7 +3161,7 @@ static void readStaffContent206(Score* score, XmlReader& e, ReadContext& ctx)
                     LOGD("Score::readStaff(): missing measure!");
                     measure = Factory::createMeasure(score->dummy()->system());
                     measure->setTick(ctx.tick());
-                    score->measures()->add(measure);
+                    score->measures()->append(measure);
                 }
                 ctx.setTick(measure->tick());
                 readMeasure206(measure, staff, e, ctx);

--- a/src/engraving/rw/read400/staffrw.cpp
+++ b/src/engraving/rw/read400/staffrw.cpp
@@ -63,7 +63,7 @@ void StaffRead::readStaff(Score* score, XmlReader& e, ReadContext& ctx)
                 MeasureRead::readMeasure(measure, e, ctx, staff);
                 measure->checkMeasure(staff);
                 if (!measure->isMMRest()) {
-                    score->measures()->add(measure);
+                    score->measures()->append(measure);
                     if (m && m->mmRest()) {
                         m->mmRest()->setNext(measure);
                     }
@@ -84,7 +84,7 @@ void StaffRead::readStaff(Score* score, XmlReader& e, ReadContext& ctx)
             } else if (tag == "HBox" || tag == "VBox" || tag == "TBox" || tag == "FBox") {
                 MeasureBase* mb = toMeasureBase(Factory::createItemByName(tag, ctx.dummy()));
                 mb->setTick(ctx.tick());
-                score->measures()->add(mb);
+                score->measures()->append(mb);
                 TRead::readItem(mb, e, ctx);
             } else if (tag == "tick") {
                 ctx.setTick(Fraction::fromTicks(ctx.fileDivision(e.readInt())));
@@ -102,7 +102,7 @@ void StaffRead::readStaff(Score* score, XmlReader& e, ReadContext& ctx)
                     LOGD("Score::readStaff(): missing measure!");
                     measure = Factory::createMeasure(ctx.dummy()->system());
                     measure->setTick(ctx.tick());
-                    score->measures()->add(measure);
+                    score->measures()->append(measure);
                 }
                 ctx.setTick(measure->tick());
                 ctx.setCurrentMeasureIndex(measureIdx++);

--- a/src/engraving/rw/read410/staffread.cpp
+++ b/src/engraving/rw/read410/staffread.cpp
@@ -65,7 +65,7 @@ void StaffRead::readStaff(Score* score, XmlReader& e, ReadContext& ctx)
                 MeasureRead::readMeasure(measure, e, ctx, staff);
                 measure->checkMeasure(staff);
                 if (!measure->isMMRest()) {
-                    score->measures()->add(measure);
+                    score->measures()->append(measure);
                     if (m && m->mmRest()) {
                         m->mmRest()->setNext(measure);
                     }
@@ -86,7 +86,7 @@ void StaffRead::readStaff(Score* score, XmlReader& e, ReadContext& ctx)
             } else if (tag == "HBox" || tag == "VBox" || tag == "TBox" || tag == "FBox") {
                 MeasureBase* mb = toMeasureBase(Factory::createItemByName(tag, ctx.dummy()));
                 mb->setTick(ctx.tick());
-                score->measures()->add(mb);
+                score->measures()->append(mb);
                 // This default value needs initialising after being added to the score, as it depends on whether this is the title frame
                 if (mb->score()->mscVersion() >= 440) {
                     mb->setSizeIsSpatiumDependent(mb->propertyDefault(Pid::SIZE_SPATIUM_DEPENDENT).toBool());
@@ -109,7 +109,7 @@ void StaffRead::readStaff(Score* score, XmlReader& e, ReadContext& ctx)
                     LOGD("Score::readStaff(): missing measure!");
                     measure = Factory::createMeasure(ctx.dummy()->system());
                     measure->setTick(ctx.tick());
-                    score->measures()->add(measure);
+                    score->measures()->append(measure);
                 }
                 ctx.setTick(measure->tick());
                 ctx.setCurrentMeasureIndex(measureIdx++);

--- a/src/importexport/bb/internal/bb.cpp
+++ b/src/importexport/bb/internal/bb.cpp
@@ -430,7 +430,7 @@ Err importBB(MasterScore* score, const QString& name)
         Fraction ts = score->sigmap()->timesig(tick.ticks()).timesig();
         measure->setTimesig(ts);
         measure->setTicks(ts);
-        score->measures()->add(measure);
+        score->measures()->append(measure);
     }
 
     //---------------------------------------------------
@@ -488,7 +488,7 @@ Err importBB(MasterScore* score, const QString& name)
     if (measureB->type() != ElementType::VBOX) {
         measureB = Factory::createTitleVBox(score->dummy()->system());
         measureB->setNext(score->first());
-        score->measures()->add(measureB);
+        score->measures()->append(measureB);
     }
     measureB->add(text);
 

--- a/src/importexport/bww/internal/bww/importbww.cpp
+++ b/src/importexport/bww/internal/bww/importbww.cpp
@@ -224,7 +224,7 @@ void MsScWriter::beginMeasure(const Bww::MeasureBeginFlags mbf)
     currentMeasure->setTick(tick);
     currentMeasure->setTimesig(mu::engraving::Fraction(beats, beat));
     currentMeasure->setNo(measureNumber);
-    score->measures()->add(currentMeasure);
+    score->measures()->append(currentMeasure);
 
     if (mbf.repeatBegin) {
         currentMeasure->setRepeatStart(true);
@@ -457,7 +457,7 @@ void MsScWriter::header(const QString title, const QString type,
     // addText(vbox, score, strTranslator, mu::engraving::TextStyleName::TRANSLATOR);
     if (vbox) {
         vbox->setTick(mu::engraving::Fraction(0, 1));
-        score->measures()->add(vbox);
+        score->measures()->append(vbox);
     }
     if (!footer.isEmpty()) {
         score->style().set(mu::engraving::Sid::oddFooterC, footer);

--- a/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
+++ b/src/importexport/guitarpro/internal/gtp/gpconverter.cpp
@@ -1036,7 +1036,7 @@ void GPConverter::setUpGPScore(const GPScore* gpscore)
     MeasureBase* m = nullptr;
     if (!_score->measures()->first()) {
         m = Factory::createTitleVBox(_score->dummy()->system());
-        _score->addMeasure(m, 0);
+        _score->measures()->append(m);
     } else {
         m = _score->measures()->first();
         if (!m->isVBox()) {
@@ -1713,7 +1713,7 @@ Measure* GPConverter::addMeasure(const GPMasterBar* mB)
     auto scoreTimeSig = Fraction(sig.numerator, sig.denominator);
     measure->setTimesig(scoreTimeSig);
     measure->setTicks(scoreTimeSig);
-    _score->measures()->add(measure);
+    _score->measures()->append(measure);
 
     return measure;
 }

--- a/src/importexport/guitarpro/internal/importgtp.cpp
+++ b/src/importexport/guitarpro/internal/importgtp.cpp
@@ -935,7 +935,7 @@ void GuitarPro::createMeasures()
             }
         }
 
-        score->measures()->add(m);
+        score->measures()->append(m);
         tick += nts;
         ts = nts;
     }
@@ -1082,7 +1082,7 @@ bool GuitarPro1::read(IODevice* io)
             }
         }
 
-        score->measures()->add(m);
+        score->measures()->append(m);
         tick += nts;
         ts = nts;
     }
@@ -1475,7 +1475,7 @@ bool GuitarPro2::read(IODevice* io)
             }
         }
 
-        score->measures()->add(m);
+        score->measures()->append(m);
         tick += nts;
         ts = nts;
     }
@@ -2224,7 +2224,7 @@ bool GuitarPro3::read(IODevice* io)
             }
         }
 
-        score->measures()->add(m);
+        score->measures()->append(m);
         tick += nts;
         ts = nts;
     }
@@ -2746,7 +2746,7 @@ static void addMetaInfo(MasterScore* score, GuitarPro* gp, bool experimental)
     MeasureBase* m = nullptr;
     if (!score->measures()->first()) {
         m = Factory::createTitleVBox(score->dummy()->system());
-        score->addMeasure(m, 0);
+        score->measures()->append(m);
     } else {
         m = score->measures()->first();
         if (!m->isVBox()) {

--- a/src/importexport/guitarpro/internal/importptb.cpp
+++ b/src/importexport/guitarpro/internal/importptb.cpp
@@ -1172,7 +1172,7 @@ Measure* PowerTab::createMeasure(ptBar* bar, const Fraction& tick)
     measure->setTimesig(nts);
     measure->setTicks(nts);
 
-    score->measures()->add(measure);
+    score->measures()->append(measure);
 
     return measure;
 }
@@ -1269,7 +1269,7 @@ Err PowerTab::read()
     MeasureBase* m;
     if (!score->measures()->first()) {
         m = Factory::createTitleVBox(score->dummy()->system());
-        score->addMeasure(m, 0);
+        score->measures()->append(m);
     } else {
         m = score->measures()->first();
         if (!m->isVBox()) {

--- a/src/importexport/mei/internal/meiimporter.cpp
+++ b/src/importexport/mei/internal/meiimporter.cpp
@@ -1119,7 +1119,7 @@ bool MeiImporter::readPgHead(pugi::xml_node pgHeadNode)
     }
 
     if (vBox) {
-        m_score->measures()->add(vBox);
+        m_score->measures()->append(vBox);
     }
 
     return true;
@@ -1444,7 +1444,7 @@ bool MeiImporter::readMeasure(pugi::xml_node measureNode)
         measure->setRepeatCount(measureSt.repeatCount);
     }
 
-    m_score->measures()->add(measure);
+    m_score->measures()->append(measure);
     m_ticks += measure->ticks();
 
     m_lastMeasure = measure;
@@ -3196,7 +3196,7 @@ bool MeiImporter::buildTextFrame()
 
     if (vBox) {
         vBox->setTick(Fraction(0, 1));
-        m_score->measures()->add(vBox);
+        m_score->measures()->append(vBox);
     }
 
     return true;

--- a/src/importexport/midi/internal/midiimport/importmidi.cpp
+++ b/src/importexport/midi/internal/midiimport/importmidi.cpp
@@ -373,7 +373,7 @@ void MTrack::processMeta(int tick, const MidiEvent& mm)
             measure = Factory::createVBox(cs->dummy()->system());
             measure->setTick(Fraction(0, 1));
             measure->setNext(cs->first());
-            cs->measures()->add(measure);
+            cs->measures()->append(measure);
         }
         measure->add(text);
     }
@@ -837,7 +837,7 @@ void tryCreatePickupMeasure(
         pickup->setIrregular(true);
         pickup->setTimesig(secondTimeSig);           // nominal time signature
         pickup->setTicks(firstTimeSig);                // actual length
-        score->measures()->add(pickup);
+        score->measures()->append(pickup);
         *begBarIndex = 1;
     } else if (isPickupWithGreaterTimeSig(firstTimeSig, secondTimeSig, firstTick)) {
         // split measure into 2 equal measures
@@ -852,14 +852,14 @@ void tryCreatePickupMeasure(
         firstBar->setNo(0);
         firstBar->setTimesig(secondTimeSig);
         firstBar->setTicks(secondTimeSig);
-        score->measures()->add(firstBar);
+        score->measures()->append(firstBar);
 
         Measure* secondBar = Factory::createMeasure(score->dummy()->system());
         secondBar->setTick(Fraction::fromTicks(firstBarTick + secondTimeSig.ticks()));
         secondBar->setNo(1);
         secondBar->setTimesig(secondTimeSig);
         secondBar->setTicks(secondTimeSig);
-        score->measures()->add(secondBar);
+        score->measures()->append(secondBar);
 
         *begBarIndex = 2;
     }
@@ -894,7 +894,7 @@ void createMeasures(const ReducedFraction& firstTick, ReducedFraction& lastTick,
         const Fraction timeSig = score->sigmap()->timesig(t).timesig();
         m->setTimesig(timeSig);
         m->setTicks(timeSig);
-        score->measures()->add(m);
+        score->measures()->append(m);
     }
 
     const Measure* m = score->lastMeasure();

--- a/src/importexport/musedata/internal/musedata.cpp
+++ b/src/importexport/musedata/internal/musedata.cpp
@@ -567,7 +567,7 @@ Measure* MuseData::createMeasure()
     Measure* mes  = Factory::createMeasure(score->dummy()->system());
     mes->setTick(curTick);
 
-    score->measures()->add(mes);
+    score->measures()->append(mes);
     return mes;
 }
 

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass1.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass1.cpp
@@ -916,7 +916,7 @@ VBox* MusicXmlParserPass1::createAndAddVBoxForCreditWords(Score* score, Fraction
 {
     VBox* vbox = Factory::createTitleVBox(score->dummy()->system());
     vbox->setTick(tick);
-    score->measures()->add(vbox);
+    score->measures()->append(vbox);
     return vbox;
 }
 
@@ -1154,7 +1154,7 @@ void MusicXmlParserPass1::createMeasuresAndVboxes(Score* score,
         measure->setTick(ms.at(i));
         measure->setTicks(ml.at(i));
         measure->setNo(int(i));
-        score->measures()->add(measure);
+        score->measures()->append(measure);
 
         // add break to previous measure or vbox
         MeasureBase* mb = vbox;

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass1.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass1.cpp
@@ -912,9 +912,10 @@ static TextStyleType tidForCreditWords(const CreditWords* const word, std::vecto
 //   createAndAddVBoxForCreditWords
 //---------------------------------------------------------
 
-VBox* MusicXmlParserPass1::createAndAddVBoxForCreditWords(Score* score)
+VBox* MusicXmlParserPass1::createAndAddVBoxForCreditWords(Score* score, Fraction tick)
 {
     VBox* vbox = Factory::createTitleVBox(score->dummy()->system());
+    vbox->setTick(tick);
     score->measures()->add(vbox);
     return vbox;
 }
@@ -996,9 +997,10 @@ static void inferFromTitle(String& title, String& inferredSubtitle, String& infe
 //---------------------------------------------------------
 
 static VBox* addCreditWords(Score* score, const CreditWordsList& crWords, const Size& pageSize,
-                            const bool top, const bool isSibeliusScore)
+                            Fraction tick, const bool isSibeliusScore)
 {
     VBox* vbox = nullptr;
+    const bool top = tick.isZero();
 
     std::vector<const CreditWords*> headerWords;
     std::vector<const CreditWords*> footerWords;
@@ -1035,7 +1037,8 @@ static VBox* addCreditWords(Score* score, const CreditWordsList& crWords, const 
             const Align align = alignForCreditWords(w, pageSize.width(), tid);
             double yoffs = tid == TextStyleType::COMPOSER ? 0.0 : (maxy - w->defaultY) * score->style().spatium() / 10;
             if (!vbox) {
-                vbox = MusicXmlParserPass1::createAndAddVBoxForCreditWords(score);
+                Fraction vBoxTick = top ? Fraction(0, 1) : tick;
+                vbox = MusicXmlParserPass1::createAndAddVBoxForCreditWords(score, vBoxTick);
             }
             addText2(vbox, score, w->words, tid, align, yoffs);
         } else if (w->type == u"rights" && score->metaTag(u"copyright").empty()) {
@@ -1101,7 +1104,7 @@ void MusicXmlParserPass1::createDefaultHeader(Score* score)
         strTranslator = metaTranslator;
     }
 
-    VBox* const vbox = MusicXmlParserPass1::createAndAddVBoxForCreditWords(score);
+    VBox* const vbox = MusicXmlParserPass1::createAndAddVBoxForCreditWords(score, Fraction(0, 1));
     vbox->setExcludeFromOtherParts(false);
     addText(vbox, score, strTitle.toXmlEscaped(),      TextStyleType::TITLE);
     addText(vbox, score, strSubTitle.toXmlEscaped(),   TextStyleType::SUBTITLE);
@@ -1139,7 +1142,7 @@ void MusicXmlParserPass1::createMeasuresAndVboxes(Score* score,
             ++pageNr;
 
             if (pageNr == 1) {
-                vbox = addCreditWords(score, crWords, pageSize, true, sibOrDolet());
+                vbox = addCreditWords(score, crWords, pageSize, Fraction(0, 0), sibOrDolet());
                 if (i == 0 && vbox) {
                     vbox->setExcludeFromOtherParts(false);
                 }
@@ -1166,7 +1169,7 @@ void MusicXmlParserPass1::createMeasuresAndVboxes(Score* score,
 
         // add a footer vbox if the next measure is on a new page or end of score has been reached
         if ((pageStartMeasureNrs.count(int(i + 1)) || i == (ml.size() - 1)) && pageNr == 1) {
-            addCreditWords(score, crWords, pageSize, false, sibOrDolet());
+            addCreditWords(score, crWords, pageSize, measure->tick() + measure->ticks(), sibOrDolet());
         }
     }
 }

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass1.h
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass1.h
@@ -200,7 +200,7 @@ public:
     bool hasBeamingInfo() const { return m_hasBeamingInfo; }
     bool isVocalStaff(const muse::String& partId) const { return m_parts.at(partId).isVocalStaff(); }
     bool isPercussionStaff(const muse::String& partId) const { return m_parts.at(partId).isPercussionStaff(); }
-    static engraving::VBox* createAndAddVBoxForCreditWords(engraving::Score* score);
+    static engraving::VBox* createAndAddVBoxForCreditWords(engraving::Score* score, engraving::Fraction tick);
     void createDefaultHeader(engraving::Score* const score);
     void createMeasuresAndVboxes(engraving::Score* const score, const std::vector<engraving::Fraction>& ml,
                                  const std::vector<engraving::Fraction>& ms, const std::set<int>& systemStartMeasureNrs,

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -3867,7 +3867,8 @@ Text* MusicXmlParserDirection::addTextToHeader(const TextStyleType textStyleType
     Text* t = Factory::createText(m_score->dummy(), textStyleType);
     t->setXmlText(m_wordsText.trimmed());
     MeasureBase* const firstMeasure = m_score->measures()->first();
-    VBox* vbox = firstMeasure->isVBox() ? toVBox(firstMeasure) : MusicXmlParserPass1::createAndAddVBoxForCreditWords(m_score);
+    VBox* vbox
+        = firstMeasure->isVBox() ? toVBox(firstMeasure) : MusicXmlParserPass1::createAndAddVBoxForCreditWords(m_score, Fraction(0, 1));
     double spatium = m_score->style().styleD(Sid::spatium);
     vbox->setBoxHeight(vbox->boxHeight() + Spatium(t->height() / spatium / 2)); // add some height
     vbox->add(t);

--- a/src/importexport/ove/internal/importove.cpp
+++ b/src/importexport/ove/internal/importove.cpp
@@ -328,7 +328,7 @@ void OveToMScore::createStructure()
         int tick = m_mtt->getTick(i, 0);
         measure->setTick(Fraction::fromTicks(tick));
         measure->setNo(i);
-        m_score->measures()->add(measure);
+        m_score->measures()->append(measure);
     }
 }
 
@@ -403,7 +403,7 @@ void OveToMScore::convertHeader()
 
     if (vbox) {
         vbox->setTick(Fraction(0, 1));
-        m_score->measures()->add(vbox);
+        m_score->measures()->append(vbox);
     }
 }
 

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -227,7 +227,7 @@ static void createMeasures(mu::engraving::Score* score, const ScoreCreateOptions
                 measure->setTicks(mu::engraving::Fraction(scoreOptions.measureTimesigNumerator,
                                                           scoreOptions.measureTimesigDenominator));
             }
-            _score->measures()->add(measure);
+            _score->measures()->append(measure);
 
             for (mu::engraving::Staff* staff : _score->staves()) {
                 mu::engraving::staff_idx_t staffIdx = staff->idx();


### PR DESCRIPTION
This PR improves the performance of `tick2measure`, `tick2measureMM` and `tick2measureBase` by maintaining an `std::multimap` of ticks and `MeasureBase*` alongside the existing linked list. `multimap` is much faster to query than the existing linked list, but adds some slowdown and overhead on adding and removing measures from the list. Firstly, the measure must be added to the map, then the map must be regenerated in order to update each measure's tick value. (One possible improvement would be to regenerate the map only from the start tick of layout)

![Screenshot 2025-04-03 at 11 21 52 1](https://github.com/user-attachments/assets/706f6f43-a93c-490c-9380-5352ed093b04)
_`std::multimap` is implemented as a red-black tree_

This slowdown is acceptable, as we are querying this list far more often than we are adding measures. In the Beethoven 9 example, when opening the project `MeasureBaseList::add` is called 2,662 times, whereas we call `tick2measure` & `tick2measureMM` a total of 281,246 times.

-----
## Profiling
<img width="1398" alt="Screenshot 2025-04-07 at 14 29 33" src="https://github.com/user-attachments/assets/cbbf0dd0-1069-4c67-b99a-ecac8944ab4d" />


Any `MeasureBaseList` or utility measure access function not in the table had a small enough impact to not be picked up by the profiler before or after the PR. %change is the change in sum time. A positive %change is a speedup, negative is a slowdown. 