### PR TITLE
Implement pause and select action (#17228)

### DIFF
--- a/src/app/configs/data/shortcuts.xml
+++ b/src/app/configs/data/shortcuts.xml
@@ -769,6 +769,11 @@
     <autorepeat>0</autorepeat>
     </SC>
   <SC>
+    <key>pause-and-select</key>
+    <seq>Ctrl+Space</seq>
+    <autorepeat>0</autorepeat>
+    </SC>
+  <SC>
     <key>play-prev-chord</key>
     <seq>Left</seq>
     </SC>

--- a/src/app/configs/data/shortcuts_azerty.xml
+++ b/src/app/configs/data/shortcuts_azerty.xml
@@ -795,6 +795,11 @@
     <autorepeat>0</autorepeat>
     </SC>
   <SC>
+    <key>pause-and-select</key>
+    <seq>Ctrl+Space</seq>
+    <autorepeat>0</autorepeat>
+    </SC>
+  <SC>
     <key>play-prev-chord</key>
     <seq>Left</seq>
     </SC>

--- a/src/app/configs/data/shortcuts_mac.xml
+++ b/src/app/configs/data/shortcuts_mac.xml
@@ -769,6 +769,11 @@
     <autorepeat>0</autorepeat>
     </SC>
   <SC>
+    <key>pause-and-select</key>
+    <seq>Alt+Space</seq>
+    <autorepeat>0</autorepeat>
+    </SC>
+  <SC>
     <key>play-prev-chord</key>
     <seq>Left</seq>
     </SC>

--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -83,6 +83,7 @@ public:
     virtual void clearSelection() = 0;
     virtual muse::async::Notification selectionChanged() const = 0;
     virtual void selectTopOrBottomOfChord(MoveDirection d) = 0;
+    virtual void findAndSelectChordRest(const Fraction& tick) = 0;
 
     virtual EngravingItem* contextItem() const = 0;
 

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -871,6 +871,68 @@ void NotationInteraction::selectTopOrBottomOfChord(MoveDirection d)
     showItem(target);
 }
 
+void NotationInteraction::findAndSelectChordRest(const Fraction& tick)
+{
+    IF_ASSERT_FAILED(selection() && score()) {
+        return;
+    }
+
+    Segment* startSeg = score()->tick2leftSegment(tick, /*useMMrest*/ false, SegmentType::ChordRest);
+    IF_ASSERT_FAILED(startSeg && startSeg->isChordRestType()) {
+        return;
+    }
+
+    staff_idx_t lastSelectedStaffIdx = 0;
+    voice_idx_t lastSelectedVoiceIdx = 0;
+    if (selection()->isRange()) {
+        lastSelectedStaffIdx = selection()->range()->startStaffIndex();
+    } else if (!selection()->elements().empty()) {
+        const EngravingItem* lastSelectedItem = selection()->elements().back();
+        if (lastSelectedItem) {
+            lastSelectedStaffIdx = lastSelectedItem->staffIdx();
+            lastSelectedVoiceIdx = lastSelectedItem->voice();
+        }
+    }
+
+    // startSeg could be a CR segment in any staff. The idea of this method is to select the CR in the last selected
+    // staff (or the top staff if none was selected). The following outer loop iterates backwards through previous CR
+    // segments until a valid CR is found in the desired staff...
+    EngravingItem* toSelect = nullptr;
+    for (Segment* currSeg = startSeg; currSeg && !toSelect; currSeg = currSeg->prev(SegmentType::ChordRest)) {
+        toSelect = currSeg->element(staff2track(lastSelectedStaffIdx, lastSelectedVoiceIdx));
+        if (toSelect && toSelect->isChordRest()) {
+            break;
+        }
+        toSelect = nullptr;
+        // Inner loop: Couldn't find a valid CR in the last selected voice - try other voices in the same staff...
+        for (voice_idx_t currVoice = 0; currVoice < VOICES; ++currVoice) {
+            if (currVoice == lastSelectedVoiceIdx) {
+                // Already tried this...
+                continue;
+            }
+            toSelect = currSeg->element(staff2track(lastSelectedStaffIdx, currVoice));
+            if (toSelect && toSelect->isChordRest()) {
+                break;
+            }
+            toSelect = nullptr;
+        }
+    }
+
+    IF_ASSERT_FAILED(toSelect) {
+        return;
+    }
+
+    std::vector<EngravingItem*> itemsToSelect;
+    if (toSelect->isChord()) {
+        const std::vector<Note*>& notes = toChord(toSelect)->notes();
+        itemsToSelect.insert(itemsToSelect.end(), notes.begin(), notes.end());
+    } else {
+        itemsToSelect = { toSelect };
+    }
+
+    select(itemsToSelect, SelectType::REPLACE);
+}
+
 void NotationInteraction::select(const std::vector<EngravingItem*>& elements, SelectType type, staff_idx_t staffIndex)
 {
     TRACEFUNC;

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -95,6 +95,7 @@ public:
     void clearSelection() override;
     muse::async::Notification selectionChanged() const override;
     void selectTopOrBottomOfChord(MoveDirection d) override;
+    void findAndSelectChordRest(const Fraction& tick) override;
     void moveSegmentSelection(MoveDirection d) override;
 
     EngravingItem* contextItem() const override;

--- a/src/notation/tests/mocks/notationinteractionmock.h
+++ b/src/notation/tests/mocks/notationinteractionmock.h
@@ -56,6 +56,7 @@ public:
     MOCK_METHOD(void, clearSelection, (), (override));
     MOCK_METHOD(muse::async::Notification, selectionChanged, (), (const, override));
     MOCK_METHOD(void, selectTopOrBottomOfChord, (MoveDirection), (override));
+    MOCK_METHOD(void, findAndSelectChordRest, (const Fraction&), (override));
 
     MOCK_METHOD(INotationSelectionFilterPtr, selectionFilter, (), (const, override));
 

--- a/src/playback/internal/playbackcontroller.h
+++ b/src/playback/internal/playbackcontroller.h
@@ -155,9 +155,11 @@ private:
     void togglePlay();
     void rewind(const muse::actions::ActionData& args);
     void play();
-    void pause();
+    void pause(bool select = false);
     void stop();
     void resume();
+
+    void selectAtRawTick(const muse::midi::tick_t& rawTick);
 
     muse::audio::secs_t playbackStartSecs() const;
     muse::audio::secs_t playbackEndSecs() const;

--- a/src/playback/internal/playbackuiactions.cpp
+++ b/src/playback/internal/playbackuiactions.cpp
@@ -46,6 +46,13 @@ const UiActionList PlaybackUiActions::m_mainActions = {
              TranslatableString("action", "Stop playback"),
              IconCode::Code::STOP
              ),
+    UiAction("pause-and-select",
+             mu::context::UiCtxProjectOpened,
+             mu::context::CTX_NOTATION_OPENED,
+             TranslatableString("action", "Pause and select"),
+             TranslatableString("action", "Pause and select playback position"),
+             IconCode::Code::PAUSE
+             ),
     UiAction("rewind",
              mu::context::UiCtxProjectOpened,
              mu::context::CTX_NOTATION_FOCUSED,


### PR DESCRIPTION
Resolves: #17228

This PR implements a shortcutable "pause and select" action. By default this is set to `Ctrl+Space` for Windows/Linux, `Alt+Space` for MacOS. The action will select the current `ChordRest` in the last selected stave (or the top stave if nothing was selected).

![image](https://github.com/user-attachments/assets/2748b3e3-0497-4a68-8e3f-f1ded8999042)