### PR TITLE
Refactor NotationViewInputController::mousePressEvent

### DIFF
--- a/src/notation/view/notationviewinputcontroller.h
+++ b/src/notation/view/notationviewinputcontroller.h
@@ -181,11 +181,11 @@ private:
     };
 
     void handleClickInNoteInputMode(QMouseEvent* event);
-    bool tryHandleClickGrip(const ClickContext& ctx);
-    bool tryHandleClickDragOutgoingElement(const ClickContext& ctx);
-    void handleClickSelect(const ClickContext& ctx);
-    void cycleThroughOverlappingHitElements(const std::vector<EngravingItem*>& hitElements, staff_idx_t hitStaffIndex);
-    bool tryHandleClickDragOutgoingRange(const ClickContext& ctx);
+    bool mousePress_considerGrip(const ClickContext& ctx); // returns true if event is consumed
+    bool mousePress_considerDragOutgoingElement(const ClickContext& ctx);
+    void mousePress_considerSelect(const ClickContext& ctx);
+    void cycleOverlappingHitElements(const std::vector<EngravingItem*>& hitElements, staff_idx_t hitStaffIndex);
+    bool mousePress_considerDragOutgoingRange(const ClickContext& ctx);
     void handleLeftClick(const ClickContext& ctx);
     void handleRightClick(const ClickContext& ctx);
     void handleLeftClickRelease(const QPointF& releasePoint);

--- a/src/notation/view/notationviewinputcontroller.h
+++ b/src/notation/view/notationviewinputcontroller.h
@@ -180,7 +180,12 @@ private:
         bool isHitGrip = false;
     };
 
-    bool needSelect(const ClickContext& ctx) const;
+    void handleClickInNoteInputMode(QMouseEvent* event);
+    bool tryHandleClickGrip(const ClickContext& ctx);
+    bool tryHandleClickDragOutgoingElement(const ClickContext& ctx);
+    void handleClickSelect(const ClickContext& ctx);
+    void cycleThroughOverlappingHitElements(const std::vector<EngravingItem*>& hitElements, staff_idx_t hitStaffIndex);
+    bool tryHandleClickDragOutgoingRange(const ClickContext& ctx);
     void handleLeftClick(const ClickContext& ctx);
     void handleRightClick(const ClickContext& ctx);
     void handleLeftClickRelease(const QPointF& releasePoint);


### PR DESCRIPTION
Split into smaller functions, to make clearer which things are done in which order.

Resolves: part 1 from https://github.com/musescore/MuseScore/issues/27579
Resolves: https://github.com/musescore/MuseScore/issues/27861