### PR TITLE
layoutChords1 refactor

### DIFF
--- a/src/engraving/rendering/score/chordlayout.cpp
+++ b/src/engraving/rendering/score/chordlayout.cpp
@@ -1886,47 +1886,49 @@ void ChordLayout::calculateChordOffsets(Segment* segment, staff_idx_t staffIdx, 
             for (int i = static_cast<int>(overlapNotes.size()) - 1; i >= 1; i -= 2) {
                 Note* previousNote = overlapNotes[i - 1];
                 Note* n = overlapNotes[i];
-                if (!(previousNote->chord()->isNudged() || n->chord()->isNudged())) {
-                    const bool prevChordSmall = previousNote->chord()->isSmall();
-                    const bool nChordSmall = n->chord()->isSmall();
-                    if (previousNote->chord()->dots() == n->chord()->dots()) {
-                        // hide one set of dots
-                        // Hide the small augmentation dot if present
-                        bool onLine = !(previousNote->line() & 1);
-                        if (prevChordSmall) {
-                            previousNote->setDotsHidden(true);
-                        } else if (nChordSmall) {
-                            n->setDotsHidden(true);
-                        } else if (onLine) {
-                            // hide dots for lower voice
-                            if (previousNote->voice() & 1) {
-                                previousNote->setDotsHidden(true);
-                            } else {
-                                n->setDotsHidden(true);
-                            }
-                        } else {
-                            // hide dots for upper voice
-                            if (!(previousNote->voice() & 1)) {
-                                previousNote->setDotsHidden(true);
-                            } else {
-                                n->setDotsHidden(true);
-                            }
-                        }
-                    }
-                    // If either chord is small, adjust offset
-                    Chord* smallChord = prevChordSmall ? previousNote->chord() : nullptr;
-                    smallChord = nChordSmall ? n->chord() : smallChord;
-                    if (smallChord && !(prevChordSmall && nChordSmall)) {
-                        if (smallChord->up()) {
-                            offsetInfo.centerUp *= 2;
-                        } else {
-                            offsetInfo.centerDown = 0;
-                        }
-                    }
-                    // formerly we hid noteheads in an effort to fix playback
-                    // but this doesn't work for cases where noteheads cannot be shared
-                    // so better to solve the problem elsewhere
+                const bool skipNote = previousNote->chord()->isNudged() || n->chord()->isNudged();
+                if (skipNote) {
+                    continue;
                 }
+                const bool prevChordSmall = previousNote->chord()->isSmall();
+                const bool nChordSmall = n->chord()->isSmall();
+                if (previousNote->chord()->dots() == n->chord()->dots()) {
+                    // hide one set of dots
+                    // Hide the small augmentation dot if present
+                    bool onLine = !(previousNote->line() & 1);
+                    if (prevChordSmall) {
+                        previousNote->setDotsHidden(true);
+                    } else if (nChordSmall) {
+                        n->setDotsHidden(true);
+                    } else if (onLine) {
+                        // hide dots for lower voice
+                        if (previousNote->voice() & 1) {
+                            previousNote->setDotsHidden(true);
+                        } else {
+                            n->setDotsHidden(true);
+                        }
+                    } else {
+                        // hide dots for upper voice
+                        if (!(previousNote->voice() & 1)) {
+                            previousNote->setDotsHidden(true);
+                        } else {
+                            n->setDotsHidden(true);
+                        }
+                    }
+                }
+                // If either chord is small, adjust offset
+                Chord* smallChord = prevChordSmall ? previousNote->chord() : nullptr;
+                smallChord = nChordSmall ? n->chord() : smallChord;
+                if (smallChord && !(prevChordSmall && nChordSmall)) {
+                    if (smallChord->up()) {
+                        offsetInfo.centerUp *= 2;
+                    } else {
+                        offsetInfo.centerDown = 0;
+                    }
+                }
+                // formerly we hid noteheads in an effort to fix playback
+                // but this doesn't work for cases where noteheads cannot be shared
+                // so better to solve the problem elsewhere
             }
         } else if (conflict && (posInfo.upDots && !posInfo.downDots)) {
             offsetInfo.upOffset = posInfo.maxDownWidth + 0.1 * sp;

--- a/src/engraving/rendering/score/chordlayout.cpp
+++ b/src/engraving/rendering/score/chordlayout.cpp
@@ -1608,15 +1608,16 @@ void ChordLayout::offsetAndLayoutChords(Segment* segment, staff_idx_t staffIdx, 
     layoutChords3(posInfo.chords, notes, staff, ctx);
 }
 
-void ChordLayout::centreChords(const Segment* segment, OffsetInfo& offsetInfo, ChordPosInfo& posInfo, staff_idx_t staffIdx,
-                               const Fraction& tick, LayoutContext& ctx)
+OffsetInfo ChordLayout::centreChords(const Segment* segment, ChordPosInfo& posInfo, staff_idx_t staffIdx,
+                                     const Fraction& tick, LayoutContext& ctx)
 {
     const Staff* staff = ctx.dom().staff(staffIdx);
     const bool isTab = staff->isTabStaff(segment->tick());
 
+    OffsetInfo offsetInfo = OffsetInfo();
     // only center chords on standard staves.  This is a simpler process for TAB and done elsewhere
     if (isTab) {
-        return;
+        return offsetInfo;
     }
 
     double sp = staff->spatium(tick);
@@ -1673,6 +1674,8 @@ void ChordLayout::centreChords(const Segment* segment, OffsetInfo& offsetInfo, C
         offsetInfo.centerDown = -headDiff * 0.5;
         offsetInfo.centerAdjustUp = offsetInfo.centerDown;
     }
+
+    return offsetInfo;
 }
 
 void ChordLayout::calculateChordOffsets(Segment* segment, staff_idx_t staffIdx, const Fraction& tick,
@@ -2089,9 +2092,7 @@ void ChordLayout::layoutChords1(LayoutContext& ctx, Segment* segment, staff_idx_
             posInfo.maxDownWidth = std::max(posInfo.maxDownWidth, hw);
         }
 
-        OffsetInfo offsetInfo = OffsetInfo();
-
-        centreChords(segment, offsetInfo, posInfo, staffIdx, tick, ctx);
+        OffsetInfo offsetInfo = centreChords(segment, posInfo, staffIdx, tick, ctx);
 
         calculateChordOffsets(segment, staffIdx, tick, offsetInfo, posInfo, ctx);
 

--- a/src/engraving/rendering/score/chordlayout.cpp
+++ b/src/engraving/rendering/score/chordlayout.cpp
@@ -1572,8 +1572,8 @@ void ChordLayout::calculateMaxNoteWidths(ChordPosInfo& posInfo, const Fraction& 
     }
 }
 
-void ChordLayout::offsetAndLayoutChords(Segment* segment, staff_idx_t staffIdx, track_idx_t partStartTrack, track_idx_t partEndTrack,
-                                        OffsetInfo& offsetInfo, const ChordPosInfo& posInfo, LayoutContext& ctx)
+void ChordLayout::applyChordOffsets(Segment* segment, staff_idx_t staffIdx, track_idx_t partStartTrack, track_idx_t partEndTrack,
+                                    OffsetInfo& offsetInfo, const ChordPosInfo& posInfo, LayoutContext& ctx)
 {
     const Staff* staff = ctx.dom().staff(staffIdx);
     const bool isTab = staff->isTabStaff(segment->tick());
@@ -2102,7 +2102,7 @@ void ChordLayout::layoutChords1(LayoutContext& ctx, Segment* segment, staff_idx_
 
         calculateChordOffsets(segment, staffIdx, tick, offsetInfo, posInfo, ctx);
 
-        offsetAndLayoutChords(segment, staffIdx, partStartTrack, partEndTrack, offsetInfo, posInfo, ctx);
+        applyChordOffsets(segment, staffIdx, partStartTrack, partEndTrack, offsetInfo, posInfo, ctx);
     }
 
     if (!isTab) {

--- a/src/engraving/rendering/score/chordlayout.cpp
+++ b/src/engraving/rendering/score/chordlayout.cpp
@@ -2073,59 +2073,7 @@ void ChordLayout::layoutChords1(LayoutContext& ctx, Segment* segment, staff_idx_
             }
         }
 
-        // apply chord offsets
-        for (track_idx_t track = partStartTrack; track < partEndTrack; ++track) {
-            EngravingItem* e = segment->element(track);
-            if (e && e->isChord() && toChord(e)->vStaffIdx() == staffIdx) {
-                Chord* chord = toChord(e);
-                Chord::LayoutData* chordLdata = chord->mutldata();
-                // only centre chords if we are separating voices and this voice has no collision
-                const bool combineVoices = chord->shouldCombineVoice();
-                if (!combineVoices && !muse::contains(tracksToAdjust, track)) {
-                    if (chord->up()) {
-                        chordLdata->moveX(offsetInfo.centerUp);
-                    } else {
-                        chordLdata->moveX(offsetInfo.centerDown);
-                    }
-                    continue;
-                }
-
-                if (chord->up()) {
-                    if (!muse::RealIsNull(offsetInfo.upOffset)) {
-                        offsetInfo.oversizeUp = isTab ? offsetInfo.oversizeUp / 2 : offsetInfo.oversizeUp;
-                        chordLdata->moveX(offsetInfo.upOffset + offsetInfo.centerAdjustUp + offsetInfo.oversizeUp);
-                        if (posInfo.downDots && !posInfo.upDots) {
-                            chordLdata->moveX(offsetInfo.dotAdjust);
-                        }
-                    } else {
-                        chordLdata->moveX(offsetInfo.centerUp);
-                    }
-                } else {
-                    if (!muse::RealIsNull(offsetInfo.downOffset)) {
-                        chordLdata->moveX(offsetInfo.downOffset + offsetInfo.centerAdjustDown);
-                        if (posInfo.upDots && !posInfo.downDots) {
-                            chordLdata->moveX(offsetInfo.dotAdjust);
-                        }
-                    } else {
-                        chordLdata->moveX(offsetInfo.centerDown);
-                    }
-                }
-            }
-        }
-
-        // layout chords
-        std::vector<Note*> notes;
-        if (posInfo.upVoices) {
-            notes.insert(notes.end(), posInfo.upStemNotes.begin(), posInfo.upStemNotes.end());
-        }
-        if (posInfo.downVoices) {
-            notes.insert(notes.end(), posInfo.downStemNotes.begin(), posInfo.downStemNotes.end());
-        }
-        if (posInfo.upVoices + posInfo.downVoices > 1) {
-            std::sort(notes.begin(), notes.end(),
-                      [](Note* n1, const Note* n2) ->bool { return n1->stringOrLine() > n2->stringOrLine(); });
-        }
-        layoutChords3(posInfo.chords, notes, staff, ctx);
+        offsetAndLayoutChords(segment, staffIdx, partStartTrack, partEndTrack, offsetInfo, posInfo, ctx);
     }
 
     if (!isTab) {

--- a/src/engraving/rendering/score/chordlayout.h
+++ b/src/engraving/rendering/score/chordlayout.h
@@ -159,8 +159,8 @@ private:
                                    LayoutContext& ctx);
     static void calculateChordOffsets(Segment* segment, staff_idx_t staffIdx, const Fraction& tick, OffsetInfo& offsetInfo,
                                       ChordPosInfo& posInfo, LayoutContext& ctx);
-    static void offsetAndLayoutChords(Segment* segment, staff_idx_t staffIdx, track_idx_t partStartTrack, track_idx_t partEndTrack,
-                                      OffsetInfo& offsetInfo, const ChordPosInfo& posInfo, LayoutContext& ctx);
+    static void applyChordOffsets(Segment* segment, staff_idx_t staffIdx, track_idx_t partStartTrack, track_idx_t partEndTrack,
+                                  OffsetInfo& offsetInfo, const ChordPosInfo& posInfo, LayoutContext& ctx);
 };
 }
 

