### PR TITLE
4.5.2: Fix import of 1.x closed voltas

### DIFF
--- a/src/engraving/rw/read114/read114.cpp
+++ b/src/engraving/rw/read114/read114.cpp
@@ -1144,7 +1144,7 @@ static void readVolta114(XmlReader& e, ReadContext& ctx, Volta* volta)
                 volta->endings().push_back(i);
             }
         } else if (tag == "subtype") {
-            e.readInt();
+            volta->setVoltaType(e.readInt() == 1 ? Volta::Type::CLOSED : Volta::Type::OPEN);
         } else if (tag == "lineWidth") {
             volta->setLineWidth(Spatium(e.readDouble()));
             volta->setPropertyFlags(Pid::LINE_WIDTH, PropertyFlags::UNSTYLED);


### PR DESCRIPTION
Resolves: #27822
Same as #27825 , submitted on the odd chance that https://github.com/musescore/MuseScore/actions/runs/14643542750 might just be an RC3 rather than the final 4.5.2 ;-)