### PR TITLE
19944 close parts with middle mouse button

### DIFF
--- a/src/engraving/style/pagestyle.cpp
+++ b/src/engraving/style/pagestyle.cpp
@@ -24,9 +24,9 @@
 #include "style.h"
 
 namespace mu::engraving {
-const std::set<Sid>& pageStyles()
+const std::vector<Sid>& pageStyles()
 {
-    static const std::set<Sid> styles {
+    static const std::vector<Sid> styles {
         Sid::pageWidth,
         Sid::pageHeight,
         Sid::pagePrintableWidth,

--- a/src/engraving/style/pagestyle.h
+++ b/src/engraving/style/pagestyle.h
@@ -19,22 +19,19 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef MU_ENGRAVING_PAGESTYLE_H
-#define MU_ENGRAVING_PAGESTYLE_H
+#pragma once
 
-#include <set>
-#include <memory>
+#include <vector>
 
 #include "styledef.h"
 
 namespace mu::engraving {
-const std::set<Sid>& pageStyles();
+const std::vector<Sid>& pageStyles();
 
 class MStyle;
 class PageSizeGetAccessor
 {
 public:
-
     PageSizeGetAccessor(const MStyle& style);
 
     double width() const;
@@ -50,14 +47,12 @@ public:
     double spatium() const;
 
 private:
-
     const MStyle& m_style;
 };
 
 class PageSizeSetAccessor
 {
 public:
-
     PageSizeSetAccessor(MStyle& style);
 
     double width() const;
@@ -85,9 +80,6 @@ public:
     void setSpatium(double v);
 
 private:
-
     MStyle& m_style;
 };
 }
-
-#endif // MU_ENGRAVING_PAGESTYLE_H

--- a/src/framework/dockwindow/thirdparty/KDDockWidgets/src/private/widgets/TabBarWidget.cpp
+++ b/src/framework/dockwindow/thirdparty/KDDockWidgets/src/private/widgets/TabBarWidget.cpp
@@ -84,8 +84,19 @@ DockWidgetBase *TabBarWidget::currentDockWidget() const
 
 void TabBarWidget::mousePressEvent(QMouseEvent *e)
 {
-    onMousePress(e->pos());
-    QTabBar::mousePressEvent(e);
+    if (e->button() == Qt::MiddleButton) {
+        int index = tabAt(e->pos());
+        if (index >= 0) {
+            if (DockWidgetBase* dw = dockWidgetAt(index)) {
+                if (!(dw->options() & DockWidgetBase::Option_NotClosable)) {
+                    dw->close();
+                }
+            }
+        }
+    } else {
+        onMousePress(e->pos());
+        QTabBar::mousePressEvent(e);
+    }
 }
 
 void TabBarWidget::mouseMoveEvent(QMouseEvent *e)

--- a/src/notation/view/widgets/pagesettings.cpp
+++ b/src/notation/view/widgets/pagesettings.cpp
@@ -261,12 +261,8 @@ void PageSettings::orientationClicked()
 
 void PageSettings::on_resetPageStyleButton_clicked()
 {
-    for (auto styleId : pageStyles()) {
-        globalContext()->currentNotation()->style()->resetStyleValue(styleId);
-    }
-
-    pageOffsetEntry->setValue(1);
-
+    score()->undoChangePageNumberOffset(0);
+    globalContext()->currentNotation()->style()->resetStyleValues(pageStyles());
     updateValues();
 }
 

--- a/src/notation/view/widgets/pagesettings.cpp
+++ b/src/notation/view/widgets/pagesettings.cpp
@@ -471,8 +471,8 @@ void PageSettings::spatiumChanged(double val)
 
 void PageSettings::pageOffsetChanged(int val)
 {
-    // TODO: Cancel does not work when page offset is changed?
-    score()->setPageNumberOffset(val - 1);
+    score()->undoChangePageNumberOffset(val - 1);
+    globalContext()->currentNotation()->notationChanged().notify();
 }
 
 void PageSettings::pageHeightChanged(double val)


### PR DESCRIPTION
Resolves: #19944  

<!-- This change implements middle-click tab closing behavior in the TabBarWidget. When a user middle-clicks on a tab, it should be able to close, improving usability when managing multiple open parts or tabs in a score. --> 

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [ ] I signed the [CLA](https://musescore.org/en/cla) (Note: website keeps saying "504 Gateway Time-out", so will sign when it works.)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable). Note: I don't know if adding more test is necessary.
