### PR TITLE
Make the number of percussion panel columns customizable

### DIFF
--- a/src/engraving/dom/drumset.cpp
+++ b/src/engraving/dom/drumset.cpp
@@ -97,6 +97,7 @@ int Drumset::defaultPitchForLine(int val) const
 
 void Drumset::save(XmlWriter& xml) const
 {
+    xml.tag("percussionPanelColumns", m_percussionPanelColumns);
     for (int i = 0; i < DRUM_INSTRUMENTS; ++i) {
         if (!isValid(i)) {
             continue;
@@ -143,7 +144,7 @@ void Drumset::save(XmlWriter& xml) const
     }
 }
 
-bool Drumset::readProperties(XmlReader& e, int pitch)
+bool Drumset::readDrumProperties(XmlReader& e, int pitch)
 {
     if (pitch < 0 || pitch > DRUM_INSTRUMENTS - 1) {
         return false;
@@ -204,7 +205,7 @@ bool Drumset::readProperties(XmlReader& e, int pitch)
 //   load
 //---------------------------------------------------------
 
-void Drumset::load(XmlReader& e)
+void Drumset::loadDrum(XmlReader& e)
 {
     int pitch = e.intAttribute("pitch", -1);
     if (pitch < 0 || pitch > DRUM_INSTRUMENTS - 1) {
@@ -212,7 +213,7 @@ void Drumset::load(XmlReader& e)
         return;
     }
     while (e.readNextStartElement()) {
-        if (readProperties(e, pitch)) {
+        if (readDrumProperties(e, pitch)) {
         } else {
             e.unknown();
         }

--- a/src/engraving/dom/drumset.h
+++ b/src/engraving/dom/drumset.h
@@ -113,6 +113,9 @@ public:
     int panelRow(int pitch) const { return m_drums[pitch].panelRow; }
     int panelColumn(int pitch) const { return m_drums[pitch].panelColumn; }
 
+    size_t percussionPanelColumns() const { return m_percussionPanelColumns; }
+    void setPercussionPanelColumns(size_t columns) { m_percussionPanelColumns = columns; }
+
     int pitchForShortcut(const String& shortcut) const;
 
     // defaultPitchForLine tries to find the pitch of a normal notehead at "line". If a normal notehead can't be found it will
@@ -120,8 +123,8 @@ public:
     int defaultPitchForLine(int line) const;
 
     void save(XmlWriter&) const;
-    void load(XmlReader&);
-    bool readProperties(XmlReader&, int);
+    void loadDrum(XmlReader&);
+    bool readDrumProperties(XmlReader&, int);
     void clear();
     int nextPitch(int) const;
     int prevPitch(int) const;
@@ -140,7 +143,7 @@ public:
             }
             return false;
         }
-        return true;
+        return m_percussionPanelColumns == other.m_percussionPanelColumns;
     }
 
     bool operator!=(const Drumset& other) const
@@ -150,6 +153,7 @@ public:
 
 private:
     DrumInstrument m_drums[DRUM_INSTRUMENTS];
+    size_t m_percussionPanelColumns = 8;
 };
 
 extern Drumset* smDrumset;

--- a/src/engraving/dom/instrtemplate.cpp
+++ b/src/engraving/dom/instrtemplate.cpp
@@ -509,13 +509,19 @@ void InstrumentTemplate::read(XmlReader& e)
         } else if (tag == "drumset") {
             useDrumset = e.readInt();
         } else if (tag == "Drum") {
-            // if we see one of this tags, a custom drumset will
-            // be created
-            if (drumset == 0) {
+            // if we see one of these tags, a custom drumset will be created
+            if (!drumset) {
                 drumset = new Drumset(*smDrumset);
                 drumset->clear();
             }
-            drumset->load(e);
+            drumset->loadDrum(e);
+        } else if (tag == "percussionPanelColumns") {
+            // if we see one of these tags, a custom drumset will be created
+            if (!drumset) {
+                drumset = new Drumset(*smDrumset);
+                drumset->clear();
+            }
+            drumset->setPercussionPanelColumns(e.readInt());
         } else if (tag == "MidiAction") {
             NamedEventList a;
             read400::TRead::read(&a, e);

--- a/src/engraving/rw/read114/read114.cpp
+++ b/src/engraving/rw/read114/read114.cpp
@@ -2416,7 +2416,7 @@ static void readDrumset(Drumset* ds, XmlReader& e)
         const AsciiStringView tag(e.name());
         if (tag == "head") {
             ds->drum(pitch).notehead = Read206::convertHeadGroup(e.readInt());
-        } else if (ds->readProperties(e, pitch)) {
+        } else if (ds->readDrumProperties(e, pitch)) {
         } else {
             e.unknown();
         }

--- a/src/engraving/rw/read206/read206.cpp
+++ b/src/engraving/rw/read206/read206.cpp
@@ -680,7 +680,7 @@ static void readDrumset206(Drumset* ds, XmlReader& e)
                     ds->drum(pitch).addVariant(div);
                 }
             }
-        } else if (ds->readProperties(e, pitch)) {
+        } else if (ds->readDrumProperties(e, pitch)) {
         } else {
             e.unknown();
         }

