### PR TITLE
Increase .mscz thumbnail size

### DIFF
--- a/src/engraving/dom/scorefile.cpp
+++ b/src/engraving/dom/scorefile.cpp
@@ -79,7 +79,7 @@ std::shared_ptr<Pixmap> Score::createThumbnail()
 
     Page* page = pages().at(0);
     RectF fr = page->pageBoundingRect();
-    double mag = 256.0 / std::max(fr.width(), fr.height());
+    double mag = 512.0 / std::max(fr.width(), fr.height());
     int w = int(fr.width() * mag);
     int h = int(fr.height() * mag);
 


### PR DESCRIPTION
As discussed in https://github.com/musescore/MuseScore/issues/27136#issuecomment-2738578071, I'm doubling the default thumbnail size which will be used in the Home tab, and the future [macOS thumbnailer](https://github.com/musescore/MuseScore/pull/27987).

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
