### PR TITLE
Fix split, join and rewrite measure tie bugs

### DIFF
--- a/src/engraving/dom/range.cpp
+++ b/src/engraving/dom/range.cpp
@@ -656,6 +656,8 @@ bool TrackList::write(Score* score, const Fraction& tick) const
             if (nn) {
                 tie->setEndNote(nn);
                 nn->setTieBack(tie);
+            } else {
+                score->doUndoRemoveElement(tie);
             }
         }
         if (s == segment) {

--- a/src/engraving/dom/range.cpp
+++ b/src/engraving/dom/range.cpp
@@ -720,6 +720,23 @@ void ScoreRange::read(Segment* first, Segment* last, bool readSpanner)
             m_tracks.push_back(dl);
         }
     }
+
+    // Make sure incoming ties are restored
+    Measure* m1 = first->measure();
+    for (track_idx_t track = startTrack; track < endTrack; track++) {
+        Chord* startChord = m1->findChord(first->tick(), track);
+        if (!startChord) {
+            continue;
+        }
+        for (Note* note : startChord->notes()) {
+            Tie* tie = note->tieBack();
+            if (!tie) {
+                continue;
+            }
+            m_startTies.push_back(tie->clone());
+            score->doUndoRemoveElement(tie);
+        }
+    }
 }
 
 //---------------------------------------------------------
@@ -793,6 +810,18 @@ bool ScoreRange::write(Score* score, const Fraction& tick) const
             score->undoAddElement(a.e);
         }
     }
+
+    // Restore ties to the beginning of the first measure
+    for (Tie* tie : m_startTies) {
+        Note* endNote = searchTieNote(tie->startNote());
+        if (!endNote) {
+            delete tie;
+            continue;
+        }
+        tie->setEndNote(endNote);
+        score->doUndoAddElement(tie);
+    }
+
     return true;
 }
 

--- a/src/engraving/dom/range.h
+++ b/src/engraving/dom/range.h
@@ -40,6 +40,7 @@ class Spanner;
 class ScoreRange;
 class ChordRest;
 class Score;
+class Tie;
 
 //---------------------------------------------------------
 //   TrackList
@@ -113,6 +114,7 @@ private:
     friend class TrackList;
 
     std::list<TrackList*> m_tracks;
+    std::vector<Tie*> m_startTies;
     Segment* m_first = nullptr;
     Segment* m_last = nullptr;
 };

--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -5900,69 +5900,71 @@ void Score::connectTies(bool silent)
         return;
     }
 
