### PR TITLE
fixed #26080: Remove markings made redundant by barrés from fretboard diagram definitions

### DIFF
--- a/src/engraving/data/harmony_to_diagram.xml
+++ b/src/engraving/data/harmony_to_diagram.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <Data>
     <HarmonyToDiagram>
         <FretDiagram>
@@ -44,7 +44,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -71,7 +70,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -98,7 +96,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="1" end="5">2</barre>
             </fretDiagram>
@@ -125,7 +122,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -181,7 +177,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="1" end="5">2</barre>
             </fretDiagram>
@@ -203,7 +198,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -257,7 +251,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -282,7 +275,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -336,7 +328,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -363,7 +354,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -417,7 +407,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="0" end="5">2</barre>
             </fretDiagram>
@@ -470,7 +459,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="0" end="5">2</barre>
             </fretDiagram>
@@ -495,7 +483,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -729,7 +716,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -777,7 +763,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="2">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="3">
                     <dot fret="2">normal</dot>
@@ -929,7 +914,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="4" end="5">2</barre>
             </fretDiagram>
@@ -1068,7 +1052,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <marker>cross</marker>
@@ -1300,7 +1283,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
@@ -1324,7 +1306,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -1405,7 +1386,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="2">normal</dot>
@@ -1429,7 +1409,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="1" end="5">2</barre>
             </fretDiagram>
@@ -1510,7 +1489,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
@@ -1531,7 +1509,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
@@ -1610,7 +1587,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -1872,7 +1848,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -1888,13 +1863,10 @@
             <frets>4</frets>
             <fretDiagram>
                 <string no="1">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="2">normal</dot>
@@ -1926,7 +1898,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -1979,7 +1950,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
@@ -2001,7 +1971,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="4">normal</dot>
@@ -2054,7 +2023,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -2137,7 +2105,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -2164,7 +2131,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -2366,7 +2332,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -2450,7 +2415,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -2567,7 +2531,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -2595,7 +2558,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -2649,7 +2611,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="3">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="3">normal</dot>
@@ -3031,7 +2992,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="2">normal</dot>
@@ -3059,7 +3019,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -3113,7 +3072,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -3289,7 +3247,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -3316,7 +3273,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -3372,7 +3328,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -3429,7 +3384,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <marker>circle</marker>
@@ -3457,7 +3411,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <marker>circle</marker>
@@ -3574,7 +3527,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -3598,7 +3550,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="3">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="4">normal</dot>
@@ -3683,7 +3634,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="2">normal</dot>
@@ -4004,7 +3954,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -4082,7 +4031,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="2">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="3">
                     <dot fret="2">normal</dot>
@@ -4178,7 +4126,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -4233,7 +4180,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -4281,7 +4227,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="4">normal</dot>
@@ -4367,7 +4312,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <marker>cross</marker>
@@ -4421,7 +4365,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -4442,7 +4385,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -4466,7 +4408,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -4484,7 +4425,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="4">normal</dot>
@@ -4514,7 +4454,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -4532,7 +4471,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="3">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="4">normal</dot>
@@ -4562,7 +4500,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -4580,7 +4517,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -4601,7 +4537,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -4622,7 +4557,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -4650,7 +4584,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -4672,7 +4605,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -4693,7 +4625,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="4">normal</dot>
@@ -4727,7 +4658,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -4806,7 +4736,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -4834,7 +4763,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -4919,7 +4847,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -4940,7 +4867,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="2">normal</dot>
@@ -4991,7 +4917,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="2">normal</dot>
@@ -5015,7 +4940,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="2">normal</dot>
@@ -5043,7 +4967,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -5064,7 +4987,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="2">normal</dot>
@@ -5089,7 +5011,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -5114,7 +5035,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -5135,7 +5055,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="2">normal</dot>
@@ -5159,7 +5078,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="2">normal</dot>
@@ -5277,7 +5195,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -5302,7 +5219,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -5360,7 +5276,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -5385,7 +5300,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -5406,7 +5320,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="2">normal</dot>
@@ -5428,13 +5341,10 @@
             <frets>4</frets>
             <fretDiagram>
                 <string no="1">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
                 <barre start="1" end="3">3</barre>
@@ -5459,7 +5369,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -5481,7 +5390,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -5512,7 +5420,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
@@ -5537,7 +5444,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -5562,7 +5468,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -5593,7 +5498,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -5621,7 +5525,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -5672,7 +5575,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="2">normal</dot>
@@ -5702,7 +5604,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="2">normal</dot>
@@ -5727,7 +5628,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -5758,7 +5658,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -5783,7 +5682,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -5802,13 +5700,10 @@
             <frets>4</frets>
             <fretDiagram>
                 <string no="1">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -5920,7 +5815,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -5941,7 +5835,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -5960,16 +5853,13 @@
             <frets>4</frets>
             <fretDiagram>
                 <string no="1">
-                    <dot fret="4">normal</dot>
                 </string>
                 <string no="2">
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
                 <barre start="1" end="4">4</barre>
@@ -5994,7 +5884,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -6021,7 +5910,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -6046,7 +5934,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="4">normal</dot>
@@ -6128,16 +6015,13 @@
             <frets>4</frets>
             <fretDiagram>
                 <string no="1">
-                    <dot fret="4">normal</dot>
                 </string>
                 <string no="2">
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
                 <barre start="1" end="4">4</barre>
@@ -6162,7 +6046,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -6186,7 +6069,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="3">normal</dot>
@@ -6302,7 +6184,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -6443,7 +6324,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="2">normal</dot>
@@ -6498,7 +6378,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -6514,7 +6393,6 @@
             <frets>4</frets>
             <fretDiagram>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -6566,13 +6444,10 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="2">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
                 <barre start="2" end="4">3</barre>
@@ -6600,7 +6475,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="4">normal</dot>
                 </string>
                 <barre start="4" end="5">4</barre>
             </fretDiagram>
@@ -6688,7 +6562,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -6712,7 +6585,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="4">normal</dot>
                 </string>
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
@@ -6736,7 +6608,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="4">normal</dot>
                 </string>
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
@@ -6764,7 +6635,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -6788,7 +6658,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="4">normal</dot>
                 </string>
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
@@ -6807,7 +6676,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -6913,7 +6781,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -6938,7 +6805,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -6963,7 +6829,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -6982,7 +6847,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -7007,7 +6871,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -7029,7 +6892,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -7054,7 +6916,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -7085,7 +6946,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
@@ -7142,7 +7002,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="4">normal</dot>
                 </string>
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
@@ -7163,7 +7022,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -7194,7 +7052,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -7222,7 +7079,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -7243,7 +7099,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="4">normal</dot>
@@ -7267,7 +7122,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -7291,7 +7145,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -7375,7 +7228,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -7406,7 +7258,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -7460,7 +7311,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -7514,7 +7364,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="4">normal</dot>
@@ -7538,7 +7387,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="4">normal</dot>
@@ -7562,7 +7410,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -7619,7 +7466,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -7647,7 +7493,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -7705,7 +7550,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -7733,7 +7577,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -7758,7 +7601,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -7783,7 +7625,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -7808,7 +7649,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -7830,7 +7670,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -7854,7 +7693,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="4">normal</dot>
                 </string>
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
@@ -7879,7 +7717,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -7903,7 +7740,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="4">normal</dot>
                 </string>
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
@@ -7925,7 +7761,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -7953,7 +7788,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -7981,7 +7815,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -8009,7 +7842,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -8030,7 +7862,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -8058,7 +7889,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -8086,7 +7916,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -8114,7 +7943,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -8142,7 +7970,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -8163,7 +7990,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -8216,7 +8042,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -8244,7 +8069,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -8327,7 +8151,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -8354,7 +8177,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -8440,7 +8262,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -8521,7 +8342,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="2">normal</dot>
@@ -8636,7 +8456,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="3">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="4">normal</dot>
@@ -8694,7 +8513,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="2">normal</dot>
@@ -8840,7 +8658,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="2">normal</dot>
@@ -8871,7 +8688,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -8899,7 +8715,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -9074,7 +8889,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -9154,7 +8968,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="3">normal</dot>
@@ -9275,7 +9088,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -9476,7 +9288,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
@@ -9820,7 +9631,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -9847,7 +9657,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -9897,7 +9706,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="3">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="3">normal</dot>
@@ -9949,7 +9757,6 @@
             <frets>4</frets>
             <fretDiagram>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -9977,7 +9784,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -10005,7 +9811,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -10060,7 +9865,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -10347,7 +10151,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -10403,7 +10206,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="2">normal</dot>
