### PR TITLE
Fix #26963: toolbars move to the right

### DIFF
--- a/src/framework/dockwindow/view/dockwindow.cpp
+++ b/src/framework/dockwindow/view/dockwindow.cpp
@@ -302,6 +302,10 @@ void DockWindow::restoreDefaultLayout()
 
     m_reloadCurrentPageAllowed = false;
     for (const DockPageView* page : m_pages.list()) {
+        if (page == m_currentPage) {
+            restorePageState(page->objectName());
+            continue;
+        }
         uiConfiguration()->setPageState(page->objectName(), QByteArray());
     }
 


### PR DESCRIPTION
When restoring deafault layout the status bar, playback toolbar, "Parts" and "Mixer" buttons move to the right.
This would happen because of the way the currente page was beeing handled on the restoreDefaultLayout() function. To fix this, when iterating through the pages if the page is the current page instead of "cleaning" the state, we restore the page state.

Resolves: #26963 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
