### PR TITLE
Extensions: Added uninstall and update process

### DIFF
--- a/src/appshell/internal/applicationactioncontroller.cpp
+++ b/src/appshell/internal/applicationactioncontroller.cpp
@@ -184,10 +184,7 @@ bool ApplicationActionController::onDropEvent(QDropEvent* event)
         case DragTarget::Extension: {
             muse::io::path_t filePath = url.toLocalFile();
             async::Async::call(this, [this, filePath]() {
-                    Ret ret = extensionInstaller()->installExtension(filePath);
-                    if (!ret) {
-                        LOGE() << ret.toString();
-                    }
+                    extensionInstaller()->installExtension(filePath);
                 });
         } break;
         case DragTarget::Unknown:

--- a/src/framework/extensions/extensionstypes.h
+++ b/src/framework/extensions/extensionstypes.h
@@ -227,6 +227,7 @@ struct Manifest {
     String version;
     int apiversion = DEFAULT_API_VERSION;
     bool legacyPlugin = false;
+    bool isUserExtension = false;
 
     std::vector<Action> actions;
 

--- a/src/framework/extensions/extensionstypes.h
+++ b/src/framework/extensions/extensionstypes.h
@@ -227,7 +227,7 @@ struct Manifest {
     String version;
     int apiversion = DEFAULT_API_VERSION;
     bool legacyPlugin = false;
-    bool isUserExtension = false;
+    bool isRemovable = false;
 
     std::vector<Action> actions;
 

--- a/src/framework/extensions/extensionstypes.h
+++ b/src/framework/extensions/extensionstypes.h
@@ -218,6 +218,7 @@ struct Manifest {
     };
 
     Uri uri;
+    io::path_t path;
     Type type = Type::Undefined;
     String title;
     String description;

--- a/src/framework/extensions/iextensioninstaller.h
+++ b/src/framework/extensions/iextensioninstaller.h
@@ -1,10 +1,10 @@
 #pragma once
 
 #include "modularity/imoduleinterface.h"
-#include "extensionstypes.h"
 
-#include "global/types/ret.h"
 #include "global/io/path.h"
+#include "global/types/ret.h"
+#include "global/types/uri.h"
 
 namespace muse::extensions {
 class IExtensionInstaller : MODULE_EXPORT_INTERFACE
@@ -14,8 +14,8 @@ public:
 
     virtual ~IExtensionInstaller() = default;
 
-    virtual Ret isFileSupported(const io::path_t path) const = 0;
-    virtual Ret installExtension(const io::path_t path) = 0;
-    virtual Ret uninstallExtension(const Uri& uri) = 0;
+    virtual Ret isFileSupported(const io::path_t& path) const = 0;
+    virtual void installExtension(const io::path_t& path) = 0;
+    virtual void uninstallExtension(const Uri& uri) = 0;
 };
 }

--- a/src/framework/extensions/iextensioninstaller.h
+++ b/src/framework/extensions/iextensioninstaller.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "modularity/imoduleinterface.h"
+#include "extensionstypes.h"
 
 #include "global/types/ret.h"
 #include "global/io/path.h"
@@ -15,5 +16,6 @@ public:
 
     virtual Ret isFileSupported(const io::path_t path) const = 0;
     virtual Ret installExtension(const io::path_t path) = 0;
+    virtual Ret uninstallExtension(const Uri& uri) = 0;
 };
 }

--- a/src/framework/extensions/iextensionsprovider.h
+++ b/src/framework/extensions/iextensionsprovider.h
@@ -38,7 +38,6 @@ public:
     virtual ~IExtensionsProvider() = default;
 
     virtual void reloadExtensions() = 0;
-    virtual Ret removeExtension(const Uri& uri) = 0;
 
     virtual ManifestList manifestList(Filter filter = Filter::All) const = 0;
     virtual async::Notification manifestListChanged() const = 0;

--- a/src/framework/extensions/iextensionsprovider.h
+++ b/src/framework/extensions/iextensionsprovider.h
@@ -38,6 +38,7 @@ public:
     virtual ~IExtensionsProvider() = default;
 
     virtual void reloadExtensions() = 0;
+    virtual Ret removeExtension(const Uri& uri) = 0;
 
     virtual ManifestList manifestList(Filter filter = Filter::All) const = 0;
     virtual async::Notification manifestListChanged() const = 0;

