### PR TITLE
Open `CustomizeKitDialog` with selected note focused (#27772)

### DIFF
--- a/src/palette/view/widgets/customizekitdialog.h
+++ b/src/palette/view/widgets/customizekitdialog.h
@@ -69,7 +69,9 @@ private:
 
     void apply();
     void cancel();
-    void loadPitchesList();
+
+    QTreeWidgetItem* loadPitchesList(); // Returns a tree item to select, if applicable...
+
     void updateExample();
 
     void fillCustomNoteheadsDataFromComboboxes(int pitch);

--- a/src/palette/view/widgets/customizekitdialog.h
+++ b/src/palette/view/widgets/customizekitdialog.h
@@ -65,6 +65,8 @@ private slots:
     void defineShortcut();
 
 private:
+    void initDrumsetAndKey();
+
     void apply();
     void cancel();
     void loadPitchesList();


### PR DESCRIPTION
Resolves: #27772

Also includes a refactor to the `CustomizeKitDialog` constructor - trying to reduce some duplication there.