### PR TITLE
27932: Fixed sound font load failure on Windows

### DIFF
--- a/src/framework/audio/internal/synthesizers/fluidsynth/sfcachedloader.h
+++ b/src/framework/audio/internal/synthesizers/fluidsynth/sfcachedloader.h
@@ -71,7 +71,7 @@ void* openSoundFont(const char* filename)
         return search->second.fileStream;
     }
 
-    std::FILE* stream = std::fopen(filename, "r");
+    std::FILE* stream = std::fopen(filename, "rb");
 
     SoundFontData sfData;
     sfData.fileStream = stream;


### PR DESCRIPTION
Resolves: #27932 

The sound font files must be open in binary mode to suppress the processing of CRLF and CTRL+Z on Windows.
See [this article](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/fopen-wfopen?view=msvc-170) for example.

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
