### PR TITLE
Remove DOM layout calls

### DIFF
--- a/src/engraving/dom/box.cpp
+++ b/src/engraving/dom/box.cpp
@@ -104,7 +104,6 @@ void Box::editDrag(EditData& ed)
         }
         mutldata()->setBbox(0.0, 0.0, system()->width(), absoluteFromSpatium(boxHeight()));
         system()->setHeight(height());
-        triggerLayout();
     } else {
         m_boxWidth += Spatium(ed.delta.x() / sp);
         if (ed.hRaster) {
@@ -112,15 +111,8 @@ void Box::editDrag(EditData& ed)
             int n = lrint(m_boxWidth.val() / hRaster);
             m_boxWidth = Spatium(hRaster * n);
         }
-        triggerLayout();
     }
-
-    renderer()->layoutItem(this);
-}
-
-void Box::endEdit(EditData&)
-{
-    renderer()->layoutItem(this);
+    triggerLayout();
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/box.h
+++ b/src/engraving/dom/box.h
@@ -45,7 +45,6 @@ public:
     virtual bool edit(EditData&) override;
     virtual void startEditDrag(EditData&) override;
     virtual void editDrag(EditData&) override;
-    virtual void endEdit(EditData&) override;
 
     virtual bool acceptDrop(EditData&) const override;
     virtual EngravingItem* drop(EditData&) override;

--- a/src/engraving/dom/bracket.cpp
+++ b/src/engraving/dom/bracket.cpp
@@ -157,8 +157,6 @@ void Bracket::editDrag(EditData& ed)
     double bracketHeight = ldata()->bracketHeight();
     bracketHeight += ed.delta.y();
     mutldata()->bracketHeight.set_value(bracketHeight);
-
-    renderer()->layoutItem(this);
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/clef.cpp
+++ b/src/engraving/dom/clef.cpp
@@ -225,7 +225,6 @@ ClefType Clef::clefType() const
 void Clef::spatiumChanged(double oldValue, double newValue)
 {
     EngravingItem::spatiumChanged(oldValue, newValue);
-    renderer()->layoutItem(this);
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -5616,8 +5616,6 @@ void Score::undoChangeClef(Staff* ostaff, EngravingItem* e, ClefType ct, bool fo
             clef->setParent(destSeg);
             clef->setIsHeader(st == SegmentType::HeaderClef);
             score->doUndoAddElement(clef);
-
-            renderer()->layoutItem(clef);
         }
         if (forInstrumentChange) {
             clef->setForInstrumentChange(true);

--- a/src/engraving/dom/image.cpp
+++ b/src/engraving/dom/image.cpp
@@ -326,7 +326,7 @@ void Image::editDrag(EditData& ed)
     if (ed.curGrip == Grip::MIDDLE) {
         setOffset(offset() + ed.evtDelta);
         setOffsetChanged(true);
-        renderer()->layoutItem(this);
+        triggerLayout();
         return;
     }
 
@@ -353,7 +353,7 @@ void Image::editDrag(EditData& ed)
         }
     }
 
-    renderer()->layoutItem(this);
+    triggerLayout();
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/ledgerline.cpp
+++ b/src/engraving/dom/ledgerline.cpp
@@ -76,6 +76,5 @@ double LedgerLine::measureXPos() const
 void LedgerLine::spatiumChanged(double oldValue, double newValue)
 {
     m_len   = (m_len / oldValue) * newValue;
-    renderer()->layoutItem(this);
 }
 }

--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -2344,7 +2344,6 @@ void Score::splitStaff(staff_idx_t staffIdx, int splitPoint)
     clef->setParent(seg);
     clef->setIsHeader(true);
     undoAddElement(clef);
-    renderer()->layoutItem(clef);
 
     undoChangeKeySig(ns, Fraction(0, 1), st->keySigEvent(Fraction(0, 1)));
 

--- a/src/engraving/dom/stem.cpp
+++ b/src/engraving/dom/stem.cpp
@@ -99,11 +99,11 @@ void Stem::editDrag(EditData& ed)
 {
     double yDelta = up() ? -ed.delta.y() : ed.delta.y();
     m_userLength += Spatium::fromMM(yDelta, spatium());
-    renderer()->layoutItem(this);
     Chord* c = chord();
     if (c->hook()) {
         c->hook()->move(PointF(0.0, ed.delta.y()));
     }
+    triggerLayout();
 }
 
 void Stem::reset()

--- a/src/engraving/dom/undo.cpp
+++ b/src/engraving/dom/undo.cpp
@@ -2770,8 +2770,6 @@ void ChangeClefType::flip(EditData*)
 
     concertClef     = ocl;
     transposingClef = otc;
-    // layout the clef to align the currentClefType with the actual one immediately
-    clef->renderer()->layoutItem(clef);
 }
 
 //---------------------------------------------------------


### PR DESCRIPTION
This PR removes some calls to `renderer()->layoutItem` which we don't need. The changes mean the following actions should be tested:
- Dragging frames (title box, horizontal frames, text frames etc.)
- Dragging brackets
- Clef, ledger line and stem scale when changing score/staff spatium
- Dragging stems
- Dragging images
- Adding clefs/changing clef types

In some cases I have replaced the call with `triggerLayout`. In other cases this wasn't necessary. 
There are some more cases to get through, but these could be a little more involved.