### PR TITLE
Fix assertion failure when select all and delete with hidden linked staff (?)

### DIFF
--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -3608,9 +3608,9 @@ void Score::deleteAnnotationsFromRange(Segment* s1, Segment* s2, track_idx_t tra
 void Score::deleteRangeAtTrack(std::vector<ChordRest*>& crsToSelect, const track_idx_t track, Segment* startSeg,
                                const Fraction& endTick, Tuplet* currentTuplet)
 {
-    while (startSeg && !startSeg->cr(track)) {
+    while (startSeg && !(startSeg->isChordRestType() && startSeg->cr(track))) {
         // Range should always start at a ChordRest segment - find the next one for this track...
-        startSeg = startSeg->next1();
+        startSeg = startSeg->next1(SegmentType::ChordRest);
     }
 
     if (!startSeg) {


### PR DESCRIPTION
Steps:
1. Create score from Guitar+Tablature template
2. Hide the linked tab staff
3. Select all
4. Delete -> assert fail

<img width="861" alt="Scherm­afbeelding 2025-06-06 om 19 01 50" src="https://github.com/user-attachments/assets/37845d98-d2b2-4f83-b1ec-fd3b71121905" />

The segment is a barline segment instead of a chord rest segment.