### PR TITLE
Fix midi import test op data

### DIFF
--- a/src/importexport/midi/tests/environment.cpp
+++ b/src/importexport/midi/tests/environment.cpp
@@ -47,7 +47,5 @@ static muse::testing::SuiteEnvironment importexport_se(
     mu::engraving::MScore::noGui = true;
 
     mu::engraving::loadInstrumentTemplates(":/engraving/instruments/instruments.xml");
-
-    LOGW() << "WARNING: actually all MIDI import/export tests are disabled!";
 }
     );

--- a/src/importexport/midi/tests/midiimport_data/chord_1_tick_long-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/chord_1_tick_long-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,39 +85,49 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Chord>
+            <eid>F_F</eid>
             <durationType>128th</durationType>
             <Note>
+              <eid>G_G</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>H_H</eid>
             <durationType>128th</durationType>
             </Rest>
           <Rest>
+            <eid>I_I</eid>
             <durationType>64th</durationType>
             </Rest>
           <Rest>
+            <eid>J_J</eid>
             <durationType>32nd</durationType>
             </Rest>
           <Rest>
+            <eid>K_K</eid>
             <durationType>16th</durationType>
             </Rest>
           <Rest>
+            <eid>L_L</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Rest>
+            <eid>M_M</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
+            <eid>N_N</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/chord_big_error-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/chord_big_error-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,36 +85,41 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Rest>
+            <eid>F_F</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Chord>
+            <eid>G_G</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>H_H</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>I_I</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>J_J</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>K_K</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/chord_collect-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/chord_collect-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -106,416 +108,460 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Rest>
+            <eid>F_F</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
+        <eid>G_G</eid>
         <voice>
           <Rest>
+            <eid>H_H</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
+        <eid>I_I</eid>
         <voice>
           <Rest>
+            <eid>J_J</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
+        <eid>K_K</eid>
         <voice>
           <Rest>
+            <eid>L_L</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
+        <eid>M_M</eid>
         <voice>
           <Rest>
+            <eid>N_N</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
+        <eid>O_O</eid>
         <voice>
           <Rest>
+            <eid>P_P</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
+        <eid>Q_Q</eid>
         <voice>
           <Rest>
+            <eid>R_R</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
+        <eid>S_S</eid>
         <voice>
           <Rest>
+            <eid>T_T</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
+        <eid>U_U</eid>
         <voice>
           <Rest>
+            <eid>V_V</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
+        <eid>W_W</eid>
         <voice>
           <Rest>
+            <eid>X_X</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
+        <eid>Y_Y</eid>
         <voice>
           <Rest>
+            <eid>Z_Z</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
+        <eid>a_a</eid>
         <voice>
+          <Beam>
+            <eid>b_b</eid>
+            <l1>-24</l1>
+            <l2>-24</l2>
+            </Beam>
           <Chord>
+            <eid>c_c</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>d_d</eid>
               <pitch>43</pitch>
               <tpc>15</tpc>
               <velocity>61</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>e_e</eid>
               <pitch>47</pitch>
               <tpc>19</tpc>
               <velocity>61</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>f_f</eid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <velocity>61</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>g_g</eid>
               <pitch>55</pitch>
               <tpc>15</tpc>
               <velocity>61</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>h_h</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <velocity>61</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>i_i</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>61</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>j_j</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>k_k</eid>
               <pitch>43</pitch>
               <tpc>15</tpc>
               <velocity>53</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>l_l</eid>
               <pitch>47</pitch>
               <tpc>19</tpc>
               <velocity>53</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>m_m</eid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <velocity>53</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>n_n</eid>
               <pitch>55</pitch>
               <tpc>15</tpc>
               <velocity>53</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>o_o</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <velocity>53</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>p_p</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>54</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>q_q</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>r_r</eid>
               <pitch>43</pitch>
               <tpc>15</tpc>
               <velocity>71</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>s_s</eid>
               <pitch>47</pitch>
               <tpc>19</tpc>
               <velocity>71</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>t_t</eid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <velocity>71</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>u_u</eid>
               <pitch>55</pitch>
               <tpc>15</tpc>
               <velocity>71</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>v_v</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <velocity>71</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>w_w</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>71</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>x_x</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>y_y</eid>
               <pitch>43</pitch>
               <tpc>15</tpc>
               <velocity>52</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>z_z</eid>
               <pitch>47</pitch>
               <tpc>19</tpc>
               <velocity>52</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>0_0</eid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <velocity>52</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>1_1</eid>
               <pitch>55</pitch>
               <tpc>15</tpc>
               <velocity>52</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>2_2</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <velocity>52</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>3_3</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>52</velocity>
-              <veloType>user</veloType>
+              </Note>
+            </Chord>
+          <Beam>
+            <eid>4_4</eid>
+            <l1>-24</l1>
+            <l2>-24</l2>
+            </Beam>
+          <Chord>
+            <eid>5_5</eid>
+            <durationType>eighth</durationType>
+            <Note>
+              <eid>6_6</eid>
+              <pitch>43</pitch>
+              <tpc>15</tpc>
+              <velocity>61</velocity>
+              </Note>
+            <Note>
+              <eid>7_7</eid>
+              <pitch>47</pitch>
+              <tpc>19</tpc>
+              <velocity>61</velocity>
+              </Note>
+            <Note>
+              <eid>8_8</eid>
+              <pitch>50</pitch>
+              <tpc>16</tpc>
+              <velocity>61</velocity>
+              </Note>
+            <Note>
+              <eid>9_9</eid>
+              <pitch>55</pitch>
+              <tpc>15</tpc>
+              <velocity>61</velocity>
+              </Note>
+            <Note>
+              <eid>+_+</eid>
+              <pitch>62</pitch>
+              <tpc>16</tpc>
+              <velocity>61</velocity>
+              </Note>
+            <Note>
+              <eid>/_/</eid>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              <velocity>61</velocity>
               </Note>
             </Chord>
           <Chord>
+            <eid>AB_AB</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>BB_BB</eid>
               <pitch>43</pitch>
               <tpc>15</tpc>
-              <velocity>61</velocity>
-              <veloType>user</veloType>
+              <velocity>50</velocity>
               </Note>
             <Note>
+              <eid>CB_CB</eid>
               <pitch>47</pitch>
               <tpc>19</tpc>
-              <velocity>61</velocity>
-              <veloType>user</veloType>
+              <velocity>50</velocity>
               </Note>
             <Note>
+              <eid>DB_DB</eid>
               <pitch>50</pitch>
               <tpc>16</tpc>
-              <velocity>61</velocity>
-              <veloType>user</veloType>
+              <velocity>50</velocity>
               </Note>
             <Note>
+              <eid>EB_EB</eid>
               <pitch>55</pitch>
               <tpc>15</tpc>
-              <velocity>61</velocity>
-              <veloType>user</veloType>
+              <velocity>50</velocity>
               </Note>
             <Note>
+              <eid>FB_FB</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
-              <velocity>61</velocity>
-              <veloType>user</veloType>
+              <velocity>50</velocity>
               </Note>
             <Note>
+              <eid>GB_GB</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
-              <velocity>61</velocity>
-              <veloType>user</veloType>
+              <velocity>50</velocity>
               </Note>
             </Chord>
           <Chord>
+            <eid>HB_HB</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>IB_IB</eid>
               <pitch>43</pitch>
               <tpc>15</tpc>
-              <velocity>50</velocity>
-              <veloType>user</veloType>
+              <velocity>72</velocity>
               </Note>
             <Note>
+              <eid>JB_JB</eid>
               <pitch>47</pitch>
               <tpc>19</tpc>
-              <velocity>50</velocity>
-              <veloType>user</veloType>
+              <velocity>72</velocity>
               </Note>
             <Note>
+              <eid>KB_KB</eid>
               <pitch>50</pitch>
               <tpc>16</tpc>
-              <velocity>50</velocity>
-              <veloType>user</veloType>
+              <velocity>72</velocity>
               </Note>
             <Note>
+              <eid>LB_LB</eid>
               <pitch>55</pitch>
               <tpc>15</tpc>
-              <velocity>50</velocity>
-              <veloType>user</veloType>
+              <velocity>72</velocity>
               </Note>
             <Note>
+              <eid>MB_MB</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
-              <velocity>50</velocity>
-              <veloType>user</veloType>
+              <velocity>72</velocity>
               </Note>
             <Note>
+              <eid>NB_NB</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
-              <velocity>50</velocity>
-              <veloType>user</veloType>
+              <velocity>72</velocity>
               </Note>
             </Chord>
           <Chord>
+            <eid>OB_OB</eid>
             <durationType>eighth</durationType>
             <Note>
-              <pitch>43</pitch>
-              <tpc>15</tpc>
-              <velocity>72</velocity>
-              <veloType>user</veloType>
-              </Note>
-            <Note>
-              <pitch>47</pitch>
-              <tpc>19</tpc>
-              <velocity>72</velocity>
-              <veloType>user</veloType>
-              </Note>
-            <Note>
-              <pitch>50</pitch>
-              <tpc>16</tpc>
-              <velocity>72</velocity>
-              <veloType>user</veloType>
-              </Note>
-            <Note>
-              <pitch>55</pitch>
-              <tpc>15</tpc>
-              <velocity>72</velocity>
-              <veloType>user</veloType>
-              </Note>
-            <Note>
-              <pitch>62</pitch>
-              <tpc>16</tpc>
-              <velocity>72</velocity>
-              <veloType>user</veloType>
-              </Note>
-            <Note>
-              <pitch>67</pitch>
-              <tpc>15</tpc>
-              <velocity>72</velocity>
-              <veloType>user</veloType>
-              </Note>
-            </Chord>
-          <Chord>
-            <durationType>eighth</durationType>
-            <Note>
+              <eid>PB_PB</eid>
               <pitch>43</pitch>
               <tpc>15</tpc>
               <velocity>49</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>QB_QB</eid>
               <pitch>47</pitch>
               <tpc>19</tpc>
               <velocity>49</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>RB_RB</eid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <velocity>49</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>SB_SB</eid>
               <pitch>55</pitch>
               <tpc>15</tpc>
               <velocity>49</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>TB_TB</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <velocity>49</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>UB_UB</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>49</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         </Measure>
       <Measure>
+        <eid>VB_VB</eid>
         <voice>
           <Rest>
+            <eid>WB_WB</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>

--- a/src/importexport/midi/tests/midiimport_data/chord_legato-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/chord_legato-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,64 +85,83 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Rest>
+            <eid>F_F</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Rest>
+            <eid>G_G</eid>
             <durationType>16th</durationType>
             </Rest>
           <Rest>
+            <eid>H_H</eid>
             <durationType>32nd</durationType>
             </Rest>
           <Rest>
+            <eid>I_I</eid>
             <durationType>64th</durationType>
             </Rest>
           <Rest>
+            <eid>J_J</eid>
             <durationType>128th</durationType>
             </Rest>
+          <Beam>
+            <eid>K_K</eid>
+            <l1>-26</l1>
+            <l2>-20</l2>
+            </Beam>
           <Chord>
+            <eid>L_L</eid>
             <durationType>128th</durationType>
             <Note>
+              <eid>M_M</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>N_N</eid>
             <durationType>64th</durationType>
             <Note>
+              <eid>O_O</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>P_P</eid>
             <dots>1</dots>
             <durationType>32nd</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>Q_Q</eid>
               </Articulation>
             <Note>
+              <eid>R_R</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>S_S</eid>
             <durationType>16th</durationType>
             </Rest>
           <Rest>
+            <eid>T_T</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Rest>
+            <eid>U_U</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/chord_small_error-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/chord_small_error-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,36 +85,41 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Rest>
+            <eid>F_F</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Chord>
+            <eid>G_G</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>H_H</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>I_I</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>J_J</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>K_K</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/clef_tied-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/clef_tied-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -84,35 +86,44 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Chord>
+            <eid>F_F</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>G_G</eid>
               <pitch>53</pitch>
               <tpc>13</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>H_H</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
+            <eid>I_I</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>
         </Measure>
       <Measure>
+        <eid>J_J</eid>
         <voice>
           <Chord>
+            <eid>K_K</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>L_L</eid>
               <Spanner type="Tie">
                 <Tie>
+                  <eid>M_M</eid>
                   </Tie>
                 <next>
                   <location>
@@ -124,14 +135,16 @@
               <pitch>65</pitch>
               <tpc>13</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>N_N</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>O_O</eid>
               <Spanner type="Tie">
                 <Tie>
+                  <eid>P_P</eid>
                   </Tie>
                 <next>
                   <location>
@@ -143,9 +156,9 @@
               <pitch>57</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>Q_Q</eid>
               <Spanner type="Tie">
                 <prev>
                   <location>
@@ -157,14 +170,16 @@
               <pitch>65</pitch>
               <tpc>13</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>R_R</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>S_S</eid>
               <Spanner type="Tie">
                 <Tie>
+                  <eid>T_T</eid>
                   </Tie>
                 <next>
                   <location>
