### PR TITLE
Implemented copy/paste list selection functionality for Clefs

### DIFF
--- a/src/engraving/dom/select.cpp
+++ b/src/engraving/dom/select.cpp
@@ -1187,6 +1187,9 @@ muse::ByteArray Selection::symbolListMimeData() const
         case ElementType::PEDAL:
             seg = toSpanner(e)->startSegment();
             break;
+        case ElementType::CLEF:
+            seg = toClef(e)->segment();
+            break;
         default:
             // Elements of other types are ignored. To allow copying them,
             // add support for them here and in `Score::pasteSymbols`.

--- a/src/engraving/rw/read410/read410.cpp
+++ b/src/engraving/rw/read410/read410.cpp
@@ -808,8 +808,9 @@ void Read410::pasteSymbols(XmlReader& e, ChordRest* dst)
     Fraction startTick   = dst->tick();        // the initial tick and track where to start pasting
     track_idx_t startTrack  = dst->track();
     track_idx_t maxTrack    = score->ntracks();
-
+   
     while (e.readNextStartElement()) {
+       
         if (done) {
             break;
         }
@@ -827,6 +828,7 @@ void Read410::pasteSymbols(XmlReader& e, ChordRest* dst)
                 break;
             }
             const AsciiStringView tag(e.name());
+
 
             if (tag == "trackOffset") {
                 destTrack = startTrack + e.readInt();
@@ -876,7 +878,8 @@ void Read410::pasteSymbols(XmlReader& e, ChordRest* dst)
                 b->setTrack(destTrack);
                 b->setParent(seg);
                 score->undoAddElement(b);
-            } else if (tag == "Breath") {
+            }
+            else if (tag == "Breath") {
                 Measure* meas = score->tick2measure(destTick);
                 Segment* seg = meas ? meas->undoGetSegment(SegmentType::Breath, destTick) : nullptr;
                 if (!seg) {
@@ -891,6 +894,21 @@ void Read410::pasteSymbols(XmlReader& e, ChordRest* dst)
                 b->setTrack(destTrack);
                 b->setParent(seg);
                 score->undoAddElement(b);
+            }else if(tag == "Clef") {
+                
+                Measure* meas = score->tick2measure(destTick);
+                Segment* seg = meas ? meas->undoGetSegment(SegmentType::Clef, destTick) : nullptr;
+                if (!seg) {
+                    LOGD() << "No Clef segment at tick " << destTick.ticks();
+                    e.skipCurrentElement();
+                    continue;
+                }
+                Clef* c = Factory::createClef(score->dummy()->segment());
+                c->setTrack(destTrack);
+                TRead::read(c, e, ctx);
+                c->setTrack(destTrack);
+                c->setParent(seg);
+                score->undoAddElement(c);
             } else if (tag == "Dynamic"
                        || tag == "Expression"
                        || tag == "StaffText"

--- a/src/engraving/tests/copypastesymbollist_tests.cpp
+++ b/src/engraving/tests/copypastesymbollist_tests.cpp
@@ -168,6 +168,11 @@ TEST_F(Engraving_CopyPasteSymbolListTests, DISABLED_copypasteFermataRest)
     copypaste(u"fermata-rest", ElementType::ARTICULATION);
 }
 
+TEST_F(Engraving_CopyPasteSymbolListTests, copypasteClef)
+{
+    copypaste(u"clef", ElementType::CLEF);
+}
+
 //---------------------------------------------------------
 //    select all elements of type in 2 first measures
 //    in the first staff and copy paste


### PR DESCRIPTION
Implemented copy/paste list selection functionality for Clefs and and associated test.

Resolves: #26695 

<!-- Add a short description of and motivation for the changes here -->
Implemented copying functionality for clefs in Selection::symbolListMimeData() and pasting in Read410::pasteSymbols. Built and tested locally on my machine successfully and proof of implementation is shown here: 
https://github.com/user-attachments/assets/15298c4f-8b43-40b4-aeb0-bc4632353b04

I would like to continue implementing more elements for copy/pasting list selections, this is just a start!

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->
- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
