### PR TITLE
Select text on edit when desired

### DIFF
--- a/src/engraving/dom/textbase.cpp
+++ b/src/engraving/dom/textbase.cpp
@@ -145,9 +145,7 @@ void TextCursor::clearSelection()
 
 void TextCursor::startEdit()
 {
-    setRow(0);
-    setColumn(0);
-    clearSelection();
+    m_text->selectAll(this);
     m_editing = true;
 }
 

--- a/src/engraving/tests/textbase_tests.cpp
+++ b/src/engraving/tests/textbase_tests.cpp
@@ -71,6 +71,7 @@ TEST_F(Engraving_TextBaseTests, dynamicAddTextBefore)
     EditData ed;
     dynamic->startEdit(ed);
     score->startCmd(TranslatableString::untranslatable("Edit dynamic text (test)"));
+    dynamic->cursor()->clearSelection();
     score->undo(new InsertText(dynamic->cursor(), String(u"poco ")), &ed);
     score->endCmd();
     dynamic->endEdit(ed);
@@ -85,7 +86,7 @@ TEST_F(Engraving_TextBaseTests, dynamicAddTextAfter)
     ed.s = String(u" ma non troppo");
     dynamic->startEdit(ed);
     score->startCmd(TranslatableString::untranslatable("Edit dynamic text (test)"));
-    dynamic->cursor()->moveCursorToEnd();
+    dynamic->cursor()->clearSelection();
     dynamic->edit(ed);
     score->endCmd();
     dynamic->endEdit(ed);
@@ -99,6 +100,7 @@ TEST_F(Engraving_TextBaseTests, dynamicAddTextNoItalic)
     EditData ed;
     dynamic->startEdit(ed);
     score->startCmd(TranslatableString::untranslatable("Edit dynamic text (test)"));
+    dynamic->cursor()->moveCursorToStart();
     dynamic->setProperty(Pid::FONT_STYLE, PropertyValue::fromValue(0));
     score->undo(new InsertText(dynamic->cursor(), String(u"moderately ")), &ed);
     score->endCmd();


### PR DESCRIPTION
Resolves: #27346

Works for entering edit mode with keyboard shortcuts as well as 'Edit element' from the context menu.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
