### PR TITLE
Fix #28337: Lingering text edit after making selection

### DIFF
--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -148,7 +148,7 @@ public:
     virtual bool textEditingAllowed(const EngravingItem* element) const = 0;
     virtual void startEditText(EngravingItem* element, const muse::PointF& elementPos = muse::PointF()) = 0;
     virtual void editText(QInputMethodEvent* event) = 0;
-    virtual void endEditText() = 0;
+    virtual void endEditText(bool startNonTextualEdit = true) = 0;
     virtual void changeTextCursorPosition(const muse::PointF& newCursorPos) = 0;
     virtual void selectText(mu::engraving::SelectTextType type) = 0;
     virtual const TextBase* editedText() const = 0;

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -893,7 +893,7 @@ void NotationInteraction::doSelect(const std::vector<EngravingItem*>& elements, 
     TRACEFUNC;
 
     if (needEndTextEditing(elements)) {
-        endEditText();
+        endEditText(/*startNonTextualEdit*/ false);
     } else if (needEndElementEditing(elements)) {
         endEditElement();
     }
@@ -4188,21 +4188,19 @@ bool NotationInteraction::handleKeyPress(QKeyEvent* event)
     return true;
 }
 
-void NotationInteraction::endEditText()
+void NotationInteraction::endEditText(bool startNonTextualEdit)
 {
     if (!isTextEditingStarted()) {
         return;
     }
 
-    EngravingItem* editedElement = m_editData.element;
+    TextBase* editedElement = toTextBase(m_editData.element);
     doEndEditElement();
+    notifyAboutTextEditingEnded(editedElement);
 
-    if (editedElement) {
-        notifyAboutTextEditingEnded(toTextBase(editedElement));
-        // When textual edit is finished, non-textual edit can still happen, so we need to start the non-textual edit mode here
-        if (editedElement->isTextBase() && toTextBase(editedElement)->supportsNonTextualEdit()) {
-            startEditElement(editedElement, false);
-        }
+    // When textual edit is finished, non-textual edit can still happen, so we need to start the non-textual edit mode here
+    if (startNonTextualEdit && editedElement->supportsNonTextualEdit()) {
+        startEditElement(editedElement, false);
     }
 
     notifyAboutTextEditingChanged();
@@ -6263,7 +6261,7 @@ void NotationInteraction::navigateToLyrics(bool back, bool moveOnly, bool end)
         return;
     }
 
-    endEditText();
+    endEditText(/*startNonTextualEdit*/ false);
 
     // look for the lyrics we are moving from; may be the current lyrics or a previous one
     // if we are skipping several chords with spaces
@@ -6413,7 +6411,7 @@ void NotationInteraction::navigateToNextSyllable()
         return;
     }
 
-    endEditText();
+    endEditText(/*startNonTextualEdit*/ false);
 
     // look for the lyrics we are moving from; may be the current lyrics or a previous one
     // we are extending with several dashes
@@ -6657,7 +6655,7 @@ void NotationInteraction::navigateToLyricsVerse(MoveDirection direction)
         }
     }
 
-    endEditText();
+    endEditText(/*startNonTextualEdit*/ false);
 
     lyrics = cr->lyrics(verse, placement);
     if (!lyrics) {
@@ -7239,7 +7237,7 @@ void NotationInteraction::addMelisma()
     FontStyle fStyle = lyrics->fontStyle();
     PropertyFlags fFlags = lyrics->propertyFlags(Pid::FONT_STYLE);
     Fraction endTick = segment->tick(); // a previous melisma cannot extend beyond this point
-    endEditText();
+    endEditText(/*startNonTextualEdit*/ false);
 
     // search next chord
     Segment* nextSegment = segment;
@@ -7444,7 +7442,7 @@ void NotationInteraction::addLyricsVerse()
     mu::engraving::FontStyle fStyle = oldLyrics->fontStyle();
     mu::engraving::PropertyFlags fFlags = oldLyrics->propertyFlags(mu::engraving::Pid::FONT_STYLE);
 
-    endEditText();
+    endEditText(/*startNonTextualEdit*/ false);
 
     score()->startCmd(TranslatableString("undoableAction", "Add lyrics verse"));
     int newVerse = oldLyrics->no() + 1;

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -157,7 +157,7 @@ public:
     bool textEditingAllowed(const EngravingItem* element) const override;
     void startEditText(EngravingItem* element, const muse::PointF& cursorPos = muse::PointF()) override;
     void editText(QInputMethodEvent* event) override;
-    void endEditText() override;
+    void endEditText(bool startNonTextualEdit = true) override;
     void changeTextCursorPosition(const muse::PointF& newCursorPos) override;
     void selectText(mu::engraving::SelectTextType type) override;
     const TextBase* editedText() const override;

--- a/src/notation/tests/mocks/notationinteractionmock.h
+++ b/src/notation/tests/mocks/notationinteractionmock.h
@@ -113,7 +113,7 @@ public:
     MOCK_METHOD(bool, textEditingAllowed, (const EngravingItem*), (const, override));
     MOCK_METHOD(void, startEditText, (EngravingItem*, const muse::PointF&), (override));
     MOCK_METHOD(void, editText, (QInputMethodEvent*), (override));
-    MOCK_METHOD(void, endEditText, (), (override));
+    MOCK_METHOD(void, endEditText, (bool), (override));
     MOCK_METHOD(void, changeTextCursorPosition, (const muse::PointF&), (override));
     MOCK_METHOD(void, selectText, (mu::engraving::SelectTextType), (override));
     MOCK_METHOD(const TextBase*, editedText, (), (const, override));


### PR DESCRIPTION
Resolves: #28337

This PR also addresses a couple of quirks with `endEditText`:
1. `m_editData.element` is null checked by `isTextEditingStarted` so there's no need to null check `editedElement`.
2. `isTextEditingStarted` also checks that `m_editData.element` is a `TextBase`, so the `isTextBase` check is redundant.