### PR TITLE
[MusicXML] prefer smufl glyphs for technical elements

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
@@ -3300,6 +3300,12 @@ static String symIdToTechn(const SymId sid)
         return u"hole";
     case SymId::guitarGolpe:
         return u"golpe";
+    case SymId::guitarClosePedal:
+        return u"stopped smufl=\"guitarClosePedal\"";
+    case SymId::guitarHalfOpenPedal:
+        return u"half-muted smufl=\"guitarHalfOpenPedal\"";
+    case SymId::guitarOpenPedal:
+        return u"open smufl=\"guitarOpenPedal\"";
     case SymId::handbellsBelltree:
         return u"belltree";
     case SymId::handbellsDamp3:

--- a/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
@@ -3283,7 +3283,6 @@ static String symIdToTechn(const SymId sid)
     case SymId::brassSmear:
         return u"smear";
     case SymId::brassMuteOpen:
-        // return u"open-string";
         return u"open";
     case SymId::brassMuteHalfClosed:
         return u"half-muted";

--- a/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
@@ -3300,12 +3300,6 @@ static String symIdToTechn(const SymId sid)
         return u"hole";
     case SymId::guitarGolpe:
         return u"golpe";
-    case SymId::guitarClosePedal:
-        return u"stopped smufl=\"guitarClosePedal\"";
-    case SymId::guitarHalfOpenPedal:
-        return u"half-muted smufl=\"guitarHalfOpenPedal\"";
-    case SymId::guitarOpenPedal:
-        return u"open smufl=\"guitarOpenPedal\"";
     case SymId::handbellsBelltree:
         return u"belltree";
     case SymId::handbellsDamp3:
@@ -3330,6 +3324,16 @@ static String symIdToTechn(const SymId sid)
         return u"pluck lift";
     case SymId::handbellsSwing:
         return u"swing";
+    case SymId::guitarClosePedal:
+    case SymId::pictOpenRimShot:
+        return String(u"stopped smufl=\"%1\"").arg(String::fromAscii(SymNames::nameForSymId(sid).ascii()));
+    case SymId::guitarHalfOpenPedal:
+    case SymId::pictHalfOpen1:
+    case SymId::pictHalfOpen2:
+        return String(u"half-muted smufl=\"%1\"").arg(String::fromAscii(SymNames::nameForSymId(sid).ascii()));
+    case SymId::guitarOpenPedal:
+    case SymId::pictOpen:
+        return String(u"open smufl=\"%1\"").arg(String::fromAscii(SymNames::nameForSymId(sid).ascii()));
     default:
         return String(); // nothing
     }

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -8400,7 +8400,14 @@ void MusicXmlParserNotations::technical()
 {
     while (m_e.readNextStartElement()) {
         SymId id { SymId::noSym };
-        if (convertArticulationToSymId(String::fromAscii(m_e.name().ascii()), id)) {
+        const String smufl = m_e.attribute("smufl");
+        if (!smufl.empty()) {
+            id = SymNames::symIdByName(smufl, SymId::noSym);
+            Notation notation = Notation::notationWithAttributes(String::fromAscii(m_e.name().ascii()),
+                                                                 m_e.attributes(), u"technical", id);
+            m_notations.push_back(notation);
+            m_e.skipCurrentElement();
+        } else if (convertArticulationToSymId(String::fromAscii(m_e.name().ascii()), id)) {
             Notation notation = Notation::notationWithAttributes(String::fromAscii(m_e.name().ascii()),
                                                                  m_e.attributes(), u"technical", id);
             m_notations.push_back(notation);
@@ -8437,17 +8444,6 @@ void MusicXmlParserNotations::technical()
 void MusicXmlParserNotations::otherTechnical()
 {
     const Color color = Color::fromString(m_e.attribute("color"));
-    const String smufl = m_e.attribute("smufl");
-
-    if (!smufl.empty()) {
-        SymId id = SymNames::symIdByName(smufl, SymId::noSym);
-        Notation notation = Notation::notationWithAttributes(String::fromAscii(m_e.name().ascii()),
-                                                             m_e.attributes(), u"technical", id);
-        m_notations.push_back(notation);
-        m_e.skipCurrentElement();
-        return;
-    }
-
     const String text = m_e.readText();
 
     if (text == u"z") {


### PR DESCRIPTION
Apart from `other-technical` the `@smufl` attribute is also available for `open`, `half-muted`, and `stopped`. Changed the import slightly that we prefer the given value for all these instruments. Adjusted the export accordingly for specific guitar notation.