### PR TITLE
[Qt6.9] Fixed Dock System

### DIFF
--- a/src/framework/dockwindow/view/dockwindow.cpp
+++ b/src/framework/dockwindow/view/dockwindow.cpp
@@ -565,6 +565,8 @@ bool DockWindow::doLoadPage(const QString& uri, const QVariantMap& params)
         return false;
     }
 
+    newPage->setVisible(true);
+
     loadPageContent(newPage);
     restorePageState(newPage);
     initDocks(newPage);
@@ -575,8 +577,6 @@ bool DockWindow::doLoadPage(const QString& uri, const QVariantMap& params)
 
     connect(m_currentPage, &DockPageView::layoutRequested,
             this, &DockWindow::forceLayout, Qt::UniqueConnection);
-
-    m_currentPage->setVisible(true);
 
     return true;
 }


### PR DESCRIPTION
It seems that Qt 6.9 changed the behavior around setting visibility for UI objects.
When navigating between pages, we first hide the previous one and then show the new one.

In Qt 6.2, hiding a page didn’t hide its children - meaning `visible = false` wasn’t applied to the `DockBase` instances under `DockPageView`.
But in Qt 6.9, it is applied.
As a result, during `loadPageContent`, all children are added as hidden (see `visibilityOption = KDDockWidgets::InitialVisibilityOption::StartHidden`).