### PR TITLE
Switch to Qt 6.9.1 on CI by default

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -26,7 +26,7 @@ on:
         required: false
       use_qt69:
         description: 'Use Qt 6.9'
-        default: 'off'
+        default: 'on'
         required: false   
   workflow_call:
     inputs:
@@ -57,7 +57,7 @@ on:
         required: false
       use_qt69:
         description: 'Use Qt 6.9'
-        default: 'off'
+        default: 'on'
         type: string
         required: false  
 

--- a/.github/workflows/build_backend.yml
+++ b/.github/workflows/build_backend.yml
@@ -20,7 +20,7 @@ on:
         required: false
       use_qt69:
         description: 'Use Qt 6.9'
-        default: 'off'
+        default: 'on'
         required: false
   workflow_call:
     inputs:
@@ -41,9 +41,12 @@ on:
         required: false
       use_qt69:
         description: 'Use Qt 6.9'
-        default: 'off'
+        default: 'on'
         type: string
         required: false
+
+env:
+  USE_QT69: ${{ inputs.use_qt69 != '' && inputs.use_qt69 || 'on' }}          
 
 jobs:
   backend:
@@ -101,10 +104,10 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
       with:
-        version: ${{ inputs.use_qt69 == 'on' && '6.9.*' || '6.2.4' }}
+        version: ${{ env.USE_QT69 == 'on' && '6.9.1' || '6.2.4' }}
         host: 'linux'
         target: 'desktop'
-        arch: ${{ inputs.use_qt69 == 'on' && 'linux_gcc_64' || 'gcc_64' }}
+        arch: ${{ env.USE_QT69 == 'on' && 'linux_gcc_64' || 'gcc_64' }}
         modules: 'qt5compat qtnetworkauth qtscxml qtshadertools qtwebsockets'
 
     - name: Setup environment

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -22,7 +22,7 @@ on:
         required: false
       use_qt69:
         description: 'Use Qt 6.9'
-        default: 'off'
+        default: 'on'
         required: false  
   workflow_call:
     inputs:
@@ -48,12 +48,25 @@ on:
         required: false
       use_qt69:
         description: 'Use Qt 6.9'
-        default: 'off'
+        default: 'on'
         type: string
-        required: false    
+        required: false
+ 
+env:
+  USE_QT69: ${{ inputs.use_qt69 != '' && inputs.use_qt69 || 'on' }}        
 
 jobs:
+  setup:
+    runs-on: ubuntu-22.04
+    outputs:
+      use_qt69: ${{ steps.set_use_qt69.outputs.use_qt69 }}
+    steps:
+      - id: set_use_qt69
+        run: |
+          echo "use_qt69=${{ env.USE_QT69 }}" >> $GITHUB_OUTPUT
+
   build:
+    needs: setup
     if: github.event_name != 'workflow_dispatch' || contains(inputs.platforms, 'linux_x64') || contains(inputs.platforms, 'linux_arm64')
     runs-on: ${{ matrix.runs-on }}
     strategy:
@@ -72,11 +85,12 @@ jobs:
             arch: x86_64
             runs-on: ubuntu-22.04
             qt-host: linux
-            qt-arch: ${{ inputs.use_qt69 == 'on' && 'linux_gcc_64' || 'gcc_64' }} 
+            qt-version: ${{ needs.setup.outputs.use_qt69 == 'on' && '6.9.1' || '6.2.4' }}
+            qt-arch: ${{ needs.setup.outputs.use_qt69 == 'on' && 'linux_gcc_64' || 'gcc_64' }} 
             dump-symbols-arch: x86-64
           - platform: linux_arm64
             arch: aarch64
-            runs-on: ${{ inputs.use_qt69 == 'on' && 'ubuntu-24.04-arm' || 'ubuntu-22.04-arm' }}  
+            runs-on: ${{ needs.setup.outputs.use_qt69 == 'on' && 'ubuntu-24.04-arm' || 'ubuntu-22.04-arm' }}  
             qt-host: linux_arm64
             qt-arch: linux_gcc_arm64
             dump-symbols-arch: aarch64
@@ -181,15 +195,15 @@ jobs:
 
     - name: Install Qt
       uses: jurplel/install-qt-action@v4 
-      if: ${{ !(matrix.qt-host == 'linux_arm64' && inputs.use_qt69 != 'on') }}
+      if: ${{ !(matrix.qt-host == 'linux_arm64' && env.USE_QT69 != 'on') }}
       with:
-        version: ${{ inputs.use_qt69 == 'on' && '6.9.*' || '6.2.4' }}
+        version: ${{ env.USE_QT69 == 'on' && '6.9.1' || '6.2.4' }}
         host: ${{ matrix.qt-host }}
         target: 'desktop'
         arch: ${{ matrix.qt-arch }}
         modules: 'qt5compat qtnetworkauth qtscxml qtshadertools qtwebsockets'
     - name: Install Qt 6.2.4 arm64
