### PR TITLE
Fix inc/dec duration command when used with dotted notes

### DIFF
--- a/src/engraving/dom/cmd.cpp
+++ b/src/engraving/dom/cmd.cpp
@@ -3295,18 +3295,17 @@ void Score::cmdIncDecDuration(int nSteps, bool stepDotted)
     ChordRest* cr = toChordRest(el);
 
     // if measure rest is selected as input, then the correct initialDuration will be the
-    // duration of the measure's time signature, else is just the input state's duration
-    TDuration initialDuration;
-    if (cr->durationType() == DurationType::V_MEASURE) {
+    // duration of the measure's time signature, else is just the ChordRest's duration
+    TDuration initialDuration = cr->durationType();
+    if (initialDuration == DurationType::V_MEASURE) {
         initialDuration = TDuration(cr->measure()->timesig(), true);
 
         if (initialDuration.fraction() < cr->measure()->timesig() && nSteps > 0) {
             // Duration already shortened by truncation; shorten one step less
             --nSteps;
         }
-    } else {
-        initialDuration = m_is.duration();
     }
+
     TDuration d = (nSteps != 0) ? initialDuration.shiftRetainDots(nSteps, stepDotted) : initialDuration;
     if (!d.isValid()) {
         return;


### PR DESCRIPTION
Resolves: #28069

The inc/dec duration command used the input state duration as the initial duration instead of the duration of the selected note. This started causing issues because the input state duration is changed on each selection change in `NotationNoteInput::updateInputState()` when the "Apply accidentals, [...]" setting is set to "To previous not entered".

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
