### PR TITLE
Add option for "invert score" to follow app theme

### DIFF
--- a/src/appshell/qml/Preferences/AppearancePreferencesPage.qml
+++ b/src/appshell/qml/Preferences/AppearancePreferencesPage.qml
@@ -214,7 +214,7 @@ PreferencesPage {
         SeparatorLine {}
 
         ThemeAdditionalOptionsSection {
-            scoreInversionEnabled: appearanceModel.scoreInversionEnabled
+            scoreInversionMode: appearanceModel.scoreInversionMode
 
             navigation.section: root.navigationSection
             navigation.order: root.navigationOrderStart + 7
@@ -229,8 +229,8 @@ PreferencesPage {
                 }
             }
 
-            onScoreInversionEnableChangeRequested: function(enable) {
-                appearanceModel.scoreInversionEnabled = enable
+            onScoreInversionModeChangeRequested: function(mode) {
+                appearanceModel.scoreInversionMode = mode
             }
         }
     }

--- a/src/appshell/qml/Preferences/internal/ThemeAdditionalOptionsSection.qml
+++ b/src/appshell/qml/Preferences/internal/ThemeAdditionalOptionsSection.qml
@@ -26,23 +26,31 @@ import Muse.UiComponents 1.0
 BaseSection {
     id: root
 
-    property alias scoreInversionEnabled: scoreInversionEnable.checked
+    property int scoreInversionMode: 0
 
     signal resetThemeToDefaultRequested()
-    signal scoreInversionEnableChangeRequested(bool enable)
+    signal scoreInversionModeChangeRequested(int mode)
 
-    CheckBox {
-        id: scoreInversionEnable
+    ComboBoxWithTitle {
+        id: scoreInversionModeDropdown
         width: parent.width
 
-        text: qsTrc("appshell/preferences", "Invert score")
+        title: qsTrc("appshell/preferences", "Invert score:")
 
-        navigation.name: "ScoreInversionBox"
+        navigation.name: "ScoreInversionModeDropdown"
         navigation.panel: root.navigation
         navigation.row: 0
 
-        onClicked: {
-            root.scoreInversionEnableChangeRequested(!checked)
+        model: [
+            { text: qsTrc("appshell/preferences", "Disabled"), value: 0 },
+            { text: qsTrc("appshell/preferences", "Follow app theme"), value: 1 },
+            { text: qsTrc("appshell/preferences", "Always"), value: 2 },
+        ]
+
+        currentIndex: scoreInversionModeDropdown.indexOfValue(root.scoreInversionMode)
+
+        onValueEdited: function(newIndex, newValue) {
+            root.scoreInversionModeChangeRequested(newValue)
         }
     }
 

--- a/src/appshell/view/preferences/appearancepreferencesmodel.cpp
+++ b/src/appshell/view/preferences/appearancepreferencesmodel.cpp
@@ -57,7 +57,7 @@ void AppearancePreferencesModel::init()
     });
 
     engravingConfiguration()->scoreInversionChanged().onNotify(this, [this]() {
-        emit invertScoreColorChanged();
+        emit scoreInversionModeChanged();
         emit foregroundColorChanged();
     });
 
@@ -252,9 +252,9 @@ QString AppearancePreferencesModel::foregroundWallpaperPath() const
     return notationConfiguration()->foregroundWallpaperPath().toQString();
 }
 
-bool AppearancePreferencesModel::scoreInversionEnabled() const
+int AppearancePreferencesModel::scoreInversionMode() const
 {
-    return engravingConfiguration()->scoreInversionEnabled();
+    return static_cast<int>(engravingConfiguration()->scoreInversionMode());
 }
 
 void AppearancePreferencesModel::setCurrentThemeCode(const QString& themeCode)
@@ -362,12 +362,12 @@ void AppearancePreferencesModel::setForegroundWallpaperPath(const QString& path)
     emit foregroundWallpaperPathChanged();
 }
 
