### PR TITLE
[MusicXML] Left align rehearsal mark in import

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
@@ -5244,6 +5244,19 @@ void ExportMusicXml::rehearsal(RehearsalMark const* const rmk, staff_idx_t staff
     }
     attr += color2xml(rmk);
     attr += positioningAttributes(rmk);
+    if (configuration()->exportLayout()) {
+        switch (rmk->align().horizontal) {
+        case AlignH::LEFT:
+            // default in MusicXML
+            break;
+        case AlignH::HCENTER:
+            attr += u" justify=\"center\"";
+            break;
+        case AlignH::RIGHT:
+            attr += u" justify=\"right\"";
+            break;
+        }
+    }
     // set the default words format
     const MStyle& style = m_score->style();
     const String mtf = style.styleSt(Sid::musicalTextFont);

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -3529,6 +3529,7 @@ void MusicXmlParserDirection::direction(const String& partId,
                     t->setPropertyFlags(Pid::PLACEMENT, PropertyFlags::UNSTYLED);
                     t->resetProperty(Pid::OFFSET);
                 }
+                t->setAlign(AlignH::LEFT);
             }
         }
 

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -3547,12 +3547,21 @@ void MusicXmlParserDirection::direction(const String& partId,
                 t->setColor(m_color);
             }
 
+            if (m_justify == u"right") {
+                t->setAlign(AlignH::RIGHT);
+            } else if (m_justify == u"center") {
+                t->setAlign(AlignH::HCENTER);
+            } else {
+                t->setAlign(AlignH::LEFT);
+            }
+
             t->setVisible(m_visible);
 
             if (m_swing.second != 0) {
                 toStaffTextBase(t)->setSwing(true);
                 toStaffTextBase(t)->setSwingParameters(m_swing.first,
-                                                       m_swing.first ? m_swing.second : toStaffTextBase(t)->style().styleI(Sid::swingRatio));
+                                                       m_swing.first ? m_swing.second
+                                                       : toStaffTextBase(t)->style().styleI(Sid::swingRatio));
                 m_swing.second = 0;
             }
 
@@ -3931,6 +3940,7 @@ void MusicXmlParserDirection::directionType(std::vector<MusicXmlSpannerDesc>& st
         }
         String type = m_e.attribute("type");
         m_color = Color::fromString(m_e.asciiAttribute("color").ascii());
+        m_justify = m_e.attribute("justify");
         if (m_e.name() == "metronome") {
             m_metroText = metronome(m_tpoMetro);
         } else if (m_e.name() == "words") {

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -3546,12 +3546,14 @@ void MusicXmlParserDirection::direction(const String& partId,
                 t->setColor(m_color);
             }
 
-            if (m_justify == u"right") {
-                t->setAlign(AlignH::RIGHT);
-            } else if (m_justify == u"center") {
-                t->setAlign(AlignH::HCENTER);
-            } else {
-                t->setAlign(AlignH::LEFT);
+            if (configuration()->importLayout()) {
+                if (m_justify == u"right") {
+                    t->setAlign(AlignH::RIGHT);
+                } else if (m_justify == u"center") {
+                    t->setAlign(AlignH::HCENTER);
+                } else {
+                    t->setAlign(AlignH::LEFT);
+                }
             }
 
             t->setVisible(m_visible);

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -3529,7 +3529,6 @@ void MusicXmlParserDirection::direction(const String& partId,
                     t->setPropertyFlags(Pid::PLACEMENT, PropertyFlags::UNSTYLED);
                     t->resetProperty(Pid::OFFSET);
                 }
-                t->setAlign(AlignH::LEFT);
             }
         }
 

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.h
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.h
@@ -620,6 +620,7 @@ private:
     muse::String m_wordsText;
     muse::String m_metroText;
     muse::String m_rehearsalText;
+    muse::String m_justify;
     muse::String m_dynaVelocity;
     muse::String m_sndCoda;
     muse::String m_sndDacapo;


### PR DESCRIPTION
The [rehearsal](https://www.w3.org/2021/06/musicxml40/musicxml-reference/elements/rehearsal/) element is left justified by definition in MusicXML. This PR adjusts the import to follow this rule. The export now also gives respect to the alignment. 