### PR TITLE
Fix ties in final measure of repeat segment bug

### DIFF
--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -2167,8 +2167,14 @@ Tie* Score::cmdToggleTie()
 
         for (size_t j = i + 1; j < notes; ++j) {
             Note* candidateNote = noteList[j];
-            if (note->part() == candidateNote->part() && note->pitch() == candidateNote->pitch()
-                && note->unisonIndex() == candidateNote->unisonIndex() && note->tick() != candidateNote->tick()) {
+            if (!candidateNote) {
+                continue;
+            }
+            const bool samePart = note->part() == candidateNote->part();
+            const bool samePitch = note->pitch() == candidateNote->pitch();
+            const bool sameUnisonIdx = note->unisonIndex() == candidateNote->unisonIndex();
+            const bool diffTick = note->tick() != candidateNote->tick();
+            if (samePart && samePitch && sameUnisonIdx && diffTick) {
                 note2 = candidateNote;
                 noteList[j] = nullptr;
                 break;

--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -2145,6 +2145,9 @@ Tie* Score::cmdToggleTie()
         Chord* chord = note->chord();
         if (oldTie) {
             // Toggle existing tie off
+            if (oldTie->tieJumpPoints()) {
+                oldTie->undoRemoveTiesFromJumpPoints();
+            }
             undoRemoveElement(oldTie);
             continue;
         }

--- a/src/engraving/dom/tie.cpp
+++ b/src/engraving/dom/tie.cpp
@@ -243,12 +243,16 @@ void Tie::updatePossibleJumpPoints()
     if (!hasFollowingJumpItem) {
         const Note* tieEndNote = endNote();
         const Chord* endChord = tieEndNote ? tieEndNote->chord() : nullptr;
+        if (!endChord) {
+            return;
+        }
         const Segment* endNoteSegment = endChord ? endChord->segment() : nullptr;
         const ChordRest* finalCROfMeasure = measure->lastChordRest(track());
         const bool finalCRHasFollowingJump = finalCROfMeasure ? finalCROfMeasure->hasFollowingJumpItem() : false;
         const bool segsAreAdjacent = segmentsAreAdjacentInRepeatStructure(segment, endNoteSegment);
+        const bool segsAreInDifferentRepeatSegments = segmentsAreInDifferentRepeatSegments(segment, endNoteSegment);
 
-        if (!(finalCRHasFollowingJump && segsAreAdjacent)) {
+        if (!(finalCRHasFollowingJump && segsAreAdjacent) || !segsAreInDifferentRepeatSegments) {
             return;
         }
     }

--- a/src/engraving/dom/utils.cpp
+++ b/src/engraving/dom/utils.cpp
@@ -1714,4 +1714,33 @@ bool segmentsAreAdjacentInRepeatStructure(const Segment* firstSeg, const Segment
 
     return false;
 }
+
+bool segmentsAreInDifferentRepeatSegments(const Segment* firstSeg, const Segment* secondSeg)
+{
+    if (!firstSeg || !secondSeg) {
+        return false;
+    }
+    Measure* firstMeasure = firstSeg->measure();
+    Measure* secondMeasure = secondSeg->measure();
+
+    if (firstMeasure == secondMeasure) {
+        return false;
+    }
+
+    Score* score = firstSeg->score();
+
+    const RepeatList& repeatList = score->repeatList(true, false);
+
+    std::vector<const Measure*> measures;
+
+    for (auto it = repeatList.begin(); it != repeatList.end(); it++) {
+        const RepeatSegment* rs = *it;
+
+        if (!rs->containsMeasure(firstMeasure) || !rs->containsMeasure(secondMeasure)) {
+            return true;
+        }
+    }
+
+    return false;
+}
 }

--- a/src/engraving/dom/utils.h
+++ b/src/engraving/dom/utils.h
@@ -116,4 +116,5 @@ extern std::vector<Measure*> findFollowingRepeatMeasures(const Measure* measure)
 extern std::vector<Measure*> findPreviousRepeatMeasures(const Measure* measure);
 extern bool repeatHasPartialLyricLine(const Measure* endRepeatMeasure);
 extern bool segmentsAreAdjacentInRepeatStructure(const Segment* firstSeg, const Segment* secondSeg);
+extern bool segmentsAreInDifferentRepeatSegments(const Segment* firstSeg, const Segment* secondSeg);
 } // namespace mu::engraving


### PR DESCRIPTION
Resolves: #27650 
Resolves: #27654

A result of allowing non adjacent ties to have partial endings https://github.com/musescore/MuseScore/pull/27490. We need to make sure non adjacent ties are in repeat segments which are different *and* adjacent.

Also resolves toggling ties off with 't' or the toolbar not removing their partial endings.
