### PR TITLE
Fix #27633: Prevent triggering note input mode when app window is not in focus

### DIFF
--- a/src/appshell/qml/Preferences/NoteInputPreferencesPage.qml
+++ b/src/appshell/qml/Preferences/NoteInputPreferencesPage.qml
@@ -68,7 +68,7 @@ PreferencesPage {
 
         MidiInputSection {
             midiInputEnabled: noteInputModel.midiInputEnabled
-            startNoteInputWhenPressingKey: noteInputModel.startNoteInputAtSelectionWhenPressingMidiKey
+            startNoteInputWhenPressingKey: noteInputModel.startNoteInputAtSelectedNoteRestWhenPressingMidiKey
             advanceToNextNote: noteInputModel.advanceToNextNoteOnKeyRelease
             delayBetweenNotes: noteInputModel.delayBetweenNotesInRealTimeModeMilliseconds
 
@@ -80,7 +80,7 @@ PreferencesPage {
             }
 
             onStartNoteInputWhenPressingKeyChangeRequested: function(start) {
-                noteInputModel.startNoteInputAtSelectionWhenPressingMidiKey = start
+                noteInputModel.startNoteInputAtSelectedNoteRestWhenPressingMidiKey = start
             }
 
             onAdvanceToNextNoteChangeRequested: function(advance) {

--- a/src/appshell/view/preferences/noteinputpreferencesmodel.cpp
+++ b/src/appshell/view/preferences/noteinputpreferencesmodel.cpp
@@ -49,8 +49,8 @@ void NoteInputPreferencesModel::load()
         emit midiInputEnabledChanged(midiInputEnabled());
     });
 
-    notationConfiguration()->startNoteInputAtSelectionWhenPressingMidiKeyChanged().onNotify(this, [this]() {
-        emit startNoteInputAtSelectionWhenPressingMidiKeyChanged(startNoteInputAtSelectionWhenPressingMidiKey());
+    notationConfiguration()->startNoteInputAtSelectedNoteRestWhenPressingMidiKeyChanged().onNotify(this, [this]() {
+        emit startNoteInputAtSelectedNoteRestWhenPressingMidiKeyChanged(startNoteInputAtSelectedNoteRestWhenPressingMidiKey());
     });
 
     playbackConfiguration()->playNotesWhenEditingChanged().onNotify(this, [this]() {
@@ -146,9 +146,9 @@ bool NoteInputPreferencesModel::midiInputEnabled() const
     return notationConfiguration()->isMidiInputEnabled();
 }
 
-bool NoteInputPreferencesModel::startNoteInputAtSelectionWhenPressingMidiKey() const
+bool NoteInputPreferencesModel::startNoteInputAtSelectedNoteRestWhenPressingMidiKey() const
 {
-    return notationConfiguration()->startNoteInputAtSelectionWhenPressingMidiKey();
+    return notationConfiguration()->startNoteInputAtSelectedNoteRestWhenPressingMidiKey();
 }
 
 bool NoteInputPreferencesModel::advanceToNextNoteOnKeyRelease() const
@@ -242,13 +242,13 @@ void NoteInputPreferencesModel::setMidiInputEnabled(bool value)
     notationConfiguration()->setIsMidiInputEnabled(value);
 }
 
-void NoteInputPreferencesModel::setStartNoteInputAtSelectionWhenPressingMidiKey(bool value)
+void NoteInputPreferencesModel::setStartNoteInputAtSelectedNoteRestWhenPressingMidiKey(bool value)
 {
-    if (value == startNoteInputAtSelectionWhenPressingMidiKey()) {
+    if (value == startNoteInputAtSelectedNoteRestWhenPressingMidiKey()) {
         return;
     }
 
-    notationConfiguration()->setStartNoteInputAtSelectionWhenPressingMidiKey(value);
+    notationConfiguration()->setStartNoteInputAtSelectedNoteRestWhenPressingMidiKey(value);
 }
 
 void NoteInputPreferencesModel::setAdvanceToNextNoteOnKeyRelease(bool value)

--- a/src/appshell/view/preferences/noteinputpreferencesmodel.h
+++ b/src/appshell/view/preferences/noteinputpreferencesmodel.h
@@ -47,7 +47,7 @@ class NoteInputPreferencesModel : public QObject, public muse::Injectable, publi
 
     Q_PROPERTY(bool midiInputEnabled READ midiInputEnabled WRITE setMidiInputEnabled NOTIFY midiInputEnabledChanged)
     Q_PROPERTY(
-        bool startNoteInputAtSelectionWhenPressingMidiKey READ startNoteInputAtSelectionWhenPressingMidiKey WRITE setStartNoteInputAtSelectionWhenPressingMidiKey NOTIFY startNoteInputAtSelectionWhenPressingMidiKeyChanged)
+        bool startNoteInputAtSelectedNoteRestWhenPressingMidiKey READ startNoteInputAtSelectedNoteRestWhenPressingMidiKey WRITE setStartNoteInputAtSelectedNoteRestWhenPressingMidiKey NOTIFY startNoteInputAtSelectedNoteRestWhenPressingMidiKeyChanged)
     Q_PROPERTY(
         bool advanceToNextNoteOnKeyRelease READ advanceToNextNoteOnKeyRelease WRITE setAdvanceToNextNoteOnKeyRelease NOTIFY advanceToNextNoteOnKeyReleaseChanged)
     Q_PROPERTY(
@@ -91,7 +91,7 @@ public:
     bool useNoteInputCursorInInputByDuration() const;
 
     bool midiInputEnabled() const;
-    bool startNoteInputAtSelectionWhenPressingMidiKey() const;
+    bool startNoteInputAtSelectedNoteRestWhenPressingMidiKey() const;
     bool advanceToNextNoteOnKeyRelease() const;
     int delayBetweenNotesInRealTimeModeMilliseconds() const;
 
@@ -115,7 +115,7 @@ public slots:
     void setUseNoteInputCursorInInputByDuration(bool value);
 
     void setMidiInputEnabled(bool value);
-    void setStartNoteInputAtSelectionWhenPressingMidiKey(bool value);
+    void setStartNoteInputAtSelectedNoteRestWhenPressingMidiKey(bool value);
     void setAdvanceToNextNoteOnKeyRelease(bool value);
     void setDelayBetweenNotesInRealTimeModeMilliseconds(int delay);
 
@@ -139,7 +139,7 @@ signals:
     void useNoteInputCursorInInputByDurationChanged(bool value);
 
     void midiInputEnabledChanged(bool value);
-    void startNoteInputAtSelectionWhenPressingMidiKeyChanged(bool value);
+    void startNoteInputAtSelectedNoteRestWhenPressingMidiKeyChanged(bool value);
     void advanceToNextNoteOnKeyReleaseChanged(bool value);
     void delayBetweenNotesInRealTimeModeMillisecondsChanged(int delay);
 

--- a/src/engraving/dom/select.cpp
+++ b/src/engraving/dom/select.cpp
@@ -1589,6 +1589,17 @@ std::list<Note*> Selection::uniqueNotes(track_idx_t track) const
     return l;
 }
 
+bool Selection::elementsSelected(const ElementTypeSet& types) const
+{
+    for (const EngravingItem* element : m_el) {
+        if (muse::contains(types, element->type())) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 //---------------------------------------------------------
 //   extendRangeSelection
 //    Extends the range selection to contain the given

--- a/src/engraving/dom/select.h
+++ b/src/engraving/dom/select.h
@@ -118,6 +118,7 @@ public:
     std::list<Note*> uniqueNotes(track_idx_t track = muse::nidx) const;
 
     bool isSingle() const { return (m_state == SelState::LIST) && (m_el.size() == 1); }
+    bool elementsSelected(const ElementTypeSet& types) const;
 
     void add(EngravingItem*);
     void deselectAll();

--- a/src/notation/inotationconfiguration.h
+++ b/src/notation/inotationconfiguration.h
@@ -143,9 +143,9 @@ public:
     virtual void setIsMidiInputEnabled(bool enabled) = 0;
     virtual muse::async::Notification isMidiInputEnabledChanged() const = 0;
 
-    virtual bool startNoteInputAtSelectionWhenPressingMidiKey() const = 0;
-    virtual void setStartNoteInputAtSelectionWhenPressingMidiKey(bool value) = 0;
-    virtual muse::async::Notification startNoteInputAtSelectionWhenPressingMidiKeyChanged() const = 0;
+    virtual bool startNoteInputAtSelectedNoteRestWhenPressingMidiKey() const = 0;
+    virtual void setStartNoteInputAtSelectedNoteRestWhenPressingMidiKey(bool value) = 0;
+    virtual muse::async::Notification startNoteInputAtSelectedNoteRestWhenPressingMidiKeyChanged() const = 0;
 
     virtual bool isAutomaticallyPanEnabled() const = 0;
     virtual void setIsAutomaticallyPanEnabled(bool enabled) = 0;

--- a/src/notation/inotationselection.h
+++ b/src/notation/inotationselection.h
@@ -57,6 +57,8 @@ public:
     virtual mu::engraving::MeasureBase* startMeasureBase() const = 0;
     virtual mu::engraving::MeasureBase* endMeasureBase() const = 0;
     virtual std::vector<mu::engraving::System*> selectedSystems() const = 0;
+
+    virtual bool elementsSelected(const mu::engraving::ElementTypeSet& types) const = 0;
 };
 
 using INotationSelectionPtr = std::shared_ptr<INotationSelection>;

--- a/src/notation/internal/notationactioncontroller.h
+++ b/src/notation/internal/notationactioncontroller.h
@@ -122,8 +122,6 @@ private:
 
     muse::async::Promise<muse::IInteractive::Result> showErrorMessage(const std::string& message);
 
-    bool isElementsSelected(const std::vector<ElementType>& elementsTypes) const;
-
     void addText(TextStyleType type);
     void addImage();
     void addFiguredBass();
@@ -208,6 +206,7 @@ private:
     void navigateToTextElementByFraction(const Fraction& fraction);
     void navigateToTextElementInNearMeasure(MoveDirection direction);
 
+    bool startNoteInputAllowed() const;
     void startNoteInput();
 
     bool hasSelection() const;
@@ -222,7 +221,6 @@ private:
     bool canRedo() const;
 
     bool isNotationPage() const;
-    bool isStandardStaff() const;
     bool isTablatureStaff() const;
 
     void checkForScoreCorruptions();
@@ -243,6 +241,8 @@ private:
                         muse::Ret (INotationInteraction::*)() const);
 
     void registerNoteInputAction(const muse::actions::ActionCode&, NoteInputMethod inputMethod);
+
+    bool noteInputActionAllowed() const;
     void registerNoteAction(const muse::actions::ActionCode&, NoteName, NoteAddingMode addingMode = NoteAddingMode::NextChord);
 
     void registerPadNoteAction(const muse::actions::ActionCode&, Pad padding);

--- a/src/notation/internal/notationconfiguration.cpp
+++ b/src/notation/internal/notationconfiguration.cpp
@@ -72,8 +72,8 @@ static const Settings::Key ADD_ACCIDENTAL_ARTICULATIONS_DOTS_TO_NEXT_NOTE_ENTERE
                                                                                   "score/addAccidentalDotsArticulationsToNextNoteEntered");
 
 static const Settings::Key IS_MIDI_INPUT_ENABLED(module_name, "io/midi/enableInput");
-static const Settings::Key START_NOTE_INPUT_AT_SELECTION_WHEN_PRESSING_MIDI_KEY(module_name,
-                                                                                "score/startNoteInputAtSelectionWhenPressingMidiKey");
+static const Settings::Key START_NOTE_INPUT_AT_SELECTED_NOTE_REST_WHEN_PRESSING_MIDI_KEY(module_name,
+                                                                                         "score/startNoteInputAtSelectionWhenPressingMidiKey");
 static const Settings::Key USE_MIDI_INPUT_WRITTEN_PITCH(module_name, "io/midi/useWrittenPitch");
 static const Settings::Key IS_AUTOMATICALLY_PAN_ENABLED(module_name, "application/playback/panPlayback");
 static const Settings::Key PLAYBACK_SMOOTH_PANNING(module_name, "application/playback/smoothPan");
@@ -252,9 +252,9 @@ void NotationConfiguration::init()
         m_isMidiInputEnabledChanged.notify();
     });
 