-      if: ${{ matrix.qt-host == 'linux_arm64' && inputs.use_qt69 != 'on' }}  
+      if: ${{ matrix.qt-host == 'linux_arm64' && env.USE_QT69 != 'on' }}  
       run: |
         bash ./buildscripts/ci/linux/arm64/install_qt.sh     
     - name: Setup environment

--- a/.github/workflows/build_linux_arm32.yml
+++ b/.github/workflows/build_linux_arm32.yml
@@ -1,7 +1,7 @@
 name: 'Build: Linux arm32'
 
 on:
-  # pull_request:
+  #pull_request:
   workflow_dispatch:
     inputs:
       build_mode:
@@ -18,7 +18,7 @@ on:
         required: false
       use_qt69:
         description: 'Use Qt 6.9'
-        default: 'off'
+        default: 'on'
         required: false   
   workflow_call:
     inputs:
@@ -39,9 +39,9 @@ on:
         required: false
       use_qt69:
         description: 'Use Qt 6.9'
-        default: 'off'
+        default: 'on'
         type: string
-        required: false  
+        required: false                
 
 jobs:
   linux_arm32:

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -18,7 +18,7 @@ on:
         required: false
       use_qt69:
         description: 'Use Qt 6.9'
-        default: 'off'
+        default: 'on'
         required: false    
   workflow_call:
     inputs:
@@ -39,12 +39,13 @@ on:
         required: false
       use_qt69:
         description: 'Use Qt 6.9'
-        default: 'off'
+        default: 'on'
         type: string
         required: false   
 
 env:
   DEVELOPER_DIR: /Applications/Xcode_16.3.app/Contents/Developer
+  USE_QT69: ${{ inputs.use_qt69 != '' && inputs.use_qt69 || 'on' }}  
 
 jobs:
   macos_universal:
@@ -163,7 +164,7 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
       with:
-        version: ${{ inputs.use_qt69 == 'on' && '6.9.*' || '6.2.4' }}
+        version: ${{ env.USE_QT69 == 'on' && '6.9.1' || '6.2.4' }}
         host: 'mac'
         target: 'desktop'
         arch: 'clang_64'

--- a/.github/workflows/build_nightly.yml
+++ b/.github/workflows/build_nightly.yml
@@ -49,6 +49,6 @@ jobs:
                 build_mode: 'nightly',
                 publish: 'on',
                 sentry_project: 'sandbox',
-                use_qt69: 'off'
+                use_qt69: 'on'
               }
             })

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -22,7 +22,7 @@ on:
         required: false
       use_qt69:
         description: 'Use Qt 6.9'
-        default: 'off'
+        default: 'on'
         required: false   
   workflow_call:
     inputs:
@@ -48,9 +48,12 @@ on:
         required: false
       use_qt69:
         description: 'Use Qt 6.9'
-        default: 'off'
+        default: 'on'
         type: string
         required: false    
+
+env:
+  USE_QT69: ${{ inputs.use_qt69 != '' && inputs.use_qt69 || 'on' }}               
 
 jobs:
   windows_x64:
@@ -158,15 +161,15 @@ jobs:
 
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
-      if: ${{ inputs.use_qt69 == 'on' }}
+      if: ${{ env.USE_QT69 == 'on' }}
       with:
-        version: ${{ inputs.use_qt69 == 'on' && '6.9.*' || '6.2.4' }} 
+        version: '6.9.1'
         host: 'windows'
         target: 'desktop'
-        arch: ${{ inputs.use_qt69 == 'on' && 'win64_msvc2022_64' || 'win64_msvc2019_64' }} 
+        arch: 'win64_msvc2022_64'
         modules: 'qt5compat qtnetworkauth qtscxml qtshadertools qtwebsockets'
     - name: Install Qt 6.2.11
-      if: ${{ inputs.use_qt69 != 'on' }}
+      if: ${{ env.USE_QT69 != 'on' }}
       run: |
         buildscripts\ci\windows\install_qt_6_2_11.bat
     - name: Setup environment
@@ -309,7 +312,7 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
       with:
-        version: '6.9.*'
+        version: '6.9.1'
         host: 'windows'
         target: 'desktop'
         arch: 'win64_msvc2022_64'

--- a/.github/workflows/check_unit_tests.yml
+++ b/.github/workflows/check_unit_tests.yml
@@ -10,10 +10,13 @@ on:
         default: 'false'
       use_qt69:
         description: 'Use Qt 6.9'
-        default: 'off'
+        default: 'on'
         required: false 
   schedule:
     - cron: "0 3 * * 4" # Every Thursday night at 03:00 for master branch
+
+env:
+  USE_QT69: ${{ inputs.use_qt69 != '' && inputs.use_qt69 || 'on' }}  
 
 jobs:
   run_tests:
@@ -53,10 +56,10 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
       with:
-        version: ${{ inputs.use_qt69 == 'on' && '6.9.*' || '6.2.4' }}
+        version: ${{ env.USE_QT69 == 'on' && '6.9.1' || '6.2.4' }}
         host: 'linux'
         target: 'desktop'
