### PR TITLE
Ensure percussion note popup only appears when shift is pressed

### DIFF
--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -1138,7 +1138,7 @@ void NotationViewInputController::keyPressEvent(QKeyEvent* event)
         updateShadowNotePopupVisibility();
     }
 
-    updateShadowNotePopupVisibility();
+    updateShadowNotePopupVisibility(/*forceHide*/ true);
 }
 
 void NotationViewInputController::keyReleaseEvent(QKeyEvent* event)


### PR DESCRIPTION
Resolves a bug where the percussion note popup was appearing for keys other than shift (e.g. cmd)