### PR TITLE
Add "respell with sharps", "respell with flats" commands

### DIFF
--- a/src/appshell/view/appmenumodel.cpp
+++ b/src/appshell/view/appmenumodel.cpp
@@ -363,6 +363,9 @@ MenuItem* AppMenuModel::makeToolsMenu()
         makeMenuItem("slash-rhythm"),
         makeSeparator(),
         makeMenuItem("pitch-spell"),
+        makeMenuItem("pitch-spell-sharps"),
+        makeMenuItem("pitch-spell-flats"),
+        makeSeparator(),
         makeMenuItem("reset-groupings"),
         makeMenuItem("resequence-rehearsal-marks"),
         /*

--- a/src/engraving/dom/pitchspelling.cpp
+++ b/src/engraving/dom/pitchspelling.cpp
@@ -701,6 +701,10 @@ void changeAllTpcs(Note* n, int tpc1)
     int tpc2 = mu::engraving::transposeTpc(tpc1, v, true);
     n->undoChangeProperty(Pid::TPC1, tpc1);
     n->undoChangeProperty(Pid::TPC2, tpc2);
+    for (Note* tied : n->tiedNotes()) {
+        tied->undoChangeProperty(Pid::TPC1, tpc1);
+        tied->undoChangeProperty(Pid::TPC2, tpc2);
+    }
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -884,8 +884,14 @@ void Score::spell()
             for (track_idx_t track = strack; track < etrack; ++track) {
                 EngravingItem* e = s->element(track);
                 if (e && e->type() == ElementType::CHORD) {
-                    std::copy_if(toChord(e)->notes().begin(), toChord(e)->notes().end(),
+                    Chord* c = toChord(e);
+                    std::copy_if(c->notes().begin(), c->notes().end(),
                                  std::back_inserter(notes), [this](EngravingItem* ce) { return selection().isNone() || ce->selected(); });
+                    for (Chord* g : c->graceNotes()) {
+                        std::copy_if(g->notes().begin(), g->notes().end(),
+                                     std::back_inserter(notes),
+                                     [this](EngravingItem* ce) { return selection().isNone() || ce->selected(); });
+                    }
                 }
             }
         }

--- a/src/engraving/dom/score.h
+++ b/src/engraving/dom/score.h
@@ -693,8 +693,6 @@ public:
     void setIsOpen(bool open);
 
     void spell();
-    void spell(staff_idx_t startStaff, staff_idx_t endStaff, Segment* startSegment, Segment* endSegment);
-    void spell(Note*);
     void changeEnharmonicSpelling(bool both);
 
     Fraction nextSeg(const Fraction& tick, int track);

--- a/src/engraving/dom/score.h
+++ b/src/engraving/dom/score.h
@@ -693,6 +693,8 @@ public:
     void setIsOpen(bool open);
 
     void spell();
+    void spellWithSharps();
+    void spellWithFlats();
     void changeEnharmonicSpelling(bool both);
 
     Fraction nextSeg(const Fraction& tick, int track);

--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -258,6 +258,8 @@ public:
 
     virtual void changeEnharmonicSpelling(bool both) = 0;
     virtual void spellPitches() = 0;
+    virtual void spellPitchesWithSharps() = 0;
+    virtual void spellPitchesWithFlats() = 0;
     virtual void regroupNotesAndRests() = 0;
     virtual void resequenceRehearsalMarks() = 0;
 

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -380,6 +380,8 @@ void NotationActionController::init()
     registerAction("slash-fill", &Interaction::fillSelectionWithSlashes);
     registerAction("slash-rhythm", &Interaction::replaceSelectedNotesWithSlashes);
     registerAction("pitch-spell", &Interaction::spellPitches);
+    registerAction("pitch-spell-sharps", &Interaction::spellPitchesWithSharps);
+    registerAction("pitch-spell-flats", &Interaction::spellPitchesWithFlats);
     registerAction("reset-groupings", &Interaction::regroupNotesAndRests);
     registerAction("resequence-rehearsal-marks", &Interaction::resequenceRehearsalMarks);
 

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -5940,6 +5940,20 @@ void NotationInteraction::spellPitches()
     apply();
 }
 
+void NotationInteraction::spellPitchesWithSharps()
+{
+    startEdit(TranslatableString("undoableAction", "Respell pitches with sharps"));
+    score()->spellWithSharps();
+    apply();
+}
+
+void NotationInteraction::spellPitchesWithFlats()
+{
+    startEdit(TranslatableString("undoableAction", "Respell pitches with flats"));
+    score()->spellWithFlats();
+    apply();
+}
+
 void NotationInteraction::regroupNotesAndRests()
 {
     startEdit(TranslatableString("undoableAction", "Regroup rhythms"));

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -262,6 +262,8 @@ public:
     void replaceSelectedNotesWithSlashes() override;
     void changeEnharmonicSpelling(bool) override;
     void spellPitches() override;
+    void spellPitchesWithSharps() override;
+    void spellPitchesWithFlats() override;
     void regroupNotesAndRests() override;
     void resequenceRehearsalMarks() override;
 

--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -468,6 +468,18 @@ const UiActionList NotationUiActions::m_actions = {
              TranslatableString("action", "Respell &pitches"),
              TranslatableString("action", "Respell pitches")
              ),
+    UiAction("pitch-spell-sharps",
+             mu::context::UiCtxProjectOpened,
+             mu::context::CTX_NOTATION_OPENED,
+             TranslatableString("action", "Respell pitches with &sharps"),
+             TranslatableString("action", "Respell pitches with sharps")
+             ),
+    UiAction("pitch-spell-flats",
+             mu::context::UiCtxProjectOpened,
+             mu::context::CTX_NOTATION_OPENED,
+             TranslatableString("action", "Respell pitches with &flats"),
+             TranslatableString("action", "Respell pitches with flats")
+             ),
     UiAction("reset-groupings",
              mu::context::UiCtxProjectOpened,
              mu::context::CTX_NOTATION_OPENED,

--- a/src/notation/tests/mocks/notationinteractionmock.h
+++ b/src/notation/tests/mocks/notationinteractionmock.h
@@ -220,6 +220,8 @@ public:
 
     MOCK_METHOD(void, changeEnharmonicSpelling, (bool), (override));
     MOCK_METHOD(void, spellPitches, (), (override));
+    MOCK_METHOD(void, spellPitchesWithSharps, (), (override));
+    MOCK_METHOD(void, spellPitchesWithFlats, (), (override));
     MOCK_METHOD(void, regroupNotesAndRests, (), (override));
     MOCK_METHOD(void, resequenceRehearsalMarks, (), (override));
 


### PR DESCRIPTION
This PR introduces two new commands, called "respell pitches with sharps" and "respell pitches with flats", which adjust the enharmonic spelling of selected notes or the entire score. This is useful to avoid laborious note-by-note editing in cases where, for example, MIDI input has spelled things using sharps but I want it to use flats, or vice versa.

Quick demo video:

https://github.com/user-attachments/assets/92142503-1468-430d-a89f-4958c68c1c05

Along the way, I also fixed a couple of minor issues I noticed with the "optimize enharmonic spellings" command:
- it didn't affect grace notes
- it didn't change all the notes of a tie if they weren't all selected

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
