### PR TITLE
Fix SVG export

### DIFF
--- a/src/importexport/imagesexport/internal/svggenerator.cpp
+++ b/src/importexport/imagesexport/internal/svggenerator.cpp
@@ -1201,7 +1201,7 @@ void SvgPaintEngine::updateState(const QPaintEngineState& s)
     // Translations, SVG transform="translate()", are handled separately from
     // other transformations such as rotation. Qt translates everything, but
     // other transformations do occur, and must be handled here.
-    QTransform t = s.transform();
+    QTransform t = s.painter()->transform();
 
     // Tablature Note Text:
     // m11 and m22 have floating point flotsam, for example: 1.000000629


### PR DESCRIPTION
Resolves: #28524 

This resolves the issue, though I'm not really sure _why_. It seems like querying the current transform via `QPaintEngineState::transform()` returns a wrong value (i.e. a null matrix) whereas making the same query via `QPainter::transform()` returns the correct matrix. @cbjeukendrup do you have any idea why this might be? Do you think we might be doing something wrong? Othewise, I guess we'll just accept it as another Qt 6.9 mistery.