### PR TITLE
midi/iex: Fix some assertion failures

### DIFF
--- a/src/importexport/midi/internal/midiimport/importmidi_quant.cpp
+++ b/src/importexport/midi/internal/midiimport/importmidi_quant.cpp
@@ -581,9 +581,9 @@ quantizeOffTimeForNonTuplet(
             ++next;
             continue;
         }
+        const bool isInSameTuplet = chord.isInTuplet && next->second.tuplet == chord.tuplet;
         const auto& tuplet = next->second.tuplet->second;
-        if (next->second.tuplet == chord.tuplet
-            || tuplet.onTime + tuplet.len <= offTime) {
+        if (isInSameTuplet || tuplet.onTime + tuplet.len <= offTime) {
             ++next;
             continue;
         }

--- a/src/importexport/midi/tests/midiimport_data/clef_melody-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/clef_melody-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,131 +85,169 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
+          <Beam>
+            <eid>F_F</eid>
+            <l1>18</l1>
+            <l2>6</l2>
+            </Beam>
           <Chord>
+            <eid>G_G</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>H_H</eid>
               <pitch>55</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>I_I</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>J_J</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>K_K</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>L_L</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>M_M</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>N_N</eid>
               <pitch>65</pitch>
               <tpc>13</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
+          <Beam>
+            <eid>O_O</eid>
+            <l1>-6</l1>
+            <l2>-4</l2>
+            </Beam>
           <Chord>
+            <eid>P_P</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>Q_Q</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>R_R</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>S_S</eid>
               <pitch>69</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>T_T</eid>
             <durationType>quarter</durationType>
             </Rest>
-          </voice>
-        </Measure>
-      <Measure>
-        <voice>
           <Clef>
             <concertClefType>F</concertClefType>
             <transposingClefType>F</transposingClefType>
+            <eid>U_U</eid>
             </Clef>
+          </voice>
+        </Measure>
+      <Measure>
+        <eid>V_V</eid>
+        <voice>
+          <Beam>
+            <eid>W_W</eid>
+            <l1>34</l1>
+            <l2>34</l2>
+            </Beam>
           <Chord>
+            <eid>X_X</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>Y_Y</eid>
               <pitch>55</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>Z_Z</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>a_a</eid>
               <pitch>52</pitch>
               <tpc>18</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>b_b</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>c_c</eid>
               <pitch>53</pitch>
               <tpc>13</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>d_d</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>e_e</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
+          <Beam>
+            <eid>f_f</eid>
+            <l1>14</l1>
+            <l2>16</l2>
+            </Beam>
           <Chord>
+            <eid>g_g</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>h_h</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>i_i</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>j_j</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>k_k</eid>
             <durationType>quarter</durationType>
             </Rest>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/clef_prev-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/clef_prev-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -84,115 +86,162 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Chord>
+            <eid>F_F</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>G_G</eid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>H_H</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
+            <eid>I_I</eid>
             <durationType>half</durationType>
             </Rest>
-          </voice>
-        </Measure>
-      <Measure>
-        <voice>
           <Clef>
             <concertClefType>G</concertClefType>
             <transposingClefType>G</transposingClefType>
+            <eid>J_J</eid>
             </Clef>
+          </voice>
+        </Measure>
+      <Measure>
+        <eid>K_K</eid>
+        <voice>
           <Tuplet>
+            <eid>L_L</eid>
             <normalNotes>2</normalNotes>
             <actualNotes>3</actualNotes>
             <baseNote>eighth</baseNote>
+            <Number>
+              <style>tuplet</style>
+              <text>3</text>
+              </Number>
             </Tuplet>
           <Chord>
+            <eid>M_M</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>N_N</eid>
+              <Accidental>
+                <subtype>accidentalSharp</subtype>
+                <eid>O_O</eid>
+                </Accidental>
               <pitch>56</pitch>
               <tpc>22</tpc>
               <velocity>76</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>P_P</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>Q_Q</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <velocity>48</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <endTuplet/>
           <Tuplet>
+            <eid>R_R</eid>
             <normalNotes>2</normalNotes>
             <actualNotes>3</actualNotes>
             <baseNote>eighth</baseNote>
+            <Number>
+              <style>tuplet</style>
+              <text>3</text>
+              </Number>
             </Tuplet>
           <Chord>
+            <eid>S_S</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>T_T</eid>
+              <Accidental>
+                <subtype>accidentalFlat</subtype>
+                <eid>U_U</eid>
+                </Accidental>
               <pitch>63</pitch>
               <tpc>11</tpc>
               <velocity>65</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>V_V</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>W_W</eid>
+              <Accidental>
+                <subtype>accidentalSharp</subtype>
+                <eid>X_X</eid>
+                </Accidental>
               <pitch>68</pitch>
               <tpc>22</tpc>
               <velocity>79</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <endTuplet/>
           <Tuplet>
+            <eid>Y_Y</eid>
             <normalNotes>2</normalNotes>
             <actualNotes>3</actualNotes>
             <baseNote>eighth</baseNote>
+            <Number>
+              <style>tuplet</style>
+              <text>3</text>
+              </Number>
             </Tuplet>
           <Rest>
+            <eid>Z_Z</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Chord>
+            <eid>a_a</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>b_b</eid>
               <pitch>68</pitch>
               <tpc>22</tpc>
               <velocity>71</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <endTuplet/>
           <Tuplet>
+            <eid>c_c</eid>
             <normalNotes>2</normalNotes>
             <actualNotes>3</actualNotes>
             <baseNote>eighth</baseNote>
+            <Number>
+              <style>tuplet</style>
+              <text>3</text>
+              </Number>
             </Tuplet>
           <Rest>
+            <eid>d_d</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Chord>
+            <eid>e_e</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>f_f</eid>
               <pitch>68</pitch>
               <tpc>22</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <endTuplet/>

--- a/src/importexport/midi/tests/midiimport_data/human_4-4-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/human_4-4-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -84,48 +86,55 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <KeySig>
-            <accidental>1</accidental>
+            <eid>E_E</eid>
+            <concertKey>1</concertKey>
             </KeySig>
           <TimeSig>
+            <eid>F_F</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Chord>
+            <eid>G_G</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>H_H</eid>
               <pitch>42</pitch>
               <tpc>20</tpc>
               <velocity>70</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>I_I</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>J_J</eid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <velocity>70</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>K_K</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>L_L</eid>
               <pitch>43</pitch>
               <tpc>15</tpc>
               <velocity>70</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>M_M</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>N_N</eid>
               <pitch>42</pitch>
               <tpc>20</tpc>
               <velocity>70</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/human_tempo-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/human_tempo-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,15 +20,17 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
         <bracket type="1" span="2" col="0" visible="1"/>
         <barLineSpan>1</barLineSpan>
         </Staff>
-      <Staff id="2">
+      <Staff>
+        <eid>D_D</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -90,556 +93,721 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>E_E</eid>
         <voice>
           <TimeSig>
+            <eid>F_F</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Tempo>
-            <tempo>2.2000000000000002</tempo>
+            <tempo>2.2</tempo>
+            <eid>G_G</eid>
             <text><sym>metNoteQuarterUp</sym> = 132</text>
             </Tempo>
           <Rest>
+            <eid>H_H</eid>
             <durationType>half</durationType>
             </Rest>
           <Rest>
+            <eid>I_I</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
+            <eid>J_J</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Rest>
+            <eid>K_K</eid>
             <durationType>16th</durationType>
             </Rest>
           <Rest>
+            <eid>L_L</eid>
             <durationType>32nd</durationType>
             </Rest>
           <Chord>
+            <eid>M_M</eid>
             <durationType>32nd</durationType>
             <Note>
+              <eid>N_N</eid>
+              <Accidental>
+                <subtype>accidentalFlat</subtype>
+                <eid>O_O</eid>
+                </Accidental>
               <pitch>75</pitch>
               <tpc>11</tpc>
               <velocity>101</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         </Measure>
       <Measure>
+        <eid>P_P</eid>
         <voice>
           <Chord>
+            <eid>Q_Q</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>R_R</eid>
               <pitch>76</pitch>
               <tpc>18</tpc>
               <velocity>100</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>S_S</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
+            <eid>T_T</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>
         <voice>
           <Rest>
+            <eid>U_U</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Chord>
+            <eid>V_V</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>W_W</eid>
               </Articulation>
             <Note>
+              <eid>X_X</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>63</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
+          <Beam>
+            <eid>Y_Y</eid>
+            <l1>56</l1>
+            <l2>56</l2>
+            </Beam>
           <Chord>
+            <eid>Z_Z</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>a_a</eid>
               </Articulation>
             <Note>
+              <eid>b_b</eid>
               <pitch>76</pitch>
               <tpc>18</tpc>
               <velocity>108</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>c_c</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>d_d</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>68</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>e_e</eid>
             <durationType>16th</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>f_f</eid>
               </Articulation>
             <Note>
+              <eid>g_g</eid>
               <pitch>76</pitch>
               <tpc>18</tpc>
               <velocity>100</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
+          <Beam>
+            <eid>h_h</eid>
+            <l1>48</l1>
+            <l2>52</l2>
+            </Beam>
           <Chord>
+            <eid>i_i</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>j_j</eid>
               </Articulation>
             <Note>
+              <eid>k_k</eid>
               <pitch>76</pitch>
               <tpc>18</tpc>
               <velocity>109</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>l_l</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>m_m</eid>
               </Articulation>
             <Note>
+              <eid>n_n</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>75</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
+          <Beam>
+            <eid>o_o</eid>
+            <l1>56</l1>
+            <l2>56</l2>
+            </Beam>
           <Chord>
+            <eid>p_p</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>q_q</eid>
               </Articulation>
             <Note>
+              <eid>r_r</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>109</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>s_s</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>t_t</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>63</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>u_u</eid>
             <durationType>16th</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>v_v</eid>
               </Articulation>
             <Note>
+              <eid>w_w</eid>
               <pitch>69</pitch>
               <tpc>17</tpc>
               <velocity>79</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         </Measure>
       <Measure>
+        <eid>x_x</eid>
         <voice>
           <Chord>
+            <eid>y_y</eid>
             <durationType>quarter</durationType>
             <Articulation>
               <subtype>articStaccatoAbove</subtype>
+              <eid>z_z</eid>
               </Articulation>
             <Note>
+              <eid>0_0</eid>
               <pitch>69</pitch>
               <tpc>17</tpc>
               <velocity>93</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>1_1</eid>
             <durationType>half</durationType>
             <Note>
+              <eid>2_2</eid>
               <pitch>68</pitch>
               <tpc>22</tpc>
               <velocity>95</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>3_3</eid>
             <durationType>quarter</durationType>
             </Rest>
           </voice>
         <voice>
           <Rest>
+            <eid>4_4</eid>
             <durationType>32nd</durationType>
             </Rest>
+          <Beam>
+            <eid>5_5</eid>
+            <l1>56</l1>
+            <l2>52</l2>
+            </Beam>
           <Chord>
+            <eid>6_6</eid>
             <dots>1</dots>
             <durationType>16th</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>7_7</eid>
               </Articulation>
             <Note>
+              <eid>8_8</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>75</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>9_9</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>+_+</eid>
               </Articulation>
             <Note>
+              <eid>/_/</eid>
+              <Accidental>
+                <subtype>accidentalSharp</subtype>
+                <eid>AB_AB</eid>
+                </Accidental>
               <pitch>68</pitch>
               <tpc>22</tpc>
               <velocity>100</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>BB_BB</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Chord>
+            <eid>CB_CB</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>DB_DB</eid>
               </Articulation>
             <Note>
+              <eid>EB_EB</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>66</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
+          <Beam>
+            <eid>FB_FB</eid>
+            <l1>52</l1>
+            <l2>52</l2>
+            </Beam>
           <Chord>
+            <eid>GB_GB</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>HB_HB</eid>
               </Articulation>
             <Note>
+              <eid>IB_IB</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>66</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>JB_JB</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>KB_KB</eid>
               </Articulation>
             <Note>
+              <eid>LB_LB</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
+          <Beam>
+            <eid>MB_MB</eid>
+            <l1>56</l1>
+            <l2>56</l2>
+            </Beam>
           <Chord>
+            <eid>NB_NB</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>OB_OB</eid>
               </Articulation>
             <Note>
+              <eid>PB_PB</eid>
               <pitch>74</pitch>
               <tpc>16</tpc>
               <velocity>104</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>QB_QB</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>RB_RB</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>71</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>SB_SB</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>TB_TB</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>100</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         </Measure>
       <Measure>
+        <eid>UB_UB</eid>
         <voice>
           <Rest>
+            <eid>VB_VB</eid>
             <durationType>half</durationType>
             </Rest>
           <Chord>
+            <eid>WB_WB</eid>
             <durationType>quarter</durationType>
             <Articulation>
               <subtype>articStaccatoAbove</subtype>
+              <eid>XB_XB</eid>
               </Articulation>
             <Note>
+              <eid>YB_YB</eid>
               <pitch>76</pitch>
               <tpc>18</tpc>
               <velocity>104</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>ZB_ZB</eid>
             <durationType>quarter</durationType>
             </Rest>
           </voice>
         <voice>
           <Chord>
+            <eid>aB_aB</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>bB_bB</eid>
               <pitch>76</pitch>
               <tpc>18</tpc>
               <velocity>103</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>cB_cB</eid>
             <durationType>64th</durationType>
             </Rest>
           <Chord>
+            <eid>dB_dB</eid>
             <dots>1</dots>
             <durationType>32nd</durationType>
             <Note>
+              <eid>eB_eB</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>60</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>fB_fB</eid>
             <durationType>16th</durationType>
             </Rest>
+          <Beam>
+            <eid>gB_gB</eid>
+            <l1>56</l1>
+            <l2>56</l2>
+            </Beam>
           <Chord>
+            <eid>hB_hB</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>iB_iB</eid>
               </Articulation>
             <Note>
+              <eid>jB_jB</eid>
               <pitch>76</pitch>
               <tpc>18</tpc>
               <velocity>106</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>kB_kB</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>lB_lB</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>82</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>mB_mB</eid>
             <durationType>16th</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>nB_nB</eid>
               </Articulation>
             <Note>
+              <eid>oB_oB</eid>
               <pitch>76</pitch>
               <tpc>18</tpc>
               <velocity>108</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>pB_pB</eid>
             <durationType>64th</durationType>
             </Rest>
           <Chord>
+            <eid>qB_qB</eid>
             <dots>1</dots>
             <durationType>32nd</durationType>
             <Note>
+              <eid>rB_rB</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>82</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>sB_sB</eid>
             <durationType>16th</durationType>
             </Rest>
+          <Beam>
+            <eid>tB_tB</eid>
+            <l1>30</l1>
+            <l2>32</l2>
+            </Beam>
           <Chord>
+            <eid>uB_uB</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>vB_vB</eid>
               <pitch>77</pitch>
               <tpc>13</tpc>
               <velocity>99</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>wB_wB</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>xB_xB</eid>
               <pitch>76</pitch>
               <tpc>18</tpc>
               <velocity>102</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
+          <Beam>
+            <eid>yB_yB</eid>
+            <l1>38</l1>
+            <l2>44</l2>
+            </Beam>
           <Chord>
+            <eid>zB_zB</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>0B_0B</eid>
               <pitch>74</pitch>
               <tpc>16</tpc>
               <velocity>92</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>1B_1B</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>2B_2B</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>88</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>3B_3B</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>4B_4B</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>88</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>5B_5B</eid>
             <durationType>16th</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>6B_6B</eid>
               </Articulation>
             <Note>
+              <eid>7B_7B</eid>
               <pitch>69</pitch>
               <tpc>17</tpc>
               <velocity>84</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         </Measure>
       <Measure>
+        <eid>8B_8B</eid>
         <voice>
           <Rest>
+            <eid>9B_9B</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Chord>
+            <eid>+B_+B</eid>
             <durationType>half</durationType>
             <Note>
+              <eid>/B_/B</eid>
               <pitch>68</pitch>
               <tpc>22</tpc>
               <velocity>89</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>AC_AC</eid>
             <durationType>quarter</durationType>
             </Rest>
           </voice>
         <voice>
+          <Beam>
+            <eid>BC_BC</eid>
+            <l1>42</l1>
+            <l2>44</l2>
+            </Beam>
           <Chord>
+            <eid>CC_CC</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>DC_DC</eid>
               <pitch>69</pitch>
               <tpc>17</tpc>
               <velocity>101</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>EC_EC</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>FC_FC</eid>
               </Articulation>
             <Note>
+              <eid>GC_GC</eid>
+              <Accidental>
+                <subtype>accidentalSharp</subtype>
+                <eid>HC_HC</eid>
+                </Accidental>
               <pitch>68</pitch>
               <tpc>22</tpc>
               <velocity>96</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>IC_IC</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Chord>
+            <eid>JC_JC</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>KC_KC</eid>
               </Articulation>
             <Note>
+              <eid>LC_LC</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>54</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
+          <Beam>
+            <eid>MC_MC</eid>
+            <l1>52</l1>
+            <l2>52</l2>
+            </Beam>
           <Chord>
+            <eid>NC_NC</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>OC_OC</eid>
               </Articulation>
             <Note>
+              <eid>PC_PC</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>71</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>QC_QC</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>RC_RC</eid>
               </Articulation>
             <Note>
+              <eid>SC_SC</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>57</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
+          <Beam>
+            <eid>TC_TC</eid>
+            <l1>56</l1>
+            <l2>56</l2>
+            </Beam>
           <Chord>
+            <eid>UC_UC</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>VC_VC</eid>
               </Articulation>
             <Note>
+              <eid>WC_WC</eid>
               <pitch>74</pitch>
               <tpc>16</tpc>
               <velocity>103</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>XC_XC</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>YC_YC</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>63</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>ZC_ZC</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>aC_aC</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>94</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
@@ -649,26 +817,34 @@
       <Measure>
         <voice>
           <TimeSig>
+            <eid>bC_bC</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Rest>
+            <eid>cC_cC</eid>
             <durationType>half</durationType>
             </Rest>
           <Rest>
+            <eid>dC_dC</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
+            <eid>eC_eC</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Rest>
+            <eid>fC_fC</eid>
             <durationType>16th</durationType>
             </Rest>
           <Chord>
+            <eid>gC_gC</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>hC_hC</eid>
               <Spanner type="Tie">
                 <Tie>
+                  <eid>iC_iC</eid>
                   </Tie>
                 <next>
                   <location>
@@ -680,11 +856,12 @@
               <pitch>57</pitch>
               <tpc>17</tpc>
               <velocity>76</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>jC_jC</eid>
               <Spanner type="Tie">
                 <Tie>
+                  <eid>kC_kC</eid>
                   </Tie>
                 <next>
                   <location>
@@ -696,11 +873,12 @@
               <pitch>60</pitch>
               <tpc>14</tpc>
               <velocity>85</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>lC_lC</eid>
               <Spanner type="Tie">
                 <Tie>
+                  <eid>mC_mC</eid>
                   </Tie>
                 <next>
                   <location>
@@ -712,16 +890,22 @@
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>86</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         </Measure>
       <Measure>
         <voice>
+          <Beam>
+            <eid>nC_nC</eid>
+            <l1>8</l1>
+            <l2>8</l2>
+            </Beam>
           <Chord>
+            <eid>oC_oC</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>pC_pC</eid>
               <Spanner type="Tie">
                 <prev>
                   <location>
@@ -733,9 +917,9 @@
               <pitch>57</pitch>
               <tpc>17</tpc>
               <velocity>76</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>qC_qC</eid>
               <Spanner type="Tie">
                 <prev>
                   <location>
@@ -747,9 +931,9 @@
               <pitch>60</pitch>
               <tpc>14</tpc>
               <velocity>85</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>rC_rC</eid>
               <Spanner type="Tie">
                 <prev>
                   <location>
@@ -761,767 +945,864 @@
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>86</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>sC_sC</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>tC_tC</eid>
               </Articulation>
             <Note>
+              <eid>uC_uC</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <velocity>59</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>vC_vC</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <velocity>70</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>wC_wC</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>xC_xC</eid>
               </Articulation>
             <Note>
+              <eid>yC_yC</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <velocity>57</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>zC_zC</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <velocity>69</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>0C_0C</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>68</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>1C_1C</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>2C_2C</eid>
               </Articulation>
             <Note>
+              <eid>3C_3C</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <velocity>59</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>4C_4C</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <velocity>70</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
+          <Beam>
+            <eid>5C_5C</eid>
+            <l1>8</l1>
+            <l2>8</l2>
+            </Beam>
           <Chord>
+            <eid>6C_6C</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>7C_7C</eid>
               </Articulation>
             <Note>
+              <eid>8C_8C</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <velocity>62</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>9C_9C</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <velocity>68</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>+C_+C</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>70</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>/C_/C</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>AD_AD</eid>
               </Articulation>
             <Note>
+              <eid>BD_BD</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <velocity>59</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>CD_CD</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <velocity>71</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>DD_DD</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>ED_ED</eid>
               </Articulation>
             <Note>
+              <eid>FD_FD</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <velocity>61</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>GD_GD</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <velocity>68</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>HD_HD</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>67</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>ID_ID</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>JD_JD</eid>
               </Articulation>
             <Note>
+              <eid>KD_KD</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <velocity>68</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>LD_LD</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <velocity>71</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         </Measure>
       <Measure>
         <voice>
+          <Beam>
+            <eid>MD_MD</eid>
+            <l1>8</l1>
+            <l2>8</l2>
+            </Beam>
           <Chord>
+            <eid>ND_ND</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>OD_OD</eid>
               </Articulation>
             <Note>
+              <eid>PD_PD</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <velocity>55</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>QD_QD</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               <velocity>59</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>RD_RD</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <velocity>77</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>SD_SD</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>TD_TD</eid>
               </Articulation>
             <Note>
+              <eid>UD_UD</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <velocity>55</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>VD_VD</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               <velocity>60</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>WD_WD</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <velocity>65</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>XD_XD</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>58</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>YD_YD</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>ZD_ZD</eid>
               </Articulation>
             <Note>
+              <eid>aD_aD</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <velocity>36</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>bD_bD</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               <velocity>55</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>cD_cD</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <velocity>68</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>dD_dD</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>61</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>eD_eD</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>fD_fD</eid>
               </Articulation>
             <Note>
+              <eid>gD_gD</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <velocity>34</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>hD_hD</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               <velocity>57</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>iD_iD</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <velocity>71</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
+          <Beam>
+            <eid>jD_jD</eid>
+            <l1>8</l1>
+            <l2>8</l2>
+            </Beam>
           <Chord>
+            <eid>kD_kD</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>lD_lD</eid>
               </Articulation>
             <Note>
+              <eid>mD_mD</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <velocity>54</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>nD_nD</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               <velocity>51</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>oD_oD</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <velocity>69</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>pD_pD</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>qD_qD</eid>
               </Articulation>
             <Note>
+              <eid>rD_rD</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <velocity>51</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>sD_sD</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               <velocity>60</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>tD_tD</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <velocity>68</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>uD_uD</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>vD_vD</eid>
               </Articulation>
             <Note>
+              <eid>wD_wD</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <velocity>53</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>xD_xD</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               <velocity>65</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>yD_yD</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <velocity>72</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>zD_zD</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>70</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>0D_0D</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>1D_1D</eid>
               </Articulation>
             <Note>
+              <eid>2D_2D</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <velocity>50</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>3D_3D</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               <velocity>68</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>4D_4D</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <velocity>71</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         </Measure>
       <Measure>
         <voice>
+          <Beam>
+            <eid>5D_5D</eid>
+            <l1>8</l1>
+            <l2>8</l2>
+            </Beam>
           <Chord>
+            <eid>6D_6D</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>7D_7D</eid>
               </Articulation>
             <Note>
+              <eid>8D_8D</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <velocity>74</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>9D_9D</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <velocity>81</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>+D_+D</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>83</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>/D_/D</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>AE_AE</eid>
               </Articulation>
             <Note>
+              <eid>BE_BE</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <velocity>43</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>CE_CE</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <velocity>66</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>DE_DE</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>EE_EE</eid>
               </Articulation>
             <Note>
+              <eid>FE_FE</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <velocity>43</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>GE_GE</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <velocity>76</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>HE_HE</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>IE_IE</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>JE_JE</eid>
               </Articulation>
             <Note>
+              <eid>KE_KE</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <velocity>78</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>LE_LE</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <velocity>93</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>ME_ME</eid>
             <durationType>64th</durationType>
             </Rest>
           <Chord>
+            <eid>NE_NE</eid>
             <dots>1</dots>
             <durationType>32nd</durationType>
             <Note>
+              <eid>OE_OE</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <velocity>60</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>PE_PE</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <velocity>88</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>QE_QE</eid>
             <durationType>16th</durationType>
             </Rest>
+          <Beam>
+            <eid>RE_RE</eid>
+            <l1>8</l1>
+            <l2>8</l2>
+            </Beam>
           <Chord>
+            <eid>SE_SE</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>TE_TE</eid>
               </Articulation>
             <Note>
+              <eid>UE_UE</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <velocity>60</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>VE_VE</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <velocity>84</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>WE_WE</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>71</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>XE_XE</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>YE_YE</eid>
               </Articulation>
             <Note>
+              <eid>ZE_ZE</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <velocity>51</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>aE_aE</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <velocity>76</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>bE_bE</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>65</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>cE_cE</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>dE_dE</eid>
               </Articulation>
             <Note>
+              <eid>eE_eE</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <velocity>44</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>fE_fE</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <velocity>63</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>gE_gE</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>61</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         </Measure>
       <Measure>
         <voice>
+          <Beam>
+            <eid>hE_hE</eid>
+            <l1>8</l1>
+            <l2>8</l2>
+            </Beam>
           <Chord>
+            <eid>iE_iE</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>jE_jE</eid>
               </Articulation>
             <Note>
+              <eid>kE_kE</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <velocity>59</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>lE_lE</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               <velocity>76</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>mE_mE</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <velocity>82</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>nE_nE</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>73</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>oE_oE</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>pE_pE</eid>
               </Articulation>
             <Note>
+              <eid>qE_qE</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <velocity>44</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>rE_rE</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               <velocity>59</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>sE_sE</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <velocity>68</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>tE_tE</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>53</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>uE_uE</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>vE_vE</eid>
               </Articulation>
             <Note>
+              <eid>wE_wE</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <velocity>42</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>xE_xE</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>yE_yE</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <velocity>65</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>zE_zE</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>60</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>0E_0E</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>1E_1E</eid>
               </Articulation>
             <Note>
+              <eid>2E_2E</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <velocity>36</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>3E_3E</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               <velocity>60</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>4E_4E</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <velocity>61</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
+          <Beam>
+            <eid>5E_5E</eid>
+            <l1>8</l1>
+            <l2>8</l2>
+            </Beam>
           <Chord>
+            <eid>6E_6E</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>7E_7E</eid>
               </Articulation>
             <Note>
+              <eid>8E_8E</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <velocity>48</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>9E_9E</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               <velocity>57</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>+E_+E</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <velocity>68</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>/E_/E</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>AF_AF</eid>
               </Articulation>
             <Note>
+              <eid>BF_BF</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <velocity>35</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>CF_CF</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               <velocity>53</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>DF_DF</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <velocity>65</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>EF_EF</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>FF_FF</eid>
               </Articulation>
             <Note>
+              <eid>GF_GF</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <velocity>40</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>HF_HF</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               <velocity>51</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>IF_IF</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <velocity>68</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>JF_JF</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>62</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>KF_KF</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>LF_LF</eid>
               </Articulation>
             <Note>
+              <eid>MF_MF</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <velocity>36</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>NF_NF</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               <velocity>51</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>OF_OF</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/lyrics_time_0-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/lyrics_time_0-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,15 +20,17 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
         <bracket type="1" span="2" col="0" visible="1"/>
         <barLineSpan>1</barLineSpan>
         </Staff>
-      <Staff id="2">
+      <Staff>
+        <eid>D_D</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -91,60 +94,79 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>E_E</eid>
         <voice>
           <KeySig>
-            <accidental>1</accidental>
+            <eid>F_F</eid>
+            <concertKey>1</concertKey>
             </KeySig>
           <TimeSig>
+            <eid>G_G</eid>
             <sigN>3</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Chord>
+            <eid>H_H</eid>
             <durationType>quarter</durationType>
             <Lyrics>
-              <text>G_maj_0 </text>
+              <eid>I_I</eid>
+              <text>G_maj_0</text>
               </Lyrics>
             <Note>
+              <eid>J_J</eid>
               <pitch>74</pitch>
               <tpc>16</tpc>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
+          <Beam>
+            <eid>K_K</eid>
+            <l1>0</l1>
+            <l2>-2</l2>
+            </Beam>
           <Chord>
+            <eid>L_L</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>M_M</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>N_N</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>O_O</eid>
               <pitch>69</pitch>
               <tpc>17</tpc>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
+          <Beam>
+            <eid>P_P</eid>
+            <l1>38</l1>
+            <l2>36</l2>
+            </Beam>
           <Chord>
+            <eid>Q_Q</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>R_R</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>S_S</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>T_T</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
@@ -154,40 +176,44 @@
       <Measure>
         <voice>
           <KeySig>
-            <accidental>1</accidental>
+            <eid>U_U</eid>
+            <concertKey>1</concertKey>
             </KeySig>
           <TimeSig>
+            <eid>V_V</eid>
             <sigN>3</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Chord>
+            <eid>W_W</eid>
             <durationType>half</durationType>
             <Note>
+              <eid>X_X</eid>
               <pitch>55</pitch>
               <tpc>15</tpc>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>Y_Y</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>Z_Z</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>a_a</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>b_b</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/lyrics_voice_1-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/lyrics_voice_1-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,15 +20,17 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
         <bracket type="1" span="2" col="0" visible="1"/>
         <barLineSpan>1</barLineSpan>
         </Staff>
-      <Staff id="2">
+      <Staff>
+        <eid>D_D</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -91,104 +94,131 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>E_E</eid>
         <voice>
           <KeySig>
-            <accidental>-2</accidental>
+            <eid>F_F</eid>
+            <concertKey>-2</concertKey>
             </KeySig>
           <TimeSig>
+            <eid>G_G</eid>
             <sigN>3</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Rest>
+            <eid>H_H</eid>
             <durationType>measure</durationType>
             <duration>3/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
+        <eid>I_I</eid>
         <voice>
           <Rest>
+            <eid>J_J</eid>
             <durationType>measure</durationType>
             <duration>3/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
+        <eid>K_K</eid>
         <voice>
           <Rest>
+            <eid>L_L</eid>
             <durationType>measure</durationType>
             <duration>3/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
+        <eid>M_M</eid>
         <voice>
           <Rest>
+            <eid>N_N</eid>
             <durationType>measure</durationType>
             <duration>3/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
+        <eid>O_O</eid>
         <voice>
           <Rest>
+            <eid>P_P</eid>
             <durationType>measure</durationType>
             <duration>3/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
+        <eid>Q_Q</eid>
         <voice>
           <Rest>
+            <eid>R_R</eid>
             <durationType>measure</durationType>
             <duration>3/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
+        <eid>S_S</eid>
         <voice>
           <Rest>
+            <eid>T_T</eid>
             <durationType>measure</durationType>
             <duration>3/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
+        <eid>U_U</eid>
         <voice>
           <Rest>
+            <eid>V_V</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
+            <eid>W_W</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Chord>
+            <eid>X_X</eid>
             <durationType>quarter</durationType>
             <Lyrics>
-              <text>C_min_0 </text>
+              <eid>Y_Y</eid>
+              <text>C_min_0</text>
               </Lyrics>
             <Lyrics>
-              <text>C_min_0 </text>
+              <eid>Z_Z</eid>
+              <text>C_min_0</text>
               </Lyrics>
             <Note>
+              <eid>a_a</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         <voice>
           <Rest>
+            <eid>b_b</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
+            <eid>c_c</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Chord>
+            <eid>d_d</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>e_e</eid>
               <Spanner type="Tie">
                 <Tie>
+                  <eid>f_f</eid>
                   </Tie>
                 <next>
                   <location>
@@ -200,24 +230,33 @@
               <pitch>63</pitch>
               <tpc>11</tpc>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         </Measure>
       <Measure>
+        <eid>g_g</eid>
         <voice>
           <Rest>
+            <eid>h_h</eid>
             <durationType>measure</durationType>
             <duration>3/4</duration>
             </Rest>
           </voice>
         <voice>
+          <Beam>
+            <eid>i_i</eid>
+            <l1>52</l1>
+            <l2>52</l2>
+            </Beam>
           <Chord>
+            <eid>j_j</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>k_k</eid>
               <Spanner type="Tie">
                 <Tie>
+                  <eid>l_l</eid>
                   </Tie>
                 <next>
                   <location>
@@ -236,18 +275,19 @@
               <pitch>63</pitch>
               <tpc>11</tpc>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>m_m</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>n_n</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>o_o</eid>
               <Spanner type="Tie">
                 <prev>
                   <location>
@@ -258,49 +298,52 @@
               <pitch>63</pitch>
               <tpc>11</tpc>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>p_p</eid>
               <pitch>69</pitch>
               <tpc>17</tpc>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>q_q</eid>
             <durationType>quarter</durationType>
             <Lyrics>
-              <text>G_min_0 </text>
+              <eid>r_r</eid>
+              <text>G_min_0</text>
               </Lyrics>
             <Note>
+              <eid>s_s</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>t_t</eid>
               <pitch>70</pitch>
               <tpc>12</tpc>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>u_u</eid>
             <durationType>quarter</durationType>
             <Lyrics>
-              <text>C_min_0 </text>
+              <eid>v_v</eid>
+              <text>C_min_0</text>
               </Lyrics>
             <Note>
+              <eid>w_w</eid>
               <pitch>63</pitch>
               <tpc>11</tpc>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>x_x</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
@@ -310,13 +353,16 @@
       <Measure>
         <voice>
           <KeySig>
-            <accidental>-2</accidental>
+            <eid>y_y</eid>
+            <concertKey>-2</concertKey>
             </KeySig>
           <TimeSig>
+            <eid>z_z</eid>
             <sigN>3</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Rest>
+            <eid>0_0</eid>
             <durationType>measure</durationType>
             <duration>3/4</duration>
             </Rest>
@@ -325,6 +371,7 @@
       <Measure>
         <voice>
           <Rest>
+            <eid>1_1</eid>
             <durationType>measure</durationType>
             <duration>3/4</duration>
             </Rest>
@@ -333,6 +380,7 @@
       <Measure>
         <voice>
           <Rest>
+            <eid>2_2</eid>
             <durationType>measure</durationType>
             <duration>3/4</duration>
             </Rest>
@@ -341,6 +389,7 @@
       <Measure>
         <voice>
           <Rest>
+            <eid>3_3</eid>
             <durationType>measure</durationType>
             <duration>3/4</duration>
             </Rest>
@@ -349,6 +398,7 @@
       <Measure>
         <voice>
           <Rest>
+            <eid>4_4</eid>
             <durationType>measure</durationType>
             <duration>3/4</duration>
             </Rest>
@@ -357,6 +407,7 @@
       <Measure>
         <voice>
           <Rest>
+            <eid>5_5</eid>
             <durationType>measure</durationType>
             <duration>3/4</duration>
             </Rest>
@@ -365,6 +416,7 @@
       <Measure>
         <voice>
           <Rest>
+            <eid>6_6</eid>
             <durationType>measure</durationType>
             <duration>3/4</duration>
             </Rest>
@@ -373,16 +425,21 @@
       <Measure>
         <voice>
           <Rest>
+            <eid>7_7</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
+            <eid>8_8</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Chord>
+            <eid>9_9</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>+_+</eid>
               <Spanner type="Tie">
                 <Tie>
+                  <eid>/_/</eid>
                   </Tie>
                 <next>
                   <location>
@@ -394,11 +451,12 @@
               <pitch>48</pitch>
               <tpc>14</tpc>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>AB_AB</eid>
               <Spanner type="Tie">
                 <Tie>
+                  <eid>BB_BB</eid>
                   </Tie>
                 <next>
                   <location>
@@ -410,7 +468,6 @@
               <pitch>55</pitch>
               <tpc>15</tpc>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
@@ -418,8 +475,10 @@
       <Measure>
         <voice>
           <Chord>
+            <eid>CB_CB</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>DB_DB</eid>
               <Spanner type="Tie">
                 <prev>
                   <location>
@@ -431,9 +490,9 @@
               <pitch>48</pitch>
               <tpc>14</tpc>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>EB_EB</eid>
               <Spanner type="Tie">
                 <prev>
                   <location>
@@ -445,37 +504,38 @@
               <pitch>55</pitch>
               <tpc>15</tpc>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>FB_FB</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>GB_GB</eid>
               <pitch>43</pitch>
               <tpc>15</tpc>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>HB_HB</eid>
               <pitch>55</pitch>
               <tpc>15</tpc>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>IB_IB</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>JB_JB</eid>
               <pitch>48</pitch>
               <tpc>14</tpc>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>KB_KB</eid>
               <pitch>55</pitch>
               <tpc>15</tpc>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/pickup_turn_off-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/pickup_turn_off-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,154 +85,202 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>6</sigN>
             <sigD>8</sigD>
             </TimeSig>
           <Rest>
+            <eid>F_F</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Chord>
+            <eid>G_G</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>H_H</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>110</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
+          <Beam>
+            <eid>I_I</eid>
+            <l1>-6</l1>
+            <l2>-4</l2>
+            </Beam>
           <Chord>
+            <eid>J_J</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>K_K</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>110</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>L_L</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>M_M</eid>
               <pitch>69</pitch>
               <tpc>17</tpc>
               <velocity>110</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>N_N</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>O_O</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>110</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         </Measure>
       <Measure>
+        <eid>P_P</eid>
         <voice>
           <TimeSig>
+            <eid>Q_Q</eid>
             <sigN>7</sigN>
             <sigD>8</sigD>
             </TimeSig>
           <Chord>
+            <eid>R_R</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>S_S</eid>
+              <Accidental>
+                <subtype>accidentalFlat</subtype>
+                <eid>T_T</eid>
+                </Accidental>
               <pitch>70</pitch>
               <tpc>12</tpc>
               <velocity>110</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>U_U</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>V_V</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>110</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>W_W</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>X_X</eid>
+              <Accidental>
+                <subtype>accidentalSharp</subtype>
+                <eid>Y_Y</eid>
+                </Accidental>
               <pitch>68</pitch>
               <tpc>22</tpc>
               <velocity>110</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
+          <Beam>
+            <eid>Z_Z</eid>
+            <l1>0</l1>
+            <l2>2</l2>
+            </Beam>
           <Chord>
+            <eid>a_a</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>b_b</eid>
+              <Accidental>
+                <subtype>accidentalNatural</subtype>
+                <eid>c_c</eid>
+                </Accidental>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>110</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>d_d</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>e_e</eid>
               <pitch>65</pitch>
               <tpc>13</tpc>
               <velocity>110</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         </Measure>
       <Measure>
+        <eid>f_f</eid>
         <voice>
           <TimeSig>
+            <eid>g_g</eid>
             <sigN>6</sigN>
             <sigD>8</sigD>
             </TimeSig>
           <Chord>
+            <eid>h_h</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>i_i</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>110</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>j_j</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>k_k</eid>
               <pitch>69</pitch>
               <tpc>17</tpc>
               <velocity>110</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
+          <Beam>
+            <eid>l_l</eid>
+            <l1>42</l1>
+            <l2>38</l2>
+            </Beam>
           <Chord>
+            <eid>m_m</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>n_n</eid>
               <pitch>69</pitch>
               <tpc>17</tpc>
               <velocity>110</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>o_o</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>p_p</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>110</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>q_q</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>r_r</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>110</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/simplify_4th_dotted_tied-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/simplify_4th_dotted_tied-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,27 +85,35 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Chord>
+            <eid>F_F</eid>
             <durationType>half</durationType>
             <Note>
+              <eid>G_G</eid>
               <pitch>65</pitch>
               <tpc>13</tpc>
               <velocity>73</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>H_H</eid>
             <durationType>half</durationType>
             <Note>
+              <eid>I_I</eid>
+              <Accidental>
+                <subtype>accidentalSharp</subtype>
+                <eid>J_J</eid>
+                </Accidental>
               <pitch>66</pitch>
               <tpc>20</tpc>
               <velocity>55</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/simplify_triplet_staccato-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/simplify_triplet_staccato-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,116 +85,171 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
+          <Beam>
+            <eid>F_F</eid>
+            <l1>8</l1>
+            <l2>8</l2>
+            </Beam>
           <Chord>
+            <eid>G_G</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>H_H</eid>
+              <Accidental>
+                <subtype>accidentalFlat</subtype>
+                <eid>I_I</eid>
+                </Accidental>
               <pitch>63</pitch>
               <tpc>11</tpc>
               <velocity>66</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>J_J</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>K_K</eid>
               </Articulation>
             <Note>
+              <eid>L_L</eid>
               <pitch>63</pitch>
               <tpc>11</tpc>
               <velocity>73</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>M_M</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Tuplet>
+            <eid>N_N</eid>
             <normalNotes>2</normalNotes>
             <actualNotes>3</actualNotes>
             <baseNote>eighth</baseNote>
+            <Number>
+              <style>tuplet</style>
+              <text>3</text>
+              </Number>
             </Tuplet>
+          <Beam>
+            <eid>O_O</eid>
+            <l1>10</l1>
+            <l2>8</l2>
+            </Beam>
           <Chord>
+            <eid>P_P</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>Q_Q</eid>
               </Articulation>
             <Note>
+              <eid>R_R</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               <velocity>73</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>S_S</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>T_T</eid>
               </Articulation>
             <Note>
+              <eid>U_U</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <velocity>83</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>V_V</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>W_W</eid>
               </Articulation>
             <Note>
+              <eid>X_X</eid>
               <pitch>63</pitch>
               <tpc>11</tpc>
               <velocity>103</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <endTuplet/>
           <Tuplet>
+            <eid>Y_Y</eid>
             <normalNotes>2</normalNotes>
             <actualNotes>3</actualNotes>
             <baseNote>eighth</baseNote>
+            <Number>
+              <style>tuplet</style>
+              <text>3</text>
+              </Number>
             </Tuplet>
+          <Beam>
+            <eid>Z_Z</eid>
+            <l1>0</l1>
+            <l2>2</l2>
+            </Beam>
           <Chord>
+            <eid>a_a</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>b_b</eid>
               </Articulation>
             <Note>
+              <eid>c_c</eid>
+              <Accidental>
+                <subtype>accidentalSharp</subtype>
+                <eid>d_d</eid>
+                </Accidental>
               <pitch>66</pitch>
               <tpc>20</tpc>
               <velocity>124</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>e_e</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>f_f</eid>
               </Articulation>
             <Note>
+              <eid>g_g</eid>
+              <Accidental>
+                <subtype>accidentalNatural</subtype>
+                <eid>h_h</eid>
+                </Accidental>
               <pitch>65</pitch>
               <tpc>13</tpc>
               <velocity>72</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>i_i</eid>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>j_j</eid>
               </Articulation>
             <Note>
+              <eid>k_k</eid>
               <pitch>63</pitch>
               <tpc>11</tpc>
               <velocity>103</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <endTuplet/>

--- a/src/importexport/midi/tests/midiimport_data/split_acid-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/split_acid-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,15 +20,17 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
         <bracket type="1" span="2" col="0" visible="1"/>
         <barLineSpan>1</barLineSpan>
         </Staff>
-      <Staff id="2">
+      <Staff>
+        <eid>D_D</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -91,30 +94,35 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>E_E</eid>
         <voice>
           <TimeSig>
+            <eid>F_F</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Chord>
+            <eid>G_G</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>H_H</eid>
               <pitch>65</pitch>
               <tpc>13</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>I_I</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Chord>
+            <eid>J_J</eid>
             <durationType>half</durationType>
             <Note>
+              <eid>K_K</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
@@ -124,61 +132,77 @@
       <Measure>
         <voice>
           <TimeSig>
+            <eid>L_L</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
+          <Beam>
+            <eid>M_M</eid>
+            <l1>24</l1>
+            <l2>24</l2>
+            </Beam>
           <Chord>
+            <eid>N_N</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>O_O</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>P_P</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>Q_Q</eid>
+              <Accidental>
+                <subtype>accidentalFlat</subtype>
+                <eid>R_R</eid>
+                </Accidental>
               <pitch>58</pitch>
               <tpc>12</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>S_S</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>T_T</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>U_U</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>V_V</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>W_W</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>X_X</eid>
               <pitch>53</pitch>
               <tpc>13</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>Y_Y</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>Z_Z</eid>
               <pitch>58</pitch>
               <tpc>12</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/swing_clef-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/swing_clef-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,76 +85,103 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <StaffText>
+            <eid>F_F</eid>
             <text>Swing</text>
             </StaffText>
           <Rest>
+            <eid>G_G</eid>
             <durationType>eighth</durationType>
             </Rest>
+          <Beam>
+            <eid>H_H</eid>
+            <l1>0</l1>
+            <l2>2</l2>
+            </Beam>
           <Chord>
+            <eid>I_I</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>J_J</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>K_K</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>L_L</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>M_M</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>N_N</eid>
               <pitch>65</pitch>
               <tpc>13</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
+          <Beam>
+            <eid>O_O</eid>
+            <l1>0</l1>
+            <l2>10</l2>
+            </Beam>
           <Chord>
+            <eid>P_P</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>Q_Q</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>R_R</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>S_S</eid>
               <pitch>65</pitch>
               <tpc>13</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>T_T</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>U_U</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>V_V</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>W_W</eid>
+              <Accidental>
+                <subtype>accidentalFlat</subtype>
+                <eid>X_X</eid>
+                </Accidental>
               <Spanner type="Tie">
                 <Tie>
+                  <eid>Y_Y</eid>
                   </Tie>
                 <next>
                   <location>
@@ -164,16 +193,18 @@
               <pitch>58</pitch>
               <tpc>12</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         </Measure>
       <Measure>
+        <eid>Z_Z</eid>
         <voice>
           <Chord>
+            <eid>a_a</eid>
             <durationType>whole</durationType>
             <Note>
+              <eid>b_b</eid>
               <Spanner type="Tie">
                 <prev>
                   <location>
@@ -185,14 +216,15 @@
               <pitch>58</pitch>
               <tpc>12</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         </Measure>
       <Measure>
+        <eid>c_c</eid>
         <voice>
           <Rest>
+            <eid>d_d</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>

--- a/src/importexport/midi/tests/midiimport_data/tuplet_16th_8th-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/tuplet_16th_8th-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,111 +85,175 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <KeySig>
-            <accidental>2</accidental>
+            <eid>E_E</eid>
+            <concertKey>2</concertKey>
             </KeySig>
           <TimeSig>
+            <eid>F_F</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Chord>
+            <eid>G_G</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>H_H</eid>
+              <Accidental>
+                <subtype>accidentalNatural</subtype>
+                <eid>I_I</eid>
+                </Accidental>
               <pitch>77</pitch>
               <tpc>13</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
+          <Beam>
+            <eid>J_J</eid>
+            <l1>32</l1>
+            <l2>34</l2>
+            </Beam>
           <Chord>
+            <eid>K_K</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>L_L</eid>
+              <Accidental>
+                <subtype>accidentalSharp</subtype>
+                <eid>M_M</eid>
+                </Accidental>
               <pitch>75</pitch>
               <tpc>23</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>N_N</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>O_O</eid>
               <pitch>73</pitch>
               <tpc>21</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
+          <Beam>
+            <eid>P_P</eid>
+            <l1>40</l1>
+            <l2>48</l2>
+            </Beam>
           <Chord>
+            <eid>Q_Q</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>R_R</eid>
+              <Accidental>
+                <subtype>accidentalNatural</subtype>
+                <eid>S_S</eid>
+                </Accidental>
               <pitch>74</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Tuplet>
+            <eid>T_T</eid>
             <normalNotes>2</normalNotes>
             <actualNotes>3</actualNotes>
             <baseNote>16th</baseNote>
+            <Number>
+              <style>tuplet</style>
+              <text>3</text>
+              </Number>
             </Tuplet>
           <Chord>
+            <eid>U_U</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>V_V</eid>
               <pitch>73</pitch>
               <tpc>21</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>W_W</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>X_X</eid>
+              <Accidental>
+                <subtype>accidentalSharp</subtype>
+                <eid>Y_Y</eid>
+                </Accidental>
               <pitch>70</pitch>
               <tpc>24</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>Z_Z</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>a_a</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <endTuplet/>
           <Tuplet>
+            <eid>b_b</eid>
             <normalNotes>2</normalNotes>
             <actualNotes>3</actualNotes>
             <baseNote>eighth</baseNote>
+            <Number>
+              <style>tuplet</style>
+              <text>3</text>
+              </Number>
             </Tuplet>
+          <Beam>
+            <eid>c_c</eid>
+            <l1>2</l1>
+            <l2>-2</l2>
+            </Beam>
           <Chord>
+            <eid>d_d</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>e_e</eid>
+              <Accidental>
+                <subtype>accidentalSharp</subtype>
+                <eid>f_f</eid>
+                </Accidental>
               <pitch>63</pitch>
               <tpc>23</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>g_g</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>h_h</eid>
+              <Accidental>
+                <subtype>accidentalNatural</subtype>
+                <eid>i_i</eid>
+                </Accidental>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>j_j</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>k_k</eid>
               <Spanner type="Tie">
                 <Tie>
+                  <eid>l_l</eid>
                   </Tie>
                 <next>
                   <location>
@@ -199,17 +265,19 @@
               <pitch>70</pitch>
               <tpc>24</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <endTuplet/>
           </voice>
         </Measure>
       <Measure>
+        <eid>m_m</eid>
         <voice>
           <Chord>
+            <eid>n_n</eid>
             <durationType>half</durationType>
             <Note>
+              <eid>o_o</eid>
               <Spanner type="Tie">
                 <prev>
                   <location>
@@ -221,10 +289,10 @@
               <pitch>70</pitch>
               <tpc>24</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>p_p</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/tuplet_3-4-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/tuplet_3-4-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,67 +85,88 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>3</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Rest>
+            <eid>F_F</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
+            <eid>G_G</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Chord>
+            <eid>H_H</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>I_I</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         </Measure>
       <Measure>
+        <eid>J_J</eid>
         <voice>
           <Tuplet>
+            <eid>K_K</eid>
             <normalNotes>2</normalNotes>
             <actualNotes>3</actualNotes>
             <baseNote>eighth</baseNote>
+            <Number>
+              <style>tuplet</style>
+              <text>3</text>
+              </Number>
             </Tuplet>
+          <Beam>
+            <eid>L_L</eid>
+            <l1>42</l1>
+            <l2>36</l2>
+            </Beam>
           <Chord>
+            <eid>M_M</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>N_N</eid>
               <pitch>69</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>O_O</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>P_P</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>Q_Q</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>R_R</eid>
               <pitch>76</pitch>
               <tpc>18</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <endTuplet/>
           <Rest>
+            <eid>S_S</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
+            <eid>T_T</eid>
             <durationType>quarter</durationType>
             </Rest>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/tuplet_nonuplet_3-4-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/tuplet_nonuplet_3-4-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,121 +85,148 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>3</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Rest>
+            <eid>F_F</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
+            <eid>G_G</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Chord>
+            <eid>H_H</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>I_I</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         </Measure>
       <Measure>
+        <eid>J_J</eid>
         <voice>
           <Tuplet>
+            <eid>K_K</eid>
             <normalNotes>8</normalNotes>
             <actualNotes>9</actualNotes>
             <baseNote>32nd</baseNote>
+            <Number>
+              <style>tuplet</style>
+              <text>9</text>
+              </Number>
             </Tuplet>
+          <Beam>
+            <eid>L_L</eid>
+            <l1>46</l1>
+            <l2>46</l2>
+            </Beam>
           <Chord>
+            <eid>M_M</eid>
             <durationType>32nd</durationType>
             <Note>
+              <eid>N_N</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>O_O</eid>
             <durationType>32nd</durationType>
             <Note>
+              <eid>P_P</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>Q_Q</eid>
             <durationType>32nd</durationType>
             <Note>
+              <eid>R_R</eid>
               <pitch>74</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>S_S</eid>
             <durationType>32nd</durationType>
             <Note>
+              <eid>T_T</eid>
               <pitch>76</pitch>
               <tpc>18</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>U_U</eid>
             <durationType>32nd</durationType>
             <Note>
+              <eid>V_V</eid>
               <pitch>77</pitch>
               <tpc>13</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>W_W</eid>
             <durationType>32nd</durationType>
             <Note>
+              <eid>X_X</eid>
               <pitch>76</pitch>
               <tpc>18</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>Y_Y</eid>
             <durationType>32nd</durationType>
             <Note>
+              <eid>Z_Z</eid>
               <pitch>74</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>a_a</eid>
             <durationType>32nd</durationType>
             <Note>
+              <eid>b_b</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>c_c</eid>
             <durationType>32nd</durationType>
             <Note>
+              <eid>d_d</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <endTuplet/>
           <Rest>
+            <eid>e_e</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
+            <eid>f_f</eid>
             <durationType>quarter</durationType>
             </Rest>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/tuplet_off_time_other_bar2-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/tuplet_off_time_other_bar2-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,48 +85,61 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Chord>
+            <eid>F_F</eid>
             <durationType>half</durationType>
             <Note>
+              <eid>G_G</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Tuplet>
+            <eid>H_H</eid>
             <normalNotes>2</normalNotes>
             <actualNotes>3</actualNotes>
             <baseNote>quarter</baseNote>
+            <Number>
+              <style>tuplet</style>
+              <text>3</text>
+              </Number>
             </Tuplet>
           <Chord>
+            <eid>I_I</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>J_J</eid>
               <pitch>74</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>K_K</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>L_L</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>M_M</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>N_N</eid>
               <Spanner type="Tie">
                 <Tie>
+                  <eid>O_O</eid>
                   </Tie>
                 <next>
                   <location>
@@ -136,22 +151,29 @@
               <pitch>69</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <endTuplet/>
           </voice>
         </Measure>
       <Measure>
+        <eid>P_P</eid>
         <voice>
           <Tuplet>
+            <eid>Q_Q</eid>
             <normalNotes>2</normalNotes>
             <actualNotes>3</actualNotes>
             <baseNote>quarter</baseNote>
+            <Number>
+              <style>tuplet</style>
+              <text>3</text>
+              </Number>
             </Tuplet>
           <Chord>
+            <eid>R_R</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>S_S</eid>
               <Spanner type="Tie">
                 <prev>
                   <location>
@@ -163,29 +185,31 @@
               <pitch>69</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>T_T</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>U_U</eid>
               <pitch>74</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>V_V</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>W_W</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <endTuplet/>
           <Rest>
+            <eid>X_X</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/tuplet_septuplet-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/tuplet_septuplet-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,103 +85,128 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>3</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Rest>
+            <eid>F_F</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
+            <eid>G_G</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Chord>
+            <eid>H_H</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>I_I</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         </Measure>
       <Measure>
+        <eid>J_J</eid>
         <voice>
           <Tuplet>
+            <eid>K_K</eid>
             <normalNotes>8</normalNotes>
             <actualNotes>7</actualNotes>
             <baseNote>32nd</baseNote>
+            <Number>
+              <style>tuplet</style>
+              <text>7</text>
+              </Number>
             </Tuplet>
+          <Beam>
+            <eid>L_L</eid>
+            <l1>52</l1>
+            <l2>52</l2>
+            </Beam>
           <Chord>
+            <eid>M_M</eid>
             <durationType>32nd</durationType>
             <Note>
+              <eid>N_N</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>O_O</eid>
             <durationType>32nd</durationType>
             <Note>
+              <eid>P_P</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>Q_Q</eid>
             <durationType>32nd</durationType>
             <Note>
+              <eid>R_R</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>S_S</eid>
             <durationType>32nd</durationType>
             <Note>
+              <eid>T_T</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>U_U</eid>
             <durationType>32nd</durationType>
             <Note>
+              <eid>V_V</eid>
               <pitch>76</pitch>
               <tpc>18</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>W_W</eid>
             <durationType>32nd</durationType>
             <Note>
+              <eid>X_X</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>Y_Y</eid>
             <durationType>32nd</durationType>
             <Note>
+              <eid>Z_Z</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <endTuplet/>
           <Rest>
+            <eid>a_a</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
+            <eid>b_b</eid>
             <durationType>quarter</durationType>
             </Rest>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/tuplet_triplet_first_tied2-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/tuplet_triplet_first_tied2-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,25 +85,36 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
+          <Beam>
+            <eid>F_F</eid>
+            <l1>40</l1>
+            <l2>42</l2>
+            </Beam>
           <Chord>
+            <eid>G_G</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>H_H</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>I_I</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>J_J</eid>
               <Spanner type="Tie">
                 <Tie>
+                  <eid>K_K</eid>
                   </Tie>
                 <next>
                   <location>
@@ -112,17 +125,28 @@
               <pitch>69</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Tuplet>
+            <eid>L_L</eid>
             <normalNotes>2</normalNotes>
             <actualNotes>3</actualNotes>
             <baseNote>eighth</baseNote>
+            <Number>
+              <style>tuplet</style>
+              <text>3</text>
+              </Number>
             </Tuplet>
+          <Beam>
+            <eid>M_M</eid>
+            <l1>42</l1>
+            <l2>40</l2>
+            </Beam>
           <Chord>
+            <eid>N_N</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>O_O</eid>
               <Spanner type="Tie">
                 <prev>
                   <location>
@@ -133,29 +157,31 @@
               <pitch>69</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>P_P</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>Q_Q</eid>
               <pitch>74</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>R_R</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>S_S</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <endTuplet/>
           <Rest>
+            <eid>T_T</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/tuplet_triplets_mixed-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/tuplet_triplets_mixed-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,15 +20,17 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
         <bracket type="1" span="2" col="0" visible="1"/>
         <barLineSpan>1</barLineSpan>
         </Staff>
-      <Staff id="2">
+      <Staff>
+        <eid>D_D</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -91,264 +94,334 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>E_E</eid>
         <voice>
           <TimeSig>
+            <eid>F_F</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Tuplet>
+            <eid>G_G</eid>
             <normalNotes>2</normalNotes>
             <actualNotes>3</actualNotes>
             <baseNote>eighth</baseNote>
+            <Number>
+              <style>tuplet</style>
+              <text>3</text>
+              </Number>
             </Tuplet>
           <Chord>
+            <eid>H_H</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>I_I</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>J_J</eid>
             <durationType>16th</durationType>
             </Rest>
+          <Beam>
+            <eid>K_K</eid>
+            <l1>38</l1>
+            <l2>36</l2>
+            </Beam>
           <Chord>
+            <eid>L_L</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>M_M</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>N_N</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>O_O</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <endTuplet/>
           <Chord>
+            <eid>P_P</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>Q_Q</eid>
               <pitch>65</pitch>
               <tpc>13</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>R_R</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>S_S</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>T_T</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>U_U</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         </Measure>
       <Measure>
+        <eid>V_V</eid>
         <voice>
           <Tuplet>
+            <eid>W_W</eid>
             <normalNotes>2</normalNotes>
             <actualNotes>3</actualNotes>
             <baseNote>eighth</baseNote>
+            <Number>
+              <style>tuplet</style>
+              <text>3</text>
+              </Number>
             </Tuplet>
+          <Beam>
+            <eid>X_X</eid>
+            <l1>-6</l1>
+            <l2>-10</l2>
+            </Beam>
           <Chord>
+            <eid>Y_Y</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>Z_Z</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>a_a</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>b_b</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>c_c</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>d_d</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <endTuplet/>
           <Chord>
+            <eid>e_e</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>f_f</eid>
               <pitch>65</pitch>
               <tpc>13</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>g_g</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>h_h</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>i_i</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>j_j</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         </Measure>
       <Measure>
+        <eid>k_k</eid>
         <voice>
           <Tuplet>
+            <eid>l_l</eid>
             <normalNotes>2</normalNotes>
             <actualNotes>3</actualNotes>
             <baseNote>eighth</baseNote>
+            <Number>
+              <style>tuplet</style>
+              <text>3</text>
+              </Number>
             </Tuplet>
+          <Beam>
+            <eid>m_m</eid>
+            <l1>-6</l1>
+            <l2>-10</l2>
+            </Beam>
           <Chord>
+            <eid>n_n</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>o_o</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>p_p</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>q_q</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>r_r</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>s_s</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <endTuplet/>
           <Chord>
+            <eid>t_t</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>u_u</eid>
               <pitch>65</pitch>
               <tpc>13</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>v_v</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>w_w</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>x_x</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>y_y</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         </Measure>
       <Measure>
+        <eid>z_z</eid>
         <voice>
           <Tuplet>
+            <eid>0_0</eid>
             <normalNotes>2</normalNotes>
             <actualNotes>3</actualNotes>
             <baseNote>eighth</baseNote>
+            <Number>
+              <style>tuplet</style>
+              <text>3</text>
+              </Number>
             </Tuplet>
+          <Beam>
+            <eid>1_1</eid>
+            <l1>-6</l1>
+            <l2>-10</l2>
+            </Beam>
           <Chord>
+            <eid>2_2</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>3_3</eid>
               <pitch>67</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>4_4</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>5_5</eid>
               <pitch>71</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>6_6</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>7_7</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <endTuplet/>
           <Chord>
+            <eid>8_8</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>9_9</eid>
               <pitch>65</pitch>
               <tpc>13</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>+_+</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>/_/</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>AB_AB</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>BB_BB</eid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
@@ -358,10 +431,12 @@
       <Measure>
         <voice>
           <TimeSig>
+            <eid>CB_CB</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Rest>
+            <eid>DB_DB</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
@@ -370,6 +445,7 @@
       <Measure>
         <voice>
           <Rest>
+            <eid>EB_EB</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
@@ -378,63 +454,79 @@
       <Measure>
         <voice>
           <Tuplet>
+            <eid>FB_FB</eid>
             <normalNotes>2</normalNotes>
             <actualNotes>3</actualNotes>
             <baseNote>eighth</baseNote>
+            <Number>
+              <style>tuplet</style>
+              <text>3</text>
+              </Number>
             </Tuplet>
+          <Beam>
+            <eid>GB_GB</eid>
+            <l1>26</l1>
+            <l2>22</l2>
+            </Beam>
           <Chord>
+            <eid>HB_HB</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>IB_IB</eid>
               <pitch>55</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>JB_JB</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>KB_KB</eid>
               <pitch>59</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>LB_LB</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>MB_MB</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <endTuplet/>
           <Chord>
+            <eid>NB_NB</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>OB_OB</eid>
               <pitch>53</pitch>
               <tpc>13</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>PB_PB</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>QB_QB</eid>
               <pitch>52</pitch>
               <tpc>18</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>RB_RB</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>SB_SB</eid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
@@ -442,6 +534,7 @@
       <Measure>
         <voice>
           <Rest>
+            <eid>TB_TB</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>

--- a/src/importexport/midi/tests/midiimport_data/voice_acid-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/voice_acid-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,86 +85,106 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Chord>
+            <eid>F_F</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>G_G</eid>
               <pitch>65</pitch>
               <tpc>13</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>H_H</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Chord>
+            <eid>I_I</eid>
             <durationType>half</durationType>
             <Note>
+              <eid>J_J</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         <voice>
+          <Beam>
+            <eid>K_K</eid>
+            <l1>68</l1>
+            <l2>68</l2>
+            </Beam>
           <Chord>
+            <eid>L_L</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>M_M</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>N_N</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>O_O</eid>
+              <Accidental>
+                <subtype>accidentalFlat</subtype>
+                <eid>P_P</eid>
+                </Accidental>
               <pitch>58</pitch>
               <tpc>12</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>Q_Q</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>R_R</eid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>S_S</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>T_T</eid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>U_U</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>V_V</eid>
               <pitch>53</pitch>
               <tpc>13</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>W_W</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>X_X</eid>
               <pitch>58</pitch>
               <tpc>12</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/voice_tuplet-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/voice_tuplet-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -83,89 +85,113 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Rest>
+            <eid>F_F</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Chord>
+            <eid>G_G</eid>
             <durationType>quarter</durationType>
             <Articulation>
               <subtype>articStaccatoAbove</subtype>
+              <eid>H_H</eid>
               </Articulation>
             <Note>
+              <eid>I_I</eid>
               <pitch>76</pitch>
               <tpc>18</tpc>
               <velocity>114</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>J_J</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>
         <voice>
+          <Beam>
+            <eid>K_K</eid>
+            <l1>56</l1>
+            <l2>56</l2>
+            </Beam>
           <Chord>
+            <eid>L_L</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>M_M</eid>
               <pitch>76</pitch>
               <tpc>18</tpc>
               <velocity>116</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>N_N</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>O_O</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>76</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>P_P</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>Q_Q</eid>
               <pitch>76</pitch>
               <tpc>18</tpc>
               <velocity>88</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Tuplet>
+            <eid>R_R</eid>
             <normalNotes>2</normalNotes>
             <actualNotes>3</actualNotes>
             <baseNote>32nd</baseNote>
+            <Number>
+              <style>tuplet</style>
+              <text>3</text>
+              </Number>
             </Tuplet>
           <Rest>
+            <eid>S_S</eid>
             <durationType>32nd</durationType>
             </Rest>
           <Chord>
+            <eid>T_T</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>U_U</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>73</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <endTuplet/>
           <Rest>
+            <eid>V_V</eid>
             <durationType>16th</durationType>
             </Rest>
           <Rest>
+            <eid>W_W</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Chord>
+            <eid>X_X</eid>
             <durationType>half</durationType>
             <Note>
+              <eid>Y_Y</eid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <velocity>68</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>

--- a/src/importexport/midi/tests/midiimport_tests.cpp
+++ b/src/importexport/midi/tests/midiimport_tests.cpp
@@ -222,8 +222,7 @@ TEST_F(MidiImportTests, human4_4) {
     dontSimplify("human_4-4");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_humanTempo) {
+TEST_F(MidiImportTests, humanTempo) {
     importThenCompareWithRef("human_tempo");
 }
 
@@ -313,7 +312,6 @@ TEST_F(MidiImportTests, meterTwoBeatsOver) {
     dontSimplify("meter_two_beats_over");
 }
 
-// TODO: update ref
 TEST_F(MidiImportTests, meterDotTie) {
     dontSimplify("meter_dot_tie");
 }
@@ -461,8 +459,7 @@ TEST_F(MidiImportTests, tupletOffTimeOtherBar2) {
     dontSimplify("tuplet_off_time_other_bar2");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_tuplet16th8th) {
+TEST_F(MidiImportTests, tuplet16th8th) {
     dontSimplify("tuplet_16th_8th");
 }
 
@@ -482,8 +479,7 @@ TEST_F(MidiImportTests, pickupMeasureLong) {
     noTempoText("pickup_long");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_pickupMeasureTurnOff) {
+TEST_F(MidiImportTests, pickupMeasureTurnOff) {
     noTempoText("pickup_turn_off");
 }
 
@@ -493,8 +489,7 @@ TEST_F(MidiImportTests, LHRH_Nontuplet) {
     staffSplit("split_nontuplet");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_LHRH_Acid) {
+TEST_F(MidiImportTests, LHRH_Acid) {
     staffSplit("split_acid");
 }
 
@@ -544,8 +539,7 @@ TEST_F(MidiImportTests, swingShuffle) {
     importThenCompareWithRef(midiFile.toStdString().c_str());
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_swingClef) {
+TEST_F(MidiImportTests, swingClef) {
     QString midiFile("swing_clef");
     auto& opers = midiImportOperations;
     opers.addNewMidiFile(midiFilePath(midiFile));
@@ -615,13 +609,11 @@ TEST_F(MidiImportTests, clefTied) {
     dontSimplify("clef_tied");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_clefMelody) {
+TEST_F(MidiImportTests, clefMelody) {
     dontSimplify("clef_melody");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_clefPrev) {
+TEST_F(MidiImportTests, clefPrev) {
     dontSimplify("clef_prev");
 }
 
@@ -643,13 +635,11 @@ TEST_F(MidiImportTests, simplify8thDottedNoStaccato) {
     simplification("simplify_8th_dotted_no_staccato");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_simplify4thDottedTied) {
+TEST_F(MidiImportTests, simplify4thDottedTied) {
     simplification("simplify_4th_dotted_tied");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_simplifyTripletStaccato) {
+TEST_F(MidiImportTests, simplifyTripletStaccato) {
     simplification("simplify_triplet_staccato");
 }
 
@@ -663,8 +653,7 @@ TEST_F(MidiImportTests, simplifyStaccato9_8) {
 
 // voice separation
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_voiceSeparationAcid) {
+TEST_F(MidiImportTests, voiceSeparationAcid) {
     voiceSeparation("voice_acid");
 }
 
@@ -712,13 +701,11 @@ TEST_F(MidiImportTests, DISABLED_instrumentClef) {
 
 // lyrics
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_lyricsTime0) {
+TEST_F(MidiImportTests, lyricsTime0) {
     noTempoText("lyrics_time_0");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_lyricsVoice1) {
+TEST_F(MidiImportTests, lyricsVoice1) {
     noTempoText("lyrics_voice_1");
 }
 

--- a/src/importexport/midi/tests/midiimport_tests.cpp
+++ b/src/importexport/midi/tests/midiimport_tests.cpp
@@ -366,9 +366,7 @@ TEST_F(MidiImportTests, tuplet5_5TupletsRests) {
     dontSimplify("tuplet_5_5_tuplets_rests");
 }
 
-// TODO: update ref
-// FIXME: MSVC debug build crashes (Assertion failed: map/set iterators incompatible)
-TEST_F(MidiImportTests, DISABLED_tuplet3_4) {
+TEST_F(MidiImportTests, tuplet3_4) {
     dontSimplify("tuplet_3-4");
 }
 
@@ -380,9 +378,7 @@ TEST_F(MidiImportTests, tupletMars) {
     dontSimplify("tuplet_mars");
 }
 
-// TODO: update ref
-// FIXME: MSVC debug build crashes (Assertion failed: map/set iterators incompatible)
-TEST_F(MidiImportTests, DISABLED_tupletNonuplet3_4) {
+TEST_F(MidiImportTests, tupletNonuplet3_4) {
     // requires 1/64 quantization
     QString midiFile("tuplet_nonuplet_3-4");
     auto& opers = midiImportOperations;
@@ -412,15 +408,11 @@ TEST_F(MidiImportTests, tupletQuadruplet) {
     dontSimplify("tuplet_quadruplet");
 }
 
-// TODO: update ref
-// FIXME: MSVC debug build crashes (Assertion failed: map/set iterators incompatible)
-TEST_F(MidiImportTests, DISABLED_tupletSeptuplet) {
+TEST_F(MidiImportTests, tupletSeptuplet) {
     dontSimplify("tuplet_septuplet");
 }
 
-// TODO: update ref
-// FIXME: MSVC debug build crashes (Assertion failed: map/set iterators incompatible)
-TEST_F(MidiImportTests, DISABLED_tupletTripletsMixed) {
+TEST_F(MidiImportTests, tupletTripletsMixed) {
     dontSimplify("tuplet_triplets_mixed");
 }
 
@@ -432,9 +424,7 @@ TEST_F(MidiImportTests, tupletTripletFirstTied) {
     dontSimplify("tuplet_triplet_first_tied");
 }
 
-// TODO: update ref
-// FIXME: MSVC debug build crashes (Assertion failed: map/set iterators incompatible)
-TEST_F(MidiImportTests, DISABLED_tupletTripletFirstTied2) {
+TEST_F(MidiImportTests, tupletTripletFirstTied2) {
     dontSimplify("tuplet_triplet_first_tied2");
 }
 
@@ -470,14 +460,11 @@ TEST_F(MidiImportTests, tupletOffTimeOtherBar) {
     dontSimplify("tuplet_off_time_other_bar");
 }
 
-// TODO: update ref
-// FIXME: MSVC debug build crashes (Assertion failed: map/set iterators incompatible)
-TEST_F(MidiImportTests, DISABLED_tupletOffTimeOtherBar2) {
+TEST_F(MidiImportTests, tupletOffTimeOtherBar2) {
     dontSimplify("tuplet_off_time_other_bar2");
 }
 
 // TODO: update ref
-// FIXME: MSVC debug build crashes (Assertion failed: map/set iterators incompatible)
 TEST_F(MidiImportTests, DISABLED_tuplet16th8th) {
     dontSimplify("tuplet_16th_8th");
 }
@@ -596,7 +583,6 @@ TEST_F(MidiImportTests, DISABLED_percNoGrandStaff) {
 }
 
 // TODO: update ref
-// FIXME: MSVC debug build crashes (Assertion failed: map/set iterators incompatible)
 TEST_F(MidiImportTests, DISABLED_percTriplet) {
     noTempoText("perc_triplet");
 }
@@ -617,7 +603,6 @@ TEST_F(MidiImportTests, DISABLED_percTupletSimplify) {
 }
 
 // TODO: update ref
-// FIXME: MSVC debug build crashes (Assertion failed: map/set iterators incompatible)
 TEST_F(MidiImportTests, DISABLED_percTupletSimplify2) {
     noTempoText("perc_tuplet_simplify2");
 }
@@ -639,7 +624,6 @@ TEST_F(MidiImportTests, DISABLED_clefMelody) {
 }
 
 // TODO: update ref
-// FIXME: MSVC debug build crashes (Assertion failed: map/set iterators incompatible)
 TEST_F(MidiImportTests, DISABLED_clefPrev) {
     dontSimplify("clef_prev");
 }
@@ -668,7 +652,6 @@ TEST_F(MidiImportTests, DISABLED_simplify4thDottedTied) {
 }
 
 // TODO: update ref
-// FIXME: MSVC debug build crashes (Assertion failed: map/set iterators incompatible)
 TEST_F(MidiImportTests, DISABLED_simplifyTripletStaccato) {
     simplification("simplify_triplet_staccato");
 }
@@ -692,9 +675,7 @@ TEST_F(MidiImportTests, voiceSeparationIntersect) {
     voiceSeparation("voice_intersect");
 }
 
-// TODO: update ref
-// FIXME: MSVC debug build crashes (Assertion failed: map/set iterators incompatible)
-TEST_F(MidiImportTests, DISABLED_voiceSeparationTuplet) {
+TEST_F(MidiImportTests, voiceSeparationTuplet) {
     voiceSeparation("voice_tuplet", true);
 }
 

--- a/src/importexport/midi/tests/midiimport_tests.cpp
+++ b/src/importexport/midi/tests/midiimport_tests.cpp
@@ -218,14 +218,11 @@ TEST_F(MidiImportTests, quantDotted4th) {
 
 // human-performed (unaligned) files
 
-// TODO: update ref
-// FIXME: MSVC debug build crashes (Assertion failed: vector iterators incompatible)
-TEST_F(MidiImportTests, DISABLED_human4_4) {
+TEST_F(MidiImportTests, human4_4) {
     dontSimplify("human_4-4");
 }
 
 // TODO: update ref
-// FIXME: MSVC debug build crashes (Assertion failed: vector iterators incompatible)
 TEST_F(MidiImportTests, DISABLED_humanTempo) {
     importThenCompareWithRef("human_tempo");
 }

--- a/thirdparty/beatroot/AgentList.cpp
+++ b/thirdparty/beatroot/AgentList.cpp
@@ -72,17 +72,15 @@ void AgentList::removeDuplicates()
                         }
                   }
             }
-      int removed = 0;
-      for (iterator itr = begin(); itr != end(); ) {
-            if ((*itr)->phaseScore < 0.0) {
-                  ++removed;
-                  delete *itr;
-                  list.erase(itr);
-                  }
-            else {
-                  ++itr;
-                  }
-            }
+
+      auto last = std::remove_if(begin(), end(), [](const Agent* agent){
+                  if (agent->phaseScore < 0.0) {
+                        delete agent;
+                        return true;
+                        }
+                  return false;
+            });
+      list.erase(last, list.end());
       }
 
 


### PR DESCRIPTION
This PR fixes two assertion failures, one of which is in third party code.
It also updates more reference scores for tests which can now run.
95/107 tests pass (up from 75)

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
