### PR TITLE
Make '&' translatable in formatLayerTitle

### DIFF
--- a/src/instrumentsscene/view/systemobjectslayertreeitem.cpp
+++ b/src/instrumentsscene/view/systemobjectslayertreeitem.cpp
@@ -53,7 +53,7 @@ static QString formatLayerTitle(const SystemObjectGroups& groups)
         }
 
         if (i == lastIdx) {
-            title += " & ";
+            title += " " + muse::qtrc("layoutpanel", "&") + " ";
         } else {
             title += ", ";
         }


### PR DESCRIPTION
Resolves: part 2 of #27645<!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

The mentioned issue has two requests:
1. Make German nouns uppercase
2. Make '&' symbol translatable

In this PR I address only 2. Please confirm that this is the only change needed to make the string translatable.

For 1, please advise how can I check the current display language and I will update with the fix for it as well.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
