### PR TITLE
fixed #27274: History panel can't be docked with other panels

### DIFF
--- a/src/framework/dockwindow/internal/dropcontroller.cpp
+++ b/src/framework/dockwindow/internal/dropcontroller.cpp
@@ -307,7 +307,7 @@ DockingHolderView* DropController::resolveDockingHolder(DockType draggedDockType
 
 DockPanelView* DropController::resolvePanelForDrop(const DockPanelView* panel, const QPoint& localPos) const
 {
-    QList<DockPanelView*> panels = currentPage()->possiblePanelsForTab(panel);
+    QList<DockPanelView*> panels = currentPage()->findPanelsForDropping(panel);
 
     for (DockPanelView* p : panels) {
         if (isMouseOverDock(localPos, p)) {

--- a/src/framework/dockwindow/view/dockpageview.cpp
+++ b/src/framework/dockwindow/view/dockpageview.cpp
@@ -180,17 +180,29 @@ DockingHolderView* DockPageView::holder(DockType type, Location location) const
     return nullptr;
 }
 
-QList<DockPanelView*> DockPageView::possiblePanelsForTab(const DockPanelView* tab) const
+QList<DockPanelView*> DockPageView::findPanelsForDropping(const DockPanelView* panel) const
 {
     QList<DockPanelView*> result;
 
-    for (DockPanelView* panel : panels()) {
-        if (panel->isTabAllowed(tab)) {
-            result << panel;
+    for (DockPanelView* destinationPanel : panels()) {
+        if (destinationPanel->isTabAllowed(panel)) {
+            result << destinationPanel;
         }
     }
 
     return result;
+}
+
+DockPanelView* DockPageView::findPanelForTab(const DockPanelView* tab) const
+{
+    for (DockPanelView* destinationPanel: panels()) {
+        if (destinationPanel->isTabAllowed(tab)
+            && destinationPanel->location() == tab->location()) {
+            return destinationPanel;
+        }
+    }
+
+    return nullptr;
 }
 
 bool DockPageView::isDockOpenAndCurrentInFrame(const QString& dockName) const
@@ -240,12 +252,6 @@ void DockPageView::setDockOpen(const QString& dockName, bool open)
     } else {
         panel->open();
     }
-}
-
-DockPanelView* DockPageView::findPanelForTab(const DockPanelView* tab) const
-{
-    QList<DockPanelView*> panels = possiblePanelsForTab(tab);
-    return !panels.isEmpty() ? panels.first() : nullptr;
 }
 
 void DockPageView::reorderSections()

--- a/src/framework/dockwindow/view/dockpageview.h
+++ b/src/framework/dockwindow/view/dockpageview.h
@@ -91,7 +91,9 @@ public:
 
     DockBase* dockByName(const QString& dockName) const;
     DockingHolderView* holder(DockType type, Location location) const;
-    QList<DockPanelView*> possiblePanelsForTab(const DockPanelView* tab) const;
+
+    QList<DockPanelView*> findPanelsForDropping(const DockPanelView* panel) const;
+    DockPanelView* findPanelForTab(const DockPanelView* tab) const;
 
     bool isDockOpenAndCurrentInFrame(const QString& dockName) const;
     void toggleDock(const QString& dockName);
@@ -124,8 +126,6 @@ signals:
 
 private:
     void componentComplete() override;
-
-    DockPanelView* findPanelForTab(const DockPanelView* tab) const;
 
     void reorderSections();
     void doReorderSections();

--- a/src/framework/dockwindow/view/dockpanelview.cpp
+++ b/src/framework/dockwindow/view/dockpanelview.cpp
@@ -287,10 +287,6 @@ bool DockPanelView::isTabAllowed(const DockPanelView* tab) const
         return false;
     }
 
-    if (tab->location() != location()) {
-        return false;
-    }
-
     return m_groupName == tab->m_groupName;
 }
 

--- a/src/framework/dockwindow/view/dockwindow.cpp
+++ b/src/framework/dockwindow/view/dockwindow.cpp
@@ -392,10 +392,11 @@ void DockWindow::loadPanels(const DockPageView* page)
     TRACEFUNC;
 
     for (DockPanelView* panel : page->panels()) {
-        if (DockPanelView* destinationPanel = findDestinationForPanel(page, panel)) {
+        if (DockPanelView* destinationPanel = page->findPanelForTab(panel)) {
             addPanelAsTab(panel, destinationPanel);
             continue;
         }
+
         const Location location = panel->location();
         const bool isSideLocation = location == Location::Left || location == Location::Right;
         addDock(panel, location, isSideLocation ? page->centralDock() : nullptr);
@@ -462,16 +463,6 @@ void DockWindow::alignTopLevelToolBars(const DockPageView* page)
     lastCentralToolBar->setMinimumWidth(lastCentralToolBar->contentWidth() + deltaForLastCentralToolBar);
 }
 
-DockPanelView* DockWindow::findDestinationForPanel(const DockPageView* page, const DockPanelView* panel) const
-{
-    for (DockPanelView* destinationPanel : page->panels()) {
-        if (destinationPanel->isTabAllowed(panel)) {
-            return destinationPanel;
-        }
-    }
-    return nullptr;
-}
-
 void DockWindow::addDock(DockBase* dock, Location location, const DockBase* relativeTo)
 {
     TRACEFUNC;
@@ -522,7 +513,7 @@ void DockWindow::handleUnknownDock(const DockPageView* page, DockBase* unknownDo
         return;
     }
 
-    if (DockPanelView* destinationPanel = findDestinationForPanel(page, unknownPanel)) {
+    if (DockPanelView* destinationPanel = page->findPanelForTab(unknownPanel)) {
         addPanelAsTab(unknownPanel, destinationPanel);
         return;
     }

--- a/src/framework/dockwindow/view/dockwindow.h
+++ b/src/framework/dockwindow/view/dockwindow.h
@@ -117,8 +117,6 @@ private:
     void loadTopLevelToolBars(const DockPageView* page);
     void alignTopLevelToolBars(const DockPageView* page);
 
-    DockPanelView* findDestinationForPanel(const DockPageView* page, const DockPanelView* panel) const;
-
     void addDock(DockBase* dock, Location location = Location::Left, const DockBase* relativeTo = nullptr);
     void addPanelAsTab(DockPanelView* panel, DockPanelView* destinationPanel);
     void registerDock(DockBase* dock);


### PR DESCRIPTION
There are two cases when a panel is added as a tab:
- When loading page content. In this case, we must take location into account to position the panel correctly. If the locations differ, we shouldn’t group them as tabs.
- When the user manually drops one panel onto another. In this scenario, the location doesn’t matter, of course.

Resolves: #27274
