### PR TITLE
VstView rework

### DIFF
--- a/src/framework/vst/view/vstview.h
+++ b/src/framework/vst/view/vstview.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <QQuickItem>
+#include <QTimer>
 
 #include "global/modularity/ioc.h"
 #include "../ivstinstancesregister.h"
@@ -33,6 +34,10 @@ class VstView : public QQuickItem, public Steinberg::IPlugFrame
     Q_OBJECT
     Q_PROPERTY(int instanceId READ instanceId WRITE setInstanceId NOTIFY instanceIdChanged FINAL)
     Q_PROPERTY(QString title READ title NOTIFY titleChanged FINAL)
+    Q_PROPERTY(int sidePadding READ sidePadding WRITE setsidePadding NOTIFY sidePaddingChanged FINAL)
+    Q_PROPERTY(int topPadding READ topPadding WRITE setTopPadding NOTIFY topPaddingChanged FINAL)
+    Q_PROPERTY(int bottomPadding READ bottomPadding WRITE setBottomPadding NOTIFY bottomPaddingChanged FINAL)
+    Q_PROPERTY(int minimumWidth READ minimumWidth WRITE setMinimumWidth NOTIFY minimumWidthChanged FINAL)
 
     muse::Inject<IVstInstancesRegister> instancesRegister;
 
@@ -54,9 +59,25 @@ public:
 
     QString title() const;
 
+    int sidePadding() const;
+    void setsidePadding(int);
+
+    int topPadding() const;
+    void setTopPadding(int);
+
+    int bottomPadding() const;
+    void setBottomPadding(int);
+
+    int minimumWidth() const;
+    void setMinimumWidth(int);
+
 signals:
     void instanceIdChanged();
     void titleChanged();
+    void sidePaddingChanged();
+    void topPaddingChanged();
+    void bottomPaddingChanged();
+    void minimumWidthChanged();
 
 private:
 
@@ -70,10 +91,24 @@ private:
 
     int m_instanceId = -1;
     IVstPluginInstancePtr m_instance;
-    QWindow* m_window = nullptr;
-    ScreenMetrics m_screenMetrics;
     PluginViewPtr m_view;
     QString m_title;
     RunLoop* m_runLoop = nullptr;
+
+    // VST plugins expect to be given an entire window where to draw their UI.
+    // Since the host might want to place some controls (like a bypass button, a preset dropdown, etc)
+    // or even just padding around the UI, a child window is needed for the exclusive use of the plugin.
+    // `VstView` will position this child window on top of its parent window, according to the
+    // different padding properties it exposes.
+    QWindow* m_vstWindow = nullptr;
+
+    QScreen* m_currentScreen = nullptr;
+    ScreenMetrics m_screenMetrics;
+    QTimer m_screenMetricsTimer;
+
+    int m_sidePadding = 0;
+    int m_topPadding = 0;
+    int m_bottomPadding = 0;
+    int m_minimumWidth = 0;
 };
 }


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/8512
Resolves: https://github.com/audacity/audacity/issues/8782
Resolves: https://github.com/audacity/audacity/issues/8777

This PR addresses two problems:

#### wrong screen scaling detected

when opening the VST on an external display with different scaling, the UI of some VSTs on Windows use the wrong scaling factor, leading to artifacts such as this:
<img width="450" alt="Image" src="https://github.com/user-attachments/assets/673e683e-7d8c-4c5d-990d-8cdf9b322ff0" />

Now we do not rely on Qt's `QtWindow::screenChanged` callback, but proactively query the screen metrics every 100ms. This is the only of many tried approaches to solving this problem. 

#### overflowing UIs

Some VSTs do not cooperate when we ask them to scale down programmatically. As a result, they overflow the bottom of the view, hiding controls (like Audacity's "Apply" button when the effect is used in destructive mode).

### Note

This PR affects the new VST view, which is currently disabled in the release build. This PR will contribute to the development of Audacity 4, which is pre-alpha and actively being tested. Problems caused by this PR, if any, are likely to get discovered there. Once we are confident about these changes in Audacity, we may want to adopt the new view in MSS without breaking a sweat.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
