### PR TITLE
Fix hairpin "<" and ">" shortcuts

### DIFF
--- a/src/app/configs/data/shortcuts.xml
+++ b/src/app/configs/data/shortcuts.xml
@@ -548,11 +548,11 @@
     </SC>
   <SC>
     <key>add-hairpin</key>
-    <seq>Shift+,</seq>
+    <seq>angledBracketLeft</seq>
     </SC>
   <SC>
     <key>add-hairpin-reverse</key>
-    <seq>Shift+.</seq>
+    <seq>angledBracketRight</seq>
     </SC>
   <SC>
     <key>notation-escape</key>

--- a/src/app/configs/data/shortcuts_azerty.xml
+++ b/src/app/configs/data/shortcuts_azerty.xml
@@ -557,11 +557,11 @@
     </SC>
   <SC>
     <key>add-hairpin</key>
-    <seq>Shift+,</seq>
+    <seq>angledBracketLeft</seq>
     </SC>
   <SC>
     <key>add-hairpin-reverse</key>
-    <seq>Shift+.</seq>
+    <seq>angledBracketRight</seq>
     </SC>
   <SC>
     <key>notation-escape</key>

--- a/src/app/configs/data/shortcuts_mac.xml
+++ b/src/app/configs/data/shortcuts_mac.xml
@@ -548,11 +548,11 @@
     </SC>
   <SC>
     <key>add-hairpin</key>
-    <seq>Shift+,</seq>
+    <seq>angledBracketLeft</seq>
     </SC>
   <SC>
     <key>add-hairpin-reverse</key>
-    <seq>Shift+.</seq>
+    <seq>angledBracketRight</seq>
     </SC>
   <SC>
     <key>notation-escape</key>

--- a/src/framework/shortcuts/internal/shortcutsregister.cpp
+++ b/src/framework/shortcuts/internal/shortcutsregister.cpp
@@ -283,7 +283,7 @@ Shortcut ShortcutsRegister::readShortcut(deprecated::XmlReader& reader) const
         } else if (tag == STANDARD_KEY_TAG) {
             shortcut.standardKey = QKeySequence::StandardKey(reader.readInt());
         } else if (tag == SEQUENCE_TAG) {
-            shortcut.sequences.push_back(reader.readString());
+            shortcut.sequences.push_back(fromCompatAngledBracketIfNeed(reader.readString()));
         } else if (tag == AUTOREPEAT_TAG) {
             shortcut.autoRepeat = reader.readInt();
         } else {
@@ -368,10 +368,37 @@ void ShortcutsRegister::writeShortcut(deprecated::XmlWriter& writer, const Short
     }
 
     for (const std::string& seq : shortcut.sequences) {
-        writer.writeTextElement(SEQUENCE_TAG, seq);
+        writer.writeTextElement(SEQUENCE_TAG, toCompatAngledBracketIfNeed(seq));
     }
 
     writer.writeEndElement();
+}
+
+static constexpr std::string_view ANGLED_BRACKET_LEFT("<");
+static constexpr std::string_view ANGLED_BRACKET_RIGHT(">");
+static constexpr std::string_view COMPAT_ANGLED_BRACKET_LEFT("angledBracketLeft");
+static constexpr std::string_view COMPAT_ANGLED_BRACKET_RIGHT("angledBracketRight");
+
+std::string ShortcutsRegister::fromCompatAngledBracketIfNeed(const std::string& sequence) const
+{
+    if (sequence == COMPAT_ANGLED_BRACKET_LEFT) {
+        return std::string(ANGLED_BRACKET_LEFT);
+    } else if (sequence == COMPAT_ANGLED_BRACKET_RIGHT) {
+        return std::string(ANGLED_BRACKET_RIGHT);
+    }
+
+    return sequence;
+}
+
+std::string ShortcutsRegister::toCompatAngledBracketIfNeed(const std::string& sequence) const
+{
+    if (sequence == ANGLED_BRACKET_LEFT) {
+        return std::string(COMPAT_ANGLED_BRACKET_LEFT);
+    } else if (sequence == ANGLED_BRACKET_RIGHT) {
+        return std::string(COMPAT_ANGLED_BRACKET_RIGHT);
+    }
+
+    return sequence;
 }
 
 Notification ShortcutsRegister::shortcutsChanged() const

--- a/src/framework/shortcuts/internal/shortcutsregister.h
+++ b/src/framework/shortcuts/internal/shortcutsregister.h
@@ -81,6 +81,9 @@ private:
     bool writeToFile(const ShortcutList& shortcuts, const io::path_t& path) const;
     void writeShortcut(deprecated::XmlWriter& writer, const Shortcut& shortcut) const;
 
+    std::string fromCompatAngledBracketIfNeed(const std::string& sequence) const;
+    std::string toCompatAngledBracketIfNeed(const std::string& sequence) const;
+
     void mergeShortcuts(ShortcutList& shortcuts, const ShortcutList& defaultShortcuts) const;
     void mergeAdditionalShortcuts(ShortcutList& shortcuts);
 


### PR DESCRIPTION
Resolves: #15091

As far as I understand, the whole problem lies in the fact that we save our list of shortcuts as an XML file, but "<" and ">" are forbidden characters in XML, so writing them in our shortcut list (be it the default one or the user-customized one) effectively produces an ill-formed XML document, which then messes everything up when we try to load the shortcuts.

<img width="302" alt="image" src="https://github.com/user-attachments/assets/bc37253e-e1de-4e28-8a6d-7512308fe6c1" />

I'm assuming that's the reason why we encoded these shortcuts as "Shift+." and "Shift+," commands. However, this only works on the English keyboard layout. On my Italian keyboard those don't make much sense (the angled brackets have a different key) and they never seemed to work anyway on my machine.

Here I'm doing a very simple solution of just substituting the problematic "<" and ">" characters with compatible strings in the XML file. This is just an internal thing we do when saving the shortcuts. The user doesn't see any of this, they just work normally with "<" and ">".