### PR TITLE
Fixed resizing of mixer panel

### DIFF
--- a/src/framework/dockwindow/thirdparty/KDDockWidgets/src/private/WidgetResizeHandler.cpp
+++ b/src/framework/dockwindow/thirdparty/KDDockWidgets/src/private/WidgetResizeHandler.cpp
@@ -90,15 +90,15 @@ bool WidgetResizeHandler::eventFilter(QObject *o, QEvent *e)
     if (m_isTopLevelWindowResizer && (!widget->isTopLevel() || o != mTarget))
         return false;
 
-    // Get the window under the cursor and check if it's our target window
-    QWindow *windowUnderCursor = qApp->topLevelAt(QCursor::pos());
-    if (!windowUnderCursor || (windowUnderCursor != widget->window()->windowHandle()))
-        return false;
-
     switch (e->type()) {
     case QEvent::MouseButtonPress: {
         if (mTarget->isMaximized())
             break;
+
+        // Get the window under the cursor and check if it's our target window
+        QWindow *windowUnderCursor = qApp->topLevelAt(QCursor::pos());
+        if (!windowUnderCursor || (windowUnderCursor != widget->window()->windowHandle()))
+            return false;
 
         auto mouseEvent = static_cast<QMouseEvent *>(e);
         auto cursorPos = cursorPosition(Qt5Qt6Compat::eventGlobalPos(mouseEvent));


### PR DESCRIPTION
Was broken in https://github.com/musescore/MuseScore/pull/27635

When the user tries to resize the window, the cursor ends up outside the window’s area, and we filter out all events in that case.
The correct behavior would be to prevent the resize only on mouse press, not during the drag.

https://github.com/user-attachments/assets/bc8b284a-d281-478b-938d-25ac18688383

