### PR TITLE
21148: Undocked panels change their sizes between MuseScore sessions

### DIFF
--- a/src/framework/dockwindow/thirdparty/KDDockWidgets/src/LayoutSaver.cpp
+++ b/src/framework/dockwindow/thirdparty/KDDockWidgets/src/LayoutSaver.cpp
@@ -1055,7 +1055,7 @@ LayoutSaver::ScalingInfo::ScalingInfo(const QString &mainWindowId, QRect savedMa
 
     this->mainWindowName = mainWindowId;
     this->savedMainWindowGeometry = savedMainWindowGeo;
-    realMainWindowGeometry = mainWindow->window()->geometry(); // window() as our main window might be embedded
+    realMainWindowGeometry = mainWindow->windowGeometry();
     widthFactor = double(realMainWindowGeometry.width()) / savedMainWindowGeo.width();
     heightFactor = double(realMainWindowGeometry.height()) / savedMainWindowGeo.height();
     mainWindowChangedScreen = currentScreenIndex != screenIndex;


### PR DESCRIPTION
Resolves: #21148 (partially, the other half should be covered by [PR27695](https://github.com/musescore/MuseScore/pull/27695)

**Symptoms:**
Undocked panels change their width and height with each launch of MuseScore. They can increase or decrease them with decrease being the more common case. The Mixer auto-calculates its height so the height is not problematic, but the width is: it will usually shrink significantly upon every launch eventually ending up as wide as a pen (as described by many users). A vertical panel, e.g. the Layout panel, when undocked will also significantly reduce its height with every launch ending up as high as a pen. The vertical panels are constrained to a width of 300px so it is not as problematic.

**Increase or decrease? By how much?**
The next time MuseScore is launched:
* all floating panels will have their widths multiplied by `1150 / W` where `W` is the width of the MuseScore window it had when it was last closed. Consequently, if `W` is less than 1150px, all widths will increase; if W is more than 1150px, all widths will be reduced. The farther W is from 1150, the more pronounced the width change.
* all floating panels will have their heights multiplied by `768 / H` where `H` is the height of the MuseScore window it had when it was last closed. Consequently, if `H` is less than 768px, all heights will increase; if H is more than 768px, all heights will be reduced. The farther H is from 768, the more pronounced the height change.

The numbers 1150 and 768 are approximate and may vary from system to system a bit. I suppose most users have MuseScore maximized to something close to 1920x1080px on their laptops. This is the reason why the panels mostly shrink.

**Cause:**
The `LayoutSaver` scales all the widget sizes relative to the the main window. In `LayoutSaver::restoreLayout()` there is a call `layout.scaleSizes(d->m_restoreOptions);` (LayoutSaver.cpp:220) which calls `scaleSizes()` on each main window (line 528). This is where the saved geometry of the window when it was last closed is compared against its current size and then everything is scaled according to that ratio. I believe the idea is that if the main window would end up outside of the screen, its size and position will be adjusted but at the same time all other floating windows should be adjusted by the same amount so as to scale the whole layout evently. The problem is this does not seem to work quite correctly.

I see a couple of issues here:
1. `LayoutSaver::Private::deserializeWindowGeometry()` is where the size of the main window is restored. If the window was not maximized, the method will use its saved size. If the window was maximized, the method will use the normal (restored) size and the window will be maximized later. This is fine. The problem is that later when `LayoutSaver::MainWindow::scaleSizes()` is calculating the scaling coefficients, it always takes the saved size of the window. So if the window was maximized, it will be created with its normal size and this normal size will be used together with the saved (maximized) size for the scaling. Does not make sense to me. There is no way for the coefficients to be 1.0 so some scaling will take place. It feels like comparing apples to pears.

2. The second problem is that in `LayoutSaver::ScalingInfo::ScalingInfo` the saved size of the window is not compared to the actual size of the window set by `LayoutSaver::Private::deserializeWindowGeometry()`. The latter uses `setTopLevelGeometry` which sets the size of the main window correctly but the former uses `mainWindow->window()->geometry();` instead. This returns a width like 1150px and height like 768px which are very close to the width and height set on the `ApplicationWindow` in `AppWindow.qml` (probably the height excludes the titlebar). So the scaling coefficients always dependent on: a) the size of main window of MuseScore when it was last closed - and - b) the fixed width and height set in `AppWindow.qml`. This does not make sense to me either.

**My fix:**
I propose that in `LayoutSaver::MainWindow::scaleSizes()` we use the same logic as in `deserializeWindowGeometry()`: use either the save or normal size of the window as the denominator and make the nominator the same size but run through `FloatingWindow::ensureRectIsOnScreen`. In almost 100% of the time the two will be equal except when the size goes out of the screen and needs adjustment. Due to the unknowns as to why KDDockWidgets does all that, my fix may not be optimal. Shout out if you have better ideas.

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
