### PR TITLE
CMake: Use Qt's `qt_add_{library,executable}`

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -232,7 +232,7 @@ endif()
 # Executable declaration
 ###########################################
 
-add_executable(MuseScoreStudio
+qt_add_executable(MuseScoreStudio
     WIN32 MACOSX_BUNDLE
     ${APP_RCC_SOURCES}
     ${MSCORE_APPEND_SRC}
@@ -310,7 +310,7 @@ target_include_directories(MuseScoreStudio PRIVATE
 ###########################################
 
 if (NOT CC_IS_EMSCRIPTEN)
-    target_link_libraries(MuseScoreStudio ${LINK_LIB} ${COVERAGE_LINK_FLAGS})
+    target_link_libraries(MuseScoreStudio PRIVATE ${LINK_LIB} ${COVERAGE_LINK_FLAGS})
 else()
     target_link_libraries(MuseScoreStudio PRIVATE ${QT_LIBRARIES})
 


### PR DESCRIPTION
I verified that they don't do anything scary, so let's use them, to keep our code in line with the documentation, and to be sure that we're ready to use modern Qt/CMake possibilities.

In preparation for the Qt update