### PR TITLE
[qt6.8] Fix left margin in the Properties panel

### DIFF
--- a/src/inspector/view/qml/MuseScore/Inspector/InspectorForm.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/InspectorForm.qml
@@ -72,8 +72,6 @@ Rectangle {
         anchors.fill: parent
 
         topMargin: 12
-        leftMargin: 12
-        rightMargin: 12
         bottomMargin: 12
 
         spacing: 12
@@ -101,20 +99,22 @@ Rectangle {
         }
 
         delegate: Column {
-            width: ListView.view.width - ListView.view.leftMargin - ListView.view.rightMargin
-
+            width: ListView.view.width
             spacing: sectionList.spacing
 
             property var navigationPanel: _item.navigationPanel
 
             SeparatorLine {
-                anchors.margins: -12
-
                 visible: model.index !== 0
             }
 
             InspectorSectionDelegate {
                 id: _item
+
+                anchors.left: parent.left
+                anchors.leftMargin: 12
+                anchors.right: parent.right
+                anchors.rightMargin: 12
 
                 sectionModel: model.inspectorSectionModel
                 anchorItem: root


### PR DESCRIPTION
Flickable.leftMargin is no longer used to set the delegates' x position, and setting their `x` property manually doesn't work either. So we have to create the margin inside the delegates, instead of around the delegates.