### PR TITLE
Add Compile-in-Visual-Studio Guide

### DIFF
--- a/docs/Compile-in-Visual-Studio.md
+++ b/docs/Compile-in-Visual-Studio.md
@@ -3,17 +3,40 @@
 This guide shows how to build MuseScore on Windows using Visual Studio 2022:
 
 1. **Prerequisites**
-   - Install Visual Studio 2022 with "Desktop development with C++" workload.
-   - Install CMake (>=3.21).
+   - Install Visual Studio 2022 with the **Desktop development with C++** workload.
+   - Install CMake (version ≥ 3.21).
    - Install Git.
 
 2. **Clone the repo**
    ```powershell
    git clone --recursive https://github.com/musescore/MuseScore.git
    cd MuseScore
-   2.1 **Optional: Disable CMake Presets in VS**  
-        If you’ve got “Always use CMake Presets” enabled, Visual Studio will ignore your `CMakeSettings.json` and generate a `CMakePresets.json` instead—so you won’t see the expected `msvc.build_x64` folder. To restore the default behavior:
+   ```
 
-        1. In VS, go **Tools → Options → CMake → General**.  
-        2. Under **CMake configuration file**, select **Never use CMake Presets**.  
-        3. Reload your “Standard Build” configuration and you’ll again get the `msvc.build_x64` folder as documented.  
+3. **Optional: Disable CMake Presets in VS**
+   If you have **Always use CMake Presets** enabled, Visual Studio will ignore your `CMakeSettings.json`
+   and generate a `CMakePresets.json` instead—so you won’t see the expected `msvc.build_x64` folder.
+   To restore the default behavior:
+   1. In Visual Studio go to **Tools → Options → CMake → General**.  
+   2. Under **CMake configuration file**, select **Never use CMake Presets**.  
+   3. Reload your “Standard Build” configuration; you’ll again get the `msvc.build_x64` folder.
+
+4. **Configure**
+   ```powershell
+   mkdir build
+   cd build
+   cmake .. -G "Visual Studio 17 2022" -A x64 `
+     -DCMAKE_BUILD_TYPE=RelWithDebInfo
+   ```
+
+5. **Open & Build**
+   1. Double-click `MuseScore.sln` in the `build` folder to open the solution in Visual Studio.
+   2. Select the **Debug** configuration from the toolbar.
+   3. Choose **Build → Build Solution** (or press Ctrl+Shift+B).
+
+6. **Run & Debug**
+   - Press **F5** to launch MuseScore under the debugger.
+   - Set breakpoints in C++ or QML and step through as needed.
+
+_See also the Qt Creator guide at https://github.com/musescore/MuseScore/wiki/Compile-in-Qt-Creator_
+

--- a/docs/Compile-in-Visual-Studio.md
+++ b/docs/Compile-in-Visual-Studio.md
@@ -11,3 +11,9 @@ This guide shows how to build MuseScore on Windows using Visual Studio 2022:
    ```powershell
    git clone --recursive https://github.com/musescore/MuseScore.git
    cd MuseScore
+   2.1 **Optional: Disable CMake Presets in VS**  
+        If you’ve got “Always use CMake Presets” enabled, Visual Studio will ignore your `CMakeSettings.json` and generate a `CMakePresets.json` instead—so you won’t see the expected `msvc.build_x64` folder. To restore the default behavior:
+
+        1. In VS, go **Tools → Options → CMake → General**.  
+        2. Under **CMake configuration file**, select **Never use CMake Presets**.  
+        3. Reload your “Standard Build” configuration and you’ll again get the `msvc.build_x64` folder as documented.  

--- a/docs/Compile-in-Visual-Studio.md
+++ b/docs/Compile-in-Visual-Studio.md
@@ -1,0 +1,13 @@
+# Compiling in Visual Studio
+
+This guide shows how to build MuseScore on Windows using Visual Studio 2022:
+
+1. **Prerequisites**
+   - Install Visual Studio 2022 with "Desktop development with C++" workload.
+   - Install CMake (>=3.21).
+   - Install Git.
+
+2. **Clone the repo**
+   ```powershell
+   git clone --recursive https://github.com/musescore/MuseScore.git
+   cd MuseScore


### PR DESCRIPTION
This PR introduces a new documentation page, docs/Compile-in-Visual-Studio.md, which provides a complete, step-by-step workflow for building MuseScore on Windows using Visual Studio 2022. It explains the “no msvc.build_x64 folder” symptom, shows how to disable the default CMake Presets option (Tools → Options → CMake → General → Never use CMake Presets), and walks users through cloning, configuring, building, and debugging in Visual Studio. It also links back to the Qt Creator guide for cross-platform consistency.

Fixes #16424.