-    SegmentType st = SegmentType::ChordRest;
-    for (Segment* s = m->first(st); s; s = s->next1(st)) {
-        for (track_idx_t i = 0; i < tracks; ++i) {
-            EngravingItem* e = s->element(i);
-            if (e == 0 || !e->isChord()) {
+    auto connectTiesForChord = [silent](Chord* c, Segment* s, track_idx_t track) -> void {
+        for (Note* n : c->notes()) {
+            if (n->laissezVib()) {
                 continue;
             }
-            Chord* c = toChord(e);
-            for (Note* n : c->notes()) {
-                if (n->laissezVib()) {
-                    continue;
+            // connect a tie without end note
+            Tie* tie = n->tieFor();
+            if (tie) {
+                tie->updatePossibleJumpPoints();
+            }
+            if (tie && !tie->isPartialTie() && !tie->endNote()) {
+                Note* nnote;
+                nnote = searchTieNote(n);
+                if (nnote == 0) {
+                    if (!silent) {
+                        LOGD("next note at %d track %zu for tie not found", s->tick().ticks(), track);
+                        delete tie;
+                        n->setTieFor(0);
+                    }
+                } else {
+                    tie->setEndNote(nnote);
+                    nnote->setTieBack(tie);
                 }
-                // connect a tie without end note
-                Tie* tie = n->tieFor();
-                if (tie) {
-                    tie->updatePossibleJumpPoints();
-                }
-                if (tie && !tie->isPartialTie() && !tie->endNote()) {
-                    Note* nnote;
-                    if (m_mscVersion <= 114) {
-                        nnote = searchTieNote114(n);
+            }
+            // connect a glissando without initial note (old glissando format)
+            for (Spanner* spanner : n->spannerBack()) {
+                if (spanner->isGlissando() && !spanner->startElement()) {
+                    Note* initialNote = Glissando::guessInitialNote(n->chord());
+                    n->removeSpannerBack(spanner);
+                    if (initialNote) {
+                        spanner->setStartElement(initialNote);
+                        spanner->setEndElement(n);
+                        spanner->setTick(initialNote->chord()->tick());
+                        spanner->setTick2(n->chord()->tick());
+                        spanner->setTrack(n->track());
+                        spanner->setTrack2(n->track());
+                        spanner->setParent(initialNote);
+                        initialNote->add(spanner);
                     } else {
-                        nnote = searchTieNote(n);
-                    }
-                    if (nnote == 0) {
-                        if (!silent) {
-                            LOGD("next note at %d track %zu for tie not found (version %d)", s->tick().ticks(), i, m_mscVersion);
-                            delete tie;
-                            n->setTieFor(0);
-                        }
-                    } else {
-                        tie->setEndNote(nnote);
-                        nnote->setTieBack(tie);
-                    }
-                }
-                // connect a glissando without initial note (old glissando format)
-                for (Spanner* spanner : n->spannerBack()) {
-                    if (spanner->isGlissando() && !spanner->startElement()) {
-                        Note* initialNote = Glissando::guessInitialNote(n->chord());
-                        n->removeSpannerBack(spanner);
-                        if (initialNote) {
-                            spanner->setStartElement(initialNote);
-                            spanner->setEndElement(n);
-                            spanner->setTick(initialNote->chord()->tick());
-                            spanner->setTick2(n->chord()->tick());
-                            spanner->setTrack(n->track());
-                            spanner->setTrack2(n->track());
-                            spanner->setParent(initialNote);
-                            initialNote->add(spanner);
-                        } else {
-                            delete spanner;
-                        }
-                    }
-                }
-                // spanner with no end element can happen during copy/paste
-                for (Spanner* spanner : n->spannerFor()) {
-                    if (spanner->endElement() == nullptr) {
-                        n->removeSpannerFor(spanner);
                         delete spanner;
                     }
                 }
             }
+            // spanner with no end element can happen during copy/paste
+            for (Spanner* spanner : n->spannerFor()) {
+                if (spanner->endElement() == nullptr) {
+                    n->removeSpannerFor(spanner);
+                    delete spanner;
+                }
+            }
+        }
+    };
+
+    SegmentType st = SegmentType::ChordRest;
+    for (Segment* s = m->first(st); s; s = s->next1(st)) {
+        for (track_idx_t track = 0; track < tracks; ++track) {
+            EngravingItem* e = s->element(track);
+            if (e == 0 || !e->isChord()) {
+                continue;
+            }
+            Chord* c = toChord(e);
+            connectTiesForChord(c, s, track);
             for (Chord* gc : c->graceNotes()) {
+                connectTiesForChord(gc, s, track);
+
                 for (Note* n : gc->notes()) {
                     // spanner with no end element apparently happens when reading some 206 files
                     // (and possibly in other situations too)

--- a/src/engraving/dom/splitMeasure.cpp
+++ b/src/engraving/dom/splitMeasure.cpp
@@ -96,20 +96,6 @@ void MasterScore::splitMeasure(const Fraction& tick)
         }
     }
 
-    // Make sure ties to the beginning of the split measure are restored.
-    std::vector<Tie*> ties;
-    for (size_t track = 0; track < ntracks(); track++) {
-        Chord* chord = measure->findChord(stick, static_cast<int>(track));
-        if (chord) {
-            for (Note* note : chord->notes()) {
-                Tie* tie = note->tieBack();
-                if (tie) {
-                    ties.push_back(tie->clone());
-                }
-            }
-        }
-    }
-
     MeasureBase* nm = measure->next();
 
     // create empty measures:
@@ -180,12 +166,6 @@ void MasterScore::splitMeasure(const Fraction& tick)
     }
 
     range.write(this, m1->tick());
-
-    // Restore ties to the beginning of the split measure.
-    for (auto tie : ties) {
-        tie->setEndNote(searchTieNote(tie->startNote()));
-        undoAddElement(tie);
-    }
 
     for (auto i : sl) {
         Spanner* s      = std::get<0>(i);

--- a/src/engraving/dom/utils.cpp
+++ b/src/engraving/dom/utils.cpp
@@ -873,47 +873,6 @@ Note* searchTieNote(const Note* note, const Segment* nextSegment, const bool dis
 }
 
 //---------------------------------------------------------
-//   searchTieNote114
-//    search Note to tie to "note", tie to next note in
-//    same voice
-//---------------------------------------------------------
-
-Note* searchTieNote114(Note* note)
-{
-    Note* note2  = 0;
-    Chord* chord = note->chord();
-    Segment* seg = chord->segment();
-    Part* part   = chord->part();
-    track_idx_t strack = part->staves().front()->idx() * VOICES;
-    track_idx_t etrack = strack + part->staves().size() * VOICES;
-
-    while ((seg = seg->next1(SegmentType::ChordRest))) {
-        for (track_idx_t track = strack; track < etrack; ++track) {
-            EngravingItem* e = seg->element(track);
-            if (e == 0 || (!e->isChord()) || (e->track() != chord->track())) {
-                continue;
-            }
-            Chord* c = toChord(e);
-            staff_idx_t staffIdx = c->staffIdx() + c->staffMove();
-            if (staffIdx != chord->staffIdx() + chord->staffMove()) {      // cannot happen?
-                continue;
-            }
-            for (Note* n : c->notes()) {
-                if (n->pitch() == note->pitch()) {
-                    if (note2 == 0 || c->track() == chord->track()) {
-                        note2 = n;
-                    }
-                }
-            }
-        }
-        if (note2) {
-            break;
-        }
-    }
-    return note2;
-}
-
-//---------------------------------------------------------
 //   absStep
 ///   Compute absolute step.
 ///   C D E F G A B ....

--- a/src/engraving/dom/utils.h
+++ b/src/engraving/dom/utils.h
@@ -75,7 +75,6 @@ extern Segment* nextSeg1(Segment* s);
 extern Segment* prevSeg1(Segment* seg);
 
 extern Note* searchTieNote(const Note* note, const Segment* nextSegment = nullptr, const bool disableOverRepeats = true);
-extern Note* searchTieNote114(Note* note);
 
 extern int absStep(int pitch);
 extern int absStep(int tpc, int pitch);

--- a/src/engraving/tests/join_data/joinTieAtStart.mscx
+++ b/src/engraving/tests/join_data/joinTieAtStart.mscx
@@ -1,0 +1,203 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="4.60">
+  <programVersion>4.6.0</programVersion>
+  <programRevision></programRevision>
+  <Score>
+    <eid>16dMLGqDOvF_RAINExrU43O</eid>
+    <Division>480</Division>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <open>1</open>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="audioComUrl"></metaTag>
+    <metaTag name="composer">Composer / arranger</metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="creationDate">2025-06-17</metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="platform">Apple Macintosh</metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="sourceRevisionId"></metaTag>
+    <metaTag name="subtitle">Subtitle</metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle">Untitled score</metaTag>
+    <Order id="orchestra">
+      <name>Orchestra</name>
+      <instrument id="flute">
+        <family id="flutes">Flutes</family>
+        </instrument>
+      <section id="woodwind" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>flutes</family>
+        <family>oboes</family>
+        <family>clarinets</family>
+        <family>saxophones</family>
+        <family>bassoons</family>
+        <unsorted group="woodwinds"/>
+        </section>
+      <section id="brass" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>horns</family>
+        <family>trumpets</family>
+        <family>cornets</family>
+        <family>flugelhorns</family>
+        <family>trombones</family>
+        <family>tubas</family>
+        <unsorted group="brass"/>
+        </section>
+      <section id="timpani" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>timpani</family>
+        </section>
+      <section id="percussion" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>keyboard-percussion</family>
+        <unsorted group="pitched-percussion"/>
+        <family>drums</family>
+        <family>unpitched-metal-percussion</family>
+        <family>unpitched-wooden-percussion</family>
+        <family>other-percussion</family>
+        <unsorted group="unpitched-percussion"/>
+        </section>
+      <family>keyboards</family>
+      <family>harps</family>
+      <family>organs</family>
+      <family>synths</family>
+      <unsorted/>
+      <soloists/>
+      <section id="voices" brackets="true" barLineSpan="false" thinBrackets="true">
+        <family>voices</family>
+        <family>voice-groups</family>
+        </section>
+      <section id="strings" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>orchestral-strings</family>
+        </section>
+      </Order>
+    <Part id="1">
+      <Staff>
+        <eid>XoWlozNOH3D_w697OyAskcP</eid>
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        </Staff>
+      <trackName>Flute</trackName>
+      <Instrument id="flute">
+        <longName>Flute</longName>
+        <shortName>Fl.</shortName>
+        <trackName>Flute</trackName>
+        <minPitchP>59</minPitchP>
+        <maxPitchP>98</maxPitchP>
+        <minPitchA>60</minPitchA>
+        <maxPitchA>93</maxPitchA>
+        <instrumentId>wind.flutes.flute</instrumentId>
+        <Channel>
+          <program value="73"/>
+          <synti>Fluid</synti>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <Measure>
+        <eid>drdaJ8ylnpJ_Ue42oCc5H3K</eid>
+        <voice>
+          <KeySig>
+            <eid>qqlwiChUQIL_ddoYVfHaWHM</eid>
+            <concertKey>0</concertKey>
+            </KeySig>
+          <TimeSig>
+            <eid>UNtwix/toyP_aJeTD6JkGEM</eid>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Chord>
+            <eid>zaNjfElOQsL_tRLKJpi7klD</eid>
+            <durationType>quarter</durationType>
+            <Note>
+              <eid>duS7uUVRGsM_jS7zHRvu1D</eid>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <eid>eZ7uS5Z4IKP_v30Y6JQLIII</eid>
+            <durationType>quarter</durationType>
+            <Note>
+              <eid>447FfYBvXEG_J8nfJj8rHsN</eid>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <eid>wAbk7TfhzzC_iw998GrJSnF</eid>
+            <durationType>quarter</durationType>
+            <Note>
+              <eid>IzzTN1nOAZK_P/IqT/8NZoH</eid>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <eid>zZnHUc3YKTD_rViSkHZBicC</eid>
+            <durationType>quarter</durationType>
+            <Note>
+              <eid>iw9zXMDsGEP_02gwoUoowcH</eid>
+              <Spanner type="Tie">
+                <Tie>
+                  <eid>XZkNHkdhNnP_Xbe3qXLDUMO</eid>
+                  </Tie>
+                <next>
+                  <location>
+                    <measures>1</measures>
+                    <fractions>-3/4</fractions>
+                    </location>
+                  </next>
+                </Spanner>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          </voice>
+        </Measure>
+      <Measure>
+        <eid>t+Tpoz3K3HG_P5KOUzQ1ypO</eid>
+        <voice>
+          <Chord>
+            <eid>xGBpNF/WxFJ_yieIyB8gsTE</eid>
+            <durationType>quarter</durationType>
+            <Note>
+              <eid>hrt3PyNCaCI_OoZE9kwm8sN</eid>
+              <Spanner type="Tie">
+                <prev>
+                  <location>
+                    <measures>-1</measures>
+                    <fractions>3/4</fractions>
+                    </location>
+                  </prev>
+                </Spanner>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          <Rest>
+            <eid>guvpYggyCGH_Y8K9t4Wfw9H</eid>
+            <durationType>quarter</durationType>
+            </Rest>
+          <Rest>
+            <eid>wQVcaAIVN/N_OeUoXKZkTQP</eid>
+            <durationType>half</durationType>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <eid>CkTBtWhFSgK_xLkTIQaZSbB</eid>
+        <voice>
+          <Rest>
+            <eid>iNlafH+1+cJ_ZRkOfcyvcjG</eid>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/src/engraving/tests/join_tests.cpp
+++ b/src/engraving/tests/join_tests.cpp
@@ -145,3 +145,53 @@ TEST_F(Engraving_JoinTests, join10)
 {
     join("join10.mscx", "join10-ref.mscx", 1);
 }
+
+TEST_F(Engraving_JoinTests, joinTieAtStart) {
+    // Test splitting a measure when there is a tie ending on the first chord on the split range
+    bool use302 = MScore::useRead302InTestMode;
+    MScore::useRead302InTestMode = false;
+
+    MasterScore* score = ScoreRW::readScore(JOIN_DATA_DIR + u"joinTieAtStart.mscx");
+    EXPECT_TRUE(score);
+
+    Measure* m1 = score->firstMeasure();
+    EXPECT_TRUE(m1);
+
+    Segment* s1 = m1->last(SegmentType::ChordRest);
+    ChordRest* cr1 = toChordRest(s1->element(0));
+    EXPECT_TRUE(cr1 && cr1->isChord());
+    Chord* c1 = toChord(cr1);
+    Note* n1 = c1->upNote();
+    EXPECT_TRUE(n1);
+
+    auto checkTie = [&]() -> Tie* {
+        Tie* t = n1->tieFor();
+        EXPECT_TRUE(t);
+
+        Note* n2 = t->endNote();
+        EXPECT_TRUE(n2);
+        EXPECT_EQ(n2->tick(), Fraction(1, 1));
+        EXPECT_EQ(n2->chord()->measure(), m1->nextMeasure());
+
+        return t;
+    };
+
+    Tie* tie1 = checkTie();
+
+    score->startCmd(TranslatableString::untranslatable("Engraving join tests"));
+    Measure* m2 = m1->nextMeasure();
+    Measure* m3 = m2->nextMeasure();
+    score->cmdJoinMeasure(m2, m3);
+    score->endCmd();
+
+    Tie* tie2 = checkTie();
+    EXPECT_NE(tie2, tie1);
+
+    score->undoRedo(true, nullptr);
+
+    Tie* tie3 = checkTie();
+    EXPECT_EQ(tie3, tie1);
+
+    delete score;
+    MScore::useRead302InTestMode = use302;
+}

--- a/src/engraving/tests/split_data/splitTieAtStart.mscx
+++ b/src/engraving/tests/split_data/splitTieAtStart.mscx
@@ -1,0 +1,203 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="4.60">
+  <programVersion>4.6.0</programVersion>
+  <programRevision></programRevision>
+  <Score>
+    <eid>16dMLGqDOvF_RAINExrU43O</eid>
+    <Division>480</Division>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <open>1</open>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="audioComUrl"></metaTag>
+    <metaTag name="composer">Composer / arranger</metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="creationDate">2025-06-17</metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="platform">Apple Macintosh</metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="sourceRevisionId"></metaTag>
+    <metaTag name="subtitle">Subtitle</metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle">Untitled score</metaTag>
+    <Order id="orchestra">
+      <name>Orchestra</name>
+      <instrument id="flute">
+        <family id="flutes">Flutes</family>
+        </instrument>
+      <section id="woodwind" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>flutes</family>
+        <family>oboes</family>
+        <family>clarinets</family>
+        <family>saxophones</family>
+        <family>bassoons</family>
+        <unsorted group="woodwinds"/>
+        </section>
+      <section id="brass" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>horns</family>
+        <family>trumpets</family>
+        <family>cornets</family>
+        <family>flugelhorns</family>
+        <family>trombones</family>
+        <family>tubas</family>
+        <unsorted group="brass"/>
+        </section>
+      <section id="timpani" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>timpani</family>
+        </section>
+      <section id="percussion" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>keyboard-percussion</family>
+        <unsorted group="pitched-percussion"/>
+        <family>drums</family>
+        <family>unpitched-metal-percussion</family>
+        <family>unpitched-wooden-percussion</family>
+        <family>other-percussion</family>
+        <unsorted group="unpitched-percussion"/>
+        </section>
+      <family>keyboards</family>
+      <family>harps</family>
+      <family>organs</family>
+      <family>synths</family>
+      <unsorted/>
+      <soloists/>
+      <section id="voices" brackets="true" barLineSpan="false" thinBrackets="true">
+        <family>voices</family>
+        <family>voice-groups</family>
+        </section>
+      <section id="strings" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>orchestral-strings</family>
+        </section>
+      </Order>
+    <Part id="1">
+      <Staff>
+        <eid>XoWlozNOH3D_w697OyAskcP</eid>
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        </Staff>
+      <trackName>Flute</trackName>
+      <Instrument id="flute">
+        <longName>Flute</longName>
+        <shortName>Fl.</shortName>
+        <trackName>Flute</trackName>
+        <minPitchP>59</minPitchP>
+        <maxPitchP>98</maxPitchP>
+        <minPitchA>60</minPitchA>
+        <maxPitchA>93</maxPitchA>
+        <instrumentId>wind.flutes.flute</instrumentId>
+        <Channel>
+          <program value="73"/>
+          <synti>Fluid</synti>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <Measure>
+        <eid>drdaJ8ylnpJ_Ue42oCc5H3K</eid>
+        <voice>
+          <KeySig>
+            <eid>qqlwiChUQIL_ddoYVfHaWHM</eid>
+            <concertKey>0</concertKey>
+            </KeySig>
+          <TimeSig>
+            <eid>UNtwix/toyP_aJeTD6JkGEM</eid>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Chord>
+            <eid>zaNjfElOQsL_tRLKJpi7klD</eid>
+            <durationType>quarter</durationType>
+            <Note>
+              <eid>duS7uUVRGsM_jS7zHRvu1D</eid>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <eid>eZ7uS5Z4IKP_v30Y6JQLIII</eid>
+            <durationType>quarter</durationType>
+            <Note>
+              <eid>447FfYBvXEG_J8nfJj8rHsN</eid>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <eid>wAbk7TfhzzC_iw998GrJSnF</eid>
+            <durationType>quarter</durationType>
+            <Note>
+              <eid>IzzTN1nOAZK_P/IqT/8NZoH</eid>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <eid>zZnHUc3YKTD_rViSkHZBicC</eid>
+            <durationType>quarter</durationType>
+            <Note>
+              <eid>iw9zXMDsGEP_02gwoUoowcH</eid>
+              <Spanner type="Tie">
+                <Tie>
+                  <eid>XZkNHkdhNnP_Xbe3qXLDUMO</eid>
+                  </Tie>
+                <next>
+                  <location>
+                    <measures>1</measures>
+                    <fractions>-3/4</fractions>
+                    </location>
+                  </next>
+                </Spanner>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          </voice>
+        </Measure>
+      <Measure>
+        <eid>t+Tpoz3K3HG_P5KOUzQ1ypO</eid>
+        <voice>
+          <Chord>
+            <eid>xGBpNF/WxFJ_yieIyB8gsTE</eid>
+            <durationType>quarter</durationType>
+            <Note>
+              <eid>hrt3PyNCaCI_OoZE9kwm8sN</eid>
+              <Spanner type="Tie">
+                <prev>
+                  <location>
+                    <measures>-1</measures>
+                    <fractions>3/4</fractions>
+                    </location>
+                  </prev>
+                </Spanner>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          <Rest>
+            <eid>guvpYggyCGH_Y8K9t4Wfw9H</eid>
+            <durationType>quarter</durationType>
+            </Rest>
+          <Rest>
+            <eid>wQVcaAIVN/N_OeUoXKZkTQP</eid>
+            <durationType>half</durationType>
+            </Rest>
+          </voice>
+        </Measure>
+      <Measure>
+        <eid>CkTBtWhFSgK_xLkTIQaZSbB</eid>
+        <voice>
+          <Rest>
+            <eid>iNlafH+1+cJ_ZRkOfcyvcjG</eid>
+            <durationType>measure</durationType>
+            <duration>4/4</duration>
+            </Rest>
+          </voice>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/src/engraving/tests/timesig_data/endOfMeasureTie.mscx
+++ b/src/engraving/tests/timesig_data/endOfMeasureTie.mscx
@@ -1,0 +1,198 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="4.60">
+  <programVersion>4.6.0</programVersion>
+  <programRevision></programRevision>
+  <Score>
+    <eid>f0fsNXB8dmN_ZFR16/BVYOL</eid>
+    <Division>480</Division>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <open>1</open>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="audioComUrl"></metaTag>
+    <metaTag name="composer">Composer / arranger</metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="creationDate">2025-06-17</metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="platform">Apple Macintosh</metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="sourceRevisionId"></metaTag>
+    <metaTag name="subtitle">Subtitle</metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle">Untitled score</metaTag>
+    <Order id="orchestra">
+      <name>Orchestra</name>
+      <instrument id="oboe">
+        <family id="oboes">Oboes</family>
+        </instrument>
+      <section id="woodwind" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>flutes</family>
+        <family>oboes</family>
+        <family>clarinets</family>
+        <family>saxophones</family>
+        <family>bassoons</family>
+        <unsorted group="woodwinds"/>
+        </section>
+      <section id="brass" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>horns</family>
+        <family>trumpets</family>
+        <family>cornets</family>
+        <family>flugelhorns</family>
+        <family>trombones</family>
+        <family>tubas</family>
+        <unsorted group="brass"/>
+        </section>
+      <section id="timpani" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>timpani</family>
+        </section>
+      <section id="percussion" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>keyboard-percussion</family>
+        <unsorted group="pitched-percussion"/>
+        <family>drums</family>
+        <family>unpitched-metal-percussion</family>
+        <family>unpitched-wooden-percussion</family>
+        <family>other-percussion</family>
+        <unsorted group="unpitched-percussion"/>
+        </section>
+      <family>keyboards</family>
+      <family>harps</family>
+      <family>organs</family>
+      <family>synths</family>
+      <unsorted/>
+      <soloists/>
+      <section id="voices" brackets="true" barLineSpan="false" thinBrackets="true">
+        <family>voices</family>
+        <family>voice-groups</family>
+        </section>
+      <section id="strings" brackets="true" barLineSpan="true" thinBrackets="true">
+        <family>orchestral-strings</family>
+        </section>
+      </Order>
+    <Part id="1">
+      <Staff>
+        <eid>uPbgiwleqFG_G9r3vXko/oH</eid>
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        </Staff>
+      <trackName>Oboe</trackName>
+      <Instrument id="oboe">
+        <longName>Oboe</longName>
+        <shortName>Ob.</shortName>
+        <trackName>Oboe</trackName>
+        <minPitchP>58</minPitchP>
+        <maxPitchP>96</maxPitchP>
+        <minPitchA>58</minPitchA>
+        <maxPitchA>87</maxPitchA>
+        <instrumentId>wind.reed.oboe</instrumentId>
+        <Channel>
+          <program value="68"/>
+          <synti>Fluid</synti>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <Measure>
+        <eid>ZxxzBpl9HXD_hqxR3/glq0F</eid>
+        <voice>
+          <KeySig>
+            <eid>82E1Dv3ttZD_uKzCJ7xsBbB</eid>
+            <concertKey>0</concertKey>
+            </KeySig>
+          <TimeSig>
+            <eid>04NNvKgupiP_FImPRZIO5zD</eid>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Chord>
+            <eid>dDP5XukCvBE_iZ0lWxEoFfJ</eid>
+            <durationType>quarter</durationType>
+            <Note>
+              <eid>Ghwtr3lF5uN_VHlGMAkA8ND</eid>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <eid>7Xm+UrjA8HI_NrF1seYnihI</eid>
+            <durationType>quarter</durationType>
+            <Note>
+              <eid>CqCeBOvIskJ_r12TO1I1HyL</eid>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <eid>Dtldpo0wDRH_x3YqI8kPblK</eid>
+            <durationType>quarter</durationType>
+            <Note>
+              <eid>UhAOJ1LnJYF_V2zVH0KP5GL</eid>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <eid>ivFSFFNw/pM_+WPh4SHvS7F</eid>
+            <durationType>quarter</durationType>
+            <Note>
+              <eid>dvtF7V2Q28E_wT7bUM8qpOL</eid>
+              <Spanner type="Tie">
+                <Tie>
+                  <eid>XkMy3S274MI_3ZCK0C5thhK</eid>
+                  </Tie>
+                <next>
+                  <location>
+                    <measures>1</measures>
+                    <fractions>-3/4</fractions>
+                    </location>
+                  </next>
+                </Spanner>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          </voice>
+        </Measure>
+      <Measure>
+        <eid>H1BaLfj6NBF_XKlPs0MwEWD</eid>
+        <voice>
+          <TimeSig>
+            <eid>D5e8q6iwnWN_8rVyblPbr6K</eid>
+            <sigN>3</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Chord>
+            <eid>MRsXTHIURZH_Uqo0VKLeF2</eid>
+            <durationType>quarter</durationType>
+            <Note>
+              <eid>TW8MuJu2ioG_fVM8ZU69UqP</eid>
+              <Spanner type="Tie">
+                <prev>
+                  <location>
+                    <measures>-1</measures>
+                    <fractions>3/4</fractions>
+                    </location>
+                  </prev>
+                </Spanner>
+              <pitch>67</pitch>
+              <tpc>15</tpc>
+              </Note>
+            </Chord>
+          <Rest>
+            <eid>Z9ieNWhuMRK_iJoyT8yWFQL</eid>
+            <durationType>quarter</durationType>
+            </Rest>
+          <Rest>
+            <eid>kbiWDL++dlK_vwfzAJV+1PO</eid>
+            <durationType>quarter</durationType>
+            </Rest>
+          </voice>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>


### PR DESCRIPTION
Resolves: #27888 
Resolves: https://github.com/musescore/MuseScore/issues/28029

To fix the score import issue, I've removed the `searchTieNote114` function - I can't see a reason for this to exist.