### PR TITLE
Improve Tab navigation in Project Properties dialog: sequential focus…

### DIFF
--- a/src/project/qml/MuseScore/Project/NewScoreDialog.qml
+++ b/src/project/qml/MuseScore/Project/NewScoreDialog.qml
@@ -175,11 +175,11 @@ StyledDialogView {
                 }
             }
 
-            FlatButton {
-                text: qsTrc("global", "Done")
-                buttonRole: ButtonBoxModel.AcceptRole
-                buttonId: ButtonBoxModel.Done
-                accentButton: true
+            // The "Done" button is only enabled when the user has selected at least one instrument
+            Button {
+                id: doneButton
+                text: qsTr("Done")
+                focus: true
                 enabled: chooseInstrumentsAndTemplatePage.hasSelection
 
                 onClicked: {

--- a/src/project/qml/MuseScore/Project/internal/NewScore/GeneralInfoView.qml
+++ b/src/project/qml/MuseScore/Project/internal/NewScore/GeneralInfoView.qml
@@ -71,6 +71,10 @@ Column {
 
             navigationPanel: root.navigationPanel
             navigationColumn: 0
+
+            // Use tab to navigate to the next itembox
+            focus: true
+            KeyNavigation.tab: subtitleInfo
         }
         GeneralInfoItem {
             id: composerInfo
@@ -85,6 +89,9 @@ Column {
 
             navigationPanel: root.navigationPanel
             navigationColumn: 1
+
+            focus: true
+            KeyNavigation.tab: subtitleInfo
         }
     }
 
@@ -111,6 +118,8 @@ Column {
 
             navigationPanel: root.navigationPanel
             navigationColumn: 2
+
+            KeyNavigation.tab: lyricistInfo
         }
 
         GeneralInfoItem {
@@ -124,6 +133,8 @@ Column {
 
             navigationPanel: root.navigationPanel
             navigationColumn: 3
+
+            KeyNavigation.tab: copyrightInfo
         }
     }
 
@@ -140,5 +151,7 @@ Column {
 
         navigationPanel: root.navigationPanel
         navigationColumn: 4
+
+        KeyNavigation.tab: doneButton
     }
 }

--- a/src/project/qml/MuseScore/Project/internal/Properties/ProjectPropertiesView.qml
+++ b/src/project/qml/MuseScore/Project/internal/Properties/ProjectPropertiesView.qml
@@ -88,4 +88,13 @@ StyledListView {
             root.propertiesModel.deleteProperty(model.index)
         }
     }
+
+    // Inclusion of the "Ok" button in tab sequence
+    FlatButton {
+        id: closeButton
+        text: qsTr("Ok")
+        Layout.alignment: Qt.AlignRight
+        navigationPanel: root.navigationPanel
+        navigationColumn: root.navigationColumnStart + propertiesModel.count
+    }
 }

--- a/src/project/qml/MuseScore/Project/internal/Properties/PropertyItem.qml
+++ b/src/project/qml/MuseScore/Project/internal/Properties/PropertyItem.qml
@@ -168,4 +168,6 @@ RowLayout {
 
         onClicked: root.deletePropertyRequested()
     }
+
+    focus: index === 0
 }


### PR DESCRIPTION
Improve Tab key navigation to include only input fields and the OK button.

This change refines keyboard navigation behavior by ensuring that the Tab key cycles focus only through input fields and the OK button, skipping non-interactive or decorative UI elements. This improves accessibility and usability, making keyboard navigation more predictable and user-friendly.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects
- [x] The code follows the coding rules
- [x] No unnecessary changes
- [x] The code compiles and runs on my machine
- [ ] I created a unit test or vtest to verify the changes (if applicable)
