### PR TITLE
Fix tie track2 crash in parts

### DIFF
--- a/src/engraving/dom/excerpt.cpp
+++ b/src/engraving/dom/excerpt.cpp
@@ -788,6 +788,7 @@ static void addTies(Note* originalNote, Note* newNote, TieMap& tieMap, Score* sc
         if (tie) {
             newNote->setTieBack(tie);
             tie->setEndNote(newNote);
+            tie->setTrack2(newNote->track());
         } else {
             LOGD("addTiesToMap: cannot find tie");
         }

--- a/src/engraving/dom/note.cpp
+++ b/src/engraving/dom/note.cpp
@@ -2377,14 +2377,12 @@ void Note::setTrack(track_idx_t val)
         m_tieFor->setTrack2(val);
         for (SpannerSegment* seg : m_tieFor->spannerSegments()) {
             seg->setTrack(val);
-            seg->setTrack(val);
         }
     }
     if (incomingPartialTie()) {
         m_tieBack->setTrack(val);
         m_tieBack->setTrack2(val);
         for (SpannerSegment* seg : m_tieBack->spannerSegments()) {
-            seg->setTrack(val);
             seg->setTrack(val);
         }
     }


### PR DESCRIPTION
Resolves: #27710 

This was unconnected to partial ties and affects all ties in parts in this score.

This PR also removes some redundant lines.