### PR TITLE
28374: Partial ties popup does not react to clicks

### DIFF
--- a/src/notation/view/internal/partialtiepopupmodel.cpp
+++ b/src/notation/view/internal/partialtiepopupmodel.cpp
@@ -79,7 +79,7 @@ void PartialTiePopupModel::init()
     load();
 }
 
-void PartialTiePopupModel::toggleItemChecked(QString& id)
+void PartialTiePopupModel::toggleItemChecked(const QString& id)
 {
     Tie* tieItem = tie();
     if (!tieItem || !tieItem->tieJumpPoints()) {

--- a/src/notation/view/internal/partialtiepopupmodel.h
+++ b/src/notation/view/internal/partialtiepopupmodel.h
@@ -22,7 +22,7 @@ public:
     QPointF dialogPosition() const;
 
     Q_INVOKABLE void init() override;
-    Q_INVOKABLE void toggleItemChecked(QString& id);
+    Q_INVOKABLE void toggleItemChecked(const QString& id);
 
     Q_INVOKABLE void onClosed();
 


### PR DESCRIPTION
Resolves: #28374

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
