### PR TITLE
Improve tab navigation in fields when creating a score

### DIFF
--- a/src/project/qml/MuseScore/Project/NewScoreDialog.qml
+++ b/src/project/qml/MuseScore/Project/NewScoreDialog.qml
@@ -182,6 +182,9 @@ StyledDialogView {
                 accentButton: true
                 enabled: chooseInstrumentsAndTemplatePage.hasSelection
 
+                navigationPanel: generalInfoView.navigationPanel
+                navigationColumn: 5
+
                 onClicked: {
                     root.onDone()
                 }

--- a/src/project/qml/MuseScore/Project/internal/NewScore/GeneralInfoView.qml
+++ b/src/project/qml/MuseScore/Project/internal/NewScore/GeneralInfoView.qml
@@ -69,9 +69,12 @@ Column {
 
             defaultText: qsTrc("project", "Untitled score")
 
-            navigationPanel: root.navigationPanel
-            navigationColumn: 0
+            TextInputField {
+                navigationPanel: root.navigationPanel
+                navigationColumn: 0
+            }
         }
+
         GeneralInfoItem {
             id: composerInfo
 
@@ -83,8 +86,10 @@ Column {
 
             defaultText: qsTrc("project", "Composer / arranger")
 
-            navigationPanel: root.navigationPanel
-            navigationColumn: 1
+            TextInputField {
+                navigationPanel: root.navigationPanel
+                navigationColumn: 2
+            }
         }
     }
 
@@ -109,8 +114,10 @@ Column {
 
             defaultText: qsTrc("project", "Subtitle")
 
-            navigationPanel: root.navigationPanel
-            navigationColumn: 2
+            TextInputField {
+                navigationPanel: root.navigationPanel
+                navigationColumn: 1
+            }
         }
 
         GeneralInfoItem {
@@ -122,8 +129,10 @@ Column {
 
             title: qsTrc("project", "Lyricist")
 
-            navigationPanel: root.navigationPanel
-            navigationColumn: 3
+            TextInputField {
+                navigationPanel: root.navigationPanel
+                navigationColumn: 3
+            }
         }
     }
 
@@ -137,8 +146,9 @@ Column {
 
         //: The caption of a field to specify copyright information
         title: qsTrc("project", "Copyright")
-
-        navigationPanel: root.navigationPanel
-        navigationColumn: 4
+        TextInputArea {
+            navigationPanel: root.navigationPanel
+            navigationColumn: 4
+        }
     }
 }


### PR DESCRIPTION
Resolves: #NNNNN <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

This change provides improved tab navigation in the interface for creating a score from the home screen.
The loop of text fields follows, title, subtitle, arranger/composer, lyricist, copyright, and the Done button

- [ ] I signed the [CLA](https://musescore.org/en/cla)
- [ ] The title of the PR describes the problem it addresses
- [ ] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [ ] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [ ] There are no unnecessary changes
- [ ] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)