-void AppearancePreferencesModel::setScoreInversionEnabled(bool value)
+void AppearancePreferencesModel::setScoreInversionMode(int mode)
 {
-    if (value == scoreInversionEnabled()) {
+    if (mode == scoreInversionMode()) {
         return;
     }
 
-    engravingConfiguration()->setScoreInversionEnabled(value);
-    emit invertScoreColorChanged();
+    engravingConfiguration()->setScoreInversionMode(static_cast<mu::engraving::ScoreInversionMode>(mode));
+    emit scoreInversionModeChanged();
 }

--- a/src/appshell/view/preferences/appearancepreferencesmodel.h
+++ b/src/appshell/view/preferences/appearancepreferencesmodel.h
@@ -58,7 +58,7 @@ class AppearancePreferencesModel : public QObject, public muse::Injectable, publ
     Q_PROPERTY(
         QString foregroundWallpaperPath READ foregroundWallpaperPath WRITE setForegroundWallpaperPath NOTIFY foregroundWallpaperPathChanged)
 
-    Q_PROPERTY(bool scoreInversionEnabled READ scoreInversionEnabled WRITE setScoreInversionEnabled NOTIFY invertScoreColorChanged)
+    Q_PROPERTY(int scoreInversionMode READ scoreInversionMode WRITE setScoreInversionMode NOTIFY scoreInversionModeChanged)
 
     muse::Inject<muse::ui::IUiConfiguration> uiConfiguration = { this };
     muse::Inject<notation::INotationConfiguration> notationConfiguration = { this };
@@ -100,7 +100,7 @@ public:
     QColor foregroundColor() const;
     QString foregroundWallpaperPath() const;
 
-    bool scoreInversionEnabled() const;
+    int scoreInversionMode() const;
 
     Q_INVOKABLE void resetAppearancePreferencesToDefault();
     Q_INVOKABLE void setNewColor(const QColor& newColor, ColorType colorType);
@@ -121,7 +121,7 @@ public slots:
     void setForegroundUseColor(bool value);
     void setForegroundColor(const QColor& color);
     void setForegroundWallpaperPath(const QString& path);
-    void setScoreInversionEnabled(bool value);
+    void setScoreInversionMode(int mode);
 
 signals:
     void isFollowSystemThemeChanged();
@@ -134,7 +134,7 @@ signals:
     void foregroundUseColorChanged();
     void foregroundColorChanged();
     void foregroundWallpaperPathChanged();
-    void invertScoreColorChanged();
+    void scoreInversionModeChanged();
 
 private:
     muse::ui::ThemeInfo currentTheme() const;

--- a/src/engraving/iengravingconfiguration.h
+++ b/src/engraving/iengravingconfiguration.h
@@ -73,7 +73,8 @@ public:
     virtual muse::async::Channel<voice_idx_t, Color> selectionColorChanged() const = 0;
 
     virtual bool scoreInversionEnabled() const = 0;
-    virtual void setScoreInversionEnabled(bool value) = 0;
+    virtual ScoreInversionMode scoreInversionMode() const = 0;
+    virtual void setScoreInversionMode(ScoreInversionMode mode) = 0;
     virtual muse::async::Notification scoreInversionChanged() const = 0;
 
     virtual bool dynamicsApplyToAllVoices() const = 0;

--- a/src/engraving/internal/engravingconfiguration.h
+++ b/src/engraving/internal/engravingconfiguration.h
@@ -81,7 +81,8 @@ public:
     Color highlightSelectionColor(voice_idx_t voice = 0) const override;
 
     bool scoreInversionEnabled() const override;
-    void setScoreInversionEnabled(bool value) override;
+    ScoreInversionMode scoreInversionMode() const override;
+    void setScoreInversionMode(ScoreInversionMode mode) override;
 
     bool dynamicsApplyToAllVoices() const override;
     void setDynamicsApplyToAllVoices(bool v) override;

--- a/src/engraving/tests/mocks/engravingconfigurationmock.h
+++ b/src/engraving/tests/mocks/engravingconfigurationmock.h
@@ -67,7 +67,8 @@ public:
     MOCK_METHOD((muse::async::Channel<bool>), dynamicsApplyToAllVoicesChanged, (), (const, override));
 
     MOCK_METHOD(bool, scoreInversionEnabled, (), (const, override));
-    MOCK_METHOD(void, setScoreInversionEnabled, (bool), (override));
+    MOCK_METHOD(ScoreInversionMode, scoreInversionMode, (), (const, override));
+    MOCK_METHOD(void, setScoreInversionMode, (ScoreInversionMode), (override));
     MOCK_METHOD(muse::async::Notification, scoreInversionChanged, (), (const, override));
 
     MOCK_METHOD(Color, formattingColor, (), (const, override));

--- a/src/engraving/types/types.h
+++ b/src/engraving/types/types.h
@@ -1184,6 +1184,16 @@ enum class LayoutFlag : unsigned char {
 };
 
 typedef muse::Flags<LayoutFlag> LayoutFlags;
+
+//---------------------------------------------------------
+//  ScoreInversionMode
+//---------------------------------------------------------
+
+enum class ScoreInversionMode : unsigned char {
+    Disabled,
+    FollowAppTheme,
+    Always
+};
 } // mu::engraving
 
 template<>

