### PR TITLE
Avoid filedialog Segfault

### DIFF
--- a/src/framework/ui/view/interactiveprovider.cpp
+++ b/src/framework/ui/view/interactiveprovider.cpp
@@ -89,7 +89,7 @@ void InteractiveProvider::raiseWindowInStack(QObject* newActiveWindow)
 
     for (int i = 0; i < m_stack.size(); ++i) {
         bool found = m_stack[i].window == newActiveWindow;
-        if (m_stack[i].window->isWidgetType()) {
+        if (m_stack[i].window && m_stack[i].window->isWidgetType()) {
             found = newActiveWindow->objectName() == (m_stack[i].window->objectName() + "Window");
         }
 


### PR DESCRIPTION
Without this patch, various file dialogs would crash musescore 4.5.1 and 4.5.2 on icewm/openSUSE-Slowroll

with such a backtrace:

    at /usr/src/debug/MuseScore-4.5.1/src/framework/ui/view/interactiveprovider.cpp:90
    this=<optimized out>, r=<optimized out>, a=<optimized out>)
    at /usr/src/debug/qtbase-everywhere-src-6.9.0/src/corelib/kernel/qobjectdefs_impl.h:461
    at /usr/src/debug/qtbase-everywhere-src-6.9.0/src/corelib/kernel/qobject.cpp:4138
    local_signal_index=6, ret=0x0) at /usr/src/debug/qtbase-everywhere-src-6.9.0/src/corelib/kernel/qobjectdefs.h:306
    at /usr/src/debug/qtbase-everywhere-src-6.9.0/build/src/gui/Gui_autogen/include/moc_qguiapplication.cpp:330
    at /usr/src/debug/qtbase-everywhere-src-6.9.0/src/corelib/kernel/qcoreapplication.h:98
    at /usr/src/debug/qtbase-everywhere-src-6.9.0/src/gui/kernel/qwindowsysteminterface.cpp:1113
    at /usr/src/debug/qtbase-everywhere-src-6.9.0/src/plugins/platforms/xcb/qxcbeventdispatcher.cpp:57
    dispatch=dispatch@entry=1, self=<optimized out>) at ../glib/gmain.c:4314
    at /usr/src/debug/qtbase-everywhere-src-6.9.0/src/corelib/kernel/qeventdispatcher_glib.cpp:399
    at /usr/src/debug/qtbase-everywhere-src-6.9.0/src/corelib/global/qflags.h:77
    type=muse::ui::InteractiveProvider::FileDialogType::SelectSavingFile, title="Save score", path=...,
    filter=std::vector of length 2, capacity 2 = {...}, confirmOverwrite=true) at /usr/include/qt6/QtCore/qflags.h:77
    filter=std::vector of length 2, capacity 2 = {...}, confirmOverwrite=true)
    at /usr/src/debug/MuseScore-4.5.1/src/framework/global/internal/interactive.cpp:208
    saveMode=<optimized out>) at /usr/src/debug/MuseScore-4.5.1/src/project/internal/opensaveprojectscenario.cpp:115
[snipped]

Resolves: #NNNNN <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
