### PR TITLE
Wrap mouse over edges when panning the score

### DIFF
--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -1026,9 +1026,9 @@ void NotationViewInputController::mouseMoveEvent(QMouseEvent* event)
 
         QPoint delta = newPos - event->pos();
         if (delta.x() != 0 || delta.y() != 0) {
-            QPoint newCursorPos = cursor.pos() + delta;
-            cursor.setPos(newCursorPos);
-            QPoint cursorDelta = cursor.pos() - newCursorPos;
+            QPoint newCursorPos = QCursor::pos() + delta;
+            QCursor::setPos(newCursorPos);
+            QPoint cursorDelta = QCursor::pos() - newCursorPos;
 
             // do not update the mouse down info if the mouse did not move because setting the mouse position is not possible on some targets (including wayland)
             // allow some margin for error because sometimes the user moves the mouse between the call to `setPos` and the call to `cursor.pos`

--- a/src/notation/view/notationviewinputcontroller.h
+++ b/src/notation/view/notationviewinputcontroller.h
@@ -22,7 +22,6 @@
 #ifndef MU_NOTATION_NOTATIONVIEWINPUTCONTROLLER_H
 #define MU_NOTATION_NOTATIONVIEWINPUTCONTROLLER_H
 
-#include <QApplication>
 #include <QtEvents>
 
 #include "modularity/ioc.h"
@@ -236,8 +235,6 @@ private:
 
     bool m_shouldStartEditOnLeftClickRelease = false;
     bool m_shouldTogglePopupOnLeftClickRelease = false;
-
-    QCursor cursor;
 };
 }
 


### PR DESCRIPTION
Resolves: #25263 following [this proposal](https://github.com/musescore/MuseScore/issues/25263#issuecomment-2970279843)

This makes it much easier to pan the score.

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [X] I created a unit test or vtest to verify the changes I made (if applicable)