### PR TITLE
Remove stemArrangement property from Slur

### DIFF
--- a/src/engraving/dom/slur.cpp
+++ b/src/engraving/dom/slur.cpp
@@ -393,7 +393,6 @@ double SlurSegment::dottedWidth() const
 Slur::Slur(const Slur& s)
     : SlurTie(s)
 {
-    _sourceStemArrangement = s._sourceStemArrangement;
     _connectedElement = s._connectedElement;
     _partialSpannerDirection = s._partialSpannerDirection;
 }
@@ -406,16 +405,6 @@ Slur::Slur(EngravingItem* parent)
     : SlurTie(ElementType::SLUR, parent)
 {
     setAnchor(Anchor::CHORD);
-}
-
-//---------------------------------------------------------
-//   calcStemArrangement
-//---------------------------------------------------------
-
-int Slur::calcStemArrangement(EngravingItem* start, EngravingItem* end)
-{
-    return (start && start->isChord() && toChord(start)->stem() && toChord(start)->stem()->up() ? 2 : 0)
-           + (end && end->isChord() && toChord(end)->stem() && toChord(end)->stem()->up() ? 4 : 0);
 }
 
 double Slur::scalingFactor() const

--- a/src/engraving/dom/slur.h
+++ b/src/engraving/dom/slur.h
@@ -116,8 +116,6 @@ public:
 
     SlurTieSegment* newSlurTieSegment(System* parent) override { return new SlurSegment(parent); }
 
-    static int calcStemArrangement(EngravingItem* start, EngravingItem* end);
-
     double scalingFactor() const override;
 
     void undoSetIncoming(bool incoming);
@@ -127,7 +125,6 @@ public:
     bool isIncoming() const;
     bool isOutgoing() const;
 private:
-    M_PROPERTY2(int, sourceStemArrangement, setSourceStemArrangement, -1)
     M_PROPERTY2(ConnectedElement, connectedElement, setConnectedElement, ConnectedElement::NONE)
     M_PROPERTY2(PartialSpannerDirection, partialSpannerDirection, setPartialSpannerDirection, PartialSpannerDirection::NONE)
 

--- a/src/engraving/rendering/score/slurtielayout.cpp
+++ b/src/engraving/rendering/score/slurtielayout.cpp
@@ -88,14 +88,6 @@ SpannerSegment* SlurTieLayout::layoutSystem(Slur* item, System* system, LayoutCo
             item->setTick2(item->tick());
         }
         computeUp(item, ctx);
-        if (item->sourceStemArrangement() != -1) {
-            if (item->sourceStemArrangement() != item->calcStemArrangement(item->startCR(), item->endCR())) {
-                // copy & paste from incompatible stem arrangement, so reset bezier points
-                for (int g = 0; g < (int)Grip::GRIPS; ++g) {
-                    slurSegment->ups((Grip)g) = UP();
-                }
-            }
-        }
         sst = item->tick2() < etick ? SpannerSegmentType::SINGLE : SpannerSegmentType::BEGIN;
     } else if (item->tick() < stick && item->tick2() >= etick) {
         sst = SpannerSegmentType::MIDDLE;

--- a/src/engraving/rw/read400/tread.cpp
+++ b/src/engraving/rw/read400/tread.cpp
@@ -3519,11 +3519,6 @@ void TRead::read(Slur* s, XmlReader& e, ReadContext& ctx)
 
 bool TRead::readProperties(Slur* s, XmlReader& e, ReadContext& ctx)
 {
-    const AsciiStringView tag(e.name());
-    if (tag == "stemArr") {
-        s->setSourceStemArrangement(e.readInt());
-        return true;
-    }
     return readProperties(static_cast<SlurTie*>(s), e, ctx);
 }
 

--- a/src/engraving/rw/read410/tread.cpp
+++ b/src/engraving/rw/read410/tread.cpp
@@ -4014,10 +4014,7 @@ void TRead::read(Slur* s, XmlReader& e, ReadContext& ctx)
 bool TRead::readProperties(Slur* s, XmlReader& e, ReadContext& ctx)
 {
     const AsciiStringView tag(e.name());
-    if (tag == "stemArr") {
-        s->setSourceStemArrangement(e.readInt());
-        return true;
-    } else if (TRead::readProperty(s, tag, e, ctx, Pid::PARTIAL_SPANNER_DIRECTION)) {
+    if (TRead::readProperty(s, tag, e, ctx, Pid::PARTIAL_SPANNER_DIRECTION)) {
         return true;
     }
 

--- a/src/engraving/rw/read460/tread.cpp
+++ b/src/engraving/rw/read460/tread.cpp
@@ -3972,10 +3972,8 @@ void TRead::read(Slur* s, XmlReader& e, ReadContext& ctx)
 bool TRead::readProperties(Slur* s, XmlReader& e, ReadContext& ctx)
 {
     const AsciiStringView tag(e.name());
-    if (tag == "stemArr") {
-        s->setSourceStemArrangement(e.readInt());
-        return true;
-    } else if (TRead::readProperty(s, tag, e, ctx, Pid::PARTIAL_SPANNER_DIRECTION)) {
+
+    if (TRead::readProperty(s, tag, e, ctx, Pid::PARTIAL_SPANNER_DIRECTION)) {
         return true;
     }
 

--- a/src/engraving/rw/write/twrite.cpp
+++ b/src/engraving/rw/write/twrite.cpp
@@ -2573,9 +2573,6 @@ void TWrite::write(const Slur* item, XmlWriter& xml, WriteContext& ctx)
         return;
     }
     xml.startElement(item);
-    if (ctx.clipboardmode()) {
-        xml.tag("stemArr", Slur::calcStemArrangement(item->startElement(), item->endElement()));
-    }
 
     writeProperty(item, xml, Pid::PARTIAL_SPANNER_DIRECTION);
 

--- a/src/engraving/tests/selectionfilter_data/selectionfilter6-base-ref.xml
+++ b/src/engraving/tests/selectionfilter_data/selectionfilter6-base-ref.xml
@@ -8,7 +8,6 @@
       <durationType>quarter</durationType>
       <Spanner type="Slur">
         <Slur>
-          <stemArr>0</stemArr>
           <ticks_f>1/4</ticks_f>
           </Slur>
         <next>
@@ -40,7 +39,6 @@
       <durationType>quarter</durationType>
       <Spanner type="Slur">
         <Slur>
-          <stemArr>0</stemArr>
           <ticks_f>1/4</ticks_f>
           </Slur>
         <next>


### PR DESCRIPTION
Resolves: #28151 

_Everything_ about this is wrong. This property was created to only work on copy-paste and never gets updated during layout. In this case, it gets copy-pasted from the palette element and results in the slur grip points getting constantly reset (saving-closing-reopening the file fixes it as the property is then forgotten).