### PR TITLE
Fix crash on set ornament style to always show cue note

### DIFF
--- a/src/engraving/dom/ornament.cpp
+++ b/src/engraving/dom/ornament.cpp
@@ -237,7 +237,7 @@ bool Ornament::hasFullIntervalChoice() const
 bool Ornament::showCueNote()
 {
     if (m_showCueNote == AutoOnOff::AUTO) {
-        return style().styleB(Sid::trillAlwaysShowCueNote) || _intervalAbove.step != IntervalStep::SECOND;
+        return (hasFullIntervalChoice() && style().styleB(Sid::trillAlwaysShowCueNote)) || _intervalAbove.step != IntervalStep::SECOND;
     }
 
     return m_showCueNote == AutoOnOff::ON;


### PR DESCRIPTION
Resolves: #27749

The crash is not file-specific. To reproduce:
- enter a mordent ornament (or any other ornament with an "interval below" property)
- set style to always show cue note
- crash

What is weird in the provided file is that all the trills have a Mordent ornament inside, instead of a Trill. I have no idea how that happened because I don't know the origin of the file. Anyway, this means that the cue note won't actually show up for these trills (in fact, even their property panel shows the wrong options, e.g. "Interval below"). If necessary, this will need to be investigated separately.