@@ -175,9 +190,9 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>U_U</eid>
               <Spanner type="Tie">
                 <prev>
                   <location>
@@ -189,12 +204,13 @@
               <pitch>57</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>V_V</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>W_W</eid>
               <Spanner type="Tie">
                 <prev>
                   <location>
@@ -205,11 +221,12 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>X_X</eid>
               <Spanner type="Tie">
                 <Tie>
+                  <eid>Y_Y</eid>
                   </Tie>
                 <next>
                   <location>
@@ -222,18 +239,21 @@
               <pitch>57</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         </Measure>
       <Measure>
+        <eid>Z_Z</eid>
         <voice>
           <Chord>
+            <eid>a_a</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>b_b</eid>
               <Spanner type="Tie">
                 <Tie>
+                  <eid>c_c</eid>
                   </Tie>
                 <next>
                   <location>
@@ -254,18 +274,19 @@
               <pitch>57</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>d_d</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>e_e</eid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>f_f</eid>
               <Spanner type="Tie">
                 <prev>
                   <location>
@@ -277,10 +298,10 @@
               <pitch>57</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>g_g</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/division-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/division-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -28,7 +30,8 @@
         <bracket type="1" span="2" col="0" visible="1"/>
         <barLineSpan>1</barLineSpan>
         </Staff>
-      <Staff id="2">
+      <Staff>
+        <eid>D_D</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -92,40 +95,48 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>E_E</eid>
         <voice>
           <TimeSig>
+            <eid>F_F</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Tempo>
-            <tempo>2.0833333333333335</tempo>
+            <tempo>2.083333</tempo>
+            <eid>G_G</eid>
             <text><sym>metNoteQuarterUp</sym> = 125</text>
             </Tempo>
           <Rest>
+            <eid>H_H</eid>
             <durationType>half</durationType>
             </Rest>
           <Rest>
+            <eid>I_I</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
+            <eid>J_J</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Chord>
+            <eid>K_K</eid>
             <durationType>eighth</durationType>
             <Articulation>
               <subtype>articStaccatoAbove</subtype>
+              <eid>L_L</eid>
               </Articulation>
             <Note>
+              <eid>M_M</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>N_N</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <velocity>84</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
@@ -135,34 +146,40 @@
       <Measure>
         <voice>
           <TimeSig>
+            <eid>O_O</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Rest>
+            <eid>P_P</eid>
             <durationType>half</durationType>
             </Rest>
           <Rest>
+            <eid>Q_Q</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
+            <eid>R_R</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Chord>
+            <eid>S_S</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>T_T</eid>
               </Articulation>
             <Note>
+              <eid>U_U</eid>
               <pitch>41</pitch>
               <tpc>13</tpc>
               <velocity>83</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>V_V</eid>
               <pitch>48</pitch>
               <tpc>14</tpc>
               <velocity>83</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/instrument_3staff_organ-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/instrument_3staff_organ-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,21 +20,24 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
         <bracket type="1" span="2" col="0" visible="1"/>
         <barLineSpan>1</barLineSpan>
         </Staff>
-      <Staff id="2">
+      <Staff>
+        <eid>D_D</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
         <defaultClef>F</defaultClef>
         </Staff>
-      <Staff id="3">
+      <Staff>
+        <eid>E_E</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -94,22 +98,26 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>F_F</eid>
         <voice>
           <TimeSig>
+            <eid>G_G</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Tempo>
             <tempo>2</tempo>
+            <eid>H_H</eid>
             <text><sym>metNoteQuarterUp</sym> = 120</text>
             </Tempo>
           <Chord>
+            <eid>I_I</eid>
             <durationType>whole</durationType>
             <Note>
+              <eid>J_J</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
@@ -119,16 +127,18 @@
       <Measure>
         <voice>
           <TimeSig>
+            <eid>K_K</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Chord>
+            <eid>L_L</eid>
             <durationType>whole</durationType>
             <Note>
+              <eid>M_M</eid>
               <pitch>48</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
@@ -138,16 +148,18 @@
       <Measure>
         <voice>
           <TimeSig>
+            <eid>N_N</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Chord>
+            <eid>O_O</eid>
             <durationType>whole</durationType>
             <Note>
+              <eid>P_P</eid>
               <pitch>48</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/instrument_grand-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/instrument_grand-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,15 +20,17 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
         <bracket type="1" span="2" col="0" visible="1"/>
         <barLineSpan>1</barLineSpan>
         </Staff>
-      <Staff id="2">
+      <Staff>
+        <eid>D_D</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -96,15 +99,17 @@
           </Channel>
         </Instrument>
       </Part>
-    <Part>
-      <Staff id="3">
+    <Part id="2">
+      <Staff>
+        <eid>E_E</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
         <bracket type="1" span="2" col="0" visible="1"/>
         <barLineSpan>1</barLineSpan>
         </Staff>
-      <Staff id="4">
+      <Staff>
+        <eid>F_F</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -170,45 +175,51 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>G_G</eid>
         <voice>
           <TimeSig>
+            <eid>H_H</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Chord>
+            <eid>I_I</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>J_J</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>K_K</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>L_L</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>M_M</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>N_N</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>O_O</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>P_P</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
@@ -218,25 +229,28 @@
       <Measure>
         <voice>
           <TimeSig>
+            <eid>Q_Q</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Chord>
+            <eid>R_R</eid>
             <durationType>half</durationType>
             <Note>
+              <eid>S_S</eid>
               <pitch>48</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>T_T</eid>
             <durationType>half</durationType>
             <Note>
+              <eid>U_U</eid>
               <pitch>55</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
@@ -246,43 +260,48 @@
       <Measure>
         <voice>
           <TimeSig>
+            <eid>V_V</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Chord>
+            <eid>W_W</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>X_X</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>Y_Y</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>Z_Z</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>a_a</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>b_b</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>c_c</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>d_d</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
@@ -292,25 +311,28 @@
       <Measure>
         <voice>
           <TimeSig>
+            <eid>e_e</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Chord>
+            <eid>f_f</eid>
             <durationType>half</durationType>
             <Note>
+              <eid>g_g</eid>
               <pitch>48</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>h_h</eid>
             <durationType>half</durationType>
             <Note>
+              <eid>i_i</eid>
               <pitch>55</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/instrument_grand2-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/instrument_grand2-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,15 +20,17 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
         <bracket type="1" span="2" col="0" visible="1"/>
         <barLineSpan>1</barLineSpan>
         </Staff>
-      <Staff id="2">
+      <Staff>
+        <eid>D_D</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -89,15 +92,17 @@
           </Channel>
         </Instrument>
       </Part>
-    <Part>
-      <Staff id="3">
+    <Part id="2">
+      <Staff>
+        <eid>E_E</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
         <bracket type="1" span="2" col="0" visible="1"/>
         <barLineSpan>1</barLineSpan>
         </Staff>
-      <Staff id="4">
+      <Staff>
+        <eid>F_F</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -161,34 +166,38 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>G_G</eid>
         <voice>
           <TimeSig>
+            <eid>H_H</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Tempo>
             <tempo>2</tempo>
+            <eid>I_I</eid>
             <text><sym>metNoteQuarterUp</sym> = 120</text>
             </Tempo>
           <Chord>
+            <eid>J_J</eid>
             <durationType>whole</durationType>
             <Note>
+              <eid>K_K</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>L_L</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>M_M</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
@@ -198,16 +207,18 @@
       <Measure>
         <voice>
           <TimeSig>
+            <eid>N_N</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Chord>
+            <eid>O_O</eid>
             <durationType>whole</durationType>
             <Note>
+              <eid>P_P</eid>
               <pitch>48</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
@@ -217,28 +228,30 @@
       <Measure>
         <voice>
           <TimeSig>
+            <eid>Q_Q</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Chord>
+            <eid>R_R</eid>
             <durationType>whole</durationType>
             <Note>
+              <eid>S_S</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>T_T</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>U_U</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
@@ -248,16 +261,18 @@
       <Measure>
         <voice>
           <TimeSig>
+            <eid>V_V</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Chord>
+            <eid>W_W</eid>
             <durationType>whole</durationType>
             <Note>
+              <eid>X_X</eid>
               <pitch>48</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/m3-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/m3-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,15 +20,17 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
         <bracket type="1" span="2" col="0" visible="1"/>
         <barLineSpan>1</barLineSpan>
         </Staff>
-      <Staff id="2">
+      <Staff>
+        <eid>D_D</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -91,25 +94,31 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>E_E</eid>
         <voice>
           <TimeSig>
+            <eid>F_F</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Chord>
+            <eid>G_G</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>H_H</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>I_I</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>J_J</eid>
               <Spanner type="Tie">
                 <Tie>
+                  <eid>K_K</eid>
                   </Tie>
                 <next>
                   <location>
@@ -121,18 +130,19 @@
               <pitch>69</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>L_L</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>M_M</eid>
               <pitch>65</pitch>
               <tpc>13</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>N_N</eid>
               <Spanner type="Tie">
                 <prev>
                   <location>
@@ -144,41 +154,45 @@
               <pitch>69</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>O_O</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>P_P</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         </Measure>
       <Measure>
+        <eid>Q_Q</eid>
         <voice>
           <Chord>
+            <eid>R_R</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>S_S</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>T_T</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>U_U</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>V_V</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>
@@ -188,22 +202,26 @@
       <Measure>
         <voice>
           <TimeSig>
+            <eid>W_W</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Chord>
+            <eid>X_X</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>Y_Y</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>Z_Z</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
+            <eid>a_a</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>
@@ -211,6 +229,7 @@
       <Measure>
         <voice>
           <Rest>
+            <eid>b_b</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>

--- a/src/importexport/midi/tests/midiimport_data/m4-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/m4-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,15 +20,17 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
         <bracket type="1" span="2" col="0" visible="1"/>
         <barLineSpan>1</barLineSpan>
         </Staff>
-      <Staff id="2">
+      <Staff>
+        <eid>D_D</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -91,31 +94,37 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>E_E</eid>
         <voice>
           <TimeSig>
+            <eid>F_F</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Chord>
+            <eid>G_G</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>H_H</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>I_I</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>J_J</eid>
               <pitch>65</pitch>
               <tpc>13</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>K_K</eid>
               <Spanner type="Tie">
                 <Tie>
+                  <eid>L_L</eid>
                   </Tie>
                 <next>
                   <location>
@@ -127,12 +136,13 @@
               <pitch>69</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>M_M</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>N_N</eid>
               <Spanner type="Tie">
                 <prev>
                   <location>
@@ -144,41 +154,45 @@
               <pitch>69</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>O_O</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>P_P</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         </Measure>
       <Measure>
+        <eid>Q_Q</eid>
         <voice>
           <Chord>
+            <eid>R_R</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>S_S</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>T_T</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>U_U</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>V_V</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>
@@ -188,22 +202,26 @@
       <Measure>
         <voice>
           <TimeSig>
+            <eid>W_W</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Chord>
+            <eid>X_X</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>Y_Y</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>Z_Z</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
+            <eid>a_a</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>
@@ -211,6 +229,7 @@
       <Measure>
         <voice>
           <Rest>
+            <eid>b_b</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>

--- a/src/importexport/midi/tests/midiimport_data/meter_12-8-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/meter_12-8-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,25 +85,31 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>12</sigN>
             <sigD>8</sigD>
             </TimeSig>
           <Chord>
+            <eid>F_F</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>G_G</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>100</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>H_H</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>I_I</eid>
               <Spanner type="Tie">
                 <Tie>
+                  <eid>J_J</eid>
                   </Tie>
                 <next>
                   <location>
@@ -112,12 +120,13 @@
               <pitch>74</pitch>
               <tpc>16</tpc>
               <velocity>100</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>K_K</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>L_L</eid>
               <Spanner type="Tie">
                 <prev>
                   <location>
@@ -128,32 +137,36 @@
               <pitch>74</pitch>
               <tpc>16</tpc>
               <velocity>100</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>M_M</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>N_N</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>100</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>O_O</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>P_P</eid>
               <pitch>74</pitch>
               <tpc>16</tpc>
               <velocity>100</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>Q_Q</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>R_R</eid>
               <Spanner type="Tie">
                 <Tie>
+                  <eid>S_S</eid>
                   </Tie>
                 <next>
                   <location>
@@ -164,12 +177,13 @@
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>100</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>T_T</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>U_U</eid>
               <Spanner type="Tie">
                 <prev>
                   <location>
@@ -180,30 +194,35 @@
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>100</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>V_V</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>W_W</eid>
               <pitch>74</pitch>
               <tpc>16</tpc>
               <velocity>100</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         </Measure>
       <Measure>
+        <eid>X_X</eid>
         <voice>
           <Rest>
+            <eid>Y_Y</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Chord>
+            <eid>Z_Z</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>a_a</eid>
               <Spanner type="Tie">
                 <Tie>
+                  <eid>b_b</eid>
                   </Tie>
                 <next>
                   <location>
