### PR TITLE
Fix issue unable to drag string on tablature under ottava

### DIFF
--- a/src/engraving/dom/note.cpp
+++ b/src/engraving/dom/note.cpp
@@ -2814,8 +2814,9 @@ void Note::verticalDrag(EditData& ed)
 
     if (tab) {
         const StringData* strData = staff()->part()->stringData(_tick, stf->idx());
+        const int pitchOffset = stf->pitchOffset(_tick);
         int nString = ned->string + (st->upsideDown() ? -lineOffset : lineOffset);
-        int nFret   = strData->fret(m_pitch, nString, staff());
+        int nFret   = strData->fret(m_pitch + pitchOffset, nString, staff());
 
         if (nFret >= 0) {                        // no fret?
             if (fret() != nFret || string() != nString) {


### PR DESCRIPTION
Resolves: #20398

Fixes issue that makes user unable to drag strings in tablature on linked staff with ottava.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
