### PR TITLE
Fix crash on clear & undo

### DIFF
--- a/src/engraving/dom/note.cpp
+++ b/src/engraving/dom/note.cpp
@@ -2527,6 +2527,9 @@ PartialTie* Note::outgoingPartialTie() const
 
 void Note::setTieFor(Tie* t)
 {
+    if (!t) {
+        m_jumpPoints.clear();
+    }
     m_tieFor = t;
     if (m_tieFor && !m_tieFor->isLaissezVib()) {
         m_tieFor->updatePossibleJumpPoints();

--- a/src/engraving/dom/tie.cpp
+++ b/src/engraving/dom/tie.cpp
@@ -501,8 +501,6 @@ void Tie::changeTieType(Tie* oldTie, Note* endNote)
         return;
     }
 
-    TranslatableString undoCmd = addPartialTie ? TranslatableString("engraving", "Replace full tie with partial tie")
-                                 : TranslatableString("engraving", "Replace partial tie with full tie");
     Tie* newTie = addPartialTie ? Factory::createPartialTie(score->dummy()->note()) : Factory::createTie(score->dummy()->note());
 
     score->undoRemoveElement(oldTie);
@@ -525,8 +523,6 @@ void Tie::changeTieType(Tie* oldTie, Note* endNote)
     newTie->setOffset(oldTie->offset());
 
     score->undoAddElement(newTie);
-
-    score->endCmd();
 }
 
 void Tie::updateStartTieOnRemoval()

