### PR TITLE
28077: [Qt6.9] Main window not maximized on startup

### DIFF
--- a/src/app/internal/guiapp.cpp
+++ b/src/app/internal/guiapp.cpp
@@ -234,7 +234,8 @@ void GuiApp::perform()
 
         // The main window must be shown at this point so KDDockWidgets can read its size correctly
         // and scale all sizes properly. https://github.com/musescore/MuseScore/issues/21148
-        obj->setProperty("visible", true);
+        QQuickWindow* w = dynamic_cast<QQuickWindow*>(obj);
+        w->setVisible(true);
 
         startupScenario()->runAfterSplashScreen();
     }, Qt::QueuedConnection);


### PR DESCRIPTION
Resolves: #28077

`obj->setProperty("visible", true);` that was added recently to fix layout issues (KDDockWidgets wants the main window to be visible when restoring the layout) does not work the same in Qt6.9: in Qt6.9 the `windowState` is ignored and the window is always shown in its normal size and location. `setVisible` works though.

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
