### PR TITLE
4.5.2: Fix GH#27741: Import 1.x irregular measure property

### DIFF
--- a/src/engraving/rw/read114/read114.cpp
+++ b/src/engraving/rw/read114/read114.cpp
@@ -2051,7 +2051,8 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e, ReadContext& ctx
         } else if (tag == "measureNumberMode") {
             m->setMeasureNumberMode(MeasureNumberMode(e.readInt()));
         } else if (tag == "irregular") {
-            m->setIrregular(e.readBool());
+            m->setIrregular(true);
+            e.skipCurrentElement();
         } else if (tag == "breakMultiMeasureRest") {
             m->setBreakMultiMeasureRest(e.readBool());
         } else if (tag == "sysInitBarLineType") {


### PR DESCRIPTION
Resolves: #27741 

Port of #27742, but only the very simple albeit somewhat hacky approach affecting/fixing 1.x import only. For potentially better options see my analysis in issue #27741 and PR #27742, those are IMHO to deep to go into 4.5.2 at such a late state.

Sample score:
[test.zip](https://github.com/user-attachments/files/19844121/test.zip)
