### PR TITLE
Fix crash on making notes invisible & undo

### DIFF
--- a/src/engraving/dom/location.cpp
+++ b/src/engraving/dom/location.cpp
@@ -236,6 +236,9 @@ int Location::note(const EngravingItem* e)
 
 PropertyValue Location::getLocationProperty(Pid pid, const EngravingItem* start, const EngravingItem* end)
 {
+    if (!start || !end) {
+        return 0;
+    }
     switch (pid) {
     case Pid::LOCATION_STAVES:
         return (track(start) / VOICES) - (track(end) / VOICES);


### PR DESCRIPTION
Resolves: #27719 

`Location::getLocationProperty` expects `start` and `end` to be valid pointers. In the case of partial ties and laissez vib ties, either of these could be null. In this case, the relative distance should be 0.