@@ -10456,7 +10258,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="2">normal</dot>
@@ -10483,7 +10284,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -10510,7 +10310,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="2">normal</dot>
@@ -10537,7 +10336,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -10590,7 +10388,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -10617,7 +10414,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -10641,7 +10437,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -10665,7 +10460,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -10752,7 +10546,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -10776,7 +10569,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -10803,7 +10595,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -10828,7 +10619,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <marker>circle</marker>
@@ -10858,7 +10648,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -11032,7 +10821,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -11057,7 +10845,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -11230,7 +11017,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -11374,7 +11160,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -11402,7 +11187,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -11481,7 +11265,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -11563,7 +11346,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -11587,7 +11369,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -11727,7 +11508,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -11751,7 +11531,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -11775,7 +11554,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -11834,7 +11612,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -11858,7 +11635,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -11888,7 +11664,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -11913,7 +11688,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -11964,13 +11738,10 @@
                     <marker>cross</marker>
                 </string>
                 <string no="2">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
                 <barre start="2" end="4">3</barre>
@@ -12114,7 +11885,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -12135,7 +11905,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -12220,7 +11989,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -12247,7 +12015,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -12271,7 +12038,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -12351,7 +12117,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -12400,7 +12165,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -12425,7 +12189,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -12444,7 +12207,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -12462,7 +12224,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -12519,7 +12280,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -13243,7 +13003,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="1" end="5">2</barre>
             </fretDiagram>
@@ -13261,7 +13020,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="1" end="5">2</barre>
             </fretDiagram>
@@ -13371,7 +13129,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="4">normal</dot>
@@ -13573,7 +13330,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="4">normal</dot>
                 </string>
                 <barre start="2" end="5">4</barre>
             </fretDiagram>
@@ -13597,7 +13353,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="4">normal</dot>
                 </string>
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
@@ -13618,7 +13373,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="2">normal</dot>
@@ -13645,7 +13399,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="2">normal</dot>
@@ -13675,7 +13428,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -13693,16 +13445,12 @@
                     <marker>cross</marker>
                 </string>
                 <string no="2">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="4">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="4">normal</dot>
                 </string>
                 <barre start="1" end="2">2</barre>
                 <barre start="3" end="5">4</barre>
@@ -13753,7 +13501,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="4">normal</dot>
                 </string>
                 <barre start="2" end="5">4</barre>
             </fretDiagram>
@@ -13775,7 +13522,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -13796,7 +13542,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="4">normal</dot>
                 </string>
                 <barre start="2" end="5">4</barre>
             </fretDiagram>
@@ -13817,7 +13562,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="4">normal</dot>
                 </string>
                 <barre start="2" end="5">4</barre>
             </fretDiagram>
@@ -13867,7 +13611,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="4">normal</dot>
                 </string>
                 <barre start="2" end="5">4</barre>
             </fretDiagram>
@@ -13888,7 +13631,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="4">normal</dot>
@@ -13915,7 +13657,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
                     <marker>circle</marker>
@@ -14003,7 +13744,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -14061,7 +13801,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -14143,7 +13882,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -14222,7 +13960,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
                     <marker>cross</marker>
@@ -14334,7 +14071,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="2">normal</dot>
@@ -14384,13 +14120,10 @@
                     <marker>circle</marker>
                 </string>
                 <string no="2">
-                    <dot fret="4">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="1" end="5">2</barre>
                 <barre start="2" end="4">4</barre>
@@ -14471,7 +14204,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -14644,7 +14376,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -14671,7 +14402,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -14730,7 +14460,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
@@ -14786,7 +14515,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -14813,7 +14541,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
@@ -14838,7 +14565,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -14892,7 +14618,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -14946,7 +14671,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -14968,7 +14692,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -14992,7 +14715,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -15016,7 +14738,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -15043,7 +14764,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -15070,7 +14790,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -15094,7 +14813,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -15121,7 +14839,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -15145,7 +14862,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -15232,7 +14948,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -15260,7 +14975,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -15284,7 +14998,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="0" end="5">2</barre>
             </fretDiagram>
@@ -15487,7 +15200,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -15690,7 +15402,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -15923,7 +15634,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -15941,7 +15651,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -16135,7 +15844,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -16159,7 +15867,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="3">normal</dot>
@@ -16244,7 +15951,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="3">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
                     <marker>cross</marker>
@@ -16353,7 +16059,6 @@
             <frets>4</frets>
             <fretDiagram>
                 <string no="1">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="2">
                     <dot fret="3">normal</dot>
@@ -16383,7 +16088,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="3">normal</dot>
@@ -16497,7 +16201,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="2" end="5">3</barre>
             </fretDiagram>
@@ -16576,7 +16279,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="2" end="5">3</barre>
             </fretDiagram>
@@ -16624,7 +16326,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="1" end="5">3</barre>
             </fretDiagram>
@@ -16648,7 +16349,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
@@ -16698,7 +16398,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="2" end="5">3</barre>
             </fretDiagram>
@@ -16716,13 +16415,10 @@
                     <marker>cross</marker>
                 </string>
                 <string no="2">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
                 <barre start="2" end="4">3</barre>
@@ -16747,7 +16443,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -17010,7 +16705,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -17058,7 +16752,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="2">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="3">
                     <marker>cross</marker>
@@ -17088,7 +16781,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <marker>cross</marker>
@@ -17144,7 +16836,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -17174,7 +16865,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -17201,7 +16891,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -17223,7 +16912,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -17238,13 +16926,10 @@
             <frets>4</frets>
             <fretDiagram>
                 <string no="2">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
                 <barre start="2" end="4">3</barre>
@@ -17269,7 +16954,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -17558,7 +17242,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -17580,7 +17263,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -17605,7 +17287,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -17626,7 +17307,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -17644,7 +17324,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="3">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="4">normal</dot>
@@ -17671,7 +17350,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -17698,7 +17376,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -17722,7 +17399,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -17746,7 +17422,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -17828,7 +17503,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -17849,7 +17523,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -17873,7 +17546,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -18010,7 +17682,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="2">normal</dot>
@@ -18068,7 +17739,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -18096,7 +17766,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -18121,7 +17790,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -18151,7 +17819,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -18176,7 +17843,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -18204,7 +17870,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -18231,7 +17896,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -18310,7 +17974,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -18361,7 +18024,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -18385,7 +18047,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -18474,7 +18135,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -18501,7 +18161,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -18556,7 +18215,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -18615,7 +18273,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -18875,7 +18532,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -18926,7 +18582,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="2">normal</dot>
@@ -18951,13 +18606,10 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="2">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
                 <barre start="2" end="4">3</barre>
@@ -19131,7 +18783,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
@@ -19272,7 +18923,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -19323,7 +18973,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="2">normal</dot>
@@ -19411,7 +19060,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -19496,7 +19144,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -19552,7 +19199,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -19577,7 +19223,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -19599,7 +19244,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="2" end="5">3</barre>
             </fretDiagram>
@@ -19618,7 +19262,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -19639,7 +19282,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -19666,7 +19308,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -19690,7 +19331,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -19714,7 +19354,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -19733,7 +19372,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -19755,7 +19393,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -19780,7 +19417,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -19805,7 +19441,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -19830,7 +19465,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -19880,16 +19514,13 @@
                     <marker>cross</marker>
                 </string>
                 <string no="2">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="3">
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
                 <barre start="2" end="4">3</barre>
@@ -20090,7 +19721,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -20120,7 +19750,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -20165,16 +19794,13 @@
             <frets>4</frets>
             <fretDiagram>
                 <string no="2">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="3">
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
                 <barre start="2" end="4">3</barre>
