### PR TITLE
Maybe fix Sentry MU4-69DK

### DIFF
--- a/src/notation/utilities/scorerangeutilities.cpp
+++ b/src/notation/utilities/scorerangeutilities.cpp
@@ -102,7 +102,7 @@ std::vector<ScoreRangeUtilities::RangeSection> ScoreRangeUtilities::splitRangeBy
         const System* currentSegmentSystem = segment->measure()->system();
 
         const Segment* nextSegment = segment->next1MMenabled();
-        while (!nextSegment->isActive()) {
+        while (nextSegment && !nextSegment->isActive()) {
             nextSegment = nextSegment->next1MMenabled();
         }
 


### PR DESCRIPTION
Can't reproduce this crash, but from the context, it looks like this null check might make sense. Not completely convinced though.

Resolves: https://sentry.musescore.org/musescore/mu4/issues/274320/