--- a/src/framework/extensions/internal/extensioninstaller.cpp
+++ b/src/framework/extensions/internal/extensioninstaller.cpp
@@ -66,7 +66,7 @@ Ret ExtensionInstaller::installExtension(const io::path_t srcPath)
             });
 
             if (result.button() == int(IInteractive::Button::Ok)) {
-                provider()->removeExtension(existingManifest.uri);
+                this->uninstallExtension(existingManifest.uri);
             } else {
                 return make_ok();
             }
@@ -95,4 +95,25 @@ Ret ExtensionInstaller::installExtension(const io::path_t srcPath)
     }
 
     return ret;
+}
+
+Ret ExtensionInstaller::uninstallExtension(const Uri& uri)
+{
+    Manifest manifest = provider()->manifest(uri);
+    if (!manifest.isValid()) {
+        return make_ret(Ret::Code::UnknownError);
+    } else if (!manifest.isRemovable) {
+        return make_ret(Ret::Code::NotSupported);
+    }
+
+    io::path_t path = manifest.path;
+
+    Ret ret = fileSystem()->remove(io::dirpath(path));
+    if (!ret) {
+        LOGE() << "Failed to delete the folder: " << path;
+        return ret;
+    }
+
+    provider()->reloadExtensions();
+    return make_ok();
 }

--- a/src/framework/extensions/internal/extensioninstaller.cpp
+++ b/src/framework/extensions/internal/extensioninstaller.cpp
@@ -48,7 +48,7 @@ Ret ExtensionInstaller::installExtension(const io::path_t srcPath)
             return make_ok();
         }
 
