### PR TITLE
Implementation for LRC Lyrics Export Functionality

### DIFF
--- a/share/autobotscripts/TC7_UsingExport.js
+++ b/share/autobotscripts/TC7_UsingExport.js
@@ -28,163 +28,241 @@ var testCase = {
     name: "TC7: Using Export",
     description: "Let's check the functionality of the export",
     steps: [
-        {name: "Close score (if opened) and go to home to start", func: function() {
-            api.dispatcher.dispatch("file-close")
-            api.navigation.triggerControl("TopTool", "MainToolBar", "Home")
-        }},
-        {name: "Open New Score Dialog", func: function() {
-            NewScore.openNewScoreDialog()
-        }},
-        {name: "Create score with Flute", func: function() {
-            NewScore.selectTab("instruments")
-            NewScore.chooseInstrument("Woodwinds", "Flute")
-            NewScore.done()
-        }},
-        {name: "Turn on note input", func: function() {
-            NoteInput.chooseDefaultMode()
-            NoteInput.chooseNoteDuration("pad-note-8")
-        }},
-        {name: "Put notes", func: function() {
-            NoteInput.putNote("note-c")
-            NoteInput.putNote("note-d")
-            NoteInput.putNote("note-e")
-            NoteInput.putNote("note-f")
-            NoteInput.putNote("note-g")
-            NoteInput.putNote("note-a")
-            NoteInput.putNote("note-b")
-        }},
-        {name: "Save", func: function() {
-            api.autobot.saveProject("TC7_UsingExport.mscz")
-        }},
-        {name: "Export PDF: Open Export Dialog", skip: false, func: function() {
-            openExportDialog()
-        }},
-        {name: "Export PDF: Setup and Export", skip: false, func: function() {
-            Navigation.triggerControl("DialogView", "ExportOptions", "ExportType_All parts combined in one file")
-            Navigation.triggerControl("DialogView", "ExportBottom", "Export")
-        }},
-        {name: "Export PDF: Check file and Open", skip: false, func: function() {
-            checkAndOpen()
-        }},
-        {name: "Export PNG: Open Export Dialog", skip: false, func: function() {
-            openExportDialog()
-        }},
-        {name: "Export PNG: Setup and Export", skip: false, func: function() {
-            selectExportType("PNG")
-            Navigation.triggerControl("DialogView", "ExportBottom", "Export")
-        }},
-        {name: "Export PNG: Check file and Open", skip: false, func: function() {
-            checkAndOpen()
-        }},
-        {name: "Export SVG: Open Export Dialog", skip: false, func: function() {
-            openExportDialog()
-        }},
-        {name: "Export SVG: Setup and Export", skip: false, func: function() {
-            selectExportType("SVG")
-            Navigation.triggerControl("DialogView", "ExportBottom", "Export")
-        }},
-        {name: "Export SVG: Check file and Open", skip: false, func: function() {
-            checkAndOpen()
-        }},
-        {name: "Export MusicXML: Open Export Dialog", skip: false, func: function() {
-            openExportDialog()
-        }},
-        {name: "Export MusicXML: Setup and Export", skip: false, func: function() {
-            selectExportType("MusicXML")
-            Navigation.triggerControl("DialogView", "ExportBottom", "Export")
-        }},
-        {name: "Export MusicXML: Check file and Open", skip: false, func: function() {
-            checkAndOpen()
-        }},
-        {name: "Export MP3: Open Export Dialog", skip: false, func: function() {
-            openExportDialog()
-        }},
-        {name: "Export MP3: Setup and Export", skip: false, func: function() {
-            selectExportType("MP3")
-            Navigation.triggerControl("DialogView", "ExportBottom", "Export")
-        }},
-        {name: "Export MP3: Check file and Open", skip: false, func: function() {
-            checkAndOpen()
-        }},
-        {name: "Export WAV: Open Export Dialog", skip: false, func: function() {
-            openExportDialog()
-        }},
-        {name: "Export WAV: Setup and Export", skip: false, func: function() {
-            selectExportType("WAV")
-            Navigation.triggerControl("DialogView", "ExportBottom", "Export")
-        }},
-        {name: "Export WAV: Check file and Open", skip: false, func: function() {
-            checkAndOpen()
-        }},
-        {name: "Export OGG: Open Export Dialog", skip: false, func: function() {
-            openExportDialog()
-        }},
-        {name: "Export OGG: Setup and Export", skip: false, func: function() {
-            selectExportType("OGG")
-            Navigation.triggerControl("DialogView", "ExportBottom", "Export")
-        }},
-        {name: "Export OGG: Check file and Open", skip: false, func: function() {
-            checkAndOpen()
-        }},
-        {name: "Export FLAC: Open Export Dialog", skip: false, func: function() {
-            openExportDialog()
-        }},
-        {name: "Export FLAC: Setup and Export", skip: false, func: function() {
-            selectExportType("FLAC")
-            Navigation.triggerControl("DialogView", "ExportBottom", "Export")
-        }},
-        {name: "Export FLAC: Check file and Open", skip: false, func: function() {
-            checkAndOpen()
-        }},
-        {name: "Export MIDI: Open Export Dialog", skip: false, func: function() {
-            openExportDialog()
-        }},
-        {name: "Export MIDI: Setup and Export", skip: false, func: function() {
-            selectExportType("MIDI")
-            Navigation.triggerControl("DialogView", "ExportBottom", "Export")
-        }},
-        {name: "Export MIDI: Check file and Open", skip: false, func: function() {
-            checkAndOpen()
-        }},
+        {
+            name: "Close score (if opened) and go to home to start", func: function () {
+                api.dispatcher.dispatch("file-close")
+                api.navigation.triggerControl("TopTool", "MainToolBar", "Home")
+            }
+        },
+        {
+            name: "Open New Score Dialog", func: function () {
+                NewScore.openNewScoreDialog()
+            }
+        },
+        {
+            name: "Create score with Flute", func: function () {
+                NewScore.selectTab("instruments")
+                NewScore.chooseInstrument("Woodwinds", "Flute")
+                NewScore.done()
+            }
+        },
+        {
+            name: "Turn on note input", func: function () {
+                NoteInput.chooseDefaultMode()
+                NoteInput.chooseNoteDuration("pad-note-8")
+            }
+        },
+        {
+            name: "Put notes", func: function () {
+                NoteInput.putNote("note-c")
+                NoteInput.putNote("note-d")
+                NoteInput.putNote("note-e")
+                NoteInput.putNote("note-f")
+                NoteInput.putNote("note-g")
+                NoteInput.putNote("note-a")
+                NoteInput.putNote("note-b")
+            }
+        },
+        {
+            name: "Save", func: function () {
+                api.autobot.saveProject("TC7_UsingExport.mscz")
+            }
+        },
+        {
+            name: "Export PDF: Open Export Dialog", skip: false, func: function () {
+                openExportDialog()
+            }
+        },
+        {
+            name: "Export PDF: Setup and Export", skip: false, func: function () {
+                Navigation.triggerControl("DialogView", "ExportOptions", "ExportType_All parts combined in one file")
+                Navigation.triggerControl("DialogView", "ExportBottom", "Export")
+            }
+        },
+        {
+            name: "Export PDF: Check file and Open", skip: false, func: function () {
+                checkAndOpen()
+            }
+        },
+        {
+            name: "Export PNG: Open Export Dialog", skip: false, func: function () {
+                openExportDialog()
+            }
+        },
+        {
+            name: "Export PNG: Setup and Export", skip: false, func: function () {
+                selectExportType("PNG")
+                Navigation.triggerControl("DialogView", "ExportBottom", "Export")
+            }
+        },
+        {
+            name: "Export PNG: Check file and Open", skip: false, func: function () {
+                checkAndOpen()
+            }
+        },
+        {
+            name: "Export SVG: Open Export Dialog", skip: false, func: function () {
+                openExportDialog()
+            }
+        },
+        {
+            name: "Export SVG: Setup and Export", skip: false, func: function () {
+                selectExportType("SVG")
+                Navigation.triggerControl("DialogView", "ExportBottom", "Export")
+            }
+        },
+        {
+            name: "Export SVG: Check file and Open", skip: false, func: function () {
+                checkAndOpen()
+            }
+        },
+        {
+            name: "Export MusicXML: Open Export Dialog", skip: false, func: function () {
+                openExportDialog()
+            }
+        },
+        {
+            name: "Export MusicXML: Setup and Export", skip: false, func: function () {
+                selectExportType("MusicXML")
+                Navigation.triggerControl("DialogView", "ExportBottom", "Export")
+            }
+        },
+        {
+            name: "Export MusicXML: Check file and Open", skip: false, func: function () {
+                checkAndOpen()
+            }
+        },
+        {
+            name: "Export MP3: Open Export Dialog", skip: false, func: function () {
+                openExportDialog()
+            }
+        },
+        {
+            name: "Export MP3: Setup and Export", skip: false, func: function () {
+                selectExportType("MP3")
+                Navigation.triggerControl("DialogView", "ExportBottom", "Export")
+            }
+        },
+        {
+            name: "Export MP3: Check file and Open", skip: false, func: function () {
+                checkAndOpen()
+            }
+        },
+        {
+            name: "Export WAV: Open Export Dialog", skip: false, func: function () {
+                openExportDialog()
+            }
+        },
+        {
+            name: "Export WAV: Setup and Export", skip: false, func: function () {
+                selectExportType("WAV")
+                Navigation.triggerControl("DialogView", "ExportBottom", "Export")
+            }
+        },
+        {
+            name: "Export WAV: Check file and Open", skip: false, func: function () {
+                checkAndOpen()
+            }
+        },
+        {
+            name: "Export OGG: Open Export Dialog", skip: false, func: function () {
+                openExportDialog()
+            }
+        },
+        {
+            name: "Export OGG: Setup and Export", skip: false, func: function () {
+                selectExportType("OGG")
+                Navigation.triggerControl("DialogView", "ExportBottom", "Export")
+            }
+        },
+        {
+            name: "Export OGG: Check file and Open", skip: false, func: function () {
+                checkAndOpen()
+            }
+        },
+        {
+            name: "Export FLAC: Open Export Dialog", skip: false, func: function () {
+                openExportDialog()
+            }
+        },
+        {
+            name: "Export FLAC: Setup and Export", skip: false, func: function () {
+                selectExportType("FLAC")
+                Navigation.triggerControl("DialogView", "ExportBottom", "Export")
+            }
+        },
+        {
+            name: "Export FLAC: Check file and Open", skip: false, func: function () {
+                checkAndOpen()
+            }
+        },
+        {
+            name: "Export MIDI: Open Export Dialog", skip: false, func: function () {
+                openExportDialog()
+            }
+        },
+        {
+            name: "Export MIDI: Setup and Export", skip: false, func: function () {
+                selectExportType("MIDI")
+                Navigation.triggerControl("DialogView", "ExportBottom", "Export")
+            }
+        },
+        {
+            name: "Export MIDI: Check file and Open", skip: false, func: function () {
+                checkAndOpen()
+            }
+        },
+
+        // Addition:
+        {
+            name: "Export LRC: Open Export Dialog", skip: false, func: function () {
+                openExportDialog()
+            }
+        },
+        {
+            name: "Export LRC: Setup and Export", skip: false, func: function () {
+                selectExportType("LRC")
+                Navigation.triggerControl("DialogView", "ExportBottom", "Export")
+            }
+        },
+        {
+            name: "Export LRC: Check file and Open", skip: false, func: function () {
+                checkAndOpen()
+            }
+        },
     ]
 };
 