-    settings()->setDefaultValue(START_NOTE_INPUT_AT_SELECTION_WHEN_PRESSING_MIDI_KEY, Val(true));
-    settings()->valueChanged(START_NOTE_INPUT_AT_SELECTION_WHEN_PRESSING_MIDI_KEY).onReceive(this, [this](const Val&) {
-        m_startNoteInputAtSelectionWhenPressingMidiKeyChanged.notify();
+    settings()->setDefaultValue(START_NOTE_INPUT_AT_SELECTED_NOTE_REST_WHEN_PRESSING_MIDI_KEY, Val(true));
+    settings()->valueChanged(START_NOTE_INPUT_AT_SELECTED_NOTE_REST_WHEN_PRESSING_MIDI_KEY).onReceive(this, [this](const Val&) {
+        m_startNoteInputAtSelectedNoteRestWhenPressingMidiKeyChanged.notify();
     });
 
     settings()->setDefaultValue(IS_AUTOMATICALLY_PAN_ENABLED, Val(true));
@@ -827,19 +827,19 @@ async::Notification NotationConfiguration::isMidiInputEnabledChanged() const
     return m_isMidiInputEnabledChanged;
 }
 
-bool NotationConfiguration::startNoteInputAtSelectionWhenPressingMidiKey() const
+bool NotationConfiguration::startNoteInputAtSelectedNoteRestWhenPressingMidiKey() const
 {
-    return settings()->value(START_NOTE_INPUT_AT_SELECTION_WHEN_PRESSING_MIDI_KEY).toBool();
+    return settings()->value(START_NOTE_INPUT_AT_SELECTED_NOTE_REST_WHEN_PRESSING_MIDI_KEY).toBool();
 }
 
-void NotationConfiguration::setStartNoteInputAtSelectionWhenPressingMidiKey(bool value)
+void NotationConfiguration::setStartNoteInputAtSelectedNoteRestWhenPressingMidiKey(bool value)
 {
-    settings()->setSharedValue(START_NOTE_INPUT_AT_SELECTION_WHEN_PRESSING_MIDI_KEY, Val(value));
+    settings()->setSharedValue(START_NOTE_INPUT_AT_SELECTED_NOTE_REST_WHEN_PRESSING_MIDI_KEY, Val(value));
 }
 
-async::Notification NotationConfiguration::startNoteInputAtSelectionWhenPressingMidiKeyChanged() const
+async::Notification NotationConfiguration::startNoteInputAtSelectedNoteRestWhenPressingMidiKeyChanged() const
 {
-    return m_startNoteInputAtSelectionWhenPressingMidiKeyChanged;
+    return m_startNoteInputAtSelectedNoteRestWhenPressingMidiKeyChanged;
 }
 
 bool NotationConfiguration::isAutomaticallyPanEnabled() const

--- a/src/notation/internal/notationconfiguration.h
+++ b/src/notation/internal/notationconfiguration.h
@@ -147,9 +147,9 @@ public:
     void setIsMidiInputEnabled(bool enabled) override;
     muse::async::Notification isMidiInputEnabledChanged() const override;
 
-    bool startNoteInputAtSelectionWhenPressingMidiKey() const override;
-    void setStartNoteInputAtSelectionWhenPressingMidiKey(bool value) override;
-    muse::async::Notification startNoteInputAtSelectionWhenPressingMidiKeyChanged() const override;
+    bool startNoteInputAtSelectedNoteRestWhenPressingMidiKey() const override;
+    void setStartNoteInputAtSelectedNoteRestWhenPressingMidiKey(bool value) override;
+    muse::async::Notification startNoteInputAtSelectedNoteRestWhenPressingMidiKeyChanged() const override;
 
     bool isAutomaticallyPanEnabled() const override;
     void setIsAutomaticallyPanEnabled(bool enabled) override;
@@ -289,7 +289,7 @@ private:
     muse::async::Notification m_addAccidentalDotsArticulationsToNextNoteEnteredChanged;
     muse::async::Notification m_useNoteInputCursorInInputByDurationChanged;
     muse::async::Notification m_isMidiInputEnabledChanged;
-    muse::async::Notification m_startNoteInputAtSelectionWhenPressingMidiKeyChanged;
+    muse::async::Notification m_startNoteInputAtSelectedNoteRestWhenPressingMidiKeyChanged;
 
     muse::async::Notification m_defaultZoomChanged;
     muse::async::Notification m_mouseZoomPrecisionChanged;

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -6014,14 +6014,14 @@ void NotationInteraction::addImageToItem(const muse::io::path_t& imagePath, Engr
 
 Ret NotationInteraction::canAddFiguredBass() const
 {
-    static const std::set<ElementType> requiredTypes {
+    static const ElementTypeSet REQUIRED_TYPES {
         ElementType::NOTE,
         ElementType::FIGURED_BASS,
         ElementType::REST
     };
 
-    bool isNoteOrRestSelected = elementsSelected(requiredTypes);
-    return isNoteOrRestSelected ? muse::make_ok() : make_ret(Err::NoteOrFiguredBassIsNotSelected);
+    bool selected = m_selection->elementsSelected(REQUIRED_TYPES);
+    return selected ? muse::make_ok() : make_ret(Err::NoteOrFiguredBassIsNotSelected);
 }
 
 void NotationInteraction::addFiguredBass()
@@ -6368,30 +6368,6 @@ void NotationInteraction::resetGripEdit()
 void NotationInteraction::resetHitElementContext()
 {
     setHitElementContext(HitElementContext());
-}
-
-bool NotationInteraction::elementsSelected(const std::set<ElementType>& elementsTypes) const
-{
-    auto selection = this->selection();
-    if (!selection || selection->isNone()) {
-        return false;
-    }
-
-    std::vector<EngravingItem*> selectedElements;
-
-    if (EngravingItem* element = selection->element()) {
-        selectedElements = { element };
-    } else {
-        selectedElements = selection->elements();
-    }
-
-    for (const EngravingItem* element: selectedElements) {
-        if (element && muse::contains(elementsTypes, element->type())) {
-            return true;
-        }
-    }
-
-    return false;
 }
 
 //! NOTE: Copied from ScoreView::lyricsTab
@@ -7725,7 +7701,7 @@ void NotationInteraction::addGuitarBend(GuitarBendType bendType)
 
 muse::Ret NotationInteraction::canAddFretboardDiagram() const
 {
-    bool canAdd = elementsSelected({ ElementType::HARMONY, ElementType::NOTE, ElementType::REST });
+    bool canAdd = m_selection->elementsSelected({ ElementType::HARMONY, ElementType::NOTE, ElementType::REST });
     return canAdd ? muse::make_ok() : make_ret(Err::NoteOrRestOrHarmonyIsNotSelected);
 }
 

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -451,8 +451,6 @@ private:
     void resetGripEdit();
     void resetHitElementContext();
 
-    bool elementsSelected(const std::set<ElementType>& elementsTypes) const;
-
     template<typename P>
     void execute(void (mu::engraving::Score::* function)(P), P param, const muse::TranslatableString& actionName);
 

--- a/src/notation/internal/notationmidiinput.cpp
+++ b/src/notation/internal/notationmidiinput.cpp
@@ -170,7 +170,7 @@ void NotationMidiInput::startNoteInputIfNeed()
     }
 
     if (configuration()->startNoteInputAtSelectionWhenPressingMidiKey()) {
-        if (!score()->selection().isNone()) {
+        if (m_notationInteraction->selection()->elementsSelected(NOTE_REST_TYPES)) {
             dispatcher()->dispatch("note-input");
         }
     }

--- a/src/notation/internal/notationmidiinput.cpp
+++ b/src/notation/internal/notationmidiinput.cpp
@@ -169,7 +169,7 @@ void NotationMidiInput::startNoteInputIfNeed()
         return;
     }
 
-    if (configuration()->startNoteInputAtSelectionWhenPressingMidiKey()) {
+    if (configuration()->startNoteInputAtSelectedNoteRestWhenPressingMidiKey()) {
         if (m_notationInteraction->selection()->elementsSelected(NOTE_REST_TYPES)) {
             dispatcher()->dispatch("note-input");
         }

--- a/src/notation/internal/notationselection.cpp
+++ b/src/notation/internal/notationselection.cpp
@@ -159,3 +159,8 @@ EngravingItem* NotationSelection::lastElementHit() const
 {
     return m_lastElementHit;
 }
+
+bool NotationSelection::elementsSelected(const mu::engraving::ElementTypeSet& types) const
+{
+    return score()->selection().elementsSelected(types);
+}

--- a/src/notation/internal/notationselection.h
+++ b/src/notation/internal/notationselection.h
@@ -62,6 +62,8 @@ public:
     mu::engraving::MeasureBase* endMeasureBase() const override;
     std::vector<mu::engraving::System*> selectedSystems() const override;
 
+    bool elementsSelected(const mu::engraving::ElementTypeSet& types) const override;
+
 private:
     mu::engraving::Score* score() const;
     EngravingItem* m_lastElementHit;

--- a/src/notation/notationtypes.h
+++ b/src/notation/notationtypes.h
@@ -623,4 +623,9 @@ enum class PercussionPanelAutoShowMode {
     UNPITCHED_STAFF_NOTE_INPUT,
     NEVER,
 };
+
+static const mu::engraving::ElementTypeSet NOTE_REST_TYPES {
+    mu::engraving::ElementType::NOTE,
+    mu::engraving::ElementType::REST,
+};
 }

--- a/src/notation/tests/mocks/notationconfigurationmock.h
+++ b/src/notation/tests/mocks/notationconfigurationmock.h
@@ -133,9 +133,9 @@ public:
     MOCK_METHOD(void, setIsMidiInputEnabled, (bool), (override));
     MOCK_METHOD(muse::async::Notification, isMidiInputEnabledChanged, (), (const, override));
 
-    MOCK_METHOD(bool, startNoteInputAtSelectionWhenPressingMidiKey, (), (const, override));
-    MOCK_METHOD(void, setStartNoteInputAtSelectionWhenPressingMidiKey, (bool), (override));
-    MOCK_METHOD(muse::async::Notification, startNoteInputAtSelectionWhenPressingMidiKeyChanged, (), (const, override));
+    MOCK_METHOD(bool, startNoteInputAtSelectedNoteRestWhenPressingMidiKey, (), (const, override));
+    MOCK_METHOD(void, setStartNoteInputAtSelectedNoteRestWhenPressingMidiKey, (bool), (override));
+    MOCK_METHOD(muse::async::Notification, startNoteInputAtSelectedNoteRestWhenPressingMidiKeyChanged, (), (const, override));
 
     MOCK_METHOD(bool, isAutomaticallyPanEnabled, (), (const, override));
     MOCK_METHOD(void, setIsAutomaticallyPanEnabled, (bool), (override));

--- a/src/notation/tests/mocks/notationselectionmock.h
+++ b/src/notation/tests/mocks/notationselectionmock.h
@@ -51,6 +51,8 @@ public:
     MOCK_METHOD(mu::engraving::MeasureBase*, startMeasureBase, (), (const, override));
     MOCK_METHOD(mu::engraving::MeasureBase*, endMeasureBase, (), (const, override));
     MOCK_METHOD(std::vector<System*>, selectedSystems, (), (const, override));
+
+    MOCK_METHOD(bool, elementsSelected, (const mu::engraving::ElementTypeSet&), (const, override));
 };
 }
 

--- a/src/stubs/notation/notationconfigurationstub.cpp
+++ b/src/stubs/notation/notationconfigurationstub.cpp
@@ -359,16 +359,16 @@ muse::async::Notification NotationConfigurationStub::isMidiInputEnabledChanged()
     return n;
 }
 