--- a/src/engraving/rendering/score/chordlayout.h
+++ b/src/engraving/rendering/score/chordlayout.h
@@ -154,9 +154,10 @@ private:
 
     static ChordPosInfo calculateChordPosInfo(Segment* segment, staff_idx_t staffIdx, track_idx_t partStartTrack, track_idx_t partEndTrack,
                                               LayoutContext& ctx);
-
     static void offsetAndLayoutChords(Segment* segment, staff_idx_t staffIdx, track_idx_t partStartTrack, track_idx_t partEndTrack,
                                       OffsetInfo& offsetInfo, const ChordPosInfo& posInfo, LayoutContext& ctx);
+    static void centreChords(const Segment* segment, OffsetInfo& offsetInfo, ChordPosInfo& posInfo, staff_idx_t staffIdx,
+                             const Fraction& tick, LayoutContext& ctx);
 };
 }
 

--- a/src/engraving/rendering/score/chordlayout.h
+++ b/src/engraving/rendering/score/chordlayout.h
@@ -154,8 +154,8 @@ private:
 
     static ChordPosInfo calculateChordPosInfo(Segment* segment, staff_idx_t staffIdx, track_idx_t partStartTrack, track_idx_t partEndTrack,
                                               LayoutContext& ctx);
-    static void centreChords(const Segment* segment, OffsetInfo& offsetInfo, ChordPosInfo& posInfo, staff_idx_t staffIdx,
-                             const Fraction& tick, LayoutContext& ctx);
+    static OffsetInfo centreChords(const Segment* segment, ChordPosInfo& posInfo, staff_idx_t staffIdx, const Fraction& tick,
+                                   LayoutContext& ctx);
     static void calculateChordOffsets(Segment* segment, staff_idx_t staffIdx, const Fraction& tick, OffsetInfo& offsetInfo,
                                       ChordPosInfo& posInfo, LayoutContext& ctx);
     static void offsetAndLayoutChords(Segment* segment, staff_idx_t staffIdx, track_idx_t partStartTrack, track_idx_t partEndTrack,

--- a/src/engraving/rendering/score/chordlayout.h
+++ b/src/engraving/rendering/score/chordlayout.h
@@ -154,6 +154,7 @@ private:
 
     static ChordPosInfo calculateChordPosInfo(Segment* segment, staff_idx_t staffIdx, track_idx_t partStartTrack, track_idx_t partEndTrack,
                                               LayoutContext& ctx);
+    static void calculateMaxNoteWidths(ChordPosInfo& posInfo, const Fraction& tick, const Staff* staff, LayoutContext& ctx);
     static OffsetInfo centreChords(const Segment* segment, ChordPosInfo& posInfo, staff_idx_t staffIdx, const Fraction& tick,
                                    LayoutContext& ctx);
     static void calculateChordOffsets(Segment* segment, staff_idx_t staffIdx, const Fraction& tick, OffsetInfo& offsetInfo,

--- a/src/engraving/rendering/score/chordlayout.h
+++ b/src/engraving/rendering/score/chordlayout.h
@@ -154,10 +154,12 @@ private:
 
     static ChordPosInfo calculateChordPosInfo(Segment* segment, staff_idx_t staffIdx, track_idx_t partStartTrack, track_idx_t partEndTrack,
                                               LayoutContext& ctx);
-    static void offsetAndLayoutChords(Segment* segment, staff_idx_t staffIdx, track_idx_t partStartTrack, track_idx_t partEndTrack,
-                                      OffsetInfo& offsetInfo, const ChordPosInfo& posInfo, LayoutContext& ctx);
     static void centreChords(const Segment* segment, OffsetInfo& offsetInfo, ChordPosInfo& posInfo, staff_idx_t staffIdx,
                              const Fraction& tick, LayoutContext& ctx);
+    static void calculateChordOffsets(Segment* segment, staff_idx_t staffIdx, const Fraction& tick, OffsetInfo& offsetInfo,
+                                      ChordPosInfo& posInfo, LayoutContext& ctx);
+    static void offsetAndLayoutChords(Segment* segment, staff_idx_t staffIdx, track_idx_t partStartTrack, track_idx_t partEndTrack,
+                                      OffsetInfo& offsetInfo, const ChordPosInfo& posInfo, LayoutContext& ctx);
 };
 }
 

