### PR TITLE
Add /MP option for multi-process compilation in MSVC

### DIFF
--- a/buildscripts/cmake/SetupBuildEnvironment.cmake
+++ b/buildscripts/cmake/SetupBuildEnvironment.cmake
@@ -73,6 +73,7 @@ if(CC_IS_MSVC)
 
     add_compile_options("/EHsc")
     add_compile_options("/utf-8")
+    add_compile_options("/MP")
 
     add_compile_definitions(WIN32 _WINDOWS)
     add_compile_definitions(_UNICODE UNICODE)


### PR DESCRIPTION
Add the /MP (multi-process) compile option for MSVC. This enables parallel builds which makes the build _much_ faster.

(Passing `-j` to the CMake build command also works. But this makes it turned on by default, which IMO it should be.)

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
