### PR TITLE
Fix #26233: Combination of pickup measure and linked staff makes scor…

### DIFF
--- a/src/engraving/dom/excerpt.cpp
+++ b/src/engraving/dom/excerpt.cpp
@@ -1243,10 +1243,14 @@ void Excerpt::cloneStaff(Staff* srcStaff, Staff* dstStaff, bool cloneSpanners)
             TremoloTwoChord* prevTremolo = nullptr;
             for (Segment* seg = m->first(); seg; seg = seg->next()) {
                 EngravingItem* oe = seg->element(srcTrack);
-                if (oe == 0 || oe->generated()) {
+                EngravingItem* de = seg->elementAt(dstTrack);
+                if (oe == 0) {
+                    if (de != 0) {
+                        seg->remove(de);
+                    }
                     continue;
                 }
-                if (oe->isTimeSig()) {
+                if (oe->isTimeSig() || oe->generated()) {
                     continue;
                 }
                 EngravingItem* ne = 0;


### PR DESCRIPTION
…e corrupted

Resolves: #26233  <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
Case for pickup measures with linked staves. If you switch the order of ascending rests, there may be an empty segment due to the longer rest/note, which was not being copied to the linked staff, which when created used the default staff configuration, causing a rest or note to be left behind, seemingly "creating a duplicate" and corrupting the score.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
