### PR TITLE
fix: style dropdown value comparison

### DIFF
--- a/src/framework/uicomponents/qml/Muse/UiComponents/StyledDropdown.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/StyledDropdown.qml
@@ -64,7 +64,8 @@ Item {
         }
 
         for (var i = 0; i < root.count; ++i) {
-            if (Utils.getItemValue(root.model, i, root.valueRole) === value) {
+            var rootValue = Utils.getItemValue(root.model, i, root.valueRole)
+            if (Utils.areEqual(rootValue, value)) {
                 return i
             }
         }
@@ -78,7 +79,8 @@ Item {
         }
 
         for (var i = 0; i < root.count; ++i) {
-            if (Utils.getItemValue(root.model, i, root.textRole) === text) {
+            var rootValue = Utils.getItemValue(root.model, i, root.textRole)
+            if (Utils.areEqual(rootValue, text)) {
                 return i
             }
         }
@@ -92,7 +94,8 @@ Item {
         }
 
         for (var i = 0; i < root.count; ++i) {
-            if (Utils.getItemValue(root.model, i, root.valueRole) === value) {
+            var rootValue = Utils.getItemValue(root.model, i, root.valueRole)
+            if (Utils.areEqual(rootValue, value)) {
                 return Utils.getItemValue(model, i, textRole, indeterminateText)
             }
         }

--- a/src/framework/uicomponents/qml/Muse/UiComponents/Utils.js
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/Utils.js
@@ -82,3 +82,13 @@ function getItemValue(model, index, roleName, def) {
 
     return item
 }
+
+function areEqual(a, b) {
+    if (a === b) {
+        return true
+    }
+    if (typeof a === 'object' && typeof b === 'object') {
+        return JSON.stringify(a) === JSON.stringify(b)
+    }
+    return false
+}


### PR DESCRIPTION
Objects in Qml treated as equal only if they point to the same memory. They can be the exact copies, but from different memory locations. In this case `===` and `==` operators will always return false. I don't know if they actualy must point to the same memory or not, but that's the reason why `void StringTuningsSettingsModel::setCurrentPreset(const QString& preset)` always received an empty string and as a result  presets didn't work.

Resolves: https://github.com/musescore/MuseScore/issues/28071
