### PR TITLE
Don't process same connector twice in ReadContext::doReconnectBrokenConnectors

### DIFF
--- a/src/engraving/rw/read410/readcontext.cpp
+++ b/src/engraving/rw/read410/readcontext.cpp
@@ -593,15 +593,18 @@ void ReadContext::doReconnectBrokenConnectors()
         }
     }
     std::sort(brokenPairs.begin(), brokenPairs.end(), distanceSort);
+    std::set<ConnectorInfoReader*> processed;
     for (auto& distPair : brokenPairs) {
         if (distPair.first == INT_MAX) {
             continue;
         }
         auto& pair = distPair.second;
-        if (pair.first->next() || pair.second->prev()) {
+        if (processed.count(pair.first) || processed.count(pair.second)) {
             continue;
         }
         pair.first->forceConnect(pair.second);
+        processed.insert(pair.first);
+        processed.insert(pair.second);
     }
     std::set<ConnectorInfoReader*> reconnected;
     for (auto& conn : _connectors) {


### PR DESCRIPTION
Resolves: #27595 

This fix should not go in 4.5.2 because a) The issue isn't a 4.5 regression (we tested 4.4 and found the same issue), b) it's too dangerous to go into a patch.

This is the latest instalment of our spanners saga and the insane way that we write spanners to file, which I've explained [here](https://github.com/musescore/MuseScore/issues/23688#:~:text=Score/part%20links-,Spanners,-In%20our%20files). I have genuinely lost count of how many of these bugs I've encountered.

We save spanners by writing a tag in the file that says
- Here starts a Gradual Tempo change that will end (x, y, z) after this point

and at some later point

- Here ends a Gradual Tempo Change that started (-x, -y, -z) before this point.

When we read the first tag we create a temporary "unconnected" spanner, until we find the second tag and pray that (x,y,x) matches exactly (-x,-y,-z). If it does, fine, we recreate the spanner correctly. If it doesn't, our spanners end up in a list of "broken connectors". And we have a function whose purpose is to try to reconnect the broken connectors.

In this case, the first tag says that the tempo change ends two measures after the current point. But because of the multirest (which also gets written to the file), we actually count three "measures" before finding the second tag. So the tempo change ends up in the broken connectors. This file has many of these broken connectors, and the reconnectBrokenConnectors function had an error which caused the same connector to be processed more than once, creating a circular connection where the last tag in the score was connected to the first. This PR fixes that.

A better fix would be avoiding the wrong measure count that causes the broken connectors in the first place. I refuse to do that because I'm hoping to change this system altogether soon.