### PR TITLE
engraving: Fix cyclic include in types/fraction.h

### DIFF
--- a/src/engraving/dom/mcursor.h
+++ b/src/engraving/dom/mcursor.h
@@ -24,7 +24,7 @@
 #define MU_ENGRAVING_MCURSOR_H
 
 #include "types/string.h"
-#include "../types/fraction.h"
+#include "../types/types.h"
 
 #include "modularity/ioc.h"
 

--- a/src/engraving/dom/sig.h
+++ b/src/engraving/dom/sig.h
@@ -26,8 +26,7 @@
 #include <cassert>
 
 #include "global/allocator.h"
-#include "types/string.h"
-#include "../types/fraction.h"
+#include "../types/types.h"
 
 namespace mu::engraving {
 int ticks_beat(int n);

--- a/src/engraving/rendering/iscorerenderer.h
+++ b/src/engraving/rendering/iscorerenderer.h
@@ -24,9 +24,8 @@
 #include <variant>
 
 #include "modularity/imoduleinterface.h"
-#include "draw/types/geometry.h"
 
-#include "../types/fraction.h"
+#include "../types/types.h"
 
 namespace muse::draw {
 class Painter;

--- a/src/engraving/rendering/score/horizontalspacing.h
+++ b/src/engraving/rendering/score/horizontalspacing.h
@@ -21,7 +21,7 @@
  */
 #pragma once
 
-#include "types/fraction.h"
+#include "types/types.h"
 
 namespace mu::engraving {
 class Chord;

--- a/src/engraving/rw/xmlreader.h
+++ b/src/engraving/rw/xmlreader.h
@@ -29,7 +29,7 @@
 #include "draw/types/color.h"
 #include "draw/types/geometry.h"
 
-#include "../types/fraction.h"
+#include "../types/types.h"
 
 namespace mu::engraving {
 class XmlReader : public muse::XmlStreamReader

--- a/src/engraving/types/fraction.h
+++ b/src/engraving/types/fraction.h
@@ -19,15 +19,14 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
-#ifndef MU_ENGRAVING_FRACTION_H
-#define MU_ENGRAVING_FRACTION_H
+#pragma once
 
 #include <cstdint>
+#include <cmath>
 #include <limits>
 #include <numeric>
 
-#include "../types/types.h"
+#include "global/types/string.h"
 
 #include "constants.h"
 
@@ -284,5 +283,3 @@ public:
 constexpr Fraction operator*(const Fraction& f, int v) { return Fraction(f) *= v; }
 constexpr Fraction operator*(int v, const Fraction& f) { return Fraction(f) *= v; }
 }
-
-#endif // MU_ENGRAVING_FRACTION_H

--- a/src/engraving/types/types.h
+++ b/src/engraving/types/types.h
@@ -19,7 +19,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 #pragma once
 
 #include <functional>
@@ -35,12 +34,14 @@
 #include "draw/types/geometry.h"
 #include "draw/types/painterpath.h"
 
+// IWYU pragma: begin_exports
 #include "bps.h"
 #include "dimension.h"
 #include "fraction.h"
 #include "groupnode.h"
 #include "pitchvalue.h"
 #include "symid.h"
+// IWYU pragma: end_exports
 
 namespace mu::engraving {
 using staff_idx_t = size_t;

--- a/src/framework/global/types/flags.h
+++ b/src/framework/global/types/flags.h
@@ -22,7 +22,7 @@
 #ifndef MUSE_GLOBAL_FLAGS_H
 #define MUSE_GLOBAL_FLAGS_H
 
-#include <cstdint>
+#include <type_traits>
 
 namespace muse {
 class Flag

--- a/src/importexport/musicxml/internal/musicxml/import/musicxmltupletstate.h
+++ b/src/importexport/musicxml/internal/musicxml/import/musicxmltupletstate.h
@@ -21,6 +21,8 @@
  */
 #pragma once
 
+#include "global/types/flags.h"
+
 #include "types/fraction.h"
 
 namespace mu::engraving {


### PR DESCRIPTION
`fraction.h` includes `types.h` which includes `fraction.h`

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
