### PR TITLE
Issue #28085: now sending kCtrlVolume events to VST instruments

### DIFF
--- a/src/framework/vst/internal/synth/vstsequencer.cpp
+++ b/src/framework/vst/internal/synth/vstsequencer.cpp
@@ -101,6 +101,10 @@ void VstSequencer::updatePlaybackEvents(EventSequenceMap& destination, const mpe
 {
     SostenutoTimeAndDurations sostenutoTimeAndDurations;
 
+    auto volumeParamIt = m_mapping.find(Steinberg::Vst::kCtrlVolume);
+    bool hasCtrlVolumeMapping = (volumeParamIt != m_mapping.cend());
+    bool volumeForFirstNoteSet = !hasCtrlVolumeMapping;
+
     for (const auto& evPair : events) {
         for (const mpe::PlaybackEvent& event : evPair.second) {
             if (!std::holds_alternative<mpe::NoteEvent>(event)) {
@@ -115,6 +119,13 @@ void VstSequencer::updatePlaybackEvents(EventSequenceMap& destination, const mpe
             int32_t noteId = noteIndex(noteEvent.pitchCtx().nominalPitchLevel);
             float velocityFraction = noteVelocityFraction(noteEvent);
             float tuning = noteTuning(noteEvent, noteId);
+
+            if (!volumeForFirstNoteSet) {
+                // Put one kCtrlVolume event at the start of the first note when using
+                // kCtrlVolume events, to make sure off stream events are audible.
+                destination[0].emplace(ParamChangeEvent { volumeParamIt->second, velocityFraction });
+                volumeForFirstNoteSet = true;
+            }
 
             destination[timestampFrom].emplace(buildEvent(VstEvent::kNoteOnEvent, noteId, velocityFraction, tuning));
             destination[timestampTo].emplace(buildEvent(VstEvent::kNoteOffEvent, noteId, velocityFraction, tuning));
@@ -147,9 +158,18 @@ void VstSequencer::updatePlaybackEvents(EventSequenceMap& destination, const mpe
 
 void VstSequencer::updateDynamicEvents(EventSequenceMap& destination, const mpe::DynamicLevelLayers& layers)
 {
+    auto volumeParamIt = m_mapping.find(Steinberg::Vst::kCtrlVolume);
+    bool hasCtrlVolumeMapping = (volumeParamIt != m_mapping.cend());
+
     for (const auto& layer : layers) {
         for (const auto& dynamic : layer.second) {
-            destination[dynamic.first].emplace(expressionLevel(dynamic.second));
+            auto level = expressionLevel(dynamic.second);
+
+            if (hasCtrlVolumeMapping) {
+                destination[dynamic.first].emplace(ParamChangeEvent { volumeParamIt->second, level });
+            } else {
+                destination[dynamic.first].emplace(level);
+            }
         }
     }
 }

--- a/src/framework/vst/internal/synth/vstsequencer.cpp
+++ b/src/framework/vst/internal/synth/vstsequencer.cpp
@@ -163,7 +163,7 @@ void VstSequencer::updateDynamicEvents(EventSequenceMap& destination, const mpe:
 
     for (const auto& layer : layers) {
         for (const auto& dynamic : layer.second) {
-            auto level = expressionLevel(dynamic.second);
+            float level = expressionLevel(dynamic.second);
 
             if (hasCtrlVolumeMapping) {
                 destination[dynamic.first].emplace(ParamChangeEvent { volumeParamIt->second, level });

--- a/src/framework/vst/internal/vstaudioclient.cpp
+++ b/src/framework/vst/internal/vstaudioclient.cpp
@@ -110,7 +110,8 @@ bool VstAudioClient::handleParamChange(const ParamChangeEvent& param)
 
 void VstAudioClient::setVolumeGain(const muse::audio::gain_t newVolumeGain)
 {
-    m_volumeGain = newVolumeGain;
+    // Only set volume when plugin is not handling volume events.
+    m_volumeGain = m_pluginHandlesVolume ? 1.f : newVolumeGain;
 }
 
 muse::audio::samples_t VstAudioClient::process(float* output, muse::audio::samples_t samplesPerChannel,
@@ -359,6 +360,10 @@ void VstAudioClient::setUpProcessData()
         component->activateBus(BusMediaType::kAudio, BusDirection::kOutput, 0, true);
         m_activeOutputBusses.emplace_back(0);
     }
+
+    // Check whether the plugin can handle kCtrlVolume and set flag accordingly.
+    auto volParamMapping = paramsMapping({ Steinberg::Vst::kCtrlVolume });
+    m_pluginHandlesVolume = !volParamMapping.empty();
 }
 
 void VstAudioClient::updateProcessSetup()

--- a/src/framework/vst/internal/vstaudioclient.cpp
+++ b/src/framework/vst/internal/vstaudioclient.cpp
@@ -77,6 +77,10 @@ void VstAudioClient::loadSupportedParams()
         controller->getParameterInfo(i, info);
         m_pluginParamInfoMap.emplace(info.id, std::move(info));
     }
+
+    // Check whether the plugin can handle kCtrlVolume and set flag accordingly.
+    auto volMapping = paramsMapping({ Steinberg::Vst::kCtrlVolume });
+    m_pluginHandlesVolume = !volMapping.empty();
 }
 
 bool VstAudioClient::handleEvent(const VstEvent& event)
@@ -360,10 +364,6 @@ void VstAudioClient::setUpProcessData()
         component->activateBus(BusMediaType::kAudio, BusDirection::kOutput, 0, true);
         m_activeOutputBusses.emplace_back(0);
     }
-
-    // Check whether the plugin can handle kCtrlVolume and set flag accordingly.
-    auto volParamMapping = paramsMapping({ Steinberg::Vst::kCtrlVolume });
-    m_pluginHandlesVolume = !volParamMapping.empty();
 }
 
 void VstAudioClient::updateProcessSetup()

--- a/src/framework/vst/internal/vstaudioclient.h
+++ b/src/framework/vst/internal/vstaudioclient.h
@@ -83,6 +83,7 @@ private:
     void addParamChange(const ParamChangeEvent& param);
 
     bool m_isActive = false;
+    bool m_pluginHandlesVolume = true;
     muse::audio::gain_t m_volumeGain = 1.f; // 0.0 - 1.0
 
     IVstPluginInstancePtr m_pluginPtr = nullptr;

--- a/src/framework/vst/internal/vstaudioclient.h
+++ b/src/framework/vst/internal/vstaudioclient.h
@@ -83,7 +83,7 @@ private:
     void addParamChange(const ParamChangeEvent& param);
 
     bool m_isActive = false;
-    bool m_pluginHandlesVolume = true;
+    bool m_pluginHandlesVolume = false;
     muse::audio::gain_t m_volumeGain = 1.f; // 0.0 - 1.0
 
     IVstPluginInstancePtr m_pluginPtr = nullptr;


### PR DESCRIPTION
Resolves: #28085

Now checking, whether a VSTi plugin supports kCtrlVolume, and then setting up the dynamic events accordingly.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