@@ -214,15 +233,17 @@
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>100</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>c_c</eid>
             <dots>1</dots>
             <durationType>quarter</durationType>
             <Note>
+              <eid>d_d</eid>
               <Spanner type="Tie">
                 <Tie>
+                  <eid>e_e</eid>
                   </Tie>
                 <next>
                   <location>
@@ -240,12 +261,13 @@
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>100</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>f_f</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>g_g</eid>
               <Spanner type="Tie">
                 <prev>
                   <location>
@@ -256,16 +278,18 @@
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>100</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>h_h</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Rest>
+            <eid>i_i</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Rest>
+            <eid>j_j</eid>
             <dots>1</dots>
             <durationType>quarter</durationType>
             </Rest>

--- a/src/importexport/midi/tests/midiimport_data/meter_4-4-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/meter_4-4-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,63 +85,76 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Chord>
+            <eid>F_F</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>G_G</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>H_H</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>I_I</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>J_J</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>K_K</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>L_L</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>M_M</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
+          <Beam>
+            <eid>N_N</eid>
+            <l1>38</l1>
+            <l2>36</l2>
+            </Beam>
           <Chord>
+            <eid>O_O</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>P_P</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>Q_Q</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>R_R</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/meter_9-8-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/meter_9-8-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,31 +85,38 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>9</sigN>
             <sigD>8</sigD>
             </TimeSig>
           <Chord>
+            <eid>F_F</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>G_G</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>H_H</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Rest>
+            <eid>I_I</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Rest>
+            <eid>J_J</eid>
             <dots>1</dots>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
+            <eid>K_K</eid>
             <dots>1</dots>
             <durationType>quarter</durationType>
             </Rest>

--- a/src/importexport/midi/tests/midiimport_data/meter_central_long_note-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/meter_central_long_note-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,36 +85,41 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Chord>
+            <eid>F_F</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>G_G</eid>
               <pitch>69</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>H_H</eid>
             <durationType>half</durationType>
             <Note>
+              <eid>I_I</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>J_J</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>K_K</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/meter_central_long_rest-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/meter_central_long_rest-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,33 +85,39 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Chord>
+            <eid>F_F</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>G_G</eid>
               <pitch>69</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>H_H</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
+            <eid>I_I</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Chord>
+            <eid>J_J</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>K_K</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/meter_chord_example-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/meter_chord_example-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,19 +85,30 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Rest>
+            <eid>F_F</eid>
             <durationType>eighth</durationType>
             </Rest>
+          <Beam>
+            <eid>G_G</eid>
+            <l1>40</l1>
+            <l2>40</l2>
+            </Beam>
           <Chord>
+            <eid>H_H</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>I_I</eid>
               <Spanner type="Tie">
                 <Tie>
+                  <eid>J_J</eid>
                   </Tie>
                 <next>
                   <location>
@@ -106,12 +119,13 @@
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>K_K</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>L_L</eid>
               <Spanner type="Tie">
                 <prev>
                   <location>
@@ -122,11 +136,12 @@
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>M_M</eid>
               <Spanner type="Tie">
                 <Tie>
+                  <eid>N_N</eid>
                   </Tie>
                 <next>
                   <location>
@@ -138,11 +153,12 @@
               <pitch>76</pitch>
               <tpc>18</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>O_O</eid>
               <Spanner type="Tie">
                 <Tie>
+                  <eid>P_P</eid>
                   </Tie>
                 <next>
                   <location>
@@ -154,11 +170,12 @@
               <pitch>81</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>Q_Q</eid>
               <Spanner type="Tie">
                 <Tie>
+                  <eid>R_R</eid>
                   </Tie>
                 <next>
                   <location>
@@ -170,12 +187,18 @@
               <pitch>86</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
+          <Beam>
+            <eid>S_S</eid>
+            <l1>32</l1>
+            <l2>30</l2>
+            </Beam>
           <Chord>
+            <eid>T_T</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>U_U</eid>
               <Spanner type="Tie">
                 <prev>
                   <location>
@@ -187,9 +210,9 @@
               <pitch>76</pitch>
               <tpc>18</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>V_V</eid>
               <Spanner type="Tie">
                 <prev>
                   <location>
@@ -201,11 +224,12 @@
               <pitch>81</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>W_W</eid>
               <Spanner type="Tie">
                 <Tie>
+                  <eid>X_X</eid>
                   </Tie>
                 <next>
                   <location>
@@ -225,12 +249,13 @@
               <pitch>86</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>Y_Y</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>Z_Z</eid>
               <Spanner type="Tie">
                 <prev>
                   <location>
@@ -242,45 +267,49 @@
               <pitch>86</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>a_a</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Rest>
+            <eid>b_b</eid>
             <durationType>16th</durationType>
             </Rest>
           <Chord>
+            <eid>c_c</eid>
             <dots>1</dots>
             <durationType>eighth</durationType>
             <Note>
+              <eid>d_d</eid>
               <pitch>69</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>e_e</eid>
               <pitch>74</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>f_f</eid>
               <pitch>77</pitch>
               <tpc>13</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>g_g</eid>
               <pitch>81</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>h_h</eid>
               <Spanner type="Tie">
                 <Tie>
+                  <eid>i_i</eid>
                   </Tie>
                 <next>
                   <location>
@@ -292,12 +321,13 @@
               <pitch>84</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>j_j</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>k_k</eid>
               <Spanner type="Tie">
                 <prev>
                   <location>
@@ -309,13 +339,14 @@
               <pitch>84</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>l_l</eid>
             <durationType>16th</durationType>
             </Rest>
           <Rest>
+            <eid>m_m</eid>
             <durationType>eighth</durationType>
             </Rest>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/meter_dot_tie-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/meter_dot_tie-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,17 +85,22 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Chord>
+            <eid>F_F</eid>
             <dots>1</dots>
             <durationType>half</durationType>
             <Note>
+              <eid>G_G</eid>
               <Spanner type="Tie">
                 <Tie>
+                  <eid>H_H</eid>
                   </Tie>
                 <next>
                   <location>
@@ -104,12 +111,18 @@
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>100</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
+          <Beam>
+            <eid>I_I</eid>
+            <l1>-12</l1>
+            <l2>-12</l2>
+            </Beam>
           <Chord>
+            <eid>J_J</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>K_K</eid>
               <Spanner type="Tie">
                 <prev>
                   <location>
@@ -120,34 +133,36 @@
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>100</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>L_L</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>M_M</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>100</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>N_N</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>O_O</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>100</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>P_P</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>Q_Q</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>100</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/meter_dots_example1-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/meter_dots_example1-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,71 +85,87 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Chord>
+            <eid>F_F</eid>
             <dots>1</dots>
             <durationType>quarter</durationType>
             <Note>
+              <eid>G_G</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>H_H</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Chord>
+            <eid>I_I</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>J_J</eid>
               <pitch>69</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>K_K</eid>
             <durationType>quarter</durationType>
             </Rest>
           </voice>
         </Measure>
       <Measure>
+        <eid>L_L</eid>
         <voice>
           <Chord>
+            <eid>M_M</eid>
             <dots>1</dots>
             <durationType>quarter</durationType>
             <Note>
+              <eid>N_N</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>O_O</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Rest>
+            <eid>P_P</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>
         </Measure>
       <Measure>
+        <eid>Q_Q</eid>
         <voice>
           <Rest>
+            <eid>R_R</eid>
             <durationType>half</durationType>
             </Rest>
           <Rest>
+            <eid>S_S</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Chord>
+            <eid>T_T</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>U_U</eid>
               <Spanner type="Tie">
                 <Tie>
+                  <eid>V_V</eid>
                   </Tie>
                 <next>
                   <location>
@@ -159,16 +177,18 @@
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         </Measure>
       <Measure>
+        <eid>W_W</eid>
         <voice>
           <Chord>
+            <eid>X_X</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>Y_Y</eid>
               <Spanner type="Tie">
                 <prev>
                   <location>
@@ -180,16 +200,18 @@
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>Z_Z</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Rest>
+            <eid>a_a</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
+            <eid>b_b</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/meter_dots_example2-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/meter_dots_example2-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,74 +85,91 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Chord>
+            <eid>F_F</eid>
             <dots>1</dots>
             <durationType>quarter</durationType>
             <Note>
+              <eid>G_G</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>H_H</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Chord>
+            <eid>I_I</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>J_J</eid>
               <pitch>69</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>K_K</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Rest>
+            <eid>L_L</eid>
             <durationType>quarter</durationType>
             </Rest>
           </voice>
         </Measure>
       <Measure>
+        <eid>M_M</eid>
         <voice>
           <Chord>
+            <eid>N_N</eid>
             <dots>1</dots>
             <durationType>quarter</durationType>
             <Note>
+              <eid>O_O</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>P_P</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Rest>
+            <eid>Q_Q</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>
         </Measure>
       <Measure>
+        <eid>R_R</eid>
         <voice>
           <Rest>
+            <eid>S_S</eid>
             <durationType>half</durationType>
             </Rest>
           <Rest>
+            <eid>T_T</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Chord>
+            <eid>U_U</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>V_V</eid>
               <Spanner type="Tie">
                 <Tie>
+                  <eid>W_W</eid>
                   </Tie>
                 <next>
                   <location>
@@ -162,16 +181,18 @@
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         </Measure>
       <Measure>
+        <eid>X_X</eid>
         <voice>
           <Chord>
+            <eid>Y_Y</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>Z_Z</eid>
               <Spanner type="Tie">
                 <prev>
                   <location>
@@ -183,16 +204,18 @@
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>a_a</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Rest>
+            <eid>b_b</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
+            <eid>c_c</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/meter_dots_example3-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/meter_dots_example3-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,62 +85,77 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Chord>
+            <eid>F_F</eid>
             <dots>1</dots>
             <durationType>quarter</durationType>
             <Note>
+              <eid>G_G</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>H_H</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Rest>
+            <eid>I_I</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>
         </Measure>
       <Measure>
+        <eid>J_J</eid>
         <voice>
           <Chord>
+            <eid>K_K</eid>
             <dots>1</dots>
             <durationType>quarter</durationType>
             <Note>
+              <eid>L_L</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>M_M</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Rest>
+            <eid>N_N</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>
         </Measure>
       <Measure>
+        <eid>O_O</eid>
         <voice>
           <Rest>
+            <eid>P_P</eid>
             <durationType>half</durationType>
             </Rest>
           <Rest>
+            <eid>Q_Q</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Chord>
+            <eid>R_R</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>S_S</eid>
               <Spanner type="Tie">
                 <Tie>
+                  <eid>T_T</eid>
                   </Tie>
                 <next>
                   <location>
@@ -150,16 +167,18 @@
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         </Measure>
       <Measure>
+        <eid>U_U</eid>
         <voice>
           <Chord>
+            <eid>V_V</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>W_W</eid>
               <Spanner type="Tie">
                 <prev>
                   <location>
@@ -171,16 +190,18 @@
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>X_X</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Rest>
+            <eid>Y_Y</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
+            <eid>Z_Z</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/meter_first_2_8th_rests_compound-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/meter_first_2_8th_rests_compound-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,48 +85,60 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>6</sigN>
             <sigD>8</sigD>
             </TimeSig>
           <Rest>
+            <eid>F_F</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Chord>
+            <eid>G_G</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>H_H</eid>
               <pitch>69</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
+          <Beam>
+            <eid>I_I</eid>
+            <l1>-6</l1>
+            <l2>-10</l2>
+            </Beam>
           <Chord>
+            <eid>J_J</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>K_K</eid>
               <pitch>69</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>L_L</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>M_M</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>N_N</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>O_O</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/meter_half_rest_3-4-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/meter_half_rest_3-4-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,43 +85,52 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>3</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Rest>
+            <eid>F_F</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
+            <eid>G_G</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Chord>
+            <eid>H_H</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>I_I</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         </Measure>
       <Measure>
+        <eid>J_J</eid>
         <voice>
           <Chord>
+            <eid>K_K</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>L_L</eid>
               <pitch>69</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>M_M</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
+            <eid>N_N</eid>
             <durationType>quarter</durationType>
             </Rest>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/meter_last_quarter_rest_compound-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/meter_last_quarter_rest_compound-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,51 +85,64 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>6</sigN>
             <sigD>8</sigD>
             </TimeSig>
+          <Beam>
+            <eid>F_F</eid>
+            <l1>-2</l1>
+            <l2>-2</l2>
+            </Beam>
           <Chord>
+            <eid>G_G</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>H_H</eid>
               <pitch>69</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>I_I</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>J_J</eid>
               <pitch>69</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>K_K</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>L_L</eid>
               <pitch>69</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>M_M</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>N_N</eid>
               <pitch>69</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>O_O</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Rest>
+            <eid>P_P</eid>
             <durationType>eighth</durationType>
             </Rest>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/meter_rests-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/meter_rests-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,177 +85,220 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Rest>
