### PR TITLE
Fix #26402: Formatting lost when special character is copied and pasted

### DIFF
--- a/src/engraving/dom/textedit.cpp
+++ b/src/engraving/dom/textedit.cpp
@@ -271,7 +271,7 @@ void TextBase::insertSym(EditData& ed, SymId id)
     deleteSelectedText(ed);
     String s = score()->engravingFont()->toString(id);
     cursor->format()->setFontFamily(u"ScoreText");
-    score()->undo(new InsertText(m_cursor, s), &ed);
+    score()->undo(new InsertText(cursor, s), &ed);
 }
 
 //---------------------------------------------------------
@@ -940,6 +940,7 @@ void TextBase::paste(EditData& ed, const String& txt)
                     sym.clear();
                 } else if (token == "/sym") {
                     symState = false;
+                    static_cast<TextEditData*>(ed.getData(this).get())->cursor()->setFormat(format);
                     insertSym(ed, SymNames::symIdByName(sym));
                 } else {
                     prepareFormat(token, format);


### PR DESCRIPTION
Resolves: #26402 

Copying and pasting a musical symbol with a modified size in a system text object caused the size to reset. This happened because the cursor used during insertion was from the paste location rather than the copied element. Additionally, the format was not properly stored in the edit text object (ed), so when TextBase::insertSym() was called, it lacked the correct formatting.
I fixed this by ensuring the correct cursor was used for insertion and explicitly setting the format in the edit text object before passing it to TextBase::insertSym() during TextBase::paste(), preserving the symbol’s modified size.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
