### PR TITLE
Fix #27317: color inversion incorrectly affecting palettes

### DIFF
--- a/src/engraving/dom/engravingitem.cpp
+++ b/src/engraving/dom/engravingitem.cpp
@@ -2394,7 +2394,7 @@ bool EngravingItem::colorsInversionEnabled() const
     return m_colorsInversionEnabled;
 }
 
-void EngravingItem::setColorsInverionEnabled(bool enabled)
+void EngravingItem::setColorsInversionEnabled(bool enabled)
 {
     m_colorsInversionEnabled = enabled;
 }

--- a/src/engraving/dom/engravingitem.h
+++ b/src/engraving/dom/engravingitem.h
@@ -490,7 +490,7 @@ public:
     double styleP(Sid idx) const;
 
     bool colorsInversionEnabled() const;
-    void setColorsInverionEnabled(bool enabled);
+    void setColorsInversionEnabled(bool enabled);
 
     struct BarBeat
     {

--- a/src/notation/utilities/engravingitempreviewpainter.cpp
+++ b/src/notation/utilities/engravingitempreviewpainter.cpp
@@ -25,6 +25,8 @@
 #include "engraving/dom/actionicon.h"
 #include "engraving/style/defaultstyle.h"
 #include "engraving/dom/masterscore.h"
+#include "engraving/dom/textlinebase.h"
+#include "engraving/dom/text.h"
 
 using namespace mu::notation;
 using namespace mu::engraving;
@@ -77,6 +79,12 @@ void EngravingItemPreviewPainter::paintItem(mu::engraving::EngravingItem* elemen
 
         item->setColorsInversionEnabled(ctx->colorsInversionEnabled);
 
+        if (item->isTextLineBaseSegment()) {
+            TextLineBaseSegment* tls = item_cast<TextLineBaseSegment*>(item);
+            tls->text()->setColorsInversionEnabled(ctx->colorsInversionEnabled);
+            tls->endText()->setColorsInversionEnabled(ctx->colorsInversionEnabled);
+        }
+
         if (!ctx->useElementColors) {
             const Color color = ctx->color;
             item->setProperty(Pid::COLOR, color);
@@ -88,6 +96,12 @@ void EngravingItemPreviewPainter::paintItem(mu::engraving::EngravingItem* elemen
         item->setColorsInversionEnabled(colorsInversionEnabledBackup);
         item->setProperty(Pid::COLOR, colorBackup);
         item->setProperty(Pid::FRAME_FG_COLOR, frameColorBackup);
+
+        if (item->isTextLineBaseSegment()) {
+            TextLineBaseSegment* tls = item_cast<TextLineBaseSegment*>(item);
+            tls->text()->setColorsInversionEnabled(colorsInversionEnabledBackup);
+            tls->endText()->setColorsInversionEnabled(colorsInversionEnabledBackup);
+        }
 
         painter->restore();
     };

--- a/src/notation/utilities/engravingitempreviewpainter.cpp
+++ b/src/notation/utilities/engravingitempreviewpainter.cpp
@@ -75,7 +75,7 @@ void EngravingItemPreviewPainter::paintItem(mu::engraving::EngravingItem* elemen
         const Color frameColorBackup = item->getProperty(Pid::FRAME_FG_COLOR).value<Color>();
         const bool colorsInversionEnabledBackup = item->colorsInversionEnabled();
 
-        item->setColorsInverionEnabled(ctx->colorsInversionEnabled);
+        item->setColorsInversionEnabled(ctx->colorsInversionEnabled);
 
         if (!ctx->useElementColors) {
             const Color color = ctx->color;
@@ -85,7 +85,7 @@ void EngravingItemPreviewPainter::paintItem(mu::engraving::EngravingItem* elemen
 
         engravingRender()->drawItem(item, painter);
 
-        item->setColorsInverionEnabled(colorsInversionEnabledBackup);
+        item->setColorsInversionEnabled(colorsInversionEnabledBackup);
         item->setProperty(Pid::COLOR, colorBackup);
         item->setProperty(Pid::FRAME_FG_COLOR, frameColorBackup);
 

--- a/src/notation/utilities/engravingitempreviewpainter.cpp
+++ b/src/notation/utilities/engravingitempreviewpainter.cpp
@@ -25,6 +25,7 @@
 #include "engraving/dom/actionicon.h"
 #include "engraving/style/defaultstyle.h"
 #include "engraving/dom/masterscore.h"
+#include "engraving/dom/spanner.h"
 #include "engraving/dom/textlinebase.h"
 #include "engraving/dom/text.h"
 
@@ -85,6 +86,11 @@ void EngravingItemPreviewPainter::paintItem(mu::engraving::EngravingItem* elemen
             tls->endText()->setColorsInversionEnabled(ctx->colorsInversionEnabled);
         }
 
+        if (item->isSpannerSegment()) {
+            SpannerSegment* ss = item_cast<SpannerSegment*>(item);
+            ss->spanner()->setColorsInversionEnabled(ctx->colorsInversionEnabled);
+        }
+
         if (!ctx->useElementColors) {
             const Color color = ctx->color;
             item->setProperty(Pid::COLOR, color);
@@ -101,6 +107,11 @@ void EngravingItemPreviewPainter::paintItem(mu::engraving::EngravingItem* elemen
             TextLineBaseSegment* tls = item_cast<TextLineBaseSegment*>(item);
             tls->text()->setColorsInversionEnabled(colorsInversionEnabledBackup);
             tls->endText()->setColorsInversionEnabled(colorsInversionEnabledBackup);
+        }
+
+        if (item->isSpannerSegment()) {
+            SpannerSegment* ss = item_cast<SpannerSegment*>(item);
+            ss->spanner()->setColorsInversionEnabled(colorsInversionEnabledBackup);
         }
 
         painter->restore();

--- a/src/palette/view/drumsetpanelview.cpp
+++ b/src/palette/view/drumsetpanelview.cpp
@@ -153,7 +153,7 @@ void DrumsetPanelView::updateColors()
     }
 
     options.useElementColors = true;
-    options.colorsInverionsEnabled = true;
+    options.colorsInversionEnabled = true;
 
     widget->setPaintOptions(options);
 

--- a/src/palette/view/widgets/palettewidget.cpp
+++ b/src/palette/view/widgets/palettewidget.cpp
@@ -1096,7 +1096,7 @@ void PaletteWidget::paintEvent(QPaintEvent* /*event*/)
         params.color = configuration()->elementsColor();
 
         params.useElementColors = m_paintOptions.useElementColors;
-        params.colorsInversionEnabled = m_paintOptions.colorsInverionsEnabled;
+        params.colorsInversionEnabled = m_paintOptions.colorsInversionEnabled;
 
         notation::EngravingItemPreviewPainter::paintItem(el.get(), params);
 

--- a/src/palette/view/widgets/palettewidget.h
+++ b/src/palette/view/widgets/palettewidget.h
@@ -167,7 +167,7 @@ public:
         muse::draw::Color selectionColor;
         muse::draw::Color linesColor;
         bool useElementColors = false;
-        bool colorsInverionsEnabled = false;
+        bool colorsInversionEnabled = false;
     };
 
     const PaintOptions& paintOptions() const;


### PR DESCRIPTION
Resolves: #27317<!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

Addresses certain elements of the palettes rendering in an incorrect color when score inversion is enabled.

## Root cause of the issue

Items drawn under the palettes should _not_ be inverted, as the palettes are drawn according to the overall app theme (light, dark, high contrast) and the appearance of palettes isn't meant to be affected by the invert score setting. To accomplish this, `EngravingItemPreviewPainter` has some code that overrides the color inversion flag right before it draws an element, then restores the original flag value after.

The problem was in two cases (that I know of), the inversion flag wasn't being propagated to related elements:
* Text line segments didn't propagate the flag to their begin and end text elements.
* Spanner segments didn't propagate the flag to their containing spanner. This affected Trill and Vibrato elements as they are drawn based on the spanner's color rather than the spanner segments' color (see `SingleDraw::draw` methods).

## Approaches to fix

In this PR I did a "minimally invasive" fix, by adding logic to `EngravingItemPreviewPainter` to detect text line and spanner segments, and explicitly set (and restore) the flag override on the related elements.

However, I can also see an argument for making `setColorsInversionEnabled` a virtual method, and having each engraving item handle it similarly to `setVisible`, `setColor`, etc. That would be a much bigger fix, but maybe is more the "right" way to do it.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
