### PR TITLE
Bump minimum macOS deployment target and `make_minimum_required`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,9 +16,9 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>. 
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.22) # Min. required by Qt 6.9
 
 project(MuseScore LANGUAGES C CXX)
 

--- a/build.cmake
+++ b/build.cmake
@@ -17,7 +17,7 @@ if(NOT DEFINED CMAKE_SCRIPT_MODE_FILE)
     )
 endif()
 
-cmake_minimum_required(VERSION 3.16) # should match version in CMakeLists.txt
+cmake_minimum_required(VERSION 3.22) # should match version in CMakeLists.txt
 
 # CMake arguments up to '-P' (ignore these)
 set(i "1")

--- a/buildscripts/ci/macos/setup.sh
+++ b/buildscripts/ci/macos/setup.sh
@@ -22,7 +22,7 @@ echo "Setup macOS build environment"
 
 trap 'echo Setup failed; exit 1' ERR
 
-export MACOSX_DEPLOYMENT_TARGET=10.14
+export MACOSX_DEPLOYMENT_TARGET=10.15
 
 # Install build tools
 echo "Install build tools"

--- a/buildscripts/cmake/SetupBuildEnvironment.cmake
+++ b/buildscripts/cmake/SetupBuildEnvironment.cmake
@@ -60,8 +60,8 @@ endif()
 
 # Mac-specific
 if(OS_IS_MAC)
-    set(MACOSX_DEPLOYMENT_TARGET 10.14)
-    set(CMAKE_OSX_DEPLOYMENT_TARGET 10.14)
+    set(MACOSX_DEPLOYMENT_TARGET 10.15)
+    set(CMAKE_OSX_DEPLOYMENT_TARGET 10.15)
 endif(OS_IS_MAC)
 
 # MSVC-specific

--- a/sandbox/cpad/CMakeLists.txt
+++ b/sandbox/cpad/CMakeLists.txt
@@ -17,7 +17,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.22)
 
 project(app LANGUAGES C CXX)
 

--- a/sandbox/engraving/CMakeLists.txt
+++ b/sandbox/engraving/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.22)
 
 project(engraving_app LANGUAGES CXX)
 

--- a/src/framework/ui/internal/platform/macos/macosplatformtheme.mm
+++ b/src/framework/ui/internal/platform/macos/macosplatformtheme.mm
@@ -56,7 +56,7 @@ void MacOSPlatformTheme::stopListening()
 
 bool MacOSPlatformTheme::isFollowSystemThemeAvailable() const
 {
-    // Supported from macOS 10.14, which is our minimum supported version
+    // Supported from macOS 10.14, while our minimum supported version is 10.15
     return true;
 }
 


### PR DESCRIPTION
In preparation for the Qt update