### PR TITLE
iex/midi: Improve instrument detection heuristic

### DIFF
--- a/src/framework/global/types/string.cpp
+++ b/src/framework/global/types/string.cpp
@@ -550,8 +550,13 @@ String String::fromUtf8(const char* str)
     if (!str) {
         return String();
     }
+    return fromUtf8(std::string_view(str));
+}
+
+String String::fromUtf8(const std::string_view str)
+{
     String s;
-    UtfCodec::utf8to16(std::string_view(str), s.mutStr());
+    UtfCodec::utf8to16(str, s.mutStr());
     return s;
 }
 

--- a/src/framework/global/types/string.h
+++ b/src/framework/global/types/string.h
@@ -259,6 +259,7 @@ public:
     static String fromUtf16BE(const ByteArray& data);
 
     static String fromUtf8(const char* str);
+    static String fromUtf8(std::string_view);
     static String fromUtf8(const ByteArray& data);
     ByteArray toUtf8() const;
 

--- a/src/importexport/midi/internal/midiimport/importmidi_instrument.cpp
+++ b/src/importexport/midi/internal/midiimport/importmidi_instrument.cpp
@@ -716,12 +716,13 @@ QString msInstrName(int trackIndex)
     if (!instr) {
         return "";
     }
-    if (!instr->trackName.isEmpty()) {
-        return instr->trackName;
-    }
     if (!instr->longNames.empty()) {
         return instr->longNames.front().name();
     }
+    if (!instr->trackName.isEmpty()) {
+        return instr->trackName;
+    }
+
     return "";
 }
 } // namespace MidiInstr

--- a/src/importexport/midi/internal/midishared/generalmidi.h
+++ b/src/importexport/midi/internal/midishared/generalmidi.h
@@ -1,0 +1,174 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2025 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <cstdint>
+
+namespace mu::iex::midi {
+// General MIDI Level 1 program numbers
+enum class GM1Program : std::uint8_t {
+    // 0-7: Piano
+    AcousticGrandPiano = 0,
+    BrightAcousticPiano,
+    ElectricGrandPiano,
+    HonkyTonkPiano,
+    ElectricPiano1,
+    ElectricPiano2,
+    Harpsichord,
+    Clavi,
+    // 8-15: Chromatic Percussion
+    Celesta,
+    Glockenspiel,
+    MusicBox,
+    Vibraphone,
+    Marimba,
+    Xylophone,
+    TubularBells,
+    Dulcimer,
+    // 16-23: Organ
+    DrawbarOrgan,
+    PercussiveOrgan,
+    RockOrgan,
+    ChurchOrgan,
+    ReedOrgan,
+    Accordion,
+    Harmonica,
+    TangoAccordion,
+    // 24-31: Guitar
+    AcousticGuitarNylon,
+    AcousticGuitarSteel,
+    ElectricGuitarJazz,
+    ElectricGuitarClean,
+    ElectricGuitarMuted,
+    OverdrivenGuitar,
+    DistortionGuitar,
+    GuitarHarmonics,
+    // 32-39: Bass
+    AcousticBass,
+    ElectricBassFinger,
+    ElectricBassPick,
+    FretlessBass,
+    SlapBass1,
+    SlapBass2,
+    SynthBass1,
+    SynthBass2,
+    // 40-47: Strings
+    Violin,
+    Viola,
+    Cello,
+    Contrabass,
+    TremoloStrings,
+    PizzicatoStrings,
+    OrchestralHarp,
+    Timpani,
+    // 48-55: Ensemble
+    StringEnsemble1,
+    StringEnsemble2,
+    SynthStrings1,
+    SynthStrings2,
+    ChoirAahs,
+    VoiceOohs,
+    SynthVoice,
+    OrchestraHit,
+    // 56-63: Brass
+    Trumpet,
+    Trombone,
+    Tuba,
+    MutedTrumpet,
+    FrenchHorn,
+    BrassSection,
+    SynthBrass1,
+    SynthBrass2,
+    // 64-71: Reed
+    SopranoSax,
+    AltoSax,
+    TenorSax,
+    BaritoneSax,
+    Oboe,
+    EnglishHorn,
+    Bassoon,
+    Clarinet,
+    // 72-79: Pipe
+    Piccolo,
+    Flute,
+    Recorder,
+    PanFlute,
+    BlownBottle,
+    Shakuhachi,
+    Whistle,
+    Ocarina,
+    // 80-87: Synth Lead
+    Lead1Square,
+    Lead2Sawtooth,
+    Lead3Calliope,
+    Lead4Chiff,
+    Lead5Charang,
+    Lead6Voice,
+    Lead7Fifths,
+    Lead8BassAndLead,
+    // 88-95: Synth Pad
+    Pad1NewAge,
+    Pad2Warm,
+    Pad3Polysynth,
+    Pad4Choir,
+    Pad5Bowed,
+    Pad6Metallic,
+    Pad7Halo,
+    Pad8Sweep,
+    // 96-103: Synth Effects
+    FX1Rain,
+    FX2Soundtrack,
+    FX3Crystal,
+    FX4Atmosphere,
+    FX5Brightness,
+    FX6Goblins,
+    FX7Echoes,
+    FX8SciFi,
+    // 104-111: Ethnic
+    Sitar,
+    Banjo,
+    Shamisen,
+    Koto,
+    Kalimba,
+    BagPipe,
+    Fiddle,
+    Shanai,
+    // 112-119: Percussive
+    TinkleBell,
+    Agogo,
+    SteelDrums,
+    Woodblock,
+    TaikoDrum,
+    MelodicTom,
+    SynthDrum,
+    ReverseCymbal,
+    // 120-127: Sound Effects
+    GuitarFretNoise,
+    BreathNoise,
+    Seashore,
+    BirdTweet,
+    TelephoneRing,
+    Helicopter,
+    Applause,
+    Gunshot,
+};
+}