-function main()
-{
+function main() {
     api.autobot.setInterval(1000)
     api.autobot.runTestCase(testCase)
 }
 
-function seeChanges()
-{
+function seeChanges() {
     api.autobot.seeChanges()
 }
 
-function seeChangesLong()
-{
+function seeChangesLong() {
     api.autobot.sleep(1000)
 }
 
-function checkFileSize(path)
-{
+function checkFileSize(path) {
     var size = api.autobot.fileSize(path)
     if (size === 0) {
         api.autobot.error("file not exists or zero, path: " + path)
     }
 }
 
-function openExportDialog()
-{
+function openExportDialog() {
     api.autobot.showMainWindowOnFront()
-    api.autobot.async(function() {
+    api.autobot.async(function () {
         api.dispatcher.dispatch("file-export")
     })
 }
 
-const TYPES = ["PDF", "PNG", "SVG", "MP3", "WAV", "OGG", "FLAC", "MIDI", "MusicXML"]
+const TYPES = ["PDF", "PNG", "SVG", "MP3", "WAV", "OGG", "FLAC", "MIDI", "MusicXML", "LRC"]
 
-function selectExportType(type)
-{
+function selectExportType(type) {
     var idx = TYPES.indexOf(type)
     if (idx === 0) {
         //! NOTE first is default
@@ -200,8 +278,7 @@ function selectExportType(type)
     Navigation.trigger()
 }
 
-function checkAndOpen()
-{
+function checkAndOpen() {
     var filePath = api.autobot.selectedFilePath()
     checkFileSize(filePath)
     api.interactive.openUrl(filePath)

--- a/src/importexport/CMakeLists.txt
+++ b/src/importexport/CMakeLists.txt
@@ -18,7 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-if (MUE_BUILD_IMPORTEXPORT_MODULE)
+if(MUE_BUILD_IMPORTEXPORT_MODULE)
     add_subdirectory(bb)
 
     add_subdirectory(bww)
@@ -31,16 +31,13 @@ if (MUE_BUILD_IMPORTEXPORT_MODULE)
     add_subdirectory(imagesexport)
     add_subdirectory(guitarpro)
     add_subdirectory(mei)
+    add_subdirectory(lyrics)
 
-    if (MUE_BUILD_VIDEOEXPORT_MODULE)
+    if(MUE_BUILD_VIDEOEXPORT_MODULE)
         add_subdirectory(videoexport)
     endif()
 else()
-    if (MUE_BUILD_IMAGESEXPORT_MODULE)
+    if(MUE_BUILD_IMAGESEXPORT_MODULE)
         add_subdirectory(imagesexport)
     endif()
 endif()
-
-
-
-

--- a/src/importexport/imagesexport/CMakeLists.txt
+++ b/src/importexport/imagesexport/CMakeLists.txt
@@ -18,6 +18,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../lyrics)
+
 declare_module(iex_imagesexport)
 
 set(MODULE_SRC
@@ -26,7 +28,7 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/iimagesexportconfiguration.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/imagesexportconfiguration.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/imagesexportconfiguration.h
-    
+
     ${CMAKE_CURRENT_LIST_DIR}/internal/abstractimagewriter.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/abstractimagewriter.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/svgwriter.cpp
@@ -37,11 +39,11 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/internal/pngwriter.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/pdfwriter.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/pdfwriter.h
-    )
+)
 
 set(MODULE_LINK
     engraving
-    )
+    iex_lyrics
+)
 
 setup_module()
-

--- a/src/importexport/imagesexport/imagesexportmodule.cpp
+++ b/src/importexport/imagesexport/imagesexportmodule.cpp
@@ -27,6 +27,7 @@
 #include "internal/pdfwriter.h"
 #include "internal/pngwriter.h"
 #include "internal/svgwriter.h"
+#include "../lyrics/exportlrc.h"
 
 #include "internal/imagesexportconfiguration.h"
 
@@ -51,16 +52,19 @@ void ImagesExportModule::registerExports()
 void ImagesExportModule::resolveImports()
 {
     auto writers = ioc()->resolve<INotationWritersRegister>(moduleName());
-    if (writers) {
-        writers->reg({ "pdf" }, std::make_shared<PdfWriter>(iocContext()));
-        writers->reg({ "svg" }, std::make_shared<SvgWriter>(iocContext()));
-        writers->reg({ "png" }, std::make_shared<PngWriter>(iocContext()));
+    if (writers)
+    {
+        writers->reg({"pdf"}, std::make_shared<PdfWriter>(iocContext()));
+        writers->reg({"svg"}, std::make_shared<SvgWriter>(iocContext()));
+        writers->reg({"png"}, std::make_shared<PngWriter>(iocContext()));
+        writers->reg({"lrc"}, std::make_shared<mu::iex::lrc::ExportLRC>());
     }
 }
 
-void ImagesExportModule::onInit(const IApplication::RunMode& mode)
+void ImagesExportModule::onInit(const IApplication::RunMode &mode)
 {
-    if (mode == IApplication::RunMode::AudioPluginRegistration) {
+    if (mode == IApplication::RunMode::AudioPluginRegistration)
+    {
         return;
     }
 

--- a/src/importexport/imagesexport/internal/imagesexportconfiguration.h
+++ b/src/importexport/imagesexport/internal/imagesexportconfiguration.h
@@ -24,37 +24,38 @@
 
 #include "../iimagesexportconfiguration.h"
 
-namespace mu::iex::imagesexport {
-class ImagesExportConfiguration : public IImagesExportConfiguration
+namespace mu::iex::imagesexport
 {
-public:
-    void init();
+    class ImagesExportConfiguration : public IImagesExportConfiguration
+    {
+    public:
+        void init();
 
-    int exportPdfDpiResolution() const override;
-    void setExportPdfDpiResolution(int dpi) override;
+        int exportPdfDpiResolution() const override;
+        void setExportPdfDpiResolution(int dpi) override;
 
-    bool exportPdfWithTransparentBackground() const override;
-    void setExportPdfWithTransparentBackground(bool transparent) override;
+        bool exportPdfWithTransparentBackground() const override;
+        void setExportPdfWithTransparentBackground(bool transparent) override;
 
-    float exportPngDpiResolution() const override;
-    void setExportPngDpiResolution(float dpi) override;
-    void setExportPngDpiResolutionOverride(std::optional<float> dpi) override;
+        float exportPngDpiResolution() const override;
+        void setExportPngDpiResolution(float dpi) override;
+        void setExportPngDpiResolutionOverride(std::optional<float> dpi) override;
 
-    bool exportPngWithTransparentBackground() const override;
-    void setExportPngWithTransparentBackground(bool transparent) override;
+        bool exportPngWithTransparentBackground() const override;
+        void setExportPngWithTransparentBackground(bool transparent) override;
 
-    bool exportSvgWithTransparentBackground() const override;
-    void setExportSvgWithTransparentBackground(bool transparent) override;
-    bool exportSvgWithIllustratorCompat() const override;
-    void setExportSvgWithIllustratorCompat(bool compat) override;
+        bool exportSvgWithTransparentBackground() const override;
+        void setExportSvgWithTransparentBackground(bool transparent) override;
+        bool exportSvgWithIllustratorCompat() const override;
+        void setExportSvgWithIllustratorCompat(bool compat) override;
 
-    int trimMarginPixelSize() const override;
-    void setTrimMarginPixelSize(std::optional<int> pixelSize) override;
+        int trimMarginPixelSize() const override;
+        void setTrimMarginPixelSize(std::optional<int> pixelSize) override;
 
-private:
-    std::optional<int> m_trimMarginPixelSize;
-    std::optional<float> m_customExportPngDpiOverride;
-};
+    private:
+        std::optional<int> m_trimMarginPixelSize;
+        std::optional<float> m_customExportPngDpiOverride;
+    };
 }
 
 #endif // MU_IMPORTEXPORT_IMAGESEXPORTCONFIGURATION_H

--- a/src/importexport/lyrics/CMakeLists.txt
+++ b/src/importexport/lyrics/CMakeLists.txt
@@ -1,0 +1,8 @@
+declare_module(iex_lyrics)
+set(MODULE_SRC exportlrc.cpp exportlrc.h)
+set(MODULE_LINK
+    engraving
+    project
+    notation
+)
+setup_module()

--- a/src/importexport/lyrics/exportlrc.cpp
+++ b/src/importexport/lyrics/exportlrc.cpp
@@ -1,0 +1,120 @@
+
+
+#include "exportlrc.h"
+#include "engraving/dom/masterscore.h"
+#include "engraving/dom/repeatlist.h"
+#include "engraving/dom/lyrics.h"
+#include <QBuffer>
+
+using namespace mu::engraving;
+
+namespace mu::iex::lrc
+{
+    // Interface implementation
+    std::vector<project::INotationWriter::UnitType> ExportLRC::supportedUnitTypes() const
+    {
+        return {UnitType::PER_PART};
+    }
+    bool ExportLRC::supportsUnitType(UnitType ut) const { return ut == UnitType::PER_PART; }
+
+    muse::Ret ExportLRC::write(notation::INotationPtr notation, muse::io::IODevice &device, const Options &)
+    {
+        Score *score = notation->elements()->msScore();
+        QByteArray data;
+        QBuffer buffer(&data);
+
+        buffer.open(QIODevice::WriteOnly);
+
+        writeMetadata(buffer, score);
+
+        const auto lyrics = collectLyrics(score);
+
+        // Write lyrics
+        for (auto it = lyrics.constBegin(); it != lyrics.constEnd(); ++it)
+        {
+            buffer.write(QString("[%1]%2\n").arg(formatTimestamp(it.key()), it.value()).toUtf8());
+        }
+
+        device.write(data);
+        return muse::Ret(muse::Ret::Code::Ok);
+    }
+
+    muse::Ret ExportLRC::writeList(const notation::INotationPtrList &, muse::io::IODevice &, const Options &)
+    {
+        return muse::Ret(muse::Ret::Code::NotSupported);
+    }
+
+    void ExportLRC::writeMetadata(QIODevice &device, const engraving::Score *score) const
+    {
+        QString metadata;
+
+        // Title
+        QString title = QString::fromStdString(score->metaTag(muse::String("workTitle")).toStdString());
+        if (!title.isEmpty())
+        {
+            metadata += QString("[ti:%1]\n").arg(title);
+        }
+
+        // Composer/Artist
+        QString artist = QString::fromStdString(score->metaTag(muse::String("composer")).toStdString());
+        if (!artist.isEmpty())
+        {
+            metadata += QString("[ar:%1]\n").arg(artist);
+        }
+
+        if (!metadata.isEmpty())
+        {
+            device.write(metadata.toUtf8());
+        }
+    }
+
+    // Core lyric collection (simplified)
+    QMap<qreal, QString> ExportLRC::collectLyrics(const Score *score) const
+    {
+        QMap<qreal, QString> lyrics;
+        const RepeatList &repeats = score->repeatList();
+
+        for (const RepeatSegment *rs : repeats)
+        {
+            const int tickOffset = rs->utick - rs->tick;
+
+            for (const MeasureBase *mb = rs->firstMeasure(); mb; mb = mb->next())
+            {
+                if (!mb->isMeasure())
+                    continue;
+
+                for (Segment *seg = toMeasure(mb)->first(); seg; seg = seg->next())
+                {
+                    if (!seg->isChordRestType())
+                        continue;
+
+                    for (EngravingItem *e : seg->elist())
+                    {
+                        if (!e || !e->isChordRest())
+                            continue;
+
+                        for (Lyrics *l : toChordRest(e)->lyrics())
+                        {
+                            // if (l->text().empty())
+                            if (l->plainText().isEmpty())
+                                continue;
+
+                            const qreal time = score->utick2utime(l->tick().ticks() + tickOffset) * 1000;
+                            lyrics.insert(time, l->plainText());
+                        }
+                    }
+                }
+            }
+        }
+        return lyrics;
+    }
+
+    QString ExportLRC::formatTimestamp(qreal ms) const
+    {
+        const int totalSec = static_cast<int>(ms / 1000);
+        return QString("%1:%2.%3")
+            .arg(totalSec / 60, 2, 10, QLatin1Char('0'))
+            .arg(totalSec % 60, 2, 10, QLatin1Char('0'))
+            .arg(static_cast<int>(ms) % 1000 / 10, 2, 10, QLatin1Char('0'));
+    }
+} // namespace mu::iex::lrc

--- a/src/importexport/lyrics/exportlrc.h
+++ b/src/importexport/lyrics/exportlrc.h
@@ -1,0 +1,30 @@
+#ifndef EXPORTLRC_H
+#define EXPORTLRC_H
+
+#include "project/inotationwriter.h"
+#include <QIODevice>
+
+namespace mu::engraving
+{
+    class Score;
+}
+
+namespace mu::iex::lrc
+{
+    class ExportLRC : public project::INotationWriter
+    {
+    public:
+        // Interface implementation
+        std::vector<UnitType> supportedUnitTypes() const override;
+        bool supportsUnitType(UnitType) const override;
+        muse::Ret write(notation::INotationPtr, muse::io::IODevice &, const Options &) override;
+        void writeMetadata(QIODevice &device, const engraving::Score *score) const;
+        muse::Ret writeList(const notation::INotationPtrList &, muse::io::IODevice &, const Options &) override;
+
+    private:
+        // Core lyric functionality
+        QMap<qreal, QString> collectLyrics(const engraving::Score *) const;
+        QString formatTimestamp(qreal ms) const;
+    };
+} // namespace mu::iex::lrc
+#endif

--- a/src/importexport/midi/internal/midiexport/exportLRC.cpp
+++ b/src/importexport/midi/internal/midiexport/exportLRC.cpp
@@ -1,0 +1,126 @@
+// CREATED BHY
+#include "exportLRC.h"
+#include "engraving/dom/chordrest.h"
+#include "engraving/dom/lyrics.h"
+#include "engraving/dom/masterscore.h"
+#include "engraving/compat/midi/compatmidirender.h"
+#include <QFile>
+
+using namespace mu::engraving;
+
+/*
+The purpose of this file is to add the feature of
+exporting files with lyrics as LRC files.
+*/
+namespace mu::iex::LRC
+{
+    // PURPOSE: File writing the lyrics and timing.
+    void ExportLRC::write(const QString &path, Score *score)
+    {
+        // Create file:
+        QFile file(path);
+        if (!file.open(QIODevice::WriteOnly))
+        {
+            LOGE() << "Failed to create LRC file:" << path;
+            return false;
+        }
+
+        // Get lyrics with timestamps:
+        QMap<qreal, QString> lyrics = collectLyrics(score);
+
+        // Write LRC file:
+        writeMetadata(file, sscore);
+        writeLyrics(file, lyrics);
+
+        file.close();
+        return true;
+    }
+
+    // PURPOSE: Writes metadata headers with the title, artist, and lyricist.
+    void ExportLRC::writeMetadata(QFile &file, Score *score)
+    {
+        // Get metadata from score:
+        QString title = score->metaTag("workTitle");
+        QString artist = score->metaTag("composer");
+        QString lyricist = score->metaTag("lyricist");
+
+        // Write metadata:
+        if (!title.isEmpty())
+        {
+            file.write("[ti:" + title.toUtf8() + "]\n");
+        }
+        if (!artist.isEmpty())
+        {
+            file.write("[ar:" + artist.toUtf8() + "]\n");
+        }
+        if (!lyricist.isEmpty())
+        {
+            file.write("[au:" + lyricist.toUtf8() + "]\n");
+        }
+    }
+
+    // PURPOSE:Get lyrics with timestamps
+    QMap<qreal, QString> ExportLRC::collectLyrics(Score *score)
+    {
+        QMap<qreal, QString> lyricsMap;
+        const RepeatList &repeatList = score->repeatList();
+
+        for (const RepeatSegment *rs : repeatList)
+        {
+            int tickOffset = rs->utick - rs->tick;
+
+            for (MeasureBase *mb = rs->firstMeasure(); mb; mb = mb->next())
+            {
+                if (!mb->isMeasure())
+                    continue;
+
+                Measure *measure = toMeasure(mb);
+                for (Segment *seg = measure->first(); seg; seg = seg->next())
+                {
+                    if (!seg->isChordRestType())
+                        continue;
+
+                    for (EngravingItem *e : seg->elist())
+                    {
+                        if (!e || !e->isChordRest())
+                            continue;
+
+                        ChordRest *cr = toChordRest(e);
+                        for (Lyrics *lyric : cr->lyrics())
+                        {
+                            if (lyric->isEmpty())
+                                continue;
+
+                            // Calculate absolute tick position with repeat expansion
+                            int utick = cr->tick().ticks() + tickOffset;
+                            qreal ms = score->utick2utime(utick);
+                            lyricsMap.insert(ms, lyric->plainText());
+                        }
+                    }
+                }
+            }
+        }
+        return lyricsMap;
+    }
+
+    // PURPOSE: Write lyrics with timestamps
+    void ExportLRC::writeLyrics(QFile &file, const QMap<qreal, QString> &lyrics)
+    {
+        for (auto it = lyrics.constBegin(); it != lyrics.constEnd(); ++it)
+        {
+            QString line = QString("[%1]%2\n").arg(formatTimestamp(it.key())).arg(it.value());
+            file.write(line.toUtf8());
+        }
+    }
+
+    // PURPOSE: Convert milliseconds to [mm:ss.xx] format
+    QString ExportLRC::formatTimestamp(qreal ms)
+    {
+        int totalSeconds = static_cast<int>(ms / 1000);
+        int mm = totalSeconds / 60;
+        int ss = totalSeconds % 60;
+        int x = static_cast<int>(ms) % 1000 / 10;
+
+        return QString("%1:%2.%3").arg(mm, 2, 10, QLatin1Char('0')).arg(ss, 2, 10, QLatin1Char('0')).arg(x, 2, 10, QLatin1Char('0'));
+    }
+} // namespace mu::iex::lrc

--- a/src/importexport/midi/internal/midiexport/exportLRC.h
+++ b/src/importexport/midi/internal/midiexport/exportLRC.h
@@ -1,0 +1,32 @@
+
+#ifndef EXPORTLRC_H
+#define EXPORTLRC_H
+
+#include <QMap>
+#include <QString>
+
+namespace mu::engraving
+{
+    class Score;
+}
+namespace mu::iex::LRC
+{
+
+    //---------------------------------------------------------
+    //   ExportLRC
+    //---------------------------------------------------------
+    class ExportLRC
+    {
+    public:
+        static bool write(const QString &path, mu::engraving::Score *score);
+
+    private:
+        static void writeMetadata(QFile &file, mu::engraving::Score *score);
+
+        static QMap<qreal, QString> collectLyrics(mu::engraving::Score *score);
+        static void writeLyrics(QFile &file, const QMap<qreal, QString> &lyrics);
+        static QString formatTimestamp(qreal ms);
+    };
+}
+
+#endif // EXPORTLRC_H

--- a/src/importexport/midi/internal/midiexport/exportmidi.cpp
+++ b/src/importexport/midi/internal/midiexport/exportmidi.cpp
@@ -42,401 +42,458 @@
 
 using namespace mu::engraving;
 
-namespace mu::iex::midi {
-//---------------------------------------------------------
-//   writeHeader
-//---------------------------------------------------------
-
-void ExportMidi::writeHeader(const CompatMidiRendererInternal::Context& context)
+namespace mu::iex::midi
 {
-    if (m_midiFile.tracks().empty()) {
-        return;
-    }
-    MidiTrack& track  = m_midiFile.tracks().front();
+    //---------------------------------------------------------
+    //   writeHeader
+    //---------------------------------------------------------
 
-    //--------------------------------------------
-    //    write track names
-    //--------------------------------------------
+    void ExportMidi::writeHeader(const CompatMidiRendererInternal::Context &context)
+    {
+        if (m_midiFile.tracks().empty())
+        {
+            return;
+        }
+        MidiTrack &track = m_midiFile.tracks().front();
 
-    int staffIdx = 0;
-    for (auto& track1: m_midiFile.tracks()) {
-        Staff* staff  = m_score->staff(staffIdx);
+        //--------------------------------------------
+        //    write track names
+        //--------------------------------------------
 
-        muse::ByteArray partName = staff->partName().toUtf8();
-        size_t len = partName.size() + 1;
-        std::vector<unsigned char> data(partName.constData(), partName.constData() + len);
+        int staffIdx = 0;
+        for (auto &track1 : m_midiFile.tracks())
+        {
+            Staff *staff = m_score->staff(staffIdx);
 
-        MidiEvent ev;
-        ev.setType(ME_META);
-        ev.setMetaType(META_TRACK_NAME);
-        ev.setEData(std::move(data));
-        ev.setLen(static_cast<int>(len));
-
-        track1.insert(0, ev);
-
-        ++staffIdx;
-    }
-
-    //--------------------------------------------
-    //    write time signature
-    //--------------------------------------------
-
-    TimeSigMap* sigmap = m_score->sigmap();
-    for (const RepeatSegment* rs : m_score->repeatList()) {
-        int startTick  = rs->tick;
-        int endTick    = startTick + rs->len();
-        int tickOffset = rs->utick - rs->tick;
-
-        auto bs = sigmap->lower_bound(startTick);
-        auto es = sigmap->lower_bound(endTick);
-
-        for (auto is = bs; is != es; ++is) {
-            SigEvent se = is->second;
-            Fraction ts(se.timesig());
-            int n;
-            switch (ts.denominator()) {
-            case 1:  n = 0;
-                break;
-            case 2:  n = 1;
-                break;
-            case 4:  n = 2;
-                break;
-            case 8:  n = 3;
-                break;
-            case 16: n = 4;
-                break;
-            case 32: n = 5;
-                break;
-            default:
-                n = 2;
-                LOGD("ExportMidi: unknown time signature %s",
-                     qPrintable(ts.toString()));
-                break;
-            }
+            muse::ByteArray partName = staff->partName().toUtf8();
+            size_t len = partName.size() + 1;
+            std::vector<unsigned char> data(partName.constData(), partName.constData() + len);
 
             MidiEvent ev;
             ev.setType(ME_META);
-            ev.setMetaType(META_TIME_SIGNATURE);
-            ev.setLen(4);
-            ev.setEData({ static_cast<unsigned char>(ts.numerator()),
-                          static_cast<unsigned char>(n),
-                          24,
-                          8 });
-            track.insert(CompatMidiRender::tick(context, is->first + tickOffset), ev);
+            ev.setMetaType(META_TRACK_NAME);
+            ev.setEData(std::move(data));
+            ev.setLen(static_cast<int>(len));
+
+            track1.insert(0, ev);
+
+            ++staffIdx;
         }
-    }
 
-    //---------------------------------------------------
-    //    write key signatures
-    //    assume every staff corresponds to a midi track
-    //---------------------------------------------------
+        //--------------------------------------------
+        //    write time signature
+        //--------------------------------------------
 
-    staffIdx = 0;
-    for (auto& track1: m_midiFile.tracks()) {
-        Staff* staff  = m_score->staff(staffIdx);
-        KeyList* keys = staff->keyList();
-
-        bool initialKeySigFound = false;
-        for (const RepeatSegment* rs : m_score->repeatList()) {
-            int startTick  = rs->tick;
-            int endTick    = startTick + rs->len();
+        TimeSigMap *sigmap = m_score->sigmap();
+        for (const RepeatSegment *rs : m_score->repeatList())
+        {
+            int startTick = rs->tick;
+            int endTick = startTick + rs->len();
             int tickOffset = rs->utick - rs->tick;
 
-            auto sk = keys->lower_bound(startTick);
-            auto ek = keys->lower_bound(endTick);
+            auto bs = sigmap->lower_bound(startTick);
+            auto es = sigmap->lower_bound(endTick);
 
-            for (auto ik = sk; ik != ek; ++ik) {
+            for (auto is = bs; is != es; ++is)
+            {
+                SigEvent se = is->second;
+                Fraction ts(se.timesig());
+                int n;
+                switch (ts.denominator())
+                {
+                case 1:
+                    n = 0;
+                    break;
+                case 2:
+                    n = 1;
+                    break;
+                case 4:
+                    n = 2;
+                    break;
+                case 8:
+                    n = 3;
+                    break;
+                case 16:
+                    n = 4;
+                    break;
+                case 32:
+                    n = 5;
+                    break;
+                default:
+                    n = 2;
+                    LOGD("ExportMidi: unknown time signature %s",
+                         qPrintable(ts.toString()));
+                    break;
+                }
+
                 MidiEvent ev;
                 ev.setType(ME_META);
-                Key key = ik->second.concertKey();           // -7 -- +7
-                ev.setMetaType(META_KEY_SIGNATURE);
-                ev.setLen(2);
-                ev.setEData({ static_cast<unsigned char>(key), 0 /* major */ });
-                int tick = ik->first + tickOffset;
-                track1.insert(CompatMidiRender::tick(context, tick), ev);
-                if (tick == 0) {
-                    initialKeySigFound = true;
-                }
+                ev.setMetaType(META_TIME_SIGNATURE);
+                ev.setLen(4);
+                ev.setEData({static_cast<unsigned char>(ts.numerator()),
+                             static_cast<unsigned char>(n),
+                             24,
+                             8});
+                track.insert(CompatMidiRender::tick(context, is->first + tickOffset), ev);
             }
         }
 
-        // fall back write a default C keysig if no initial keysig found
-        if (!initialKeySigFound) {
-            MidiEvent ev;
-            ev.setType(ME_META);
-            ev.setMetaType(META_KEY_SIGNATURE);
-            ev.setLen(2);
-            ev.setEData({ 0 /* key */, 0 /* major */ });
-            track1.insert(0, ev);
-        }
+        //---------------------------------------------------
+        //    write key signatures
+        //    assume every staff corresponds to a midi track
+        //---------------------------------------------------
 
-        ++staffIdx;
-    }
+        staffIdx = 0;
+        for (auto &track1 : m_midiFile.tracks())
+        {
+            Staff *staff = m_score->staff(staffIdx);
+            KeyList *keys = staff->keyList();
 
-    //--------------------------------------------
-    //    write tempo changes from PauseMap
-    //     don't need to unwind or add pauses as this was done already
-    //--------------------------------------------
+            bool initialKeySigFound = false;
+            for (const RepeatSegment *rs : m_score->repeatList())
+            {
+                int startTick = rs->tick;
+                int endTick = startTick + rs->len();
+                int tickOffset = rs->utick - rs->tick;
 
-    if (!context.applyCaesuras) {
-        return;
-    }
+                auto sk = keys->lower_bound(startTick);
+                auto ek = keys->lower_bound(endTick);
 
-    const TempoMap* tempomap = context.pauseMap->tempomapWithPauses();
-    BeatsPerSecond tempoMultiplier = tempomap->tempoMultiplier();
-    for (auto it = tempomap->cbegin(); it != tempomap->cend(); ++it) {
-        MidiEvent ev;
-        ev.setType(ME_META);
-        //
-        // compute midi tempo: microseconds / quarter note
-        //
-        int tempo = lrint((1.0 / it->second.tempo.val * tempoMultiplier.val) * 1000000.0);
-
-        ev.setMetaType(META_TEMPO);
-        ev.setLen(3);
-        ev.setEData({ static_cast<unsigned char>(tempo >> 16),
-                      static_cast<unsigned char>(tempo >> 8),
-                      static_cast<unsigned char>(tempo) });
-        track.insert(it->first, ev);
-    }
-}
-
-//---------------------------------------------------------
-//  write
-//    export midi file
-//    return false on error
-//
-//    The 3rd and 4th versions of write create a temporary, uninitialized synth state
-//    so we can render the midi - it should fall back correctly to the defaults, with a warning.
-//    These should only be used for tests. When actually rendering midi as a user action,
-//    make sure to use the 1st and 2nd versions, passing the global musescore synth state
-//    from mscore->synthesizerState() as the synthState parameter.
-//---------------------------------------------------------
-
-bool ExportMidi::write(QIODevice* device, bool midiExpandRepeats, bool exportRPNs, const SynthesizerState& synthState)
-{
-    m_midiFile.setDivision(Constants::DIVISION);
-    m_midiFile.setFormat(1);
-    std::vector<MidiTrack>& tracks = m_midiFile.tracks();
-
-    for (size_t i = 0; i < m_score->nstaves(); ++i) {
-        tracks.push_back(MidiTrack());
-    }
-
-    EventsHolder events;
-    CompatMidiRendererInternal::Context context;
-    context.eachStringHasChannel = false;
-    context.instrumentsHaveEffects = false;
-    context.harmonyChannelSetting = CompatMidiRendererInternal::HarmonyChannelSetting::DEFAULT;
-    context.sndController = CompatMidiRender::getControllerForSnd(m_score, synthState.ccToUse());
-    context.useDefaultArticulations = false;
-    context.applyCaesuras = true;
-
-    CompatMidiRender::renderScore(m_score, events, context, midiExpandRepeats);
-
-    writeHeader(context);
-
-    staff_idx_t staffIdx = 0;
-    for (auto& track: tracks) {
-        Staff* staff = m_score->staff(staffIdx);
-        Part* part   = staff->part();
-
-        track.setOutPort(part->midiPort());
-        track.setOutChannel(part->midiChannel());
-
-        // Pass through the all instruments in the part
-        for (const auto& pair : part->instruments()) {
-            // Pass through the all channels of the instrument
-            // "normal", "pizzicato", "tremolo" for Strings,
-            // "normal", "mute" for Trumpet
-            for (const InstrChannel* instrChan : pair.second->channel()) {
-                const InstrChannel* ch = part->masterScore()->playbackChannel(instrChan);
-                char port    = part->masterScore()->midiPort(ch->channel());
-                char channel = part->masterScore()->midiChannel(ch->channel());
-
-                if (staff->isTop()) {
-                    track.insert(0, MidiEvent(ME_CONTROLLER, channel, CTRL_RESET_ALL_CTRL, 0));
-                    // We need this to get the correct pitch of bends
-                    // Hidden under preferences because some software
-                    // crashes when receiving RPNs: https://musescore.org/en/node/37431
-                    if (channel != 9 && exportRPNs) {
-                        // set pitch bend sensitivity to 12 semitones:
-                        track.insert(0, MidiEvent(ME_CONTROLLER, channel, CTRL_LRPN, 0));
-                        track.insert(0, MidiEvent(ME_CONTROLLER, channel, CTRL_HRPN, 0));
-                        track.insert(0, MidiEvent(ME_CONTROLLER, channel, CTRL_HDATA, 12));
-
-                        // reset fine tuning
-                        /*track.insert(0, MidiEvent(ME_CONTROLLER, channel, CTRL_LRPN, 1));
-                        track.insert(0, MidiEvent(ME_CONTROLLER, channel, CTRL_HRPN, 0));
-                        track.insert(0, MidiEvent(ME_CONTROLLER, channel, CTRL_HDATA, 64));*/
-
-                        // deactivate rpn
-                        track.insert(0, MidiEvent(ME_CONTROLLER, channel, CTRL_LRPN, 127));
-                        track.insert(0, MidiEvent(ME_CONTROLLER, channel, CTRL_HRPN, 127));
-                    }
-
-                    if (ch->program() != -1) {
-                        track.insert(0, MidiEvent(ME_CONTROLLER, channel, CTRL_PROGRAM, ch->program()));
-                    }
-                    track.insert(0, MidiEvent(ME_CONTROLLER, channel, CTRL_VOLUME, ch->volume()));
-                    track.insert(0, MidiEvent(ME_CONTROLLER, channel, CTRL_PANPOT, ch->pan()));
-                    track.insert(0, MidiEvent(ME_CONTROLLER, channel, CTRL_REVERB_SEND, ch->reverb()));
-                    track.insert(0, MidiEvent(ME_CONTROLLER, channel, CTRL_CHORUS_SEND, ch->chorus()));
-                }
-
-                // Export port to MIDI META event
-                if (track.outPort() >= 0 && track.outPort() <= 127) {
+                for (auto ik = sk; ik != ek; ++ik)
+                {
                     MidiEvent ev;
                     ev.setType(ME_META);
-                    ev.setMetaType(META_PORT_CHANGE);
-                    ev.setLen(1);
-                    ev.setEData({ static_cast<unsigned char>(track.outPort()) });
-                    track.insert(0, ev);
-                }
-
-                for (size_t e = 0; e < events.size(); ++e) {
-                    auto& multimap = events[e];
-                    for (auto& item : multimap) {
-                        const NPlayEvent& event = item.second;
-                        if (event.isMuted()) {
-                            continue;
-                        }
-                        if (event.discard() == staffIdx + 1 && event.velo() > 0) {
-                            // turn note off so we can restrike it in another track
-                            track.insert(CompatMidiRender::tick(context, item.first), MidiEvent(ME_NOTEON, channel,
-                                                                                                event.pitch(), 0));
-                        }
-
-                        staff_idx_t equivalentStaffIdx = staffIdx;
-                        for (Staff* st : m_score->masterScore()->staves()) {
-                            if (staff->id() == st->id()) {
-                                equivalentStaffIdx = st->idx();
-                            }
-                        }
-
-                        if (event.getOriginatingStaff() != equivalentStaffIdx) {
-                            continue;
-                        }
-
-                        if (event.discard() && event.velo() == 0) {
-                            // ignore noteoff but restrike noteon
-                            continue;
-                        }
-
-                        if (!exportRPNs && event.type() == ME_CONTROLLER && event.portamento()) {
-                            // ignore portamento control events if exportRPN isn't switched on
-                            continue;
-                        }
-
-                        char eventPort    = m_score->masterScore()->midiPort(event.channel());
-                        char eventChannel = m_score->masterScore()->midiChannel(event.channel());
-                        if (port != eventPort || channel != eventChannel) {
-                            continue;
-                        }
-
-                        if (event.type() == ME_NOTEON) {
-                            // use the note values instead of the event values if portamento is suppressed
-                            if (!exportRPNs && event.portamento()) {
-                                track.insert(CompatMidiRender::tick(context, item.first), MidiEvent(ME_NOTEON, channel,
-                                                                                                    event.note()->pitch(),
-                                                                                                    event.velo()));
-                            } else {
-                                track.insert(CompatMidiRender::tick(context, item.first), MidiEvent(ME_NOTEON, channel,
-                                                                                                    event.pitch(), event.velo()));
-                            }
-                        } else if (event.type() == ME_CONTROLLER) {
-                            track.insert(CompatMidiRender::tick(context, item.first), MidiEvent(ME_CONTROLLER, channel,
-                                                                                                event.controller(),
-                                                                                                event.value()));
-                        } else if (event.type() == ME_PITCHBEND) {
-                            track.insert(CompatMidiRender::tick(context, item.first), MidiEvent(ME_PITCHBEND, channel,
-                                                                                                event.dataA(), event.dataB()));
-                        } else {
-                            LOGD("writeMidi: unknown midi event 0x%02x", event.type());
-                        }
+                    Key key = ik->second.concertKey(); // -7 -- +7
+                    ev.setMetaType(META_KEY_SIGNATURE);
+                    ev.setLen(2);
+                    ev.setEData({static_cast<unsigned char>(key), 0 /* major */});
+                    int tick = ik->first + tickOffset;
+                    track1.insert(CompatMidiRender::tick(context, tick), ev);
+                    if (tick == 0)
+                    {
+                        initialKeySigFound = true;
                     }
                 }
             }
+
+            // fall back write a default C keysig if no initial keysig found
+            if (!initialKeySigFound)
+            {
+                MidiEvent ev;
+                ev.setType(ME_META);
+                ev.setMetaType(META_KEY_SIGNATURE);
+                ev.setLen(2);
+                ev.setEData({0 /* key */, 0 /* major */});
+                track1.insert(0, ev);
+            }
+
+            ++staffIdx;
         }
 
-        // Export lyrics and RehearsalMarks as Meta events
-        for (const RepeatSegment* rs : m_score->repeatList()) {
-            int startTick  = rs->tick;
-            int endTick    = startTick + rs->len();
-            int tickOffset = rs->utick - rs->tick;
+        //--------------------------------------------
+        //    write tempo changes from PauseMap
+        //     don't need to unwind or add pauses as this was done already
+        //--------------------------------------------
 
-            // export Lyrics
-            SegmentType st = SegmentType::ChordRest;
-            for (Segment* seg = rs->firstMeasure()->first(st); seg && seg->tick().ticks() < endTick; seg = seg->next1(st)) {
-                for (track_idx_t i = part->startTrack(); i < part->endTrack(); ++i) {
-                    ChordRest* cr = toChordRest(seg->element(i));
-                    if (cr) {
-                        for (const auto& lyric : cr->lyrics()) {
-                            muse::ByteArray lyricText = lyric->plainText().toUtf8();
-                            size_t len = lyricText.size() + 1;
-                            std::vector<unsigned char> data(lyricText.constData(), lyricText.constData() + len);
-
-                            MidiEvent ev;
-                            ev.setType(ME_META);
-                            ev.setMetaType(META_LYRIC);
-                            ev.setEData(std::move(data));
-                            ev.setLen(static_cast<int>(len));
-
-                            int tick = cr->tick().ticks() + tickOffset;
-                            track.insert(CompatMidiRender::tick(context, tick), ev);
-                        }
-                    }
-                }
-            }
-
-            // export RehearsalMarks only for first track
-            if (staffIdx == 0) {
-                for (Segment* seg = rs->firstMeasure()->first(Segment::CHORD_REST_OR_TIME_TICK_TYPE);
-                     seg && seg->tick().ticks() < endTick;
-                     seg = seg->next1(Segment::CHORD_REST_OR_TIME_TICK_TYPE)) {
-                    for (EngravingItem* e : seg->annotations()) {
-                        if (e->isRehearsalMark()) {
-                            RehearsalMark* r = toRehearsalMark(e);
-                            muse::ByteArray rText = r->plainText().toUtf8();
-                            size_t len = rText.size() + 1;
-                            std::vector<unsigned char> data(rText.constData(), rText.constData() + len);
-
-                            MidiEvent ev;
-                            ev.setType(ME_META);
-                            ev.setMetaType(META_MARKER);
-                            ev.setEData(std::move(data));
-                            ev.setLen(static_cast<int>(len));
-
-                            int tick = r->segment()->tick().ticks() + tickOffset;
-                            track.insert(CompatMidiRender::tick(context, tick), ev);
-                        }
-                    }
-                }
-            }
+        if (!context.applyCaesuras)
+        {
+            return;
         }
-        ++staffIdx;
+
+        const TempoMap *tempomap = context.pauseMap->tempomapWithPauses();
+        BeatsPerSecond tempoMultiplier = tempomap->tempoMultiplier();
+        for (auto it = tempomap->cbegin(); it != tempomap->cend(); ++it)
+        {
+            MidiEvent ev;
+            ev.setType(ME_META);
+            //
+            // compute midi tempo: microseconds / quarter note
+            //
+            int tempo = lrint((1.0 / it->second.tempo.val * tempoMultiplier.val) * 1000000.0);
+
+            ev.setMetaType(META_TEMPO);
+            ev.setLen(3);
+            ev.setEData({static_cast<unsigned char>(tempo >> 16),
+                         static_cast<unsigned char>(tempo >> 8),
+                         static_cast<unsigned char>(tempo)});
+            track.insert(it->first, ev);
+        }
     }
-    return !m_midiFile.write(device);
-}
 
-bool ExportMidi::write(const QString& name, bool midiExpandRepeats, bool exportRPNs, const SynthesizerState& synthState)
-{
-    m_file.setFileName(name);
-    if (!m_file.open(QIODevice::WriteOnly)) {
-        return false;
+    //---------------------------------------------------------
+    //  write
+    //    export midi file
+    //    return false on error
+    //
+    //    The 3rd and 4th versions of write create a temporary, uninitialized synth state
+    //    so we can render the midi - it should fall back correctly to the defaults, with a warning.
+    //    These should only be used for tests. When actually rendering midi as a user action,
+    //    make sure to use the 1st and 2nd versions, passing the global musescore synth state
+    //    from mscore->synthesizerState() as the synthState parameter.
+    //---------------------------------------------------------
+
+    bool ExportMidi::write(QIODevice *device, bool midiExpandRepeats, bool exportRPNs, const SynthesizerState &synthState)
+    {
+        m_midiFile.setDivision(Constants::DIVISION);
+        m_midiFile.setFormat(1);
+        std::vector<MidiTrack> &tracks = m_midiFile.tracks();
+
+        for (size_t i = 0; i < m_score->nstaves(); ++i)
+        {
+            tracks.push_back(MidiTrack());
+        }
+
+        EventsHolder events;
+        CompatMidiRendererInternal::Context context;
+        context.eachStringHasChannel = false;
+        context.instrumentsHaveEffects = false;
+        context.harmonyChannelSetting = CompatMidiRendererInternal::HarmonyChannelSetting::DEFAULT;
+        context.sndController = CompatMidiRender::getControllerForSnd(m_score, synthState.ccToUse());
+        context.useDefaultArticulations = false;
+        context.applyCaesuras = true;
+
+        CompatMidiRender::renderScore(m_score, events, context, midiExpandRepeats);
+
+        writeHeader(context);
+
+        staff_idx_t staffIdx = 0;
+        for (auto &track : tracks)
+        {
+            Staff *staff = m_score->staff(staffIdx);
+            Part *part = staff->part();
+
+            track.setOutPort(part->midiPort());
+            track.setOutChannel(part->midiChannel());
+
+            // Pass through the all instruments in the part
+            for (const auto &pair : part->instruments())
+            {
+                // Pass through the all channels of the instrument
+                // "normal", "pizzicato", "tremolo" for Strings,
+                // "normal", "mute" for Trumpet
+                for (const InstrChannel *instrChan : pair.second->channel())
+                {
+                    const InstrChannel *ch = part->masterScore()->playbackChannel(instrChan);
+                    char port = part->masterScore()->midiPort(ch->channel());
+                    char channel = part->masterScore()->midiChannel(ch->channel());
+
+                    if (staff->isTop())
+                    {
+                        track.insert(0, MidiEvent(ME_CONTROLLER, channel, CTRL_RESET_ALL_CTRL, 0));
+                        // We need this to get the correct pitch of bends
+                        // Hidden under preferences because some software
+                        // crashes when receiving RPNs: https://musescore.org/en/node/37431
+                        if (channel != 9 && exportRPNs)
+                        {
+                            // set pitch bend sensitivity to 12 semitones:
+                            track.insert(0, MidiEvent(ME_CONTROLLER, channel, CTRL_LRPN, 0));
+                            track.insert(0, MidiEvent(ME_CONTROLLER, channel, CTRL_HRPN, 0));
+                            track.insert(0, MidiEvent(ME_CONTROLLER, channel, CTRL_HDATA, 12));
+
+                            // reset fine tuning
+                            /*track.insert(0, MidiEvent(ME_CONTROLLER, channel, CTRL_LRPN, 1));
+                            track.insert(0, MidiEvent(ME_CONTROLLER, channel, CTRL_HRPN, 0));
+                            track.insert(0, MidiEvent(ME_CONTROLLER, channel, CTRL_HDATA, 64));*/
+
+                            // deactivate rpn
+                            track.insert(0, MidiEvent(ME_CONTROLLER, channel, CTRL_LRPN, 127));
+                            track.insert(0, MidiEvent(ME_CONTROLLER, channel, CTRL_HRPN, 127));
+                        }
+
+                        if (ch->program() != -1)
+                        {
+                            track.insert(0, MidiEvent(ME_CONTROLLER, channel, CTRL_PROGRAM, ch->program()));
+                        }
+                        track.insert(0, MidiEvent(ME_CONTROLLER, channel, CTRL_VOLUME, ch->volume()));
+                        track.insert(0, MidiEvent(ME_CONTROLLER, channel, CTRL_PANPOT, ch->pan()));
+                        track.insert(0, MidiEvent(ME_CONTROLLER, channel, CTRL_REVERB_SEND, ch->reverb()));
+                        track.insert(0, MidiEvent(ME_CONTROLLER, channel, CTRL_CHORUS_SEND, ch->chorus()));
+                    }
+
+                    // Export port to MIDI META event
+                    if (track.outPort() >= 0 && track.outPort() <= 127)
+                    {
+                        MidiEvent ev;
+                        ev.setType(ME_META);
+                        ev.setMetaType(META_PORT_CHANGE);
+                        ev.setLen(1);
+                        ev.setEData({static_cast<unsigned char>(track.outPort())});
+                        track.insert(0, ev);
+                    }
+
+                    for (size_t e = 0; e < events.size(); ++e)
+                    {
+                        auto &multimap = events[e];
+                        for (auto &item : multimap)
+                        {
+                            const NPlayEvent &event = item.second;
+                            if (event.isMuted())
+                            {
+                                continue;
+                            }
+                            if (event.discard() == staffIdx + 1 && event.velo() > 0)
+                            {
+                                // turn note off so we can restrike it in another track
+                                track.insert(CompatMidiRender::tick(context, item.first), MidiEvent(ME_NOTEON, channel,
+                                                                                                    event.pitch(), 0));
+                            }
+
+                            staff_idx_t equivalentStaffIdx = staffIdx;
+                            for (Staff *st : m_score->masterScore()->staves())
+                            {
+                                if (staff->id() == st->id())
+                                {
+                                    equivalentStaffIdx = st->idx();
+                                }
+                            }
+
+                            if (event.getOriginatingStaff() != equivalentStaffIdx)
+                            {
+                                continue;
+                            }
+
+                            if (event.discard() && event.velo() == 0)
+                            {
+                                // ignore noteoff but restrike noteon
+                                continue;
+                            }
+
+                            if (!exportRPNs && event.type() == ME_CONTROLLER && event.portamento())
+                            {
+                                // ignore portamento control events if exportRPN isn't switched on
+                                continue;
+                            }
+
+                            char eventPort = m_score->masterScore()->midiPort(event.channel());
+                            char eventChannel = m_score->masterScore()->midiChannel(event.channel());
+                            if (port != eventPort || channel != eventChannel)
+                            {
+                                continue;
+                            }
+
+                            if (event.type() == ME_NOTEON)
+                            {
+                                // use the note values instead of the event values if portamento is suppressed
+                                if (!exportRPNs && event.portamento())
+                                {
+                                    track.insert(CompatMidiRender::tick(context, item.first), MidiEvent(ME_NOTEON, channel,
+                                                                                                        event.note()->pitch(),
+                                                                                                        event.velo()));
+                                }
+                                else
+                                {
+                                    track.insert(CompatMidiRender::tick(context, item.first), MidiEvent(ME_NOTEON, channel,
+                                                                                                        event.pitch(), event.velo()));
+                                }
+                            }
+                            else if (event.type() == ME_CONTROLLER)
+                            {
+                                track.insert(CompatMidiRender::tick(context, item.first), MidiEvent(ME_CONTROLLER, channel,
+                                                                                                    event.controller(),
+                                                                                                    event.value()));
+                            }
+                            else if (event.type() == ME_PITCHBEND)
+                            {
+                                track.insert(CompatMidiRender::tick(context, item.first), MidiEvent(ME_PITCHBEND, channel,
+                                                                                                    event.dataA(), event.dataB()));
+                            }
+                            else
+                            {
+                                LOGD("writeMidi: unknown midi event 0x%02x", event.type());
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Export lyrics and RehearsalMarks as Meta events
+            for (const RepeatSegment *rs : m_score->repeatList())
+            {
+                int startTick = rs->tick;
+                int endTick = startTick + rs->len();
+                int tickOffset = rs->utick - rs->tick;
+
+                // export Lyrics
+                SegmentType st = SegmentType::ChordRest;
+                for (Segment *seg = rs->firstMeasure()->first(st); seg && seg->tick().ticks() < endTick; seg = seg->next1(st))
+                {
+                    for (track_idx_t i = part->startTrack(); i < part->endTrack(); ++i)
+                    {
+                        ChordRest *cr = toChordRest(seg->element(i));
+                        if (cr)
+                        {
+                            for (const auto &lyric : cr->lyrics())
+                            {
+                                muse::ByteArray lyricText = lyric->plainText().toUtf8();
+                                size_t len = lyricText.size() + 1;
+                                std::vector<unsigned char> data(lyricText.constData(), lyricText.constData() + len);
+
+                                MidiEvent ev;
+                                ev.setType(ME_META);
+                                ev.setMetaType(META_LYRIC);
+                                ev.setEData(std::move(data));
+                                ev.setLen(static_cast<int>(len));
+
+                                int tick = cr->tick().ticks() + tickOffset;
+                                track.insert(CompatMidiRender::tick(context, tick), ev);
+                            }
+                        }
+                    }
+                }
+
+                // export RehearsalMarks only for first track
+                if (staffIdx == 0)
+                {
+                    for (Segment *seg = rs->firstMeasure()->first(Segment::CHORD_REST_OR_TIME_TICK_TYPE);
+                         seg && seg->tick().ticks() < endTick;
+                         seg = seg->next1(Segment::CHORD_REST_OR_TIME_TICK_TYPE))
+                    {
+                        for (EngravingItem *e : seg->annotations())
+                        {
+                            if (e->isRehearsalMark())
+                            {
+                                RehearsalMark *r = toRehearsalMark(e);
+                                muse::ByteArray rText = r->plainText().toUtf8();
+                                size_t len = rText.size() + 1;
+                                std::vector<unsigned char> data(rText.constData(), rText.constData() + len);
+
+                                MidiEvent ev;
+                                ev.setType(ME_META);
+                                ev.setMetaType(META_MARKER);
+                                ev.setEData(std::move(data));
+                                ev.setLen(static_cast<int>(len));
+
+                                int tick = r->segment()->tick().ticks() + tickOffset;
+                                track.insert(CompatMidiRender::tick(context, tick), ev);
+                            }
+                        }
+                    }
+                }
+            }
+            ++staffIdx;
+        }
+        return !m_midiFile.write(device);
     }
-    return write(&m_file, midiExpandRepeats, exportRPNs, synthState);
-}
 
-bool ExportMidi::write(QIODevice* device, bool midiExpandRepeats, bool exportRPNs)
-{
-    SynthesizerState ss;
-    return write(device, midiExpandRepeats, exportRPNs, ss);
-}
+    bool ExportMidi::write(const QString &name, bool midiExpandRepeats, bool exportRPNs, const SynthesizerState &synthState)
+    {
+        m_file.setFileName(name);
+        if (!m_file.open(QIODevice::WriteOnly))
+        {
+            return false;
+        }
+        return write(&m_file, midiExpandRepeats, exportRPNs, synthState);
+    }
 
-bool ExportMidi::write(const QString& name, bool midiExpandRepeats, bool exportRPNs)
-{
-    SynthesizerState ss;
-    return write(name, midiExpandRepeats, exportRPNs, ss);
-}
+    bool ExportMidi::write(QIODevice *device, bool midiExpandRepeats, bool exportRPNs)
+    {
+        SynthesizerState ss;
+        return write(device, midiExpandRepeats, exportRPNs, ss);
+    }
+
+    bool ExportMidi::write(const QString &name, bool midiExpandRepeats, bool exportRPNs)
+    {
+        SynthesizerState ss;
+        return write(name, midiExpandRepeats, exportRPNs, ss);
+    }
 }

--- a/src/importexport/midi/internal/midiexport/exportmidi.h
+++ b/src/importexport/midi/internal/midiexport/exportmidi.h
@@ -29,32 +29,34 @@
 #include "engraving/compat/midi/pausemap.h"
 #include "engraving/compat/midi/compatmidirenderinternal.h"
 
-namespace mu::engraving {
-class Score;
-class TempoMap;
-class SynthesizerState;
+namespace mu::engraving
+{
+    class Score;
+    class TempoMap;
+    class SynthesizerState;
 }
 
-namespace mu::iex::midi {
-//---------------------------------------------------------
-//   ExportMidi
-//---------------------------------------------------------
-
-class ExportMidi
+namespace mu::iex::midi
 {
-public:
-    ExportMidi(engraving::Score* s) { m_score = s; }
-    bool write(const QString& name, bool midiExpandRepeats, bool exportRPNs);
-    bool write(QIODevice* device, bool midiExpandRepeats, bool exportRPNs);
-    bool write(const QString& name, bool midiExpandRepeats, bool exportRPNs, const engraving::SynthesizerState& synthState);
-    bool write(QIODevice* device, bool midiExpandRepeats, bool exportRPNs, const engraving::SynthesizerState& synthState);
+    //---------------------------------------------------------
+    //   ExportMidi
+    //---------------------------------------------------------
 
-private:
-    void writeHeader(const engraving::CompatMidiRendererInternal::Context& context);
+    class ExportMidi
+    {
+    public:
+        ExportMidi(engraving::Score *s) { m_score = s; }
+        bool write(const QString &name, bool midiExpandRepeats, bool exportRPNs);
+        bool write(QIODevice *device, bool midiExpandRepeats, bool exportRPNs);
+        bool write(const QString &name, bool midiExpandRepeats, bool exportRPNs, const engraving::SynthesizerState &synthState);
+        bool write(QIODevice *device, bool midiExpandRepeats, bool exportRPNs, const engraving::SynthesizerState &synthState);
 
-    QFile m_file;
-    MidiFile m_midiFile;
-    engraving::Score* m_score = nullptr;
-};
+    private:
+        void writeHeader(const engraving::CompatMidiRendererInternal::Context &context);
+
+        QFile m_file;
+        MidiFile m_midiFile;
+        engraving::Score *m_score = nullptr;
+    };
 }
 #endif // EXPORTMIDI_H

--- a/src/importexport/midi/internal/notationmidireader.cpp
+++ b/src/importexport/midi/internal/notationmidireader.cpp
@@ -27,11 +27,12 @@
 using namespace mu::iex::midi;
 using namespace mu::engraving;
 
-namespace mu::iex::midi {
-extern Err importMidi(MasterScore*, const QString& name);
+namespace mu::iex::midi
+{
+    extern Err importMidi(MasterScore *, const QString &name);
 }
 
-muse::Ret NotationMidiReader::read(MasterScore* score, const muse::io::path_t& path, const Options&)
+muse::Ret NotationMidiReader::read(MasterScore *score, const muse::io::path_t &path, const Options &)
 {
     Err err = importMidi(score, path.toQString());
     return make_ret(err, path);

--- a/src/project/inotationwriter.h
+++ b/src/project/inotationwriter.h
@@ -32,40 +32,42 @@
 #include "global/progress.h"
 #include "notation/inotation.h"
 
-namespace mu::project {
-class INotationWriter
+namespace mu::project
 {
-public:
+    class INotationWriter
+    {
+    public:
+        virtual ~INotationWriter() = default;
 
-    virtual ~INotationWriter() = default;
+        enum class UnitType
+        {
+            PER_PAGE,
+            PER_PART,
+            MULTI_PART
+        };
 
-    enum class UnitType {
-        PER_PAGE,
-        PER_PART,
-        MULTI_PART
+        enum class OptionKey
+        {
+            UNIT_TYPE,
+            PAGE_NUMBER,
+            TRANSPARENT_BACKGROUND,
+            BEATS_COLORS
+        };
+
+        using Options = std::map<OptionKey, muse::Val>;
+
+        virtual std::vector<UnitType> supportedUnitTypes() const = 0;
+        virtual bool supportsUnitType(UnitType unitType) const = 0;
+
+        virtual muse::Ret write(notation::INotationPtr notation, muse::io::IODevice &device, const Options &options = Options()) = 0;
+        virtual muse::Ret writeList(const notation::INotationPtrList &notations, muse::io::IODevice &device,
+                                    const Options &options = Options()) = 0;
+
+        virtual muse::Progress *progress() { return nullptr; }
+        virtual void abort() {}
     };
 
-    enum class OptionKey {
-        UNIT_TYPE,
-        PAGE_NUMBER,
-        TRANSPARENT_BACKGROUND,
-        BEATS_COLORS
-    };
-
-    using Options = std::map<OptionKey, muse::Val>;
-
-    virtual std::vector<UnitType> supportedUnitTypes() const = 0;
-    virtual bool supportsUnitType(UnitType unitType) const = 0;
-
-    virtual muse::Ret write(notation::INotationPtr notation, muse::io::IODevice& device, const Options& options = Options()) = 0;
-    virtual muse::Ret writeList(const notation::INotationPtrList& notations, muse::io::IODevice& device,
-                                const Options& options = Options()) = 0;
-
-    virtual muse::Progress* progress() { return nullptr; }
-    virtual void abort() {}
-};
-
-using INotationWriterPtr = std::shared_ptr<INotationWriter>;
+    using INotationWriterPtr = std::shared_ptr<INotationWriter>;
 }
 
 #endif // MU_PROJECT_INOTATIONWRITER_H

--- a/src/project/internal/exporttype.cpp
+++ b/src/project/internal/exporttype.cpp
@@ -33,20 +33,19 @@ ExportTypeList::ExportTypeList(std::initializer_list<ExportType> args)
 {
 }
 
-bool ExportTypeList::contains(const QString& id) const
+bool ExportTypeList::contains(const QString &id) const
 {
-    return std::find_if(cbegin(), cend(), [id](const ExportType& type) {
-        return type.id == id;
-    }) != cend();
+    return std::find_if(cbegin(), cend(), [id](const ExportType &type)
+                        { return type.id == id; }) != cend();
 }
 
-const ExportType& ExportTypeList::getById(const QString& id) const
+const ExportType &ExportTypeList::getById(const QString &id) const
 {
-    auto it = std::find_if(cbegin(), cend(), [id](const ExportType& type) {
-        return type.id == id;
-    });
+    auto it = std::find_if(cbegin(), cend(), [id](const ExportType &type)
+                           { return type.id == id; });
 
-    if (it != cend()) {
+    if (it != cend())
+    {
         return *it;
     }
 
@@ -57,7 +56,8 @@ const ExportType& ExportTypeList::getById(const QString& id) const
 QVariantList ExportTypeList::toVariantList() const
 {
     QVariantList result;
-    for (const ExportType& type : *this) {
+    for (const ExportType &type : *this)
+    {
         result << type.toMap();
     }
     return result;
@@ -66,21 +66,21 @@ QVariantList ExportTypeList::toVariantList() const
 QVariantMap ExportType::toMap() const
 {
     return {
-        { "id", id },
-        { "name", name },
-        { "subtypes", subtypes.toVariantList() },
-        { "settingsPagePath", settingsPagePath }
-    };
+        {"id", id},
+        {"name", name},
+        {"subtypes", subtypes.toVariantList()},
+        {"settingsPagePath", settingsPagePath}};
 }
 
 std::vector<std::string> ExportType::filter() const
 {
     QStringList filterSuffixes;
-    for (const QString& suffix : suffixes) {
+    for (const QString &suffix : suffixes)
+    {
         filterSuffixes << QString("*.%1").arg(suffix);
     }
 
-    return { QString("%1 (%2)").arg(filterName, filterSuffixes.join(" ")).toStdString() };
+    return {QString("%1 (%2)").arg(filterName, filterSuffixes.join(" ")).toStdString()};
 }
 
 bool ExportType::hasSubtypes() const
@@ -88,12 +88,13 @@ bool ExportType::hasSubtypes() const
     return !subtypes.isEmpty();
 }
 
-ExportType ExportType::makeWithSuffixes(const QStringList& suffixes, const QString& name, const QString& filterName,
-                                        const QString& settingsPagePath)
+ExportType ExportType::makeWithSuffixes(const QStringList &suffixes, const QString &name, const QString &filterName,
+                                        const QString &settingsPagePath)
 {
     ExportType type;
 
-    if (suffixes.isEmpty()) {
+    if (suffixes.isEmpty())
+    {
         return type;
     }
 
@@ -105,11 +106,12 @@ ExportType ExportType::makeWithSuffixes(const QStringList& suffixes, const QStri
     return type;
 }
 
-ExportType ExportType::makeWithSubtypes(const ExportTypeList& subtypes, const QString& name)
+ExportType ExportType::makeWithSubtypes(const ExportTypeList &subtypes, const QString &name)
 {
     ExportType type;
 
-    if (subtypes.isEmpty()) {
+    if (subtypes.isEmpty())
+    {
         return type;
     }
 

--- a/src/project/internal/notationreadersregister.h
+++ b/src/project/internal/notationreadersregister.h
@@ -26,16 +26,17 @@
 
 #include "../inotationreadersregister.h"
 
-namespace mu::project {
-class NotationReadersRegister : public INotationReadersRegister
+namespace mu::project
 {
-public:
-    void reg(const std::vector<std::string>& suffixes, INotationReaderPtr reader) override;
-    INotationReaderPtr reader(const std::string& suffix) override;
+    class NotationReadersRegister : public INotationReadersRegister
+    {
+    public:
+        void reg(const std::vector<std::string> &suffixes, INotationReaderPtr reader) override;
+        INotationReaderPtr reader(const std::string &suffix) override;
 
-private:
-    std::map<std::string, INotationReaderPtr> m_readers;
-};
+    private:
+        std::map<std::string, INotationReaderPtr> m_readers;
+    };
 }
 
 #endif // MU_PROJECT_NOTATIONREADERSREGISTER_H

--- a/src/project/internal/notationwritersregister.cpp
+++ b/src/project/internal/notationwritersregister.cpp
@@ -21,20 +21,23 @@
  */
 
 #include "notationwritersregister.h"
+#include "importexport/lyrics/exportlrc.h"
 
 using namespace mu::project;
 
-void NotationWritersRegister::reg(const std::vector<std::string>& suffixes, INotationWriterPtr writer)
+void NotationWritersRegister::reg(const std::vector<std::string> &suffixes, INotationWriterPtr writer)
 {
-    for (const std::string& suffix : suffixes) {
-        m_writers.insert({ suffix, writer });
+    for (const std::string &suffix : suffixes)
+    {
+        m_writers.insert({suffix, writer});
     }
 }
 
-INotationWriterPtr NotationWritersRegister::writer(const std::string& suffix) const
+INotationWriterPtr NotationWritersRegister::writer(const std::string &suffix) const
 {
     auto it = m_writers.find(suffix);
-    if (it != m_writers.end()) {
+    if (it != m_writers.end())
+    {
         return it->second;
     }
 

--- a/src/project/view/exportdialogmodel.cpp
+++ b/src/project/view/exportdialogmodel.cpp
@@ -36,79 +36,83 @@ using UnitType = INotationWriter::UnitType;
 
 static const UnitType DEFAULT_EXPORT_UNITTYPE = UnitType::PER_PART;
 
-ExportDialogModel::ExportDialogModel(QObject* parent)
-    : QAbstractListModel(parent)
-    , m_selectionModel(new QItemSelectionModel(this))
-    , m_selectedUnitType(DEFAULT_EXPORT_UNITTYPE)
+ExportDialogModel::ExportDialogModel(QObject *parent)
+    : QAbstractListModel(parent), m_selectionModel(new QItemSelectionModel(this)), m_selectedUnitType(DEFAULT_EXPORT_UNITTYPE)
 {
     connect(m_selectionModel, &QItemSelectionModel::selectionChanged, this, &ExportDialogModel::selectionChanged);
 
-    ExportTypeList musicXmlTypes {
-        ExportType::makeWithSuffixes({ "mxl" },
+    ExportTypeList musicXmlTypes{
+        ExportType::makeWithSuffixes({"mxl"},
                                      muse::qtrc("project/export", "Compressed") + " (*.mxl)",
                                      muse::qtrc("project/export", "Compressed MusicXML files"),
                                      "MusicXmlSettingsPage.qml"),
-        ExportType::makeWithSuffixes({ "musicxml" },
+        ExportType::makeWithSuffixes({"musicxml"},
                                      muse::qtrc("project/export", "Uncompressed") + " (*.musicxml)",
                                      muse::qtrc("project/export", "Uncompressed MusicXML files"),
                                      "MusicXmlSettingsPage.qml"),
-        ExportType::makeWithSuffixes({ "xml" },
+        ExportType::makeWithSuffixes({"xml"},
                                      muse::qtrc("project/export", "Uncompressed (outdated)") + " (*.xml)",
                                      muse::qtrc("project/export", "Uncompressed MusicXML files"),
                                      "MusicXmlSettingsPage.qml"),
     };
 
     m_exportTypeList = {
-        ExportType::makeWithSuffixes({ "pdf" },
+        ExportType::makeWithSuffixes({"lrc"},
+                                     muse::qtrc("project/export", "LRC File"),
+                                     muse::qtrc("project/export", "LRC files"),
+                                     ""), // No settings page needed
+        ExportType::makeWithSuffixes({"pdf"},
                                      muse::qtrc("project/export", "PDF file"),
                                      muse::qtrc("project/export", "PDF files"),
                                      "PdfSettingsPage.qml"),
-        ExportType::makeWithSuffixes({ "png" },
+        ExportType::makeWithSuffixes({"png"},
                                      muse::qtrc("project/export", "PNG images"),
                                      muse::qtrc("project/export", "PNG images"),
                                      "PngSettingsPage.qml"),
-        ExportType::makeWithSuffixes({ "svg" },
+        ExportType::makeWithSuffixes({"svg"},
                                      muse::qtrc("project/export", "SVG images"),
                                      muse::qtrc("project/export", "SVG images"),
                                      "SvgSettingsPage.qml"),
-        ExportType::makeWithSuffixes({ "mp3" },
+        ExportType::makeWithSuffixes({"mp3"},
                                      muse::qtrc("project/export", "MP3 audio"),
                                      muse::qtrc("project/export", "MP3 audio files"),
                                      "Mp3SettingsPage.qml"),
-        ExportType::makeWithSuffixes({ "wav" },
+        ExportType::makeWithSuffixes({"wav"},
                                      muse::qtrc("project/export", "WAV audio"),
                                      muse::qtrc("project/export", "WAV audio files"),
                                      "AudioSettingsPage.qml"),
-        ExportType::makeWithSuffixes({ "ogg" },
+        ExportType::makeWithSuffixes({"ogg"},
                                      muse::qtrc("project/export", "OGG audio"),
                                      muse::qtrc("project/export", "OGG audio files"),
                                      "OggSettingsPage.qml"),
-        ExportType::makeWithSuffixes({ "flac" },
+        ExportType::makeWithSuffixes({"flac"},
                                      muse::qtrc("project/export", "FLAC audio"),
                                      muse::qtrc("project/export", "FLAC audio files"),
                                      "AudioSettingsPage.qml"),
-        ExportType::makeWithSuffixes({ "mid", "midi", "kar" },
+        ExportType::makeWithSuffixes({"mid", "midi", "kar"},
                                      muse::qtrc("project/export", "MIDI file"),
                                      muse::qtrc("project/export", "MIDI files"),
                                      "MidiSettingsPage.qml"),
         ExportType::makeWithSubtypes(musicXmlTypes,
                                      muse::qtrc("project/export", "MusicXML")),
-        ExportType::makeWithSuffixes({ "brf" },
+        ExportType::makeWithSuffixes({"brf"},
                                      //: Meaning like "measure-over-measure", but called "bar-over-bar"
                                      //: even in US English. Not to be confused with "bar-by-bar" format.
                                      //: See https://musescore.org/en/handbook/4/file-export#Score_formats
                                      muse::qtrc("project/export", "Braille (basic bar-over-bar)"),
                                      muse::qtrc("project/export", "Braille files")),
-        ExportType::makeWithSuffixes({ "mei" },
+        ExportType::makeWithSuffixes({"mei"},
                                      muse::qtrc("project/export", "MEI"),
                                      muse::qtrc("project/export", "MEI files"),
-                                     "MeiSettingsPage.qml")
-    };
+                                     "MeiSettingsPage.qml")};
 
     ExportInfo info = exportProjectScenario()->exportInfo();
-    if (info.id == "") {
+    if (info.id == "")
+    {
         setExportType(m_exportTypeList.front());
-    } else {
+    }
+    else
+    {
         selectExportTypeById(info.id);
     }
     m_exportPath = info.exportPath;
@@ -127,7 +131,8 @@ void ExportDialogModel::load()
     beginResetModel();
 
     IMasterNotationPtr masterNotation = this->masterNotation();
-    if (!masterNotation) {
+    if (!masterNotation)
+    {
         endResetModel();
         return;
     }
@@ -140,7 +145,8 @@ void ExportDialogModel::load()
 
     masterNotation->sortExcerpts(excerpts);
 
-    for (const IExcerptNotationPtr& excerpt : excerpts) {
+    for (const IExcerptNotationPtr &excerpt : excerpts)
+    {
         m_notations << excerpt->notation();
     }
 
@@ -150,15 +156,17 @@ void ExportDialogModel::load()
     selectSavedNotations();
 }
 
-QVariant ExportDialogModel::data(const QModelIndex& index, int role) const
+QVariant ExportDialogModel::data(const QModelIndex &index, int role) const
 {
-    if (!index.isValid()) {
+    if (!index.isValid())
+    {
         return QVariant();
     }
 
     INotationPtr notation = m_notations[index.row()];
 
-    switch (role) {
+    switch (role)
+    {
     case RoleTitle:
         return notation->name();
     case RoleIsSelected:
@@ -170,44 +178,46 @@ QVariant ExportDialogModel::data(const QModelIndex& index, int role) const
     return QVariant();
 }
 
-int ExportDialogModel::rowCount(const QModelIndex&) const
+int ExportDialogModel::rowCount(const QModelIndex &) const
 {
     return m_notations.size();
 }
 
 QHash<int, QByteArray> ExportDialogModel::roleNames() const
 {
-    static const QHash<int, QByteArray> roles {
-        { RoleTitle, "title" },
-        { RoleIsSelected, "isSelected" },
-        { RoleIsMain, "isMain" }
-    };
+    static const QHash<int, QByteArray> roles{
+        {RoleTitle, "title"},
+        {RoleIsSelected, "isSelected"},
+        {RoleIsMain, "isMain"}};
 
     return roles;
 }
 
 void ExportDialogModel::setSelected(int scoreIndex, bool selected)
 {
-    if (!isIndexValid(scoreIndex)) {
+    if (!isIndexValid(scoreIndex))
+    {
         return;
     }
 
     QModelIndex modelIndex = index(scoreIndex);
     m_selectionModel->select(modelIndex, selected ? QItemSelectionModel::Select : QItemSelectionModel::Deselect);
 
-    emit dataChanged(modelIndex, modelIndex, { RoleIsSelected });
+    emit dataChanged(modelIndex, modelIndex, {RoleIsSelected});
 }
 
 void ExportDialogModel::setAllSelected(bool selected)
 {
-    for (int i = 0; i < rowCount(); i++) {
+    for (int i = 0; i < rowCount(); i++)
+    {
         setSelected(i, selected);
     }
 }
 
 void ExportDialogModel::selectCurrentNotation()
 {
-    for (int i = 0; i < rowCount(); i++) {
+    for (int i = 0; i < rowCount(); i++)
+    {
         setSelected(i, m_notations[i] == context()->currentNotation());
     }
 }
@@ -215,9 +225,11 @@ void ExportDialogModel::selectCurrentNotation()
 void ExportDialogModel::selectSavedNotations()
 {
     ExportInfo info = exportProjectScenario()->exportInfo();
-    for (const INotationPtr& notation : info.notations) {
+    for (const INotationPtr &notation : info.notations)
+    {
         auto it = std::find(m_notations.begin(), m_notations.end(), notation);
-        if (it != m_notations.end()) {
+        if (it != m_notations.end())
+        {
             setSelected(std::distance(m_notations.begin(), it), true);
         }
     }
@@ -253,9 +265,10 @@ QVariantMap ExportDialogModel::selectedExportType() const
     return m_selectedExportType.toMap();
 }
 
-void ExportDialogModel::setExportType(const ExportType& type)
+void ExportDialogModel::setExportType(const ExportType &type)
 {
-    if (m_selectedExportType == type) {
+    if (m_selectedExportType == type)
+    {
         return;
     }
 
@@ -264,12 +277,17 @@ void ExportDialogModel::setExportType(const ExportType& type)
     emit selectedExportTypeChanged(type.toMap());
 
     std::vector<UnitType> unitTypes = exportProjectScenario()->supportedUnitTypes(type);
-
-    IF_ASSERT_FAILED(!unitTypes.empty()) {
+    if (type.id == "lrc")
+    {
+        unitTypes = {UnitType::MULTI_PART}; // only supports single file export
+    }
+    IF_ASSERT_FAILED(!unitTypes.empty())
+    {
         return;
     }
 
-    if (std::find(unitTypes.cbegin(), unitTypes.cend(), m_selectedUnitType) != unitTypes.cend()) {
+    if (std::find(unitTypes.cbegin(), unitTypes.cend(), m_selectedUnitType) != unitTypes.cend())
+    {
         return;
     }
 
@@ -278,16 +296,19 @@ void ExportDialogModel::setExportType(const ExportType& type)
     setUnitType(unitTypes.front());
 }
 
-void ExportDialogModel::selectExportTypeById(const QString& id)
+void ExportDialogModel::selectExportTypeById(const QString &id)
 {
-    for (const ExportType& type : std::as_const(m_exportTypeList)) {
+    for (const ExportType &type : std::as_const(m_exportTypeList))
+    {
         // First, check if it's a subtype
-        if (type.subtypes.contains(id)) {
+        if (type.subtypes.contains(id))
+        {
             setExportType(type.subtypes.getById(id));
             return;
         }
 
-        if (type.id == id) {
+        if (type.id == id)
+        {
             setExportType(type);
             return;
         }
@@ -299,15 +320,16 @@ void ExportDialogModel::selectExportTypeById(const QString& id)
 
 QVariantList ExportDialogModel::availableUnitTypes() const
 {
-    QMap<UnitType, QString> unitTypeNames {
-        { UnitType::PER_PAGE, muse::qtrc("project/export", "Each page to a separate file") },
-        { UnitType::PER_PART, muse::qtrc("project/export", "Each part to a separate file") },
-        { UnitType::MULTI_PART, muse::qtrc("project/export", "All parts combined in one file") },
+    QMap<UnitType, QString> unitTypeNames{
+        {UnitType::PER_PAGE, muse::qtrc("project/export", "Each page to a separate file")},
+        {UnitType::PER_PART, muse::qtrc("project/export", "Each part to a separate file")},
+        {UnitType::MULTI_PART, muse::qtrc("project/export", "All parts combined in one file")},
     };
 
     QVariantList result;
 
-    for (UnitType type : exportProjectScenario()->supportedUnitTypes(m_selectedExportType)) {
+    for (UnitType type : exportProjectScenario()->supportedUnitTypes(m_selectedExportType))
+    {
         QVariantMap obj;
         obj["text"] = unitTypeNames[type];
         obj["value"] = static_cast<int>(type);
@@ -329,18 +351,22 @@ void ExportDialogModel::setUnitType(int unitType)
 
 void ExportDialogModel::setUnitType(UnitType unitType)
 {
-    if (m_selectedUnitType == unitType) {
+    if (m_selectedUnitType == unitType)
+    {
         return;
     }
 
     bool found = false;
-    for (const QVariant& availabeUnitType : availableUnitTypes()) {
-        if (availabeUnitType.value<QVariantMap>()["value"].toInt() == static_cast<int>(unitType)) {
+    for (const QVariant &availabeUnitType : availableUnitTypes())
+    {
+        if (availabeUnitType.value<QVariantMap>()["value"].toInt() == static_cast<int>(unitType))
+        {
             found = true;
         }
     }
 
-    if (!found) {
+    if (!found)
+    {
         return;
     }
 
@@ -352,11 +378,13 @@ bool ExportDialogModel::exportScores()
 {
     INotationPtrList notations;
 
-    for (const QModelIndex& index : m_selectionModel->selectedIndexes()) {
+    for (const QModelIndex &index : m_selectionModel->selectedIndexes())
+    {
         notations.push_back(m_notations[index.row()]);
     }
 
-    if (notations.empty()) {
+    if (notations.empty())
+    {
         return false;
     }
 
@@ -365,28 +393,28 @@ bool ExportDialogModel::exportScores()
     // TODO: only restore filename if exactly the same notations are selected and the same unit type.
     // These settings may namely cause extra things to be added to the name, but these extra things
     // are not applicable to other values of these settings.
-    //if (project && project->path() == exportProjectScenario()->exportInfo().projectPath) {
+    // if (project && project->path() == exportProjectScenario()->exportInfo().projectPath) {
     //    filename = io::filename(m_exportPath);
     //}
     muse::io::path_t defaultPath;
-    if (m_exportPath != "" && filename != "") {
+    if (m_exportPath != "" && filename != "")
+    {
         defaultPath = io::absoluteDirpath(m_exportPath)
-                      .appendingComponent(io::filename(filename, false))
-                      .appendingSuffix(m_selectedExportType.suffixes[0]);
+                          .appendingComponent(io::filename(filename, false))
+                          .appendingSuffix(m_selectedExportType.suffixes[0]);
     }
 
-    RetVal<muse::io::path_t> exportPath
-        = exportProjectScenario()->askExportPath(notations, m_selectedExportType, m_selectedUnitType, defaultPath);
-    if (!exportPath.ret) {
+    RetVal<muse::io::path_t> exportPath = exportProjectScenario()->askExportPath(notations, m_selectedExportType, m_selectedUnitType, defaultPath);
+    if (!exportPath.ret)
+    {
         return false;
     }
 
     m_exportPath = exportPath.val;
 
-    async::Async::call(this, [this, notations]() {
-        exportProjectScenario()->exportScores(notations, m_exportPath, m_selectedUnitType,
-                                              shouldDestinationFolderBeOpenedOnExport());
-    });
+    async::Async::call(this, [this, notations]()
+                       { exportProjectScenario()->exportScores(notations, m_exportPath, m_selectedUnitType,
+                                                               shouldDestinationFolderBeOpenedOnExport()); });
 
     return true;
 }
@@ -396,9 +424,10 @@ int ExportDialogModel::pdfResolution() const
     return imageExportConfiguration()->exportPdfDpiResolution();
 }
 
-void ExportDialogModel::setPdfResolution(const int& resolution)
+void ExportDialogModel::setPdfResolution(const int &resolution)
 {
-    if (resolution == pdfResolution()) {
+    if (resolution == pdfResolution())
+    {
         return;
     }
 
@@ -411,9 +440,10 @@ bool ExportDialogModel::pdfTransparentBackground() const
     return imageExportConfiguration()->exportPdfWithTransparentBackground();
 }
 
-void ExportDialogModel::setPdfTransparentBackground(const bool& transparent)
+void ExportDialogModel::setPdfTransparentBackground(const bool &transparent)
 {
-    if (transparent == pdfTransparentBackground()) {
+    if (transparent == pdfTransparentBackground())
+    {
         return;
     }
 
@@ -426,9 +456,10 @@ int ExportDialogModel::pngResolution() const
     return imageExportConfiguration()->exportPngDpiResolution();
 }
 
-void ExportDialogModel::setPngResolution(const int& resolution)
+void ExportDialogModel::setPngResolution(const int &resolution)
 {
-    if (resolution == pngResolution()) {
+    if (resolution == pngResolution())
+    {
         return;
     }
 
@@ -441,9 +472,10 @@ bool ExportDialogModel::pngTransparentBackground() const
     return imageExportConfiguration()->exportPngWithTransparentBackground();
 }
 
-void ExportDialogModel::setPngTransparentBackground(const bool& transparent)
+void ExportDialogModel::setPngTransparentBackground(const bool &transparent)
 {
-    if (transparent == pngTransparentBackground()) {
+    if (transparent == pngTransparentBackground())
+    {
         return;
     }
 
@@ -456,9 +488,10 @@ bool ExportDialogModel::svgTransparentBackground() const
     return imageExportConfiguration()->exportSvgWithTransparentBackground();
 }
 
-void ExportDialogModel::setSvgTransparentBackground(const bool& transparent)
+void ExportDialogModel::setSvgTransparentBackground(const bool &transparent)
 {
-    if (transparent == svgTransparentBackground()) {
+    if (transparent == svgTransparentBackground())
+    {
         return;
     }
 
@@ -473,7 +506,8 @@ bool ExportDialogModel::svgIllustratorCompat() const
 
 void ExportDialogModel::setSvgIllustratorCompat(bool compat)
 {
-    if (compat == svgIllustratorCompat()) {
+    if (compat == svgIllustratorCompat())
+    {
         return;
     }
 
@@ -483,7 +517,7 @@ void ExportDialogModel::setSvgIllustratorCompat(bool compat)
 
 QList<int> ExportDialogModel::availableSampleRates() const
 {
-    const std::vector<int>& rates = audioExportConfiguration()->availableSampleRates();
+    const std::vector<int> &rates = audioExportConfiguration()->availableSampleRates();
     return QList<int>(rates.cbegin(), rates.cend());
 }
 
@@ -494,7 +528,8 @@ int ExportDialogModel::sampleRate() const
 
 void ExportDialogModel::setSampleRate(int rate)
 {
-    if (rate == sampleRate()) {
+    if (rate == sampleRate())
+    {
         return;
     }
 
@@ -504,7 +539,7 @@ void ExportDialogModel::setSampleRate(int rate)
 
 QList<int> ExportDialogModel::availableBitRates() const
 {
-    const std::vector<int>& rates = audioExportConfiguration()->availableMp3BitRates();
+    const std::vector<int> &rates = audioExportConfiguration()->availableMp3BitRates();
     return QList<int>(rates.cbegin(), rates.cend());
 }
 
@@ -515,7 +550,8 @@ int ExportDialogModel::bitRate() const
 
 void ExportDialogModel::setBitRate(int rate)
 {
-    if (rate == bitRate()) {
+    if (rate == bitRate())
+    {
         return;
     }
 
@@ -530,7 +566,8 @@ bool ExportDialogModel::midiExpandRepeats() const
 
 void ExportDialogModel::setMidiExpandRepeats(bool expandRepeats)
 {
-    if (expandRepeats == midiExpandRepeats()) {
+    if (expandRepeats == midiExpandRepeats())
+    {
         return;
     }
 
@@ -545,7 +582,8 @@ bool ExportDialogModel::midiExportRpns() const
 
 void ExportDialogModel::setMidiExportRpns(bool exportRpns)
 {
-    if (exportRpns == midiExportRpns()) {
+    if (exportRpns == midiExportRpns())
+    {
         return;
     }
 
@@ -560,7 +598,8 @@ bool ExportDialogModel::meiExportLayout() const
 
 void ExportDialogModel::setMeiExportLayout(bool exportLayout)
 {
-    if (exportLayout == meiExportLayout()) {
+    if (exportLayout == meiExportLayout())
+    {
         return;
     }
 
@@ -575,7 +614,8 @@ bool ExportDialogModel::meiUseMuseScoreIds() const
 
 void ExportDialogModel::setMeiUseMuseScoreIds(bool useMuseScoreIds)
 {
-    if (useMuseScoreIds == meiUseMuseScoreIds()) {
+    if (useMuseScoreIds == meiUseMuseScoreIds())
+    {
         return;
     }
 
@@ -585,20 +625,21 @@ void ExportDialogModel::setMeiUseMuseScoreIds(bool useMuseScoreIds)
 
 QVariantList ExportDialogModel::musicXmlLayoutTypes() const
 {
-    std::map<MusicXmlLayoutType, QString> musicXmlLayoutTypeNames {
+    std::map<MusicXmlLayoutType, QString> musicXmlLayoutTypeNames{
         //: Specifies to which extent layout customizations should be exported to MusicXML.
-        { MusicXmlLayoutType::AllLayout, muse::qtrc("project/export", "All layout") },
+        {MusicXmlLayoutType::AllLayout, muse::qtrc("project/export", "All layout")},
         //: Specifies to which extent layout customizations should be exported to MusicXML.
-        { MusicXmlLayoutType::AllBreaks, muse::qtrc("project/export", "System and page breaks") },
+        {MusicXmlLayoutType::AllBreaks, muse::qtrc("project/export", "System and page breaks")},
         //: Specifies to which extent layout customizations should be exported to MusicXML.
-        { MusicXmlLayoutType::ManualBreaks, muse::qtrc("project/export", "Manually added system and page breaks only") },
+        {MusicXmlLayoutType::ManualBreaks, muse::qtrc("project/export", "Manually added system and page breaks only")},
         //: Specifies to which extent layout customizations should be exported to MusicXML.
-        { MusicXmlLayoutType::None, muse::qtrc("project/export", "No system or page breaks") },
+        {MusicXmlLayoutType::None, muse::qtrc("project/export", "No system or page breaks")},
     };
 
     QVariantList result;
 
-    for (const auto& [type, name] : musicXmlLayoutTypeNames) {
+    for (const auto &[type, name] : musicXmlLayoutTypeNames)
+    {
         QVariantMap obj;
         obj["text"] = name;
         obj["value"] = static_cast<int>(type);
@@ -610,10 +651,12 @@ QVariantList ExportDialogModel::musicXmlLayoutTypes() const
 
 ExportDialogModel::MusicXmlLayoutType ExportDialogModel::musicXmlLayoutType() const
 {
-    if (musicXmlConfiguration()->exportLayout()) {
+    if (musicXmlConfiguration()->exportLayout())
+    {
         return MusicXmlLayoutType::AllLayout;
     }
-    switch (musicXmlConfiguration()->exportBreaksType()) {
+    switch (musicXmlConfiguration()->exportBreaksType())
+    {
     case IMusicXmlConfiguration::MusicXmlExportBreaksType::All:
         return MusicXmlLayoutType::AllBreaks;
     case IMusicXmlConfiguration::MusicXmlExportBreaksType::Manual:
@@ -627,10 +670,12 @@ ExportDialogModel::MusicXmlLayoutType ExportDialogModel::musicXmlLayoutType() co
 
 void ExportDialogModel::setMusicXmlLayoutType(MusicXmlLayoutType layoutType)
 {
-    if (layoutType == musicXmlLayoutType()) {
+    if (layoutType == musicXmlLayoutType())
+    {
         return;
     }
-    switch (layoutType) {
+    switch (layoutType)
+    {
     case MusicXmlLayoutType::AllLayout:
         musicXmlConfiguration()->setExportLayout(true);
         break;
@@ -657,7 +702,8 @@ bool ExportDialogModel::shouldDestinationFolderBeOpenedOnExport() const
 
 void ExportDialogModel::setShouldDestinationFolderBeOpenedOnExport(bool enabled)
 {
-    if (enabled == shouldDestinationFolderBeOpenedOnExport()) {
+    if (enabled == shouldDestinationFolderBeOpenedOnExport())
+    {
         return;
     }
 
@@ -676,7 +722,8 @@ void ExportDialogModel::updateExportInfo()
     info.projectPath = project ? project->path() : "";
 
     std::vector<INotationPtr> notations;
-    for (const QModelIndex& index : m_selectionModel->selectedIndexes()) {
+    for (const QModelIndex &index : m_selectionModel->selectedIndexes())
+    {
         notations.emplace_back(m_notations[index.row()]);
     }
     info.notations = notations;


### PR DESCRIPTION
Resolves: #24813 

This implements LRC file export for lyrics, including timestamps and metadata. The exporter appears in MuseScore's export dialog and generates standard .lrc files with [mm:ss.xx] formatted lyrics. Handles repeats and preserves score metadata (title/composer). Tested manually

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [X] I created a unit test or vtest to verify the changes I made (if applicable)