### PR TITLE
[MusicXML] add support for encoder

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
@@ -7068,6 +7068,11 @@ void ExportMusicXml::identification(XmlWriter& xml, Score const* const score)
 
     xml.startElement("encoding");
 
+    String encoder = score->metaTag(u"encoder");
+    if (!encoder.empty()) {
+        xml.tag("encoder", encoder);
+    }
+
     if (MScore::debugMode) {
         xml.tag("software", String(u"MuseScore 0.7.0"));
         xml.tag("encoding-date", String(u"2007-09-10"));

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass1.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass1.cpp
@@ -1489,7 +1489,9 @@ void MusicXmlParserPass1::identification()
         } else if (m_e.name() == "encoding") {
             // TODO
             while (m_e.readNextStartElement()) {
-                if (m_e.name() == "software") {
+                if (m_e.name() == "encoder") {
+                    m_score->setMetaTag(u"encoder", m_e.readText());
+                } else if (m_e.name() == "software") {
                     String exporterString = m_e.readText().toLower();
                     setExporterSoftware(exporterString);
                 } else if (m_e.name() == "supports" && m_e.asciiAttribute("element") == "beam" && m_e.asciiAttribute("type") == "yes") {

--- a/src/importexport/musicxml/tests/data/testOrnaments.xml
+++ b/src/importexport/musicxml/tests/data/testOrnaments.xml
@@ -5,8 +5,8 @@
     <work-title>Ornaments import test</work-title>
     </work>
   <identification>
-    <creator type="composer">Klaus Rettinghaus</creator>
     <encoding>
+      <encoder>Klaus Rettinghaus</encoder>
       <software>MuseScore 0.7.0</software>
       <encoding-date>2007-09-10</encoding-date>
       <supports element="accidental" type="yes"/>

--- a/src/importexport/musicxml/tests/data/testSibOttavas_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testSibOttavas_ref.mscx
@@ -147,6 +147,7 @@
     <metaTag name="arranger"></metaTag>
     <metaTag name="composer"></metaTag>
     <metaTag name="copyright"></metaTag>
+    <metaTag name="encoder">James Mizen</metaTag>
     <metaTag name="lyricist"></metaTag>
     <metaTag name="movementNumber"></metaTag>
     <metaTag name="movementTitle"></metaTag>


### PR DESCRIPTION
This PR adds import/export of the encoder name to the metadata in MusicXML support.