-        if (alreadyInstalled && !existingManifest.isUserExtension) {
+        if (alreadyInstalled && !existingManifest.isRemovable) {
             interactive()->error(trc("extensions", "This extension cannot be updated."), std::string(),
                                  { interactive()->buttonData(IInteractive::Button::Ok) });
 

--- a/src/framework/extensions/internal/extensioninstaller.cpp
+++ b/src/framework/extensions/internal/extensioninstaller.cpp
@@ -2,6 +2,7 @@
 
 #include "global/io/fileinfo.h"
 #include "global/serialization/zipreader.h"
+#include "global/translation.h"
 #include "global/uuid.h"
 
 #include "../extensionstypes.h"
@@ -41,24 +42,27 @@ Ret ExtensionInstaller::installExtension(const io::path_t srcPath)
         if (alreadyInstalled && existingManifest.version == m.version) {
             LOGI() << "already installed: " << m.uri;
 
-            interactive()->info("Info", "The extension is already installed.", { interactive()->buttonData(IInteractive::Button::Ok) });
+            interactive()->info(trc("extensions", "The extension is already installed."), std::string(),
+                                { interactive()->buttonData(IInteractive::Button::Ok) });
 
             return make_ok();
         }
 
         if (alreadyInstalled && !existingManifest.isUserExtension) {
-            interactive()->error("Error", "This extension cannot be updated.", { interactive()->buttonData(IInteractive::Button::Ok) });
+            interactive()->error(trc("extensions", "This extension cannot be updated."), std::string(),
+                                 { interactive()->buttonData(IInteractive::Button::Ok) });
 
             return make_ok();
         }
 
         if (alreadyInstalled) {
-            std::stringstream text;
-            text << "The extension \"" << existingManifest.title.toStdString() <<
-                "\" is already installed in a different version.\nDo you want to upgrade?\n\nCurrent version: " <<
-                existingManifest.version.toStdString() << "\nNew version: " << m.version.toStdString();
-            IInteractive::Result result = interactive()->question("Update Extension", text.str(), {
-                interactive()->buttonData(IInteractive::Button::Cancel), interactive()->buttonData(IInteractive::Button::Ok)
+            std::string text = qtrc("extensions", "Another version of the extension “%1” is already installed (version %2). "
+                                                  "Do you want to replace it with version %3?")
+                               .arg(existingManifest.title, existingManifest.version, m.version).toStdString();
+
+            IInteractive::Result result = interactive()->question(trc("extensions", "Update Extension"), text, {
+                interactive()->buttonData(IInteractive::Button::Cancel),
+                interactive()->buttonData(IInteractive::Button::Ok)
             });
 
             if (result.button() == int(IInteractive::Button::Ok)) {

--- a/src/framework/extensions/internal/extensioninstaller.cpp
+++ b/src/framework/extensions/internal/extensioninstaller.cpp
@@ -46,6 +46,12 @@ Ret ExtensionInstaller::installExtension(const io::path_t srcPath)
             return make_ok();
         }
 
+        if (alreadyInstalled && !existingManifest.isUserExtension) {
+            interactive()->error("Error", "This extension cannot be updated.", { interactive()->buttonData(IInteractive::Button::Ok) });
+
+            return make_ok();
+        }
+
         if (alreadyInstalled) {
             std::stringstream text;
             text << "The extension \"" << existingManifest.title.toStdString() <<

--- a/src/framework/extensions/internal/extensioninstaller.cpp
+++ b/src/framework/extensions/internal/extensioninstaller.cpp
@@ -30,6 +30,11 @@ void ExtensionInstaller::installExtension(const io::path_t& srcPath)
     const ByteArray data = zip.fileData("manifest.json");
     if (data.empty()) {
         LOGE() << "not found manifest.json in: " << srcPath;
+
+        interactive()->error(trc("extensions", "Failed to install extension"),
+                             trc("extensions", "The extension does not contain a valid manifest file."),
+                             { interactive()->buttonData(IInteractive::Button::Ok) });
+
         return;
     }
 
@@ -87,6 +92,15 @@ void ExtensionInstaller::doInstallExtension(const io::path_t& srcPath)
     Ret ret = zip.unpack(srcPath, dstPath);
     if (!ret) {
         LOGE() << "failed unpack from: " << srcPath << ", to: " << dstPath << ", err: " << ret.toString();
+
+        interactive()->error(trc("extensions", "Failed to install extension"),
+#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
+                             qtrc("extensions", "Error code: %1").arg(ret.toString()).toStdString(),
+#else
+                             qtrc("extensions", "Error code: %1").arg(QString::fromStdString(ret.toString())).toStdString(),
+#endif
+                             { interactive()->buttonData(IInteractive::Button::Ok) });
+
         return;
     }
 

--- a/src/framework/extensions/internal/extensioninstaller.h
+++ b/src/framework/extensions/internal/extensioninstaller.h
@@ -2,6 +2,7 @@
 
 #include "../iextensioninstaller.h"
 
+#include "async/asyncable.h"
 #include "modularity/ioc.h"
 #include "../iextensionsconfiguration.h"
 #include "../iextensionsprovider.h"
@@ -9,7 +10,7 @@
 #include "io/ifilesystem.h"
 
 namespace muse::extensions {
-class ExtensionInstaller : public IExtensionInstaller
+class ExtensionInstaller : public IExtensionInstaller, public async::Asyncable
 {
     muse::GlobalInject<IExtensionsConfiguration> configuration;
     muse::GlobalInject<IExtensionsProvider> provider;
@@ -19,8 +20,11 @@ class ExtensionInstaller : public IExtensionInstaller
 public:
     ExtensionInstaller() = default;
 
-    Ret isFileSupported(const io::path_t path) const override;
-    Ret installExtension(const io::path_t path) override;
-    Ret uninstallExtension(const Uri& uri) override;
+    Ret isFileSupported(const io::path_t& path) const override;
+    void installExtension(const io::path_t& path) override;
+    void uninstallExtension(const Uri& uri) override;
+
+private:
+    void doInstallExtension(const io::path_t& srcPath);
 };
 }

--- a/src/framework/extensions/internal/extensioninstaller.h
+++ b/src/framework/extensions/internal/extensioninstaller.h
@@ -5,12 +5,16 @@
 #include "modularity/ioc.h"
 #include "../iextensionsconfiguration.h"
 #include "../iextensionsprovider.h"
+#include "global/iinteractive.h"
+#include "io/ifilesystem.h"
 
 namespace muse::extensions {
 class ExtensionInstaller : public IExtensionInstaller
 {
     muse::GlobalInject<IExtensionsConfiguration> configuration;
     muse::GlobalInject<IExtensionsProvider> provider;
+    muse::GlobalInject<muse::IInteractive> interactive;
+    muse::GlobalInject<io::IFileSystem> fileSystem;
 
 public:
     ExtensionInstaller() = default;

--- a/src/framework/extensions/internal/extensioninstaller.h
+++ b/src/framework/extensions/internal/extensioninstaller.h
@@ -21,5 +21,6 @@ public:
 
     Ret isFileSupported(const io::path_t path) const override;
     Ret installExtension(const io::path_t path) override;
+    Ret uninstallExtension(const Uri& uri) override;
 };
 }

--- a/src/framework/extensions/internal/extensionsloader.cpp
+++ b/src/framework/extensions/internal/extensionsloader.cpp
@@ -58,7 +58,7 @@ ManifestList ExtensionsLoader::loadManifestList(const io::path_t& defPath, const
         retList.push_back(m);
     }
 
-    for (const Manifest& m : externalManifests) {
+    for (Manifest& m : externalManifests) {
         if (!m.isValid()) {
             continue;
         }
@@ -67,6 +67,7 @@ ManifestList ExtensionsLoader::loadManifestList(const io::path_t& defPath, const
             continue;
         }
 
+        m.isUserExtension = true;
         retList.push_back(m);
     }
 

--- a/src/framework/extensions/internal/extensionsloader.cpp
+++ b/src/framework/extensions/internal/extensionsloader.cpp
@@ -80,6 +80,7 @@ ManifestList ExtensionsLoader::manifestList(const io::path_t& rootPath) const
     for (const io::path_t& path : paths) {
         LOGD() << "parsing manifest: " << path;
         Manifest manifest = parseManifest(path);
+        manifest.path = path;
         resolvePaths(manifest, io::FileInfo(path).dirPath());
         manifests.push_back(manifest);
     }

--- a/src/framework/extensions/internal/extensionsloader.cpp
+++ b/src/framework/extensions/internal/extensionsloader.cpp
@@ -67,7 +67,7 @@ ManifestList ExtensionsLoader::loadManifestList(const io::path_t& defPath, const
             continue;
         }
 
-        m.isUserExtension = true;
+        m.isRemovable = true;
         retList.push_back(m);
     }
 

--- a/src/framework/extensions/internal/extensionsprovider.cpp
+++ b/src/framework/extensions/internal/extensionsprovider.cpp
@@ -23,7 +23,7 @@
 
 #include "global/containers.h"
 #include "global/async/async.h"
-#include "global/io/fileinfo.h"
+#include "global/io/path.h"
 
 #include "extensionsloader.h"
 #include "legacy/extpluginsloader.h"
@@ -78,14 +78,14 @@ muse::Ret ExtensionsProvider::removeExtension(const Uri& uri)
 
     io::path_t path = manifest.path;
 
-    if (!fileSystem()->remove(io::FileInfo(path).dirPath())) {
+    Ret ret = fileSystem()->remove(io::dirpath(path));
+    if (!ret) {
         LOGE() << "Failed to delete the folder: " << path;
-        return make_ok();
-    } else {
-        LOGI() << "Successfully deleted the folder: " << path;
-        this->reloadExtensions();
-        return make_ret(Ret::Code::UnknownError);
+        return ret;
     }
+
+    reloadExtensions();
+    return make_ok();
 }
 
 ManifestList ExtensionsProvider::manifestList(Filter filter) const

--- a/src/framework/extensions/internal/extensionsprovider.cpp
+++ b/src/framework/extensions/internal/extensionsprovider.cpp
@@ -69,25 +69,6 @@ void ExtensionsProvider::reloadExtensions()
     m_manifestListChanged.notify();
 }
 
-muse::Ret ExtensionsProvider::removeExtension(const Uri& uri)
-{
-    const Manifest manifest = this->manifest(uri);
-    if (!manifest.isValid()) {
-        return make_ret(Ret::Code::UnknownError);
-    }
-
-    io::path_t path = manifest.path;
-
-    Ret ret = fileSystem()->remove(io::dirpath(path));
-    if (!ret) {
-        LOGE() << "Failed to delete the folder: " << path;
-        return ret;
-    }
-
-    reloadExtensions();
-    return make_ok();
-}
-
 ManifestList ExtensionsProvider::manifestList(Filter filter) const
 {
     if (filter == Filter::Enabled) {

--- a/src/framework/extensions/internal/extensionsprovider.cpp
+++ b/src/framework/extensions/internal/extensionsprovider.cpp
@@ -23,6 +23,7 @@
 
 #include "global/containers.h"
 #include "global/async/async.h"
+#include "global/io/fileinfo.h"
 
 #include "extensionsloader.h"
 #include "legacy/extpluginsloader.h"
@@ -66,6 +67,25 @@ void ExtensionsProvider::reloadExtensions()
     }
 
     m_manifestListChanged.notify();
+}
+
+muse::Ret ExtensionsProvider::removeExtension(const Uri& uri)
+{
+    const Manifest manifest = this->manifest(uri);
+    if (!manifest.isValid()) {
+        return make_ret(Ret::Code::UnknownError);
+    }
+
+    io::path_t path = manifest.path;
+
+    if (!fileSystem()->remove(io::FileInfo(path).dirPath())) {
+        LOGE() << "Failed to delete the folder: " << path;
+        return make_ok();
+    } else {
+        LOGI() << "Successfully deleted the folder: " << path;
+        this->reloadExtensions();
+        return make_ret(Ret::Code::UnknownError);
+    }
 }
 
 ManifestList ExtensionsProvider::manifestList(Filter filter) const

--- a/src/framework/extensions/internal/extensionsprovider.h
+++ b/src/framework/extensions/internal/extensionsprovider.h
@@ -44,7 +44,6 @@ public:
         : Injectable(iocCtx) {}
 
     void reloadExtensions() override;
-    Ret removeExtension(const Uri& uri) override;
 
     ManifestList manifestList(Filter filter = Filter::All) const override;
     async::Notification manifestListChanged() const override;

--- a/src/framework/extensions/internal/extensionsprovider.h
+++ b/src/framework/extensions/internal/extensionsprovider.h
@@ -29,6 +29,7 @@
 #include "../iextensionsprovider.h"
 #include "../iextensionsexecpointsregister.h"
 #include "global/iinteractive.h"
+#include "io/ifilesystem.h"
 
 namespace muse::extensions {
 class ExtensionsProvider : public IExtensionsProvider, public Injectable, public async::Asyncable
@@ -36,12 +37,14 @@ class ExtensionsProvider : public IExtensionsProvider, public Injectable, public
     Inject<IExtensionsConfiguration> configuration = { this };
     Inject<IExtensionsExecPointsRegister> execPointsRegister = { this };
     Inject<IInteractive> interactive = { this };
+    Inject<io::IFileSystem> fileSystem  = { this };
 
 public:
     ExtensionsProvider(const modularity::ContextPtr& iocCtx)
         : Injectable(iocCtx) {}
 
     void reloadExtensions() override;
+    Ret removeExtension(const Uri& uri) override;
 
     ManifestList manifestList(Filter filter = Filter::All) const override;
     async::Notification manifestListChanged() const override;

--- a/src/framework/extensions/internal/legacy/extpluginsloader.cpp
+++ b/src/framework/extensions/internal/legacy/extpluginsloader.cpp
@@ -80,7 +80,7 @@ ManifestList ExtPluginsLoader::loadManifestList(const io::path_t& defPath, const
         if (!m.isValid()) {
             continue;
         }
-        m.isUserExtension = true;
+        m.isRemovable = true;
         retList.push_back(m);
     }
 

--- a/src/framework/extensions/internal/legacy/extpluginsloader.cpp
+++ b/src/framework/extensions/internal/legacy/extpluginsloader.cpp
@@ -76,10 +76,11 @@ ManifestList ExtPluginsLoader::loadManifestList(const io::path_t& defPath, const
         retList.push_back(m);
     }
 
-    for (const Manifest& m : externalManifests) {
+    for (Manifest& m : externalManifests) {
         if (!m.isValid()) {
             continue;
         }
+        m.isUserExtension = true;
         retList.push_back(m);
     }
 

--- a/src/framework/extensions/internal/legacy/extpluginsloader.cpp
+++ b/src/framework/extensions/internal/legacy/extpluginsloader.cpp
@@ -95,6 +95,7 @@ ManifestList ExtPluginsLoader::manifestList(const io::path_t& rootPath) const
         if (!manifest.isValid()) {
             continue;
         }
+        manifest.path = path;
         resolvePaths(manifest, io::FileInfo(path).dirPath());
         manifests.push_back(manifest);
     }

--- a/src/framework/extensions/qml/Muse/Extensions/ExtensionsListPanel.qml
+++ b/src/framework/extensions/qml/Muse/Extensions/ExtensionsListPanel.qml
@@ -187,6 +187,7 @@ Item {
         background: flickable
 
         isEnabled: Boolean(selectedPlugin) ? selectedPlugin.enabled : false
+        isUserExtension: Boolean(selectedPlugin) ? selectedPlugin.isUserExtension : false
 
         additionalInfoModel: [
             {"title": qsTrc("extensions", "Version:"), "value": Boolean(selectedPlugin) ? selectedPlugin.version : "" },

--- a/src/framework/extensions/qml/Muse/Extensions/ExtensionsListPanel.qml
+++ b/src/framework/extensions/qml/Muse/Extensions/ExtensionsListPanel.qml
@@ -198,6 +198,12 @@ Item {
             extensionsModel.selectExecPoint(selectedPlugin.uri, index)
         }
 
+        onRemove: function() {
+            extensionsModel.removeExtension(selectedPlugin.uri)
+            prv.resetSelectedPlugin()
+            panel.close()
+        }
+
         onEditShortcutRequested: {
             Qt.callLater(extensionsModel.editShortcut, selectedPlugin.uri)
             panel.close()

--- a/src/framework/extensions/qml/Muse/Extensions/ExtensionsListPanel.qml
+++ b/src/framework/extensions/qml/Muse/Extensions/ExtensionsListPanel.qml
@@ -187,7 +187,7 @@ Item {
         background: flickable
 
         isEnabled: Boolean(selectedPlugin) ? selectedPlugin.enabled : false
-        isUserExtension: Boolean(selectedPlugin) ? selectedPlugin.isUserExtension : false
+        isRemovable: Boolean(selectedPlugin) ? selectedPlugin.isRemovable : false
 
         additionalInfoModel: [
             {"title": qsTrc("extensions", "Version:"), "value": Boolean(selectedPlugin) ? selectedPlugin.version : "" },

--- a/src/framework/extensions/qml/Muse/Extensions/ExtensionsListPanel.qml
+++ b/src/framework/extensions/qml/Muse/Extensions/ExtensionsListPanel.qml
@@ -199,7 +199,7 @@ Item {
             extensionsModel.selectExecPoint(selectedPlugin.uri, index)
         }
 
-        onRemove: function() {
+        onRemoveRequest: function() {
             extensionsModel.removeExtension(selectedPlugin.uri)
             prv.resetSelectedPlugin()
             panel.close()

--- a/src/framework/extensions/qml/Muse/Extensions/internal/EnablePanel.qml
+++ b/src/framework/extensions/qml/Muse/Extensions/internal/EnablePanel.qml
@@ -36,7 +36,7 @@ InfoPanel {
 
     signal editShortcutRequested()
     signal execPointSelected(int index)
-    signal remove()
+    signal removeRequest()
 
     buttonsPanel: RowLayout {
         id: buttons
@@ -107,7 +107,7 @@ InfoPanel {
                 text: qsTrc("workspace", "Remove")
 
                 onClicked: {
-                    root.remove()
+                    root.removeRequest()
                 }
             }
 

--- a/src/framework/extensions/qml/Muse/Extensions/internal/EnablePanel.qml
+++ b/src/framework/extensions/qml/Muse/Extensions/internal/EnablePanel.qml
@@ -32,6 +32,7 @@ InfoPanel {
 
     property var execPointsModel: null
     property int currentExecPointIndex: 0
+    property bool isUserExtension: false
 
     signal editShortcutRequested()
     signal execPointSelected(int index)
@@ -91,7 +92,8 @@ InfoPanel {
 
             FlatButton {
                 id: removeButton
-
+                
+                visible: root.isUserExtension
                 navigation.name: text + "Button"
                 navigation.panel: root.contentNavigation
                 navigation.column: 2

--- a/src/framework/extensions/qml/Muse/Extensions/internal/EnablePanel.qml
+++ b/src/framework/extensions/qml/Muse/Extensions/internal/EnablePanel.qml
@@ -32,7 +32,7 @@ InfoPanel {
 
     property var execPointsModel: null
     property int currentExecPointIndex: 0
-    property bool isUserExtension: false
+    property bool isRemovable: false
 
     signal editShortcutRequested()
     signal execPointSelected(int index)
@@ -93,7 +93,7 @@ InfoPanel {
             FlatButton {
                 id: removeButton
                 
-                visible: root.isUserExtension
+                visible: root.isRemovable
                 navigation.name: text + "Button"
                 navigation.panel: root.contentNavigation
                 navigation.column: 2

--- a/src/framework/extensions/qml/Muse/Extensions/internal/EnablePanel.qml
+++ b/src/framework/extensions/qml/Muse/Extensions/internal/EnablePanel.qml
@@ -35,6 +35,7 @@ InfoPanel {
 
     signal editShortcutRequested()
     signal execPointSelected(int index)
+    signal remove()
 
     buttonsPanel: RowLayout {
         id: buttons
@@ -84,37 +85,61 @@ InfoPanel {
             }
         }
 
-
-
-        FlatButton {
-            id: mainButton
+        RowLayout {
             Layout.alignment: Qt.AlignRight
+            spacing: 22
 
-            navigation.name: text + "Button"
-            navigation.panel: root.contentNavigation
-            navigation.column: 3
-            accessible.ignored: true
-            navigation.onActiveChanged: {
-                if (!navigation.active) {
-                    accessible.ignored = false
+            FlatButton {
+                id: removeButton
+
+                navigation.name: text + "Button"
+                navigation.panel: root.contentNavigation
+                navigation.column: 2
+                accessible.ignored: true
+                navigation.onActiveChanged: {
+                    if (!navigation.active) {
+                        accessible.ignored = false
+                    }
+                }
+
+                text: qsTrc("workspace", "Remove")
+
+                onClicked: {
+                    root.remove()
                 }
             }
 
-            text: !root.isEnabled ? qsTrc("extensions", "Enable") : qsTrc("extensions", "Disable")
 
-            Component.onCompleted: {
-                root.mainButton = mainButton
-            }
 
-            onClicked: {
-                //! NOTE temporary
-                // The function with the choice of the call point is not ready yet.
-                // Therefore, here is the previous solution with the button,
-                // but in fact the choice is made from the list
-                // 0 - disabled
-                // 1 - enabled (manual call)
-                // (here we switch to the opposite state)
-                root.execPointSelected(root.isEnabled ? 0 : 1)
+            FlatButton {
+                id: mainButton
+
+                navigation.name: text + "Button"
+                navigation.panel: root.contentNavigation
+                navigation.column: 3
+                accessible.ignored: true
+                navigation.onActiveChanged: {
+                    if (!navigation.active) {
+                        accessible.ignored = false
+                    }
+                }
+
+                text: !root.isEnabled ? qsTrc("extensions", "Enable") : qsTrc("extensions", "Disable")
+
+                Component.onCompleted: {
+                    root.mainButton = mainButton
+                }
+
+                onClicked: {
+                    //! NOTE temporary
+                    // The function with the choice of the call point is not ready yet.
+                    // Therefore, here is the previous solution with the button,
+                    // but in fact the choice is made from the list
+                    // 0 - disabled
+                    // 1 - enabled (manual call)
+                    // (here we switch to the opposite state)
+                    root.execPointSelected(root.isEnabled ? 0 : 1)
+                }
             }
         }
     }

--- a/src/framework/extensions/view/extensionslistmodel.cpp
+++ b/src/framework/extensions/view/extensionslistmodel.cpp
@@ -219,6 +219,11 @@ void ExtensionsListModel::reloadPlugins()
     provider()->reloadExtensions();
 }
 
+void ExtensionsListModel::removeExtension(const QString& uri)
+{
+    provider()->removeExtension(Uri(uri.toStdString()));
+}
+
 QVariantList ExtensionsListModel::categories() const
 {
     QVariantList result;

--- a/src/framework/extensions/view/extensionslistmodel.cpp
+++ b/src/framework/extensions/view/extensionslistmodel.cpp
@@ -44,6 +44,7 @@ ExtensionsListModel::ExtensionsListModel(QObject* parent)
         { rCategory, "category" },
         { rVersion, "version" },
         { rShortcuts, "shortcuts" },
+        { rIsUserExtension, "isUserExtension" }
     };
 }
 
@@ -119,6 +120,9 @@ QVariant ExtensionsListModel::data(const QModelIndex& index, int role) const
 
         //: No keyboard shortcut is assigned to this plugin.
         return muse::qtrc("extensions", "Not defined");
+    }
+    case rIsUserExtension: {
+        return plugin.isUserExtension;
     }
     }
 

--- a/src/framework/extensions/view/extensionslistmodel.cpp
+++ b/src/framework/extensions/view/extensionslistmodel.cpp
@@ -44,7 +44,7 @@ ExtensionsListModel::ExtensionsListModel(QObject* parent)
         { rCategory, "category" },
         { rVersion, "version" },
         { rShortcuts, "shortcuts" },
-        { rIsUserExtension, "isUserExtension" }
+        { rIsRemovable, "isRemovable" }
     };
 }
 
@@ -121,8 +121,8 @@ QVariant ExtensionsListModel::data(const QModelIndex& index, int role) const
         //: No keyboard shortcut is assigned to this plugin.
         return muse::qtrc("extensions", "Not defined");
     }
-    case rIsUserExtension: {
-        return plugin.isUserExtension;
+    case rIsRemovable: {
+        return plugin.isRemovable;
     }
     }
 

--- a/src/framework/extensions/view/extensionslistmodel.cpp
+++ b/src/framework/extensions/view/extensionslistmodel.cpp
@@ -225,7 +225,7 @@ void ExtensionsListModel::reloadPlugins()
 
 void ExtensionsListModel::removeExtension(const QString& uri)
 {
-    provider()->removeExtension(Uri(uri.toStdString()));
+    installer()->uninstallExtension(Uri(uri.toStdString()));
 }
 
 QVariantList ExtensionsListModel::categories() const

--- a/src/framework/extensions/view/extensionslistmodel.h
+++ b/src/framework/extensions/view/extensionslistmodel.h
@@ -29,6 +29,7 @@
 
 #include "modularity/ioc.h"
 #include "iinteractive.h"
+#include "extensions/iextensioninstaller.h"
 #include "extensions/iextensionsconfiguration.h"
 #include "extensions/iextensionsprovider.h"
 #include "shortcuts/ishortcutsregister.h"
@@ -40,6 +41,7 @@ class ExtensionsListModel : public QAbstractListModel, public Injectable, public
 
     Inject<IInteractive> interactive = { this };
     Inject<IExtensionsProvider> provider = { this };
+    Inject<IExtensionInstaller> installer = { this };
     Inject<IExtensionsConfiguration> configuration = { this };
     Inject<shortcuts::IShortcutsRegister> shortcutsRegister = { this };
 

--- a/src/framework/extensions/view/extensionslistmodel.h
+++ b/src/framework/extensions/view/extensionslistmodel.h
@@ -77,7 +77,7 @@ private:
         rCategory,
         rVersion,
         rShortcuts,
-        rIsUserExtension
+        rIsRemovable
     };
 
     struct ExecPoints {

--- a/src/framework/extensions/view/extensionslistmodel.h
+++ b/src/framework/extensions/view/extensionslistmodel.h
@@ -74,7 +74,8 @@ private:
         rEnabled,
         rCategory,
         rVersion,
-        rShortcuts
+        rShortcuts,
+        rIsUserExtension
     };
 
     struct ExecPoints {

--- a/src/framework/extensions/view/extensionslistmodel.h
+++ b/src/framework/extensions/view/extensionslistmodel.h
@@ -58,6 +58,7 @@ public:
 
     Q_INVOKABLE void editShortcut(const QString& uri);
     Q_INVOKABLE void reloadPlugins();
+    Q_INVOKABLE void removeExtension(const QString& uri);
 
     Q_INVOKABLE QVariantList categories() const;
 

--- a/src/framework/global/serialization/zipreader.cpp
+++ b/src/framework/global/serialization/zipreader.cpp
@@ -124,11 +124,17 @@ Ret ZipUnpack::unpack(const io::path_t& zipPath, const io::path_t& dirPath)
 
     ZipReader zip(zipPath);
     for (const ZipReader::FileInfo& fi : zip.fileInfoList()) {
+        const io::path_t filePath = dirPath + "/" + fi.filePath;
+
         if (fi.isDir) {
-            ret = io::Dir::mkpath(dirPath + "/" + fi.filePath);
+            ret = io::Dir::mkpath(filePath);
         } else if (fi.isFile) {
-            ByteArray data = zip.fileData(fi.filePath.toStdString());
-            ret = io::File::writeFile(dirPath + "/" + fi.filePath, data);
+            ret = io::Dir::mkpath(io::dirpath(filePath));
+
+            if (ret) {
+                const ByteArray data = zip.fileData(fi.filePath.toStdString());
+                ret = io::File::writeFile(filePath, data);
+            }
         }
 
         if (!ret) {


### PR DESCRIPTION
Hi all,
I recently played around with the new extension format (`.mext`) and noticed that it is currently not possible to ship updates for an extension without performing a manual update process (deleting the folder, drag&drop the extension for installation). I didn't find any issues for this, so I thought this could be a small fun weekend project. So this PR introduces two new features improve the process:

- Added two new modal popups (1e981f7142f99bd1720b05fd82c981a665f10745)
    - When the user tries to install the extension with the same version
    - When the user tries to install the extension with another version. The popup contains the current and old version number. If the user agrees, the old version is removed and the new version is installed.
- Added a button to the extension panel, to be able to remove/uninstall an extension (e371e3d187c48b9a9099dc22526d580503187dde)

I am no C++ expert, so please let me know if you see any room for improvements that I should change.

**Remaining ToDos:**
- [x] Localization of the strings in the modal popup. I probably need some help here, since I don't know the workflow. 

---

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually 
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
