### PR TITLE
27097: Fix off-centered note names on Harp pedal popup

### DIFF
--- a/src/framework/uicomponents/qml/Muse/UiComponents/RoundedRadioButton.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/RoundedRadioButton.qml
@@ -34,7 +34,7 @@ RadioDelegate {
 
     ButtonGroup.group: ListView.view && ListView.view instanceof RadioButtonGroup ? ListView.view.radioButtonGroup : null
 
-    implicitWidth: leftPadding + implicitIndicatorWidth + spacing + implicitContentWidth + rightPadding
+    implicitWidth: leftPadding + implicitIndicatorWidth + (implicitIndicatorWidth > 0 && implicitContentWidth > 0 ? spacing : 0) + implicitContentWidth + rightPadding
     implicitHeight: topPadding + Math.max(implicitIndicatorHeight, implicitContentHeight) + bottomPadding
 
     spacing: 6


### PR DESCRIPTION
Resolves: #27097

It is not the notes. it is the radio buttons that are off-centered actually.

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
