### PR TITLE
Selection filter refinements

### DIFF
--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -3705,6 +3705,12 @@ void Score::deleteRangeAtTrack(std::vector<ChordRest*>& crsToSelect, const track
             continue;
         }
 
+        for (EngravingItem* elem : collectElementsAnchoredToChordRest(cr1)) {
+            if (filter.canSelect(elem)) {
+                undoRemoveElement(elem);
+            }
+        }
+
         if (cr1->isRestFamily()) {
             if (cr1->selected()) {
                 restDuration += cr1->ticks();
@@ -3717,49 +3723,25 @@ void Score::deleteRangeAtTrack(std::vector<ChordRest*>& crsToSelect, const track
 
         Chord* chord = toChord(cr1);
 
-        // TODO: Not loving the duplication with Selection::appendChord here...
-        Arpeggio* arp = chord->arpeggio();
-        if (arp && filter.canSelect(arp)) {
-            undoRemoveElement(arp);
-        }
-        TremoloTwoChord* tremTwo = chord->tremoloTwoChord();
-        if (tremTwo && filter.canSelect(tremTwo)) {
-            undoRemoveElement(tremTwo);
-        }
-        TremoloSingleChord* tremSing = chord->tremoloSingleChord();
-        if (tremSing && filter.canSelect(tremSing)) {
-            undoRemoveElement(tremSing);
-        }
-        for (Articulation* art : chord->articulations()) {
-            if (filter.canSelect(art)) {
-                undoRemoveElement(art);
-            }
-        }
-
         const std::vector<Note*> allNotes = chord->notes();
         std::unordered_set<Note*> notesToRemove;
         for (size_t noteIdx = 0; noteIdx < allNotes.size(); ++noteIdx) {
             Note* note = allNotes.at(noteIdx);
-
-            // TODO: More duplication here...
-            LaissezVib* lv = note->laissezVib();
-            if (lv && filter.canSelect(lv)) {
-                undoRemoveElement(lv);
+            if (filter.canSelectNoteIdx(noteIdx, allNotes.size(), selectionContainsMultiNoteChords)) {
+                notesToRemove.emplace(note);
+                //! NOTE: Don't need to remove anchored elements - they won't survive the deletion of their parent note...
+                continue;
             }
-            PartialTie* ipt = note->incomingPartialTie();
-            if (ipt && filter.canSelect(ipt)) {
-                undoRemoveElement(lv);
-            }
-            PartialTie* opt = note->outgoingPartialTie();
-            if (opt && filter.canSelect(opt)) {
-                undoRemoveElement(lv);
-            }
-            const EngravingItem* endElement = note->tieFor() ? note->tieFor()->endElement() : nullptr;
-            if (endElement && endElement->isNote()) {
-                const Note* endNote = toNote(endElement);
-                const Segment* endSeg = endNote->chord()->segment();
-                if (!endSeg || endSeg->tick() <= endTick) {
-                    undoRemoveElement(note->tieFor());
+            for (EngravingItem* elem : collectElementsAnchoredToNote(note, true, false)) {
+                if (!filter.canSelect(elem)) {
+                    continue;
+                }
+                if (!elem->isSpanner() || elem->isPartialTie() || elem->isLaissezVib()) {
+                    undoRemoveElement(elem);
+                    continue;
+                }
+                if (noteAnchoredSpannerIsInRange(toSpanner(elem), cr1->tick(), endTick)) {
+                    undoRemoveElement(elem);
                 }
             }
             if (!filter.canSelectNoteIdx(noteIdx, allNotes.size(), selectionContainsMultiNoteChords)) {

--- a/src/engraving/dom/select.cpp
+++ b/src/engraving/dom/select.cpp
@@ -603,6 +603,10 @@ void Selection::appendChordRest(ChordRest* cr)
             m_el.push_back(note->accidental());
         }
         for (EngravingItem* el : note->el()) {
+            if (el->isFingering()) {
+                // Slight hack (already handled, see collectElementsAnchoredToNote)...
+                continue;
+            }
             m_el.push_back(el);
         }
         for (NoteDot* dot : note->dots()) {

--- a/src/engraving/dom/select.cpp
+++ b/src/engraving/dom/select.cpp
@@ -539,9 +539,7 @@ void Selection::appendFiltered(const std::unordered_set<EngravingItem*>& elems)
 
         // Special handling for grace notes...
         if (elem->isChord() && toChord(elem)->isGrace()) {
-            if (canSelect(elem)) {
-                appendChordRest(toChordRest(elem));
-            }
+            appendChordRest(toChordRest(elem));
         }
 
         appendFiltered(elem);
@@ -586,6 +584,10 @@ void Selection::appendChordRest(ChordRest* cr)
 
         const std::unordered_set<EngravingItem*> noteAnchored = collectElementsAnchoredToNote(note, true, false);
         appendFiltered(noteAnchored);
+
+        if (chord->isGrace() && !canSelect(chord)) {
+            continue;
+        }
 
         //! Hack Explainer: Due to the fact that this method is called while we're still in the process of "building" our
         //! selection, we can't know for certain whether the selection as a whole will contain multi-note Chords (and thus

--- a/src/engraving/dom/select.h
+++ b/src/engraving/dom/select.h
@@ -172,10 +172,8 @@ private:
     bool canSelectNoteIdx(size_t noteIdx, size_t totalNotesInChord, bool rangeContainsMultiNoteChords) const;
     bool canSelectVoice(track_idx_t track) const { return selectionFilter().canSelectVoice(track); }
     void appendFiltered(EngravingItem* e);
+    void appendFiltered(const std::unordered_set<EngravingItem*>& elems);
     void appendChordRest(ChordRest* cr);
-    void appendChord(Chord* chord);
-    void appendChordFilteredExtras(Chord* chord);
-    void appendNoteFilteredExtras(Note* note);
     void appendTupletHierarchy(Tuplet* innermostTuplet);
     void appendGuitarBend(GuitarBend* guitarBend);
 

--- a/src/engraving/dom/utils.cpp
+++ b/src/engraving/dom/utils.cpp
@@ -1523,6 +1523,12 @@ std::unordered_set<EngravingItem*> collectElementsAnchoredToNote(const Note* not
     if (opt && !opt->segmentsEmpty()) {
         elems.emplace(opt);
     }
+    // The following is a bit of a hack - addressing properly would require a fingering rework...
+    for (EngravingItem* elem : note->el()) {
+        if (elem->isFingering()) {
+            elems.emplace(elem);
+        }
+    }
     if (includeForwardTiesSpanners) {
         Tie* tieFor = note->tieFor();
         if (tieFor && !tieFor->segmentsEmpty()) {

--- a/src/engraving/dom/utils.h
+++ b/src/engraving/dom/utils.h
@@ -31,6 +31,7 @@
 namespace mu::engraving {
 class Score;
 class Chord;
+class ChordRest;
 class EngravingItem;
 class KeySig;
 class Note;
@@ -38,6 +39,7 @@ class Rest;
 class Measure;
 class Score;
 class Segment;
+class Spanner;
 class System;
 class Staff;
 class Tuplet;
@@ -100,6 +102,11 @@ extern bool moveDownWhenAddingStaves(EngravingItem* item, staff_idx_t startStaff
 extern void collectChordsAndRest(Segment* segment, staff_idx_t staffIdx, std::vector<Chord*>& chords, std::vector<Rest*>& rests);
 extern void collectChordsOverlappingRests(Segment* segment, staff_idx_t staffIdx, std::vector<Chord*>& chords);
 extern std::vector<EngravingItem*> collectSystemObjects(const Score* score, const std::vector<Staff*>& staves = {});
+extern std::unordered_set<EngravingItem*> collectElementsAnchoredToChordRest(const ChordRest* cr);
+extern std::unordered_set<EngravingItem*> collectElementsAnchoredToNote(const Note* cr, bool includeForwardTiesSpanners,
+                                                                        bool includeBackwardTiesSpanners);
+
+extern bool noteAnchoredSpannerIsInRange(const Spanner*, const Fraction& rangeStart, const Fraction& rangeEnd);
 
 extern Interval ornamentIntervalToGeneralInterval(OrnamentInterval interval);
 

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -885,9 +885,18 @@ void NotationInteraction::select(const std::vector<EngravingItem*>& elements, Se
     const Fraction oldStartTick = selection.tickStart();
     const Fraction oldEndTick = selection.tickEnd();
 
+    const staff_idx_t oldStartStaff = selection.staffStart();
+    const staff_idx_t oldEndStaff = selection.staffEnd();
+
     doSelect(elements, type, staffIndex);
 
-    const bool rangeChanged = selection.isRange() && (oldStartTick != selection.tickStart() || oldEndTick != selection.tickEnd());
+    bool rangeChanged = false;
+    if (selection.isRange()) {
+        const bool ticksChanged = oldStartTick != selection.tickStart() || oldEndTick != selection.tickEnd();
+        const bool stavesChanged = oldStartStaff != selection.staffStart() || oldEndStaff != selection.staffEnd();
+        rangeChanged = ticksChanged || stavesChanged;
+    }
+
     if (rangeChanged || oldSelectionState != selection.state() || oldSelectedElements != selection.elements()) {
         notifyAboutSelectionChangedIfNeed();
     } else {

--- a/src/notation/qml/MuseScore/NotationScene/SelectionFilterPanel.qml
+++ b/src/notation/qml/MuseScore/NotationScene/SelectionFilterPanel.qml
@@ -36,8 +36,8 @@ Item {
     property NavigationSection navigationSection: null
     property int navigationOrderStart: 0
 
-    readonly property bool isAllSelected: voicesModel.isAllSelected && notesInChordModel.isAllSelected && elementsModel.isAllSelected
-    readonly property bool isNoneSelected: voicesModel.isNoneSelected && notesInChordModel.isNoneSelected && elementsModel.isNoneSelected
+    readonly property bool isAllSelected: notesInChordModel.isAllSelected && elementsModel.isAllSelected
+    readonly property bool isNoneSelected: notesInChordModel.isNoneSelected && elementsModel.isNoneSelected
 
     StyledFlickable {
         id: flickable


### PR DESCRIPTION
### Overview
1. There was some duplication between our selection and delete range logic - this has been addressed in 25ba66e4218367ea476b4ccd5c2c3efd94f8e367
2. Grace notes, glissandi, and lyrics were not playing nicely with the selection filter - fixed in 25ba66e4218367ea476b4ccd5c2c3efd94f8e367
3. Fingerings were also not responding to the selection filter - fixed in cd6bec7249c4558d73b20d77ec9b32df83d297da
4. Empty range selections were not updating when the staff changed but the "ticks" stayed the same - fixed in f03813ee4413ce3f6f7e4881de8541e365df0621
5. An oversight from [#28557](https://github.com/musescore/MuseScore/pull/28557) - clear/select all buttons' "enabled state" should ignore voices - fixed in 7c26822693493341c1d15d9bf237a1cdfdc12f62

---

### Video demonstrating points 2 and 3:
https://github.com/user-attachments/assets/a68f5b3f-6d0e-442d-b109-5918cb5f44a9

---

### Video demonstrating point 4:
https://github.com/user-attachments/assets/f9b41ebe-fd18-4638-94e6-23e8da76df4b


