### PR TITLE
Fix #27126: Bugs relating to Select -> More

### DIFF
--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -83,6 +83,8 @@ public:
     virtual muse::async::Notification selectionChanged() const = 0;
     virtual void selectTopOrBottomOfChord(MoveDirection d) = 0;
 
+    virtual EngravingItem* contextItem() const = 0;
+
     // SelectionFilter
     virtual bool isSelectionTypeFiltered(SelectionFilterType type) const = 0;
     virtual void setSelectionTypeFiltered(SelectionFilterType type, bool filtered) = 0;
@@ -322,6 +324,4 @@ public:
 };
 
 using INotationInteractionPtr = std::shared_ptr<INotationInteraction>;
-
-EngravingItem* contextItem(INotationInteractionPtr);
 }

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -1424,7 +1424,7 @@ void NotationActionController::addText(TextStyleType type)
         return;
     }
 
-    EngravingItem* item = contextItem(interaction);
+    EngravingItem* item = interaction->contextItem();
 
     if (isVerticalBoxTextStyle(type)) {
         if (!item || !item->isVBox()) {
@@ -1456,7 +1456,7 @@ void NotationActionController::addImage()
         return;
     }
 
-    EngravingItem* item = contextItem(interaction);
+    EngravingItem* item = interaction->contextItem();
     if (!interaction->canAddImageToItem(item)) {
         return;
     }
@@ -1596,7 +1596,7 @@ void NotationActionController::openSelectionMoreOptions()
         return;
     }
 
-    auto item = contextItem(interaction);
+    auto item = interaction->contextItem();
     if (!item) {
         return;
     }

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -1424,7 +1424,15 @@ void NotationActionController::addText(TextStyleType type)
         return;
     }
 
