### PR TITLE
[MusicXML] improve tab and percussion clef handling

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
@@ -2602,7 +2602,9 @@ void ExportMusicXml::clef(staff_idx_t staff, const ClefType ct, const String& ex
 
     int line = ClefInfo::line(ct);
     m_xml.tag("sign", info.sign);
-    m_xml.tag("line", line);
+    if (info.sign != "TAB") {
+        m_xml.tag("line", line);
+    }
     if (info.octChng) {
         m_xml.tag("clef-octave-change", info.octChng);
     }

--- a/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
@@ -2602,7 +2602,7 @@ void ExportMusicXml::clef(staff_idx_t staff, const ClefType ct, const String& ex
 
     int line = ClefInfo::line(ct);
     m_xml.tag("sign", info.sign);
-    if (info.sign != "TAB") {
+    if ((std::string_view(info.sign) != "percussion") && (std::string_view(info.sign) != "TAB")) {
         m_xml.tag("line", line);
     }
     if (info.octChng) {

--- a/src/importexport/musicxml/tests/data/testDrumset1.xml
+++ b/src/importexport/musicxml/tests/data/testDrumset1.xml
@@ -117,7 +117,6 @@
           </time>
         <clef>
           <sign>percussion</sign>
-          <line>2</line>
           </clef>
         </attributes>
       <note>

--- a/src/importexport/musicxml/tests/data/testDrumset2.xml
+++ b/src/importexport/musicxml/tests/data/testDrumset2.xml
@@ -107,7 +107,6 @@
           </time>
         <clef>
           <sign>percussion</sign>
-          <line>2</line>
           </clef>
         </attributes>
       <note>
@@ -175,7 +174,6 @@
           </time>
         <clef>
           <sign>percussion</sign>
-          <line>2</line>
           </clef>
         <staff-details>
           <staff-lines>3</staff-lines>
@@ -247,7 +245,6 @@
           </time>
         <clef>
           <sign>percussion</sign>
-          <line>2</line>
           </clef>
         <staff-details>
           <staff-lines>1</staff-lines>

--- a/src/importexport/musicxml/tests/data/testGuitarBends_ref.xml
+++ b/src/importexport/musicxml/tests/data/testGuitarBends_ref.xml
@@ -45,7 +45,6 @@
           </time>
         <clef>
           <sign>TAB</sign>
-          <line>5</line>
           </clef>
         <staff-details>
           <staff-lines>6</staff-lines>

--- a/src/importexport/musicxml/tests/data/testHammerPull.xml
+++ b/src/importexport/musicxml/tests/data/testHammerPull.xml
@@ -51,7 +51,6 @@
           </clef>
         <clef number="2">
           <sign>TAB</sign>
-          <line>5</line>
           </clef>
         <staff-details number="2">
           <staff-lines>6</staff-lines>

--- a/src/importexport/musicxml/tests/data/testHarmony7_ref.xml
+++ b/src/importexport/musicxml/tests/data/testHarmony7_ref.xml
@@ -51,7 +51,6 @@
           </clef>
         <clef number="2">
           <sign>TAB</sign>
-          <line>5</line>
           </clef>
         <staff-details number="2">
           <staff-type>alternate</staff-type>

--- a/src/importexport/musicxml/tests/data/testMS3KitAndPerc.xml
+++ b/src/importexport/musicxml/tests/data/testMS3KitAndPerc.xml
@@ -546,7 +546,6 @@
           </time>
         <clef>
           <sign>percussion</sign>
-          <line>2</line>
           </clef>
         </attributes>
       <note default-x="71.01" default-y="5.00">
@@ -2114,7 +2113,6 @@
           </time>
         <clef>
           <sign>percussion</sign>
-          <line>2</line>
           </clef>
         </attributes>
       <note>

--- a/src/importexport/musicxml/tests/data/testMidiPortExport_ref.xml
+++ b/src/importexport/musicxml/tests/data/testMidiPortExport_ref.xml
@@ -4357,7 +4357,6 @@
           </key>
         <clef>
           <sign>percussion</sign>
-          <line>2</line>
           </clef>
         </attributes>
       <note>
@@ -4379,7 +4378,6 @@
           </key>
         <clef>
           <sign>percussion</sign>
-          <line>2</line>
           </clef>
         </attributes>
       <note>
@@ -4401,7 +4399,6 @@
           </key>
         <clef>
           <sign>percussion</sign>
-          <line>2</line>
           </clef>
         </attributes>
       <note>
@@ -4423,7 +4420,6 @@
           </key>
         <clef>
           <sign>percussion</sign>
-          <line>2</line>
           </clef>
         </attributes>
       <note>
@@ -4445,7 +4441,6 @@
           </key>
         <clef>
           <sign>percussion</sign>
-          <line>2</line>
           </clef>
         </attributes>
       <note>
@@ -4467,7 +4462,6 @@
           </key>
         <clef>
           <sign>percussion</sign>
-          <line>2</line>
           </clef>
         </attributes>
       <note>
@@ -4489,7 +4483,6 @@
           </key>
         <clef>
           <sign>percussion</sign>
-          <line>2</line>
           </clef>
         </attributes>
       <note>
@@ -4511,7 +4504,6 @@
           </key>
         <clef>
           <sign>percussion</sign>
-          <line>2</line>
           </clef>
         </attributes>
       <note>
@@ -4533,7 +4525,6 @@
           </key>
         <clef>
           <sign>percussion</sign>
-          <line>2</line>
           </clef>
         </attributes>
       <note>
@@ -4555,7 +4546,6 @@
           </key>
         <clef>
           <sign>percussion</sign>
-          <line>2</line>
           </clef>
         </attributes>
       <note>
@@ -4577,7 +4567,6 @@
           </key>
         <clef>
           <sign>percussion</sign>
-          <line>2</line>
           </clef>
         </attributes>
       <note>
@@ -4599,7 +4588,6 @@
           </key>
         <clef>
           <sign>percussion</sign>
-          <line>2</line>
           </clef>
         </attributes>
       <note>
@@ -4621,7 +4609,6 @@
           </key>
         <clef>
           <sign>percussion</sign>
-          <line>2</line>
           </clef>
         </attributes>
       <note>
@@ -4643,7 +4630,6 @@
           </key>
         <clef>
           <sign>percussion</sign>
-          <line>2</line>
           </clef>
         </attributes>
       <note>
@@ -4665,7 +4651,6 @@
           </key>
         <clef>
           <sign>percussion</sign>
-          <line>2</line>
           </clef>
         </attributes>
       <note>
@@ -4687,7 +4672,6 @@
           </key>
         <clef>
           <sign>percussion</sign>
-          <line>2</line>
           </clef>
         </attributes>
       <note>
@@ -4709,7 +4693,6 @@
           </key>
         <clef>
           <sign>percussion</sign>
-          <line>2</line>
           </clef>
         </attributes>
       <note>

--- a/src/importexport/musicxml/tests/data/testNegativeOctave_ref.xml
+++ b/src/importexport/musicxml/tests/data/testNegativeOctave_ref.xml
@@ -45,7 +45,6 @@
           </time>
         <clef>
           <sign>TAB</sign>
-          <line>5</line>
           </clef>
         <staff-details>
           <staff-lines>6</staff-lines>

--- a/src/importexport/musicxml/tests/data/testSticking.xml
+++ b/src/importexport/musicxml/tests/data/testSticking.xml
@@ -305,7 +305,6 @@
           </time>
         <clef>
           <sign>percussion</sign>
-          <line>2</line>
           </clef>
         </attributes>
       <direction>

--- a/src/importexport/musicxml/tests/data/testStringData.xml
+++ b/src/importexport/musicxml/tests/data/testStringData.xml
@@ -45,7 +45,6 @@
           </time>
         <clef>
           <sign>TAB</sign>
-          <line>5</line>
           </clef>
         <staff-details>
           <staff-lines>6</staff-lines>

--- a/src/importexport/musicxml/tests/data/testSystemBrackets3.xml
+++ b/src/importexport/musicxml/tests/data/testSystemBrackets3.xml
@@ -166,7 +166,6 @@ Gtr.</part-abbreviation>
           </clef>
         <clef number="2">
           <sign>TAB</sign>
-          <line>5</line>
           </clef>
         <staff-details number="2">
           <staff-lines>6</staff-lines>
@@ -235,7 +234,6 @@ Gtr.</part-abbreviation>
           </clef>
         <clef number="2">
           <sign>TAB</sign>
-          <line>5</line>
           </clef>
         <staff-details number="2">
           <staff-lines>6</staff-lines>
@@ -304,7 +302,6 @@ Gtr.</part-abbreviation>
           </clef>
         <clef number="2">
           <sign>TAB</sign>
-          <line>5</line>
           </clef>
         <staff-details number="2">
           <staff-lines>6</staff-lines>

--- a/src/importexport/musicxml/tests/data/testTablature1.xml
+++ b/src/importexport/musicxml/tests/data/testTablature1.xml
@@ -46,7 +46,6 @@
           </time>
         <clef>
           <sign>TAB</sign>
-          <line>5</line>
           </clef>
         <staff-details>
           <staff-lines>6</staff-lines>

--- a/src/importexport/musicxml/tests/data/testTablature2.xml
+++ b/src/importexport/musicxml/tests/data/testTablature2.xml
@@ -46,7 +46,6 @@
           </time>
         <clef>
           <sign>TAB</sign>
-          <line>5</line>
           </clef>
         <staff-details>
           <staff-lines>6</staff-lines>

--- a/src/importexport/musicxml/tests/data/testTablature3.xml
+++ b/src/importexport/musicxml/tests/data/testTablature3.xml
@@ -46,7 +46,6 @@
           </time>
         <clef>
           <sign>TAB</sign>
-          <line>5</line>
           </clef>
         <staff-details>
           <staff-lines>6</staff-lines>

--- a/src/importexport/musicxml/tests/data/testTablature4.xml
+++ b/src/importexport/musicxml/tests/data/testTablature4.xml
@@ -66,7 +66,6 @@
           </clef>
         <clef number="2">
           <sign>TAB</sign>
-          <line>5</line>
           </clef>
         <staff-details number="2">
           <staff-lines>6</staff-lines>
@@ -145,7 +144,6 @@
         <staves>2</staves>
         <clef number="1">
           <sign>TAB</sign>
-          <line>5</line>
           </clef>
         <clef number="2">
           <sign>G</sign>

--- a/src/importexport/musicxml/tests/data/testTablature5.xml
+++ b/src/importexport/musicxml/tests/data/testTablature5.xml
@@ -46,7 +46,6 @@
           </time>
         <clef>
           <sign>TAB</sign>
-          <line>5</line>
           </clef>
         <staff-details>
           <staff-lines>6</staff-lines>

--- a/src/importexport/musicxml/tests/data/testTablature5_ref.xml
+++ b/src/importexport/musicxml/tests/data/testTablature5_ref.xml
@@ -46,7 +46,6 @@
           </time>
         <clef>
           <sign>TAB</sign>
-          <line>5</line>
           </clef>
         <staff-details>
           <staff-lines>6</staff-lines>

--- a/src/importexport/musicxml/tests/data/testTapping.xml
+++ b/src/importexport/musicxml/tests/data/testTapping.xml
@@ -51,7 +51,6 @@
           </clef>
         <clef number="2">
           <sign>TAB</sign>
-          <line>5</line>
           </clef>
         <staff-details number="2">
           <staff-lines>6</staff-lines>

--- a/src/importexport/musicxml/tests/data/testVirtualInstruments.xml
+++ b/src/importexport/musicxml/tests/data/testVirtualInstruments.xml
@@ -203,7 +203,6 @@
           </time>
         <clef>
           <sign>percussion</sign>
-          <line>2</line>
           </clef>
         </attributes>
       <note>

--- a/src/importexport/musicxml/tests/data/testVirtualInstruments_ref.xml
+++ b/src/importexport/musicxml/tests/data/testVirtualInstruments_ref.xml
@@ -458,7 +458,6 @@
           </time>
         <clef>
           <sign>percussion</sign>
-          <line>2</line>
           </clef>
         </attributes>
       <note>


### PR DESCRIPTION
As clarified [here](https://github.com/w3c/musicxml/issues/469), TAB clefs shouldn't carry a line element. This PR adds a condition to filter those out.
