### PR TITLE
Improve copying of Google fonts to the backend docker

### DIFF
--- a/buildscripts/ci/backend/docker/setup.sh
+++ b/buildscripts/ci/backend/docker/setup.sh
@@ -103,7 +103,7 @@ cd fonts-main
 
 echo "Installing Google Fonts..."
 mkdir -p "$FONTS_DIR"
-find . -type f \( -iname "*.ttf" -o -iname "*.otf" \) -exec cp {} "$FONTS_DIR" \;
+find . -type f \( -iname "*.ttf" -o -iname "*.otf" \) -print0 | xargs -0 -r mv-t "$FONTS_DIR"
 
 echo "Installing Fonts Cache..."
 fc-cache -f -v


### PR DESCRIPTION
Instead of using one `cp` per font (currently 3726) a) use only as many as needed per max. command line len (for me that's just 3) and b) use `mv`, which would result in a lightning fast rename operation if source and destination are in the same file system (but won't harm if not, just decays to a `cp` followed by an `rm`, which the script performs at the end anyhow).