### PR TITLE
Fix open file dialog

### DIFF
--- a/src/framework/global/internal/interactive.cpp
+++ b/src/framework/global/internal/interactive.cpp
@@ -305,7 +305,7 @@ async::Promise<io::path_t> Interactive::selectOpeningFile(const std::string& tit
             (void)resolve(file);
         });
 
-        dlg->show();
+        dlg->open();
 
         return async::Promise<io::path_t>::Result::unchecked();
     }, async::PromiseType::AsyncByBody);


### PR DESCRIPTION
Resolves: #28271

QWidget::show() shows the non-native QWidget based dialog. Use QDialog::open() instead.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