-bool NotationConfigurationStub::startNoteInputAtSelectionWhenPressingMidiKey() const
+bool NotationConfigurationStub::startNoteInputAtSelectedNoteRestWhenPressingMidiKey() const
 {
     return false;
 }
 
-void NotationConfigurationStub::setStartNoteInputAtSelectionWhenPressingMidiKey(bool)
+void NotationConfigurationStub::setStartNoteInputAtSelectedNoteRestWhenPressingMidiKey(bool)
 {
 }
 
-muse::async::Notification NotationConfigurationStub::startNoteInputAtSelectionWhenPressingMidiKeyChanged() const
+muse::async::Notification NotationConfigurationStub::startNoteInputAtSelectedNoteRestWhenPressingMidiKeyChanged() const
 {
     static muse::async::Notification n;
     return n;

--- a/src/stubs/notation/notationconfigurationstub.h
+++ b/src/stubs/notation/notationconfigurationstub.h
@@ -132,9 +132,9 @@ public:
     void setIsMidiInputEnabled(bool enabled)  override;
     muse::async::Notification isMidiInputEnabledChanged() const override;
 
-    bool startNoteInputAtSelectionWhenPressingMidiKey() const override;
-    void setStartNoteInputAtSelectionWhenPressingMidiKey(bool value) override;
-    muse::async::Notification startNoteInputAtSelectionWhenPressingMidiKeyChanged() const override;
+    bool startNoteInputAtSelectedNoteRestWhenPressingMidiKey() const override;
+    void setStartNoteInputAtSelectedNoteRestWhenPressingMidiKey(bool value) override;
+    muse::async::Notification startNoteInputAtSelectedNoteRestWhenPressingMidiKeyChanged() const override;
 
     bool isAutomaticallyPanEnabled() const override;
     void setIsAutomaticallyPanEnabled(bool enabled)  override;


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/27633