### PR TITLE
feat musescore#27351: Implement new columns and interactive sorting

### DIFF
--- a/src/project/qml/MuseScore/Project/ScoresListView.qml
+++ b/src/project/qml/MuseScore/Project/ScoresListView.qml
@@ -77,14 +77,17 @@ Item {
                 horizontalAlignment: Text.AlignLeft
                 anchors.verticalCenter: parent.verticalCenter
 
-                color: headerMouseArea.containsMouse ? "grey" : "white"
+                opacity: headerMouseArea.containsMouse ? 0.5 : 1.0
             }
             
             StyledIconLabel {
                 visible: sortable && root.model && root.model.currentSortKey === sortKey
-                iconCode: (root.model && root.model.sortOrder === Qt.AscendingOrder) ? IconCode.ARROW_UP : IconCode.ARROW_DOWN
+                iconCode: (root.model && root.model.sortOrder === Qt.AscendingOrder) ?  IconCode.SMALL_ARROW_DOWN : IconCode.SMALL_ARROW_UP
+
                 font.pixelSize: 12
                 anchors.verticalCenter: parent.verticalCenter
+
+                opacity: headerMouseArea.containsMouse ? 0.5 : 1.0
             }
         }
         

--- a/src/project/qml/MuseScore/Project/ScoresListView.qml
+++ b/src/project/qml/MuseScore/Project/ScoresListView.qml
@@ -84,7 +84,7 @@ Item {
                 visible: sortable && root.model && root.model.currentSortKey === sortKey
                 iconCode: (root.model && root.model.sortOrder === Qt.AscendingOrder) ?  IconCode.SMALL_ARROW_DOWN : IconCode.SMALL_ARROW_UP
 
-                font.pixelSize: 12
+                font.pixelSize: 16
                 anchors.verticalCenter: parent.verticalCenter
 
                 opacity: headerMouseArea.containsMouse ? 0.5 : 1.0

--- a/src/project/qml/MuseScore/Project/internal/ScoresPage/RecentScoresView.qml
+++ b/src/project/qml/MuseScore/Project/internal/ScoresPage/RecentScoresView.qml
@@ -97,6 +97,45 @@ ScoresView {
 
             columns: [
                 ScoresListView.ColumnItem {
+                    id: composerColumn
+
+                    header: qsTrc("project", "Composer")
+                    width: function (parentWidth) {
+                        let parentWidthExcludingSpacing = parentWidth - (list.columns.length - 1) * list.view.columnSpacing;
+                        return 0.15 * parentWidthExcludingSpacing
+                    }
+
+                    delegate: StyledTextLabel {
+                        id: composerLabel
+                        text: (score.composer && score.composer !== "Composer / arranger") ? score.composer : "-"
+
+                        font: ui.theme.largeBodyFont
+                        horizontalAlignment: Text.AlignLeft
+
+                        NavigationFocusBorder {
+                            navigationCtrl: NavigationControl {
+                                name: "ComposerLabel"
+                                panel: navigationPanel
+                                row: navigationRow
+                                column: navigationColumnStart
+                                enabled: composerLabel.visible && composerLabel.enabled && !composerLabel.isEmpty
+                                accessible.name: composerColumn.header + ": " + composerLabel.text
+                                accessible.role: MUAccessible.StaticText
+
+                                onActiveChanged: {
+                                    if (active) {
+                                        listItem.scrollIntoView()
+                                    }
+                                }
+                            }
+
+                            anchors.margins: -radius
+                            radius: 2 + border.width
+                        }
+                    }
+                },
+
+                ScoresListView.ColumnItem {
                     id: modifiedColumn
 
                     //: Stands for "Last time that this score was modified".
@@ -104,8 +143,8 @@ ScoresView {
                     header: qsTrc("project", "Modified")
 
                     width: function (parentWidth) {
-                        let parentWidthExclusingSpacing = parentWidth - list.columns.length * list.view.columnSpacing;
-                        return 0.25 * parentWidthExclusingSpacing
+                        let parentWidthExcludingSpacing = parentWidth - (list.columns.length - 1) * list.view.columnSpacing;
+                        return 0.10 * parentWidthExcludingSpacing
                     }
 
                     delegate: StyledTextLabel {
@@ -120,9 +159,88 @@ ScoresView {
                                 name: "ModifiedLabel"
                                 panel: navigationPanel
                                 row: navigationRow
-                                column: navigationColumnStart
+                                column: navigationColumnStart + 3
                                 enabled: modifiedLabel.visible && modifiedLabel.enabled && !modifiedLabel.isEmpty
                                 accessible.name: modifiedColumn.header + ": " + modifiedLabel.text
+                                accessible.role: MUAccessible.StaticText
+
+                                onActiveChanged: {
+                                    if (active) {
+                                        listItem.scrollIntoView()
+                                    }
+                                }
+                            }
+
+                            anchors.margins: -radius
+                            radius: 2 + border.width
+                        }
+                    }
+                },
+
+                ScoresListView.ColumnItem {
+                    id: creationDateColumn
+
+                    header: qsTrc("project", "Created")
+                    width: function (parentWidth) {
+                        let parentWidthExcludingSpacing = parentWidth - (list.columns.length - 1) * list.view.columnSpacing;
+                        return 0.10 * parentWidthExcludingSpacing
+                    }
+
+                    delegate: StyledTextLabel {
+                        id: creationDateLabel
+                        text: score.creationDate ?? "-"
+
+                        font: ui.theme.largeBodyFont
+                        horizontalAlignment: Text.AlignLeft
+
+                        NavigationFocusBorder {
+                            navigationCtrl: NavigationControl {
+                                name: "CreationDateLabel"
+                                panel: navigationPanel
+                                row: navigationRow
+                                column: navigationColumnStart + 2
+                                enabled: creationDateLabel.visible && creationDateLabel.enabled && !creationDateLabel.isEmpty
+                                accessible.name: creationDateColumn.header + ": " + creationDateLabel.text
+                                accessible.role: MUAccessible.StaticText
+
+                                onActiveChanged: {
+                                    if (active) {
+                                        listItem.scrollIntoView()
+                                    }
+                                }
+                            }
+
+                            anchors.margins: -radius
+                            radius: 2 + border.width
+                        }
+                    }
+                },
+
+                ScoresListView.ColumnItem {
+                    id: filePathColumn
+
+                    header: qsTrc("project", "File Path")
+                    width: function (parentWidth) {
+                        let parentWidthExcludingSpacing = parentWidth - (list.columns.length - 1) * list.view.columnSpacing;
+                        return 0.35 * parentWidthExcludingSpacing
+                    }
+
+                    delegate: StyledTextLabel {
+                        id: filePathLabel
+                        text: score.path ?? "-"
+
+                        font: ui.theme.largeBodyFont
+                        horizontalAlignment: Text.AlignLeft
+                        elide: Text.ElideMiddle
+
+                        NavigationFocusBorder {
+                            navigationCtrl: NavigationControl {
+                                name: "FilePathLabel"
+                                panel: navigationPanel
+                                row: navigationRow
+                                column: navigationColumnStart + 4
+                                enabled: filePathLabel.visible && filePathLabel.enabled && !filePathLabel.isEmpty
+                                accessible.name: filePathColumn.header + ": " + filePathLabel.text
                                 accessible.role: MUAccessible.StaticText
 
                                 onActiveChanged: {
@@ -143,8 +261,8 @@ ScoresView {
                     header: qsTrc("global", "Size", "file size")
 
                     width: function (parentWidth) {
-                        let parentWidthExclusingSpacing = parentWidth - list.columns.length * list.view.columnSpacing;
-                        return 0.15 * parentWidthExclusingSpacing
+                        let parentWidthExcludingSpacing = parentWidth - (list.columns.length - 1) * list.view.columnSpacing;
+                        return 0.05 * parentWidthExcludingSpacing
                     }
 
                     delegate: StyledTextLabel {

--- a/src/project/view/abstractscoresmodel.cpp
+++ b/src/project/view/abstractscoresmodel.cpp
@@ -138,7 +138,7 @@ bool AbstractScoresModel::compareItems(const QVariantMap& a, const QVariantMap& 
     if (aIsEmpty) {
         return false;
     }
-    if(bIsEmpty) {
+    if (bIsEmpty) {
         return true;
     }
 

--- a/src/project/view/abstractscoresmodel.cpp
+++ b/src/project/view/abstractscoresmodel.cpp
@@ -89,17 +89,17 @@ QList<int> AbstractScoresModel::nonScoreItemIndices() const
 }
 
 void AbstractScoresModel::sortBy(const QString& key)
-{    
+{
     if (m_sortKey == key) {
         m_sortOrder = (m_sortOrder == Qt::AscendingOrder) ? Qt::DescendingOrder : Qt::AscendingOrder;
     } else {
         m_sortKey = key;
         m_sortOrder = Qt::AscendingOrder;
     }
-    
+
     emit sortKeyChanged();
     emit sortOrderChanged();
-    
+
     load();
 }
 
@@ -117,7 +117,7 @@ void AbstractScoresModel::sortScoreItems(std::vector<QVariantMap>& items)
 bool AbstractScoresModel::compareItems(const QVariantMap& a, const QVariantMap& b, const QString& key, Qt::SortOrder order)
 {
     QVariant valueA, valueB;
-    
+
     if (key == "timeSinceModified") {
         valueA = a.value("rawModifiedTime");
         valueB = b.value("rawModifiedTime");
@@ -128,14 +128,20 @@ bool AbstractScoresModel::compareItems(const QVariantMap& a, const QVariantMap& 
         valueA = a.value(key, "");
         valueB = b.value(key, "");
     }
-    
+
     bool aIsEmpty = isValueEmpty(valueA);
     bool bIsEmpty = isValueEmpty(valueB);
-    
-    if (aIsEmpty && bIsEmpty) return false;
-    if (aIsEmpty) return false;
-    if (bIsEmpty) return true;
-    
+
+    if (aIsEmpty && bIsEmpty) {
+        return false;
+    }
+    if (aIsEmpty) {
+        return false;
+    }
+    if(bIsEmpty) {
+        return true;
+    }
+
     bool result = false;
     if (valueA.typeId() == QMetaType::QString) {
         result = QString::localeAwareCompare(valueA.toString(), valueB.toString()) < 0;
@@ -144,7 +150,7 @@ bool AbstractScoresModel::compareItems(const QVariantMap& a, const QVariantMap& 
     } else {
         result = QString::localeAwareCompare(valueA.toString(), valueB.toString()) < 0;
     }
-    
+
     return (order == Qt::AscendingOrder) ? result : !result;
 }
 
@@ -153,12 +159,12 @@ bool AbstractScoresModel::isValueEmpty(const QVariant& value)
     if (value.isNull() || !value.isValid()) {
         return true;
     }
-    
+
     if (value.typeId() == QMetaType::QString) {
         QString str = value.toString().trimmed();
         return str.isEmpty() || str == "-";
     }
-    
+
     return false;
 }
 

--- a/src/project/view/abstractscoresmodel.cpp
+++ b/src/project/view/abstractscoresmodel.cpp
@@ -180,7 +180,7 @@ bool AbstractScoresModel::isValueEmpty(const QVariant& value)
 
     if (value.typeId() == QMetaType::QString) {
         QString str = value.toString().trimmed();
-        return str.isEmpty() || str == "-";
+        return str.isEmpty() || str == "-" || str == "Composer / arranger";
     }
 
     return false;

--- a/src/project/view/abstractscoresmodel.h
+++ b/src/project/view/abstractscoresmodel.h
@@ -77,6 +77,7 @@ protected:
     static const QString CLOUD_VISIBILITY_KEY;
     static const QString CLOUD_VIEW_COUNT_KEY;
 
+    void clearSort();
     void sortScoreItems(std::vector<QVariantMap>& items);
     bool compareItems(const QVariantMap& a, const QVariantMap& b, const QString& key, Qt::SortOrder order);
     bool isValueEmpty(const QVariant& value);
@@ -84,6 +85,7 @@ protected:
     std::vector<QVariantMap> m_items;
     QString m_sortKey;
     Qt::SortOrder m_sortOrder;
+    bool m_isSorted = false;
 };
 }
 

--- a/src/project/view/abstractscoresmodel.h
+++ b/src/project/view/abstractscoresmodel.h
@@ -45,7 +45,7 @@ public:
     QHash<int, QByteArray> roleNames() const override;
 
     virtual QList<int> nonScoreItemIndices() const;
-    
+
     QString currentSortKey() const;
     Qt::SortOrder sortOrder() const;
 
@@ -80,7 +80,7 @@ protected:
     void sortScoreItems(std::vector<QVariantMap>& items);
     bool compareItems(const QVariantMap& a, const QVariantMap& b, const QString& key, Qt::SortOrder order);
     bool isValueEmpty(const QVariant& value);
-    
+
     std::vector<QVariantMap> m_items;
     QString m_sortKey;
     Qt::SortOrder m_sortOrder;

--- a/src/project/view/abstractscoresmodel.h
+++ b/src/project/view/abstractscoresmodel.h
@@ -31,20 +31,28 @@ class AbstractScoresModel : public QAbstractListModel
 
     Q_PROPERTY(int rowCount READ rowCount NOTIFY rowCountChanged)
     Q_PROPERTY(QList<int> nonScoreItemIndices READ nonScoreItemIndices NOTIFY rowCountChanged)
+    Q_PROPERTY(QString currentSortKey READ currentSortKey NOTIFY sortKeyChanged)
+    Q_PROPERTY(Qt::SortOrder sortOrder READ sortOrder NOTIFY sortOrderChanged)
 
 public:
     explicit AbstractScoresModel(QObject* parent = nullptr);
 
     Q_INVOKABLE virtual void load() = 0;
+    Q_INVOKABLE void sortBy(const QString& key);
 
     QVariant data(const QModelIndex& index, int role) const override;
     int rowCount(const QModelIndex& parent = QModelIndex()) const override;
     QHash<int, QByteArray> roleNames() const override;
 
     virtual QList<int> nonScoreItemIndices() const;
+    
+    QString currentSortKey() const;
+    Qt::SortOrder sortOrder() const;
 
 signals:
     void rowCountChanged();
+    void sortKeyChanged();
+    void sortOrderChanged();
 
 protected:
     enum Roles {
@@ -55,6 +63,9 @@ protected:
 
     static const QString NAME_KEY;
     static const QString PATH_KEY;
+    static const QString COMPOSER_KEY;
+    static const QString ARRANGER_KEY;
+    static const QString CREATION_DATE_KEY;
     static const QString SUFFIX_KEY;
     static const QString FILE_SIZE_KEY;
     static const QString THUMBNAIL_URL_KEY;
@@ -66,7 +77,13 @@ protected:
     static const QString CLOUD_VISIBILITY_KEY;
     static const QString CLOUD_VIEW_COUNT_KEY;
 
+    void sortScoreItems(std::vector<QVariantMap>& items);
+    bool compareItems(const QVariantMap& a, const QVariantMap& b, const QString& key, Qt::SortOrder order);
+    bool isValueEmpty(const QVariant& value);
+    
     std::vector<QVariantMap> m_items;
+    QString m_sortKey;
+    Qt::SortOrder m_sortOrder;
 };
 }
 

--- a/src/project/view/cloudscoresmodel.cpp
+++ b/src/project/view/cloudscoresmodel.cpp
@@ -171,7 +171,7 @@ void CloudScoresModel::loadItemsIfNecessary()
 }
 
 void CloudScoresModel::sortBy(const QString& key)
-{    
+{
     if (m_sortKey == key) {
         m_sortOrder = (m_sortOrder == Qt::AscendingOrder) ? Qt::DescendingOrder : Qt::AscendingOrder;
     } else {
@@ -188,7 +188,6 @@ void CloudScoresModel::sortBy(const QString& key)
         sortScoreItems(m_items);
         endResetModel();
     }
-
 }
 
 bool CloudScoresModel::needsLoading()

--- a/src/project/view/cloudscoresmodel.cpp
+++ b/src/project/view/cloudscoresmodel.cpp
@@ -144,6 +144,9 @@ void CloudScoresModel::loadItemsIfNecessary()
                     obj[CLOUD_VISIBILITY_KEY] = static_cast<int>(item.visibility);
                     obj[CLOUD_VIEW_COUNT_KEY] = item.viewCount;
 
+                    obj["rawModifiedTime"] = item.lastModified.date().toString();
+                    obj["rawFileSize"] = item.fileSize;
+
                     m_items.push_back(obj);
                 }
 
@@ -165,6 +168,27 @@ void CloudScoresModel::loadItemsIfNecessary()
     } else {
         setState(State::Fine);
     }
+}
+
+void CloudScoresModel::sortBy(const QString& key)
+{    
+    if (m_sortKey == key) {
+        m_sortOrder = (m_sortOrder == Qt::AscendingOrder) ? Qt::DescendingOrder : Qt::AscendingOrder;
+    } else {
+        m_sortKey = key;
+        m_sortOrder = Qt::AscendingOrder;
+    }
+    
+    emit sortKeyChanged();
+    emit sortOrderChanged();
+    
+    // Sort the existing items
+    if (!m_items.empty()) {
+        beginResetModel();
+        sortScoreItems(m_items);
+        endResetModel();
+    }
+    
 }
 
 bool CloudScoresModel::needsLoading()

--- a/src/project/view/cloudscoresmodel.cpp
+++ b/src/project/view/cloudscoresmodel.cpp
@@ -172,11 +172,17 @@ void CloudScoresModel::loadItemsIfNecessary()
 
 void CloudScoresModel::sortBy(const QString& key)
 {
-    if (m_sortKey == key) {
-        m_sortOrder = (m_sortOrder == Qt::AscendingOrder) ? Qt::DescendingOrder : Qt::AscendingOrder;
+    if (m_sortKey == key && m_isSorted) {
+        if (m_sortOrder == Qt::AscendingOrder) {
+            m_sortOrder = Qt::DescendingOrder;
+        } else {
+            clearSort();
+            return;
+        }
     } else {
         m_sortKey = key;
         m_sortOrder = Qt::AscendingOrder;
+        m_isSorted = true;
     }
 
     emit sortKeyChanged();

--- a/src/project/view/cloudscoresmodel.cpp
+++ b/src/project/view/cloudscoresmodel.cpp
@@ -145,7 +145,7 @@ void CloudScoresModel::loadItemsIfNecessary()
                     obj[CLOUD_VIEW_COUNT_KEY] = item.viewCount;
 
                     obj["rawModifiedTime"] = item.lastModified.date().toString();
-                    obj["rawFileSize"] = item.fileSize;
+                    obj["rawFileSize"] = static_cast<qulonglong>(item.fileSize);
 
                     m_items.push_back(obj);
                 }
@@ -178,17 +178,17 @@ void CloudScoresModel::sortBy(const QString& key)
         m_sortKey = key;
         m_sortOrder = Qt::AscendingOrder;
     }
-    
+
     emit sortKeyChanged();
     emit sortOrderChanged();
-    
+
     // Sort the existing items
     if (!m_items.empty()) {
         beginResetModel();
         sortScoreItems(m_items);
         endResetModel();
     }
-    
+
 }
 
 bool CloudScoresModel::needsLoading()

--- a/src/project/view/cloudscoresmodel.h
+++ b/src/project/view/cloudscoresmodel.h
@@ -64,6 +64,8 @@ public:
     int desiredRowCount() const;
     void setDesiredRowCount(int count);
 
+    Q_INVOKABLE void sortBy(const QString& key);
+
 signals:
     void stateChanged();
     void hasMoreChanged();

--- a/src/project/view/cloudscoresmodel.h
+++ b/src/project/view/cloudscoresmodel.h
@@ -74,12 +74,13 @@ signals:
 
 private:
     void setState(State state);
-
+    void restoreOriginalOrder();
     void loadItemsIfNecessary();
     bool needsLoading();
 
     State m_state = State::Fine;
     bool m_isWaitingForPromise = false;
+    bool m_needsResortAfterLoad = false;
 
     size_t m_totalItems = muse::nidx;
 

--- a/src/project/view/recentscoresmodel.cpp
+++ b/src/project/view/recentscoresmodel.cpp
@@ -98,9 +98,9 @@ void RecentScoresModel::updateRecentScores()
         obj[TIME_SINCE_MODIFIED_KEY] = DataFormatter::formatTimeSince(io::FileInfo(file.path).lastModified().date()).toQString();
         obj[IS_CREATE_NEW_KEY] = false;
         obj[IS_NO_RESULTS_FOUND_KEY] = false;
-        
+
         obj["rawModifiedTime"] = io::FileInfo(file.path).lastModified().date().toString().toQString();
-        obj["rawFileSize"] = fileSize.val;
+        obj["rawFileSize"] = static_cast<qulonglong>(fileSize.val);
 
         scoreItems.push_back(obj);
     }
@@ -121,7 +121,6 @@ void RecentScoresModel::updateRecentScores()
     setRecentScores(items);
 }
 
-
 void RecentScoresModel::readFromScore(const muse::io::path_t& path, QVariantMap &obj)
 {
     MscReader::Params params;
@@ -139,20 +138,20 @@ void RecentScoresModel::readFromScore(const muse::io::path_t& path, QVariantMap 
     }
 
     XmlStreamReader xml(scoreData);
-    
+
     while (!xml.atEnd()) {
-        xml.readNext();        
+        xml.readNext();
         if (xml.isStartElement() && xml.name() == "Score") {
             while (!xml.atEnd()) {
-                xml.readNext();                
+                xml.readNext();
                 if (xml.isEndElement() && xml.name() == "Score") {
                     break;
                 }
-                
+
                 if (xml.isStartElement() && xml.name() == "metaTag") {
                     QString metaTagNameAttribute = xml.attribute("name").toQString();
                     QString metaTagValue = xml.readText().toQString();
-                    
+
                     if (metaTagNameAttribute == "composer") {
                         obj[COMPOSER_KEY] = metaTagValue;
                     } else if (metaTagNameAttribute == "arranger") {

--- a/src/project/view/recentscoresmodel.cpp
+++ b/src/project/view/recentscoresmodel.cpp
@@ -21,9 +21,13 @@
  */
 #include "recentscoresmodel.h"
 
+#include <algorithm>
+
 #include "translation.h"
 #include "dataformatter.h"
 #include "io/fileinfo.h"
+#include "engraving/infrastructure/mscreader.h"
+#include "serialization/xmlstreamreader.h"
 
 #include "engraving/infrastructure/mscio.h"
 
@@ -31,6 +35,9 @@
 
 using namespace muse;
 using namespace mu::project;
+using namespace muse::io;
+using namespace mu;
+using namespace mu::engraving;
 
 RecentScoresModel::RecentScoresModel(QObject* parent)
     : AbstractScoresModel(parent)
@@ -62,7 +69,7 @@ void RecentScoresModel::updateRecentScores()
     const RecentFilesList& recentScores = recentFilesController()->recentFilesList();
 
     std::vector<QVariantMap> items;
-    items.reserve(recentScores.size());
+    items.reserve(recentScores.size() + 2);
 
     QVariantMap addItem;
     addItem[NAME_KEY] = muse::qtrc("project", "New score");
@@ -71,6 +78,7 @@ void RecentScoresModel::updateRecentScores()
     addItem[IS_CLOUD_KEY] = false;
     items.push_back(addItem);
 
+    std::vector<QVariantMap> scoreItems;
     for (const RecentFile& file : recentScores) {
         QVariantMap obj;
 
@@ -82,6 +90,7 @@ void RecentScoresModel::updateRecentScores()
 
         obj[NAME_KEY] = file.displayName(isSuffixInteresting);
         obj[PATH_KEY] = file.path.toQString();
+        readFromScore(file.path, obj); //reads metainfo from file
         obj[SUFFIX_KEY] = QString::fromStdString(suffix);
         obj[FILE_SIZE_KEY] = fileSizeString;
         obj[IS_CLOUD_KEY] = configuration()->isCloudProject(file.path);
@@ -89,9 +98,18 @@ void RecentScoresModel::updateRecentScores()
         obj[TIME_SINCE_MODIFIED_KEY] = DataFormatter::formatTimeSince(io::FileInfo(file.path).lastModified().date()).toQString();
         obj[IS_CREATE_NEW_KEY] = false;
         obj[IS_NO_RESULTS_FOUND_KEY] = false;
+        
+        obj["rawModifiedTime"] = io::FileInfo(file.path).lastModified().date().toString().toQString();
+        obj["rawFileSize"] = fileSize.val;
 
-        items.push_back(obj);
+        scoreItems.push_back(obj);
     }
+
+    if (!m_sortKey.isEmpty()) {
+        sortScoreItems(scoreItems);
+    }
+
+    items.insert(items.end(), scoreItems.begin(), scoreItems.end());
 
     QVariantMap noResultsFoundItem;
     noResultsFoundItem[NAME_KEY] = "";
@@ -101,6 +119,52 @@ void RecentScoresModel::updateRecentScores()
     items.push_back(noResultsFoundItem);
 
     setRecentScores(items);
+}
+
+
+void RecentScoresModel::readFromScore(const muse::io::path_t& path, QVariantMap &obj)
+{
+    MscReader::Params params;
+    params.filePath = path;
+
+    MscReader reader(params);
+    Ret ret = reader.open();
+    if (!ret) {
+        return;
+    }
+
+    ByteArray scoreData = reader.readScoreFile();
+    if (scoreData.empty()) {
+        return;
+    }
+
+    XmlStreamReader xml(scoreData);
+    
+    while (!xml.atEnd()) {
+        xml.readNext();        
+        if (xml.isStartElement() && xml.name() == "Score") {
+            while (!xml.atEnd()) {
+                xml.readNext();                
+                if (xml.isEndElement() && xml.name() == "Score") {
+                    break;
+                }
+                
+                if (xml.isStartElement() && xml.name() == "metaTag") {
+                    QString metaTagNameAttribute = xml.attribute("name").toQString();
+                    QString metaTagValue = xml.readText().toQString();
+                    
+                    if (metaTagNameAttribute == "composer") {
+                        obj[COMPOSER_KEY] = metaTagValue;
+                    } else if (metaTagNameAttribute == "arranger") {
+                        obj[ARRANGER_KEY] = metaTagValue;
+                    } else if (metaTagNameAttribute == "creationDate") {
+                        obj[CREATION_DATE_KEY] = metaTagValue;
+                    }
+                }
+            }
+            break;
+        }
+    }
 }
 
 QList<int> RecentScoresModel::nonScoreItemIndices() const

--- a/src/project/view/recentscoresmodel.cpp
+++ b/src/project/view/recentscoresmodel.cpp
@@ -121,7 +121,7 @@ void RecentScoresModel::updateRecentScores()
     setRecentScores(items);
 }
 
-void RecentScoresModel::readFromScore(const muse::io::path_t& path, QVariantMap &obj)
+void RecentScoresModel::readFromScore(const muse::io::path_t& path, QVariantMap& obj)
 {
     MscReader::Params params;
     params.filePath = path;

--- a/src/project/view/recentscoresmodel.h
+++ b/src/project/view/recentscoresmodel.h
@@ -49,6 +49,7 @@ public:
 private:
     void updateRecentScores();
     void setRecentScores(const std::vector<QVariantMap>& items);
+    void readFromScore(const muse::io::path_t& path, QVariantMap& obj);
 };
 }
 


### PR DESCRIPTION
Resolves: #27351 

<!-- Add a short description of and motivation for the changes here -->
This commit introduces enhancements to the recent files and "my online scores" browser interface by adding new metadata columns and implementing interactive column sorting. The new columns are:
    - Composer
    - File Path
    - Creation Time
Co-authored-by: João Tiago Tagarroso Lobo <joao.t.lobo@tecnico.ulisboa.pt>
<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [ ] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