+            <eid>F_F</eid>
             <durationType>half</durationType>
             </Rest>
           <Rest>
+            <eid>G_G</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
+            <eid>H_H</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Chord>
+            <eid>I_I</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>J_J</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         </Measure>
       <Measure>
+        <eid>K_K</eid>
         <voice>
           <Rest>
+            <eid>L_L</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
+        <eid>M_M</eid>
         <voice>
           <Rest>
+            <eid>N_N</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
+        <eid>O_O</eid>
         <voice>
           <Rest>
+            <eid>P_P</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
+        <eid>Q_Q</eid>
         <voice>
           <Rest>
+            <eid>R_R</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
+        <eid>S_S</eid>
         <voice>
           <Rest>
+            <eid>T_T</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
+        <eid>U_U</eid>
         <voice>
           <Rest>
+            <eid>V_V</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
+        <eid>W_W</eid>
         <voice>
           <Rest>
+            <eid>X_X</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
+        <eid>Y_Y</eid>
         <voice>
           <Rest>
+            <eid>Z_Z</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
+        <eid>a_a</eid>
         <voice>
           <Rest>
+            <eid>b_b</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
+        <eid>c_c</eid>
         <voice>
           <Rest>
+            <eid>d_d</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
+        <eid>e_e</eid>
         <voice>
           <Rest>
+            <eid>f_f</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
+        <eid>g_g</eid>
         <voice>
           <Rest>
+            <eid>h_h</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
+        <eid>i_i</eid>
         <voice>
           <Rest>
+            <eid>j_j</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
+        <eid>k_k</eid>
         <voice>
           <Rest>
+            <eid>l_l</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
+        <eid>m_m</eid>
         <voice>
           <Rest>
+            <eid>n_n</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
+        <eid>o_o</eid>
         <voice>
           <Rest>
+            <eid>p_p</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
+        <eid>q_q</eid>
         <voice>
           <Chord>
+            <eid>r_r</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>s_s</eid>
               <pitch>81</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>t_t</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Rest>
+            <eid>u_u</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
+            <eid>v_v</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/meter_two_beats_over-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/meter_two_beats_over-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,25 +85,36 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>3</sigN>
             <sigD>4</sigD>
             </TimeSig>
+          <Beam>
+            <eid>F_F</eid>
+            <l1>-4</l1>
+            <l2>-6</l2>
+            </Beam>
           <Chord>
+            <eid>G_G</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>H_H</eid>
               <pitch>69</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>I_I</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>J_J</eid>
               <Spanner type="Tie">
                 <Tie>
+                  <eid>K_K</eid>
                   </Tie>
                 <next>
                   <location>
@@ -112,13 +125,14 @@
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>L_L</eid>
             <dots>1</dots>
             <durationType>quarter</durationType>
             <Note>
+              <eid>M_M</eid>
               <Spanner type="Tie">
                 <prev>
                   <location>
@@ -129,16 +143,16 @@
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>N_N</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>O_O</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/min_duration-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/min_duration-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,73 +85,92 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>3</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Rest>
+            <eid>F_F</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
+            <eid>G_G</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
+            <eid>H_H</eid>
             <durationType>16th</durationType>
             </Rest>
           <Rest>
+            <eid>I_I</eid>
             <durationType>32nd</durationType>
             </Rest>
           <Rest>
+            <eid>J_J</eid>
             <durationType>64th</durationType>
             </Rest>
           <Chord>
+            <eid>K_K</eid>
             <durationType>128th</durationType>
             <Note>
+              <eid>L_L</eid>
               <pitch>81</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>M_M</eid>
             <durationType>128th</durationType>
             </Rest>
           <Rest>
+            <eid>N_N</eid>
             <durationType>eighth</durationType>
             </Rest>
           </voice>
         </Measure>
       <Measure>
+        <eid>O_O</eid>
         <voice>
           <Rest>
+            <eid>P_P</eid>
             <durationType>16th</durationType>
             </Rest>
           <Chord>
+            <eid>Q_Q</eid>
             <durationType>128th</durationType>
             <Note>
+              <eid>R_R</eid>
               <pitch>84</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>S_S</eid>
             <durationType>128th</durationType>
             </Rest>
           <Rest>
+            <eid>T_T</eid>
             <durationType>64th</durationType>
             </Rest>
           <Rest>
+            <eid>U_U</eid>
             <durationType>32nd</durationType>
             </Rest>
           <Rest>
+            <eid>V_V</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Rest>
+            <eid>W_W</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
+            <eid>X_X</eid>
             <durationType>quarter</durationType>
             </Rest>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/pickup-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/pickup-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,79 +85,94 @@
       </Part>
     <Staff id="1">
       <Measure len="1/4">
+        <eid>D_D</eid>
         <irregular>1</irregular>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Chord>
+            <eid>F_F</eid>
             <dots>1</dots>
             <durationType>eighth</durationType>
             <Note>
+              <eid>G_G</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>H_H</eid>
             <durationType>16th</durationType>
             </Rest>
           </voice>
         </Measure>
       <Measure>
+        <eid>I_I</eid>
         <voice>
           <Chord>
+            <eid>J_J</eid>
             <dots>1</dots>
             <durationType>eighth</durationType>
             <Note>
+              <eid>K_K</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>L_L</eid>
             <durationType>16th</durationType>
             </Rest>
           <Chord>
+            <eid>M_M</eid>
             <dots>1</dots>
             <durationType>eighth</durationType>
             <Note>
+              <eid>N_N</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>O_O</eid>
             <durationType>16th</durationType>
             </Rest>
           <Rest>
+            <eid>P_P</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>
         </Measure>
       <Measure>
+        <eid>Q_Q</eid>
         <voice>
           <Chord>
+            <eid>R_R</eid>
             <dots>1</dots>
             <durationType>eighth</durationType>
             <Note>
+              <eid>S_S</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>T_T</eid>
             <durationType>16th</durationType>
             </Rest>
           <Rest>
+            <eid>U_U</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
+            <eid>V_V</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/pickup_long-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/pickup_long-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,17 +20,18 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
         </Staff>
-      <trackName>Horn in F</trackName>
+      <trackName>Horn</trackName>
       <Instrument id="horn">
-        <longName>Horn in F</longName>
-        <shortName>F Hn.</shortName>
-        <trackName>Horn in F</trackName>
+        <longName>Horn</longName>
+        <shortName>Hn.</shortName>
+        <trackName>Horn</trackName>
         <minPitchP>31</minPitchP>
         <maxPitchP>77</maxPitchP>
         <minPitchA>41</minPitchA>
@@ -87,96 +89,111 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <KeySig>
-            <accidental>-1</accidental>
+            <eid>E_E</eid>
+            <concertKey>-1</concertKey>
+            <actualKey>0</actualKey>
             </KeySig>
           <TimeSig>
+            <eid>F_F</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Rest>
+            <eid>G_G</eid>
             <durationType>half</durationType>
             </Rest>
           <Rest>
+            <eid>H_H</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Chord>
+            <eid>I_I</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>J_J</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>18</tpc2>
               <velocity>100</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         </Measure>
       <Measure>
+        <eid>K_K</eid>
         <voice>
           <Chord>
+            <eid>L_L</eid>
             <durationType>half</durationType>
             <Note>
+              <eid>M_M</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <tpc2>17</tpc2>
               <velocity>100</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>N_N</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>O_O</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <tpc2>15</tpc2>
               <velocity>100</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>P_P</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>Q_Q</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <tpc2>17</tpc2>
               <velocity>100</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         </Measure>
       <Measure>
+        <eid>R_R</eid>
         <voice>
           <Chord>
+            <eid>S_S</eid>
             <durationType>half</durationType>
             <Note>
+              <eid>T_T</eid>
               <pitch>58</pitch>
               <tpc>12</tpc>
               <tpc2>13</tpc2>
               <velocity>100</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>U_U</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>V_V</eid>
               <pitch>53</pitch>
               <tpc>13</tpc>
               <tpc2>14</tpc2>
               <velocity>100</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>W_W</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>X_X</eid>
               <pitch>58</pitch>
               <tpc>12</tpc>
               <tpc2>13</tpc2>
               <velocity>100</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/quant_dotted_4th-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/quant_dotted_4th-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,25 +85,30 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Chord>
+            <eid>F_F</eid>
             <dots>1</dots>
             <durationType>quarter</durationType>
             <Note>
+              <eid>G_G</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>H_H</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Rest>
+            <eid>I_I</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/simplify_16th_staccato-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/simplify_16th_staccato-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,40 +85,48 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Rest>
+            <eid>F_F</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
+            <eid>G_G</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Chord>
+            <eid>H_H</eid>
             <durationType>eighth</durationType>
             <Articulation>
               <subtype>articStaccatoAbove</subtype>
+              <eid>I_I</eid>
               </Articulation>
             <Note>
+              <eid>J_J</eid>
               <pitch>77</pitch>
               <tpc>13</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>K_K</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Chord>
+            <eid>L_L</eid>
             <dots>1</dots>
             <durationType>quarter</durationType>
             <Note>
+              <eid>M_M</eid>
               <pitch>77</pitch>
               <tpc>13</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/simplify_32nd_staccato-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/simplify_32nd_staccato-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,63 +85,80 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
+          <Beam>
+            <eid>F_F</eid>
+            <l1>8</l1>
+            <l2>8</l2>
+            </Beam>
           <Chord>
+            <eid>G_G</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>H_H</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>90</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>I_I</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>J_J</eid>
               </Articulation>
             <Note>
+              <eid>K_K</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>83</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>L_L</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
+            <eid>M_M</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Chord>
+            <eid>N_N</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>O_O</eid>
               </Articulation>
             <Note>
+              <eid>P_P</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>103</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>Q_Q</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Chord>
+            <eid>R_R</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>S_S</eid>
               </Articulation>
             <Note>
+              <eid>T_T</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>83</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/simplify_8th_dont-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/simplify_8th_dont-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,22 +85,29 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Rest>
+            <eid>F_F</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
+            <eid>G_G</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Chord>
+            <eid>H_H</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>I_I</eid>
               <Spanner type="Tie">
                 <Tie>
+                  <eid>J_J</eid>
                   </Tie>
                 <next>
                   <location>
@@ -109,14 +118,16 @@
               <pitch>60</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>K_K</eid>
             <durationType>half</durationType>
             <Note>
+              <eid>L_L</eid>
               <Spanner type="Tie">
                 <Tie>
+                  <eid>M_M</eid>
                   </Tie>
                 <next>
                   <location>
@@ -135,16 +146,18 @@
               <pitch>60</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         </Measure>
       <Measure>
+        <eid>N_N</eid>
         <voice>
           <Chord>
+            <eid>O_O</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>P_P</eid>
               <Spanner type="Tie">
                 <prev>
                   <location>
@@ -156,16 +169,18 @@
               <pitch>60</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>Q_Q</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Rest>
+            <eid>R_R</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
+            <eid>S_S</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/simplify_8th_dotted_no_staccato-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/simplify_8th_dotted_no_staccato-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,39 +85,45 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Rest>
+            <eid>F_F</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Chord>
+            <eid>G_G</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>H_H</eid>
               <pitch>65</pitch>
               <tpc>13</tpc>
               <velocity>56</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>I_I</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>J_J</eid>
               <pitch>65</pitch>
               <tpc>13</tpc>
               <velocity>66</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>K_K</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>L_L</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>73</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/simplify_dotted_3-4-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/simplify_dotted_3-4-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,19 +85,22 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>3</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Chord>
+            <eid>F_F</eid>
             <dots>1</dots>
             <durationType>half</durationType>
             <Note>
+              <eid>G_G</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/simplify_staccato_9-8-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/simplify_staccato_9-8-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,29 +85,35 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>9</sigN>
             <sigD>8</sigD>
             </TimeSig>
           <Chord>
+            <eid>F_F</eid>
             <dots>1</dots>
             <durationType>quarter</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>G_G</eid>
               </Articulation>
             <Note>
+              <eid>H_H</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>I_I</eid>
             <dots>1</dots>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
+            <eid>J_J</eid>
             <dots>1</dots>
             <durationType>quarter</durationType>
             </Rest>

--- a/src/importexport/midi/tests/midiimport_data/split_2_melodies-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/split_2_melodies-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,15 +20,17 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
         <bracket type="1" span="2" col="0" visible="1"/>
         <barLineSpan>1</barLineSpan>
         </Staff>
-      <Staff id="2">
+      <Staff>
+        <eid>D_D</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -90,81 +93,101 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>E_E</eid>
         <voice>
           <TimeSig>
+            <eid>F_F</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
+          <Beam>
+            <eid>G_G</eid>
+            <l1>44</l1>
+            <l2>38</l2>
+            </Beam>
           <Chord>
+            <eid>H_H</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>I_I</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>J_J</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>K_K</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>L_L</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>M_M</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>N_N</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>O_O</eid>
               <pitch>76</pitch>
               <tpc>18</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
