### PR TITLE
Fix #28195: Tempo lines slipping through selection filter

### DIFF
--- a/src/engraving/dom/selectionfilter.cpp
+++ b/src/engraving/dom/selectionfilter.cpp
@@ -161,11 +161,11 @@ bool SelectionFilter::canSelect(const EngravingItem* e) const
     }
 
     // Special cases...
-    if (e->isTextBase()) { // only TEXT, INSTRCHANGE and STAFFTEXT are caught here, rest are system thus not in selection
+    if (e->isTextBase()) {
         return isFiltered(ElementsSelectionFilterTypes::OTHER_TEXT);
     }
 
-    if (e->isSLine()) { // NoteLine, Volta
+    if (e->isSLine() || e->isSLineSegment()) { // NoteLine, Volta
         return isFiltered(ElementsSelectionFilterTypes::OTHER_LINE);
     }
 


### PR DESCRIPTION
Resolves: #28195

Tempo lines are one more case that wasn't caught by #27093 - see that PR for a full explainer.

Also removed an old, outdated comment...