### PR TITLE
Do not require pressing shift to use box select, making it possible to use without the keyboard

### DIFF
--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -990,7 +990,7 @@ void NotationViewInputController::mouseMoveEvent(QMouseEvent* event)
             viewInteraction()->drag(m_mouseDownInfo.logicalBeginPoint, logicPos, mode);
 
             return;
-        } else if (hitElement == nullptr && (keyState & Qt::ShiftModifier)) {
+        } else if (hitElement == nullptr && (event->buttons() & Qt::LeftButton)) {
             if (!viewInteraction()->isDragStarted()) {
                 viewInteraction()->startDrag(std::vector<EngravingItem*>(), PointF(), [](const EngravingItem*) { return false; });
             }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/378466

Currently, both the middle mouse button and the left mouse button pan across the score. This PR changes the left mouse button to box select notes on the score, which removes the necessity of pressing shift in order to box select notes. You can still pan across the score with the middle mouse button.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [X] I created a unit test or vtest to verify the changes I made (if applicable)