@@ -20197,7 +19823,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -20254,7 +19879,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -20335,7 +19959,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -20396,7 +20019,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
@@ -20415,7 +20037,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -20531,7 +20152,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -20552,7 +20172,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -20577,7 +20196,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -20605,7 +20223,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -20630,7 +20247,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -20652,7 +20268,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -20706,7 +20321,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -20791,7 +20405,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -20815,7 +20428,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -20866,7 +20478,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -20925,7 +20536,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -20975,7 +20585,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -20999,7 +20608,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -21087,7 +20695,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -21520,7 +21127,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -21544,7 +21150,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -21597,7 +21202,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -21653,7 +21257,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -21674,7 +21277,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -21701,7 +21303,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -21728,7 +21329,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -21755,7 +21355,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -21805,7 +21404,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -21826,7 +21424,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="3">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="4">normal</dot>
@@ -21917,7 +21514,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -21941,7 +21537,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -21962,7 +21557,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="4">normal</dot>
@@ -21995,7 +21589,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="1" end="5">2</barre>
             </fretDiagram>
@@ -22071,7 +21664,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="3">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="3">normal</dot>
@@ -22192,7 +21784,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
@@ -22249,7 +21840,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -22332,7 +21922,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -22356,7 +21945,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="1" end="5">2</barre>
             </fretDiagram>
@@ -22584,7 +22172,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -22698,7 +22285,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="1" end="5">2</barre>
             </fretDiagram>
@@ -22719,7 +22305,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="0" end="5">2</barre>
             </fretDiagram>
@@ -22743,7 +22328,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -22796,7 +22380,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -22823,7 +22406,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -22847,7 +22429,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -22871,7 +22452,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -22895,7 +22475,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -22954,7 +22533,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="4" end="5">2</barre>
             </fretDiagram>
@@ -23007,7 +22585,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -23150,7 +22727,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="4" end="5">2</barre>
             </fretDiagram>
@@ -23172,7 +22748,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -23193,16 +22768,13 @@
                     <marker>cross</marker>
                 </string>
                 <string no="2">
-                    <dot fret="4">normal</dot>
                 </string>
                 <string no="3">
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="1" end="5">2</barre>
                 <barre start="2" end="4">4</barre>
@@ -23315,7 +22887,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -23429,7 +23000,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -23447,16 +23017,13 @@
             <frets>4</frets>
             <fretDiagram>
                 <string no="2">
-                    <dot fret="4">normal</dot>
                 </string>
                 <string no="3">
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="0" end="5">2</barre>
                 <barre start="2" end="4">4</barre>
@@ -23508,7 +23075,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -23567,7 +23133,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -23594,7 +23159,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="4">normal</dot>
                 </string>
                 <barre start="4" end="5">4</barre>
             </fretDiagram>
@@ -23619,7 +23183,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -23641,7 +23204,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -23672,7 +23234,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -23726,7 +23287,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -23840,7 +23400,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="1" end="5">2</barre>
             </fretDiagram>
@@ -24008,7 +23567,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -24033,7 +23591,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -24057,7 +23614,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -24169,7 +23725,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -24199,7 +23754,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="1" end="5">2</barre>
             </fretDiagram>
@@ -24223,7 +23777,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="0" end="5">2</barre>
             </fretDiagram>
@@ -24244,7 +23797,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -24269,7 +23821,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -24529,7 +24080,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="1" end="5">2</barre>
             </fretDiagram>
@@ -24551,7 +24101,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="2">normal</dot>
@@ -24581,7 +24130,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="1" end="5">2</barre>
             </fretDiagram>
@@ -24602,7 +24150,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="0" end="5">2</barre>
             </fretDiagram>
@@ -24626,7 +24173,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -24883,7 +24429,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="1" end="5">3</barre>
             </fretDiagram>
@@ -24967,7 +24512,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -25022,7 +24566,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="3">normal</dot>
@@ -25056,7 +24599,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -25084,7 +24626,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -25109,7 +24650,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
@@ -25243,7 +24783,6 @@
             <frets>4</frets>
             <fretDiagram>
                 <string no="1">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="2">
                     <dot fret="3">normal</dot>
@@ -25337,7 +24876,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <marker>cross</marker>
@@ -25510,7 +25048,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -25534,7 +25071,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="3">normal</dot>
@@ -25561,7 +25097,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="3">normal</dot>
@@ -25588,7 +25123,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="3">normal</dot>
@@ -25703,7 +25237,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="3">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="3">normal</dot>
@@ -25728,7 +25261,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -25840,7 +25372,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
@@ -25923,7 +25454,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
@@ -26003,7 +25533,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="3">normal</dot>
@@ -26031,7 +25560,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="3">normal</dot>
@@ -26094,7 +25622,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
@@ -26147,7 +25674,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
@@ -26200,7 +25726,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -26314,7 +25839,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
@@ -26367,7 +25891,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -26450,7 +25973,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="2">normal</dot>
@@ -26533,7 +26055,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="2">normal</dot>
@@ -26737,7 +26258,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -26852,7 +26372,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="3">normal</dot>
@@ -26886,7 +26405,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
@@ -26943,7 +26461,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
@@ -27028,7 +26545,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -27050,7 +26566,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -27106,7 +26621,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -27157,7 +26671,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -27181,7 +26694,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
@@ -27205,7 +26717,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -27235,7 +26746,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
@@ -27317,7 +26827,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
@@ -27370,7 +26879,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
@@ -27397,7 +26905,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
@@ -27421,7 +26928,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -27471,7 +26977,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="1" end="5">3</barre>
             </fretDiagram>
@@ -27791,7 +27296,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -28110,7 +27614,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -28249,7 +27752,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="2">normal</dot>
@@ -28273,7 +27775,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="2">normal</dot>
@@ -28301,7 +27802,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -28361,7 +27861,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="1" end="5">2</barre>
             </fretDiagram>
@@ -28411,7 +27910,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="4">normal</dot>
@@ -28473,7 +27971,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="1" end="5">2</barre>
             </fretDiagram>
@@ -28494,7 +27991,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="4">normal</dot>
                 </string>
                 <barre start="2" end="5">4</barre>
             </fretDiagram>
@@ -28515,7 +28011,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="2">normal</dot>
@@ -28569,7 +28064,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -28584,7 +28078,6 @@
             <frets>4</frets>
             <fretDiagram>
                 <string no="1">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="2">
                     <dot fret="3">normal</dot>
@@ -28698,10 +28191,8 @@
             <frets>4</frets>
             <fretDiagram>
                 <string no="0">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="1">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="2">
                     <dot fret="3">normal</dot>
@@ -28710,7 +28201,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
                 <barre start="0" end="1">2</barre>
@@ -28852,7 +28342,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -28879,7 +28368,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -28904,7 +28392,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -28931,7 +28418,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -28988,7 +28474,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="1" end="5">2</barre>
             </fretDiagram>
@@ -29004,16 +28489,12 @@
             <frets>4</frets>
             <fretDiagram>
                 <string no="1">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="2">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
                 <barre start="1" end="4">3</barre>
@@ -29038,7 +28519,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="1" end="5">2</barre>
             </fretDiagram>
@@ -29085,16 +28565,13 @@
                     <marker>cross</marker>
                 </string>
                 <string no="2">
-                    <dot fret="4">normal</dot>
                 </string>
                 <string no="3">
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="1" end="5">2</barre>
                 <barre start="2" end="4">4</barre>
@@ -29123,7 +28600,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -29174,7 +28650,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -29201,7 +28676,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="0" end="5">2</barre>
             </fretDiagram>
@@ -29259,7 +28733,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
@@ -29310,7 +28783,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -29332,7 +28804,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -29359,7 +28830,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="1" end="5">2</barre>
             </fretDiagram>
@@ -29381,7 +28851,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -29437,7 +28906,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -29464,7 +28932,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="0" end="5">2</barre>
             </fretDiagram>
@@ -29486,7 +28953,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="2">normal</dot>
@@ -29520,7 +28986,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -29600,7 +29065,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="1" end="5">3</barre>
             </fretDiagram>
@@ -29622,7 +29086,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="2">normal</dot>
@@ -29738,7 +29201,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -29854,7 +29316,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -29882,7 +29343,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -29903,7 +29363,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -29927,7 +29386,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -29980,7 +29438,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
                     <marker>cross</marker>
@@ -30037,7 +29494,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="2">normal</dot>
@@ -30064,7 +29520,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -30123,7 +29578,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="4">normal</dot>
                 </string>
                 <barre start="4" end="5">4</barre>
             </fretDiagram>
@@ -30145,7 +29599,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="2" end="5">3</barre>
             </fretDiagram>