--- a/src/importexport/midi/internal/midishared/midishared.cmake
+++ b/src/importexport/midi/internal/midishared/midishared.cmake
@@ -1,4 +1,5 @@
 set (MIDISHARED_SRC
+    ${CMAKE_CURRENT_LIST_DIR}/generalmidi.h
     ${CMAKE_CURRENT_LIST_DIR}/midievent.h
     ${CMAKE_CURRENT_LIST_DIR}/midifile.cpp
     ${CMAKE_CURRENT_LIST_DIR}/midifile.h

--- a/src/importexport/midi/tests/midiimport_data/instrument_channels-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/instrument_channels-ref.mscx
@@ -27,9 +27,9 @@
           <name>stdNormal</name>
           </StaffType>
         </Staff>
-      <trackName>Violins (section)</trackName>
+      <trackName>Violins</trackName>
       <Instrument id="violins">
-        <longName>Violins (section)</longName>
+        <longName>Violins</longName>
         <shortName>Vlns.</shortName>
         <trackName>Violins (section)</trackName>
         <minPitchP>55</minPitchP>

--- a/src/importexport/midi/tests/midiimport_data/instrument_channels-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/instrument_channels-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,17 +20,18 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
         </Staff>
-      <trackName>Violins</trackName>
+      <trackName>Violins (section)</trackName>
       <Instrument id="violins">
-        <longName>Violins</longName>
+        <longName>Violins (section)</longName>
         <shortName>Vlns.</shortName>
-        <trackName>Violins</trackName>
+        <trackName>Violins (section)</trackName>
         <minPitchP>55</minPitchP>
         <maxPitchP>103</maxPitchP>
         <minPitchA>55</minPitchA>
@@ -99,17 +101,18 @@
           </Channel>
         </Instrument>
       </Part>
-    <Part>
-      <Staff id="2">
+    <Part id="2">
+      <Staff>
+        <eid>D_D</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
         </Staff>
-      <trackName>B♭ Trumpet</trackName>
+      <trackName>Trumpet</trackName>
       <Instrument id="bb-trumpet">
-        <longName>B♭ Trumpet</longName>
-        <shortName>B♭ Tpt.</shortName>
-        <trackName>B♭ Trumpet</trackName>
+        <longName>Trumpet</longName>
+        <shortName>Tpt.</shortName>
+        <trackName>Trumpet</trackName>
         <minPitchP>52</minPitchP>
         <maxPitchP>85</maxPitchP>
         <minPitchA>52</minPitchA>
@@ -170,8 +173,9 @@
           </Channel>
         </Instrument>
       </Part>
-    <Part>
-      <Staff id="3">
+    <Part id="3">
+      <Staff>
+        <eid>E_E</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -243,76 +247,93 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>F_F</eid>
         <voice>
           <TimeSig>
+            <eid>G_G</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Tempo>
             <tempo>2</tempo>
+            <eid>H_H</eid>
             <text><sym>metNoteQuarterUp</sym> = 120</text>
             </Tempo>
           <Rest>
+            <eid>I_I</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Chord>
+            <eid>J_J</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>K_K</eid>
               <pitch>88</pitch>
               <tpc>18</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>L_L</eid>
             <durationType>quarter</durationType>
             <Articulation>
               <subtype>articStaccatoAbove</subtype>
+              <eid>M_M</eid>
               </Articulation>
             <Note>
+              <eid>N_N</eid>
               <pitch>86</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>O_O</eid>
             <durationType>quarter</durationType>
             </Rest>
+          <Beam>
+            <eid>P_P</eid>
+            <l1>22</l1>
+            <l2>24</l2>
+            </Beam>
           <Chord>
+            <eid>Q_Q</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>R_R</eid>
               <pitch>84</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>S_S</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>T_T</eid>
               <pitch>83</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>U_U</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>V_V</eid>
               <pitch>81</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>W_W</eid>
             <durationType>16th</durationType>
             <Note>
+              <eid>X_X</eid>
               <pitch>79</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
@@ -322,26 +343,31 @@
       <Measure>
         <voice>
           <TimeSig>
+            <eid>Y_Y</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Rest>
+            <eid>Z_Z</eid>
             <durationType>half</durationType>
             </Rest>
           <Rest>
+            <eid>a_a</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
+            <eid>b_b</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Chord>
+            <eid>c_c</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>d_d</eid>
               <pitch>72</pitch>
               <tpc>14</tpc>
               <tpc2>16</tpc2>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
@@ -351,55 +377,64 @@
       <Measure>
         <voice>
           <TimeSig>
+            <eid>e_e</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Rest>
+            <eid>f_f</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Chord>
+            <eid>g_g</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>h_h</eid>
               <pitch>41</pitch>
               <tpc>13</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>i_i</eid>
             <durationType>quarter</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>j_j</eid>
               </Articulation>
             <Note>
+              <eid>k_k</eid>
               <pitch>40</pitch>
               <tpc>18</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>l_l</eid>
             <durationType>quarter</durationType>
             <Articulation>
-              <subtype>articStaccatoAbove</subtype>
+              <subtype>articStaccatoBelow</subtype>
+              <eid>m_m</eid>
               </Articulation>
             <Note>
+              <eid>n_n</eid>
               <pitch>41</pitch>
               <tpc>13</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>o_o</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Chord>
+            <eid>p_p</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>q_q</eid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/instrument_clef-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/instrument_clef-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -101,45 +103,51 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Chord>
+            <eid>F_F</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>G_G</eid>
               <pitch>36</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>H_H</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>I_I</eid>
               <pitch>43</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>J_J</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>K_K</eid>
               <pitch>48</pitch>
               <tpc>14</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>L_L</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>M_M</eid>
               <pitch>43</pitch>
               <tpc>15</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/meter_15-8-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/meter_15-8-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="pitched">
           <name>stdNormal</name>
           </StaffType>
@@ -101,100 +103,131 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <KeySig>
-            <accidental>-2</accidental>
+            <eid>E_E</eid>
+            <concertKey>-2</concertKey>
             </KeySig>
           <TimeSig>
+            <eid>F_F</eid>
             <sigN>15</sigN>
             <sigD>8</sigD>
             </TimeSig>
           <Chord>
+            <eid>G_G</eid>
             <dots>1</dots>
             <durationType>eighth</durationType>
             <Note>
+              <eid>H_H</eid>
               <pitch>39</pitch>
               <tpc>11</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>I_I</eid>
             <durationType>16th</durationType>
             </Rest>
           <Rest>
+            <eid>J_J</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Chord>
+            <eid>K_K</eid>
             <dots>1</dots>
             <durationType>eighth</durationType>
             <Note>
+              <eid>L_L</eid>
+              <Accidental>
+                <subtype>accidentalFlat</subtype>
+                <eid>M_M</eid>
+                </Accidental>
               <pitch>44</pitch>
               <tpc>10</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>N_N</eid>
             <durationType>16th</durationType>
             </Rest>
           <Rest>
+            <eid>O_O</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Chord>
+            <eid>P_P</eid>
             <dots>1</dots>
             <durationType>eighth</durationType>
             <Note>
+              <eid>Q_Q</eid>
+              <Accidental>
+                <subtype>accidentalSharp</subtype>
+                <eid>R_R</eid>
+                </Accidental>
               <pitch>42</pitch>
               <tpc>20</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>S_S</eid>
             <durationType>16th</durationType>
             </Rest>
           <Rest>
+            <eid>T_T</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Chord>
+            <eid>U_U</eid>
             <dots>1</dots>
             <durationType>eighth</durationType>
             <Note>
+              <eid>V_V</eid>
+              <Accidental>
+                <subtype>accidentalNatural</subtype>
+                <eid>W_W</eid>
+                </Accidental>
               <pitch>41</pitch>
               <tpc>13</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>X_X</eid>
             <durationType>16th</durationType>
             </Rest>
           <Rest>
+            <eid>Y_Y</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Chord>
+            <eid>Z_Z</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>a_a</eid>
               <pitch>41</pitch>
               <tpc>13</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>b_b</eid>
             <durationType>16th</durationType>
             </Rest>
           <Chord>
+            <eid>c_c</eid>
             <durationType>eighth</durationType>
             <Note>
+              <eid>d_d</eid>
               <pitch>34</pitch>
               <tpc>12</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>e_e</eid>
             <durationType>16th</durationType>
             </Rest>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/perc_drums-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/perc_drums-ref.mscx
@@ -29,9 +29,9 @@
           </StaffType>
         <defaultClef>PERC</defaultClef>
         </Staff>
-      <trackName>Drum Kit (large), drum</trackName>
+      <trackName>Drum Kit, drum</trackName>
       <Instrument id="drumset">
-        <longName>Drum Kit (large), drum</longName>
+        <longName>Drum Kit, drum</longName>
         <shortName>D. Kit</shortName>
         <trackName>Drum Kit (large)</trackName>
         <instrumentId>drum.group.set</instrumentId>

--- a/src/importexport/midi/tests/midiimport_data/perc_drums-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/perc_drums-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,27 +20,30 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="percussion">
           <name>perc5Line</name>
           <keysig>0</keysig>
           </StaffType>
         <defaultClef>PERC</defaultClef>
         </Staff>
-      <trackName>Drumset, drum</trackName>
+      <trackName>Drum Kit (large), drum</trackName>
       <Instrument id="drumset">
-        <longName>Drumset, drum</longName>
-        <shortName>D. Set</shortName>
-        <trackName>Drumset</trackName>
+        <longName>Drum Kit (large), drum</longName>
+        <shortName>D. Kit</shortName>
+        <trackName>Drum Kit (large)</trackName>
         <instrumentId>drum.group.set</instrumentId>
         <useDrumset>1</useDrumset>
         <Drum pitch="35">
           <head>normal</head>
-          <line>7</line>
+          <line>8</line>
           <voice>1</voice>
-          <name>Acoustic Bass Drum</name>
+          <name>Bass Drum 2</name>
           <stem>2</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>0</panelColumn>
           </Drum>
         <Drum pitch="36">
           <head>normal</head>
@@ -47,14 +51,18 @@
           <voice>1</voice>
           <name>Bass Drum 1</name>
           <stem>2</stem>
-          <shortcut>B</shortcut>
+          <shortcut>A</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>0</panelColumn>
           </Drum>
         <Drum pitch="37">
-          <head>cross</head>
+          <head>slashed1</head>
           <line>3</line>
           <voice>0</voice>
           <name>Side Stick</name>
           <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>1</panelColumn>
           </Drum>
         <Drum pitch="38">
           <head>normal</head>
@@ -62,21 +70,27 @@
           <voice>0</voice>
           <name>Acoustic Snare</name>
           <stem>1</stem>
-          <shortcut>A</shortcut>
+          <shortcut>B</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>1</panelColumn>
           </Drum>
         <Drum pitch="40">
-          <head>normal</head>
+          <head>slash</head>
           <line>3</line>
           <voice>0</voice>
           <name>Electric Snare</name>
           <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>0</panelColumn>
           </Drum>
         <Drum pitch="41">
           <head>normal</head>
-          <line>5</line>
+          <line>6</line>
           <voice>0</voice>
           <name>Low Floor Tom</name>
           <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>7</panelColumn>
           </Drum>
         <Drum pitch="42">
           <head>cross</head>
@@ -84,14 +98,19 @@
           <voice>0</voice>
           <name>Closed Hi-Hat</name>
           <stem>1</stem>
-          <shortcut>G</shortcut>
+          <shortcut>C</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>2</panelColumn>
           </Drum>
         <Drum pitch="43">
           <head>normal</head>
           <line>5</line>
-          <voice>1</voice>
+          <voice>0</voice>
           <name>High Floor Tom</name>
-          <stem>2</stem>
+          <stem>1</stem>
+          <shortcut>H</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>7</panelColumn>
           </Drum>
         <Drum pitch="44">
           <head>cross</head>
@@ -99,35 +118,46 @@
           <voice>1</voice>
           <name>Pedal Hi-Hat</name>
           <stem>2</stem>
-          <shortcut>F</shortcut>
+          <panelRow>1</panelRow>
+          <panelColumn>2</panelColumn>
           </Drum>
         <Drum pitch="45">
           <head>normal</head>
-          <line>2</line>
+          <line>4</line>
           <voice>0</voice>
           <name>Low Tom</name>
           <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>6</panelColumn>
           </Drum>
         <Drum pitch="46">
-          <head>cross</head>
-          <line>1</line>
+          <head>xcircle</head>
+          <line>-1</line>
           <voice>0</voice>
           <name>Open Hi-Hat</name>
           <stem>1</stem>
+          <shortcut>D</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>3</panelColumn>
           </Drum>
         <Drum pitch="47">
           <head>normal</head>
-          <line>1</line>
+          <line>2</line>
           <voice>0</voice>
           <name>Low-Mid Tom</name>
           <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>5</panelColumn>
           </Drum>
         <Drum pitch="48">
           <head>normal</head>
-          <line>0</line>
+          <line>1</line>
           <voice>0</voice>
           <name>Hi-Mid Tom</name>
           <stem>1</stem>
+          <shortcut>G</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>6</panelColumn>
           </Drum>
         <Drum pitch="49">
           <head>cross</head>
@@ -135,7 +165,9 @@
           <voice>0</voice>
           <name>Crash Cymbal 1</name>
           <stem>1</stem>
-          <shortcut>C</shortcut>
+          <shortcut>E</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>4</panelColumn>
           </Drum>
         <Drum pitch="50">
           <head>normal</head>
@@ -143,7 +175,8 @@
           <voice>0</voice>
           <name>High Tom</name>
           <stem>1</stem>
-          <shortcut>E</shortcut>
+          <panelRow>1</panelRow>
+          <panelColumn>4</panelColumn>
           </Drum>
         <Drum pitch="51">
           <head>cross</head>
@@ -151,14 +184,24 @@
           <voice>0</voice>
           <name>Ride Cymbal 1</name>
           <stem>1</stem>
-          <shortcut>D</shortcut>
+          <shortcut>F</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>5</panelColumn>
           </Drum>
         <Drum pitch="52">
-          <head>cross</head>
+          <head>normal</head>
+          <noteheads>
+            <whole>noteheadHeavyXHat</whole>
+            <half>noteheadHeavyXHat</half>
+            <quarter>noteheadHeavyXHat</quarter>
+            <breve>noteheadHeavyXHat</breve>
+            </noteheads>
           <line>-3</line>
           <voice>0</voice>
-          <name>Chinese Cymbal</name>
+          <name>China Cymbal</name>
           <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>3</panelColumn>
           </Drum>
         <Drum pitch="53">
           <head>diamond</head>
@@ -166,20 +209,26 @@
           <voice>0</voice>
           <name>Ride Bell</name>
           <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>5</panelColumn>
           </Drum>
         <Drum pitch="54">
           <head>diamond</head>
-          <line>2</line>
+          <line>1</line>
           <voice>0</voice>
           <name>Tambourine</name>
           <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>1</panelColumn>
           </Drum>
         <Drum pitch="55">
           <head>cross</head>
-          <line>-3</line>
+          <line>-4</line>
           <voice>0</voice>
           <name>Splash Cymbal</name>
           <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>4</panelColumn>
           </Drum>
         <Drum pitch="56">
           <head>triangle-down</head>
@@ -187,6 +236,8 @@
           <voice>0</voice>
           <name>Cowbell</name>
           <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>2</panelColumn>
           </Drum>
         <Drum pitch="57">
           <head>cross</head>
@@ -194,6 +245,8 @@
           <voice>0</voice>
           <name>Crash Cymbal 2</name>
           <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>3</panelColumn>
           </Drum>
         <Drum pitch="59">
           <head>cross</head>
@@ -201,22 +254,11 @@
           <voice>0</voice>
           <name>Ride Cymbal 2</name>
           <stem>1</stem>
-          </Drum>
-        <Drum pitch="63">
-          <head>cross</head>
-          <line>4</line>
-          <voice>0</voice>
-          <name>Open Hi Conga</name>
-          <stem>1</stem>
-          </Drum>
-        <Drum pitch="64">
-          <head>cross</head>
-          <line>6</line>
-          <voice>0</voice>
-          <name>Low Conga</name>
-          <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>6</panelColumn>
           </Drum>
         <clef>PERC</clef>
+        <singleNoteDynamics>0</singleNoteDynamics>
         <Articulation>
           <velocity>100</velocity>
           <gateTime>100</gateTime>
@@ -266,269 +308,332 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>2</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Rest>
+            <eid>F_F</eid>
             <durationType>measure</durationType>
             <duration>2/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
+        <eid>G_G</eid>
         <voice>
           <Rest>
+            <eid>H_H</eid>
             <durationType>measure</durationType>
             <duration>2/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
+        <eid>I_I</eid>
         <voice>
+          <Beam>
+            <eid>J_J</eid>
+            <l1>-28</l1>
+            <l2>-28</l2>
+            </Beam>
           <Chord>
+            <eid>K_K</eid>
             <durationType>16th</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>L_L</eid>
               <pitch>46</pitch>
               <tpc>12</tpc>
+              <head>xcircle</head>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>M_M</eid>
             <durationType>16th</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>N_N</eid>
               <pitch>46</pitch>
               <tpc>12</tpc>
+              <head>xcircle</head>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>O_O</eid>
             <durationType>16th</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>P_P</eid>
               <pitch>38</pitch>
               <tpc>16</tpc>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>Q_Q</eid>
               <pitch>46</pitch>
               <tpc>12</tpc>
+              <head>xcircle</head>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>R_R</eid>
             <durationType>16th</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>S_S</eid>
               <pitch>38</pitch>
               <tpc>16</tpc>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>T_T</eid>
               <pitch>46</pitch>
               <tpc>12</tpc>
+              <head>xcircle</head>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
+          <Beam>
+            <eid>U_U</eid>
+            <l1>-28</l1>
+            <l2>-28</l2>
+            </Beam>
           <Chord>
+            <eid>V_V</eid>
             <durationType>16th</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>W_W</eid>
               <pitch>46</pitch>
               <tpc>12</tpc>
+              <head>xcircle</head>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>X_X</eid>
             <durationType>16th</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>Y_Y</eid>
               <pitch>46</pitch>
               <tpc>12</tpc>
+              <head>xcircle</head>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>Z_Z</eid>
             <durationType>16th</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>a_a</eid>
               <pitch>38</pitch>
               <tpc>16</tpc>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>b_b</eid>
               <pitch>46</pitch>
               <tpc>12</tpc>
+              <head>xcircle</head>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>c_c</eid>
             <durationType>16th</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>d_d</eid>
               <pitch>46</pitch>
               <tpc>12</tpc>
+              <head>xcircle</head>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         <voice>
           <Chord>
+            <eid>e_e</eid>
             <durationType>quarter</durationType>
             <StemDirection>down</StemDirection>
             <Note>
+              <eid>f_f</eid>
               <pitch>36</pitch>
               <tpc>14</tpc>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>g_g</eid>
             <durationType>quarter</durationType>
             <StemDirection>down</StemDirection>
             <Note>
+              <eid>h_h</eid>
               <pitch>36</pitch>
               <tpc>14</tpc>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         </Measure>
       <Measure>
+        <eid>i_i</eid>
         <voice>
+          <Beam>
+            <eid>j_j</eid>
+            <l1>-28</l1>
+            <l2>-28</l2>
+            </Beam>
           <Chord>
+            <eid>k_k</eid>
             <durationType>16th</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>l_l</eid>
               <pitch>46</pitch>
               <tpc>12</tpc>
+              <head>xcircle</head>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>m_m</eid>
             <durationType>16th</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>n_n</eid>
               <pitch>46</pitch>
               <tpc>12</tpc>
+              <head>xcircle</head>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>o_o</eid>
             <durationType>16th</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>p_p</eid>
               <pitch>38</pitch>
               <tpc>16</tpc>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>q_q</eid>
               <pitch>46</pitch>
               <tpc>12</tpc>
+              <head>xcircle</head>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>r_r</eid>
             <durationType>16th</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>s_s</eid>
               <pitch>38</pitch>
               <tpc>16</tpc>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>t_t</eid>
               <pitch>46</pitch>
               <tpc>12</tpc>
+              <head>xcircle</head>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
+          <Beam>
+            <eid>u_u</eid>
+            <l1>-28</l1>
+            <l2>-28</l2>
+            </Beam>
           <Chord>
+            <eid>v_v</eid>
             <durationType>16th</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>w_w</eid>
               <pitch>46</pitch>
               <tpc>12</tpc>
+              <head>xcircle</head>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>x_x</eid>
             <durationType>16th</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>y_y</eid>
               <pitch>46</pitch>
               <tpc>12</tpc>
+              <head>xcircle</head>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>z_z</eid>
             <durationType>16th</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>0_0</eid>
               <pitch>38</pitch>
               <tpc>16</tpc>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>1_1</eid>
               <pitch>46</pitch>
               <tpc>12</tpc>
+              <head>xcircle</head>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>2_2</eid>
             <durationType>16th</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>3_3</eid>
               <pitch>46</pitch>
               <tpc>12</tpc>
+              <head>xcircle</head>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         <voice>
           <Chord>
+            <eid>4_4</eid>
             <durationType>quarter</durationType>
             <StemDirection>down</StemDirection>
             <Note>
+              <eid>5_5</eid>
               <pitch>36</pitch>
               <tpc>14</tpc>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>6_6</eid>
             <durationType>quarter</durationType>
             <StemDirection>down</StemDirection>
             <Note>
+              <eid>7_7</eid>
               <pitch>36</pitch>
               <tpc>14</tpc>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/perc_no_grand_staff-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/perc_no_grand_staff-ref.mscx
@@ -104,9 +104,9 @@
           </StaffType>
         <defaultClef>PERC</defaultClef>
         </Staff>
-      <trackName>Drum Kit (large)</trackName>
+      <trackName>Drum Kit</trackName>
       <Instrument id="drumset">
-        <longName>Drum Kit (large)</longName>
+        <longName>Drum Kit</longName>
         <shortName>D. Kit</shortName>
         <trackName>Drum Kit (large)</trackName>
         <instrumentId>drum.group.set</instrumentId>

--- a/src/importexport/midi/tests/midiimport_data/perc_no_grand_staff-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/perc_no_grand_staff-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,8 +20,9 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="percussion">
           <name>perc1Line</name>
           <lines>1</lines>
@@ -40,8 +42,10 @@
           <line>0</line>
           <voice>0</voice>
           <name>Tambourine</name>
-          <stem>2</stem>
+          <stem>1</stem>
           <shortcut>A</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>0</panelColumn>
           </Drum>
         <clef>PERC</clef>
         <Articulation>
@@ -91,27 +95,30 @@
           </Channel>
         </Instrument>
       </Part>
-    <Part>
-      <Staff id="2">
+    <Part id="2">
+      <Staff>
+        <eid>D_D</eid>
         <StaffType group="percussion">
           <name>perc5Line</name>
           <keysig>0</keysig>
           </StaffType>
         <defaultClef>PERC</defaultClef>
         </Staff>
-      <trackName>Drumset</trackName>
+      <trackName>Drum Kit (large)</trackName>
       <Instrument id="drumset">
-        <longName>Drumset</longName>
-        <shortName>D. Set</shortName>
-        <trackName>Drumset</trackName>
+        <longName>Drum Kit (large)</longName>
+        <shortName>D. Kit</shortName>
+        <trackName>Drum Kit (large)</trackName>
         <instrumentId>drum.group.set</instrumentId>
         <useDrumset>1</useDrumset>
         <Drum pitch="35">
           <head>normal</head>
-          <line>7</line>
+          <line>8</line>
           <voice>1</voice>
-          <name>Acoustic Bass Drum</name>
+          <name>Bass Drum 2</name>
           <stem>2</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>0</panelColumn>
           </Drum>
         <Drum pitch="36">
           <head>normal</head>
@@ -119,14 +126,18 @@
           <voice>1</voice>
           <name>Bass Drum 1</name>
           <stem>2</stem>
-          <shortcut>B</shortcut>
+          <shortcut>A</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>0</panelColumn>
           </Drum>
         <Drum pitch="37">
-          <head>cross</head>
+          <head>slashed1</head>
           <line>3</line>
           <voice>0</voice>
           <name>Side Stick</name>
           <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>1</panelColumn>
           </Drum>
         <Drum pitch="38">
           <head>normal</head>
@@ -134,21 +145,27 @@
           <voice>0</voice>
           <name>Acoustic Snare</name>
           <stem>1</stem>
-          <shortcut>A</shortcut>
+          <shortcut>B</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>1</panelColumn>
           </Drum>
         <Drum pitch="40">
-          <head>normal</head>
+          <head>slash</head>
           <line>3</line>
           <voice>0</voice>
           <name>Electric Snare</name>
           <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>0</panelColumn>
           </Drum>
         <Drum pitch="41">
           <head>normal</head>
-          <line>5</line>
+          <line>6</line>
           <voice>0</voice>
           <name>Low Floor Tom</name>
           <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>7</panelColumn>
           </Drum>
         <Drum pitch="42">
           <head>cross</head>
@@ -156,14 +173,19 @@
           <voice>0</voice>
           <name>Closed Hi-Hat</name>
           <stem>1</stem>
-          <shortcut>G</shortcut>
+          <shortcut>C</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>2</panelColumn>
           </Drum>
         <Drum pitch="43">
           <head>normal</head>
           <line>5</line>
-          <voice>1</voice>
+          <voice>0</voice>
           <name>High Floor Tom</name>
-          <stem>2</stem>
+          <stem>1</stem>
+          <shortcut>H</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>7</panelColumn>
           </Drum>
         <Drum pitch="44">
           <head>cross</head>
@@ -171,35 +193,46 @@
           <voice>1</voice>
           <name>Pedal Hi-Hat</name>
           <stem>2</stem>
-          <shortcut>F</shortcut>
+          <panelRow>1</panelRow>
+          <panelColumn>2</panelColumn>
           </Drum>
         <Drum pitch="45">
           <head>normal</head>
-          <line>2</line>
+          <line>4</line>
           <voice>0</voice>
           <name>Low Tom</name>
           <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>6</panelColumn>
           </Drum>
         <Drum pitch="46">
-          <head>cross</head>
-          <line>1</line>
+          <head>xcircle</head>
+          <line>-1</line>
           <voice>0</voice>
           <name>Open Hi-Hat</name>
           <stem>1</stem>
+          <shortcut>D</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>3</panelColumn>
           </Drum>
         <Drum pitch="47">
           <head>normal</head>
-          <line>1</line>
+          <line>2</line>
           <voice>0</voice>
           <name>Low-Mid Tom</name>
           <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>5</panelColumn>
           </Drum>
         <Drum pitch="48">
           <head>normal</head>
-          <line>0</line>
+          <line>1</line>
           <voice>0</voice>
           <name>Hi-Mid Tom</name>
           <stem>1</stem>
+          <shortcut>G</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>6</panelColumn>
           </Drum>
         <Drum pitch="49">
           <head>cross</head>
@@ -207,7 +240,9 @@
           <voice>0</voice>
           <name>Crash Cymbal 1</name>
           <stem>1</stem>
-          <shortcut>C</shortcut>
+          <shortcut>E</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>4</panelColumn>
           </Drum>
         <Drum pitch="50">
           <head>normal</head>
@@ -215,7 +250,8 @@
           <voice>0</voice>
           <name>High Tom</name>
           <stem>1</stem>
-          <shortcut>E</shortcut>
+          <panelRow>1</panelRow>
+          <panelColumn>4</panelColumn>
           </Drum>
         <Drum pitch="51">
           <head>cross</head>
@@ -223,14 +259,24 @@
           <voice>0</voice>
           <name>Ride Cymbal 1</name>
           <stem>1</stem>
-          <shortcut>D</shortcut>
+          <shortcut>F</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>5</panelColumn>
           </Drum>
         <Drum pitch="52">
-          <head>cross</head>
+          <head>normal</head>
+          <noteheads>
+            <whole>noteheadHeavyXHat</whole>
+            <half>noteheadHeavyXHat</half>
+            <quarter>noteheadHeavyXHat</quarter>
+            <breve>noteheadHeavyXHat</breve>
+            </noteheads>
           <line>-3</line>
           <voice>0</voice>
-          <name>Chinese Cymbal</name>
+          <name>China Cymbal</name>
           <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>3</panelColumn>
           </Drum>
         <Drum pitch="53">
           <head>diamond</head>
@@ -238,20 +284,26 @@
           <voice>0</voice>
           <name>Ride Bell</name>
           <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>5</panelColumn>
           </Drum>
         <Drum pitch="54">
           <head>diamond</head>
-          <line>2</line>
+          <line>1</line>
           <voice>0</voice>
           <name>Tambourine</name>
           <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>1</panelColumn>
           </Drum>
         <Drum pitch="55">
           <head>cross</head>
-          <line>-3</line>
+          <line>-4</line>
           <voice>0</voice>
           <name>Splash Cymbal</name>
           <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>4</panelColumn>
           </Drum>
         <Drum pitch="56">
           <head>triangle-down</head>
@@ -259,6 +311,8 @@
           <voice>0</voice>
           <name>Cowbell</name>
           <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>2</panelColumn>
           </Drum>
         <Drum pitch="57">
           <head>cross</head>
@@ -266,6 +320,8 @@
           <voice>0</voice>
           <name>Crash Cymbal 2</name>
           <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>3</panelColumn>
           </Drum>
         <Drum pitch="59">
           <head>cross</head>
@@ -273,22 +329,11 @@
           <voice>0</voice>
           <name>Ride Cymbal 2</name>
           <stem>1</stem>
-          </Drum>
-        <Drum pitch="63">
-          <head>cross</head>
-          <line>4</line>
-          <voice>0</voice>
-          <name>Open Hi Conga</name>
-          <stem>1</stem>
-          </Drum>
-        <Drum pitch="64">
-          <head>cross</head>
-          <line>6</line>
-          <voice>0</voice>
-          <name>Low Conga</name>
-          <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>6</panelColumn>
           </Drum>
         <clef>PERC</clef>
+        <singleNoteDynamics>0</singleNoteDynamics>
         <Articulation>
           <velocity>100</velocity>
           <gateTime>100</gateTime>
@@ -338,36 +383,43 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>E_E</eid>
         <voice>
           <TimeSig>
+            <eid>F_F</eid>
             <sigN>12</sigN>
             <sigD>8</sigD>
             </TimeSig>
           <Rest>
+            <eid>G_G</eid>
             <durationType>measure</durationType>
             <duration>12/8</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
+        <eid>H_H</eid>
         <voice>
           <Rest>
+            <eid>I_I</eid>
             <dots>1</dots>
             <durationType>half</durationType>
             </Rest>
           <Rest>
+            <eid>J_J</eid>
             <dots>1</dots>
             <durationType>quarter</durationType>
             </Rest>
           <Chord>
+            <eid>K_K</eid>
             <dots>1</dots>
             <durationType>quarter</durationType>
-            <StemDirection>down</StemDirection>
+            <StemDirection>up</StemDirection>
             <Note>
+              <eid>L_L</eid>
               <pitch>54</pitch>
               <tpc>20</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
@@ -377,10 +429,12 @@
       <Measure>
         <voice>
           <TimeSig>
+            <eid>M_M</eid>
             <sigN>12</sigN>
             <sigD>8</sigD>
             </TimeSig>
           <Rest>
+            <eid>N_N</eid>
             <durationType>measure</durationType>
             <duration>12/8</duration>
             </Rest>
@@ -389,128 +443,164 @@
       <Measure>
         <voice>
           <Chord>
+            <eid>O_O</eid>
             <dots>1</dots>
             <durationType>quarter</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>P_P</eid>
               <pitch>49</pitch>
               <tpc>21</tpc>
+              <head>cross</head>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
+          <Beam>
+            <eid>Q_Q</eid>
+            <l1>-22</l1>
+            <l2>-26</l2>
+            </Beam>
           <Chord>
+            <eid>R_R</eid>
             <durationType>eighth</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>S_S</eid>
               <pitch>38</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>T_T</eid>
             <durationType>eighth</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>U_U</eid>
               <pitch>42</pitch>
               <tpc>20</tpc>
+              <head>cross</head>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>V_V</eid>
             <durationType>eighth</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>W_W</eid>
               <pitch>42</pitch>
               <tpc>20</tpc>
+              <head>cross</head>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>X_X</eid>
             <durationType>eighth</durationType>
             </Rest>
+          <Beam>
+            <eid>Y_Y</eid>
+            <l1>-24</l1>
+            <l2>-24</l2>
+            </Beam>
           <Chord>
+            <eid>Z_Z</eid>
             <durationType>eighth</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>a_a</eid>
               <pitch>42</pitch>
               <tpc>20</tpc>
+              <head>cross</head>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>b_b</eid>
             <durationType>eighth</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>c_c</eid>
               <pitch>42</pitch>
               <tpc>20</tpc>
+              <head>cross</head>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
+          <Beam>
+            <eid>d_d</eid>
+            <l1>-22</l1>
+            <l2>-26</l2>
+            </Beam>
           <Chord>
+            <eid>e_e</eid>
             <durationType>eighth</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>f_f</eid>
               <pitch>38</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>g_g</eid>
             <durationType>eighth</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>h_h</eid>
               <pitch>42</pitch>
               <tpc>20</tpc>
+              <head>cross</head>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>i_i</eid>
             <durationType>eighth</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>j_j</eid>
               <pitch>42</pitch>
               <tpc>20</tpc>
+              <head>cross</head>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         <voice>
           <Chord>
+            <eid>k_k</eid>
             <dots>1</dots>
             <durationType>quarter</durationType>
             <StemDirection>down</StemDirection>
             <Note>
+              <eid>l_l</eid>
               <pitch>35</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>m_m</eid>
             <dots>1</dots>
             <durationType>quarter</durationType>
             </Rest>
           <Chord>
+            <eid>n_n</eid>
             <dots>1</dots>
             <durationType>quarter</durationType>
             <StemDirection>down</StemDirection>
             <Note>
+              <eid>o_o</eid>
               <pitch>35</pitch>
               <tpc>19</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>p_p</eid>
             <dots>1</dots>
             <durationType>quarter</durationType>
             </Rest>

--- a/src/importexport/midi/tests/midiimport_data/perc_remove_ties-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/perc_remove_ties-ref.mscx
@@ -29,9 +29,9 @@
           </StaffType>
         <defaultClef>PERC</defaultClef>
         </Staff>
-      <trackName>Drum Kit (large), Drum Set</trackName>
+      <trackName>Drum Kit, Drum Set</trackName>
       <Instrument id="drumset">
-        <longName>Drum Kit (large), Drum Set</longName>
+        <longName>Drum Kit, Drum Set</longName>
         <shortName>D. Kit</shortName>
         <trackName>Drum Kit (large)</trackName>
         <instrumentId>drum.group.set</instrumentId>

--- a/src/importexport/midi/tests/midiimport_data/perc_remove_ties-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/perc_remove_ties-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,27 +20,30 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="percussion">
           <name>perc5Line</name>
           <keysig>0</keysig>
           </StaffType>
         <defaultClef>PERC</defaultClef>
         </Staff>
-      <trackName>Drumset, Drum Set</trackName>
+      <trackName>Drum Kit (large), Drum Set</trackName>
       <Instrument id="drumset">
-        <longName>Drumset, Drum Set</longName>
-        <shortName>D. Set</shortName>
-        <trackName>Drumset</trackName>
+        <longName>Drum Kit (large), Drum Set</longName>
+        <shortName>D. Kit</shortName>
+        <trackName>Drum Kit (large)</trackName>
         <instrumentId>drum.group.set</instrumentId>
         <useDrumset>1</useDrumset>
         <Drum pitch="35">
           <head>normal</head>
-          <line>7</line>
+          <line>8</line>
           <voice>1</voice>
-          <name>Acoustic Bass Drum</name>
+          <name>Bass Drum 2</name>
           <stem>2</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>0</panelColumn>
           </Drum>
         <Drum pitch="36">
           <head>normal</head>
@@ -47,14 +51,18 @@
           <voice>1</voice>
           <name>Bass Drum 1</name>
           <stem>2</stem>
-          <shortcut>B</shortcut>
+          <shortcut>A</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>0</panelColumn>
           </Drum>
         <Drum pitch="37">
-          <head>cross</head>
+          <head>slashed1</head>
           <line>3</line>
           <voice>0</voice>
           <name>Side Stick</name>
           <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>1</panelColumn>
           </Drum>
         <Drum pitch="38">
           <head>normal</head>
@@ -62,21 +70,27 @@
           <voice>0</voice>
           <name>Acoustic Snare</name>
           <stem>1</stem>
-          <shortcut>A</shortcut>
+          <shortcut>B</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>1</panelColumn>
           </Drum>
         <Drum pitch="40">
-          <head>normal</head>
+          <head>slash</head>
           <line>3</line>
           <voice>0</voice>
           <name>Electric Snare</name>
           <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>0</panelColumn>
           </Drum>
         <Drum pitch="41">
           <head>normal</head>
-          <line>5</line>
+          <line>6</line>
           <voice>0</voice>
           <name>Low Floor Tom</name>
           <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>7</panelColumn>
           </Drum>
         <Drum pitch="42">
           <head>cross</head>
@@ -84,14 +98,19 @@
           <voice>0</voice>
           <name>Closed Hi-Hat</name>
           <stem>1</stem>
-          <shortcut>G</shortcut>
+          <shortcut>C</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>2</panelColumn>
           </Drum>
         <Drum pitch="43">
           <head>normal</head>
           <line>5</line>
-          <voice>1</voice>
+          <voice>0</voice>
           <name>High Floor Tom</name>
-          <stem>2</stem>
+          <stem>1</stem>
+          <shortcut>H</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>7</panelColumn>
           </Drum>
         <Drum pitch="44">
           <head>cross</head>
@@ -99,35 +118,46 @@
           <voice>1</voice>
           <name>Pedal Hi-Hat</name>
           <stem>2</stem>
-          <shortcut>F</shortcut>
+          <panelRow>1</panelRow>
+          <panelColumn>2</panelColumn>
           </Drum>
         <Drum pitch="45">
           <head>normal</head>
-          <line>2</line>
+          <line>4</line>
           <voice>0</voice>
           <name>Low Tom</name>
           <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>6</panelColumn>
           </Drum>
         <Drum pitch="46">
-          <head>cross</head>
-          <line>1</line>
+          <head>xcircle</head>
+          <line>-1</line>
           <voice>0</voice>
           <name>Open Hi-Hat</name>
           <stem>1</stem>
+          <shortcut>D</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>3</panelColumn>
           </Drum>
         <Drum pitch="47">
           <head>normal</head>
-          <line>1</line>
+          <line>2</line>
           <voice>0</voice>
           <name>Low-Mid Tom</name>
           <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>5</panelColumn>
           </Drum>
         <Drum pitch="48">
           <head>normal</head>
-          <line>0</line>
+          <line>1</line>
           <voice>0</voice>
           <name>Hi-Mid Tom</name>
           <stem>1</stem>
+          <shortcut>G</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>6</panelColumn>
           </Drum>
         <Drum pitch="49">
           <head>cross</head>
@@ -135,7 +165,9 @@
           <voice>0</voice>
           <name>Crash Cymbal 1</name>
           <stem>1</stem>
-          <shortcut>C</shortcut>
+          <shortcut>E</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>4</panelColumn>
           </Drum>
         <Drum pitch="50">
           <head>normal</head>
@@ -143,7 +175,8 @@
           <voice>0</voice>
           <name>High Tom</name>
           <stem>1</stem>
-          <shortcut>E</shortcut>
+          <panelRow>1</panelRow>
+          <panelColumn>4</panelColumn>
           </Drum>
         <Drum pitch="51">
           <head>cross</head>
@@ -151,14 +184,24 @@
           <voice>0</voice>
           <name>Ride Cymbal 1</name>
           <stem>1</stem>
-          <shortcut>D</shortcut>
+          <shortcut>F</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>5</panelColumn>
           </Drum>
         <Drum pitch="52">
-          <head>cross</head>
+          <head>normal</head>
+          <noteheads>
+            <whole>noteheadHeavyXHat</whole>
+            <half>noteheadHeavyXHat</half>
+            <quarter>noteheadHeavyXHat</quarter>
+            <breve>noteheadHeavyXHat</breve>
+            </noteheads>
           <line>-3</line>
           <voice>0</voice>
-          <name>Chinese Cymbal</name>
+          <name>China Cymbal</name>
           <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>3</panelColumn>
           </Drum>
         <Drum pitch="53">
           <head>diamond</head>
@@ -166,20 +209,26 @@
           <voice>0</voice>
           <name>Ride Bell</name>
           <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>5</panelColumn>
           </Drum>
         <Drum pitch="54">
           <head>diamond</head>
-          <line>2</line>
+          <line>1</line>
           <voice>0</voice>
           <name>Tambourine</name>
           <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>1</panelColumn>
           </Drum>
         <Drum pitch="55">
           <head>cross</head>
-          <line>-3</line>
+          <line>-4</line>
           <voice>0</voice>
           <name>Splash Cymbal</name>
           <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>4</panelColumn>
           </Drum>
         <Drum pitch="56">
           <head>triangle-down</head>
@@ -187,6 +236,8 @@
           <voice>0</voice>
           <name>Cowbell</name>
           <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>2</panelColumn>
           </Drum>
         <Drum pitch="57">
           <head>cross</head>
@@ -194,6 +245,8 @@
           <voice>0</voice>
           <name>Crash Cymbal 2</name>
           <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>3</panelColumn>
           </Drum>
         <Drum pitch="59">
           <head>cross</head>
@@ -201,22 +254,11 @@
           <voice>0</voice>
           <name>Ride Cymbal 2</name>
           <stem>1</stem>
-          </Drum>
-        <Drum pitch="63">
-          <head>cross</head>
-          <line>4</line>
-          <voice>0</voice>
-          <name>Open Hi Conga</name>
-          <stem>1</stem>
-          </Drum>
-        <Drum pitch="64">
-          <head>cross</head>
-          <line>6</line>
-          <voice>0</voice>
-          <name>Low Conga</name>
-          <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>6</panelColumn>
           </Drum>
         <clef>PERC</clef>
+        <singleNoteDynamics>0</singleNoteDynamics>
         <Articulation>
           <velocity>100</velocity>
           <gateTime>100</gateTime>
@@ -267,501 +309,626 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
+          <Beam>
+            <eid>F_F</eid>
+            <l1>-24</l1>
+            <l2>-24</l2>
+            </Beam>
           <Chord>
+            <eid>G_G</eid>
             <durationType>eighth</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>H_H</eid>
               <pitch>42</pitch>
               <tpc>20</tpc>
+              <head>cross</head>
               <velocity>68</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>I_I</eid>
             <durationType>eighth</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>J_J</eid>
               <pitch>42</pitch>
               <tpc>20</tpc>
+              <head>cross</head>
               <velocity>74</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>K_K</eid>
             <durationType>eighth</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>L_L</eid>
               <pitch>38</pitch>
               <tpc>16</tpc>
               <velocity>90</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>M_M</eid>
               <pitch>42</pitch>
               <tpc>20</tpc>
+              <head>cross</head>
               <velocity>79</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>N_N</eid>
             <durationType>eighth</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>O_O</eid>
               <pitch>42</pitch>
               <tpc>20</tpc>
+              <head>cross</head>
               <velocity>77</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
+          <Beam>
+            <eid>P_P</eid>
+            <l1>-24</l1>
+            <l2>-24</l2>
+            </Beam>
           <Chord>
+            <eid>Q_Q</eid>
             <durationType>eighth</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>R_R</eid>
               <pitch>42</pitch>
               <tpc>20</tpc>
+              <head>cross</head>
               <velocity>76</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>S_S</eid>
             <durationType>eighth</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>T_T</eid>
               <pitch>42</pitch>
               <tpc>20</tpc>
+              <head>cross</head>
               <velocity>76</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>U_U</eid>
             <durationType>eighth</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>V_V</eid>
               <pitch>38</pitch>
               <tpc>16</tpc>
               <velocity>85</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>W_W</eid>
               <pitch>42</pitch>
               <tpc>20</tpc>
+              <head>cross</head>
               <velocity>78</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>X_X</eid>
             <durationType>eighth</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>Y_Y</eid>
               <pitch>42</pitch>
               <tpc>20</tpc>
+              <head>cross</head>
               <velocity>79</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         <voice>
           <Chord>
+            <eid>Z_Z</eid>
             <durationType>quarter</durationType>
             <StemDirection>down</StemDirection>
             <Note>
+              <eid>a_a</eid>
               <pitch>36</pitch>
               <tpc>14</tpc>
               <velocity>73</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>b_b</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Chord>
+            <eid>c_c</eid>
             <durationType>quarter</durationType>
             <StemDirection>down</StemDirection>
             <Note>
+              <eid>d_d</eid>
               <pitch>36</pitch>
               <tpc>14</tpc>
               <velocity>65</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>e_e</eid>
             <durationType>quarter</durationType>
             </Rest>
           </voice>
         </Measure>
       <Measure>
+        <eid>f_f</eid>
         <voice>
+          <Beam>
+            <eid>g_g</eid>
+            <l1>-24</l1>
+            <l2>-24</l2>
+            </Beam>
           <Chord>
+            <eid>h_h</eid>
             <durationType>eighth</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>i_i</eid>
               <pitch>42</pitch>
               <tpc>20</tpc>
+              <head>cross</head>
               <velocity>78</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>j_j</eid>
             <durationType>eighth</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>k_k</eid>
               <pitch>42</pitch>
               <tpc>20</tpc>
+              <head>cross</head>
               <velocity>71</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>l_l</eid>
             <durationType>eighth</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>m_m</eid>
               <pitch>38</pitch>
               <tpc>16</tpc>
               <velocity>91</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>n_n</eid>
               <pitch>42</pitch>
               <tpc>20</tpc>
+              <head>cross</head>
               <velocity>76</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>o_o</eid>
             <durationType>eighth</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>p_p</eid>
               <pitch>42</pitch>
               <tpc>20</tpc>
+              <head>cross</head>
               <velocity>75</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
+          <Beam>
+            <eid>q_q</eid>
+            <l1>-24</l1>
+            <l2>-24</l2>
+            </Beam>
           <Chord>
+            <eid>r_r</eid>
             <durationType>eighth</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>s_s</eid>
               <pitch>42</pitch>
               <tpc>20</tpc>
+              <head>cross</head>
               <velocity>77</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>t_t</eid>
             <durationType>eighth</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>u_u</eid>
               <pitch>42</pitch>
               <tpc>20</tpc>
+              <head>cross</head>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>v_v</eid>
             <durationType>eighth</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>w_w</eid>
               <pitch>38</pitch>
               <tpc>16</tpc>
               <velocity>90</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>x_x</eid>
               <pitch>42</pitch>
               <tpc>20</tpc>
+              <head>cross</head>
               <velocity>78</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>y_y</eid>
             <durationType>eighth</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>z_z</eid>
               <pitch>42</pitch>
               <tpc>20</tpc>
+              <head>cross</head>
               <velocity>79</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         <voice>
           <Chord>
+            <eid>0_0</eid>
             <durationType>quarter</durationType>
             <StemDirection>down</StemDirection>
             <Note>
+              <eid>1_1</eid>
               <pitch>36</pitch>
               <tpc>14</tpc>
               <velocity>62</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>2_2</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Chord>
+            <eid>3_3</eid>
             <durationType>quarter</durationType>
             <StemDirection>down</StemDirection>
             <Note>
+              <eid>4_4</eid>
               <pitch>36</pitch>
               <tpc>14</tpc>
               <velocity>70</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>5_5</eid>
             <durationType>quarter</durationType>
             </Rest>
           </voice>
         </Measure>
       <Measure>
+        <eid>6_6</eid>
         <voice>
+          <Beam>
+            <eid>7_7</eid>
+            <l1>-24</l1>
+            <l2>-24</l2>
+            </Beam>
           <Chord>
+            <eid>8_8</eid>
             <durationType>eighth</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>9_9</eid>
               <pitch>42</pitch>
               <tpc>20</tpc>
+              <head>cross</head>
               <velocity>73</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>+_+</eid>
             <durationType>eighth</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>/_/</eid>
               <pitch>42</pitch>
               <tpc>20</tpc>
+              <head>cross</head>
               <velocity>79</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>AB_AB</eid>
             <durationType>eighth</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>BB_BB</eid>
               <pitch>38</pitch>
               <tpc>16</tpc>
               <velocity>87</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>CB_CB</eid>
               <pitch>42</pitch>
               <tpc>20</tpc>
+              <head>cross</head>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>DB_DB</eid>
             <durationType>eighth</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>EB_EB</eid>
               <pitch>42</pitch>
               <tpc>20</tpc>
+              <head>cross</head>
               <velocity>76</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
+          <Beam>
+            <eid>FB_FB</eid>
+            <l1>-24</l1>
+            <l2>-24</l2>
+            </Beam>
           <Chord>
+            <eid>GB_GB</eid>
             <durationType>eighth</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>HB_HB</eid>
               <pitch>42</pitch>
               <tpc>20</tpc>
+              <head>cross</head>
               <velocity>79</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>IB_IB</eid>
             <durationType>eighth</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>JB_JB</eid>
               <pitch>42</pitch>
               <tpc>20</tpc>
+              <head>cross</head>
               <velocity>73</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>KB_KB</eid>
             <durationType>eighth</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>LB_LB</eid>
               <pitch>38</pitch>
               <tpc>16</tpc>
               <velocity>87</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>MB_MB</eid>
               <pitch>42</pitch>
               <tpc>20</tpc>
+              <head>cross</head>
               <velocity>77</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>NB_NB</eid>
             <durationType>eighth</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>OB_OB</eid>
               <pitch>42</pitch>
               <tpc>20</tpc>
+              <head>cross</head>
               <velocity>74</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         <voice>
           <Chord>
+            <eid>PB_PB</eid>
             <durationType>quarter</durationType>
             <StemDirection>down</StemDirection>
             <Note>
+              <eid>QB_QB</eid>
               <pitch>36</pitch>
               <tpc>14</tpc>
               <velocity>60</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>RB_RB</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Chord>
+            <eid>SB_SB</eid>
             <durationType>quarter</durationType>
             <StemDirection>down</StemDirection>
             <Note>
+              <eid>TB_TB</eid>
               <pitch>36</pitch>
               <tpc>14</tpc>
               <velocity>63</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>UB_UB</eid>
             <durationType>quarter</durationType>
             </Rest>
           </voice>
         </Measure>
       <Measure>
+        <eid>VB_VB</eid>
         <voice>
+          <Beam>
+            <eid>WB_WB</eid>
+            <l1>-24</l1>
+            <l2>-24</l2>
+            </Beam>
           <Chord>
+            <eid>XB_XB</eid>
             <durationType>eighth</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>YB_YB</eid>
               <pitch>42</pitch>
               <tpc>20</tpc>
+              <head>cross</head>
               <velocity>76</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>ZB_ZB</eid>
             <durationType>eighth</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>aB_aB</eid>
               <pitch>42</pitch>
               <tpc>20</tpc>
+              <head>cross</head>
               <velocity>75</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>bB_bB</eid>
             <durationType>eighth</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>cB_cB</eid>
               <pitch>38</pitch>
               <tpc>16</tpc>
               <velocity>92</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>dB_dB</eid>
               <pitch>42</pitch>
               <tpc>20</tpc>
+              <head>cross</head>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>eB_eB</eid>
             <durationType>eighth</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>fB_fB</eid>
               <pitch>42</pitch>
               <tpc>20</tpc>
+              <head>cross</head>
               <velocity>74</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
+          <Beam>
+            <eid>gB_gB</eid>
+            <l1>-24</l1>
+            <l2>-24</l2>
+            </Beam>
           <Chord>
+            <eid>hB_hB</eid>
             <durationType>eighth</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>iB_iB</eid>
               <pitch>42</pitch>
               <tpc>20</tpc>
+              <head>cross</head>
               <velocity>74</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>jB_jB</eid>
             <durationType>eighth</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>kB_kB</eid>
               <pitch>42</pitch>
               <tpc>20</tpc>
+              <head>cross</head>
               <velocity>75</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>lB_lB</eid>
             <durationType>eighth</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>mB_mB</eid>
               <pitch>38</pitch>
               <tpc>16</tpc>
               <velocity>91</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>nB_nB</eid>
               <pitch>42</pitch>
               <tpc>20</tpc>
+              <head>cross</head>
               <velocity>75</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>oB_oB</eid>
             <durationType>eighth</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>pB_pB</eid>
               <pitch>42</pitch>
               <tpc>20</tpc>
+              <head>cross</head>
               <velocity>75</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         <voice>
           <Chord>
+            <eid>qB_qB</eid>
             <durationType>quarter</durationType>
             <StemDirection>down</StemDirection>
             <Note>
+              <eid>rB_rB</eid>
               <pitch>36</pitch>
               <tpc>14</tpc>
               <velocity>67</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>sB_sB</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Chord>
+            <eid>tB_tB</eid>
             <durationType>quarter</durationType>
             <StemDirection>down</StemDirection>
             <Note>
+              <eid>uB_uB</eid>
               <pitch>36</pitch>
               <tpc>14</tpc>
               <velocity>63</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>vB_vB</eid>
             <durationType>quarter</durationType>
             </Rest>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/perc_respect_beat-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/perc_respect_beat-ref.mscx
@@ -29,9 +29,9 @@
           </StaffType>
         <defaultClef>PERC</defaultClef>
         </Staff>
-      <trackName>Drum Kit (large)</trackName>
+      <trackName>Drum Kit</trackName>
       <Instrument id="drumset">
-        <longName>Drum Kit (large)</longName>
+        <longName>Drum Kit</longName>
         <shortName>D. Kit</shortName>
         <trackName>Drum Kit (large)</trackName>
         <instrumentId>drum.group.set</instrumentId>

--- a/src/importexport/midi/tests/midiimport_data/perc_respect_beat-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/perc_respect_beat-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,37 +20,242 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="percussion">
-          <name>perc1Line</name>
-          <lines>1</lines>
+          <name>perc5Line</name>
           <keysig>0</keysig>
           </StaffType>
         <defaultClef>PERC</defaultClef>
         </Staff>
-      <trackName>Concert Snare Drum</trackName>
-      <Instrument id="snare-drum">
-        <longName>Concert Snare Drum</longName>
-        <shortName>Con. Sn.</shortName>
-        <trackName>Concert Snare Drum</trackName>
-        <instrumentId>drum.snare-drum</instrumentId>
+      <trackName>Drum Kit (large)</trackName>
+      <Instrument id="drumset">
+        <longName>Drum Kit (large)</longName>
+        <shortName>D. Kit</shortName>
+        <trackName>Drum Kit (large)</trackName>
+        <instrumentId>drum.group.set</instrumentId>
         <useDrumset>1</useDrumset>
-        <Drum pitch="37">
-          <head>cross</head>
-          <line>0</line>
-          <voice>0</voice>
-          <name>Side Stick</name>
+        <Drum pitch="35">
+          <head>normal</head>
+          <line>8</line>
+          <voice>1</voice>
+          <name>Bass Drum 2</name>
+          <stem>2</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>0</panelColumn>
+          </Drum>
+        <Drum pitch="36">
+          <head>normal</head>
+          <line>7</line>
+          <voice>1</voice>
+          <name>Bass Drum 1</name>
           <stem>2</stem>
           <shortcut>A</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>0</panelColumn>
+          </Drum>
+        <Drum pitch="37">
+          <head>slashed1</head>
+          <line>3</line>
+          <voice>0</voice>
+          <name>Side Stick</name>
+          <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>1</panelColumn>
           </Drum>
         <Drum pitch="38">
           <head>normal</head>
-          <line>0</line>
+          <line>3</line>
           <voice>0</voice>
           <name>Acoustic Snare</name>
-          <stem>2</stem>
+          <stem>1</stem>
           <shortcut>B</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>1</panelColumn>
+          </Drum>
+        <Drum pitch="40">
+          <head>slash</head>
+          <line>3</line>
+          <voice>0</voice>
+          <name>Electric Snare</name>
+          <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>0</panelColumn>
+          </Drum>
+        <Drum pitch="41">
+          <head>normal</head>
+          <line>6</line>
+          <voice>0</voice>
+          <name>Low Floor Tom</name>
+          <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>7</panelColumn>
+          </Drum>
+        <Drum pitch="42">
+          <head>cross</head>
+          <line>-1</line>
+          <voice>0</voice>
+          <name>Closed Hi-Hat</name>
+          <stem>1</stem>
+          <shortcut>C</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>2</panelColumn>
+          </Drum>
+        <Drum pitch="43">
+          <head>normal</head>
+          <line>5</line>
+          <voice>0</voice>
+          <name>High Floor Tom</name>
+          <stem>1</stem>
+          <shortcut>H</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>7</panelColumn>
+          </Drum>
+        <Drum pitch="44">
+          <head>cross</head>
+          <line>9</line>
+          <voice>1</voice>
+          <name>Pedal Hi-Hat</name>
+          <stem>2</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>2</panelColumn>
+          </Drum>
+        <Drum pitch="45">
+          <head>normal</head>
+          <line>4</line>
+          <voice>0</voice>
+          <name>Low Tom</name>
+          <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>6</panelColumn>
+          </Drum>
+        <Drum pitch="46">
+          <head>xcircle</head>
+          <line>-1</line>
+          <voice>0</voice>
+          <name>Open Hi-Hat</name>
+          <stem>1</stem>
+          <shortcut>D</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>3</panelColumn>
+          </Drum>
+        <Drum pitch="47">
+          <head>normal</head>
+          <line>2</line>
+          <voice>0</voice>
+          <name>Low-Mid Tom</name>
+          <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>5</panelColumn>
+          </Drum>
+        <Drum pitch="48">
+          <head>normal</head>
+          <line>1</line>
+          <voice>0</voice>
+          <name>Hi-Mid Tom</name>
+          <stem>1</stem>
+          <shortcut>G</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>6</panelColumn>
+          </Drum>
+        <Drum pitch="49">
+          <head>cross</head>
+          <line>-2</line>
+          <voice>0</voice>
+          <name>Crash Cymbal 1</name>
+          <stem>1</stem>
+          <shortcut>E</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>4</panelColumn>
+          </Drum>
+        <Drum pitch="50">
+          <head>normal</head>
+          <line>0</line>
+          <voice>0</voice>
+          <name>High Tom</name>
+          <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>4</panelColumn>
+          </Drum>
+        <Drum pitch="51">
+          <head>cross</head>
+          <line>0</line>
+          <voice>0</voice>
+          <name>Ride Cymbal 1</name>
+          <stem>1</stem>
+          <shortcut>F</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>5</panelColumn>
+          </Drum>
+        <Drum pitch="52">
+          <head>normal</head>
+          <noteheads>
+            <whole>noteheadHeavyXHat</whole>
+            <half>noteheadHeavyXHat</half>
+            <quarter>noteheadHeavyXHat</quarter>
+            <breve>noteheadHeavyXHat</breve>
+            </noteheads>
+          <line>-3</line>
+          <voice>0</voice>
+          <name>China Cymbal</name>
+          <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>3</panelColumn>
+          </Drum>
+        <Drum pitch="53">
+          <head>diamond</head>
+          <line>0</line>
+          <voice>0</voice>
+          <name>Ride Bell</name>
+          <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>5</panelColumn>
+          </Drum>
+        <Drum pitch="54">
+          <head>diamond</head>
+          <line>1</line>
+          <voice>0</voice>
+          <name>Tambourine</name>
+          <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>1</panelColumn>
+          </Drum>
+        <Drum pitch="55">
+          <head>cross</head>
+          <line>-4</line>
+          <voice>0</voice>
+          <name>Splash Cymbal</name>
+          <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>4</panelColumn>
+          </Drum>
+        <Drum pitch="56">
+          <head>triangle-down</head>
+          <line>1</line>
+          <voice>0</voice>
+          <name>Cowbell</name>
+          <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>2</panelColumn>
+          </Drum>
+        <Drum pitch="57">
+          <head>cross</head>
+          <line>-3</line>
+          <voice>0</voice>
+          <name>Crash Cymbal 2</name>
+          <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>3</panelColumn>
+          </Drum>
+        <Drum pitch="59">
+          <head>cross</head>
+          <line>2</line>
+          <voice>0</voice>
+          <name>Ride Cymbal 2</name>
+          <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>6</panelColumn>
           </Drum>
         <clef>PERC</clef>
         <singleNoteDynamics>0</singleNoteDynamics>
@@ -102,39 +308,51 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Chord>
+            <eid>F_F</eid>
             <durationType>quarter</durationType>
+            <StemDirection>up</StemDirection>
             <Note>
+              <eid>G_G</eid>
               <pitch>51</pitch>
               <tpc>11</tpc>
+              <head>cross</head>
               <velocity>127</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>H_H</eid>
             <durationType>quarter</durationType>
+            <StemDirection>up</StemDirection>
             <Note>
+              <eid>I_I</eid>
               <pitch>51</pitch>
               <tpc>11</tpc>
+              <head>cross</head>
               <velocity>127</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>J_J</eid>
             <durationType>quarter</durationType>
+            <StemDirection>up</StemDirection>
             <Note>
+              <eid>K_K</eid>
               <pitch>51</pitch>
               <tpc>11</tpc>
+              <head>cross</head>
               <velocity>127</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>L_L</eid>
             <durationType>quarter</durationType>
             </Rest>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/perc_short_notes-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/perc_short_notes-ref.mscx
@@ -29,9 +29,9 @@
           </StaffType>
         <defaultClef>PERC</defaultClef>
         </Staff>
-      <trackName>Drum Kit (large)</trackName>
+      <trackName>Drum Kit</trackName>
       <Instrument id="drumset">
-        <longName>Drum Kit (large)</longName>
+        <longName>Drum Kit</longName>
         <shortName>D. Kit</shortName>
         <trackName>Drum Kit (large)</trackName>
         <instrumentId>drum.group.set</instrumentId>

--- a/src/importexport/midi/tests/midiimport_data/perc_short_notes-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/perc_short_notes-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,27 +20,30 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="percussion">
           <name>perc5Line</name>
           <keysig>0</keysig>
           </StaffType>
         <defaultClef>PERC</defaultClef>
         </Staff>
-      <trackName>Drumset</trackName>
+      <trackName>Drum Kit (large)</trackName>
       <Instrument id="drumset">
-        <longName>Drumset</longName>
-        <shortName>D. Set</shortName>
-        <trackName>Drumset</trackName>
+        <longName>Drum Kit (large)</longName>
+        <shortName>D. Kit</shortName>
+        <trackName>Drum Kit (large)</trackName>
         <instrumentId>drum.group.set</instrumentId>
         <useDrumset>1</useDrumset>
         <Drum pitch="35">
           <head>normal</head>
-          <line>7</line>
+          <line>8</line>
           <voice>1</voice>
-          <name>Acoustic Bass Drum</name>
+          <name>Bass Drum 2</name>
           <stem>2</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>0</panelColumn>
           </Drum>
         <Drum pitch="36">
           <head>normal</head>
@@ -47,14 +51,18 @@
           <voice>1</voice>
           <name>Bass Drum 1</name>
           <stem>2</stem>
-          <shortcut>B</shortcut>
+          <shortcut>A</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>0</panelColumn>
           </Drum>
         <Drum pitch="37">
-          <head>cross</head>
+          <head>slashed1</head>
           <line>3</line>
           <voice>0</voice>
           <name>Side Stick</name>
           <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>1</panelColumn>
           </Drum>
         <Drum pitch="38">
           <head>normal</head>
@@ -62,21 +70,27 @@
           <voice>0</voice>
           <name>Acoustic Snare</name>
           <stem>1</stem>
-          <shortcut>A</shortcut>
+          <shortcut>B</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>1</panelColumn>
           </Drum>
         <Drum pitch="40">
-          <head>normal</head>
+          <head>slash</head>
           <line>3</line>
           <voice>0</voice>
           <name>Electric Snare</name>
           <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>0</panelColumn>
           </Drum>
         <Drum pitch="41">
           <head>normal</head>
-          <line>5</line>
+          <line>6</line>
           <voice>0</voice>
           <name>Low Floor Tom</name>
           <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>7</panelColumn>
           </Drum>
         <Drum pitch="42">
           <head>cross</head>
@@ -84,14 +98,19 @@
           <voice>0</voice>
           <name>Closed Hi-Hat</name>
           <stem>1</stem>
-          <shortcut>G</shortcut>
+          <shortcut>C</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>2</panelColumn>
           </Drum>
         <Drum pitch="43">
           <head>normal</head>
           <line>5</line>
-          <voice>1</voice>
+          <voice>0</voice>
           <name>High Floor Tom</name>
-          <stem>2</stem>
+          <stem>1</stem>
+          <shortcut>H</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>7</panelColumn>
           </Drum>
         <Drum pitch="44">
           <head>cross</head>
@@ -99,35 +118,46 @@
           <voice>1</voice>
           <name>Pedal Hi-Hat</name>
           <stem>2</stem>
-          <shortcut>F</shortcut>
+          <panelRow>1</panelRow>
+          <panelColumn>2</panelColumn>
           </Drum>
         <Drum pitch="45">
           <head>normal</head>
-          <line>2</line>
+          <line>4</line>
           <voice>0</voice>
           <name>Low Tom</name>
           <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>6</panelColumn>
           </Drum>
         <Drum pitch="46">
-          <head>cross</head>
-          <line>1</line>
+          <head>xcircle</head>
+          <line>-1</line>
           <voice>0</voice>
           <name>Open Hi-Hat</name>
           <stem>1</stem>
+          <shortcut>D</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>3</panelColumn>
           </Drum>
         <Drum pitch="47">
           <head>normal</head>
-          <line>1</line>
+          <line>2</line>
           <voice>0</voice>
           <name>Low-Mid Tom</name>
           <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>5</panelColumn>
           </Drum>
         <Drum pitch="48">
           <head>normal</head>
-          <line>0</line>
+          <line>1</line>
           <voice>0</voice>
           <name>Hi-Mid Tom</name>
           <stem>1</stem>
+          <shortcut>G</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>6</panelColumn>
           </Drum>
         <Drum pitch="49">
           <head>cross</head>
@@ -135,7 +165,9 @@
           <voice>0</voice>
           <name>Crash Cymbal 1</name>
           <stem>1</stem>
-          <shortcut>C</shortcut>
+          <shortcut>E</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>4</panelColumn>
           </Drum>
         <Drum pitch="50">
           <head>normal</head>
@@ -143,7 +175,8 @@
           <voice>0</voice>
           <name>High Tom</name>
           <stem>1</stem>
-          <shortcut>E</shortcut>
+          <panelRow>1</panelRow>
+          <panelColumn>4</panelColumn>
           </Drum>
         <Drum pitch="51">
           <head>cross</head>
@@ -151,14 +184,24 @@
           <voice>0</voice>
           <name>Ride Cymbal 1</name>
           <stem>1</stem>
-          <shortcut>D</shortcut>
+          <shortcut>F</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>5</panelColumn>
           </Drum>
         <Drum pitch="52">
-          <head>cross</head>
+          <head>normal</head>
+          <noteheads>
+            <whole>noteheadHeavyXHat</whole>
+            <half>noteheadHeavyXHat</half>
+            <quarter>noteheadHeavyXHat</quarter>
+            <breve>noteheadHeavyXHat</breve>
+            </noteheads>
           <line>-3</line>
           <voice>0</voice>
-          <name>Chinese Cymbal</name>
+          <name>China Cymbal</name>
           <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>3</panelColumn>
           </Drum>
         <Drum pitch="53">
           <head>diamond</head>
@@ -166,20 +209,26 @@
           <voice>0</voice>
           <name>Ride Bell</name>
           <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>5</panelColumn>
           </Drum>
         <Drum pitch="54">
           <head>diamond</head>
-          <line>2</line>
+          <line>1</line>
           <voice>0</voice>
           <name>Tambourine</name>
           <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>1</panelColumn>
           </Drum>
         <Drum pitch="55">
           <head>cross</head>
-          <line>-3</line>
+          <line>-4</line>
           <voice>0</voice>
           <name>Splash Cymbal</name>
           <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>4</panelColumn>
           </Drum>
         <Drum pitch="56">
           <head>triangle-down</head>
@@ -187,6 +236,8 @@
           <voice>0</voice>
           <name>Cowbell</name>
           <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>2</panelColumn>
           </Drum>
         <Drum pitch="57">
           <head>cross</head>
@@ -194,6 +245,8 @@
           <voice>0</voice>
           <name>Crash Cymbal 2</name>
           <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>3</panelColumn>
           </Drum>
         <Drum pitch="59">
           <head>cross</head>
@@ -201,22 +254,11 @@
           <voice>0</voice>
           <name>Ride Cymbal 2</name>
           <stem>1</stem>
-          </Drum>
-        <Drum pitch="63">
-          <head>cross</head>
-          <line>4</line>
-          <voice>0</voice>
-          <name>Open Hi Conga</name>
-          <stem>1</stem>
-          </Drum>
-        <Drum pitch="64">
-          <head>cross</head>
-          <line>6</line>
-          <voice>0</voice>
-          <name>Low Conga</name>
-          <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>6</panelColumn>
           </Drum>
         <clef>PERC</clef>
+        <singleNoteDynamics>0</singleNoteDynamics>
         <Articulation>
           <velocity>100</velocity>
           <gateTime>100</gateTime>
@@ -267,211 +309,264 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>6</sigN>
             <sigD>8</sigD>
             </TimeSig>
+          <Beam>
+            <eid>F_F</eid>
+            <l1>-24</l1>
+            <l2>-24</l2>
+            </Beam>
           <Chord>
+            <eid>G_G</eid>
             <durationType>eighth</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>H_H</eid>
               <pitch>42</pitch>
               <tpc>20</tpc>
+              <head>cross</head>
               <velocity>95</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>I_I</eid>
             <durationType>eighth</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>J_J</eid>
               <pitch>42</pitch>
               <tpc>20</tpc>
+              <head>cross</head>
               <velocity>95</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>K_K</eid>
             <durationType>eighth</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>L_L</eid>
               <pitch>42</pitch>
               <tpc>20</tpc>
+              <head>cross</head>
               <velocity>95</velocity>
-              <veloType>user</veloType>
+              </Note>
+            </Chord>
+          <Beam>
+            <eid>M_M</eid>
+            <l1>-24</l1>
+            <l2>-24</l2>
+            </Beam>
+          <Chord>
+            <eid>N_N</eid>
+            <durationType>eighth</durationType>
+            <StemDirection>up</StemDirection>
+            <Note>
+              <eid>O_O</eid>
+              <pitch>42</pitch>
+              <tpc>20</tpc>
+              <head>cross</head>
+              <velocity>95</velocity>
               </Note>
             </Chord>
           <Chord>
+            <eid>P_P</eid>
             <durationType>eighth</durationType>
             <StemDirection>up</StemDirection>
             <Note>
-              <pitch>42</pitch>
-              <tpc>20</tpc>
-              <velocity>95</velocity>
-              <veloType>user</veloType>
-              </Note>
-            </Chord>
-          <Chord>
-            <durationType>eighth</durationType>
-            <StemDirection>up</StemDirection>
-            <Note>
+              <eid>Q_Q</eid>
               <pitch>38</pitch>
               <tpc>16</tpc>
               <velocity>95</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>R_R</eid>
               <pitch>42</pitch>
               <tpc>20</tpc>
+              <head>cross</head>
               <velocity>95</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>S_S</eid>
             <durationType>eighth</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>T_T</eid>
               <pitch>42</pitch>
               <tpc>20</tpc>
+              <head>cross</head>
               <velocity>95</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         <voice>
           <Chord>
+            <eid>U_U</eid>
             <durationType>eighth</durationType>
             <StemDirection>down</StemDirection>
             <Note>
+              <eid>V_V</eid>
               <pitch>36</pitch>
               <tpc>14</tpc>
               <velocity>95</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>W_W</eid>
             <durationType>quarter</durationType>
             <StemDirection>down</StemDirection>
             <Note>
+              <eid>X_X</eid>
               <pitch>36</pitch>
               <tpc>14</tpc>
               <velocity>95</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>Y_Y</eid>
             <dots>1</dots>
             <durationType>quarter</durationType>
             <StemDirection>down</StemDirection>
             <Note>
+              <eid>Z_Z</eid>
               <pitch>36</pitch>
               <tpc>14</tpc>
               <velocity>95</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         </Measure>
       <Measure>
+        <eid>a_a</eid>
         <voice>
+          <Beam>
+            <eid>b_b</eid>
+            <l1>-24</l1>
+            <l2>-24</l2>
+            </Beam>
           <Chord>
+            <eid>c_c</eid>
             <durationType>eighth</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>d_d</eid>
               <pitch>42</pitch>
               <tpc>20</tpc>
+              <head>cross</head>
               <velocity>95</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>e_e</eid>
             <durationType>eighth</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>f_f</eid>
               <pitch>42</pitch>
               <tpc>20</tpc>
+              <head>cross</head>
               <velocity>95</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>g_g</eid>
             <durationType>eighth</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>h_h</eid>
               <pitch>42</pitch>
               <tpc>20</tpc>
+              <head>cross</head>
               <velocity>95</velocity>
-              <veloType>user</veloType>
+              </Note>
+            </Chord>
+          <Beam>
+            <eid>i_i</eid>
+            <l1>-24</l1>
+            <l2>-24</l2>
+            </Beam>
+          <Chord>
+            <eid>j_j</eid>
+            <durationType>eighth</durationType>
+            <StemDirection>up</StemDirection>
+            <Note>
+              <eid>k_k</eid>
+              <pitch>42</pitch>
+              <tpc>20</tpc>
+              <head>cross</head>
+              <velocity>95</velocity>
               </Note>
             </Chord>
           <Chord>
+            <eid>l_l</eid>
             <durationType>eighth</durationType>
             <StemDirection>up</StemDirection>
             <Note>
-              <pitch>42</pitch>
-              <tpc>20</tpc>
-              <velocity>95</velocity>
-              <veloType>user</veloType>
-              </Note>
-            </Chord>
-          <Chord>
-            <durationType>eighth</durationType>
-            <StemDirection>up</StemDirection>
-            <Note>
+              <eid>m_m</eid>
               <pitch>38</pitch>
               <tpc>16</tpc>
               <velocity>95</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>n_n</eid>
               <pitch>42</pitch>
               <tpc>20</tpc>
+              <head>cross</head>
               <velocity>95</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>o_o</eid>
             <durationType>eighth</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>p_p</eid>
               <pitch>46</pitch>
               <tpc>12</tpc>
+              <head>xcircle</head>
               <velocity>95</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         <voice>
           <Chord>
+            <eid>q_q</eid>
             <durationType>eighth</durationType>
             <StemDirection>down</StemDirection>
             <Note>
+              <eid>r_r</eid>
               <pitch>36</pitch>
               <tpc>14</tpc>
               <velocity>95</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>s_s</eid>
             <durationType>quarter</durationType>
             <StemDirection>down</StemDirection>
             <Note>
+              <eid>t_t</eid>
               <pitch>36</pitch>
               <tpc>14</tpc>
               <velocity>95</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>u_u</eid>
             <dots>1</dots>
             <durationType>quarter</durationType>
             <StemDirection>down</StemDirection>
             <Note>
+              <eid>v_v</eid>
               <pitch>36</pitch>
               <tpc>14</tpc>
               <velocity>95</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/perc_triplet-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/perc_triplet-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,37 +20,242 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="percussion">
-          <name>perc1Line</name>
-          <lines>1</lines>
+          <name>perc5Line</name>
           <keysig>0</keysig>
           </StaffType>
         <defaultClef>PERC</defaultClef>
         </Staff>
-      <trackName>Concert Snare Drum</trackName>
-      <Instrument id="snare-drum">
-        <longName>Concert Snare Drum</longName>
-        <shortName>Con. Sn.</shortName>
-        <trackName>Concert Snare Drum</trackName>
-        <instrumentId>drum.snare-drum</instrumentId>
+      <trackName>Drum Kit (large)</trackName>
+      <Instrument id="drumset">
+        <longName>Drum Kit (large)</longName>
+        <shortName>D. Kit</shortName>
+        <trackName>Drum Kit (large)</trackName>
+        <instrumentId>drum.group.set</instrumentId>
         <useDrumset>1</useDrumset>
-        <Drum pitch="37">
-          <head>cross</head>
-          <line>0</line>
-          <voice>0</voice>
-          <name>Side Stick</name>
+        <Drum pitch="35">
+          <head>normal</head>
+          <line>8</line>
+          <voice>1</voice>
+          <name>Bass Drum 2</name>
+          <stem>2</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>0</panelColumn>
+          </Drum>
+        <Drum pitch="36">
+          <head>normal</head>
+          <line>7</line>
+          <voice>1</voice>
+          <name>Bass Drum 1</name>
           <stem>2</stem>
           <shortcut>A</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>0</panelColumn>
+          </Drum>
+        <Drum pitch="37">
+          <head>slashed1</head>
+          <line>3</line>
+          <voice>0</voice>
+          <name>Side Stick</name>
+          <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>1</panelColumn>
           </Drum>
         <Drum pitch="38">
           <head>normal</head>
-          <line>0</line>
+          <line>3</line>
           <voice>0</voice>
           <name>Acoustic Snare</name>
-          <stem>2</stem>
+          <stem>1</stem>
           <shortcut>B</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>1</panelColumn>
+          </Drum>
+        <Drum pitch="40">
+          <head>slash</head>
+          <line>3</line>
+          <voice>0</voice>
+          <name>Electric Snare</name>
+          <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>0</panelColumn>
+          </Drum>
+        <Drum pitch="41">
+          <head>normal</head>
+          <line>6</line>
+          <voice>0</voice>
+          <name>Low Floor Tom</name>
+          <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>7</panelColumn>
+          </Drum>
+        <Drum pitch="42">
+          <head>cross</head>
+          <line>-1</line>
+          <voice>0</voice>
+          <name>Closed Hi-Hat</name>
+          <stem>1</stem>
+          <shortcut>C</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>2</panelColumn>
+          </Drum>
+        <Drum pitch="43">
+          <head>normal</head>
+          <line>5</line>
+          <voice>0</voice>
+          <name>High Floor Tom</name>
+          <stem>1</stem>
+          <shortcut>H</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>7</panelColumn>
+          </Drum>
+        <Drum pitch="44">
+          <head>cross</head>
+          <line>9</line>
+          <voice>1</voice>
+          <name>Pedal Hi-Hat</name>
+          <stem>2</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>2</panelColumn>
+          </Drum>
+        <Drum pitch="45">
+          <head>normal</head>
+          <line>4</line>
+          <voice>0</voice>
+          <name>Low Tom</name>
+          <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>6</panelColumn>
+          </Drum>
+        <Drum pitch="46">
+          <head>xcircle</head>
+          <line>-1</line>
+          <voice>0</voice>
+          <name>Open Hi-Hat</name>
+          <stem>1</stem>
+          <shortcut>D</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>3</panelColumn>
+          </Drum>
+        <Drum pitch="47">
+          <head>normal</head>
+          <line>2</line>
+          <voice>0</voice>
+          <name>Low-Mid Tom</name>
+          <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>5</panelColumn>
+          </Drum>
+        <Drum pitch="48">
+          <head>normal</head>
+          <line>1</line>
+          <voice>0</voice>
+          <name>Hi-Mid Tom</name>
+          <stem>1</stem>
+          <shortcut>G</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>6</panelColumn>
+          </Drum>
+        <Drum pitch="49">
+          <head>cross</head>
+          <line>-2</line>
+          <voice>0</voice>
+          <name>Crash Cymbal 1</name>
+          <stem>1</stem>
+          <shortcut>E</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>4</panelColumn>
+          </Drum>
+        <Drum pitch="50">
+          <head>normal</head>
+          <line>0</line>
+          <voice>0</voice>
+          <name>High Tom</name>
+          <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>4</panelColumn>
+          </Drum>
+        <Drum pitch="51">
+          <head>cross</head>
+          <line>0</line>
+          <voice>0</voice>
+          <name>Ride Cymbal 1</name>
+          <stem>1</stem>
+          <shortcut>F</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>5</panelColumn>
+          </Drum>
+        <Drum pitch="52">
+          <head>normal</head>
+          <noteheads>
+            <whole>noteheadHeavyXHat</whole>
+            <half>noteheadHeavyXHat</half>
+            <quarter>noteheadHeavyXHat</quarter>
+            <breve>noteheadHeavyXHat</breve>
+            </noteheads>
+          <line>-3</line>
+          <voice>0</voice>
+          <name>China Cymbal</name>
+          <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>3</panelColumn>
+          </Drum>
+        <Drum pitch="53">
+          <head>diamond</head>
+          <line>0</line>
+          <voice>0</voice>
+          <name>Ride Bell</name>
+          <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>5</panelColumn>
+          </Drum>
+        <Drum pitch="54">
+          <head>diamond</head>
+          <line>1</line>
+          <voice>0</voice>
+          <name>Tambourine</name>
+          <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>1</panelColumn>
+          </Drum>
+        <Drum pitch="55">
+          <head>cross</head>
+          <line>-4</line>
+          <voice>0</voice>
+          <name>Splash Cymbal</name>
+          <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>4</panelColumn>
+          </Drum>
+        <Drum pitch="56">
+          <head>triangle-down</head>
+          <line>1</line>
+          <voice>0</voice>
+          <name>Cowbell</name>
+          <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>2</panelColumn>
+          </Drum>
+        <Drum pitch="57">
+          <head>cross</head>
+          <line>-3</line>
+          <voice>0</voice>
+          <name>Crash Cymbal 2</name>
+          <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>3</panelColumn>
+          </Drum>
+        <Drum pitch="59">
+          <head>cross</head>
+          <line>2</line>
+          <voice>0</voice>
+          <name>Ride Cymbal 2</name>
+          <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>6</panelColumn>
           </Drum>
         <clef>PERC</clef>
         <singleNoteDynamics>0</singleNoteDynamics>
@@ -102,60 +308,82 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Chord>
+            <eid>F_F</eid>
             <durationType>quarter</durationType>
+            <StemDirection>up</StemDirection>
             <Note>
+              <eid>G_G</eid>
               <pitch>51</pitch>
               <tpc>11</tpc>
+              <head>cross</head>
               <velocity>127</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>H_H</eid>
             <durationType>quarter</durationType>
+            <StemDirection>up</StemDirection>
             <Note>
+              <eid>I_I</eid>
               <pitch>51</pitch>
               <tpc>11</tpc>
+              <head>cross</head>
               <velocity>127</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Tuplet>
+            <eid>J_J</eid>
             <normalNotes>2</normalNotes>
             <actualNotes>3</actualNotes>
             <baseNote>eighth</baseNote>
+            <Number>
+              <style>tuplet</style>
+              <text>3</text>
+              </Number>
             </Tuplet>
           <Chord>
+            <eid>K_K</eid>
             <durationType>quarter</durationType>
+            <StemDirection>up</StemDirection>
             <Note>
+              <eid>L_L</eid>
               <pitch>51</pitch>
               <tpc>11</tpc>
+              <head>cross</head>
               <velocity>127</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>M_M</eid>
             <durationType>eighth</durationType>
+            <StemDirection>up</StemDirection>
             <Note>
+              <eid>N_N</eid>
               <pitch>51</pitch>
               <tpc>11</tpc>
+              <head>cross</head>
               <velocity>127</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <endTuplet/>
           <Chord>
+            <eid>O_O</eid>
             <durationType>quarter</durationType>
+            <StemDirection>up</StemDirection>
             <Note>
+              <eid>P_P</eid>
               <pitch>51</pitch>
               <tpc>11</tpc>
+              <head>cross</head>
               <velocity>127</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/perc_triplet-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/perc_triplet-ref.mscx
@@ -29,9 +29,9 @@
           </StaffType>
         <defaultClef>PERC</defaultClef>
         </Staff>
-      <trackName>Drum Kit (large)</trackName>
+      <trackName>Drum Kit</trackName>
       <Instrument id="drumset">
-        <longName>Drum Kit (large)</longName>
+        <longName>Drum Kit</longName>
         <shortName>D. Kit</shortName>
         <trackName>Drum Kit (large)</trackName>
         <instrumentId>drum.group.set</instrumentId>

--- a/src/importexport/midi/tests/midiimport_data/perc_tuplet_simplify-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/perc_tuplet_simplify-ref.mscx
@@ -29,9 +29,9 @@
           </StaffType>
         <defaultClef>PERC</defaultClef>
         </Staff>
-      <trackName>Drum Kit (large)</trackName>
+      <trackName>Drum Kit</trackName>
       <Instrument id="drumset">
-        <longName>Drum Kit (large)</longName>
+        <longName>Drum Kit</longName>
         <shortName>D. Kit</shortName>
         <trackName>Drum Kit (large)</trackName>
         <instrumentId>drum.group.set</instrumentId>

--- a/src/importexport/midi/tests/midiimport_data/perc_tuplet_simplify-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/perc_tuplet_simplify-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,27 +20,30 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="percussion">
           <name>perc5Line</name>
           <keysig>0</keysig>
           </StaffType>
         <defaultClef>PERC</defaultClef>
         </Staff>
-      <trackName>Drumset</trackName>
+      <trackName>Drum Kit (large)</trackName>
       <Instrument id="drumset">
-        <longName>Drumset</longName>
-        <shortName>D. Set</shortName>
-        <trackName>Drumset</trackName>
+        <longName>Drum Kit (large)</longName>
+        <shortName>D. Kit</shortName>
+        <trackName>Drum Kit (large)</trackName>
         <instrumentId>drum.group.set</instrumentId>
         <useDrumset>1</useDrumset>
         <Drum pitch="35">
           <head>normal</head>
-          <line>7</line>
+          <line>8</line>
           <voice>1</voice>
-          <name>Acoustic Bass Drum</name>
+          <name>Bass Drum 2</name>
           <stem>2</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>0</panelColumn>
           </Drum>
         <Drum pitch="36">
           <head>normal</head>
@@ -47,14 +51,18 @@
           <voice>1</voice>
           <name>Bass Drum 1</name>
           <stem>2</stem>
-          <shortcut>B</shortcut>
+          <shortcut>A</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>0</panelColumn>
           </Drum>
         <Drum pitch="37">
-          <head>cross</head>
+          <head>slashed1</head>
           <line>3</line>
           <voice>0</voice>
           <name>Side Stick</name>
           <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>1</panelColumn>
           </Drum>
         <Drum pitch="38">
           <head>normal</head>
@@ -62,21 +70,27 @@
           <voice>0</voice>
           <name>Acoustic Snare</name>
           <stem>1</stem>
-          <shortcut>A</shortcut>
+          <shortcut>B</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>1</panelColumn>
           </Drum>
         <Drum pitch="40">
-          <head>normal</head>
+          <head>slash</head>
           <line>3</line>
           <voice>0</voice>
           <name>Electric Snare</name>
           <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>0</panelColumn>
           </Drum>
         <Drum pitch="41">
           <head>normal</head>
-          <line>5</line>
+          <line>6</line>
           <voice>0</voice>
           <name>Low Floor Tom</name>
           <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>7</panelColumn>
           </Drum>
         <Drum pitch="42">
           <head>cross</head>
@@ -84,14 +98,19 @@
           <voice>0</voice>
           <name>Closed Hi-Hat</name>
           <stem>1</stem>
-          <shortcut>G</shortcut>
+          <shortcut>C</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>2</panelColumn>
           </Drum>
         <Drum pitch="43">
           <head>normal</head>
           <line>5</line>
-          <voice>1</voice>
+          <voice>0</voice>
           <name>High Floor Tom</name>
-          <stem>2</stem>
+          <stem>1</stem>
+          <shortcut>H</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>7</panelColumn>
           </Drum>
         <Drum pitch="44">
           <head>cross</head>
@@ -99,35 +118,46 @@
           <voice>1</voice>
           <name>Pedal Hi-Hat</name>
           <stem>2</stem>
-          <shortcut>F</shortcut>
+          <panelRow>1</panelRow>
+          <panelColumn>2</panelColumn>
           </Drum>
         <Drum pitch="45">
           <head>normal</head>
-          <line>2</line>
+          <line>4</line>
           <voice>0</voice>
           <name>Low Tom</name>
           <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>6</panelColumn>
           </Drum>
         <Drum pitch="46">
-          <head>cross</head>
-          <line>1</line>
+          <head>xcircle</head>
+          <line>-1</line>
           <voice>0</voice>
           <name>Open Hi-Hat</name>
           <stem>1</stem>
+          <shortcut>D</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>3</panelColumn>
           </Drum>
         <Drum pitch="47">
           <head>normal</head>
-          <line>1</line>
+          <line>2</line>
           <voice>0</voice>
           <name>Low-Mid Tom</name>
           <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>5</panelColumn>
           </Drum>
         <Drum pitch="48">
           <head>normal</head>
-          <line>0</line>
+          <line>1</line>
           <voice>0</voice>
           <name>Hi-Mid Tom</name>
           <stem>1</stem>
+          <shortcut>G</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>6</panelColumn>
           </Drum>
         <Drum pitch="49">
           <head>cross</head>
@@ -135,7 +165,9 @@
           <voice>0</voice>
           <name>Crash Cymbal 1</name>
           <stem>1</stem>
-          <shortcut>C</shortcut>
+          <shortcut>E</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>4</panelColumn>
           </Drum>
         <Drum pitch="50">
           <head>normal</head>
@@ -143,7 +175,8 @@
           <voice>0</voice>
           <name>High Tom</name>
           <stem>1</stem>
-          <shortcut>E</shortcut>
+          <panelRow>1</panelRow>
+          <panelColumn>4</panelColumn>
           </Drum>
         <Drum pitch="51">
           <head>cross</head>
@@ -151,14 +184,24 @@
           <voice>0</voice>
           <name>Ride Cymbal 1</name>
           <stem>1</stem>
-          <shortcut>D</shortcut>
+          <shortcut>F</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>5</panelColumn>
           </Drum>
         <Drum pitch="52">
-          <head>cross</head>
+          <head>normal</head>
+          <noteheads>
+            <whole>noteheadHeavyXHat</whole>
+            <half>noteheadHeavyXHat</half>
+            <quarter>noteheadHeavyXHat</quarter>
+            <breve>noteheadHeavyXHat</breve>
+            </noteheads>
           <line>-3</line>
           <voice>0</voice>
-          <name>Chinese Cymbal</name>
+          <name>China Cymbal</name>
           <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>3</panelColumn>
           </Drum>
         <Drum pitch="53">
           <head>diamond</head>
@@ -166,20 +209,26 @@
           <voice>0</voice>
           <name>Ride Bell</name>
           <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>5</panelColumn>
           </Drum>
         <Drum pitch="54">
           <head>diamond</head>
-          <line>2</line>
+          <line>1</line>
           <voice>0</voice>
           <name>Tambourine</name>
           <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>1</panelColumn>
           </Drum>
         <Drum pitch="55">
           <head>cross</head>
-          <line>-3</line>
+          <line>-4</line>
           <voice>0</voice>
           <name>Splash Cymbal</name>
           <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>4</panelColumn>
           </Drum>
         <Drum pitch="56">
           <head>triangle-down</head>
@@ -187,6 +236,8 @@
           <voice>0</voice>
           <name>Cowbell</name>
           <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>2</panelColumn>
           </Drum>
         <Drum pitch="57">
           <head>cross</head>
@@ -194,6 +245,8 @@
           <voice>0</voice>
           <name>Crash Cymbal 2</name>
           <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>3</panelColumn>
           </Drum>
         <Drum pitch="59">
           <head>cross</head>
@@ -201,22 +254,11 @@
           <voice>0</voice>
           <name>Ride Cymbal 2</name>
           <stem>1</stem>
-          </Drum>
-        <Drum pitch="63">
-          <head>cross</head>
-          <line>4</line>
-          <voice>0</voice>
-          <name>Open Hi Conga</name>
-          <stem>1</stem>
-          </Drum>
-        <Drum pitch="64">
-          <head>cross</head>
-          <line>6</line>
-          <voice>0</voice>
-          <name>Low Conga</name>
-          <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>6</panelColumn>
           </Drum>
         <clef>PERC</clef>
+        <singleNoteDynamics>0</singleNoteDynamics>
         <Articulation>
           <velocity>100</velocity>
           <gateTime>100</gateTime>
@@ -266,81 +308,104 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Rest>
+            <eid>F_F</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Tuplet>
+            <eid>G_G</eid>
             <normalNotes>2</normalNotes>
             <actualNotes>3</actualNotes>
             <baseNote>32nd</baseNote>
+            <Number>
+              <style>tuplet</style>
+              <text>3</text>
+              </Number>
             </Tuplet>
+          <Beam>
+            <eid>H_H</eid>
+            <l1>-18</l1>
+            <l2>-18</l2>
+            </Beam>
           <Chord>
+            <eid>I_I</eid>
             <durationType>32nd</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>J_J</eid>
               <pitch>38</pitch>
               <tpc>16</tpc>
               <velocity>110</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>K_K</eid>
             <durationType>16th</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>L_L</eid>
               <pitch>38</pitch>
               <tpc>16</tpc>
               <velocity>109</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <endTuplet/>
           <Rest>
+            <eid>M_M</eid>
             <durationType>16th</durationType>
             </Rest>
           <Rest>
+            <eid>N_N</eid>
             <durationType>16th</durationType>
             </Rest>
           <Chord>
+            <eid>O_O</eid>
             <durationType>16th</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>P_P</eid>
               <pitch>47</pitch>
               <tpc>19</tpc>
               <velocity>126</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>Q_Q</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>
         <voice>
           <Chord>
+            <eid>R_R</eid>
             <durationType>quarter</durationType>
             <StemDirection>down</StemDirection>
             <Note>
+              <eid>S_S</eid>
+              <pitch>44</pitch>
+              <tpc>22</tpc>
+              <head>cross</head>
+              <velocity>111</velocity>
+              </Note>
+            <Note>
+              <eid>T_T</eid>
               <pitch>36</pitch>
               <tpc>14</tpc>
               <velocity>120</velocity>
-              <veloType>user</veloType>
-              </Note>
-            <Note>
-              <pitch>44</pitch>
-              <tpc>22</tpc>
-              <velocity>111</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>U_U</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
+            <eid>V_V</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/perc_tuplet_simplify2-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/perc_tuplet_simplify2-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,202 +20,32 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="percussion">
-          <name>perc5Line</name>
+          <name>perc1Line</name>
+          <lines>1</lines>
           <keysig>0</keysig>
           </StaffType>
         <defaultClef>PERC</defaultClef>
         </Staff>
-      <trackName>Drumset</trackName>
-      <Instrument id="drumset">
-        <longName>Drumset</longName>
-        <shortName>D. Set</shortName>
-        <trackName>Drumset</trackName>
-        <instrumentId>drum.group.set</instrumentId>
+      <trackName>Slit Drum</trackName>
+      <Instrument id="slit-drum">
+        <longName>Slit Drum</longName>
+        <shortName>Slt. Dr.</shortName>
+        <trackName>Slit Drum</trackName>
+        <instrumentId>drum.slit-drum</instrumentId>
         <useDrumset>1</useDrumset>
-        <Drum pitch="35">
+        <Drum pitch="77">
           <head>normal</head>
-          <line>7</line>
-          <voice>1</voice>
-          <name>Acoustic Bass Drum</name>
-          <stem>2</stem>
-          </Drum>
-        <Drum pitch="36">
-          <head>normal</head>
-          <line>7</line>
-          <voice>1</voice>
-          <name>Bass Drum 1</name>
-          <stem>2</stem>
-          <shortcut>B</shortcut>
-          </Drum>
-        <Drum pitch="37">
-          <head>cross</head>
-          <line>3</line>
+          <line>0</line>
           <voice>0</voice>
-          <name>Side Stick</name>
-          <stem>1</stem>
-          </Drum>
-        <Drum pitch="38">
-          <head>normal</head>
-          <line>3</line>
-          <voice>0</voice>
-          <name>Acoustic Snare</name>
+          <name>Slit Drum</name>
           <stem>1</stem>
           <shortcut>A</shortcut>
-          </Drum>
-        <Drum pitch="40">
-          <head>normal</head>
-          <line>3</line>
-          <voice>0</voice>
-          <name>Electric Snare</name>
-          <stem>1</stem>
-          </Drum>
-        <Drum pitch="41">
-          <head>normal</head>
-          <line>5</line>
-          <voice>0</voice>
-          <name>Low Floor Tom</name>
-          <stem>1</stem>
-          </Drum>
-        <Drum pitch="42">
-          <head>cross</head>
-          <line>-1</line>
-          <voice>0</voice>
-          <name>Closed Hi-Hat</name>
-          <stem>1</stem>
-          <shortcut>G</shortcut>
-          </Drum>
-        <Drum pitch="43">
-          <head>normal</head>
-          <line>5</line>
-          <voice>1</voice>
-          <name>High Floor Tom</name>
-          <stem>2</stem>
-          </Drum>
-        <Drum pitch="44">
-          <head>cross</head>
-          <line>9</line>
-          <voice>1</voice>
-          <name>Pedal Hi-Hat</name>
-          <stem>2</stem>
-          <shortcut>F</shortcut>
-          </Drum>
-        <Drum pitch="45">
-          <head>normal</head>
-          <line>2</line>
-          <voice>0</voice>
-          <name>Low Tom</name>
-          <stem>1</stem>
-          </Drum>
-        <Drum pitch="46">
-          <head>cross</head>
-          <line>1</line>
-          <voice>0</voice>
-          <name>Open Hi-Hat</name>
-          <stem>1</stem>
-          </Drum>
-        <Drum pitch="47">
-          <head>normal</head>
-          <line>1</line>
-          <voice>0</voice>
-          <name>Low-Mid Tom</name>
-          <stem>1</stem>
-          </Drum>
-        <Drum pitch="48">
-          <head>normal</head>
-          <line>0</line>
-          <voice>0</voice>
-          <name>Hi-Mid Tom</name>
-          <stem>1</stem>
-          </Drum>
-        <Drum pitch="49">
-          <head>cross</head>
-          <line>-2</line>
-          <voice>0</voice>
-          <name>Crash Cymbal 1</name>
-          <stem>1</stem>
-          <shortcut>C</shortcut>
-          </Drum>
-        <Drum pitch="50">
-          <head>normal</head>
-          <line>0</line>
-          <voice>0</voice>
-          <name>High Tom</name>
-          <stem>1</stem>
-          <shortcut>E</shortcut>
-          </Drum>
-        <Drum pitch="51">
-          <head>cross</head>
-          <line>0</line>
-          <voice>0</voice>
-          <name>Ride Cymbal 1</name>
-          <stem>1</stem>
-          <shortcut>D</shortcut>
-          </Drum>
-        <Drum pitch="52">
-          <head>cross</head>
-          <line>-3</line>
-          <voice>0</voice>
-          <name>Chinese Cymbal</name>
-          <stem>1</stem>
-          </Drum>
-        <Drum pitch="53">
-          <head>diamond</head>
-          <line>0</line>
-          <voice>0</voice>
-          <name>Ride Bell</name>
-          <stem>1</stem>
-          </Drum>
-        <Drum pitch="54">
-          <head>diamond</head>
-          <line>2</line>
-          <voice>0</voice>
-          <name>Tambourine</name>
-          <stem>1</stem>
-          </Drum>
-        <Drum pitch="55">
-          <head>cross</head>
-          <line>-3</line>
-          <voice>0</voice>
-          <name>Splash Cymbal</name>
-          <stem>1</stem>
-          </Drum>
-        <Drum pitch="56">
-          <head>triangle-down</head>
-          <line>1</line>
-          <voice>0</voice>
-          <name>Cowbell</name>
-          <stem>1</stem>
-          </Drum>
-        <Drum pitch="57">
-          <head>cross</head>
-          <line>-3</line>
-          <voice>0</voice>
-          <name>Crash Cymbal 2</name>
-          <stem>1</stem>
-          </Drum>
-        <Drum pitch="59">
-          <head>cross</head>
-          <line>2</line>
-          <voice>0</voice>
-          <name>Ride Cymbal 2</name>
-          <stem>1</stem>
-          </Drum>
-        <Drum pitch="63">
-          <head>cross</head>
-          <line>4</line>
-          <voice>0</voice>
-          <name>Open Hi Conga</name>
-          <stem>1</stem>
-          </Drum>
-        <Drum pitch="64">
-          <head>cross</head>
-          <line>6</line>
-          <voice>0</voice>
-          <name>Low Conga</name>
-          <stem>1</stem>
+          <panelRow>0</panelRow>
+          <panelColumn>0</panelColumn>
           </Drum>
         <clef>PERC</clef>
         <Articulation>
@@ -266,132 +97,163 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Rest>
+            <eid>F_F</eid>
             <durationType>measure</durationType>
             <duration>4/4</duration>
             </Rest>
           </voice>
         </Measure>
       <Measure>
+        <eid>G_G</eid>
         <voice>
+          <Beam>
+            <eid>H_H</eid>
+            <l1>-20</l1>
+            <l2>-20</l2>
+            </Beam>
           <Chord>
+            <eid>I_I</eid>
             <durationType>eighth</durationType>
+            <StemDirection>up</StemDirection>
             <Note>
+              <eid>J_J</eid>
               <pitch>77</pitch>
               <tpc>13</tpc>
               <velocity>62</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>K_K</eid>
               <pitch>80</pitch>
               <tpc>22</tpc>
               <velocity>31</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>L_L</eid>
             <durationType>eighth</durationType>
+            <StemDirection>up</StemDirection>
             <Note>
+              <eid>M_M</eid>
               <pitch>77</pitch>
               <tpc>13</tpc>
               <velocity>69</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>N_N</eid>
               <pitch>80</pitch>
               <tpc>22</tpc>
               <velocity>34</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Tuplet>
+            <eid>O_O</eid>
             <normalNotes>2</normalNotes>
             <actualNotes>3</actualNotes>
             <baseNote>eighth</baseNote>
+            <Number>
+              <style>tuplet</style>
+              <text>3</text>
+              </Number>
             </Tuplet>
           <Rest>
+            <eid>P_P</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Chord>
+            <eid>Q_Q</eid>
             <durationType>eighth</durationType>
+            <StemDirection>up</StemDirection>
             <Note>
+              <eid>R_R</eid>
               <pitch>77</pitch>
               <tpc>13</tpc>
               <velocity>60</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>S_S</eid>
               <pitch>80</pitch>
               <tpc>22</tpc>
               <velocity>30</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>T_T</eid>
             <durationType>16th</durationType>
             </Rest>
           <Chord>
+            <eid>U_U</eid>
             <durationType>16th</durationType>
+            <StemDirection>up</StemDirection>
             <Note>
+              <eid>V_V</eid>
               <pitch>73</pitch>
               <tpc>21</tpc>
               <velocity>67</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>W_W</eid>
               <pitch>77</pitch>
               <tpc>13</tpc>
               <velocity>33</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <endTuplet/>
           <Rest>
+            <eid>X_X</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Chord>
+            <eid>Y_Y</eid>
             <durationType>quarter</durationType>
             <Note>
+              <eid>Z_Z</eid>
               <pitch>70</pitch>
               <tpc>12</tpc>
               <velocity>58</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>a_a</eid>
               <pitch>73</pitch>
               <tpc>21</tpc>
               <velocity>29</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         </Measure>
       <Measure>
+        <eid>b_b</eid>
         <voice>
           <Chord>
+            <eid>c_c</eid>
             <durationType>quarter</durationType>
+            <StemDirection>up</StemDirection>
             <Note>
+              <eid>d_d</eid>
               <pitch>73</pitch>
               <tpc>21</tpc>
               <velocity>64</velocity>
-              <veloType>user</veloType>
               </Note>
             <Note>
+              <eid>e_e</eid>
               <pitch>77</pitch>
               <tpc>13</tpc>
               <velocity>32</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>f_f</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
+            <eid>g_g</eid>
             <durationType>half</durationType>
             </Rest>
           </voice>

--- a/src/importexport/midi/tests/midiimport_data/perc_tuplet_voice-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/perc_tuplet_voice-ref.mscx
@@ -29,9 +29,9 @@
           </StaffType>
         <defaultClef>PERC</defaultClef>
         </Staff>
-      <trackName>Drum Kit (large)</trackName>
+      <trackName>Drum Kit</trackName>
       <Instrument id="drumset">
-        <longName>Drum Kit (large)</longName>
+        <longName>Drum Kit</longName>
         <shortName>D. Kit</shortName>
         <trackName>Drum Kit (large)</trackName>
         <instrumentId>drum.group.set</instrumentId>

--- a/src/importexport/midi/tests/midiimport_data/perc_tuplet_voice-ref.mscx
+++ b/src/importexport/midi/tests/midiimport_data/perc_tuplet_voice-ref.mscx
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="4.00">
+<museScore version="4.60">
   <Score>
+    <eid>B_B</eid>
     <Division>480</Division>
     <Style>
-      <Spatium>1.74978</Spatium>
+      <spatium>1.74978</spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
@@ -19,27 +20,30 @@
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle"></metaTag>
-    <Part>
-      <Staff id="1">
+    <Part id="1">
+      <Staff>
+        <eid>C_C</eid>
         <StaffType group="percussion">
           <name>perc5Line</name>
           <keysig>0</keysig>
           </StaffType>
         <defaultClef>PERC</defaultClef>
         </Staff>
-      <trackName>Drumset</trackName>
+      <trackName>Drum Kit (large)</trackName>
       <Instrument id="drumset">
-        <longName>Drumset</longName>
-        <shortName>D. Set</shortName>
-        <trackName>Drumset</trackName>
+        <longName>Drum Kit (large)</longName>
+        <shortName>D. Kit</shortName>
+        <trackName>Drum Kit (large)</trackName>
         <instrumentId>drum.group.set</instrumentId>
         <useDrumset>1</useDrumset>
         <Drum pitch="35">
           <head>normal</head>
-          <line>7</line>
+          <line>8</line>
           <voice>1</voice>
-          <name>Acoustic Bass Drum</name>
+          <name>Bass Drum 2</name>
           <stem>2</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>0</panelColumn>
           </Drum>
         <Drum pitch="36">
           <head>normal</head>
@@ -47,14 +51,18 @@
           <voice>1</voice>
           <name>Bass Drum 1</name>
           <stem>2</stem>
-          <shortcut>B</shortcut>
+          <shortcut>A</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>0</panelColumn>
           </Drum>
         <Drum pitch="37">
-          <head>cross</head>
+          <head>slashed1</head>
           <line>3</line>
           <voice>0</voice>
           <name>Side Stick</name>
           <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>1</panelColumn>
           </Drum>
         <Drum pitch="38">
           <head>normal</head>
@@ -62,21 +70,27 @@
           <voice>0</voice>
           <name>Acoustic Snare</name>
           <stem>1</stem>
-          <shortcut>A</shortcut>
+          <shortcut>B</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>1</panelColumn>
           </Drum>
         <Drum pitch="40">
-          <head>normal</head>
+          <head>slash</head>
           <line>3</line>
           <voice>0</voice>
           <name>Electric Snare</name>
           <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>0</panelColumn>
           </Drum>
         <Drum pitch="41">
           <head>normal</head>
-          <line>5</line>
+          <line>6</line>
           <voice>0</voice>
           <name>Low Floor Tom</name>
           <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>7</panelColumn>
           </Drum>
         <Drum pitch="42">
           <head>cross</head>
@@ -84,14 +98,19 @@
           <voice>0</voice>
           <name>Closed Hi-Hat</name>
           <stem>1</stem>
-          <shortcut>G</shortcut>
+          <shortcut>C</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>2</panelColumn>
           </Drum>
         <Drum pitch="43">
           <head>normal</head>
           <line>5</line>
-          <voice>1</voice>
+          <voice>0</voice>
           <name>High Floor Tom</name>
-          <stem>2</stem>
+          <stem>1</stem>
+          <shortcut>H</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>7</panelColumn>
           </Drum>
         <Drum pitch="44">
           <head>cross</head>
@@ -99,35 +118,46 @@
           <voice>1</voice>
           <name>Pedal Hi-Hat</name>
           <stem>2</stem>
-          <shortcut>F</shortcut>
+          <panelRow>1</panelRow>
+          <panelColumn>2</panelColumn>
           </Drum>
         <Drum pitch="45">
           <head>normal</head>
-          <line>2</line>
+          <line>4</line>
           <voice>0</voice>
           <name>Low Tom</name>
           <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>6</panelColumn>
           </Drum>
         <Drum pitch="46">
-          <head>cross</head>
-          <line>1</line>
+          <head>xcircle</head>
+          <line>-1</line>
           <voice>0</voice>
           <name>Open Hi-Hat</name>
           <stem>1</stem>
+          <shortcut>D</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>3</panelColumn>
           </Drum>
         <Drum pitch="47">
           <head>normal</head>
-          <line>1</line>
+          <line>2</line>
           <voice>0</voice>
           <name>Low-Mid Tom</name>
           <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>5</panelColumn>
           </Drum>
         <Drum pitch="48">
           <head>normal</head>
-          <line>0</line>
+          <line>1</line>
           <voice>0</voice>
           <name>Hi-Mid Tom</name>
           <stem>1</stem>
+          <shortcut>G</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>6</panelColumn>
           </Drum>
         <Drum pitch="49">
           <head>cross</head>
@@ -135,7 +165,9 @@
           <voice>0</voice>
           <name>Crash Cymbal 1</name>
           <stem>1</stem>
-          <shortcut>C</shortcut>
+          <shortcut>E</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>4</panelColumn>
           </Drum>
         <Drum pitch="50">
           <head>normal</head>
@@ -143,7 +175,8 @@
           <voice>0</voice>
           <name>High Tom</name>
           <stem>1</stem>
-          <shortcut>E</shortcut>
+          <panelRow>1</panelRow>
+          <panelColumn>4</panelColumn>
           </Drum>
         <Drum pitch="51">
           <head>cross</head>
@@ -151,14 +184,24 @@
           <voice>0</voice>
           <name>Ride Cymbal 1</name>
           <stem>1</stem>
-          <shortcut>D</shortcut>
+          <shortcut>F</shortcut>
+          <panelRow>0</panelRow>
+          <panelColumn>5</panelColumn>
           </Drum>
         <Drum pitch="52">
-          <head>cross</head>
+          <head>normal</head>
+          <noteheads>
+            <whole>noteheadHeavyXHat</whole>
+            <half>noteheadHeavyXHat</half>
+            <quarter>noteheadHeavyXHat</quarter>
+            <breve>noteheadHeavyXHat</breve>
+            </noteheads>
           <line>-3</line>
           <voice>0</voice>
-          <name>Chinese Cymbal</name>
+          <name>China Cymbal</name>
           <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>3</panelColumn>
           </Drum>
         <Drum pitch="53">
           <head>diamond</head>
@@ -166,20 +209,26 @@
           <voice>0</voice>
           <name>Ride Bell</name>
           <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>5</panelColumn>
           </Drum>
         <Drum pitch="54">
           <head>diamond</head>
-          <line>2</line>
+          <line>1</line>
           <voice>0</voice>
           <name>Tambourine</name>
           <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>1</panelColumn>
           </Drum>
         <Drum pitch="55">
           <head>cross</head>
-          <line>-3</line>
+          <line>-4</line>
           <voice>0</voice>
           <name>Splash Cymbal</name>
           <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>4</panelColumn>
           </Drum>
         <Drum pitch="56">
           <head>triangle-down</head>
@@ -187,6 +236,8 @@
           <voice>0</voice>
           <name>Cowbell</name>
           <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>2</panelColumn>
           </Drum>
         <Drum pitch="57">
           <head>cross</head>
@@ -194,6 +245,8 @@
           <voice>0</voice>
           <name>Crash Cymbal 2</name>
           <stem>1</stem>
+          <panelRow>1</panelRow>
+          <panelColumn>3</panelColumn>
           </Drum>
         <Drum pitch="59">
           <head>cross</head>
@@ -201,22 +254,11 @@
           <voice>0</voice>
           <name>Ride Cymbal 2</name>
           <stem>1</stem>
-          </Drum>
-        <Drum pitch="63">
-          <head>cross</head>
-          <line>4</line>
-          <voice>0</voice>
-          <name>Open Hi Conga</name>
-          <stem>1</stem>
-          </Drum>
-        <Drum pitch="64">
-          <head>cross</head>
-          <line>6</line>
-          <voice>0</voice>
-          <name>Low Conga</name>
-          <stem>1</stem>
+          <panelRow>2</panelRow>
+          <panelColumn>6</panelColumn>
           </Drum>
         <clef>PERC</clef>
+        <singleNoteDynamics>0</singleNoteDynamics>
         <Articulation>
           <velocity>100</velocity>
           <gateTime>100</gateTime>
@@ -266,99 +308,117 @@
       </Part>
     <Staff id="1">
       <Measure>
+        <eid>D_D</eid>
         <voice>
           <TimeSig>
+            <eid>E_E</eid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
           <Rest>
+            <eid>F_F</eid>
             <durationType>quarter</durationType>
             </Rest>
           <Chord>
+            <eid>G_G</eid>
             <durationType>quarter</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>H_H</eid>
               <pitch>38</pitch>
               <tpc>16</tpc>
               <velocity>81</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>I_I</eid>
             <durationType>quarter</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>J_J</eid>
               <pitch>38</pitch>
               <tpc>16</tpc>
               <velocity>80</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>K_K</eid>
             <durationType>quarter</durationType>
             <StemDirection>up</StemDirection>
             <Note>
+              <eid>L_L</eid>
               <pitch>38</pitch>
               <tpc>16</tpc>
               <velocity>81</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           </voice>
         <voice>
           <Tuplet>
+            <eid>M_M</eid>
             <normalNotes>2</normalNotes>
             <actualNotes>3</actualNotes>
             <baseNote>eighth</baseNote>
+            <Number>
+              <style>tuplet</style>
+              <text>3</text>
+              </Number>
             </Tuplet>
           <Chord>
+            <eid>N_N</eid>
             <durationType>eighth</durationType>
             <StemDirection>down</StemDirection>
             <Note>
+              <eid>O_O</eid>
               <pitch>36</pitch>
               <tpc>14</tpc>
               <velocity>82</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Chord>
+            <eid>P_P</eid>
             <durationType>quarter</durationType>
             <StemDirection>down</StemDirection>
             <Note>
+              <eid>Q_Q</eid>
               <pitch>36</pitch>
               <tpc>14</tpc>
               <velocity>82</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <endTuplet/>
           <Rest>
+            <eid>R_R</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Chord>
+            <eid>S_S</eid>
             <durationType>eighth</durationType>
             <StemDirection>down</StemDirection>
             <Note>
+              <eid>T_T</eid>
               <pitch>36</pitch>
               <tpc>14</tpc>
               <velocity>79</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>U_U</eid>
             <durationType>eighth</durationType>
             </Rest>
           <Chord>
+            <eid>V_V</eid>
             <durationType>eighth</durationType>
             <StemDirection>down</StemDirection>
             <Note>
+              <eid>W_W</eid>
               <pitch>36</pitch>
               <tpc>14</tpc>
               <velocity>79</velocity>
-              <veloType>user</veloType>
               </Note>
             </Chord>
           <Rest>
+            <eid>X_X</eid>
             <durationType>quarter</durationType>
             </Rest>
           </voice>

--- a/src/importexport/midi/tests/midiimport_tests.cpp
+++ b/src/importexport/midi/tests/midiimport_tests.cpp
@@ -263,8 +263,7 @@ TEST_F(MidiImportTests, metertimeSig12_8) {
     dontSimplify("meter_12-8");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_metertimeSig15_8) {
+TEST_F(MidiImportTests, metertimeSig15_8) {
     dontSimplify("meter_15-8");
 }
 
@@ -558,48 +557,39 @@ TEST_F(MidiImportTests, swingClef) {
 
 // percussion
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_percDrums) {
+TEST_F(MidiImportTests, percDrums) {
     noTempoText("perc_drums");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_percRemoveTies) {
+TEST_F(MidiImportTests, percRemoveTies) {
     noTempoText("perc_remove_ties");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_percNoGrandStaff) {
+TEST_F(MidiImportTests, percNoGrandStaff) {
     noTempoText("perc_no_grand_staff");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_percTriplet) {
+TEST_F(MidiImportTests, percTriplet) {
     noTempoText("perc_triplet");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_percRespectBeat) {
+TEST_F(MidiImportTests, percRespectBeat) {
     noTempoText("perc_respect_beat");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_percTupletVoice) {
+TEST_F(MidiImportTests, percTupletVoice) {
     noTempoText("perc_tuplet_voice");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_percTupletSimplify) {
+TEST_F(MidiImportTests, percTupletSimplify) {
     noTempoText("perc_tuplet_simplify");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_percTupletSimplify2) {
+TEST_F(MidiImportTests, percTupletSimplify2) {
     noTempoText("perc_tuplet_simplify2");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_percShortNotes) {
+TEST_F(MidiImportTests, percShortNotes) {
     noTempoText("perc_short_notes");
 }
 
@@ -685,8 +675,7 @@ TEST_F(MidiImportTests, instrumentGrand2) {
     importThenCompareWithRef("instrument_grand2");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_instrumentChannels) {
+TEST_F(MidiImportTests, instrumentChannels) {
     importThenCompareWithRef("instrument_channels");
 }
 
@@ -694,8 +683,7 @@ TEST_F(MidiImportTests, instrument3StaffOrgan) {
     importThenCompareWithRef("instrument_3staff_organ");
 }
 
-// TODO: update ref
-TEST_F(MidiImportTests, DISABLED_instrumentClef) {
+TEST_F(MidiImportTests, instrumentClef) {
     noTempoText("instrument_clef");
 }
 


### PR DESCRIPTION
The instrument detection heuristic relied on the old order of the instruments.xml (first changed by 28fa244). This resulted in (slightly) different instruments to be preferred (5 string bass instead of regular etc.). This commit introduces preferred instruments for each General MIDI Level 1 instrument to solve that.

Percussion was affected more by the instrument order change. Here, it resulted in completely wrong instruments to be selected by findClosestInstrument. (Automobile brake drums or Bongos instead of drumsets). This is solved by changing the findClosestInstrument algorithms for percussion to prefer instruments that can play the most used percussion notes.

*All* import unit tests pass 🎉 

*A note regarding the `perc_triplet` test*: I believe that the previously used concert snare drum was wrong. The MIDI file only contains notes with a pitch of 51 which maps to ride cymbals in all of the MIDI specs that I checked (GM1, GM2, Roland GS, Yamaha XG).

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
