### PR TITLE
Fix #23090: Added style option to display dynamics in expression text style

### DIFF
--- a/src/engraving/dom/dynamic.h
+++ b/src/engraving/dom/dynamic.h
@@ -139,7 +139,12 @@ public:
     Shape symShapeWithCutouts(SymId id) const override;
 
     static Dyn dynInfo(DynamicType type);
+    static String xmlToText(String xml);
+    void styleChanged() override;
+    bool useExpressionTextStyle() const;
 
+    void startEdit(EditData&) override;
+    void endEdit(EditData&) override;
 private:
 
     M_PROPERTY(bool, avoidBarLines, setAvoidBarLines)

--- a/src/engraving/dom/textbase.cpp
+++ b/src/engraving/dom/textbase.cpp
@@ -749,10 +749,11 @@ TextFragment::TextFragment(const String& s)
     text = s;
 }
 
-TextFragment::TextFragment(TextCursor* cursor, const String& s)
+TextFragment::TextFragment(TextCursor* cursor, const String& s, mu::engraving::TextFragmentType t)
     : TextFragment(s)
 {
     format = *cursor->format();
+    type = t;
 }
 
 TextFragment::TextFragment(const TextFragment& f)
@@ -760,6 +761,7 @@ TextFragment::TextFragment(const TextFragment& f)
     text = f.text;
     format = f.format;
     pos = f.pos;
+    type = f.type;
 }
 
 TextFragment& TextFragment::operator =(const TextFragment& f)
@@ -767,6 +769,7 @@ TextFragment& TextFragment::operator =(const TextFragment& f)
     text = f.text;
     format = f.format;
     pos = f.pos;
+    type = f.type;
     return *this;
 }
 
@@ -780,6 +783,7 @@ TextFragment TextFragment::split(int column)
     int col = 0;
     TextFragment f;
     f.format = format;