--- a/src/engraving/rendering/score/chordlayout.h
+++ b/src/engraving/rendering/score/chordlayout.h
@@ -43,6 +43,44 @@ class Slur;
 }
 
 namespace mu::engraving::rendering::score {
+struct ChordPosInfo {
+    std::vector<Chord*> chords;
+    std::vector<Note*> upStemNotes;
+    std::vector<Note*> downStemNotes;
+    int upVoices       = 0;
+    int downVoices     = 0;
+    double maxUpWidth   = 0.0;
+    double maxDownWidth = 0.0;
+    double maxUpMag     = 0.0;
+    double maxDownMag   = 0.0;
+
+    // dots and hooks can affect layout of notes as well as vice versa
+    int upDots         = 0;
+    int downDots       = 0;
+    bool upHooks       = false;
+    bool downHooks     = false;
+
+    // also check for grace notes
+    bool upGrace       = false;
+    bool downGrace     = false;
+};
+
+struct OffsetInfo {
+    double upOffset           = 0.0;      // offset to apply to upstem chords
+    double downOffset         = 0.0;      // offset to apply to downstem chords
+    double dotAdjust          = 0.0;      // additional chord offset to account for dots
+    double dotAdjustThreshold = 0.0;      // if it exceeds this amount
+
+    // centering adjustments for whole note, breve, and small chords
+    double centerUp          = 0.0;      // offset to apply in order to center upstem chords
+    double oversizeUp        = 0.0;      // adjustment to oversized upstem chord needed if laid out to the right
+    double centerDown        = 0.0;      // offset to apply in order to center downstem chords
+    double centerAdjustUp    = 0.0;      // adjustment to upstem chord needed after centering donwstem chord
+    double centerAdjustDown  = 0.0;      // adjustment to downstem chord needed after centering upstem chord
+
+    std::set<track_idx_t> tracksToAdjust;
+};
+
 class ChordLayout
 {
 public:
@@ -113,6 +151,12 @@ private:
     static bool leaveSpaceForTie(const Articulation* item);
 
     static void computeUpBeamCase(Chord* item, Beam* beam);
+
+    static ChordPosInfo calculateChordPosInfo(Segment* segment, staff_idx_t staffIdx, track_idx_t partStartTrack, track_idx_t partEndTrack,
+                                              LayoutContext& ctx);
+
+    static void offsetAndLayoutChords(Segment* segment, staff_idx_t staffIdx, track_idx_t partStartTrack, track_idx_t partEndTrack,
+                                      OffsetInfo& offsetInfo, const ChordPosInfo& posInfo, LayoutContext& ctx);
 };
 }
 


### PR DESCRIPTION
This PR splits `layoutChords1` into a series of smaller functions. There are also some small readability changes to the logic.
