### PR TITLE
Improvements for Page settings dialog

### DIFF
--- a/src/engraving/style/pagestyle.cpp
+++ b/src/engraving/style/pagestyle.cpp
@@ -24,9 +24,9 @@
 #include "style.h"
 
 namespace mu::engraving {
-const std::set<Sid>& pageStyles()
+const std::vector<Sid>& pageStyles()
 {
-    static const std::set<Sid> styles {
+    static const std::vector<Sid> styles {
         Sid::pageWidth,
         Sid::pageHeight,
         Sid::pagePrintableWidth,

--- a/src/engraving/style/pagestyle.h
+++ b/src/engraving/style/pagestyle.h
@@ -19,22 +19,19 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef MU_ENGRAVING_PAGESTYLE_H
-#define MU_ENGRAVING_PAGESTYLE_H
+#pragma once
 
-#include <set>
-#include <memory>
+#include <vector>
 
 #include "styledef.h"
 
 namespace mu::engraving {
-const std::set<Sid>& pageStyles();
+const std::vector<Sid>& pageStyles();
 
 class MStyle;
 class PageSizeGetAccessor
 {
 public:
-
     PageSizeGetAccessor(const MStyle& style);
 
     double width() const;
@@ -50,14 +47,12 @@ public:
     double spatium() const;
 
 private:
-
     const MStyle& m_style;
 };
 
 class PageSizeSetAccessor
 {
 public:
-
     PageSizeSetAccessor(MStyle& style);
 
     double width() const;
@@ -85,9 +80,6 @@ public:
     void setSpatium(double v);
 
 private:
-
     MStyle& m_style;
 };
 }
-
-#endif // MU_ENGRAVING_PAGESTYLE_H

--- a/src/notation/view/widgets/pagesettings.cpp
+++ b/src/notation/view/widgets/pagesettings.cpp
@@ -261,12 +261,8 @@ void PageSettings::orientationClicked()
 
 void PageSettings::on_resetPageStyleButton_clicked()
 {
-    for (auto styleId : pageStyles()) {
-        globalContext()->currentNotation()->style()->resetStyleValue(styleId);
-    }
-
-    pageOffsetEntry->setValue(1);
-
+    score()->undoChangePageNumberOffset(0);
+    globalContext()->currentNotation()->style()->resetStyleValues(pageStyles());
     updateValues();
 }
 

--- a/src/notation/view/widgets/pagesettings.cpp
+++ b/src/notation/view/widgets/pagesettings.cpp
@@ -471,8 +471,8 @@ void PageSettings::spatiumChanged(double val)
 
 void PageSettings::pageOffsetChanged(int val)
 {
-    // TODO: Cancel does not work when page offset is changed?
-    score()->setPageNumberOffset(val - 1);
+    score()->undoChangePageNumberOffset(val - 1);
+    globalContext()->currentNotation()->notationChanged().notify();
 }
 
 void PageSettings::pageHeightChanged(double val)


### PR DESCRIPTION
- Improve efficiency of `Reset all …` button
- Fix undo/redo issues around changing the first page number (sometimes, the score did not update, or not fully)

(found while reviewing https://github.com/musescore/MuseScore/pull/27392)