@@ -30224,7 +29677,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -30246,7 +29698,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -30268,7 +29719,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -30296,7 +29746,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -30405,7 +29854,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -30456,7 +29904,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -30626,7 +30073,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -30712,7 +30158,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -30851,7 +30296,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="3">normal</dot>
@@ -31056,7 +30500,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -31078,7 +30521,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -31249,7 +30691,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -31332,7 +30773,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -31415,7 +30855,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -31530,7 +30969,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -31555,7 +30993,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -31576,7 +31013,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -31604,7 +31040,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -31632,7 +31067,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -31657,7 +31091,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -31745,7 +31178,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -31767,7 +31199,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -31855,7 +31286,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -31966,7 +31396,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -32078,7 +31507,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -32167,7 +31595,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -32249,7 +31676,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -32392,7 +31818,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -32446,7 +31871,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -32468,7 +31892,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -32493,7 +31916,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -32608,7 +32030,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="2" end="5">3</barre>
             </fretDiagram>
@@ -32624,7 +32045,6 @@
             <frets>4</frets>
             <fretDiagram>
                 <string no="1">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="2">
                     <dot fret="3">normal</dot>
@@ -32657,7 +32077,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="4">normal</dot>
@@ -32835,7 +32254,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -33040,7 +32458,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -33088,13 +32505,10 @@
             <frets>4</frets>
             <fretDiagram>
                 <string no="2">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
                 <barre start="2" end="4">3</barre>
@@ -33147,7 +32561,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -33202,7 +32615,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -33233,7 +32645,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
@@ -33291,7 +32702,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
@@ -33316,7 +32726,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -33341,7 +32750,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="4">normal</dot>
                 </string>
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
@@ -33365,7 +32773,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="4">normal</dot>
                 </string>
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
@@ -33392,7 +32799,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="2" end="5">3</barre>
             </fretDiagram>
@@ -33417,7 +32823,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -33447,7 +32852,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="2" end="5">3</barre>
             </fretDiagram>
@@ -33469,7 +32873,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -33494,7 +32897,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -33516,7 +32918,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -33543,7 +32944,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -33655,7 +33055,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -33738,7 +33137,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -33765,7 +33163,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <marker>circle</marker>
@@ -33968,7 +33365,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="4">normal</dot>
                 </string>
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
@@ -33996,7 +33392,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -34045,7 +33440,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -34067,7 +33461,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="2">normal</dot>
@@ -34217,7 +33610,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -34242,7 +33634,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -34294,7 +33685,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="2">normal</dot>
@@ -34498,7 +33888,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -34526,7 +33915,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -34550,7 +33938,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -34575,7 +33962,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
@@ -34594,7 +33980,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -34616,7 +34001,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -34641,7 +34025,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -34721,7 +34104,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -34742,7 +34124,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="2">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="3">
                     <dot fret="4">normal</dot>
@@ -34776,7 +34157,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -34801,7 +34181,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -34859,7 +34238,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -34884,7 +34262,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -34906,16 +34283,13 @@
                     <marker>cross</marker>
                 </string>
                 <string no="2">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="3">
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
                 <barre start="2" end="4">3</barre>
@@ -35001,7 +34375,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -35032,7 +34405,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -35057,7 +34429,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -35233,7 +34604,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -35261,7 +34631,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -35289,7 +34658,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -35314,7 +34682,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -35401,7 +34768,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -35423,7 +34789,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -35450,7 +34815,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -35477,7 +34841,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -35505,7 +34868,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -35521,16 +34883,12 @@
             <frets>4</frets>
             <fretDiagram>
                 <string no="1">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="2">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -35558,7 +34916,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -35647,7 +35004,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -35672,7 +35028,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -35697,7 +35052,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -35783,7 +35137,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -35808,7 +35161,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -35836,7 +35188,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -35863,7 +35214,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -35949,7 +35299,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -36035,7 +35384,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -36059,7 +35407,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="4">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="2">normal</dot>
@@ -36147,7 +35494,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -36174,7 +35520,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -36347,7 +35692,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -36395,7 +35739,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -36420,7 +35763,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -36472,7 +35814,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="2">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="3">
                     <dot fret="2">normal</dot>
@@ -36506,7 +35847,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -36533,7 +35873,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -36618,7 +35957,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -36640,7 +35978,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -36671,7 +36008,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -36747,7 +36083,6 @@
             <frets>4</frets>
             <fretDiagram>
                 <string no="1">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="2">
                     <dot fret="3">normal</dot>
@@ -36957,7 +36292,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="2">normal</dot>
@@ -36988,7 +36322,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -37188,7 +36521,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="2">normal</dot>
@@ -37332,7 +36664,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -37385,7 +36716,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="2">normal</dot>
@@ -37413,7 +36743,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -37437,7 +36766,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="2">normal</dot>
@@ -37461,7 +36789,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="2">normal</dot>
@@ -37488,7 +36815,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="2">normal</dot>
@@ -37515,7 +36841,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="2">normal</dot>
@@ -37546,7 +36871,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -37571,7 +36895,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -37628,7 +36951,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -37716,7 +37038,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -37771,7 +37092,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -37915,7 +37235,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -38146,7 +37465,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="2">normal</dot>
@@ -38173,7 +37491,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="2">normal</dot>
@@ -38200,7 +37517,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="2">normal</dot>
@@ -38260,7 +37576,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
@@ -38285,7 +37600,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -38403,7 +37717,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
@@ -38431,7 +37744,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
@@ -38549,7 +37861,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
@@ -38778,7 +38089,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -38803,7 +38113,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -38831,7 +38140,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -38922,7 +38230,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -38977,7 +38284,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -39005,7 +38311,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -39269,7 +38574,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -39317,7 +38621,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -39698,7 +39001,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -39842,7 +39144,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -39869,7 +39170,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -40007,7 +39307,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="2">normal</dot>
@@ -40032,7 +39331,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -40060,7 +39358,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -40229,7 +39526,6 @@
             <frets>4</frets>
             <fretDiagram>
                 <string no="1">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="2">
                     <dot fret="3">normal</dot>
@@ -40320,7 +39616,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="4">normal</dot>
@@ -40347,7 +39642,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="4">normal</dot>
@@ -40374,7 +39668,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="3">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="4">normal</dot>
@@ -40401,7 +39694,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="3">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="4">normal</dot>
@@ -40432,7 +39724,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -40454,7 +39745,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -40479,7 +39769,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -40495,19 +39784,14 @@
             <frets>4</frets>
             <fretDiagram>
                 <string no="1">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="2">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="0" end="1">1</barre>
                 <barre start="2" end="5">3</barre>
@@ -40527,7 +39811,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -40546,13 +39829,10 @@
                     <marker>cross</marker>
                 </string>
                 <string no="2">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
                 <barre start="2" end="4">3</barre>
@@ -40569,19 +39849,14 @@
             <frets>4</frets>
             <fretDiagram>
                 <string no="1">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="2">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="0" end="1">1</barre>
                 <barre start="2" end="5">3</barre>
@@ -40640,7 +39915,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -40665,7 +39939,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -40689,7 +39962,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -40708,13 +39980,10 @@
             <frets>4</frets>
             <fretDiagram>
                 <string no="2">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
                 <barre start="2" end="4">3</barre>
@@ -40739,7 +40008,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -40795,7 +40063,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -40999,7 +40266,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="4">normal</dot>
                 </string>
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
@@ -41083,7 +40349,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -41105,7 +40370,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -41129,7 +40393,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="4">normal</dot>
                 </string>
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
@@ -41157,7 +40420,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -41184,7 +40446,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="2" end="5">3</barre>
             </fretDiagram>
@@ -41206,7 +40467,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="2">normal</dot>
@@ -41239,7 +40499,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="2" end="5">3</barre>
             </fretDiagram>
