### PR TITLE
MuseSampler: call setPosition before setPlaying

### DIFF
--- a/src/framework/musesampler/internal/musesamplerwrapper.cpp
+++ b/src/framework/musesampler/internal/musesamplerwrapper.cpp
@@ -244,23 +244,22 @@ bool MuseSamplerWrapper::isActive() const
     return m_sequencer.isActive();
 }
 
-void MuseSamplerWrapper::setIsActive(bool arg)
+void MuseSamplerWrapper::setIsActive(bool active)
 {
     IF_ASSERT_FAILED(m_samplerLib && m_sampler) {
         return;
     }
 
-    if (isActive() == arg) {
+    if (isActive() == active) {
         return;
     }
 
-    m_sequencer.setActive(arg);
-
-    m_samplerLib->setPlaying(m_sampler, arg);
-
-    if (arg) {
+    if (active) {
         m_samplerLib->setPosition(m_sampler, m_currentPosition);
     }
+
+    m_sequencer.setActive(active);
+    m_samplerLib->setPlaying(m_sampler, active);
 }
 
 bool MuseSamplerWrapper::initSampler(const sample_rate_t sampleRate, const samples_t blockSize)

--- a/src/framework/musesampler/internal/musesamplerwrapper.h
+++ b/src/framework/musesampler/internal/musesamplerwrapper.h
@@ -68,7 +68,7 @@ private:
     muse::audio::msecs_t playbackPosition() const override;
     void setPlaybackPosition(const muse::audio::msecs_t newPosition) override;
     bool isActive() const override;
-    void setIsActive(bool arg) override;
+    void setIsActive(bool active) override;
 
     bool initSampler(const muse::audio::sample_rate_t sampleRate, const muse::audio::samples_t blockSize);
 


### PR DESCRIPTION
This change is necessary (but not sufficient by itself; additional changes are needed on the sampler side) to fix the following problem:

>Playback starts part way through the first beat (MuseSounds only) – i.e. the problem that, from wherever you commence playback, the first note appears to fade in, effectively cutting-off the start of the note