### PR TITLE
Fix undo on partial tie selection drag move

### DIFF
--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -7592,7 +7592,7 @@ void Score::undoRemoveStaleTieJumpPoints(bool undo)
             startCmd(TranslatableString("engraving", "Remove stale partial tie"));
             undoRemoveElement(incomingPT);
             endCmd();
-            if (undoIdx != undoStack()->currentIndex() && undoStack()->currentIndex() > 2) {
+            if (undoIdx != undoStack()->currentIndex() && undoStack()->currentIndex() >= 2) {
                 undoStack()->mergeCommands(undoStack()->currentIndex() - 2);
             }
         } else {


### PR DESCRIPTION
Resolves: #27714 (partially)

This fixes the undo part of the issue. The crash on close is related to a hairpin.