+          <Beam>
+            <eid>P_P</eid>
+            <l1>38</l1>
+            <l2>38</l2>
+            </Beam>
           <Chord>
+            <eid>Q_Q</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>R_R</eid>
               <pitch>74</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>S_S</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>T_T</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>U_U</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>V_V</eid>
               <pitch>77</pitch>
               <tpc>13</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>W_W</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>X_X</eid>
               <pitch>74</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
@@ -174,79 +197,98 @@
       <Measure>
         <voice>
           <TimeSig>
+            <eid>Y_Y</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
+          <Beam>
+            <eid>Z_Z</eid>
+            <l1>2</l1>
+            <l2>2</l2>
+            </Beam>
           <Chord>
+            <eid>a_a</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>b_b</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>c_c</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>d_d</eid>
               <pitch>65</pitch>
               <tpc>13</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>e_e</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>f_f</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>g_g</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>h_h</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
+          <Beam>
+            <eid>i_i</eid>
+            <l1>-10</l1>
+            <l2>-10</l2>
+            </Beam>
           <Chord>
+            <eid>j_j</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>k_k</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>l_l</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>m_m</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>n_n</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>o_o</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>p_p</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>q_q</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/split_nontuplet-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/split_nontuplet-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,15 +20,17 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
         <bracket type="1" span="2" col="0" visible="1"/>
         <barLineSpan>1</barLineSpan>
         </Staff>
-      <Staff id="2">
+      <Staff>
+        <eid>D_D</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -90,61 +93,80 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>E_E</eid>
         <voice>
           <TimeSig>
+            <eid>F_F</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Tuplet>
+            <eid>G_G</eid>
             <normalNotes>2</normalNotes>
             <actualNotes>3</actualNotes>
             <baseNote>eighth</baseNote>
+            <Number>
+              <style>tuplet</style>
+              <text>3</text>
+              </Number>
             </Tuplet>
+          <Beam>
+            <eid>H_H</eid>
+            <l1>-10</l1>
+            <l2>-6</l2>
+            </Beam>
           <Chord>
+            <eid>I_I</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>J_J</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>K_K</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>L_L</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>M_M</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>N_N</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <endTuplet/>
           <Rest>
+            <eid>O_O</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Chord>
+            <eid>P_P</eid>
             <dots>1</dots>
             <durationType>eighth</durationType>
             <Note>
+              <eid>Q_Q</eid>
               <pitch>77</pitch>
               <tpc>13</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>R_R</eid>
             <durationType>16th</durationType>
             </Rest>
           <Rest>
+            <eid>S_S</eid>
             <durationType>quarter</durationType>
             </Rest>
           </voice>
@@ -154,28 +176,32 @@
       <Measure>
         <voice>
           <TimeSig>
+            <eid>T_T</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Rest>
+            <eid>U_U</eid>
             <durationType>half</durationType>
             </Rest>
           <Chord>
+            <eid>V_V</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>W_W</eid>
               <pitch>69</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>X_X</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>Y_Y</eid>
             <durationType>quarter</durationType>
             </Rest>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/split_octave-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/split_octave-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,15 +20,17 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
         <bracket type="1" span="2" col="0" visible="1"/>
         <barLineSpan>1</barLineSpan>
         </Staff>
-      <Staff id="2">
+      <Staff>
+        <eid>D_D</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -90,81 +93,101 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>E_E</eid>
         <voice>
           <TimeSig>
+            <eid>F_F</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
+          <Beam>
+            <eid>G_G</eid>
+            <l1>32</l1>
+            <l2>32</l2>
+            </Beam>
           <Chord>
+            <eid>H_H</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>I_I</eid>
               <pitch>77</pitch>
               <tpc>13</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>J_J</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>K_K</eid>
               <pitch>76</pitch>
               <tpc>18</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>L_L</eid>
               <pitch>79</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>M_M</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>N_N</eid>
               <pitch>74</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>O_O</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>P_P</eid>
               <pitch>83</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
+          <Beam>
+            <eid>Q_Q</eid>
+            <l1>24</l1>
+            <l2>34</l2>
+            </Beam>
           <Chord>
+            <eid>R_R</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>S_S</eid>
               <pitch>81</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>T_T</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>U_U</eid>
               <pitch>84</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>V_V</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>W_W</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>X_X</eid>
             <durationType>eighth</durationType>
             </Rest>
           </voice>
@@ -174,70 +197,83 @@
       <Measure>
         <voice>
           <TimeSig>
+            <eid>Y_Y</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
+          <Beam>
+            <eid>Z_Z</eid>
+            <l1>2</l1>
+            <l2>-2</l2>
+            </Beam>
           <Chord>
+            <eid>a_a</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>b_b</eid>
               <pitch>52</pitch>
               <tpc>18</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>c_c</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>d_d</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>e_e</eid>
               <pitch>55</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>f_f</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>g_g</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>h_h</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>i_i</eid>
               <pitch>69</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>j_j</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Rest>
+            <eid>k_k</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Chord>
+            <eid>l_l</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>m_m</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>n_n</eid>
             <durationType>eighth</durationType>
             </Rest>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/split_tuplet-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/split_tuplet-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,15 +20,17 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
         <bracket type="1" span="2" col="0" visible="1"/>
         <barLineSpan>1</barLineSpan>
         </Staff>
-      <Staff id="2">
+      <Staff>
+        <eid>D_D</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -90,48 +93,65 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>E_E</eid>
         <voice>
           <TimeSig>
+            <eid>F_F</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Tuplet>
+            <eid>G_G</eid>
             <normalNotes>2</normalNotes>
             <actualNotes>3</actualNotes>
             <baseNote>eighth</baseNote>
+            <Number>
+              <style>tuplet</style>
+              <text>3</text>
+              </Number>
             </Tuplet>
+          <Beam>
+            <eid>H_H</eid>
+            <l1>-10</l1>
+            <l2>-4</l2>
+            </Beam>
           <Chord>
+            <eid>I_I</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>J_J</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>K_K</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>L_L</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>M_M</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>N_N</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <endTuplet/>
           <Rest>
+            <eid>O_O</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
+            <eid>P_P</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>
@@ -141,34 +161,40 @@
       <Measure>
         <voice>
           <TimeSig>
+            <eid>Q_Q</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Chord>
+            <eid>R_R</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>S_S</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>T_T</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>U_U</eid>
             <durationType>16th</durationType>
             </Rest>
           <Rest>
+            <eid>V_V</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Rest>
+            <eid>W_W</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
+            <eid>X_X</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/swing_shuffle-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/swing_shuffle-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,84 +85,105 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <StaffText>
+            <eid>F_F</eid>
             <text>Shuffle</text>
             </StaffText>
+          <Beam>
+            <eid>G_G</eid>
+            <l1>-4</l1>
+            <l2>-10</l2>
+            </Beam>
           <Chord>
+            <eid>H_H</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>I_I</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>J_J</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>K_K</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>L_L</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>M_M</eid>
               <pitch>69</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>N_N</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>O_O</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
+          <Beam>
+            <eid>P_P</eid>
+            <l1>-12</l1>
+            <l2>-6</l2>
+            </Beam>
           <Chord>
+            <eid>Q_Q</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>R_R</eid>
               <pitch>74</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>S_S</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>T_T</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>U_U</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>V_V</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>W_W</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>X_X</eid>
               <pitch>65</pitch>
               <tpc>13</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/swing_triplets-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/swing_triplets-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,84 +85,105 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <StaffText>
+            <eid>F_F</eid>
             <text>Swing</text>
             </StaffText>
+          <Beam>
+            <eid>G_G</eid>
+            <l1>-4</l1>
+            <l2>-10</l2>
+            </Beam>
           <Chord>
+            <eid>H_H</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>I_I</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>J_J</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>K_K</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>L_L</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>M_M</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>N_N</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>O_O</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
+          <Beam>
+            <eid>P_P</eid>
+            <l1>32</l1>
+            <l2>32</l2>
+            </Beam>
           <Chord>
+            <eid>Q_Q</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>R_R</eid>
               <pitch>79</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>S_S</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>T_T</eid>
               <pitch>74</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>U_U</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>V_V</eid>
               <pitch>76</pitch>
               <tpc>18</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>W_W</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>X_X</eid>
               <pitch>74</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/timesig_changes-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/timesig_changes-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,22 +85,29 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Rest>
+            <eid>F_F</eid>
             <durationType>half</durationType>
             </Rest>
           <Rest>
+            <eid>G_G</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Chord>
+            <eid>H_H</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>I_I</eid>
               <Spanner type="Tie">
                 <Tie>
+                  <eid>J_J</eid>
                   </Tie>
                 <next>
                   <location>
@@ -110,18 +119,21 @@
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>100</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         </Measure>
       <Measure>
+        <eid>K_K</eid>
         <voice>
           <Chord>
+            <eid>L_L</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>M_M</eid>
               <Spanner type="Tie">
                 <Tie>
+                  <eid>N_N</eid>
                   </Tie>
                 <next>
                   <location>
@@ -140,12 +152,13 @@
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>100</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>O_O</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>P_P</eid>
               <Spanner type="Tie">
                 <prev>
                   <location>
@@ -156,35 +169,43 @@
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>100</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>Q_Q</eid>
             <durationType>16th</durationType>
             </Rest>
           <Rest>
+            <eid>R_R</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Rest>
+            <eid>S_S</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>
         </Measure>
       <Measure>
+        <eid>T_T</eid>
         <voice>
           <KeySig>
-            <accidental>1</accidental>
+            <eid>U_U</eid>
+            <concertKey>1</concertKey>
             </KeySig>
           <TimeSig>
+            <eid>V_V</eid>
             <sigN>3</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Chord>
+            <eid>W_W</eid>
             <dots>1</dots>
             <durationType>half</durationType>
             <Note>
+              <eid>X_X</eid>
               <Spanner type="Tie">
                 <Tie>
+                  <eid>Y_Y</eid>
                   </Tie>
                 <next>
                   <location>
@@ -195,18 +216,21 @@
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>100</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         </Measure>
       <Measure>
+        <eid>Z_Z</eid>
         <voice>
           <Chord>
+            <eid>a_a</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>b_b</eid>
               <Spanner type="Tie">
                 <Tie>
+                  <eid>c_c</eid>
                   </Tie>
                 <next>
                   <location>
@@ -224,12 +248,13 @@
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>100</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>d_d</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>e_e</eid>
               <Spanner type="Tie">
                 <prev>
                   <location>
@@ -240,16 +265,18 @@
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>100</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>f_f</eid>
             <durationType>16th</durationType>
             </Rest>
           <Rest>
+            <eid>g_g</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Rest>
+            <eid>h_h</eid>
             <durationType>quarter</durationType>
             </Rest>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/tuplet_2_voices_3_5_tuplets-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/tuplet_2_voices_3_5_tuplets-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,128 +85,163 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Tuplet>
+            <eid>F_F</eid>
             <normalNotes>2</normalNotes>
             <actualNotes>3</actualNotes>
             <baseNote>eighth</baseNote>
+            <Number>
+              <style>tuplet</style>
+              <text>3</text>
+              </Number>
             </Tuplet>
+          <Beam>
+            <eid>G_G</eid>
+            <l1>-4</l1>
+            <l2>-10</l2>
+            </Beam>
           <Chord>
+            <eid>H_H</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>I_I</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>J_J</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>K_K</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>L_L</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>M_M</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <endTuplet/>
           <Rest>
+            <eid>N_N</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
+            <eid>O_O</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>
         <voice>
           <Tuplet>
+            <eid>P_P</eid>
             <normalNotes>4</normalNotes>
             <actualNotes>5</actualNotes>
             <baseNote>16th</baseNote>
+            <Number>
+              <style>tuplet</style>
+              <text>5</text>
+              </Number>
             </Tuplet>
+          <Beam>
+            <eid>Q_Q</eid>
+            <l1>62</l1>
+            <l2>68</l2>
+            </Beam>
           <Chord>
+            <eid>R_R</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>S_S</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>T_T</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>U_U</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>V_V</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>W_W</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>X_X</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>Y_Y</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>Z_Z</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>a_a</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <endTuplet/>
           <Chord>
+            <eid>b_b</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>c_c</eid>
               <pitch>65</pitch>
               <tpc>13</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>d_d</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>e_e</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>f_f</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>g_g</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/tuplet_2_voices_tuplet_non-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/tuplet_2_voices_tuplet_non-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,95 +85,122 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Tuplet>
+            <eid>F_F</eid>
             <normalNotes>2</normalNotes>
             <actualNotes>3</actualNotes>
             <baseNote>eighth</baseNote>
+            <Number>
+              <style>tuplet</style>
+              <text>3</text>
+              </Number>
             </Tuplet>
+          <Beam>
+            <eid>G_G</eid>
+            <l1>-6</l1>
+            <l2>-10</l2>
+            </Beam>
           <Chord>
+            <eid>H_H</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>I_I</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>J_J</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>K_K</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>L_L</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>M_M</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <endTuplet/>
           <Chord>