+    f.type = type;
 
     for (size_t i = 0; i < text.size(); ++i) {
         const Char& c = text.at(i);
@@ -883,7 +887,8 @@ Font TextFragment::font(const TextBase* t) const
 
     String family;
     Font::Type fontType = Font::Type::Unknown;
-    if (format.fontFamily() == "ScoreText") {
+    bool dynamicsUseExpressionTextStyle = t->isDynamic() && toDynamic(t)->useExpressionTextStyle();
+    if (format.fontFamily() == "ScoreText" && !dynamicsUseExpressionTextStyle) {
         if (t->isDynamic()
             || t->isStringTunings()
             || t->textStyleType() == TextStyleType::OTTAVA
@@ -898,7 +903,7 @@ Font TextFragment::font(const TextBase* t) const
                 m = MUSICAL_SYMBOLS_DEFAULT_FONT_SIZE;
                 if (t->isDynamic()) {
                     m *= t->getProperty(Pid::DYNAMICS_SIZE).toDouble() * spatiumScaling;
-                    if (t->style().styleB(Sid::dynamicsOverrideFont)) {
+                    if (t->style().styleB(Sid::dynamicsOverrideFont) && !t->style().styleB(Sid::dynamicsUseExpressionTextStyle)) {
                         std::string fontName2 = engravingFonts()->fontByName(t->style().styleSt(Sid::dynamicsFont).toStdString())->family();
                         family = String::fromStdString(fontName2);
                     }
@@ -960,7 +965,7 @@ Font TextFragment::font(const TextBase* t) const
             }
         }
     } else {
-        family = format.fontFamily();
+        family = dynamicsUseExpressionTextStyle ? t->style().styleSt(Sid::expressionFontFace) : format.fontFamily();
         fontType = Font::Type::Unknown;
         font.setBold(format.bold());
         font.setItalic(format.italic());
@@ -1286,22 +1291,22 @@ void TextBlock::insert(TextCursor* cursor, const String& s)
     removeEmptyFragment();   // since we are going to write text, we don't need an empty fragment to hold format info. if such exists, delete it
     auto i = fragment(static_cast<int>(cursor->column()), &rcol, &ridx);
     if (i != m_fragments.end()) {
-        if (!(i->format == *cursor->format())) {
+        if (!(i->format == *cursor->format() && i->type == cursor->type())) {
             if (rcol == 0) {
-                m_fragments.insert(i, TextFragment(cursor, s));
+                m_fragments.insert(i, TextFragment(cursor, s, cursor->type()));
             } else {
                 TextFragment f2 = i->split(rcol);
-                i = m_fragments.insert(std::next(i), TextFragment(cursor, s));
+                i = m_fragments.insert(std::next(i), TextFragment(cursor, s, cursor->type()));
                 m_fragments.insert(std::next(i), f2);
             }
         } else {
             i->text.insert(ridx, s);
         }
     } else {
-        if (!m_fragments.empty() && m_fragments.back().format == *cursor->format()) {
+        if (!m_fragments.empty() && m_fragments.back().format == *cursor->format() && m_fragments.back().type == cursor->type()) {
             m_fragments.back().text.append(s);
         } else {
-            m_fragments.push_back(TextFragment(cursor, s));
+            m_fragments.push_back(TextFragment(cursor, s, cursor->type()));
         }
     }
 }
@@ -1707,6 +1712,9 @@ TextBase::TextBase(const TextBase& st)
 {
     m_cursor                      = new TextCursor(this);
     m_cursor->setFormat(*(st.cursor()->format()));
+    if (st.cursor()->editing()) {
+        m_cursor->startEdit();
+    }
     m_text                        = st.m_text;
     m_textInvalid                  = st.m_textInvalid;
     m_layoutToParentWidth         = st.m_layoutToParentWidth;
@@ -1891,14 +1899,27 @@ void TextBase::createBlocks(LayoutData* ldata) const
                     symState = false;
                     SymId id = SymNames::symIdByName(sym);
                     if (id != SymId::noSym) {
-                        CharFormat fmt = *cursor.format(); // save format
-
-                        //char32_t code = score()->scoreFont()->symCode(id);
-                        char32_t code = id
-                                        == SymId::space ? static_cast<char32_t>(' ') : score()->engravingFonts()->fallbackFont()->symCode(id);
-                        cursor.format()->setFontFamily(u"ScoreText");
-                        insert(&cursor, code, ldata);
-                        cursor.setFormat(fmt); // restore format
+                        if (isDynamic() && toDynamic(this)->useExpressionTextStyle()) {
+                            DynamicType dynamicType = TConv::dynamicType(id);
+                            if (dynamicType != DynamicType::OTHER) {
+                                TextFragmentType type = cursor.type();
+                                cursor.setType(TextFragmentType::PLAIN_DYNAMIC);
+                                std::string dynamic = TConv::toXml(dynamicType).ascii();
+                                for (char32_t ch : dynamic) {
+                                    insert(&cursor, ch, ldata);
+                                }
+                                cursor.setType(type);
+                            }
+                        } else {
+                            CharFormat fmt = *cursor.format(); // save format
+                            //char32_t code = score()->scoreFont()->symCode(id);
+                            char32_t code = id
+                                            == SymId::space ? static_cast<char32_t>(' ') : score()->engravingFonts()->fallbackFont()->
+                                            symCode(id);
+                            cursor.format()->setFontFamily(u"ScoreText");
+                            insert(&cursor, code, ldata);
+                            cursor.setFormat(fmt); // restore format
+                        }
                     } else {
                         LOGD("unknown symbol <%s>", muPrintable(sym));
                     }
@@ -2265,6 +2286,8 @@ String TextBase::genText(const LayoutData* ldata) const
                 for (size_t i = 0; i < f.text.size(); ++i) {
                     text += toSymbolXml(f.text.at(i));
                 }
+            } else if (f.type == TextFragmentType::PLAIN_DYNAMIC) {
+                text += Dynamic::xmlToText(f.text);
             } else {
                 text += XmlWriter::xmlString(f.text);
             }

--- a/src/engraving/dom/textbase.h
+++ b/src/engraving/dom/textbase.h
@@ -113,6 +113,12 @@ private:
     String m_fontFamily;
 };
 
+enum class TextFragmentType
+{
+    DEFAULT,
+    PLAIN_DYNAMIC
+};
+
 //---------------------------------------------------------
 //   TextCursor
 //    Contains current position and start of selection
@@ -153,6 +159,9 @@ public:
     CharFormat* format() { return &m_format; }
     const CharFormat* format() const { return &m_format; }
     void setFormat(const CharFormat& f) { m_format = f; }
+
+    TextFragmentType type() { return m_type; }
+    void setType(TextFragmentType type) { m_type = type; }
 
     size_t row() const { return m_row; }
     size_t column() const { return m_column; }
@@ -199,6 +208,7 @@ private:
 
     TextBase* m_text = nullptr;
     CharFormat m_format;
+    TextFragmentType m_type = TextFragmentType::DEFAULT;
     size_t m_row = 0;
     size_t m_column = 0;
     size_t m_selectLine = 0;           // start of selection
@@ -220,10 +230,11 @@ public:
     mutable CharFormat format;
     PointF pos;                    // y is relative to TextBlock->y()
     mutable String text;
+    TextFragmentType type = TextFragmentType::DEFAULT;
 
     TextFragment() = default;
     TextFragment(const String& s);
-    TextFragment(TextCursor*, const String&);
+    TextFragment(TextCursor*, const String&, TextFragmentType = TextFragmentType::DEFAULT);
     TextFragment(const TextFragment& f);
 
     TextFragment& operator =(const TextFragment& f);

--- a/src/engraving/dom/textedit.cpp
+++ b/src/engraving/dom/textedit.cpp
@@ -225,10 +225,10 @@ void TextBase::endEditTextual(EditData& ed)
         return;
     }
 
+    resetFormatting();
     if (textWasEdited) {
         setXmlText(ted->oldXmlText); // reset text to value before editing
         undo->reopen();
-        resetFormatting();
 
         // change property to set text to actual value again - this also changes text of linked elements
         undoChangeProperty(Pid::TEXT, actualXmlText);

--- a/src/engraving/style/styledef.cpp
+++ b/src/engraving/style/styledef.cpp
@@ -722,6 +722,7 @@ const std::array<StyleDef::StyleValue, size_t(Sid::STYLES)> StyleDef::styleValue
 
     styleDef(dynamicsOverrideFont,                       false),
     styleDef(dynamicsFont,                               PropertyValue(String(u"Leland"))),
+    styleDef(dynamicsUseExpressionTextStyle,             false),
     styleDef(dynamicsSize,                               1.0), // percentage of the standard size
     styleDef(dynamicsPlacement,                          PlacementV::BELOW),
     styleDef(dynamicsPosAbove,                           PointF(.0, -1.0)),

--- a/src/engraving/style/styledef.h
+++ b/src/engraving/style/styledef.h
@@ -734,6 +734,7 @@ enum class Sid {
 
     dynamicsOverrideFont,
     dynamicsFont,
+    dynamicsUseExpressionTextStyle,
     dynamicsSize,
     dynamicsPlacement,
     dynamicsPosAbove,

--- a/src/engraving/tests/textbase_tests.cpp
+++ b/src/engraving/tests/textbase_tests.cpp
@@ -50,7 +50,7 @@ public:
 Dynamic* Engraving_TextBaseTests::addDynamic(MasterScore* score)
 {
     Dynamic* dynamic = new Dynamic(score->dummy()->segment());
-    dynamic->setXmlText("<sym>dynamicForte</sym>");
+    dynamic->setXmlText(u"<sym>dynamicForte</sym>");
     ChordRest* chordRest = score->firstSegment(SegmentType::ChordRest)->nextChordRest(0);
     EditData ed;
     ed.dropElement = dynamic;

--- a/src/engraving/types/typesconv.cpp
+++ b/src/engraving/types/typesconv.cpp
@@ -957,7 +957,7 @@ DynamicType TConv::dynamicType(SymId v)
         return i.symId == v;
     });
 
-    IF_ASSERT_FAILED(it != DYNAMIC_TYPES.cend()) {
+    if (it == DYNAMIC_TYPES.cend()) {
         return DynamicType::OTHER;
     }
     return it->type;
@@ -1075,7 +1075,7 @@ AsciiStringView TConv::toXml(DynamicType v)
         return i.type == v;
     });
 
-    IF_ASSERT_FAILED(it != DYNAMIC_TYPES.cend()) {
+    if (it == DYNAMIC_TYPES.cend()) {
         static AsciiStringView dummy;
         return dummy;
     }

--- a/src/notation/view/widgets/editstyle.cpp
+++ b/src/notation/view/widgets/editstyle.cpp
@@ -625,14 +625,15 @@ EditStyle::EditStyle(QWidget* parent)
         { StyleId::autoplaceHairpinDynamicsDistance, false, autoplaceHairpinDynamicsDistance,
           resetAutoplaceHairpinDynamicsDistance },
 
-        { StyleId::dynamicsPosAbove,        false, dynamicsPosAbove,           resetDynamicsPosAbove },
-        { StyleId::dynamicsPosBelow,        false, dynamicsPosBelow,           resetDynamicsPosBelow },
-        { StyleId::dynamicsMinDistance,     false, dynamicsMinDistance,        resetDynamicsMinDistance },
-        { StyleId::avoidBarLines,           false, avoidBarLines,              resetAvoidBarLines },
-        { StyleId::snapToDynamics,          false, snapExpression,             resetSnapExpression },
-        { StyleId::dynamicsSize,            true,  dynamicsSize,               resetDynamicsSize },
-        { StyleId::dynamicsOverrideFont,    false, dynamicsOverrideFont,       0 },
-        { StyleId::dynamicsFont,            false, dynamicsFont,               0 },
+        { StyleId::dynamicsPosAbove,               false, dynamicsPosAbove,               resetDynamicsPosAbove },
+        { StyleId::dynamicsPosBelow,               false, dynamicsPosBelow,               resetDynamicsPosBelow },
+        { StyleId::dynamicsMinDistance,            false, dynamicsMinDistance,            resetDynamicsMinDistance },
+        { StyleId::avoidBarLines,                  false, avoidBarLines,                  resetAvoidBarLines },
+        { StyleId::snapToDynamics,                 false, snapExpression,                 resetSnapExpression },
+        { StyleId::dynamicsSize,                   true,  dynamicsSize,                   resetDynamicsSize },
+        { StyleId::dynamicsOverrideFont,           false, dynamicsOverrideFont,           0 },
+        { StyleId::dynamicsFont,                   false, dynamicsFont,                   0 },
+        { StyleId::dynamicsUseExpressionTextStyle, false, dynamicsUseExpressionTextStyle, 0 },
 
         { StyleId::dynamicsHairpinVoiceBasedPlacement, false, dynamicsAndHairpinPos, resetDynamicsAndHairpinPos },
         { StyleId::dynamicsHairpinsAutoCenterOnGrandStaff, false, dynamicsAndHairpinsCenterOnGrandStaff, 0 },
@@ -1109,6 +1110,10 @@ EditStyle::EditStyle(QWidget* parent)
     });
     connect(dynamicsAndHairpinPos, &QComboBox::currentIndexChanged, dynamicsAndHairpinsAboveOnVocalStaves, [=]() {
         dynamicsAndHairpinsAboveOnVocalStaves->setEnabled(dynamicsAndHairpinPos->currentIndex() != int(DirectionV::UP));
+    });
+
+    connect(dynamicsFontChoose, &QRadioButton::toggled, dynamicsFont, [=]() {
+        dynamicsFont->setEnabled(dynamicsFontChoose->isChecked());
     });
 
     WidgetUtils::setWidgetIcon(resetTextStyleName, IconCode::Code::UNDO);

--- a/src/notation/view/widgets/editstyle.ui
+++ b/src/notation/view/widgets/editstyle.ui
@@ -8331,37 +8331,13 @@
                <string>Dynamics</string>
               </property>
               <layout class="QGridLayout" name="gridLayout_672">
-               <item row="5" column="0">
-                <widget class="QLabel" name="label_220">
-                 <property name="text">
-                  <string>Autoplace min. distance:</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="3" column="1">
+               <item row="4" column="1">
                 <widget class="mu::notation::OffsetSelect" name="dynamicsPosAbove" native="true"/>
                </item>
-               <item row="4" column="0">
-                <widget class="QLabel" name="label_223">
-                 <property name="text">
-                  <string>Offset below:</string>
-                 </property>
-                </widget>
+               <item row="5" column="1">
+                <widget class="mu::notation::OffsetSelect" name="dynamicsPosBelow" native="true"/>
                </item>
-               <item row="4" column="2">
-                <widget class="QToolButton" name="resetDynamicsPosBelow">
-                 <property name="toolTip">
-                  <string>Reset to default</string>
-                 </property>
-                 <property name="accessibleName">
-                  <string>Reset 'Offset below' value</string>
-                 </property>
-                 <property name="text">
-                  <string notr="true"/>
-                 </property>
-                </widget>
-               </item>
-               <item row="2" column="2">
+               <item row="3" column="2">
                 <widget class="QToolButton" name="resetDynamicsSize">
                  <property name="toolTip">
                   <string>Reset to default</string>
@@ -8374,40 +8350,156 @@
                  </property>
                 </widget>
                </item>
-               <item row="1" column="2">
-                <widget class="QToolButton" name="resetAvoidBarLines">
-                 <property name="toolTip">
-                  <string>Reset to default</string>
-                 </property>
-                 <property name="accessibleName">
-                  <string>Reset 'Avoid barlines' value</string>
-                 </property>
-                 <property name="text">
-                  <string notr="true"/>
-                 </property>
-                </widget>
-               </item>
                <item row="5" column="2">
-                <widget class="QToolButton" name="resetDynamicsMinDistance">
+                <widget class="QToolButton" name="resetDynamicsPosBelow">
                  <property name="toolTip">
                   <string>Reset to default</string>
                  </property>
                  <property name="accessibleName">
-                  <string>Reset 'Autoplace min. distance' value</string>
+                  <string>Reset 'Offset below' value</string>
                  </property>
                  <property name="text">
                   <string notr="true"/>
                  </property>
                 </widget>
                </item>
-               <item row="3" column="0">
-                <widget class="QLabel" name="label_221">
+               <item row="6" column="0">
+                <widget class="QLabel" name="label_220">
                  <property name="text">
-                  <string>Offset above:</string>
+                  <string>Autoplace min. distance:</string>
                  </property>
                 </widget>
                </item>
-               <item row="2" column="1">
+               <item row="4" column="2">
+                <widget class="QToolButton" name="resetDynamicsPosAbove">
+                 <property name="toolTip">
+                  <string>Reset to default</string>
+                 </property>
+                 <property name="accessibleName">
+                  <string>Reset 'Offset above' value</string>
+                 </property>
+                 <property name="text">
+                  <string notr="true"/>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="0" colspan="4">
+                <widget class="QGroupBox" name="dynamicsOverrideFont">
+                 <property name="enabled">
+                  <bool>true</bool>
+                 </property>
+                 <property name="focusPolicy">
+                  <enum>Qt::StrongFocus</enum>
+                 </property>
+                 <property name="accessibleName">
+                  <string>Override score font</string>
+                 </property>
+                 <property name="title">
+                  <string>Override score font</string>
+                 </property>
+                 <property name="checkable">
+                  <bool>true</bool>
+                 </property>
+                 <layout class="QVBoxLayout" name="verticalLayout_73">
+                  <property name="spacing">
+                   <number>7</number>
+                  </property>
+                  <property name="leftMargin">
+                   <number>8</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>8</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>7</number>
+                  </property>
+                  <item>
+                   <layout class="QHBoxLayout" name="chooseFont">
+                    <property name="spacing">
+                     <number>5</number>
+                    </property>
+                    <item>
+                     <widget class="QRadioButton" name="dynamicsFontChoose">
+                      <property name="sizePolicy">
+                       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                        <horstretch>0</horstretch>
+                        <verstretch>0</verstretch>
+                       </sizepolicy>
+                      </property>
+                      <property name="text">
+                       <string>Choose font:</string>
+                      </property>
+                      <property name="checked">
+                       <bool>true</bool>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QComboBox" name="dynamicsFont">
+                      <property name="enabled">
+                       <bool>true</bool>
+                      </property>
+                      <property name="sizePolicy">
+                       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                        <horstretch>0</horstretch>
+                        <verstretch>0</verstretch>
+                       </sizepolicy>
+                      </property>
+                      <property name="minimumSize">
+                       <size>
+                        <width>225</width>
+                        <height>0</height>
+                       </size>
+                      </property>
+                      <property name="maximumSize">
+                       <size>
+                        <width>16777215</width>
+                        <height>16777215</height>
+                       </size>
+                      </property>
+                      <property name="accessibleDescription">
+                       <string/>
+                      </property>
+                      <property name="autoFillBackground">
+                       <bool>false</bool>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <spacer name="horizontalSpacer_73">
+                      <property name="orientation">
+                       <enum>Qt::Horizontal</enum>
+                      </property>
+                      <property name="sizeHint" stdset="0">
+                       <size>
+                        <width>40</width>
+                        <height>20</height>
+                       </size>
+                      </property>
+                     </spacer>
+                    </item>
+                   </layout>
+                  </item>
+                  <item>
+                   <widget class="QRadioButton" name="dynamicsUseExpressionTextStyle">
+                    <property name="minimumSize">
+                     <size>
+                      <width>0</width>
+                      <height>24</height>
+                     </size>
+                    </property>
+                    <property name="autoFillBackground">
+                     <bool>false</bool>
+                    </property>
+                    <property name="text">
+                     <string>Use expression text style</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item row="3" column="1">
                 <widget class="QDoubleSpinBox" name="dynamicsSize">
                  <property name="keyboardTracking">
                   <bool>false</bool>
@@ -8423,7 +8515,70 @@
                  </property>
                 </widget>
                </item>
-               <item row="5" column="1">
+               <item row="5" column="0">
+                <widget class="QLabel" name="label_223">
+                 <property name="text">
+                  <string>Offset below:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="0">
+                <widget class="QLabel" name="label_225">
+                 <property name="text">
+                  <string>Scale:</string>
+                 </property>
+                 <property name="margin">
+                  <number>0</number>
+                 </property>
+                </widget>
+               </item>
+               <item row="6" column="3">
+                <spacer name="horizontalSpacer_30">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item row="6" column="2">
+                <widget class="QToolButton" name="resetDynamicsMinDistance">
+                 <property name="toolTip">
+                  <string>Reset to default</string>
+                 </property>
+                 <property name="accessibleName">
+                  <string>Reset 'Autoplace min. distance' value</string>
+                 </property>
+                 <property name="text">
+                  <string notr="true"/>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="0">
+                <widget class="QCheckBox" name="avoidBarLines">
+                 <property name="text">
+                  <string>Avoid barlines</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="2">
+                <widget class="QToolButton" name="resetAvoidBarLines">
+                 <property name="toolTip">
+                  <string>Reset to default</string>
+                 </property>
+                 <property name="accessibleName">
+                  <string>Reset 'Avoid barlines' setting</string>
+                 </property>
+                 <property name="text">
+                  <string notr="true"/>
+                 </property>
+                </widget>
+               </item>
+               <item row="6" column="1">
                 <widget class="QDoubleSpinBox" name="dynamicsMinDistance">
                  <property name="keyboardTracking">
                   <bool>false</bool>
@@ -8448,83 +8603,12 @@
                  </property>
                 </widget>
                </item>
-               <item row="1" column="0">
-                <widget class="QCheckBox" name="avoidBarLines">
+               <item row="4" column="0">
+                <widget class="QLabel" name="label_221">
                  <property name="text">
-                  <string>Avoid barlines</string>
+                  <string>Offset above:</string>
                  </property>
                 </widget>
-               </item>
-               <item row="3" column="2">
-                <widget class="QToolButton" name="resetDynamicsPosAbove">
-                 <property name="toolTip">
-                  <string>Reset to default</string>
-                 </property>
-                 <property name="accessibleName">
-                  <string>Reset 'Offset above' value</string>
-                 </property>
-                 <property name="text">
-                  <string notr="true"/>
-                 </property>
-                </widget>
-               </item>
-               <item row="4" column="1">
-                <widget class="mu::notation::OffsetSelect" name="dynamicsPosBelow" native="true"/>
-               </item>
-               <item row="2" column="0">
-                <widget class="QLabel" name="label_225">
-                 <property name="text">
-                  <string>Scale:</string>
-                 </property>
-                 <property name="margin">
-                  <number>0</number>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="0" colspan="4">
-                <widget class="QGroupBox" name="dynamicsOverrideFont">
-                 <property name="accessibleName">
-                  <string>Override score font</string>
-                 </property>
-                 <property name="title">
-                  <string>Override score font</string>
-                 </property>
-                 <property name="checkable">
-                  <bool>true</bool>
-                 </property>
-                 <layout class="QHBoxLayout" name="horizontalLayout_14">
-                  <item>
-                   <widget class="QLabel" name="label_224">
-                    <property name="text">
-                     <string>Font:</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QComboBox" name="dynamicsFont">
-                    <property name="minimumSize">
-                     <size>
-                      <width>0</width>
-                      <height>0</height>
-                     </size>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item row="5" column="3">
-                <spacer name="horizontalSpacer_30">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>40</width>
-                   <height>20</height>
-                  </size>
-                 </property>
-                </spacer>
                </item>
               </layout>
              </widget>
@@ -8535,6 +8619,23 @@
                <string>Hairpins</string>
               </property>
               <layout class="QGridLayout" name="gridLayout_7">
+               <item row="0" column="1">
+                <widget class="mu::notation::OffsetSelect" name="hairpinPosAbove" native="true">
+                 <property name="focusPolicy">
+                  <enum>Qt::StrongFocus</enum>
+                 </property>
+                </widget>
+               </item>
+               <item row="5" column="0">
+                <widget class="QLabel" name="label_117">
+                 <property name="text">
+                  <string>Autoplace, distance to dynamics:</string>
+                 </property>
+                 <property name="buddy">
+                  <cstring>autoplaceHairpinDynamicsDistance</cstring>
+                 </property>
+                </widget>
+               </item>
                <item row="5" column="2">
                 <widget class="QToolButton" name="resetAutoplaceHairpinDynamicsDistance">
                  <property name="sizePolicy">
@@ -8554,84 +8655,6 @@
                  </property>
                 </widget>
                </item>
-               <item row="0" column="0">
-                <widget class="QLabel" name="label_95">
-                 <property name="text">
-                  <string>Offset above:</string>
-                 </property>
-                 <property name="buddy">
-                  <cstring>hairpinPosAbove</cstring>
-                 </property>
-                </widget>
-               </item>
-               <item row="3" column="1">
-                <widget class="QDoubleSpinBox" name="hairpinHeight">
-                 <property name="keyboardTracking">
-                  <bool>false</bool>
-                 </property>
-                 <property name="suffix">
-                  <string extracomment="spatium unit">sp</string>
-                 </property>
-                 <property name="singleStep">
-                  <double>0.100000000000000</double>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="1">
-                <widget class="mu::notation::OffsetSelect" name="hairpinPosAbove" native="true">
-                 <property name="focusPolicy">
-                  <enum>Qt::StrongFocus</enum>
-                 </property>
-                </widget>
-               </item>
-               <item row="5" column="0">
-                <widget class="QLabel" name="label_117">
-                 <property name="text">
-                  <string>Autoplace, distance to dynamics:</string>
-                 </property>
-                 <property name="buddy">
-                  <cstring>autoplaceHairpinDynamicsDistance</cstring>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="2">
-                <widget class="QToolButton" name="resetHairpinPosAbove">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="toolTip">
-                  <string>Reset to default</string>
-                 </property>
-                 <property name="accessibleName">
-                  <string>Reset 'Offset above' value</string>
-                 </property>
-                 <property name="text">
-                  <string notr="true"/>
-                 </property>
-                </widget>
-               </item>
-               <item row="4" column="2">
-                <widget class="QToolButton" name="resetHairpinContinueHeight">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="toolTip">
-                  <string>Reset to default</string>
-                 </property>
-                 <property name="accessibleName">
-                  <string>Reset 'Continue height' value</string>
-                 </property>
-                 <property name="text">
-                  <string notr="true"/>
-                 </property>
-                </widget>
-               </item>
                <item row="3" column="0">
                 <widget class="QLabel" name="label_9">
                  <property name="text">
@@ -8642,13 +8665,13 @@
                  </property>
                 </widget>
                </item>
-               <item row="6" column="0">
-                <widget class="QLabel" name="label_8">
+               <item row="4" column="0">
+                <widget class="QLabel" name="label_10">
                  <property name="text">
-                  <string>Line thickness:</string>
+                  <string>Continue height:</string>
                  </property>
                  <property name="buddy">
-                  <cstring>hairpinLineWidth</cstring>
+                  <cstring>hairpinContinueHeight</cstring>
                  </property>
                 </widget>
                </item>
@@ -8684,10 +8707,126 @@
                  </property>
                 </widget>
                </item>
+               <item row="1" column="0">
+                <widget class="QLabel" name="label_129">
+                 <property name="text">
+                  <string>Offset below:</string>
+                 </property>
+                 <property name="buddy">
+                  <cstring>hairpinPosBelow</cstring>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="1">
+                <widget class="QDoubleSpinBox" name="hairpinContinueHeight">
+                 <property name="keyboardTracking">
+                  <bool>false</bool>
+                 </property>
+                 <property name="suffix">
+                  <string extracomment="spatium unit">sp</string>
+                 </property>
+                 <property name="singleStep">
+                  <double>0.100000000000000</double>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="2">
+                <widget class="QToolButton" name="resetHairpinPosAbove">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="toolTip">
+                  <string>Reset to default</string>
+                 </property>
+                 <property name="accessibleName">
+                  <string>Reset 'Offset above' value</string>
+                 </property>
+                 <property name="text">
+                  <string notr="true"/>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="3">
+                <spacer name="horizontalSpacer_671">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item row="3" column="2">
+                <widget class="QToolButton" name="resetHairpinHeight">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="toolTip">
+                  <string>Reset to default</string>
+                 </property>
+                 <property name="accessibleName">
+                  <string>Reset 'Height' value</string>
+                 </property>
+                 <property name="text">
+                  <string notr="true"/>
+                 </property>
+                </widget>
+               </item>
+               <item row="6" column="0">
+                <widget class="QLabel" name="label_8">
+                 <property name="text">
+                  <string>Line thickness:</string>
+                 </property>
+                 <property name="buddy">
+                  <cstring>hairpinLineWidth</cstring>
+                 </property>
+                </widget>
+               </item>
                <item row="1" column="1">
                 <widget class="mu::notation::OffsetSelect" name="hairpinPosBelow" native="true">
                  <property name="focusPolicy">
                   <enum>Qt::StrongFocus</enum>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="2">
+                <widget class="QToolButton" name="resetHairpinContinueHeight">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="toolTip">
+                  <string>Reset to default</string>
+                 </property>
+                 <property name="accessibleName">
+                  <string>Reset 'Continue height' value</string>
+                 </property>
+                 <property name="text">
+                  <string notr="true"/>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="1">
+                <widget class="QDoubleSpinBox" name="hairpinHeight">
+                 <property name="keyboardTracking">
+                  <bool>false</bool>
+                 </property>
+                 <property name="suffix">
+                  <string extracomment="spatium unit">sp</string>
+                 </property>
+                 <property name="singleStep">
+                  <double>0.100000000000000</double>
                  </property>
                 </widget>
                </item>
@@ -8704,13 +8843,13 @@
                  </property>
                 </widget>
                </item>
-               <item row="1" column="0">
-                <widget class="QLabel" name="label_129">
+               <item row="0" column="0">
+                <widget class="QLabel" name="label_95">
                  <property name="text">
                   <string>Offset below:</string>
                  </property>
                  <property name="buddy">
-                  <cstring>hairpinPosBelow</cstring>
+                  <cstring>hairpinPosAbove</cstring>
                  </property>
                 </widget>
                </item>
@@ -8732,61 +8871,6 @@
                   <string notr="true"/>
                  </property>
                 </widget>
-               </item>
-               <item row="4" column="1">
-                <widget class="QDoubleSpinBox" name="hairpinContinueHeight">
-                 <property name="keyboardTracking">
-                  <bool>false</bool>
-                 </property>
-                 <property name="suffix">
-                  <string extracomment="spatium unit">sp</string>
-                 </property>
-                 <property name="singleStep">
-                  <double>0.100000000000000</double>
-                 </property>
-                </widget>
-               </item>
-               <item row="4" column="0">
-                <widget class="QLabel" name="label_10">
-                 <property name="text">
-                  <string>Continue height:</string>
-                 </property>
-                 <property name="buddy">
-                  <cstring>hairpinContinueHeight</cstring>
-                 </property>
-                </widget>
-               </item>
-               <item row="3" column="2">
-                <widget class="QToolButton" name="resetHairpinHeight">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="toolTip">
-                  <string>Reset to default</string>
-                 </property>
-                 <property name="accessibleName">
-                  <string>Reset 'Height' value</string>
-                 </property>
-                 <property name="text">
-                  <string notr="true"/>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="3">
-                <spacer name="horizontalSpacer_671">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>40</width>
-                   <height>20</height>
-                  </size>
-                 </property>
-                </spacer>
                </item>
               </layout>
              </widget>


### PR DESCRIPTION
Resolves: #23090  <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
Which font the dynamic should be displayed in is decided in the Dynamic's setXmlText method which is overridden. Additionally, fragments are also assigned a type to denote what type of text it contains. It currently contains a plain dynamic one which is for dynamics in expression text style along with a default one for all the other text.
<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)

@shoogle 