### PR TITLE
Create Customizable Elision Shortcut

### DIFF
--- a/src/app/configs/data/shortcuts.xml
+++ b/src/app/configs/data/shortcuts.xml
@@ -968,6 +968,10 @@
     <seq>Shift+-</seq>
   </SC>
   <SC>
+    <key>add-elision</key>
+    <seq>Ctrl+Alt+=</seq>
+  </SC>
+  <SC>
     <key>next-lyric-verse</key>
     <seq>Down</seq>
   </SC>

--- a/src/app/configs/data/shortcuts_mac.xml
+++ b/src/app/configs/data/shortcuts_mac.xml
@@ -969,6 +969,10 @@
     <seq>Shift+-</seq>
   </SC>
   <SC>
+    <key>add-elision</key>
+    <seq>Ctrl+Alt+=</seq>
+  </SC>
+  <SC>
     <key>next-lyric-verse</key>
     <seq>Down</seq>
   </SC>

--- a/src/engraving/dom/textedit.cpp
+++ b/src/engraving/dom/textedit.cpp
@@ -716,12 +716,7 @@ bool TextBase::editTextual(EditData& ed)
                 return true;
             }
         }
-        if (ctrlPressed && altPressed) {
-            if (ed.key == Key_Minus || ed.key == Key_Underscore) {
-                insertSym(ed, SymId::lyricsElision);
-                return true;
-            }
-        }
+
     }
     if (!s.isEmpty()) {
         deleteSelectedText(ed);

--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -271,6 +271,7 @@ public:
     virtual void setScoreConfig(const ScoreConfig& config) = 0;
 
     virtual void addMelisma() = 0;
+    virtual void addElision() = 0;
     virtual void addLyricsVerse() = 0;
 
     virtual muse::Ret canAddGuitarBend() const = 0;

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -157,6 +157,7 @@ void NotationActionController::init()
     registerAction("next-syllable", &Interaction::navigateToNextSyllable, PlayMode::NoPlay, &Controller::isEditingLyrics);
 
     registerAction("add-melisma", &Interaction::addMelisma, PlayMode::NoPlay, &Controller::isEditingLyrics);
+    registerAction("add-elision", &Interaction::addElision, PlayMode::NoPlay, &Controller::isEditingLyrics);
     registerAction("add-lyric-verse", &Interaction::addLyricsVerse, PlayMode::NoPlay, &Controller::isEditingLyrics);
 
     registerAction("flat2", [this]() { toggleAccidental(AccidentalType::FLAT2); });

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -291,6 +291,7 @@ public:
     void navigateToNearText(MoveDirection direction) override;
 
     void addMelisma() override;
+    void addElision() override;
     void addLyricsVerse() override;
 
     muse::Ret canAddGuitarBend() const override;

--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -1772,6 +1772,12 @@ const UiActionList NotationUiActions::m_actions = {
              TranslatableString("action", "Add extension line"),
              TranslatableString("action", "Lyrics: enter extension line")
              ),
+    UiAction("add-elision",
+             mu::context::UiCtxProjectOpened,
+             mu::context::CTX_NOTATION_TEXT_EDITING,
+             TranslatableString("action", "Add elision"),
+             TranslatableString("action", "Lyrics: enter elision")
+             ),
     UiAction("add-lyric-verse",
              mu::context::UiCtxProjectOpened,
              mu::context::CTX_NOTATION_OPENED,

--- a/src/notation/tests/mocks/notationinteractionmock.h
+++ b/src/notation/tests/mocks/notationinteractionmock.h
@@ -234,6 +234,7 @@ public:
     MOCK_METHOD(void, setScoreConfig, (const ScoreConfig&), (override));
 
     MOCK_METHOD(void, addMelisma, (), (override));
+    MOCK_METHOD(void, addElision, (), (override));
     MOCK_METHOD(void, addLyricsVerse, (), (override));
 
     MOCK_METHOD(muse::Ret, canAddGuitarBend, (), (const, override));


### PR DESCRIPTION
Resolves: #19174 

<!-- Add a short description of and motivation for the changes here -->
This PR introduces a new addElision() handler in NotationInteraction and wires it up to a user-configurable shortcut (default Ctrl+Alt+= / Cmd+Opt+=) (changed from the original Ctrl+Alt+_/- to avoid stepping on voice-assignment-all-in-staff shortcut), so inserting the elision symbol is no longer hard-coded.

    - Context checks ensure we’re only in a lyrics text edit.

    - Undo support via score()->undo(new InsertText(…)).

    - Immediate refresh: we manually trigger a layout + view update so the symbol snaps into position under the note before the next keystroke.

    - Typing flow: we re-enter inline‐edit mode and restore the cursor location so the user can continue typing without interruption.

This is my first PR ever, and turned out to be more difficult than I anticipated because the original hardcoded shortcut was all in textBase/textedit.cpp and thus couldn't be quite exactly replicated in notationinteraction.cpp where the customizable shortcuts live. So while this PR does implement a functional shortcut to insert an elision symbol, it might not be the desired strategy/solution. Looking forward to getting some feedback and continuing to work on this if needed!

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [] I created a unit test or vtest to verify the changes I made (if applicable)
