### PR TITLE
Fix #28280: use real-time keyboard state in MIDI note input

### DIFF
--- a/src/notation/internal/notationmidiinput.cpp
+++ b/src/notation/internal/notationmidiinput.cpp
@@ -265,7 +265,7 @@ Note* NotationMidiInput::addNoteToScore(const muse::midi::Event& e)
     }
 
     // holding shift while inputting midi will add the new pitch to the prior existing chord
-    if (QGuiApplication::keyboardModifiers() & Qt::ShiftModifier) {
+    if (QGuiApplication::queryKeyboardModifiers() & Qt::ShiftModifier) {
         mu::engraving::EngravingItem* cr = is.lastSegment()->element(is.track());
         if (cr && cr->isChord()) {
             inputEv.chord = true;


### PR DESCRIPTION
Resolves: #28280

The issue appears to be that `QGuiApplication::keyboardModifiers()` returns stale data. In particular, since the keyboard shortcut to enter repitch mode (Ctrl+Shift+I) includes Shift, this code thought that Shift was still held down, which makes it add the new note rather than replace it.

Fixed by using `queryKeyboardModifiers()` instead, which returns the up-to-date keyboard state.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
