### PR TITLE
Don't layout ledger lines and accidentals in TAB

### DIFF
--- a/src/engraving/rendering/score/chordlayout.cpp
+++ b/src/engraving/rendering/score/chordlayout.cpp
@@ -2079,11 +2079,13 @@ void ChordLayout::layoutChords1(LayoutContext& ctx, Segment* segment, staff_idx_
         layoutChords3(chords, notes, staff, ctx);
     }
 
-    layoutLedgerLines(chords);
-    AccidentalsLayout::layoutAccidentals(chords, ctx);
-    for (Chord* chord : chords) {
-        for (Chord* grace : chord->graceNotes()) {
-            AccidentalsLayout::layoutAccidentals({ grace }, ctx);
+    if (!isTab) {
+        layoutLedgerLines(chords);
+        AccidentalsLayout::layoutAccidentals(chords, ctx);
+        for (Chord* chord : chords) {
+            for (Chord* grace : chord->graceNotes()) {
+                AccidentalsLayout::layoutAccidentals({ grace }, ctx);
+            }
         }
     }
 


### PR DESCRIPTION
Resolves: #27736 

The freeze is caused by ledger lines, because the note line value defaults to -10000 and on TAB staves that value may remain invalid as TABs don't have note "lines", so the program was trying to layout tens of thousands of ledge lines.