### PR TITLE
String tuning should trigger the layout of everything until the next

### DIFF
--- a/src/engraving/dom/part.h
+++ b/src/engraving/dom/part.h
@@ -199,6 +199,8 @@ public:
 
     std::map<int, HarpPedalDiagram*> harpDiagrams;
 
+    const std::map<int, StringTunings*>& stringTunings() const { return m_stringTunings; }
+
 private:
     friend class read206::Read206;
 

--- a/src/engraving/dom/stringtunings.cpp
+++ b/src/engraving/dom/stringtunings.cpp
@@ -244,6 +244,24 @@ bool StringTunings::noStringVisible() const
     return m_noStringVisible;
 }
 
+void StringTunings::triggerLayout() const
+{
+    if (!part()) {
+        return StaffTextBase::triggerLayout();
+    }
+
+    Fraction startTick = tick();
+
+    const std::map<int, StringTunings*>& allStringTuningsOnThisPart = part()->stringTunings();
+    auto iterOfNextStringTuningOnThisPart = allStringTuningsOnThisPart.upper_bound(startTick.ticks());
+    StringTunings* nextStringTuning = iterOfNextStringTuningOnThisPart != allStringTuningsOnThisPart.end()
+                                      ? iterOfNextStringTuningOnThisPart->second : nullptr;
+
+    Fraction endTick = nextStringTuning ? nextStringTuning->tick() : score()->endTick();
+
+    score()->setLayout(startTick, endTick, staffIdx(), staffIdx(), this);
+}
+
 String StringTunings::generateText() const
 {
     const StringData* stringData = this->stringData();

--- a/src/engraving/dom/stringtunings.h
+++ b/src/engraving/dom/stringtunings.h
@@ -60,6 +60,8 @@ public:
 
     bool noStringVisible() const;
 
+    void triggerLayout() const override;
+
 private:
     String generateText() const;
 


### PR DESCRIPTION
string tuning (or end of the piece if there is none after)

Resolves: when adding/editing/remove a StringTuning element, only the first system gets updated. The other systems will only be updated if a new layout is triggered in that range. See:

https://github.com/user-attachments/assets/d769a6fb-7e39-4984-a904-44fadfb9ff10

