### PR TITLE
allow R on list selection

### DIFF
--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -4962,6 +4962,34 @@ Ret NotationInteraction::repeatSelection()
         return muse::make_ok();
     }
 
+    if (!score()->noteEntryMode() && selection.isList()) {
+        startEdit(TranslatableString("undoableAction", "Repeat selection"));
+        InputState& is = score()->inputState();
+        std::vector<Note*> nList;
+
+        for (EngravingItem* el : selection.elements()) {
+            if (el && el->isNote()) {//&& toChordRest(el)->segment() != score()->lastSegment()) {
+                Chord* c = toNote(el)->chord();
+
+                is.moveInputPos(el);
+                is.setTrack(c->track());
+                is.setSegment(c->segment());
+                is.moveToNextInputPos();
+
+                for (Note* note : c->notes()) {
+                    NoteVal nval = note->noteVal();
+                    Note* nn = score()->addPitch(nval, note != c->notes()[0]);
+                    nList.push_back(nn);
+                }
+            }
+        }
+        for (Note* n : nList) {
+            score()->select(n, SelectType::ADD);
+        }
+        apply();
+        return muse::make_ok();
+    }
+
     if (!selection.isRange()) {
         ChordRest* cr = score()->getSelectedChordRest();
         if (!cr) {


### PR DESCRIPTION
Resolves: #27669 partially

Added code block to allow R to work on list selection with multiple notes. 


https://github.com/user-attachments/assets/2d3292bb-5df6-4833-8a6b-b7885d850077



- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
