### PR TITLE
Remove unused fretNumPos property

### DIFF
--- a/src/engraving/dom/fret.cpp
+++ b/src/engraving/dom/fret.cpp
@@ -90,7 +90,6 @@ FretDiagram::FretDiagram(const FretDiagram& f)
     m_fretOffset = f.m_fretOffset;
     m_maxFrets   = f.m_maxFrets;
     m_userMag    = f.m_userMag;
-    m_numPos     = f.m_numPos;
     m_dots       = f.m_dots;
     m_markers    = f.m_markers;
     m_barres     = f.m_barres;
@@ -115,7 +114,6 @@ void FretDiagram::initDefaultValues()
     m_orientation = Orientation::VERTICAL;
 
     m_userMag = 1.0;
-    m_numPos = 0;
 
     m_showFingering = false;
     m_fingering = std::vector<int>(m_strings, 0);
@@ -632,6 +630,11 @@ void FretDiagram::undoFretClear()
     }
 }
 
+int FretDiagram::numPos() const
+{
+    return style().styleI(Sid::fretNumPos);
+}
+
 //---------------------------------------------------------
 //   dot
 //    take fret value of zero to mean all dots
@@ -818,8 +821,6 @@ PropertyValue FretDiagram::getProperty(Pid propertyId) const
         return showNut();
     case Pid::FRET_OFFSET:
         return fretOffset();
-    case Pid::FRET_NUM_POS:
-        return m_numPos;
     case Pid::ORIENTATION:
         return m_orientation;
     case Pid::FRET_SHOW_FINGERINGS:
@@ -852,9 +853,6 @@ bool FretDiagram::setProperty(Pid propertyId, const PropertyValue& v)
         break;
     case Pid::FRET_OFFSET:
         setFretOffset(v.toInt());
-        break;
-    case Pid::FRET_NUM_POS:
-        m_numPos = v.toInt();
         break;
     case Pid::ORIENTATION:
         m_orientation = v.value<Orientation>();
@@ -1169,7 +1167,6 @@ FretUndoData::FretUndoData(FretDiagram* fd)
     m_orientation = m_diagram->m_orientation;
 
     m_userMag = m_diagram->m_userMag;
-    m_numPos = m_diagram->m_numPos;
 
     m_showFingering = m_diagram->m_showFingering;
 }
@@ -1199,7 +1196,6 @@ void FretUndoData::updateDiagram()
     m_diagram->m_orientation = m_orientation;
 
     m_diagram->m_userMag = m_userMag;
-    m_diagram->m_numPos = m_numPos;
 
     m_diagram->m_showFingering = m_showFingering;
 }

--- a/src/engraving/dom/fret.h
+++ b/src/engraving/dom/fret.h
@@ -202,7 +202,7 @@ public:
     void setShowNut(bool val) { m_showNut = val; }
     double userMag() const { return m_userMag; }
     void setUserMag(double m) { m_userMag = m; }
-    int numPos() const { return m_numPos; }
+    int numPos() const;
 
     Orientation orientation() const { return m_orientation; }
 
@@ -309,7 +309,6 @@ private:
     Harmony* m_harmony = nullptr;
 
     double m_userMag = 1.0;                 // allowed 0.1 - 10.0
-    int m_numPos = 0;
 
     bool m_showFingering = false;
     std::vector<int> m_fingering = std::vector<int>(m_strings, 0);

--- a/src/engraving/rendering/score/tlayout.cpp
+++ b/src/engraving/rendering/score/tlayout.cpp
@@ -2624,7 +2624,7 @@ void TLayout::layoutFretDiagram(const FretDiagram* item, FretDiagram::LayoutData
                 continue;
             }
             if ((barre.startString == 0 && item->numPos() == 0)
-                || (barre.endString == -1 && item->numPos() == 1)) {
+                || ((barre.endString == -1) || (barre.endString == item->strings() - 1) && item->numPos() == 1)) {
                 padding += 0.20 * ldata->dotDiameter * ctx.conf().styleD(Sid::barreLineWidth);
                 break;
             }

--- a/src/engraving/rw/write/twrite.cpp
+++ b/src/engraving/rw/write/twrite.cpp
@@ -1306,7 +1306,6 @@ void TWrite::write(const FretDiagram* item, XmlWriter& xml, WriteContext& ctx)
         Pid::FRET_STRINGS,
         Pid::FRET_NUT,
         Pid::MAG,
-        Pid::FRET_NUM_POS,
         Pid::ORIENTATION,
         Pid::FRET_SHOW_FINGERINGS,
         Pid::FRET_FINGERING,


### PR DESCRIPTION
Resolves: #27872

This looks like the leftover of either an old feature or a half-implemented one. The fret number position is not an individually editable property so the Fret object shouldn't have a private variable for it, it should just return the style value. Incidentally, it also seems that we were writing this property to file but not reading it, so I've removed that too.