### PR TITLE
Fixes for repitch mode with chords

### DIFF
--- a/src/engraving/dom/cmd.cpp
+++ b/src/engraving/dom/cmd.cpp
@@ -5066,7 +5066,11 @@ void Score::cmdAddPitch(int step, bool addFlag, bool insert)
                 NoteVal nval2 = noteValForPosition(pos, AccidentalType::NONE, error);
                 forceAccidental = (nval.pitch == nval2.pitch);
             }
-            addNote(chord, nval, forceAccidental, m_is.articulationIds());
+            if (inputState().usingNoteEntryMethod(NoteEntryMethod::REPITCH)) {
+                addPitchToChord(nval, chord, /* externalInputState */ nullptr, forceAccidental);
+            } else {
+                addNote(chord, nval, forceAccidental, m_is.articulationIds());
+            }
             m_is.setAccidentalType(AccidentalType::NONE);
             return;
         }

--- a/src/engraving/dom/noteentry.cpp
+++ b/src/engraving/dom/noteentry.cpp
@@ -234,17 +234,24 @@ Note* Score::addPitch(NoteVal& nval, bool addFlag, InputState* externalInputStat
                     undoRemoveElement(n->tieBack());
                 }
             }
-            // for single note chords only, preserve ties by changing pitch of all forward notes
+            // for the first note of the chord only, preserve ties by changing pitch of all forward notes
             // the tie forward itself will be added later
             // multi-note chords get reduced to single note chords anyhow since we remove the old notes below
