### PR TITLE
Allow to position multiple panels in the same location side by side

### DIFF
--- a/src/framework/dockwindow/view/dockwindow.cpp
+++ b/src/framework/dockwindow/view/dockwindow.cpp
@@ -391,14 +391,29 @@ void DockWindow::loadPanels(const DockPageView* page)
 {
     TRACEFUNC;
 
+    DockBase* centralDock = page->centralDock();
+
+    QMap<Location, DockBase*> lastRelativeToByLocation = {
+        { Location::Left, centralDock },
+        { Location::Right, centralDock }
+    };
+
     for (DockPanelView* panel : page->panels()) {
         if (DockPanelView* destinationPanel = findDestinationForPanel(page, panel)) {
             addPanelAsTab(panel, destinationPanel);
             continue;
         }
+
         const Location location = panel->location();
         const bool isSideLocation = location == Location::Left || location == Location::Right;
-        addDock(panel, location, isSideLocation ? page->centralDock() : nullptr);
+
+        DockBase* relativeTo = nullptr;
+        if (isSideLocation) {
+            relativeTo = lastRelativeToByLocation.value(location);
+            lastRelativeToByLocation[location] = panel;
+        }
+
+        addDock(panel, location, relativeTo);
     }
 
     for (Location location : POSSIBLE_LOCATIONS) {


### PR DESCRIPTION
Support position multiple panels at the same location.
For now this is a simple solution where the side panels are added in sequence.
For location::left the next panel will be added on the left of the previous one.
For location right on the other hand they will be added on the right.

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
