### PR TITLE
11242: Docks should remember their position

### DIFF
--- a/src/framework/dockwindow/internal/dockbase.cpp
+++ b/src/framework/dockwindow/internal/dockbase.cpp
@@ -432,6 +432,11 @@ void DockBase::deinit()
     setInited(false);
 }
 
+bool DockBase::hasLastPositions() const
+{
+    return m_dockWidget ? m_dockWidget->hasLastPositions() : false;
+}
+
 bool DockBase::isOpen() const
 {
     IF_ASSERT_FAILED(m_dockWidget) {
@@ -449,7 +454,13 @@ void DockBase::open()
         return;
     }
 
-    m_dockWidget->show();
+    // If the widget is in the frame (was not closed), just ask the frame to make the widget's tab active.
+    // Otherwise show the widget. This will add it back into the frame or float it. It will also make it active.
+    if (m_dockWidget->frame() && m_dockWidget->frame()->containsDockWidget(m_dockWidget)) {
+        m_dockWidget->frame()->setCurrentDockWidget(m_dockWidget);
+    } else {
+        m_dockWidget->show();
+    }
     setVisible(true);
 
     applySizeConstraints();
@@ -463,7 +474,7 @@ void DockBase::close()
         return;
     }
 
-    m_dockWidget->forceClose();
+    m_dockWidget->close();
     setVisible(false);
 }
 

--- a/src/framework/dockwindow/internal/dockbase.h
+++ b/src/framework/dockwindow/internal/dockbase.h
@@ -114,6 +114,7 @@ public:
 
     bool isInSameFrame(const DockBase* other) const;
     void setFramePanelOrder(int order);
+    bool hasLastPositions() const;
 
     Q_INVOKABLE bool isOpen() const;
     Q_INVOKABLE void open();

--- a/src/framework/dockwindow/thirdparty/KDDockWidgets/src/DockWidgetBase.cpp
+++ b/src/framework/dockwindow/thirdparty/KDDockWidgets/src/DockWidgetBase.cpp
@@ -368,6 +368,11 @@ QStringList DockWidgetBase::affinities() const
     return d->affinities;
 }
 
+bool DockWidgetBase::hasLastPositions() const
+{
+    return d->m_lastPositions.isValid();
+}
+
 void DockWidgetBase::show()
 {
     if (isWindow() && (d->m_lastPositions.wasFloating() || !d->m_lastPositions.isValid())) {

--- a/src/framework/dockwindow/thirdparty/KDDockWidgets/src/DockWidgetBase.h
+++ b/src/framework/dockwindow/thirdparty/KDDockWidgets/src/DockWidgetBase.h
@@ -336,6 +336,9 @@ public:
      */
     QStringList affinities() const;
 
+    /// @brief Returns whether the widget has last positions.
+    bool hasLastPositions() const;
+
     /// @brief Equivalent to QWidget::show(), but it's optimized to reduce flickering on some platforms
     Q_INVOKABLE void show();
 

--- a/src/framework/dockwindow/view/dockpageview.cpp
+++ b/src/framework/dockwindow/view/dockpageview.cpp
@@ -224,6 +224,11 @@ void DockPageView::setDockOpen(const QString& dockName, bool open)
         return;
     }
 
+    if (dock->hasLastPositions()) {
+        dock->open();
+        return;
+    }
+
     DockPanelView* panel = dynamic_cast<DockPanelView*>(dock);
     if (!panel) {
         dock->open();


### PR DESCRIPTION
Resolves: #11242
Resolves: #18345 (however the height is not retained because the Mixer auto-calculates it)
Resolves: #11218 (partially: the tab will already become active instead of closed but was not always retaining the sidebar)
Resolves: #26678

I am proposing a couple of simple changes to fix the problem with the docks not remembering their position which is a big nuisance:
1. When an undocked panel is closed and reopen, it will not reappear undocked. When a docked panel is docked to a dock holder that is not its default, is closed and reopen, it will reappear docked but in its default dock holder. The problem here is that when a panel is to be shown, we simply search for a suitable panel that can host it and move it there. I have discovered that if we simply call the `open` method on the panel like we do with the non-panels, this will call the `show` method on the widget. From there KDockWidgets has all the functionality to restore the widget to it position prior to it getting closed. So I am proposing that we call the `open` method and bypass our destination-panel-search logic with the following two exceptions:
* When a widget is not closed but is not the active tab, simply calling the show() method was not enough - it would not change the active tab although the contents of the widget would become visible. So I first check for this case with a simple check whether the widget has a frame and the frame contains. If this is true, we just need to have the frame activate the tab with the widget. Otherwise we call the `show()` method which will do its best to restore the widget and activate it.
* I've added a check for whether the widget being shown, has a last position stored for it before it got closed. If it does we are good but if it does not, there is no way we can restore it to its previous position. I am not sure if we will ever hit this scenario, most likely when starting the app for the first time or after resetting to factory settings but even then maybe our default workspace has a last position for each widget, I don't know. In any case I decided to handle this scenario. The `show()` method in this case would show the widget undocked with some size which makes sense. However, I prefer to fallback to our destination-panel-search logic instead. To this end, I unfortunately had to add a small method to `DockWidgetBase` which is third-party code but I didn't find another way to do it - everything around the last position is private and no virtual methods...

2. When an undocked dock is closed and reopen, it won't return to its position provided it is restored as an undocked widget (this is the case with non-panels such as the toolbars and with panels for which a destination panel cannot be found, e.g. the Mixer on my machine). The cause is that when we are closing the widget, we call `forceClose()` which turns on a flag called `m_isForceClosing` in DockWidgetBase.cpp::873 and this later on prevents the code from capturing its current position (i.e. its last position) in `DockWidgetBase::Private::close()` around line 650. I am proposing that we call `close()` instead of `forceClose()` so the current position is captured correctly before the widget is closed so it can be restored to it later on when shown.

Most widgets have size constraints and others also have some auto-size logic built into them. For example, the vertical panels are restricted to 300px in width meaning that if you resize them more or less than this width when undocked, if you close and reopen them, they will return to this width. The horizontal panels, such as the Mixer, have a maximum height of 520px. Moreover, the Mixer panel and the Playback controls have additional size constraints. [Personally I am not a fan of these constraints (more freedom would be nice). There is an unfinished story to lift those constraints or bring them to less limiting values.] So when restoring a closed widget it may not have its pre-closure size, but at least the position should be retained.

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
