### PR TITLE
Fix MusicXML incompatibility with MuseScore 3 (and older)

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
@@ -4759,7 +4759,7 @@ static void directionTag(XmlWriter& xml, Attributes& attr, EngravingItem const* 
             }
         }           // if (pel && ...
 
-        if (el->systemFlag()) {
+        if (el->systemFlag() && !ExportMusicXml::configuration()->exportMu3Compat()) {
             tagname += u" system=\"only-top\"";
         }
     }
@@ -5048,7 +5048,7 @@ void ExportMusicXml::tempoText(TempoText const* const text, staff_idx_t staff)
 
     XmlWriter::Attributes tempoAttrs;
     tempoAttrs = { { "placement", (text->placement() == PlacementV::BELOW) ? "below" : "above" } };
-    if (text->systemFlag()) {
+    if (text->systemFlag() && !ExportMusicXml::configuration()->exportMu3Compat()) {
         tempoAttrs.emplace_back(std::make_pair("system", text->isLinked() ? "also-top" : "only-top"));
     }
 


### PR DESCRIPTION
Resolves: #27763

`system="only-top"` and `system="also-top"` seem to be MusicXML 4.x only and MuseScore 3.(6.2 and older) stumbles accross this.
So this PR makes use of the existing advanced preferences compatibility setting.
We could get away with this by just ignoring that message too... which makes this PR here more of a convenience fix.