@@ -41296,7 +40555,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -41321,7 +40579,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -41348,7 +40605,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="4">normal</dot>
                 </string>
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
@@ -41367,7 +40623,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -41424,7 +40679,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -41451,7 +40705,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -41475,7 +40728,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="4">normal</dot>
                 </string>
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
@@ -41496,7 +40748,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -41520,7 +40771,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -41547,7 +40797,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -41574,7 +40823,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -41601,7 +40849,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -41628,7 +40875,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -41652,7 +40898,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -41679,7 +40924,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -41736,7 +40980,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -41793,7 +41036,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -41880,7 +41122,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -41902,7 +41143,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -42102,7 +41342,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -42215,7 +41454,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -42299,7 +41537,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -42323,7 +41560,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -42410,7 +41646,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -42437,7 +41672,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -42456,7 +41690,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -42542,7 +41775,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -42566,7 +41798,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -42623,7 +41854,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -42704,7 +41934,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -42731,7 +41960,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -42788,7 +42016,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -42816,7 +42043,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -42929,7 +42155,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -42956,7 +42181,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -43009,7 +42233,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -43036,7 +42259,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -43063,7 +42285,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -43090,7 +42311,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -43148,7 +42368,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -43172,7 +42391,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -43199,7 +42417,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -43230,7 +42447,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -43255,7 +42471,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -43277,7 +42492,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -43304,7 +42518,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="4" end="5">2</barre>
             </fretDiagram>
@@ -43361,7 +42574,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -43389,7 +42601,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -43417,7 +42628,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -43442,7 +42652,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -43499,7 +42708,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -43518,7 +42726,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="2">normal</dot>
@@ -43640,7 +42847,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -43781,7 +42987,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -43867,7 +43072,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -43894,7 +43098,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -43922,7 +43125,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="4">normal</dot>
                 </string>
                 <barre start="4" end="5">4</barre>
             </fretDiagram>
@@ -43980,7 +43182,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -44005,7 +43206,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -44056,7 +43256,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="2">normal</dot>
@@ -44117,7 +43316,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -44171,7 +43369,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -44225,7 +43422,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -44256,7 +43452,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -44283,7 +43478,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -44307,7 +43501,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -44331,7 +43524,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -44416,7 +43608,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -44443,7 +43634,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -44470,7 +43660,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -44526,7 +43715,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -44634,7 +43822,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="2">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="3">
                     <dot fret="3">normal</dot>
@@ -45022,7 +44209,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -45046,7 +44232,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -45070,7 +44255,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -45094,7 +44278,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -45176,7 +44359,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -45200,7 +44382,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -45224,7 +44405,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -45251,7 +44431,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="4" end="5">2</barre>
             </fretDiagram>
@@ -45304,7 +44483,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -45331,7 +44509,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -45359,7 +44536,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -46000,7 +45176,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -46167,7 +45342,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -46192,7 +45366,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -46222,7 +45395,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -46394,7 +45566,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -46503,7 +45674,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -46554,7 +45724,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -46717,13 +45886,10 @@
             <frets>4</frets>
             <fretDiagram>
                 <string no="2">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
                 <barre start="2" end="4">3</barre>
@@ -46839,7 +46005,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
@@ -46894,7 +46059,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -46916,7 +46080,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -47115,7 +46278,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
@@ -47168,7 +46330,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -47227,7 +46388,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -47255,7 +46415,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -47306,7 +46465,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -47331,7 +46489,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -47355,7 +46512,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="2">normal</dot>
@@ -47533,7 +46689,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="4" end="5">2</barre>
             </fretDiagram>
@@ -47555,7 +46710,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="2" end="5">3</barre>
             </fretDiagram>
@@ -47579,7 +46733,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -47633,7 +46786,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -47722,7 +46874,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -47749,7 +46900,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
@@ -47774,7 +46924,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -47802,7 +46951,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -47827,7 +46975,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -47909,7 +47056,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="4">normal</dot>
@@ -48088,7 +47234,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -48313,7 +47458,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -48335,7 +47479,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -48415,7 +47558,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -48465,7 +47607,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="3">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="3">normal</dot>
@@ -48582,7 +47723,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
@@ -48606,7 +47746,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
@@ -48625,7 +47764,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -48763,7 +47901,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="3">normal</dot>
@@ -48851,7 +47988,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -49106,7 +48242,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="2">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="3">
                     <dot fret="4">normal</dot>
@@ -49256,7 +48391,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -49603,7 +48737,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -49718,7 +48851,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -49743,7 +48875,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -49826,7 +48957,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -49854,7 +48984,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -49882,7 +49011,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -49907,7 +49035,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -50371,7 +49498,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -50431,7 +49557,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
@@ -50489,7 +49614,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -50517,7 +49641,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
@@ -50746,7 +49869,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -50777,7 +49899,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -50793,16 +49914,12 @@
             <frets>4</frets>
             <fretDiagram>
                 <string no="1">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
                 <barre start="1" end="4">2</barre>
@@ -50828,7 +49945,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -50856,7 +49972,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -50939,7 +50054,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -50996,7 +50110,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -51021,7 +50134,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -51043,7 +50155,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -51067,7 +50178,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
@@ -51474,7 +50584,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -51554,7 +50663,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -51582,7 +50690,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -51637,7 +50744,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="2">normal</dot>
@@ -51662,7 +50768,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="2">normal</dot>
@@ -51689,7 +50794,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -51717,7 +50821,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -51741,7 +50844,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -51772,7 +50874,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -51797,7 +50898,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -51854,7 +50954,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -51882,7 +50981,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -51904,7 +51002,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -51956,7 +51053,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -52010,7 +51106,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -52038,7 +51133,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -52060,7 +51154,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="3">normal</dot>
@@ -52145,7 +51238,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -52283,7 +51375,6 @@
             <frets>4</frets>
             <fretDiagram>
                 <string no="1">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="2">
                     <dot fret="3">normal</dot>
@@ -52524,7 +51615,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -52552,7 +51642,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
@@ -52574,7 +51663,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="2">normal</dot>
@@ -52604,7 +51692,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -52628,7 +51715,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -52653,7 +51739,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -52705,7 +51790,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="2">normal</dot>
@@ -52765,7 +51849,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -52787,7 +51870,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -52812,7 +51894,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -52868,7 +51949,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -52893,7 +51973,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="3">normal</dot>
@@ -52953,7 +52032,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -52981,7 +52059,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -53009,7 +52086,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -53124,7 +52200,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -53152,7 +52227,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -53168,13 +52242,10 @@
             <frets>4</frets>
             <fretDiagram>
                 <string no="2">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
                 <barre start="2" end="4">3</barre>
@@ -53374,7 +52445,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -53435,7 +52505,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
@@ -53522,7 +52591,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
@@ -53550,7 +52618,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -53575,7 +52642,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -53626,7 +52692,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -53651,7 +52716,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -53705,7 +52769,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -53733,7 +52796,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -53787,7 +52849,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -53812,7 +52873,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -53837,7 +52897,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
@@ -53865,7 +52924,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -53890,7 +52948,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -53915,7 +52972,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -53940,7 +52996,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="2">normal</dot>
@@ -53962,7 +53017,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -53981,13 +53035,10 @@
                     <marker>cross</marker>
                 </string>
                 <string no="2">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
                 <barre start="2" end="3">3</barre>
@@ -54010,7 +53061,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -54032,7 +53082,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -54051,7 +53100,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -54079,7 +53127,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -54101,7 +53148,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -54125,7 +53171,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="2" end="5">3</barre>
             </fretDiagram>
@@ -54144,7 +53189,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -54168,7 +53212,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="3">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="4">normal</dot>
@@ -54199,7 +53242,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -54254,7 +53296,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -54279,7 +53320,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -54306,7 +53346,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
@@ -54333,7 +53372,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
@@ -54354,7 +53392,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="3">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="4">normal</dot>
@@ -54378,7 +53415,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="4">normal</dot>
@@ -54442,7 +53478,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -54470,7 +53505,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -54497,7 +53531,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -54577,7 +53610,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="2">normal</dot>
@@ -54630,7 +53662,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="2">normal</dot>
@@ -54654,7 +53685,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="2">normal</dot>
@@ -54762,7 +53792,6 @@
             <frets>4</frets>
             <fretDiagram>
                 <string no="1">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="2">
                     <dot fret="2">normal</dot>
@@ -54830,7 +53859,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -54858,7 +53886,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -54883,7 +53910,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -54932,7 +53958,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -54953,7 +53978,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -55037,7 +54061,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="2">normal</dot>
@@ -55091,7 +54114,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="2">normal</dot>
@@ -55148,7 +54170,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -55206,7 +54227,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -55260,7 +54280,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -55285,7 +54304,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -55312,7 +54330,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -55336,7 +54353,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -55384,7 +54400,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="2">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="3">
                     <dot fret="3">normal</dot>
@@ -55420,7 +54435,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="4" end="5">2</barre>
             </fretDiagram>
