### PR TITLE
Fix #28126: Get staff group from instrument when inserting clef

### DIFF
--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -5615,6 +5615,9 @@ void Score::undoChangeClef(Staff* ostaff, EngravingItem* e, ClefType ct, bool fo
 
         StaffType* staffType = staff->staffType(e->tick());
         StaffGroup staffGroup = staffType->group();
+        if (staffGroup != StaffGroup::TAB) {
+            staffGroup = staff->part()->instrument(e->tick())->useDrumset() ? StaffGroup::PERCUSSION : StaffGroup::STANDARD;
+        }
         if (ClefInfo::staffGroup(ct) != staffGroup && !forInstrumentChange) {
             continue;
         }


### PR DESCRIPTION
Resolves: #28126

This does a minimal fix by getting the `StaffGroup` from the instrument, rather than the staff, when inserting a clef; this allows putting pitched clefs in sections using a pitched instrument. It doesn't however address the larger issue of `staffType` not reflecting instrument changes, which seems to be more difficult to fix.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