--- a/src/engraving/tests/partialtie_data/toggle_delete.mscx
+++ b/src/engraving/tests/partialtie_data/toggle_delete.mscx
@@ -1,0 +1,221 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="4.50">
+  <programVersion>4.6.0</programVersion>
+  <programRevision></programRevision>
+  <Score>
+    <eid>qVFxTf3T3mB_zhVk2Rsb+QJ</eid>
+    <Division>480</Division>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <open>1</open>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="audioComUrl"></metaTag>
+    <metaTag name="composer">Composer / arranger</metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="creationDate">2025-04-09</metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="platform">Microsoft Windows</metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="sourceRevisionId"></metaTag>
+    <metaTag name="subtitle">Subtitle</metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle">Untitled score</metaTag>
+    <Order id="orchestral">
+      <name>Orchestral</name>
+      <instrument id="piano">
+        <family id="keyboards">Keyboards</family>
+        </instrument>
+      <section id="woodwind" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>flutes</family>
+        <family>oboes</family>
+        <family>clarinets</family>
+        <family>saxophones</family>
+        <family>bassoons</family>
+        <unsorted group="woodwinds"/>
+        </section>
+      <section id="brass" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>horns</family>
+        <family>trumpets</family>
+        <family>cornets</family>
+        <family>flugelhorns</family>
+        <family>trombones</family>
+        <family>tubas</family>
+        </section>
+      <section id="timpani" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>timpani</family>
+        </section>
+      <section id="percussion" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>keyboard-percussion</family>
+        <family>drums</family>
+        <family>unpitched-metal-percussion</family>
+        <family>unpitched-wooden-percussion</family>
+        <family>other-percussion</family>
+        </section>
+      <family>keyboards</family>
+      <family>harps</family>
+      <family>organs</family>
+      <family>synths</family>
+      <soloists/>
+      <section id="voices" brackets="true" barLineSpan="false" thinBrackets="true">
+        <family>voices</family>
+        <family>voice-groups</family>
+        </section>
+      <section id="strings" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>orchestral-strings</family>
+        </section>
+      <unsorted/>
+      </Order>
+    <Part id="1">
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <bracket type="1" span="2" col="2" visible="1"/>
+        <barLineSpan>1</barLineSpan>
+        </Staff>
+      <trackName>Piano</trackName>
+      <Instrument id="piano">
+        <longName>Piano</longName>
+        <shortName>Pno.</shortName>
+        <trackName>Piano</trackName>
+        <minPitchP>21</minPitchP>
+        <maxPitchP>108</maxPitchP>
+        <minPitchA>21</minPitchA>
+        <maxPitchA>108</maxPitchA>
+        <instrumentId>keyboard.piano</instrumentId>
+        <clef staff="2">F</clef>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>95</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>150</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="sforzatoStaccato">
+          <velocity>150</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoStaccato">
+          <velocity>120</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoTenuto">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="0"/>
+          <synti>Fluid</synti>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <VBox>
+        <height>10</height>
+        <eid>31KGPwAjKTO_OpUrrLYYxQN</eid>
+        <Text>
+          <eid>9REvIZsk1FP_gqvfMscBjlD</eid>
+          <style>title</style>
+          <text>Untitled score</text>
+          </Text>
+        <Text>
+          <eid>r0xRLeG/vvP_adgudieqBa</eid>
+          <style>subtitle</style>
+          <text>Subtitle</text>
+          </Text>
+        <Text>
+          <eid>35gA21ymCLM_ie4y8Qrk30O</eid>
+          <style>composer</style>
+          <text>Composer / arranger</text>
+          </Text>
+        </VBox>
+      <Measure>
+        <eid>TP0QgLibskJ_kby36/fLZWF</eid>
+        <endRepeat>2</endRepeat>
+        <voice>
+          <KeySig>
+            <eid>zYOeRXzloQM_FTw1rkhXsZN</eid>
+            <concertKey>0</concertKey>
+            </KeySig>
+          <TimeSig>
+            <eid>gR8VkNxZRQC_QbUMTkKe7/O</eid>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Chord>
+            <eid>D9fhQL4rmrO_m5DoG0GrjKC</eid>
+            <durationType>quarter</durationType>
+            <Note>
+              <eid>vxpTczkzxTH_6GfT29anigE</eid>
+              <pitch>72</pitch>
+              <tpc>14</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <eid>rP3PojB+hUD_1C5skb6xz+H</eid>
+            <durationType>quarter</durationType>
+            <Note>
+              <eid>i0zdQTTNEwI_AbWryg+BQrD</eid>
+              <pitch>72</pitch>
+              <tpc>14</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <eid>Q7RQV/OgDVN_Kb3Nm5+x+vJ</eid>
+            <durationType>quarter</durationType>
+            <Note>
+              <eid>ZoKGDLz80VM_HYFn9SyCTE</eid>
+              <pitch>72</pitch>
+              <tpc>14</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <eid>IGoQydnKvnF_YyhMh9dLNuJ</eid>
+            <durationType>quarter</durationType>
+            <Note>
+              <eid>84Zq7VD98VL_qbZJCq6XGIK</eid>
+              <pitch>72</pitch>
+              <tpc>14</tpc>
+              </Note>
+            </Chord>
+          </voice>
+        </Measure>
+      <Measure>
+        <eid>d8BaC4fnH+K_YpVUmPVqR2P</eid>
+        <voice>
+          <Rest>
+            <eid>x3xkVW7G94D_kZS4gCllOIE</eid>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/src/engraving/tests/partialtie_tests.cpp
+++ b/src/engraving/tests/partialtie_tests.cpp
@@ -527,3 +527,94 @@ TEST_F(Engraving_PartialTieTests, partialTieListSelection)
 
     testPartialTieListSelection(test, startPointTick, secondTieNoteTick, jumpPoints);
 }