@@ -55442,7 +54456,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -55467,7 +54480,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="2" end="5">3</barre>
             </fretDiagram>
@@ -55492,7 +54504,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -55541,7 +54552,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="2">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="3">
                     <dot fret="3">normal</dot>
@@ -55599,7 +54609,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="2">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="3">
                     <dot fret="3">normal</dot>
@@ -55665,7 +54674,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
@@ -55749,7 +54757,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -55860,7 +54867,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
@@ -55885,7 +54891,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -55913,7 +54918,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -55934,7 +54938,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="2" end="5">3</barre>
             </fretDiagram>
@@ -55958,7 +54961,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
@@ -56100,7 +55102,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -56127,7 +55128,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -56154,7 +55154,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -56300,7 +55299,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -56324,7 +55322,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -56352,7 +55349,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -56379,7 +55375,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -56437,7 +55432,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -56464,7 +55458,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -56489,7 +55482,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -56715,7 +55707,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -56775,7 +55766,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -56803,7 +55793,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -56857,7 +55846,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -56882,7 +55870,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -56904,7 +55891,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -56934,7 +55920,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
@@ -56990,7 +55975,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
@@ -57014,7 +55998,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="2" end="5">3</barre>
             </fretDiagram>
@@ -57041,7 +56024,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
@@ -57069,7 +56051,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -57212,7 +56193,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="2" end="5">3</barre>
             </fretDiagram>
@@ -57293,7 +56273,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="4">normal</dot>
@@ -57324,7 +56303,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -57346,7 +56324,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -57368,7 +56345,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -57393,7 +56369,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -57417,7 +56392,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -57439,7 +56413,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -57525,7 +56498,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -57576,7 +56548,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -57598,7 +56569,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -57620,7 +56590,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -57645,7 +56614,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -57670,7 +56638,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -57698,7 +56665,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -57723,7 +56689,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -58301,7 +57266,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -58322,7 +57286,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="3">normal</dot>
@@ -58382,7 +57345,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
@@ -58406,7 +57368,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
@@ -58430,7 +57391,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
@@ -58454,7 +57414,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
@@ -58507,7 +57466,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
@@ -58564,7 +57522,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -59232,7 +58189,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -59259,7 +58215,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="4">normal</dot>
                 </string>
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
@@ -59306,7 +58261,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="2">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="3">
                     <dot fret="4">normal</dot>
@@ -59333,16 +58287,12 @@
                     <marker>cross</marker>
                 </string>
                 <string no="2">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="4">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="4">normal</dot>
                 </string>
                 <barre start="1" end="2">2</barre>
                 <barre start="3" end="5">4</barre>
@@ -59365,7 +58315,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -59657,7 +58606,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -59684,7 +58632,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
@@ -59882,7 +58829,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="1" end="5">2</barre>
             </fretDiagram>
@@ -60195,7 +59141,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -60657,7 +59602,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -60773,7 +59717,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -60797,7 +59740,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="4">normal</dot>
                 </string>
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
@@ -60938,7 +59880,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -61166,13 +60107,10 @@
                     <marker>cross</marker>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="2" end="3">1</barre>
                 <barre start="4" end="5">2</barre>
@@ -61430,7 +60368,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -61452,7 +60389,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="2">normal</dot>
@@ -61505,7 +60441,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="2">normal</dot>
@@ -61561,7 +60496,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="2" end="5">3</barre>
             </fretDiagram>
@@ -61788,7 +60722,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -61803,16 +60736,13 @@
             <frets>4</frets>
             <fretDiagram>
                 <string no="1">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
                 <barre start="1" end="3">3</barre>
@@ -61951,7 +60881,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="2">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="3">
                     <dot fret="3">normal</dot>
@@ -62033,7 +60962,6 @@
             <frets>4</frets>
             <fretDiagram>
                 <string no="2">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="3">
                     <marker>cross</marker>
@@ -62185,7 +61113,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -62409,7 +61336,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -62466,7 +61392,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -62669,7 +61594,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -62722,7 +61646,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -62747,7 +61670,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="2">normal</dot>
@@ -62807,7 +61729,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -62858,7 +61779,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -62882,7 +61802,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -62901,7 +61820,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="2">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="3">
                     <dot fret="3">normal</dot>
@@ -62928,7 +61846,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="2">normal</dot>
@@ -62955,7 +61872,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -63008,7 +61924,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -63035,7 +61950,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -63062,7 +61976,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -63087,7 +62000,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -63118,7 +62030,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
@@ -63145,7 +62056,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -63169,7 +62079,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -63200,7 +62109,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
@@ -63257,7 +62165,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
@@ -63301,13 +62208,10 @@
             <frets>4</frets>
             <fretDiagram>
                 <string no="1">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
                 <barre start="1" end="3">3</barre>
@@ -63335,7 +62239,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -63359,7 +62262,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -63383,7 +62285,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -63407,7 +62308,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -63460,7 +62360,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -63487,7 +62386,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -63518,7 +62416,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -63598,7 +62495,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -63655,7 +62551,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -63683,7 +62578,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -63708,7 +62602,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -63736,7 +62629,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -63760,7 +62652,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="2" end="5">3</barre>
             </fretDiagram>
@@ -63842,7 +62733,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -63898,7 +62788,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -63952,7 +62841,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="4">normal</dot>
@@ -63980,7 +62868,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="4">normal</dot>
@@ -64473,7 +63360,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -64498,7 +63384,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="2">normal</dot>
@@ -64902,7 +63787,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="4">normal</dot>
                 </string>
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
@@ -65042,7 +63926,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -65090,7 +63973,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -65138,7 +64020,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -65165,7 +64046,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -65189,7 +64069,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -65272,7 +64151,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -65328,7 +64206,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -65375,7 +64252,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -65426,7 +64302,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -65447,7 +64322,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -65471,7 +64345,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="4">normal</dot>
                 </string>
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
@@ -65495,7 +64368,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="4">normal</dot>
                 </string>
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
@@ -65519,7 +64391,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="4">normal</dot>
                 </string>
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
@@ -65538,7 +64409,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="2">normal</dot>
@@ -65568,7 +64438,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="4">normal</dot>
                 </string>
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
@@ -65655,7 +64524,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -65676,7 +64544,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -65694,7 +64561,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -65715,7 +64581,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -65736,7 +64601,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -65757,7 +64621,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -65772,13 +64635,10 @@
             <frets>4</frets>
             <fretDiagram>
                 <string no="1">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
                 <barre start="1" end="3">3</barre>
@@ -65800,7 +64660,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -65821,7 +64680,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -65865,7 +64723,6 @@
             <frets>4</frets>
             <fretDiagram>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -65893,7 +64750,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
@@ -65914,7 +64770,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="4">normal</dot>
@@ -65942,7 +64797,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -65969,7 +64823,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="4">normal</dot>
                 </string>
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
@@ -65993,7 +64846,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -66020,7 +64872,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -66042,7 +64893,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <marker>cross</marker>
@@ -66072,7 +64922,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -66132,7 +64981,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
@@ -66150,7 +64998,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -66171,7 +65018,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="3">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="3">normal</dot>
@@ -66693,7 +65539,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -66776,7 +65621,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -66804,7 +65648,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -66828,7 +65671,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -66852,7 +65694,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -66873,7 +65714,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -66900,7 +65740,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -66924,7 +65763,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -66948,7 +65786,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -66969,7 +65806,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -66993,7 +65829,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -67017,7 +65852,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -67041,7 +65875,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -67065,7 +65898,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -67086,7 +65918,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -67110,7 +65941,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -67134,7 +65964,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -67158,7 +65987,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -67185,7 +66013,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -67270,7 +66097,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -67298,7 +66124,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -67322,7 +66147,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -67349,7 +66173,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -67376,7 +66199,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -67403,7 +66225,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -67430,7 +66251,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -67457,7 +66277,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -67481,7 +66300,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -67538,7 +66356,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -67678,7 +66495,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -67708,7 +66524,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -67765,7 +66580,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -67789,7 +66603,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="0" end="5">2</barre>
             </fretDiagram>
@@ -67808,7 +66621,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -67894,7 +66706,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
@@ -67947,7 +66758,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="0" end="5">2</barre>
             </fretDiagram>
@@ -68052,7 +66862,6 @@
             <frets>4</frets>
             <fretDiagram>
                 <string no="2">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="3">
                     <marker>cross</marker>
