### PR TITLE
fixed #26084: Context Menus appear incorrectly on multiple monitors with different scaling factors, but only after moving musescore between monitors

### DIFF
--- a/src/framework/uicomponents/view/popupview.cpp
+++ b/src/framework/uicomponents/view/popupview.cpp
@@ -237,6 +237,8 @@ void PopupView::doOpen()
 
     beforeOpen();
 
+    resolveParentWindow();
+
     updateGeometry();
 
     if (!isDialog()) {
@@ -271,7 +273,6 @@ void PopupView::doOpen()
         m_window->setResizable(m_resizable);
     }
 
-    resolveParentWindow();
     resolveNavigationParentControl();
 
     QScreen* screen = resolveScreen();


### PR DESCRIPTION
Resolves: #26084
Resolves: #27398