### PR TITLE
Better volume control for VST instruments.

### DIFF
--- a/src/framework/vst/internal/synth/vstsequencer.cpp
+++ b/src/framework/vst/internal/synth/vstsequencer.cpp
@@ -116,6 +116,10 @@ void VstSequencer::updatePlaybackEvents(EventSequenceMap& destination, const mpe
             float velocityFraction = noteVelocityFraction(noteEvent);
             float tuning = noteTuning(noteEvent, noteId);
 
+            if (noteEvent.expressionCtx().articulations.averageDynamicOffsetMap().size() > 0) {
+                velocityFraction = 1.0f;
+            }
+
             destination[timestampFrom].emplace(buildEvent(VstEvent::kNoteOnEvent, noteId, velocityFraction, tuning));
             destination[timestampTo].emplace(buildEvent(VstEvent::kNoteOffEvent, noteId, velocityFraction, tuning));
 

--- a/src/framework/vst/internal/vstaudioclient.cpp
+++ b/src/framework/vst/internal/vstaudioclient.cpp
@@ -423,7 +423,7 @@ bool VstAudioClient::fillOutputBufferInstrument(samples_t sampleCount, float* ou
 
             for (audioch_t audioChannelIndex = 0; audioChannelIndex < bus.numChannels; ++audioChannelIndex) {
                 float sample = bus.channelBuffers32[audioChannelIndex][sampleIndex];
-                output[offset + audioChannelIndex] += sample * m_volumeGain;
+                output[offset + audioChannelIndex] += sample * m_volumeGain * m_volumeGain * m_volumeGain;
 
                 if (isSilence && sample != 0.f) {
                     isSilence = false;


### PR DESCRIPTION
Resolves: #28085

Adds better volume control for VST instruments during dynamic effects (crescendo, forte-piano, etc).

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