-        arch: ${{ inputs.use_qt69 == 'on' && 'linux_gcc_64' || 'gcc_64' }}
+        arch: ${{ env.USE_QT69 == 'on' && 'linux_gcc_64' || 'gcc_64' }}
         modules: 'qt5compat qtnetworkauth qtscxml qtshadertools qtwebsockets'
     - name: Setup environment
       run: |

--- a/.github/workflows/check_visual_tests.yml
+++ b/.github/workflows/check_visual_tests.yml
@@ -6,8 +6,12 @@ on:
     inputs:
       use_qt69:
         description: 'Use Qt 6.9'
-        default: 'off'
+        default: 'on'
         required: false 
+
+env:
+  USE_QT69: ${{ inputs.use_qt69 != '' && inputs.use_qt69 || 'on' }}  
+
 jobs:
   setup:
     name: "Setup VTests workflow"
@@ -87,10 +91,10 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
       with:
-        version: ${{ inputs.use_qt69 == 'on' && '6.9.*' || '6.2.4' }}
+        version: ${{ env.USE_QT69 == 'on' && '6.9.1' || '6.2.4' }}
         host: 'linux'
         target: 'desktop'
-        arch: ${{ inputs.use_qt69 == 'on' && 'linux_gcc_64' || 'gcc_64' }}
+        arch: ${{ env.USE_QT69 == 'on' && 'linux_gcc_64' || 'gcc_64' }}
         modules: 'qt5compat qtnetworkauth qtscxml qtshadertools qtwebsockets'
     - name: Setup environment
       run: |
@@ -134,10 +138,10 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
       with:
-        version: ${{ inputs.use_qt69 == 'on' && '6.9.*' || '6.2.4' }}
+        version: ${{ env.USE_QT69 == 'on' && '6.9.1' || '6.2.4' }}
         host: 'linux'
         target: 'desktop'
-        arch: ${{ inputs.use_qt69 == 'on' && 'linux_gcc_64' || 'gcc_64' }}
+        arch: ${{ env.USE_QT69 == 'on' && 'linux_gcc_64' || 'gcc_64' }}
         modules: 'qt5compat qtnetworkauth qtscxml qtshadertools qtwebsockets'
     - name: Setup environment
       run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ on:
         default: false
       use_qt69:
         description: 'Use Qt 6.9'
-        default: 'off'
+        default: 'on'
         required: false   
 
 defaults:

--- a/.github/workflows/translate_lupdate.yml
+++ b/.github/workflows/translate_lupdate.yml
@@ -10,7 +10,7 @@ on:
         default: false
       use_qt69:
         description: 'Use Qt 6.9'
-        default: 'off'
+        default: 'on'
         required: false   
   schedule:
     - cron: "0 12 * * Sun"
@@ -35,7 +35,7 @@ jobs:
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
         with:
-          version: ${{ inputs.use_qt69 == 'on' && '6.9.*' || '6.2.4' }}
+          version: ${{ inputs.use_qt69 == 'on' && '6.9.1' || '6.2.4' }}
           host: "linux"
           target: "desktop"
           arch: ${{ inputs.use_qt69 == 'on' && 'linux_gcc_64' || 'gcc_64' }}

--- a/.github/workflows/translate_tx_pull_to_s3.yml
+++ b/.github/workflows/translate_tx_pull_to_s3.yml
@@ -21,8 +21,11 @@ on:
         default: false
       use_qt69:
         description: "Use Qt 6.9"
-        default: "off"
+        default: "on"
         required: false
+
+env:
+  USE_QT69: ${{ inputs.use_qt69 != '' && inputs.use_qt69 || 'on' }}          
 
 jobs:
   tx_pull:
@@ -76,10 +79,10 @@ jobs:
         if: env.DO_PUSH_TO_S3 == 'true'
         uses: jurplel/install-qt-action@v4
         with:
-          version: ${{ inputs.use_qt69 == 'on' && '6.9.*' || '6.2.4' }}
+          version: ${{ env.USE_QT69 == 'on' && '6.9.1' || '6.2.4' }}
           host: "linux"
           target: "desktop"
-          arch: ${{ inputs.use_qt69 == 'on' && 'linux_gcc_64' || 'gcc_64' }}
+          arch: ${{ env.USE_QT69== 'on' && 'linux_gcc_64' || 'gcc_64' }}
           archives: "qttools qtbase icu"
 
       - name: Setup environment for pushing to S3


### PR DESCRIPTION
We want to switch to Qt 6.9 by the 4.6 release, but it's not certain.

There are a number of issues with Qt 6.9 that we haven't resolved yet.
(They will all be posted on GitHub soon)
There are probably issues that we don't know about yet.

We want to switch all builds to Qt 6.9 now, so that we can use them en masse, force the resolution of known issues, and increase the chance of detecting unknown issues.

After a while, we'll see if we can release 4.6 with Qt 6.9, or if we should go back to Qt 6.2 for 4.6, and keep Qt 6.9 for a later release.