### PR TITLE
Use link icon for linked staffs in Layout panel

### DIFF
--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/LayoutPanelItemDelegate.qml
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/LayoutPanelItemDelegate.qml
@@ -40,6 +40,7 @@ FocusableControl {
     readonly property bool isSelected: item && item.isSelected
     readonly property bool isSelectable: item && item.isSelectable
     readonly property bool isExpandable: item && item.isExpandable
+    readonly property bool isLinked: item && item.isLinked
     readonly property bool settingsAvailable: item && item.settingsAvailable
     readonly property bool settingsEnabled: item && item.settingsEnabled
 
@@ -284,10 +285,21 @@ FocusableControl {
                 }
             }
 
+            StyledIconLabel {
+                id: linkIcon
+
+                anchors.left: expandButton.right
+                anchors.leftMargin: 4
+                anchors.verticalCenter: expandButton.verticalCenter
+                visible: root.isLinked
+                iconCode: IconCode.LINK
+                opacity: model && model.itemRole.isVisible ? 1 : 0.75
+            }
+
             StyledTextLabel {
                 id: titleLabel
 
-                anchors.left: expandButton.right
+                anchors.left: root.isLinked ? linkIcon.right : expandButton.right
                 anchors.leftMargin: 4
                 anchors.right: parent.right
                 anchors.rightMargin: 8

--- a/src/instrumentsscene/view/abstractlayoutpaneltreeitem.cpp
+++ b/src/instrumentsscene/view/abstractlayoutpaneltreeitem.cpp
@@ -88,6 +88,11 @@ bool AbstractLayoutPanelTreeItem::isExpandable() const
     return m_isExpandable;
 }
 
+bool AbstractLayoutPanelTreeItem::isLinked() const
+{
+    return m_isLinked;
+}
+
 bool AbstractLayoutPanelTreeItem::settingsAvailable() const
 {
     return m_settingsAvailable;
@@ -302,6 +307,16 @@ void AbstractLayoutPanelTreeItem::setIsExpandable(bool expandable)
 
     m_isExpandable = expandable;
     emit isExpandableChanged(expandable);
+}
+
+void AbstractLayoutPanelTreeItem::setIsLinked(bool linked)
+{
+    if (m_isLinked == linked) {
+        return;
+    }
+
+    m_isLinked = linked;
+    emit isLinkedChanged(linked);
 }
 
 void AbstractLayoutPanelTreeItem::setSettingsAvailable(bool available)

--- a/src/instrumentsscene/view/abstractlayoutpaneltreeitem.h
+++ b/src/instrumentsscene/view/abstractlayoutpaneltreeitem.h
@@ -53,6 +53,7 @@ class AbstractLayoutPanelTreeItem : public QObject
     Q_PROPERTY(int type READ typeInt CONSTANT)
     Q_PROPERTY(bool isVisible READ isVisible NOTIFY isVisibleChanged)
     Q_PROPERTY(bool isExpandable READ isExpandable NOTIFY isExpandableChanged)
+    Q_PROPERTY(bool isLinked READ isLinked NOTIFY isLinkedChanged)
     Q_PROPERTY(bool isRemovable READ isRemovable NOTIFY isRemovableChanged)
     Q_PROPERTY(bool isSelectable READ isSelectable CONSTANT)
     Q_PROPERTY(bool isSelected READ isSelected NOTIFY isSelectedChanged)
@@ -71,6 +72,7 @@ public:
     LayoutPanelItemType::ItemType type() const;
     bool isVisible() const;
     bool isExpandable() const;
+    bool isLinked() const;
     bool isRemovable() const;
 
     bool isSelectable() const;
@@ -114,6 +116,7 @@ public slots:
     void setIsVisible(bool isVisible, bool setChildren = true);
     void setId(const muse::ID& id);
     void setIsExpandable(bool expandable);
+    void setIsLinked(bool linked);
     void setIsRemovable(bool removable);
     void setIsSelectable(bool selectable);
     void setIsSelected(bool selected);
@@ -124,6 +127,7 @@ signals:
     void titleChanged(QString title);
     void isVisibleChanged(bool isVisible);
     void isExpandableChanged(bool isExpandable);
+    void isLinkedChanged(bool isLinked);
     void isRemovableChanged(bool isRemovable);
     void isSelectableChanged(bool isSelectable);
     void isSelectedChanged(bool isSelected);
@@ -145,6 +149,7 @@ private:
     LayoutPanelItemType::ItemType m_type = LayoutPanelItemType::UNDEFINED;
     bool m_isVisible = false;
     bool m_isExpandable = false;
+    bool m_isLinked = false;
     bool m_isRemovable = false;
     bool m_isSelectable = false;
     bool m_isSelected = false;

--- a/src/instrumentsscene/view/stafftreeitem.cpp
+++ b/src/instrumentsscene/view/stafftreeitem.cpp
@@ -59,14 +59,14 @@ void StaffTreeItem::init(const Staff* masterStaff)
         staff = masterStaff;
     }
 
-    QString staffName = staff->staffName();
+    bool linked = masterStaff->isLinked();
 
-    //: Prefix for the display name for a linked staff. Preferably, keep this short.
-    QString title = masterStaff->isLinked() ? muse::qtrc("layoutpanel", "[LINK] %1").arg(staffName) : staffName;
+    QString title = staff->staffName();
 
     setId(staff->id());
     setTitle(title);
     setIsVisible(visible);
+    setIsLinked(linked);
 
     m_isInited = true;
 }


### PR DESCRIPTION
Resolves: #26532

Use link icon instead of [LINK] text in staff name. Implements isLinked bool and eliminates a translation string.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
