### PR TITLE
Fix build failure with Qt 6.3-6.7

### DIFF
--- a/buildscripts/cmake/DeclareModuleSetup.cmake
+++ b/buildscripts/cmake/DeclareModuleSetup.cmake
@@ -104,7 +104,7 @@ macro(setup_module)
     endif()
 
     if (MODULE_USE_QT AND QT_SUPPORT)
-        if (${Qt6_VERSION} VERSION_GREATER_EQUAL "6.3.0")
+        if (${Qt6_VERSION} VERSION_GREATER_EQUAL "6.7.0")
             # STATIC/SHARED based on BUILD_SHARED_LIBS, which is set in SetupBuildEnvironment.cmake
             qt_add_library(${MODULE} ${MODULE_SRC})
         else()


### PR DESCRIPTION
Not that we'd ever use those versions, but this fix is a tiny effort, so... why not.

The reason is that before Qt 6.7, the `qt_add_library` command and similar would not take `BUILD_SHARED_LIBS` into account.

Resolves: https://github.com/musescore/MuseScore/issues/28267