@@ -68080,7 +66889,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="2">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="3">
                     <dot fret="3">normal</dot>
@@ -68113,7 +66921,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="1" end="5">2</barre>
             </fretDiagram>
@@ -68162,7 +66969,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="2">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="3">
                     <dot fret="3">normal</dot>
@@ -68251,7 +67057,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="2">normal</dot>
@@ -68284,7 +67089,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
@@ -68334,7 +67138,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="0" end="5">2</barre>
             </fretDiagram>
@@ -68445,7 +67248,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
@@ -68561,7 +67363,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -68645,7 +67446,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -68670,7 +67470,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -68692,7 +67491,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="2">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="3">
                     <dot fret="3">normal</dot>
@@ -68722,7 +67520,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -68806,7 +67603,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="1" end="5">2</barre>
             </fretDiagram>
@@ -68830,7 +67626,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
@@ -68854,7 +67649,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
@@ -68878,7 +67672,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
@@ -68902,7 +67695,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
@@ -68987,7 +67779,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
@@ -69014,7 +67805,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
@@ -69038,7 +67828,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
@@ -69066,7 +67855,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
@@ -69085,13 +67873,10 @@
                     <marker>cross</marker>
                 </string>
                 <string no="2">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -69182,7 +67967,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
@@ -69227,13 +68011,10 @@
             <frets>4</frets>
             <fretDiagram>
                 <string no="1">
-                    <dot fret="4">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="0" end="5">2</barre>
                 <barre start="1" end="3">4</barre>
@@ -69256,7 +68037,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="2">normal</dot>
@@ -69286,7 +68066,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
@@ -69310,7 +68089,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
@@ -69334,7 +68112,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
@@ -69385,7 +68162,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="2">normal</dot>
@@ -69416,7 +68192,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -69440,7 +68215,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -69498,7 +68272,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -69558,7 +68331,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -69612,7 +68384,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -69896,7 +68667,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="2">normal</dot>
@@ -69950,7 +68720,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="2">normal</dot>
@@ -70006,7 +68775,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="2">normal</dot>
@@ -70146,7 +68914,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="0" end="5">2</barre>
             </fretDiagram>
@@ -70286,7 +69053,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -70313,7 +69079,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -70334,7 +69099,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <marker>circle</marker>
@@ -70358,7 +69122,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <marker>circle</marker>
@@ -70385,7 +69148,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -70403,7 +69165,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="0" end="5">2</barre>
             </fretDiagram>
@@ -70453,7 +69214,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -70481,7 +69241,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -70506,7 +69265,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -70531,7 +69289,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="4">normal</dot>
                 </string>
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
@@ -70556,7 +69313,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
@@ -70581,7 +69337,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -70606,7 +69361,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
@@ -70631,7 +69385,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
@@ -70685,7 +69438,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -70706,7 +69458,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -70760,7 +69511,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
@@ -70836,7 +69586,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="1" end="5">2</barre>
             </fretDiagram>
@@ -70857,7 +69606,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
@@ -70879,7 +69627,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -70900,7 +69647,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
@@ -70981,7 +69727,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -71005,7 +69750,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -71058,7 +69802,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -71088,7 +69831,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="4" end="5">2</barre>
             </fretDiagram>
@@ -71109,7 +69851,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -71166,7 +69907,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -71276,16 +70016,12 @@
                     <marker>cross</marker>
                 </string>
                 <string no="2">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="1" end="2">1</barre>
                 <barre start="3" end="5">3</barre>
@@ -71366,7 +70102,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="0" end="5">2</barre>
             </fretDiagram>
@@ -71387,7 +70122,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -71414,7 +70148,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -71441,7 +70174,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -71462,7 +70194,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="1" end="5">2</barre>
             </fretDiagram>
@@ -71486,7 +70217,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -71510,7 +70240,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -71534,7 +70263,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -71558,7 +70286,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -71579,7 +70306,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
@@ -71603,7 +70329,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -71627,7 +70352,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -71651,7 +70375,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -71675,7 +70398,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -71702,7 +70424,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -71758,7 +70479,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="4" end="5">2</barre>
             </fretDiagram>
@@ -71842,7 +70562,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="1" end="5">2</barre>
             </fretDiagram>
@@ -71898,7 +70617,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="4" end="5">2</barre>
             </fretDiagram>
@@ -71925,7 +70643,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="4" end="5">2</barre>
             </fretDiagram>
@@ -71952,7 +70669,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="4" end="5">2</barre>
             </fretDiagram>
@@ -71980,7 +70696,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -72007,7 +70722,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="4" end="5">2</barre>
             </fretDiagram>
@@ -72034,7 +70748,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="4" end="5">2</barre>
             </fretDiagram>
@@ -72148,7 +70861,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
@@ -72175,7 +70887,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="4" end="5">2</barre>
             </fretDiagram>
@@ -72200,7 +70911,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -72373,7 +71083,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="4" end="5">2</barre>
             </fretDiagram>
@@ -72395,7 +71104,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="4">normal</dot>
@@ -72425,7 +71133,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
@@ -72452,7 +71159,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -72476,7 +71182,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -72503,7 +71208,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -72559,7 +71263,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -72586,7 +71289,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -72642,7 +71344,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -72758,7 +71459,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -72843,7 +71543,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -72867,7 +71566,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -72894,7 +71592,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -72918,7 +71615,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -72945,7 +71641,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -73030,7 +71725,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -73057,7 +71751,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -73084,7 +71777,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -73463,7 +72155,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -73548,7 +72239,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
@@ -73662,7 +72352,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
@@ -73796,7 +72485,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="3">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="3">normal</dot>
@@ -73972,7 +72660,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="0" end="5">2</barre>
             </fretDiagram>
@@ -74145,7 +72832,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -74172,7 +72858,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -74255,7 +72940,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -74313,7 +72997,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -74455,7 +73138,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="4">normal</dot>
                 </string>
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
@@ -74537,7 +73219,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="4">normal</dot>
                 </string>
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
@@ -74562,7 +73243,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -74586,7 +73266,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -74639,7 +73318,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="2" end="5">3</barre>
             </fretDiagram>
@@ -74895,7 +73573,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="4">normal</dot>
                 </string>
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
@@ -74922,7 +73599,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="4">normal</dot>
                 </string>
                 <barre start="4" end="5">4</barre>
             </fretDiagram>
@@ -74978,7 +73654,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="2" end="5">3</barre>
             </fretDiagram>
@@ -75093,7 +73768,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
@@ -75151,7 +73825,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
@@ -75178,7 +73851,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -75200,7 +73872,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -75216,13 +73887,10 @@
             <frets>4</frets>
             <fretDiagram>
                 <string no="1">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="2">normal</dot>
@@ -75253,7 +73921,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -75280,7 +73947,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -75305,7 +73971,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -75332,7 +73997,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -75357,7 +74021,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -75384,7 +74047,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -75411,7 +74073,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -75524,7 +74185,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -75607,7 +74267,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -75632,7 +74291,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -75660,7 +74318,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -75715,7 +74372,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -75734,13 +74390,10 @@
             <frets>4</frets>
             <fretDiagram>
                 <string no="1">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -76000,7 +74653,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -76348,7 +75000,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -76547,7 +75198,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -76607,7 +75257,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -76629,7 +75278,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="2">normal</dot>
@@ -76773,7 +75421,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -76798,7 +75445,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="2">normal</dot>
@@ -76913,7 +75559,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="0" end="5">2</barre>
             </fretDiagram>
@@ -77024,7 +75669,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="0" end="5">2</barre>
             </fretDiagram>
@@ -77101,7 +75745,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -77123,7 +75766,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="2">normal</dot>
@@ -77154,7 +75796,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -77264,7 +75905,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="0" end="5">2</barre>
             </fretDiagram>
@@ -77370,7 +76010,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="2">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="3">
                     <dot fret="3">normal</dot>
@@ -77407,7 +76046,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -77521,7 +76159,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
@@ -77545,7 +76182,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
@@ -77573,7 +76209,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
@@ -77618,13 +76253,10 @@
             <frets>4</frets>
             <fretDiagram>
                 <string no="1">
-                    <dot fret="4">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="0" end="5">2</barre>
                 <barre start="1" end="3">4</barre>