--- a/src/framework/global/settings.cpp
+++ b/src/framework/global/settings.cpp
@@ -68,6 +68,22 @@ io::path_t Settings::filePath() const
     return m_settings->fileName();
 }
 
+void Settings::remove(const Key& key)
+{
+#ifdef MUSE_MODULE_MULTIINSTANCES
+    muse::mi::WriteResourceLockGuard resource_lock(multiInstancesProvider.get(), SETTINGS_RESOURCE_NAME);
+#endif
+    m_settings->remove(QString::fromStdString(key.key));
+}
+
+bool Settings::contains(const Key& key) const
+{
+#ifdef MUSE_MODULE_MULTIINSTANCES
+    muse::mi::ReadResourceLockGuard resource_lock(multiInstancesProvider.get(), SETTINGS_RESOURCE_NAME);
+#endif
+    return m_settings->contains(QString::fromStdString(key.key));
+}
+
 const Settings::Items& Settings::items() const
 {
     return m_isTransactionStarted ? m_localSettings : m_items;

--- a/src/framework/global/settings.h
+++ b/src/framework/global/settings.h
@@ -112,6 +112,9 @@ public:
 
     io::path_t filePath() const;
 
+    void remove(const Key& key);
+    bool contains(const Key& key) const;
+
 private:
     Settings();
     ~Settings();

--- a/src/notation/internal/notationconfiguration.cpp
+++ b/src/notation/internal/notationconfiguration.cpp
@@ -530,7 +530,7 @@ void NotationConfiguration::resetForeground()
     settings()->setSharedValue(FOREGROUND_USE_COLOR, settings()->defaultValue(FOREGROUND_USE_COLOR));
     settings()->setSharedValue(FOREGROUND_WALLPAPER_PATH, settings()->defaultValue(FOREGROUND_WALLPAPER_PATH));
 
-    engravingConfiguration()->setScoreInversionEnabled(false);
+    engravingConfiguration()->setScoreInversionMode(mu::engraving::ScoreInversionMode::Disabled);
 }
 
 muse::async::Notification NotationConfiguration::foregroundChanged() const


### PR DESCRIPTION
This PR adds the option for "invert score" to follow the app theme: that is, automatically turning on when the app theme is dark, and off when it's light.

In the Appearance preferences, the checkbox has been turned into a dropdown with three choices: Disabled, Follow app theme, and Always.

Quick demo video:

https://github.com/user-attachments/assets/7c60e589-bc05-45a6-a384-89d8608c919e

- A new setting `scoreInversionMode` has been added under the engraving configuration, superseding the old `scoreInversionEnabled`.
- I added some code to detect the old bool setting and map it to the new enum, removing the old setting in the process.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
