### PR TITLE
Fix properties panel not updating when pasting

### DIFF
--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -953,16 +953,13 @@ void NotationInteraction::selectElementsWithSameTypeOnSegment(mu::engraving::Ele
 void NotationInteraction::selectAndStartEditIfNeeded(EngravingItem* element)
 {
     if (element->isSpanner() && !toSpanner(element)->segmentsEmpty()) {
-        SpannerSegment* frontSeg = toSpanner(element)->frontSegment();
-        select({ frontSeg }, SelectType::SINGLE);
-        if (frontSeg->needStartEditingAfterSelecting()) {
-            startEditElement(frontSeg, false);
-        }
-    } else {
-        select({ element }, SelectType::SINGLE);
-        if (element->needStartEditingAfterSelecting()) {
-            startEditElement(element, false);
-        }
+        element = toSpanner(element)->frontSegment();
+    }
+
+    select({ element }, SelectType::SINGLE);
+
+    if (element->needStartEditingAfterSelecting()) {
+        startEditElement(element, false);
     }
 }
 

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -954,12 +954,12 @@ void NotationInteraction::selectAndStartEditIfNeeded(EngravingItem* element)
 {
     if (element->isSpanner() && !toSpanner(element)->segmentsEmpty()) {
         SpannerSegment* frontSeg = toSpanner(element)->frontSegment();
-        doSelect({ frontSeg }, SelectType::SINGLE);
+        select({ frontSeg }, SelectType::SINGLE);
         if (frontSeg->needStartEditingAfterSelecting()) {
             startEditElement(frontSeg, false);
         }
     } else {
-        doSelect({ element }, SelectType::SINGLE);
+        select({ element }, SelectType::SINGLE);
         if (element->needStartEditingAfterSelecting()) {
             startEditElement(element, false);
         }


### PR DESCRIPTION
Resolves: #27846 

The `InspectorListModel` listens for selection changes on `NotationInteraction` to update the displayed elements. `NotationInteraction` notifies selection listeners in `apply()` (indirectly via the undo stack). However, since `apply()` is called before the selection is updated in `pasteSelection()`, no selection update notification was sent.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