+            <eid>N_N</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>O_O</eid>
               <pitch>65</pitch>
               <tpc>13</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>P_P</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>Q_Q</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>R_R</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>S_S</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         <voice>
+          <Beam>
+            <eid>T_T</eid>
+            <l1>66</l1>
+            <l2>68</l2>
+            </Beam>
           <Chord>
+            <eid>U_U</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>V_V</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>W_W</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>X_X</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>Y_Y</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
+            <eid>Z_Z</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/tuplet_3_5_7_tuplets-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/tuplet_3_5_7_tuplets-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,205 +85,259 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Tuplet>
+            <eid>F_F</eid>
             <normalNotes>2</normalNotes>
             <actualNotes>3</actualNotes>
             <baseNote>eighth</baseNote>
+            <Number>
+              <style>tuplet</style>
+              <text>3</text>
+              </Number>
             </Tuplet>
+          <Beam>
+            <eid>G_G</eid>
+            <l1>-28</l1>
+            <l2>-28</l2>
+            </Beam>
           <Chord>
+            <eid>H_H</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>I_I</eid>
               <pitch>77</pitch>
               <tpc>13</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>J_J</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>K_K</eid>
               <pitch>81</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>L_L</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>M_M</eid>
               <pitch>79</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <endTuplet/>
           <Rest>
+            <eid>N_N</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
+            <eid>O_O</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>
         <voice>
           <Tuplet>
+            <eid>P_P</eid>
             <normalNotes>4</normalNotes>
             <actualNotes>5</actualNotes>
             <baseNote>16th</baseNote>
+            <Number>
+              <style>tuplet</style>
+              <text>5</text>
+              </Number>
             </Tuplet>
+          <Beam>
+            <eid>Q_Q</eid>
+            <l1>38</l1>
+            <l2>38</l2>
+            </Beam>
           <Chord>
+            <eid>R_R</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>S_S</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>T_T</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>U_U</eid>
               <pitch>74</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>V_V</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>W_W</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>X_X</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>Y_Y</eid>
               <pitch>74</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>Z_Z</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>a_a</eid>
               <pitch>76</pitch>
               <tpc>18</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <endTuplet/>
           <Chord>
+            <eid>b_b</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>c_c</eid>
               <pitch>65</pitch>
               <tpc>13</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>d_d</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>e_e</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>f_f</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>g_g</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         <voice>
           <Tuplet>
+            <eid>h_h</eid>
             <normalNotes>8</normalNotes>
             <actualNotes>7</actualNotes>
             <baseNote>32nd</baseNote>
+            <Number>
+              <style>tuplet</style>
+              <text>7</text>
+              </Number>
             </Tuplet>
+          <Beam>
+            <eid>i_i</eid>
+            <l1>10</l1>
+            <l2>9</l2>
+            </Beam>
           <Chord>
+            <eid>j_j</eid>
             <durationType>32nd</durationType>
             <Note>
+              <eid>k_k</eid>
               <pitch>52</pitch>
               <tpc>18</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>l_l</eid>
             <durationType>32nd</durationType>
             <Note>
+              <eid>m_m</eid>
               <pitch>47</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>n_n</eid>
             <durationType>32nd</durationType>
             <Note>
+              <eid>o_o</eid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>p_p</eid>
             <durationType>32nd</durationType>
             <Note>
+              <eid>q_q</eid>
               <pitch>47</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>r_r</eid>
             <durationType>32nd</durationType>
             <Note>
+              <eid>s_s</eid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>t_t</eid>
             <durationType>32nd</durationType>
             <Note>
+              <eid>u_u</eid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>v_v</eid>
             <durationType>32nd</durationType>
             <Note>
+              <eid>w_w</eid>
               <pitch>53</pitch>
               <tpc>13</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <endTuplet/>
           <Rest>
+            <eid>x_x</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
+            <eid>y_y</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/tuplet_5_5_tuplets_rests-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/tuplet_5_5_tuplets_rests-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,15 +20,17 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
         <bracket type="1" span="2" col="0" visible="1"/>
         <barLineSpan>1</barLineSpan>
         </Staff>
-      <Staff id="2">
+      <Staff>
+        <eid>D_D</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -91,72 +94,91 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>E_E</eid>
         <voice>
           <TimeSig>
+            <eid>F_F</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Tuplet>
+            <eid>G_G</eid>
             <normalNotes>4</normalNotes>
             <actualNotes>5</actualNotes>
             <baseNote>16th</baseNote>
+            <Number>
+              <style>tuplet</style>
+              <text>5</text>
+              </Number>
             </Tuplet>
           <Chord>
+            <eid>H_H</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>I_I</eid>
               <pitch>76</pitch>
               <tpc>18</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>J_J</eid>
             <durationType>16th</durationType>
             </Rest>
+          <Beam>
+            <eid>K_K</eid>
+            <l1>38</l1>
+            <l2>40</l2>
+            </Beam>
           <Chord>
+            <eid>L_L</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>M_M</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>N_N</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>O_O</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <endTuplet/>
           <Chord>
+            <eid>P_P</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>Q_Q</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>R_R</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>S_S</eid>
               <pitch>65</pitch>
               <tpc>13</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>T_T</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>U_U</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
@@ -166,70 +188,88 @@
       <Measure>
         <voice>
           <TimeSig>
+            <eid>V_V</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Tuplet>
+            <eid>W_W</eid>
             <normalNotes>4</normalNotes>
             <actualNotes>5</actualNotes>
             <baseNote>16th</baseNote>
+            <Number>
+              <style>tuplet</style>
+              <text>5</text>
+              </Number>
             </Tuplet>
+          <Beam>
+            <eid>X_X</eid>
+            <l1>-12</l1>
+            <l2>-12</l2>
+            </Beam>
           <Chord>
+            <eid>Y_Y</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>Z_Z</eid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>a_a</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>b_b</eid>
               <pitch>52</pitch>
               <tpc>18</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>c_c</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>d_d</eid>
               <pitch>48</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>e_e</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>f_f</eid>
               <pitch>47</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>g_g</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>h_h</eid>
               <pitch>47</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>i_i</eid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <endTuplet/>
           <Rest>
+            <eid>j_j</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
+            <eid>k_k</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/tuplet_7_staccato-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/tuplet_7_staccato-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -84,102 +86,129 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Tuplet>
+            <eid>F_F</eid>
             <normalNotes>8</normalNotes>
             <actualNotes>7</actualNotes>
             <baseNote>32nd</baseNote>
+            <Number>
+              <style>tuplet</style>
+              <text>7</text>
+              </Number>
             </Tuplet>
+          <Beam>
+            <eid>G_G</eid>
+            <l1>52</l1>
+            <l2>52</l2>
+            </Beam>
           <Chord>
+            <eid>H_H</eid>
             <durationType>32nd</durationType>
             <Articulation>
               <subtype>articStaccatoAbove</subtype>
+              <eid>I_I</eid>
               </Articulation>
             <Note>
+              <eid>J_J</eid>
               <pitch>52</pitch>
               <tpc>18</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>K_K</eid>
             <durationType>32nd</durationType>
             <Articulation>
               <subtype>articStaccatoAbove</subtype>
+              <eid>L_L</eid>
               </Articulation>
             <Note>
+              <eid>M_M</eid>
               <pitch>47</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>N_N</eid>
             <durationType>32nd</durationType>
             <Note>
+              <eid>O_O</eid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>P_P</eid>
             <durationType>32nd</durationType>
             <Articulation>
               <subtype>articStaccatoAbove</subtype>
+              <eid>Q_Q</eid>
               </Articulation>
             <Note>
+              <eid>R_R</eid>
               <pitch>47</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>S_S</eid>
             <durationType>32nd</durationType>
             <Articulation>
               <subtype>articStaccatoAbove</subtype>
+              <eid>T_T</eid>
               </Articulation>
             <Note>
+              <eid>U_U</eid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>V_V</eid>
             <durationType>32nd</durationType>
             <Articulation>
               <subtype>articStaccatoAbove</subtype>
+              <eid>W_W</eid>
               </Articulation>
             <Note>
+              <eid>X_X</eid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>Y_Y</eid>
             <durationType>32nd</durationType>
             <Articulation>
               <subtype>articStaccatoAbove</subtype>
+              <eid>Z_Z</eid>
               </Articulation>
             <Note>
+              <eid>a_a</eid>
               <pitch>53</pitch>
               <tpc>13</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <endTuplet/>
           <Rest>
+            <eid>b_b</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
+            <eid>c_c</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/tuplet_duplet-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/tuplet_duplet-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,75 +85,96 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>6</sigN>
             <sigD>8</sigD>
             </TimeSig>
+          <Beam>
+            <eid>F_F</eid>
+            <l1>42</l1>
+            <l2>38</l2>
+            </Beam>
           <Chord>
+            <eid>G_G</eid>
             <dots>1</dots>
             <durationType>eighth</durationType>
             <Note>
+              <eid>H_H</eid>
               <pitch>69</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>I_I</eid>
             <dots>1</dots>
             <durationType>eighth</durationType>
             <Note>
+              <eid>J_J</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
+          <Beam>
+            <eid>K_K</eid>
+            <l1>-4</l1>
+            <l2>-12</l2>
+            </Beam>
           <Chord>
+            <eid>L_L</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>M_M</eid>
               <pitch>65</pitch>
               <tpc>13</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>N_N</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>O_O</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>P_P</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>Q_Q</eid>
               <pitch>74</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         </Measure>
       <Measure>
+        <eid>R_R</eid>
         <voice>
           <Chord>
+            <eid>S_S</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>T_T</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>U_U</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Rest>
+            <eid>V_V</eid>
             <dots>1</dots>
             <durationType>quarter</durationType>
             </Rest>

--- a/src/importexport/midi/tests/midiimport_data/tuplet_mars-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/tuplet_mars-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,87 +85,112 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>5</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Tuplet>
+            <eid>F_F</eid>
             <normalNotes>2</normalNotes>
             <actualNotes>3</actualNotes>
             <baseNote>eighth</baseNote>
+            <Number>
+              <style>tuplet</style>
+              <text>3</text>
+              </Number>
             </Tuplet>
+          <Beam>
+            <eid>G_G</eid>
+            <l1>16</l1>
+            <l2>16</l2>
+            </Beam>
           <Chord>
+            <eid>H_H</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>I_I</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>J_J</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>K_K</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>L_L</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>M_M</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <endTuplet/>
           <Chord>
+            <eid>N_N</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>O_O</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>P_P</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>Q_Q</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
+          <Beam>
+            <eid>R_R</eid>
+            <l1>16</l1>
+            <l2>16</l2>
+            </Beam>
           <Chord>
+            <eid>S_S</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>T_T</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>U_U</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>V_V</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>W_W</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>X_X</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/tuplet_nonuplet_4-4-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/tuplet_nonuplet_4-4-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,130 +85,156 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Tuplet>
+            <eid>F_F</eid>
             <normalNotes>8</normalNotes>
             <actualNotes>9</actualNotes>
             <baseNote>32nd</baseNote>
+            <Number>
+              <style>tuplet</style>
+              <text>9</text>
+              </Number>
             </Tuplet>
+          <Beam>
+            <eid>G_G</eid>
+            <l1>46</l1>
+            <l2>46</l2>
+            </Beam>
           <Chord>
+            <eid>H_H</eid>
             <durationType>32nd</durationType>
             <Note>
+              <eid>I_I</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>J_J</eid>
             <durationType>32nd</durationType>
             <Note>
+              <eid>K_K</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>L_L</eid>
             <durationType>32nd</durationType>
             <Note>
+              <eid>M_M</eid>
               <pitch>74</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>N_N</eid>
             <durationType>32nd</durationType>
             <Note>
+              <eid>O_O</eid>
               <pitch>76</pitch>
               <tpc>18</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>P_P</eid>
             <durationType>32nd</durationType>
             <Note>
+              <eid>Q_Q</eid>
               <pitch>77</pitch>
               <tpc>13</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>R_R</eid>
             <durationType>32nd</durationType>
             <Note>
+              <eid>S_S</eid>
               <pitch>76</pitch>
               <tpc>18</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>T_T</eid>
             <durationType>32nd</durationType>
             <Note>
+              <eid>U_U</eid>
               <pitch>74</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>V_V</eid>
             <durationType>32nd</durationType>
             <Note>
+              <eid>W_W</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>X_X</eid>
             <durationType>32nd</durationType>
             <Note>
+              <eid>Y_Y</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <endTuplet/>
           <Chord>
+            <eid>Z_Z</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>a_a</eid>
               <pitch>65</pitch>
               <tpc>13</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>b_b</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>c_c</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>d_d</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>e_e</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         </Measure>
       <Measure>
+        <eid>f_f</eid>
         <voice>
           <Rest>
+            <eid>g_g</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>

