### PR TITLE
Fix gcc compiler warning

### DIFF
--- a/src/importexport/guitarpro/internal/guitarbendimport/benddatacollector.cpp
+++ b/src/importexport/guitarpro/internal/guitarbendimport/benddatacollector.cpp
@@ -39,7 +39,6 @@ static void fillChordDurationsFromBendDiagram(BendDataContext& bendDataCtx, Frac
                                               const BendDataCollector::ImportedBendInfo& importedInfo);
 static void fillBendDataForNote(BendDataContext& bendDataCtx, const BendDataCollector::ImportedBendInfo& importedInfo,
                                 int noteIndexInChord);
-static bool isSlightBend(const BendDataCollector::ImportedBendInfo& importedInfo);
 static BendDataCollector::ImportedBendInfo fillBendInfo(const Note* note, const PitchValues& pitchValues);
 
 bool BendDataCollector::ImportedBendInfo::isSlightBend() const


### PR DESCRIPTION
reg.: ‘bool mu::iex::guitarpro::isSlightBend(const mu::iex::guitarpro::BendDataCollector::ImportedBendInfo&)’ declared ‘static’ but never defined [-Wunused-function]