### PR TITLE
Append space to lyrics when exporting MIDI

### DIFF
--- a/src/importexport/midi/internal/midiexport/exportmidi.cpp
+++ b/src/importexport/midi/internal/midiexport/exportmidi.cpp
@@ -372,7 +372,13 @@ bool ExportMidi::write(QIODevice* device, bool midiExpandRepeats, bool exportRPN
                     ChordRest* cr = toChordRest(seg->element(i));
                     if (cr) {
                         for (const auto& lyric : cr->lyrics()) {
+                            LyricsSyllabic syllabic = lyric->syllabic();
                             muse::ByteArray lyricText = lyric->plainText().toUtf8();
+                            if ((syllabic == LyricsSyllabic::SINGLE || syllabic == LyricsSyllabic::END)
+                                && (lyricText.empty() || lyricText[lyricText.size() - 1] != ' ')) {
+                                lyricText.push_back(' ');
+                            }
+
                             size_t len = lyricText.size() + 1;
                             std::vector<unsigned char> data(lyricText.constData(), lyricText.constData() + len);
 

--- a/src/importexport/midi/internal/midiimport/importmidi_lyrics.cpp
+++ b/src/importexport/midi/internal/midiimport/importmidi_lyrics.cpp
@@ -68,6 +68,7 @@ extractLyricsFromTrack(const MidiTrack& track, int division, bool isDivisionInTp
         if (isLyricEvent(e)) {
             const uchar* data = (uchar*)e.edata();
             std::string text = MidiCharset::fromUchar(data);
+            text.erase(text.find_last_not_of(' ') + 1);
             if (isLyricText(text)) {
                 const auto tick = toMuseScoreTicks(i.first, division, isDivisionInTps);
                 // no charset handling here


### PR DESCRIPTION
Remake of #27500 

When working with other MIDI software, and trying to open a MIDI exported from MuseScore, the lyrics were squished together, while other MIDI files didn't have squished lyrics. By looking into the files that weren't squished, there was a space character at the end of the final syllable (or the syllable if there's only one).

An example of this is in midis2jam2:

Before this PR:
![image](https://github.com/user-attachments/assets/0a791f8d-3747-47bc-a54a-05833ea38e57)

With this PR:
![image](https://github.com/user-attachments/assets/f160c3bc-a32c-4ba2-8415-24d23e1c9e84)

Here is what the sheet music looks like:
![image](https://github.com/user-attachments/assets/4dad9584-c22c-45fd-8b6e-418f51cc3737)

I know this use case scenario might be a little niche, but I took some time out of my day to fix/add this.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
