### PR TITLE
Fix QJsonValueRef usage by replacing with QJsonValueConstRef

### DIFF
--- a/src/converter/internal/compat/backendapi.cpp
+++ b/src/converter/internal/compat/backendapi.cpp
@@ -268,11 +268,11 @@ QVariantMap BackendApi::readBeatsColors(const muse::io::path_t& filePath)
 
     QVariantMap result;
 
-    for (const QJsonValueRef colorObj: colors) {
+    for (const QJsonValueConstRef colorObj: colors) {
         const QJsonArray beatsIndexes = colorObj[u"beats"].toArray();
         const QColor beatsColor = QColor(colorObj[u"color"].toString());
 
-        for (const QJsonValueRef index: beatsIndexes) {
+        for (const QJsonValueConstRef index: beatsIndexes) {
             result[index.toString()] = beatsColor;
         }
     }

--- a/src/converter/internal/convertercontroller.cpp
+++ b/src/converter/internal/convertercontroller.cpp
@@ -258,7 +258,7 @@ RetVal<ConverterController::BatchJob> ConverterController::parseBatchJob(const m
         return io::Dir::fromNativeSeparators(path).toQString();
     };
 
-    for (const QJsonValueRef obj : arr) {
+    for (const QJsonValueConstRef obj : arr) {
         Job job;
         job.in = correctUserInputPath(obj[u"in"].toString());
 
@@ -278,7 +278,7 @@ RetVal<ConverterController::BatchJob> ConverterController::parseBatchJob(const m
             rv.val.push_back(std::move(job));
         } else if (outValue.isArray()) {
             const QJsonArray outArray = outValue.toArray();
-            for (const QJsonValueRef outItem : outArray) {
+            for (const QJsonValueConstRef outItem : outArray) {
                 Job partJob = job; // Copy the input path
                 if (outItem.isString()) {
                     partJob.out = correctUserInputPath(outItem.toString());


### PR DESCRIPTION
Resolves: #28034

The loop iterating over QJsonArray was declared as QJsonValueRef, causing a compilation error: “cannot convert from 'const QJsonValueConstRef' to 'QJsonValueRef'”. Changing the loop variable to QJsonValueConstRef (or using auto) resolves the type mismatch and preserves the array elements as constant references.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
