### PR TITLE
Only display tuplet as selected if it is fully contained in range

### DIFF
--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -117,20 +117,14 @@ static ChordRest* chordOrRest(EngravingItem* el)
     return nullptr;
 }
 
-static Tuplet* topTupletInRange(Tuplet* currentTuplet, const Fraction& startTick, const Fraction& endTick, bool fullMeasure)
+static Tuplet* topTupletInRange(Tuplet* currentTuplet, const Fraction& startTick, const Fraction& endTick)
 {
-    const auto isInRange = [startTick, endTick, fullMeasure](const Tuplet* tuplet) -> bool {
-        const bool startsInRange = tuplet->tick() >= startTick;
-        const bool endsInRange = tuplet->tick() + tuplet->actualTicks() <= endTick || fullMeasure;
-        return startsInRange && endsInRange;
-    };
-
-    if (!currentTuplet || !isInRange(currentTuplet)) {
+    if (!currentTuplet || !currentTuplet->isInRange(startTick, endTick)) {
         return nullptr;
     }
 
     while (Tuplet* nextTuplet = currentTuplet->tuplet()) {
-        if (!isInRange(nextTuplet)) {
+        if (!nextTuplet->isInRange(startTick, endTick)) {
             break;
         }
         currentTuplet = nextTuplet;
@@ -3657,7 +3651,7 @@ std::vector<ChordRest*> Score::deleteRange(Segment* s1, Segment* s2, track_idx_t
                 }
 
                 currentTuplet = cr1->tuplet();
-                if (Tuplet* topTuplet = topTupletInRange(cr1->tuplet(), startTick, endTick, /*fullMeasure*/ false)) {
+                if (Tuplet* topTuplet = topTupletInRange(cr1->tuplet(), startTick, endTick)) {
                     cmdDeleteTuplet(topTuplet, false);
                     f += topTuplet->ticks();
                     currentTuplet = topTuplet->tuplet();
@@ -3680,7 +3674,7 @@ std::vector<ChordRest*> Score::deleteRange(Segment* s1, Segment* s2, track_idx_t
                 setRest(tick, track, f, false, currentTuplet);
             }
 
-            if (Tuplet* topTuplet = topTupletInRange(cr1->tuplet(), startTick, endTick, fullMeasure)) {
+            if (Tuplet* topTuplet = topTupletInRange(cr1->tuplet(), startTick, fullMeasure ? Fraction::max() : endTick)) {
                 cmdDeleteTuplet(topTuplet, false);
                 tick = topTuplet->tick();
                 f = topTuplet->ticks();

--- a/src/engraving/dom/select.cpp
+++ b/src/engraving/dom/select.cpp
@@ -681,7 +681,8 @@ void Selection::appendChord(Chord* chord)
 
 void Selection::appendTupletHierarchy(Tuplet* innermostTuplet)
 {
-    if (muse::contains(m_el, static_cast<EngravingItem*>(innermostTuplet))) {
+    if (muse::contains(m_el, static_cast<EngravingItem*>(innermostTuplet))
+        || !innermostTuplet->isInRange(tickStart(), tickEnd())) {
         return;
     }
 

--- a/src/engraving/dom/tuplet.cpp
+++ b/src/engraving/dom/tuplet.cpp
@@ -164,6 +164,13 @@ Fraction Tuplet::rtick() const
     return tick() - measure()->tick();
 }
 
+bool Tuplet::isInRange(const Fraction& startTick, const Fraction& endTick) const
+{
+    const bool startsInRange = tick() >= startTick;
+    const bool endsInRange = tick() + actualTicks() <= endTick;
+    return startsInRange && endsInRange;
+}
+
 //---------------------------------------------------------
 //   resetNumberProperty
 //   reset number properties to default values

--- a/src/engraving/dom/tuplet.h
+++ b/src/engraving/dom/tuplet.h
@@ -121,6 +121,7 @@ public:
     Fraction tick() const override { return m_tick; }
     Fraction rtick() const override;
     void setTick(const Fraction& v) { m_tick = v; }
+    bool isInRange(const Fraction& startTick, const Fraction& endTick) const;
     Fraction elementsDuration();
     void sortElements();
     bool cross() const;


### PR DESCRIPTION
Before these changes, a tuplet would display as selected if any of its "contained ChordRests" were present in a range selection:

<img width="907" alt="before" src="https://github.com/user-attachments/assets/e9058ed8-c771-441e-bfa5-c007f4f49933" />

---
What we actually want, though, is for tuplets to display as selected only if they are fully contained by a range selection:

<img width="1001" alt="after" src="https://github.com/user-attachments/assets/caa79d02-a0c4-4c31-94ee-f3f258b72fa3" />