### PR TITLE
Fix #12222: Enable Enter/Esc in measures count dialog

### DIFF
--- a/src/framework/uicomponents/qml/Muse/UiComponents/IncrementalPropertyControl.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/IncrementalPropertyControl.qml
@@ -57,6 +57,8 @@ Item {
 
     signal valueEdited(var newValue)
     signal valueEditingFinished(var newValue)
+    signal accepted()
+    signal escaped()
 
     implicitHeight: 30
     implicitWidth: parent.width
@@ -258,6 +260,14 @@ Item {
             }
 
             root.valueEditingFinished(+newVal.toFixed(root.decimals))
+        }
+
+        onAccepted: {
+            root.accepted()
+        }
+
+        onEscaped: {
+            root.escaped()
         }
     }
 

--- a/src/notation/qml/MuseScore/NotationScene/SelectMeasuresCountDialog.qml
+++ b/src/notation/qml/MuseScore/NotationScene/SelectMeasuresCountDialog.qml
@@ -82,6 +82,15 @@ StyledDialogView {
                 onValueEdited: function(newValue) {
                     root.measuresCount = newValue
                 }
+
+                onAccepted: {
+                    root.ret = { errcode: 0, value: root.measuresCount }
+                    root.hide()
+                }
+
+                onEscaped: {
+                    root.reject()
+                }
             }
         }
 


### PR DESCRIPTION
Resolves: #12222

TextInputField already had "accepted" and "escaped" signals that it fires when Enter or Esc are pressed. I plumbed those through the IncrementalPropertyControl and then added handlers for them in SelectMeasuresCountDialog.

There was [one comment](https://github.com/musescore/MuseScore/issues/12222#issuecomment-2255768550) indicating that needing to press Esc twice was by design (once to stop interacting with the text field, and again to exit the dialog). If it's desired, I'm happy to revert that part of the PR, but I think in this instance with the measure count being the only thing in the dialog besides the OK/Cancel buttons, it makes a lot of sense to have a single Esc exit the dialog. (You can also get out of the text box by pressing Tab.)

~There's still one wonky thing where after using the up/down arrow keys to edit the number, pressing Enter no longer works, although Esc does (and you can still tab away). I'll update the PR if I figure that out.~ (This bit is fixed by #26699!)

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
