### PR TITLE
Performance improvement by reducing number of calls to beam layout

### DIFF
--- a/src/engraving/dom/segment.cpp
+++ b/src/engraving/dom/segment.cpp
@@ -2510,7 +2510,6 @@ void Segment::createShapes()
     for (size_t staffIdx = 0; staffIdx < score()->nstaves(); ++staffIdx) {
         createShape(staffIdx);
     }
-    addPreAppendedToShape();
 }
 
 //---------------------------------------------------------
@@ -2609,12 +2608,8 @@ void Segment::createShape(staff_idx_t staffIdx)
             s.add(e->shape().translate(e->pos() + e->staffOffset()));
         }
     }
-}
 
-void Segment::addPreAppendedToShape()
-{
-    track_idx_t tracks = score()->ntracks();
-    for (unsigned track = 0; track < tracks; ++track) {
+    for (unsigned track = strack; track < etrack; ++track) {
         if (!m_preAppendedItems[track]) {
             continue;
         }

--- a/src/engraving/dom/segment.cpp
+++ b/src/engraving/dom/segment.cpp
@@ -2609,7 +2609,7 @@ void Segment::createShape(staff_idx_t staffIdx)
         }
     }
 
-    for (unsigned track = strack; track < etrack; ++track) {
+    for (track_idx_t track = strack; track < etrack; ++track) {
         if (!m_preAppendedItems[track]) {
             continue;
         }

--- a/src/engraving/dom/segment.h
+++ b/src/engraving/dom/segment.h
@@ -288,7 +288,6 @@ public:
     EngravingItem* preAppendedItem(track_idx_t track) { return m_preAppendedItems[track]; }
     void preAppend(EngravingItem* item, track_idx_t track) { m_preAppendedItems[track] = item; }
     void clearPreAppended(track_idx_t track) { m_preAppendedItems[track] = nullptr; }
-    void addPreAppendedToShape();
 
     bool goesBefore(const Segment* nextSegment) const;
 

--- a/src/engraving/rendering/score/beamlayout.cpp
+++ b/src/engraving/rendering/score/beamlayout.cpp
@@ -399,7 +399,7 @@ bool BeamLayout::isStartOfNonCrossBeam(ChordRest* cr)
 {
     Beam* b = cr->beam();
     if (b && b->elements().front() == cr) {
-        if (b->cross() || b->fullCross()) {
+        if (b->cross()) {
             return false;
         }
 
@@ -413,7 +413,7 @@ bool BeamLayout::isStartOfCrossBeam(ChordRest* cr)
 {
     Beam* b = cr->beam();
     if (b && b->elements().front() == cr) {
-        if (b->cross() || b->fullCross()) {
+        if (b->cross()) {
             return true;
         }
     }
@@ -871,7 +871,7 @@ void BeamLayout::layoutNonCrossBeams(ChordRest* cr, LayoutContext& ctx)
     }
 
     for (ChordRest* beamCR : beam->elements()) {
-        if (beamCR->isRest()) {
+        if (beamCR->isRest() && beamCR->vStaffIdx() == beam->staffIdx()) {
             verticalAdjustBeamedRests(toRest(beamCR), beam, ctx);
         }
 

--- a/src/engraving/rendering/score/beamlayout.cpp
+++ b/src/engraving/rendering/score/beamlayout.cpp
@@ -57,6 +57,8 @@ using namespace mu::engraving::rendering::score;
 
 void BeamLayout::layout(Beam* item, const LayoutContext& ctx)
 {
+    TRACEFUNC;
+
     Beam::LayoutData* ldata = item->mutldata();
     // all of the beam layout code depends on _elements being in order by tick
     // this may not be the case if two cr's were recently swapped.
@@ -299,6 +301,8 @@ void BeamLayout::layout1(Beam* item, LayoutContext& ctx)
 
 void BeamLayout::layout2(Beam* item, const LayoutContext& ctx, const std::vector<ChordRest*>& chordRests, SpannerSegmentType, int frag)
 {
+    TRACEFUNC;
+
     BeamTremoloLayout::setupLData(item, item->mutldata(), ctx);
     Chord* startChord = nullptr;
     Chord* endChord = nullptr;
@@ -653,6 +657,8 @@ void BeamLayout::beamGraceNotes(LayoutContext& ctx, Chord* mainNote, bool after)
 
 void BeamLayout::createBeams(LayoutContext& ctx, Measure* measure)
 {
+    TRACEFUNC;
+
     for (track_idx_t track = 0; track < ctx.dom().ntracks(); ++track) {
         const Staff* stf = ctx.dom().staff(track2staff(track));
 

--- a/src/engraving/rendering/score/beamlayout.cpp
+++ b/src/engraving/rendering/score/beamlayout.cpp
@@ -395,65 +395,29 @@ void BeamLayout::layout2(Beam* item, const LayoutContext& ctx, const std::vector
     setTremAnchors(item, ctx);
 }
 
-//---------------------------------------------------------
-//   isTopBeam
-//    returns true for the first CR of a beam that is not cross-staff
-//---------------------------------------------------------
-
-bool BeamLayout::isTopBeam(ChordRest* cr)
+bool BeamLayout::isStartOfNonCrossBeam(ChordRest* cr)
 {
     Beam* b = cr->beam();
     if (b && b->elements().front() == cr) {
-        // beam already considered cross?
         if (b->cross() || b->fullCross()) {
             return false;
         }
 
-        // for beams not already considered cross,
-        // consider them so here if any elements were moved up
-        for (ChordRest* cr1 : b->elements()) {
-            // some element moved up?
-            if (cr1->staffMove() != 0) {
-                return false;
-            }
-        }
-
-        // not cross
         return true;
     }
 
-    // no beam or not first element
     return false;
 }
 
-//---------------------------------------------------------
-//   notTopBeam
-//    returns true for the first CR of a beam that is cross-staff
-//---------------------------------------------------------
-
-bool BeamLayout::notTopBeam(ChordRest* cr)
+bool BeamLayout::isStartOfCrossBeam(ChordRest* cr)
 {
     Beam* b = cr->beam();
     if (b && b->elements().front() == cr) {
-        // beam already considered cross?
         if (b->cross() || b->fullCross()) {
             return true;
         }
-
-        // for beams not already considered cross,
-        // consider them so here if any elements were moved up
-        for (ChordRest* cr1 : b->elements()) {
-            // some element moved up?
-            if (cr1->staffMove() != 0) {
-                return true;
-            }
-        }
-
-        // not cross
-        return false;
     }
 
-    // no beam or not first element
     return false;
 }
 
@@ -885,7 +849,7 @@ void BeamLayout::layoutNonCrossBeams(ChordRest* cr, LayoutContext& ctx)
         }
     }
 
-    if (!BeamLayout::isTopBeam(cr)) {
+    if (!BeamLayout::isStartOfNonCrossBeam(cr)) {
         return;
     }
 

--- a/src/engraving/rendering/score/beamlayout.cpp
+++ b/src/engraving/rendering/score/beamlayout.cpp
@@ -115,6 +115,7 @@ void BeamLayout::layout(Beam* item, const LayoutContext& ctx)
 
     // The beam may have changed shape. one-note trems within this beam need to be layed out here
     for (ChordRest* cr : item->elements()) {
+        ChordLayout::computeUp(cr, ctx);
         if (cr->isChord() && toChord(cr)->tremoloSingleChord()) {
             TremoloLayout::layout(toChord(cr)->tremoloSingleChord(), ctx);
         }
@@ -878,6 +879,12 @@ void BeamLayout::createBeams(LayoutContext& ctx, Measure* measure)
 
 void BeamLayout::layoutNonCrossBeams(ChordRest* cr, LayoutContext& ctx)
 {
+    if (cr->isChord()) {
+        for (Chord* grace : toChord(cr)->graceNotes()) {
+            layoutNonCrossBeams(grace, ctx);
+        }
+    }
+
     if (!BeamLayout::isTopBeam(cr)) {
         return;
     }
@@ -905,16 +912,6 @@ void BeamLayout::layoutNonCrossBeams(ChordRest* cr, LayoutContext& ctx)
         }
 
         beamCR->segment()->createShape(beamCR->staffIdx());
-    }
-
-    if (!cr->isChord()) {
-        return;
-    }
-
-    for (Chord* grace : toChord(cr)->graceNotes()) {
-        if (BeamLayout::isTopBeam(grace)) {
-            TLayout::layoutBeam(grace->beam(), ctx);
-        }
     }
 }
 

--- a/src/engraving/rendering/score/beamlayout.h
+++ b/src/engraving/rendering/score/beamlayout.h
@@ -48,8 +48,8 @@ public:
     static void layoutIfNeed(Beam* item, const LayoutContext& ctx);
     static void layout1(Beam* item, LayoutContext& ctx);
 
-    static bool isTopBeam(ChordRest* cr);
-    static bool notTopBeam(ChordRest* cr);
+    static bool isStartOfNonCrossBeam(ChordRest* cr);
+    static bool isStartOfCrossBeam(ChordRest* cr);
     static void createBeams(LayoutContext& ctx, Measure* measure);
     static void restoreBeams(Measure* m, LayoutContext& ctx);
     static bool measureMayHaveBeamsJoinedIntoNext(const Measure* measure);

--- a/src/engraving/rendering/score/chordlayout.cpp
+++ b/src/engraving/rendering/score/chordlayout.cpp
@@ -1215,6 +1215,8 @@ void ChordLayout::layoutArticulations3(Chord* item, Slur* slur, LayoutContext& c
 //! May be called again when the chord is added to or removed from a beam.
 void ChordLayout::layoutStem(Chord* item, const LayoutContext& ctx)
 {
+    TRACEFUNC;
+
     LAYOUT_CALL() << "chord: " << item->eid();
 
     // Stem needs to know hook's bbox and SMuFL anchors.

--- a/src/engraving/rendering/score/chordlayout.cpp
+++ b/src/engraving/rendering/score/chordlayout.cpp
@@ -1255,19 +1255,14 @@ void ChordLayout::layoutStem(Chord* item, const LayoutContext& ctx)
     }
 }
 
-void ChordLayout::computeUpBeamCase(Chord* item, Beam* beam, const LayoutContext& ctx)
+void ChordLayout::computeUpBeamCase(Chord* item, Beam* beam)
 {
-    if (item == beam->elements().front()) {
-        // TODO: remove this
-        BeamLayout::layout(beam, ctx);
-    }
-
-    if (!beam->userModified() && !beam->cross()) {
-        item->setUp(beam->up());
+    if (beam->userModified()) {
+        item->setUp(isChordPosBelowBeam(item, beam));
     } else if (beam->cross()) {
         item->setUp(item->isBelowCrossBeam(beam));
-    } else if (beam->userModified()) {
-        item->setUp(isChordPosBelowBeam(item, beam));
+    } else {
+        item->setUp(beam->up());
     }
 }
 
@@ -1280,6 +1275,10 @@ bool ChordLayout::isChordPosBelowBeam(Chord* item, Beam* beam)
 
     PointF startAnchor = beam->startAnchor();
     PointF endAnchor = beam->endAnchor();
+
+    if (startAnchor.isNull() || endAnchor.isNull()) {
+        return beam->cross() ? item->isBelowCrossBeam(beam) : beam->up();
+    }
 
     if (item == beam->elements().front()) {
         return noteY > startAnchor.y();
@@ -1396,7 +1395,7 @@ void ChordLayout::computeUp(const Chord* item, Chord::LayoutData* ldata, const L
     }
 
     if (hasBeam) {
-        computeUpBeamCase(const_cast<Chord*>(item), item->beam(), ctx);
+        computeUpBeamCase(const_cast<Chord*>(item), item->beam());
         return;
     } else if (item->tremoloTwoChord()) {
         ldata->up = computeUp_TremoloTwoNotesCase(item, item->tremoloTwoChord(), ctx);
@@ -2197,6 +2196,7 @@ double ChordLayout::layoutChords2(std::vector<Note*>& notes, bool up, LayoutCont
         }
         note->mutldata()->mirror.set_value(mirror);
         if (chord->stem()) {
+            chord->stem()->mutldata()->setPosX(chord->stemPosX());
             TLayout::layoutStem(chord->stem(), chord->stem()->mutldata(), ctx.conf()); // needed because mirroring can cause stem position to change
         }
 

--- a/src/engraving/rendering/score/chordlayout.h
+++ b/src/engraving/rendering/score/chordlayout.h
@@ -112,7 +112,7 @@ private:
 
     static bool leaveSpaceForTie(const Articulation* item);
 
-    static void computeUpBeamCase(Chord* item, Beam* beam, const LayoutContext& ctx);
+    static void computeUpBeamCase(Chord* item, Beam* beam);
 };
 }
 

--- a/src/engraving/rendering/score/pagelayout.cpp
+++ b/src/engraving/rendering/score/pagelayout.cpp
@@ -308,16 +308,6 @@ void PageLayout::collectPage(LayoutContext& ctx)
                         if (BeamLayout::isStartOfCrossBeam(cr)) {                           // layout cross staff beams
                             TLayout::layoutBeam(cr->beam(), ctx);
                             BeamLayout::checkCrossPosAndStemConsistency(cr->beam(), ctx);
-                            for (EngravingItem* item : cr->beam()->elements()) {
-                                if (!item || !item->isRest()) {
-                                    continue;
-                                }
-                                Rest* rest = toRest(item);
-                                Beam* beam = rest->beam();
-                                if (beam && beam->fullCross() && rest->staffMove()) {
-                                    BeamLayout::verticalAdjustBeamedRests(rest, beam, ctx);
-                                }
-                            }
                         }
                         if (TupletLayout::notTopTuplet(cr)) {
                             // fix layout of tuplets

--- a/src/engraving/rendering/score/pagelayout.cpp
+++ b/src/engraving/rendering/score/pagelayout.cpp
@@ -305,7 +305,7 @@ void PageLayout::collectPage(LayoutContext& ctx)
                             continue;
                         }
                         ChordRest* cr = toChordRest(e2);
-                        if (BeamLayout::notTopBeam(cr)) {                           // layout cross staff beams
+                        if (BeamLayout::isStartOfCrossBeam(cr)) {                           // layout cross staff beams
                             TLayout::layoutBeam(cr->beam(), ctx);
                             BeamLayout::checkCrossPosAndStemConsistency(cr->beam(), ctx);
                             for (EngravingItem* item : cr->beam()->elements()) {

--- a/src/engraving/rendering/score/scorehorizontalviewlayout.cpp
+++ b/src/engraving/rendering/score/scorehorizontalviewlayout.cpp
@@ -183,7 +183,7 @@ void ScoreHorizontalViewLayout::layoutLinear(LayoutContext& ctx)
                         continue;
                     }
                     ChordRest* cr = toChordRest(e);
-                    if (BeamLayout::notTopBeam(cr)) {                           // layout cross staff beams
+                    if (BeamLayout::isStartOfCrossBeam(cr)) {                           // layout cross staff beams
                         TLayout::layoutBeam(cr->beam(), ctx);
                     }
                     if (TupletLayout::notTopTuplet(cr)) {

--- a/src/engraving/rendering/score/systemlayout.cpp
+++ b/src/engraving/rendering/score/systemlayout.cpp
@@ -1358,7 +1358,7 @@ void SystemLayout::createSkylines(const ElementsToLayout& elementsToLayout, Layo
                         // add beams to skline
                         if (e->isChordRest()) {
                             ChordRest* cr = toChordRest(e);
-                            if (BeamLayout::isTopBeam(cr)) {
+                            if (BeamLayout::isStartOfNonCrossBeam(cr)) {
                                 Beam* b = cr->beam();
                                 b->addSkyline(skyline);
                             }

--- a/src/engraving/rendering/score/systemlayout.cpp
+++ b/src/engraving/rendering/score/systemlayout.cpp
@@ -1675,7 +1675,7 @@ bool SystemLayout::measureHasCrossStuffOrModifiedBeams(const Measure* measure)
                 continue;
             }
             const Beam* beam = toChordRest(e)->beam();
-            if (beam && (beam->cross() || beam->fullCross() || beam->userModified())) {
+            if (beam && (beam->cross() || beam->userModified())) {
                 return true;
             }
             const Chord* c = e->isChord() ? toChord(e) : nullptr;
@@ -1689,7 +1689,7 @@ bool SystemLayout::measureHasCrossStuffOrModifiedBeams(const Measure* measure)
             }
             if (e->isChord() && !toChord(e)->graceNotes().empty()) {
                 for (const Chord* grace : toChord(e)->graceNotes()) {
-                    if (grace->beam() && (grace->beam()->cross() || grace->beam()->fullCross() || grace->beam()->userModified())) {
+                    if (grace->beam() && (grace->beam()->cross() || grace->beam()->userModified())) {
                         return true;
                     }
                 }
@@ -1719,7 +1719,7 @@ void SystemLayout::updateCrossBeams(System* system, LayoutContext& ctx)
                     continue;
                 }
                 for (Chord* grace : toChord(e)->graceNotes()) {
-                    if (grace->beam() && (grace->beam()->cross() || grace->beam()->fullCross() || grace->beam()->userModified()) && grace->beam()->elements().front() == grace) {
+                    if (grace->beam() && (grace->beam()->cross() || grace->beam()->userModified()) && grace->beam()->elements().front() == grace) {
                         BeamLayout::layout(grace->beam(), ctx);
                     }
                 }
@@ -1741,7 +1741,7 @@ void SystemLayout::updateCrossBeams(System* system, LayoutContext& ctx)
                     continue;
                 }
                 Chord* chord = toChord(e);
-                if (chord->beam() && (chord->beam()->cross() || chord->beam()->fullCross() || chord->beam()->userModified()) && chord->beam()->elements().front() == chord) {
+                if (chord->beam() && (chord->beam()->cross() || chord->beam()->userModified()) && chord->beam()->elements().front() == chord) {
                     bool prevUp = chord->up();
                     Stem* stem = chord->stem();
                     double prevStemLength = stem ? stem->length() : 0.0;

--- a/src/engraving/rendering/score/systemlayout.cpp
+++ b/src/engraving/rendering/score/systemlayout.cpp
@@ -1675,7 +1675,7 @@ bool SystemLayout::measureHasCrossStuffOrModifiedBeams(const Measure* measure)
                 continue;
             }
             const Beam* beam = toChordRest(e)->beam();
-            if (beam && (beam->cross() || beam->userModified())) {
+            if (beam && (beam->cross() || beam->fullCross() || beam->userModified())) {
                 return true;
             }
             const Chord* c = e->isChord() ? toChord(e) : nullptr;
@@ -1689,7 +1689,7 @@ bool SystemLayout::measureHasCrossStuffOrModifiedBeams(const Measure* measure)
             }
             if (e->isChord() && !toChord(e)->graceNotes().empty()) {
                 for (const Chord* grace : toChord(e)->graceNotes()) {
-                    if (grace->beam() && (grace->beam()->cross() || grace->beam()->userModified())) {
+                    if (grace->beam() && (grace->beam()->cross() || grace->beam()->fullCross() || grace->beam()->userModified())) {
                         return true;
                     }
                 }
@@ -1719,8 +1719,8 @@ void SystemLayout::updateCrossBeams(System* system, LayoutContext& ctx)
                     continue;
                 }
                 for (Chord* grace : toChord(e)->graceNotes()) {
-                    if (grace->beam() && (grace->beam()->cross() || grace->beam()->userModified())) {
-                        ChordLayout::computeUp(grace, ctx);
+                    if (grace->beam() && (grace->beam()->cross() || grace->beam()->fullCross() || grace->beam()->userModified()) && grace->beam()->elements().front() == grace) {
+                        BeamLayout::layout(grace->beam(), ctx);
                     }
                 }
             }
@@ -1741,11 +1741,11 @@ void SystemLayout::updateCrossBeams(System* system, LayoutContext& ctx)
                     continue;
                 }
                 Chord* chord = toChord(e);
-                if (chord->beam() && (chord->beam()->cross() || chord->beam()->userModified())) {
+                if (chord->beam() && (chord->beam()->cross() || chord->beam()->fullCross() || chord->beam()->userModified()) && chord->beam()->elements().front() == chord) {
                     bool prevUp = chord->up();
                     Stem* stem = chord->stem();
                     double prevStemLength = stem ? stem->length() : 0.0;
-                    ChordLayout::computeUp(chord, ctx);
+                    BeamLayout::layout(chord->beam(), ctx);
                     if (chord->up() != prevUp || (stem && stem->length() != prevStemLength)) {
                         // If the chord has changed direction needs to be re-laid out
                         ChordLayout::layoutChords1(ctx, &seg, chord->vStaffIdx());

--- a/src/engraving/rendering/score/systemlayout.cpp
+++ b/src/engraving/rendering/score/systemlayout.cpp
@@ -1719,7 +1719,8 @@ void SystemLayout::updateCrossBeams(System* system, LayoutContext& ctx)
                     continue;
                 }
                 for (Chord* grace : toChord(e)->graceNotes()) {
-                    if (grace->beam() && (grace->beam()->cross() || grace->beam()->userModified()) && grace->beam()->elements().front() == grace) {
+                    if (grace->beam() && (grace->beam()->cross() || grace->beam()->userModified())
+                        && grace->beam()->elements().front() == grace) {
                         BeamLayout::layout(grace->beam(), ctx);
                     }
                 }
@@ -1741,7 +1742,8 @@ void SystemLayout::updateCrossBeams(System* system, LayoutContext& ctx)
                     continue;
                 }
                 Chord* chord = toChord(e);
-                if (chord->beam() && (chord->beam()->cross() || chord->beam()->userModified()) && chord->beam()->elements().front() == chord) {
+                if (chord->beam() && (chord->beam()->cross() || chord->beam()->userModified())
+                    && chord->beam()->elements().front() == chord) {
                     bool prevUp = chord->up();
                     Stem* stem = chord->stem();
                     double prevStemLength = stem ? stem->length() : 0.0;


### PR DESCRIPTION
The fundamental change of this PR is to remove the beam layout call from ChordLayout::computeUpBeamCase. This alone gives us a 5-6% improvement in the _total_ layout time in my test file (that obviuosly depends on how many beams exist in any given file). Everything else is just about cleaning up and fixing all the various problems that this hack was previously covering.

(Makes sense to code review this one commit at a time so it's clearer what I'm doing.)