@@ -77683,7 +76315,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -77737,7 +76368,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -77765,7 +76395,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -77793,7 +76422,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -77844,7 +76472,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -77869,7 +76496,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -77885,16 +76511,13 @@
             <frets>4</frets>
             <fretDiagram>
                 <string no="1">
-                    <dot fret="4">normal</dot>
                 </string>
                 <string no="2">
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
                 <barre start="1" end="4">4</barre>
@@ -77911,16 +76534,13 @@
             <frets>4</frets>
             <fretDiagram>
                 <string no="1">
-                    <dot fret="4">normal</dot>
                 </string>
                 <string no="2">
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
                 <barre start="1" end="4">4</barre>
@@ -78117,7 +76737,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="2">normal</dot>
@@ -78173,7 +76792,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -78200,7 +76818,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -78227,7 +76844,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -78251,7 +76867,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -78269,7 +76884,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="0" end="5">2</barre>
             </fretDiagram>
@@ -78296,7 +76910,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
@@ -78320,7 +76933,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -78344,7 +76956,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -78368,7 +76979,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -78392,7 +77002,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -78410,7 +77019,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -78487,16 +77095,12 @@
             <frets>4</frets>
             <fretDiagram>
                 <string no="2">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="0" end="2">1</barre>
                 <barre start="3" end="5">3</barre>
@@ -78518,7 +77122,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -78548,7 +77151,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -78573,7 +77175,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
@@ -78597,7 +77198,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -78624,7 +77224,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -78677,7 +77276,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -78731,7 +77329,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -78752,7 +77349,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -78774,7 +77370,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -78801,7 +77396,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -78828,7 +77422,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -78855,7 +77448,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="4" end="5">2</barre>
             </fretDiagram>
@@ -78879,7 +77471,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="1" end="5">2</barre>
             </fretDiagram>
@@ -78907,7 +77498,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -78960,7 +77550,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="1" end="5">2</barre>
             </fretDiagram>
@@ -78987,7 +77576,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="4" end="5">2</barre>
             </fretDiagram>
@@ -79014,7 +77602,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="4" end="5">2</barre>
             </fretDiagram>
@@ -79038,7 +77625,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
@@ -79094,7 +77680,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="4" end="5">2</barre>
             </fretDiagram>
@@ -79118,7 +77703,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
@@ -79290,7 +77874,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="4" end="5">2</barre>
             </fretDiagram>
@@ -79338,7 +77921,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <marker>cross</marker>
@@ -79369,7 +77951,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -79423,7 +78004,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -79445,7 +78025,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -79498,7 +78077,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="2" end="5">3</barre>
             </fretDiagram>
@@ -79546,7 +78124,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -79571,7 +78148,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="4">normal</dot>
@@ -79622,16 +78198,12 @@
             <frets>4</frets>
             <fretDiagram>
                 <string no="1">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="2">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
                 <barre start="1" end="4">3</barre>
@@ -79689,7 +78261,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
@@ -79717,7 +78288,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -79741,7 +78311,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
@@ -79794,7 +78363,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
@@ -79818,7 +78386,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -79839,7 +78406,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -79861,7 +78427,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -79886,7 +78451,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -80050,16 +78614,12 @@
                     <marker>cross</marker>
                 </string>
                 <string no="2">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="1" end="2">1</barre>
                 <barre start="3" end="5">2</barre>
@@ -80088,7 +78648,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -80112,7 +78671,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
@@ -80133,7 +78691,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="3">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="4">normal</dot>
@@ -80160,7 +78717,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="2" end="5">3</barre>
             </fretDiagram>
@@ -80178,7 +78734,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="1" end="5">3</barre>
             </fretDiagram>
@@ -80200,7 +78755,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -80222,7 +78776,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -80243,7 +78796,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="2" end="5">3</barre>
             </fretDiagram>
@@ -80264,7 +78816,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="3">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="4">normal</dot>
@@ -80292,7 +78843,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -80311,7 +78861,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -80359,7 +78908,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -80378,7 +78926,6 @@
             <frets>4</frets>
             <fretDiagram>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -80429,7 +78976,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -80454,7 +79000,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -80479,7 +79024,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -80504,7 +79048,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -80529,7 +79072,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="4">normal</dot>
@@ -80551,7 +79093,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -80579,7 +79120,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -80607,7 +79147,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -80635,7 +79174,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -80719,7 +79257,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -80746,7 +79283,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
@@ -80771,7 +79307,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -80796,7 +79331,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -80909,7 +79443,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="1" end="5">2</barre>
             </fretDiagram>
@@ -81373,7 +79906,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="4" end="5">2</barre>
             </fretDiagram>
@@ -81400,7 +79932,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="4" end="5">2</barre>
             </fretDiagram>
@@ -81421,7 +79952,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
                     <marker>cross</marker>
@@ -81540,7 +80070,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -81596,7 +80125,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -81741,7 +80269,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -81763,7 +80290,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -81818,7 +80344,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -81839,7 +80364,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="1" end="5">3</barre>
             </fretDiagram>
@@ -81863,7 +80387,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -81885,7 +80408,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -81915,7 +80437,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
@@ -81940,7 +80461,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -81965,7 +80485,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -81989,7 +80508,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
@@ -82011,7 +80529,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -82035,7 +80552,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
@@ -82088,7 +80604,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
@@ -82112,7 +80627,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
@@ -82133,7 +80647,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="2" end="5">3</barre>
             </fretDiagram>
@@ -82157,7 +80670,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
@@ -82181,7 +80693,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
@@ -82209,7 +80720,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -82266,7 +80776,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -82381,7 +80890,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -82409,7 +80917,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -82553,7 +81060,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -82581,7 +81087,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -82724,7 +81229,6 @@
                     <dot fret="4">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
@@ -82954,7 +81458,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -83125,7 +81628,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -83213,7 +81715,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -83232,7 +81733,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="2">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="3">
                     <marker>cross</marker>
@@ -83266,7 +81766,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -83287,7 +81786,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="2">normal</dot>
@@ -83312,7 +81810,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -83333,7 +81830,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="2">normal</dot>
@@ -83361,7 +81857,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -83389,7 +81884,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -83444,7 +81938,6 @@
                     <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="2">normal</dot>
                 </string>
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
@@ -83472,7 +81965,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
@@ -83518,13 +82010,10 @@
             <frets>4</frets>
             <fretDiagram>
                 <string no="1">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="3">
-                    <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
                 <barre start="1" end="3">3</barre>
@@ -83550,7 +82039,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -83721,7 +82209,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="2">normal</dot>
@@ -83835,7 +82322,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -83892,7 +82378,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -83911,7 +82396,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -83965,7 +82449,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="3">normal</dot>
                 </string>
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
@@ -84015,7 +82498,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -84072,7 +82554,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -84180,7 +82661,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="4">normal</dot>
                 </string>
                 <barre start="2" end="5">4</barre>
             </fretDiagram>
@@ -84231,7 +82711,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="4">normal</dot>
                 </string>
                 <barre start="2" end="5">4</barre>
             </fretDiagram>
@@ -84279,7 +82758,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -84301,7 +82779,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -84352,7 +82829,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -84374,7 +82850,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -84399,7 +82874,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="3">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="4">
                     <dot fret="3">normal</dot>
@@ -84430,7 +82904,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -84452,7 +82925,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -84474,7 +82946,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="4">
-                    <dot fret="1">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -84502,7 +82973,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -84526,7 +82996,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="4">normal</dot>
                 </string>
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
@@ -84548,7 +83017,6 @@
                     <marker>cross</marker>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -84663,7 +83131,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
@@ -84688,7 +83155,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
@@ -84716,7 +83182,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -84744,7 +83209,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
@@ -84769,7 +83233,6 @@
                     <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
@@ -84824,7 +83287,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -84879,7 +83341,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
@@ -85048,7 +83509,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -85075,7 +83535,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -85276,7 +83735,6 @@
                     <marker>circle</marker>
                 </string>
                 <string no="4">
-                    <dot fret="2">normal</dot>
                 </string>
                 <string no="5">
                     <dot fret="3">normal</dot>
@@ -85568,7 +84026,6 @@
                     <dot fret="3">normal</dot>
                 </string>
                 <string no="5">
-                    <dot fret="1">normal</dot>
                 </string>
                 <barre start="4" end="5">1</barre>
             </fretDiagram>


### PR DESCRIPTION
Resolves: #26080