### PR TITLE
[MusicXML] add support for hairpin style

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
@@ -5551,7 +5551,7 @@ void ExportMusicXml::hairpin(Hairpin const* const hp, staff_idx_t staff, const F
             if (hp->hairpinCircledTip() && hp->hairpinType() == HairpinType::DIM_HAIRPIN) {
                 tag += u" niente=\"yes\"";
             }
-            if (configuration()->exportLayout() && hp->hairpinType() == HairpinType::DECRESC_HAIRPIN) {
+            if (configuration()->exportLayout() && hp->hairpinType() == HairpinType::DIM_HAIRPIN) {
                 tag += String(u" spread=\"%1\"").arg(String::number(hp->hairpinHeight().val() * 10, 2));
             }
         }

--- a/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
@@ -5528,10 +5528,31 @@ void ExportMusicXml::hairpin(Hairpin const* const hp, staff_idx_t staff, const F
             }
             tag += color2xml(hp);
             tag += positioningAttributes(hp, isStart);
+            switch (hp->lineStyle()) {
+            case LineType::DASHED:
+                tag += u" line-type=\"dashed\"";
+                break;
+            case LineType::DOTTED:
+                tag += u" line-type=\"dotted\"";
+                break;
+            case LineType::SOLID:
+            default:
+                break;
+            }
+            if (configuration()->exportLayout() && (hp->lineStyle() == LineType::DASHED)) {
+                tag += String(u" dash-length=\"%1\"").arg(String::number(hp->dashLineLen() * 10, 2));
+                tag += String(u" space-length=\"%1\"").arg(String::number(hp->dashGapLen() * 10, 2));
+            }
+            if (configuration()->exportLayout() && hp->hairpinType() == HairpinType::CRESC_HAIRPIN) {
+                tag += String(u" spread=\"%1\"").arg(String::number(hp->hairpinHeight().val() * 10, 2));
+            }
         } else {
             tag += u"\"stop\"";
             if (hp->hairpinCircledTip() && hp->hairpinType() == HairpinType::DIM_HAIRPIN) {
                 tag += u" niente=\"yes\"";
+            }
+            if (configuration()->exportLayout() && hp->hairpinType() == HairpinType::DECRESC_HAIRPIN) {
+                tag += String(u" spread=\"%1\"").arg(String::number(hp->hairpinHeight().val() * 10, 2));
             }
         }
         tag += String(u" number=\"%1\"").arg(n + 1);

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -5351,8 +5351,6 @@ void MusicXmlParserDirection::wedge(const String& type, const int number,
             h->setLineStyle(LineType::DASHED);
         } else if (lineType == "dotted") {
             h->setLineStyle(LineType::DOTTED);
-        } else if (lineType == "solid" || lineType.empty()) {
-            h->setLineStyle(LineType::SOLID);
         }
         const String spread = m_e.attribute("spread");
         if (!spread.empty() && configuration()->importLayout()) {

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -5346,6 +5346,19 @@ void MusicXmlParserDirection::wedge(const String& type, const int number,
         if (color.isValid()) {
             h->setLineColor(color);
         }
+        AsciiStringView lineType = m_e.asciiAttribute("line-type");
+        if (lineType == "dashed") {
+            h->setLineStyle(LineType::DASHED);
+        } else if (lineType == "dotted") {
+            h->setLineStyle(LineType::DOTTED);
+        } else if (lineType == "solid" || lineType.empty()) {
+            h->setLineStyle(LineType::SOLID);
+        }
+        const String spread = m_e.attribute("spread");
+        if (!spread.empty() && configuration()->importLayout()) {
+            const Spatium val(spread.toDouble() / 10.0);
+            h->setHairpinHeight(val);
+        }
         starts.push_back(MusicXmlSpannerDesc(h, ElementType::HAIRPIN, number));
     } else if (type == "stop") {
         Hairpin* h = spdesc.isStarted ? toHairpin(spdesc.sp) : Factory::createHairpin(m_score->dummy()->segment());


### PR DESCRIPTION
This PR adds import/export of hairpin line styles and heights to the MusicXML support. With layout for dashed lines also the styling of the dashes gets exported.