### PR TITLE
Fix #26074: Ensure floating windows resize only when upfront.

### DIFF
--- a/src/framework/dockwindow/thirdparty/KDDockWidgets/src/private/WidgetResizeHandler.cpp
+++ b/src/framework/dockwindow/thirdparty/KDDockWidgets/src/private/WidgetResizeHandler.cpp
@@ -90,6 +90,11 @@ bool WidgetResizeHandler::eventFilter(QObject *o, QEvent *e)
     if (m_isTopLevelWindowResizer && (!widget->isTopLevel() || o != mTarget))
         return false;
 
+    // Get the window under the cursor and check if it's our target window
+    QWindow *windowUnderCursor = qApp->topLevelAt(QCursor::pos());
+    if (!windowUnderCursor || (windowUnderCursor != widget->window()->windowHandle()))
+        return false;
+
     switch (e->type()) {
     case QEvent::MouseButtonPress: {
         if (mTarget->isMaximized())


### PR DESCRIPTION
Resolves: #26074 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
