### PR TITLE
Fix crash on range selection over multimeasure rest

### DIFF
--- a/src/engraving/dom/select.cpp
+++ b/src/engraving/dom/select.cpp
@@ -578,23 +578,22 @@ void Selection::appendChordRest(ChordRest* cr)
         appendTupletHierarchy(tuplet);
     }
 
-    if (cr->isRest()) {
-        appendFiltered(cr);
-        Rest* r = toRest(cr);
-        for (int i = 0; i < r->dots(); ++i) {
-            appendFiltered(r->dot(i));
+    if (cr->isChord()) {
+        Chord* chord = toChord(cr);
+        for (Chord* graceNote : chord->graceNotes()) {
+            if (canSelect(graceNote)) {
+                appendChord(graceNote);
+            }
         }
+        appendChord(chord);
         return;
     }
 
-    Chord* chord = toChord(cr);
-    for (Chord* graceNote : chord->graceNotes()) {
-        if (canSelect(graceNote)) {
-            appendChord(graceNote);
-        }
+    appendFiltered(cr);
+    Rest* r = toRest(cr);
+    for (int i = 0; i < r->dots(); ++i) {
+        appendFiltered(r->dot(i));
     }
-
-    appendChord(chord);
 }
 
 void Selection::appendChord(Chord* chord)


### PR DESCRIPTION
Repro steps:
1. Toggle multimeasure rests
2. Select all (Ctrl-A)

Caused by 8d84f0599b8023930ca259495d6a23000a769ae1

`isRest` will be false if the item is a multi-measure rest. This means we skip the conditional and try to call `toChord` on a multi-measure rest (which crashes).