### PR TITLE
Online scores page: fix edge case with pagination vs search

### DIFF
--- a/src/framework/cloud/qml/Muse/Cloud/internal/CloudScoresGridView.qml
+++ b/src/framework/cloud/qml/Muse/Cloud/internal/CloudScoresGridView.qml
@@ -31,24 +31,44 @@ ScoresGridView {
     navigation.name: "OnlineScoresGrid"
     navigation.accessible.name: qsTrc("project", "Online scores grid")
 
+    isNoResultsMessageAllowed: model.state === CloudScoresModel.Fine
+
     Component.onCompleted: {
         prv.updateDesiredRowCount()
+    }
+
+    Connections {
+        target: root.model
+        onStateChanged: {
+            if (root.model.state === CloudScoresModel.Fine) {
+                // After the model has loaded more, check if even more is needed
+                prv.updateDesiredRowCount();
+            }
+        }
     }
 
     QtObject {
         id: prv
 
         readonly property int remainingFullRowsBelowViewport:
-            Math.floor(root.model.rowCount / root.view.columns) - Math.ceil((root.view.contentY + root.view.height) / root.view.cellHeight)
+            Math.floor(root.view.count / root.view.columns) - Math.ceil((root.view.contentY + root.view.height) / root.view.cellHeight)
 
-        onRemainingFullRowsBelowViewportChanged: {
-            updateDesiredRowCount()
+        readonly property bool isSatisfied: remainingFullRowsBelowViewport >= 3
+
+        onIsSatisfiedChanged: {
+            if (!isSatisfied) {
+                updateDesiredRowCount();
+            }
         }
 
         property bool updateDesiredRowCountScheduled: false
 
         function updateDesiredRowCount() {
             if (updateDesiredRowCountScheduled) {
+                return
+            }
+
+            if (isSatisfied || !root.model.hasMore) {
                 return
             }
 

--- a/src/framework/cloud/qml/Muse/Cloud/internal/CloudScoresListView.qml
+++ b/src/framework/cloud/qml/Muse/Cloud/internal/CloudScoresListView.qml
@@ -38,20 +38,38 @@ ScoresListView {
         prv.updateDesiredRowCount()
     }
 
+    Connections {
+        target: root.model
+        onStateChanged: {
+            if (root.model.state === CloudScoresModel.Fine) {
+                // After the model has loaded more, check if even more is needed
+                prv.updateDesiredRowCount();
+            }
+        }
+    }
+
     QtObject {
         id: prv
 
         readonly property int remainingScoresBelowViewport:
-            root.model.rowCount - Math.ceil((view.contentY + view.height) / view.rowHeight)
+            root.view.count - Math.ceil((root.view.contentY + root.view.height) / root.view.rowHeight)
 
-        onRemainingScoresBelowViewportChanged: {
-            updateDesiredRowCount()
+        readonly property bool isSatisfied: remainingScoresBelowViewport >= 20
+
+        onIsSatisfiedChanged: {
+            if (!isSatisfied) {
+                updateDesiredRowCount();
+            }
         }
 
         property bool updateDesiredRowCountScheduled: false
 
         function updateDesiredRowCount() {
             if (updateDesiredRowCountScheduled) {
+                return
+            }
+
+            if (isSatisfied || !root.model.hasMore) {
                 return
             }
 

--- a/src/project/qml/MuseScore/Project/ScoresGridView.qml
+++ b/src/project/qml/MuseScore/Project/ScoresGridView.qml
@@ -34,6 +34,8 @@ Item {
     property AbstractScoresModel model
     property string searchText
 
+    property bool isNoResultsMessageAllowed: true
+
     property color backgroundColor: ui.theme.backgroundSecondaryColor
     property real sideMargin: 46
 
@@ -187,8 +189,7 @@ Item {
         id: noResultsMessage
         anchors.fill: parent
 
-        // This will become visible if a "No results found" item is not provided by the model.
-        visible: Boolean(root.searchText) && itemTypeFilterModel.rowCount === 0
+        visible: Boolean(root.searchText) && view.count === 0 && root.isNoResultsMessageAllowed
 
         Message {
             anchors.top: parent.top

--- a/src/project/qml/MuseScore/Project/internal/ScoresPage/RecentScoresView.qml
+++ b/src/project/qml/MuseScore/Project/internal/ScoresPage/RecentScoresView.qml
@@ -48,6 +48,8 @@ ScoresView {
             model: recentScoresModel
             searchText: root.searchText
 
+            isNoResultsMessageAllowed: false // provided by the model instead
+
             backgroundColor: root.backgroundColor
             sideMargin: root.sideMargin
 


### PR DESCRIPTION
Ensure that the model keeps loading more batches of scores, until the viewport is filled, even when searching.

Resolves: #28306