-    EngravingItem* item = interaction->contextItem();
+    EngravingItem* item = nullptr;
+
+    const INotationSelectionPtr sel = interaction->selection();
+    if (sel->isRange()) {
+        const INotationSelectionRangePtr range = sel->range();
+        item = range->rangeStartSegment()->firstElementForNavigation(range->startStaffIndex());
+    } else {
+        item = interaction->contextItem();
+    }
 
     if (isVerticalBoxTextStyle(type)) {
         if (!item || !item->isVBox()) {

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -834,6 +834,21 @@ void NotationInteraction::moveSegmentSelection(MoveDirection d)
     showItem(e);
 }
 
+EngravingItem* NotationInteraction::contextItem() const
+{
+    EngravingItem* item = nullptr;
+    const INotationSelectionPtr sel = selection();
+
+    if (sel->isRange()) {
+        const INotationSelectionRangePtr range = sel->range();
+        item = range->rangeStartSegment()->firstElementForNavigation(range->startStaffIndex());
+    } else {
+        item = sel->element();
+    }
+
+    return item ? item : hitElementContext().element;
+}
+
 void NotationInteraction::selectTopOrBottomOfChord(MoveDirection d)
 {
     IF_ASSERT_FAILED(MoveDirection::Up == d || MoveDirection::Down == d) {
@@ -7742,24 +7757,4 @@ muse::async::Channel<NotationInteraction::ShowItemRequest> NotationInteraction::
 void NotationInteraction::setGetViewRectFunc(const std::function<RectF()>& func)
 {
     static_cast<NotationNoteInput*>(m_noteInput.get())->setGetViewRectFunc(func);
-}
-
-namespace mu::notation {
-EngravingItem* contextItem(INotationInteractionPtr interaction)
-{
-    EngravingItem* item = nullptr;
-    const INotationSelectionPtr sel = interaction->selection();
-
-    if (sel->isRange()) {
-        const INotationSelectionRangePtr range = sel->range();
-        item = range->rangeStartSegment()->firstElementForNavigation(range->startStaffIndex());
-    } else {
-        item = sel->element();
-    }
-
-    if (item == nullptr) {
-        return interaction->hitElementContext().element;
-    }
-    return item;
-}
 }

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -836,16 +836,7 @@ void NotationInteraction::moveSegmentSelection(MoveDirection d)
 
 EngravingItem* NotationInteraction::contextItem() const
 {
-    EngravingItem* item = nullptr;
-    const INotationSelectionPtr sel = selection();
-
-    if (sel->isRange()) {
-        const INotationSelectionRangePtr range = sel->range();
-        item = range->rangeStartSegment()->firstElementForNavigation(range->startStaffIndex());
-    } else {
-        item = sel->element();
-    }
-
+    EngravingItem* item = selection()->element();
     return item ? item : hitElementContext().element;
 }
 

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -94,6 +94,8 @@ public:
     void selectTopOrBottomOfChord(MoveDirection d) override;
     void moveSegmentSelection(MoveDirection d) override;
 
+    EngravingItem* contextItem() const override;
+
     // SelectionFilter
     bool isSelectionTypeFiltered(SelectionFilterType type) const override;
     void setSelectionTypeFiltered(SelectionFilterType type, bool filtered) override;

--- a/src/notation/tests/mocks/notationinteractionmock.h
+++ b/src/notation/tests/mocks/notationinteractionmock.h
@@ -99,6 +99,8 @@ public:
     MOCK_METHOD(void, selectEmptyTrailingMeasure, (), (override));
     MOCK_METHOD(void, moveSegmentSelection, (MoveDirection), (override));
 
+    MOCK_METHOD(EngravingItem*, contextItem, (), (const, override));
+
     MOCK_METHOD(void, movePitch, (MoveDirection, PitchMode), (override));
     MOCK_METHOD(void, nudge, (MoveDirection, bool), (override));
     MOCK_METHOD(void, nudgeAnchors, (MoveDirection), (override));

--- a/src/notation/view/widgets/selectdialog.cpp
+++ b/src/notation/view/widgets/selectdialog.cpp
@@ -46,7 +46,16 @@ SelectDialog::SelectDialog(QWidget* parent)
     setupUi(this);
     setWindowFlags(this->windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
-    m_element = contextItem(globalContext()->currentNotation()->interaction());
+    const INotationInteractionPtr interaction = globalContext()->currentNotation()->interaction();
+    IF_ASSERT_FAILED(interaction) {
+        return;
+    }
+
+    m_element = interaction->contextItem();
+    IF_ASSERT_FAILED(m_element) {
+        return;
+    }
+
     type->setText(m_element->translatedTypeUserName().toQString());
     subtype->setText(m_element->translatedSubtypeUserName().toQString());
 
@@ -225,7 +234,7 @@ void SelectDialog::apply() const
         return;
     }
 
-    EngravingItem* selectedElement = contextItem(interaction);
+    EngravingItem* selectedElement = interaction->contextItem();
     if (!selectedElement) {
         return;
     }

--- a/src/notation/view/widgets/selectnotedialog.cpp
+++ b/src/notation/view/widgets/selectnotedialog.cpp
@@ -57,8 +57,12 @@ SelectNoteDialog::SelectNoteDialog(QWidget* parent)
     setupUi(this);
     setWindowFlags(this->windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
-    m_note = dynamic_cast<mu::engraving::Note*>(contextItem(globalContext()->currentNotation()->interaction()));
+    const INotationInteractionPtr interaction = globalContext()->currentNotation()->interaction();
+    IF_ASSERT_FAILED(interaction) {
+        return;
+    }
 
+    m_note = dynamic_cast<mu::engraving::Note*>(interaction->contextItem());
     IF_ASSERT_FAILED(m_note) {
         return;
     }
@@ -250,7 +254,7 @@ void SelectNoteDialog::apply() const
         return;
     }
 
-    EngravingItem* selectedElement = contextItem(interaction);
+    EngravingItem* selectedElement = interaction->contextItem();
     if (!selectedElement) {
         return;
     }


### PR DESCRIPTION
Resolves: #27126
Resolves the second point in: #27548

Caused by #25254 - looks like I got ahead of myself with some of the changes described in [this](https://github.com/musescore/MuseScore/pull/25254#pullrequestreview-2402450097) comment (adding range handling to `contextItem` caused the "hit element" to be ignored when using Select -> More...)

For some background to the changes in this PR, there are two contexts where the `contextItem` method is used:
1. When opening `SelectDialog` & `SelectNoteDialog` (Select -> More...)
2. When `addText` and `addImage` actions are called

After partially reverting the above changes, the first idea I had was to remove the `contextItem` method completely. The functionality of this method is a little bit ambiguous and at first glance it looked like things would be clearer if we were to simply use `hitElementContext().element` for the dialogs (because these only ever open with a hit element), and `Selection::element` for `addText`/`Image` (because these are only ever called on a selection).

Unfortunately there are some edge cases that prevent us from doing this (namely when opening context menus via keyboard navigation, where the hit element is null and `Selection::element` is used instead). We could potentially bring these cases in line by providing a hit element during keyboard navigation, but I'm not sure that would be worth it...

The idea with this PR is simply to move the range logic back into `addText`, as was originally the case in #25254. This PR also includes a refactor of `contextItem` as I see no reason for it to be defined differently to our other `NotationInteraction` methods.