### PR TITLE
Fix #27581: Input of intervals via braille panel

### DIFF
--- a/src/braille/internal/notationbraille.cpp
+++ b/src/braille/internal/notationbraille.cpp
@@ -618,6 +618,8 @@ void NotationBraille::setKeys(const QString& sequence)
                 return;
             }
 
+            interaction()->noteInput()->addNote(params, NoteAddingMode::CurrentChord);
+
             if (brailleInput()->addedOctave() != -1) {
                 if (brailleInput()->addedOctave() < brailleInput()->octave()) {
                     for (int i = brailleInput()->addedOctave(); i < brailleInput()->octave(); i++) {


### PR DESCRIPTION
Resolves: #27581

Caused by a silly mistake from me in dce242c2aaf827c0e147622d23d6f23916ec9f45 - the call to `addNote` was lost in the `Interval` case when all the `NoteInputParams` stuff was changed.