### PR TITLE
System object paste improvement

### DIFF
--- a/src/engraving/dom/paste.cpp
+++ b/src/engraving/dom/paste.cpp
@@ -379,6 +379,13 @@ static EngravingItem* pasteSystemObject(EditData& srcData, EngravingItem* target
         return nullptr;
     }
 
+    // System objects can only be pasted on the *top* staff of an instrument
+    Part* targetPart = targetStaff->part();
+    targetStaff = targetPart ? targetPart->staves().front() : nullptr;
+    if (!targetStaff) {
+        return nullptr;
+    }
+
     if (targetStaff == targetScore->staff(0) || targetScore->isSystemObjectStaff(targetStaff)) {
         return target->drop(srcData);
     }


### PR DESCRIPTION
Resolves: #27690 

The original issue is not an issue. This PR fixes the inconsistency pointed out in [this comment](https://github.com/musescore/MuseScore/issues/27690#issuecomment-2802247512) by making sure that, if the user tries to paste a system object onto the middle-stave of an instrument, the object is always pasted on the top stave.