--- a/src/importexport/midi/tests/midiimport_data/tuplet_off_time_other_bar-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/tuplet_off_time_other_bar-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,16 +85,21 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Chord>
+            <eid>F_F</eid>
             <durationType>whole</durationType>
             <Note>
+              <eid>G_G</eid>
               <Spanner type="Tie">
                 <Tie>
+                  <eid>H_H</eid>
                   </Tie>
                 <next>
                   <location>
@@ -103,21 +110,33 @@
               <pitch>69</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         </Measure>
       <Measure>
+        <eid>I_I</eid>
         <voice>
           <Tuplet>
+            <eid>J_J</eid>
             <normalNotes>2</normalNotes>
             <actualNotes>3</actualNotes>
             <baseNote>eighth</baseNote>
+            <Number>
+              <style>tuplet</style>
+              <text>3</text>
+              </Number>
             </Tuplet>
+          <Beam>
+            <eid>K_K</eid>
+            <l1>-12</l1>
+            <l2>-12</l2>
+            </Beam>
           <Chord>
+            <eid>L_L</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>M_M</eid>
               <Spanner type="Tie">
                 <prev>
                   <location>
@@ -128,32 +147,35 @@
               <pitch>69</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>N_N</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>O_O</eid>
               <pitch>74</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>P_P</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>Q_Q</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <endTuplet/>
           <Rest>
+            <eid>R_R</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
+            <eid>S_S</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/tuplet_quadruplet-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/tuplet_quadruplet-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,97 +85,125 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>6</sigN>
             <sigD>8</sigD>
             </TimeSig>
           <Tuplet>
+            <eid>F_F</eid>
             <normalNotes>3</normalNotes>
             <actualNotes>4</actualNotes>
             <baseNote>eighth</baseNote>
+            <Number>
+              <style>tuplet</style>
+              <text>4</text>
+              </Number>
             </Tuplet>
+          <Beam>
+            <eid>G_G</eid>
+            <l1>-10</l1>
+            <l2>-10</l2>
+            </Beam>
           <Chord>
+            <eid>H_H</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>I_I</eid>
               <pitch>65</pitch>
               <tpc>13</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>J_J</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>K_K</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>L_L</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>M_M</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>N_N</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>O_O</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <endTuplet/>
+          <Beam>
+            <eid>P_P</eid>
+            <l1>44</l1>
+            <l2>44</l2>
+            </Beam>
           <Chord>
+            <eid>Q_Q</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>R_R</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>S_S</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>T_T</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>U_U</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>V_V</eid>
               <pitch>74</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         </Measure>
       <Measure>
+        <eid>W_W</eid>
         <voice>
           <Chord>
+            <eid>X_X</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>Y_Y</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>Z_Z</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Rest>
+            <eid>a_a</eid>
             <dots>1</dots>
             <durationType>quarter</durationType>
             </Rest>

--- a/src/importexport/midi/tests/midiimport_data/tuplet_tied_3_5_tuplets-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/tuplet_tied_3_5_tuplets-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,39 +85,56 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Tuplet>
+            <eid>F_F</eid>
             <normalNotes>2</normalNotes>
             <actualNotes>3</actualNotes>
             <baseNote>eighth</baseNote>
+            <Number>
+              <style>tuplet</style>
+              <text>3</text>
+              </Number>
             </Tuplet>
+          <Beam>
+            <eid>G_G</eid>
+            <l1>-4</l1>
+            <l2>-10</l2>
+            </Beam>
           <Chord>
+            <eid>H_H</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>I_I</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>J_J</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>K_K</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>L_L</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>M_M</eid>
               <Spanner type="Tie">
                 <Tie>
+                  <eid>N_N</eid>
                   </Tie>
                 <next>
                   <location>
@@ -126,15 +145,17 @@
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <endTuplet/>
           <Chord>
+            <eid>O_O</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>P_P</eid>
               <Spanner type="Tie">
                 <Tie>
+                  <eid>Q_Q</eid>
                   </Tie>
                 <next>
                   <location>
@@ -152,17 +173,28 @@
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Tuplet>
+            <eid>R_R</eid>
             <normalNotes>4</normalNotes>
             <actualNotes>5</actualNotes>
             <baseNote>16th</baseNote>
+            <Number>
+              <style>tuplet</style>
+              <text>5</text>
+              </Number>
             </Tuplet>
+          <Beam>
+            <eid>S_S</eid>
+            <l1>-14</l1>
+            <l2>-12</l2>
+            </Beam>
           <Chord>
+            <eid>T_T</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>U_U</eid>
               <Spanner type="Tie">
                 <prev>
                   <location>
@@ -173,47 +205,51 @@
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>V_V</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>W_W</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>X_X</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>Y_Y</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>Z_Z</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>a_a</eid>
               <pitch>65</pitch>
               <tpc>13</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>b_b</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>c_c</eid>
               <pitch>69</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <endTuplet/>
           <Rest>
+            <eid>d_d</eid>
             <durationType>quarter</durationType>
             </Rest>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/tuplet_tied_3_5_tuplets2-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/tuplet_tied_3_5_tuplets2-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,39 +85,56 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Tuplet>
+            <eid>F_F</eid>
             <normalNotes>2</normalNotes>
             <actualNotes>3</actualNotes>
             <baseNote>eighth</baseNote>
+            <Number>
+              <style>tuplet</style>
+              <text>3</text>
+              </Number>
             </Tuplet>
+          <Beam>
+            <eid>G_G</eid>
+            <l1>-4</l1>
+            <l2>-10</l2>
+            </Beam>
           <Chord>
+            <eid>H_H</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>I_I</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>J_J</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>K_K</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>L_L</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>M_M</eid>
               <Spanner type="Tie">
                 <Tie>
+                  <eid>N_N</eid>
                   </Tie>
                 <next>
                   <location>
@@ -126,18 +145,29 @@
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <endTuplet/>
           <Tuplet>
+            <eid>O_O</eid>
             <normalNotes>4</normalNotes>
             <actualNotes>5</actualNotes>
             <baseNote>16th</baseNote>
+            <Number>
+              <style>tuplet</style>
+              <text>5</text>
+              </Number>
             </Tuplet>
+          <Beam>
+            <eid>P_P</eid>
+            <l1>-14</l1>
+            <l2>-12</l2>
+            </Beam>
           <Chord>
+            <eid>Q_Q</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>R_R</eid>
               <Spanner type="Tie">
                 <prev>
                   <location>
@@ -148,47 +178,51 @@
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>S_S</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>T_T</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>U_U</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>V_V</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>W_W</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>X_X</eid>
               <pitch>65</pitch>
               <tpc>13</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>Y_Y</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>Z_Z</eid>
               <pitch>69</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <endTuplet/>
           <Rest>
+            <eid>a_a</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/tuplet_triplet-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/tuplet_triplet-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,69 +85,87 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Tuplet>
+            <eid>F_F</eid>
             <normalNotes>2</normalNotes>
             <actualNotes>3</actualNotes>
             <baseNote>eighth</baseNote>
+            <Number>
+              <style>tuplet</style>
+              <text>3</text>
+              </Number>
             </Tuplet>
+          <Beam>
+            <eid>G_G</eid>
+            <l1>-6</l1>
+            <l2>-10</l2>
+            </Beam>
           <Chord>
+            <eid>H_H</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>I_I</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>J_J</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>K_K</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>L_L</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>M_M</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <endTuplet/>
           <Chord>
+            <eid>N_N</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>O_O</eid>
               <pitch>65</pitch>
               <tpc>13</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>P_P</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>Q_Q</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>R_R</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>S_S</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/tuplet_triplet_first_tied-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/tuplet_triplet_first_tied-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,19 +85,25 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Rest>
+            <eid>F_F</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Chord>
+            <eid>G_G</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>H_H</eid>
               <Spanner type="Tie">
                 <Tie>
+                  <eid>I_I</eid>
                   </Tie>
                 <next>
                   <location>
@@ -106,17 +114,28 @@
               <pitch>69</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Tuplet>
+            <eid>J_J</eid>
             <normalNotes>2</normalNotes>
             <actualNotes>3</actualNotes>
             <baseNote>eighth</baseNote>
+            <Number>
+              <style>tuplet</style>
+              <text>3</text>
+              </Number>
             </Tuplet>
+          <Beam>
+            <eid>K_K</eid>
+            <l1>42</l1>
+            <l2>40</l2>
+            </Beam>
           <Chord>
+            <eid>L_L</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>M_M</eid>
               <Spanner type="Tie">
                 <prev>
                   <location>
@@ -127,29 +146,31 @@
               <pitch>69</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>N_N</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>O_O</eid>
               <pitch>74</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>P_P</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>Q_Q</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <endTuplet/>
           <Rest>
+            <eid>R_R</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/tuplet_triplet_last_tied-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/tuplet_triplet_last_tied-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,39 +85,56 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Tuplet>
+            <eid>F_F</eid>
             <normalNotes>2</normalNotes>
             <actualNotes>3</actualNotes>
             <baseNote>eighth</baseNote>
+            <Number>
+              <style>tuplet</style>
+              <text>3</text>
+              </Number>
             </Tuplet>
+          <Beam>
+            <eid>G_G</eid>
+            <l1>-10</l1>
+            <l2>-10</l2>
+            </Beam>
           <Chord>
+            <eid>H_H</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>I_I</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>J_J</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>K_K</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>L_L</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>M_M</eid>
               <Spanner type="Tie">
                 <Tie>
+                  <eid>N_N</eid>
                   </Tie>
                 <next>
                   <location>
@@ -126,13 +145,14 @@
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <endTuplet/>
           <Chord>
+            <eid>O_O</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>P_P</eid>
               <Spanner type="Tie">
                 <prev>
                   <location>
@@ -143,10 +163,10 @@
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>Q_Q</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/voice_central-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/voice_central-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,50 +85,57 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Chord>
+            <eid>F_F</eid>
             <durationType>half</durationType>
             <Note>
+              <eid>G_G</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>H_H</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>
         <voice>
           <Chord>
+            <eid>I_I</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>J_J</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>K_K</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>L_L</eid>
               <pitch>77</pitch>
               <tpc>13</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>M_M</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
+            <eid>N_N</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/voice_intersect-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/voice_intersect-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,42 +85,48 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>3</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Rest>
+            <eid>F_F</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Chord>
+            <eid>G_G</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>H_H</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>I_I</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>J_J</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         <voice>
           <Chord>
+            <eid>K_K</eid>
             <dots>1</dots>
             <durationType>half</durationType>
             <Note>
+              <eid>L_L</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>

--- a/src/importexport/midi/tests/midiimport_tests.cpp
+++ b/src/importexport/midi/tests/midiimport_tests.cpp
@@ -154,7 +154,7 @@ protected:
 
     String midiFilePath(const String fileName)
     {
-        return MIDI_IMPORT_DATA_DIR + u"/" + fileName + u".mid";
+        return engraving::ScoreRW::rootPath() + u"/" + MIDI_IMPORT_DATA_DIR + u"/" + fileName + u".mid";
     }
 };
 
@@ -175,7 +175,7 @@ std::unique_ptr<engraving::MasterScore> MidiImportTests::importMidi(const String
         return mu::iex::midi::importMidi(score, path.toQString());
     };
 
