### PR TITLE
Fix arm32 Linux build

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -202,7 +202,7 @@ jobs:
         LUPDATE_ARGS: ""
         POSTPROCESS_ARGS: ${{ env.DO_PLACEHOLDER_TRANSLATIONS == 'true' && '--generate-placeholder-translations' || '' }}
       run: |
-        bash ./buildscripts/ci/translation/run_lupdate.sh
+        bash ./tools/translations/run_lupdate.sh
     - name: Update .ts files (tx pull)
       if: env.DO_UPDATE_TS == 'true'
       uses: transifex/cli-action@v2

--- a/.github/workflows/build_linux_arm32.yml
+++ b/.github/workflows/build_linux_arm32.yml
@@ -147,10 +147,10 @@ jobs:
         C_URL=${SENTRY_URL}; if [ -z "$C_URL" ]; then C_URL="''"; fi
         sudo docker run --platform linux/arm -i -v "${PWD}:/MuseScore" -v /usr/bin/qemu-arm-static:/usr/bin/qemu-arm-static "arm32v7/ubuntu:jammy" /bin/bash -c "\
           cd /MuseScore && \
-          git config --global --add safe.directory /MuseScore && \
           bash /MuseScore/buildscripts/ci/linux/setup.sh --arch armv7l && \
           bash /MuseScore/buildscripts/ci/linux/arm32/install_qt.sh && \
-          bash /MuseScore/tools/translation/run_lupdate.sh && \
+          git config --global --add safe.directory /MuseScore && \
+          bash /MuseScore/buildscripts/ci/translation/run_lupdate.sh && \
           bash /MuseScore/buildscripts/ci/linux/build.sh -n ${{ env.BUILD_NUMBER }} --crash_log_url $C_URL --arch armv7l && \
           bash /MuseScore/buildscripts/ci/linux/package.sh --arch armv7l && \
           bash /MuseScore/buildscripts/ci/tools/checksum.sh \


### PR DESCRIPTION
- Git is not installed by default, so cannot be used before `setup.sh`
- Since the build runs as multiple scripts in succession inside Docker, `install_qt.sh` cannot edit the environment for the next scripts, so in this case we do need to use the 'environment file' created by `setup.sh`, i.e. we need `buildscripts/ci/translation/run_lupdate.sh`
- On normal Linux, we _can_ edit the environment for the next scripts via `$GITHUB_ENV`, so here, we can simply use `tools/translations/run_lupdate.sh`

Test run: https://github.com/cbjeukendrup/MuseScore/actions/runs/15147357232