### PR TITLE
CMake: fix arm64 architecture detection on Windows

### DIFF
--- a/buildscripts/cmake/GetPlatformInfo.cmake
+++ b/buildscripts/cmake/GetPlatformInfo.cmake
@@ -37,14 +37,14 @@ else()
 endif()
 
 # architecture detection
-# based on QT5 processor detection code
-# qtbase/blobs/master/src/corelib/global/qprocessordetection.h
+# based on Qt processor detection code
+# https://github.com/qt/qtbase/blob/dev/src/corelib/global/qprocessordetection.h
 
 # we only have binary blobs compatible with x86_64, aarch64, and armv7l
 
 set(archdetect_c_code "
-    #if defined(__arm__) || defined(__TARGET_ARCH_ARM) || defined(_M_ARM) || defined(__aarch64__) || defined(__ARM64__)
-        #if defined(__aarch64__) || defined(__ARM64__)
+    #if defined(__arm__) || defined(__TARGET_ARCH_ARM) || defined(_M_ARM) || defined(_M_ARM64) || defined(__aarch64__) || defined(__ARM64__)
+        #if defined(__aarch64__) || defined(__ARM64__) || defined(_M_ARM64)
             #error cmake_ARCH aarch64
         #elif defined(__ARM_ARCH_7A__)
             #error cmake_ARCH armv7l


### PR DESCRIPTION
The equivalent change in the Qt processor detection code, on which this snippet is based, was made in https://github.com/qt/qtbase/commit/fbbe8aba9d70a3c13d1cd7797eb4dbbd1f05ade5#diff-bf87ad79323b9136d980adec50b0280e4527e294d7f0f1a4e6511c385dbffe35.

(We don't support building on Windows on ARM yet, but I think that won't be too long anymore.)