### PR TITLE
Get rid of the last remaining VLAs

### DIFF
--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -1774,15 +1774,8 @@ void Score::regroupNotesAndRests(const Fraction& startTick, const Fraction& endT
                 if (!(curr->tuplet())) {
                     // store start/end note for backward/forward ties ending/starting on the group of notes being rewritten
                     size_t numNotes = chord->notes().size();
-#if (!defined (_MSCVER) && !defined (_MSC_VER))
-                    Note* tieBack[numNotes];
-                    Note* tieFor[numNotes];
-#else
-                    // MSVC does not support VLA. Replace with std::vector. If profiling determines that the
-                    //    heap allocation is slow, an optimization might be used.
                     std::vector<Note*> tieBack(numNotes);
                     std::vector<Note*> tieFor(numNotes);
-#endif
                     for (size_t i = 0; i < numNotes; i++) {
                         Note* n = chord->notes()[i];
                         Note* nn = lastTiedChord->notes()[i];

--- a/src/engraving/dom/stringdata.cpp
+++ b/src/engraving/dom/stringdata.cpp
@@ -182,16 +182,7 @@ void StringData::fretChords(Chord* chord) const
     }
 
     // we need to keep track of string allocation
-#if (!defined (_MSCVER) && !defined (_MSC_VER))
-    int bUsed[strings];                      // initially all strings are available
-    for (int nString = 0; nString < strings; ++nString) {
-        bUsed[nString] = 0;
-    }
-#else
-    // MSVC does not support VLA. Replace with std::vector. If profiling determines that the
-    //    heap allocation is slow, an optimization might be used.
     std::vector<int> bUsed(strings);
-#endif
 
     // determine used range of frets
     int minFret = INT32_MAX;

--- a/src/importexport/capella/internal/capella.cpp
+++ b/src/importexport/capella/internal/capella.cpp
@@ -1464,14 +1464,8 @@ void TextObj::read()
 {
     BasicRectObj::read();
     unsigned size = cap->readUnsigned();
-#if (!defined (_MSCVER) && !defined (_MSC_VER))
-    char txt[size + 1];
-#else
-    // MSVC does not support VLA. Replace with std::vector. If profiling determines that the
-    //    heap allocation is slow, an optimization might be used.
     std::vector<char> vtxt(size + 1);
     char* txt = vtxt.data();
-#endif
     cap->read(txt, size);
     txt[size] = 0;
     text = QString(txt);
@@ -1556,14 +1550,8 @@ void MetafileObj::read()
 {
     BasicRectObj::read();
     unsigned size = cap->readUnsigned();
-#if (!defined (_MSCVER) && !defined (_MSC_VER))
-    char enhMetaFileBits[size];
-#else
-    // MSVC does not support VLA. Replace with std::vector. If profiling determines that the
-    //    heap allocation is slow, an optimization might be used.
     std::vector<char> vEnhMetaFileBits(size);
     char* enhMetaFileBits = vEnhMetaFileBits.data();
-#endif
     cap->read(enhMetaFileBits, size);
     // LOGD("MetaFileObj::read %d bytes", size);
 }

--- a/src/notation/view/widgets/timeline.cpp
+++ b/src/notation/view/widgets/timeline.cpp
@@ -1077,16 +1077,7 @@ void Timeline::drawGrid(int globalRows, int globalCols, int startMeasure, int en
     int xPos = 0;
 
     // Create stagger array if _collapsedMeta is false
-#if (!defined (_MSCVER) && !defined (_MSC_VER))
-    int staggerArr[numMetas];
-    for (unsigned row = 0; row < numMetas; row++) {
-        staggerArr[row] = 0;
-    }
-#else
-    // MSVC does not support VLA. Replace with std::vector. If profiling determines that the
-    // heap allocation is slow, an optimization might be used.
     std::vector<int> staggerArr(numMetas, 0);    // Default initialized, loop not required
-#endif
 
     bool noKey = true;
     std::get<4>(_repeatInfo) = false;


### PR DESCRIPTION
which don't work on MSVC anyways and are a non-standard C++ extension, so use `std::vector` throughout