### PR TITLE
Disable outgoingDragElement for NoteLine

### DIFF
--- a/src/engraving/rendering/single/singledraw.cpp
+++ b/src/engraving/rendering/single/singledraw.cpp
@@ -83,6 +83,7 @@
 #include "dom/measurerepeat.h"
 
 #include "dom/note.h"
+#include "dom/noteline.h"
 
 #include "dom/ornament.h"
 #include "dom/ottava.h"
@@ -249,6 +250,8 @@ void SingleDraw::drawItem(const EngravingItem* item, Painter* painter)
     case ElementType::NOTE:                 draw(item_cast<const Note*>(item), painter);
         break;
     case ElementType::NOTEHEAD:             draw(item_cast<const NoteHead*>(item), painter);
+        break;
+    case ElementType::NOTELINE_SEGMENT:     draw(item_cast<const NoteLineSegment*>(item), painter);
         break;
 
     case ElementType::ORNAMENT:             draw(item_cast<const Ornament*>(item), painter);
@@ -562,6 +565,12 @@ void SingleDraw::draw(const Note* item, Painter* painter)
 void SingleDraw::draw(const NoteHead* item, Painter* painter)
 {
     draw(static_cast<const Symbol*>(item), painter);
+}
+
+void SingleDraw::draw(const NoteLineSegment*, Painter*)
+{
+    // TRACE_DRAW_ITEM;
+    // To be implemented
 }
 
 void SingleDraw::draw(const Ornament* item, Painter* painter)

--- a/src/engraving/rendering/single/singledraw.h
+++ b/src/engraving/rendering/single/singledraw.h
@@ -99,6 +99,7 @@ class MeasureRepeat;
 
 class Note;
 class NoteHead;
+class NoteLineSegment;
 
 class Ornament;
 class Ottava;
@@ -223,6 +224,7 @@ private:
 
     static void draw(const Note* item, muse::draw::Painter* painter);
     static void draw(const NoteHead* item, muse::draw::Painter* painter);
+    static void draw(const NoteLineSegment* item, muse::draw::Painter* painter);
 
     static void draw(const Ornament* item, muse::draw::Painter* painter);
     static void draw(const OttavaSegment* item, muse::draw::Painter* painter);

--- a/src/engraving/rendering/single/singlelayout.cpp
+++ b/src/engraving/rendering/single/singlelayout.cpp
@@ -64,6 +64,7 @@
 #include "dom/measurenumber.h"
 #include "dom/measurerepeat.h"
 #include "dom/note.h"
+#include "dom/noteline.h"
 #include "dom/ornament.h"
 #include "dom/ottava.h"
 #include "dom/palmmute.h"
@@ -179,6 +180,8 @@ void SingleLayout::layoutItem(EngravingItem* item)
     case ElementType::MEASURE_REPEAT: layout(toMeasureRepeat(item), ctx);
         break;
     case ElementType::NOTEHEAD:     layout(toNoteHead(item), ctx);
+        break;
+    case ElementType::NOTELINE:     layout(toNoteLine(item), ctx);
         break;
     case ElementType::OTTAVA:       layout(toOttava(item), ctx);
         break;
@@ -977,7 +980,7 @@ void SingleLayout::layout(GradualTempoChangeSegment* item, const Context& ctx)
 void SingleLayout::layout(GuitarBend*, const Context&)
 {
     NOT_IMPLEMENTED;
-    //! NOTE: Bends can be removed from disallowed elements in NotationInteraction::dragCopyAllowed once this has been implemented
+    //! NOTE: Bends can be removed from disallowed elements in NotationInteraction::isOutgoingDragElementAllowed once this has been implemented
 }
 
 void SingleLayout::layout(GuitarBendSegment*, const Context&)
@@ -1282,6 +1285,12 @@ void SingleLayout::layout(Lyrics* item, const Context& ctx)
 void SingleLayout::layout(NoteHead* item, const Context& ctx)
 {
     layout(static_cast<Symbol*>(item), ctx);
+}
+
+void SingleLayout::layout(NoteLine* item, const Context& ctx)
+{
+    NOT_IMPLEMENTED;
+    //! NOTE: NoteLines can be removed from disallowed elements in NotationInteraction::isOutgoingDragElementAllowed once this has been implemented
 }
 
 void SingleLayout::layout(Marker* item, const Context& ctx)

--- a/src/engraving/rendering/single/singlelayout.cpp
+++ b/src/engraving/rendering/single/singlelayout.cpp
@@ -1287,7 +1287,7 @@ void SingleLayout::layout(NoteHead* item, const Context& ctx)
     layout(static_cast<Symbol*>(item), ctx);
 }
 
-void SingleLayout::layout(NoteLine* item, const Context& ctx)
+void SingleLayout::layout(NoteLine*, const Context&)
 {
     NOT_IMPLEMENTED;
     //! NOTE: NoteLines can be removed from disallowed elements in NotationInteraction::isOutgoingDragElementAllowed once this has been implemented

--- a/src/engraving/rendering/single/singlelayout.h
+++ b/src/engraving/rendering/single/singlelayout.h
@@ -86,6 +86,7 @@ class MeasureNumber;
 class MeasureRepeat;
 
 class NoteHead;
+class NoteLine;
 
 class Ornament;
 class Ottava;
@@ -199,6 +200,7 @@ public:
     static void layout(Lyrics* item, const Context& ctx);
 
     static void layout(NoteHead* item, const Context& ctx);
+    static void layout(NoteLine* item, const Context& ctx);
 
     static void layout(Marker* item, const Context& ctx);
     static void layout(MeasureNumber* item, const Context& ctx);

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -1287,12 +1287,14 @@ bool NotationInteraction::isOutgoingDragElementAllowed(const EngravingItem* elem
     case ElementType::HBOX:
     case ElementType::TBOX:
     case ElementType::FBOX:
-    // TODO: Bends can't be copy-dragged until corresponding SingleLayout::layout and SingleDraw::draw methods have been implemented
+    // TODO: Bends & NoteLines can't be copy-dragged until corresponding SingleLayout::layout and SingleDraw::draw methods have been implemented
     case ElementType::GUITAR_BEND:
     case ElementType::GUITAR_BEND_SEGMENT:
     case ElementType::GUITAR_BEND_HOLD:
     case ElementType::GUITAR_BEND_HOLD_SEGMENT:
     case ElementType::GUITAR_BEND_TEXT:
+    case ElementType::NOTELINE:
+    case ElementType::NOTELINE_SEGMENT:
         return false;
     default: return true;
     }


### PR DESCRIPTION
Resolves: #27663 

This is the same temporary solution as we have for [guitar bends](https://github.com/musescore/MuseScore/pull/21774) which disables this interaction and prevents the crash.
