### PR TITLE
Fix Harmony dragging

### DIFF
--- a/src/engraving/dom/harmony.cpp
+++ b/src/engraving/dom/harmony.cpp
@@ -2080,13 +2080,23 @@ double Harmony::mag() const
 
 void Harmony::undoMoveSegment(Segment* newSeg, Fraction tickDiff)
 {
+    IF_ASSERT_FAILED(parentItem()->isSegment()) {
+        return;
+    }
+
     if (newSeg->isTimeTickType()) {
         Measure* measure = newSeg->measure();
         Segment* chordRestSegAtSameTick = measure->undoGetSegment(SegmentType::ChordRest, newSeg->tick());
         newSeg = chordRestSegAtSameTick;
     }
 
+    Segment* oldSegment = toSegment(parent());
     TextBase::undoMoveSegment(newSeg, tickDiff);
+
+    oldSegment->checkEmpty();
+    if (oldSegment->empty()) {
+        score()->undoRemoveElement(oldSegment);
+    }
 }
 
 HarmonyInfo::HarmonyInfo(const HarmonyInfo& h)


### PR DESCRIPTION
Resolves: #28199 

Remove segment if it's left empty after moving the Harmony, otherwise we leave back a lot of empty ChordRest segments which mess up spacing calculations.