-            // so there will be no way to preserve those ties
-            if (notes.size() == 1 && notes.front()->tieFor()) {
+            if (notes.front()->tieFor()) {
                 Note* tn = notes.front()->tieFor()->endNote();
                 while (tn) {
                     Chord* tc = tn->chord();
                     if (tc->notes().size() != 1) {
-                        undoRemoveElement(tn->tieBack());
-                        break;
+                        std::vector<Note*> notesToRemove;
+                        for (Note* n : tc->notes()) {
+                            if (n != tn) {
+                                notesToRemove.push_back(n);
+                            }
+                        }
+                        for (Note* n : notesToRemove) {
+                            undoRemoveElement(n);
+                        }
+                        assert(tc->notes().size() == 1 && tc->notes().front() == tn);
                     }
                     if (!firstTiedNote) {
                         firstTiedNote = tn;
@@ -694,17 +701,24 @@ Ret Score::repitchNote(const Position& p, bool replace)
                 undoRemoveElement(e);
             }
         }
-        // for single note chords only, preserve ties by changing pitch of all forward notes
+        // for the first note of the chord only, preserve ties by changing pitch of all forward notes
         // the tie forward itself will be added later
         // multi-note chords get reduced to single note chords anyhow since we remove the old notes below
-        // so there will be no way to preserve those ties
-        if (notes.size() == 1 && notes.front()->tieFor()) {
+        if (notes.front()->tieFor()) {
             Note* tn = notes.front()->tieFor()->endNote();
             while (tn) {
                 Chord* tc = tn->chord();
                 if (tc->notes().size() != 1) {
-                    undoRemoveElement(tn->tieBack());
-                    break;
+                    std::vector<Note*> notesToRemove;
+                    for (Note* n : tc->notes()) {
+                        if (n != tn) {
+                            notesToRemove.push_back(n);
+                        }
+                    }
+                    for (Note* n : notesToRemove) {
+                        undoRemoveElement(n);
+                    }
+                    assert(tc->notes().size() == 1 && tc->notes().front() == tn);
                 }
                 if (!firstTiedNote) {
                     firstTiedNote = tn;

--- a/src/engraving/dom/noteentry.cpp
+++ b/src/engraving/dom/noteentry.cpp
@@ -363,7 +363,16 @@ Note* Score::addPitchToChord(NoteVal& nval, Chord* chord, InputState* externalIn
         note = addNote(chord, nval, /* forceAccidental */ false, is.articulationIds(), externalInputState);
     }
 
-    if (is.lastSegment() == is.segment()) {
+    if (is.usingNoteEntryMethod(NoteEntryMethod::REPITCH)) {
+        // move cursor to next note
+        ChordRest* next = nextChordRest(note->chord());
+        while (next && !next->isChord()) {
+            next = nextChordRest(next);
+        }
+        if (next) {
+            is.moveInputPos(next->segment());
+        }
+    } else if (is.lastSegment() == is.segment()) {
         NoteEntryMethod entryMethod = is.noteEntryMethod();
         if (entryMethod != NoteEntryMethod::REALTIME_AUTO && entryMethod != NoteEntryMethod::REALTIME_MANUAL) {
             is.moveToNextInputPos();

--- a/src/engraving/dom/noteentry.cpp
+++ b/src/engraving/dom/noteentry.cpp
@@ -290,7 +290,7 @@ Note* Score::addPitchToChord(NoteVal& nval, Chord* chord, InputState* externalIn
             note = addNote(chord, nval, forceAccidental, /* articulationIds */ {}, externalInputState);
         }
     } else {
-        note = addNote(chord, nval, forceAccidental, is.articulationIds(), externalInputState);
+        note = addNote(chord, nval, forceAccidental, /* articulationIds */ {}, externalInputState);
     }
 
     if (is.usingNoteEntryMethod(NoteEntryMethod::REPITCH)) {

--- a/src/engraving/dom/noteentry.cpp
+++ b/src/engraving/dom/noteentry.cpp
@@ -267,7 +267,7 @@ Note* Score::addPitch(NoteVal& nval, bool addFlag, InputState* externalInputStat
     return note;
 }
 
-Note* Score::addPitchToChord(NoteVal& nval, Chord* chord, InputState* externalInputState)
+Note* Score::addPitchToChord(NoteVal& nval, Chord* chord, InputState* externalInputState, bool forceAccidental)
 {
     IF_ASSERT_FAILED(chord) {
         return nullptr;
@@ -285,12 +285,12 @@ Note* Score::addPitchToChord(NoteVal& nval, Chord* chord, InputState* externalIn
 
     Note* note = nullptr;
     if (isTied(chord)) {
-        note = addNoteToTiedChord(chord, nval, /* forceAccidental */ false);
+        note = addNoteToTiedChord(chord, nval, forceAccidental);
         if (!note) {
-            note = addNote(chord, nval, /* forceAccidental */ false, /* articulationIds */ {}, externalInputState);
+            note = addNote(chord, nval, forceAccidental, /* articulationIds */ {}, externalInputState);
         }
     } else {
-        note = addNote(chord, nval, /* forceAccidental */ false, is.articulationIds(), externalInputState);
+        note = addNote(chord, nval, forceAccidental, is.articulationIds(), externalInputState);
     }
 
     if (is.usingNoteEntryMethod(NoteEntryMethod::REPITCH)) {
@@ -619,6 +619,11 @@ Ret Score::repitchNote(const Position& p, bool replace)
     if (m_is.accidentalType() != AccidentalType::NONE) {
         NoteVal nval2 = noteValForPosition(p, AccidentalType::NONE, error);
         forceAccidental = (nval.pitch == nval2.pitch);
+    }
+
+    // Note: not sure this is ever called with replace == false, since add (not replace) case is handled already in cmdAddPitch
+    if (!replace) {
+        return addPitchToChord(nval, chord, /* externalInputState */ nullptr, forceAccidental);
     }
 
     auto [note, lastTiedNote] = repitchReplaceNote(chord, nval, forceAccidental);

--- a/src/engraving/dom/score.h
+++ b/src/engraving/dom/score.h
@@ -30,6 +30,7 @@
 #include <set>
 #include <memory>
 #include <optional>
+#include <utility>
 
 #include "global/async/channel.h"
 #include "global/types/ret.h"
@@ -564,6 +565,7 @@ public:
     void cloneVoice(track_idx_t strack, track_idx_t dtrack, Segment* sf, const Fraction& lTick, bool link = true, bool spanner = true);
 
     muse::Ret repitchNote(const Position& pos, bool replace);
+    std::pair<Note*, Note*> repitchReplaceNote(Chord*, const NoteVal&, bool forceAccidental = false);   // returns new note and last tied note
     void regroupNotesAndRests(const Fraction& startTick, const Fraction& endTick, track_idx_t track);
 
     void startCmd(const TranslatableString& actionName);             // start undoable command

--- a/src/engraving/dom/score.h
+++ b/src/engraving/dom/score.h
@@ -1155,7 +1155,7 @@ private:
 
     void applyAccidentalToInputNotes(AccidentalType accidentalType);
 
-    Note* addPitchToChord(NoteVal&, Chord* chord, InputState* externalInputState = nullptr);
+    Note* addPitchToChord(NoteVal&, Chord* chord, InputState* externalInputState = nullptr, bool forceAccidental = false);
     Note* addTiedMidiPitch(int pitch, bool addFlag, Chord* prevChord, bool allowTransposition);
     Note* addNoteToTiedChord(Chord*, const NoteVal& noteVal, bool forceAccidental = false, const std::set<SymId>& articulationIds = {});
 


### PR DESCRIPTION
Resolves: #13467, #25948

Various fixes for chords in repitch mode having wrong behavior, or at least inconsistent with the behavior for single notes.

- Refactored common logic from MIDI entry and keyboard/mouse entry into a new function, `Score::repitchReplaceNote`.
- Preserve ties when repitching chords.
   
   Previously, single-note chords with ties would have all the tied notes repitched when the first note was repitched, and the cursor would then skip past all the tied notes, treating the whole tie sequence as a unit. But when a multi-note chord was repitched, we would break the ties and treat all the tied notes individually.
   
   Now, when repitching a chord we take the first note in the chord as the "template" for ties, repitching all its tied notes as in the single-note case, and removing any other pitches from those chords. Then, when adding new pitches to the repitched chord, we follow the existing ties and add new pitches to all the tied chords as well.
   
   This does mean that chords with a heterogeneous set of ties (e.g. some notes tied, others not) when repitched will take their tie pattern from the first (lowest) note of the chord, and won't attempt to maintain a more complex tie pattern; that could perhaps be improved in future, but I think it's still an improvement over the current behavior.

- Correctly move the cursor past rests after repitching a chord. Previously, it would only move the cursor to the next chordrest, and require an extra keypress to jump to the next actual chord.
- Don't overwrite articulations when repitching chords.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
