### PR TITLE
Only extend range selection to full measure on release, not press

### DIFF
--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -768,7 +768,9 @@ void NotationViewInputController::mousePress_considerSelect(const ClickContext& 
     } else {
         const INotationSelectionPtr selection = viewInteraction()->selection();
 
-        if (selection->isRange() && selection->range()->containsItem(ctx.hitElement, ctx.hitStaff)) {
+        if (selection->isRange()
+            && (selection->range()->containsItem(ctx.hitElement, ctx.hitStaff)
+                || selection->range()->containsPoint(ctx.logicClickPos))) {
             return;
         }
     }


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/28556

Might have been caused by https://github.com/musescore/MuseScore/pull/27865