+TEST_F(Engraving_PartialTieTests, toggleTiePartialThenRestore)
+{
+    const String test = u"toggle_delete";
+
+    Score* score = ScoreRW::readScore(PARTIALTIE_DATA_DIR + test + u".mscx");
+    EXPECT_TRUE(score);
+
+    const Fraction tieFromTick = Fraction(3, 4);
+    const Fraction tieToTick = Fraction(4, 4);
+
+    Measure* m1 = score->firstMeasure();
+    EXPECT_TRUE(m1);
+    Measure* m2 = m1->nextMeasure();
+    EXPECT_TRUE(m2);
+    Segment* tieFromSegment = m1->findSegment(SegmentType::ChordRest, tieFromTick);
+    EXPECT_TRUE(tieFromSegment);
+    Segment* tieToSegment = m2->findSegment(SegmentType::ChordRest, tieToTick);
+    EXPECT_TRUE(tieToSegment);
+
+    const int pitchC = 42;
+
+    score->startCmd(TranslatableString::untranslatable("Partial tie tests"));
+    score->inputState().setTrack(0);
+    score->inputState().setSegment(tieToSegment);
+    score->inputState().setDuration(DurationType::V_WHOLE);
+    score->inputState().setNoteEntryMode(true);
+
+    score->cmdAddPitch(pitchC, false, false);
+    score->endCmd();
+
+    Chord* tieToChord = m2->findChord(Fraction(4, 4), 0);
+    Note* tieToNote = tieToChord ? tieToChord->upNote() : nullptr;
+    EXPECT_TRUE(tieToChord);
+    EXPECT_TRUE(tieToNote);
+
+    Chord* tieFromChord = toChord(tieFromSegment->element(0));
+    Note* tieFromNote = tieFromChord ? tieFromChord->upNote() : nullptr;
+    EXPECT_TRUE(tieFromNote);
+
+    // Toggle tie at 4/4
+    score->select(tieFromNote);
+    score->startCmd(TranslatableString::untranslatable("Partial tie tests"));
+    score->cmdToggleTie();
+    score->endCmd();
+
+    // Clear the second measure
+
+    score->select(m2, SelectType::SINGLE, 0);
+    score->startCmd(TranslatableString::untranslatable("Partial tie tests"));
+    score->cmdDeleteSelection();
+    score->endCmd();
+
+    // Verify the tie is now partial
+    Tie* tie = tieFromNote->tieFor();
+    EXPECT_TRUE(tie);
+    EXPECT_TRUE(tie->isPartialTie());
+
+    // Undo
+    score->undoRedo(true, nullptr); // undo clear
+    score->undoRedo(true, nullptr); // undo toggle tie
+    score->undoRedo(true, nullptr); // undo add note
+
+    tieToSegment = m2->findSegment(SegmentType::ChordRest, tieToTick);
+    EXPECT_TRUE(tieToSegment);
+
+    score->startCmd(TranslatableString::untranslatable("Partial tie tests"));
+    score->inputState().setTrack(0);
+    score->inputState().setSegment(tieToSegment);
+    score->inputState().setDuration(DurationType::V_WHOLE);
+    score->inputState().setNoteEntryMode(true);
+
+    score->cmdAddPitch(pitchC, false, false);
+    score->endCmd();
+
+    Chord* newTieToChord = m2->findChord(Fraction(4, 4), 0);
+    Note* newTieToNote = newTieToChord ? newTieToChord->upNote() : nullptr;
+    EXPECT_TRUE(newTieToChord);
+    EXPECT_TRUE(newTieToNote);
+
+    // Toggle tie again at 4/4
+    score->select(tieFromNote);
+    score->startCmd(TranslatableString::untranslatable("Partial tie tests"));
+    score->cmdToggleTie();
+    score->endCmd();
+
+    // Verify the tie is now full
+    Tie* newTie = tieFromNote->tieFor();
+    EXPECT_TRUE(newTie);
+    EXPECT_FALSE(newTie->isPartialTie());
+    EXPECT_EQ(newTie->endNote(), newTieToNote);
+}


### PR DESCRIPTION
Resolves: #27618 
This was caused by starting and ending an undo command where it wasn't necessary (as one would always be in progress). Ending the command meant that the other changes (removing the note in this case) weren't added to the undo stack.

The PR also fixes another crash caused by following the reproduction steps in the issue then repeating steps 2 & 3:
2. Add C to 2nd measure
3. Add tie to C note in 1st measure

This was caused by another dangling pointer.