### PR TITLE
Feat: Implement Text Justification for Text Layout

### DIFF
--- a/src/engraving/api/v1/apitypes.h
+++ b/src/engraving/api/v1/apitypes.h
@@ -365,8 +365,9 @@ enum class Align : char {
     BOTTOM   = 4,
     VCENTER  = 8,
     BASELINE = 16,
+    JUSTIFY = 32,
     CENTER = Align::HCENTER | Align::VCENTER,
-    HMASK  = Align::LEFT | Align::RIGHT | Align::HCENTER,
+    HMASK = Align::LEFT | Align::RIGHT | Align::HCENTER | Align::JUSTIFY,
     VMASK  = Align::TOP | Align::BOTTOM | Align::VCENTER | Align::BASELINE
 };
 Q_ENUM_NS(Align);

--- a/src/engraving/dom/textbase.cpp
+++ b/src/engraving/dom/textbase.cpp
@@ -1028,6 +1028,10 @@ void TextBlock::layout(const TextBase* t)
         default:
             break;
         }
+    } else {
+        // fallback: default width in case of no parent item
+        FontMetrics fm(t->font());
+        layoutWidth = fm.width(t->plainText());
     }
 
     if (m_fragments.empty()) {
@@ -1121,14 +1125,69 @@ void TextBlock::layout(const TextBase* t)
         rx = -bbox.left();
     } else if (alignH == AlignH::RIGHT) {
         rx = layoutWidth - bbox.right();
+    } else if (alignH == AlignH::JUSTIFY) {
+        struct SubFragment {
+            String text;
+            CharFormat format;
+            double width;
+        };
+        std::vector<SubFragment> subfrags;
+        for (const TextFragment& f : m_fragments) {
+            String current;
+            FontMetrics fm(f.font(t));
+            for (size_t i = 0; i < f.text.size(); ++i) {
+                Char c = f.text.at(i);
+                current += c;
+                if (c.isSpace()) {
+                    double w = fm.width(current);
+                    subfrags.push_back({ current, f.format, w });
+                    current.clear();
+                }
+            }
+            if (!current.isEmpty()) {
+                double w = fm.width(current);
+                subfrags.push_back({ current, f.format, w });
+            }
+        }
+
+        int numSpaces = 0;
+        double textWidth = 0;
+        for (const auto& sf : subfrags) {
+            numSpaces++;
+            textWidth += sf.width; // accumulate text width
+        }
+        numSpaces--;
+        double spaceToFill = layoutWidth - textWidth;
+        if (numSpaces > 0 && spaceToFill > 0) {
+            m_fragments.clear();
+            double extraSpacing = spaceToFill / numSpaces;
+            x = 0.0;
+            for (const auto& sf : subfrags) {
+                TextFragment frag;
+                frag.text = sf.text;
+                frag.format = sf.format;
+                frag.pos.rx() = x;
+                m_fragments.push_back(frag);
+                x += sf.width + extraSpacing;
+            }
+        }
     }
 
     rx += lm;
 
-    for (TextFragment& f : m_fragments) {
-        f.pos.rx() += rx;
+    if (alignH != AlignH::JUSTIFY) {
+        for (TextFragment& f : m_fragments) {
+            f.pos.rx() += rx;
+        }
+        m_shape.translate(PointF(rx, 0.0));
+    } else {
+        m_shape.clear();
+        for (const TextFragment& f : m_fragments) {
+            FontMetrics fm(f.font(t));
+            RectF textBRect = fm.tightBoundingRect(f.text).translated(f.pos);
+            m_shape.add(textBRect, t);
+        }
     }
-    m_shape.translate(PointF(rx, 0.0));
 }
 
 //---------------------------------------------------------