--- a/src/engraving/rw/read400/tread.cpp
+++ b/src/engraving/rw/read400/tread.cpp
@@ -840,8 +840,7 @@ bool TRead::readProperties(Instrument* item, XmlReader& e, ReadContext& ctx, Par
             item->setDrumset(new Drumset(*smDrumset));
         }
     } else if (tag == "Drum") {
-        // if we see on of this tags, a custom drumset will
-        // be created
+        // if we see one of these tags, a custom drumset will be created
         if (!item->drumset()) {
             item->setDrumset(new Drumset(*smDrumset));
         }
@@ -849,7 +848,17 @@ bool TRead::readProperties(Instrument* item, XmlReader& e, ReadContext& ctx, Par
             const_cast<Drumset*>(item->drumset())->clear();
             *customDrumset = true;
         }
-        const_cast<Drumset*>(item->drumset())->load(e);
+        const_cast<Drumset*>(item->drumset())->loadDrum(e);
+    } else if (tag == "percussionPanelColumns") {
+        // if we see one of these tags, a custom drumset will be created
+        if (!item->drumset()) {
+            item->setDrumset(new Drumset(*smDrumset));
+        }
+        if (!(*customDrumset)) {
+            const_cast<Drumset*>(item->drumset())->clear();
+            *customDrumset = true;
+        }
+        item->drumset()->setPercussionPanelColumns(e.readInt());
     }
     // support tag "Tablature" for a while for compatibility with existent 2.0 scores
     else if (tag == "Tablature" || tag == "StringData") {

--- a/src/engraving/rw/read410/tread.cpp
+++ b/src/engraving/rw/read410/tread.cpp
@@ -1041,8 +1041,7 @@ bool TRead::readProperties(Instrument* item, XmlReader& e, ReadContext& ctx, Par
             item->setDrumset(new Drumset(*smDrumset));
         }
     } else if (tag == "Drum") {
-        // if we see on of this tags, a custom drumset will
-        // be created
+        // if we see one of these tags, a custom drumset will be created
         if (!item->drumset()) {
             item->setDrumset(new Drumset(*smDrumset));
         }
@@ -1050,7 +1049,17 @@ bool TRead::readProperties(Instrument* item, XmlReader& e, ReadContext& ctx, Par
             const_cast<Drumset*>(item->drumset())->clear();
             *customDrumset = true;
         }
-        const_cast<Drumset*>(item->drumset())->load(e);
+        const_cast<Drumset*>(item->drumset())->loadDrum(e);
+    } else if (tag == "percussionPanelColumns") {
+        // if we see one of these tags, a custom drumset will be created
+        if (!item->drumset()) {
+            item->setDrumset(new Drumset(*smDrumset));
+        }
+        if (!(*customDrumset)) {
+            const_cast<Drumset*>(item->drumset())->clear();
+            *customDrumset = true;
+        }
+        item->drumset()->setPercussionPanelColumns(e.readInt());
     }
     // support tag "Tablature" for a while for compatibility with existent 2.0 scores
     else if (tag == "Tablature" || tag == "StringData") {

--- a/src/engraving/rw/read460/tread.cpp
+++ b/src/engraving/rw/read460/tread.cpp
@@ -976,8 +976,7 @@ bool TRead::readProperties(Instrument* item, XmlReader& e, ReadContext& ctx, Par
             item->setDrumset(new Drumset(*smDrumset));
         }
     } else if (tag == "Drum") {
-        // if we see on of this tags, a custom drumset will
-        // be created
+        // if we see one of this tags, a custom drumset will be created
         if (!item->drumset()) {
             item->setDrumset(new Drumset(*smDrumset));
         }
@@ -985,7 +984,17 @@ bool TRead::readProperties(Instrument* item, XmlReader& e, ReadContext& ctx, Par
             const_cast<Drumset*>(item->drumset())->clear();
             *customDrumset = true;
         }
-        const_cast<Drumset*>(item->drumset())->load(e);
+        const_cast<Drumset*>(item->drumset())->loadDrum(e);
+    } else if (tag == "percussionPanelColumns") {
+        // if we see one of these tags, a custom drumset will be created
+        if (!item->drumset()) {
+            item->setDrumset(new Drumset(*smDrumset));
+        }
+        if (!(*customDrumset)) {
+            const_cast<Drumset*>(item->drumset())->clear();
+            *customDrumset = true;
+        }
+        item->drumset()->setPercussionPanelColumns(e.readInt());
     }
     // support tag "Tablature" for a while for compatibility with existent 2.0 scores
     else if (tag == "Tablature" || tag == "StringData") {

--- a/src/engraving/tests/compat114_data/drumset-ref.mscx
+++ b/src/engraving/tests/compat114_data/drumset-ref.mscx
@@ -48,6 +48,7 @@
         <trackName>Drumset 5 lines</trackName>
         <instrumentId>drum.group.set</instrumentId>
         <useDrumset>1</useDrumset>
+        <percussionPanelColumns>8</percussionPanelColumns>
         <Drum pitch="35">
           <head>normal</head>
           <line>7</line>

--- a/src/engraving/tests/compat114_data/tamtam-ref.mscx
+++ b/src/engraving/tests/compat114_data/tamtam-ref.mscx
@@ -51,6 +51,7 @@
         <trackName>Tam-tam</trackName>
         <instrumentId>metal.tamtam</instrumentId>
         <useDrumset>1</useDrumset>
+        <percussionPanelColumns>8</percussionPanelColumns>
         <Drum pitch="52">
           <head>cross</head>
           <line>0</line>

--- a/src/engraving/tests/compat206_data/drumset-ref.mscx
+++ b/src/engraving/tests/compat206_data/drumset-ref.mscx
@@ -37,6 +37,7 @@
         <trackName>Drumset</trackName>
         <instrumentId>drum.group.set</instrumentId>
         <useDrumset>1</useDrumset>
+        <percussionPanelColumns>8</percussionPanelColumns>
         <Drum pitch="35">
           <head>normal</head>
           <line>7</line>
@@ -272,6 +273,7 @@
         <trackName>Snare Drum</trackName>
         <instrumentId>drum.snare-drum</instrumentId>
         <useDrumset>1</useDrumset>
+        <percussionPanelColumns>8</percussionPanelColumns>
         <Drum pitch="48">
           <head>diamond</head>
           <line>0</line>
@@ -405,6 +407,7 @@
         <trackName>Tenor Drums</trackName>
         <instrumentId>drum.tenor-drum</instrumentId>
         <useDrumset>1</useDrumset>
+        <percussionPanelColumns>8</percussionPanelColumns>
         <Drum pitch="24">
           <head>normal</head>
           <line>7</line>
@@ -615,6 +618,7 @@
         <trackName>Bass Drums</trackName>
         <instrumentId>drum.bass-drum</instrumentId>
         <useDrumset>1</useDrumset>
+        <percussionPanelColumns>8</percussionPanelColumns>
         <Drum pitch="1">
           <head>normal</head>
           <line>7</line>

--- a/src/engraving/tests/copypaste_data/copypasteNote12-ref.mscx
+++ b/src/engraving/tests/copypaste_data/copypasteNote12-ref.mscx
@@ -88,6 +88,7 @@
         <trackName>Snare Drum</trackName>
         <instrumentId>drum.snare-drum</instrumentId>
         <useDrumset>1</useDrumset>
+        <percussionPanelColumns>8</percussionPanelColumns>
         <Drum pitch="37">
           <head>cross</head>
           <line>0</line>

--- a/src/engraving/tests/copypaste_data/copypasteSplit04-ref.mscx
+++ b/src/engraving/tests/copypaste_data/copypasteSplit04-ref.mscx
@@ -88,6 +88,7 @@
         <trackName>Snare Drum</trackName>
         <instrumentId>drum.snare-drum</instrumentId>
         <useDrumset>1</useDrumset>
+        <percussionPanelColumns>8</percussionPanelColumns>
         <Drum pitch="37">
           <head>cross</head>
           <line>0</line>

--- a/src/engraving/tests/tools_data/undoSlashFill01-ref.mscx
+++ b/src/engraving/tests/tools_data/undoSlashFill01-ref.mscx
@@ -97,6 +97,7 @@
         <trackName>Drumset</trackName>
         <instrumentId>drum.group.set</instrumentId>
         <useDrumset>1</useDrumset>
+        <percussionPanelColumns>8</percussionPanelColumns>
         <Drum pitch="35">
           <head>normal</head>
           <line>7</line>

--- a/src/engraving/tests/tools_data/undoSlashFill02-ref.mscx
+++ b/src/engraving/tests/tools_data/undoSlashFill02-ref.mscx
@@ -97,6 +97,7 @@
         <trackName>Drumset</trackName>
         <instrumentId>drum.group.set</instrumentId>
         <useDrumset>1</useDrumset>
+        <percussionPanelColumns>8</percussionPanelColumns>
         <Drum pitch="35">
           <head>normal</head>
           <line>7</line>

--- a/src/engraving/tests/tools_data/undoSlashRhythm01-ref.mscx
+++ b/src/engraving/tests/tools_data/undoSlashRhythm01-ref.mscx
@@ -97,6 +97,7 @@
         <trackName>Drumset</trackName>
         <instrumentId>drum.group.set</instrumentId>
         <useDrumset>1</useDrumset>
+        <percussionPanelColumns>8</percussionPanelColumns>
         <Drum pitch="35">
           <head>normal</head>
           <line>7</line>

--- a/src/engraving/tests/tools_data/undoSlashRhythm02-ref.mscx
+++ b/src/engraving/tests/tools_data/undoSlashRhythm02-ref.mscx
@@ -97,6 +97,7 @@
         <trackName>Drumset</trackName>
         <instrumentId>drum.group.set</instrumentId>
         <useDrumset>1</useDrumset>
+        <percussionPanelColumns>8</percussionPanelColumns>
         <Drum pitch="35">
           <head>normal</head>
           <line>7</line>

--- a/src/importexport/guitarpro/tests/data/all-percussion.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/all-percussion.gp-ref.mscx
@@ -33,6 +33,7 @@
         <trackName></trackName>
         <instrumentId>drum.group</instrumentId>
         <useDrumset>1</useDrumset>
+        <percussionPanelColumns>8</percussionPanelColumns>
         <Drum pitch="27">
           <head>normal</head>
           <line>3</line>

--- a/src/importexport/guitarpro/tests/data/all-percussion.gp5-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/all-percussion.gp5-ref.mscx
@@ -32,6 +32,7 @@
         <trackName></trackName>
         <instrumentId>drum.group</instrumentId>
         <useDrumset>1</useDrumset>
+        <percussionPanelColumns>8</percussionPanelColumns>
         <Drum pitch="27">
           <head>normal</head>
           <line>3</line>

--- a/src/importexport/guitarpro/tests/data/percussion-beams.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/percussion-beams.gp-ref.mscx
@@ -33,6 +33,7 @@
         <trackName></trackName>
         <instrumentId>drum.group</instrumentId>
         <useDrumset>1</useDrumset>
+        <percussionPanelColumns>8</percussionPanelColumns>
         <Drum pitch="27">
           <head>normal</head>
           <line>3</line>

--- a/src/importexport/guitarpro/tests/data/tuplet-empty-measure.gp-ref.mscx
+++ b/src/importexport/guitarpro/tests/data/tuplet-empty-measure.gp-ref.mscx
@@ -33,6 +33,7 @@
         <trackName></trackName>
         <instrumentId>drum.group</instrumentId>
         <useDrumset>1</useDrumset>
+        <percussionPanelColumns>8</percussionPanelColumns>
         <Drum pitch="27">
           <head>normal</head>
           <line>3</line>

--- a/src/importexport/midi/tests/midiimport_data/perc_drums-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/perc_drums-ref.mscx
@@ -36,6 +36,7 @@
         <trackName>Drum Kit (large)</trackName>
         <instrumentId>drum.group.set</instrumentId>
         <useDrumset>1</useDrumset>
+        <percussionPanelColumns>8</percussionPanelColumns>
         <Drum pitch="35">
           <head>normal</head>
           <line>8</line>

--- a/src/importexport/midi/tests/midiimport_data/perc_no_grand_staff-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/perc_no_grand_staff-ref.mscx
@@ -37,6 +37,7 @@
         <trackName>Tambourine</trackName>
         <instrumentId>drum.tambourine</instrumentId>
         <useDrumset>1</useDrumset>
+        <percussionPanelColumns>8</percussionPanelColumns>
         <Drum pitch="54">
           <head>normal</head>
           <line>0</line>
@@ -111,6 +112,7 @@
         <trackName>Drum Kit (large)</trackName>
         <instrumentId>drum.group.set</instrumentId>
         <useDrumset>1</useDrumset>
+        <percussionPanelColumns>8</percussionPanelColumns>
         <Drum pitch="35">
           <head>normal</head>
           <line>8</line>

--- a/src/importexport/midi/tests/midiimport_data/perc_remove_ties-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/perc_remove_ties-ref.mscx
@@ -36,6 +36,7 @@
         <trackName>Drum Kit (large)</trackName>
         <instrumentId>drum.group.set</instrumentId>
         <useDrumset>1</useDrumset>
+        <percussionPanelColumns>8</percussionPanelColumns>
         <Drum pitch="35">
           <head>normal</head>
           <line>8</line>

--- a/src/importexport/midi/tests/midiimport_data/perc_respect_beat-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/perc_respect_beat-ref.mscx
@@ -36,6 +36,7 @@
         <trackName>Drum Kit (large)</trackName>
         <instrumentId>drum.group.set</instrumentId>
         <useDrumset>1</useDrumset>
+        <percussionPanelColumns>8</percussionPanelColumns>
         <Drum pitch="35">
           <head>normal</head>
           <line>8</line>

--- a/src/importexport/midi/tests/midiimport_data/perc_short_notes-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/perc_short_notes-ref.mscx
@@ -36,6 +36,7 @@
         <trackName>Drum Kit (large)</trackName>
         <instrumentId>drum.group.set</instrumentId>
         <useDrumset>1</useDrumset>
+        <percussionPanelColumns>8</percussionPanelColumns>
         <Drum pitch="35">
           <head>normal</head>
           <line>8</line>

--- a/src/importexport/midi/tests/midiimport_data/perc_triplet-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/perc_triplet-ref.mscx
@@ -36,6 +36,7 @@
         <trackName>Drum Kit (large)</trackName>
         <instrumentId>drum.group.set</instrumentId>
         <useDrumset>1</useDrumset>
+        <percussionPanelColumns>8</percussionPanelColumns>
         <Drum pitch="35">
           <head>normal</head>
           <line>8</line>

--- a/src/importexport/midi/tests/midiimport_data/perc_tuplet_simplify-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/perc_tuplet_simplify-ref.mscx
@@ -36,6 +36,7 @@
         <trackName>Drum Kit (large)</trackName>
         <instrumentId>drum.group.set</instrumentId>
         <useDrumset>1</useDrumset>
+        <percussionPanelColumns>8</percussionPanelColumns>
         <Drum pitch="35">
           <head>normal</head>
           <line>8</line>

--- a/src/importexport/midi/tests/midiimport_data/perc_tuplet_simplify2-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/perc_tuplet_simplify2-ref.mscx
@@ -37,6 +37,7 @@
         <trackName>Slit Drum</trackName>
         <instrumentId>drum.slit-drum</instrumentId>
         <useDrumset>1</useDrumset>
+        <percussionPanelColumns>8</percussionPanelColumns>
         <Drum pitch="77">
           <head>normal</head>
           <line>0</line>

--- a/src/importexport/midi/tests/midiimport_data/perc_tuplet_voice-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/perc_tuplet_voice-ref.mscx
@@ -36,6 +36,7 @@
         <trackName>Drum Kit (large)</trackName>
         <instrumentId>drum.group.set</instrumentId>
         <useDrumset>1</useDrumset>
+        <percussionPanelColumns>8</percussionPanelColumns>
         <Drum pitch="35">
           <head>normal</head>
           <line>8</line>

--- a/src/importexport/musicxml/tests/data/testFinaleInstr_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testFinaleInstr_ref.mscx
@@ -1291,6 +1291,7 @@
         <trackName>Percussion 1</trackName>
         <instrumentId>drum.group</instrumentId>
         <useDrumset>1</useDrumset>
+        <percussionPanelColumns>8</percussionPanelColumns>
         <Drum pitch="27">
           <head>slash</head>
           <line>8</line>
@@ -1932,6 +1933,7 @@
         <trackName>Percussion 2</trackName>
         <instrumentId>drum.group</instrumentId>
         <useDrumset>1</useDrumset>
+        <percussionPanelColumns>8</percussionPanelColumns>
         <Drum pitch="27">
           <head>slash</head>
           <line>8</line>

--- a/src/importexport/musicxml/tests/data/testImportDrums2_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testImportDrums2_ref.mscx
@@ -59,6 +59,7 @@
         <trackName>Drum Set (Rock)</trackName>
         <instrumentId>drum.group.set</instrumentId>
         <useDrumset>1</useDrumset>
+        <percussionPanelColumns>8</percussionPanelColumns>
         <Drum pitch="35">
           <head>normal</head>
           <line>8</line>

--- a/src/importexport/musicxml/tests/data/testImportDrums_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testImportDrums_ref.mscx
@@ -48,6 +48,7 @@
         <trackName>Drums</trackName>
         <instrumentId>drum.group.set</instrumentId>
         <useDrumset>1</useDrumset>
+        <percussionPanelColumns>8</percussionPanelColumns>
         <Drum pitch="35">
           <head>normal</head>
           <line>8</line>

--- a/src/importexport/musicxml/tests/data/testInstrImport_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testInstrImport_ref.mscx
@@ -1157,6 +1157,7 @@
         <trackName>Percussion</trackName>
         <instrumentId>drum.group.set</instrumentId>
         <useDrumset>1</useDrumset>
+        <percussionPanelColumns>8</percussionPanelColumns>
         <Drum pitch="27">
           <head>cross</head>
           <line>-1</line>

--- a/src/importexport/musicxml/tests/data/testMS3KitAndPerc_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testMS3KitAndPerc_ref.mscx
@@ -68,6 +68,7 @@
         <trackName>Drum Kit</trackName>
         <instrumentId>drum.group.set</instrumentId>
         <useDrumset>1</useDrumset>
+        <percussionPanelColumns>8</percussionPanelColumns>
         <Drum pitch="35">
           <head>normal</head>
           <line>7</line>
@@ -309,6 +310,7 @@
         <trackName>Percussion</trackName>
         <instrumentId>drum.group.set</instrumentId>
         <useDrumset>1</useDrumset>
+        <percussionPanelColumns>8</percussionPanelColumns>
         <Drum pitch="27">
           <head>cross</head>
           <line>-1</line>

--- a/src/importexport/musicxml/tests/data/testStickingLyrics_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testStickingLyrics_ref.mscx
@@ -59,6 +59,7 @@
         <trackName>Marching Snare Drums [5 lines]</trackName>
         <instrumentId>drum.group.set</instrumentId>
         <useDrumset>1</useDrumset>
+        <percussionPanelColumns>8</percussionPanelColumns>
         <Drum pitch="35">
           <head>normal</head>
           <line>8</line>

--- a/src/importexport/musicxml/tests/data/testSticking_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testSticking_ref.mscx
@@ -66,6 +66,7 @@
         <trackName>Percussion</trackName>
         <instrumentId>drum.group.set</instrumentId>
         <useDrumset>1</useDrumset>
+        <percussionPanelColumns>8</percussionPanelColumns>
         <Drum pitch="27">
           <head>normal</head>
           <line>0</line>

--- a/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
+++ b/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
@@ -233,6 +233,7 @@ Item {
 
                 width: cellWidth * numColumns
                 Layout.fillHeight: true
+                Layout.preferredWidth: width
 
                 interactive: false
 

--- a/src/notation/utilities/percussionutilities.cpp
+++ b/src/notation/utilities/percussionutilities.cpp
@@ -41,7 +41,9 @@ void PercussionUtilities::readDrumset(const muse::ByteArray& drumMapping, Drumse
         if (reader.name() == "museScore") {
             while (reader.readNextStartElement()) {
                 if (reader.name() == "Drum") {
-                    drumset.load(reader);
+                    drumset.loadDrum(reader);
+                } else if (reader.name() == "percussionPanelColumns") {
+                    drumset.setPercussionPanelColumns(reader.readInt());
                 } else {
                     reader.unknown();
                 }

--- a/src/notation/view/percussionpanel/percussionpanelmodel.h
+++ b/src/notation/view/percussionpanel/percussionpanelmodel.h
@@ -120,6 +120,8 @@ private:
     void updateSoundTitle(const InstrumentTrackId& trackId);
     void setSoundTitle(const QString& soundTitle);
 
+    QVariantMap createColumnSubItem(int numColumns) const;
+
     bool eventFilter(QObject* watched, QEvent* event) override;
 
     void onPadTriggered(int pitch, const PercussionPanelPadModel::PadAction& action);
@@ -133,6 +135,8 @@ private:
     void resetLayout();
     Drumset standardDefaultDrumset() const;
     Drumset museSamplerDefaultDrumset() const;
+
+    void setColumns(int numColumns);
 
     mu::engraving::InstrumentTrackId currentTrackId() const;
 

--- a/src/notation/view/percussionpanel/percussionpanelpadlistmodel.cpp
+++ b/src/notation/view/percussionpanel/percussionpanelpadlistmodel.cpp
@@ -70,14 +70,14 @@ void PercussionPanelPadListModel::init()
 
 void PercussionPanelPadListModel::addEmptyRow(bool focusFirstInNewRow)
 {
-    for (size_t i = 0; i < NUM_COLUMNS; ++i) {
+    for (int i = 0; i < numColumns(); ++i) {
         m_padModels.append(nullptr);
     }
     emit layoutChanged();
     emit numPadsChanged();
 
     if (focusFirstInNewRow) {
-        const int indexToFocus = numPads() - NUM_COLUMNS;
+        const int indexToFocus = numPads() - numColumns();
         emit padFocusRequested(indexToFocus);
     }
 }
@@ -85,15 +85,15 @@ void PercussionPanelPadListModel::addEmptyRow(bool focusFirstInNewRow)
 void PercussionPanelPadListModel::deleteRow(int row)
 {
     // Update the drumset...
-    const int startIdx = row * NUM_COLUMNS;
-    for (int i = startIdx; i < startIdx + NUM_COLUMNS; ++i) {
+    const size_t startIdx = row * numColumns();
+    for (size_t i = startIdx; i < startIdx + numColumns(); ++i) {
         if (const PercussionPanelPadModel* model = m_padModels.at(i)) {
             m_drumset->setDrum(model->pitch(), mu::engraving::DrumInstrument());
         }
     }
 
     // Then remove the row...
-    m_padModels.remove(row * NUM_COLUMNS, NUM_COLUMNS);
+    m_padModels.remove(row * numColumns(), numColumns());
 
     emit layoutChanged();
     emit numPadsChanged();
@@ -102,12 +102,12 @@ void PercussionPanelPadListModel::deleteRow(int row)
 void PercussionPanelPadListModel::removeEmptyRows()
 {
     bool rowsRemoved = false;
-    const int lastRowIndex = numPads() / NUM_COLUMNS - 1;
-    for (int i = lastRowIndex; i >= 0; --i) {
-        const int numRows = numPads() / NUM_COLUMNS;
-        const bool rowIsEmpty = numEmptySlotsAtRow(i) == NUM_COLUMNS;
+    const int lastRowIndex = numPads() / numColumns() - 1;
+    for (int i = lastRowIndex; i >= 0 && i <= lastRowIndex; --i) {
+        const size_t numRows = numPads() / numColumns();
+        const bool rowIsEmpty = numEmptySlotsAtRow(i) == numColumns();
         if (rowIsEmpty && numRows > 1) { // never delete the first row
-            m_padModels.remove(i * NUM_COLUMNS, NUM_COLUMNS);
+            m_padModels.remove(i * numColumns(), numColumns());
             rowsRemoved = true;
         }
     }
@@ -166,6 +166,7 @@ mu::engraving::Drumset PercussionPanelPadListModel::constructDefaultLayout(const
     //! drums that aren't accounted for in the default drumset are appended chromatically once the rest of the layout has been decided...
 
     mu::engraving::Drumset defaultLayout = *m_drumset;
+    defaultLayout.setPercussionPanelColumns(defaultDrumset.percussionPanelColumns());
 
     int highestIndex = -1;
     QList<int /*pitch*/> noTemplateFound;
@@ -189,7 +190,7 @@ mu::engraving::Drumset PercussionPanelPadListModel::constructDefaultLayout(const
         defaultLayout.drum(pitch).panelRow = templateRow;
         defaultLayout.drum(pitch).panelColumn = templateColumn;
 
-        const int modelIndex = templateRow * NUM_COLUMNS + templateColumn;
+        const int modelIndex = templateRow * numColumns() + templateColumn;
 
         if (modelIndex > highestIndex) {
             highestIndex = modelIndex;
@@ -198,8 +199,8 @@ mu::engraving::Drumset PercussionPanelPadListModel::constructDefaultLayout(const
 
     for (int pitch : noTemplateFound) {
         ++highestIndex;
-        defaultLayout.drum(pitch).panelRow = highestIndex / NUM_COLUMNS;
-        defaultLayout.drum(pitch).panelColumn = highestIndex % NUM_COLUMNS;
+        defaultLayout.drum(pitch).panelRow = highestIndex / numColumns();
+        defaultLayout.drum(pitch).panelColumn = highestIndex % numColumns();
     }
 
     return defaultLayout;
@@ -262,11 +263,12 @@ void PercussionPanelPadListModel::load()
 
     if (!m_drumset) {
         // Add an empty row...
-        for (size_t i = 0; i < NUM_COLUMNS; ++i) {
+        for (int i = 0; i < numColumns(); ++i) {
             m_padModels.append(nullptr);
         }
         endResetModel();
         emit numPadsChanged();
+        emit numColumnsChanged();
         return;
     }
 
@@ -296,13 +298,13 @@ void PercussionPanelPadListModel::load()
     for (int i = 0; i < modelsToAppend.size(); ++i) {
         PercussionPanelPadModel* model = modelsToAppend.value(i);
         engraving::DrumInstrument& drum = m_drumset->drum(model->pitch());
-        drum.panelRow = requiredSize / NUM_COLUMNS;
-        drum.panelColumn = requiredSize % NUM_COLUMNS;
+        drum.panelRow = requiredSize / numColumns();
+        drum.panelColumn = requiredSize % numColumns();
         modelsMap.insert(requiredSize++, model);
     }
 
-    // Round up to nearest multiple of NUM_COLUMNS
-    requiredSize = ((requiredSize + NUM_COLUMNS - 1) / NUM_COLUMNS) * NUM_COLUMNS;
+    // Round up to nearest multiple of numColumns()
+    requiredSize = ((requiredSize + numColumns() - 1) / numColumns()) * numColumns();
 
     //! NOTE: There is an argument that m_padModels itself should be a map instead of a list, as this would
     //! prevent the following double work. In practice, however, this makes some other operations (such as
@@ -315,6 +317,7 @@ void PercussionPanelPadListModel::load()
     endResetModel();
 
     emit numPadsChanged();
+    emit numColumnsChanged();
 }
 
 bool PercussionPanelPadListModel::indexIsValid(int index) const
@@ -352,7 +355,7 @@ int PercussionPanelPadListModel::createModelIndexForPitch(int pitch) const
     const int panelRow = m_drumset->panelRow(pitch);
     const int panelColumn = m_drumset->panelColumn(pitch);
 
-    IF_ASSERT_FAILED(panelColumn < NUM_COLUMNS) {
+    IF_ASSERT_FAILED(panelColumn < numColumns()) {
         LOGE() << "Percussion panel - column out of bounds for " << m_drumset->name(pitch);
         return -1;
     }
@@ -362,7 +365,7 @@ int PercussionPanelPadListModel::createModelIndexForPitch(int pitch) const
         return -1;
     }
 
-    const int modelIndex = panelRow * NUM_COLUMNS + panelColumn;
+    const int modelIndex = panelRow * numColumns() + panelColumn;
 
     const PercussionPanelPadModel* existingModel = modelIndex < m_padModels.size() ? m_padModels.at(modelIndex) : nullptr;
     IF_ASSERT_FAILED(!existingModel) {
@@ -437,8 +440,8 @@ void PercussionPanelPadListModel::movePad(int fromIndex, int toIndex)
 int PercussionPanelPadListModel::numEmptySlotsAtRow(int row) const
 {
     int count = 0;
-    const size_t rowStartIdx = row * NUM_COLUMNS;
-    for (size_t i = rowStartIdx; i < rowStartIdx + NUM_COLUMNS; ++i) {
+    const size_t rowStartIdx = row * numColumns();
+    for (size_t i = rowStartIdx; i < rowStartIdx + numColumns(); ++i) {
         if (!m_padModels.at(i)) {
             ++count;
         }

--- a/src/notation/view/percussionpanel/percussionpanelpadlistmodel.h
+++ b/src/notation/view/percussionpanel/percussionpanelpadlistmodel.h
@@ -43,7 +43,7 @@ class PercussionPanelPadListModel : public QAbstractListModel, public muse::Inje
 
     Q_OBJECT
 
-    Q_PROPERTY(int numColumns READ numColumns CONSTANT)
+    Q_PROPERTY(int numColumns READ numColumns NOTIFY numColumnsChanged)
     Q_PROPERTY(int numPads READ numPads NOTIFY numPadsChanged)
 
 public:
@@ -67,7 +67,7 @@ public:
 
     bool hasActivePads() const { return m_drumset; }
 
-    int numColumns() const { return NUM_COLUMNS; }
+    int numColumns() const { return m_drumset ? static_cast<int>(m_drumset->percussionPanelColumns()) : DEFAULT_NUM_COLUMNS; }
     int numPads() const { return m_padModels.count(); }
 
     void setDrumset(const engraving::Drumset* drumset);
@@ -87,10 +87,11 @@ public:
 
 signals:
     void numPadsChanged();
+    void numColumnsChanged();
     void padFocusRequested(int padIndex); //! NOTE: This won't work if it is called immediately before a layoutChange
 
 private:
-    static constexpr int NUM_COLUMNS = 8;
+    static constexpr int DEFAULT_NUM_COLUMNS = 8;
 
     enum Roles {
         PadModelRole = Qt::UserRole + 1,

--- a/src/palette/view/widgets/customizekitdialog.cpp
+++ b/src/palette/view/widgets/customizekitdialog.cpp
@@ -592,7 +592,7 @@ void CustomizeKitDialog::updateExample()
 }
 
 //---------------------------------------------------------
-//   load
+//   loadDrum
 //---------------------------------------------------------
 
 void CustomizeKitDialog::load()
@@ -628,7 +628,9 @@ void CustomizeKitDialog::load()
             }
             while (e.readNextStartElement()) {
                 if (e.name() == "Drum") {
-                    m_editedDrumset.load(e);
+                    m_editedDrumset.loadDrum(e);
+                } else if (e.name() == "percussionPanelColumns") {
+                    m_editedDrumset.setPercussionPanelColumns(e.readInt());
                 } else {
                     e.unknown();
                 }

--- a/src/project/internal/mdlmigrator.cpp
+++ b/src/project/internal/mdlmigrator.cpp
@@ -110,7 +110,7 @@ bool MdlMigrator::loadDrumset(Drumset* drumset, path_t path)
             }
             while (xml.readNextStartElement()) {
                 if (xml.name() == "Drum") {
-                    drumset->load(xml);
+                    drumset->loadDrum(xml);
                 } else {
                     xml.unknown();
                 }


### PR DESCRIPTION
This PR adds an item to the Percussion Panel Layout menu with options to customize the number of columns. This property is instrument-specific, so a new `percussionPanelColumns` XML tag has been introduced.

<img width="1253" alt="Screenshot 2025-06-13 at 15 04 10" src="https://github.com/user-attachments/assets/9e4ad48d-930e-4dd5-973e-5883f2f1a18f" />
