### PR TITLE
Fix #27025: Ensure excerpt solo-mute states are initialised properly for pre-4.4.0 scores

### DIFF
--- a/src/notation/imasternotation.h
+++ b/src/notation/imasternotation.h
@@ -62,6 +62,7 @@ public:
     virtual muse::async::Notification hasPartsChanged() const = 0;
 
     virtual INotationPlaybackPtr playback() const = 0;
+    virtual void initNotationSoloMuteState(const INotationPtr notation) = 0;
 };
 
 using IMasterNotationPtr = std::shared_ptr<IMasterNotation>;

--- a/src/notation/internal/masternotation.h
+++ b/src/notation/internal/masternotation.h
@@ -69,6 +69,7 @@ public:
     muse::async::Notification hasPartsChanged() const override;
 
     INotationPlaybackPtr playback() const override;
+    void initNotationSoloMuteState(const INotationPtr notation) override;
 
 private:
 

--- a/src/playback/internal/playbackcontroller.h
+++ b/src/playback/internal/playbackcontroller.h
@@ -197,8 +197,6 @@ private:
     void setupSequenceTracks();
     void setupSequencePlayer();
 
-    void initMuteStates();
-
     void updateSoloMuteStates();
     void updateAuxMuteStates();
 

--- a/src/project/internal/notationproject.cpp
+++ b/src/project/internal/notationproject.cpp
@@ -227,14 +227,16 @@ Ret NotationProject::doLoad(const muse::io::path_t& path, const muse::io::path_t
     // Load view settings & solo-mute states (needs to be done after notations are created)
     m_masterNotation->notation()->viewState()->read(reader);
     m_masterNotation->notation()->soloMuteState()->read(reader);
+    const int mscVersion = m_masterNotation->mscVersion();
     for (const IExcerptNotationPtr& excerpt : m_masterNotation->excerpts()) {
-        if (!excerpt->hasFileName()) {
+        const INotationPtr excerptNotation = excerpt->notation();
+        if (!excerpt->hasFileName() || mscVersion < 440) {
+            m_masterNotation->initNotationSoloMuteState(excerptNotation);
             continue;
         }
-
         muse::io::path_t ePath = u"Excerpts/" + excerpt->fileName() + u"/";
-        excerpt->notation()->viewState()->read(reader, ePath);
-        excerpt->notation()->soloMuteState()->read(reader, ePath);
+        excerptNotation->viewState()->read(reader, ePath);
+        excerptNotation->soloMuteState()->read(reader, ePath);
     }
 
     // Apply compat audio settings (needs to be done after notations are created)


### PR DESCRIPTION
Resolves: #27025

Caused by #25021 and #19433

The main culprit is `onTrackNewlyAdded` - the idea of this method is to mute instruments newly added via the Layout panel in all excerpts (part scores) except for the current one*. Part of the problem is that, when loading pre-4.4.0 scores with existing parts, `onTrackNewlyAdded` gets a call and mutes the given track in all excerpts.

To avoid this we first need to initialise all excerpt solo mute states when loading pre-4.4.0 scores and be sure not to override that state when calling `onTrackNewlyAdded` by checking `trackSoloMuteStateExists`.

*#17250 is a known limitation related to this.