--- a/src/engraving/rendering/score/harmonylayout.cpp
+++ b/src/engraving/rendering/score/harmonylayout.cpp
@@ -89,6 +89,9 @@ void HarmonyLayout::layoutHarmony(const Harmony* item, Harmony::LayoutData* ldat
                 case AlignH::RIGHT:
                     xx = -hAlignBox.right();
                     break;
+                case AlignH::JUSTIFY:
+                    xx = -hAlignBox.left();
+                    break;
                 }
             } else {
                 switch (item->noteheadAlign()) {
@@ -100,6 +103,9 @@ void HarmonyLayout::layoutHarmony(const Harmony* item, Harmony::LayoutData* ldat
                     break;
                 case AlignH::RIGHT:
                     xx = -hAlignBox.right();
+                    break;
+                case AlignH::JUSTIFY:
+                    xx = -hAlignBox.left();
                     break;
                 }
             }
@@ -138,6 +144,9 @@ void HarmonyLayout::layoutHarmony(const Harmony* item, Harmony::LayoutData* ldat
             case AlignH::RIGHT:
                 newPosX = fd->mainWidth();
                 break;
+            case AlignH::JUSTIFY:
+                newPosX = 0.0;
+                break;
             }
         } else {
             switch (item->noteheadAlign()) {
@@ -149,6 +158,9 @@ void HarmonyLayout::layoutHarmony(const Harmony* item, Harmony::LayoutData* ldat
                 break;
             case AlignH::RIGHT:
                 newPosX = cw;
+                break;
+            case AlignH::JUSTIFY:
+                newPosX = 0.0;
                 break;
             }
         }

--- a/src/engraving/rendering/score/systemlayout.cpp
+++ b/src/engraving/rendering/score/systemlayout.cpp
@@ -1869,6 +1869,10 @@ void SystemLayout::layoutSystem(System* system, LayoutContext& ctx, double xo1, 
             case AlignH::RIGHT:
                 t->mutldata()->setPosX(maxNamesWidth);
                 break;
+            case AlignH::JUSTIFY:
+                // Justify is not supported for instrument names
+                t->mutldata()->setPosX(0); // Same treatment as AlignH::LEFT
+                break;
             }
         }
     }

--- a/src/engraving/types/types.h
+++ b/src/engraving/types/types.h
@@ -271,7 +271,8 @@ enum class AlignV : unsigned char {
 enum class AlignH : unsigned char {
     LEFT,
     RIGHT,
-    HCENTER
+    HCENTER,
+    JUSTIFY
 };
 
 struct Align {

--- a/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
@@ -5271,6 +5271,9 @@ void ExportMusicXml::rehearsal(RehearsalMark const* const rmk, staff_idx_t staff
         case AlignH::RIGHT:
             attr += u" justify=\"right\"";
             break;
+        case AlignH::JUSTIFY:
+            attr += u" justify=\"justify\"";
+            break;
         }
     }
     // set the default words format

--- a/src/inspector/types/texttypes.h
+++ b/src/inspector/types/texttypes.h
@@ -45,6 +45,7 @@ public:
         FONT_ALIGN_H_LEFT = 0,
         FONT_ALIGN_H_RIGHT = 1,
         FONT_ALIGN_H_CENTER = 2,
+        FONT_ALIGN_H_JUSTIFY = 3,
     };
 
     enum class FontVerticalAlignment {

--- a/src/inspector/view/qml/MuseScore/Inspector/text/TextInspectorView.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/text/TextInspectorView.qml
@@ -217,6 +217,12 @@ InspectorSectionView {
                             typeRole: TextTypes.FONT_ALIGN_H_RIGHT,
                             title: qsTrc("inspector", "Align right"),
                             description: qsTrc("inspector", "Align right edge of text to reference point")
+                        },
+                        {
+                            iconRole: IconCode.TEXT_ALIGN_JUSTIFY, 
+                            typeRole: TextTypes.FONT_ALIGN_H_JUSTIFY,
+                            title: qsTrc("inspector", "Justify"),
+                            description: qsTrc("inspector", "Justify text to fill the available width")
                         }
                     ]
 


### PR DESCRIPTION
This PR implements Text Justification across multiple lines in the text layout engine.

- Added logic to support text justification in layout computation.

- Updated bounding box calculation to handle justified text.

- Further tuning may be needed to handle some edge cases in the UI.

This feature is based on the [GSoC project idea](https://github.com/musescore/MuseScore/wiki/Project-ideas-for-GSoC#rich-text-formatting) proposed by the MuseScore team.

The original work also included early support for footnotes, but following [a maintainer's recommendation](https://github.com/musescore/MuseScore/pull/28393#issuecomment-2975792413), this PR isolates only the text justification functionality for easier review.

"@franciscolh04 thank you for your contribution. As a first bit of advice, I would ask you to split the Text Justification project and the Footnotes project into 2 separate branches and separate PRs, since they are completely unrelated to each other. Will make it much easier for you to work on, and for us to review."

This PR addresses that request.

Co-authored-by: Mafalda Dias <mafalda.p.dias@tecnico.ulisboa.pt>

---

- [x] We signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
