### PR TITLE
[MusicXML] Improve tempo import from Dorico

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass1.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass1.cpp
@@ -416,6 +416,8 @@ void MusicXmlParserPass1::setExporterSoftware(String& exporter)
         } else {
             m_exporterSoftware = MusicXmlExporterSoftware::SIBELIUS;
         }
+    } else if (exporter.contains(u"dorico")) {
+        m_exporterSoftware = MusicXmlExporterSoftware::DORICO;
     } else if (exporter.contains(u"finale")) {
         m_exporterSoftware = MusicXmlExporterSoftware::FINALE;
     } else if (exporter.contains(u"noteflight")) {

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -2708,6 +2708,7 @@ void MusicXmlParserPass2::measure(const String& partId, const Fraction time)
     DelayedArpMap delayedArps;
     HarmonyMap delayedHarmony;
     bool measureHasCoda = false;
+    double tempo = 0.0;  // helper for Dorico imports
 
     // collect candidates for courtesy accidentals to work out at measure end
     std::map<Note*, int> alterMap;
@@ -2717,8 +2718,10 @@ void MusicXmlParserPass2::measure(const String& partId, const Fraction time)
             attributes(partId, measure, time + mTime);
         } else if (m_e.name() == "direction") {
             MusicXmlParserDirection dir(m_e, m_score, m_pass1, *this, m_logger);
+            dir.setBpm(tempo);
             dir.direction(partId, measure, time + mTime, m_spanners, delayedDirections, inferredFingerings, delayedHarmony, measureHasCoda,
                           m_segnos);
+            tempo = 0.0;
         } else if (m_e.name() == "figured-bass") {
             FiguredBass* fb = figuredBass();
             if (fb) {
@@ -2727,6 +2730,28 @@ void MusicXmlParserPass2::measure(const String& partId, const Fraction time)
         } else if (m_e.name() == "harmony") {
             harmony(partId, measure, time + mTime, delayedHarmony);
         } else if (m_e.name() == "note") {
+            if (tempo) {
+                // sound tempo="..."
+                // create an invisible default TempoText
+                // to prevent duplicates, only if none is present yet
+                Fraction tick = time + mTime;
+
+                if (canAddTempoText(m_score->tempomap(), tick.ticks())) {
+                    double tpo = tempo / 60;
+                    TempoText* t = Factory::createTempoText(m_score->dummy()->segment());
+                    t->setXmlText(String(u"%1 = %2").arg(TempoText::duration2tempoTextString(TDuration(DurationType::V_QUARTER)),
+                                                         String(tempo)));
+                    t->setVisible(false);
+                    t->setTempo(tpo);
+                    t->setFollowText(true);
+
+                    m_score->setTempo(tick, tpo);
+
+                    addElemOffset(t, m_pass1.trackForPart(partId), u"above", measure, tick);
+                }
+                tempo = 0.0;
+            }
+
             // Correct delayed ottava tick
             if (m_delayedOttava && m_delayedOttava->tick2() < time + mTime) {
                 handleSpannerStop(m_delayedOttava, m_delayedOttava->track2(), time + mTime, m_spanners);
@@ -2787,29 +2812,7 @@ void MusicXmlParserPass2::measure(const String& partId, const Fraction time)
                 }
             }
         } else if (m_e.name() == "sound") {
-            String tempo = m_e.attribute("tempo");
-
-            if (!tempo.empty()) {
-                // sound tempo="..."
-                // create an invisible default TempoText
-                // to prevent duplicates, only if none is present yet
-                Fraction tick = time + mTime;
-
-                if (canAddTempoText(m_score->tempomap(), tick.ticks())) {
-                    double tpo = tempo.toDouble() / 60;
-                    TempoText* t = Factory::createTempoText(m_score->dummy()->segment());
-                    t->setXmlText(String(u"%1 = %2").arg(TempoText::duration2tempoTextString(TDuration(DurationType::V_QUARTER)),
-                                                         tempo));
-                    t->setVisible(false);
-                    t->setTempo(tpo);
-                    t->setFollowText(true);
-
-                    m_score->setTempo(tick, tpo);
-
-                    addElemOffset(t, m_pass1.trackForPart(partId), u"above", measure, tick);
-                }
-            }
-            m_e.skipCurrentElement();
+            tempo = m_e.attribute("tempo").toDouble();
         } else if (m_e.name() == "barline") {
             barline(partId, measure, time + mTime);
         } else if (m_e.name() == "print") {

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -2718,10 +2718,12 @@ void MusicXmlParserPass2::measure(const String& partId, const Fraction time)
             attributes(partId, measure, time + mTime);
         } else if (m_e.name() == "direction") {
             MusicXmlParserDirection dir(m_e, m_score, m_pass1, *this, m_logger);
-            dir.setBpm(tempo);
-            dir.direction(partId, measure, time + mTime, m_spanners, delayedDirections, inferredFingerings, delayedHarmony, measureHasCoda,
-                          m_segnos);
-            tempo = 0.0;
+            if (m_pass1.exporterSoftware() == MusicXmlExporterSoftware::DORICO) {
+                dir.setBpm(tempo);
+                tempo = 0.0;
+            }
+            dir.direction(partId, measure, time + mTime, m_spanners, delayedDirections,
+                          inferredFingerings, delayedHarmony, measureHasCoda, m_segnos);
         } else if (m_e.name() == "figured-bass") {
             FiguredBass* fb = figuredBass();
             if (fb) {

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.h
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.h
@@ -556,7 +556,7 @@ public:
 
     double totalY() const { return m_defaultY + m_relativeY; }
     muse::String placement() const;
-    const void setBpm(const double bpm) { m_tpoSound = bpm; }
+    void setBpm(const double bpm) { m_tpoSound = bpm; }
 
 private:
     void directionType(std::vector<MusicXmlSpannerDesc>& starts, std::vector<MusicXmlSpannerDesc>& stops);

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.h
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.h
@@ -556,6 +556,7 @@ public:
 
     double totalY() const { return m_defaultY + m_relativeY; }
     muse::String placement() const;
+    const void setBpm(const double bpm) { m_tpoSound = bpm; }
 
 private:
     void directionType(std::vector<MusicXmlSpannerDesc>& starts, std::vector<MusicXmlSpannerDesc>& stops);

--- a/src/importexport/musicxml/internal/musicxml/shared/musicxmltypes.h
+++ b/src/importexport/musicxml/internal/musicxml/shared/musicxmltypes.h
@@ -34,12 +34,12 @@ namespace mu::iex::musicxml {
 const int MAX_NUMBER_LEVEL = 16; // maximum number of overlapping MusicXML objects
 
 enum class MusicXmlExporterSoftware : char {
-    SIBELIUS,
     DOLET6,
     DOLET8,
+    DORICO,
     FINALE,
     NOTEFLIGHT,
-    DORICO,
+    SIBELIUS,
     OTHER
 };
 

--- a/src/importexport/musicxml/internal/musicxml/shared/musicxmltypes.h
+++ b/src/importexport/musicxml/internal/musicxml/shared/musicxmltypes.h
@@ -39,6 +39,7 @@ enum class MusicXmlExporterSoftware : char {
     DOLET8,
     FINALE,
     NOTEFLIGHT,
+    DORICO,
     OTHER
 };
 


### PR DESCRIPTION
As shown in #27961 Dorico separates the tempo change from the text (direction) in MusicXML. That led to problems with some lost text or (meaningless) text with separated invisible tempo changes. 

This PR adds a check for Dorico style tempo changes and adds the tempo change to the following `direction`. 

### Before:

<img width="1151" alt="grafik" src="https://github.com/user-attachments/assets/5ac4b9e5-c3b0-4e8f-91e1-dd98b32f2200" />

### After:

<img width="1151" alt="grafik" src="https://github.com/user-attachments/assets/b844137a-fb43-4061-b66d-3bd9e53f1026" />

closes #27961
