### PR TITLE
Fix crash on drag first measure on itself

### DIFF
--- a/src/engraving/dom/segment.cpp
+++ b/src/engraving/dom/segment.cpp
@@ -1106,7 +1106,7 @@ bool Segment::isTupletSubdivision() const
 bool Segment::isInsideTupletOnStaff(staff_idx_t staffIdx) const
 {
     const Segment* refCRSeg = isChordRestType() && hasElements(staffIdx) ? this : prev1WithElemsOnStaff(staffIdx, SegmentType::ChordRest);
-    if (refCRSeg->measure() != measure()) {
+    if (!refCRSeg || refCRSeg->measure() != measure()) {
         return false;
     }
 


### PR DESCRIPTION
Resolves: #27575 

The null check should be there anyway, since null is a possible return of the previous function. That fixes the crash. 

In this particular case, there could be perhaps a further check higher up where, if we detect that we're cut-pasting something onto itself, we reject the operation (the null instance occurs because the cut removes all elements from the cut region, but the cut region is _also_ the paste region in this case).