-    return std::unique_ptr<engraving::MasterScore> { engraving::ScoreRW::readScore(fileName, false, doImportMidi) };
+    return std::unique_ptr<engraving::MasterScore> { engraving::ScoreRW::readScore(fileName, true, doImportMidi) };
 }
 
 TEST_F(MidiImportTests, m1) {
@@ -188,14 +188,12 @@ TEST_F(MidiImportTests, m2) {
 }
 
 // voices, typeA, resolve with tie
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_m3) {
+TEST_F(MidiImportTests, m3) {
     dontSimplify("m3");
 }
 
 // voices, typeB, resolve with tie
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_m4) {
+TEST_F(MidiImportTests, m4) {
     dontSimplify("m4");
 }
 
@@ -205,8 +203,7 @@ TEST_F(MidiImportTests, m5) {
 }
 
 // quantization
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_quantDotted4th) {
+TEST_F(MidiImportTests, quantDotted4th) {
     String midiFile(u"quant_dotted_4th");
     auto& opers = midiImportOperations;
     opers.addNewMidiFile(midiFilePath(midiFile));
@@ -235,45 +232,38 @@ TEST_F(MidiImportTests, DISABLED_humanTempo) {
 
 // chord detection
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_chordSmallError) {
+TEST_F(MidiImportTests, chordSmallError) {
     noTempoText("chord_small_error");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_chordBigError) {
+TEST_F(MidiImportTests, chordBigError) {
     noTempoText("chord_big_error");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_chordLegato) {
+TEST_F(MidiImportTests, chordLegato) {
     noTempoText("chord_legato");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_chordCollect) {
+TEST_F(MidiImportTests, chordCollect) {
     noTempoText("chord_collect");
 }
 
 // very short note - don't remove note but show it with min allowed duration (1/128)
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_chordVeryShort) {
+TEST_F(MidiImportTests, chordVeryShort) {
     dontSimplify("chord_1_tick_long");
 }
 
 // test scores for meter (duration subdivision)
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_meterTimeSig4_4) {
+
+TEST_F(MidiImportTests, meterTimeSig4_4) {
     dontSimplify("meter_4-4");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_metertimeSig9_8) {
+TEST_F(MidiImportTests, metertimeSig9_8) {
     dontSimplify("meter_9-8");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_metertimeSig12_8) {
+TEST_F(MidiImportTests, metertimeSig12_8) {
     dontSimplify("meter_12-8");
 }
 
@@ -282,77 +272,64 @@ TEST_F(MidiImportTests, DISABLED_metertimeSig15_8) {
     dontSimplify("meter_15-8");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_meterCentralLongNote) {
+TEST_F(MidiImportTests, meterCentralLongNote) {
     dontSimplify("meter_central_long_note");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_meterCentralLongRest) {
+TEST_F(MidiImportTests, meterCentralLongRest) {
     dontSimplify("meter_central_long_rest");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_meterChordExample) {
+TEST_F(MidiImportTests, meterChordExample) {
     dontSimplify("meter_chord_example");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_meterDotsExample1) {
+TEST_F(MidiImportTests, meterDotsExample1) {
     dontSimplify("meter_dots_example1");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_meterDotsExample2) {
+TEST_F(MidiImportTests, meterDotsExample2) {
     dontSimplify("meter_dots_example2");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_meterDotsExample3) {
+TEST_F(MidiImportTests, meterDotsExample3) {
     dontSimplify("meter_dots_example3");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_meterHalfRest3_4) {
+TEST_F(MidiImportTests, meterHalfRest3_4) {
     dontSimplify("meter_half_rest_3-4");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_meterFirst2_8thRestsCompound) {
+TEST_F(MidiImportTests, meterFirst2_8thRestsCompound) {
     dontSimplify("meter_first_2_8th_rests_compound");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_meterLastQuarterRestCompound) {
+TEST_F(MidiImportTests, meterLastQuarterRestCompound) {
     dontSimplify("meter_last_quarter_rest_compound");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_meterRests) {
+TEST_F(MidiImportTests, meterRests) {
     dontSimplify("meter_rests");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_meterTwoBeatsOver) {
+TEST_F(MidiImportTests, meterTwoBeatsOver) {
     dontSimplify("meter_two_beats_over");
 }
 
 // TODO: update ref
-TEST_F(MidiImportTests, DISABLED_meterDotTie) {
+TEST_F(MidiImportTests, meterDotTie) {
     dontSimplify("meter_dot_tie");
 }
 
 // time sig
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_timesigChanges) {
+TEST_F(MidiImportTests, timesigChanges) {
     dontSimplify("timesig_changes");
 }
 
 // test scores for tuplets
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_tuplet2Voices3_5Tuplets) {
+TEST_F(MidiImportTests, tuplet2Voices3_5Tuplets) {
     // requires 1/32 quantization
     QString midiFile("tuplet_2_voices_3_5_tuplets");
     auto& opers = midiImportOperations;
@@ -366,13 +343,11 @@ TEST_F(MidiImportTests, DISABLED_tuplet2Voices3_5Tuplets) {
     importThenCompareWithRef(midiFile.toStdString().c_str());
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_tuplet2VoicesTupletNon) {
+TEST_F(MidiImportTests, tuplet2VoicesTupletNon) {
     noTempoText("tuplet_2_voices_tuplet_non");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_tuplet3_5_7tuplets) {
+TEST_F(MidiImportTests, tuplet3_5_7tuplets) {
     QString midiFile("tuplet_3_5_7_tuplets");
     auto& opers = midiImportOperations;
     opers.addNewMidiFile(midiFilePath(midiFile));
@@ -387,8 +362,7 @@ TEST_F(MidiImportTests, DISABLED_tuplet3_5_7tuplets) {
     importThenCompareWithRef(midiFile.toStdString().c_str());
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_tuplet5_5TupletsRests) {
+TEST_F(MidiImportTests, tuplet5_5TupletsRests) {
     dontSimplify("tuplet_5_5_tuplets_rests");
 }
 
@@ -398,13 +372,11 @@ TEST_F(MidiImportTests, DISABLED_tuplet3_4) {
     dontSimplify("tuplet_3-4");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_tupletDuplet) {
+TEST_F(MidiImportTests, tupletDuplet) {
     dontSimplify("tuplet_duplet");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_tupletMars) {
+TEST_F(MidiImportTests, tupletMars) {
     dontSimplify("tuplet_mars");
 }
 
@@ -423,8 +395,7 @@ TEST_F(MidiImportTests, DISABLED_tupletNonuplet3_4) {
     dontSimplify(midiFile.toStdString().c_str());
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_tupletNonuplet4_4) {
+TEST_F(MidiImportTests, tupletNonuplet4_4) {
     // requires 1/64 quantization
     QString midiFile("tuplet_nonuplet_4-4");
     auto& opers = midiImportOperations;
@@ -437,8 +408,7 @@ TEST_F(MidiImportTests, DISABLED_tupletNonuplet4_4) {
     dontSimplify(midiFile.toStdString().c_str());
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_tupletQuadruplet) {
+TEST_F(MidiImportTests, tupletQuadruplet) {
     dontSimplify("tuplet_quadruplet");
 }
 
@@ -454,13 +424,11 @@ TEST_F(MidiImportTests, DISABLED_tupletTripletsMixed) {
     dontSimplify("tuplet_triplets_mixed");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_tupletTriplet) {
+TEST_F(MidiImportTests, tupletTriplet) {
     dontSimplify("tuplet_triplet");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_tupletTripletFirstTied) {
+TEST_F(MidiImportTests, tupletTripletFirstTied) {
     dontSimplify("tuplet_triplet_first_tied");
 }
 
@@ -470,13 +438,11 @@ TEST_F(MidiImportTests, DISABLED_tupletTripletFirstTied2) {
     dontSimplify("tuplet_triplet_first_tied2");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_tupletTripletLastTied) {
+TEST_F(MidiImportTests, tupletTripletLastTied) {
     dontSimplify("tuplet_triplet_last_tied");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_tupletTied3_5) {
+TEST_F(MidiImportTests, tupletTied3_5) {
     // requires 1/32 quantization
     QString midiFile("tuplet_tied_3_5_tuplets");
     auto& opers = midiImportOperations;
@@ -488,8 +454,7 @@ TEST_F(MidiImportTests, DISABLED_tupletTied3_5) {
     dontSimplify(midiFile.toStdString().c_str());
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_tupletTied3_5_2) {
+TEST_F(MidiImportTests, tupletTied3_5_2) {
     // requires 1/32 quantization
     QString midiFile("tuplet_tied_3_5_tuplets2");
     auto& opers = midiImportOperations;
@@ -501,8 +466,7 @@ TEST_F(MidiImportTests, DISABLED_tupletTied3_5_2) {
     dontSimplify(midiFile.toStdString().c_str());
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_tupletOffTimeOtherBar) {
+TEST_F(MidiImportTests, tupletOffTimeOtherBar) {
     dontSimplify("tuplet_off_time_other_bar");
 }
 
@@ -518,23 +482,19 @@ TEST_F(MidiImportTests, DISABLED_tuplet16th8th) {
     dontSimplify("tuplet_16th_8th");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_tuplet7Staccato) {
+TEST_F(MidiImportTests, tuplet7Staccato) {
     noTempoText("tuplet_7_staccato");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_minDuration) {
+TEST_F(MidiImportTests, minDuration) {
     dontSimplify("min_duration");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_pickupMeasure) {
+TEST_F(MidiImportTests, pickupMeasure) {
     dontSimplify("pickup");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_pickupMeasureLong) {
+TEST_F(MidiImportTests, pickupMeasureLong) {
     noTempoText("pickup_long");
 }
 
@@ -545,8 +505,7 @@ TEST_F(MidiImportTests, DISABLED_pickupMeasureTurnOff) {
 
 // LH/RH separation
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_LHRH_Nontuplet) {
+TEST_F(MidiImportTests, LHRH_Nontuplet) {
     staffSplit("split_nontuplet");
 }
 
@@ -555,25 +514,21 @@ TEST_F(MidiImportTests, DISABLED_LHRH_Acid) {
     staffSplit("split_acid");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_LHRH_Tuplet) {
+TEST_F(MidiImportTests, LHRH_Tuplet) {
     staffSplit("split_tuplet");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_LHRH_2melodies) {
+TEST_F(MidiImportTests, LHRH_2melodies) {
     staffSplit("split_2_melodies");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_LHRH_octave) {
+TEST_F(MidiImportTests, LHRH_octave) {
     staffSplit("split_octave");
 }
 
 // swing
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_swingTriplets) {
+TEST_F(MidiImportTests, swingTriplets) {
     QString midiFile("swing_triplets");
     auto& opers = midiImportOperations;
     opers.addNewMidiFile(midiFilePath(midiFile));
@@ -589,8 +544,7 @@ TEST_F(MidiImportTests, DISABLED_swingTriplets) {
     importThenCompareWithRef(midiFile.toStdString().c_str());
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_swingShuffle) {
+TEST_F(MidiImportTests, swingShuffle) {
     QString midiFile("swing_shuffle");
     auto& opers = midiImportOperations;
     opers.addNewMidiFile(midiFilePath(midiFile));
@@ -675,8 +629,7 @@ TEST_F(MidiImportTests, DISABLED_percShortNotes) {
 
 // clef changes along the score
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_clefTied) {
+TEST_F(MidiImportTests, clefTied) {
     dontSimplify("clef_tied");
 }
 
@@ -693,23 +646,19 @@ TEST_F(MidiImportTests, DISABLED_clefPrev) {
 
 // duration simplification
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_simplify16thStaccato) {
+TEST_F(MidiImportTests, simplify16thStaccato) {
     simplification("simplify_16th_staccato");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_simplify8thDont) {
+TEST_F(MidiImportTests, simplify8thDont) {
     simplification("simplify_8th_dont");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_simplify32ndStaccato) {
+TEST_F(MidiImportTests, simplify32ndStaccato) {
     simplification("simplify_32nd_staccato");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_simplify8thDottedNoStaccato) {
+TEST_F(MidiImportTests, simplify8thDottedNoStaccato) {
     simplification("simplify_8th_dotted_no_staccato");
 }
 
@@ -724,13 +673,11 @@ TEST_F(MidiImportTests, DISABLED_simplifyTripletStaccato) {
     simplification("simplify_triplet_staccato");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_simplifyDotted3_4) {
+TEST_F(MidiImportTests, simplifyDotted3_4) {
     simplification("simplify_dotted_3-4");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_simplifyStaccato9_8) {
+TEST_F(MidiImportTests, simplifyStaccato9_8) {
     simplification("simplify_staccato_9-8");
 }
 
@@ -741,8 +688,7 @@ TEST_F(MidiImportTests, DISABLED_voiceSeparationAcid) {
     voiceSeparation("voice_acid");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_voiceSeparationIntersect) {
+TEST_F(MidiImportTests, voiceSeparationIntersect) {
     voiceSeparation("voice_intersect");
 }
 
@@ -752,27 +698,23 @@ TEST_F(MidiImportTests, DISABLED_voiceSeparationTuplet) {
     voiceSeparation("voice_tuplet", true);
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_voiceSeparationCentral) {
+TEST_F(MidiImportTests, voiceSeparationCentral) {
     voiceSeparation("voice_central");
 }
 
 // division (fps and ticks per frame case)
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_division) {
+TEST_F(MidiImportTests, division) {
     importThenCompareWithRef("division");
 }
 
 // MIDI instruments and Grand Staff
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_instrumentGrand) {
+TEST_F(MidiImportTests, instrumentGrand) {
     importThenCompareWithRef("instrument_grand");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_instrumentGrand2) {
+TEST_F(MidiImportTests, instrumentGrand2) {
     importThenCompareWithRef("instrument_grand2");
 }
 
@@ -781,8 +723,7 @@ TEST_F(MidiImportTests, DISABLED_instrumentChannels) {
     importThenCompareWithRef("instrument_channels");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_instrument3StaffOrgan) {
+TEST_F(MidiImportTests, instrument3StaffOrgan) {
     importThenCompareWithRef("instrument_3staff_organ");
 }
 
@@ -1518,8 +1459,7 @@ static int findColByHeader(const TracksModel& model, const char* colHeader)
     return -1;
 }
 
-// FIXME
-TEST_F(MidiImportTests, DISABLED_testGuiTracksModel) {
+TEST_F(MidiImportTests, testGuiTracksModel) {
     QString midiFile("perc_drums");
     QString midiFileFullPath = midiFilePath(midiFile);
     auto& opers = midiImportOperations;


### PR DESCRIPTION
This PR fixes a small bug with the import operations defaults in the test fixture. As a result, most of the reference scores have been updated. (see commit messages for details)
75/107 tests pass (up from 13/107)

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
