### PR TITLE
Fix crash when selecting LV tie on hidden staff

### DIFF
--- a/src/engraving/dom/select.cpp
+++ b/src/engraving/dom/select.cpp
@@ -538,15 +538,15 @@ void Selection::appendChord(Chord* chord)
             }
         }
 
-        if (note->laissezVib()) {
+        if (note->laissezVib() && !note->laissezVib()->segmentsEmpty()) {
             appendFiltered(note->laissezVib()->frontSegment());
         }
 
-        if (note->incomingPartialTie()) {
+        if (note->incomingPartialTie() && !note->incomingPartialTie()->segmentsEmpty()) {
             appendFiltered(note->incomingPartialTie()->frontSegment());
         }
 
-        if (note->outgoingPartialTie()) {
+        if (note->outgoingPartialTie() && !note->outgoingPartialTie()->segmentsEmpty()) {
             appendFiltered(note->outgoingPartialTie()->frontSegment());
         }
     }


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/28258

Different way to reproduce the same crash:
1. Create score from Guitar + Tab template
2. Hide the linked Tab staff
3. Add another instrument below
4. Create a note with LV tie on the topmost staff (the original guitar notation staff)
5. Select the note
6. Press Shift+Down to select staff below -> crash

I assume that the reason that the LV tie has no segments, is that it's skipped during layout because its staff is invisible. I'm not sure what the consequences are of the fact that the LV segment is effectively missing from the selection, after this fix. 