### PR TITLE
Fix #27354: Save floating panel geometry even if hidden in tab during…

### DIFF
--- a/src/framework/dockwindow/thirdparty/KDDockWidgets/src/DockWidgetBase.cpp
+++ b/src/framework/dockwindow/thirdparty/KDDockWidgets/src/DockWidgetBase.cpp
@@ -938,7 +938,8 @@ Frame *DockWidgetBase::Private::frame() const
 
 void DockWidgetBase::Private::saveLastFloatingGeometry()
 {
-    if (q->isFloating() && q->isVisible()) {
+    // if (q->isFloating() && q->isVisible()) {
+    if (q->isFloating()) {
         // It's getting docked, save last floating position
         lastPositions().setLastFloatingGeometry(q->window()->geometry());
     }


### PR DESCRIPTION
Resolves: #[27354](https://github.com/musescore/MuseScore/issues/27354): Save floating panel geometry even if hidden in tab during docking

Previously, `saveLastFloatingGeometry()` would only store geometry if the panel was both floating and visible.

This caused issues for panels that were open but background (tabbed but hidden) at the time of docking—they would not be shown in view menu upon when switching back to score view.

This commit removes the visibility check to ensure that the geometry of all floating panels is preserved, regardless of their tab visibility. So that it can fix the issue where only the front-most visible panel in a tabbed dock was shown as checked in the View menu.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
