### PR TITLE
Don't remove partial tie twice

### DIFF
--- a/src/notation/view/internal/partialtiepopupmodel.cpp
+++ b/src/notation/view/internal/partialtiepopupmodel.cpp
@@ -179,7 +179,9 @@ void mu::notation::PartialTiePopupModel::onClosed()
         return;
     }
 
-    if (tieItem->allJumpPointsInactive()) {
+    Note* startNote = tieItem->startNote();
+
+    if (tieItem->allJumpPointsInactive() && startNote && startNote->tieFor() == tieItem) {
         Score* score = tieItem->score();
         beginCommand(TranslatableString("engraving", "Remove partial tie"));
         score->undoRemoveElement(tieItem);


### PR DESCRIPTION
Resolves: #27738 

Partial ties were being removed from the note before this point. It's possible we don't need this section of code at all, but in the interests of time I've just added a check to prevent the crash.