### PR TITLE
`Score::deleteRange` and `Selection::updateSelectedElements` refactor [Tech debt]

### DIFF
--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -3568,138 +3568,140 @@ void Score::deleteAnnotationsFromRange(Segment* s1, Segment* s2, track_idx_t tra
 std::vector<ChordRest*> Score::deleteRange(Segment* s1, Segment* s2, track_idx_t track1, track_idx_t track2, const SelectionFilter& filter)
 {
     std::vector<ChordRest*> crs;
+    IF_ASSERT_FAILED(s1) {
+        return crs;
+    }
 
-    if (s1) {
-        // delete content from measures underlying mmrests
-        if (s1 && s1->measure() && s1->measure()->isMMRest()) {
-            s1 = s1->measure()->mmRestFirst()->first();
+    // delete content from measures underlying mmrests
+    if (s1 && s1->measure() && s1->measure()->isMMRest()) {
+        s1 = s1->measure()->mmRestFirst()->first();
+    }
+    if (s2 && s2->measure() && s2->measure()->isMMRest()) {
+        s2 = s2->measure()->mmRestLast()->last();
+    }
+
+    const Fraction stick1 = s1->tick();
+    const Fraction stick2 = s2 ? s2->tick() : lastMeasure()->endTick();
+
+    Segment* ss1 = s1;
+    if (!ss1->isChordRestType()) {
+        ss1 = ss1->next1(SegmentType::ChordRest);
+    }
+    bool fullMeasure = ss1 && (ss1->measure()->first(SegmentType::ChordRest) == ss1)
+                       && (s2 == 0 || s2->isEndBarLineType());
+
+    Fraction tick2 = s2 ? s2->tick() : Fraction::max();
+
+    deleteOrShortenOutSpannersFromRange(stick1, stick2, track1, track2, filter);
+    deleteAnnotationsFromRange(s1, s2, track1, track2, filter);
+
+    for (track_idx_t track = track1; track < track2; ++track) {
+        if (!filter.canSelectVoice(track)) {
+            continue;
         }
-        if (s2 && s2->measure() && s2->measure()->isMMRest()) {
-            s2 = s2->measure()->mmRestLast()->last();
-        }
-
-        const Fraction stick1 = s1->tick();
-        const Fraction stick2 = s2 ? s2->tick() : lastMeasure()->endTick();
-
-        Segment* ss1 = s1;
-        if (!ss1->isChordRestType()) {
-            ss1 = ss1->next1(SegmentType::ChordRest);
-        }
-        bool fullMeasure = ss1 && (ss1->measure()->first(SegmentType::ChordRest) == ss1)
-                           && (s2 == 0 || s2->isEndBarLineType());
-
-        Fraction tick2 = s2 ? s2->tick() : Fraction::max();
-
-        deleteOrShortenOutSpannersFromRange(stick1, stick2, track1, track2, filter);
-        deleteAnnotationsFromRange(s1, s2, track1, track2, filter);
-
-        for (track_idx_t track = track1; track < track2; ++track) {
-            if (!filter.canSelectVoice(track)) {
+        Fraction f;
+        Fraction tick  = Fraction(-1, 1);
+        Tuplet* currentTuplet = 0;
+        for (Segment* s = s1; s && (s->tick() < stick2); s = s->next1()) {
+            if (s->element(track) && s->isBreathType()) {
+                deleteItem(s->element(track));
                 continue;
             }
-            Fraction f;
-            Fraction tick  = Fraction(-1, 1);
-            Tuplet* currentTuplet = 0;
-            for (Segment* s = s1; s && (s->tick() < stick2); s = s->next1()) {
-                if (s->element(track) && s->isBreathType()) {
-                    deleteItem(s->element(track));
-                    continue;
-                }
 
-                EngravingItem* e = s->element(track);
-                if (!e) {
-                    continue;
+            EngravingItem* e = s->element(track);
+            if (!e) {
+                continue;
+            }
+            if (!s->isChordRestType()) {
+                // do not delete TimeSig/KeySig,
+                // it doesn't make sense to do it, except on full system
+                if (!s->isTimeTickType() && !s->isTimeSigType() && !s->isKeySigType()
+                    && !s->isType(SegmentType::BarLineType) /*covers all barLine types*/) {
+                    undoRemoveElement(e);
                 }
-                if (!s->isChordRestType()) {
-                    // do not delete TimeSig/KeySig,
-                    // it doesn't make sense to do it, except on full system
-                    if (!s->isTimeTickType() && !s->isTimeSigType() && !s->isKeySigType()
-                        && !s->isType(SegmentType::BarLineType) /*covers all barLine types*/) {
-                        undoRemoveElement(e);
-                    }
-                    continue;
-                }
-                ChordRest* cr1 = toChordRest(e);
-                if (tick == Fraction(-1, 1)) {
-                    // first ChordRest found:
-                    Fraction offset = cr1->rtick();
-                    if (cr1->measure()->tick() >= s1->tick() && offset.isNotZero()) {
-                        f = offset;
-                        tick = s->measure()->tick();
-                    } else {
-                        f = Fraction(0, 1);
-                        tick = s->tick();
-                    }
-                    currentTuplet = cr1->tuplet();
-                    if (currentTuplet && ((currentTuplet->tick()) >= stick1)
-                        && ((currentTuplet->tick() + currentTuplet->actualTicks()) <= tick2)) {
-                        // Find highest-level complete tuplet contained in range
-                        Tuplet* t = cr1->tuplet();
-                        while (t->tuplet() && ((t->tuplet()->tick()) >= stick1)
-                               && ((t->tuplet()->tick() + t->tuplet()->actualTicks()) <= tick2)) {
-                            t = t->tuplet();
-                        }
-                        cmdDeleteTuplet(t, false);
-                        f += t->ticks();
-                        currentTuplet = t->tuplet();
-                        continue;
-                    }
-                }
-                if (e->isMeasureRepeat()) {
-                    deleteItem(e);
-                    continue;
-                }
-
-                if (currentTuplet != cr1->tuplet()) {
-                    if (f.isValid() && !fullMeasure) { // Set rests for the previous tuplet we were dealing with
-                        setRest(tick, track, f, false, currentTuplet);
-                    }
-                    Tuplet* t = cr1->tuplet();
-                    if (t && ((t->tick()) >= stick1) && (((t->tick() + t->actualTicks()) <= tick2) || fullMeasure)) { // If deleting a complete tuplet
-                        // Find highest-level complete tuplet contained in range
-                        while (t->tuplet() && ((t->tuplet()->tick()) >= stick1)
-                               && ((t->tuplet()->tick() + t->tuplet()->actualTicks()) <= tick2)) {
-                            t = t->tuplet();
-                        }
-                        cmdDeleteTuplet(t, false);
-                        tick = t->tick();
-                        f = t->ticks();
-                        currentTuplet = t->tuplet();
-                        continue;
-                    }
-                    // Not deleting a complete tuplet
-                    tick = cr1->tick();
-                    currentTuplet = cr1->tuplet();
-                    removeChordRest(cr1, true);
-                    f = cr1->ticks();
+                continue;
+            }
+            ChordRest* cr1 = toChordRest(e);
+            if (tick == Fraction(-1, 1)) {
+                // first ChordRest found:
+                Fraction offset = cr1->rtick();
+                if (cr1->measure()->tick() >= s1->tick() && offset.isNotZero()) {
+                    f = offset;
+                    tick = s->measure()->tick();
                 } else {
-                    removeChordRest(cr1, true);
-                    f += cr1->ticks();
+                    f = Fraction(0, 1);
+                    tick = s->tick();
+                }
+                currentTuplet = cr1->tuplet();
+                if (currentTuplet && ((currentTuplet->tick()) >= stick1)
+                    && ((currentTuplet->tick() + currentTuplet->actualTicks()) <= tick2)) {
+                    // Find highest-level complete tuplet contained in range
+                    Tuplet* t = cr1->tuplet();
+                    while (t->tuplet() && ((t->tuplet()->tick()) >= stick1)
+                           && ((t->tuplet()->tick() + t->tuplet()->actualTicks()) <= tick2)) {
+                        t = t->tuplet();
+                    }
+                    cmdDeleteTuplet(t, false);
+                    f += t->ticks();
+                    currentTuplet = t->tuplet();
+                    continue;
                 }
             }
-            if (f.isValid() && !f.isZero()) {
-                if (fullMeasure) {
-                    // handle this as special case to be able to
-                    // fix broken measures:
-                    Staff* staff = Score::staff(track / VOICES);
-                    for (Measure* m = s1->measure(); m; m = m->nextMeasure()) {
-                        Fraction tick3   = m->tick();
-                        Fraction ff = m->stretchedLen(staff);
-                        Rest* r = setRest(tick3, track, ff, false, 0);
-                        crs.push_back(r);
-                        if (s2 && (m == s2->measure())) {
-                            break;
-                        }
+            if (e->isMeasureRepeat()) {
+                deleteItem(e);
+                continue;
+            }
+
+            if (currentTuplet != cr1->tuplet()) {
+                if (f.isValid() && !fullMeasure) {     // Set rests for the previous tuplet we were dealing with
+                    setRest(tick, track, f, false, currentTuplet);
+                }
+                Tuplet* t = cr1->tuplet();
+                if (t && ((t->tick()) >= stick1) && (((t->tick() + t->actualTicks()) <= tick2) || fullMeasure)) {     // If deleting a complete tuplet
+                    // Find highest-level complete tuplet contained in range
+                    while (t->tuplet() && ((t->tuplet()->tick()) >= stick1)
+                           && ((t->tuplet()->tick() + t->tuplet()->actualTicks()) <= tick2)) {
+                        t = t->tuplet();
                     }
-                } else {
-                    std::vector<Rest*> rests = setRests(tick, track, f, false, currentTuplet);
-                    for (Rest* r : rests) {
-                        crs.push_back(r);
+                    cmdDeleteTuplet(t, false);
+                    tick = t->tick();
+                    f = t->ticks();
+                    currentTuplet = t->tuplet();
+                    continue;
+                }
+                // Not deleting a complete tuplet
+                tick = cr1->tick();
+                currentTuplet = cr1->tuplet();
+                removeChordRest(cr1, true);
+                f = cr1->ticks();
+            } else {
+                removeChordRest(cr1, true);
+                f += cr1->ticks();
+            }
+        }
+        if (f.isValid() && !f.isZero()) {
+            if (fullMeasure) {
+                // handle this as special case to be able to
+                // fix broken measures:
+                Staff* staff = Score::staff(track / VOICES);
+                for (Measure* m = s1->measure(); m; m = m->nextMeasure()) {
+                    Fraction tick3   = m->tick();
+                    Fraction ff = m->stretchedLen(staff);
+                    Rest* r = setRest(tick3, track, ff, false, 0);
+                    crs.push_back(r);
+                    if (s2 && (m == s2->measure())) {
+                        break;
                     }
+                }
+            } else {
+                std::vector<Rest*> rests = setRests(tick, track, f, false, currentTuplet);
+                for (Rest* r : rests) {
+                    crs.push_back(r);
                 }
             }
         }
     }
+
     return crs;
 }
 

--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -3605,12 +3605,13 @@ std::vector<ChordRest*> Score::deleteRange(Segment* s1, Segment* s2, track_idx_t
     const Fraction startTick = s1->tick();
     const Fraction endTick = s2 ? s2->tick() : Fraction::max();
 
-    Segment* ss1 = s1;
-    if (!ss1->isChordRestType()) {
-        ss1 = ss1->next1(SegmentType::ChordRest);
+    const Segment* firstCRSeg = s1->isChordRestType() ? s1 : s1->next1(SegmentType::ChordRest);
+    IF_ASSERT_FAILED(firstCRSeg) {
+        return crs;
     }
-    bool fullMeasure = ss1 && (ss1->measure()->first(SegmentType::ChordRest) == ss1)
-                       && (s2 == 0 || s2->isEndBarLineType());
+
+    const bool fullMeasure = firstCRSeg == firstCRSeg->measure()->first(SegmentType::ChordRest)
+                             && (!s2 || s2->isEndBarLineType());
 
     deleteOrShortenOutSpannersFromRange(startTick, endTick, track1, track2, filter);
     deleteAnnotationsFromRange(s1, s2, track1, track2, filter);

--- a/src/engraving/dom/measure.cpp
+++ b/src/engraving/dom/measure.cpp
@@ -2535,7 +2535,7 @@ bool Measure::isOnlyDeletedRests(track_idx_t track) const
 //   stretchedLen
 //---------------------------------------------------------
 
-Fraction Measure::stretchedLen(Staff* staff) const
+Fraction Measure::stretchedLen(const Staff* staff) const
 {
     return ticks() * staff->timeStretch(tick());
 }

--- a/src/engraving/dom/measure.h
+++ b/src/engraving/dom/measure.h
@@ -190,7 +190,7 @@ public:
     Fraction timesig() const { return m_timesig; }
     void setTimesig(const Fraction& f) { m_timesig = f; }
 
-    Fraction stretchedLen(Staff*) const;
+    Fraction stretchedLen(const Staff*) const;
     bool isIrregular() const { return m_timesig != m_len; }
 
     int size() const { return m_segments.size(); }

--- a/src/engraving/dom/select.cpp
+++ b/src/engraving/dom/select.cpp
@@ -639,30 +639,32 @@ void Selection::appendChord(Chord* chord)
             m_el.push_back(dot);
         }
 
-        if (note->tieFor() && (note->tieFor()->endElement() != 0)) {
-            if (note->tieFor()->endElement()->isNote()) {
-                Note* endNote = toNote(note->tieFor()->endElement());
-                Segment* s = endNote->chord()->segment();
-                if (!s || s->tick() < tickEnd()) {
-                    for (auto seg : note->tieFor()->spannerSegments()) {
-                        appendFiltered(seg);
-                    }
+        const EngravingItem* endElement = note->tieFor() ? note->tieFor()->endElement() : nullptr;
+        if (endElement && endElement->isNote()) {
+            const Note* endNote = toNote(endElement);
+            const Segment* endSeg = endNote->chord()->segment();
+            if (!endSeg || endSeg->tick() < tickEnd()) {
+                for (SpannerSegment* spannerSeg : note->tieFor()->spannerSegments()) {
+                    appendFiltered(spannerSeg);
                 }
             }
         }
+
         for (Spanner* sp : note->spannerFor()) {
-            if (sp->endElement()->isNote()) {
-                Note* endNote = toNote(sp->endElement());
-                Segment* s = endNote->chord()->segment();
-                if (!s || s->tick() < tickEnd()) {
-                    if (sp->isGuitarBend()) {
-                        appendGuitarBend(toGuitarBend(sp));
-                        continue;
-                    }
-                    m_el.push_back(sp);
+            if (!sp->endElement()->isNote()) {
+                continue;
+            }
+            const Note* endNote = toNote(sp->endElement());
+            const Segment* endSeg = endNote->chord()->segment();
+            if (!endSeg || endSeg->tick() < tickEnd()) {
+                if (sp->isGuitarBend()) {
+                    appendGuitarBend(toGuitarBend(sp));
+                    continue;
                 }
+                m_el.push_back(sp);
             }
         }
+
         if (note->laissezVib()) {
             appendFiltered(note->laissezVib()->frontSegment());
         }

--- a/src/engraving/dom/select.h
+++ b/src/engraving/dom/select.h
@@ -229,6 +229,7 @@ private:
     bool canSelect(EngravingItem* e) const { return selectionFilter().canSelect(e); }
     bool canSelectVoice(track_idx_t track) const { return selectionFilter().canSelectVoice(track); }
     void appendFiltered(EngravingItem* e);
+    void appendChordRest(ChordRest* cr);
     void appendChord(Chord* chord);
     void appendTupletHierarchy(Tuplet* innermostTuplet);
     void appendGuitarBend(GuitarBend* guitarBend);


### PR DESCRIPTION
As part of our new "notes in chords" selection filter, we'll need to update most (maybe all) of our "range actions" to accomodate individually de-selected notes.

While working on this, I felt that `Score::deleteRange`, `Selection::updateSelectedElements`, and some adjacent methods should be given a quick makeover before any extra logic is added. A lot of this code is quite old and has a few issues such as nondescript variables, unecessary nesting, and duplicated logic.