### PR TITLE
Fix error on move clef with mmRests

### DIFF
--- a/src/engraving/rendering/score/measurelayout.cpp
+++ b/src/engraving/rendering/score/measurelayout.cpp
@@ -204,7 +204,7 @@ void MeasureLayout::createMMRest(LayoutContext& ctx, Measure* firstMeasure, Meas
         // reuse existing mmrest
         if (mmrMeasure->ticks() != len) {
             Segment* bls = mmrMeasure->findSegmentR(SegmentType::EndBarLine, mmrMeasure->ticks());
-            Segment* cs = mmrMeasure->findSegment(SegmentType::Clef | SegmentType::HeaderClef, mmrMeasure->ticks());
+            Segment* cs = mmrMeasure->findSegmentR(SegmentType::Clef, mmrMeasure->ticks());
             // adjust length
             mmrMeasure->setTicks(len);
             // move existing end barline and clef


### PR DESCRIPTION
Resolves: this can cause a HeaderClef segment to move into a position where it shouldn't be, which in turn can cause a cascade of errors resulting in messed up mmRests.