### PR TITLE
fixed #28398: If a fretboard diagram has been manually edited, never overwrite it when its chord symbol is changed

### DIFF
--- a/share/templates/01-General/01-Treble_Clef/score_style.mss
+++ b/share/templates/01-General/01-Treble_Clef/score_style.mss
@@ -297,7 +297,7 @@
     <fretMag>1</fretMag>
     <fretPlacement>0</fretPlacement>
     <fretStrings>6</fretStrings>
-    <fretFrets>5</fretFrets>
+    <fretFrets>4</fretFrets>
     <fretNut>1</fretNut>
     <fretDotSize>1</fretDotSize>
     <fretStringSpacing>0.7</fretStringSpacing>

--- a/share/templates/01-General/02-Bass_Clef/score_style.mss
+++ b/share/templates/01-General/02-Bass_Clef/score_style.mss
@@ -297,7 +297,7 @@
     <fretMag>1</fretMag>
     <fretPlacement>0</fretPlacement>
     <fretStrings>6</fretStrings>
-    <fretFrets>5</fretFrets>
+    <fretFrets>4</fretFrets>
     <fretNut>1</fretNut>
     <fretDotSize>1</fretDotSize>
     <fretStringSpacing>0.7</fretStringSpacing>

--- a/share/templates/01-General/03-Grand_Staff/score_style.mss
+++ b/share/templates/01-General/03-Grand_Staff/score_style.mss
@@ -297,7 +297,7 @@
     <fretMag>1</fretMag>
     <fretPlacement>0</fretPlacement>
     <fretStrings>6</fretStrings>
-    <fretFrets>5</fretFrets>
+    <fretFrets>4</fretFrets>
     <fretNut>1</fretNut>
     <fretDotSize>1</fretDotSize>
     <fretStringSpacing>0.7</fretStringSpacing>

--- a/share/templates/02-Choral/01-SATB/score_style.mss
+++ b/share/templates/02-Choral/01-SATB/score_style.mss
@@ -297,7 +297,7 @@
     <fretMag>1</fretMag>
     <fretPlacement>0</fretPlacement>
     <fretStrings>6</fretStrings>
-    <fretFrets>5</fretFrets>
+    <fretFrets>4</fretFrets>
     <fretNut>1</fretNut>
     <fretDotSize>1</fretDotSize>
     <fretStringSpacing>0.7</fretStringSpacing>

--- a/share/templates/02-Choral/02-SATB_+_Organ/score_style.mss
+++ b/share/templates/02-Choral/02-SATB_+_Organ/score_style.mss
@@ -297,7 +297,7 @@
     <fretMag>1</fretMag>
     <fretPlacement>0</fretPlacement>
     <fretStrings>6</fretStrings>
-    <fretFrets>5</fretFrets>
+    <fretFrets>4</fretFrets>
     <fretNut>1</fretNut>
     <fretDotSize>1</fretDotSize>
     <fretStringSpacing>0.7</fretStringSpacing>

--- a/share/templates/02-Choral/03-SATB_+_Piano/score_style.mss
+++ b/share/templates/02-Choral/03-SATB_+_Piano/score_style.mss
@@ -297,7 +297,7 @@
     <fretMag>1</fretMag>
     <fretPlacement>0</fretPlacement>
     <fretStrings>6</fretStrings>
-    <fretFrets>5</fretFrets>
+    <fretFrets>4</fretFrets>
     <fretNut>1</fretNut>
     <fretDotSize>1</fretDotSize>
     <fretStringSpacing>0.7</fretStringSpacing>

--- a/share/templates/02-Choral/04-SATB_Closed_Score/score_style.mss
+++ b/share/templates/02-Choral/04-SATB_Closed_Score/score_style.mss
@@ -297,7 +297,7 @@
     <fretMag>1</fretMag>
     <fretPlacement>0</fretPlacement>
     <fretStrings>6</fretStrings>
-    <fretFrets>5</fretFrets>
+    <fretFrets>4</fretFrets>
     <fretNut>1</fretNut>
     <fretDotSize>1</fretDotSize>
     <fretStringSpacing>0.7</fretStringSpacing>

--- a/share/templates/02-Choral/05-SATB_Closed_Score_+_Organ/score_style.mss
+++ b/share/templates/02-Choral/05-SATB_Closed_Score_+_Organ/score_style.mss
@@ -297,7 +297,7 @@
     <fretMag>1</fretMag>
     <fretPlacement>0</fretPlacement>
     <fretStrings>6</fretStrings>
-    <fretFrets>5</fretFrets>
+    <fretFrets>4</fretFrets>
     <fretNut>1</fretNut>
     <fretDotSize>1</fretDotSize>
     <fretStringSpacing>0.7</fretStringSpacing>

--- a/share/templates/02-Choral/06-SATB_Closed_Score_+_Piano/score_style.mss
+++ b/share/templates/02-Choral/06-SATB_Closed_Score_+_Piano/score_style.mss
@@ -297,7 +297,7 @@
     <fretMag>1</fretMag>
     <fretPlacement>0</fretPlacement>
     <fretStrings>6</fretStrings>
-    <fretFrets>5</fretFrets>
+    <fretFrets>4</fretFrets>
     <fretNut>1</fretNut>
     <fretDotSize>1</fretDotSize>
     <fretStringSpacing>0.7</fretStringSpacing>

--- a/share/templates/02-Choral/07-Voice_+_Piano/score_style.mss
+++ b/share/templates/02-Choral/07-Voice_+_Piano/score_style.mss
@@ -297,7 +297,7 @@
     <fretMag>1</fretMag>
     <fretPlacement>0</fretPlacement>
     <fretStrings>6</fretStrings>
-    <fretFrets>5</fretFrets>
+    <fretFrets>4</fretFrets>
     <fretNut>1</fretNut>
     <fretDotSize>1</fretDotSize>
     <fretStringSpacing>0.7</fretStringSpacing>

--- a/share/templates/02-Choral/08-Barbershop_Quartet_(Men)/score_style.mss
+++ b/share/templates/02-Choral/08-Barbershop_Quartet_(Men)/score_style.mss
@@ -297,7 +297,7 @@
     <fretMag>1</fretMag>
     <fretPlacement>0</fretPlacement>
     <fretStrings>6</fretStrings>
-    <fretFrets>5</fretFrets>
+    <fretFrets>4</fretFrets>
     <fretNut>1</fretNut>
     <fretDotSize>1</fretDotSize>
     <fretStringSpacing>0.7</fretStringSpacing>

--- a/share/templates/02-Choral/09-Barbershop_Quartet_(Women)/score_style.mss
+++ b/share/templates/02-Choral/09-Barbershop_Quartet_(Women)/score_style.mss
@@ -297,7 +297,7 @@
     <fretMag>1</fretMag>
     <fretPlacement>0</fretPlacement>
     <fretStrings>6</fretStrings>
-    <fretFrets>5</fretFrets>
+    <fretFrets>4</fretFrets>
     <fretNut>1</fretNut>
     <fretDotSize>1</fretDotSize>
     <fretStringSpacing>0.7</fretStringSpacing>

--- a/share/templates/02-Choral/10-Liturgical_Unmetrical/score_style.mss
+++ b/share/templates/02-Choral/10-Liturgical_Unmetrical/score_style.mss
@@ -297,7 +297,7 @@
     <fretMag>1</fretMag>
     <fretPlacement>0</fretPlacement>
     <fretStrings>6</fretStrings>
-    <fretFrets>5</fretFrets>
+    <fretFrets>4</fretFrets>
     <fretNut>1</fretNut>
     <fretDotSize>1</fretDotSize>
     <fretStringSpacing>0.7</fretStringSpacing>

--- a/share/templates/02-Choral/11-Liturgical_Unmetrical_+_Organ/score_style.mss
+++ b/share/templates/02-Choral/11-Liturgical_Unmetrical_+_Organ/score_style.mss
@@ -297,7 +297,7 @@
     <fretMag>1</fretMag>
     <fretPlacement>0</fretPlacement>
     <fretStrings>6</fretStrings>
-    <fretFrets>5</fretFrets>
+    <fretFrets>4</fretFrets>
     <fretNut>1</fretNut>
     <fretDotSize>1</fretDotSize>
     <fretStringSpacing>0.7</fretStringSpacing>

--- a/share/templates/03-Chamber_Music/01-String_Quartet/score_style.mss
+++ b/share/templates/03-Chamber_Music/01-String_Quartet/score_style.mss
@@ -297,7 +297,7 @@
     <fretMag>1</fretMag>
     <fretPlacement>0</fretPlacement>
     <fretStrings>6</fretStrings>
-    <fretFrets>5</fretFrets>
+    <fretFrets>4</fretFrets>
     <fretNut>1</fretNut>
     <fretDotSize>1</fretDotSize>
     <fretStringSpacing>0.7</fretStringSpacing>

--- a/share/templates/03-Chamber_Music/02-Wind_Quartet/score_style.mss
+++ b/share/templates/03-Chamber_Music/02-Wind_Quartet/score_style.mss
@@ -297,7 +297,7 @@
     <fretMag>1</fretMag>
     <fretPlacement>0</fretPlacement>
     <fretStrings>6</fretStrings>
-    <fretFrets>5</fretFrets>
+    <fretFrets>4</fretFrets>
     <fretNut>1</fretNut>
     <fretDotSize>1</fretDotSize>
     <fretStringSpacing>0.7</fretStringSpacing>

--- a/share/templates/03-Chamber_Music/03-Wind_Quintet/score_style.mss
+++ b/share/templates/03-Chamber_Music/03-Wind_Quintet/score_style.mss
@@ -297,7 +297,7 @@
     <fretMag>1</fretMag>
     <fretPlacement>0</fretPlacement>
     <fretStrings>6</fretStrings>
-    <fretFrets>5</fretFrets>
+    <fretFrets>4</fretFrets>
     <fretNut>1</fretNut>
     <fretDotSize>1</fretDotSize>
     <fretStringSpacing>0.7</fretStringSpacing>

--- a/share/templates/03-Chamber_Music/04-Saxophone_Quartet/score_style.mss
+++ b/share/templates/03-Chamber_Music/04-Saxophone_Quartet/score_style.mss
@@ -297,7 +297,7 @@
     <fretMag>1</fretMag>
     <fretPlacement>0</fretPlacement>
     <fretStrings>6</fretStrings>
-    <fretFrets>5</fretFrets>
+    <fretFrets>4</fretFrets>
     <fretNut>1</fretNut>
     <fretDotSize>1</fretDotSize>
     <fretStringSpacing>0.7</fretStringSpacing>

--- a/share/templates/03-Chamber_Music/05-Brass_Quartet/score_style.mss
+++ b/share/templates/03-Chamber_Music/05-Brass_Quartet/score_style.mss
@@ -297,7 +297,7 @@
     <fretMag>1</fretMag>
     <fretPlacement>0</fretPlacement>
     <fretStrings>6</fretStrings>
-    <fretFrets>5</fretFrets>
+    <fretFrets>4</fretFrets>
     <fretNut>1</fretNut>
     <fretDotSize>1</fretDotSize>
     <fretStringSpacing>0.7</fretStringSpacing>

--- a/share/templates/03-Chamber_Music/06-Brass_Quintet/score_style.mss
+++ b/share/templates/03-Chamber_Music/06-Brass_Quintet/score_style.mss
@@ -297,7 +297,7 @@
     <fretMag>1</fretMag>
     <fretPlacement>0</fretPlacement>
     <fretStrings>6</fretStrings>
-    <fretFrets>5</fretFrets>
+    <fretFrets>4</fretFrets>
     <fretNut>1</fretNut>
     <fretDotSize>1</fretDotSize>
     <fretStringSpacing>0.7</fretStringSpacing>

--- a/share/templates/04-Solo/01-Guitar/score_style.mss
+++ b/share/templates/04-Solo/01-Guitar/score_style.mss
@@ -297,7 +297,7 @@
     <fretMag>1</fretMag>
     <fretPlacement>0</fretPlacement>
     <fretStrings>6</fretStrings>
-    <fretFrets>5</fretFrets>
+    <fretFrets>4</fretFrets>
     <fretNut>1</fretNut>
     <fretDotSize>1</fretDotSize>
     <fretStringSpacing>0.7</fretStringSpacing>

--- a/share/templates/04-Solo/02-Guitar_+_Tablature/score_style.mss
+++ b/share/templates/04-Solo/02-Guitar_+_Tablature/score_style.mss
@@ -297,7 +297,7 @@
     <fretMag>1</fretMag>
     <fretPlacement>0</fretPlacement>
     <fretStrings>6</fretStrings>
-    <fretFrets>5</fretFrets>
+    <fretFrets>4</fretFrets>
     <fretNut>1</fretNut>
     <fretDotSize>1</fretDotSize>
     <fretStringSpacing>0.7</fretStringSpacing>

--- a/share/templates/04-Solo/03-Guitar_Tablature/score_style.mss
+++ b/share/templates/04-Solo/03-Guitar_Tablature/score_style.mss
@@ -297,7 +297,7 @@
     <fretMag>1</fretMag>
     <fretPlacement>0</fretPlacement>
     <fretStrings>6</fretStrings>
-    <fretFrets>5</fretFrets>
+    <fretFrets>4</fretFrets>
     <fretNut>1</fretNut>
     <fretDotSize>1</fretDotSize>
     <fretStringSpacing>0.7</fretStringSpacing>

--- a/share/templates/04-Solo/04-Piano/score_style.mss
+++ b/share/templates/04-Solo/04-Piano/score_style.mss
@@ -297,7 +297,7 @@
     <fretMag>1</fretMag>
     <fretPlacement>0</fretPlacement>
     <fretStrings>6</fretStrings>
-    <fretFrets>5</fretFrets>
+    <fretFrets>4</fretFrets>
     <fretNut>1</fretNut>
     <fretDotSize>1</fretDotSize>
     <fretStringSpacing>0.7</fretStringSpacing>

--- a/share/templates/05-Jazz/01-Jazz_Lead_Sheet/score_style.mss
+++ b/share/templates/05-Jazz/01-Jazz_Lead_Sheet/score_style.mss
@@ -297,7 +297,7 @@
     <fretMag>1</fretMag>
     <fretPlacement>0</fretPlacement>
     <fretStrings>6</fretStrings>
-    <fretFrets>5</fretFrets>
+    <fretFrets>4</fretFrets>
     <fretNut>1</fretNut>
     <fretDotSize>1</fretDotSize>
     <fretStringSpacing>0.7</fretStringSpacing>

--- a/share/templates/05-Jazz/02-Big_Band/score_style.mss
+++ b/share/templates/05-Jazz/02-Big_Band/score_style.mss
@@ -297,7 +297,7 @@
     <fretMag>1</fretMag>
     <fretPlacement>0</fretPlacement>
     <fretStrings>6</fretStrings>
-    <fretFrets>5</fretFrets>
+    <fretFrets>4</fretFrets>
     <fretNut>1</fretNut>
     <fretDotSize>1</fretDotSize>
     <fretStringSpacing>0.7</fretStringSpacing>

--- a/share/templates/05-Jazz/03-Jazz_Combo/score_style.mss
+++ b/share/templates/05-Jazz/03-Jazz_Combo/score_style.mss
@@ -297,7 +297,7 @@
     <fretMag>1</fretMag>
     <fretPlacement>0</fretPlacement>
     <fretStrings>6</fretStrings>
-    <fretFrets>5</fretFrets>
+    <fretFrets>4</fretFrets>
     <fretNut>1</fretNut>
     <fretDotSize>1</fretDotSize>
     <fretStringSpacing>0.7</fretStringSpacing>

--- a/share/templates/06-Popular/01-Rock_Band/score_style.mss
+++ b/share/templates/06-Popular/01-Rock_Band/score_style.mss
@@ -297,7 +297,7 @@
     <fretMag>1</fretMag>
     <fretPlacement>0</fretPlacement>
     <fretStrings>6</fretStrings>
-    <fretFrets>5</fretFrets>
+    <fretFrets>4</fretFrets>
     <fretNut>1</fretNut>
     <fretDotSize>1</fretDotSize>
     <fretStringSpacing>0.7</fretStringSpacing>

--- a/share/templates/06-Popular/02-Bluegrass_Band/score_style.mss
+++ b/share/templates/06-Popular/02-Bluegrass_Band/score_style.mss
@@ -297,7 +297,7 @@
     <fretMag>1</fretMag>
     <fretPlacement>0</fretPlacement>
     <fretStrings>6</fretStrings>
-    <fretFrets>5</fretFrets>
+    <fretFrets>4</fretFrets>
     <fretNut>1</fretNut>
     <fretDotSize>1</fretDotSize>
     <fretStringSpacing>0.7</fretStringSpacing>

--- a/share/templates/07-Band_and_Percussion/01-Concert_Band/score_style.mss
+++ b/share/templates/07-Band_and_Percussion/01-Concert_Band/score_style.mss
@@ -297,7 +297,7 @@
     <fretMag>1</fretMag>
     <fretPlacement>0</fretPlacement>
     <fretStrings>6</fretStrings>
-    <fretFrets>5</fretFrets>
+    <fretFrets>4</fretFrets>
     <fretNut>1</fretNut>
     <fretDotSize>1</fretDotSize>
     <fretStringSpacing>0.7</fretStringSpacing>

--- a/share/templates/07-Band_and_Percussion/02-Small_Concert_Band/score_style.mss
+++ b/share/templates/07-Band_and_Percussion/02-Small_Concert_Band/score_style.mss
@@ -297,7 +297,7 @@
     <fretMag>1</fretMag>
     <fretPlacement>0</fretPlacement>
     <fretStrings>6</fretStrings>
-    <fretFrets>5</fretFrets>
+    <fretFrets>4</fretFrets>
     <fretNut>1</fretNut>
     <fretDotSize>1</fretDotSize>
     <fretStringSpacing>0.7</fretStringSpacing>

--- a/share/templates/07-Band_and_Percussion/03-Brass_Band/score_style.mss
+++ b/share/templates/07-Band_and_Percussion/03-Brass_Band/score_style.mss
@@ -297,7 +297,7 @@
     <fretMag>1</fretMag>
     <fretPlacement>0</fretPlacement>
     <fretStrings>6</fretStrings>
-    <fretFrets>5</fretFrets>
+    <fretFrets>4</fretFrets>
     <fretNut>1</fretNut>
     <fretDotSize>1</fretDotSize>
     <fretStringSpacing>0.7</fretStringSpacing>

--- a/share/templates/07-Band_and_Percussion/04-Marching_Band/score_style.mss
+++ b/share/templates/07-Band_and_Percussion/04-Marching_Band/score_style.mss
@@ -297,7 +297,7 @@
     <fretMag>1</fretMag>
     <fretPlacement>0</fretPlacement>
     <fretStrings>6</fretStrings>
-    <fretFrets>5</fretFrets>
+    <fretFrets>4</fretFrets>
     <fretNut>1</fretNut>
     <fretDotSize>1</fretDotSize>
     <fretStringSpacing>0.7</fretStringSpacing>

--- a/share/templates/07-Band_and_Percussion/05-Small_Marching_Band/score_style.mss
+++ b/share/templates/07-Band_and_Percussion/05-Small_Marching_Band/score_style.mss
@@ -297,7 +297,7 @@
     <fretMag>1</fretMag>
     <fretPlacement>0</fretPlacement>
     <fretStrings>6</fretStrings>
-    <fretFrets>5</fretFrets>
+    <fretFrets>4</fretFrets>
     <fretNut>1</fretNut>
     <fretDotSize>1</fretDotSize>
     <fretStringSpacing>0.7</fretStringSpacing>

--- a/share/templates/07-Band_and_Percussion/06-Battery_Percussion/score_style.mss
+++ b/share/templates/07-Band_and_Percussion/06-Battery_Percussion/score_style.mss
@@ -297,7 +297,7 @@
     <fretMag>1</fretMag>
     <fretPlacement>0</fretPlacement>
     <fretStrings>6</fretStrings>
-    <fretFrets>5</fretFrets>
+    <fretFrets>4</fretFrets>
     <fretNut>1</fretNut>
     <fretDotSize>1</fretDotSize>
     <fretStringSpacing>0.7</fretStringSpacing>

--- a/share/templates/07-Band_and_Percussion/07-Large_Pit_Percussion/score_style.mss
+++ b/share/templates/07-Band_and_Percussion/07-Large_Pit_Percussion/score_style.mss
@@ -297,7 +297,7 @@
     <fretMag>1</fretMag>
     <fretPlacement>0</fretPlacement>
     <fretStrings>6</fretStrings>
-    <fretFrets>5</fretFrets>
+    <fretFrets>4</fretFrets>
     <fretNut>1</fretNut>
     <fretDotSize>1</fretDotSize>
     <fretStringSpacing>0.7</fretStringSpacing>

--- a/share/templates/07-Band_and_Percussion/08-Small_Pit_Percussion/score_style.mss
+++ b/share/templates/07-Band_and_Percussion/08-Small_Pit_Percussion/score_style.mss
@@ -297,7 +297,7 @@
     <fretMag>1</fretMag>
     <fretPlacement>0</fretPlacement>
     <fretStrings>6</fretStrings>
-    <fretFrets>5</fretFrets>
+    <fretFrets>4</fretFrets>
     <fretNut>1</fretNut>
     <fretDotSize>1</fretDotSize>
     <fretStringSpacing>0.7</fretStringSpacing>

--- a/share/templates/07-Band_and_Percussion/09-European_Concert_Band/score_style.mss
+++ b/share/templates/07-Band_and_Percussion/09-European_Concert_Band/score_style.mss
@@ -297,7 +297,7 @@
     <fretMag>1</fretMag>
     <fretPlacement>0</fretPlacement>
     <fretStrings>6</fretStrings>
-    <fretFrets>5</fretFrets>
+    <fretFrets>4</fretFrets>
     <fretNut>1</fretNut>
     <fretDotSize>1</fretDotSize>
     <fretStringSpacing>0.7</fretStringSpacing>

--- a/share/templates/08-Orchestral/01-Classical_Orchestra/score_style.mss
+++ b/share/templates/08-Orchestral/01-Classical_Orchestra/score_style.mss
@@ -297,7 +297,7 @@
     <fretMag>1</fretMag>
     <fretPlacement>0</fretPlacement>
     <fretStrings>6</fretStrings>
-    <fretFrets>5</fretFrets>
+    <fretFrets>4</fretFrets>
     <fretNut>1</fretNut>
     <fretDotSize>1</fretDotSize>
     <fretStringSpacing>0.7</fretStringSpacing>

--- a/share/templates/08-Orchestral/02-Symphony_Orchestra/score_style.mss
+++ b/share/templates/08-Orchestral/02-Symphony_Orchestra/score_style.mss
@@ -297,7 +297,7 @@
     <fretMag>1</fretMag>
     <fretPlacement>0</fretPlacement>
     <fretStrings>6</fretStrings>
-    <fretFrets>5</fretFrets>
+    <fretFrets>4</fretFrets>
     <fretNut>1</fretNut>
     <fretDotSize>1</fretDotSize>
     <fretStringSpacing>0.7</fretStringSpacing>

--- a/share/templates/08-Orchestral/03-String_Orchestra/score_style.mss
+++ b/share/templates/08-Orchestral/03-String_Orchestra/score_style.mss
@@ -297,7 +297,7 @@
     <fretMag>1</fretMag>
     <fretPlacement>0</fretPlacement>
     <fretStrings>6</fretStrings>
-    <fretFrets>5</fretFrets>
+    <fretFrets>4</fretFrets>
     <fretNut>1</fretNut>
     <fretDotSize>1</fretDotSize>
     <fretStringSpacing>0.7</fretStringSpacing>

--- a/src/engraving/data/harmony_to_diagram.xml
+++ b/src/engraving/data/harmony_to_diagram.xml
@@ -24,7 +24,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO222O</pattern>
+        <pattern>XO[2-O][2-O][2-O]O</pattern>
         <Harmony>
             <name>a</name>
         </Harmony>
@@ -48,7 +48,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-665--</pattern>
+        <pattern>-[6-O][6-O][5-O]--;B4[0-5]</pattern>
         <Harmony>
             <name>a</name>
         </Harmony>
@@ -74,7 +74,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-333-</pattern>
+        <pattern>X-[3-O][3-O][3-O]-;B1[1-5]</pattern>
         <Harmony>
             <name>a#</name>
         </Harmony>
@@ -100,7 +100,7 @@
                 <barre start="1" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-444-</pattern>
+        <pattern>X-[4-O][4-O][4-O]-;B2[1-5]</pattern>
         <Harmony>
             <name>b</name>
         </Harmony>
@@ -126,7 +126,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-333-</pattern>
+        <pattern>X-[3-O][3-O][3-O]-;B1[1-5]</pattern>
         <Harmony>
             <name>bb</name>
         </Harmony>
@@ -155,7 +155,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X32O1O</pattern>
+        <pattern>X[3-O][2-O]O[1-O]O</pattern>
         <Harmony>
             <name>c</name>
         </Harmony>
@@ -181,7 +181,7 @@
                 <barre start="1" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-444-</pattern>
+        <pattern>X-[4-O][4-O][4-O]-;B2[1-5]</pattern>
         <Harmony>
             <name>cb</name>
         </Harmony>
@@ -205,7 +205,7 @@
                 <barre start="2" end="4">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4---X</pattern>
+        <pattern>X[4-O]---X;B6[2-4]</pattern>
         <Harmony>
             <name>c#</name>
         </Harmony>
@@ -234,7 +234,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO232</pattern>
+        <pattern>XXO[2-O][3-O][2-O]</pattern>
         <Harmony>
             <name>d</name>
         </Harmony>
@@ -258,7 +258,7 @@
                 <barre start="2" end="4">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4---X</pattern>
+        <pattern>X[4-O]---X;B6[2-4]</pattern>
         <Harmony>
             <name>db</name>
         </Harmony>
@@ -282,7 +282,7 @@
                 <barre start="2" end="4">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6---X</pattern>
+        <pattern>X[6-O]---X;B8[2-4]</pattern>
         <Harmony>
             <name>d#</name>
         </Harmony>
@@ -311,7 +311,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O221OO</pattern>
+        <pattern>O[2-O][2-O][1-O]OO</pattern>
         <Harmony>
             <name>e</name>
         </Harmony>
@@ -335,7 +335,7 @@
                 <barre start="2" end="4">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6---X</pattern>
+        <pattern>X[6-O]---X;B8[2-4]</pattern>
         <Harmony>
             <name>eb</name>
         </Harmony>
@@ -358,7 +358,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-332--</pattern>
+        <pattern>-[3-O][3-O][2-O]--;B1[0-5]</pattern>
         <Harmony>
             <name>f</name>
         </Harmony>
@@ -387,7 +387,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O221OO</pattern>
+        <pattern>O[2-O][2-O][1-O]OO</pattern>
         <Harmony>
             <name>fb</name>
         </Harmony>
@@ -411,7 +411,7 @@
                 <barre start="0" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-443--</pattern>
+        <pattern>-[4-O][4-O][3-O]--;B2[0-5]</pattern>
         <Harmony>
             <name>f#</name>
         </Harmony>
@@ -440,7 +440,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>32OOO3</pattern>
+        <pattern>[3-O][2-O]OOO[3-O]</pattern>
         <Harmony>
             <name>g</name>
         </Harmony>
@@ -463,7 +463,7 @@
                 <barre start="0" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-443--</pattern>
+        <pattern>-[4-O][4-O][3-O]--;B2[0-5]</pattern>
         <Harmony>
             <name>gb</name>
         </Harmony>
@@ -487,7 +487,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-665--</pattern>
+        <pattern>-[6-O][6-O][5-O]--;B4[0-5]</pattern>
         <Harmony>
             <name>g#</name>
         </Harmony>
@@ -516,7 +516,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO222O</pattern>
+        <pattern>XO[2-O][2-O][2-O]O</pattern>
         <Harmony>
             <name>a</name>
         </Harmony>
@@ -545,7 +545,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO122X</pattern>
+        <pattern>XO[1-O][2-O][2-O]X</pattern>
         <Harmony>
             <name>a(b5)</name>
         </Harmony>
@@ -574,7 +574,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX122X</pattern>
+        <pattern>XX[1-O][2-O][2-O]X</pattern>
         <Harmony>
             <name>a(b5)/d#</name>
         </Harmony>
@@ -604,7 +604,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO7645</pattern>
+        <pattern>XO[7-O][6-O][4-O][5-O]</pattern>
         <Harmony>
             <name>a(#11)</name>
         </Harmony>
@@ -663,7 +663,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO5677</pattern>
+        <pattern>XO[5-O][6-O][7-O][7-O]</pattern>
         <Harmony>
             <name>a13</name>
         </Harmony>
@@ -693,7 +693,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX5677</pattern>
+        <pattern>XX[5-O][6-O][7-O][7-O]</pattern>
         <Harmony>
             <name>a13/g</name>
         </Harmony>
@@ -720,7 +720,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO53--</pattern>
+        <pattern>XO[5-O][3-O]--;B2[4-5]</pattern>
         <Harmony>
             <name>a13b9</name>
         </Harmony>
@@ -749,7 +749,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2O2O2O</pattern>
+        <pattern>[2-O]O[2-O]O[2-O]O</pattern>
         <Harmony>
             <name>a13/f#</name>
         </Harmony>
@@ -776,7 +776,7 @@
                 <barre start="1" end="2">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--677</pattern>
+        <pattern>X--[6-O][7-O][7-O];B5[1-2]</pattern>
         <Harmony>
             <name>a13/d</name>
         </Harmony>
@@ -805,7 +805,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>OO2O22</pattern>
+        <pattern>OO[2-O]O[2-O][2-O]</pattern>
         <Harmony>
             <name>a13/e</name>
         </Harmony>
@@ -834,7 +834,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO1O22</pattern>
+        <pattern>XO[1-O]O[2-O][2-O]</pattern>
         <Harmony>
             <name>a13#11</name>
         </Harmony>
@@ -863,7 +863,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO2OO2</pattern>
+        <pattern>XO[2-O]OO[2-O]</pattern>
         <Harmony>
             <name>a13sus2</name>
         </Harmony>
@@ -892,7 +892,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO2O32</pattern>
+        <pattern>XO[2-O]O[3-O][2-O]</pattern>
         <Harmony>
             <name>a13sus4</name>
         </Harmony>
@@ -918,7 +918,7 @@
                 <barre start="4" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4XO--</pattern>
+        <pattern>X[4-O]XO--;B2[4-5]</pattern>
         <Harmony>
             <name>a13/c#</name>
         </Harmony>
@@ -947,7 +947,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO1O22</pattern>
+        <pattern>XO[1-O]O[2-O][2-O]</pattern>
         <Harmony>
             <name>a13b5</name>
         </Harmony>
@@ -977,7 +977,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>577XXX</pattern>
+        <pattern>[5-O][7-O][7-O]XXX</pattern>
         <Harmony>
             <name>a5</name>
         </Harmony>
@@ -1006,7 +1006,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO42OO</pattern>
+        <pattern>XO[4-O][2-O]OO</pattern>
         <Harmony>
             <name>a5(add6add9)</name>
         </Harmony>
@@ -1035,7 +1035,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X322XX</pattern>
+        <pattern>X[3-O][2-O][2-O]XX</pattern>
         <Harmony>
             <name>a5/c</name>
         </Harmony>
@@ -1062,7 +1062,7 @@
                 <barre start="2" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4--XX</pattern>
+        <pattern>X[4-O]--XX;B2[2-3]</pattern>
         <Harmony>
             <name>a5/c#</name>
         </Harmony>
@@ -1092,7 +1092,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO25X</pattern>
+        <pattern>XXO[2-O][5-O]X</pattern>
         <Harmony>
             <name>a5/d</name>
         </Harmony>
@@ -1121,7 +1121,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>OO22XX</pattern>
+        <pattern>OO[2-O][2-O]XX</pattern>
         <Harmony>
             <name>a5/e</name>
         </Harmony>
@@ -1150,7 +1150,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>1O22XX</pattern>
+        <pattern>[1-O]O[2-O][2-O]XX</pattern>
         <Harmony>
             <name>a5/f</name>
         </Harmony>
@@ -1179,7 +1179,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3O22XX</pattern>
+        <pattern>[3-O]O[2-O][2-O]XX</pattern>
         <Harmony>
             <name>a5/g</name>
         </Harmony>
@@ -1208,7 +1208,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4O22XX</pattern>
+        <pattern>[4-O]O[2-O][2-O]XX</pattern>
         <Harmony>
             <name>a5/g#</name>
         </Harmony>
@@ -1237,7 +1237,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2X22XX</pattern>
+        <pattern>[2-O]X[2-O][2-O]XX</pattern>
         <Harmony>
             <name>a5/f#</name>
         </Harmony>
@@ -1267,7 +1267,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO224X</pattern>
+        <pattern>XO[2-O][2-O][4-O]X</pattern>
         <Harmony>
             <name>a5#4</name>
         </Harmony>
@@ -1287,7 +1287,7 @@
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO----</pattern>
+        <pattern>XO----;B2[2-5]</pattern>
         <Harmony>
             <name>a6</name>
         </Harmony>
@@ -1310,7 +1310,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO1---</pattern>
+        <pattern>XO[1-O]---;B2[3-5]</pattern>
         <Harmony>
             <name>a6(b5)</name>
         </Harmony>
@@ -1340,7 +1340,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO7677</pattern>
+        <pattern>XO[7-O][6-O][7-O][7-O]</pattern>
         <Harmony>
             <name>a69()</name>
         </Harmony>
@@ -1369,7 +1369,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO442O</pattern>
+        <pattern>XO[4-O][4-O][2-O]O</pattern>
         <Harmony>
             <name>a69</name>
         </Harmony>
@@ -1396,7 +1396,7 @@
                 <barre start="2" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>55--5X</pattern>
+        <pattern>[5-O][5-O]--[5-O]X;B4[2-3]</pattern>
         <Harmony>
             <name>a69sus4</name>
         </Harmony>
@@ -1413,7 +1413,7 @@
                 <barre start="1" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-----</pattern>
+        <pattern>X-----;B2[1-5]</pattern>
         <Harmony>
             <name>a6/b</name>
         </Harmony>
@@ -1443,7 +1443,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO7677</pattern>
+        <pattern>XO[7-O][6-O][7-O][7-O]</pattern>
         <Harmony>
             <name>a6(add2)</name>
         </Harmony>
@@ -1473,7 +1473,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4425X</pattern>
+        <pattern>X[4-O][4-O][2-O][5-O]X</pattern>
         <Harmony>
             <name>a6/c#</name>
         </Harmony>
@@ -1493,7 +1493,7 @@
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>OO----</pattern>
+        <pattern>OO----;B2[2-5]</pattern>
         <Harmony>
             <name>a6/e</name>
         </Harmony>
@@ -1513,7 +1513,7 @@
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO----</pattern>
+        <pattern>XO----;B2[2-5]</pattern>
         <Harmony>
             <name>a6/g</name>
         </Harmony>
@@ -1542,7 +1542,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO2O2O</pattern>
+        <pattern>XO[2-O]O[2-O]O</pattern>
         <Harmony>
             <name>a7</name>
         </Harmony>
@@ -1571,7 +1571,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO2O22</pattern>
+        <pattern>XO[2-O]O[2-O][2-O]</pattern>
         <Harmony>
             <name>a7(add13)</name>
         </Harmony>
@@ -1594,7 +1594,7 @@
                 <barre start="2" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X---X</pattern>
+        <pattern>[4-O]X---X;B2[2-4]</pattern>
         <Harmony>
             <name>a6/g#</name>
         </Harmony>
@@ -1624,7 +1624,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO563O</pattern>
+        <pattern>XO[5-O][6-O][3-O]O</pattern>
         <Harmony>
             <name>a7(add4)</name>
         </Harmony>
@@ -1653,7 +1653,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>1O2O2O</pattern>
+        <pattern>[1-O]O[2-O]O[2-O]O</pattern>
         <Harmony>
             <name>a7/f</name>
         </Harmony>
@@ -1682,7 +1682,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO2O21</pattern>
+        <pattern>XO[2-O]O[2-O][1-O]</pattern>
         <Harmony>
             <name>a7b13</name>
         </Harmony>
@@ -1711,7 +1711,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO1223</pattern>
+        <pattern>XO[1-O][2-O][2-O][3-O]</pattern>
         <Harmony>
             <name>a7b5</name>
         </Harmony>
@@ -1740,7 +1740,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO2343</pattern>
+        <pattern>XO[2-O][3-O][4-O][3-O]</pattern>
         <Harmony>
             <name>a7(b9b5no3)</name>
         </Harmony>
@@ -1769,7 +1769,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1O23</pattern>
+        <pattern>XX[1-O]O[2-O][3-O]</pattern>
         <Harmony>
             <name>a7b5/eb</name>
         </Harmony>
@@ -1799,7 +1799,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO5656</pattern>
+        <pattern>XO[5-O][6-O][5-O][6-O]</pattern>
         <Harmony>
             <name>a7b9</name>
         </Harmony>
@@ -1828,7 +1828,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO323</pattern>
+        <pattern>XXO[3-O][2-O][3-O]</pattern>
         <Harmony>
             <name>a7b9/d</name>
         </Harmony>
@@ -1852,7 +1852,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO5---</pattern>
+        <pattern>XO[5-O]---;B6[3-5]</pattern>
         <Harmony>
             <name>a7(b13b9)</name>
         </Harmony>
@@ -1875,7 +1875,7 @@
                 <barre start="1" end="3">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-----6</pattern>
+        <pattern>-----[6-O];B5[0-4];B6[1-3]</pattern>
         <Harmony>
             <name>a7(#11b9)</name>
         </Harmony>
@@ -1902,7 +1902,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X45-5-</pattern>
+        <pattern>X[4-O][5-O]-[5-O]-;B3[3-5]</pattern>
         <Harmony>
             <name>a7b9/c#</name>
         </Harmony>
@@ -1931,7 +1931,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO3323</pattern>
+        <pattern>XO[3-O][3-O][2-O][3-O]</pattern>
         <Harmony>
             <name>a7b9#5</name>
         </Harmony>
@@ -1954,7 +1954,7 @@
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO2---</pattern>
+        <pattern>XO[2-O]---;B3[3-5]</pattern>
         <Harmony>
             <name>a7b9sus4</name>
         </Harmony>
@@ -1981,7 +1981,7 @@
                 <barre start="2" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO--53</pattern>
+        <pattern>XO--[5-O][3-O];B2[2-3]</pattern>
         <Harmony>
             <name>a7(no3)</name>
         </Harmony>
@@ -2010,7 +2010,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>OO2323</pattern>
+        <pattern>OO[2-O][3-O][2-O][3-O]</pattern>
         <Harmony>
             <name>a7b9/e</name>
         </Harmony>
@@ -2030,7 +2030,7 @@
                 <barre start="1" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X----3</pattern>
+        <pattern>X----[3-O];B2[1-4]</pattern>
         <Harmony>
             <name>a7/b</name>
         </Harmony>
@@ -2060,7 +2060,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO5646</pattern>
+        <pattern>XO[5-O][6-O][4-O][6-O]</pattern>
         <Harmony>
             <name>a7(b9b5)</name>
         </Harmony>
@@ -2089,7 +2089,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X12O2O</pattern>
+        <pattern>X[1-O][2-O]O[2-O]O</pattern>
         <Harmony>
             <name>a7/bb</name>
         </Harmony>
@@ -2112,7 +2112,7 @@
                 <barre start="2" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4---3</pattern>
+        <pattern>X[4-O]---[3-O];B2[2-4]</pattern>
         <Harmony>
             <name>a7/c#</name>
         </Harmony>
@@ -2138,7 +2138,7 @@
                 <barre start="3" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO--3</pattern>
+        <pattern>XXO--[3-O];B2[3-4]</pattern>
         <Harmony>
             <name>a7/d</name>
         </Harmony>
@@ -2167,7 +2167,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>OO2O2O</pattern>
+        <pattern>OO[2-O]O[2-O]O</pattern>
         <Harmony>
             <name>a7/e</name>
         </Harmony>
@@ -2196,7 +2196,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1O2O</pattern>
+        <pattern>XX[1-O]O[2-O]O</pattern>
         <Harmony>
             <name>a7/eb</name>
         </Harmony>
@@ -2225,7 +2225,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2O2O2O</pattern>
+        <pattern>[2-O]O[2-O]O[2-O]O</pattern>
         <Harmony>
             <name>a7/f#</name>
         </Harmony>
@@ -2254,7 +2254,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3O2O2O</pattern>
+        <pattern>[3-O]O[2-O]O[2-O]O</pattern>
         <Harmony>
             <name>a7/g</name>
         </Harmony>
@@ -2283,7 +2283,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO1O23</pattern>
+        <pattern>XO[1-O]O[2-O][3-O]</pattern>
         <Harmony>
             <name>a7#11</name>
         </Harmony>
@@ -2312,7 +2312,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO3O21</pattern>
+        <pattern>XO[3-O]O[2-O][1-O]</pattern>
         <Harmony>
             <name>a7#5</name>
         </Harmony>
@@ -2336,7 +2336,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO5---</pattern>
+        <pattern>XO[5-O]---;B6[3-5]</pattern>
         <Harmony>
             <name>a7(b9#5)</name>
         </Harmony>
@@ -2365,7 +2365,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXXO21</pattern>
+        <pattern>XXXO[2-O][1-O]</pattern>
         <Harmony>
             <name>a7#5/g</name>
         </Harmony>
@@ -2395,7 +2395,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4566X</pattern>
+        <pattern>X[4-O][5-O][6-O][6-O]X</pattern>
         <Harmony>
             <name>a7#5/c#</name>
         </Harmony>
@@ -2422,7 +2422,7 @@
                 <barre start="3" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO5--8</pattern>
+        <pattern>XO[5-O]--[8-O];B6[3-4]</pattern>
         <Harmony>
             <name>a7(#9#5)</name>
         </Harmony>
@@ -2452,7 +2452,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4566X</pattern>
+        <pattern>X[4-O][5-O][6-O][6-O]X</pattern>
         <Harmony>
             <name>a7#5/c#</name>
         </Harmony>
@@ -2481,7 +2481,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XOOO21</pattern>
+        <pattern>XOOO[2-O][1-O]</pattern>
         <Harmony>
             <name>a7#5sus4</name>
         </Harmony>
@@ -2511,7 +2511,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO7688</pattern>
+        <pattern>XO[7-O][6-O][8-O][8-O]</pattern>
         <Harmony>
             <name>a7#9</name>
         </Harmony>
@@ -2538,7 +2538,7 @@
                 <barre start="3" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO5--8</pattern>
+        <pattern>XO[5-O]--[8-O];B6[3-4]</pattern>
         <Harmony>
             <name>a7(b13#9)</name>
         </Harmony>
@@ -2565,7 +2565,7 @@
                 <barre start="3" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO5--8</pattern>
+        <pattern>XO[5-O]--[8-O];B6[3-4]</pattern>
         <Harmony>
             <name>a7(#9#5)</name>
         </Harmony>
@@ -2595,7 +2595,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X12111213X</pattern>
+        <pattern>X[12-O][11-O][12-O][13-O]X</pattern>
         <Harmony>
             <name>a7#9/e</name>
         </Harmony>
@@ -2621,7 +2621,7 @@
                 <barre start="2" end="3">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO--33</pattern>
+        <pattern>XO--[3-O][3-O];B2[2-3]</pattern>
         <Harmony>
             <name>a7sus4</name>
         </Harmony>
@@ -2650,7 +2650,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X22O3O</pattern>
+        <pattern>X[2-O][2-O]O[3-O]O</pattern>
         <Harmony>
             <name>a7sus4/b</name>
         </Harmony>
@@ -2679,7 +2679,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X42O3O</pattern>
+        <pattern>X[4-O][2-O]O[3-O]O</pattern>
         <Harmony>
             <name>a7sus4/c#</name>
         </Harmony>
@@ -2709,7 +2709,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO253</pattern>
+        <pattern>XXO[2-O][5-O][3-O]</pattern>
         <Harmony>
             <name>a7sus4/d</name>
         </Harmony>
@@ -2738,7 +2738,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>OO2O3O</pattern>
+        <pattern>OO[2-O]O[3-O]O</pattern>
         <Harmony>
             <name>a7sus4/e</name>
         </Harmony>
@@ -2767,7 +2767,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X42OOO</pattern>
+        <pattern>X[4-O][2-O]OOO</pattern>
         <Harmony>
             <name>a9</name>
         </Harmony>
@@ -2796,7 +2796,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XOO423</pattern>
+        <pattern>XOO[4-O][2-O][3-O]</pattern>
         <Harmony>
             <name>a9(add4)</name>
         </Harmony>
@@ -2826,7 +2826,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO5667</pattern>
+        <pattern>XO[5-O][6-O][6-O][7-O]</pattern>
         <Harmony>
             <name>a9b13</name>
         </Harmony>
@@ -2856,7 +2856,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO5647</pattern>
+        <pattern>XO[5-O][6-O][4-O][7-O]</pattern>
         <Harmony>
             <name>a9b5</name>
         </Harmony>
@@ -2885,7 +2885,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X42OOO</pattern>
+        <pattern>X[4-O][2-O]OOO</pattern>
         <Harmony>
             <name>a9/c#</name>
         </Harmony>
@@ -2915,7 +2915,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X556OO</pattern>
+        <pattern>X[5-O][5-O][6-O]OO</pattern>
         <Harmony>
             <name>a9/d</name>
         </Harmony>
@@ -2945,7 +2945,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X756OO</pattern>
+        <pattern>X[7-O][5-O][6-O]OO</pattern>
         <Harmony>
             <name>a9/e</name>
         </Harmony>
@@ -2975,7 +2975,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX56OO</pattern>
+        <pattern>XX[5-O][6-O]OO</pattern>
         <Harmony>
             <name>a9/g</name>
         </Harmony>
@@ -2999,7 +2999,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>5-5--5</pattern>
+        <pattern>[5-O]-[5-O]--[5-O];B4[1-4]</pattern>
         <Harmony>
             <name>a9#11</name>
         </Harmony>
@@ -3026,7 +3026,7 @@
                 <barre start="3" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO5--7</pattern>
+        <pattern>XO[5-O]--[7-O];B6[3-4]</pattern>
         <Harmony>
             <name>a9#5</name>
         </Harmony>
@@ -3055,7 +3055,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO2433</pattern>
+        <pattern>XO[2-O][4-O][3-O][3-O]</pattern>
         <Harmony>
             <name>a9sus4</name>
         </Harmony>
@@ -3079,7 +3079,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--7-7</pattern>
+        <pattern>X--[7-O]-[7-O];B5[1-4]</pattern>
         <Harmony>
             <name>a9sus4/d</name>
         </Harmony>
@@ -3108,7 +3108,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO242O</pattern>
+        <pattern>XO[2-O][4-O][2-O]O</pattern>
         <Harmony>
             <name>aadd2</name>
         </Harmony>
@@ -3138,7 +3138,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>7776OO</pattern>
+        <pattern>[7-O][7-O][7-O][6-O]OO</pattern>
         <Harmony>
             <name>aadd2/b</name>
         </Harmony>
@@ -3168,7 +3168,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X476OO</pattern>
+        <pattern>X[4-O][7-O][6-O]OO</pattern>
         <Harmony>
             <name>aadd2/c#</name>
         </Harmony>
@@ -3198,7 +3198,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X576OO</pattern>
+        <pattern>X[5-O][7-O][6-O]OO</pattern>
         <Harmony>
             <name>aadd2/d</name>
         </Harmony>
@@ -3228,7 +3228,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O776OO</pattern>
+        <pattern>O[7-O][7-O][6-O]OO</pattern>
         <Harmony>
             <name>aadd2/e</name>
         </Harmony>
@@ -3254,7 +3254,7 @@
                 <barre start="2" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3O-4-X</pattern>
+        <pattern>[3-O]O-[4-O]-X;B2[2-4]</pattern>
         <Harmony>
             <name>aadd2/g</name>
         </Harmony>
@@ -3280,7 +3280,7 @@
                 <barre start="2" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4O-4-X</pattern>
+        <pattern>[4-O]O-[4-O]-X;B2[2-4]</pattern>
         <Harmony>
             <name>aadd2/g#</name>
         </Harmony>
@@ -3309,7 +3309,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XOO22O</pattern>
+        <pattern>XOO[2-O][2-O]O</pattern>
         <Harmony>
             <name>aadd4</name>
         </Harmony>
@@ -3335,7 +3335,7 @@
                 <barre start="3" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4O--X</pattern>
+        <pattern>X[4-O]O--X;B2[3-4]</pattern>
         <Harmony>
             <name>aadd4/c#</name>
         </Harmony>
@@ -3364,7 +3364,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO242O</pattern>
+        <pattern>XO[2-O][4-O][2-O]O</pattern>
         <Harmony>
             <name>aadd9</name>
         </Harmony>
@@ -3391,7 +3391,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO-5-O</pattern>
+        <pattern>XO-[5-O]-O;B2[2-4]</pattern>
         <Harmony>
             <name>a(#9)</name>
         </Harmony>
@@ -3418,7 +3418,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO-5-O</pattern>
+        <pattern>XO-[5-O]-O;B2[2-4]</pattern>
         <Harmony>
             <name>a(#9)</name>
         </Harmony>
@@ -3448,7 +3448,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>7776OO</pattern>
+        <pattern>[7-O][7-O][7-O][6-O]OO</pattern>
         <Harmony>
             <name>aadd9/b</name>
         </Harmony>
@@ -3478,7 +3478,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X476OO</pattern>
+        <pattern>X[4-O][7-O][6-O]OO</pattern>
         <Harmony>
             <name>aadd9/c#</name>
         </Harmony>
@@ -3508,7 +3508,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O776OO</pattern>
+        <pattern>O[7-O][7-O][6-O]OO</pattern>
         <Harmony>
             <name>aadd9/e</name>
         </Harmony>
@@ -3534,7 +3534,7 @@
                 <barre start="2" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4O-4-X</pattern>
+        <pattern>[4-O]O-[4-O]-X;B2[2-4]</pattern>
         <Harmony>
             <name>aadd9/g#</name>
         </Harmony>
@@ -3560,7 +3560,7 @@
                 <barre start="2" end="3">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO--4X</pattern>
+        <pattern>XO--[4-O]X;B2[2-3]</pattern>
         <Harmony>
             <name>a(#4)</name>
         </Harmony>
@@ -3589,7 +3589,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO121X</pattern>
+        <pattern>XO[1-O][2-O][1-O]X</pattern>
         <Harmony>
             <name>adim</name>
         </Harmony>
@@ -3618,7 +3618,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO1212</pattern>
+        <pattern>XO[1-O][2-O][1-O][2-O]</pattern>
         <Harmony>
             <name>adim7</name>
         </Harmony>
@@ -3641,7 +3641,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--2-2</pattern>
+        <pattern>X--[2-O]-[2-O];B1[1-4]</pattern>
         <Harmony>
             <name>adim7/bb</name>
         </Harmony>
@@ -3670,7 +3670,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3424X</pattern>
+        <pattern>X[3-O][4-O][2-O][4-O]X</pattern>
         <Harmony>
             <name>adim7/c</name>
         </Harmony>
@@ -3699,7 +3699,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1212</pattern>
+        <pattern>XX[1-O][2-O][1-O][2-O]</pattern>
         <Harmony>
             <name>adim7/d#</name>
         </Harmony>
@@ -3728,7 +3728,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>OO1212</pattern>
+        <pattern>OO[1-O][2-O][1-O][2-O]</pattern>
         <Harmony>
             <name>adim7/e</name>
         </Harmony>
@@ -3757,7 +3757,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1212</pattern>
+        <pattern>XX[1-O][2-O][1-O][2-O]</pattern>
         <Harmony>
             <name>adim7/eb</name>
         </Harmony>
@@ -3787,7 +3787,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX5545</pattern>
+        <pattern>XX[5-O][5-O][4-O][5-O]</pattern>
         <Harmony>
             <name>adim7/g</name>
         </Harmony>
@@ -3817,7 +3817,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX5545</pattern>
+        <pattern>XX[5-O][5-O][4-O][5-O]</pattern>
         <Harmony>
             <name>adim/g</name>
         </Harmony>
@@ -3846,7 +3846,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3121X</pattern>
+        <pattern>X[3-O][1-O][2-O][1-O]X</pattern>
         <Harmony>
             <name>adim/c</name>
         </Harmony>
@@ -3876,7 +3876,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X5X545</pattern>
+        <pattern>X[5-O]X[5-O][4-O][5-O]</pattern>
         <Harmony>
             <name>adim/d</name>
         </Harmony>
@@ -3905,7 +3905,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>OO121X</pattern>
+        <pattern>OO[1-O][2-O][1-O]X</pattern>
         <Harmony>
             <name>adim/e</name>
         </Harmony>
@@ -3934,7 +3934,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX121X</pattern>
+        <pattern>XX[1-O][2-O][1-O]X</pattern>
         <Harmony>
             <name>adim/eb</name>
         </Harmony>
@@ -3958,7 +3958,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-665--</pattern>
+        <pattern>-[6-O][6-O][5-O]--;B4[0-5]</pattern>
         <Harmony>
             <name>ab</name>
         </Harmony>
@@ -3987,7 +3987,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X432X</pattern>
+        <pattern>[4-O]X[4-O][3-O][2-O]X</pattern>
         <Harmony>
             <name>ab11</name>
         </Harmony>
@@ -4017,7 +4017,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X456X</pattern>
+        <pattern>[4-O]X[4-O][5-O][6-O]X</pattern>
         <Harmony>
             <name>ab13</name>
         </Harmony>
@@ -4044,7 +4044,7 @@
                 <barre start="0" end="2">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-5-56X</pattern>
+        <pattern>-[5-O]-[5-O][6-O]X;B4[0-2]</pattern>
         <Harmony>
             <name>ab13#11</name>
         </Harmony>
@@ -4073,7 +4073,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4331</pattern>
+        <pattern>XX[4-O][3-O][3-O][1-O]</pattern>
         <Harmony>
             <name>ab13b5</name>
         </Harmony>
@@ -4103,7 +4103,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4565</pattern>
+        <pattern>XX[4-O][5-O][6-O][5-O]</pattern>
         <Harmony>
             <name>ab13b9</name>
         </Harmony>
@@ -4130,7 +4130,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6-56-</pattern>
+        <pattern>X[6-O]-[5-O][6-O]-;B4[2-5]</pattern>
         <Harmony>
             <name>ab13/eb</name>
         </Harmony>
@@ -4160,7 +4160,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3455X</pattern>
+        <pattern>X[3-O][4-O][5-O][5-O]X</pattern>
         <Harmony>
             <name>ab13#5</name>
         </Harmony>
@@ -4184,7 +4184,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-6-66-</pattern>
+        <pattern>-[6-O]-[6-O][6-O]-;B4[0-5]</pattern>
         <Harmony>
             <name>ab13sus4</name>
         </Harmony>
@@ -4214,7 +4214,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>466XXX</pattern>
+        <pattern>[4-O][6-O][6-O]XXX</pattern>
         <Harmony>
             <name>ab5</name>
         </Harmony>
@@ -4237,7 +4237,7 @@
                 <barre start="1" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X---44</pattern>
+        <pattern>X---[4-O][4-O];B1[1-3]</pattern>
         <Harmony>
             <name>ab5/bb</name>
         </Harmony>
@@ -4267,7 +4267,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4567</pattern>
+        <pattern>XX[4-O][5-O][6-O][7-O]</pattern>
         <Harmony>
             <name>ab13#9</name>
         </Harmony>
@@ -4296,7 +4296,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X211XX</pattern>
+        <pattern>X[2-O][1-O][1-O]XX</pattern>
         <Harmony>
             <name>ab5</name>
         </Harmony>
@@ -4322,7 +4322,7 @@
                 <barre start="2" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2X--XX</pattern>
+        <pattern>[2-O]X--XX;B1[2-3]</pattern>
         <Harmony>
             <name>ab5/gb</name>
         </Harmony>
@@ -4352,7 +4352,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X354X</pattern>
+        <pattern>[4-O]X[3-O][5-O][4-O]X</pattern>
         <Harmony>
             <name>ab6</name>
         </Harmony>
@@ -4369,7 +4369,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-3----</pattern>
+        <pattern>-[3-O]----;B1[0-5]</pattern>
         <Harmony>
             <name>ab6/f</name>
         </Harmony>
@@ -4389,7 +4389,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X----</pattern>
+        <pattern>[3-O]X----;B1[2-5]</pattern>
         <Harmony>
             <name>ab6/g</name>
         </Harmony>
@@ -4412,7 +4412,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X-3--</pattern>
+        <pattern>[4-O]X-[3-O]--;B1[2-5]</pattern>
         <Harmony>
             <name>ab6add2</name>
         </Harmony>
@@ -4435,7 +4435,7 @@
                 <barre start="1" end="3">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4---44</pattern>
+        <pattern>[4-O]---[4-O][4-O];B3[1-3]</pattern>
         <Harmony>
             <name>ab69</name>
         </Harmony>
@@ -4458,7 +4458,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4-3--</pattern>
+        <pattern>X[4-O]-[3-O]--;B1[2-5]</pattern>
         <Harmony>
             <name>ab69/db</name>
         </Harmony>
@@ -4481,7 +4481,7 @@
                 <barre start="1" end="3">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X---44</pattern>
+        <pattern>X---[4-O][4-O];B3[1-3]</pattern>
         <Harmony>
             <name>ab69/c</name>
         </Harmony>
@@ -4504,7 +4504,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-3--</pattern>
+        <pattern>XX-[3-O]--;B1[2-5]</pattern>
         <Harmony>
             <name>ab69/eb</name>
         </Harmony>
@@ -4521,7 +4521,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-----</pattern>
+        <pattern>X-----;B1[1-5]</pattern>
         <Harmony>
             <name>ab6/bb</name>
         </Harmony>
@@ -4541,7 +4541,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3----</pattern>
+        <pattern>X[3-O]----;B1[2-5]</pattern>
         <Harmony>
             <name>ab6/c</name>
         </Harmony>
@@ -4561,7 +4561,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX----</pattern>
+        <pattern>XX----;B1[2-5]</pattern>
         <Harmony>
             <name>ab6/eb</name>
         </Harmony>
@@ -4588,7 +4588,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-56-</pattern>
+        <pattern>XX-[5-O][6-O]-;B4[2-5]</pattern>
         <Harmony>
             <name>ab6/gb</name>
         </Harmony>
@@ -4609,7 +4609,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-6-5--</pattern>
+        <pattern>-[6-O]-[5-O]--;B4[0-5]</pattern>
         <Harmony>
             <name>ab7</name>
         </Harmony>
@@ -4635,7 +4635,7 @@
                 <barre start="2" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX--42</pattern>
+        <pattern>XX--[4-O][2-O];B1[2-3]</pattern>
         <Harmony>
             <name>ab7(no3)</name>
         </Harmony>
@@ -4662,7 +4662,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-57-</pattern>
+        <pattern>XX-[5-O][7-O]-;B4[2-5]</pattern>
         <Harmony>
             <name>ab7(no5)</name>
         </Harmony>
@@ -4692,7 +4692,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X456X</pattern>
+        <pattern>[4-O]X[4-O][5-O][6-O]X</pattern>
         <Harmony>
             <name>ab7(add13)</name>
         </Harmony>
@@ -4722,7 +4722,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X455X</pattern>
+        <pattern>[4-O]X[4-O][5-O][5-O]X</pattern>
         <Harmony>
             <name>ab7(b13)</name>
         </Harmony>
@@ -4740,7 +4740,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>---5--</pattern>
+        <pattern>---[5-O]--;B4[0-5]</pattern>
         <Harmony>
             <name>ab7(add4)</name>
         </Harmony>
@@ -4767,7 +4767,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX45--</pattern>
+        <pattern>XX[4-O][5-O]--;B2[4-5]</pattern>
         <Harmony>
             <name>ab7(add4)/gb</name>
         </Harmony>
@@ -4797,7 +4797,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X453X</pattern>
+        <pattern>[4-O]X[4-O][5-O][3-O]X</pattern>
         <Harmony>
             <name>ab7b5</name>
         </Harmony>
@@ -4827,7 +4827,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X66575</pattern>
+        <pattern>X[6-O][6-O][5-O][7-O][5-O]</pattern>
         <Harmony>
             <name>ab7b9</name>
         </Harmony>
@@ -4851,7 +4851,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X4---</pattern>
+        <pattern>[4-O]X[4-O]---;B5[3-5]</pattern>
         <Harmony>
             <name>ab7(b13b9)</name>
         </Harmony>
@@ -4874,7 +4874,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO---2</pattern>
+        <pattern>XO---[2-O];B1[2-4]</pattern>
         <Harmony>
             <name>ab7/a</name>
         </Harmony>
@@ -4904,7 +4904,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4535</pattern>
+        <pattern>XX[4-O][5-O][3-O][5-O]</pattern>
         <Harmony>
             <name>ab7(#11b9)</name>
         </Harmony>
@@ -4924,7 +4924,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X----2</pattern>
+        <pattern>X----[2-O];B1[1-4]</pattern>
         <Harmony>
             <name>ab7/bb</name>
         </Harmony>
@@ -4947,7 +4947,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3---2</pattern>
+        <pattern>X[3-O]---[2-O];B1[2-4]</pattern>
         <Harmony>
             <name>ab7/c</name>
         </Harmony>
@@ -4971,7 +4971,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X5-5--</pattern>
+        <pattern>X[5-O]-[5-O]--;B4[2-5]</pattern>
         <Harmony>
             <name>ab7/d</name>
         </Harmony>
@@ -4994,7 +4994,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX---2</pattern>
+        <pattern>XX---[2-O];B1[2-4]</pattern>
         <Harmony>
             <name>ab7/eb</name>
         </Harmony>
@@ -5015,7 +5015,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--5--</pattern>
+        <pattern>X--[5-O]--;B4[1-5]</pattern>
         <Harmony>
             <name>ab7/db</name>
         </Harmony>
@@ -5039,7 +5039,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-5--</pattern>
+        <pattern>XX-[5-O]--;B4[2-5]</pattern>
         <Harmony>
             <name>ab7/f#</name>
         </Harmony>
@@ -5062,7 +5062,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>33---2</pattern>
+        <pattern>[3-O][3-O]---[2-O];B1[2-4]</pattern>
         <Harmony>
             <name>ab7/g</name>
         </Harmony>
@@ -5085,7 +5085,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2X---2</pattern>
+        <pattern>[2-O]X---[2-O];B1[2-4]</pattern>
         <Harmony>
             <name>ab7/gb</name>
         </Harmony>
@@ -5115,7 +5115,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X453X</pattern>
+        <pattern>[4-O]X[4-O][5-O][3-O]X</pattern>
         <Harmony>
             <name>ab7#11</name>
         </Harmony>
@@ -5145,7 +5145,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X453X</pattern>
+        <pattern>[4-O]X[4-O][5-O][3-O]X</pattern>
         <Harmony>
             <name>ab7#4</name>
         </Harmony>
@@ -5175,7 +5175,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X455X</pattern>
+        <pattern>[4-O]X[4-O][5-O][5-O]X</pattern>
         <Harmony>
             <name>ab7#5</name>
         </Harmony>
@@ -5199,7 +5199,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X4---</pattern>
+        <pattern>[4-O]X[4-O]---;B5[3-5]</pattern>
         <Harmony>
             <name>ab7(b9#5)</name>
         </Harmony>
@@ -5226,7 +5226,7 @@
                 <barre start="3" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X4--7</pattern>
+        <pattern>[4-O]X[4-O]--[7-O];B5[3-4]</pattern>
         <Harmony>
             <name>ab7(#9#5)</name>
         </Harmony>
@@ -5256,7 +5256,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X11101112X</pattern>
+        <pattern>X[11-O][10-O][11-O][12-O]X</pattern>
         <Harmony>
             <name>ab7#9</name>
         </Harmony>
@@ -5283,7 +5283,7 @@
                 <barre start="3" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X4--7</pattern>
+        <pattern>[4-O]X[4-O]--[7-O];B5[3-4]</pattern>
         <Harmony>
             <name>ab7(b13#9)</name>
         </Harmony>
@@ -5304,7 +5304,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--6--</pattern>
+        <pattern>X--[6-O]--;B4[1-5]</pattern>
         <Harmony>
             <name>ab7sus4/db</name>
         </Harmony>
@@ -5330,7 +5330,7 @@
                 <barre start="2" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX--22</pattern>
+        <pattern>XX--[2-O][2-O];B1[2-3]</pattern>
         <Harmony>
             <name>ab7sus4/eb</name>
         </Harmony>
@@ -5350,7 +5350,7 @@
                 <barre start="1" end="3">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>------</pattern>
+        <pattern>------;B4[0-5];B6[1-3]</pattern>
         <Harmony>
             <name>ab7sus4</name>
         </Harmony>
@@ -5373,7 +5373,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X4---</pattern>
+        <pattern>[4-O]X[4-O]---;B2[3-5]</pattern>
         <Harmony>
             <name>ab7b9sus4</name>
         </Harmony>
@@ -5397,7 +5397,7 @@
                 <barre start="0" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-6-5-6</pattern>
+        <pattern>-[6-O]-[5-O]-[6-O];B4[0-4]</pattern>
         <Harmony>
             <name>ab9</name>
         </Harmony>
@@ -5424,7 +5424,7 @@
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X45--</pattern>
+        <pattern>[4-O]X[4-O][5-O]--;B6[4-5]</pattern>
         <Harmony>
             <name>ab9(add13)</name>
         </Harmony>
@@ -5448,7 +5448,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>11X10---</pattern>
+        <pattern>[11-O]X[10-O]---;B11[3-5]</pattern>
         <Harmony>
             <name>ab9/eb</name>
         </Harmony>
@@ -5475,7 +5475,7 @@
                 <barre start="3" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X4--6</pattern>
+        <pattern>[4-O]X[4-O]--[6-O];B5[3-4]</pattern>
         <Harmony>
             <name>ab9b13</name>
         </Harmony>
@@ -5502,7 +5502,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X11-1111-</pattern>
+        <pattern>X[11-O]-[11-O][11-O]-;B10[2-5]</pattern>
         <Harmony>
             <name>ab9b5</name>
         </Harmony>
@@ -5529,7 +5529,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-87-</pattern>
+        <pattern>XX-[8-O][7-O]-;B6[2-5]</pattern>
         <Harmony>
             <name>ab9(no3)</name>
         </Harmony>
@@ -5558,7 +5558,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X434X</pattern>
+        <pattern>[4-O]X[4-O][3-O][4-O]X</pattern>
         <Harmony>
             <name>ab9(no3)</name>
         </Harmony>
@@ -5585,7 +5585,7 @@
                 <barre start="1" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-4-44</pattern>
+        <pattern>X-[4-O]-[4-O][4-O];B3[1-3]</pattern>
         <Harmony>
             <name>ab9/c</name>
         </Harmony>
@@ -5611,7 +5611,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2X-3-2</pattern>
+        <pattern>[2-O]X-[3-O]-[2-O];B1[2-4]</pattern>
         <Harmony>
             <name>ab9/gb</name>
         </Harmony>
@@ -5635,7 +5635,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--5-6</pattern>
+        <pattern>X--[5-O]-[6-O];B4[1-4]</pattern>
         <Harmony>
             <name>ab9/db</name>
         </Harmony>
@@ -5662,7 +5662,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X11-1111-</pattern>
+        <pattern>X[11-O]-[11-O][11-O]-;B10[2-5]</pattern>
         <Harmony>
             <name>ab9#11</name>
         </Harmony>
@@ -5689,7 +5689,7 @@
                 <barre start="3" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X4--6</pattern>
+        <pattern>[4-O]X[4-O]--[6-O];B5[3-4]</pattern>
         <Harmony>
             <name>ab9#5</name>
         </Harmony>
@@ -5712,7 +5712,7 @@
                 <barre start="1" end="3">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-----6</pattern>
+        <pattern>-----[6-O];B4[0-4];B6[1-3]</pattern>
         <Harmony>
             <name>ab9sus4</name>
         </Harmony>
@@ -5742,7 +5742,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX6546</pattern>
+        <pattern>XX[6-O][5-O][4-O][6-O]</pattern>
         <Harmony>
             <name>abadd9</name>
         </Harmony>
@@ -5772,7 +5772,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6X546</pattern>
+        <pattern>X[6-O]X[5-O][4-O][6-O]</pattern>
         <Harmony>
             <name>abadd9/eb</name>
         </Harmony>
@@ -5802,7 +5802,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX6546</pattern>
+        <pattern>XX[6-O][5-O][4-O][6-O]</pattern>
         <Harmony>
             <name>abadd2</name>
         </Harmony>
@@ -5822,7 +5822,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X----4</pattern>
+        <pattern>X----[4-O];B1[1-4]</pattern>
         <Harmony>
             <name>abadd2/bb</name>
         </Harmony>
@@ -5842,7 +5842,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X----4</pattern>
+        <pattern>X----[4-O];B1[1-4]</pattern>
         <Harmony>
             <name>abadd2/bb</name>
         </Harmony>
@@ -5865,7 +5865,7 @@
                 <barre start="1" end="4">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>--10---</pattern>
+        <pattern>--[10-O]---;B8[0-5];B11[1-4]</pattern>
         <Harmony>
             <name>abadd2/c</name>
         </Harmony>
@@ -5891,7 +5891,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O3-3-X</pattern>
+        <pattern>O[3-O]-[3-O]-X;B1[2-4]</pattern>
         <Harmony>
             <name>abadd2/e</name>
         </Harmony>
@@ -5917,7 +5917,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-3-4</pattern>
+        <pattern>XX-[3-O]-[4-O];B1[2-4]</pattern>
         <Harmony>
             <name>abadd2/eb</name>
         </Harmony>
@@ -5944,7 +5944,7 @@
                 <barre start="2" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX--98</pattern>
+        <pattern>XX--[9-O][8-O];B6[2-3]</pattern>
         <Harmony>
             <name>abadd4</name>
         </Harmony>
@@ -5974,7 +5974,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4524</pattern>
+        <pattern>XX[4-O][5-O][2-O][4-O]</pattern>
         <Harmony>
             <name>abadd4/gb</name>
         </Harmony>
@@ -6004,7 +6004,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4667XX</pattern>
+        <pattern>[4-O][6-O][6-O][7-O]XX</pattern>
         <Harmony>
             <name>ab(#4)</name>
         </Harmony>
@@ -6027,7 +6027,7 @@
                 <barre start="1" end="4">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>--10---</pattern>
+        <pattern>--[10-O]---;B8[0-5];B11[1-4]</pattern>
         <Harmony>
             <name>abadd9/c</name>
         </Harmony>
@@ -6053,7 +6053,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X-3-X</pattern>
+        <pattern>[3-O]X-[3-O]-X;B1[2-4]</pattern>
         <Harmony>
             <name>abadd9/g</name>
         </Harmony>
@@ -6079,7 +6079,7 @@
                 <barre start="2" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX--34</pattern>
+        <pattern>XX--[3-O][4-O];B1[2-3]</pattern>
         <Harmony>
             <name>ab(#4)/eb</name>
         </Harmony>
@@ -6109,7 +6109,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXX434</pattern>
+        <pattern>XXX[4-O][3-O][4-O]</pattern>
         <Harmony>
             <name>abdim</name>
         </Harmony>
@@ -6139,7 +6139,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>8667XX</pattern>
+        <pattern>[8-O][6-O][6-O][7-O]XX</pattern>
         <Harmony>
             <name>ab(#4)/c</name>
         </Harmony>
@@ -6168,7 +6168,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO1O1</pattern>
+        <pattern>XXO[1-O]O[1-O]</pattern>
         <Harmony>
             <name>abdim7</name>
         </Harmony>
@@ -6191,7 +6191,7 @@
                 <barre start="1" end="4">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--4-4</pattern>
+        <pattern>X--[4-O]-[4-O];B3[1-4]</pattern>
         <Harmony>
             <name>abdim7/c</name>
         </Harmony>
@@ -6220,7 +6220,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3XO1O1</pattern>
+        <pattern>[3-O]XO[1-O]O[1-O]</pattern>
         <Harmony>
             <name>abdim7/g</name>
         </Harmony>
@@ -6249,7 +6249,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2O1O1</pattern>
+        <pattern>X[2-O]O[1-O]O[1-O]</pattern>
         <Harmony>
             <name>abdim/b</name>
         </Harmony>
@@ -6278,7 +6278,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1O1O1</pattern>
+        <pattern>X[1-O]O[1-O]O[1-O]</pattern>
         <Harmony>
             <name>abdim7/bb</name>
         </Harmony>
@@ -6307,7 +6307,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2O1O1</pattern>
+        <pattern>X[2-O]O[1-O]O[1-O]</pattern>
         <Harmony>
             <name>abdim</name>
         </Harmony>
@@ -6331,7 +6331,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--7-7</pattern>
+        <pattern>X--[7-O]-[7-O];B6[1-4]</pattern>
         <Harmony>
             <name>abdim7/eb</name>
         </Harmony>
@@ -6361,7 +6361,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX653X</pattern>
+        <pattern>XX[6-O][5-O][3-O]X</pattern>
         <Harmony>
             <name>ab(b5)</name>
         </Harmony>
@@ -6382,7 +6382,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-66---</pattern>
+        <pattern>-[6-O][6-O]---;B4[0-5]</pattern>
         <Harmony>
             <name>abm</name>
         </Harmony>
@@ -6400,7 +6400,7 @@
                 <barre start="0" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-----6</pattern>
+        <pattern>-----[6-O];B4[0-4]</pattern>
         <Harmony>
             <name>abm11</name>
         </Harmony>
@@ -6430,7 +6430,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X3446</pattern>
+        <pattern>[4-O]X[3-O][4-O][4-O][6-O]</pattern>
         <Harmony>
             <name>abm13</name>
         </Harmony>
@@ -6453,7 +6453,7 @@
                 <barre start="2" end="4">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-6----</pattern>
+        <pattern>-[6-O]----;B4[0-5];B6[2-4]</pattern>
         <Harmony>
             <name>abm6</name>
         </Harmony>
@@ -6479,7 +6479,7 @@
                 <barre start="4" end="5">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X233--</pattern>
+        <pattern>X[2-O][3-O][3-O]--;B4[4-5]</pattern>
         <Harmony>
             <name>abm69</name>
         </Harmony>
@@ -6509,7 +6509,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX6466</pattern>
+        <pattern>XX[6-O][4-O][6-O][6-O]</pattern>
         <Harmony>
             <name>abm69</name>
         </Harmony>
@@ -6539,7 +6539,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6553X</pattern>
+        <pattern>X[6-O][5-O][5-O][3-O]X</pattern>
         <Harmony>
             <name>abm7(add4)/eb</name>
         </Harmony>
@@ -6566,7 +6566,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>6X6-6-</pattern>
+        <pattern>[6-O]X[6-O]-[6-O]-;B4[3-5]</pattern>
         <Harmony>
             <name>abm6/bb</name>
         </Harmony>
@@ -6589,7 +6589,7 @@
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X33---</pattern>
+        <pattern>X[3-O][3-O]---;B4[3-5]</pattern>
         <Harmony>
             <name>abm6/c</name>
         </Harmony>
@@ -6612,7 +6612,7 @@
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X23---</pattern>
+        <pattern>X[2-O][3-O]---;B4[3-5]</pattern>
         <Harmony>
             <name>abm6</name>
         </Harmony>
@@ -6639,7 +6639,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6X-6-</pattern>
+        <pattern>X[6-O]X-[6-O]-;B4[3-5]</pattern>
         <Harmony>
             <name>abm6/eb</name>
         </Harmony>
@@ -6662,7 +6662,7 @@
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3---</pattern>
+        <pattern>XX[3-O]---;B4[3-5]</pattern>
         <Harmony>
             <name>abm6/f</name>
         </Harmony>
@@ -6680,7 +6680,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-6----</pattern>
+        <pattern>-[6-O]----;B4[0-5]</pattern>
         <Harmony>
             <name>abm7</name>
         </Harmony>
@@ -6709,7 +6709,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X442X</pattern>
+        <pattern>[4-O]X[4-O][4-O][2-O]X</pattern>
         <Harmony>
             <name>abm7(add4)</name>
         </Harmony>
@@ -6738,7 +6738,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X443X</pattern>
+        <pattern>[4-O]X[4-O][4-O][3-O]X</pattern>
         <Harmony>
             <name>abm7b5</name>
         </Harmony>
@@ -6767,7 +6767,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4443X</pattern>
+        <pattern>X[4-O][4-O][4-O][3-O]X</pattern>
         <Harmony>
             <name>abm7b5/db</name>
         </Harmony>
@@ -6785,7 +6785,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-----</pattern>
+        <pattern>X-----;B4[1-5]</pattern>
         <Harmony>
             <name>abm7/db</name>
         </Harmony>
@@ -6812,7 +6812,7 @@
                 <barre start="3" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX6--6</pattern>
+        <pattern>XX[6-O]--[6-O];B4[3-4]</pattern>
         <Harmony>
             <name>abm(add2)</name>
         </Harmony>
@@ -6833,7 +6833,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX----</pattern>
+        <pattern>XX----;B4[2-5]</pattern>
         <Harmony>
             <name>abm7/gb</name>
         </Harmony>
@@ -6854,7 +6854,7 @@
                 <barre start="0" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-6---6</pattern>
+        <pattern>-[6-O]---[6-O];B4[0-4]</pattern>
         <Harmony>
             <name>abm9</name>
         </Harmony>
@@ -6878,7 +6878,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>6X---6</pattern>
+        <pattern>[6-O]X---[6-O];B4[2-4]</pattern>
         <Harmony>
             <name>abm9/bb</name>
         </Harmony>
@@ -6899,7 +6899,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X----6</pattern>
+        <pattern>X----[6-O];B4[1-4]</pattern>
         <Harmony>
             <name>abm9/db</name>
         </Harmony>
@@ -6923,7 +6923,7 @@
                 <barre start="0" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-66--6</pattern>
+        <pattern>-[6-O][6-O]--[6-O];B4[0-4]</pattern>
         <Harmony>
             <name>abm(add9)</name>
         </Harmony>
@@ -6950,7 +6950,7 @@
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X55--</pattern>
+        <pattern>[4-O]X[5-O][5-O]--;B6[4-5]</pattern>
         <Harmony>
             <name>abmaj13</name>
         </Harmony>
@@ -6980,7 +6980,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6553X</pattern>
+        <pattern>X[6-O][5-O][5-O][3-O]X</pattern>
         <Harmony>
             <name>abm7(add4)/eb</name>
         </Harmony>
@@ -7006,7 +7006,7 @@
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4-2-</pattern>
+        <pattern>XX[4-O]-[2-O]-;B4[3-5]</pattern>
         <Harmony>
             <name>abm(add4)/gb</name>
         </Harmony>
@@ -7029,7 +7029,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX---3</pattern>
+        <pattern>XX---[3-O];B1[2-4]</pattern>
         <Harmony>
             <name>abmaj7</name>
         </Harmony>
@@ -7056,7 +7056,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX65--</pattern>
+        <pattern>XX[6-O][5-O]--;B3[4-5]</pattern>
         <Harmony>
             <name>abmaj7b5</name>
         </Harmony>
@@ -7083,7 +7083,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X565--</pattern>
+        <pattern>X[5-O][6-O][5-O]--;B3[4-5]</pattern>
         <Harmony>
             <name>abmaj7b5/d</name>
         </Harmony>
@@ -7109,7 +7109,7 @@
                 <barre start="2" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX--43</pattern>
+        <pattern>XX--[4-O][3-O];B1[2-3]</pattern>
         <Harmony>
             <name>abmaj7(no3)</name>
         </Harmony>
@@ -7129,7 +7129,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X----3</pattern>
+        <pattern>X----[3-O];B1[1-4]</pattern>
         <Harmony>
             <name>abmaj7/bb</name>
         </Harmony>
@@ -7152,7 +7152,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3---3</pattern>
+        <pattern>X[3-O]---[3-O];B1[2-4]</pattern>
         <Harmony>
             <name>abmaj7/c</name>
         </Harmony>
@@ -7182,7 +7182,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4554X</pattern>
+        <pattern>X[4-O][5-O][5-O][4-O]X</pattern>
         <Harmony>
             <name>abmaj7/db</name>
         </Harmony>
@@ -7212,7 +7212,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6554X</pattern>
+        <pattern>X[6-O][5-O][5-O][4-O]X</pattern>
         <Harmony>
             <name>abmaj7/eb</name>
         </Harmony>
@@ -7235,7 +7235,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X---3</pattern>
+        <pattern>[3-O]X---[3-O];B1[2-4]</pattern>
         <Harmony>
             <name>abmaj7/g</name>
         </Harmony>
@@ -7262,7 +7262,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX65--</pattern>
+        <pattern>XX[6-O][5-O]--;B3[4-5]</pattern>
         <Harmony>
             <name>abmaj7#11</name>
         </Harmony>
@@ -7292,7 +7292,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X555X</pattern>
+        <pattern>[4-O]X[5-O][5-O][5-O]X</pattern>
         <Harmony>
             <name>abmaj7#5</name>
         </Harmony>
@@ -7318,7 +7318,7 @@
                 <barre start="3" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X32--3</pattern>
+        <pattern>X[3-O][2-O]--[3-O];B1[3-4]</pattern>
         <Harmony>
             <name>abmaj7#5/c</name>
         </Harmony>
@@ -7348,7 +7348,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X534X</pattern>
+        <pattern>[4-O]X[5-O][3-O][4-O]X</pattern>
         <Harmony>
             <name>abmaj9</name>
         </Harmony>
@@ -7374,7 +7374,7 @@
                 <barre start="2" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX--43</pattern>
+        <pattern>XX--[4-O][3-O];B1[2-3]</pattern>
         <Harmony>
             <name>abmaj9(no3)</name>
         </Harmony>
@@ -7397,7 +7397,7 @@
                 <barre start="1" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X---43</pattern>
+        <pattern>X---[4-O][3-O];B1[1-3]</pattern>
         <Harmony>
             <name>abmaj9(no3)/bb</name>
         </Harmony>
@@ -7417,7 +7417,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X----3</pattern>
+        <pattern>X----[3-O];B1[1-4]</pattern>
         <Harmony>
             <name>abmaj9/bb</name>
         </Harmony>
@@ -7447,7 +7447,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX5546</pattern>
+        <pattern>XX[5-O][5-O][4-O][6-O]</pattern>
         <Harmony>
             <name>abmaj9/g</name>
         </Harmony>
@@ -7473,7 +7473,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3-3-3</pattern>
+        <pattern>X[3-O]-[3-O]-[3-O];B1[2-4]</pattern>
         <Harmony>
             <name>abmaj9/c</name>
         </Harmony>
@@ -7500,7 +7500,7 @@
                 <barre start="3" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X5--X</pattern>
+        <pattern>[4-O]X[5-O]--X;B3[3-4]</pattern>
         <Harmony>
             <name>abmaj9#11</name>
         </Harmony>
@@ -7530,7 +7530,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX6443</pattern>
+        <pattern>XX[6-O][4-O][4-O][3-O]</pattern>
         <Harmony>
             <name>abm(#7)</name>
         </Harmony>
@@ -7557,7 +7557,7 @@
                 <barre start="3" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX5--6</pattern>
+        <pattern>XX[5-O]--[6-O];B4[3-4]</pattern>
         <Harmony>
             <name>abm(add9)</name>
         </Harmony>
@@ -7581,7 +7581,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXX---</pattern>
+        <pattern>XXX---;B4[3-5]</pattern>
         <Harmony>
             <name>abm/b</name>
         </Harmony>
@@ -7605,7 +7605,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>6X6---</pattern>
+        <pattern>[6-O]X[6-O]---;B4[3-5]</pattern>
         <Harmony>
             <name>abm/bb</name>
         </Harmony>
@@ -7629,7 +7629,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXX---</pattern>
+        <pattern>XXX---;B4[3-5]</pattern>
         <Harmony>
             <name>abm</name>
         </Harmony>
@@ -7653,7 +7653,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3X---</pattern>
+        <pattern>X[3-O]X---;B4[3-5]</pattern>
         <Harmony>
             <name>abm/c</name>
         </Harmony>
@@ -7674,7 +7674,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-6---</pattern>
+        <pattern>X-[6-O]---;B4[1-5]</pattern>
         <Harmony>
             <name>abm/db</name>
         </Harmony>
@@ -7697,7 +7697,7 @@
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX2---</pattern>
+        <pattern>XX[2-O]---;B4[3-5]</pattern>
         <Harmony>
             <name>abm/e</name>
         </Harmony>
@@ -7721,7 +7721,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X66---</pattern>
+        <pattern>X[6-O][6-O]---;B4[3-5]</pattern>
         <Harmony>
             <name>abm/eb</name>
         </Harmony>
@@ -7744,7 +7744,7 @@
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3---</pattern>
+        <pattern>XX[3-O]---;B4[3-5]</pattern>
         <Harmony>
             <name>abm/f</name>
         </Harmony>
@@ -7765,7 +7765,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX----</pattern>
+        <pattern>XX----;B4[2-5]</pattern>
         <Harmony>
             <name>abm/gb</name>
         </Harmony>
@@ -7792,7 +7792,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX6-5-</pattern>
+        <pattern>XX[6-O]-[5-O]-;B4[3-5]</pattern>
         <Harmony>
             <name>abm(#5)</name>
         </Harmony>
@@ -7819,7 +7819,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO65--</pattern>
+        <pattern>XO[6-O][5-O]--;B4[4-5]</pattern>
         <Harmony>
             <name>ab/a</name>
         </Harmony>
@@ -7846,7 +7846,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>6X65--</pattern>
+        <pattern>[6-O]X[6-O][5-O]--;B4[4-5]</pattern>
         <Harmony>
             <name>ab/bb</name>
         </Harmony>
@@ -7869,7 +7869,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3---X</pattern>
+        <pattern>X[3-O]---X;B1[2-4]</pattern>
         <Harmony>
             <name>ab/c</name>
         </Harmony>
@@ -7893,7 +7893,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-65--</pattern>
+        <pattern>X-[6-O][5-O]--;B4[1-5]</pattern>
         <Harmony>
             <name>ab/db</name>
         </Harmony>
@@ -7920,7 +7920,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO5--</pattern>
+        <pattern>XXO[5-O]--;B4[4-5]</pattern>
         <Harmony>
             <name>ab/d</name>
         </Harmony>
@@ -7947,7 +7947,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O765--</pattern>
+        <pattern>O[7-O][6-O][5-O]--;B4[4-5]</pattern>
         <Harmony>
             <name>ab/e</name>
         </Harmony>
@@ -7974,7 +7974,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O765--</pattern>
+        <pattern>O[7-O][6-O][5-O]--;B4[4-5]</pattern>
         <Harmony>
             <name>ab/fb</name>
         </Harmony>
@@ -7997,7 +7997,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX---4</pattern>
+        <pattern>XX---[4-O];B1[2-4]</pattern>
         <Harmony>
             <name>ab/eb</name>
         </Harmony>
@@ -8026,7 +8026,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>1X111X</pattern>
+        <pattern>[1-O]X[1-O][1-O][1-O]X</pattern>
         <Harmony>
             <name>ab/f</name>
         </Harmony>
@@ -8049,7 +8049,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X---X</pattern>
+        <pattern>[3-O]X---X;B1[2-4]</pattern>
         <Harmony>
             <name>ab/g</name>
         </Harmony>
@@ -8073,7 +8073,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-5--</pattern>
+        <pattern>XX-[5-O]--;B4[2-5]</pattern>
         <Harmony>
             <name>ab/gb</name>
         </Harmony>
@@ -8103,7 +8103,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX6554</pattern>
+        <pattern>XX[6-O][5-O][5-O][4-O]</pattern>
         <Harmony>
             <name>ab+</name>
         </Harmony>
@@ -8132,7 +8132,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX211O</pattern>
+        <pattern>XX[2-O][1-O][1-O]O</pattern>
         <Harmony>
             <name>ab+/e</name>
         </Harmony>
@@ -8158,7 +8158,7 @@
                 <barre start="3" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>332--X</pattern>
+        <pattern>[3-O][3-O][2-O]--X;B1[3-4]</pattern>
         <Harmony>
             <name>ab+/g</name>
         </Harmony>
@@ -8184,7 +8184,7 @@
                 <barre start="3" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2X2--X</pattern>
+        <pattern>[2-O]X[2-O]--X;B1[3-4]</pattern>
         <Harmony>
             <name>ab+/gb</name>
         </Harmony>
@@ -8213,7 +8213,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1211O</pattern>
+        <pattern>X[1-O][2-O][1-O][1-O]O</pattern>
         <Harmony>
             <name>ab+/bb</name>
         </Harmony>
@@ -8242,7 +8242,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX211O</pattern>
+        <pattern>XX[2-O][1-O][1-O]O</pattern>
         <Harmony>
             <name>abaug</name>
         </Harmony>
@@ -8266,7 +8266,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-666--</pattern>
+        <pattern>-[6-O][6-O][6-O]--;B4[0-5]</pattern>
         <Harmony>
             <name>absus</name>
         </Harmony>
@@ -8296,7 +8296,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX634X</pattern>
+        <pattern>XX[6-O][3-O][4-O]X</pattern>
         <Harmony>
             <name>absus2</name>
         </Harmony>
@@ -8325,7 +8325,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X132X</pattern>
+        <pattern>[4-O]X[1-O][3-O][2-O]X</pattern>
         <Harmony>
             <name>absus2add4</name>
         </Harmony>
@@ -8352,7 +8352,7 @@
                 <barre start="2" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>9X--9X</pattern>
+        <pattern>[9-O]X--[9-O]X;B8[2-3]</pattern>
         <Harmony>
             <name>absus2/db</name>
         </Harmony>
@@ -8381,7 +8381,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1344</pattern>
+        <pattern>XX[1-O][3-O][4-O][4-O]</pattern>
         <Harmony>
             <name>absus2/eb</name>
         </Harmony>
@@ -8410,7 +8410,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3X344</pattern>
+        <pattern>X[3-O]X[3-O][4-O][4-O]</pattern>
         <Harmony>
             <name>absus2/c</name>
         </Harmony>
@@ -8439,7 +8439,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X133X</pattern>
+        <pattern>[4-O]X[1-O][3-O][3-O]X</pattern>
         <Harmony>
             <name>ab(#11sus2)</name>
         </Harmony>
@@ -8466,7 +8466,7 @@
                 <barre start="2" end="3">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>6X--9X</pattern>
+        <pattern>[6-O]X--[9-O]X;B8[2-3]</pattern>
         <Harmony>
             <name>absus2/bb</name>
         </Harmony>
@@ -8496,7 +8496,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>7X889X</pattern>
+        <pattern>[7-O]X[8-O][8-O][9-O]X</pattern>
         <Harmony>
             <name>absus2</name>
         </Harmony>
@@ -8523,7 +8523,7 @@
                 <barre start="1" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-6-4X</pattern>
+        <pattern>X-[6-O]-[4-O]X;B3[1-3]</pattern>
         <Harmony>
             <name>absus2/c</name>
         </Harmony>
@@ -8552,7 +8552,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3344</pattern>
+        <pattern>XX[3-O][3-O][4-O][4-O]</pattern>
         <Harmony>
             <name>absus2/f</name>
         </Harmony>
@@ -8582,7 +8582,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX6646</pattern>
+        <pattern>XX[6-O][6-O][4-O][6-O]</pattern>
         <Harmony>
             <name>ab(add2sus4)</name>
         </Harmony>
@@ -8612,7 +8612,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>OX6646</pattern>
+        <pattern>OX[6-O][6-O][4-O][6-O]</pattern>
         <Harmony>
             <name>ab(add2sus4)/e</name>
         </Harmony>
@@ -8642,7 +8642,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>6X664X</pattern>
+        <pattern>[6-O]X[6-O][6-O][4-O]X</pattern>
         <Harmony>
             <name>absus/bb</name>
         </Harmony>
@@ -8668,7 +8668,7 @@
                 <barre start="2" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3--2X</pattern>
+        <pattern>X[3-O]--[2-O]X;B1[2-3]</pattern>
         <Harmony>
             <name>absus/c</name>
         </Harmony>
@@ -8692,7 +8692,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-66--</pattern>
+        <pattern>X-[6-O][6-O]--;B4[1-5]</pattern>
         <Harmony>
             <name>absus/db</name>
         </Harmony>
@@ -8719,7 +8719,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X666--</pattern>
+        <pattern>X[6-O][6-O][6-O]--;B4[4-5]</pattern>
         <Harmony>
             <name>absus/eb</name>
         </Harmony>
@@ -8748,7 +8748,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3124</pattern>
+        <pattern>XX[3-O][1-O][2-O][4-O]</pattern>
         <Harmony>
             <name>absus/f</name>
         </Harmony>
@@ -8778,7 +8778,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X7664X</pattern>
+        <pattern>X[7-O][6-O][6-O][4-O]X</pattern>
         <Harmony>
             <name>absus/fb</name>
         </Harmony>
@@ -8807,7 +8807,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO221O</pattern>
+        <pattern>XO[2-O][2-O][1-O]O</pattern>
         <Harmony>
             <name>am</name>
         </Harmony>
@@ -8837,7 +8837,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>5X553X</pattern>
+        <pattern>[5-O]X[5-O][5-O][3-O]X</pattern>
         <Harmony>
             <name>am11</name>
         </Harmony>
@@ -8866,7 +8866,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO1O33</pattern>
+        <pattern>XO[1-O]O[3-O][3-O]</pattern>
         <Harmony>
             <name>am11b5</name>
         </Harmony>
@@ -8893,7 +8893,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO55--</pattern>
+        <pattern>XO[5-O][5-O]--;B3[4-5]</pattern>
         <Harmony>
             <name>am11(no5)</name>
         </Harmony>
@@ -8922,7 +8922,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO2O12</pattern>
+        <pattern>XO[2-O]O[1-O][2-O]</pattern>
         <Harmony>
             <name>am13</name>
         </Harmony>
@@ -8951,7 +8951,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO2212</pattern>
+        <pattern>XO[2-O][2-O][1-O][2-O]</pattern>
         <Harmony>
             <name>am6</name>
         </Harmony>
@@ -8978,7 +8978,7 @@
                 <barre start="2" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>OO--77</pattern>
+        <pattern>OO--[7-O][7-O];B5[2-3]</pattern>
         <Harmony>
             <name>am13/e</name>
         </Harmony>
@@ -9008,7 +9008,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO7577</pattern>
+        <pattern>XO[7-O][5-O][7-O][7-O]</pattern>
         <Harmony>
             <name>am6(add2)</name>
         </Harmony>
@@ -9038,7 +9038,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO45OO</pattern>
+        <pattern>XO[4-O][5-O]OO</pattern>
         <Harmony>
             <name>am69()</name>
         </Harmony>
@@ -9068,7 +9068,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO7577</pattern>
+        <pattern>XO[7-O][5-O][7-O][7-O]</pattern>
         <Harmony>
             <name>am69</name>
         </Harmony>
@@ -9092,7 +9092,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4---</pattern>
+        <pattern>XX[4-O]---;B5[3-5]</pattern>
         <Harmony>
             <name>am6/f#</name>
         </Harmony>
@@ -9121,7 +9121,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2X212</pattern>
+        <pattern>X[2-O]X[2-O][1-O][2-O]</pattern>
         <Harmony>
             <name>am6/b</name>
         </Harmony>
@@ -9150,7 +9150,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3X212</pattern>
+        <pattern>X[3-O]X[2-O][1-O][2-O]</pattern>
         <Harmony>
             <name>am6/c</name>
         </Harmony>
@@ -9179,7 +9179,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>OO2212</pattern>
+        <pattern>OO[2-O][2-O][1-O][2-O]</pattern>
         <Harmony>
             <name>am6/e</name>
         </Harmony>
@@ -9208,7 +9208,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO2O1O</pattern>
+        <pattern>XO[2-O]O[1-O]O</pattern>
         <Harmony>
             <name>am7</name>
         </Harmony>
@@ -9238,7 +9238,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>5X553X</pattern>
+        <pattern>[5-O]X[5-O][5-O][3-O]X</pattern>
         <Harmony>
             <name>am7(add11)</name>
         </Harmony>
@@ -9268,7 +9268,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>OO553O</pattern>
+        <pattern>OO[5-O][5-O][3-O]O</pattern>
         <Harmony>
             <name>am7(add11)/e</name>
         </Harmony>
@@ -9292,7 +9292,7 @@
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X4---</pattern>
+        <pattern>[3-O]X[4-O]---;B5[3-5]</pattern>
         <Harmony>
             <name>am6/g</name>
         </Harmony>
@@ -9321,7 +9321,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO1O1X</pattern>
+        <pattern>XO[1-O]O[1-O]X</pattern>
         <Harmony>
             <name>am7b5</name>
         </Harmony>
@@ -9350,7 +9350,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X31O1X</pattern>
+        <pattern>X[3-O][1-O]O[1-O]X</pattern>
         <Harmony>
             <name>am7b5/c</name>
         </Harmony>
@@ -9380,7 +9380,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>5X553X</pattern>
+        <pattern>[5-O]X[5-O][5-O][3-O]X</pattern>
         <Harmony>
             <name>am7(add4)</name>
         </Harmony>
@@ -9410,7 +9410,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X5554X</pattern>
+        <pattern>X[5-O][5-O][5-O][4-O]X</pattern>
         <Harmony>
             <name>am7b5/d</name>
         </Harmony>
@@ -9439,7 +9439,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1O13</pattern>
+        <pattern>XX[1-O]O[1-O][3-O]</pattern>
         <Harmony>
             <name>am7b5/eb</name>
         </Harmony>
@@ -9469,7 +9469,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX5545</pattern>
+        <pattern>XX[5-O][5-O][4-O][5-O]</pattern>
         <Harmony>
             <name>am7b5/g</name>
         </Harmony>
@@ -9498,7 +9498,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO3O1X</pattern>
+        <pattern>XO[3-O]O[1-O]X</pattern>
         <Harmony>
             <name>am7b6</name>
         </Harmony>
@@ -9527,7 +9527,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3X213</pattern>
+        <pattern>X[3-O]X[2-O][1-O][3-O]</pattern>
         <Harmony>
             <name>am7/c</name>
         </Harmony>
@@ -9556,7 +9556,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X22O1O</pattern>
+        <pattern>X[2-O][2-O]O[1-O]O</pattern>
         <Harmony>
             <name>am7/b</name>
         </Harmony>
@@ -9585,7 +9585,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO213</pattern>
+        <pattern>XXO[2-O][1-O][3-O]</pattern>
         <Harmony>
             <name>am7/d</name>
         </Harmony>
@@ -9614,7 +9614,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX2213</pattern>
+        <pattern>XX[2-O][2-O][1-O][3-O]</pattern>
         <Harmony>
             <name>am7/e</name>
         </Harmony>
@@ -9635,7 +9635,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX----</pattern>
+        <pattern>XX----;B5[2-5]</pattern>
         <Harmony>
             <name>am7/g</name>
         </Harmony>
@@ -9661,7 +9661,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO3O--</pattern>
+        <pattern>XO[3-O]O--;B1[4-5]</pattern>
         <Harmony>
             <name>am7#5</name>
         </Harmony>
@@ -9690,7 +9690,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO2O3O</pattern>
+        <pattern>XO[2-O]O[3-O]O</pattern>
         <Harmony>
             <name>am7sus4</name>
         </Harmony>
@@ -9716,7 +9716,7 @@
                 <barre start="2" end="3">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO--33</pattern>
+        <pattern>XO--[3-O][3-O];B2[2-3]</pattern>
         <Harmony>
             <name>am7(sus4)</name>
         </Harmony>
@@ -9746,7 +9746,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO55OO</pattern>
+        <pattern>XO[5-O][5-O]OO</pattern>
         <Harmony>
             <name>am9</name>
         </Harmony>
@@ -9764,7 +9764,7 @@
                 <barre start="0" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-----7</pattern>
+        <pattern>-----[7-O];B5[0-4]</pattern>
         <Harmony>
             <name>am9(add4)</name>
         </Harmony>
@@ -9791,7 +9791,7 @@
                 <barre start="3" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO6--7</pattern>
+        <pattern>XO[6-O]--[7-O];B5[3-4]</pattern>
         <Harmony>
             <name>am9(maj7)</name>
         </Harmony>
@@ -9818,7 +9818,7 @@
                 <barre start="3" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO6--7</pattern>
+        <pattern>XO[6-O]--[7-O];B5[3-4]</pattern>
         <Harmony>
             <name>am9(maj7)</name>
         </Harmony>
@@ -9848,7 +9848,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X555OO</pattern>
+        <pattern>X[5-O][5-O][5-O]OO</pattern>
         <Harmony>
             <name>am9/d</name>
         </Harmony>
@@ -9872,7 +9872,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX---7</pattern>
+        <pattern>XX---[7-O];B5[2-4]</pattern>
         <Harmony>
             <name>am9/g</name>
         </Harmony>
@@ -9902,7 +9902,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX6587</pattern>
+        <pattern>XX[6-O][5-O][8-O][7-O]</pattern>
         <Harmony>
             <name>am9/g#</name>
         </Harmony>
@@ -9931,7 +9931,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO241O</pattern>
+        <pattern>XO[2-O][4-O][1-O]O</pattern>
         <Harmony>
             <name>am(add2)</name>
         </Harmony>
@@ -9960,7 +9960,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX341O</pattern>
+        <pattern>XX[3-O][4-O][1-O]O</pattern>
         <Harmony>
             <name>am(add2)/f</name>
         </Harmony>
@@ -9989,7 +9989,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X322OO</pattern>
+        <pattern>X[3-O][2-O][2-O]OO</pattern>
         <Harmony>
             <name>am(add2)/c</name>
         </Harmony>
@@ -10018,7 +10018,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X241O</pattern>
+        <pattern>[3-O]X[2-O][4-O][1-O]O</pattern>
         <Harmony>
             <name>am(add2)/g</name>
         </Harmony>
@@ -10047,7 +10047,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XOO21O</pattern>
+        <pattern>XOO[2-O][1-O]O</pattern>
         <Harmony>
             <name>am(add4)</name>
         </Harmony>
@@ -10076,7 +10076,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3O21O</pattern>
+        <pattern>X[3-O]O[2-O][1-O]O</pattern>
         <Harmony>
             <name>am(add4)/c</name>
         </Harmony>
@@ -10105,7 +10105,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O3O21O</pattern>
+        <pattern>O[3-O]O[2-O][1-O]O</pattern>
         <Harmony>
             <name>am(add4)/e</name>
         </Harmony>
@@ -10134,7 +10134,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3XO21O</pattern>
+        <pattern>[3-O]XO[2-O][1-O]O</pattern>
         <Harmony>
             <name>am(add4)/g</name>
         </Harmony>
@@ -10158,7 +10158,7 @@
                 <barre start="0" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-77--7</pattern>
+        <pattern>-[7-O][7-O]--[7-O];B5[0-4]</pattern>
         <Harmony>
             <name>am(add9)</name>
         </Harmony>
@@ -10187,7 +10187,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>OO241O</pattern>
+        <pattern>OO[2-O][4-O][1-O]O</pattern>
         <Harmony>
             <name>am(add9)/e</name>
         </Harmony>
@@ -10213,7 +10213,7 @@
                 <barre start="2" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO-1-2</pattern>
+        <pattern>XO-[1-O]-[2-O];B2[2-4]</pattern>
         <Harmony>
             <name>amaj13</name>
         </Harmony>
@@ -10242,7 +10242,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO1122</pattern>
+        <pattern>XO[1-O][1-O][2-O][2-O]</pattern>
         <Harmony>
             <name>amaj13b5</name>
         </Harmony>
@@ -10268,7 +10268,7 @@
                 <barre start="2" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO--22</pattern>
+        <pattern>XO--[2-O][2-O];B1[2-3]</pattern>
         <Harmony>
             <name>amaj13#11/c#</name>
         </Harmony>
@@ -10291,7 +10291,7 @@
                 <barre start="2" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO---4</pattern>
+        <pattern>XO---[4-O];B2[2-4]</pattern>
         <Harmony>
             <name>amaj7</name>
         </Harmony>
@@ -10317,7 +10317,7 @@
                 <barre start="2" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO-1-2</pattern>
+        <pattern>XO-[1-O]-[2-O];B2[2-4]</pattern>
         <Harmony>
             <name>amaj7(add13)</name>
         </Harmony>
@@ -10343,7 +10343,7 @@
                 <barre start="3" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO1--4</pattern>
+        <pattern>XO[1-O]--[4-O];B2[3-4]</pattern>
         <Harmony>
             <name>amaj7b5</name>
         </Harmony>
@@ -10372,7 +10372,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2212O</pattern>
+        <pattern>X[2-O][2-O][1-O][2-O]O</pattern>
         <Harmony>
             <name>amaj7/b</name>
         </Harmony>
@@ -10395,7 +10395,7 @@
                 <barre start="2" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4---4</pattern>
+        <pattern>X[4-O]---[4-O];B2[2-4]</pattern>
         <Harmony>
             <name>amaj7/c#</name>
         </Harmony>
@@ -10421,7 +10421,7 @@
                 <barre start="3" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO--4</pattern>
+        <pattern>XXO--[4-O];B2[3-4]</pattern>
         <Harmony>
             <name>amaj7/d</name>
         </Harmony>
@@ -10444,7 +10444,7 @@
                 <barre start="2" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>OO---4</pattern>
+        <pattern>OO---[4-O];B2[2-4]</pattern>
         <Harmony>
             <name>amaj7/e</name>
         </Harmony>
@@ -10467,7 +10467,7 @@
                 <barre start="2" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X---4</pattern>
+        <pattern>[4-O]X---[4-O];B2[2-4]</pattern>
         <Harmony>
             <name>amaj7/g#</name>
         </Harmony>
@@ -10497,7 +10497,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>5X664X</pattern>
+        <pattern>[5-O]X[6-O][6-O][4-O]X</pattern>
         <Harmony>
             <name>amaj7#11</name>
         </Harmony>
@@ -10527,7 +10527,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>5X666X</pattern>
+        <pattern>[5-O]X[6-O][6-O][6-O]X</pattern>
         <Harmony>
             <name>amaj7#5</name>
         </Harmony>
@@ -10553,7 +10553,7 @@
                 <barre start="2" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO-4-4</pattern>
+        <pattern>XO-[4-O]-[4-O];B2[2-4]</pattern>
         <Harmony>
             <name>amaj9</name>
         </Harmony>
@@ -10576,7 +10576,7 @@
                 <barre start="1" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--4-4</pattern>
+        <pattern>X--[4-O]-[4-O];B2[1-4]</pattern>
         <Harmony>
             <name>amaj9/b</name>
         </Harmony>
@@ -10602,7 +10602,7 @@
                 <barre start="2" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4-4-4</pattern>
+        <pattern>X[4-O]-[4-O]-[4-O];B2[2-4]</pattern>
         <Harmony>
             <name>amaj9/c#</name>
         </Harmony>
@@ -10629,7 +10629,7 @@
                 <barre start="2" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>OO--OO</pattern>
+        <pattern>OO--OO;B6[2-3]</pattern>
         <Harmony>
             <name>amaj9/e</name>
         </Harmony>
@@ -10655,7 +10655,7 @@
                 <barre start="2" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X-4-4</pattern>
+        <pattern>[4-O]X-[4-O]-[4-O];B2[2-4]</pattern>
         <Harmony>
             <name>amaj9/g#</name>
         </Harmony>
@@ -10685,7 +10685,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>5X664X</pattern>
+        <pattern>[5-O]X[6-O][6-O][4-O]X</pattern>
         <Harmony>
             <name>amaj9#11</name>
         </Harmony>
@@ -10714,7 +10714,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO21OO</pattern>
+        <pattern>XO[2-O][1-O]OO</pattern>
         <Harmony>
             <name>amaj9(no3)</name>
         </Harmony>
@@ -10743,7 +10743,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO21OO</pattern>
+        <pattern>XO[2-O][1-O]OO</pattern>
         <Harmony>
             <name>amaj9(no3)/e</name>
         </Harmony>
@@ -10772,7 +10772,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO211O</pattern>
+        <pattern>XO[2-O][1-O][1-O]O</pattern>
         <Harmony>
             <name>am(#7)</name>
         </Harmony>
@@ -10801,7 +10801,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3211O</pattern>
+        <pattern>X[3-O][2-O][1-O][1-O]O</pattern>
         <Harmony>
             <name>am(#7)/c</name>
         </Harmony>
@@ -10825,7 +10825,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX6---</pattern>
+        <pattern>XX[6-O]---;B5[3-5]</pattern>
         <Harmony>
             <name>am(#7)/g#</name>
         </Harmony>
@@ -10852,7 +10852,7 @@
                 <barre start="3" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO6--7</pattern>
+        <pattern>XO[6-O]--[7-O];B5[3-4]</pattern>
         <Harmony>
             <name>am(add9)</name>
         </Harmony>
@@ -10881,7 +10881,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2221O</pattern>
+        <pattern>X[2-O][2-O][2-O][1-O]O</pattern>
         <Harmony>
             <name>am/b</name>
         </Harmony>
@@ -10910,7 +10910,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1221O</pattern>
+        <pattern>X[1-O][2-O][2-O][1-O]O</pattern>
         <Harmony>
             <name>am/bb</name>
         </Harmony>
@@ -10939,7 +10939,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3221O</pattern>
+        <pattern>X[3-O][2-O][2-O][1-O]O</pattern>
         <Harmony>
             <name>am/c</name>
         </Harmony>
@@ -10968,7 +10968,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO21O</pattern>
+        <pattern>XXO[2-O][1-O]O</pattern>
         <Harmony>
             <name>am/d</name>
         </Harmony>
@@ -10997,7 +10997,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX221O</pattern>
+        <pattern>XX[2-O][2-O][1-O]O</pattern>
         <Harmony>
             <name>am/e</name>
         </Harmony>
@@ -11024,7 +11024,7 @@
                 <barre start="3" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>8O6--7</pattern>
+        <pattern>[8-O]O[6-O]--[7-O];B5[3-4]</pattern>
         <Harmony>
             <name>am(add9)/g#</name>
         </Harmony>
@@ -11053,7 +11053,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>1X221O</pattern>
+        <pattern>[1-O]X[2-O][2-O][1-O]O</pattern>
         <Harmony>
             <name>am/f</name>
         </Harmony>
@@ -11082,7 +11082,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX121O</pattern>
+        <pattern>XX[1-O][2-O][1-O]O</pattern>
         <Harmony>
             <name>am/eb</name>
         </Harmony>
@@ -11111,7 +11111,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2X221O</pattern>
+        <pattern>[2-O]X[2-O][2-O][1-O]O</pattern>
         <Harmony>
             <name>am/f#</name>
         </Harmony>
@@ -11140,7 +11140,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X221O</pattern>
+        <pattern>[3-O]X[2-O][2-O][1-O]O</pattern>
         <Harmony>
             <name>am/g</name>
         </Harmony>
@@ -11164,7 +11164,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX6---</pattern>
+        <pattern>XX[6-O]---;B5[3-5]</pattern>
         <Harmony>
             <name>am/g#</name>
         </Harmony>
@@ -11191,7 +11191,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO7-6-</pattern>
+        <pattern>XO[7-O]-[6-O]-;B5[3-5]</pattern>
         <Harmony>
             <name>am(#5)</name>
         </Harmony>
@@ -11220,7 +11220,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO223O</pattern>
+        <pattern>XO[2-O][2-O][3-O]O</pattern>
         <Harmony>
             <name>amsus4</name>
         </Harmony>
@@ -11249,7 +11249,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO22XX</pattern>
+        <pattern>XO[2-O][2-O]XX</pattern>
         <Harmony>
             <name>a5</name>
         </Harmony>
@@ -11272,7 +11272,7 @@
                 <barre start="2" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X---X</pattern>
+        <pattern>[4-O]X---X;B2[2-4]</pattern>
         <Harmony>
             <name>a/ab</name>
         </Harmony>
@@ -11301,7 +11301,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2222O</pattern>
+        <pattern>X[2-O][2-O][2-O][2-O]O</pattern>
         <Harmony>
             <name>a/b</name>
         </Harmony>
@@ -11330,7 +11330,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1222O</pattern>
+        <pattern>X[1-O][2-O][2-O][2-O]O</pattern>
         <Harmony>
             <name>a/bb</name>
         </Harmony>
@@ -11353,7 +11353,7 @@
                 <barre start="2" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3---X</pattern>
+        <pattern>X[3-O]---X;B2[2-4]</pattern>
         <Harmony>
             <name>a/c</name>
         </Harmony>
@@ -11376,7 +11376,7 @@
                 <barre start="2" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4---X</pattern>
+        <pattern>X[4-O]---X;B2[2-4]</pattern>
         <Harmony>
             <name>a/c#</name>
         </Harmony>
@@ -11405,7 +11405,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO22O</pattern>
+        <pattern>XXO[2-O][2-O]O</pattern>
         <Harmony>
             <name>a/d</name>
         </Harmony>
@@ -11434,7 +11434,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX122O</pattern>
+        <pattern>XX[1-O][2-O][2-O]O</pattern>
         <Harmony>
             <name>a/d#</name>
         </Harmony>
@@ -11463,7 +11463,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>OO222O</pattern>
+        <pattern>OO[2-O][2-O][2-O]O</pattern>
         <Harmony>
             <name>a/e</name>
         </Harmony>
@@ -11492,7 +11492,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>1X222X</pattern>
+        <pattern>[1-O]X[2-O][2-O][2-O]X</pattern>
         <Harmony>
             <name>a/f</name>
         </Harmony>
@@ -11515,7 +11515,7 @@
                 <barre start="2" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2X---X</pattern>
+        <pattern>[2-O]X---X;B2[2-4]</pattern>
         <Harmony>
             <name>a/f#</name>
         </Harmony>
@@ -11538,7 +11538,7 @@
                 <barre start="2" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X---X</pattern>
+        <pattern>[3-O]X---X;B2[2-4]</pattern>
         <Harmony>
             <name>a/g</name>
         </Harmony>
@@ -11561,7 +11561,7 @@
                 <barre start="2" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X---X</pattern>
+        <pattern>[4-O]X---X;B2[2-4]</pattern>
         <Harmony>
             <name>a/g#</name>
         </Harmony>
@@ -11590,7 +11590,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO3221</pattern>
+        <pattern>XO[3-O][2-O][2-O][1-O]</pattern>
         <Harmony>
             <name>a+</name>
         </Harmony>
@@ -11616,7 +11616,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO3-2-</pattern>
+        <pattern>XO[3-O]-[2-O]-;B1[3-5]</pattern>
         <Harmony>
             <name>a+(#7)</name>
         </Harmony>
@@ -11642,7 +11642,7 @@
                 <barre start="3" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X3--X</pattern>
+        <pattern>[3-O]X[3-O]--X;B2[3-4]</pattern>
         <Harmony>
             <name>a+/g</name>
         </Harmony>
@@ -11668,7 +11668,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-333-</pattern>
+        <pattern>X-[3-O][3-O][3-O]-;B1[1-5]</pattern>
         <Harmony>
             <name>a#</name>
         </Harmony>
@@ -11695,7 +11695,7 @@
                 <barre start="3" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X43--5</pattern>
+        <pattern>X[4-O][3-O]--[5-O];B2[3-4]</pattern>
         <Harmony>
             <name>a+/c#</name>
         </Harmony>
@@ -11725,7 +11725,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>688XXX</pattern>
+        <pattern>[6-O][8-O][8-O]XXX</pattern>
         <Harmony>
             <name>a#5</name>
         </Harmony>
@@ -11747,7 +11747,7 @@
                 <barre start="2" end="4">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-----</pattern>
+        <pattern>X-----;B1[1-5];B3[2-4]</pattern>
         <Harmony>
             <name>a#7</name>
         </Harmony>
@@ -11776,7 +11776,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX232X</pattern>
+        <pattern>XX[2-O][3-O][2-O]X</pattern>
         <Harmony>
             <name>a#dim</name>
         </Harmony>
@@ -11805,7 +11805,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X12O2O</pattern>
+        <pattern>X[1-O][2-O]O[2-O]O</pattern>
         <Harmony>
             <name>a#dim7</name>
         </Harmony>
@@ -11834,7 +11834,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX2221</pattern>
+        <pattern>XX[2-O][2-O][2-O][1-O]</pattern>
         <Harmony>
             <name>a+/e</name>
         </Harmony>
@@ -11863,7 +11863,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX2323</pattern>
+        <pattern>XX[2-O][3-O][2-O][3-O]</pattern>
         <Harmony>
             <name>a#dim7/e</name>
         </Harmony>
@@ -11889,7 +11889,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO-3-</pattern>
+        <pattern>XXO-[3-O]-;B1[3-5]</pattern>
         <Harmony>
             <name>a#7/d</name>
         </Harmony>
@@ -11912,7 +11912,7 @@
                 <barre start="1" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--3-3</pattern>
+        <pattern>X--[3-O]-[3-O];B2[1-4]</pattern>
         <Harmony>
             <name>a#dim/b</name>
         </Harmony>
@@ -11941,7 +11941,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O133XX</pattern>
+        <pattern>O[1-O][3-O][3-O]XX</pattern>
         <Harmony>
             <name>a#5/e</name>
         </Harmony>
@@ -11970,7 +11970,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X232X</pattern>
+        <pattern>[4-O]X[2-O][3-O][2-O]X</pattern>
         <Harmony>
             <name>a#dim/g#</name>
         </Harmony>
@@ -11993,7 +11993,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-3-4-</pattern>
+        <pattern>X-[3-O]-[4-O]-;B1[1-5]</pattern>
         <Harmony>
             <name>a#7sus4</name>
         </Harmony>
@@ -12019,7 +12019,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-332-</pattern>
+        <pattern>X-[3-O][3-O][2-O]-;B1[1-5]</pattern>
         <Harmony>
             <name>a#m</name>
         </Harmony>
@@ -12042,7 +12042,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-3-2-</pattern>
+        <pattern>X-[3-O]-[2-O]-;B1[1-5]</pattern>
         <Harmony>
             <name>a#m7</name>
         </Harmony>
@@ -12071,7 +12071,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1212X</pattern>
+        <pattern>X[1-O][2-O][1-O][2-O]X</pattern>
         <Harmony>
             <name>a#m7b5</name>
         </Harmony>
@@ -12100,7 +12100,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1X12X</pattern>
+        <pattern>X[1-O]X[1-O][2-O]X</pattern>
         <Harmony>
             <name>a#m7(no5)</name>
         </Harmony>
@@ -12121,7 +12121,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX----</pattern>
+        <pattern>XX----;B6[2-5]</pattern>
         <Harmony>
             <name>a#m7/g#</name>
         </Harmony>
@@ -12151,7 +12151,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>6X677X</pattern>
+        <pattern>[6-O]X[6-O][7-O][7-O]X</pattern>
         <Harmony>
             <name>a#7#5</name>
         </Harmony>
@@ -12172,7 +12172,7 @@
                 <barre start="0" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-8---8</pattern>
+        <pattern>-[8-O]---[8-O];B6[0-4]</pattern>
         <Harmony>
             <name>a#m9</name>
         </Harmony>
@@ -12193,7 +12193,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-8---</pattern>
+        <pattern>X-[8-O]---;B6[1-5]</pattern>
         <Harmony>
             <name>a#m/d#</name>
         </Harmony>
@@ -12211,7 +12211,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-----</pattern>
+        <pattern>X-----;B6[1-5]</pattern>
         <Harmony>
             <name>a#m7/d#</name>
         </Harmony>
@@ -12231,7 +12231,7 @@
                 <barre start="1" end="4">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X----X</pattern>
+        <pattern>X----X;B3[1-4]</pattern>
         <Harmony>
             <name>a#/c</name>
         </Harmony>
@@ -12260,7 +12260,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4332</pattern>
+        <pattern>XX[4-O][3-O][3-O][2-O]</pattern>
         <Harmony>
             <name>a#+</name>
         </Harmony>
@@ -12284,7 +12284,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-88-8-</pattern>
+        <pattern>-[8-O][8-O]-[8-O]-;B6[0-5]</pattern>
         <Harmony>
             <name>a#m6</name>
         </Harmony>
@@ -12313,7 +12313,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO223O</pattern>
+        <pattern>XO[2-O][2-O][3-O]O</pattern>
         <Harmony>
             <name>asus</name>
         </Harmony>
@@ -12343,7 +12343,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO435</pattern>
+        <pattern>XXO[4-O][3-O][5-O]</pattern>
         <Harmony>
             <name>a(add9sus4)/d</name>
         </Harmony>
@@ -12372,7 +12372,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO22OO</pattern>
+        <pattern>XO[2-O][2-O]OO</pattern>
         <Harmony>
             <name>asus2</name>
         </Harmony>
@@ -12401,7 +12401,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO243O</pattern>
+        <pattern>XO[2-O][4-O][3-O]O</pattern>
         <Harmony>
             <name>asus2add4</name>
         </Harmony>
@@ -12430,7 +12430,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XOO2OO</pattern>
+        <pattern>XOO[2-O]OO</pattern>
         <Harmony>
             <name>asus4add2</name>
         </Harmony>
@@ -12459,7 +12459,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2O2OO</pattern>
+        <pattern>X[2-O]O[2-O]OO</pattern>
         <Harmony>
             <name>asus2add4/b</name>
         </Harmony>
@@ -12488,7 +12488,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X322OO</pattern>
+        <pattern>X[3-O][2-O][2-O]OO</pattern>
         <Harmony>
             <name>asus2/c</name>
         </Harmony>
@@ -12517,7 +12517,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X422OO</pattern>
+        <pattern>X[4-O][2-O][2-O]OO</pattern>
         <Harmony>
             <name>asus2/c#</name>
         </Harmony>
@@ -12546,7 +12546,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO2OO</pattern>
+        <pattern>XXO[2-O]OO</pattern>
         <Harmony>
             <name>asus2/d</name>
         </Harmony>
@@ -12575,7 +12575,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX22OO</pattern>
+        <pattern>XX[2-O][2-O]OO</pattern>
         <Harmony>
             <name>asus2/e</name>
         </Harmony>
@@ -12604,7 +12604,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2O22OO</pattern>
+        <pattern>[2-O]O[2-O][2-O]OO</pattern>
         <Harmony>
             <name>asus2/f#</name>
         </Harmony>
@@ -12633,7 +12633,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X22OO</pattern>
+        <pattern>[4-O]X[2-O][2-O]OO</pattern>
         <Harmony>
             <name>asus2/g#</name>
         </Harmony>
@@ -12662,7 +12662,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO244O</pattern>
+        <pattern>XO[2-O][4-O][4-O]O</pattern>
         <Harmony>
             <name>a(#11sus2)</name>
         </Harmony>
@@ -12691,7 +12691,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO244O</pattern>
+        <pattern>XO[2-O][4-O][4-O]O</pattern>
         <Harmony>
             <name>a(#4sus2)</name>
         </Harmony>
@@ -12720,7 +12720,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4244X</pattern>
+        <pattern>X[4-O][2-O][4-O][4-O]X</pattern>
         <Harmony>
             <name>a(#4sus2)/c#</name>
         </Harmony>
@@ -12749,7 +12749,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO223O</pattern>
+        <pattern>XO[2-O][2-O][3-O]O</pattern>
         <Harmony>
             <name>asus4</name>
         </Harmony>
@@ -12778,7 +12778,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO243O</pattern>
+        <pattern>XO[2-O][4-O][3-O]O</pattern>
         <Harmony>
             <name>a(add2sus4)</name>
         </Harmony>
@@ -12807,7 +12807,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO243O</pattern>
+        <pattern>XO[2-O][4-O][3-O]O</pattern>
         <Harmony>
             <name>a(add9sus4)</name>
         </Harmony>
@@ -12836,7 +12836,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2223O</pattern>
+        <pattern>X[2-O][2-O][2-O][3-O]O</pattern>
         <Harmony>
             <name>asus/b</name>
         </Harmony>
@@ -12865,7 +12865,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4223O</pattern>
+        <pattern>X[4-O][2-O][2-O][3-O]O</pattern>
         <Harmony>
             <name>asus/c#</name>
         </Harmony>
@@ -12894,7 +12894,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO23O</pattern>
+        <pattern>XXO[2-O][3-O]O</pattern>
         <Harmony>
             <name>asus/d</name>
         </Harmony>
@@ -12923,7 +12923,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX223O</pattern>
+        <pattern>XX[2-O][2-O][3-O]O</pattern>
         <Harmony>
             <name>asus/e</name>
         </Harmony>
@@ -12952,7 +12952,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2X223O</pattern>
+        <pattern>[2-O]X[2-O][2-O][3-O]O</pattern>
         <Harmony>
             <name>asus/f#</name>
         </Harmony>
@@ -12981,7 +12981,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X223O</pattern>
+        <pattern>[3-O]X[2-O][2-O][3-O]O</pattern>
         <Harmony>
             <name>asus/g</name>
         </Harmony>
@@ -13007,7 +13007,7 @@
                 <barre start="1" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-444-</pattern>
+        <pattern>X-[4-O][4-O][4-O]-;B2[1-5]</pattern>
         <Harmony>
             <name>b</name>
         </Harmony>
@@ -13024,7 +13024,7 @@
                 <barre start="1" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-----</pattern>
+        <pattern>X-----;B2[1-5]</pattern>
         <Harmony>
             <name>b11</name>
         </Harmony>
@@ -13054,7 +13054,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX7899</pattern>
+        <pattern>XX[7-O][8-O][9-O][9-O]</pattern>
         <Harmony>
             <name>b13</name>
         </Harmony>
@@ -13084,7 +13084,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>8X789X</pattern>
+        <pattern>[8-O]X[7-O][8-O][9-O]X</pattern>
         <Harmony>
             <name>b13b9</name>
         </Harmony>
@@ -13113,7 +13113,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX12O4</pattern>
+        <pattern>XX[1-O][2-O]O[4-O]</pattern>
         <Harmony>
             <name>b13/d#</name>
         </Harmony>
@@ -13139,7 +13139,7 @@
                 <barre start="1" end="3">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-3-44</pattern>
+        <pattern>X-[3-O]-[4-O][4-O];B2[1-3]</pattern>
         <Harmony>
             <name>b13#11</name>
         </Harmony>
@@ -13168,7 +13168,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X244XX</pattern>
+        <pattern>X[2-O][4-O][4-O]XX</pattern>
         <Harmony>
             <name>b5</name>
         </Harmony>
@@ -13197,7 +13197,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO12OO</pattern>
+        <pattern>XO[1-O][2-O]OO</pattern>
         <Harmony>
             <name>b11/a</name>
         </Harmony>
@@ -13227,7 +13227,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO44XX</pattern>
+        <pattern>XO[4-O][4-O]XX</pattern>
         <Harmony>
             <name>b5/a</name>
         </Harmony>
@@ -13256,7 +13256,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO11OO</pattern>
+        <pattern>XO[1-O][1-O]OO</pattern>
         <Harmony>
             <name>b13/a</name>
         </Harmony>
@@ -13285,7 +13285,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O144XX</pattern>
+        <pattern>O[1-O][4-O][4-O]XX</pattern>
         <Harmony>
             <name>b5/e</name>
         </Harmony>
@@ -13314,7 +13314,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4244XX</pattern>
+        <pattern>[4-O][2-O][4-O][4-O]XX</pattern>
         <Harmony>
             <name>b5/g#</name>
         </Harmony>
@@ -13334,7 +13334,7 @@
                 <barre start="2" end="5">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2----</pattern>
+        <pattern>X[2-O]----;B4[2-5]</pattern>
         <Harmony>
             <name>b6</name>
         </Harmony>
@@ -13357,7 +13357,7 @@
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X23---</pattern>
+        <pattern>X[2-O][3-O]---;B4[3-5]</pattern>
         <Harmony>
             <name>b6b5</name>
         </Harmony>
@@ -13383,7 +13383,7 @@
                 <barre start="2" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2--22</pattern>
+        <pattern>X[2-O]--[2-O][2-O];B1[2-3]</pattern>
         <Harmony>
             <name>b69</name>
         </Harmony>
@@ -13409,7 +13409,7 @@
                 <barre start="2" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>22--2X</pattern>
+        <pattern>[2-O][2-O]--[2-O]X;B1[2-3]</pattern>
         <Harmony>
             <name>b69/f#</name>
         </Harmony>
@@ -13432,7 +13432,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2--2-</pattern>
+        <pattern>X[2-O]--[2-O]-;B1[2-5]</pattern>
         <Harmony>
             <name>b69(b5)</name>
         </Harmony>
@@ -13456,7 +13456,7 @@
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-----</pattern>
+        <pattern>X-----;B2[1-2];B4[3-5]</pattern>
         <Harmony>
             <name>b6(add4)</name>
         </Harmony>
@@ -13485,7 +13485,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2X122</pattern>
+        <pattern>X[2-O]X[1-O][2-O][2-O]</pattern>
         <Harmony>
             <name>b69(no3)</name>
         </Harmony>
@@ -13505,7 +13505,7 @@
                 <barre start="2" end="5">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2----</pattern>
+        <pattern>X[2-O]----;B4[2-5]</pattern>
         <Harmony>
             <name>b6/f#</name>
         </Harmony>
@@ -13526,7 +13526,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6----</pattern>
+        <pattern>X[6-O]----;B4[2-5]</pattern>
         <Harmony>
             <name>b6/eb</name>
         </Harmony>
@@ -13546,7 +13546,7 @@
                 <barre start="2" end="5">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X----</pattern>
+        <pattern>[3-O]X----;B4[2-5]</pattern>
         <Harmony>
             <name>b6/g</name>
         </Harmony>
@@ -13566,7 +13566,7 @@
                 <barre start="2" end="5">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1----</pattern>
+        <pattern>X[1-O]----;B4[2-5]</pattern>
         <Harmony>
             <name>b6/a#</name>
         </Harmony>
@@ -13595,7 +13595,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X212O2</pattern>
+        <pattern>X[2-O][1-O][2-O]O[2-O]</pattern>
         <Harmony>
             <name>b7</name>
         </Harmony>
@@ -13615,7 +13615,7 @@
                 <barre start="2" end="5">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3----</pattern>
+        <pattern>X[3-O]----;B4[2-5]</pattern>
         <Harmony>
             <name>b6/c</name>
         </Harmony>
@@ -13641,7 +13641,7 @@
                 <barre start="1" end="3">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-4-44</pattern>
+        <pattern>X-[4-O]-[4-O][4-O];B2[1-3]</pattern>
         <Harmony>
             <name>b7(add13)</name>
         </Harmony>
@@ -13667,7 +13667,7 @@
                 <barre start="1" end="3">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-1-OO</pattern>
+        <pattern>X-[1-O]-OO;B2[1-3]</pattern>
         <Harmony>
             <name>b7(add4)</name>
         </Harmony>
@@ -13696,7 +13696,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X212O3</pattern>
+        <pattern>X[2-O][1-O][2-O]O[3-O]</pattern>
         <Harmony>
             <name>b7b13</name>
         </Harmony>
@@ -13725,7 +13725,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X212O1</pattern>
+        <pattern>X[2-O][1-O][2-O]O[1-O]</pattern>
         <Harmony>
             <name>b7b5</name>
         </Harmony>
@@ -13751,7 +13751,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2-2-X</pattern>
+        <pattern>X[2-O]-[2-O]-X;B1[2-4]</pattern>
         <Harmony>
             <name>b7b9</name>
         </Harmony>
@@ -13781,7 +13781,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3445</pattern>
+        <pattern>XX[3-O][4-O][4-O][5-O]</pattern>
         <Harmony>
             <name>b7b5/f</name>
         </Harmony>
@@ -13805,7 +13805,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>7X7---</pattern>
+        <pattern>[7-O]X[7-O]---;B8[3-5]</pattern>
         <Harmony>
             <name>b7(b13b9)</name>
         </Harmony>
@@ -13834,7 +13834,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO11O2</pattern>
+        <pattern>XO[1-O][1-O]O[2-O]</pattern>
         <Harmony>
             <name>b6/a</name>
         </Harmony>
@@ -13863,7 +13863,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1212</pattern>
+        <pattern>XX[1-O][2-O][1-O][2-O]</pattern>
         <Harmony>
             <name>b7b9/d#</name>
         </Harmony>
@@ -13886,7 +13886,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2-2--</pattern>
+        <pattern>X[2-O]-[2-O]--;B1[2-5]</pattern>
         <Harmony>
             <name>b7(#11b9)</name>
         </Harmony>
@@ -13915,7 +13915,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2X121X</pattern>
+        <pattern>[2-O]X[1-O][2-O][1-O]X</pattern>
         <Harmony>
             <name>b7b9/f#</name>
         </Harmony>
@@ -13944,7 +13944,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2221X</pattern>
+        <pattern>X[2-O][2-O][2-O][1-O]X</pattern>
         <Harmony>
             <name>b7b9sus4</name>
         </Harmony>
@@ -13970,7 +13970,7 @@
                 <barre start="1" end="3">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-4-XX</pattern>
+        <pattern>X-[4-O]-XX;B2[1-3]</pattern>
         <Harmony>
             <name>b7(no3)</name>
         </Harmony>
@@ -13999,7 +13999,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO12O2</pattern>
+        <pattern>XO[1-O][2-O]O[2-O]</pattern>
         <Harmony>
             <name>b7/a</name>
         </Harmony>
@@ -14028,7 +14028,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X112O2</pattern>
+        <pattern>X[1-O][1-O][2-O]O[2-O]</pattern>
         <Harmony>
             <name>b7/bb</name>
         </Harmony>
@@ -14057,7 +14057,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3424X</pattern>
+        <pattern>X[3-O][4-O][2-O][4-O]X</pattern>
         <Harmony>
             <name>b7/c</name>
         </Harmony>
@@ -14078,7 +14078,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X----5</pattern>
+        <pattern>X----[5-O];B4[1-4]</pattern>
         <Harmony>
             <name>b7/c#</name>
         </Harmony>
@@ -14107,7 +14107,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX12O2</pattern>
+        <pattern>XX[1-O][2-O]O[2-O]</pattern>
         <Harmony>
             <name>b7/d#</name>
         </Harmony>
@@ -14129,7 +14129,7 @@
                 <barre start="2" end="4">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O-----</pattern>
+        <pattern>O-----;B2[1-5];B4[2-4]</pattern>
         <Harmony>
             <name>b7/e</name>
         </Harmony>
@@ -14158,7 +14158,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX12O2</pattern>
+        <pattern>XX[1-O][2-O]O[2-O]</pattern>
         <Harmony>
             <name>b7/eb</name>
         </Harmony>
@@ -14187,7 +14187,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX32O2</pattern>
+        <pattern>XX[3-O][2-O]O[2-O]</pattern>
         <Harmony>
             <name>b7/f</name>
         </Harmony>
@@ -14211,7 +14211,7 @@
                 <barre start="2" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X---5</pattern>
+        <pattern>[3-O]X---[5-O];B4[2-4]</pattern>
         <Harmony>
             <name>b7/g</name>
         </Harmony>
@@ -14240,7 +14240,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2X12O2</pattern>
+        <pattern>[2-O]X[1-O][2-O]O[2-O]</pattern>
         <Harmony>
             <name>b7/f#</name>
         </Harmony>
@@ -14270,7 +14270,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>7X788X</pattern>
+        <pattern>[7-O]X[7-O][8-O][8-O]X</pattern>
         <Harmony>
             <name>b+7</name>
         </Harmony>
@@ -14299,7 +14299,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2X12O2</pattern>
+        <pattern>[2-O]X[1-O][2-O]O[2-O]</pattern>
         <Harmony>
             <name>b7/gb</name>
         </Harmony>
@@ -14328,7 +14328,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X212O1</pattern>
+        <pattern>X[2-O][1-O][2-O]O[1-O]</pattern>
         <Harmony>
             <name>b7#11</name>
         </Harmony>
@@ -14357,7 +14357,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X212O3</pattern>
+        <pattern>X[2-O][1-O][2-O]O[3-O]</pattern>
         <Harmony>
             <name>b7#5</name>
         </Harmony>
@@ -14383,7 +14383,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2-2-3</pattern>
+        <pattern>X[2-O]-[2-O]-[3-O];B1[2-4]</pattern>
         <Harmony>
             <name>b7(b9#5)</name>
         </Harmony>
@@ -14409,7 +14409,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-2-3</pattern>
+        <pattern>XX-[2-O]-[3-O];B1[2-4]</pattern>
         <Harmony>
             <name>b7(b9#5)/d#</name>
         </Harmony>
@@ -14438,7 +14438,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX12O3</pattern>
+        <pattern>XX[1-O][2-O]O[3-O]</pattern>
         <Harmony>
             <name>b7#5/d#</name>
         </Harmony>
@@ -14464,7 +14464,7 @@
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X212--</pattern>
+        <pattern>X[2-O][1-O][2-O]--;B3[4-5]</pattern>
         <Harmony>
             <name>b7(#9#5)</name>
         </Harmony>
@@ -14493,7 +14493,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2123X</pattern>
+        <pattern>X[2-O][1-O][2-O][3-O]X</pattern>
         <Harmony>
             <name>b7#9</name>
         </Harmony>
@@ -14519,7 +14519,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2-23-</pattern>
+        <pattern>X[2-O]-[2-O][3-O]-;B1[2-5]</pattern>
         <Harmony>
             <name>b7(#11#9)</name>
         </Harmony>
@@ -14545,7 +14545,7 @@
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X212--</pattern>
+        <pattern>X[2-O][1-O][2-O]--;B3[4-5]</pattern>
         <Harmony>
             <name>b7(b13#9)</name>
         </Harmony>
@@ -14569,7 +14569,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-4-5-</pattern>
+        <pattern>X-[4-O]-[5-O]-;B2[1-5]</pattern>
         <Harmony>
             <name>b7sus4</name>
         </Harmony>
@@ -14598,7 +14598,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2221O</pattern>
+        <pattern>X[2-O][2-O][2-O][1-O]O</pattern>
         <Harmony>
             <name>b7(b9sus4)</name>
         </Harmony>
@@ -14622,7 +14622,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-4-5-</pattern>
+        <pattern>X-[4-O]-[5-O]-;B2[1-5]</pattern>
         <Harmony>
             <name>b7sus4</name>
         </Harmony>
@@ -14651,7 +14651,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX12OO</pattern>
+        <pattern>XX[1-O][2-O]OO</pattern>
         <Harmony>
             <name>b7sus4/d#</name>
         </Harmony>
@@ -14675,7 +14675,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O-4-5-</pattern>
+        <pattern>O-[4-O]-[5-O]-;B2[1-5]</pattern>
         <Harmony>
             <name>b7sus4/e</name>
         </Harmony>
@@ -14696,7 +14696,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>--4-5-</pattern>
+        <pattern>--[4-O]-[5-O]-;B2[0-5]</pattern>
         <Harmony>
             <name>b7sus4/f#</name>
         </Harmony>
@@ -14719,7 +14719,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X21---</pattern>
+        <pattern>X[2-O][1-O]---;B2[3-5]</pattern>
         <Harmony>
             <name>b9</name>
         </Harmony>
@@ -14745,7 +14745,7 @@
                 <barre start="3" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X21--3</pattern>
+        <pattern>X[2-O][1-O]--[3-O];B2[3-4]</pattern>
         <Harmony>
             <name>b9b13</name>
         </Harmony>
@@ -14768,7 +14768,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1---</pattern>
+        <pattern>XX[1-O]---;B2[3-5]</pattern>
         <Harmony>
             <name>b9/d#</name>
         </Harmony>
@@ -14794,7 +14794,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2-22-</pattern>
+        <pattern>X[2-O]-[2-O][2-O]-;B1[2-5]</pattern>
         <Harmony>
             <name>b9b5</name>
         </Harmony>
@@ -14817,7 +14817,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2X1---</pattern>
+        <pattern>[2-O]X[1-O]---;B2[3-5]</pattern>
         <Harmony>
             <name>b9/f#</name>
         </Harmony>
@@ -14843,7 +14843,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2-22-</pattern>
+        <pattern>X[2-O]-[2-O][2-O]-;B1[2-5]</pattern>
         <Harmony>
             <name>b9#11</name>
         </Harmony>
@@ -14869,7 +14869,7 @@
                 <barre start="3" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X21--3</pattern>
+        <pattern>X[2-O][1-O]--[3-O];B2[3-4]</pattern>
         <Harmony>
             <name>b9#5</name>
         </Harmony>
@@ -14899,7 +14899,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>7X765X</pattern>
+        <pattern>[7-O]X[7-O][6-O][5-O]X</pattern>
         <Harmony>
             <name>b9sus4</name>
         </Harmony>
@@ -14928,7 +14928,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO1222</pattern>
+        <pattern>XO[1-O][2-O][2-O][2-O]</pattern>
         <Harmony>
             <name>b9/a</name>
         </Harmony>
@@ -14955,7 +14955,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>7X-6-X</pattern>
+        <pattern>[7-O]X-[6-O]-X;B4[2-4]</pattern>
         <Harmony>
             <name>badd2</name>
         </Harmony>
@@ -14982,7 +14982,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6-6-X</pattern>
+        <pattern>X[6-O]-[6-O]-X;B4[2-4]</pattern>
         <Harmony>
             <name>badd2/d#</name>
         </Harmony>
@@ -15002,7 +15002,7 @@
                 <barre start="0" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>--44--</pattern>
+        <pattern>--[4-O][4-O]--;B2[0-5]</pattern>
         <Harmony>
             <name>badd2/f#</name>
         </Harmony>
@@ -15031,7 +15031,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2444O</pattern>
+        <pattern>X[2-O][4-O][4-O][4-O]O</pattern>
         <Harmony>
             <name>badd4</name>
         </Harmony>
@@ -15061,7 +15061,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO444O</pattern>
+        <pattern>XO[4-O][4-O][4-O]O</pattern>
         <Harmony>
             <name>badd4/a</name>
         </Harmony>
@@ -15091,7 +15091,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X644OO</pattern>
+        <pattern>X[6-O][4-O][4-O]OO</pattern>
         <Harmony>
             <name>badd4/d#</name>
         </Harmony>
@@ -15121,7 +15121,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX444O</pattern>
+        <pattern>XX[4-O][4-O][4-O]O</pattern>
         <Harmony>
             <name>badd4/f#</name>
         </Harmony>
@@ -15150,7 +15150,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2344X</pattern>
+        <pattern>X[2-O][3-O][4-O][4-O]X</pattern>
         <Harmony>
             <name>b(#4)</name>
         </Harmony>
@@ -15180,7 +15180,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX9879</pattern>
+        <pattern>XX[9-O][8-O][7-O][9-O]</pattern>
         <Harmony>
             <name>badd9</name>
         </Harmony>
@@ -15207,7 +15207,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6-6-X</pattern>
+        <pattern>X[6-O]-[6-O]-X;B4[2-4]</pattern>
         <Harmony>
             <name>badd9/d#</name>
         </Harmony>
@@ -15237,7 +15237,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X9X879</pattern>
+        <pattern>X[9-O]X[8-O][7-O][9-O]</pattern>
         <Harmony>
             <name>badd9/f#</name>
         </Harmony>
@@ -15266,7 +15266,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2344X</pattern>
+        <pattern>X[2-O][3-O][4-O][4-O]X</pattern>
         <Harmony>
             <name>b(b5)</name>
         </Harmony>
@@ -15295,7 +15295,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2343X</pattern>
+        <pattern>X[2-O][3-O][4-O][3-O]X</pattern>
         <Harmony>
             <name>bdim</name>
         </Harmony>
@@ -15324,7 +15324,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO343X</pattern>
+        <pattern>XO[3-O][4-O][3-O]X</pattern>
         <Harmony>
             <name>bdim/a</name>
         </Harmony>
@@ -15353,7 +15353,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO1O1</pattern>
+        <pattern>XXO[1-O]O[1-O]</pattern>
         <Harmony>
             <name>bdim7</name>
         </Harmony>
@@ -15382,7 +15382,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XOO1O1</pattern>
+        <pattern>XOO[1-O]O[1-O]</pattern>
         <Harmony>
             <name>bdim7/a</name>
         </Harmony>
@@ -15409,7 +15409,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X-4-X</pattern>
+        <pattern>[4-O]X-[4-O]-X;B3[2-4]</pattern>
         <Harmony>
             <name>bdim7/ab</name>
         </Harmony>
@@ -15438,7 +15438,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3X1O1</pattern>
+        <pattern>X[3-O]X[1-O]O[1-O]</pattern>
         <Harmony>
             <name>bdim7/c</name>
         </Harmony>
@@ -15467,7 +15467,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO1O1</pattern>
+        <pattern>XXO[1-O]O[1-O]</pattern>
         <Harmony>
             <name>bdim7/d</name>
         </Harmony>
@@ -15496,7 +15496,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX11O1</pattern>
+        <pattern>XX[1-O][1-O]O[1-O]</pattern>
         <Harmony>
             <name>bdim7/eb</name>
         </Harmony>
@@ -15525,7 +15525,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1O1O1</pattern>
+        <pattern>X[1-O]O[1-O]O[1-O]</pattern>
         <Harmony>
             <name>bdim/bb</name>
         </Harmony>
@@ -15554,7 +15554,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO431</pattern>
+        <pattern>XXO[4-O][3-O][1-O]</pattern>
         <Harmony>
             <name>bdim/d</name>
         </Harmony>
@@ -15583,7 +15583,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O2343X</pattern>
+        <pattern>O[2-O][3-O][4-O][3-O]X</pattern>
         <Harmony>
             <name>bdim/e</name>
         </Harmony>
@@ -15612,7 +15612,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX343X</pattern>
+        <pattern>XX[3-O][4-O][3-O]X</pattern>
         <Harmony>
             <name>bdim/f</name>
         </Harmony>
@@ -15638,7 +15638,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-333-</pattern>
+        <pattern>X-[3-O][3-O][3-O]-;B1[1-5]</pattern>
         <Harmony>
             <name>bb</name>
         </Harmony>
@@ -15655,7 +15655,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-----</pattern>
+        <pattern>X-----;B1[1-5]</pattern>
         <Harmony>
             <name>bb11</name>
         </Harmony>
@@ -15684,7 +15684,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX333O</pattern>
+        <pattern>XX[3-O][3-O][3-O]O</pattern>
         <Harmony>
             <name>bb(#11)</name>
         </Harmony>
@@ -15714,7 +15714,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX6788</pattern>
+        <pattern>XX[6-O][7-O][8-O][8-O]</pattern>
         <Harmony>
             <name>bb13</name>
         </Harmony>
@@ -15743,7 +15743,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1OO1O</pattern>
+        <pattern>X[1-O]OO[1-O]O</pattern>
         <Harmony>
             <name>bb13b5</name>
         </Harmony>
@@ -15773,7 +15773,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>7X678X</pattern>
+        <pattern>[7-O]X[6-O][7-O][8-O]X</pattern>
         <Harmony>
             <name>bb13b9</name>
         </Harmony>
@@ -15802,7 +15802,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO133</pattern>
+        <pattern>XXO[1-O][3-O][3-O]</pattern>
         <Harmony>
             <name>bb13/d</name>
         </Harmony>
@@ -15831,7 +15831,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3133</pattern>
+        <pattern>XX[3-O][1-O][3-O][3-O]</pattern>
         <Harmony>
             <name>bb13/f</name>
         </Harmony>
@@ -15851,7 +15851,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X----3</pattern>
+        <pattern>X----[3-O];B1[1-4]</pattern>
         <Harmony>
             <name>bb13sus4</name>
         </Harmony>
@@ -15877,7 +15877,7 @@
                 <barre start="1" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-2-33</pattern>
+        <pattern>X-[2-O]-[3-O][3-O];B1[1-3]</pattern>
         <Harmony>
             <name>bb13#11</name>
         </Harmony>
@@ -15906,7 +15906,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1O123</pattern>
+        <pattern>X[1-O]O[1-O][2-O][3-O]</pattern>
         <Harmony>
             <name>bb13#9</name>
         </Harmony>
@@ -15935,7 +15935,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X133XX</pattern>
+        <pattern>X[1-O][3-O][3-O]XX</pattern>
         <Harmony>
             <name>bb5</name>
         </Harmony>
@@ -15961,7 +15961,7 @@
                 <barre start="2" end="3">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X--XX</pattern>
+        <pattern>[4-O]X--XX;B3[2-3]</pattern>
         <Harmony>
             <name>bb5/ab</name>
         </Harmony>
@@ -15990,7 +15990,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO33XX</pattern>
+        <pattern>XO[3-O][3-O]XX</pattern>
         <Harmony>
             <name>bb5/a</name>
         </Harmony>
@@ -16019,7 +16019,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X333XX</pattern>
+        <pattern>X[3-O][3-O][3-O]XX</pattern>
         <Harmony>
             <name>bb5/c</name>
         </Harmony>
@@ -16049,7 +16049,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X5336X</pattern>
+        <pattern>X[5-O][3-O][3-O][6-O]X</pattern>
         <Harmony>
             <name>bb5/d</name>
         </Harmony>
@@ -16075,7 +16075,7 @@
                 <barre start="0" end="1">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>--33XX</pattern>
+        <pattern>--[3-O][3-O]XX;B1[0-1]</pattern>
         <Harmony>
             <name>bb5/f</name>
         </Harmony>
@@ -16098,7 +16098,7 @@
                 <barre start="0" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>--2-33</pattern>
+        <pattern>--[2-O]-[3-O][3-O];B1[0-3]</pattern>
         <Harmony>
             <name>bb13#11/f</name>
         </Harmony>
@@ -16127,7 +16127,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3133XX</pattern>
+        <pattern>[3-O][1-O][3-O][3-O]XX</pattern>
         <Harmony>
             <name>bb5/g</name>
         </Harmony>
@@ -16156,7 +16156,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X13O3X</pattern>
+        <pattern>X[1-O][3-O]O[3-O]X</pattern>
         <Harmony>
             <name>bb6</name>
         </Harmony>
@@ -16185,7 +16185,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1OO11</pattern>
+        <pattern>X[1-O]OO[1-O][1-O]</pattern>
         <Harmony>
             <name>bb69</name>
         </Harmony>
@@ -16205,7 +16205,7 @@
                 <barre start="2" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO----</pattern>
+        <pattern>XO----;B3[2-5]</pattern>
         <Harmony>
             <name>bb6/a</name>
         </Harmony>
@@ -16234,7 +16234,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXOO11</pattern>
+        <pattern>XXOO[1-O][1-O]</pattern>
         <Harmony>
             <name>bb69/d</name>
         </Harmony>
@@ -16263,7 +16263,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1OO1O</pattern>
+        <pattern>X[1-O]OO[1-O]O</pattern>
         <Harmony>
             <name>bb69(#11)</name>
         </Harmony>
@@ -16283,7 +16283,7 @@
                 <barre start="2" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X----</pattern>
+        <pattern>[4-O]X----;B3[2-5]</pattern>
         <Harmony>
             <name>bb6/ab</name>
         </Harmony>
@@ -16313,7 +16313,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>685XXX</pattern>
+        <pattern>[6-O][8-O][5-O]XXX</pattern>
         <Harmony>
             <name>bb6(no3)</name>
         </Harmony>
@@ -16330,7 +16330,7 @@
                 <barre start="1" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-----</pattern>
+        <pattern>X-----;B3[1-5]</pattern>
         <Harmony>
             <name>bb6/c</name>
         </Harmony>
@@ -16353,7 +16353,7 @@
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO---</pattern>
+        <pattern>XXO---;B3[3-5]</pattern>
         <Harmony>
             <name>bb6/d</name>
         </Harmony>
@@ -16382,7 +16382,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>11OO11</pattern>
+        <pattern>[1-O][1-O]OO[1-O][1-O]</pattern>
         <Harmony>
             <name>bb69/f</name>
         </Harmony>
@@ -16402,7 +16402,7 @@
                 <barre start="2" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX----</pattern>
+        <pattern>XX----;B3[2-5]</pattern>
         <Harmony>
             <name>bb6/f</name>
         </Harmony>
@@ -16424,7 +16424,7 @@
                 <barre start="2" end="4">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-----</pattern>
+        <pattern>X-----;B1[1-5];B3[2-4]</pattern>
         <Harmony>
             <name>bb7</name>
         </Harmony>
@@ -16447,7 +16447,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO---</pattern>
+        <pattern>XXO---;B1[3-5]</pattern>
         <Harmony>
             <name>bb7(add9)/d</name>
         </Harmony>
@@ -16477,7 +16477,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>6X678X</pattern>
+        <pattern>[6-O]X[6-O][7-O][8-O]X</pattern>
         <Harmony>
             <name>bb7(add13)</name>
         </Harmony>
@@ -16507,7 +16507,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>6X674X</pattern>
+        <pattern>[6-O]X[6-O][7-O][4-O]X</pattern>
         <Harmony>
             <name>bb7(add4)</name>
         </Harmony>
@@ -16537,7 +16537,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>6X677X</pattern>
+        <pattern>[6-O]X[6-O][7-O][7-O]X</pattern>
         <Harmony>
             <name>bb7(b13)</name>
         </Harmony>
@@ -16567,7 +16567,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>6X675X</pattern>
+        <pattern>[6-O]X[6-O][7-O][5-O]X</pattern>
         <Harmony>
             <name>bb7b5</name>
         </Harmony>
@@ -16596,7 +16596,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1O1OO</pattern>
+        <pattern>X[1-O]O[1-O]OO</pattern>
         <Harmony>
             <name>bb7(b9b5)</name>
         </Harmony>
@@ -16626,7 +16626,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>6X67XX</pattern>
+        <pattern>[6-O]X[6-O][7-O]XX</pattern>
         <Harmony>
             <name>bb7(no5)</name>
         </Harmony>
@@ -16656,7 +16656,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>7X78XX</pattern>
+        <pattern>[7-O]X[7-O][8-O]XX</pattern>
         <Harmony>
             <name>b7(no5)</name>
         </Harmony>
@@ -16685,7 +16685,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1O1O1</pattern>
+        <pattern>X[1-O]O[1-O]O[1-O]</pattern>
         <Harmony>
             <name>bb7b9</name>
         </Harmony>
@@ -16709,7 +16709,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>6X6---</pattern>
+        <pattern>[6-O]X[6-O]---;B7[3-5]</pattern>
         <Harmony>
             <name>bb7(b13b9)</name>
         </Harmony>
@@ -16738,7 +16738,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO1O1</pattern>
+        <pattern>XXO[1-O]O[1-O]</pattern>
         <Harmony>
             <name>bb7b9/d</name>
         </Harmony>
@@ -16765,7 +16765,7 @@
                 <barre start="0" end="2">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-8-XXX</pattern>
+        <pattern>-[8-O]-XXX;B6[0-2]</pattern>
         <Harmony>
             <name>bb7(no3)</name>
         </Harmony>
@@ -16791,7 +16791,7 @@
                 <barre start="1" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-3-XX</pattern>
+        <pattern>X-[3-O]-XX;B1[1-3]</pattern>
         <Harmony>
             <name>bb7(no3)</name>
         </Harmony>
@@ -16820,7 +16820,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XOO131</pattern>
+        <pattern>XOO[1-O][3-O][1-O]</pattern>
         <Harmony>
             <name>bb7/a</name>
         </Harmony>
@@ -16843,7 +16843,7 @@
                 <barre start="2" end="4">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X---4</pattern>
+        <pattern>[4-O]X---[4-O];B3[2-4]</pattern>
         <Harmony>
             <name>bb7/ab</name>
         </Harmony>
@@ -16869,7 +16869,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3O-3-</pattern>
+        <pattern>X[3-O]O-[3-O]-;B1[3-5]</pattern>
         <Harmony>
             <name>bb7/c</name>
         </Harmony>
@@ -16895,7 +16895,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO-3-</pattern>
+        <pattern>XXO-[3-O]-;B1[3-5]</pattern>
         <Harmony>
             <name>bb7/d</name>
         </Harmony>
@@ -16916,7 +16916,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--7--</pattern>
+        <pattern>X--[7-O]--;B6[1-5]</pattern>
         <Harmony>
             <name>bb7/eb</name>
         </Harmony>
@@ -16935,7 +16935,7 @@
                 <barre start="2" end="4">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>------</pattern>
+        <pattern>------;B1[0-5];B3[2-4]</pattern>
         <Harmony>
             <name>bb7/f</name>
         </Harmony>
@@ -16958,7 +16958,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O-3-3-</pattern>
+        <pattern>O-[3-O]-[3-O]-;B1[1-5]</pattern>
         <Harmony>
             <name>bb7/fb</name>
         </Harmony>
@@ -16988,7 +16988,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>6X677X</pattern>
+        <pattern>[6-O]X[6-O][7-O][7-O]X</pattern>
         <Harmony>
             <name>bb+7</name>
         </Harmony>
@@ -17018,7 +17018,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>6X675X</pattern>
+        <pattern>[6-O]X[6-O][7-O][5-O]X</pattern>
         <Harmony>
             <name>bb7#11</name>
         </Harmony>
@@ -17048,7 +17048,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>6X677X</pattern>
+        <pattern>[6-O]X[6-O][7-O][7-O]X</pattern>
         <Harmony>
             <name>bb7#5</name>
         </Harmony>
@@ -17077,7 +17077,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1O1O2</pattern>
+        <pattern>X[1-O]O[1-O]O[2-O]</pattern>
         <Harmony>
             <name>bb7(b9#5)</name>
         </Harmony>
@@ -17106,7 +17106,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1O122</pattern>
+        <pattern>X[1-O]O[1-O][2-O][2-O]</pattern>
         <Harmony>
             <name>bb7(#9#5)</name>
         </Harmony>
@@ -17136,7 +17136,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X5677X</pattern>
+        <pattern>X[5-O][6-O][7-O][7-O]X</pattern>
         <Harmony>
             <name>bb7#5/d</name>
         </Harmony>
@@ -17165,7 +17165,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1O12X</pattern>
+        <pattern>X[1-O]O[1-O][2-O]X</pattern>
         <Harmony>
             <name>bb7#9</name>
         </Harmony>
@@ -17194,7 +17194,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1O122</pattern>
+        <pattern>X[1-O]O[1-O][2-O][2-O]</pattern>
         <Harmony>
             <name>bb7(b13#9)</name>
         </Harmony>
@@ -17223,7 +17223,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>11O12X</pattern>
+        <pattern>[1-O][1-O]O[1-O][2-O]X</pattern>
         <Harmony>
             <name>bb7#9/f</name>
         </Harmony>
@@ -17246,7 +17246,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-3-4-</pattern>
+        <pattern>X-[3-O]-[4-O]-;B1[1-5]</pattern>
         <Harmony>
             <name>bb7sus4</name>
         </Harmony>
@@ -17267,7 +17267,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--8--</pattern>
+        <pattern>X--[8-O]--;B6[1-5]</pattern>
         <Harmony>
             <name>bb7sus4/eb</name>
         </Harmony>
@@ -17291,7 +17291,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>6X6---</pattern>
+        <pattern>[6-O]X[6-O]---;B4[3-5]</pattern>
         <Harmony>
             <name>bb7b9sus4</name>
         </Harmony>
@@ -17311,7 +17311,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-3---</pattern>
+        <pattern>X-[3-O]---;B1[1-5]</pattern>
         <Harmony>
             <name>bb7sus2</name>
         </Harmony>
@@ -17334,7 +17334,7 @@
                 <barre start="1" end="3">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X---44</pattern>
+        <pattern>X---[4-O][4-O];B3[1-3]</pattern>
         <Harmony>
             <name>bb7sus4/c</name>
         </Harmony>
@@ -17354,7 +17354,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>--3-4-</pattern>
+        <pattern>--[3-O]-[4-O]-;B1[0-5]</pattern>
         <Harmony>
             <name>bb7sus4/f</name>
         </Harmony>
@@ -17380,7 +17380,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X3-4-</pattern>
+        <pattern>[3-O]X[3-O]-[4-O]-;B1[3-5]</pattern>
         <Harmony>
             <name>bb7sus4/g</name>
         </Harmony>
@@ -17403,7 +17403,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1O---</pattern>
+        <pattern>X[1-O]O---;B1[3-5]</pattern>
         <Harmony>
             <name>bb9</name>
         </Harmony>
@@ -17426,7 +17426,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4XO---</pattern>
+        <pattern>[4-O]XO---;B1[3-5]</pattern>
         <Harmony>
             <name>bb9/ab</name>
         </Harmony>
@@ -17455,7 +17455,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1O112</pattern>
+        <pattern>X[1-O]O[1-O][1-O][2-O]</pattern>
         <Harmony>
             <name>bb9b13</name>
         </Harmony>
@@ -17484,7 +17484,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1O11O</pattern>
+        <pattern>X[1-O]O[1-O][1-O]O</pattern>
         <Harmony>
             <name>bb9b5</name>
         </Harmony>
@@ -17507,7 +17507,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO---</pattern>
+        <pattern>XXO---;B1[3-5]</pattern>
         <Harmony>
             <name>bb9/d</name>
         </Harmony>
@@ -17527,7 +17527,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX----</pattern>
+        <pattern>XX----;B1[2-5]</pattern>
         <Harmony>
             <name>bb9/eb</name>
         </Harmony>
@@ -17550,7 +17550,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>1XO---</pattern>
+        <pattern>[1-O]XO---;B1[3-5]</pattern>
         <Harmony>
             <name>bb9/f</name>
         </Harmony>
@@ -17579,7 +17579,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1O11O</pattern>
+        <pattern>X[1-O]O[1-O][1-O]O</pattern>
         <Harmony>
             <name>bb9#11</name>
         </Harmony>
@@ -17608,7 +17608,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1O11O</pattern>
+        <pattern>X[1-O]O[1-O][1-O]O</pattern>
         <Harmony>
             <name>bb9(#4)</name>
         </Harmony>
@@ -17637,7 +17637,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1O113</pattern>
+        <pattern>X[1-O]O[1-O][1-O][3-O]</pattern>
         <Harmony>
             <name>bb9(add13)</name>
         </Harmony>
@@ -17666,7 +17666,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1O112</pattern>
+        <pattern>X[1-O]O[1-O][1-O][2-O]</pattern>
         <Harmony>
             <name>bb9#5</name>
         </Harmony>
@@ -17689,7 +17689,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX---2</pattern>
+        <pattern>XX---[2-O];B1[2-4]</pattern>
         <Harmony>
             <name>bb9#5/eb</name>
         </Harmony>
@@ -17719,7 +17719,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>6X654X</pattern>
+        <pattern>[6-O]X[6-O][5-O][4-O]X</pattern>
         <Harmony>
             <name>bb9sus4</name>
         </Harmony>
@@ -17746,7 +17746,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>6X-5-X</pattern>
+        <pattern>[6-O]X-[5-O]-X;B3[2-4]</pattern>
         <Harmony>
             <name>bbadd2</name>
         </Harmony>
@@ -17773,7 +17773,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X-5-X</pattern>
+        <pattern>[4-O]X-[5-O]-X;B3[2-4]</pattern>
         <Harmony>
             <name>bbadd2/ab</name>
         </Harmony>
@@ -17797,7 +17797,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--5-X</pattern>
+        <pattern>X--[5-O]-X;B3[1-4]</pattern>
         <Harmony>
             <name>bbadd2/c</name>
         </Harmony>
@@ -17823,7 +17823,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO3--</pattern>
+        <pattern>XXO[3-O]--;B1[4-5]</pattern>
         <Harmony>
             <name>bbadd2/d</name>
         </Harmony>
@@ -17850,7 +17850,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-87-8</pattern>
+        <pattern>X-[8-O][7-O]-[8-O];B6[1-4]</pattern>
         <Harmony>
             <name>bbadd2/eb</name>
         </Harmony>
@@ -17877,7 +17877,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-5-6</pattern>
+        <pattern>XX-[5-O]-[6-O];B3[2-4]</pattern>
         <Harmony>
             <name>bbadd2/f</name>
         </Harmony>
@@ -17900,7 +17900,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--33-</pattern>
+        <pattern>X--[3-O][3-O]-;B1[1-5]</pattern>
         <Harmony>
             <name>bbadd4</name>
         </Harmony>
@@ -17929,7 +17929,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4XO34X</pattern>
+        <pattern>[4-O]XO[3-O][4-O]X</pattern>
         <Harmony>
             <name>bbadd4/ab</name>
         </Harmony>
@@ -17958,7 +17958,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO341</pattern>
+        <pattern>XXO[3-O][4-O][1-O]</pattern>
         <Harmony>
             <name>bbadd4/d</name>
         </Harmony>
@@ -17978,7 +17978,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>---33-</pattern>
+        <pattern>---[3-O][3-O]-;B1[0-5]</pattern>
         <Harmony>
             <name>bbadd4/f</name>
         </Harmony>
@@ -18008,7 +18008,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX8768</pattern>
+        <pattern>XX[8-O][7-O][6-O][8-O]</pattern>
         <Harmony>
             <name>bbadd9</name>
         </Harmony>
@@ -18031,7 +18031,7 @@
                 <barre start="2" end="4">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4---X</pattern>
+        <pattern>X[4-O]---X;B3[2-4]</pattern>
         <Harmony>
             <name>bb(#9)</name>
         </Harmony>
@@ -18054,7 +18054,7 @@
                 <barre start="2" end="4">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4---X</pattern>
+        <pattern>X[4-O]---X;B3[2-4]</pattern>
         <Harmony>
             <name>bb(#9)</name>
         </Harmony>
@@ -18083,7 +18083,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1O31O</pattern>
+        <pattern>X[1-O]O[3-O][1-O]O</pattern>
         <Harmony>
             <name>bb(#11add9)</name>
         </Harmony>
@@ -18113,7 +18113,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO8768</pattern>
+        <pattern>XO[8-O][7-O][6-O][8-O]</pattern>
         <Harmony>
             <name>bbadd9/a</name>
         </Harmony>
@@ -18139,7 +18139,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X333--</pattern>
+        <pattern>X[3-O][3-O][3-O]--;B1[4-5]</pattern>
         <Harmony>
             <name>bbadd9/c</name>
         </Harmony>
@@ -18165,7 +18165,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO3--</pattern>
+        <pattern>XXO[3-O]--;B1[4-5]</pattern>
         <Harmony>
             <name>bbadd9/d</name>
         </Harmony>
@@ -18195,7 +18195,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X8X768</pattern>
+        <pattern>X[8-O]X[7-O][6-O][8-O]</pattern>
         <Harmony>
             <name>bbadd9/f</name>
         </Harmony>
@@ -18222,7 +18222,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X-5-X</pattern>
+        <pattern>[4-O]X-[5-O]-X;B3[2-4]</pattern>
         <Harmony>
             <name>bbadd9/ab</name>
         </Harmony>
@@ -18251,7 +18251,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX232O</pattern>
+        <pattern>XX[2-O][3-O][2-O]O</pattern>
         <Harmony>
             <name>bbdim</name>
         </Harmony>
@@ -18277,7 +18277,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-233-</pattern>
+        <pattern>X-[2-O][3-O][3-O]-;B1[1-5]</pattern>
         <Harmony>
             <name>bb(#4)</name>
         </Harmony>
@@ -18307,7 +18307,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO36O</pattern>
+        <pattern>XXO[3-O][6-O]O</pattern>
         <Harmony>
             <name>bb(#4)/d</name>
         </Harmony>
@@ -18336,7 +18336,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X12O2O</pattern>
+        <pattern>X[1-O][2-O]O[2-O]O</pattern>
         <Harmony>
             <name>bbdim7</name>
         </Harmony>
@@ -18365,7 +18365,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3323</pattern>
+        <pattern>XX[3-O][3-O][2-O][3-O]</pattern>
         <Harmony>
             <name>bbdim7/f</name>
         </Harmony>
@@ -18394,7 +18394,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>312O2O</pattern>
+        <pattern>[3-O][1-O][2-O]O[2-O]O</pattern>
         <Harmony>
             <name>bbdim7/g</name>
         </Harmony>
@@ -18423,7 +18423,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4X32O</pattern>
+        <pattern>X[4-O]X[3-O][2-O]O</pattern>
         <Harmony>
             <name>bbdim/db</name>
         </Harmony>
@@ -18452,7 +18452,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX132O</pattern>
+        <pattern>XX[1-O][3-O][2-O]O</pattern>
         <Harmony>
             <name>bbdim/eb</name>
         </Harmony>
@@ -18481,7 +18481,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX332O</pattern>
+        <pattern>XX[3-O][3-O][2-O]O</pattern>
         <Harmony>
             <name>bbdim/f</name>
         </Harmony>
@@ -18510,7 +18510,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1233X</pattern>
+        <pattern>X[1-O][2-O][3-O][3-O]X</pattern>
         <Harmony>
             <name>bb(b5)</name>
         </Harmony>
@@ -18536,7 +18536,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-332-</pattern>
+        <pattern>X-[3-O][3-O][2-O]-;B1[1-5]</pattern>
         <Harmony>
             <name>bbm</name>
         </Harmony>
@@ -18566,7 +18566,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>6X664X</pattern>
+        <pattern>[6-O]X[6-O][6-O][4-O]X</pattern>
         <Harmony>
             <name>bbm11</name>
         </Harmony>
@@ -18592,7 +18592,7 @@
                 <barre start="1" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-3-23</pattern>
+        <pattern>X-[3-O]-[2-O][3-O];B1[1-3]</pattern>
         <Harmony>
             <name>bbm13</name>
         </Harmony>
@@ -18615,7 +18615,7 @@
                 <barre start="2" end="4">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-8----</pattern>
+        <pattern>-[8-O]----;B6[0-5];B8[2-4]</pattern>
         <Harmony>
             <name>bbm6</name>
         </Harmony>
@@ -18644,7 +18644,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2332X</pattern>
+        <pattern>X[2-O][3-O][3-O][2-O]X</pattern>
         <Harmony>
             <name>bbm</name>
         </Harmony>
@@ -18673,7 +18673,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4332X</pattern>
+        <pattern>X[4-O][3-O][3-O][2-O]X</pattern>
         <Harmony>
             <name>bbm/db</name>
         </Harmony>
@@ -18702,7 +18702,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X332X</pattern>
+        <pattern>[4-O]X[3-O][3-O][2-O]X</pattern>
         <Harmony>
             <name>bbm/ab</name>
         </Harmony>
@@ -18731,7 +18731,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4321</pattern>
+        <pattern>XX[4-O][3-O][2-O][1-O]</pattern>
         <Harmony>
             <name>bbm/gb</name>
         </Harmony>
@@ -18760,7 +18760,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4321</pattern>
+        <pattern>XX[4-O][3-O][2-O][1-O]</pattern>
         <Harmony>
             <name>bbm/f#</name>
         </Harmony>
@@ -18787,7 +18787,7 @@
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X455--</pattern>
+        <pattern>X[4-O][5-O][5-O]--;B6[4-5]</pattern>
         <Harmony>
             <name>bbm69</name>
         </Harmony>
@@ -18816,7 +18816,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X332X</pattern>
+        <pattern>[3-O]X[3-O][3-O][2-O]X</pattern>
         <Harmony>
             <name>bbm6/g</name>
         </Harmony>
@@ -18845,7 +18845,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3X323</pattern>
+        <pattern>X[3-O]X[3-O][2-O][3-O]</pattern>
         <Harmony>
             <name>bbm6/c</name>
         </Harmony>
@@ -18875,7 +18875,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4532X</pattern>
+        <pattern>X[4-O][5-O][3-O][2-O]X</pattern>
         <Harmony>
             <name>bbm6/db</name>
         </Harmony>
@@ -18904,7 +18904,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3323</pattern>
+        <pattern>XX[3-O][3-O][2-O][3-O]</pattern>
         <Harmony>
             <name>bbm6/f</name>
         </Harmony>
@@ -18927,7 +18927,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-3-2-</pattern>
+        <pattern>X-[3-O]-[2-O]-;B1[1-5]</pattern>
         <Harmony>
             <name>bbm7</name>
         </Harmony>
@@ -18957,7 +18957,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>6X664X</pattern>
+        <pattern>[6-O]X[6-O][6-O][4-O]X</pattern>
         <Harmony>
             <name>bbm7(add11)</name>
         </Harmony>
@@ -18983,7 +18983,7 @@
                 <barre start="1" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-3-23</pattern>
+        <pattern>X-[3-O]-[2-O][3-O];B1[1-3]</pattern>
         <Harmony>
             <name>bbm7(add13)</name>
         </Harmony>
@@ -19013,7 +19013,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4X566</pattern>
+        <pattern>X[4-O]X[5-O][6-O][6-O]</pattern>
         <Harmony>
             <name>bbm(add2)/db</name>
         </Harmony>
@@ -19043,7 +19043,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>6X664X</pattern>
+        <pattern>[6-O]X[6-O][6-O][4-O]X</pattern>
         <Harmony>
             <name>bbm7(add4)</name>
         </Harmony>
@@ -19067,7 +19067,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>6X---8</pattern>
+        <pattern>[6-O]X---[8-O];B6[2-4]</pattern>
         <Harmony>
             <name>bbm7(add9)</name>
         </Harmony>
@@ -19096,7 +19096,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1332O</pattern>
+        <pattern>X[1-O][3-O][3-O][2-O]O</pattern>
         <Harmony>
             <name>bbm(#4)</name>
         </Harmony>
@@ -19125,7 +19125,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1212X</pattern>
+        <pattern>X[1-O][2-O][1-O][2-O]X</pattern>
         <Harmony>
             <name>bbm7b5</name>
         </Harmony>
@@ -19151,7 +19151,7 @@
                 <barre start="2" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1-1-X</pattern>
+        <pattern>X[1-O]-[1-O]-X;B2[2-4]</pattern>
         <Harmony>
             <name>bbm7b5/ab</name>
         </Harmony>
@@ -19180,7 +19180,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3212O</pattern>
+        <pattern>X[3-O][2-O][1-O][2-O]O</pattern>
         <Harmony>
             <name>bbm7b5/c</name>
         </Harmony>
@@ -19206,7 +19206,7 @@
                 <barre start="2" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4-3-4</pattern>
+        <pattern>X[4-O]-[3-O]-[4-O];B2[2-4]</pattern>
         <Harmony>
             <name>bbm7b5/db</name>
         </Harmony>
@@ -19227,7 +19227,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX----</pattern>
+        <pattern>XX----;B6[2-5]</pattern>
         <Harmony>
             <name>bbm7/ab</name>
         </Harmony>
@@ -19248,7 +19248,7 @@
                 <barre start="2" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4----</pattern>
+        <pattern>X[4-O]----;B6[2-5]</pattern>
         <Harmony>
             <name>bbm7/db</name>
         </Harmony>
@@ -19266,7 +19266,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-----</pattern>
+        <pattern>X-----;B6[1-5]</pattern>
         <Harmony>
             <name>bbm7/eb</name>
         </Harmony>
@@ -19286,7 +19286,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>--3-2-</pattern>
+        <pattern>--[3-O]-[2-O]-;B1[0-5]</pattern>
         <Harmony>
             <name>bbm7/f</name>
         </Harmony>
@@ -19312,7 +19312,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X3-2-</pattern>
+        <pattern>[3-O]X[3-O]-[2-O]-;B1[3-5]</pattern>
         <Harmony>
             <name>bbm7/g</name>
         </Harmony>
@@ -19335,7 +19335,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-3-4-</pattern>
+        <pattern>X-[3-O]-[4-O]-;B1[1-5]</pattern>
         <Harmony>
             <name>bbm7sus4</name>
         </Harmony>
@@ -19358,7 +19358,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-3-4-</pattern>
+        <pattern>X-[3-O]-[4-O]-;B1[1-5]</pattern>
         <Harmony>
             <name>bbm7sus4</name>
         </Harmony>
@@ -19379,7 +19379,7 @@
                 <barre start="0" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-8---8</pattern>
+        <pattern>-[8-O]---[8-O];B6[0-4]</pattern>
         <Harmony>
             <name>bbm9</name>
         </Harmony>
@@ -19400,7 +19400,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X----8</pattern>
+        <pattern>X----[8-O];B6[1-4]</pattern>
         <Harmony>
             <name>bbm9/eb</name>
         </Harmony>
@@ -19424,7 +19424,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX---8</pattern>
+        <pattern>XX---[8-O];B6[2-4]</pattern>
         <Harmony>
             <name>bbm9/ab</name>
         </Harmony>
@@ -19448,7 +19448,7 @@
                 <barre start="0" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-88--8</pattern>
+        <pattern>-[8-O][8-O]--[8-O];B6[0-4]</pattern>
         <Harmony>
             <name>bbm(add2)</name>
         </Harmony>
@@ -19472,7 +19472,7 @@
                 <barre start="0" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-88--8</pattern>
+        <pattern>-[8-O][8-O]--[8-O];B6[0-4]</pattern>
         <Harmony>
             <name>bbm(add9)</name>
         </Harmony>
@@ -19501,7 +19501,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1X233</pattern>
+        <pattern>X[1-O]X[2-O][3-O][3-O]</pattern>
         <Harmony>
             <name>bbmaj13</name>
         </Harmony>
@@ -19526,7 +19526,7 @@
                 <barre start="2" end="4">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--2--</pattern>
+        <pattern>X--[2-O]--;B1[1-5];B3[2-4]</pattern>
         <Harmony>
             <name>bbmaj7</name>
         </Harmony>
@@ -19555,7 +19555,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1223O</pattern>
+        <pattern>X[1-O][2-O][2-O][3-O]O</pattern>
         <Harmony>
             <name>bbmaj7b5</name>
         </Harmony>
@@ -19584,7 +19584,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X132XX</pattern>
+        <pattern>X[1-O][3-O][2-O]XX</pattern>
         <Harmony>
             <name>bbmaj7(no3)</name>
         </Harmony>
@@ -19613,7 +19613,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X132XX</pattern>
+        <pattern>X[1-O][3-O][2-O]XX</pattern>
         <Harmony>
             <name>bbmaj7(no3)</name>
         </Harmony>
@@ -19642,7 +19642,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3132XX</pattern>
+        <pattern>[3-O][1-O][3-O][2-O]XX</pattern>
         <Harmony>
             <name>bbmaj7(no3)/g</name>
         </Harmony>
@@ -19672,7 +19672,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO8765</pattern>
+        <pattern>XO[8-O][7-O][6-O][5-O]</pattern>
         <Harmony>
             <name>bbmaj7/a</name>
         </Harmony>
@@ -19701,7 +19701,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3323X</pattern>
+        <pattern>X[3-O][3-O][2-O][3-O]X</pattern>
         <Harmony>
             <name>bbmaj7/c</name>
         </Harmony>
@@ -19728,7 +19728,7 @@
                 <barre start="3" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO--5</pattern>
+        <pattern>XXO--[5-O];B3[3-4]</pattern>
         <Harmony>
             <name>bbmaj7/d</name>
         </Harmony>
@@ -19754,7 +19754,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O-323-</pattern>
+        <pattern>O-[3-O][2-O][3-O]-;B1[1-5]</pattern>
         <Harmony>
             <name>bbmaj7/e</name>
         </Harmony>
@@ -19784,7 +19784,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6776X</pattern>
+        <pattern>X[6-O][7-O][7-O][6-O]X</pattern>
         <Harmony>
             <name>bbmaj7/eb</name>
         </Harmony>
@@ -19806,7 +19806,7 @@
                 <barre start="2" end="4">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>---2--</pattern>
+        <pattern>---[2-O]--;B1[0-5];B3[2-4]</pattern>
         <Harmony>
             <name>bbmaj7/f</name>
         </Harmony>
@@ -19830,7 +19830,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X---6</pattern>
+        <pattern>[3-O]X---[6-O];B3[2-4]</pattern>
         <Harmony>
             <name>bbmaj7/g</name>
         </Harmony>
@@ -19859,7 +19859,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1323O</pattern>
+        <pattern>X[1-O][3-O][2-O][3-O]O</pattern>
         <Harmony>
             <name>bbmaj7#11</name>
         </Harmony>
@@ -19883,7 +19883,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-8-6-</pattern>
+        <pattern>X-[8-O]-[6-O]-;B5[1-5]</pattern>
         <Harmony>
             <name>bbmaj7sus2/d</name>
         </Harmony>
@@ -19913,7 +19913,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>6X777X</pattern>
+        <pattern>[6-O]X[7-O][7-O][7-O]X</pattern>
         <Harmony>
             <name>bbmaj7#5</name>
         </Harmony>
@@ -19942,7 +19942,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O1423X</pattern>
+        <pattern>O[1-O][4-O][2-O][3-O]X</pattern>
         <Harmony>
             <name>bbmaj7#5/e</name>
         </Harmony>
@@ -19966,7 +19966,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X9---X</pattern>
+        <pattern>X[9-O]---X;B7[2-4]</pattern>
         <Harmony>
             <name>bbmaj7#5/f#</name>
         </Harmony>
@@ -19996,7 +19996,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>6X756X</pattern>
+        <pattern>[6-O]X[7-O][5-O][6-O]X</pattern>
         <Harmony>
             <name>bbmaj9</name>
         </Harmony>
@@ -20023,7 +20023,7 @@
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>6X77--</pattern>
+        <pattern>[6-O]X[7-O][7-O]--;B8[4-5]</pattern>
         <Harmony>
             <name>bbmaj9(add13)</name>
         </Harmony>
@@ -20044,7 +20044,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X----5</pattern>
+        <pattern>X----[5-O];B3[1-4]</pattern>
         <Harmony>
             <name>bbmaj9/c</name>
         </Harmony>
@@ -20073,7 +20073,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO313</pattern>
+        <pattern>XXO[3-O][1-O][3-O]</pattern>
         <Harmony>
             <name>bbmaj9/d</name>
         </Harmony>
@@ -20103,7 +20103,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6756X</pattern>
+        <pattern>X[6-O][7-O][5-O][6-O]X</pattern>
         <Harmony>
             <name>bbmaj9/eb</name>
         </Harmony>
@@ -20132,7 +20132,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1O21O</pattern>
+        <pattern>X[1-O]O[2-O][1-O]O</pattern>
         <Harmony>
             <name>bbmaj9#11</name>
         </Harmony>
@@ -20156,7 +20156,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX7---</pattern>
+        <pattern>XX[7-O]---;B6[3-5]</pattern>
         <Harmony>
             <name>bbm(#7)</name>
         </Harmony>
@@ -20176,7 +20176,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>--32--</pattern>
+        <pattern>--[3-O][2-O]--;B1[0-5]</pattern>
         <Harmony>
             <name>bbmaj9/f</name>
         </Harmony>
@@ -20203,7 +20203,7 @@
                 <barre start="3" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X33--5</pattern>
+        <pattern>X[3-O][3-O]--[5-O];B2[3-4]</pattern>
         <Harmony>
             <name>bbm(#7)/c</name>
         </Harmony>
@@ -20227,7 +20227,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>987---</pattern>
+        <pattern>[9-O][8-O][7-O]---;B6[3-5]</pattern>
         <Harmony>
             <name>bbm(#7)/db</name>
         </Harmony>
@@ -20251,7 +20251,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X87---</pattern>
+        <pattern>X[8-O][7-O]---;B6[3-5]</pattern>
         <Harmony>
             <name>bbm(#7)/f</name>
         </Harmony>
@@ -20275,7 +20275,7 @@
                 <barre start="0" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-87--8</pattern>
+        <pattern>-[8-O][7-O]--[8-O];B6[0-4]</pattern>
         <Harmony>
             <name>bbm(add9)</name>
         </Harmony>
@@ -20304,7 +20304,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO321</pattern>
+        <pattern>XXO[3-O][2-O][1-O]</pattern>
         <Harmony>
             <name>bbm/d</name>
         </Harmony>
@@ -20325,7 +20325,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX----</pattern>
+        <pattern>XX----;B6[2-5]</pattern>
         <Harmony>
             <name>bbm/ab</name>
         </Harmony>
@@ -20354,7 +20354,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3X321</pattern>
+        <pattern>X[3-O]X[3-O][2-O][1-O]</pattern>
         <Harmony>
             <name>bbm/c</name>
         </Harmony>
@@ -20383,7 +20383,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4332X</pattern>
+        <pattern>X[4-O][3-O][3-O][2-O]X</pattern>
         <Harmony>
             <name>bbm/db</name>
         </Harmony>
@@ -20409,7 +20409,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-33-</pattern>
+        <pattern>XX-[3-O][3-O]-;B1[2-5]</pattern>
         <Harmony>
             <name>bb/eb</name>
         </Harmony>
@@ -20432,7 +20432,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>--332-</pattern>
+        <pattern>--[3-O][3-O][2-O]-;B1[0-5]</pattern>
         <Harmony>
             <name>bbm/f</name>
         </Harmony>
@@ -20461,7 +20461,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X332X</pattern>
+        <pattern>[3-O]X[3-O][3-O][2-O]X</pattern>
         <Harmony>
             <name>bbm/g</name>
         </Harmony>
@@ -20485,7 +20485,7 @@
                 <barre start="0" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-98--X</pattern>
+        <pattern>-[9-O][8-O]--X;B6[0-4]</pattern>
         <Harmony>
             <name>bbm(#5)</name>
         </Harmony>
@@ -20514,7 +20514,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO3321</pattern>
+        <pattern>XO[3-O][3-O][2-O][1-O]</pattern>
         <Harmony>
             <name>bbm/a</name>
         </Harmony>
@@ -20540,7 +20540,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-32-</pattern>
+        <pattern>XX-[3-O][2-O]-;B1[2-5]</pattern>
         <Harmony>
             <name>bbm/eb</name>
         </Harmony>
@@ -20569,7 +20569,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO3331</pattern>
+        <pattern>XO[3-O][3-O][3-O][1-O]</pattern>
         <Harmony>
             <name>bb/a</name>
         </Harmony>
@@ -20592,7 +20592,7 @@
                 <barre start="2" end="4">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X---X</pattern>
+        <pattern>[4-O]X---X;B3[2-4]</pattern>
         <Harmony>
             <name>bb/ab</name>
         </Harmony>
@@ -20615,7 +20615,7 @@
                 <barre start="2" end="4">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2---X</pattern>
+        <pattern>X[2-O]---X;B3[2-4]</pattern>
         <Harmony>
             <name>bb/b</name>
         </Harmony>
@@ -20644,7 +20644,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3X331</pattern>
+        <pattern>X[3-O]X[3-O][3-O][1-O]</pattern>
         <Harmony>
             <name>bb/c</name>
         </Harmony>
@@ -20673,7 +20673,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO331</pattern>
+        <pattern>XXO[3-O][3-O][1-O]</pattern>
         <Harmony>
             <name>bb/d</name>
         </Harmony>
@@ -20699,7 +20699,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O-333-</pattern>
+        <pattern>O-[3-O][3-O][3-O]-;B1[1-5]</pattern>
         <Harmony>
             <name>bb/e</name>
         </Harmony>
@@ -20728,7 +20728,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3331</pattern>
+        <pattern>XX[3-O][3-O][3-O][1-O]</pattern>
         <Harmony>
             <name>bb/f</name>
         </Harmony>
@@ -20757,7 +20757,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4331</pattern>
+        <pattern>XX[4-O][3-O][3-O][1-O]</pattern>
         <Harmony>
             <name>bb/f#</name>
         </Harmony>
@@ -20786,7 +20786,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X333X</pattern>
+        <pattern>[3-O]X[3-O][3-O][3-O]X</pattern>
         <Harmony>
             <name>bb/g</name>
         </Harmony>
@@ -20815,7 +20815,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4331</pattern>
+        <pattern>XX[4-O][3-O][3-O][1-O]</pattern>
         <Harmony>
             <name>bb/gb</name>
         </Harmony>
@@ -20844,7 +20844,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4332</pattern>
+        <pattern>XX[4-O][3-O][3-O][2-O]</pattern>
         <Harmony>
             <name>bb+</name>
         </Harmony>
@@ -20873,7 +20873,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO4332</pattern>
+        <pattern>XO[4-O][3-O][3-O][2-O]</pattern>
         <Harmony>
             <name>bb+/a</name>
         </Harmony>
@@ -20902,7 +20902,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO332</pattern>
+        <pattern>XXO[3-O][3-O][2-O]</pattern>
         <Harmony>
             <name>bb+/d</name>
         </Harmony>
@@ -20931,7 +20931,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX2332</pattern>
+        <pattern>XX[2-O][3-O][3-O][2-O]</pattern>
         <Harmony>
             <name>bb+/e</name>
         </Harmony>
@@ -20960,7 +20960,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1332</pattern>
+        <pattern>XX[1-O][3-O][3-O][2-O]</pattern>
         <Harmony>
             <name>bb+/eb</name>
         </Harmony>
@@ -20989,7 +20989,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3332</pattern>
+        <pattern>XX[3-O][3-O][3-O][2-O]</pattern>
         <Harmony>
             <name>bb+/f</name>
         </Harmony>
@@ -21018,7 +21018,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4332</pattern>
+        <pattern>XX[4-O][3-O][3-O][2-O]</pattern>
         <Harmony>
             <name>bb+/f#</name>
         </Harmony>
@@ -21047,7 +21047,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4332</pattern>
+        <pattern>XX[4-O][3-O][3-O][2-O]</pattern>
         <Harmony>
             <name>bb+/gb</name>
         </Harmony>
@@ -21076,7 +21076,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3X33O</pattern>
+        <pattern>X[3-O]X[3-O][3-O]O</pattern>
         <Harmony>
             <name>bb(#4)/c</name>
         </Harmony>
@@ -21105,7 +21105,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4332</pattern>
+        <pattern>XX[4-O][3-O][3-O][2-O]</pattern>
         <Harmony>
             <name>bbaug</name>
         </Harmony>
@@ -21131,7 +21131,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-334-</pattern>
+        <pattern>X-[3-O][3-O][4-O]-;B1[1-5]</pattern>
         <Harmony>
             <name>bbsus</name>
         </Harmony>
@@ -21154,7 +21154,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-33--</pattern>
+        <pattern>X-[3-O][3-O]--;B1[1-5]</pattern>
         <Harmony>
             <name>bbsus2</name>
         </Harmony>
@@ -21183,7 +21183,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X11XO1</pattern>
+        <pattern>X[1-O][1-O]XO[1-O]</pattern>
         <Harmony>
             <name>bb(b9sus4)</name>
         </Harmony>
@@ -21206,7 +21206,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-3--</pattern>
+        <pattern>XX-[3-O]--;B1[2-5]</pattern>
         <Harmony>
             <name>bbsus2/eb</name>
         </Harmony>
@@ -21235,7 +21235,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X331X</pattern>
+        <pattern>[4-O]X[3-O][3-O][1-O]X</pattern>
         <Harmony>
             <name>bbsus2/ab</name>
         </Harmony>
@@ -21261,7 +21261,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X333--</pattern>
+        <pattern>X[3-O][3-O][3-O]--;B1[4-5]</pattern>
         <Harmony>
             <name>bbsus2/c</name>
         </Harmony>
@@ -21281,7 +21281,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--3--</pattern>
+        <pattern>X--[3-O]--;B1[1-5]</pattern>
         <Harmony>
             <name>bbsus2add4</name>
         </Harmony>
@@ -21307,7 +21307,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3-34-</pattern>
+        <pattern>X[3-O]-[3-O][4-O]-;B1[2-5]</pattern>
         <Harmony>
             <name>bbsus2add4/c</name>
         </Harmony>
@@ -21333,7 +21333,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO3--</pattern>
+        <pattern>XXO[3-O]--;B1[4-5]</pattern>
         <Harmony>
             <name>bbsus2/d</name>
         </Harmony>
@@ -21359,7 +21359,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX33--</pattern>
+        <pattern>XX[3-O][3-O]--;B1[4-5]</pattern>
         <Harmony>
             <name>bbsus2/f</name>
         </Harmony>
@@ -21388,7 +21388,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX331O</pattern>
+        <pattern>XX[3-O][3-O][1-O]O</pattern>
         <Harmony>
             <name>bb(#4sus2)</name>
         </Harmony>
@@ -21408,7 +21408,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--3--</pattern>
+        <pattern>X--[3-O]--;B1[1-5]</pattern>
         <Harmony>
             <name>bb(add2sus4)</name>
         </Harmony>
@@ -21434,7 +21434,7 @@
                 <barre start="2" end="3">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X--4X</pattern>
+        <pattern>[4-O]X--[4-O]X;B3[2-3]</pattern>
         <Harmony>
             <name>bbsus/ab</name>
         </Harmony>
@@ -21463,7 +21463,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3X341</pattern>
+        <pattern>X[3-O]X[3-O][4-O][1-O]</pattern>
         <Harmony>
             <name>bbsus/c</name>
         </Harmony>
@@ -21492,7 +21492,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO341</pattern>
+        <pattern>XXO[3-O][4-O][1-O]</pattern>
         <Harmony>
             <name>bbsus/d</name>
         </Harmony>
@@ -21518,7 +21518,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-34-</pattern>
+        <pattern>XX-[3-O][4-O]-;B1[2-5]</pattern>
         <Harmony>
             <name>bbsus/eb</name>
         </Harmony>
@@ -21541,7 +21541,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>--334-</pattern>
+        <pattern>--[3-O][3-O][4-O]-;B1[0-5]</pattern>
         <Harmony>
             <name>bbsus/f</name>
         </Harmony>
@@ -21567,7 +21567,7 @@
                 <barre start="2" end="3">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>31--4X</pattern>
+        <pattern>[3-O][1-O]--[4-O]X;B3[2-3]</pattern>
         <Harmony>
             <name>bbsus/g</name>
         </Harmony>
@@ -21593,7 +21593,7 @@
                 <barre start="1" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-443-</pattern>
+        <pattern>X-[4-O][4-O][3-O]-;B2[1-5]</pattern>
         <Harmony>
             <name>bm</name>
         </Harmony>
@@ -21622,7 +21622,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2X23O</pattern>
+        <pattern>X[2-O]X[2-O][3-O]O</pattern>
         <Harmony>
             <name>bm11</name>
         </Harmony>
@@ -21651,7 +21651,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2323O</pattern>
+        <pattern>X[2-O][3-O][2-O][3-O]O</pattern>
         <Harmony>
             <name>bm11b5</name>
         </Harmony>
@@ -21674,7 +21674,7 @@
                 <barre start="1" end="3">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X---33</pattern>
+        <pattern>X---[3-O][3-O];B2[1-3]</pattern>
         <Harmony>
             <name>bm11b6</name>
         </Harmony>
@@ -21703,7 +21703,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2X23O</pattern>
+        <pattern>X[2-O]X[2-O][3-O]O</pattern>
         <Harmony>
             <name>bm11(no5)</name>
         </Harmony>
@@ -21732,7 +21732,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2X23O</pattern>
+        <pattern>X[2-O]X[2-O][3-O]O</pattern>
         <Harmony>
             <name>bm13</name>
         </Harmony>
@@ -21761,7 +21761,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2O1O2</pattern>
+        <pattern>X[2-O]O[1-O]O[2-O]</pattern>
         <Harmony>
             <name>bm6</name>
         </Harmony>
@@ -21788,7 +21788,7 @@
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X566--</pattern>
+        <pattern>X[5-O][6-O][6-O]--;B7[4-5]</pattern>
         <Harmony>
             <name>bm69</name>
         </Harmony>
@@ -21817,7 +21817,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XOO1O2</pattern>
+        <pattern>XOO[1-O]O[2-O]</pattern>
         <Harmony>
             <name>bm6/a</name>
         </Harmony>
@@ -21844,7 +21844,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>8X9-9-</pattern>
+        <pattern>[8-O]X[9-O]-[9-O]-;B7[3-5]</pattern>
         <Harmony>
             <name>bm6/c</name>
         </Harmony>
@@ -21873,7 +21873,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO1O2</pattern>
+        <pattern>XXO[1-O]O[2-O]</pattern>
         <Harmony>
             <name>bm6/d</name>
         </Harmony>
@@ -21902,7 +21902,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>22O1O2</pattern>
+        <pattern>[2-O][2-O]O[1-O]O[2-O]</pattern>
         <Harmony>
             <name>bm6/f#</name>
         </Harmony>
@@ -21926,7 +21926,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX6---</pattern>
+        <pattern>XX[6-O]---;B7[3-5]</pattern>
         <Harmony>
             <name>bm6/g#</name>
         </Harmony>
@@ -21949,7 +21949,7 @@
                 <barre start="1" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-4-3-</pattern>
+        <pattern>X-[4-O]-[3-O]-;B2[1-5]</pattern>
         <Harmony>
             <name>bm7</name>
         </Harmony>
@@ -21978,7 +21978,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2X23O</pattern>
+        <pattern>X[2-O]X[2-O][3-O]O</pattern>
         <Harmony>
             <name>bm7(add11)</name>
         </Harmony>
@@ -22007,7 +22007,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2X23O</pattern>
+        <pattern>X[2-O]X[2-O][3-O]O</pattern>
         <Harmony>
             <name>bm7(add11)</name>
         </Harmony>
@@ -22036,7 +22036,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2X23O</pattern>
+        <pattern>X[2-O]X[2-O][3-O]O</pattern>
         <Harmony>
             <name>bm7(add4)</name>
         </Harmony>
@@ -22065,7 +22065,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2323X</pattern>
+        <pattern>X[2-O][3-O][2-O][3-O]X</pattern>
         <Harmony>
             <name>bm7b5</name>
         </Harmony>
@@ -22094,7 +22094,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XOO2O1</pattern>
+        <pattern>XOO[2-O]O[1-O]</pattern>
         <Harmony>
             <name>bm7b5/a</name>
         </Harmony>
@@ -22123,7 +22123,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO2O1</pattern>
+        <pattern>XXO[2-O]O[1-O]</pattern>
         <Harmony>
             <name>bm7b5/d</name>
         </Harmony>
@@ -22152,7 +22152,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O2O2O1</pattern>
+        <pattern>O[2-O]O[2-O]O[1-O]</pattern>
         <Harmony>
             <name>bm7b5/e</name>
         </Harmony>
@@ -22179,7 +22179,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-4-5</pattern>
+        <pattern>XX-[4-O]-[5-O];B3[2-4]</pattern>
         <Harmony>
             <name>bm7b5/f</name>
         </Harmony>
@@ -22208,7 +22208,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2X23X</pattern>
+        <pattern>X[2-O]X[2-O][3-O]X</pattern>
         <Harmony>
             <name>bm7(no5)</name>
         </Harmony>
@@ -22237,7 +22237,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XOO2O2</pattern>
+        <pattern>XOO[2-O]O[2-O]</pattern>
         <Harmony>
             <name>bm7/a</name>
         </Harmony>
@@ -22266,7 +22266,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO2O2</pattern>
+        <pattern>XXO[2-O]O[2-O]</pattern>
         <Harmony>
             <name>bm7/d</name>
         </Harmony>
@@ -22289,7 +22289,7 @@
                 <barre start="1" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O-4-3-</pattern>
+        <pattern>O-[4-O]-[3-O]-;B2[1-5]</pattern>
         <Harmony>
             <name>bm7/e</name>
         </Harmony>
@@ -22309,7 +22309,7 @@
                 <barre start="0" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>--4-3-</pattern>
+        <pattern>--[4-O]-[3-O]-;B2[0-5]</pattern>
         <Harmony>
             <name>bm7/f#</name>
         </Harmony>
@@ -22332,7 +22332,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2O---</pattern>
+        <pattern>X[2-O]O---;B2[3-5]</pattern>
         <Harmony>
             <name>bm9</name>
         </Harmony>
@@ -22361,7 +22361,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2O22O</pattern>
+        <pattern>X[2-O]O[2-O][2-O]O</pattern>
         <Harmony>
             <name>bm9(add4)</name>
         </Harmony>
@@ -22387,7 +22387,7 @@
                 <barre start="3" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2O--3</pattern>
+        <pattern>X[2-O]O--[3-O];B2[3-4]</pattern>
         <Harmony>
             <name>bm9#5</name>
         </Harmony>
@@ -22410,7 +22410,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XOO---</pattern>
+        <pattern>XOO---;B2[3-5]</pattern>
         <Harmony>
             <name>bm9/a</name>
         </Harmony>
@@ -22433,7 +22433,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1O---</pattern>
+        <pattern>X[1-O]O---;B2[3-5]</pattern>
         <Harmony>
             <name>bm9/a#</name>
         </Harmony>
@@ -22456,7 +22456,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>22O---</pattern>
+        <pattern>[2-O][2-O]O---;B2[3-5]</pattern>
         <Harmony>
             <name>bm9/f#</name>
         </Harmony>
@@ -22482,7 +22482,7 @@
                 <barre start="3" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4XO--X</pattern>
+        <pattern>[4-O]XO--X;B2[3-4]</pattern>
         <Harmony>
             <name>bm9/g#</name>
         </Harmony>
@@ -22511,7 +22511,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2O42X</pattern>
+        <pattern>X[2-O]O[4-O][2-O]X</pattern>
         <Harmony>
             <name>bm(add2)</name>
         </Harmony>
@@ -22537,7 +22537,7 @@
                 <barre start="4" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO44--</pattern>
+        <pattern>XO[4-O][4-O]--;B2[4-5]</pattern>
         <Harmony>
             <name>bm(add2)/a</name>
         </Harmony>
@@ -22566,7 +22566,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4443X</pattern>
+        <pattern>X[4-O][4-O][4-O][3-O]X</pattern>
         <Harmony>
             <name>bm(add2)/c#</name>
         </Harmony>
@@ -22589,7 +22589,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O2O---</pattern>
+        <pattern>O[2-O]O---;B2[3-5]</pattern>
         <Harmony>
             <name>bm9/e</name>
         </Harmony>
@@ -22618,7 +22618,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XOO42X</pattern>
+        <pattern>XOO[4-O][2-O]X</pattern>
         <Harmony>
             <name>bm(add2)/a</name>
         </Harmony>
@@ -22647,7 +22647,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4XO42X</pattern>
+        <pattern>[4-O]XO[4-O][2-O]X</pattern>
         <Harmony>
             <name>bm(add2)/g#</name>
         </Harmony>
@@ -22676,7 +22676,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2443O</pattern>
+        <pattern>X[2-O][4-O][4-O][3-O]O</pattern>
         <Harmony>
             <name>bm(add4)</name>
         </Harmony>
@@ -22705,7 +22705,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3XO42X</pattern>
+        <pattern>[3-O]XO[4-O][2-O]X</pattern>
         <Harmony>
             <name>bm(add2)/g</name>
         </Harmony>
@@ -22731,7 +22731,7 @@
                 <barre start="4" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO4--</pattern>
+        <pattern>XXO[4-O]--;B2[4-5]</pattern>
         <Harmony>
             <name>bm(add2)/d</name>
         </Harmony>
@@ -22755,7 +22755,7 @@
                 <barre start="0" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-99--9</pattern>
+        <pattern>-[9-O][9-O]--[9-O];B7[0-4]</pattern>
         <Harmony>
             <name>bm(add9)</name>
         </Harmony>
@@ -22780,7 +22780,7 @@
                 <barre start="2" end="4">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--3--</pattern>
+        <pattern>X--[3-O]--;B2[1-5];B4[2-4]</pattern>
         <Harmony>
             <name>bmaj7</name>
         </Harmony>
@@ -22809,7 +22809,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3241</pattern>
+        <pattern>XX[3-O][2-O][4-O][1-O]</pattern>
         <Harmony>
             <name>bmaj7b5/e#</name>
         </Harmony>
@@ -22838,7 +22838,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4434X</pattern>
+        <pattern>X[4-O][4-O][3-O][4-O]X</pattern>
         <Harmony>
             <name>bmaj7/c#</name>
         </Harmony>
@@ -22867,7 +22867,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X243XX</pattern>
+        <pattern>X[2-O][4-O][3-O]XX</pattern>
         <Harmony>
             <name>bmaj7(no3)</name>
         </Harmony>
@@ -22894,7 +22894,7 @@
                 <barre start="3" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3--6</pattern>
+        <pattern>XX[3-O]--[6-O];B4[3-4]</pattern>
         <Harmony>
             <name>bmaj7(no5)/f</name>
         </Harmony>
@@ -22924,7 +22924,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO443O</pattern>
+        <pattern>XO[4-O][4-O][3-O]O</pattern>
         <Harmony>
             <name>bm(add4)/a</name>
         </Harmony>
@@ -22953,7 +22953,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2X443O</pattern>
+        <pattern>[2-O]X[4-O][4-O][3-O]O</pattern>
         <Harmony>
             <name>bm(add4)/f#</name>
         </Harmony>
@@ -22983,7 +22983,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3434X</pattern>
+        <pattern>X[3-O][4-O][3-O][4-O]X</pattern>
         <Harmony>
             <name>bmaj7/c</name>
         </Harmony>
@@ -23007,7 +23007,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6---6</pattern>
+        <pattern>X[6-O]---[6-O];B4[2-4]</pattern>
         <Harmony>
             <name>bmaj7/d#</name>
         </Harmony>
@@ -23029,7 +23029,7 @@
                 <barre start="2" end="4">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>---3--</pattern>
+        <pattern>---[3-O]--;B2[0-5];B4[2-4]</pattern>
         <Harmony>
             <name>bmaj7/f#</name>
         </Harmony>
@@ -23058,7 +23058,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2X341</pattern>
+        <pattern>X[2-O]X[3-O][4-O][1-O]</pattern>
         <Harmony>
             <name>bmaj7#11</name>
         </Harmony>
@@ -23082,7 +23082,7 @@
                 <barre start="2" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>7X---X</pattern>
+        <pattern>[7-O]X---X;B8[2-4]</pattern>
         <Harmony>
             <name>bmaj7#5</name>
         </Harmony>
@@ -23111,7 +23111,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2132X</pattern>
+        <pattern>X[2-O][1-O][3-O][2-O]X</pattern>
         <Harmony>
             <name>bmaj9</name>
         </Harmony>
@@ -23137,7 +23137,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2-32-</pattern>
+        <pattern>X[2-O]-[3-O][2-O]-;B1[2-5]</pattern>
         <Harmony>
             <name>bmaj9#11</name>
         </Harmony>
@@ -23163,7 +23163,7 @@
                 <barre start="4" end="5">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X213--</pattern>
+        <pattern>X[2-O][1-O][3-O]--;B4[4-5]</pattern>
         <Harmony>
             <name>bmaj13</name>
         </Harmony>
@@ -23187,7 +23187,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX8---</pattern>
+        <pattern>XX[8-O]---;B7[3-5]</pattern>
         <Harmony>
             <name>bm(#7)</name>
         </Harmony>
@@ -23211,7 +23211,7 @@
                 <barre start="0" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-98--9</pattern>
+        <pattern>-[9-O][8-O]--[9-O];B7[0-4]</pattern>
         <Harmony>
             <name>bm(add9)</name>
         </Harmony>
@@ -23238,7 +23238,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>7X-77-</pattern>
+        <pattern>[7-O]X-[7-O][7-O]-;B6[2-5]</pattern>
         <Harmony>
             <name>bm(add13)</name>
         </Harmony>
@@ -23267,7 +23267,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO4432</pattern>
+        <pattern>XO[4-O][4-O][3-O][2-O]</pattern>
         <Harmony>
             <name>bm/a</name>
         </Harmony>
@@ -23291,7 +23291,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX8---</pattern>
+        <pattern>XX[8-O]---;B7[3-5]</pattern>
         <Harmony>
             <name>bm/a#</name>
         </Harmony>
@@ -23320,7 +23320,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4443X</pattern>
+        <pattern>X[4-O][4-O][4-O][3-O]X</pattern>
         <Harmony>
             <name>bm/c#</name>
         </Harmony>
@@ -23349,7 +23349,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3443X</pattern>
+        <pattern>X[3-O][4-O][4-O][3-O]X</pattern>
         <Harmony>
             <name>bm/c</name>
         </Harmony>
@@ -23378,7 +23378,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO432</pattern>
+        <pattern>XXO[4-O][3-O][2-O]</pattern>
         <Harmony>
             <name>bm/d</name>
         </Harmony>
@@ -23404,7 +23404,7 @@
                 <barre start="1" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O-443-</pattern>
+        <pattern>O-[4-O][4-O][3-O]-;B2[1-5]</pattern>
         <Harmony>
             <name>bm/e</name>
         </Harmony>
@@ -23433,7 +23433,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4432</pattern>
+        <pattern>XX[4-O][4-O][3-O][2-O]</pattern>
         <Harmony>
             <name>bm/f#</name>
         </Harmony>
@@ -23462,7 +23462,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3XO432</pattern>
+        <pattern>[3-O]XO[4-O][3-O][2-O]</pattern>
         <Harmony>
             <name>bm/g</name>
         </Harmony>
@@ -23491,7 +23491,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4XO432</pattern>
+        <pattern>[4-O]XO[4-O][3-O][2-O]</pattern>
         <Harmony>
             <name>bm/g#</name>
         </Harmony>
@@ -23521,7 +23521,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2543X</pattern>
+        <pattern>X[2-O][5-O][4-O][3-O]X</pattern>
         <Harmony>
             <name>bm(#5)</name>
         </Harmony>
@@ -23550,7 +23550,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO4442</pattern>
+        <pattern>XO[4-O][4-O][4-O][2-O]</pattern>
         <Harmony>
             <name>b/a</name>
         </Harmony>
@@ -23574,7 +23574,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>6X---X</pattern>
+        <pattern>[6-O]X---X;B4[2-4]</pattern>
         <Harmony>
             <name>b/a#</name>
         </Harmony>
@@ -23598,7 +23598,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>6X---X</pattern>
+        <pattern>[6-O]X---X;B4[2-4]</pattern>
         <Harmony>
             <name>b/bb</name>
         </Harmony>
@@ -23621,7 +23621,7 @@
                 <barre start="2" end="4">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3---X</pattern>
+        <pattern>X[3-O]---X;B4[2-4]</pattern>
         <Harmony>
             <name>b/c</name>
         </Harmony>
@@ -23650,7 +23650,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4X442</pattern>
+        <pattern>X[4-O]X[4-O][4-O][2-O]</pattern>
         <Harmony>
             <name>b/c#</name>
         </Harmony>
@@ -23679,7 +23679,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO442</pattern>
+        <pattern>XXO[4-O][4-O][2-O]</pattern>
         <Harmony>
             <name>b/d</name>
         </Harmony>
@@ -23708,7 +23708,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4X442</pattern>
+        <pattern>X[4-O]X[4-O][4-O][2-O]</pattern>
         <Harmony>
             <name>b/db</name>
         </Harmony>
@@ -23732,7 +23732,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6---X</pattern>
+        <pattern>X[6-O]---X;B4[2-4]</pattern>
         <Harmony>
             <name>b/d#</name>
         </Harmony>
@@ -23758,7 +23758,7 @@
                 <barre start="1" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O-444-</pattern>
+        <pattern>O-[4-O][4-O][4-O]-;B2[1-5]</pattern>
         <Harmony>
             <name>b/e</name>
         </Harmony>
@@ -23781,7 +23781,7 @@
                 <barre start="0" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>--444-</pattern>
+        <pattern>--[4-O][4-O][4-O]-;B2[0-5]</pattern>
         <Harmony>
             <name>b/f#</name>
         </Harmony>
@@ -23804,7 +23804,7 @@
                 <barre start="2" end="4">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X---X</pattern>
+        <pattern>[3-O]X---X;B4[2-4]</pattern>
         <Harmony>
             <name>b/g</name>
         </Harmony>
@@ -23828,7 +23828,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X---X</pattern>
+        <pattern>[4-O]X---X;B4[2-4]</pattern>
         <Harmony>
             <name>b/g#</name>
         </Harmony>
@@ -23857,7 +23857,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X21OO3</pattern>
+        <pattern>X[2-O][1-O]OO[3-O]</pattern>
         <Harmony>
             <name>b+</name>
         </Harmony>
@@ -23886,7 +23886,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO1OO3</pattern>
+        <pattern>XO[1-O]OO[3-O]</pattern>
         <Harmony>
             <name>b+/a</name>
         </Harmony>
@@ -23915,7 +23915,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1OO3</pattern>
+        <pattern>XX[1-O]OO[3-O]</pattern>
         <Harmony>
             <name>b+/d#</name>
         </Harmony>
@@ -23944,7 +23944,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O21OO3</pattern>
+        <pattern>O[2-O][1-O]OO[3-O]</pattern>
         <Harmony>
             <name>b+/e</name>
         </Harmony>
@@ -23973,7 +23973,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1OO3</pattern>
+        <pattern>XX[1-O]OO[3-O]</pattern>
         <Harmony>
             <name>b+/eb</name>
         </Harmony>
@@ -24002,7 +24002,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3443</pattern>
+        <pattern>XX[3-O][4-O][4-O][3-O]</pattern>
         <Harmony>
             <name>b+/f</name>
         </Harmony>
@@ -24032,7 +24032,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4443</pattern>
+        <pattern>XX[4-O][4-O][4-O][3-O]</pattern>
         <Harmony>
             <name>b+/f#</name>
         </Harmony>
@@ -24061,7 +24061,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X244OO</pattern>
+        <pattern>X[2-O][4-O][4-O]OO</pattern>
         <Harmony>
             <name>bsus</name>
         </Harmony>
@@ -24084,7 +24084,7 @@
                 <barre start="1" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-44--</pattern>
+        <pattern>X-[4-O][4-O]--;B2[1-5]</pattern>
         <Harmony>
             <name>bsus2</name>
         </Harmony>
@@ -24111,7 +24111,7 @@
                 <barre start="1" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-9-7X</pattern>
+        <pattern>X-[9-O]-[7-O]X;B6[1-3]</pattern>
         <Harmony>
             <name>bsus2/d#</name>
         </Harmony>
@@ -24134,7 +24134,7 @@
                 <barre start="1" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O-44--</pattern>
+        <pattern>O-[4-O][4-O]--;B2[1-5]</pattern>
         <Harmony>
             <name>bsus2/e</name>
         </Harmony>
@@ -24154,7 +24154,7 @@
                 <barre start="0" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>--44--</pattern>
+        <pattern>--[4-O][4-O]--;B2[0-5]</pattern>
         <Harmony>
             <name>bsus2/f#</name>
         </Harmony>
@@ -24180,7 +24180,7 @@
                 <barre start="1" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-34-X</pattern>
+        <pattern>X-[3-O][4-O]-X;B2[1-4]</pattern>
         <Harmony>
             <name>b(#4sus2)</name>
         </Harmony>
@@ -24209,7 +24209,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX442O</pattern>
+        <pattern>XX[4-O][4-O][2-O]O</pattern>
         <Harmony>
             <name>b(add2sus4)</name>
         </Harmony>
@@ -24239,7 +24239,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO44OO</pattern>
+        <pattern>XO[4-O][4-O]OO</pattern>
         <Harmony>
             <name>bsus/a</name>
         </Harmony>
@@ -24269,7 +24269,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X444OO</pattern>
+        <pattern>X[4-O][4-O][4-O]OO</pattern>
         <Harmony>
             <name>bsus/c#</name>
         </Harmony>
@@ -24299,7 +24299,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X644OO</pattern>
+        <pattern>X[6-O][4-O][4-O]OO</pattern>
         <Harmony>
             <name>bsus/d#</name>
         </Harmony>
@@ -24329,7 +24329,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX44OO</pattern>
+        <pattern>XX[4-O][4-O]OO</pattern>
         <Harmony>
             <name>bsus/f#</name>
         </Harmony>
@@ -24358,7 +24358,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O244OO</pattern>
+        <pattern>O[2-O][4-O][4-O]OO</pattern>
         <Harmony>
             <name>bsus/e</name>
         </Harmony>
@@ -24387,7 +24387,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X32O1O</pattern>
+        <pattern>X[3-O][2-O]O[1-O]O</pattern>
         <Harmony>
             <name>c</name>
         </Harmony>
@@ -24416,7 +24416,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X32O12</pattern>
+        <pattern>X[3-O][2-O]O[1-O][2-O]</pattern>
         <Harmony>
             <name>c(#11)</name>
         </Harmony>
@@ -24433,7 +24433,7 @@
                 <barre start="1" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-----</pattern>
+        <pattern>X-----;B3[1-5]</pattern>
         <Harmony>
             <name>c11</name>
         </Harmony>
@@ -24462,7 +24462,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3X321</pattern>
+        <pattern>X[3-O]X[3-O][2-O][1-O]</pattern>
         <Harmony>
             <name>c11b9</name>
         </Harmony>
@@ -24492,7 +24492,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X8896X</pattern>
+        <pattern>X[8-O][8-O][9-O][6-O]X</pattern>
         <Harmony>
             <name>c11/f</name>
         </Harmony>
@@ -24519,7 +24519,7 @@
                 <barre start="3" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X32--5</pattern>
+        <pattern>X[3-O][2-O]--[5-O];B3[3-4]</pattern>
         <Harmony>
             <name>c13</name>
         </Harmony>
@@ -24549,7 +24549,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4X355</pattern>
+        <pattern>X[4-O]X[3-O][5-O][5-O]</pattern>
         <Harmony>
             <name>c13b9</name>
         </Harmony>
@@ -24576,7 +24576,7 @@
                 <barre start="1" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-4-55</pattern>
+        <pattern>X-[4-O]-[5-O][5-O];B3[1-3]</pattern>
         <Harmony>
             <name>c13#11</name>
         </Harmony>
@@ -24603,7 +24603,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X98-10-</pattern>
+        <pattern>X[9-O][8-O]-[10-O]-;B9[3-5]</pattern>
         <Harmony>
             <name>c13(#11b9)</name>
         </Harmony>
@@ -24630,7 +24630,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-1010-</pattern>
+        <pattern>XX-[10-O][10-O]-;B8[2-5]</pattern>
         <Harmony>
             <name>c13sus4</name>
         </Harmony>
@@ -24654,7 +24654,7 @@
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-3--</pattern>
+        <pattern>XX-[3-O]--;B5[4-5]</pattern>
         <Harmony>
             <name>c13/e</name>
         </Harmony>
@@ -24683,7 +24683,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3OO1O</pattern>
+        <pattern>X[3-O]OO[1-O]O</pattern>
         <Harmony>
             <name>cadd2</name>
         </Harmony>
@@ -24712,7 +24712,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXOO1O</pattern>
+        <pattern>XXOO[1-O]O</pattern>
         <Harmony>
             <name>cadd2/d</name>
         </Harmony>
@@ -24742,7 +24742,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X355XX</pattern>
+        <pattern>X[3-O][5-O][5-O]XX</pattern>
         <Harmony>
             <name>c5</name>
         </Harmony>
@@ -24772,7 +24772,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO55XX</pattern>
+        <pattern>XO[5-O][5-O]XX</pattern>
         <Harmony>
             <name>c5/a</name>
         </Harmony>
@@ -24799,7 +24799,7 @@
                 <barre start="0" end="1">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>--55XX</pattern>
+        <pattern>--[5-O][5-O]XX;B3[0-1]</pattern>
         <Harmony>
             <name>c5/g</name>
         </Harmony>
@@ -24829,7 +24829,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4355XX</pattern>
+        <pattern>[4-O][3-O][5-O][5-O]XX</pattern>
         <Harmony>
             <name>c5/ab</name>
         </Harmony>
@@ -24859,7 +24859,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X255XX</pattern>
+        <pattern>X[2-O][5-O][5-O]XX</pattern>
         <Harmony>
             <name>c5/b</name>
         </Harmony>
@@ -24886,7 +24886,7 @@
                 <barre start="2" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>6X--XX</pattern>
+        <pattern>[6-O]X--XX;B5[2-3]</pattern>
         <Harmony>
             <name>c5/bb</name>
         </Harmony>
@@ -24915,7 +24915,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3O1X</pattern>
+        <pattern>XX[3-O]O[1-O]X</pattern>
         <Harmony>
             <name>c5/f</name>
         </Harmony>
@@ -24944,7 +24944,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXOO13</pattern>
+        <pattern>XXOO[1-O][3-O]</pattern>
         <Harmony>
             <name>c5/d</name>
         </Harmony>
@@ -24974,7 +24974,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O355XX</pattern>
+        <pattern>O[3-O][5-O][5-O]XX</pattern>
         <Harmony>
             <name>c5/e</name>
         </Harmony>
@@ -25003,7 +25003,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3XO12</pattern>
+        <pattern>X[3-O]XO[1-O][2-O]</pattern>
         <Harmony>
             <name>c5#4</name>
         </Harmony>
@@ -25032,7 +25032,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3221O</pattern>
+        <pattern>X[3-O][2-O][2-O][1-O]O</pattern>
         <Harmony>
             <name>c6</name>
         </Harmony>
@@ -25055,7 +25055,7 @@
                 <barre start="2" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3---X</pattern>
+        <pattern>X[3-O]---X;B2[2-4]</pattern>
         <Harmony>
             <name>c6b9</name>
         </Harmony>
@@ -25081,7 +25081,7 @@
                 <barre start="2" end="3">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3--33</pattern>
+        <pattern>X[3-O]--[3-O][3-O];B2[2-3]</pattern>
         <Harmony>
             <name>c69()</name>
         </Harmony>
@@ -25107,7 +25107,7 @@
                 <barre start="2" end="3">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3--33</pattern>
+        <pattern>X[3-O]--[3-O][3-O];B2[2-3]</pattern>
         <Harmony>
             <name>c6(add2)</name>
         </Harmony>
@@ -25133,7 +25133,7 @@
                 <barre start="2" end="3">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3--33</pattern>
+        <pattern>X[3-O]--[3-O][3-O];B2[2-3]</pattern>
         <Harmony>
             <name>c69</name>
         </Harmony>
@@ -25163,7 +25163,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O3455X</pattern>
+        <pattern>O[3-O][4-O][5-O][5-O]X</pattern>
         <Harmony>
             <name>c(b5)/e</name>
         </Harmony>
@@ -25192,7 +25192,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO2213</pattern>
+        <pattern>XO[2-O][2-O][1-O][3-O]</pattern>
         <Harmony>
             <name>c6/a</name>
         </Harmony>
@@ -25221,7 +25221,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2X213</pattern>
+        <pattern>X[2-O]X[2-O][1-O][3-O]</pattern>
         <Harmony>
             <name>c6/b</name>
         </Harmony>
@@ -25247,7 +25247,7 @@
                 <barre start="2" end="3">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X--33</pattern>
+        <pattern>[3-O]X--[3-O][3-O];B2[2-3]</pattern>
         <Harmony>
             <name>c69/g</name>
         </Harmony>
@@ -25265,7 +25265,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-----</pattern>
+        <pattern>X-----;B5[1-5]</pattern>
         <Harmony>
             <name>c6/d</name>
         </Harmony>
@@ -25294,7 +25294,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX2213</pattern>
+        <pattern>XX[2-O][2-O][1-O][3-O]</pattern>
         <Harmony>
             <name>c6/e</name>
         </Harmony>
@@ -25323,7 +25323,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>33O21O</pattern>
+        <pattern>[3-O][3-O]O[2-O][1-O]O</pattern>
         <Harmony>
             <name>c6(add2)/g</name>
         </Harmony>
@@ -25352,7 +25352,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X221O</pattern>
+        <pattern>[3-O]X[2-O][2-O][1-O]O</pattern>
         <Harmony>
             <name>c6/g</name>
         </Harmony>
@@ -25376,7 +25376,7 @@
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X34---</pattern>
+        <pattern>X[3-O][4-O]---;B5[3-5]</pattern>
         <Harmony>
             <name>c6b5</name>
         </Harmony>
@@ -25405,7 +25405,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3X233</pattern>
+        <pattern>X[3-O]X[2-O][3-O][3-O]</pattern>
         <Harmony>
             <name>c6sus2</name>
         </Harmony>
@@ -25435,7 +25435,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>OOO56X</pattern>
+        <pattern>OOO[5-O][6-O]X</pattern>
         <Harmony>
             <name>c6sus4/d</name>
         </Harmony>
@@ -25458,7 +25458,7 @@
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3--3-</pattern>
+        <pattern>X[3-O]--[3-O]-;B2[2-5]</pattern>
         <Harmony>
             <name>c69#11</name>
         </Harmony>
@@ -25487,7 +25487,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3231O</pattern>
+        <pattern>X[3-O][2-O][3-O][1-O]O</pattern>
         <Harmony>
             <name>c7</name>
         </Harmony>
@@ -25516,7 +25516,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X14O1O</pattern>
+        <pattern>X[1-O][4-O]O[1-O]O</pattern>
         <Harmony>
             <name>c7(add4)/bb</name>
         </Harmony>
@@ -25543,7 +25543,7 @@
                 <barre start="1" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-5-55</pattern>
+        <pattern>X-[5-O]-[5-O][5-O];B3[1-3]</pattern>
         <Harmony>
             <name>c7(add13)</name>
         </Harmony>
@@ -25570,7 +25570,7 @@
                 <barre start="1" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-5-54</pattern>
+        <pattern>X-[5-O]-[5-O][4-O];B3[1-3]</pattern>
         <Harmony>
             <name>c7b13</name>
         </Harmony>
@@ -25600,7 +25600,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>8X897X</pattern>
+        <pattern>[8-O]X[8-O][9-O][7-O]X</pattern>
         <Harmony>
             <name>c7b5</name>
         </Harmony>
@@ -25626,7 +25626,7 @@
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3-34-</pattern>
+        <pattern>X[3-O]-[3-O][4-O]-;B2[2-5]</pattern>
         <Harmony>
             <name>c7(#9b5)</name>
         </Harmony>
@@ -25655,7 +25655,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3232X</pattern>
+        <pattern>X[3-O][2-O][3-O][2-O]X</pattern>
         <Harmony>
             <name>c7b9</name>
         </Harmony>
@@ -25678,7 +25678,7 @@
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3-3--</pattern>
+        <pattern>X[3-O]-[3-O]--;B2[2-5]</pattern>
         <Harmony>
             <name>c7(b9b5)</name>
         </Harmony>
@@ -25707,7 +25707,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2X231X</pattern>
+        <pattern>[2-O]X[2-O][3-O][1-O]X</pattern>
         <Harmony>
             <name>c7b5/gb</name>
         </Harmony>
@@ -25733,7 +25733,7 @@
                 <barre start="2" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3-3-4</pattern>
+        <pattern>X[3-O]-[3-O]-[4-O];B2[2-4]</pattern>
         <Harmony>
             <name>c7(b13b9)</name>
         </Harmony>
@@ -25762,7 +25762,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3331O</pattern>
+        <pattern>X[3-O][3-O][3-O][1-O]O</pattern>
         <Harmony>
             <name>c7(add4)</name>
         </Harmony>
@@ -25791,7 +25791,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX2323</pattern>
+        <pattern>XX[2-O][3-O][2-O][3-O]</pattern>
         <Harmony>
             <name>c7b9/e</name>
         </Harmony>
@@ -25820,7 +25820,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3323</pattern>
+        <pattern>XX[3-O][3-O][2-O][3-O]</pattern>
         <Harmony>
             <name>c7b9/f</name>
         </Harmony>
@@ -25843,7 +25843,7 @@
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O3-3--</pattern>
+        <pattern>O[3-O]-[3-O]--;B2[2-5]</pattern>
         <Harmony>
             <name>c7(#11b9)</name>
         </Harmony>
@@ -25872,7 +25872,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3332X</pattern>
+        <pattern>X[3-O][3-O][3-O][2-O]X</pattern>
         <Harmony>
             <name>c7b9sus4</name>
         </Harmony>
@@ -25898,7 +25898,7 @@
                 <barre start="2" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3-3-4</pattern>
+        <pattern>X[3-O]-[3-O]-[4-O];B2[2-4]</pattern>
         <Harmony>
             <name>c7(b9#5)</name>
         </Harmony>
@@ -25927,7 +25927,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO231O</pattern>
+        <pattern>XO[2-O][3-O][1-O]O</pattern>
         <Harmony>
             <name>c7/a</name>
         </Harmony>
@@ -25956,7 +25956,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2231O</pattern>
+        <pattern>X[2-O][2-O][3-O][1-O]O</pattern>
         <Harmony>
             <name>c7/b</name>
         </Harmony>
@@ -25980,7 +25980,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>6X---6</pattern>
+        <pattern>[6-O]X---[6-O];B5[2-4]</pattern>
         <Harmony>
             <name>c7/bb</name>
         </Harmony>
@@ -26009,7 +26009,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO31O</pattern>
+        <pattern>XXO[3-O][1-O]O</pattern>
         <Harmony>
             <name>c7/d</name>
         </Harmony>
@@ -26038,7 +26038,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX231O</pattern>
+        <pattern>XX[2-O][3-O][1-O]O</pattern>
         <Harmony>
             <name>c7/e</name>
         </Harmony>
@@ -26062,7 +26062,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6---6</pattern>
+        <pattern>X[6-O]---[6-O];B5[2-4]</pattern>
         <Harmony>
             <name>c7/eb</name>
         </Harmony>
@@ -26091,7 +26091,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX331O</pattern>
+        <pattern>XX[3-O][3-O][1-O]O</pattern>
         <Harmony>
             <name>c7/f</name>
         </Harmony>
@@ -26120,7 +26120,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X231O</pattern>
+        <pattern>[3-O]X[2-O][3-O][1-O]O</pattern>
         <Harmony>
             <name>c7/g</name>
         </Harmony>
@@ -26150,7 +26150,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>8X897X</pattern>
+        <pattern>[8-O]X[8-O][9-O][7-O]X</pattern>
         <Harmony>
             <name>c7#11</name>
         </Harmony>
@@ -26180,7 +26180,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>8X899X</pattern>
+        <pattern>[8-O]X[8-O][9-O][9-O]X</pattern>
         <Harmony>
             <name>c7#5</name>
         </Harmony>
@@ -26210,7 +26210,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>8X899X</pattern>
+        <pattern>[8-O]X[8-O][9-O][9-O]X</pattern>
         <Harmony>
             <name>c7#5</name>
         </Harmony>
@@ -26239,7 +26239,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O323X4</pattern>
+        <pattern>O[3-O][2-O][3-O]X[4-O]</pattern>
         <Harmony>
             <name>c7#5/e</name>
         </Harmony>
@@ -26265,7 +26265,7 @@
                 <barre start="2" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3-3-4</pattern>
+        <pattern>X[3-O]-[3-O]-[4-O];B2[2-4]</pattern>
         <Harmony>
             <name>c7(b9#5)</name>
         </Harmony>
@@ -26295,7 +26295,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXX354</pattern>
+        <pattern>XXX[3-O][5-O][4-O]</pattern>
         <Harmony>
             <name>c7#5/bb</name>
         </Harmony>
@@ -26325,7 +26325,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX2324</pattern>
+        <pattern>XX[2-O][3-O][2-O][4-O]</pattern>
         <Harmony>
             <name>c7(b9#5)/e</name>
         </Harmony>
@@ -26355,7 +26355,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO354</pattern>
+        <pattern>XXO[3-O][5-O][4-O]</pattern>
         <Harmony>
             <name>c7#5/d</name>
         </Harmony>
@@ -26382,7 +26382,7 @@
                 <barre start="2" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX--54</pattern>
+        <pattern>XX--[5-O][4-O];B3[2-3]</pattern>
         <Harmony>
             <name>c7#5/f</name>
         </Harmony>
@@ -26409,7 +26409,7 @@
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X323--</pattern>
+        <pattern>X[3-O][2-O][3-O]--;B4[4-5]</pattern>
         <Harmony>
             <name>c7(#9#5)</name>
         </Harmony>
@@ -26438,7 +26438,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3234X</pattern>
+        <pattern>X[3-O][2-O][3-O][4-O]X</pattern>
         <Harmony>
             <name>c7#9</name>
         </Harmony>
@@ -26465,7 +26465,7 @@
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X323--</pattern>
+        <pattern>X[3-O][2-O][3-O]--;B4[4-5]</pattern>
         <Harmony>
             <name>c7(b13#9)</name>
         </Harmony>
@@ -26494,7 +26494,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>1X234X</pattern>
+        <pattern>[1-O]X[2-O][3-O][4-O]X</pattern>
         <Harmony>
             <name>c7#9/f</name>
         </Harmony>
@@ -26523,7 +26523,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X234X</pattern>
+        <pattern>[3-O]X[2-O][3-O][4-O]X</pattern>
         <Harmony>
             <name>c7#9/g</name>
         </Harmony>
@@ -26549,7 +26549,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3X3--</pattern>
+        <pattern>X[3-O]X[3-O]--;B1[4-5]</pattern>
         <Harmony>
             <name>c7sus4</name>
         </Harmony>
@@ -26570,7 +26570,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-5---</pattern>
+        <pattern>X-[5-O]---;B3[1-5]</pattern>
         <Harmony>
             <name>c7sus2</name>
         </Harmony>
@@ -26599,7 +26599,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X33O21</pattern>
+        <pattern>X[3-O][3-O]O[2-O][1-O]</pattern>
         <Harmony>
             <name>c7b9sus4</name>
         </Harmony>
@@ -26625,7 +26625,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX33--</pattern>
+        <pattern>XX[3-O][3-O]--;B1[4-5]</pattern>
         <Harmony>
             <name>c7(sus4no5)</name>
         </Harmony>
@@ -26654,7 +26654,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3313</pattern>
+        <pattern>XX[3-O][3-O][1-O][3-O]</pattern>
         <Harmony>
             <name>c7sus4/f</name>
         </Harmony>
@@ -26675,7 +26675,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>--5-6-</pattern>
+        <pattern>--[5-O]-[6-O]-;B3[0-5]</pattern>
         <Harmony>
             <name>c7sus4/g</name>
         </Harmony>
@@ -26698,7 +26698,7 @@
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X32---</pattern>
+        <pattern>X[3-O][2-O]---;B3[3-5]</pattern>
         <Harmony>
             <name>c9</name>
         </Harmony>
@@ -26724,7 +26724,7 @@
                 <barre start="3" end="4">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X32--4</pattern>
+        <pattern>X[3-O][2-O]--[4-O];B3[3-4]</pattern>
         <Harmony>
             <name>c9b13</name>
         </Harmony>
@@ -26750,7 +26750,7 @@
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3-33-</pattern>
+        <pattern>X[3-O]-[3-O][3-O]-;B2[2-5]</pattern>
         <Harmony>
             <name>c9b5</name>
         </Harmony>
@@ -26779,7 +26779,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1233X</pattern>
+        <pattern>X[1-O][2-O][3-O][3-O]X</pattern>
         <Harmony>
             <name>c9/bb</name>
         </Harmony>
@@ -26808,7 +26808,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO33O</pattern>
+        <pattern>XXO[3-O][3-O]O</pattern>
         <Harmony>
             <name>c9/d</name>
         </Harmony>
@@ -26831,7 +26831,7 @@
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX2---</pattern>
+        <pattern>XX[2-O]---;B3[3-5]</pattern>
         <Harmony>
             <name>c9/e</name>
         </Harmony>
@@ -26860,7 +26860,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX333O</pattern>
+        <pattern>XX[3-O][3-O][3-O]O</pattern>
         <Harmony>
             <name>c9/f</name>
         </Harmony>
@@ -26883,7 +26883,7 @@
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X2---</pattern>
+        <pattern>[3-O]X[2-O]---;B3[3-5]</pattern>
         <Harmony>
             <name>c9/g</name>
         </Harmony>
@@ -26909,7 +26909,7 @@
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3-33-</pattern>
+        <pattern>X[3-O]-[3-O][3-O]-;B2[2-5]</pattern>
         <Harmony>
             <name>c9#11</name>
         </Harmony>
@@ -26935,7 +26935,7 @@
                 <barre start="3" end="4">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X32--4</pattern>
+        <pattern>X[3-O][2-O]--[4-O];B3[3-4]</pattern>
         <Harmony>
             <name>c9#5</name>
         </Harmony>
@@ -26964,7 +26964,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3X331</pattern>
+        <pattern>X[3-O]X[3-O][3-O][1-O]</pattern>
         <Harmony>
             <name>c9sus4</name>
         </Harmony>
@@ -26981,7 +26981,7 @@
                 <barre start="1" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>1-----</pattern>
+        <pattern>[1-O]-----;B3[1-5]</pattern>
         <Harmony>
             <name>c9sus4/f</name>
         </Harmony>
@@ -27010,7 +27010,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3OO1O</pattern>
+        <pattern>X[3-O]OO[1-O]O</pattern>
         <Harmony>
             <name>cadd2</name>
         </Harmony>
@@ -27040,7 +27040,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO553O</pattern>
+        <pattern>XO[5-O][5-O][3-O]O</pattern>
         <Harmony>
             <name>cadd2/a</name>
         </Harmony>
@@ -27069,7 +27069,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X12O3O</pattern>
+        <pattern>X[1-O][2-O]O[3-O]O</pattern>
         <Harmony>
             <name>cadd2/bb</name>
         </Harmony>
@@ -27099,7 +27099,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X5553O</pattern>
+        <pattern>X[5-O][5-O][5-O][3-O]O</pattern>
         <Harmony>
             <name>cadd2/d</name>
         </Harmony>
@@ -27128,7 +27128,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2OO1O</pattern>
+        <pattern>X[2-O]OO[1-O]O</pattern>
         <Harmony>
             <name>cadd2/b</name>
         </Harmony>
@@ -27157,7 +27157,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O32O3O</pattern>
+        <pattern>O[3-O][2-O]O[3-O]O</pattern>
         <Harmony>
             <name>cadd2/e</name>
         </Harmony>
@@ -27186,7 +27186,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>332O3O</pattern>
+        <pattern>[3-O][3-O][2-O]O[3-O]O</pattern>
         <Harmony>
             <name>cadd2/g</name>
         </Harmony>
@@ -27215,7 +27215,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X33O1O</pattern>
+        <pattern>X[3-O][3-O]O[1-O]O</pattern>
         <Harmony>
             <name>cadd4</name>
         </Harmony>
@@ -27244,7 +27244,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO3O1O</pattern>
+        <pattern>XO[3-O]O[1-O]O</pattern>
         <Harmony>
             <name>cadd4/a</name>
         </Harmony>
@@ -27273,7 +27273,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X13O1O</pattern>
+        <pattern>X[1-O][3-O]O[1-O]O</pattern>
         <Harmony>
             <name>cadd4/bb</name>
         </Harmony>
@@ -27300,7 +27300,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X5-55-</pattern>
+        <pattern>X[5-O]-[5-O][5-O]-;B3[2-5]</pattern>
         <Harmony>
             <name>cadd4/d</name>
         </Harmony>
@@ -27329,7 +27329,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>333O1O</pattern>
+        <pattern>[3-O][3-O][3-O]O[1-O]O</pattern>
         <Harmony>
             <name>cadd4/f</name>
         </Harmony>
@@ -27358,7 +27358,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O33O1O</pattern>
+        <pattern>O[3-O][3-O]O[1-O]O</pattern>
         <Harmony>
             <name>cadd4/e</name>
         </Harmony>
@@ -27387,7 +27387,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>333O1O</pattern>
+        <pattern>[3-O][3-O][3-O]O[1-O]O</pattern>
         <Harmony>
             <name>cadd4/g</name>
         </Harmony>
@@ -27416,7 +27416,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X32O3O</pattern>
+        <pattern>X[3-O][2-O]O[3-O]O</pattern>
         <Harmony>
             <name>cadd9</name>
         </Harmony>
@@ -27446,7 +27446,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X5553O</pattern>
+        <pattern>X[5-O][5-O][5-O][3-O]O</pattern>
         <Harmony>
             <name>cadd9/d</name>
         </Harmony>
@@ -27475,7 +27475,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O32O3O</pattern>
+        <pattern>O[3-O][2-O]O[3-O]O</pattern>
         <Harmony>
             <name>cadd9/e</name>
         </Harmony>
@@ -27504,7 +27504,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3O3O</pattern>
+        <pattern>XX[3-O]O[3-O]O</pattern>
         <Harmony>
             <name>cadd9/f</name>
         </Harmony>
@@ -27533,7 +27533,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X2O3O</pattern>
+        <pattern>[3-O]X[2-O]O[3-O]O</pattern>
         <Harmony>
             <name>cadd9/g</name>
         </Harmony>
@@ -27562,7 +27562,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X32O4O</pattern>
+        <pattern>X[3-O][2-O]O[4-O]O</pattern>
         <Harmony>
             <name>c(#9)</name>
         </Harmony>
@@ -27591,7 +27591,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X32O4O</pattern>
+        <pattern>X[3-O][2-O]O[4-O]O</pattern>
         <Harmony>
             <name>c(#9)</name>
         </Harmony>
@@ -27618,7 +27618,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-455-</pattern>
+        <pattern>X-[4-O][5-O][5-O]-;B3[1-5]</pattern>
         <Harmony>
             <name>c(#4)</name>
         </Harmony>
@@ -27648,7 +27648,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3454X</pattern>
+        <pattern>X[3-O][4-O][5-O][4-O]X</pattern>
         <Harmony>
             <name>cdim</name>
         </Harmony>
@@ -27677,7 +27677,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1212</pattern>
+        <pattern>XX[1-O][2-O][1-O][2-O]</pattern>
         <Harmony>
             <name>cdim7</name>
         </Harmony>
@@ -27706,7 +27706,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1212</pattern>
+        <pattern>XX[1-O][2-O][1-O][2-O]</pattern>
         <Harmony>
             <name>cdim7/eb</name>
         </Harmony>
@@ -27736,7 +27736,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX5545</pattern>
+        <pattern>XX[5-O][5-O][4-O][5-O]</pattern>
         <Harmony>
             <name>cdim7/g</name>
         </Harmony>
@@ -27759,7 +27759,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--2-2</pattern>
+        <pattern>X--[2-O]-[2-O];B1[1-4]</pattern>
         <Harmony>
             <name>cdim/bb</name>
         </Harmony>
@@ -27782,7 +27782,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--2-2</pattern>
+        <pattern>X--[2-O]-[2-O];B1[1-4]</pattern>
         <Harmony>
             <name>cdim7/bb</name>
         </Harmony>
@@ -27809,7 +27809,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6-5-X</pattern>
+        <pattern>X[6-O]-[5-O]-X;B4[2-4]</pattern>
         <Harmony>
             <name>cdim/eb</name>
         </Harmony>
@@ -27839,7 +27839,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX5542</pattern>
+        <pattern>XX[5-O][5-O][4-O][2-O]</pattern>
         <Harmony>
             <name>cdim/g</name>
         </Harmony>
@@ -27865,7 +27865,7 @@
                 <barre start="1" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-444-</pattern>
+        <pattern>X-[4-O][4-O][4-O]-;B2[1-5]</pattern>
         <Harmony>
             <name>cb</name>
         </Harmony>
@@ -27894,7 +27894,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2X244</pattern>
+        <pattern>X[2-O]X[2-O][4-O][4-O]</pattern>
         <Harmony>
             <name>cb13</name>
         </Harmony>
@@ -27920,7 +27920,7 @@
                 <barre start="1" end="3">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-3-44</pattern>
+        <pattern>X-[3-O]-[4-O][4-O];B2[1-3]</pattern>
         <Harmony>
             <name>cb13#11</name>
         </Harmony>
@@ -27949,7 +27949,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X244XX</pattern>
+        <pattern>X[2-O][4-O][4-O]XX</pattern>
         <Harmony>
             <name>cb5</name>
         </Harmony>
@@ -27975,7 +27975,7 @@
                 <barre start="1" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-344-</pattern>
+        <pattern>X-[3-O][4-O][4-O]-;B2[1-5]</pattern>
         <Harmony>
             <name>cb(b5)</name>
         </Harmony>
@@ -27995,7 +27995,7 @@
                 <barre start="2" end="5">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2----</pattern>
+        <pattern>X[2-O]----;B4[2-5]</pattern>
         <Harmony>
             <name>cb6</name>
         </Harmony>
@@ -28021,7 +28021,7 @@
                 <barre start="2" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2--22</pattern>
+        <pattern>X[2-O]--[2-O][2-O];B1[2-3]</pattern>
         <Harmony>
             <name>cb69</name>
         </Harmony>
@@ -28050,7 +28050,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X234XX</pattern>
+        <pattern>X[2-O][3-O][4-O]XX</pattern>
         <Harmony>
             <name>cb5(#4)</name>
         </Harmony>
@@ -28068,7 +28068,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-----</pattern>
+        <pattern>X-----;B4[1-5]</pattern>
         <Harmony>
             <name>cb6/db</name>
         </Harmony>
@@ -28094,7 +28094,7 @@
                 <barre start="0" end="1">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>--34XX</pattern>
+        <pattern>--[3-O][4-O]XX;B2[0-1]</pattern>
         <Harmony>
             <name>cb5(#4)/gb</name>
         </Harmony>
@@ -28123,7 +28123,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X212O2</pattern>
+        <pattern>X[2-O][1-O][2-O]O[2-O]</pattern>
         <Harmony>
             <name>cb7</name>
         </Harmony>
@@ -28152,7 +28152,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO1O1</pattern>
+        <pattern>XXO[1-O]O[1-O]</pattern>
         <Harmony>
             <name>cbdim7</name>
         </Harmony>
@@ -28181,7 +28181,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X212O1</pattern>
+        <pattern>X[2-O][1-O][2-O]O[1-O]</pattern>
         <Harmony>
             <name>cb7b5</name>
         </Harmony>
@@ -28206,7 +28206,7 @@
                 <barre start="0" end="1">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>--3-3-</pattern>
+        <pattern>--[3-O]-[3-O]-;B1[3-5];B2[0-1]</pattern>
         <Harmony>
             <name>cbdim7/gb</name>
         </Harmony>
@@ -28235,7 +28235,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X21212</pattern>
+        <pattern>X[2-O][1-O][2-O][1-O][2-O]</pattern>
         <Harmony>
             <name>cb7b9</name>
         </Harmony>
@@ -28264,7 +28264,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X424X</pattern>
+        <pattern>[4-O]X[4-O][2-O][4-O]X</pattern>
         <Harmony>
             <name>cb7/ab</name>
         </Harmony>
@@ -28293,7 +28293,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX12O2</pattern>
+        <pattern>XX[1-O][2-O]O[2-O]</pattern>
         <Harmony>
             <name>cb7/eb</name>
         </Harmony>
@@ -28323,7 +28323,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>7X78XX</pattern>
+        <pattern>[7-O]X[7-O][8-O]XX</pattern>
         <Harmony>
             <name>cb7(no5)</name>
         </Harmony>
@@ -28346,7 +28346,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X21---</pattern>
+        <pattern>X[2-O][1-O]---;B2[3-5]</pattern>
         <Harmony>
             <name>cb9</name>
         </Harmony>
@@ -28372,7 +28372,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2-22-</pattern>
+        <pattern>X[2-O]-[2-O][2-O]-;B1[2-5]</pattern>
         <Harmony>
             <name>cb9#11</name>
         </Harmony>
@@ -28399,7 +28399,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>7X-6-X</pattern>
+        <pattern>[7-O]X-[6-O]-X;B4[2-4]</pattern>
         <Harmony>
             <name>cbadd2</name>
         </Harmony>
@@ -28422,7 +28422,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2X1---</pattern>
+        <pattern>[2-O]X[1-O]---;B2[3-5]</pattern>
         <Harmony>
             <name>cb9/gb</name>
         </Harmony>
@@ -28452,7 +28452,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX9879</pattern>
+        <pattern>XX[9-O][8-O][7-O][9-O]</pattern>
         <Harmony>
             <name>cbadd9</name>
         </Harmony>
@@ -28478,7 +28478,7 @@
                 <barre start="1" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-443-</pattern>
+        <pattern>X-[4-O][4-O][3-O]-;B2[1-5]</pattern>
         <Harmony>
             <name>cbm</name>
         </Harmony>
@@ -28500,7 +28500,7 @@
                 <barre start="1" end="4">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>------</pattern>
+        <pattern>------;B7[0-5];B9[1-4]</pattern>
         <Harmony>
             <name>cbm6</name>
         </Harmony>
@@ -28523,7 +28523,7 @@
                 <barre start="1" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-4-3-</pattern>
+        <pattern>X-[4-O]-[3-O]-;B2[1-5]</pattern>
         <Harmony>
             <name>cbm7</name>
         </Harmony>
@@ -28552,7 +28552,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO432</pattern>
+        <pattern>XXO[4-O][3-O][2-O]</pattern>
         <Harmony>
             <name>cbm/d</name>
         </Harmony>
@@ -28577,7 +28577,7 @@
                 <barre start="2" end="4">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--3--</pattern>
+        <pattern>X--[3-O]--;B2[1-5];B4[2-4]</pattern>
         <Harmony>
             <name>cbmaj7</name>
         </Harmony>
@@ -28604,7 +28604,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>7X-77-</pattern>
+        <pattern>[7-O]X-[7-O][7-O]-;B6[2-5]</pattern>
         <Harmony>
             <name>cbm(add13)</name>
         </Harmony>
@@ -28633,7 +28633,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2344X</pattern>
+        <pattern>X[2-O][3-O][4-O][4-O]X</pattern>
         <Harmony>
             <name>cbmaj7b5</name>
         </Harmony>
@@ -28657,7 +28657,7 @@
                 <barre start="2" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>7X---X</pattern>
+        <pattern>[7-O]X---X;B8[2-4]</pattern>
         <Harmony>
             <name>cbmaj7#5</name>
         </Harmony>
@@ -28680,7 +28680,7 @@
                 <barre start="0" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>--434-</pattern>
+        <pattern>--[4-O][3-O][4-O]-;B2[0-5]</pattern>
         <Harmony>
             <name>cbmaj7/gb</name>
         </Harmony>
@@ -28710,7 +28710,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>7X867X</pattern>
+        <pattern>[7-O]X[8-O][6-O][7-O]X</pattern>
         <Harmony>
             <name>cbmaj9</name>
         </Harmony>
@@ -28737,7 +28737,7 @@
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>7X88--</pattern>
+        <pattern>[7-O]X[8-O][8-O]--;B9[4-5]</pattern>
         <Harmony>
             <name>cbmaj9(add13)</name>
         </Harmony>
@@ -28766,7 +28766,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4434X</pattern>
+        <pattern>X[4-O][4-O][3-O][4-O]X</pattern>
         <Harmony>
             <name>cbmaj7/db</name>
         </Harmony>
@@ -28790,7 +28790,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>6X---X</pattern>
+        <pattern>[6-O]X---X;B4[2-4]</pattern>
         <Harmony>
             <name>cb/bb</name>
         </Harmony>
@@ -28811,7 +28811,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X----X</pattern>
+        <pattern>X----X;B4[1-4]</pattern>
         <Harmony>
             <name>cb/db</name>
         </Harmony>
@@ -28834,7 +28834,7 @@
                 <barre start="1" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-44--</pattern>
+        <pattern>X-[4-O][4-O]--;B2[1-5]</pattern>
         <Harmony>
             <name>cbsus2</name>
         </Harmony>
@@ -28858,7 +28858,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6---X</pattern>
+        <pattern>X[6-O]---X;B4[2-4]</pattern>
         <Harmony>
             <name>cb/eb</name>
         </Harmony>
@@ -28887,7 +28887,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3442</pattern>
+        <pattern>XX[3-O][4-O][4-O][2-O]</pattern>
         <Harmony>
             <name>cb/f</name>
         </Harmony>
@@ -28913,7 +28913,7 @@
                 <barre start="1" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-34-X</pattern>
+        <pattern>X-[3-O][4-O]-X;B2[1-4]</pattern>
         <Harmony>
             <name>cb(#4sus2)</name>
         </Harmony>
@@ -28936,7 +28936,7 @@
                 <barre start="0" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>--444-</pattern>
+        <pattern>--[4-O][4-O][4-O]-;B2[0-5]</pattern>
         <Harmony>
             <name>cb/gb</name>
         </Harmony>
@@ -28963,7 +28963,7 @@
                 <barre start="1" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-9-7X</pattern>
+        <pattern>X-[9-O]-[7-O]X;B6[1-3]</pattern>
         <Harmony>
             <name>cbsus2/eb</name>
         </Harmony>
@@ -28990,7 +28990,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-554-</pattern>
+        <pattern>X-[5-O][5-O][4-O]-;B3[1-5]</pattern>
         <Harmony>
             <name>cm</name>
         </Harmony>
@@ -29020,7 +29020,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4554X</pattern>
+        <pattern>X[4-O][5-O][5-O][4-O]X</pattern>
         <Harmony>
             <name>cm/db</name>
         </Harmony>
@@ -29049,7 +29049,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3X341</pattern>
+        <pattern>X[3-O]X[3-O][4-O][1-O]</pattern>
         <Harmony>
             <name>cm11</name>
         </Harmony>
@@ -29069,7 +29069,7 @@
                 <barre start="1" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>1---4-</pattern>
+        <pattern>[1-O]---[4-O]-;B3[1-5]</pattern>
         <Harmony>
             <name>cm11/f</name>
         </Harmony>
@@ -29096,7 +29096,7 @@
                 <barre start="1" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-5-45</pattern>
+        <pattern>X-[5-O]-[4-O][5-O];B3[1-3]</pattern>
         <Harmony>
             <name>cm6</name>
         </Harmony>
@@ -29126,7 +29126,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>8X886X</pattern>
+        <pattern>[8-O]X[8-O][8-O][6-O]X</pattern>
         <Harmony>
             <name>cm11/bb</name>
         </Harmony>
@@ -29156,7 +29156,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1081010</pattern>
+        <pattern>XX[10-O][8-O][10-O][10-O]</pattern>
         <Harmony>
             <name>cm69</name>
         </Harmony>
@@ -29185,7 +29185,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO1O1X</pattern>
+        <pattern>XO[1-O]O[1-O]X</pattern>
         <Harmony>
             <name>cm6/a</name>
         </Harmony>
@@ -29208,7 +29208,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--2-3</pattern>
+        <pattern>X--[2-O]-[3-O];B1[1-4]</pattern>
         <Harmony>
             <name>cm6/bb</name>
         </Harmony>
@@ -29238,7 +29238,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO345</pattern>
+        <pattern>XXO[3-O][4-O][5-O]</pattern>
         <Harmony>
             <name>cm6/d</name>
         </Harmony>
@@ -29267,7 +29267,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1213</pattern>
+        <pattern>XX[1-O][2-O][1-O][3-O]</pattern>
         <Harmony>
             <name>cm6/eb</name>
         </Harmony>
@@ -29297,7 +29297,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3545</pattern>
+        <pattern>XX[3-O][5-O][4-O][5-O]</pattern>
         <Harmony>
             <name>cm6/f</name>
         </Harmony>
@@ -29323,7 +29323,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X-2-X</pattern>
+        <pattern>[3-O]X-[2-O]-X;B1[2-4]</pattern>
         <Harmony>
             <name>cm6/g</name>
         </Harmony>
@@ -29347,7 +29347,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-5-4-</pattern>
+        <pattern>X-[5-O]-[4-O]-;B3[1-5]</pattern>
         <Harmony>
             <name>cm7</name>
         </Harmony>
@@ -29367,7 +29367,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--3--</pattern>
+        <pattern>X--[3-O]--;B1[1-5]</pattern>
         <Harmony>
             <name>cm7(add4)/bb</name>
         </Harmony>
@@ -29393,7 +29393,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-3-3</pattern>
+        <pattern>XX-[3-O]-[3-O];B1[2-4]</pattern>
         <Harmony>
             <name>cm7/eb</name>
         </Harmony>
@@ -29422,7 +29422,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3X341</pattern>
+        <pattern>X[3-O]X[3-O][4-O][1-O]</pattern>
         <Harmony>
             <name>cm7(add4)</name>
         </Harmony>
@@ -29448,7 +29448,7 @@
                 <barre start="1" end="3">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-1-XX</pattern>
+        <pattern>X-[1-O]-XX;B3[1-3]</pattern>
         <Harmony>
             <name>cm7(no5)</name>
         </Harmony>
@@ -29477,7 +29477,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3434X</pattern>
+        <pattern>X[3-O][4-O][3-O][4-O]X</pattern>
         <Harmony>
             <name>cm7b5</name>
         </Harmony>
@@ -29501,7 +29501,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>8X---9</pattern>
+        <pattern>[8-O]X---[9-O];B8[2-4]</pattern>
         <Harmony>
             <name>cm7(b9b5)</name>
         </Harmony>
@@ -29527,7 +29527,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2X-3-X</pattern>
+        <pattern>[2-O]X-[3-O]-X;B1[2-4]</pattern>
         <Harmony>
             <name>cm7b5/gb</name>
         </Harmony>
@@ -29556,7 +29556,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3434X</pattern>
+        <pattern>X[3-O][4-O][3-O][4-O]X</pattern>
         <Harmony>
             <name>cm7b5/eb</name>
         </Harmony>
@@ -29582,7 +29582,7 @@
                 <barre start="4" end="5">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X313--</pattern>
+        <pattern>X[3-O][1-O][3-O]--;B4[4-5]</pattern>
         <Harmony>
             <name>cm7b6</name>
         </Harmony>
@@ -29603,7 +29603,7 @@
                 <barre start="2" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>6X----</pattern>
+        <pattern>[6-O]X----;B8[2-5]</pattern>
         <Harmony>
             <name>cm7/bb</name>
         </Harmony>
@@ -29633,7 +29633,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X8X878</pattern>
+        <pattern>X[8-O]X[8-O][7-O][8-O]</pattern>
         <Harmony>
             <name>cm7b5/f</name>
         </Harmony>
@@ -29663,7 +29663,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO546</pattern>
+        <pattern>XXO[5-O][4-O][6-O]</pattern>
         <Harmony>
             <name>cm7/d</name>
         </Harmony>
@@ -29681,7 +29681,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-----</pattern>
+        <pattern>X-----;B8[1-5]</pattern>
         <Harmony>
             <name>cm7/f</name>
         </Harmony>
@@ -29702,7 +29702,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>--5-4-</pattern>
+        <pattern>--[5-O]-[4-O]-;B3[0-5]</pattern>
         <Harmony>
             <name>cm7/g</name>
         </Harmony>
@@ -29726,7 +29726,7 @@
                 <barre start="2" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>7X---X</pattern>
+        <pattern>[7-O]X---X;B8[2-4]</pattern>
         <Harmony>
             <name>cm7/b</name>
         </Harmony>
@@ -29750,7 +29750,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-5-6-</pattern>
+        <pattern>X-[5-O]-[6-O]-;B3[1-5]</pattern>
         <Harmony>
             <name>cm7sus4</name>
         </Harmony>
@@ -29779,7 +29779,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3133X</pattern>
+        <pattern>X[3-O][1-O][3-O][3-O]X</pattern>
         <Harmony>
             <name>cm9</name>
         </Harmony>
@@ -29808,7 +29808,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3X341</pattern>
+        <pattern>X[3-O]X[3-O][4-O][1-O]</pattern>
         <Harmony>
             <name>cm9(add4)</name>
         </Harmony>
@@ -29837,7 +29837,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3133X</pattern>
+        <pattern>X[3-O][1-O][3-O][3-O]X</pattern>
         <Harmony>
             <name>cm9(no5)</name>
         </Harmony>
@@ -29861,7 +29861,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX---10</pattern>
+        <pattern>XX---[10-O];B8[2-4]</pattern>
         <Harmony>
             <name>cm9/bb</name>
         </Harmony>
@@ -29890,7 +29890,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX133X</pattern>
+        <pattern>XX[1-O][3-O][3-O]X</pattern>
         <Harmony>
             <name>cm9/eb</name>
         </Harmony>
@@ -29911,7 +29911,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X----10</pattern>
+        <pattern>X----[10-O];B8[1-4]</pattern>
         <Harmony>
             <name>cm9/f</name>
         </Harmony>
@@ -29940,7 +29940,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X133X</pattern>
+        <pattern>[3-O]X[1-O][3-O][3-O]X</pattern>
         <Harmony>
             <name>cm9/g</name>
         </Harmony>
@@ -29969,7 +29969,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3434X</pattern>
+        <pattern>X[3-O][4-O][3-O][4-O]X</pattern>
         <Harmony>
             <name>cm9b5</name>
         </Harmony>
@@ -29998,7 +29998,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X31O3X</pattern>
+        <pattern>X[3-O][1-O]O[3-O]X</pattern>
         <Harmony>
             <name>cm(add2)</name>
         </Harmony>
@@ -30027,7 +30027,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>331O3X</pattern>
+        <pattern>[3-O][3-O][1-O]O[3-O]X</pattern>
         <Harmony>
             <name>cm(add2)/g</name>
         </Harmony>
@@ -30056,7 +30056,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>331O3X</pattern>
+        <pattern>[3-O][3-O][1-O]O[3-O]X</pattern>
         <Harmony>
             <name>cm(add2)/eb</name>
         </Harmony>
@@ -30080,7 +30080,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX---10</pattern>
+        <pattern>XX---[10-O];B8[2-4]</pattern>
         <Harmony>
             <name>cm(add2)/bb</name>
         </Harmony>
@@ -30109,7 +30109,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>331O3X</pattern>
+        <pattern>[3-O][3-O][1-O]O[3-O]X</pattern>
         <Harmony>
             <name>cm(add9)/g</name>
         </Harmony>
@@ -30138,7 +30138,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X1O3X</pattern>
+        <pattern>[3-O]X[1-O]O[3-O]X</pattern>
         <Harmony>
             <name>cm(add2)/g</name>
         </Harmony>
@@ -30162,7 +30162,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--54-</pattern>
+        <pattern>X--[5-O][4-O]-;B3[1-5]</pattern>
         <Harmony>
             <name>cm(add4)</name>
         </Harmony>
@@ -30191,7 +30191,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1O11</pattern>
+        <pattern>XX[1-O]O[1-O][1-O]</pattern>
         <Harmony>
             <name>cm(add4)/eb</name>
         </Harmony>
@@ -30220,7 +30220,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X31O3X</pattern>
+        <pattern>X[3-O][1-O]O[3-O]X</pattern>
         <Harmony>
             <name>cm(add9)</name>
         </Harmony>
@@ -30250,7 +30250,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO543</pattern>
+        <pattern>XXO[5-O][4-O][3-O]</pattern>
         <Harmony>
             <name>cm(add9)/d</name>
         </Harmony>
@@ -30280,7 +30280,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3X455</pattern>
+        <pattern>X[3-O]X[4-O][5-O][5-O]</pattern>
         <Harmony>
             <name>cmaj13</name>
         </Harmony>
@@ -30306,7 +30306,7 @@
                 <barre start="2" end="3">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3--33</pattern>
+        <pattern>X[3-O]--[3-O][3-O];B2[2-3]</pattern>
         <Harmony>
             <name>c69</name>
         </Harmony>
@@ -30335,7 +30335,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X32OOO</pattern>
+        <pattern>X[3-O][2-O]OOO</pattern>
         <Harmony>
             <name>cmaj7</name>
         </Harmony>
@@ -30365,7 +30365,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3X455</pattern>
+        <pattern>X[3-O]X[4-O][5-O][5-O]</pattern>
         <Harmony>
             <name>cmaj7(add13)</name>
         </Harmony>
@@ -30395,7 +30395,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3445X</pattern>
+        <pattern>X[3-O][4-O][4-O][5-O]X</pattern>
         <Harmony>
             <name>cmaj7b5</name>
         </Harmony>
@@ -30425,7 +30425,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2455X</pattern>
+        <pattern>X[2-O][4-O][5-O][5-O]X</pattern>
         <Harmony>
             <name>cmaj7b5/b</name>
         </Harmony>
@@ -30454,7 +30454,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2344OO</pattern>
+        <pattern>[2-O][3-O][4-O][4-O]OO</pattern>
         <Harmony>
             <name>cmaj7b5/f#</name>
         </Harmony>
@@ -30483,7 +30483,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X324OO</pattern>
+        <pattern>X[3-O][2-O][4-O]OO</pattern>
         <Harmony>
             <name>cmaj7(no5)</name>
         </Harmony>
@@ -30507,7 +30507,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>7X---X</pattern>
+        <pattern>[7-O]X---X;B5[2-4]</pattern>
         <Harmony>
             <name>cmaj7/b</name>
         </Harmony>
@@ -30528,7 +30528,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X----7</pattern>
+        <pattern>X----[7-O];B5[1-4]</pattern>
         <Harmony>
             <name>cmaj7/d</name>
         </Harmony>
@@ -30557,7 +30557,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O32OOO</pattern>
+        <pattern>O[3-O][2-O]OOO</pattern>
         <Harmony>
             <name>cmaj7/e</name>
         </Harmony>
@@ -30586,7 +30586,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>132OOO</pattern>
+        <pattern>[1-O][3-O][2-O]OOO</pattern>
         <Harmony>
             <name>cmaj7/f</name>
         </Harmony>
@@ -30615,7 +30615,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>332OOO</pattern>
+        <pattern>[3-O][3-O][2-O]OOO</pattern>
         <Harmony>
             <name>cmaj7/g</name>
         </Harmony>
@@ -30644,7 +30644,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X322OO</pattern>
+        <pattern>X[3-O][2-O][2-O]OO</pattern>
         <Harmony>
             <name>cmaj7(add13)</name>
         </Harmony>
@@ -30674,7 +30674,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3455X</pattern>
+        <pattern>X[3-O][4-O][5-O][5-O]X</pattern>
         <Harmony>
             <name>cmaj7#11</name>
         </Harmony>
@@ -30695,7 +30695,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>--54--</pattern>
+        <pattern>--[5-O][4-O]--;B3[0-5]</pattern>
         <Harmony>
             <name>cmaj7sus2/g</name>
         </Harmony>
@@ -30724,7 +30724,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X321OO</pattern>
+        <pattern>X[3-O][2-O][1-O]OO</pattern>
         <Harmony>
             <name>cmaj7#5</name>
         </Harmony>
@@ -30753,7 +30753,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2211O</pattern>
+        <pattern>X[2-O][2-O][1-O][1-O]O</pattern>
         <Harmony>
             <name>cmaj7#5/b</name>
         </Harmony>
@@ -30777,7 +30777,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-54--</pattern>
+        <pattern>X-[5-O][4-O]--;B3[1-5]</pattern>
         <Harmony>
             <name>cmaj7sus2</name>
         </Harmony>
@@ -30806,7 +30806,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3243X</pattern>
+        <pattern>X[3-O][2-O][4-O][3-O]X</pattern>
         <Harmony>
             <name>cmaj9</name>
         </Harmony>
@@ -30835,7 +30835,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2243O</pattern>
+        <pattern>X[2-O][2-O][4-O][3-O]O</pattern>
         <Harmony>
             <name>cmaj9/b</name>
         </Harmony>
@@ -30862,7 +30862,7 @@
                 <barre start="3" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO--7</pattern>
+        <pattern>XXO--[7-O];B5[3-4]</pattern>
         <Harmony>
             <name>cmaj9/d</name>
         </Harmony>
@@ -30891,7 +30891,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3243O</pattern>
+        <pattern>X[3-O][2-O][4-O][3-O]O</pattern>
         <Harmony>
             <name>cmaj9/e</name>
         </Harmony>
@@ -30920,7 +30920,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X243O</pattern>
+        <pattern>[3-O]X[2-O][4-O][3-O]O</pattern>
         <Harmony>
             <name>cmaj9/g</name>
         </Harmony>
@@ -30949,7 +30949,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3443O</pattern>
+        <pattern>X[3-O][4-O][4-O][3-O]O</pattern>
         <Harmony>
             <name>cmaj9#11</name>
         </Harmony>
@@ -30973,7 +30973,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX9---</pattern>
+        <pattern>XX[9-O]---;B8[3-5]</pattern>
         <Harmony>
             <name>cm(#7)</name>
         </Harmony>
@@ -30997,7 +30997,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX9---</pattern>
+        <pattern>XX[9-O]---;B8[3-5]</pattern>
         <Harmony>
             <name>cm(#7)/b</name>
         </Harmony>
@@ -31020,7 +31020,7 @@
                 <barre start="2" end="4">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3---X</pattern>
+        <pattern>X[3-O]---X;B4[2-4]</pattern>
         <Harmony>
             <name>cm(#7b5)</name>
         </Harmony>
@@ -31047,7 +31047,7 @@
                 <barre start="3" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X65--X</pattern>
+        <pattern>X[6-O][5-O]--X;B4[3-4]</pattern>
         <Harmony>
             <name>cm(#7)/eb</name>
         </Harmony>
@@ -31071,7 +31071,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X109---</pattern>
+        <pattern>X[10-O][9-O]---;B8[3-5]</pattern>
         <Harmony>
             <name>cm(#7)/g</name>
         </Harmony>
@@ -31098,7 +31098,7 @@
                 <barre start="3" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX9--10</pattern>
+        <pattern>XX[9-O]--[10-O];B8[3-4]</pattern>
         <Harmony>
             <name>cm(add9)</name>
         </Harmony>
@@ -31128,7 +31128,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO554X</pattern>
+        <pattern>XO[5-O][5-O][4-O]X</pattern>
         <Harmony>
             <name>cm/a</name>
         </Harmony>
@@ -31158,7 +31158,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X554X</pattern>
+        <pattern>[4-O]X[5-O][5-O][4-O]X</pattern>
         <Harmony>
             <name>cm/ab</name>
         </Harmony>
@@ -31182,7 +31182,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX9---</pattern>
+        <pattern>XX[9-O]---;B8[3-5]</pattern>
         <Harmony>
             <name>cm/b</name>
         </Harmony>
@@ -31203,7 +31203,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX----</pattern>
+        <pattern>XX----;B8[2-5]</pattern>
         <Harmony>
             <name>cm/bb</name>
         </Harmony>
@@ -31233,7 +31233,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO543</pattern>
+        <pattern>XXO[5-O][4-O][3-O]</pattern>
         <Harmony>
             <name>cm/d</name>
         </Harmony>
@@ -31263,7 +31263,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3O35</pattern>
+        <pattern>XX[3-O]O[3-O][5-O]</pattern>
         <Harmony>
             <name>cm/eb</name>
         </Harmony>
@@ -31290,7 +31290,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-54-</pattern>
+        <pattern>XX-[5-O][4-O]-;B3[2-5]</pattern>
         <Harmony>
             <name>cm/f</name>
         </Harmony>
@@ -31320,7 +31320,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX5543</pattern>
+        <pattern>XX[5-O][5-O][4-O][3-O]</pattern>
         <Harmony>
             <name>cm/g</name>
         </Harmony>
@@ -31350,7 +31350,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3X544</pattern>
+        <pattern>X[3-O]X[5-O][4-O][4-O]</pattern>
         <Harmony>
             <name>cm(#5)</name>
         </Harmony>
@@ -31379,7 +31379,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO2O1O</pattern>
+        <pattern>XO[2-O]O[1-O]O</pattern>
         <Harmony>
             <name>c/a</name>
         </Harmony>
@@ -31403,7 +31403,7 @@
                 <barre start="2" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X---X</pattern>
+        <pattern>[4-O]X---X;B5[2-4]</pattern>
         <Harmony>
             <name>c/ab</name>
         </Harmony>
@@ -31432,7 +31432,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X22O1O</pattern>
+        <pattern>X[2-O][2-O]O[1-O]O</pattern>
         <Harmony>
             <name>c/b</name>
         </Harmony>
@@ -31461,7 +31461,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X12O1O</pattern>
+        <pattern>X[1-O][2-O]O[1-O]O</pattern>
         <Harmony>
             <name>c/bb</name>
         </Harmony>
@@ -31490,7 +31490,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXOO1O</pattern>
+        <pattern>XXOO[1-O]O</pattern>
         <Harmony>
             <name>c/d</name>
         </Harmony>
@@ -31514,7 +31514,7 @@
                 <barre start="2" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4---X</pattern>
+        <pattern>X[4-O]---X;B5[2-4]</pattern>
         <Harmony>
             <name>c/db</name>
         </Harmony>
@@ -31543,7 +31543,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX2O1O</pattern>
+        <pattern>XX[2-O]O[1-O]O</pattern>
         <Harmony>
             <name>c/e</name>
         </Harmony>
@@ -31572,7 +31572,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1O1O</pattern>
+        <pattern>XX[1-O]O[1-O]O</pattern>
         <Harmony>
             <name>c/eb</name>
         </Harmony>
@@ -31599,7 +31599,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-55-</pattern>
+        <pattern>XX-[5-O][5-O]-;B3[2-5]</pattern>
         <Harmony>
             <name>c/f</name>
         </Harmony>
@@ -31628,7 +31628,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2X2O1O</pattern>
+        <pattern>[2-O]X[2-O]O[1-O]O</pattern>
         <Harmony>
             <name>c/f#</name>
         </Harmony>
@@ -31657,7 +31657,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>332O1O</pattern>
+        <pattern>[3-O][3-O][2-O]O[1-O]O</pattern>
         <Harmony>
             <name>c/g</name>
         </Harmony>
@@ -31683,7 +31683,7 @@
                 <barre start="3" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X32--X</pattern>
+        <pattern>X[3-O][2-O]--X;B1[3-4]</pattern>
         <Harmony>
             <name>c+</name>
         </Harmony>
@@ -31712,7 +31712,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO211O</pattern>
+        <pattern>XO[2-O][1-O][1-O]O</pattern>
         <Harmony>
             <name>c+/a</name>
         </Harmony>
@@ -31741,7 +31741,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2211O</pattern>
+        <pattern>X[2-O][2-O][1-O][1-O]O</pattern>
         <Harmony>
             <name>c+/b</name>
         </Harmony>
@@ -31770,7 +31770,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO11O</pattern>
+        <pattern>XXO[1-O][1-O]O</pattern>
         <Harmony>
             <name>c+/d</name>
         </Harmony>
@@ -31799,7 +31799,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX211O</pattern>
+        <pattern>XX[2-O][1-O][1-O]O</pattern>
         <Harmony>
             <name>c+/e</name>
         </Harmony>
@@ -31825,7 +31825,7 @@
                 <barre start="3" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>332--X</pattern>
+        <pattern>[3-O][3-O][2-O]--X;B1[3-4]</pattern>
         <Harmony>
             <name>c+/g</name>
         </Harmony>
@@ -31854,7 +31854,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXX11O</pattern>
+        <pattern>XXX[1-O][1-O]O</pattern>
         <Harmony>
             <name>c+/g#</name>
         </Harmony>
@@ -31878,7 +31878,7 @@
                 <barre start="2" end="4">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4---X</pattern>
+        <pattern>X[4-O]---X;B6[2-4]</pattern>
         <Harmony>
             <name>c#</name>
         </Harmony>
@@ -31896,7 +31896,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-----</pattern>
+        <pattern>X-----;B4[1-5]</pattern>
         <Harmony>
             <name>c#11</name>
         </Harmony>
@@ -31923,7 +31923,7 @@
                 <barre start="3" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X43--6</pattern>
+        <pattern>X[4-O][3-O]--[6-O];B4[3-4]</pattern>
         <Harmony>
             <name>c#13</name>
         </Harmony>
@@ -31953,7 +31953,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X5X466</pattern>
+        <pattern>X[5-O]X[4-O][6-O][6-O]</pattern>
         <Harmony>
             <name>c#13b9</name>
         </Harmony>
@@ -31983,7 +31983,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4566X</pattern>
+        <pattern>X[4-O][5-O][6-O][6-O]X</pattern>
         <Harmony>
             <name>c(#4)</name>
         </Harmony>
@@ -32013,7 +32013,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X466XX</pattern>
+        <pattern>X[4-O][6-O][6-O]XX</pattern>
         <Harmony>
             <name>c#5</name>
         </Harmony>
@@ -32034,7 +32034,7 @@
                 <barre start="2" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4----</pattern>
+        <pattern>X[4-O]----;B6[2-5]</pattern>
         <Harmony>
             <name>c#6</name>
         </Harmony>
@@ -32061,7 +32061,7 @@
                 <barre start="0" end="1">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>--66XX</pattern>
+        <pattern>--[6-O][6-O]XX;B4[0-1]</pattern>
         <Harmony>
             <name>c#5/g#</name>
         </Harmony>
@@ -32087,7 +32087,7 @@
                 <barre start="2" end="3">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4--44</pattern>
+        <pattern>X[4-O]--[4-O][4-O];B3[2-3]</pattern>
         <Harmony>
             <name>c#69</name>
         </Harmony>
@@ -32116,7 +32116,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2X12X</pattern>
+        <pattern>X[2-O]X[1-O][2-O]X</pattern>
         <Harmony>
             <name>c#5/b</name>
         </Harmony>
@@ -32145,7 +32145,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4342X</pattern>
+        <pattern>X[4-O][3-O][4-O][2-O]X</pattern>
         <Harmony>
             <name>c#7</name>
         </Harmony>
@@ -32175,7 +32175,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>9X9108X</pattern>
+        <pattern>[9-O]X[9-O][10-O][8-O]X</pattern>
         <Harmony>
             <name>c#7b5</name>
         </Harmony>
@@ -32205,7 +32205,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X434X5</pattern>
+        <pattern>X[4-O][3-O][4-O]X[5-O]</pattern>
         <Harmony>
             <name>c#7#5</name>
         </Harmony>
@@ -32234,7 +32234,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4343X</pattern>
+        <pattern>X[4-O][3-O][4-O][3-O]X</pattern>
         <Harmony>
             <name>c#7b9</name>
         </Harmony>
@@ -32261,7 +32261,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4-4-5</pattern>
+        <pattern>X[4-O]-[4-O]-[5-O];B3[2-4]</pattern>
         <Harmony>
             <name>c#7(b13b9)</name>
         </Harmony>
@@ -32291,7 +32291,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3434</pattern>
+        <pattern>XX[3-O][4-O][3-O][4-O]</pattern>
         <Harmony>
             <name>c#7b9/e#</name>
         </Harmony>
@@ -32321,7 +32321,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4X434</pattern>
+        <pattern>X[4-O]X[4-O][3-O][4-O]</pattern>
         <Harmony>
             <name>c#7(b9no3)</name>
         </Harmony>
@@ -32351,7 +32351,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4X4O4</pattern>
+        <pattern>X[4-O]X[4-O]O[4-O]</pattern>
         <Harmony>
             <name>c#7(no3)</name>
         </Harmony>
@@ -32381,7 +32381,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X234X5</pattern>
+        <pattern>X[2-O][3-O][4-O]X[5-O]</pattern>
         <Harmony>
             <name>c#7#5/b</name>
         </Harmony>
@@ -32410,7 +32410,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX34O4</pattern>
+        <pattern>XX[3-O][4-O]O[4-O]</pattern>
         <Harmony>
             <name>c#7/e#</name>
         </Harmony>
@@ -32439,7 +32439,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX34O4</pattern>
+        <pattern>XX[3-O][4-O]O[4-O]</pattern>
         <Harmony>
             <name>c#7/f</name>
         </Harmony>
@@ -32465,7 +32465,7 @@
                 <barre start="0" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-434-X</pattern>
+        <pattern>-[4-O][3-O][4-O]-X;B2[0-4]</pattern>
         <Harmony>
             <name>c#7/f#</name>
         </Harmony>
@@ -32494,7 +32494,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X234O4</pattern>
+        <pattern>X[2-O][3-O][4-O]O[4-O]</pattern>
         <Harmony>
             <name>c#7/b</name>
         </Harmony>
@@ -32514,7 +32514,7 @@
                 <barre start="2" end="4">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>------</pattern>
+        <pattern>------;B4[0-5];B6[2-4]</pattern>
         <Harmony>
             <name>c#7/g#</name>
         </Harmony>
@@ -32544,7 +32544,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>9X9108X</pattern>
+        <pattern>[9-O]X[9-O][10-O][8-O]X</pattern>
         <Harmony>
             <name>c#7#11</name>
         </Harmony>
@@ -32565,7 +32565,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>--5-6-</pattern>
+        <pattern>--[5-O]-[6-O]-;B4[0-5]</pattern>
         <Harmony>
             <name>c#7#11/g#</name>
         </Harmony>
@@ -32595,7 +32595,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>9X91010X</pattern>
+        <pattern>[9-O]X[9-O][10-O][10-O]X</pattern>
         <Harmony>
             <name>c#7#5</name>
         </Harmony>
@@ -32622,7 +32622,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4-4-5</pattern>
+        <pattern>X[4-O]-[4-O]-[5-O];B3[2-4]</pattern>
         <Harmony>
             <name>c#7(b9#5)</name>
         </Harmony>
@@ -32649,7 +32649,7 @@
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X434--</pattern>
+        <pattern>X[4-O][3-O][4-O]--;B5[4-5]</pattern>
         <Harmony>
             <name>c#7(#9#5)</name>
         </Harmony>
@@ -32679,7 +32679,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4345X</pattern>
+        <pattern>X[4-O][3-O][4-O][5-O]X</pattern>
         <Harmony>
             <name>c#7#9</name>
         </Harmony>
@@ -32706,7 +32706,7 @@
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X434--</pattern>
+        <pattern>X[4-O][3-O][4-O]--;B5[4-5]</pattern>
         <Harmony>
             <name>c#7(b13#9)</name>
         </Harmony>
@@ -32730,7 +32730,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-6-7-</pattern>
+        <pattern>X-[6-O]-[7-O]-;B4[1-5]</pattern>
         <Harmony>
             <name>c#7sus4</name>
         </Harmony>
@@ -32754,7 +32754,7 @@
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X46---</pattern>
+        <pattern>X[4-O][6-O]---;B7[3-5]</pattern>
         <Harmony>
             <name>c#7(b9sus4)</name>
         </Harmony>
@@ -32777,7 +32777,7 @@
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X43---</pattern>
+        <pattern>X[4-O][3-O]---;B4[3-5]</pattern>
         <Harmony>
             <name>c#9</name>
         </Harmony>
@@ -32803,7 +32803,7 @@
                 <barre start="2" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4-44-</pattern>
+        <pattern>X[4-O]-[4-O][4-O]-;B3[2-5]</pattern>
         <Harmony>
             <name>c#9b5</name>
         </Harmony>
@@ -32830,7 +32830,7 @@
                 <barre start="3" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X43--5</pattern>
+        <pattern>X[4-O][3-O]--[5-O];B4[3-4]</pattern>
         <Harmony>
             <name>c#9b13</name>
         </Harmony>
@@ -32856,7 +32856,7 @@
                 <barre start="2" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4-44-</pattern>
+        <pattern>X[4-O]-[4-O][4-O]-;B3[2-5]</pattern>
         <Harmony>
             <name>c#9#11</name>
         </Harmony>
@@ -32877,7 +32877,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>--6-7-</pattern>
+        <pattern>--[6-O]-[7-O]-;B4[0-5]</pattern>
         <Harmony>
             <name>c#7sus4/g#</name>
         </Harmony>
@@ -32904,7 +32904,7 @@
                 <barre start="3" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X43--5</pattern>
+        <pattern>X[4-O][3-O]--[5-O];B4[3-4]</pattern>
         <Harmony>
             <name>c#9#5</name>
         </Harmony>
@@ -32922,7 +32922,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-----</pattern>
+        <pattern>X-----;B4[1-5]</pattern>
         <Harmony>
             <name>c#9sus4</name>
         </Harmony>
@@ -32948,7 +32948,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4-2-</pattern>
+        <pattern>XX[4-O]-[2-O]-;B1[3-5]</pattern>
         <Harmony>
             <name>c#add4</name>
         </Harmony>
@@ -32977,7 +32977,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4314X</pattern>
+        <pattern>X[4-O][3-O][1-O][4-O]X</pattern>
         <Harmony>
             <name>c#add9</name>
         </Harmony>
@@ -33007,7 +33007,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4565X</pattern>
+        <pattern>X[4-O][5-O][6-O][5-O]X</pattern>
         <Harmony>
             <name>c#dim</name>
         </Harmony>
@@ -33036,7 +33036,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX2323</pattern>
+        <pattern>XX[2-O][3-O][2-O][3-O]</pattern>
         <Harmony>
             <name>c#dim7</name>
         </Harmony>
@@ -33059,7 +33059,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2--2-</pattern>
+        <pattern>X[2-O]--[2-O]-;B1[2-5]</pattern>
         <Harmony>
             <name>c#add2/b</name>
         </Harmony>
@@ -33088,7 +33088,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X12O2O</pattern>
+        <pattern>X[1-O][2-O]O[2-O]O</pattern>
         <Harmony>
             <name>c#dim7/bb</name>
         </Harmony>
@@ -33117,7 +33117,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO323</pattern>
+        <pattern>XXO[3-O][2-O][3-O]</pattern>
         <Harmony>
             <name>c#dim7/d</name>
         </Harmony>
@@ -33144,7 +33144,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>7X-6-X</pattern>
+        <pattern>[7-O]X-[6-O]-X;B5[2-4]</pattern>
         <Harmony>
             <name>c#dim/b</name>
         </Harmony>
@@ -33170,7 +33170,7 @@
                 <barre start="2" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X-3-O</pattern>
+        <pattern>[3-O]X-[3-O]-O;B2[2-4]</pattern>
         <Harmony>
             <name>c#dim7/g</name>
         </Harmony>
@@ -33200,7 +33200,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO643</pattern>
+        <pattern>XXO[6-O][4-O][3-O]</pattern>
         <Harmony>
             <name>c#dim/d</name>
         </Harmony>
@@ -33229,7 +33229,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX2O2O</pattern>
+        <pattern>XX[2-O]O[2-O]O</pattern>
         <Harmony>
             <name>c#dim/e</name>
         </Harmony>
@@ -33258,7 +33258,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X2O2O</pattern>
+        <pattern>[3-O]X[2-O]O[2-O]O</pattern>
         <Harmony>
             <name>c#dim/g</name>
         </Harmony>
@@ -33288,7 +33288,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4566X</pattern>
+        <pattern>X[4-O][5-O][6-O][6-O]X</pattern>
         <Harmony>
             <name>c#(b5)</name>
         </Harmony>
@@ -33317,7 +33317,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXXO21</pattern>
+        <pattern>XXXO[2-O][1-O]</pattern>
         <Harmony>
             <name>c#9b5/g</name>
         </Harmony>
@@ -33346,7 +33346,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>343OXX</pattern>
+        <pattern>[3-O][4-O][3-O]OXX</pattern>
         <Harmony>
             <name>c#(b5)/g</name>
         </Harmony>
@@ -33369,7 +33369,7 @@
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3---</pattern>
+        <pattern>XX[3-O]---;B4[3-5]</pattern>
         <Harmony>
             <name>c#9/f</name>
         </Harmony>
@@ -33396,7 +33396,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-665-</pattern>
+        <pattern>X-[6-O][6-O][5-O]-;B4[1-5]</pattern>
         <Harmony>
             <name>c#m</name>
         </Harmony>
@@ -33426,7 +33426,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4X452</pattern>
+        <pattern>X[4-O]X[4-O][5-O][2-O]</pattern>
         <Harmony>
             <name>c#m11</name>
         </Harmony>
@@ -33444,7 +33444,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>----5-</pattern>
+        <pattern>----[5-O]-;B4[0-5]</pattern>
         <Harmony>
             <name>c#m11/g#</name>
         </Harmony>
@@ -33471,7 +33471,7 @@
                 <barre start="1" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-6-56</pattern>
+        <pattern>X-[6-O]-[5-O][6-O];B4[1-3]</pattern>
         <Harmony>
             <name>c#m6</name>
         </Harmony>
@@ -33500,7 +33500,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX2344</pattern>
+        <pattern>XX[2-O][3-O][4-O][4-O]</pattern>
         <Harmony>
             <name>c#m69</name>
         </Harmony>
@@ -33529,7 +33529,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX232O</pattern>
+        <pattern>XX[2-O][3-O][2-O]O</pattern>
         <Harmony>
             <name>c#m6/e</name>
         </Harmony>
@@ -33558,7 +33558,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3212O</pattern>
+        <pattern>X[3-O][2-O][1-O][2-O]O</pattern>
         <Harmony>
             <name>c#m/b#</name>
         </Harmony>
@@ -33587,7 +33587,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX112O</pattern>
+        <pattern>XX[1-O][1-O][2-O]O</pattern>
         <Harmony>
             <name>c#m/d#</name>
         </Harmony>
@@ -33614,7 +33614,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1011-11-</pattern>
+        <pattern>X[10-O][11-O]-[11-O]-;B9[3-5]</pattern>
         <Harmony>
             <name>c#m6/g</name>
         </Harmony>
@@ -33638,7 +33638,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-6-5-</pattern>
+        <pattern>X-[6-O]-[5-O]-;B4[1-5]</pattern>
         <Harmony>
             <name>c#m7</name>
         </Harmony>
@@ -33668,7 +33668,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4X452</pattern>
+        <pattern>X[4-O]X[4-O][5-O][2-O]</pattern>
         <Harmony>
             <name>c#m7(add11)</name>
         </Harmony>
@@ -33695,7 +33695,7 @@
                 <barre start="1" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-6-56</pattern>
+        <pattern>X-[6-O]-[5-O][6-O];B4[1-3]</pattern>
         <Harmony>
             <name>c#m7add13</name>
         </Harmony>
@@ -33725,7 +33725,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4X452</pattern>
+        <pattern>X[4-O]X[4-O][5-O][2-O]</pattern>
         <Harmony>
             <name>c#m7(add4)</name>
         </Harmony>
@@ -33755,7 +33755,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4545X</pattern>
+        <pattern>X[4-O][5-O][4-O][5-O]X</pattern>
         <Harmony>
             <name>c#m7b5</name>
         </Harmony>
@@ -33784,7 +33784,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXOO2O</pattern>
+        <pattern>XXOO[2-O]O</pattern>
         <Harmony>
             <name>c#m7b5/d</name>
         </Harmony>
@@ -33813,7 +33813,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O22OOO</pattern>
+        <pattern>O[2-O][2-O]OOO</pattern>
         <Harmony>
             <name>c#m7b5/e</name>
         </Harmony>
@@ -33842,7 +33842,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>342OOO</pattern>
+        <pattern>[3-O][4-O][2-O]OOO</pattern>
         <Harmony>
             <name>c#m7b5/g</name>
         </Harmony>
@@ -33871,7 +33871,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X424OO</pattern>
+        <pattern>X[4-O][2-O][4-O]OO</pattern>
         <Harmony>
             <name>c#m7(no5)</name>
         </Harmony>
@@ -33892,7 +33892,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX----</pattern>
+        <pattern>XX----;B9[2-5]</pattern>
         <Harmony>
             <name>c#m7/b</name>
         </Harmony>
@@ -33919,7 +33919,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X66-5-</pattern>
+        <pattern>X[6-O][6-O]-[5-O]-;B4[3-5]</pattern>
         <Harmony>
             <name>c#m7/d#</name>
         </Harmony>
@@ -33945,7 +33945,7 @@
                 <barre start="2" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-4-4</pattern>
+        <pattern>XX-[4-O]-[4-O];B2[2-4]</pattern>
         <Harmony>
             <name>c#m7/e</name>
         </Harmony>
@@ -33966,7 +33966,7 @@
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X8----</pattern>
+        <pattern>X[8-O]----;B9[2-5]</pattern>
         <Harmony>
             <name>c#m7/f</name>
         </Harmony>
@@ -33984,7 +33984,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-----</pattern>
+        <pattern>X-----;B9[1-5]</pattern>
         <Harmony>
             <name>c#m7/f#</name>
         </Harmony>
@@ -34008,7 +34008,7 @@
                 <barre start="2" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>8X---X</pattern>
+        <pattern>[8-O]X---X;B9[2-4]</pattern>
         <Harmony>
             <name>c#m7/b#</name>
         </Harmony>
@@ -34029,7 +34029,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>--6-5-</pattern>
+        <pattern>--[6-O]-[5-O]-;B4[0-5]</pattern>
         <Harmony>
             <name>c#m7/g#</name>
         </Harmony>
@@ -34058,7 +34058,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4244X</pattern>
+        <pattern>X[4-O][2-O][4-O][4-O]X</pattern>
         <Harmony>
             <name>c#m9</name>
         </Harmony>
@@ -34087,7 +34087,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4X443</pattern>
+        <pattern>X[4-O]X[4-O][4-O][3-O]</pattern>
         <Harmony>
             <name>c#m9b5</name>
         </Harmony>
@@ -34111,7 +34111,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX---11</pattern>
+        <pattern>XX---[11-O];B9[2-4]</pattern>
         <Harmony>
             <name>c#m9/b</name>
         </Harmony>
@@ -34137,7 +34137,7 @@
                 <barre start="0" end="2">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-4-44X</pattern>
+        <pattern>-[4-O]-[4-O][4-O]X;B2[0-2]</pattern>
         <Harmony>
             <name>c#m9/f#</name>
         </Harmony>
@@ -34164,7 +34164,7 @@
                 <barre start="3" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX11--11</pattern>
+        <pattern>XX[11-O]--[11-O];B9[3-4]</pattern>
         <Harmony>
             <name>c#m(add2)</name>
         </Harmony>
@@ -34188,7 +34188,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX---11</pattern>
+        <pattern>XX---[11-O];B9[2-4]</pattern>
         <Harmony>
             <name>c#m(add2)/b</name>
         </Harmony>
@@ -34218,7 +34218,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4667O</pattern>
+        <pattern>X[4-O][6-O][6-O][7-O]O</pattern>
         <Harmony>
             <name>c#m(add4)</name>
         </Harmony>
@@ -34245,7 +34245,7 @@
                 <barre start="3" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX11--11</pattern>
+        <pattern>XX[11-O]--[11-O];B9[3-4]</pattern>
         <Harmony>
             <name>c#m(add9)</name>
         </Harmony>
@@ -34269,7 +34269,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX---11</pattern>
+        <pattern>XX---[11-O];B9[2-4]</pattern>
         <Harmony>
             <name>c#m(add9)/b</name>
         </Harmony>
@@ -34295,7 +34295,7 @@
                 <barre start="2" end="4">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--5--</pattern>
+        <pattern>X--[5-O]--;B4[1-5];B6[2-4]</pattern>
         <Harmony>
             <name>c#maj7</name>
         </Harmony>
@@ -34325,7 +34325,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4556X</pattern>
+        <pattern>X[4-O][5-O][5-O][6-O]X</pattern>
         <Harmony>
             <name>c#maj7#11</name>
         </Harmony>
@@ -34355,7 +34355,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4354X</pattern>
+        <pattern>X[4-O][3-O][5-O][4-O]X</pattern>
         <Harmony>
             <name>c#maj9</name>
         </Harmony>
@@ -34382,7 +34382,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-55-X</pattern>
+        <pattern>X-[5-O][5-O]-X;B4[1-4]</pattern>
         <Harmony>
             <name>c#maj9#11</name>
         </Harmony>
@@ -34409,7 +34409,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-655-</pattern>
+        <pattern>X-[6-O][5-O][5-O]-;B4[1-5]</pattern>
         <Harmony>
             <name>c#m(#7)</name>
         </Harmony>
@@ -34436,7 +34436,7 @@
                 <barre start="3" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX10--11</pattern>
+        <pattern>XX[10-O]--[11-O];B9[3-4]</pattern>
         <Harmony>
             <name>c#m(add9)</name>
         </Harmony>
@@ -34465,7 +34465,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3211O</pattern>
+        <pattern>X[3-O][2-O][1-O][1-O]O</pattern>
         <Harmony>
             <name>c#m(#7)/b#</name>
         </Harmony>
@@ -34494,7 +34494,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO212O</pattern>
+        <pattern>XO[2-O][1-O][2-O]O</pattern>
         <Harmony>
             <name>c#m/a</name>
         </Harmony>
@@ -34523,7 +34523,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1212O</pattern>
+        <pattern>X[1-O][2-O][1-O][2-O]O</pattern>
         <Harmony>
             <name>c#m/a#</name>
         </Harmony>
@@ -34552,7 +34552,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2212O</pattern>
+        <pattern>X[2-O][2-O][1-O][2-O]O</pattern>
         <Harmony>
             <name>c#m/b</name>
         </Harmony>
@@ -34581,7 +34581,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO12O</pattern>
+        <pattern>XXO[1-O][2-O]O</pattern>
         <Harmony>
             <name>c#m/d</name>
         </Harmony>
@@ -34608,7 +34608,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O-665-</pattern>
+        <pattern>O-[6-O][6-O][5-O]-;B4[1-5]</pattern>
         <Harmony>
             <name>c#m/e</name>
         </Harmony>
@@ -34635,7 +34635,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-665-</pattern>
+        <pattern>X-[6-O][6-O][5-O]-;B4[1-5]</pattern>
         <Harmony>
             <name>c#m/f</name>
         </Harmony>
@@ -34662,7 +34662,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-65-</pattern>
+        <pattern>XX-[6-O][5-O]-;B4[2-5]</pattern>
         <Harmony>
             <name>c#m/f#</name>
         </Harmony>
@@ -34686,7 +34686,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>--665-</pattern>
+        <pattern>--[6-O][6-O][5-O]-;B4[0-5]</pattern>
         <Harmony>
             <name>c#m/g#</name>
         </Harmony>
@@ -34716,7 +34716,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4X655</pattern>
+        <pattern>X[4-O]X[6-O][5-O][5-O]</pattern>
         <Harmony>
             <name>c#m(#5)</name>
         </Harmony>
@@ -34746,7 +34746,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X466XX</pattern>
+        <pattern>X[4-O][6-O][6-O]XX</pattern>
         <Harmony>
             <name>c#5</name>
         </Harmony>
@@ -34772,7 +34772,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO3-2-</pattern>
+        <pattern>XO[3-O]-[2-O]-;B1[3-5]</pattern>
         <Harmony>
             <name>c#/a</name>
         </Harmony>
@@ -34796,7 +34796,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>7X---X</pattern>
+        <pattern>[7-O]X---X;B6[2-4]</pattern>
         <Harmony>
             <name>c#/b</name>
         </Harmony>
@@ -34819,7 +34819,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX--2-</pattern>
+        <pattern>XX--[2-O]-;B1[2-5]</pattern>
         <Harmony>
             <name>c#/d#</name>
         </Harmony>
@@ -34845,7 +34845,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3-2-</pattern>
+        <pattern>XX[3-O]-[2-O]-;B1[3-5]</pattern>
         <Harmony>
             <name>c#/e#</name>
         </Harmony>
@@ -34872,7 +34872,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-66-</pattern>
+        <pattern>XX-[6-O][6-O]-;B4[2-5]</pattern>
         <Harmony>
             <name>c#/f#</name>
         </Harmony>
@@ -34897,7 +34897,7 @@
                 <barre start="2" end="4">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-----X</pattern>
+        <pattern>-----X;B4[0-1];B6[2-4]</pattern>
         <Harmony>
             <name>c#/g#</name>
         </Harmony>
@@ -34923,7 +34923,7 @@
                 <barre start="3" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X43--X</pattern>
+        <pattern>X[4-O][3-O]--X;B2[3-4]</pattern>
         <Harmony>
             <name>c#+</name>
         </Harmony>
@@ -34952,7 +34952,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO221</pattern>
+        <pattern>XXO[2-O][2-O][1-O]</pattern>
         <Harmony>
             <name>c#+/d</name>
         </Harmony>
@@ -34981,7 +34981,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3221</pattern>
+        <pattern>XX[3-O][2-O][2-O][1-O]</pattern>
         <Harmony>
             <name>c#+/e#</name>
         </Harmony>
@@ -35008,7 +35008,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-667-</pattern>
+        <pattern>X-[6-O][6-O][7-O]-;B4[1-5]</pattern>
         <Harmony>
             <name>c#sus</name>
         </Harmony>
@@ -35032,7 +35032,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-66--</pattern>
+        <pattern>X-[6-O][6-O]--;B4[1-5]</pattern>
         <Harmony>
             <name>c#sus2</name>
         </Harmony>
@@ -35056,7 +35056,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O-66--</pattern>
+        <pattern>O-[6-O][6-O]--;B4[1-5]</pattern>
         <Harmony>
             <name>c#sus2/e</name>
         </Harmony>
@@ -35085,7 +35085,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2X122</pattern>
+        <pattern>X[2-O]X[1-O][2-O][2-O]</pattern>
         <Harmony>
             <name>c#sus/b</name>
         </Harmony>
@@ -35114,7 +35114,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX2122</pattern>
+        <pattern>XX[2-O][1-O][2-O][2-O]</pattern>
         <Harmony>
             <name>c#sus/e</name>
         </Harmony>
@@ -35141,7 +35141,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-556-</pattern>
+        <pattern>X-[5-O][5-O][6-O]-;B3[1-5]</pattern>
         <Harmony>
             <name>csus</name>
         </Harmony>
@@ -35165,7 +35165,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-55--</pattern>
+        <pattern>X-[5-O][5-O]--;B3[1-5]</pattern>
         <Harmony>
             <name>csus2</name>
         </Harmony>
@@ -35192,7 +35192,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO55--</pattern>
+        <pattern>XO[5-O][5-O]--;B3[4-5]</pattern>
         <Harmony>
             <name>csus2/a</name>
         </Harmony>
@@ -35218,7 +35218,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2XO--</pattern>
+        <pattern>X[2-O]XO--;B1[4-5]</pattern>
         <Harmony>
             <name>csus/b</name>
         </Harmony>
@@ -35247,7 +35247,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2OO1X</pattern>
+        <pattern>X[2-O]OO[1-O]X</pattern>
         <Harmony>
             <name>csus2/b</name>
         </Harmony>
@@ -35276,7 +35276,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1OO13</pattern>
+        <pattern>X[1-O]OO[1-O][3-O]</pattern>
         <Harmony>
             <name>csus2/bb</name>
         </Harmony>
@@ -35303,7 +35303,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X555--</pattern>
+        <pattern>X[5-O][5-O][5-O]--;B3[4-5]</pattern>
         <Harmony>
             <name>csus2/d</name>
         </Harmony>
@@ -35332,7 +35332,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX2O33</pattern>
+        <pattern>XX[2-O]O[3-O][3-O]</pattern>
         <Harmony>
             <name>csus2/e</name>
         </Harmony>
@@ -35361,7 +35361,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3O33</pattern>
+        <pattern>XX[3-O]O[3-O][3-O]</pattern>
         <Harmony>
             <name>csus2/f</name>
         </Harmony>
@@ -35388,7 +35388,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX55--</pattern>
+        <pattern>XX[5-O][5-O]--;B3[4-5]</pattern>
         <Harmony>
             <name>csus2/g</name>
         </Harmony>
@@ -35414,7 +35414,7 @@
                 <barre start="1" end="4">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-XO-2</pattern>
+        <pattern>X-XO-[2-O];B3[1-4]</pattern>
         <Harmony>
             <name>c(#4sus2)</name>
         </Harmony>
@@ -35443,7 +35443,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3OO11</pattern>
+        <pattern>X[3-O]OO[1-O][1-O]</pattern>
         <Harmony>
             <name>csus4add2</name>
         </Harmony>
@@ -35472,7 +35472,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X33O33</pattern>
+        <pattern>X[3-O][3-O]O[3-O][3-O]</pattern>
         <Harmony>
             <name>c(add2sus4)</name>
         </Harmony>
@@ -35498,7 +35498,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>33OO--</pattern>
+        <pattern>[3-O][3-O]OO--;B1[4-5]</pattern>
         <Harmony>
             <name>c(add2sus4)/g</name>
         </Harmony>
@@ -35524,7 +35524,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO3O--</pattern>
+        <pattern>XO[3-O]O--;B1[4-5]</pattern>
         <Harmony>
             <name>csus/a</name>
         </Harmony>
@@ -35554,7 +35554,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X556X</pattern>
+        <pattern>[4-O]X[5-O][5-O][6-O]X</pattern>
         <Harmony>
             <name>csus/ab</name>
         </Harmony>
@@ -35583,7 +35583,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1XO11</pattern>
+        <pattern>X[1-O]XO[1-O][1-O]</pattern>
         <Harmony>
             <name>csus/bb</name>
         </Harmony>
@@ -35612,7 +35612,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXOO11</pattern>
+        <pattern>XXOO[1-O][1-O]</pattern>
         <Harmony>
             <name>csus/d</name>
         </Harmony>
@@ -35641,7 +35641,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O33O11</pattern>
+        <pattern>O[3-O][3-O]O[1-O][1-O]</pattern>
         <Harmony>
             <name>csus/e</name>
         </Harmony>
@@ -35670,7 +35670,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1O11</pattern>
+        <pattern>XX[1-O]O[1-O][1-O]</pattern>
         <Harmony>
             <name>csus/eb</name>
         </Harmony>
@@ -35696,7 +35696,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>333O--</pattern>
+        <pattern>[3-O][3-O][3-O]O--;B1[4-5]</pattern>
         <Harmony>
             <name>csus/g</name>
         </Harmony>
@@ -35725,7 +35725,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO232</pattern>
+        <pattern>XXO[2-O][3-O][2-O]</pattern>
         <Harmony>
             <name>d</name>
         </Harmony>
@@ -35743,7 +35743,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-----</pattern>
+        <pattern>X-----;B5[1-5]</pattern>
         <Harmony>
             <name>d11</name>
         </Harmony>
@@ -35770,7 +35770,7 @@
                 <barre start="3" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X54--7</pattern>
+        <pattern>X[5-O][4-O]--[7-O];B5[3-4]</pattern>
         <Harmony>
             <name>d13</name>
         </Harmony>
@@ -35800,7 +35800,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>11X101112X</pattern>
+        <pattern>[11-O]X[10-O][11-O][12-O]X</pattern>
         <Harmony>
             <name>d13b9</name>
         </Harmony>
@@ -35827,7 +35827,7 @@
                 <barre start="1" end="2">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--111211</pattern>
+        <pattern>X--[11-O][12-O][11-O];B10[1-2]</pattern>
         <Harmony>
             <name>d13b9/g</name>
         </Harmony>
@@ -35854,7 +35854,7 @@
                 <barre start="3" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX6--7</pattern>
+        <pattern>XX[6-O]--[7-O];B5[3-4]</pattern>
         <Harmony>
             <name>d13/ab</name>
         </Harmony>
@@ -35880,7 +35880,7 @@
                 <barre start="1" end="4">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-44-X</pattern>
+        <pattern>X-[4-O][4-O]-X;B3[1-4]</pattern>
         <Harmony>
             <name>d13/c</name>
         </Harmony>
@@ -35910,7 +35910,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XOO667</pattern>
+        <pattern>XOO[6-O][6-O][7-O]</pattern>
         <Harmony>
             <name>dmaj7(add13)</name>
         </Harmony>
@@ -35940,7 +35940,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4567</pattern>
+        <pattern>XX[4-O][5-O][6-O][7-O]</pattern>
         <Harmony>
             <name>d13#9</name>
         </Harmony>
@@ -35964,7 +35964,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-6--7</pattern>
+        <pattern>X-[6-O]--[7-O];B5[1-4]</pattern>
         <Harmony>
             <name>d13#11</name>
         </Harmony>
@@ -35985,7 +35985,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X----7</pattern>
+        <pattern>X----[7-O];B5[1-4]</pattern>
         <Harmony>
             <name>d13sus4</name>
         </Harmony>
@@ -36012,7 +36012,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO-55-</pattern>
+        <pattern>XO-[5-O][5-O]-;B4[2-5]</pattern>
         <Harmony>
             <name>d13#11/a</name>
         </Harmony>
@@ -36042,7 +36042,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X5777O</pattern>
+        <pattern>X[5-O][7-O][7-O][7-O]O</pattern>
         <Harmony>
             <name>dadd2</name>
         </Harmony>
@@ -36072,7 +36072,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X577XX</pattern>
+        <pattern>X[5-O][7-O][7-O]XX</pattern>
         <Harmony>
             <name>d5</name>
         </Harmony>
@@ -36099,7 +36099,7 @@
                 <barre start="0" end="1">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>--77XX</pattern>
+        <pattern>--[7-O][7-O]XX;B5[0-1]</pattern>
         <Harmony>
             <name>d5/a</name>
         </Harmony>
@@ -36129,7 +36129,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2O23X</pattern>
+        <pattern>X[2-O]O[2-O][3-O]X</pattern>
         <Harmony>
             <name>d5/b</name>
         </Harmony>
@@ -36158,7 +36158,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3X23X</pattern>
+        <pattern>X[3-O]X[2-O][3-O]X</pattern>
         <Harmony>
             <name>d5/c</name>
         </Harmony>
@@ -36188,7 +36188,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X477XX</pattern>
+        <pattern>X[4-O][7-O][7-O]XX</pattern>
         <Harmony>
             <name>d5/c#</name>
         </Harmony>
@@ -36217,7 +36217,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3XO23X</pattern>
+        <pattern>[3-O]XO[2-O][3-O]X</pattern>
         <Harmony>
             <name>d5/g</name>
         </Harmony>
@@ -36246,7 +36246,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO234</pattern>
+        <pattern>XXO[2-O][3-O][4-O]</pattern>
         <Harmony>
             <name>d5(#4)</name>
         </Harmony>
@@ -36275,7 +36275,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO2O2</pattern>
+        <pattern>XXO[2-O]O[2-O]</pattern>
         <Harmony>
             <name>d6</name>
         </Harmony>
@@ -36302,7 +36302,7 @@
                 <barre start="2" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X5--55</pattern>
+        <pattern>X[5-O]--[5-O][5-O];B4[2-3]</pattern>
         <Harmony>
             <name>d69</name>
         </Harmony>
@@ -36326,7 +36326,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X5--5-</pattern>
+        <pattern>X[5-O]--[5-O]-;B4[2-5]</pattern>
         <Harmony>
             <name>d69(#11)</name>
         </Harmony>
@@ -36356,7 +36356,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO47OO</pattern>
+        <pattern>XO[4-O][7-O]OO</pattern>
         <Harmony>
             <name>d69/a</name>
         </Harmony>
@@ -36386,7 +36386,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX5455</pattern>
+        <pattern>XX[5-O][4-O][5-O][5-O]</pattern>
         <Harmony>
             <name>d69sus4</name>
         </Harmony>
@@ -36416,7 +36416,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X54OOX</pattern>
+        <pattern>X[5-O][4-O]OOX</pattern>
         <Harmony>
             <name>d6(add4)</name>
         </Harmony>
@@ -36446,7 +36446,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO2O5</pattern>
+        <pattern>XXO[2-O]O[5-O]</pattern>
         <Harmony>
             <name>d6(no3)</name>
         </Harmony>
@@ -36475,7 +36475,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XOO2O2</pattern>
+        <pattern>XOO[2-O]O[2-O]</pattern>
         <Harmony>
             <name>d6/a</name>
         </Harmony>
@@ -36504,7 +36504,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>OOO2O2</pattern>
+        <pattern>OOO[2-O]O[2-O]</pattern>
         <Harmony>
             <name>d6/e</name>
         </Harmony>
@@ -36531,7 +36531,7 @@
                 <barre start="2" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX--55</pattern>
+        <pattern>XX--[5-O][5-O];B4[2-3]</pattern>
         <Harmony>
             <name>d69/f#</name>
         </Harmony>
@@ -36560,7 +36560,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2O2O2</pattern>
+        <pattern>X[2-O]O[2-O]O[2-O]</pattern>
         <Harmony>
             <name>d6/b</name>
         </Harmony>
@@ -36589,7 +36589,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2OO2O2</pattern>
+        <pattern>[2-O]OO[2-O]O[2-O]</pattern>
         <Harmony>
             <name>d6/f#</name>
         </Harmony>
@@ -36618,7 +36618,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO212</pattern>
+        <pattern>XXO[2-O][1-O][2-O]</pattern>
         <Harmony>
             <name>d7</name>
         </Harmony>
@@ -36647,7 +36647,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4O2O2</pattern>
+        <pattern>X[4-O]O[2-O]O[2-O]</pattern>
         <Harmony>
             <name>d6/c#</name>
         </Harmony>
@@ -36668,7 +36668,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X---7-</pattern>
+        <pattern>X---[7-O]-;B5[1-5]</pattern>
         <Harmony>
             <name>d7(add4)</name>
         </Harmony>
@@ -36697,7 +36697,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO312</pattern>
+        <pattern>XXO[3-O][1-O][2-O]</pattern>
         <Harmony>
             <name>d7b13</name>
         </Harmony>
@@ -36723,7 +36723,7 @@
                 <barre start="3" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO--2</pattern>
+        <pattern>XXO--[2-O];B1[3-4]</pattern>
         <Harmony>
             <name>d7b5</name>
         </Harmony>
@@ -36747,7 +36747,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X5-5--</pattern>
+        <pattern>X[5-O]-[5-O]--;B4[2-5]</pattern>
         <Harmony>
             <name>d7(b9b5)</name>
         </Harmony>
@@ -36773,7 +36773,7 @@
                 <barre start="3" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXX--2</pattern>
+        <pattern>XXX--[2-O];B1[3-4]</pattern>
         <Harmony>
             <name>d7b5/ab</name>
         </Harmony>
@@ -36796,7 +36796,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX---2</pattern>
+        <pattern>XX---[2-O];B1[2-4]</pattern>
         <Harmony>
             <name>d7b5/eb</name>
         </Harmony>
@@ -36822,7 +36822,7 @@
                 <barre start="3" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3X--2</pattern>
+        <pattern>X[3-O]X--[2-O];B1[3-4]</pattern>
         <Harmony>
             <name>d7b5/c</name>
         </Harmony>
@@ -36848,7 +36848,7 @@
                 <barre start="3" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3XO--2</pattern>
+        <pattern>[3-O]XO--[2-O];B1[3-4]</pattern>
         <Harmony>
             <name>d7b5/g</name>
         </Harmony>
@@ -36875,7 +36875,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X5-56-</pattern>
+        <pattern>X[5-O]-[5-O][6-O]-;B4[2-5]</pattern>
         <Harmony>
             <name>d7(#9b5)</name>
         </Harmony>
@@ -36902,7 +36902,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X5-5-X</pattern>
+        <pattern>X[5-O]-[5-O]-X;B4[2-4]</pattern>
         <Harmony>
             <name>d7b9</name>
         </Harmony>
@@ -36931,7 +36931,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1212</pattern>
+        <pattern>XX[1-O][2-O][1-O][2-O]</pattern>
         <Harmony>
             <name>d7b9/eb</name>
         </Harmony>
@@ -36958,7 +36958,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X5-5-6</pattern>
+        <pattern>X[5-O]-[5-O]-[6-O];B4[2-4]</pattern>
         <Harmony>
             <name>d7(b13b9)</name>
         </Harmony>
@@ -36988,7 +36988,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4545</pattern>
+        <pattern>XX[4-O][5-O][4-O][5-O]</pattern>
         <Harmony>
             <name>d7b9/f#</name>
         </Harmony>
@@ -37018,7 +37018,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX5542</pattern>
+        <pattern>XX[5-O][5-O][4-O][2-O]</pattern>
         <Harmony>
             <name>d7b9/g</name>
         </Harmony>
@@ -37042,7 +37042,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X5-5--</pattern>
+        <pattern>X[5-O]-[5-O]--;B4[2-5]</pattern>
         <Harmony>
             <name>d7(#11b9)</name>
         </Harmony>
@@ -37072,7 +37072,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO543</pattern>
+        <pattern>XXO[5-O][4-O][3-O]</pattern>
         <Harmony>
             <name>d7b9sus4</name>
         </Harmony>
@@ -37099,7 +37099,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X5-5-6</pattern>
+        <pattern>X[5-O]-[5-O]-[6-O];B4[2-4]</pattern>
         <Harmony>
             <name>d7b9#5</name>
         </Harmony>
@@ -37128,7 +37128,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO21X</pattern>
+        <pattern>XXO[2-O][1-O]X</pattern>
         <Harmony>
             <name>d7(no3)</name>
         </Harmony>
@@ -37157,7 +37157,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO21X</pattern>
+        <pattern>XXO[2-O][1-O]X</pattern>
         <Harmony>
             <name>d7(no3)</name>
         </Harmony>
@@ -37186,7 +37186,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XOO21X</pattern>
+        <pattern>XOO[2-O][1-O]X</pattern>
         <Harmony>
             <name>d7(no3)/a</name>
         </Harmony>
@@ -37215,7 +37215,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4342X</pattern>
+        <pattern>X[4-O][3-O][4-O][2-O]X</pattern>
         <Harmony>
             <name>d7(no5)</name>
         </Harmony>
@@ -37242,7 +37242,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-45-X</pattern>
+        <pattern>X-[4-O][5-O]-X;B3[1-4]</pattern>
         <Harmony>
             <name>d7(no5)/c</name>
         </Harmony>
@@ -37271,7 +37271,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XOO212</pattern>
+        <pattern>XOO[2-O][1-O][2-O]</pattern>
         <Harmony>
             <name>d7/a</name>
         </Harmony>
@@ -37301,7 +37301,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X453X</pattern>
+        <pattern>[4-O]X[4-O][5-O][3-O]X</pattern>
         <Harmony>
             <name>d7/ab</name>
         </Harmony>
@@ -37330,7 +37330,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3X212</pattern>
+        <pattern>X[3-O]X[2-O][1-O][2-O]</pattern>
         <Harmony>
             <name>d7/c</name>
         </Harmony>
@@ -37359,7 +37359,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>OOO212</pattern>
+        <pattern>OOO[2-O][1-O][2-O]</pattern>
         <Harmony>
             <name>d7/e</name>
         </Harmony>
@@ -37388,7 +37388,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3212</pattern>
+        <pattern>XX[3-O][2-O][1-O][2-O]</pattern>
         <Harmony>
             <name>d7/f</name>
         </Harmony>
@@ -37417,7 +37417,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2XO212</pattern>
+        <pattern>[2-O]XO[2-O][1-O][2-O]</pattern>
         <Harmony>
             <name>d7/f#</name>
         </Harmony>
@@ -37446,7 +37446,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3XO212</pattern>
+        <pattern>[3-O]XO[2-O][1-O][2-O]</pattern>
         <Harmony>
             <name>d7/g</name>
         </Harmony>
@@ -37472,7 +37472,7 @@
                 <barre start="3" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO--2</pattern>
+        <pattern>XXO--[2-O];B1[3-4]</pattern>
         <Harmony>
             <name>d7#11</name>
         </Harmony>
@@ -37498,7 +37498,7 @@
                 <barre start="3" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3--2</pattern>
+        <pattern>XX[3-O]--[2-O];B1[3-4]</pattern>
         <Harmony>
             <name>d7#11/e#</name>
         </Harmony>
@@ -37524,7 +37524,7 @@
                 <barre start="3" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO--2</pattern>
+        <pattern>XXO--[2-O];B1[3-4]</pattern>
         <Harmony>
             <name>d7#4</name>
         </Harmony>
@@ -37553,7 +37553,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO312</pattern>
+        <pattern>XXO[3-O][1-O][2-O]</pattern>
         <Harmony>
             <name>d7#5</name>
         </Harmony>
@@ -37580,7 +37580,7 @@
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X545--</pattern>
+        <pattern>X[5-O][4-O][5-O]--;B6[4-5]</pattern>
         <Harmony>
             <name>d7(#11#9#5)</name>
         </Harmony>
@@ -37607,7 +37607,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X5-5-6</pattern>
+        <pattern>X[5-O]-[5-O]-[6-O];B4[2-4]</pattern>
         <Harmony>
             <name>d7(b9#5)</name>
         </Harmony>
@@ -37636,7 +37636,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XOO312</pattern>
+        <pattern>XOO[3-O][1-O][2-O]</pattern>
         <Harmony>
             <name>d7#5/a</name>
         </Harmony>
@@ -37665,7 +37665,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4312</pattern>
+        <pattern>XX[4-O][3-O][1-O][2-O]</pattern>
         <Harmony>
             <name>d7#5/f#</name>
         </Harmony>
@@ -37694,7 +37694,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3XO312</pattern>
+        <pattern>[3-O]XO[3-O][1-O][2-O]</pattern>
         <Harmony>
             <name>d7#5/g</name>
         </Harmony>
@@ -37721,7 +37721,7 @@
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X545--</pattern>
+        <pattern>X[5-O][4-O][5-O]--;B6[4-5]</pattern>
         <Harmony>
             <name>d7(#9#5)</name>
         </Harmony>
@@ -37748,7 +37748,7 @@
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X545--</pattern>
+        <pattern>X[5-O][4-O][5-O]--;B6[4-5]</pattern>
         <Harmony>
             <name>d7(#9#5)/b</name>
         </Harmony>
@@ -37778,7 +37778,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X5456X</pattern>
+        <pattern>X[5-O][4-O][5-O][6-O]X</pattern>
         <Harmony>
             <name>d7#9</name>
         </Harmony>
@@ -37808,7 +37808,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>556566</pattern>
+        <pattern>[5-O][5-O][6-O][5-O][6-O][6-O]</pattern>
         <Harmony>
             <name>d7(b13#9)</name>
         </Harmony>
@@ -37838,7 +37838,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO456X</pattern>
+        <pattern>XO[4-O][5-O][6-O]X</pattern>
         <Harmony>
             <name>d7#9/a</name>
         </Harmony>
@@ -37865,7 +37865,7 @@
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X545--</pattern>
+        <pattern>X[5-O][4-O][5-O]--;B6[4-5]</pattern>
         <Harmony>
             <name>d7(#9#5)</name>
         </Harmony>
@@ -37894,7 +37894,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO213</pattern>
+        <pattern>XXO[2-O][1-O][3-O]</pattern>
         <Harmony>
             <name>d7sus4</name>
         </Harmony>
@@ -37924,7 +37924,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO553</pattern>
+        <pattern>XXO[5-O][5-O][3-O]</pattern>
         <Harmony>
             <name>d7(add2sus4)</name>
         </Harmony>
@@ -37953,7 +37953,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3XO213</pattern>
+        <pattern>[3-O]XO[2-O][1-O][3-O]</pattern>
         <Harmony>
             <name>d7sus4/g</name>
         </Harmony>
@@ -37982,7 +37982,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO21O</pattern>
+        <pattern>XXO[2-O][1-O]O</pattern>
         <Harmony>
             <name>d7sus2</name>
         </Harmony>
@@ -38011,7 +38011,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2OOO12</pattern>
+        <pattern>[2-O]OOO[1-O][2-O]</pattern>
         <Harmony>
             <name>d7sus4/f#</name>
         </Harmony>
@@ -38040,7 +38040,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2OOO12</pattern>
+        <pattern>[2-O]OOO[1-O][2-O]</pattern>
         <Harmony>
             <name>d7sus4/f#</name>
         </Harmony>
@@ -38069,7 +38069,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XOO213</pattern>
+        <pattern>XOO[2-O][1-O][3-O]</pattern>
         <Harmony>
             <name>d7sus4/a</name>
         </Harmony>
@@ -38093,7 +38093,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X54---</pattern>
+        <pattern>X[5-O][4-O]---;B5[3-5]</pattern>
         <Harmony>
             <name>d9</name>
         </Harmony>
@@ -38120,7 +38120,7 @@
                 <barre start="3" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X54--7</pattern>
+        <pattern>X[5-O][4-O]--[7-O];B5[3-4]</pattern>
         <Harmony>
             <name>d9(add13)</name>
         </Harmony>
@@ -38147,7 +38147,7 @@
                 <barre start="3" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X43--5</pattern>
+        <pattern>X[4-O][3-O]--[5-O];B4[3-4]</pattern>
         <Harmony>
             <name>d9b13</name>
         </Harmony>
@@ -38177,7 +38177,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X453O</pattern>
+        <pattern>[3-O]X[4-O][5-O][3-O]O</pattern>
         <Harmony>
             <name>d9/g</name>
         </Harmony>
@@ -38207,7 +38207,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X567XX</pattern>
+        <pattern>X[5-O][6-O][7-O]XX</pattern>
         <Harmony>
             <name>d(b5)</name>
         </Harmony>
@@ -38234,7 +38234,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X5-55-</pattern>
+        <pattern>X[5-O]-[5-O][5-O]-;B4[2-5]</pattern>
         <Harmony>
             <name>d9b5</name>
         </Harmony>
@@ -38264,7 +38264,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4553</pattern>
+        <pattern>XX[4-O][5-O][5-O][3-O]</pattern>
         <Harmony>
             <name>d9(add4)/f#</name>
         </Harmony>
@@ -38291,7 +38291,7 @@
                 <barre start="3" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX6--7</pattern>
+        <pattern>XX[6-O]--[7-O];B5[3-4]</pattern>
         <Harmony>
             <name>d9(b5add13)</name>
         </Harmony>
@@ -38315,7 +38315,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO4---</pattern>
+        <pattern>XO[4-O]---;B5[3-5]</pattern>
         <Harmony>
             <name>d9/a</name>
         </Harmony>
@@ -38345,7 +38345,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3455X</pattern>
+        <pattern>X[3-O][4-O][5-O][5-O]X</pattern>
         <Harmony>
             <name>d9/c</name>
         </Harmony>
@@ -38375,7 +38375,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O5455X</pattern>
+        <pattern>O[5-O][4-O][5-O][5-O]X</pattern>
         <Harmony>
             <name>d9/e</name>
         </Harmony>
@@ -38404,7 +38404,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXX23X</pattern>
+        <pattern>XXX[2-O][3-O]X</pattern>
         <Harmony>
             <name>dadd2</name>
         </Harmony>
@@ -38433,7 +38433,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2XO23O</pattern>
+        <pattern>[2-O]XO[2-O][3-O]O</pattern>
         <Harmony>
             <name>dadd2/f#</name>
         </Harmony>
@@ -38463,7 +38463,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X54O3X</pattern>
+        <pattern>X[5-O][4-O]O[3-O]X</pattern>
         <Harmony>
             <name>dadd4</name>
         </Harmony>
@@ -38493,7 +38493,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2XOO35</pattern>
+        <pattern>[2-O]XOO[3-O][5-O]</pattern>
         <Harmony>
             <name>dadd4/f#</name>
         </Harmony>
@@ -38522,7 +38522,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4231</pattern>
+        <pattern>XX[4-O][2-O][3-O][1-O]</pattern>
         <Harmony>
             <name>d(#9)</name>
         </Harmony>
@@ -38551,7 +38551,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4231</pattern>
+        <pattern>XX[4-O][2-O][3-O][1-O]</pattern>
         <Harmony>
             <name>d(#9)</name>
         </Harmony>
@@ -38578,7 +38578,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X5-55-</pattern>
+        <pattern>X[5-O]-[5-O][5-O]-;B4[2-5]</pattern>
         <Harmony>
             <name>d9#11</name>
         </Harmony>
@@ -38607,7 +38607,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2OO21O</pattern>
+        <pattern>[2-O]OO[2-O][1-O]O</pattern>
         <Harmony>
             <name>d9/f#</name>
         </Harmony>
@@ -38625,7 +38625,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-----</pattern>
+        <pattern>X-----;B5[1-5]</pattern>
         <Harmony>
             <name>d9sus4</name>
         </Harmony>
@@ -38655,7 +38655,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X54556</pattern>
+        <pattern>X[5-O][4-O][5-O][5-O][6-O]</pattern>
         <Harmony>
             <name>d9#5</name>
         </Harmony>
@@ -38685,7 +38685,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO777O</pattern>
+        <pattern>XO[7-O][7-O][7-O]O</pattern>
         <Harmony>
             <name>dadd2/a</name>
         </Harmony>
@@ -38715,7 +38715,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>7X777O</pattern>
+        <pattern>[7-O]X[7-O][7-O][7-O]O</pattern>
         <Harmony>
             <name>dadd2/b</name>
         </Harmony>
@@ -38745,7 +38745,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X5423O</pattern>
+        <pattern>X[5-O][4-O][2-O][3-O]O</pattern>
         <Harmony>
             <name>dadd9</name>
         </Harmony>
@@ -38774,7 +38774,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO423O</pattern>
+        <pattern>XO[4-O][2-O][3-O]O</pattern>
         <Harmony>
             <name>dadd9/a</name>
         </Harmony>
@@ -38803,7 +38803,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>OO423O</pattern>
+        <pattern>OO[4-O][2-O][3-O]O</pattern>
         <Harmony>
             <name>dadd2/e</name>
         </Harmony>
@@ -38832,7 +38832,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2OO23O</pattern>
+        <pattern>[2-O]OO[2-O][3-O]O</pattern>
         <Harmony>
             <name>dadd2/f#</name>
         </Harmony>
@@ -38861,7 +38861,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3XO23O</pattern>
+        <pattern>[3-O]XO[2-O][3-O]O</pattern>
         <Harmony>
             <name>dadd2/g</name>
         </Harmony>
@@ -38890,7 +38890,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3OO32</pattern>
+        <pattern>X[3-O]OO[3-O][2-O]</pattern>
         <Harmony>
             <name>dadd4/c</name>
         </Harmony>
@@ -38920,7 +38920,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>554O3X</pattern>
+        <pattern>[5-O][5-O][4-O]O[3-O]X</pattern>
         <Harmony>
             <name>dadd4/a</name>
         </Harmony>
@@ -38949,7 +38949,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X34O3X</pattern>
+        <pattern>X[3-O][4-O]O[3-O]X</pattern>
         <Harmony>
             <name>dadd4/c</name>
         </Harmony>
@@ -38978,7 +38978,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2OO233</pattern>
+        <pattern>[2-O]OO[2-O][3-O][3-O]</pattern>
         <Harmony>
             <name>dadd4/f#</name>
         </Harmony>
@@ -39005,7 +39005,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-677-</pattern>
+        <pattern>X-[6-O][7-O][7-O]-;B5[1-5]</pattern>
         <Harmony>
             <name>d(#4)</name>
         </Harmony>
@@ -39034,7 +39034,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2XO23O</pattern>
+        <pattern>[2-O]XO[2-O][3-O]O</pattern>
         <Harmony>
             <name>dadd9/f#</name>
         </Harmony>
@@ -39063,7 +39063,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO131</pattern>
+        <pattern>XXO[1-O][3-O][1-O]</pattern>
         <Harmony>
             <name>ddim</name>
         </Harmony>
@@ -39092,7 +39092,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XOO1O1</pattern>
+        <pattern>XOO[1-O]O[1-O]</pattern>
         <Harmony>
             <name>ddim/a</name>
         </Harmony>
@@ -39122,7 +39122,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX6767</pattern>
+        <pattern>XX[6-O][7-O][6-O][7-O]</pattern>
         <Harmony>
             <name>ddim/ab</name>
         </Harmony>
@@ -39148,7 +39148,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3X-3-</pattern>
+        <pattern>X[3-O]X-[3-O]-;B1[3-5]</pattern>
         <Harmony>
             <name>ddim/c</name>
         </Harmony>
@@ -39174,7 +39174,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3-3-</pattern>
+        <pattern>XX[3-O]-[3-O]-;B1[3-5]</pattern>
         <Harmony>
             <name>ddim/f</name>
         </Harmony>
@@ -39203,7 +39203,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO1O1</pattern>
+        <pattern>XXO[1-O]O[1-O]</pattern>
         <Harmony>
             <name>ddim7</name>
         </Harmony>
@@ -39232,7 +39232,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XOO1O1</pattern>
+        <pattern>XOO[1-O]O[1-O]</pattern>
         <Harmony>
             <name>ddim7/a</name>
         </Harmony>
@@ -39261,7 +39261,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3O1O1</pattern>
+        <pattern>X[3-O]O[1-O]O[1-O]</pattern>
         <Harmony>
             <name>ddim7/c</name>
         </Harmony>
@@ -39290,7 +39290,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1O1O1</pattern>
+        <pattern>X[1-O]O[1-O]O[1-O]</pattern>
         <Harmony>
             <name>ddim7/bb</name>
         </Harmony>
@@ -39314,7 +39314,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--7-7</pattern>
+        <pattern>X--[7-O]-[7-O];B6[1-4]</pattern>
         <Harmony>
             <name>ddim7/eb</name>
         </Harmony>
@@ -39338,7 +39338,7 @@
                 <barre start="2" end="4">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4---X</pattern>
+        <pattern>X[4-O]---X;B6[2-4]</pattern>
         <Harmony>
             <name>db</name>
         </Harmony>
@@ -39365,7 +39365,7 @@
                 <barre start="3" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X43--6</pattern>
+        <pattern>X[4-O][3-O]--[6-O];B4[3-4]</pattern>
         <Harmony>
             <name>db13</name>
         </Harmony>
@@ -39395,7 +39395,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX668O</pattern>
+        <pattern>XX[6-O][6-O][8-O]O</pattern>
         <Harmony>
             <name>db(#11)</name>
         </Harmony>
@@ -39425,7 +39425,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX5466</pattern>
+        <pattern>XX[5-O][4-O][6-O][6-O]</pattern>
         <Harmony>
             <name>db13#11</name>
         </Harmony>
@@ -39455,7 +39455,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>10X91011X</pattern>
+        <pattern>[10-O]X[9-O][10-O][11-O]X</pattern>
         <Harmony>
             <name>db13b9</name>
         </Harmony>
@@ -39485,7 +39485,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXX664</pattern>
+        <pattern>XXX[6-O][6-O][4-O]</pattern>
         <Harmony>
             <name>dbadd4</name>
         </Harmony>
@@ -39515,7 +39515,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X466XX</pattern>
+        <pattern>X[4-O][6-O][6-O]XX</pattern>
         <Harmony>
             <name>db5</name>
         </Harmony>
@@ -39542,7 +39542,7 @@
                 <barre start="0" end="1">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>--66XX</pattern>
+        <pattern>--[6-O][6-O]XX;B4[0-1]</pattern>
         <Harmony>
             <name>db5/ab</name>
         </Harmony>
@@ -39571,7 +39571,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX412X</pattern>
+        <pattern>XX[4-O][1-O][2-O]X</pattern>
         <Harmony>
             <name>db5/f#</name>
         </Harmony>
@@ -39600,7 +39600,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4332X</pattern>
+        <pattern>X[4-O][3-O][3-O][2-O]X</pattern>
         <Harmony>
             <name>db6</name>
         </Harmony>
@@ -39626,7 +39626,7 @@
                 <barre start="2" end="3">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4--44</pattern>
+        <pattern>X[4-O]--[4-O][4-O];B3[2-3]</pattern>
         <Harmony>
             <name>db69()</name>
         </Harmony>
@@ -39652,7 +39652,7 @@
                 <barre start="2" end="3">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4--44</pattern>
+        <pattern>X[4-O]--[4-O][4-O];B3[2-3]</pattern>
         <Harmony>
             <name>db69</name>
         </Harmony>
@@ -39678,7 +39678,7 @@
                 <barre start="2" end="3">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X--44</pattern>
+        <pattern>[4-O]X--[4-O][4-O];B3[2-3]</pattern>
         <Harmony>
             <name>db69/ab</name>
         </Harmony>
@@ -39704,7 +39704,7 @@
                 <barre start="2" end="3">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX--44</pattern>
+        <pattern>XX--[4-O][4-O];B3[2-3]</pattern>
         <Harmony>
             <name>db69/f</name>
         </Harmony>
@@ -39728,7 +39728,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4--4-</pattern>
+        <pattern>X[4-O]--[4-O]-;B3[2-5]</pattern>
         <Harmony>
             <name>db69#11</name>
         </Harmony>
@@ -39749,7 +39749,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X8----</pattern>
+        <pattern>X[8-O]----;B6[2-5]</pattern>
         <Harmony>
             <name>db6/f</name>
         </Harmony>
@@ -39773,7 +39773,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4--4-</pattern>
+        <pattern>X[4-O]--[4-O]-;B3[2-5]</pattern>
         <Harmony>
             <name>db69#11/eb</name>
         </Harmony>
@@ -39797,7 +39797,7 @@
                 <barre start="2" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>------</pattern>
+        <pattern>------;B4[0-1];B6[2-5]</pattern>
         <Harmony>
             <name>db6/ab</name>
         </Harmony>
@@ -39815,7 +39815,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-----</pattern>
+        <pattern>X-----;B6[1-5]</pattern>
         <Harmony>
             <name>db6/eb</name>
         </Harmony>
@@ -39838,7 +39838,7 @@
                 <barre start="2" end="4">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-----</pattern>
+        <pattern>X-----;B4[1-5];B6[2-4]</pattern>
         <Harmony>
             <name>db7</name>
         </Harmony>
@@ -39862,7 +39862,7 @@
                 <barre start="2" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>------</pattern>
+        <pattern>------;B4[0-1];B6[2-5]</pattern>
         <Harmony>
             <name>db6/ab</name>
         </Harmony>
@@ -39892,7 +39892,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>9X9108X</pattern>
+        <pattern>[9-O]X[9-O][10-O][8-O]X</pattern>
         <Harmony>
             <name>db7b5</name>
         </Harmony>
@@ -39919,7 +39919,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4-45-</pattern>
+        <pattern>X[4-O]-[4-O][5-O]-;B3[2-5]</pattern>
         <Harmony>
             <name>db7(#9b5)</name>
         </Harmony>
@@ -39943,7 +39943,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4-4--</pattern>
+        <pattern>X[4-O]-[4-O]--;B3[2-5]</pattern>
         <Harmony>
             <name>db7(b9b5)</name>
         </Harmony>
@@ -39969,7 +39969,7 @@
                 <barre start="2" end="4">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4-4-X</pattern>
+        <pattern>X[4-O]-[4-O]-X;B3[2-4]</pattern>
         <Harmony>
             <name>db7b9</name>
         </Harmony>
@@ -39989,7 +39989,7 @@
                 <barre start="2" end="4">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>------</pattern>
+        <pattern>------;B4[0-5];B6[2-4]</pattern>
         <Harmony>
             <name>db7/ab</name>
         </Harmony>
@@ -40015,7 +40015,7 @@
                 <barre start="0" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-434-X</pattern>
+        <pattern>-[4-O][3-O][4-O]-X;B2[0-4]</pattern>
         <Harmony>
             <name>db7/gb</name>
         </Harmony>
@@ -40044,7 +40044,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X342X</pattern>
+        <pattern>[3-O]X[3-O][4-O][2-O]X</pattern>
         <Harmony>
             <name>db7/g</name>
         </Harmony>
@@ -40070,7 +40070,7 @@
                 <barre start="1" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-34-X</pattern>
+        <pattern>X-[3-O][4-O]-X;B2[1-4]</pattern>
         <Harmony>
             <name>db7</name>
         </Harmony>
@@ -40100,7 +40100,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6646X</pattern>
+        <pattern>X[6-O][6-O][4-O][6-O]X</pattern>
         <Harmony>
             <name>db7/eb</name>
         </Harmony>
@@ -40129,7 +40129,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX342X</pattern>
+        <pattern>XX[3-O][4-O][2-O]X</pattern>
         <Harmony>
             <name>db7/f</name>
         </Harmony>
@@ -40158,7 +40158,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2XOO1</pattern>
+        <pattern>X[2-O]XOO[1-O]</pattern>
         <Harmony>
             <name>db7b5/b</name>
         </Harmony>
@@ -40187,7 +40187,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3OO3</pattern>
+        <pattern>XX[3-O]OO[3-O]</pattern>
         <Harmony>
             <name>db7b5/f</name>
         </Harmony>
@@ -40217,7 +40217,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>9X9108X</pattern>
+        <pattern>[9-O]X[9-O][10-O][8-O]X</pattern>
         <Harmony>
             <name>db7#11</name>
         </Harmony>
@@ -40247,7 +40247,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X434X5</pattern>
+        <pattern>X[4-O][3-O][4-O]X[5-O]</pattern>
         <Harmony>
             <name>db7#5</name>
         </Harmony>
@@ -40270,7 +40270,7 @@
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X43---</pattern>
+        <pattern>X[4-O][3-O]---;B4[3-5]</pattern>
         <Harmony>
             <name>db9</name>
         </Harmony>
@@ -40300,7 +40300,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4345X</pattern>
+        <pattern>X[4-O][3-O][4-O][5-O]X</pattern>
         <Harmony>
             <name>db7#9</name>
         </Harmony>
@@ -40329,7 +40329,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X234O4</pattern>
+        <pattern>X[2-O][3-O][4-O]O[4-O]</pattern>
         <Harmony>
             <name>db7/b</name>
         </Harmony>
@@ -40353,7 +40353,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-6-7-</pattern>
+        <pattern>X-[6-O]-[7-O]-;B4[1-5]</pattern>
         <Harmony>
             <name>db7sus4</name>
         </Harmony>
@@ -40374,7 +40374,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>--6-7-</pattern>
+        <pattern>--[6-O]-[7-O]-;B4[0-5]</pattern>
         <Harmony>
             <name>db7sus4/ab</name>
         </Harmony>
@@ -40397,7 +40397,7 @@
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X23---</pattern>
+        <pattern>X[2-O][3-O]---;B4[3-5]</pattern>
         <Harmony>
             <name>db9</name>
         </Harmony>
@@ -40424,7 +40424,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4-45-</pattern>
+        <pattern>X[4-O]-[4-O][5-O]-;B3[2-5]</pattern>
         <Harmony>
             <name>db7(#11#9)</name>
         </Harmony>
@@ -40450,7 +40450,7 @@
                 <barre start="2" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4-44-</pattern>
+        <pattern>X[4-O]-[4-O][4-O]-;B3[2-5]</pattern>
         <Harmony>
             <name>db9b5</name>
         </Harmony>
@@ -40477,7 +40477,7 @@
                 <barre start="2" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4--44</pattern>
+        <pattern>X[4-O]--[4-O][4-O];B3[2-3]</pattern>
         <Harmony>
             <name>db69()</name>
         </Harmony>
@@ -40503,7 +40503,7 @@
                 <barre start="2" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4-44-</pattern>
+        <pattern>X[4-O]-[4-O][4-O]-;B3[2-5]</pattern>
         <Harmony>
             <name>db9#11</name>
         </Harmony>
@@ -40532,7 +40532,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4X443</pattern>
+        <pattern>X[4-O]X[4-O][4-O][3-O]</pattern>
         <Harmony>
             <name>db9(#11no3)</name>
         </Harmony>
@@ -40559,7 +40559,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4-44-</pattern>
+        <pattern>X[4-O]-[4-O][4-O]-;B3[2-5]</pattern>
         <Harmony>
             <name>db9#11#5</name>
         </Harmony>
@@ -40586,7 +40586,7 @@
                 <barre start="3" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X43--5</pattern>
+        <pattern>X[4-O][3-O]--[5-O];B4[3-4]</pattern>
         <Harmony>
             <name>db9#5</name>
         </Harmony>
@@ -40609,7 +40609,7 @@
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3---</pattern>
+        <pattern>XX[3-O]---;B4[3-5]</pattern>
         <Harmony>
             <name>db9/f</name>
         </Harmony>
@@ -40627,7 +40627,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-----</pattern>
+        <pattern>X-----;B4[1-5]</pattern>
         <Harmony>
             <name>db9sus4</name>
         </Harmony>
@@ -40657,7 +40657,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X5453X</pattern>
+        <pattern>X[5-O][4-O][5-O][3-O]X</pattern>
         <Harmony>
             <name>db7(no5)</name>
         </Harmony>
@@ -40683,7 +40683,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X43-4-</pattern>
+        <pattern>X[4-O][3-O]-[4-O]-;B1[3-5]</pattern>
         <Harmony>
             <name>dbadd2</name>
         </Harmony>
@@ -40709,7 +40709,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X3-4-</pattern>
+        <pattern>[4-O]X[3-O]-[4-O]-;B1[3-5]</pattern>
         <Harmony>
             <name>dbadd2/ab</name>
         </Harmony>
@@ -40732,7 +40732,7 @@
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2X3---</pattern>
+        <pattern>[2-O]X[3-O]---;B4[3-5]</pattern>
         <Harmony>
             <name>db9/gb</name>
         </Harmony>
@@ -40752,7 +40752,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X---2-</pattern>
+        <pattern>X---[2-O]-;B1[1-5]</pattern>
         <Harmony>
             <name>dbadd2/bb</name>
         </Harmony>
@@ -40775,7 +40775,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX--2-</pattern>
+        <pattern>XX--[2-O]-;B1[2-5]</pattern>
         <Harmony>
             <name>dbadd2/eb</name>
         </Harmony>
@@ -40801,7 +40801,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X33-4-</pattern>
+        <pattern>X[3-O][3-O]-[4-O]-;B1[3-5]</pattern>
         <Harmony>
             <name>dbadd2/c</name>
         </Harmony>
@@ -40827,7 +40827,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X3-4-</pattern>
+        <pattern>[4-O]X[3-O]-[4-O]-;B1[3-5]</pattern>
         <Harmony>
             <name>dbadd9/ab</name>
         </Harmony>
@@ -40853,7 +40853,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3-4-</pattern>
+        <pattern>XX[3-O]-[4-O]-;B1[3-5]</pattern>
         <Harmony>
             <name>dbadd2/f</name>
         </Harmony>
@@ -40879,7 +40879,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X43-4-</pattern>
+        <pattern>X[4-O][3-O]-[4-O]-;B1[3-5]</pattern>
         <Harmony>
             <name>dbadd9</name>
         </Harmony>
@@ -40902,7 +40902,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2X--2-</pattern>
+        <pattern>[2-O]X--[2-O]-;B1[2-5]</pattern>
         <Harmony>
             <name>dbadd2/gb</name>
         </Harmony>
@@ -40928,7 +40928,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3-4-</pattern>
+        <pattern>XX[3-O]-[4-O]-;B1[3-5]</pattern>
         <Harmony>
             <name>dbadd9/f</name>
         </Harmony>
@@ -40957,7 +40957,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3122</pattern>
+        <pattern>XX[3-O][1-O][2-O][2-O]</pattern>
         <Harmony>
             <name>dbadd4/f</name>
         </Harmony>
@@ -40984,7 +40984,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-566-</pattern>
+        <pattern>X-[5-O][6-O][6-O]-;B4[1-5]</pattern>
         <Harmony>
             <name>db(#4)</name>
         </Harmony>
@@ -41013,7 +41013,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>343O2X</pattern>
+        <pattern>[3-O][4-O][3-O]O[2-O]X</pattern>
         <Harmony>
             <name>db(#4)/g</name>
         </Harmony>
@@ -41040,7 +41040,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6X6--</pattern>
+        <pattern>X[6-O]X[6-O]--;B4[4-5]</pattern>
         <Harmony>
             <name>dbadd9/eb</name>
         </Harmony>
@@ -41070,7 +41070,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4565X</pattern>
+        <pattern>X[4-O][5-O][6-O][5-O]X</pattern>
         <Harmony>
             <name>dbdim</name>
         </Harmony>
@@ -41099,7 +41099,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX2323</pattern>
+        <pattern>XX[2-O][3-O][2-O][3-O]</pattern>
         <Harmony>
             <name>dbdim7</name>
         </Harmony>
@@ -41126,7 +41126,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-665-</pattern>
+        <pattern>X-[6-O][6-O][5-O]-;B4[1-5]</pattern>
         <Harmony>
             <name>dbm</name>
         </Harmony>
@@ -41147,7 +41147,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X---5-</pattern>
+        <pattern>X---[5-O]-;B4[1-5]</pattern>
         <Harmony>
             <name>dbm11</name>
         </Harmony>
@@ -41176,7 +41176,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4X32O</pattern>
+        <pattern>X[4-O]X[3-O][2-O]O</pattern>
         <Harmony>
             <name>dbm6</name>
         </Harmony>
@@ -41205,7 +41205,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3323</pattern>
+        <pattern>XX[3-O][3-O][2-O][3-O]</pattern>
         <Harmony>
             <name>dbdim7/f</name>
         </Harmony>
@@ -41234,7 +41234,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>44X32O</pattern>
+        <pattern>[4-O][4-O]X[3-O][2-O]O</pattern>
         <Harmony>
             <name>dbm6/ab</name>
         </Harmony>
@@ -41264,7 +41264,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3665X</pattern>
+        <pattern>X[3-O][6-O][6-O][5-O]X</pattern>
         <Harmony>
             <name>dbm/c</name>
         </Harmony>
@@ -41293,7 +41293,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX232O</pattern>
+        <pattern>XX[2-O][3-O][2-O]O</pattern>
         <Harmony>
             <name>dbm6/fb</name>
         </Harmony>
@@ -41322,7 +41322,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX112O</pattern>
+        <pattern>XX[1-O][1-O][2-O]O</pattern>
         <Harmony>
             <name>dbm/eb</name>
         </Harmony>
@@ -41346,7 +41346,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-6-5-</pattern>
+        <pattern>X-[6-O]-[5-O]-;B4[1-5]</pattern>
         <Harmony>
             <name>dbm7</name>
         </Harmony>
@@ -41376,7 +41376,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4545X</pattern>
+        <pattern>X[4-O][5-O][4-O][5-O]X</pattern>
         <Harmony>
             <name>dbm7b5</name>
         </Harmony>
@@ -41405,7 +41405,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX232O</pattern>
+        <pattern>XX[2-O][3-O][2-O]O</pattern>
         <Harmony>
             <name>dbm6/e</name>
         </Harmony>
@@ -41434,7 +41434,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4244X</pattern>
+        <pattern>X[4-O][2-O][4-O][4-O]X</pattern>
         <Harmony>
             <name>dbm9</name>
         </Harmony>
@@ -41458,7 +41458,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-66--</pattern>
+        <pattern>X-[6-O][6-O]--;B4[1-5]</pattern>
         <Harmony>
             <name>dbm(add2)</name>
         </Harmony>
@@ -41488,7 +41488,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4X566</pattern>
+        <pattern>X[4-O]X[5-O][6-O][6-O]</pattern>
         <Harmony>
             <name>dbmaj13</name>
         </Harmony>
@@ -41518,7 +41518,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4X443</pattern>
+        <pattern>X[4-O]X[4-O][4-O][3-O]</pattern>
         <Harmony>
             <name>dbm9#11</name>
         </Harmony>
@@ -41541,7 +41541,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X43---</pattern>
+        <pattern>X[4-O][3-O]---;B1[3-5]</pattern>
         <Harmony>
             <name>dbmaj7</name>
         </Harmony>
@@ -41564,7 +41564,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X33---</pattern>
+        <pattern>X[3-O][3-O]---;B1[3-5]</pattern>
         <Harmony>
             <name>dbmaj7/c</name>
         </Harmony>
@@ -41594,7 +41594,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4556X</pattern>
+        <pattern>X[4-O][5-O][5-O][6-O]X</pattern>
         <Harmony>
             <name>dbmaj7b5</name>
         </Harmony>
@@ -41624,7 +41624,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X656X</pattern>
+        <pattern>[4-O]X[6-O][5-O][6-O]X</pattern>
         <Harmony>
             <name>dbmaj7/ab</name>
         </Harmony>
@@ -41650,7 +41650,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X43O--</pattern>
+        <pattern>X[4-O][3-O]O--;B1[4-5]</pattern>
         <Harmony>
             <name>dbmaj7b5/f</name>
         </Harmony>
@@ -41676,7 +41676,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>343O--</pattern>
+        <pattern>[3-O][4-O][3-O]O--;B1[4-5]</pattern>
         <Harmony>
             <name>dbmaj7b5/g</name>
         </Harmony>
@@ -41697,7 +41697,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X----8</pattern>
+        <pattern>X----[8-O];B6[1-4]</pattern>
         <Harmony>
             <name>dbmaj7/eb</name>
         </Harmony>
@@ -41727,7 +41727,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X566X</pattern>
+        <pattern>[4-O]X[5-O][6-O][6-O]X</pattern>
         <Harmony>
             <name>db(b5)/ab</name>
         </Harmony>
@@ -41756,7 +41756,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3XO21</pattern>
+        <pattern>X[3-O]XO[2-O][1-O]</pattern>
         <Harmony>
             <name>db(b5)/c</name>
         </Harmony>
@@ -41779,7 +41779,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3---</pattern>
+        <pattern>XX[3-O]---;B1[3-5]</pattern>
         <Harmony>
             <name>dbmaj7/f</name>
         </Harmony>
@@ -41802,7 +41802,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>243---</pattern>
+        <pattern>[2-O][4-O][3-O]---;B1[3-5]</pattern>
         <Harmony>
             <name>dbmaj7/gb</name>
         </Harmony>
@@ -41832,7 +41832,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4556X</pattern>
+        <pattern>X[4-O][5-O][5-O][6-O]X</pattern>
         <Harmony>
             <name>dbmaj7#11</name>
         </Harmony>
@@ -41858,7 +41858,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X432--</pattern>
+        <pattern>X[4-O][3-O][2-O]--;B1[4-5]</pattern>
         <Harmony>
             <name>dbmaj7#5</name>
         </Harmony>
@@ -41888,7 +41888,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4354X</pattern>
+        <pattern>X[4-O][3-O][5-O][4-O]X</pattern>
         <Harmony>
             <name>dbmaj9</name>
         </Harmony>
@@ -41918,7 +41918,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X465XX</pattern>
+        <pattern>X[4-O][6-O][5-O]XX</pattern>
         <Harmony>
             <name>dbmaj7(no3)</name>
         </Harmony>
@@ -41938,7 +41938,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>1X----</pattern>
+        <pattern>[1-O]X----;B1[2-5]</pattern>
         <Harmony>
             <name>dbmaj9/f</name>
         </Harmony>
@@ -41964,7 +41964,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X43O--</pattern>
+        <pattern>X[4-O][3-O]O--;B1[4-5]</pattern>
         <Harmony>
             <name>dbmaj9#11</name>
         </Harmony>
@@ -41993,7 +41993,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4314X</pattern>
+        <pattern>X[4-O][3-O][1-O][4-O]X</pattern>
         <Harmony>
             <name>dbmaj(add2)</name>
         </Harmony>
@@ -42020,7 +42020,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-655-</pattern>
+        <pattern>X-[6-O][5-O][5-O]-;B4[1-5]</pattern>
         <Harmony>
             <name>dbm(#7)</name>
         </Harmony>
@@ -42047,7 +42047,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X5-5-</pattern>
+        <pattern>[4-O]X[5-O]-[5-O]-;B3[3-5]</pattern>
         <Harmony>
             <name>dbdim/ab</name>
         </Harmony>
@@ -42077,7 +42077,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX6654</pattern>
+        <pattern>XX[6-O][6-O][5-O][4-O]</pattern>
         <Harmony>
             <name>dbm/ab</name>
         </Harmony>
@@ -42106,7 +42106,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX312O</pattern>
+        <pattern>XX[3-O][1-O][2-O]O</pattern>
         <Harmony>
             <name>dbm/f</name>
         </Harmony>
@@ -42135,7 +42135,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX212O</pattern>
+        <pattern>XX[2-O][1-O][2-O]O</pattern>
         <Harmony>
             <name>dbm/fb</name>
         </Harmony>
@@ -42159,7 +42159,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>--666-</pattern>
+        <pattern>--[6-O][6-O][6-O]-;B4[0-5]</pattern>
         <Harmony>
             <name>db/ab</name>
         </Harmony>
@@ -42185,7 +42185,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X23-2-</pattern>
+        <pattern>X[2-O][3-O]-[2-O]-;B1[3-5]</pattern>
         <Harmony>
             <name>db/b</name>
         </Harmony>
@@ -42214,7 +42214,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1X121</pattern>
+        <pattern>X[1-O]X[1-O][2-O][1-O]</pattern>
         <Harmony>
             <name>db/bb</name>
         </Harmony>
@@ -42237,7 +42237,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX--2-</pattern>
+        <pattern>XX--[2-O]-;B1[2-5]</pattern>
         <Harmony>
             <name>db/eb</name>
         </Harmony>
@@ -42263,7 +42263,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3-2-</pattern>
+        <pattern>XX[3-O]-[2-O]-;B1[3-5]</pattern>
         <Harmony>
             <name>db/f</name>
         </Harmony>
@@ -42289,7 +42289,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X23-2-</pattern>
+        <pattern>X[2-O][3-O]-[2-O]-;B1[3-5]</pattern>
         <Harmony>
             <name>db</name>
         </Harmony>
@@ -42315,7 +42315,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3X-2-</pattern>
+        <pattern>X[3-O]X-[2-O]-;B1[3-5]</pattern>
         <Harmony>
             <name>db/c</name>
         </Harmony>
@@ -42345,7 +42345,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX5664</pattern>
+        <pattern>XX[5-O][6-O][6-O][4-O]</pattern>
         <Harmony>
             <name>db/g</name>
         </Harmony>
@@ -42372,7 +42372,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-66-</pattern>
+        <pattern>XX-[6-O][6-O]-;B4[2-5]</pattern>
         <Harmony>
             <name>db/gb</name>
         </Harmony>
@@ -42398,7 +42398,7 @@
                 <barre start="3" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X43--X</pattern>
+        <pattern>X[4-O][3-O]--X;B2[3-4]</pattern>
         <Harmony>
             <name>db+</name>
         </Harmony>
@@ -42424,7 +42424,7 @@
                 <barre start="3" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>343--X</pattern>
+        <pattern>[3-O][4-O][3-O]--X;B2[3-4]</pattern>
         <Harmony>
             <name>db+/g</name>
         </Harmony>
@@ -42451,7 +42451,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-667-</pattern>
+        <pattern>X-[6-O][6-O][7-O]-;B4[1-5]</pattern>
         <Harmony>
             <name>dbsus</name>
         </Harmony>
@@ -42475,7 +42475,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-66--</pattern>
+        <pattern>X-[6-O][6-O]--;B4[1-5]</pattern>
         <Harmony>
             <name>dbsus2</name>
         </Harmony>
@@ -42496,7 +42496,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--6--</pattern>
+        <pattern>X--[6-O]--;B4[1-5]</pattern>
         <Harmony>
             <name>dbsus4add2</name>
         </Harmony>
@@ -42522,7 +42522,7 @@
                 <barre start="4" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX31--</pattern>
+        <pattern>XX[3-O][1-O]--;B2[4-5]</pattern>
         <Harmony>
             <name>dbsus/f</name>
         </Harmony>
@@ -42551,7 +42551,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2X41XX</pattern>
+        <pattern>[2-O]X[4-O][1-O]XX</pattern>
         <Harmony>
             <name>dbsus/gb</name>
         </Harmony>
@@ -42578,7 +42578,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX56--</pattern>
+        <pattern>XX[5-O][6-O]--;B4[4-5]</pattern>
         <Harmony>
             <name>dbsus2/g</name>
         </Harmony>
@@ -42605,7 +42605,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>6X66--</pattern>
+        <pattern>[6-O]X[6-O][6-O]--;B4[4-5]</pattern>
         <Harmony>
             <name>dbsus2/bb</name>
         </Harmony>
@@ -42632,7 +42632,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X666--</pattern>
+        <pattern>X[6-O][6-O][6-O]--;B4[4-5]</pattern>
         <Harmony>
             <name>dbsus2/eb</name>
         </Harmony>
@@ -42659,7 +42659,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-56-X</pattern>
+        <pattern>X-[5-O][6-O]-X;B4[1-4]</pattern>
         <Harmony>
             <name>db(#4sus2)</name>
         </Harmony>
@@ -42688,7 +42688,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>1X112X</pattern>
+        <pattern>[1-O]X[1-O][1-O][2-O]X</pattern>
         <Harmony>
             <name>dbsus2/f</name>
         </Harmony>
@@ -42712,7 +42712,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>--667-</pattern>
+        <pattern>--[6-O][6-O][7-O]-;B4[0-5]</pattern>
         <Harmony>
             <name>dbsus/ab</name>
         </Harmony>
@@ -42736,7 +42736,7 @@
                 <barre start="1" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X---7X</pattern>
+        <pattern>X---[7-O]X;B6[1-3]</pattern>
         <Harmony>
             <name>dbsus/eb</name>
         </Harmony>
@@ -42765,7 +42765,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO231</pattern>
+        <pattern>XXO[2-O][3-O][1-O]</pattern>
         <Harmony>
             <name>dm</name>
         </Harmony>
@@ -42795,7 +42795,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X5X563</pattern>
+        <pattern>X[5-O]X[5-O][6-O][3-O]</pattern>
         <Harmony>
             <name>dm11</name>
         </Harmony>
@@ -42825,7 +42825,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X5XO53</pattern>
+        <pattern>X[5-O]XO[5-O][3-O]</pattern>
         <Harmony>
             <name>dm11/c</name>
         </Harmony>
@@ -42851,7 +42851,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X222--</pattern>
+        <pattern>X[2-O][2-O][2-O]--;B1[4-5]</pattern>
         <Harmony>
             <name>dm11(b9b5)</name>
         </Harmony>
@@ -42880,7 +42880,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO2O1</pattern>
+        <pattern>XXO[2-O]O[1-O]</pattern>
         <Harmony>
             <name>dm6</name>
         </Harmony>
@@ -42909,7 +42909,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2O2O1</pattern>
+        <pattern>X[2-O]O[2-O]O[1-O]</pattern>
         <Harmony>
             <name>dm6/b</name>
         </Harmony>
@@ -42939,7 +42939,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X5345X</pattern>
+        <pattern>X[5-O][3-O][4-O][5-O]X</pattern>
         <Harmony>
             <name>dm69</name>
         </Harmony>
@@ -42968,7 +42968,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>OOO2O1</pattern>
+        <pattern>OOO[2-O]O[1-O]</pattern>
         <Harmony>
             <name>dm6/e</name>
         </Harmony>
@@ -42994,7 +42994,7 @@
                 <barre start="2" end="4">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X-4-X</pattern>
+        <pattern>[4-O]X-[4-O]-X;B3[2-4]</pattern>
         <Harmony>
             <name>dm6/ab</name>
         </Harmony>
@@ -43023,7 +43023,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XOO2O1</pattern>
+        <pattern>XOO[2-O]O[1-O]</pattern>
         <Harmony>
             <name>dm6/a</name>
         </Harmony>
@@ -43052,7 +43052,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>1XO2O1</pattern>
+        <pattern>[1-O]XO[2-O]O[1-O]</pattern>
         <Harmony>
             <name>dm6/f</name>
         </Harmony>
@@ -43076,7 +43076,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-5-56-</pattern>
+        <pattern>-[5-O]-[5-O][6-O]-;B3[0-5]</pattern>
         <Harmony>
             <name>dm11/g</name>
         </Harmony>
@@ -43102,7 +43102,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO2--</pattern>
+        <pattern>XXO[2-O]--;B1[4-5]</pattern>
         <Harmony>
             <name>dm7</name>
         </Harmony>
@@ -43129,7 +43129,7 @@
                 <barre start="4" end="5">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X535--</pattern>
+        <pattern>X[5-O][3-O][5-O]--;B6[4-5]</pattern>
         <Harmony>
             <name>dm7#5</name>
         </Harmony>
@@ -43159,7 +43159,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X5X563</pattern>
+        <pattern>X[5-O]X[5-O][6-O][3-O]</pattern>
         <Harmony>
             <name>dm7(add11)</name>
         </Harmony>
@@ -43186,7 +43186,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X5-45-</pattern>
+        <pattern>X[5-O]-[4-O][5-O]-;B3[2-5]</pattern>
         <Harmony>
             <name>dm13</name>
         </Harmony>
@@ -43210,7 +43210,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO-5--</pattern>
+        <pattern>XO-[5-O]--;B3[2-5]</pattern>
         <Harmony>
             <name>dm7(add4)/a</name>
         </Harmony>
@@ -43239,7 +43239,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO213</pattern>
+        <pattern>XXO[2-O][1-O][3-O]</pattern>
         <Harmony>
             <name>dm7sus4</name>
         </Harmony>
@@ -43266,7 +43266,7 @@
                 <barre start="1" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-7-67</pattern>
+        <pattern>X-[7-O]-[6-O][7-O];B5[1-3]</pattern>
         <Harmony>
             <name>dm7(add13)</name>
         </Harmony>
@@ -43296,7 +43296,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X5355X</pattern>
+        <pattern>X[5-O][3-O][5-O][5-O]X</pattern>
         <Harmony>
             <name>dm7(add2)</name>
         </Harmony>
@@ -43320,7 +43320,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-6--</pattern>
+        <pattern>XX-[6-O]--;B4[2-5]</pattern>
         <Harmony>
             <name>dbsus2/gb</name>
         </Harmony>
@@ -43350,7 +43350,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X5X563</pattern>
+        <pattern>X[5-O]X[5-O][6-O][3-O]</pattern>
         <Harmony>
             <name>dm7(add4)</name>
         </Harmony>
@@ -43373,7 +43373,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO---</pattern>
+        <pattern>XXO---;B1[3-5]</pattern>
         <Harmony>
             <name>dm7b5</name>
         </Harmony>
@@ -43402,7 +43402,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO213</pattern>
+        <pattern>XXO[2-O][1-O][3-O]</pattern>
         <Harmony>
             <name>dm7sus4</name>
         </Harmony>
@@ -43429,7 +43429,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X-5-X</pattern>
+        <pattern>[4-O]X-[5-O]-X;B3[2-4]</pattern>
         <Harmony>
             <name>dm7b5/ab</name>
         </Harmony>
@@ -43456,7 +43456,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-676-</pattern>
+        <pattern>X-[6-O][7-O][6-O]-;B5[1-5]</pattern>
         <Harmony>
             <name>dm(#4)</name>
         </Harmony>
@@ -43482,7 +43482,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3X-3-</pattern>
+        <pattern>X[3-O]X-[3-O]-;B1[3-5]</pattern>
         <Harmony>
             <name>dm7b5/c</name>
         </Harmony>
@@ -43505,7 +43505,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>1XO---</pattern>
+        <pattern>[1-O]XO---;B1[3-5]</pattern>
         <Harmony>
             <name>dm7b5/f</name>
         </Harmony>
@@ -43528,7 +43528,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3XO---</pattern>
+        <pattern>[3-O]XO---;B1[3-5]</pattern>
         <Harmony>
             <name>dm7b5/g</name>
         </Harmony>
@@ -43557,7 +43557,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO311</pattern>
+        <pattern>XXO[3-O][1-O][1-O]</pattern>
         <Harmony>
             <name>dm7#9</name>
         </Harmony>
@@ -43586,7 +43586,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO311</pattern>
+        <pattern>XXO[3-O][1-O][1-O]</pattern>
         <Harmony>
             <name>dm7#9</name>
         </Harmony>
@@ -43612,7 +43612,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XOO2--</pattern>
+        <pattern>XOO[2-O]--;B1[4-5]</pattern>
         <Harmony>
             <name>dm7/a</name>
         </Harmony>
@@ -43638,7 +43638,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3O2--</pattern>
+        <pattern>X[3-O]O[2-O]--;B1[4-5]</pattern>
         <Harmony>
             <name>dm7/c</name>
         </Harmony>
@@ -43664,7 +43664,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX22--</pattern>
+        <pattern>XX[2-O][2-O]--;B1[4-5]</pattern>
         <Harmony>
             <name>dm7/e</name>
         </Harmony>
@@ -43693,7 +43693,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>1XO211</pattern>
+        <pattern>[1-O]XO[2-O][1-O][1-O]</pattern>
         <Harmony>
             <name>dm7/f</name>
         </Harmony>
@@ -43719,7 +43719,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3OO2--</pattern>
+        <pattern>[3-O]OO[2-O]--;B1[4-5]</pattern>
         <Harmony>
             <name>dm7/g</name>
         </Harmony>
@@ -43749,7 +43749,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X5355X</pattern>
+        <pattern>X[5-O][3-O][5-O][5-O]X</pattern>
         <Harmony>
             <name>dm9</name>
         </Harmony>
@@ -43778,7 +43778,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO22O</pattern>
+        <pattern>XXO[2-O][2-O]O</pattern>
         <Harmony>
             <name>dm11b5</name>
         </Harmony>
@@ -43808,7 +43808,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO355X</pattern>
+        <pattern>XO[3-O][5-O][5-O]X</pattern>
         <Harmony>
             <name>dm9/a</name>
         </Harmony>
@@ -43835,7 +43835,7 @@
                 <barre start="1" end="2">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--55X</pattern>
+        <pattern>X--[5-O][5-O]X;B3[1-2]</pattern>
         <Harmony>
             <name>dm9/c</name>
         </Harmony>
@@ -43865,7 +43865,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3XO56O</pattern>
+        <pattern>[3-O]XO[5-O][6-O]O</pattern>
         <Harmony>
             <name>dm9/g</name>
         </Harmony>
@@ -43894,7 +43894,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>1OO21O</pattern>
+        <pattern>[1-O]OO[2-O][1-O]O</pattern>
         <Harmony>
             <name>dm9/f</name>
         </Harmony>
@@ -43924,7 +43924,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X5776O</pattern>
+        <pattern>X[5-O][7-O][7-O][6-O]O</pattern>
         <Harmony>
             <name>dm(add2)</name>
         </Harmony>
@@ -43953,7 +43953,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XOOO31</pattern>
+        <pattern>XOOO[3-O][1-O]</pattern>
         <Harmony>
             <name>dm(add4)</name>
         </Harmony>
@@ -43982,7 +43982,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>1OO23O</pattern>
+        <pattern>[1-O]OO[2-O][3-O]O</pattern>
         <Harmony>
             <name>dm(add2)/f</name>
         </Harmony>
@@ -44012,7 +44012,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X5776O</pattern>
+        <pattern>X[5-O][7-O][7-O][6-O]O</pattern>
         <Harmony>
             <name>dm(add9)</name>
         </Harmony>
@@ -44042,7 +44042,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>7X776O</pattern>
+        <pattern>[7-O]X[7-O][7-O][6-O]O</pattern>
         <Harmony>
             <name>dm(add9)/b</name>
         </Harmony>
@@ -44072,7 +44072,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>8X776O</pattern>
+        <pattern>[8-O]X[7-O][7-O][6-O]O</pattern>
         <Harmony>
             <name>dm(add9)/c</name>
         </Harmony>
@@ -44102,7 +44102,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X5X677</pattern>
+        <pattern>X[5-O]X[6-O][7-O][7-O]</pattern>
         <Harmony>
             <name>dmaj13</name>
         </Harmony>
@@ -44131,7 +44131,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO2231</pattern>
+        <pattern>XO[2-O][2-O][3-O][1-O]</pattern>
         <Harmony>
             <name>dm(add2)/a</name>
         </Harmony>
@@ -44161,7 +44161,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XOO677</pattern>
+        <pattern>XOO[6-O][7-O][7-O]</pattern>
         <Harmony>
             <name>dmaj13/a</name>
         </Harmony>
@@ -44190,7 +44190,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>1X323O</pattern>
+        <pattern>[1-O]X[3-O][2-O][3-O]O</pattern>
         <Harmony>
             <name>dm(add9)/f</name>
         </Harmony>
@@ -44213,7 +44213,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO---</pattern>
+        <pattern>XXO---;B2[3-5]</pattern>
         <Harmony>
             <name>dmaj7</name>
         </Harmony>
@@ -44236,7 +44236,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XOO---</pattern>
+        <pattern>XOO---;B2[3-5]</pattern>
         <Harmony>
             <name>dmaj7/a</name>
         </Harmony>
@@ -44259,7 +44259,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2X---</pattern>
+        <pattern>X[2-O]X---;B2[3-5]</pattern>
         <Harmony>
             <name>dmaj7/b</name>
         </Harmony>
@@ -44282,7 +44282,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3X---</pattern>
+        <pattern>X[3-O]X---;B2[3-5]</pattern>
         <Harmony>
             <name>dmaj7/c</name>
         </Harmony>
@@ -44311,7 +44311,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4O222</pattern>
+        <pattern>X[4-O]O[2-O][2-O][2-O]</pattern>
         <Harmony>
             <name>dmaj7/c#</name>
         </Harmony>
@@ -44340,7 +44340,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX2222</pattern>
+        <pattern>XX[2-O][2-O][2-O][2-O]</pattern>
         <Harmony>
             <name>dmaj7/e</name>
         </Harmony>
@@ -44363,7 +44363,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3---</pattern>
+        <pattern>XX[3-O]---;B2[3-5]</pattern>
         <Harmony>
             <name>dmaj7/f</name>
         </Harmony>
@@ -44386,7 +44386,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2XO---</pattern>
+        <pattern>[2-O]XO---;B2[3-5]</pattern>
         <Harmony>
             <name>dmaj7/f#</name>
         </Harmony>
@@ -44409,7 +44409,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3XO---</pattern>
+        <pattern>[3-O]XO---;B2[3-5]</pattern>
         <Harmony>
             <name>dmaj7/g</name>
         </Harmony>
@@ -44435,7 +44435,7 @@
                 <barre start="4" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO3--</pattern>
+        <pattern>XXO[3-O]--;B2[4-5]</pattern>
         <Harmony>
             <name>dmaj7#5</name>
         </Harmony>
@@ -44464,7 +44464,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO122</pattern>
+        <pattern>XXO[1-O][2-O][2-O]</pattern>
         <Harmony>
             <name>dmaj7#11</name>
         </Harmony>
@@ -44490,7 +44490,7 @@
                 <barre start="3" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3XO--3</pattern>
+        <pattern>[3-O]XO--[3-O];B2[3-4]</pattern>
         <Harmony>
             <name>dmaj7sus4/g</name>
         </Harmony>
@@ -44516,7 +44516,7 @@
                 <barre start="3" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO--3</pattern>
+        <pattern>XXO--[3-O];B2[3-4]</pattern>
         <Harmony>
             <name>dmaj7sus4</name>
         </Harmony>
@@ -44543,7 +44543,7 @@
                 <barre start="3" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO--5</pattern>
+        <pattern>XXO--[5-O];B2[3-4]</pattern>
         <Harmony>
             <name>dmaj7(no3)</name>
         </Harmony>
@@ -44573,7 +44573,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X5465X</pattern>
+        <pattern>X[5-O][4-O][6-O][5-O]X</pattern>
         <Harmony>
             <name>dmaj9</name>
         </Harmony>
@@ -44602,7 +44602,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO422O</pattern>
+        <pattern>XO[4-O][2-O][2-O]O</pattern>
         <Harmony>
             <name>dmaj9/a</name>
         </Harmony>
@@ -44631,7 +44631,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>OOO22O</pattern>
+        <pattern>OOO[2-O][2-O]O</pattern>
         <Harmony>
             <name>dmaj9/e</name>
         </Harmony>
@@ -44660,7 +44660,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2OO22O</pattern>
+        <pattern>[2-O]OO[2-O][2-O]O</pattern>
         <Harmony>
             <name>dmaj9/f#</name>
         </Harmony>
@@ -44689,7 +44689,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4O22O</pattern>
+        <pattern>X[4-O]O[2-O][2-O]O</pattern>
         <Harmony>
             <name>dmaj9/c#</name>
         </Harmony>
@@ -44718,7 +44718,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO12O</pattern>
+        <pattern>XXO[1-O][2-O]O</pattern>
         <Harmony>
             <name>dmaj9#11</name>
         </Harmony>
@@ -44747,7 +44747,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO22O</pattern>
+        <pattern>XXO[2-O][2-O]O</pattern>
         <Harmony>
             <name>dmaj9(no3)</name>
         </Harmony>
@@ -44776,7 +44776,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XOO22O</pattern>
+        <pattern>XOO[2-O][2-O]O</pattern>
         <Harmony>
             <name>dmaj9(no3)/a</name>
         </Harmony>
@@ -44805,7 +44805,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO221</pattern>
+        <pattern>XXO[2-O][2-O][1-O]</pattern>
         <Harmony>
             <name>dm(#7)</name>
         </Harmony>
@@ -44834,7 +44834,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XOO221</pattern>
+        <pattern>XOO[2-O][2-O][1-O]</pattern>
         <Harmony>
             <name>dm(#7)/a</name>
         </Harmony>
@@ -44863,7 +44863,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4X231</pattern>
+        <pattern>X[4-O]X[2-O][3-O][1-O]</pattern>
         <Harmony>
             <name>dm(#7)/c#</name>
         </Harmony>
@@ -44892,7 +44892,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3XO221</pattern>
+        <pattern>[3-O]XO[2-O][2-O][1-O]</pattern>
         <Harmony>
             <name>dm(#7)/g</name>
         </Harmony>
@@ -44922,7 +44922,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO66O</pattern>
+        <pattern>XXO[6-O][6-O]O</pattern>
         <Harmony>
             <name>dm(add9)</name>
         </Harmony>
@@ -44951,7 +44951,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XOO231</pattern>
+        <pattern>XOO[2-O][3-O][1-O]</pattern>
         <Harmony>
             <name>dm/a</name>
         </Harmony>
@@ -44980,7 +44980,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2O231</pattern>
+        <pattern>X[2-O]O[2-O][3-O][1-O]</pattern>
         <Harmony>
             <name>dm/b</name>
         </Harmony>
@@ -45009,7 +45009,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1O231</pattern>
+        <pattern>X[1-O]O[2-O][3-O][1-O]</pattern>
         <Harmony>
             <name>dm/bb</name>
         </Harmony>
@@ -45038,7 +45038,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1O211</pattern>
+        <pattern>X[1-O]O[2-O][1-O][1-O]</pattern>
         <Harmony>
             <name>dm7/bb</name>
         </Harmony>
@@ -45067,7 +45067,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3O231</pattern>
+        <pattern>X[3-O]O[2-O][3-O][1-O]</pattern>
         <Harmony>
             <name>dm/c</name>
         </Harmony>
@@ -45096,7 +45096,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4323X</pattern>
+        <pattern>X[4-O][3-O][2-O][3-O]X</pattern>
         <Harmony>
             <name>dm/c#</name>
         </Harmony>
@@ -45125,7 +45125,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4323X</pattern>
+        <pattern>X[4-O][3-O][2-O][3-O]X</pattern>
         <Harmony>
             <name>dm/db</name>
         </Harmony>
@@ -45154,7 +45154,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX2231</pattern>
+        <pattern>XX[2-O][2-O][3-O][1-O]</pattern>
         <Harmony>
             <name>dm/e</name>
         </Harmony>
@@ -45180,7 +45180,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-23-</pattern>
+        <pattern>XX-[2-O][3-O]-;B1[2-5]</pattern>
         <Harmony>
             <name>dm/eb</name>
         </Harmony>
@@ -45209,7 +45209,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3231</pattern>
+        <pattern>XX[3-O][2-O][3-O][1-O]</pattern>
         <Harmony>
             <name>dm/f</name>
         </Harmony>
@@ -45238,7 +45238,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3XO231</pattern>
+        <pattern>[3-O]XO[2-O][3-O][1-O]</pattern>
         <Harmony>
             <name>dm/g</name>
         </Harmony>
@@ -45267,7 +45267,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO331</pattern>
+        <pattern>XXO[3-O][3-O][1-O]</pattern>
         <Harmony>
             <name>dm(#5)</name>
         </Harmony>
@@ -45296,7 +45296,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO23X</pattern>
+        <pattern>XXO[2-O][3-O]X</pattern>
         <Harmony>
             <name>d5</name>
         </Harmony>
@@ -45325,7 +45325,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XOO232</pattern>
+        <pattern>XOO[2-O][3-O][2-O]</pattern>
         <Harmony>
             <name>d/a</name>
         </Harmony>
@@ -45349,7 +45349,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>7X---X</pattern>
+        <pattern>[7-O]X---X;B7[2-4]</pattern>
         <Harmony>
             <name>d/b</name>
         </Harmony>
@@ -45373,7 +45373,7 @@
                 <barre start="2" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>6X---X</pattern>
+        <pattern>[6-O]X---X;B7[2-4]</pattern>
         <Harmony>
             <name>d/bb</name>
         </Harmony>
@@ -45399,7 +45399,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3X-3-</pattern>
+        <pattern>X[3-O]X-[3-O]-;B2[3-5]</pattern>
         <Harmony>
             <name>d/c</name>
         </Harmony>
@@ -45428,7 +45428,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4X232</pattern>
+        <pattern>X[4-O]X[2-O][3-O][2-O]</pattern>
         <Harmony>
             <name>d/c#</name>
         </Harmony>
@@ -45457,7 +45457,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>OOO232</pattern>
+        <pattern>OOO[2-O][3-O][2-O]</pattern>
         <Harmony>
             <name>d/e</name>
         </Harmony>
@@ -45486,7 +45486,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1232</pattern>
+        <pattern>XX[1-O][2-O][3-O][2-O]</pattern>
         <Harmony>
             <name>d/eb</name>
         </Harmony>
@@ -45515,7 +45515,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>1OO232</pattern>
+        <pattern>[1-O]OO[2-O][3-O][2-O]</pattern>
         <Harmony>
             <name>d/f</name>
         </Harmony>
@@ -45544,7 +45544,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2XO23X</pattern>
+        <pattern>[2-O]XO[2-O][3-O]X</pattern>
         <Harmony>
             <name>d/f#</name>
         </Harmony>
@@ -45570,7 +45570,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3XO-3-</pattern>
+        <pattern>[3-O]XO-[3-O]-;B2[3-5]</pattern>
         <Harmony>
             <name>d/g</name>
         </Harmony>
@@ -45599,7 +45599,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X423X</pattern>
+        <pattern>[4-O]X[4-O][2-O][3-O]X</pattern>
         <Harmony>
             <name>d/g#</name>
         </Harmony>
@@ -45628,7 +45628,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO332</pattern>
+        <pattern>XXO[3-O][3-O][2-O]</pattern>
         <Harmony>
             <name>d+</name>
         </Harmony>
@@ -45657,7 +45657,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2XO332</pattern>
+        <pattern>[2-O]XO[3-O][3-O][2-O]</pattern>
         <Harmony>
             <name>d+/f#</name>
         </Harmony>
@@ -45681,7 +45681,7 @@
                 <barre start="2" end="4">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6---X</pattern>
+        <pattern>X[6-O]---X;B8[2-4]</pattern>
         <Harmony>
             <name>d#</name>
         </Harmony>
@@ -45710,7 +45710,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX2332</pattern>
+        <pattern>XX[2-O][3-O][3-O][2-O]</pattern>
         <Harmony>
             <name>d+/e</name>
         </Harmony>
@@ -45728,7 +45728,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-----</pattern>
+        <pattern>X-----;B6[1-5]</pattern>
         <Harmony>
             <name>d#11</name>
         </Harmony>
@@ -45758,7 +45758,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X688XX</pattern>
+        <pattern>X[6-O][8-O][8-O]XX</pattern>
         <Harmony>
             <name>d#5</name>
         </Harmony>
@@ -45788,7 +45788,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O688XX</pattern>
+        <pattern>O[6-O][8-O][8-O]XX</pattern>
         <Harmony>
             <name>d#5/e</name>
         </Harmony>
@@ -45817,7 +45817,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1323</pattern>
+        <pattern>XX[1-O][3-O][2-O][3-O]</pattern>
         <Harmony>
             <name>d#7</name>
         </Harmony>
@@ -45846,7 +45846,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1223</pattern>
+        <pattern>XX[1-O][2-O][2-O][3-O]</pattern>
         <Harmony>
             <name>d#7b5</name>
         </Harmony>
@@ -45875,7 +45875,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX2323</pattern>
+        <pattern>XX[2-O][3-O][2-O][3-O]</pattern>
         <Harmony>
             <name>d#7b9</name>
         </Harmony>
@@ -45895,7 +45895,7 @@
                 <barre start="2" end="4">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>------</pattern>
+        <pattern>------;B6[0-5];B8[2-4]</pattern>
         <Harmony>
             <name>d#7/a#</name>
         </Harmony>
@@ -45924,7 +45924,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X132X</pattern>
+        <pattern>[3-O]X[1-O][3-O][2-O]X</pattern>
         <Harmony>
             <name>d#7/g</name>
         </Harmony>
@@ -45953,7 +45953,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1O22</pattern>
+        <pattern>XX[1-O]O[2-O][2-O]</pattern>
         <Harmony>
             <name>d#7#9</name>
         </Harmony>
@@ -45982,7 +45982,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO1O22</pattern>
+        <pattern>XO[1-O]O[2-O][2-O]</pattern>
         <Harmony>
             <name>d#7#9/a</name>
         </Harmony>
@@ -46009,7 +46009,7 @@
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X656--</pattern>
+        <pattern>X[6-O][5-O][6-O]--;B7[4-5]</pattern>
         <Harmony>
             <name>d#7(#9#5)</name>
         </Harmony>
@@ -46039,7 +46039,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O6564X</pattern>
+        <pattern>O[6-O][5-O][6-O][4-O]X</pattern>
         <Harmony>
             <name>d#7/e</name>
         </Harmony>
@@ -46063,7 +46063,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-8-9-</pattern>
+        <pattern>X-[8-O]-[9-O]-;B6[1-5]</pattern>
         <Harmony>
             <name>d#7sus4</name>
         </Harmony>
@@ -46084,7 +46084,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>--8-9-</pattern>
+        <pattern>--[8-O]-[9-O]-;B6[0-5]</pattern>
         <Harmony>
             <name>d#7sus4/a#</name>
         </Harmony>
@@ -46113,7 +46113,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1O21</pattern>
+        <pattern>XX[1-O]O[2-O][1-O]</pattern>
         <Harmony>
             <name>d#9</name>
         </Harmony>
@@ -46143,7 +46143,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6787X</pattern>
+        <pattern>X[6-O][7-O][8-O][7-O]X</pattern>
         <Harmony>
             <name>d#dim</name>
         </Harmony>
@@ -46172,7 +46172,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO424X</pattern>
+        <pattern>XO[4-O][2-O][4-O]X</pattern>
         <Harmony>
             <name>d#dim/a</name>
         </Harmony>
@@ -46201,7 +46201,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO242</pattern>
+        <pattern>XXO[2-O][4-O][2-O]</pattern>
         <Harmony>
             <name>d#dim/d</name>
         </Harmony>
@@ -46230,7 +46230,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1212</pattern>
+        <pattern>XX[1-O][2-O][1-O][2-O]</pattern>
         <Harmony>
             <name>d#dim7</name>
         </Harmony>
@@ -46259,7 +46259,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>OX1212</pattern>
+        <pattern>OX[1-O][2-O][1-O][2-O]</pattern>
         <Harmony>
             <name>d#dim7/e</name>
         </Harmony>
@@ -46282,7 +46282,7 @@
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX--4-</pattern>
+        <pattern>XX--[4-O]-;B2[2-5]</pattern>
         <Harmony>
             <name>d#dim/e</name>
         </Harmony>
@@ -46311,7 +46311,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO1212</pattern>
+        <pattern>XO[1-O][2-O][1-O][2-O]</pattern>
         <Harmony>
             <name>d#dim7/a</name>
         </Harmony>
@@ -46337,7 +46337,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2X-2-X</pattern>
+        <pattern>[2-O]X-[2-O]-X;B1[2-4]</pattern>
         <Harmony>
             <name>d#dim7/f#</name>
         </Harmony>
@@ -46366,7 +46366,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2X12XX</pattern>
+        <pattern>[2-O]X[1-O][2-O]XX</pattern>
         <Harmony>
             <name>d#dim/f#</name>
         </Harmony>
@@ -46392,7 +46392,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X34-4-</pattern>
+        <pattern>X[3-O][4-O]-[4-O]-;B2[3-5]</pattern>
         <Harmony>
             <name>d#dim7/c</name>
         </Harmony>
@@ -46419,7 +46419,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-887-</pattern>
+        <pattern>X-[8-O][8-O][7-O]-;B6[1-5]</pattern>
         <Harmony>
             <name>d#m</name>
         </Harmony>
@@ -46448,7 +46448,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4341</pattern>
+        <pattern>XX[4-O][3-O][4-O][1-O]</pattern>
         <Harmony>
             <name>d#m(add2)</name>
         </Harmony>
@@ -46469,7 +46469,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X---7-</pattern>
+        <pattern>X---[7-O]-;B6[1-5]</pattern>
         <Harmony>
             <name>d#m11</name>
         </Harmony>
@@ -46493,7 +46493,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-8-7-</pattern>
+        <pattern>X-[8-O]-[7-O]-;B6[1-5]</pattern>
         <Harmony>
             <name>d#m7</name>
         </Harmony>
@@ -46519,7 +46519,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-3-2</pattern>
+        <pattern>XX-[3-O]-[2-O];B1[2-4]</pattern>
         <Harmony>
             <name>d#m6</name>
         </Harmony>
@@ -46549,7 +46549,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6767X</pattern>
+        <pattern>X[6-O][7-O][6-O][7-O]X</pattern>
         <Harmony>
             <name>d#m7b5</name>
         </Harmony>
@@ -46579,7 +46579,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6466X</pattern>
+        <pattern>X[6-O][4-O][6-O][6-O]X</pattern>
         <Harmony>
             <name>d#m9</name>
         </Harmony>
@@ -46609,7 +46609,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX6879</pattern>
+        <pattern>XX[6-O][8-O][7-O][9-O]</pattern>
         <Harmony>
             <name>d#m7/g#</name>
         </Harmony>
@@ -46638,7 +46638,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3434X</pattern>
+        <pattern>X[3-O][4-O][3-O][4-O]X</pattern>
         <Harmony>
             <name>d#m/c</name>
         </Harmony>
@@ -46667,7 +46667,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4434X</pattern>
+        <pattern>X[4-O][4-O][3-O][4-O]X</pattern>
         <Harmony>
             <name>d#m/c#</name>
         </Harmony>
@@ -46693,7 +46693,7 @@
                 <barre start="4" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>OX13--</pattern>
+        <pattern>OX[1-O][3-O]--;B2[4-5]</pattern>
         <Harmony>
             <name>d#m7/e</name>
         </Harmony>
@@ -46714,7 +46714,7 @@
                 <barre start="2" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X9----</pattern>
+        <pattern>X[9-O]----;B11[2-5]</pattern>
         <Harmony>
             <name>d#m7/f#</name>
         </Harmony>
@@ -46737,7 +46737,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO1---</pattern>
+        <pattern>XO[1-O]---;B2[3-5]</pattern>
         <Harmony>
             <name>d#m7b5/a</name>
         </Harmony>
@@ -46766,7 +46766,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4342</pattern>
+        <pattern>XX[4-O][3-O][4-O][2-O]</pattern>
         <Harmony>
             <name>d#m/f#</name>
         </Harmony>
@@ -46793,7 +46793,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-5-6</pattern>
+        <pattern>XX-[5-O]-[6-O];B4[2-4]</pattern>
         <Harmony>
             <name>d#m6/f#</name>
         </Harmony>
@@ -46822,7 +46822,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X434X</pattern>
+        <pattern>[3-O]X[4-O][3-O][4-O]X</pattern>
         <Harmony>
             <name>d#m/g</name>
         </Harmony>
@@ -46851,7 +46851,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX2343</pattern>
+        <pattern>XX[2-O][3-O][4-O][3-O]</pattern>
         <Harmony>
             <name>d#/e</name>
         </Harmony>
@@ -46878,7 +46878,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-87-</pattern>
+        <pattern>XX-[8-O][7-O]-;B6[2-5]</pattern>
         <Harmony>
             <name>d#m/g#</name>
         </Harmony>
@@ -46904,7 +46904,7 @@
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4-4-</pattern>
+        <pattern>XX[4-O]-[4-O]-;B3[3-5]</pattern>
         <Harmony>
             <name>d#/f#</name>
         </Harmony>
@@ -46928,7 +46928,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>--887-</pattern>
+        <pattern>--[8-O][8-O][7-O]-;B6[0-5]</pattern>
         <Harmony>
             <name>d#m/a#</name>
         </Harmony>
@@ -46955,7 +46955,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX5-4-</pattern>
+        <pattern>XX[5-O]-[4-O]-;B3[3-5]</pattern>
         <Harmony>
             <name>d#/g</name>
         </Harmony>
@@ -46979,7 +46979,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>--888-</pattern>
+        <pattern>--[8-O][8-O][8-O]-;B6[0-5]</pattern>
         <Harmony>
             <name>d#/a#</name>
         </Harmony>
@@ -47009,7 +47009,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX5443</pattern>
+        <pattern>XX[5-O][4-O][4-O][3-O]</pattern>
         <Harmony>
             <name>d#+</name>
         </Harmony>
@@ -47039,7 +47039,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>11X111212X</pattern>
+        <pattern>[11-O]X[11-O][12-O][12-O]X</pattern>
         <Harmony>
             <name>d#+7</name>
         </Harmony>
@@ -47066,7 +47066,7 @@
                 <barre start="2" end="3">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6--9X</pattern>
+        <pattern>X[6-O]--[9-O]X;B8[2-3]</pattern>
         <Harmony>
             <name>d#sus</name>
         </Harmony>
@@ -47095,7 +47095,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO233</pattern>
+        <pattern>XXO[2-O][3-O][3-O]</pattern>
         <Harmony>
             <name>dsus</name>
         </Harmony>
@@ -47124,7 +47124,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO233</pattern>
+        <pattern>XXO[2-O][3-O][3-O]</pattern>
         <Harmony>
             <name>dsus4</name>
         </Harmony>
@@ -47153,7 +47153,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO23O</pattern>
+        <pattern>XXO[2-O][3-O]O</pattern>
         <Harmony>
             <name>dsus2</name>
         </Harmony>
@@ -47182,7 +47182,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXOO3O</pattern>
+        <pattern>XXOO[3-O]O</pattern>
         <Harmony>
             <name>dsus4add2</name>
         </Harmony>
@@ -47211,7 +47211,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2O23O</pattern>
+        <pattern>X[2-O]O[2-O][3-O]O</pattern>
         <Harmony>
             <name>dsus2/b</name>
         </Harmony>
@@ -47238,7 +47238,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-89-</pattern>
+        <pattern>XX-[8-O][9-O]-;B6[2-5]</pattern>
         <Harmony>
             <name>d#sus/g#</name>
         </Harmony>
@@ -47267,7 +47267,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1O23O</pattern>
+        <pattern>X[1-O]O[2-O][3-O]O</pattern>
         <Harmony>
             <name>dsus2/bb</name>
         </Harmony>
@@ -47296,7 +47296,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3O23O</pattern>
+        <pattern>X[3-O]O[2-O][3-O]O</pattern>
         <Harmony>
             <name>dsus2/c</name>
         </Harmony>
@@ -47325,7 +47325,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4X23O</pattern>
+        <pattern>X[4-O]X[2-O][3-O]O</pattern>
         <Harmony>
             <name>dsus2/c#</name>
         </Harmony>
@@ -47354,7 +47354,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XOO13O</pattern>
+        <pattern>XOO[1-O][3-O]O</pattern>
         <Harmony>
             <name>d(#4sus2)</name>
         </Harmony>
@@ -47383,7 +47383,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX323O</pattern>
+        <pattern>XX[3-O][2-O][3-O]O</pattern>
         <Harmony>
             <name>dsus2/f</name>
         </Harmony>
@@ -47412,7 +47412,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2OO23O</pattern>
+        <pattern>[2-O]OO[2-O][3-O]O</pattern>
         <Harmony>
             <name>dsus2/f#</name>
         </Harmony>
@@ -47441,7 +47441,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3XO23O</pattern>
+        <pattern>[3-O]XO[2-O][3-O]O</pattern>
         <Harmony>
             <name>dsus2/g</name>
         </Harmony>
@@ -47462,7 +47462,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-7---</pattern>
+        <pattern>X-[7-O]---;B5[1-5]</pattern>
         <Harmony>
             <name>d(add2sus4)</name>
         </Harmony>
@@ -47483,7 +47483,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-7---</pattern>
+        <pattern>X-[7-O]---;B5[1-5]</pattern>
         <Harmony>
             <name>d(add2sus4)</name>
         </Harmony>
@@ -47512,7 +47512,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XOO233</pattern>
+        <pattern>XOO[2-O][3-O][3-O]</pattern>
         <Harmony>
             <name>dsus/a</name>
         </Harmony>
@@ -47541,7 +47541,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2O233</pattern>
+        <pattern>X[2-O]O[2-O][3-O][3-O]</pattern>
         <Harmony>
             <name>dsus/b</name>
         </Harmony>
@@ -47562,7 +47562,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-7---</pattern>
+        <pattern>X-[7-O]---;B5[1-5]</pattern>
         <Harmony>
             <name>d(add9sus4)</name>
         </Harmony>
@@ -47591,7 +47591,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3X233</pattern>
+        <pattern>X[3-O]X[2-O][3-O][3-O]</pattern>
         <Harmony>
             <name>dsus/c</name>
         </Harmony>
@@ -47617,7 +47617,7 @@
                 <barre start="2" end="3">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX--33</pattern>
+        <pattern>XX--[3-O][3-O];B2[2-3]</pattern>
         <Harmony>
             <name>dsus/e</name>
         </Harmony>
@@ -47646,7 +47646,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2XO233</pattern>
+        <pattern>[2-O]XO[2-O][3-O][3-O]</pattern>
         <Harmony>
             <name>dsus/f#</name>
         </Harmony>
@@ -47675,7 +47675,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3XO233</pattern>
+        <pattern>[3-O]XO[2-O][3-O][3-O]</pattern>
         <Harmony>
             <name>dsus/g</name>
         </Harmony>
@@ -47704,7 +47704,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O221OO</pattern>
+        <pattern>O[2-O][2-O][1-O]OO</pattern>
         <Harmony>
             <name>e</name>
         </Harmony>
@@ -47727,7 +47727,7 @@
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>OO--3-</pattern>
+        <pattern>OO--[3-O]-;B2[2-5]</pattern>
         <Harmony>
             <name>e11sus4</name>
         </Harmony>
@@ -47750,7 +47750,7 @@
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>OO--3-</pattern>
+        <pattern>OO--[3-O]-;B2[2-5]</pattern>
         <Harmony>
             <name>e11sus4</name>
         </Harmony>
@@ -47768,7 +47768,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O-----</pattern>
+        <pattern>O-----;B7[1-5]</pattern>
         <Harmony>
             <name>e11</name>
         </Harmony>
@@ -47797,7 +47797,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O2O122</pattern>
+        <pattern>O[2-O]O[1-O][2-O][2-O]</pattern>
         <Harmony>
             <name>e13</name>
         </Harmony>
@@ -47826,7 +47826,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO121</pattern>
+        <pattern>XXO[1-O][2-O][1-O]</pattern>
         <Harmony>
             <name>e13b9</name>
         </Harmony>
@@ -47855,7 +47855,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO12O</pattern>
+        <pattern>XXO[1-O][2-O]O</pattern>
         <Harmony>
             <name>e13/d</name>
         </Harmony>
@@ -47884,7 +47884,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2O12O</pattern>
+        <pattern>X[2-O]O[1-O][2-O]O</pattern>
         <Harmony>
             <name>e13/b</name>
         </Harmony>
@@ -47911,7 +47911,7 @@
                 <barre start="1" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O-8-99</pattern>
+        <pattern>O-[8-O]-[9-O][9-O];B7[1-3]</pattern>
         <Harmony>
             <name>e13#11</name>
         </Harmony>
@@ -47940,7 +47940,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O2O22O</pattern>
+        <pattern>O[2-O]O[2-O][2-O]O</pattern>
         <Harmony>
             <name>e13sus4</name>
         </Harmony>
@@ -47969,7 +47969,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX211O</pattern>
+        <pattern>XX[2-O][1-O][1-O]O</pattern>
         <Harmony>
             <name>e+</name>
         </Harmony>
@@ -47995,7 +47995,7 @@
                 <barre start="3" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X2--X</pattern>
+        <pattern>[4-O]X[2-O]--X;B1[3-4]</pattern>
         <Harmony>
             <name>e+/g#</name>
         </Harmony>
@@ -48024,7 +48024,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O22XXX</pattern>
+        <pattern>O[2-O][2-O]XXX</pattern>
         <Harmony>
             <name>e5</name>
         </Harmony>
@@ -48054,7 +48054,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O7109OO</pattern>
+        <pattern>O[7-O][10-O][9-O]OO</pattern>
         <Harmony>
             <name>e5(b13)</name>
         </Harmony>
@@ -48083,7 +48083,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO24XX</pattern>
+        <pattern>XO[2-O][4-O]XX</pattern>
         <Harmony>
             <name>e5/a</name>
         </Harmony>
@@ -48112,7 +48112,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X22XOO</pattern>
+        <pattern>X[2-O][2-O]XOO</pattern>
         <Harmony>
             <name>e5/b</name>
         </Harmony>
@@ -48141,7 +48141,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X424OO</pattern>
+        <pattern>X[4-O][2-O][4-O]OO</pattern>
         <Harmony>
             <name>e5/c#</name>
         </Harmony>
@@ -48171,7 +48171,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X524OO</pattern>
+        <pattern>X[5-O][2-O][4-O]OO</pattern>
         <Harmony>
             <name>e5/d</name>
         </Harmony>
@@ -48200,7 +48200,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX14OO</pattern>
+        <pattern>XX[1-O][4-O]OO</pattern>
         <Harmony>
             <name>e5/d#</name>
         </Harmony>
@@ -48229,7 +48229,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>122XXX</pattern>
+        <pattern>[1-O][2-O][2-O]XXX</pattern>
         <Harmony>
             <name>e5/f</name>
         </Harmony>
@@ -48255,7 +48255,7 @@
                 <barre start="1" end="2">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3--4XX</pattern>
+        <pattern>[3-O]--[4-O]XX;B2[1-2]</pattern>
         <Harmony>
             <name>e5/g</name>
         </Harmony>
@@ -48284,7 +48284,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X24OO</pattern>
+        <pattern>[4-O]X[2-O][4-O]OO</pattern>
         <Harmony>
             <name>e5/g#</name>
         </Harmony>
@@ -48313,7 +48313,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O2212O</pattern>
+        <pattern>O[2-O][2-O][1-O][2-O]O</pattern>
         <Harmony>
             <name>e6</name>
         </Harmony>
@@ -48342,7 +48342,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX242O</pattern>
+        <pattern>XX[2-O][4-O][2-O]O</pattern>
         <Harmony>
             <name>e6(no3)</name>
         </Harmony>
@@ -48371,7 +48371,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O2X122</pattern>
+        <pattern>O[2-O]X[1-O][2-O][2-O]</pattern>
         <Harmony>
             <name>e69</name>
         </Harmony>
@@ -48395,7 +48395,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X7--7-</pattern>
+        <pattern>X[7-O]--[7-O]-;B6[2-5]</pattern>
         <Harmony>
             <name>e69#11</name>
         </Harmony>
@@ -48424,7 +48424,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2212O</pattern>
+        <pattern>X[2-O][2-O][1-O][2-O]O</pattern>
         <Harmony>
             <name>e6/b</name>
         </Harmony>
@@ -48453,7 +48453,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3212O</pattern>
+        <pattern>X[3-O][2-O][1-O][2-O]O</pattern>
         <Harmony>
             <name>e6/c</name>
         </Harmony>
@@ -48482,7 +48482,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4212O</pattern>
+        <pattern>X[4-O][2-O][1-O][2-O]O</pattern>
         <Harmony>
             <name>e6/c#</name>
         </Harmony>
@@ -48511,7 +48511,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX112O</pattern>
+        <pattern>XX[1-O][1-O][2-O]O</pattern>
         <Harmony>
             <name>e6/d#</name>
         </Harmony>
@@ -48540,7 +48540,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2X212O</pattern>
+        <pattern>[2-O]X[2-O][1-O][2-O]O</pattern>
         <Harmony>
             <name>e6/f#</name>
         </Harmony>
@@ -48569,7 +48569,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXXO2O</pattern>
+        <pattern>XXXO[2-O]O</pattern>
         <Harmony>
             <name>e6/g</name>
         </Harmony>
@@ -48598,7 +48598,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXX12O</pattern>
+        <pattern>XXX[1-O][2-O]O</pattern>
         <Harmony>
             <name>e6/g#</name>
         </Harmony>
@@ -48627,7 +48627,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O2O1OO</pattern>
+        <pattern>O[2-O]O[1-O]OO</pattern>
         <Harmony>
             <name>e7</name>
         </Harmony>
@@ -48656,7 +48656,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2O12O</pattern>
+        <pattern>X[2-O]O[1-O][2-O]O</pattern>
         <Harmony>
             <name>e7(add13)/b</name>
         </Harmony>
@@ -48685,7 +48685,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>OO213O</pattern>
+        <pattern>OO[2-O][1-O][3-O]O</pattern>
         <Harmony>
             <name>e7(add4)</name>
         </Harmony>
@@ -48714,7 +48714,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O2O12O</pattern>
+        <pattern>O[2-O]O[1-O][2-O]O</pattern>
         <Harmony>
             <name>e7add13</name>
         </Harmony>
@@ -48741,7 +48741,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O767--</pattern>
+        <pattern>O[7-O][6-O][7-O]--;B5[4-5]</pattern>
         <Harmony>
             <name>e7(add4)</name>
         </Harmony>
@@ -48770,7 +48770,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O2O11O</pattern>
+        <pattern>O[2-O]O[1-O][1-O]O</pattern>
         <Harmony>
             <name>e7b13</name>
         </Harmony>
@@ -48799,7 +48799,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX2334</pattern>
+        <pattern>XX[2-O][3-O][3-O][4-O]</pattern>
         <Harmony>
             <name>e7b5</name>
         </Harmony>
@@ -48828,7 +48828,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1O1OO</pattern>
+        <pattern>X[1-O]O[1-O]OO</pattern>
         <Harmony>
             <name>e7b5/bb</name>
         </Harmony>
@@ -48855,7 +48855,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O7-78-</pattern>
+        <pattern>O[7-O]-[7-O][8-O]-;B6[2-5]</pattern>
         <Harmony>
             <name>e7(#9b5)</name>
         </Harmony>
@@ -48879,7 +48879,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O7-7--</pattern>
+        <pattern>O[7-O]-[7-O]--;B6[2-5]</pattern>
         <Harmony>
             <name>e7(b9b5)</name>
         </Harmony>
@@ -48908,7 +48908,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O2O1O1</pattern>
+        <pattern>O[2-O]O[1-O]O[1-O]</pattern>
         <Harmony>
             <name>e7b9</name>
         </Harmony>
@@ -48937,7 +48937,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X233O</pattern>
+        <pattern>[4-O]X[2-O][3-O][3-O]O</pattern>
         <Harmony>
             <name>e7b5/g#</name>
         </Harmony>
@@ -48964,7 +48964,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O7-7-8</pattern>
+        <pattern>O[7-O]-[7-O]-[8-O];B6[2-4]</pattern>
         <Harmony>
             <name>e7(b13b9)</name>
         </Harmony>
@@ -48991,7 +48991,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X-4-X</pattern>
+        <pattern>[4-O]X-[4-O]-X;B3[2-4]</pattern>
         <Harmony>
             <name>e7b9/g#</name>
         </Harmony>
@@ -49015,7 +49015,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O7-7--</pattern>
+        <pattern>O[7-O]-[7-O]--;B6[2-5]</pattern>
         <Harmony>
             <name>e7(#11b9)</name>
         </Harmony>
@@ -49042,7 +49042,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O7-7-8</pattern>
+        <pattern>O[7-O]-[7-O]-[8-O];B6[2-4]</pattern>
         <Harmony>
             <name>e7(b9#5)</name>
         </Harmony>
@@ -49071,7 +49071,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O2O4OO</pattern>
+        <pattern>O[2-O]O[4-O]OO</pattern>
         <Harmony>
             <name>e7(no3)</name>
         </Harmony>
@@ -49100,7 +49100,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O2O4OO</pattern>
+        <pattern>O[2-O]O[4-O]OO</pattern>
         <Harmony>
             <name>e7(no3)</name>
         </Harmony>
@@ -49129,7 +49129,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO43O</pattern>
+        <pattern>XXO[4-O][3-O]O</pattern>
         <Harmony>
             <name>e7(no3)/d</name>
         </Harmony>
@@ -49159,7 +49159,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6564X</pattern>
+        <pattern>X[6-O][5-O][6-O][4-O]X</pattern>
         <Harmony>
             <name>e7(no5)</name>
         </Harmony>
@@ -49188,7 +49188,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO213O</pattern>
+        <pattern>XO[2-O][1-O][3-O]O</pattern>
         <Harmony>
             <name>e7/a</name>
         </Harmony>
@@ -49217,7 +49217,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2213O</pattern>
+        <pattern>X[2-O][2-O][1-O][3-O]O</pattern>
         <Harmony>
             <name>e7/b</name>
         </Harmony>
@@ -49246,7 +49246,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3213O</pattern>
+        <pattern>X[3-O][2-O][1-O][3-O]O</pattern>
         <Harmony>
             <name>e7/c</name>
         </Harmony>
@@ -49275,7 +49275,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO1OO</pattern>
+        <pattern>XXO[1-O]OO</pattern>
         <Harmony>
             <name>e7/d</name>
         </Harmony>
@@ -49304,7 +49304,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX113O</pattern>
+        <pattern>XX[1-O][1-O][3-O]O</pattern>
         <Harmony>
             <name>e7/d#</name>
         </Harmony>
@@ -49333,7 +49333,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX113O</pattern>
+        <pattern>XX[1-O][1-O][3-O]O</pattern>
         <Harmony>
             <name>e7/eb</name>
         </Harmony>
@@ -49362,7 +49362,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4434</pattern>
+        <pattern>XX[4-O][4-O][3-O][4-O]</pattern>
         <Harmony>
             <name>e7/f#</name>
         </Harmony>
@@ -49391,7 +49391,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4XO43O</pattern>
+        <pattern>[4-O]XO[4-O][3-O]O</pattern>
         <Harmony>
             <name>e7/g#</name>
         </Harmony>
@@ -49420,7 +49420,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO11O</pattern>
+        <pattern>XXO[1-O][1-O]O</pattern>
         <Harmony>
             <name>e+7</name>
         </Harmony>
@@ -49449,7 +49449,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX2334</pattern>
+        <pattern>XX[2-O][3-O][3-O][4-O]</pattern>
         <Harmony>
             <name>e7#11</name>
         </Harmony>
@@ -49478,7 +49478,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO11O</pattern>
+        <pattern>XXO[1-O][1-O]O</pattern>
         <Harmony>
             <name>e7#5</name>
         </Harmony>
@@ -49505,7 +49505,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O7-7-8</pattern>
+        <pattern>O[7-O]-[7-O]-[8-O];B6[2-4]</pattern>
         <Harmony>
             <name>e7(b9#5)</name>
         </Harmony>
@@ -49534,7 +49534,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO11O</pattern>
+        <pattern>XXO[1-O][1-O]O</pattern>
         <Harmony>
             <name>e7#5/d</name>
         </Harmony>
@@ -49561,7 +49561,7 @@
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O767--</pattern>
+        <pattern>O[7-O][6-O][7-O]--;B8[4-5]</pattern>
         <Harmony>
             <name>e7(#9#5)</name>
         </Harmony>
@@ -49591,7 +49591,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O7678X</pattern>
+        <pattern>O[7-O][6-O][7-O][8-O]X</pattern>
         <Harmony>
             <name>e7#9</name>
         </Harmony>
@@ -49618,7 +49618,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O7-78-</pattern>
+        <pattern>O[7-O]-[7-O][8-O]-;B6[2-5]</pattern>
         <Harmony>
             <name>e7(#11#9)</name>
         </Harmony>
@@ -49645,7 +49645,7 @@
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O767--</pattern>
+        <pattern>O[7-O][6-O][7-O]--;B8[4-5]</pattern>
         <Harmony>
             <name>e7(b13#9)</name>
         </Harmony>
@@ -49674,7 +49674,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O2O2OO</pattern>
+        <pattern>O[2-O]O[2-O]OO</pattern>
         <Harmony>
             <name>e7sus4</name>
         </Harmony>
@@ -49704,7 +49704,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>7X678X</pattern>
+        <pattern>[7-O]X[6-O][7-O][8-O]X</pattern>
         <Harmony>
             <name>e7#9/b</name>
         </Harmony>
@@ -49733,7 +49733,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O2O2O1</pattern>
+        <pattern>O[2-O]O[2-O]O[1-O]</pattern>
         <Harmony>
             <name>e7b9sus4</name>
         </Harmony>
@@ -49762,7 +49762,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2O2OO</pattern>
+        <pattern>X[2-O]O[2-O]OO</pattern>
         <Harmony>
             <name>e7sus4/b</name>
         </Harmony>
@@ -49791,7 +49791,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4O2OO</pattern>
+        <pattern>X[4-O]O[2-O]OO</pattern>
         <Harmony>
             <name>e7sus4/c#</name>
         </Harmony>
@@ -49820,7 +49820,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO2OO</pattern>
+        <pattern>XXO[2-O]OO</pattern>
         <Harmony>
             <name>e7sus4/d</name>
         </Harmony>
@@ -49849,7 +49849,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O2O1O2</pattern>
+        <pattern>O[2-O]O[1-O]O[2-O]</pattern>
         <Harmony>
             <name>e9</name>
         </Harmony>
@@ -49876,7 +49876,7 @@
                 <barre start="3" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O76--8</pattern>
+        <pattern>O[7-O][6-O]--[8-O];B7[3-4]</pattern>
         <Harmony>
             <name>e9b13</name>
         </Harmony>
@@ -49903,7 +49903,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O7-77-</pattern>
+        <pattern>O[7-O]-[7-O][7-O]-;B6[2-5]</pattern>
         <Harmony>
             <name>e9b5</name>
         </Harmony>
@@ -49925,7 +49925,7 @@
                 <barre start="1" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>------</pattern>
+        <pattern>------;B6[0-5];B7[1-4]</pattern>
         <Harmony>
             <name>e9b5/bb</name>
         </Harmony>
@@ -49949,7 +49949,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO6---</pattern>
+        <pattern>XO[6-O]---;B7[3-5]</pattern>
         <Harmony>
             <name>e9/a</name>
         </Harmony>
@@ -49976,7 +49976,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-77-</pattern>
+        <pattern>XX-[7-O][7-O]-;B6[2-5]</pattern>
         <Harmony>
             <name>e9b5/g#</name>
         </Harmony>
@@ -50005,7 +50005,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2O1O2</pattern>
+        <pattern>X[2-O]O[1-O]O[2-O]</pattern>
         <Harmony>
             <name>e9/b</name>
         </Harmony>
@@ -50034,7 +50034,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO1O2</pattern>
+        <pattern>XXO[1-O]O[2-O]</pattern>
         <Harmony>
             <name>e9/d</name>
         </Harmony>
@@ -50058,7 +50058,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX6---</pattern>
+        <pattern>XX[6-O]---;B7[3-5]</pattern>
         <Harmony>
             <name>e9/g#</name>
         </Harmony>
@@ -50087,7 +50087,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2XO1O2</pattern>
+        <pattern>[2-O]XO[1-O]O[2-O]</pattern>
         <Harmony>
             <name>e9/f#</name>
         </Harmony>
@@ -50114,7 +50114,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O7-77-</pattern>
+        <pattern>O[7-O]-[7-O][7-O]-;B6[2-5]</pattern>
         <Harmony>
             <name>e9#11</name>
         </Harmony>
@@ -50141,7 +50141,7 @@
                 <barre start="3" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O76--8</pattern>
+        <pattern>O[7-O][6-O]--[8-O];B7[3-4]</pattern>
         <Harmony>
             <name>e9#5</name>
         </Harmony>
@@ -50159,7 +50159,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O-----</pattern>
+        <pattern>O-----;B7[1-5]</pattern>
         <Harmony>
             <name>e9sus4</name>
         </Harmony>
@@ -50182,7 +50182,7 @@
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO--3-</pattern>
+        <pattern>XO--[3-O]-;B2[2-5]</pattern>
         <Harmony>
             <name>e9sus4/a</name>
         </Harmony>
@@ -50211,7 +50211,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O241OO</pattern>
+        <pattern>O[2-O][4-O][1-O]OO</pattern>
         <Harmony>
             <name>eadd2</name>
         </Harmony>
@@ -50240,7 +50240,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X241OO</pattern>
+        <pattern>X[2-O][4-O][1-O]OO</pattern>
         <Harmony>
             <name>eadd2/b</name>
         </Harmony>
@@ -50269,7 +50269,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO1O2</pattern>
+        <pattern>XXO[1-O]O[2-O]</pattern>
         <Harmony>
             <name>eadd2/d</name>
         </Harmony>
@@ -50299,7 +50299,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X44OO</pattern>
+        <pattern>[4-O]X[4-O][4-O]OO</pattern>
         <Harmony>
             <name>eadd2/g#</name>
         </Harmony>
@@ -50328,7 +50328,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>OO21OO</pattern>
+        <pattern>OO[2-O][1-O]OO</pattern>
         <Harmony>
             <name>eadd4</name>
         </Harmony>
@@ -50357,7 +50357,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2O21OO</pattern>
+        <pattern>[2-O]O[2-O][1-O]OO</pattern>
         <Harmony>
             <name>eadd4/f#</name>
         </Harmony>
@@ -50386,7 +50386,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X222OO</pattern>
+        <pattern>X[2-O][2-O][2-O]OO</pattern>
         <Harmony>
             <name>eadd4/b</name>
         </Harmony>
@@ -50415,7 +50415,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X22OO</pattern>
+        <pattern>[4-O]X[2-O][2-O]OO</pattern>
         <Harmony>
             <name>eadd4/g#</name>
         </Harmony>
@@ -50444,7 +50444,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O221O2</pattern>
+        <pattern>O[2-O][2-O][1-O]O[2-O]</pattern>
         <Harmony>
             <name>eadd9</name>
         </Harmony>
@@ -50473,7 +50473,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X221O2</pattern>
+        <pattern>X[2-O][2-O][1-O]O[2-O]</pattern>
         <Harmony>
             <name>eadd9/b</name>
         </Harmony>
@@ -50503,7 +50503,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X44OO</pattern>
+        <pattern>[4-O]X[4-O][4-O]OO</pattern>
         <Harmony>
             <name>eadd9/g#</name>
         </Harmony>
@@ -50532,7 +50532,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O223OO</pattern>
+        <pattern>O[2-O][2-O][3-O]OO</pattern>
         <Harmony>
             <name>e(#4)</name>
         </Harmony>
@@ -50561,7 +50561,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X223OO</pattern>
+        <pattern>X[2-O][2-O][3-O]OO</pattern>
         <Harmony>
             <name>e(#4)/b</name>
         </Harmony>
@@ -50588,7 +50588,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXX-5-</pattern>
+        <pattern>XXX-[5-O]-;B3[3-5]</pattern>
         <Harmony>
             <name>edim</name>
         </Harmony>
@@ -50617,7 +50617,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX2323</pattern>
+        <pattern>XX[2-O][3-O][2-O][3-O]</pattern>
         <Harmony>
             <name>edim7</name>
         </Harmony>
@@ -50647,7 +50647,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX6656</pattern>
+        <pattern>XX[6-O][6-O][5-O][6-O]</pattern>
         <Harmony>
             <name>edim7/ab</name>
         </Harmony>
@@ -50670,7 +50670,7 @@
                 <barre start="1" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--3-3</pattern>
+        <pattern>X--[3-O]-[3-O];B2[1-4]</pattern>
         <Harmony>
             <name>edim7/b</name>
         </Harmony>
@@ -50697,7 +50697,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>6X-6-X</pattern>
+        <pattern>[6-O]X-[6-O]-X;B5[2-4]</pattern>
         <Harmony>
             <name>edim7/bb</name>
         </Harmony>
@@ -50727,7 +50727,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4535X</pattern>
+        <pattern>X[4-O][5-O][3-O][5-O]X</pattern>
         <Harmony>
             <name>edim7/c#</name>
         </Harmony>
@@ -50751,7 +50751,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--6-6</pattern>
+        <pattern>X--[6-O]-[6-O];B5[1-4]</pattern>
         <Harmony>
             <name>edim7/d</name>
         </Harmony>
@@ -50775,7 +50775,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--9-9</pattern>
+        <pattern>X--[9-O]-[9-O];B8[1-4]</pattern>
         <Harmony>
             <name>edim7/f</name>
         </Harmony>
@@ -50801,7 +50801,7 @@
                 <barre start="2" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3-3-3</pattern>
+        <pattern>X[3-O]-[3-O]-[3-O];B2[2-4]</pattern>
         <Harmony>
             <name>edim7/c</name>
         </Harmony>
@@ -50828,7 +50828,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X-3-X</pattern>
+        <pattern>[3-O]X-[3-O]-X;B2[2-4]</pattern>
         <Harmony>
             <name>edim7/g</name>
         </Harmony>
@@ -50851,7 +50851,7 @@
                 <barre start="1" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--3-3</pattern>
+        <pattern>X--[3-O]-[3-O];B2[1-4]</pattern>
         <Harmony>
             <name>edim/b</name>
         </Harmony>
@@ -50878,7 +50878,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO-5-</pattern>
+        <pattern>XXO-[5-O]-;B3[3-5]</pattern>
         <Harmony>
             <name>edim/d</name>
         </Harmony>
@@ -50902,7 +50902,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX--5-</pattern>
+        <pattern>XX--[5-O]-;B3[2-5]</pattern>
         <Harmony>
             <name>edim/f</name>
         </Harmony>
@@ -50931,7 +50931,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO2323</pattern>
+        <pattern>XO[2-O][3-O][2-O][3-O]</pattern>
         <Harmony>
             <name>edim/a</name>
         </Harmony>
@@ -50958,7 +50958,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX5-5-</pattern>
+        <pattern>XX[5-O]-[5-O]-;B3[3-5]</pattern>
         <Harmony>
             <name>edim/g</name>
         </Harmony>
@@ -50985,7 +50985,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXX-5-</pattern>
+        <pattern>XXX-[5-O]-;B3[3-5]</pattern>
         <Harmony>
             <name>edim/bb</name>
         </Harmony>
@@ -51009,7 +51009,7 @@
                 <barre start="2" end="4">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6---X</pattern>
+        <pattern>X[6-O]---X;B8[2-4]</pattern>
         <Harmony>
             <name>eb</name>
         </Harmony>
@@ -51039,7 +51039,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX5345</pattern>
+        <pattern>XX[5-O][3-O][4-O][5-O]</pattern>
         <Harmony>
             <name>eb(#11)</name>
         </Harmony>
@@ -51057,7 +51057,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-----</pattern>
+        <pattern>X-----;B6[1-5]</pattern>
         <Harmony>
             <name>eb11</name>
         </Harmony>
@@ -51086,7 +51086,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX112O</pattern>
+        <pattern>XX[1-O][1-O][2-O]O</pattern>
         <Harmony>
             <name>eb11b9</name>
         </Harmony>
@@ -51113,7 +51113,7 @@
                 <barre start="3" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X65--8</pattern>
+        <pattern>X[6-O][5-O]--[8-O];B6[3-4]</pattern>
         <Harmony>
             <name>eb13</name>
         </Harmony>
@@ -51140,7 +51140,7 @@
                 <barre start="3" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>6X5--8</pattern>
+        <pattern>[6-O]X[5-O]--[8-O];B6[3-4]</pattern>
         <Harmony>
             <name>eb13/bb</name>
         </Harmony>
@@ -51164,7 +51164,7 @@
                 <barre start="1" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X---88</pattern>
+        <pattern>X---[8-O][8-O];B6[1-3]</pattern>
         <Harmony>
             <name>eb13(add4)</name>
         </Harmony>
@@ -51194,7 +51194,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6788X</pattern>
+        <pattern>X[6-O][7-O][8-O][8-O]X</pattern>
         <Harmony>
             <name>eb(b5)</name>
         </Harmony>
@@ -51224,7 +51224,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X7X688</pattern>
+        <pattern>X[7-O]X[6-O][8-O][8-O]</pattern>
         <Harmony>
             <name>eb13b9</name>
         </Harmony>
@@ -51245,7 +51245,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X----8</pattern>
+        <pattern>X----[8-O];B6[1-4]</pattern>
         <Harmony>
             <name>eb13sus4</name>
         </Harmony>
@@ -51275,7 +51275,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX7688</pattern>
+        <pattern>XX[7-O][6-O][8-O][8-O]</pattern>
         <Harmony>
             <name>eb13#11</name>
         </Harmony>
@@ -51305,7 +51305,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X688XX</pattern>
+        <pattern>X[6-O][8-O][8-O]XX</pattern>
         <Harmony>
             <name>eb5</name>
         </Harmony>
@@ -51335,7 +51335,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X7899X</pattern>
+        <pattern>X[7-O][8-O][9-O][9-O]X</pattern>
         <Harmony>
             <name>e(b5)</name>
         </Harmony>
@@ -51364,7 +51364,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X13XX</pattern>
+        <pattern>[4-O]X[1-O][3-O]XX</pattern>
         <Harmony>
             <name>eb5/ab</name>
         </Harmony>
@@ -51391,7 +51391,7 @@
                 <barre start="0" end="1">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>--88XX</pattern>
+        <pattern>--[8-O][8-O]XX;B6[0-1]</pattern>
         <Harmony>
             <name>eb5/bb</name>
         </Harmony>
@@ -51420,7 +51420,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3134X</pattern>
+        <pattern>X[3-O][1-O][3-O][4-O]X</pattern>
         <Harmony>
             <name>eb5/c</name>
         </Harmony>
@@ -51449,7 +51449,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX234X</pattern>
+        <pattern>XX[2-O][3-O][4-O]X</pattern>
         <Harmony>
             <name>eb5/e</name>
         </Harmony>
@@ -51479,7 +51479,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X588XX</pattern>
+        <pattern>X[5-O][8-O][8-O]XX</pattern>
         <Harmony>
             <name>eb5/d</name>
         </Harmony>
@@ -51509,7 +51509,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X888XX</pattern>
+        <pattern>X[8-O][8-O][8-O]XX</pattern>
         <Harmony>
             <name>eb5/f</name>
         </Harmony>
@@ -51538,7 +51538,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X13XX</pattern>
+        <pattern>[3-O]X[1-O][3-O]XX</pattern>
         <Harmony>
             <name>eb5/g</name>
         </Harmony>
@@ -51567,7 +51567,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X68X10X</pattern>
+        <pattern>X[6-O][8-O]X[10-O]X</pattern>
         <Harmony>
             <name>eb5(#11)</name>
         </Harmony>
@@ -51596,7 +51596,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X121XX</pattern>
+        <pattern>X[1-O][2-O][1-O]XX</pattern>
         <Harmony>
             <name>e(b5)/bb</name>
         </Harmony>
@@ -51622,7 +51622,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-3-3</pattern>
+        <pattern>XX-[3-O]-[3-O];B1[2-4]</pattern>
         <Harmony>
             <name>eb6</name>
         </Harmony>
@@ -51646,7 +51646,7 @@
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X67---</pattern>
+        <pattern>X[6-O][7-O]---;B8[3-5]</pattern>
         <Harmony>
             <name>eb6b5</name>
         </Harmony>
@@ -51673,7 +51673,7 @@
                 <barre start="2" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6--66</pattern>
+        <pattern>X[6-O]--[6-O][6-O];B5[2-3]</pattern>
         <Harmony>
             <name>eb69</name>
         </Harmony>
@@ -51699,7 +51699,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-3-X</pattern>
+        <pattern>XX-[3-O]-X;B1[2-4]</pattern>
         <Harmony>
             <name>eb6(no3)</name>
         </Harmony>
@@ -51722,7 +51722,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--3-3</pattern>
+        <pattern>X--[3-O]-[3-O];B1[1-4]</pattern>
         <Harmony>
             <name>eb6/bb</name>
         </Harmony>
@@ -51743,7 +51743,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>8X----</pattern>
+        <pattern>[8-O]X----;B8[2-5]</pattern>
         <Harmony>
             <name>eb6/c</name>
         </Harmony>
@@ -51773,7 +51773,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X5554X</pattern>
+        <pattern>X[5-O][5-O][5-O][4-O]X</pattern>
         <Harmony>
             <name>eb6/d</name>
         </Harmony>
@@ -51800,7 +51800,7 @@
                 <barre start="2" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX--66</pattern>
+        <pattern>XX--[6-O][6-O];B5[2-3]</pattern>
         <Harmony>
             <name>eb69/g</name>
         </Harmony>
@@ -51829,7 +51829,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3313</pattern>
+        <pattern>XX[3-O][3-O][1-O][3-O]</pattern>
         <Harmony>
             <name>eb6/f</name>
         </Harmony>
@@ -51853,7 +51853,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6--6-</pattern>
+        <pattern>X[6-O]--[6-O]-;B5[2-5]</pattern>
         <Harmony>
             <name>eb69(#11)</name>
         </Harmony>
@@ -51874,7 +51874,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>--5-4-</pattern>
+        <pattern>--[5-O]-[4-O]-;B3[0-5]</pattern>
         <Harmony>
             <name>eb6/g</name>
         </Harmony>
@@ -51901,7 +51901,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-88-8</pattern>
+        <pattern>X-[8-O][8-O]-[8-O];B6[1-4]</pattern>
         <Harmony>
             <name>eb6sus2</name>
         </Harmony>
@@ -51930,7 +51930,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1323</pattern>
+        <pattern>XX[1-O][3-O][2-O][3-O]</pattern>
         <Harmony>
             <name>eb7</name>
         </Harmony>
@@ -51956,7 +51956,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2X-3-3</pattern>
+        <pattern>[2-O]X-[3-O]-[3-O];B1[2-4]</pattern>
         <Harmony>
             <name>eb6/gb</name>
         </Harmony>
@@ -51983,7 +51983,7 @@
                 <barre start="1" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-8-88</pattern>
+        <pattern>X-[8-O]-[8-O][8-O];B6[1-3]</pattern>
         <Harmony>
             <name>eb7(add13)</name>
         </Harmony>
@@ -52012,7 +52012,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1223</pattern>
+        <pattern>XX[1-O][2-O][2-O][3-O]</pattern>
         <Harmony>
             <name>eb7b5</name>
         </Harmony>
@@ -52039,7 +52039,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6-6-X</pattern>
+        <pattern>X[6-O]-[6-O]-X;B5[2-4]</pattern>
         <Harmony>
             <name>eb7b9</name>
         </Harmony>
@@ -52066,7 +52066,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6-6-7</pattern>
+        <pattern>X[6-O]-[6-O]-[7-O];B5[2-4]</pattern>
         <Harmony>
             <name>eb7(b13b9)</name>
         </Harmony>
@@ -52093,7 +52093,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6-6-7</pattern>
+        <pattern>X[6-O]-[6-O]-[7-O];B5[2-4]</pattern>
         <Harmony>
             <name>eb7(b9#5)</name>
         </Harmony>
@@ -52122,7 +52122,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX132X</pattern>
+        <pattern>XX[1-O][3-O][2-O]X</pattern>
         <Harmony>
             <name>eb7(no3)</name>
         </Harmony>
@@ -52151,7 +52151,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX132X</pattern>
+        <pattern>XX[1-O][3-O][2-O]X</pattern>
         <Harmony>
             <name>eb7(no3)</name>
         </Harmony>
@@ -52181,7 +52181,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X7675X</pattern>
+        <pattern>X[7-O][6-O][7-O][5-O]X</pattern>
         <Harmony>
             <name>eb7(no5)</name>
         </Harmony>
@@ -52207,7 +52207,7 @@
                 <barre start="3" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3--3</pattern>
+        <pattern>XX[3-O]--[3-O];B2[3-4]</pattern>
         <Harmony>
             <name>eb7b5/f</name>
         </Harmony>
@@ -52231,7 +52231,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX--8-</pattern>
+        <pattern>XX--[8-O]-;B6[2-5]</pattern>
         <Harmony>
             <name>eb7/ab</name>
         </Harmony>
@@ -52251,7 +52251,7 @@
                 <barre start="2" end="4">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>------</pattern>
+        <pattern>------;B6[0-5];B8[2-4]</pattern>
         <Harmony>
             <name>eb7/bb</name>
         </Harmony>
@@ -52280,7 +52280,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO323</pattern>
+        <pattern>XXO[3-O][2-O][3-O]</pattern>
         <Harmony>
             <name>eb7/d</name>
         </Harmony>
@@ -52309,7 +52309,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4X323</pattern>
+        <pattern>X[4-O]X[3-O][2-O][3-O]</pattern>
         <Harmony>
             <name>eb7/db</name>
         </Harmony>
@@ -52338,7 +52338,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3323</pattern>
+        <pattern>XX[3-O][3-O][2-O][3-O]</pattern>
         <Harmony>
             <name>eb7/f</name>
         </Harmony>
@@ -52367,7 +52367,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X132X</pattern>
+        <pattern>[3-O]X[1-O][3-O][2-O]X</pattern>
         <Harmony>
             <name>eb7/g</name>
         </Harmony>
@@ -52396,7 +52396,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1223</pattern>
+        <pattern>XX[1-O][2-O][2-O][3-O]</pattern>
         <Harmony>
             <name>eb7#11</name>
         </Harmony>
@@ -52425,7 +52425,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXX423</pattern>
+        <pattern>XXX[4-O][2-O][3-O]</pattern>
         <Harmony>
             <name>eb7#5</name>
         </Harmony>
@@ -52452,7 +52452,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6-6-7</pattern>
+        <pattern>X[6-O]-[6-O]-[7-O];B5[2-4]</pattern>
         <Harmony>
             <name>eb7(b9#5)</name>
         </Harmony>
@@ -52482,7 +52482,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX5423</pattern>
+        <pattern>XX[5-O][4-O][2-O][3-O]</pattern>
         <Harmony>
             <name>eb7#5/g</name>
         </Harmony>
@@ -52509,7 +52509,7 @@
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X656--</pattern>
+        <pattern>X[6-O][5-O][6-O]--;B7[4-5]</pattern>
         <Harmony>
             <name>eb7(#9#5)</name>
         </Harmony>
@@ -52538,7 +52538,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1O22</pattern>
+        <pattern>XX[1-O]O[2-O][2-O]</pattern>
         <Harmony>
             <name>eb7#9</name>
         </Harmony>
@@ -52568,7 +52568,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX5676</pattern>
+        <pattern>XX[5-O][6-O][7-O][6-O]</pattern>
         <Harmony>
             <name>eb7#9/g</name>
         </Harmony>
@@ -52595,7 +52595,7 @@
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X656--</pattern>
+        <pattern>X[6-O][5-O][6-O]--;B7[4-5]</pattern>
         <Harmony>
             <name>eb7(b13#9)</name>
         </Harmony>
@@ -52622,7 +52622,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6-67-</pattern>
+        <pattern>X[6-O]-[6-O][7-O]-;B5[2-5]</pattern>
         <Harmony>
             <name>eb7(#11#9)</name>
         </Harmony>
@@ -52646,7 +52646,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-8-9-</pattern>
+        <pattern>X-[8-O]-[9-O]-;B6[1-5]</pattern>
         <Harmony>
             <name>eb7sus4</name>
         </Harmony>
@@ -52675,7 +52675,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX112O</pattern>
+        <pattern>XX[1-O][1-O][2-O]O</pattern>
         <Harmony>
             <name>eb7(b9sus4)</name>
         </Harmony>
@@ -52696,7 +52696,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>--8-9-</pattern>
+        <pattern>--[8-O]-[9-O]-;B6[0-5]</pattern>
         <Harmony>
             <name>eb7sus4/bb</name>
         </Harmony>
@@ -52720,7 +52720,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-666--</pattern>
+        <pattern>-[6-O][6-O][6-O]--;B4[0-5]</pattern>
         <Harmony>
             <name>eb7sus4/ab</name>
         </Harmony>
@@ -52749,7 +52749,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1O21</pattern>
+        <pattern>XX[1-O]O[2-O][1-O]</pattern>
         <Harmony>
             <name>eb9</name>
         </Harmony>
@@ -52776,7 +52776,7 @@
                 <barre start="3" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X65--7</pattern>
+        <pattern>X[6-O][5-O]--[7-O];B6[3-4]</pattern>
         <Harmony>
             <name>eb9b13</name>
         </Harmony>
@@ -52800,7 +52800,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6-6--</pattern>
+        <pattern>X[6-O]-[6-O]--;B5[2-5]</pattern>
         <Harmony>
             <name>eb9b5</name>
         </Harmony>
@@ -52829,7 +52829,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>1X1O2X</pattern>
+        <pattern>[1-O]X[1-O]O[2-O]X</pattern>
         <Harmony>
             <name>eb9/f</name>
         </Harmony>
@@ -52853,7 +52853,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>6X5---</pattern>
+        <pattern>[6-O]X[5-O]---;B6[3-5]</pattern>
         <Harmony>
             <name>eb9/bb</name>
         </Harmony>
@@ -52877,7 +52877,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX5---</pattern>
+        <pattern>XX[5-O]---;B6[3-5]</pattern>
         <Harmony>
             <name>eb9/g</name>
         </Harmony>
@@ -52901,7 +52901,7 @@
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X5---</pattern>
+        <pattern>[4-O]X[5-O]---;B6[3-5]</pattern>
         <Harmony>
             <name>eb9/ab</name>
         </Harmony>
@@ -52928,7 +52928,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6-66-</pattern>
+        <pattern>X[6-O]-[6-O][6-O]-;B5[2-5]</pattern>
         <Harmony>
             <name>eb9#11</name>
         </Harmony>
@@ -52952,7 +52952,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6X---</pattern>
+        <pattern>X[6-O]X---;B6[3-5]</pattern>
         <Harmony>
             <name>eb9(no3)</name>
         </Harmony>
@@ -52979,7 +52979,7 @@
                 <barre start="3" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X65--7</pattern>
+        <pattern>X[6-O][5-O]--[7-O];B6[3-4]</pattern>
         <Harmony>
             <name>eb9#5</name>
         </Harmony>
@@ -53003,7 +53003,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-7--7</pattern>
+        <pattern>X-[7-O]--[7-O];B6[1-4]</pattern>
         <Harmony>
             <name>eb9(#11#5)</name>
         </Harmony>
@@ -53021,7 +53021,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-----</pattern>
+        <pattern>X-----;B6[1-5]</pattern>
         <Harmony>
             <name>eb9sus4</name>
         </Harmony>
@@ -53044,7 +53044,7 @@
                 <barre start="2" end="3">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-----</pattern>
+        <pattern>X-----;B6[1-5];B8[2-3]</pattern>
         <Harmony>
             <name>ebadd2</name>
         </Harmony>
@@ -53065,7 +53065,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>--88--</pattern>
+        <pattern>--[8-O][8-O]--;B6[0-5]</pattern>
         <Harmony>
             <name>ebadd2/bb</name>
         </Harmony>
@@ -53086,7 +53086,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>--88--</pattern>
+        <pattern>--[8-O][8-O]--;B6[0-5]</pattern>
         <Harmony>
             <name>ebadd2/bb</name>
         </Harmony>
@@ -53107,7 +53107,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X----X</pattern>
+        <pattern>X----X;B8[1-4]</pattern>
         <Harmony>
             <name>ebadd2/f</name>
         </Harmony>
@@ -53131,7 +53131,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X--4-</pattern>
+        <pattern>[4-O]X--[4-O]-;B3[2-5]</pattern>
         <Harmony>
             <name>ebadd9/ab</name>
         </Harmony>
@@ -53152,7 +53152,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>--88--</pattern>
+        <pattern>--[8-O][8-O]--;B6[0-5]</pattern>
         <Harmony>
             <name>ebadd9/bb</name>
         </Harmony>
@@ -53175,7 +53175,7 @@
                 <barre start="2" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4--4-</pattern>
+        <pattern>X[4-O]--[4-O]-;B3[2-5]</pattern>
         <Harmony>
             <name>ebadd9/db</name>
         </Harmony>
@@ -53196,7 +53196,7 @@
                 <barre start="1" end="4">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3----X</pattern>
+        <pattern>[3-O]----X;B6[1-4]</pattern>
         <Harmony>
             <name>eb9sus4/g</name>
         </Harmony>
@@ -53222,7 +53222,7 @@
                 <barre start="2" end="3">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X--4X</pattern>
+        <pattern>[3-O]X--[4-O]X;B3[2-3]</pattern>
         <Harmony>
             <name>ebadd9/g</name>
         </Harmony>
@@ -53246,7 +53246,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-78--</pattern>
+        <pattern>X-[7-O][8-O]--;B6[1-5]</pattern>
         <Harmony>
             <name>eb(#11add9)</name>
         </Harmony>
@@ -53276,7 +53276,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X8788X</pattern>
+        <pattern>X[8-O][7-O][8-O][8-O]X</pattern>
         <Harmony>
             <name>eb(#4)/f</name>
         </Harmony>
@@ -53300,7 +53300,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-5-6-</pattern>
+        <pattern>X-[5-O]-[6-O]-;B3[1-5]</pattern>
         <Harmony>
             <name>ebadd2/c</name>
         </Harmony>
@@ -53324,7 +53324,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X5--4-</pattern>
+        <pattern>X[5-O]--[4-O]-;B3[2-5]</pattern>
         <Harmony>
             <name>ebadd2/d</name>
         </Harmony>
@@ -53350,7 +53350,7 @@
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4-4-</pattern>
+        <pattern>XX[4-O]-[4-O]-;B3[3-5]</pattern>
         <Harmony>
             <name>eb(#9)</name>
         </Harmony>
@@ -53376,7 +53376,7 @@
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4-4-</pattern>
+        <pattern>XX[4-O]-[4-O]-;B3[3-5]</pattern>
         <Harmony>
             <name>eb(#9)</name>
         </Harmony>
@@ -53402,7 +53402,7 @@
                 <barre start="2" end="3">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X--4X</pattern>
+        <pattern>[3-O]X--[4-O]X;B3[2-3]</pattern>
         <Harmony>
             <name>ebadd2/g</name>
         </Harmony>
@@ -53425,7 +53425,7 @@
                 <barre start="1" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X---43</pattern>
+        <pattern>X---[4-O][3-O];B1[1-3]</pattern>
         <Harmony>
             <name>ebadd4</name>
         </Harmony>
@@ -53455,7 +53455,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X8X896</pattern>
+        <pattern>X[8-O]X[8-O][9-O][6-O]</pattern>
         <Harmony>
             <name>ebadd4/f</name>
         </Harmony>
@@ -53482,7 +53482,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-788-</pattern>
+        <pattern>X-[7-O][8-O][8-O]-;B6[1-5]</pattern>
         <Harmony>
             <name>eb(#4)</name>
         </Harmony>
@@ -53509,7 +53509,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X65-6-</pattern>
+        <pattern>X[6-O][5-O]-[6-O]-;B3[3-5]</pattern>
         <Harmony>
             <name>ebadd9</name>
         </Harmony>
@@ -53535,7 +53535,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X-34-</pattern>
+        <pattern>[3-O]X-[3-O][4-O]-;B1[2-5]</pattern>
         <Harmony>
             <name>ebadd9/g</name>
         </Harmony>
@@ -53565,7 +53565,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6787X</pattern>
+        <pattern>X[6-O][7-O][8-O][7-O]X</pattern>
         <Harmony>
             <name>ebdim</name>
         </Harmony>
@@ -53594,7 +53594,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1212</pattern>
+        <pattern>XX[1-O][2-O][1-O][2-O]</pattern>
         <Harmony>
             <name>ebdim7</name>
         </Harmony>
@@ -53617,7 +53617,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--2-2</pattern>
+        <pattern>X--[2-O]-[2-O];B1[1-4]</pattern>
         <Harmony>
             <name>ebdim7/bb</name>
         </Harmony>
@@ -53646,7 +53646,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3424X</pattern>
+        <pattern>X[3-O][4-O][2-O][4-O]X</pattern>
         <Harmony>
             <name>ebdim7/c</name>
         </Harmony>
@@ -53669,7 +53669,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--2-2</pattern>
+        <pattern>X--[2-O]-[2-O];B1[1-4]</pattern>
         <Harmony>
             <name>ebdim7/db</name>
         </Harmony>
@@ -53692,7 +53692,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--2-2</pattern>
+        <pattern>X--[2-O]-[2-O];B1[1-4]</pattern>
         <Harmony>
             <name>ebdim7/db</name>
         </Harmony>
@@ -53721,7 +53721,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX2212</pattern>
+        <pattern>XX[2-O][2-O][1-O][2-O]</pattern>
         <Harmony>
             <name>ebdim7/e</name>
         </Harmony>
@@ -53751,7 +53751,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX5545</pattern>
+        <pattern>XX[5-O][5-O][4-O][5-O]</pattern>
         <Harmony>
             <name>ebdim7/g</name>
         </Harmony>
@@ -53781,7 +53781,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO787X</pattern>
+        <pattern>XO[7-O][8-O][7-O]X</pattern>
         <Harmony>
             <name>ebdim/a</name>
         </Harmony>
@@ -53808,7 +53808,7 @@
                 <barre start="0" end="1">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>--787X</pattern>
+        <pattern>--[7-O][8-O][7-O]X;B6[0-1]</pattern>
         <Harmony>
             <name>ebdim/bb</name>
         </Harmony>
@@ -53837,7 +53837,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1232</pattern>
+        <pattern>XX[1-O][2-O][3-O][2-O]</pattern>
         <Harmony>
             <name>ebdim(#7)</name>
         </Harmony>
@@ -53863,7 +53863,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4-4-</pattern>
+        <pattern>XX[4-O]-[4-O]-;B2[3-5]</pattern>
         <Harmony>
             <name>ebdim/gb</name>
         </Harmony>
@@ -53890,7 +53890,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-887-</pattern>
+        <pattern>X-[8-O][8-O][7-O]-;B6[1-5]</pattern>
         <Harmony>
             <name>ebm</name>
         </Harmony>
@@ -53914,7 +53914,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--87-</pattern>
+        <pattern>X--[8-O][7-O]-;B6[1-5]</pattern>
         <Harmony>
             <name>ebm(add4)</name>
         </Harmony>
@@ -53944,7 +53944,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6X674</pattern>
+        <pattern>X[6-O]X[6-O][7-O][4-O]</pattern>
         <Harmony>
             <name>ebm11</name>
         </Harmony>
@@ -53962,7 +53962,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>----7-</pattern>
+        <pattern>----[7-O]-;B6[0-5]</pattern>
         <Harmony>
             <name>ebm11/bb</name>
         </Harmony>
@@ -53982,7 +53982,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2---2-</pattern>
+        <pattern>[2-O]---[2-O]-;B1[1-5]</pattern>
         <Harmony>
             <name>ebm11/gb</name>
         </Harmony>
@@ -54012,7 +54012,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6X674</pattern>
+        <pattern>X[6-O]X[6-O][7-O][4-O]</pattern>
         <Harmony>
             <name>ebm13</name>
         </Harmony>
@@ -54042,7 +54042,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6X674</pattern>
+        <pattern>X[6-O]X[6-O][7-O][4-O]</pattern>
         <Harmony>
             <name>ebm13/c</name>
         </Harmony>
@@ -54068,7 +54068,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-3-2</pattern>
+        <pattern>XX-[3-O]-[2-O];B1[2-4]</pattern>
         <Harmony>
             <name>ebm6</name>
         </Harmony>
@@ -54098,7 +54098,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6456X</pattern>
+        <pattern>X[6-O][4-O][5-O][6-O]X</pattern>
         <Harmony>
             <name>ebm69</name>
         </Harmony>
@@ -54121,7 +54121,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--3-2</pattern>
+        <pattern>X--[3-O]-[2-O];B1[1-4]</pattern>
         <Harmony>
             <name>ebm6/bb</name>
         </Harmony>
@@ -54150,7 +54150,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3312</pattern>
+        <pattern>XX[3-O][3-O][1-O][2-O]</pattern>
         <Harmony>
             <name>ebm6/f</name>
         </Harmony>
@@ -54177,7 +54177,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-5-6</pattern>
+        <pattern>XX-[5-O]-[6-O];B4[2-4]</pattern>
         <Harmony>
             <name>ebm6/gb</name>
         </Harmony>
@@ -54207,7 +54207,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6X674</pattern>
+        <pattern>X[6-O]X[6-O][7-O][4-O]</pattern>
         <Harmony>
             <name>ebm6sus4</name>
         </Harmony>
@@ -54231,7 +54231,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-8-7-</pattern>
+        <pattern>X-[8-O]-[7-O]-;B6[1-5]</pattern>
         <Harmony>
             <name>ebm7</name>
         </Harmony>
@@ -54261,7 +54261,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6X674</pattern>
+        <pattern>X[6-O]X[6-O][7-O][4-O]</pattern>
         <Harmony>
             <name>ebm7(add4)</name>
         </Harmony>
@@ -54284,7 +54284,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1---</pattern>
+        <pattern>XX[1-O]---;B2[3-5]</pattern>
         <Harmony>
             <name>ebm7b5</name>
         </Harmony>
@@ -54311,7 +54311,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6-6-X</pattern>
+        <pattern>X[6-O]-[6-O]-X;B4[2-4]</pattern>
         <Harmony>
             <name>ebm7(no5)</name>
         </Harmony>
@@ -54334,7 +54334,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4X---</pattern>
+        <pattern>X[4-O]X---;B2[3-5]</pattern>
         <Harmony>
             <name>ebm7b5/db</name>
         </Harmony>
@@ -54357,7 +54357,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2X1---</pattern>
+        <pattern>[2-O]X[1-O]---;B2[3-5]</pattern>
         <Harmony>
             <name>ebm7b5/f#</name>
         </Harmony>
@@ -54387,7 +54387,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX6879</pattern>
+        <pattern>XX[6-O][8-O][7-O][9-O]</pattern>
         <Harmony>
             <name>ebm7/ab</name>
         </Harmony>
@@ -54413,7 +54413,7 @@
                 <barre start="1" end="2">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--322</pattern>
+        <pattern>X--[3-O][2-O][2-O];B1[1-2]</pattern>
         <Harmony>
             <name>ebm7/bb</name>
         </Harmony>
@@ -54439,7 +54439,7 @@
                 <barre start="4" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X313--</pattern>
+        <pattern>X[3-O][1-O][3-O]--;B2[4-5]</pattern>
         <Harmony>
             <name>ebm7/c</name>
         </Harmony>
@@ -54463,7 +54463,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--6-6</pattern>
+        <pattern>X--[6-O]-[6-O];B4[1-4]</pattern>
         <Harmony>
             <name>ebm7/db</name>
         </Harmony>
@@ -54484,7 +54484,7 @@
                 <barre start="2" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X9----</pattern>
+        <pattern>X[9-O]----;B11[2-5]</pattern>
         <Harmony>
             <name>ebm7/gb</name>
         </Harmony>
@@ -54508,7 +54508,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-8-9-</pattern>
+        <pattern>X-[8-O]-[9-O]-;B6[1-5]</pattern>
         <Harmony>
             <name>ebm7sus4</name>
         </Harmony>
@@ -54538,7 +54538,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6466X</pattern>
+        <pattern>X[6-O][4-O][6-O][6-O]X</pattern>
         <Harmony>
             <name>ebm9</name>
         </Harmony>
@@ -54565,7 +54565,7 @@
                 <barre start="0" end="2">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-6-66X</pattern>
+        <pattern>-[6-O]-[6-O][6-O]X;B4[0-2]</pattern>
         <Harmony>
             <name>ebm9/ab</name>
         </Harmony>
@@ -54595,7 +54595,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>6X466X</pattern>
+        <pattern>[6-O]X[4-O][6-O][6-O]X</pattern>
         <Harmony>
             <name>ebm9/bb</name>
         </Harmony>
@@ -54622,7 +54622,7 @@
                 <barre start="1" end="2">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--66X</pattern>
+        <pattern>X--[6-O][6-O]X;B4[1-2]</pattern>
         <Harmony>
             <name>ebm9/db</name>
         </Harmony>
@@ -54651,7 +54651,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4341</pattern>
+        <pattern>XX[4-O][3-O][4-O][1-O]</pattern>
         <Harmony>
             <name>ebm(add9)</name>
         </Harmony>
@@ -54678,7 +54678,7 @@
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X677--</pattern>
+        <pattern>X[6-O][7-O][7-O]--;B8[4-5]</pattern>
         <Harmony>
             <name>ebmaj13#11</name>
         </Harmony>
@@ -54707,7 +54707,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1O11</pattern>
+        <pattern>XX[1-O]O[1-O][1-O]</pattern>
         <Harmony>
             <name>eb69</name>
         </Harmony>
@@ -54737,7 +54737,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6X788</pattern>
+        <pattern>X[6-O]X[7-O][8-O][8-O]</pattern>
         <Harmony>
             <name>ebmaj13</name>
         </Harmony>
@@ -54761,7 +54761,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X65---</pattern>
+        <pattern>X[6-O][5-O]---;B3[3-5]</pattern>
         <Harmony>
             <name>ebmaj7</name>
         </Harmony>
@@ -54790,7 +54790,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1233</pattern>
+        <pattern>XX[1-O][2-O][3-O][3-O]</pattern>
         <Harmony>
             <name>ebmaj7b5</name>
         </Harmony>
@@ -54819,7 +54819,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X123X</pattern>
+        <pattern>[3-O]X[1-O][2-O][3-O]X</pattern>
         <Harmony>
             <name>ebmaj7b5/g</name>
         </Harmony>
@@ -54848,7 +54848,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX133X</pattern>
+        <pattern>XX[1-O][3-O][3-O]X</pattern>
         <Harmony>
             <name>ebmaj7(no3)</name>
         </Harmony>
@@ -54871,7 +54871,7 @@
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X21---</pattern>
+        <pattern>X[2-O][1-O]---;B3[3-5]</pattern>
         <Harmony>
             <name>ebmaj7/b</name>
         </Harmony>
@@ -54895,7 +54895,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>6X5---</pattern>
+        <pattern>[6-O]X[5-O]---;B3[3-5]</pattern>
         <Harmony>
             <name>ebmaj7/bb</name>
         </Harmony>
@@ -54922,7 +54922,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X654--</pattern>
+        <pattern>X[6-O][5-O][4-O]--;B3[4-5]</pattern>
         <Harmony>
             <name>ebmaj7#5</name>
         </Harmony>
@@ -54942,7 +54942,7 @@
                 <barre start="2" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX----</pattern>
+        <pattern>XX----;B3[2-5]</pattern>
         <Harmony>
             <name>ebmaj7/f</name>
         </Harmony>
@@ -54965,7 +54965,7 @@
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO---</pattern>
+        <pattern>XXO---;B3[3-5]</pattern>
         <Harmony>
             <name>ebmaj7/d</name>
         </Harmony>
@@ -54994,7 +54994,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X133X</pattern>
+        <pattern>[3-O]X[1-O][3-O][3-O]X</pattern>
         <Harmony>
             <name>ebmaj7/g</name>
         </Harmony>
@@ -55024,7 +55024,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6778X</pattern>
+        <pattern>X[6-O][7-O][7-O][8-O]X</pattern>
         <Harmony>
             <name>ebmaj7#11</name>
         </Harmony>
@@ -55053,7 +55053,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X143X</pattern>
+        <pattern>[3-O]X[1-O][4-O][3-O]X</pattern>
         <Harmony>
             <name>ebmaj7#5/g</name>
         </Harmony>
@@ -55082,7 +55082,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX133X</pattern>
+        <pattern>XX[1-O][3-O][3-O]X</pattern>
         <Harmony>
             <name>ebmaj7(no3)</name>
         </Harmony>
@@ -55106,7 +55106,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-87--</pattern>
+        <pattern>X-[8-O][7-O]--;B6[1-5]</pattern>
         <Harmony>
             <name>ebmaj9</name>
         </Harmony>
@@ -55132,7 +55132,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-23-</pattern>
+        <pattern>XX-[2-O][3-O]-;B1[2-5]</pattern>
         <Harmony>
             <name>ebmaj9b5</name>
         </Harmony>
@@ -55158,7 +55158,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-33-</pattern>
+        <pattern>XX-[3-O][3-O]-;B1[2-5]</pattern>
         <Harmony>
             <name>ebmaj9(no3)</name>
         </Harmony>
@@ -55187,7 +55187,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO331</pattern>
+        <pattern>XXO[3-O][3-O][1-O]</pattern>
         <Harmony>
             <name>ebmaj9/d</name>
         </Harmony>
@@ -55217,7 +55217,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X8X786</pattern>
+        <pattern>X[8-O]X[7-O][8-O][6-O]</pattern>
         <Harmony>
             <name>ebmaj9/f</name>
         </Harmony>
@@ -55247,7 +55247,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X8X786</pattern>
+        <pattern>X[8-O]X[7-O][8-O][6-O]</pattern>
         <Harmony>
             <name>ebmaj9/f</name>
         </Harmony>
@@ -55277,7 +55277,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X8X786</pattern>
+        <pattern>X[8-O]X[7-O][8-O][6-O]</pattern>
         <Harmony>
             <name>ebmaj9/f</name>
         </Harmony>
@@ -55303,7 +55303,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-23-</pattern>
+        <pattern>XX-[2-O][3-O]-;B1[2-5]</pattern>
         <Harmony>
             <name>ebmaj9#11</name>
         </Harmony>
@@ -55326,7 +55326,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--33-</pattern>
+        <pattern>X--[3-O][3-O]-;B1[1-5]</pattern>
         <Harmony>
             <name>ebmaj9/bb</name>
         </Harmony>
@@ -55353,7 +55353,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-877-</pattern>
+        <pattern>X-[8-O][7-O][7-O]-;B6[1-5]</pattern>
         <Harmony>
             <name>ebm(#7)</name>
         </Harmony>
@@ -55379,7 +55379,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X-33-</pattern>
+        <pattern>[3-O]X-[3-O][3-O]-;B1[2-5]</pattern>
         <Harmony>
             <name>ebmaj9/g</name>
         </Harmony>
@@ -55409,7 +55409,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6476X</pattern>
+        <pattern>X[6-O][4-O][7-O][6-O]X</pattern>
         <Harmony>
             <name>ebm(add9)</name>
         </Harmony>
@@ -55436,7 +55436,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-87-</pattern>
+        <pattern>XX-[8-O][7-O]-;B6[2-5]</pattern>
         <Harmony>
             <name>ebm/ab</name>
         </Harmony>
@@ -55462,7 +55462,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2X-33-</pattern>
+        <pattern>[2-O]X-[3-O][3-O]-;B1[2-5]</pattern>
         <Harmony>
             <name>ebmaj9/f#</name>
         </Harmony>
@@ -55486,7 +55486,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>--887-</pattern>
+        <pattern>--[8-O][8-O][7-O]-;B6[0-5]</pattern>
         <Harmony>
             <name>ebm/bb</name>
         </Harmony>
@@ -55515,7 +55515,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4X342</pattern>
+        <pattern>X[4-O]X[3-O][4-O][2-O]</pattern>
         <Harmony>
             <name>ebm/db</name>
         </Harmony>
@@ -55544,7 +55544,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3X342</pattern>
+        <pattern>X[3-O]X[3-O][4-O][2-O]</pattern>
         <Harmony>
             <name>ebm/c</name>
         </Harmony>
@@ -55573,7 +55573,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3342</pattern>
+        <pattern>XX[3-O][3-O][4-O][2-O]</pattern>
         <Harmony>
             <name>ebm/f</name>
         </Harmony>
@@ -55602,7 +55602,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO342</pattern>
+        <pattern>XXO[3-O][4-O][2-O]</pattern>
         <Harmony>
             <name>ebm/d</name>
         </Harmony>
@@ -55632,7 +55632,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX5453</pattern>
+        <pattern>XX[5-O][4-O][5-O][3-O]</pattern>
         <Harmony>
             <name>ebm/gb</name>
         </Harmony>
@@ -55661,7 +55661,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXXO42</pattern>
+        <pattern>XXXO[4-O][2-O]</pattern>
         <Harmony>
             <name>ebm/g</name>
         </Harmony>
@@ -55690,7 +55690,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO4342</pattern>
+        <pattern>XO[4-O][3-O][4-O][2-O]</pattern>
         <Harmony>
             <name>ebm/a</name>
         </Harmony>
@@ -55714,7 +55714,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6---7</pattern>
+        <pattern>X[6-O]---[7-O];B4[2-4]</pattern>
         <Harmony>
             <name>ebm(#5)</name>
         </Harmony>
@@ -55743,7 +55743,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1O4X</pattern>
+        <pattern>XX[1-O]O[4-O]X</pattern>
         <Harmony>
             <name>ebno5</name>
         </Harmony>
@@ -55770,7 +55770,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO5-4-</pattern>
+        <pattern>XO[5-O]-[4-O]-;B3[3-5]</pattern>
         <Harmony>
             <name>eb/a</name>
         </Harmony>
@@ -55797,7 +55797,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-88-</pattern>
+        <pattern>XX-[8-O][8-O]-;B6[2-5]</pattern>
         <Harmony>
             <name>eb/ab</name>
         </Harmony>
@@ -55826,7 +55826,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2X343</pattern>
+        <pattern>X[2-O]X[3-O][4-O][3-O]</pattern>
         <Harmony>
             <name>eb/b</name>
         </Harmony>
@@ -55850,7 +55850,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>--888-</pattern>
+        <pattern>--[8-O][8-O][8-O]-;B6[0-5]</pattern>
         <Harmony>
             <name>eb/bb</name>
         </Harmony>
@@ -55874,7 +55874,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-5-4-</pattern>
+        <pattern>X-[5-O]-[4-O]-;B3[1-5]</pattern>
         <Harmony>
             <name>eb/c</name>
         </Harmony>
@@ -55898,7 +55898,7 @@
                 <barre start="2" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>7X---X</pattern>
+        <pattern>[7-O]X---X;B8[2-4]</pattern>
         <Harmony>
             <name>eb</name>
         </Harmony>
@@ -55924,7 +55924,7 @@
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4X-4-</pattern>
+        <pattern>X[4-O]X-[4-O]-;B3[3-5]</pattern>
         <Harmony>
             <name>eb/c#</name>
         </Harmony>
@@ -55953,7 +55953,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO343</pattern>
+        <pattern>XXO[3-O][4-O][3-O]</pattern>
         <Harmony>
             <name>eb/d</name>
         </Harmony>
@@ -55979,7 +55979,7 @@
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4X-4-</pattern>
+        <pattern>X[4-O]X-[4-O]-;B3[3-5]</pattern>
         <Harmony>
             <name>eb/db</name>
         </Harmony>
@@ -56002,7 +56002,7 @@
                 <barre start="2" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX--4-</pattern>
+        <pattern>XX--[4-O]-;B3[2-5]</pattern>
         <Harmony>
             <name>eb/f</name>
         </Harmony>
@@ -56028,7 +56028,7 @@
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4-4-</pattern>
+        <pattern>XX[4-O]-[4-O]-;B3[3-5]</pattern>
         <Harmony>
             <name>eb/f#</name>
         </Harmony>
@@ -56055,7 +56055,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX5-4-</pattern>
+        <pattern>XX[5-O]-[4-O]-;B3[3-5]</pattern>
         <Harmony>
             <name>eb/g</name>
         </Harmony>
@@ -56084,7 +56084,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1OO3</pattern>
+        <pattern>XX[1-O]OO[3-O]</pattern>
         <Harmony>
             <name>eb+</name>
         </Harmony>
@@ -56113,7 +56113,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X21OO3</pattern>
+        <pattern>X[2-O][1-O]OO[3-O]</pattern>
         <Harmony>
             <name>eb+/b</name>
         </Harmony>
@@ -56142,7 +56142,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1XOO3</pattern>
+        <pattern>X[1-O]XOO[3-O]</pattern>
         <Harmony>
             <name>eb+/bb</name>
         </Harmony>
@@ -56171,7 +56171,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO443</pattern>
+        <pattern>XXO[4-O][4-O][3-O]</pattern>
         <Harmony>
             <name>eb+/d</name>
         </Harmony>
@@ -56197,7 +56197,7 @@
                 <barre start="2" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-44-</pattern>
+        <pattern>XX-[4-O][4-O]-;B3[2-5]</pattern>
         <Harmony>
             <name>eb+/f</name>
         </Harmony>
@@ -56226,7 +56226,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4X443</pattern>
+        <pattern>X[4-O]X[4-O][4-O][3-O]</pattern>
         <Harmony>
             <name>eb+/db</name>
         </Harmony>
@@ -56256,7 +56256,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX5443</pattern>
+        <pattern>XX[5-O][4-O][4-O][3-O]</pattern>
         <Harmony>
             <name>eb+/g</name>
         </Harmony>
@@ -56283,7 +56283,7 @@
                 <barre start="2" end="3">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6--9X</pattern>
+        <pattern>X[6-O]--[9-O]X;B8[2-3]</pattern>
         <Harmony>
             <name>ebsus</name>
         </Harmony>
@@ -56307,7 +56307,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-88--</pattern>
+        <pattern>X-[8-O][8-O]--;B6[1-5]</pattern>
         <Harmony>
             <name>ebsus2</name>
         </Harmony>
@@ -56328,7 +56328,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>--88--</pattern>
+        <pattern>--[8-O][8-O]--;B6[0-5]</pattern>
         <Harmony>
             <name>ebadd2/bb</name>
         </Harmony>
@@ -56349,7 +56349,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>--88--</pattern>
+        <pattern>--[8-O][8-O]--;B6[0-5]</pattern>
         <Harmony>
             <name>ebadd2/bb</name>
         </Harmony>
@@ -56373,7 +56373,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-8--</pattern>
+        <pattern>XX-[8-O]--;B6[2-5]</pattern>
         <Harmony>
             <name>ebsus2/ab</name>
         </Harmony>
@@ -56396,7 +56396,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX--4-</pattern>
+        <pattern>XX--[4-O]-;B1[2-5]</pattern>
         <Harmony>
             <name>eb(sus4add2)</name>
         </Harmony>
@@ -56417,7 +56417,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--8--</pattern>
+        <pattern>X--[8-O]--;B6[1-5]</pattern>
         <Harmony>
             <name>ebsus4add2</name>
         </Harmony>
@@ -56446,7 +56446,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3X341</pattern>
+        <pattern>X[3-O]X[3-O][4-O][1-O]</pattern>
         <Harmony>
             <name>ebsus2/c</name>
         </Harmony>
@@ -56475,7 +56475,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO341</pattern>
+        <pattern>XXO[3-O][4-O][1-O]</pattern>
         <Harmony>
             <name>ebsus2/d</name>
         </Harmony>
@@ -56502,7 +56502,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>9X88--</pattern>
+        <pattern>[9-O]X[8-O][8-O]--;B6[4-5]</pattern>
         <Harmony>
             <name>ebsus2/db</name>
         </Harmony>
@@ -56531,7 +56531,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X334X</pattern>
+        <pattern>[3-O]X[3-O][3-O][4-O]X</pattern>
         <Harmony>
             <name>ebsus2/g</name>
         </Harmony>
@@ -56552,7 +56552,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--8--</pattern>
+        <pattern>X--[8-O]--;B6[1-5]</pattern>
         <Harmony>
             <name>ebsus2add4</name>
         </Harmony>
@@ -56573,7 +56573,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--8--</pattern>
+        <pattern>X--[8-O]--;B6[1-5]</pattern>
         <Harmony>
             <name>ebsus2add4</name>
         </Harmony>
@@ -56594,7 +56594,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--8--</pattern>
+        <pattern>X--[8-O]--;B6[1-5]</pattern>
         <Harmony>
             <name>eb(add2sus4)</name>
         </Harmony>
@@ -56618,7 +56618,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-78--</pattern>
+        <pattern>X-[7-O][8-O]--;B6[1-5]</pattern>
         <Harmony>
             <name>eb(#4sus2)</name>
         </Harmony>
@@ -56642,7 +56642,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-88--</pattern>
+        <pattern>X-[8-O][8-O]--;B6[1-5]</pattern>
         <Harmony>
             <name>ebsus2no2add9</name>
         </Harmony>
@@ -56669,7 +56669,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-89-</pattern>
+        <pattern>XX-[8-O][9-O]-;B6[2-5]</pattern>
         <Harmony>
             <name>ebsus/ab</name>
         </Harmony>
@@ -56693,7 +56693,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>--889-</pattern>
+        <pattern>--[8-O][8-O][9-O]-;B6[0-5]</pattern>
         <Harmony>
             <name>ebsus/bb</name>
         </Harmony>
@@ -56722,7 +56722,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3X344</pattern>
+        <pattern>X[3-O]X[3-O][4-O][4-O]</pattern>
         <Harmony>
             <name>ebsus/c</name>
         </Harmony>
@@ -56751,7 +56751,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2X344</pattern>
+        <pattern>X[2-O]X[3-O][4-O][4-O]</pattern>
         <Harmony>
             <name>ebsus</name>
         </Harmony>
@@ -56780,7 +56780,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4X344</pattern>
+        <pattern>X[4-O]X[3-O][4-O][4-O]</pattern>
         <Harmony>
             <name>ebsus/db</name>
         </Harmony>
@@ -56809,7 +56809,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3344</pattern>
+        <pattern>XX[3-O][3-O][4-O][4-O]</pattern>
         <Harmony>
             <name>ebsus/f</name>
         </Harmony>
@@ -56839,7 +56839,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX5344</pattern>
+        <pattern>XX[5-O][3-O][4-O][4-O]</pattern>
         <Harmony>
             <name>ebsus/g</name>
         </Harmony>
@@ -56868,7 +56868,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O22OOO</pattern>
+        <pattern>O[2-O][2-O]OOO</pattern>
         <Harmony>
             <name>em</name>
         </Harmony>
@@ -56898,7 +56898,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O7X785</pattern>
+        <pattern>O[7-O]X[7-O][8-O][5-O]</pattern>
         <Harmony>
             <name>em11</name>
         </Harmony>
@@ -56928,7 +56928,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O7X786</pattern>
+        <pattern>O[7-O]X[7-O][8-O][6-O]</pattern>
         <Harmony>
             <name>em11b5</name>
         </Harmony>
@@ -56958,7 +56958,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O7X789</pattern>
+        <pattern>O[7-O]X[7-O][8-O][9-O]</pattern>
         <Harmony>
             <name>em13</name>
         </Harmony>
@@ -56987,7 +56987,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X12O3X</pattern>
+        <pattern>X[1-O][2-O]O[3-O]X</pattern>
         <Harmony>
             <name>em11b5/bb</name>
         </Harmony>
@@ -57016,7 +57016,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O22O2O</pattern>
+        <pattern>O[2-O][2-O]O[2-O]O</pattern>
         <Harmony>
             <name>em6</name>
         </Harmony>
@@ -57045,7 +57045,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O22O22</pattern>
+        <pattern>O[2-O][2-O]O[2-O][2-O]</pattern>
         <Harmony>
             <name>em69</name>
         </Harmony>
@@ -57074,7 +57074,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X22O2O</pattern>
+        <pattern>X[2-O][2-O]O[2-O]O</pattern>
         <Harmony>
             <name>em6/b</name>
         </Harmony>
@@ -57103,7 +57103,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X42OOO</pattern>
+        <pattern>X[4-O][2-O]OOO</pattern>
         <Harmony>
             <name>em6/c#</name>
         </Harmony>
@@ -57132,7 +57132,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2X2O2O</pattern>
+        <pattern>[2-O]X[2-O]O[2-O]O</pattern>
         <Harmony>
             <name>em6/f#</name>
         </Harmony>
@@ -57161,7 +57161,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>322O2O</pattern>
+        <pattern>[3-O][2-O][2-O]O[2-O]O</pattern>
         <Harmony>
             <name>em6/g</name>
         </Harmony>
@@ -57190,7 +57190,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O22O3O</pattern>
+        <pattern>O[2-O][2-O]O[3-O]O</pattern>
         <Harmony>
             <name>em7</name>
         </Harmony>
@@ -57219,7 +57219,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O2OOOO</pattern>
+        <pattern>O[2-O]OOOO</pattern>
         <Harmony>
             <name>em7</name>
         </Harmony>
@@ -57249,7 +57249,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O7X785</pattern>
+        <pattern>O[7-O]X[7-O][8-O][5-O]</pattern>
         <Harmony>
             <name>em7(add4)</name>
         </Harmony>
@@ -57270,7 +57270,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--7--</pattern>
+        <pattern>X--[7-O]--;B5[1-5]</pattern>
         <Harmony>
             <name>em7(add4)/d</name>
         </Harmony>
@@ -57296,7 +57296,7 @@
                 <barre start="2" end="3">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3--33</pattern>
+        <pattern>X[3-O]--[3-O][3-O];B2[2-3]</pattern>
         <Harmony>
             <name>em7(add4)/c</name>
         </Harmony>
@@ -57326,7 +57326,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O7X785</pattern>
+        <pattern>O[7-O]X[7-O][8-O][5-O]</pattern>
         <Harmony>
             <name>em7(add11)</name>
         </Harmony>
@@ -57349,7 +57349,7 @@
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX2---</pattern>
+        <pattern>XX[2-O]---;B3[3-5]</pattern>
         <Harmony>
             <name>em7b5</name>
         </Harmony>
@@ -57372,7 +57372,7 @@
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO2---</pattern>
+        <pattern>XO[2-O]---;B3[3-5]</pattern>
         <Harmony>
             <name>em7b5/a</name>
         </Harmony>
@@ -57395,7 +57395,7 @@
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X12---</pattern>
+        <pattern>X[1-O][2-O]---;B3[3-5]</pattern>
         <Harmony>
             <name>em7b5/bb</name>
         </Harmony>
@@ -57418,7 +57418,7 @@
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X2---</pattern>
+        <pattern>[3-O]X[2-O]---;B3[3-5]</pattern>
         <Harmony>
             <name>em7b5/g</name>
         </Harmony>
@@ -57447,7 +57447,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O22O31</pattern>
+        <pattern>O[2-O][2-O]O[3-O][1-O]</pattern>
         <Harmony>
             <name>em7b9</name>
         </Harmony>
@@ -57470,7 +57470,7 @@
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2X2---</pattern>
+        <pattern>[2-O]X[2-O]---;B3[3-5]</pattern>
         <Harmony>
             <name>em7b5/f#</name>
         </Harmony>
@@ -57499,7 +57499,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO2O3O</pattern>
+        <pattern>XO[2-O]O[3-O]O</pattern>
         <Harmony>
             <name>em7/a</name>
         </Harmony>
@@ -57526,7 +57526,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO-5-</pattern>
+        <pattern>XXO-[5-O]-;B3[3-5]</pattern>
         <Harmony>
             <name>em7b5/d</name>
         </Harmony>
@@ -57555,7 +57555,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X22O3O</pattern>
+        <pattern>X[2-O][2-O]O[3-O]O</pattern>
         <Harmony>
             <name>em7/b</name>
         </Harmony>
@@ -57585,7 +57585,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3543O</pattern>
+        <pattern>X[3-O][5-O][4-O][3-O]O</pattern>
         <Harmony>
             <name>em7/c</name>
         </Harmony>
@@ -57644,7 +57644,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O7X788</pattern>
+        <pattern>O[7-O]X[7-O][8-O][8-O]</pattern>
         <Harmony>
             <name>em7#5</name>
         </Harmony>
@@ -57673,7 +57673,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1O3O</pattern>
+        <pattern>XX[1-O]O[3-O]O</pattern>
         <Harmony>
             <name>em7/eb</name>
         </Harmony>
@@ -57702,7 +57702,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>322O3O</pattern>
+        <pattern>[3-O][2-O][2-O]O[3-O]O</pattern>
         <Harmony>
             <name>em7/g</name>
         </Harmony>
@@ -57731,7 +57731,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1O3O</pattern>
+        <pattern>XX[1-O]O[3-O]O</pattern>
         <Harmony>
             <name>em7/d#</name>
         </Harmony>
@@ -57760,7 +57760,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O2223O</pattern>
+        <pattern>O[2-O][2-O][2-O][3-O]O</pattern>
         <Harmony>
             <name>em7sus4</name>
         </Harmony>
@@ -57789,7 +57789,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O3OO1O</pattern>
+        <pattern>O[3-O]OO[1-O]O</pattern>
         <Harmony>
             <name>em7#9</name>
         </Harmony>
@@ -57818,7 +57818,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O3OO1O</pattern>
+        <pattern>O[3-O]OO[1-O]O</pattern>
         <Harmony>
             <name>em7#9</name>
         </Harmony>
@@ -57847,7 +57847,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O22O32</pattern>
+        <pattern>O[2-O][2-O]O[3-O][2-O]</pattern>
         <Harmony>
             <name>em9</name>
         </Harmony>
@@ -57877,7 +57877,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O7X78X</pattern>
+        <pattern>O[7-O]X[7-O][8-O]X</pattern>
         <Harmony>
             <name>em7(no5)</name>
         </Harmony>
@@ -57906,7 +57906,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX2O32</pattern>
+        <pattern>XX[2-O]O[3-O][2-O]</pattern>
         <Harmony>
             <name>em9(no5)</name>
         </Harmony>
@@ -57935,7 +57935,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO2O32</pattern>
+        <pattern>XO[2-O]O[3-O][2-O]</pattern>
         <Harmony>
             <name>em9/a</name>
         </Harmony>
@@ -57964,7 +57964,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXOO32</pattern>
+        <pattern>XXOO[3-O][2-O]</pattern>
         <Harmony>
             <name>em9/d</name>
         </Harmony>
@@ -57993,7 +57993,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X222O3</pattern>
+        <pattern>X[2-O][2-O][2-O]O[3-O]</pattern>
         <Harmony>
             <name>em(add4)/b</name>
         </Harmony>
@@ -58022,7 +58022,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X22OO2</pattern>
+        <pattern>X[2-O][2-O]OO[2-O]</pattern>
         <Harmony>
             <name>em(add9)/b</name>
         </Harmony>
@@ -58051,7 +58051,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O24OOO</pattern>
+        <pattern>O[2-O][4-O]OOO</pattern>
         <Harmony>
             <name>em(add2)</name>
         </Harmony>
@@ -58081,7 +58081,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX5452</pattern>
+        <pattern>XX[5-O][4-O][5-O][2-O]</pattern>
         <Harmony>
             <name>em(add2)/g</name>
         </Harmony>
@@ -58110,7 +58110,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O222O3</pattern>
+        <pattern>O[2-O][2-O][2-O]O[3-O]</pattern>
         <Harmony>
             <name>em(add4)</name>
         </Harmony>
@@ -58139,7 +58139,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O22OO2</pattern>
+        <pattern>O[2-O][2-O]OO[2-O]</pattern>
         <Harmony>
             <name>em(add9)</name>
         </Harmony>
@@ -58169,7 +58169,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X65OOO</pattern>
+        <pattern>X[6-O][5-O]OOO</pattern>
         <Harmony>
             <name>em(add9)/d</name>
         </Harmony>
@@ -58196,7 +58196,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O-98-9</pattern>
+        <pattern>O-[9-O][8-O]-[9-O];B7[1-4]</pattern>
         <Harmony>
             <name>emaj13</name>
         </Harmony>
@@ -58219,7 +58219,7 @@
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX2---</pattern>
+        <pattern>XX[2-O]---;B4[3-5]</pattern>
         <Harmony>
             <name>emaj7</name>
         </Harmony>
@@ -58248,7 +58248,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX244O</pattern>
+        <pattern>XX[2-O][4-O][4-O]O</pattern>
         <Harmony>
             <name>emaj7(no3)</name>
         </Harmony>
@@ -58274,7 +58274,7 @@
                 <barre start="1" end="2">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--44O</pattern>
+        <pattern>X--[4-O][4-O]O;B2[1-2]</pattern>
         <Harmony>
             <name>emaj7(no3)/b</name>
         </Harmony>
@@ -58298,7 +58298,7 @@
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-----</pattern>
+        <pattern>X-----;B2[1-2];B4[3-5]</pattern>
         <Harmony>
             <name>emaj7/b</name>
         </Harmony>
@@ -58319,7 +58319,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX----</pattern>
+        <pattern>XX----;B4[2-5]</pattern>
         <Harmony>
             <name>emaj7/f#</name>
         </Harmony>
@@ -58348,7 +58348,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X244X</pattern>
+        <pattern>[4-O]X[2-O][4-O][4-O]X</pattern>
         <Harmony>
             <name>emaj7/g#</name>
         </Harmony>
@@ -58377,7 +58377,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX11OO</pattern>
+        <pattern>XX[1-O][1-O]OO</pattern>
         <Harmony>
             <name>emaj7/d#</name>
         </Harmony>
@@ -58406,7 +58406,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2X344</pattern>
+        <pattern>X[2-O]X[3-O][4-O][4-O]</pattern>
         <Harmony>
             <name>emaj7#11</name>
         </Harmony>
@@ -58436,7 +58436,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>466X5X</pattern>
+        <pattern>[4-O][6-O][6-O]X[5-O]X</pattern>
         <Harmony>
             <name>emaj7(no5)/g#</name>
         </Harmony>
@@ -58465,7 +58465,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O211O2</pattern>
+        <pattern>O[2-O][1-O][1-O]O[2-O]</pattern>
         <Harmony>
             <name>emaj9</name>
         </Harmony>
@@ -58495,7 +58495,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O7X898</pattern>
+        <pattern>O[7-O]X[8-O][9-O][8-O]</pattern>
         <Harmony>
             <name>emaj9#5</name>
         </Harmony>
@@ -58525,7 +58525,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>OX444O</pattern>
+        <pattern>OX[4-O][4-O][4-O]O</pattern>
         <Harmony>
             <name>emaj9(no3)</name>
         </Harmony>
@@ -58554,7 +58554,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO142</pattern>
+        <pattern>XXO[1-O][4-O][2-O]</pattern>
         <Harmony>
             <name>emaj9/d</name>
         </Harmony>
@@ -58583,7 +58583,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2212X</pattern>
+        <pattern>X[2-O][2-O][1-O][2-O]X</pattern>
         <Harmony>
             <name>emaj9/f</name>
         </Harmony>
@@ -58610,7 +58610,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O7-87-</pattern>
+        <pattern>O[7-O]-[8-O][7-O]-;B6[2-5]</pattern>
         <Harmony>
             <name>emaj9#11</name>
         </Harmony>
@@ -58636,7 +58636,7 @@
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X-44-</pattern>
+        <pattern>[4-O]X-[4-O][4-O]-;B2[2-5]</pattern>
         <Harmony>
             <name>emaj9/g#</name>
         </Harmony>
@@ -58665,7 +58665,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O21O22</pattern>
+        <pattern>O[2-O][1-O]O[2-O][2-O]</pattern>
         <Harmony>
             <name>em(add13)</name>
         </Harmony>
@@ -58694,7 +58694,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O21OOO</pattern>
+        <pattern>O[2-O][1-O]OOO</pattern>
         <Harmony>
             <name>em(#7)</name>
         </Harmony>
@@ -58723,7 +58723,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1OOO</pattern>
+        <pattern>XX[1-O]OOO</pattern>
         <Harmony>
             <name>em(#7)/d#</name>
         </Harmony>
@@ -58752,7 +58752,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O21O32</pattern>
+        <pattern>O[2-O][1-O]O[3-O][2-O]</pattern>
         <Harmony>
             <name>em(add9)</name>
         </Harmony>
@@ -58781,7 +58781,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2X1OOO</pattern>
+        <pattern>[2-O]X[1-O]OOO</pattern>
         <Harmony>
             <name>em(#7)/f#</name>
         </Harmony>
@@ -58810,7 +58810,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>221OOO</pattern>
+        <pattern>[2-O][2-O][1-O]OOO</pattern>
         <Harmony>
             <name>em(#7)/gb</name>
         </Harmony>
@@ -58833,7 +58833,7 @@
                 <barre start="1" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--44-</pattern>
+        <pattern>X--[4-O][4-O]-;B2[1-5]</pattern>
         <Harmony>
             <name>emaj9/b</name>
         </Harmony>
@@ -58862,7 +58862,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO2OOO</pattern>
+        <pattern>XO[2-O]OOO</pattern>
         <Harmony>
             <name>em/a</name>
         </Harmony>
@@ -58891,7 +58891,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>321OOO</pattern>
+        <pattern>[3-O][2-O][1-O]OOO</pattern>
         <Harmony>
             <name>em(#7)/g</name>
         </Harmony>
@@ -58920,7 +58920,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X22OOO</pattern>
+        <pattern>X[2-O][2-O]OOO</pattern>
         <Harmony>
             <name>em/b</name>
         </Harmony>
@@ -58949,7 +58949,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X32OOO</pattern>
+        <pattern>X[3-O][2-O]OOO</pattern>
         <Harmony>
             <name>em/c</name>
         </Harmony>
@@ -58978,7 +58978,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X42OOO</pattern>
+        <pattern>X[4-O][2-O]OOO</pattern>
         <Harmony>
             <name>em/c#</name>
         </Harmony>
@@ -59036,7 +59036,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1OOO</pattern>
+        <pattern>XX[1-O]OOO</pattern>
         <Harmony>
             <name>em/d#</name>
         </Harmony>
@@ -59065,7 +59065,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3OOO</pattern>
+        <pattern>XX[3-O]OOO</pattern>
         <Harmony>
             <name>em/f</name>
         </Harmony>
@@ -59095,7 +59095,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4OOO</pattern>
+        <pattern>XX[4-O]OOO</pattern>
         <Harmony>
             <name>em/f#</name>
         </Harmony>
@@ -59124,7 +59124,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>322OOO</pattern>
+        <pattern>[3-O][2-O][2-O]OOO</pattern>
         <Harmony>
             <name>em/g</name>
         </Harmony>
@@ -59148,7 +59148,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X7---7</pattern>
+        <pattern>X[7-O]---[7-O];B5[2-4]</pattern>
         <Harmony>
             <name>em(#5)</name>
         </Harmony>
@@ -59177,7 +59177,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O222OO</pattern>
+        <pattern>O[2-O][2-O][2-O]OO</pattern>
         <Harmony>
             <name>em(sus4)</name>
         </Harmony>
@@ -59206,7 +59206,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O22XOO</pattern>
+        <pattern>O[2-O][2-O]XOO</pattern>
         <Harmony>
             <name>e5</name>
         </Harmony>
@@ -59235,7 +59235,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO21OO</pattern>
+        <pattern>XO[2-O][1-O]OO</pattern>
         <Harmony>
             <name>e/a</name>
         </Harmony>
@@ -59264,7 +59264,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X221OO</pattern>
+        <pattern>X[2-O][2-O][1-O]OO</pattern>
         <Harmony>
             <name>e/b</name>
         </Harmony>
@@ -59293,7 +59293,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X321OO</pattern>
+        <pattern>X[3-O][2-O][1-O]OO</pattern>
         <Harmony>
             <name>e/c</name>
         </Harmony>
@@ -59322,7 +59322,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X421OO</pattern>
+        <pattern>X[4-O][2-O][1-O]OO</pattern>
         <Harmony>
             <name>e/c#</name>
         </Harmony>
@@ -59351,7 +59351,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO1OO</pattern>
+        <pattern>XXO[1-O]OO</pattern>
         <Harmony>
             <name>e/d</name>
         </Harmony>
@@ -59380,7 +59380,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX11OO</pattern>
+        <pattern>XX[1-O][1-O]OO</pattern>
         <Harmony>
             <name>e/d#</name>
         </Harmony>
@@ -59409,7 +59409,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>1X21OO</pattern>
+        <pattern>[1-O]X[2-O][1-O]OO</pattern>
         <Harmony>
             <name>e/f</name>
         </Harmony>
@@ -59438,7 +59438,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2X21OO</pattern>
+        <pattern>[2-O]X[2-O][1-O]OO</pattern>
         <Harmony>
             <name>e/f#</name>
         </Harmony>
@@ -59467,7 +59467,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X24OO</pattern>
+        <pattern>[4-O]X[2-O][4-O]OO</pattern>
         <Harmony>
             <name>e/g#</name>
         </Harmony>
@@ -59496,7 +59496,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X121OO</pattern>
+        <pattern>X[1-O][2-O][1-O]OO</pattern>
         <Harmony>
             <name>e/bb</name>
         </Harmony>
@@ -59525,7 +59525,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX211O</pattern>
+        <pattern>XX[2-O][1-O][1-O]O</pattern>
         <Harmony>
             <name>e+</name>
         </Harmony>
@@ -59554,7 +59554,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO11O</pattern>
+        <pattern>XXO[1-O][1-O]O</pattern>
         <Harmony>
             <name>e+7</name>
         </Harmony>
@@ -59583,7 +59583,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX2X1O</pattern>
+        <pattern>XX[2-O]X[1-O]O</pattern>
         <Harmony>
             <name>e+(no3)</name>
         </Harmony>
@@ -59609,7 +59609,7 @@
                 <barre start="3" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>332--X</pattern>
+        <pattern>[3-O][3-O][2-O]--X;B1[3-4]</pattern>
         <Harmony>
             <name>e+/g</name>
         </Harmony>
@@ -59639,7 +59639,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX6554</pattern>
+        <pattern>XX[6-O][5-O][5-O][4-O]</pattern>
         <Harmony>
             <name>e+/g#</name>
         </Harmony>
@@ -59669,7 +59669,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X89109X</pattern>
+        <pattern>X[8-O][9-O][10-O][9-O]X</pattern>
         <Harmony>
             <name>e#dim</name>
         </Harmony>
@@ -59698,7 +59698,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3434</pattern>
+        <pattern>XX[3-O][4-O][3-O][4-O]</pattern>
         <Harmony>
             <name>e#dim7</name>
         </Harmony>
@@ -59721,7 +59721,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3---</pattern>
+        <pattern>XX[3-O]---;B1[3-5]</pattern>
         <Harmony>
             <name>e#m</name>
         </Harmony>
@@ -59744,7 +59744,7 @@
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3---</pattern>
+        <pattern>XX[3-O]---;B4[3-5]</pattern>
         <Harmony>
             <name>e#m7b5</name>
         </Harmony>
@@ -59773,7 +59773,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O222OO</pattern>
+        <pattern>O[2-O][2-O][2-O]OO</pattern>
         <Harmony>
             <name>esus</name>
         </Harmony>
@@ -59802,7 +59802,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X422OO</pattern>
+        <pattern>X[4-O][2-O][2-O]OO</pattern>
         <Harmony>
             <name>esus/c#</name>
         </Harmony>
@@ -59831,7 +59831,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O244OO</pattern>
+        <pattern>O[2-O][4-O][4-O]OO</pattern>
         <Harmony>
             <name>esus2</name>
         </Harmony>
@@ -59861,7 +59861,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X444OO</pattern>
+        <pattern>X[4-O][4-O][4-O]OO</pattern>
         <Harmony>
             <name>esus2/c#</name>
         </Harmony>
@@ -59884,7 +59884,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X3---</pattern>
+        <pattern>[4-O]X[3-O]---;B1[3-5]</pattern>
         <Harmony>
             <name>e#m/g#</name>
         </Harmony>
@@ -59914,7 +59914,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO452</pattern>
+        <pattern>XXO[4-O][5-O][2-O]</pattern>
         <Harmony>
             <name>esus2/d</name>
         </Harmony>
@@ -59944,7 +59944,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X44OO</pattern>
+        <pattern>[4-O]X[4-O][4-O]OO</pattern>
         <Harmony>
             <name>esus2/g#</name>
         </Harmony>
@@ -59973,7 +59973,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO2XO2</pattern>
+        <pattern>XO[2-O]XO[2-O]</pattern>
         <Harmony>
             <name>esus2/a</name>
         </Harmony>
@@ -60002,7 +60002,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O222O2</pattern>
+        <pattern>O[2-O][2-O][2-O]O[2-O]</pattern>
         <Harmony>
             <name>e(add2sus4)</name>
         </Harmony>
@@ -60031,7 +60031,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O242OO</pattern>
+        <pattern>O[2-O][4-O][2-O]OO</pattern>
         <Harmony>
             <name>esus2add4</name>
         </Harmony>
@@ -60060,7 +60060,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O242OO</pattern>
+        <pattern>O[2-O][4-O][2-O]OO</pattern>
         <Harmony>
             <name>esus4add2</name>
         </Harmony>
@@ -60090,7 +60090,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O989XX</pattern>
+        <pattern>O[9-O][8-O][9-O]XX</pattern>
         <Harmony>
             <name>e(#4sus2)</name>
         </Harmony>
@@ -60116,7 +60116,7 @@
                 <barre start="4" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX----</pattern>
+        <pattern>XX----;B4[2-3];B5[4-5]</pattern>
         <Harmony>
             <name>e(add2sus4)/f#</name>
         </Harmony>
@@ -60145,7 +60145,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O242OO</pattern>
+        <pattern>O[2-O][4-O][2-O]OO</pattern>
         <Harmony>
             <name>e(add9sus4)</name>
         </Harmony>
@@ -60175,7 +60175,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO2455</pattern>
+        <pattern>XO[2-O][4-O][5-O][5-O]</pattern>
         <Harmony>
             <name>esus/a</name>
         </Harmony>
@@ -60204,7 +60204,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X222OO</pattern>
+        <pattern>X[2-O][2-O][2-O]OO</pattern>
         <Harmony>
             <name>esus/b</name>
         </Harmony>
@@ -60233,7 +60233,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO2OO</pattern>
+        <pattern>XXO[2-O]OO</pattern>
         <Harmony>
             <name>esus/d</name>
         </Harmony>
@@ -60262,7 +60262,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>1222OO</pattern>
+        <pattern>[1-O][2-O][2-O][2-O]OO</pattern>
         <Harmony>
             <name>esus/f</name>
         </Harmony>
@@ -60291,7 +60291,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2222OO</pattern>
+        <pattern>[2-O][2-O][2-O][2-O]OO</pattern>
         <Harmony>
             <name>esus/f#</name>
         </Harmony>
@@ -60320,7 +60320,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X22OO</pattern>
+        <pattern>[3-O]X[2-O][2-O]OO</pattern>
         <Harmony>
             <name>esus/g</name>
         </Harmony>
@@ -60349,7 +60349,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X22OO</pattern>
+        <pattern>[4-O]X[2-O][2-O]OO</pattern>
         <Harmony>
             <name>esus/g#</name>
         </Harmony>
@@ -60372,7 +60372,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-332--</pattern>
+        <pattern>-[3-O][3-O][2-O]--;B1[0-5]</pattern>
         <Harmony>
             <name>f</name>
         </Harmony>
@@ -60399,7 +60399,7 @@
                 <barre start="2" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX--45</pattern>
+        <pattern>XX--[4-O][5-O];B3[2-3]</pattern>
         <Harmony>
             <name>f11</name>
         </Harmony>
@@ -60428,7 +60428,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>1X122X</pattern>
+        <pattern>[1-O]X[1-O][2-O][2-O]X</pattern>
         <Harmony>
             <name>f11(b13)</name>
         </Harmony>
@@ -60448,7 +60448,7 @@
                 <barre start="0" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>---2-2</pattern>
+        <pattern>---[2-O]-[2-O];B1[0-4]</pattern>
         <Harmony>
             <name>f11b9</name>
         </Harmony>
@@ -60477,7 +60477,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1233</pattern>
+        <pattern>XX[1-O][2-O][3-O][3-O]</pattern>
         <Harmony>
             <name>f13</name>
         </Harmony>
@@ -60500,7 +60500,7 @@
                 <barre start="2" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-4--</pattern>
+        <pattern>XX-[4-O]--;B3[2-5]</pattern>
         <Harmony>
             <name>f13b5</name>
         </Harmony>
@@ -60529,7 +60529,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2X123X</pattern>
+        <pattern>[2-O]X[1-O][2-O][3-O]X</pattern>
         <Harmony>
             <name>f13b9</name>
         </Harmony>
@@ -60558,7 +60558,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO123X</pattern>
+        <pattern>XO[1-O][2-O][3-O]X</pattern>
         <Harmony>
             <name>f13/a</name>
         </Harmony>
@@ -60582,7 +60582,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2-23-</pattern>
+        <pattern>X[2-O]-[2-O][3-O]-</pattern>
         <Harmony>
             <name>f13/b</name>
         </Harmony>
@@ -60612,7 +60612,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3OO45</pattern>
+        <pattern>X[3-O]OO[4-O][5-O]</pattern>
         <Harmony>
             <name>f13/c</name>
         </Harmony>
@@ -60641,7 +60641,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1233</pattern>
+        <pattern>XX[1-O][2-O][3-O][3-O]</pattern>
         <Harmony>
             <name>f13/eb</name>
         </Harmony>
@@ -60670,7 +60670,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX123O</pattern>
+        <pattern>XX[1-O][2-O][3-O]O</pattern>
         <Harmony>
             <name>f13#11</name>
         </Harmony>
@@ -60699,7 +60699,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1234</pattern>
+        <pattern>XX[1-O][2-O][3-O][4-O]</pattern>
         <Harmony>
             <name>f13#9</name>
         </Harmony>
@@ -60726,7 +60726,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X8-89-</pattern>
+        <pattern>X[8-O]-[8-O][9-O]-;B7[2-5]</pattern>
         <Harmony>
             <name>f13(#11#9)</name>
         </Harmony>
@@ -60748,7 +60748,7 @@
                 <barre start="1" end="3">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>----3-</pattern>
+        <pattern>----[3-O]-;B1[0-5];B3[1-3]</pattern>
         <Harmony>
             <name>f13sus4</name>
         </Harmony>
@@ -60777,7 +60777,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>133XXX</pattern>
+        <pattern>[1-O][3-O][3-O]XXX</pattern>
         <Harmony>
             <name>f5</name>
         </Harmony>
@@ -60807,7 +60807,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X356X</pattern>
+        <pattern>[4-O]X[3-O][5-O][6-O]X</pattern>
         <Harmony>
             <name>f5/ab</name>
         </Harmony>
@@ -60837,7 +60837,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO35XX</pattern>
+        <pattern>XO[3-O][5-O]XX</pattern>
         <Harmony>
             <name>f5/a</name>
         </Harmony>
@@ -60867,7 +60867,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>6X35XX</pattern>
+        <pattern>[6-O]X[3-O][5-O]XX</pattern>
         <Harmony>
             <name>f5/bb</name>
         </Harmony>
@@ -60894,7 +60894,7 @@
                 <barre start="1" end="2">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--56X</pattern>
+        <pattern>X--[5-O][6-O]X;B3[1-2]</pattern>
         <Harmony>
             <name>f5/c</name>
         </Harmony>
@@ -60923,7 +60923,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1X11</pattern>
+        <pattern>XX[1-O]X[1-O][1-O]</pattern>
         <Harmony>
             <name>f5/eb</name>
         </Harmony>
@@ -60952,7 +60952,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O33XXX</pattern>
+        <pattern>O[3-O][3-O]XXX</pattern>
         <Harmony>
             <name>f5/e</name>
         </Harmony>
@@ -60975,7 +60975,7 @@
                 <barre start="0" end="2">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>---XXX</pattern>
+        <pattern>---XXX;B3[0-2]</pattern>
         <Harmony>
             <name>f5/g</name>
         </Harmony>
@@ -61004,7 +61004,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3231</pattern>
+        <pattern>XX[3-O][2-O][3-O][1-O]</pattern>
         <Harmony>
             <name>f6</name>
         </Harmony>
@@ -61033,7 +61033,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3233</pattern>
+        <pattern>XX[3-O][2-O][3-O][3-O]</pattern>
         <Harmony>
             <name>f69()</name>
         </Harmony>
@@ -61062,7 +61062,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3233</pattern>
+        <pattern>XX[3-O][2-O][3-O][3-O]</pattern>
         <Harmony>
             <name>f69</name>
         </Harmony>
@@ -61091,7 +61091,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO3233</pattern>
+        <pattern>XO[3-O][2-O][3-O][3-O]</pattern>
         <Harmony>
             <name>f69/a</name>
         </Harmony>
@@ -61117,7 +61117,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3OOO--</pattern>
+        <pattern>[3-O]OOO--;B1[4-5]</pattern>
         <Harmony>
             <name>f69/g</name>
         </Harmony>
@@ -61146,7 +61146,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO3231</pattern>
+        <pattern>XO[3-O][2-O][3-O][1-O]</pattern>
         <Harmony>
             <name>f6/a</name>
         </Harmony>
@@ -61175,7 +61175,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3X231</pattern>
+        <pattern>X[3-O]X[2-O][3-O][1-O]</pattern>
         <Harmony>
             <name>f6/c</name>
         </Harmony>
@@ -61204,7 +61204,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X323X</pattern>
+        <pattern>[3-O]X[3-O][2-O][3-O]X</pattern>
         <Harmony>
             <name>f6/g</name>
         </Harmony>
@@ -61233,7 +61233,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO231</pattern>
+        <pattern>XXO[2-O][3-O][1-O]</pattern>
         <Harmony>
             <name>f6/d</name>
         </Harmony>
@@ -61262,7 +61262,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4O211</pattern>
+        <pattern>X[4-O]O[2-O][1-O][1-O]</pattern>
         <Harmony>
             <name>f6/db</name>
         </Harmony>
@@ -61291,7 +61291,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX2231</pattern>
+        <pattern>XX[2-O][2-O][3-O][1-O]</pattern>
         <Harmony>
             <name>f6/e</name>
         </Harmony>
@@ -61320,7 +61320,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2OO211</pattern>
+        <pattern>[2-O]OO[2-O][1-O][1-O]</pattern>
         <Harmony>
             <name>f6/gb</name>
         </Harmony>
@@ -61340,7 +61340,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-3-2--</pattern>
+        <pattern>-[3-O]-[2-O]--;B1[0-5]</pattern>
         <Harmony>
             <name>f7</name>
         </Harmony>
@@ -61369,7 +61369,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>1X123X</pattern>
+        <pattern>[1-O]X[1-O][2-O][3-O]X</pattern>
         <Harmony>
             <name>f7(add13)</name>
         </Harmony>
@@ -61396,7 +61396,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X878--</pattern>
+        <pattern>X[8-O][7-O][8-O]--;B6[4-5]</pattern>
         <Harmony>
             <name>f7(add4)</name>
         </Harmony>
@@ -61425,7 +61425,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>1X122X</pattern>
+        <pattern>[1-O]X[1-O][2-O][2-O]X</pattern>
         <Harmony>
             <name>f7b13</name>
         </Harmony>
@@ -61454,7 +61454,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>1X12OX</pattern>
+        <pattern>[1-O]X[1-O][2-O]OX</pattern>
         <Harmony>
             <name>f7b5</name>
         </Harmony>
@@ -61484,7 +61484,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X23242</pattern>
+        <pattern>X[2-O][3-O][2-O][4-O][2-O]</pattern>
         <Harmony>
             <name>f7(b9b5)</name>
         </Harmony>
@@ -61513,7 +61513,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X212OX</pattern>
+        <pattern>X[2-O][1-O][2-O]OX</pattern>
         <Harmony>
             <name>f7b5</name>
         </Harmony>
@@ -61543,7 +61543,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO3445</pattern>
+        <pattern>XO[3-O][4-O][4-O][5-O]</pattern>
         <Harmony>
             <name>f7b5/a</name>
         </Harmony>
@@ -61572,7 +61572,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX12O1</pattern>
+        <pattern>XX[1-O][2-O]O[1-O]</pattern>
         <Harmony>
             <name>f7b5/eb</name>
         </Harmony>
@@ -61598,7 +61598,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3-4-</pattern>
+        <pattern>XX[3-O]-[4-O]-;B2[3-5]</pattern>
         <Harmony>
             <name>f7b9</name>
         </Harmony>
@@ -61627,7 +61627,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO3242</pattern>
+        <pattern>XO[3-O][2-O][4-O][2-O]</pattern>
         <Harmony>
             <name>f7b9/a</name>
         </Harmony>
@@ -61650,7 +61650,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>1X1---</pattern>
+        <pattern>[1-O]X[1-O]---;B2[3-5]</pattern>
         <Harmony>
             <name>f7(b13b9)</name>
         </Harmony>
@@ -61677,7 +61677,7 @@
                 <barre start="3" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO--5</pattern>
+        <pattern>XXO--[5-O];B4[3-4]</pattern>
         <Harmony>
             <name>f7b5/d</name>
         </Harmony>
@@ -61706,7 +61706,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3241</pattern>
+        <pattern>XX[3-O][2-O][4-O][1-O]</pattern>
         <Harmony>
             <name>f7(no5)</name>
         </Harmony>
@@ -61733,7 +61733,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X8-89-</pattern>
+        <pattern>X[8-O]-[8-O][9-O]-;B7[2-5]</pattern>
         <Harmony>
             <name>f7(#9b5)</name>
         </Harmony>
@@ -61763,7 +61763,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO3545</pattern>
+        <pattern>XO[3-O][5-O][4-O][5-O]</pattern>
         <Harmony>
             <name>f7/a</name>
         </Harmony>
@@ -61783,7 +61783,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--2--</pattern>
+        <pattern>X--[2-O]--;B1[1-5]</pattern>
         <Harmony>
             <name>f7/bb</name>
         </Harmony>
@@ -61806,7 +61806,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2-2--</pattern>
+        <pattern>X[2-O]-[2-O]--;B1[2-5]</pattern>
         <Harmony>
             <name>f7/b</name>
         </Harmony>
@@ -61833,7 +61833,7 @@
                 <barre start="1" end="2">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--545</pattern>
+        <pattern>X--[5-O][4-O][5-O];B3[1-2]</pattern>
         <Harmony>
             <name>f7/c</name>
         </Harmony>
@@ -61853,7 +61853,7 @@
                 <barre start="0" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>---3-2</pattern>
+        <pattern>---[3-O]-[2-O];B1[0-4]</pattern>
         <Harmony>
             <name>f7b9sus4</name>
         </Harmony>
@@ -61876,7 +61876,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-2--</pattern>
+        <pattern>XX-[2-O]--;B1[2-5]</pattern>
         <Harmony>
             <name>f7/eb</name>
         </Harmony>
@@ -61905,7 +61905,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>1X12OX</pattern>
+        <pattern>[1-O]X[1-O][2-O]OX</pattern>
         <Harmony>
             <name>f7#11</name>
         </Harmony>
@@ -61928,7 +61928,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O3-2--</pattern>
+        <pattern>O[3-O]-[2-O]--;B1[2-5]</pattern>
         <Harmony>
             <name>f7/e</name>
         </Harmony>
@@ -61954,7 +61954,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-22-</pattern>
+        <pattern>XX-[2-O][2-O]-;B1[2-5]</pattern>
         <Harmony>
             <name>f7#5</name>
         </Harmony>
@@ -61980,7 +61980,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-22-</pattern>
+        <pattern>XX-[2-O][2-O]-;B1[2-5]</pattern>
         <Harmony>
             <name>f7#5/eb</name>
         </Harmony>
@@ -62007,7 +62007,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X8-8-9</pattern>
+        <pattern>X[8-O]-[8-O]-[9-O];B7[2-4]</pattern>
         <Harmony>
             <name>f7(b9#5)</name>
         </Harmony>
@@ -62034,7 +62034,7 @@
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X878--</pattern>
+        <pattern>X[8-O][7-O][8-O]--;B9[4-5]</pattern>
         <Harmony>
             <name>f7(#9#5)</name>
         </Harmony>
@@ -62060,7 +62060,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO-22-</pattern>
+        <pattern>XO-[2-O][2-O]-;B1[2-5]</pattern>
         <Harmony>
             <name>f7#5/a</name>
         </Harmony>
@@ -62086,7 +62086,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-2-4</pattern>
+        <pattern>XX-[2-O]-[4-O];B1[2-4]</pattern>
         <Harmony>
             <name>f7#9</name>
         </Harmony>
@@ -62113,7 +62113,7 @@
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X878--</pattern>
+        <pattern>X[8-O][7-O][8-O]--;B9[4-5]</pattern>
         <Harmony>
             <name>f7(b13#9)</name>
         </Harmony>
@@ -62142,7 +62142,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXX244</pattern>
+        <pattern>XXX[2-O][4-O][4-O]</pattern>
         <Harmony>
             <name>f7#9/a</name>
         </Harmony>
@@ -62169,7 +62169,7 @@
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X878--</pattern>
+        <pattern>X[8-O][7-O][8-O]--;B9[4-5]</pattern>
         <Harmony>
             <name>f7(#9#5)</name>
         </Harmony>
@@ -62198,7 +62198,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4244</pattern>
+        <pattern>XX[4-O][2-O][4-O][4-O]</pattern>
         <Harmony>
             <name>f7(#9b9)</name>
         </Harmony>
@@ -62217,7 +62217,7 @@
                 <barre start="1" end="3">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>------</pattern>
+        <pattern>------;B1[0-5];B3[1-3]</pattern>
         <Harmony>
             <name>f7sus4</name>
         </Harmony>
@@ -62243,7 +62243,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-334-</pattern>
+        <pattern>X-[3-O][3-O][4-O]-;B1[1-5]</pattern>
         <Harmony>
             <name>f7sus4/bb</name>
         </Harmony>
@@ -62266,7 +62266,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3-3--</pattern>
+        <pattern>X[3-O]-[3-O]--;B1[2-5]</pattern>
         <Harmony>
             <name>f7sus4/c</name>
         </Harmony>
@@ -62289,7 +62289,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-3--</pattern>
+        <pattern>XX-[3-O]--;B1[2-5]</pattern>
         <Harmony>
             <name>f7sus4/eb</name>
         </Harmony>
@@ -62312,7 +62312,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X-3--</pattern>
+        <pattern>[3-O]X-[3-O]--;B1[2-5]</pattern>
         <Harmony>
             <name>f7sus4/g</name>
         </Harmony>
@@ -62341,7 +62341,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3243</pattern>
+        <pattern>XX[3-O][2-O][4-O][3-O]</pattern>
         <Harmony>
             <name>f9</name>
         </Harmony>
@@ -62367,7 +62367,7 @@
                 <barre start="3" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>1X1--3</pattern>
+        <pattern>[1-O]X[1-O]--[3-O];B2[3-4]</pattern>
         <Harmony>
             <name>f9b13</name>
         </Harmony>
@@ -62393,7 +62393,7 @@
                 <barre start="3" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X21--3</pattern>
+        <pattern>X[2-O][1-O]--[3-O];B2[3-4]</pattern>
         <Harmony>
             <name>f9(b13b5)</name>
         </Harmony>
@@ -62420,7 +62420,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X8-88-</pattern>
+        <pattern>X[8-O]-[8-O][8-O]-;B7[2-5]</pattern>
         <Harmony>
             <name>f9b5</name>
         </Harmony>
@@ -62450,7 +62450,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6758X</pattern>
+        <pattern>X[6-O][7-O][5-O][8-O]X</pattern>
         <Harmony>
             <name>f9/eb</name>
         </Harmony>
@@ -62479,7 +62479,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO3243</pattern>
+        <pattern>XO[3-O][2-O][4-O][3-O]</pattern>
         <Harmony>
             <name>f9/a</name>
         </Harmony>
@@ -62499,7 +62499,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--2--</pattern>
+        <pattern>X--[2-O]--;B1[1-5]</pattern>
         <Harmony>
             <name>f9/bb</name>
         </Harmony>
@@ -62528,7 +62528,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3X243</pattern>
+        <pattern>X[3-O]X[2-O][4-O][3-O]</pattern>
         <Harmony>
             <name>f9/c</name>
         </Harmony>
@@ -62555,7 +62555,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X8-88-</pattern>
+        <pattern>X[8-O]-[8-O][8-O]-;B7[2-5]</pattern>
         <Harmony>
             <name>f9#11</name>
         </Harmony>
@@ -62582,7 +62582,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X8-88-</pattern>
+        <pattern>X[8-O]-[8-O][8-O]-;B7[2-5]</pattern>
         <Harmony>
             <name>f9b5</name>
         </Harmony>
@@ -62609,7 +62609,7 @@
                 <barre start="3" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X87--9</pattern>
+        <pattern>X[8-O][7-O]--[9-O];B8[3-4]</pattern>
         <Harmony>
             <name>f9#5</name>
         </Harmony>
@@ -62633,7 +62633,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X8X---</pattern>
+        <pattern>X[8-O]X---;B8[3-5]</pattern>
         <Harmony>
             <name>f9(no3)</name>
         </Harmony>
@@ -62656,7 +62656,7 @@
                 <barre start="2" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX--4-</pattern>
+        <pattern>XX--[4-O]-;B3[2-5]</pattern>
         <Harmony>
             <name>f9sus4</name>
         </Harmony>
@@ -62685,7 +62685,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3213</pattern>
+        <pattern>XX[3-O][2-O][1-O][3-O]</pattern>
         <Harmony>
             <name>fadd2</name>
         </Harmony>
@@ -62714,7 +62714,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO3213</pattern>
+        <pattern>XO[3-O][2-O][1-O][3-O]</pattern>
         <Harmony>
             <name>fadd2/a</name>
         </Harmony>
@@ -62740,7 +62740,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-32-3</pattern>
+        <pattern>X-[3-O][2-O]-[3-O];B1[1-4]</pattern>
         <Harmony>
             <name>fadd2/bb</name>
         </Harmony>
@@ -62769,7 +62769,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3X213</pattern>
+        <pattern>X[3-O]X[2-O][1-O][3-O]</pattern>
         <Harmony>
             <name>fadd2/c</name>
         </Harmony>
@@ -62795,7 +62795,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-2-3</pattern>
+        <pattern>XX-[2-O]-[3-O];B1[2-4]</pattern>
         <Harmony>
             <name>fadd2/eb</name>
         </Harmony>
@@ -62824,7 +62824,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X321X</pattern>
+        <pattern>[3-O]X[3-O][2-O][1-O]X</pattern>
         <Harmony>
             <name>fadd2/g</name>
         </Harmony>
@@ -62851,7 +62851,7 @@
                 <barre start="2" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX--65</pattern>
+        <pattern>XX--[6-O][5-O];B3[2-3]</pattern>
         <Harmony>
             <name>fadd4</name>
         </Harmony>
@@ -62878,7 +62878,7 @@
                 <barre start="2" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO--65</pattern>
+        <pattern>XO--[6-O][5-O];B3[2-3]</pattern>
         <Harmony>
             <name>fadd4/a</name>
         </Harmony>
@@ -62907,7 +62907,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3213</pattern>
+        <pattern>XX[3-O][2-O][1-O][3-O]</pattern>
         <Harmony>
             <name>fadd9</name>
         </Harmony>
@@ -62936,7 +62936,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX32O3</pattern>
+        <pattern>XX[3-O][2-O]O[3-O]</pattern>
         <Harmony>
             <name>f(#11add9)</name>
         </Harmony>
@@ -62965,7 +62965,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO3213</pattern>
+        <pattern>XO[3-O][2-O][1-O][3-O]</pattern>
         <Harmony>
             <name>fadd9/a</name>
         </Harmony>
@@ -62994,7 +62994,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO3213</pattern>
+        <pattern>XO[3-O][2-O][1-O][3-O]</pattern>
         <Harmony>
             <name>fadd9/a</name>
         </Harmony>
@@ -63023,7 +63023,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3X213</pattern>
+        <pattern>X[3-O]X[2-O][1-O][3-O]</pattern>
         <Harmony>
             <name>fadd9/c</name>
         </Harmony>
@@ -63052,7 +63052,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3X213</pattern>
+        <pattern>X[3-O]X[2-O][1-O][3-O]</pattern>
         <Harmony>
             <name>fadd9/c</name>
         </Harmony>
@@ -63081,7 +63081,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X321X</pattern>
+        <pattern>[3-O]X[3-O][2-O][1-O]X</pattern>
         <Harmony>
             <name>fadd9/g</name>
         </Harmony>
@@ -63110,7 +63110,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X321X</pattern>
+        <pattern>[3-O]X[3-O][2-O][1-O]X</pattern>
         <Harmony>
             <name>fadd9/g</name>
         </Harmony>
@@ -63139,7 +63139,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>1332OX</pattern>
+        <pattern>[1-O][3-O][3-O][2-O]OX</pattern>
         <Harmony>
             <name>f(#4)</name>
         </Harmony>
@@ -63168,7 +63168,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3214</pattern>
+        <pattern>XX[3-O][2-O][1-O][4-O]</pattern>
         <Harmony>
             <name>f(#9)</name>
         </Harmony>
@@ -63197,7 +63197,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3214</pattern>
+        <pattern>XX[3-O][2-O][1-O][4-O]</pattern>
         <Harmony>
             <name>f(#9)</name>
         </Harmony>
@@ -63227,7 +63227,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X89109X</pattern>
+        <pattern>X[8-O][9-O][10-O][9-O]X</pattern>
         <Harmony>
             <name>fdim</name>
         </Harmony>
@@ -63256,7 +63256,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3434</pattern>
+        <pattern>XX[3-O][4-O][3-O][4-O]</pattern>
         <Harmony>
             <name>fdim7</name>
         </Harmony>
@@ -63285,7 +63285,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO3434</pattern>
+        <pattern>XO[3-O][4-O][3-O][4-O]</pattern>
         <Harmony>
             <name>fdim7/a</name>
         </Harmony>
@@ -63315,7 +63315,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X343X</pattern>
+        <pattern>[4-O]X[3-O][4-O][3-O]X</pattern>
         <Harmony>
             <name>fdim7/ab</name>
         </Harmony>
@@ -63344,7 +63344,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1O1O1</pattern>
+        <pattern>X[1-O]O[1-O]O[1-O]</pattern>
         <Harmony>
             <name>fdim7/bb</name>
         </Harmony>
@@ -63367,7 +63367,7 @@
                 <barre start="1" end="4">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--4-4</pattern>
+        <pattern>X--[4-O]-[4-O];B3[1-4]</pattern>
         <Harmony>
             <name>fdim7/c</name>
         </Harmony>
@@ -63391,7 +63391,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--7-7</pattern>
+        <pattern>X--[7-O]-[7-O];B6[1-4]</pattern>
         <Harmony>
             <name>fdim7/eb</name>
         </Harmony>
@@ -63420,7 +63420,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2XO1O1</pattern>
+        <pattern>[2-O]XO[1-O]O[1-O]</pattern>
         <Harmony>
             <name>fdim7/gb</name>
         </Harmony>
@@ -63449,7 +63449,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXX1O1</pattern>
+        <pattern>XXX[1-O]O[1-O]</pattern>
         <Harmony>
             <name>fdim/ab</name>
         </Harmony>
@@ -63478,7 +63478,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X331OX</pattern>
+        <pattern>X[3-O][3-O][1-O]OX</pattern>
         <Harmony>
             <name>fdim/c</name>
         </Harmony>
@@ -63507,7 +63507,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX11O1</pattern>
+        <pattern>XX[1-O][1-O]O[1-O]</pattern>
         <Harmony>
             <name>fdim/eb</name>
         </Harmony>
@@ -63536,7 +63536,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO1O1</pattern>
+        <pattern>XXO[1-O]O[1-O]</pattern>
         <Harmony>
             <name>fdim/d</name>
         </Harmony>
@@ -63565,7 +63565,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O221OO</pattern>
+        <pattern>O[2-O][2-O][1-O]OO</pattern>
         <Harmony>
             <name>fb</name>
         </Harmony>
@@ -63594,7 +63594,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O22XXX</pattern>
+        <pattern>O[2-O][2-O]XXX</pattern>
         <Harmony>
             <name>fb5</name>
         </Harmony>
@@ -63623,7 +63623,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O241OO</pattern>
+        <pattern>O[2-O][4-O][1-O]OO</pattern>
         <Harmony>
             <name>fbadd2</name>
         </Harmony>
@@ -63652,7 +63652,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2X21O2</pattern>
+        <pattern>[2-O]X[2-O][1-O]O[2-O]</pattern>
         <Harmony>
             <name>fbadd2/gb</name>
         </Harmony>
@@ -63681,7 +63681,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O2212O</pattern>
+        <pattern>O[2-O][2-O][1-O][2-O]O</pattern>
         <Harmony>
             <name>fb6</name>
         </Harmony>
@@ -63710,7 +63710,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O2O1OO</pattern>
+        <pattern>O[2-O]O[1-O]OO</pattern>
         <Harmony>
             <name>fb7</name>
         </Harmony>
@@ -63739,7 +63739,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2212O</pattern>
+        <pattern>X[2-O][2-O][1-O][2-O]O</pattern>
         <Harmony>
             <name>fb6</name>
         </Harmony>
@@ -63768,7 +63768,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX2132</pattern>
+        <pattern>XX[2-O][1-O][3-O][2-O]</pattern>
         <Harmony>
             <name>fb9</name>
         </Harmony>
@@ -63791,7 +63791,7 @@
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX2---</pattern>
+        <pattern>XX[2-O]---;B4[3-5]</pattern>
         <Harmony>
             <name>fbmaj7</name>
         </Harmony>
@@ -63820,7 +63820,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2X344</pattern>
+        <pattern>X[2-O]X[3-O][4-O][4-O]</pattern>
         <Harmony>
             <name>fbmaj7#11</name>
         </Harmony>
@@ -63849,7 +63849,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O211O2</pattern>
+        <pattern>O[2-O][1-O][1-O]O[2-O]</pattern>
         <Harmony>
             <name>fbmaj9</name>
         </Harmony>
@@ -63878,7 +63878,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2221OO</pattern>
+        <pattern>[2-O][2-O][2-O][1-O]OO</pattern>
         <Harmony>
             <name>fb/gb</name>
         </Harmony>
@@ -63907,7 +63907,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X221OO</pattern>
+        <pattern>X[2-O][2-O][1-O]OO</pattern>
         <Harmony>
             <name>fb</name>
         </Harmony>
@@ -63930,7 +63930,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3---</pattern>
+        <pattern>XX[3-O]---;B1[3-5]</pattern>
         <Harmony>
             <name>fm</name>
         </Harmony>
@@ -63960,7 +63960,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X8X896</pattern>
+        <pattern>X[8-O]X[8-O][9-O][6-O]</pattern>
         <Harmony>
             <name>fm11</name>
         </Harmony>
@@ -63977,7 +63977,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4-----</pattern>
+        <pattern>[4-O]-----;B1[1-5]</pattern>
         <Harmony>
             <name>fm11/ab</name>
         </Harmony>
@@ -64007,7 +64007,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X8989X</pattern>
+        <pattern>X[8-O][9-O][8-O][9-O]X</pattern>
         <Harmony>
             <name>fm11b5</name>
         </Harmony>
@@ -64024,7 +64024,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-----</pattern>
+        <pattern>X-----;B1[1-5]</pattern>
         <Harmony>
             <name>fm11/bb</name>
         </Harmony>
@@ -64050,7 +64050,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3-3-</pattern>
+        <pattern>XX[3-O]-[3-O]-;B1[3-5]</pattern>
         <Harmony>
             <name>fm6</name>
         </Harmony>
@@ -64073,7 +64073,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-3-32-</pattern>
+        <pattern>-[3-O]-[3-O][2-O]-;B1[0-5]</pattern>
         <Harmony>
             <name>fm11b13</name>
         </Harmony>
@@ -64102,7 +64102,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3133</pattern>
+        <pattern>XX[3-O][1-O][3-O][3-O]</pattern>
         <Harmony>
             <name>fm69</name>
         </Harmony>
@@ -64131,7 +64131,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X33133</pattern>
+        <pattern>X[3-O][3-O][1-O][3-O][3-O]</pattern>
         <Harmony>
             <name>fm69/c</name>
         </Harmony>
@@ -64158,7 +64158,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-7-8</pattern>
+        <pattern>XX-[7-O]-[8-O];B6[2-4]</pattern>
         <Harmony>
             <name>fm6/ab</name>
         </Harmony>
@@ -64187,7 +64187,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3313X</pattern>
+        <pattern>X[3-O][3-O][1-O][3-O]X</pattern>
         <Harmony>
             <name>fm6/c</name>
         </Harmony>
@@ -64210,7 +64210,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO---</pattern>
+        <pattern>XXO---;B1[3-5]</pattern>
         <Harmony>
             <name>fm6/d</name>
         </Harmony>
@@ -64239,7 +64239,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X313X</pattern>
+        <pattern>[3-O]X[3-O][1-O][3-O]X</pattern>
         <Harmony>
             <name>fm6/g</name>
         </Harmony>
@@ -64256,7 +64256,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-3----</pattern>
+        <pattern>-[3-O]----;B1[0-5]</pattern>
         <Harmony>
             <name>fm7</name>
         </Harmony>
@@ -64286,7 +64286,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X8X896</pattern>
+        <pattern>X[8-O]X[8-O][9-O][6-O]</pattern>
         <Harmony>
             <name>fm7(add11)</name>
         </Harmony>
@@ -64306,7 +64306,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>--3-4-</pattern>
+        <pattern>--[3-O]-[4-O]-;B1[0-5]</pattern>
         <Harmony>
             <name>fm7(add4)</name>
         </Harmony>
@@ -64326,7 +64326,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3---4-</pattern>
+        <pattern>[3-O]---[4-O]-;B1[1-5]</pattern>
         <Harmony>
             <name>fm7(add4)/g</name>
         </Harmony>
@@ -64349,7 +64349,7 @@
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3---</pattern>
+        <pattern>XX[3-O]---;B4[3-5]</pattern>
         <Harmony>
             <name>fm7b5</name>
         </Harmony>
@@ -64372,7 +64372,7 @@
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X3---</pattern>
+        <pattern>[4-O]X[3-O]---;B4[3-5]</pattern>
         <Harmony>
             <name>fm7b5/ab</name>
         </Harmony>
@@ -64395,7 +64395,7 @@
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X13---</pattern>
+        <pattern>X[1-O][3-O]---;B4[3-5]</pattern>
         <Harmony>
             <name>fm7b5/bb</name>
         </Harmony>
@@ -64419,7 +64419,7 @@
                 <barre start="0" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>--9-9X</pattern>
+        <pattern>--[9-O]-[9-O]X;B8[0-3]</pattern>
         <Harmony>
             <name>fm7b5/c</name>
         </Harmony>
@@ -64442,7 +64442,7 @@
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X23---</pattern>
+        <pattern>X[2-O][3-O]---;B4[3-5]</pattern>
         <Harmony>
             <name>fm7b5</name>
         </Harmony>
@@ -64472,7 +64472,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6646X</pattern>
+        <pattern>X[6-O][6-O][4-O][6-O]X</pattern>
         <Harmony>
             <name>fm7b5/eb</name>
         </Harmony>
@@ -64502,7 +64502,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX6878</pattern>
+        <pattern>XX[6-O][8-O][7-O][8-O]</pattern>
         <Harmony>
             <name>fm7b9/ab</name>
         </Harmony>
@@ -64528,7 +64528,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3-4-</pattern>
+        <pattern>XX[3-O]-[4-O]-;B1[3-5]</pattern>
         <Harmony>
             <name>fm7(no5)</name>
         </Harmony>
@@ -64548,7 +64548,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X----</pattern>
+        <pattern>[4-O]X----;B1[2-5]</pattern>
         <Harmony>
             <name>fm7/ab</name>
         </Harmony>
@@ -64565,7 +64565,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-----</pattern>
+        <pattern>X-----;B1[1-5]</pattern>
         <Harmony>
             <name>fm7/bb</name>
         </Harmony>
@@ -64585,7 +64585,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3----</pattern>
+        <pattern>X[3-O]----;B1[2-5]</pattern>
         <Harmony>
             <name>fm7/c</name>
         </Harmony>
@@ -64605,7 +64605,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX----</pattern>
+        <pattern>XX----;B1[2-5]</pattern>
         <Harmony>
             <name>fm7/eb</name>
         </Harmony>
@@ -64625,7 +64625,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X----</pattern>
+        <pattern>[3-O]X----;B1[2-5]</pattern>
         <Harmony>
             <name>fm7/g</name>
         </Harmony>
@@ -64644,7 +64644,7 @@
                 <barre start="1" end="3">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>------</pattern>
+        <pattern>------;B1[0-5];B3[1-3]</pattern>
         <Harmony>
             <name>fm7sus4</name>
         </Harmony>
@@ -64664,7 +64664,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-3---</pattern>
+        <pattern>X-[3-O]---;B1[1-5]</pattern>
         <Harmony>
             <name>f7sus4/bb</name>
         </Harmony>
@@ -64684,7 +64684,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-3---</pattern>
+        <pattern>X-[3-O]---;B1[1-5]</pattern>
         <Harmony>
             <name>f7sus4/bb</name>
         </Harmony>
@@ -64713,7 +64713,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3143</pattern>
+        <pattern>XX[3-O][1-O][4-O][3-O]</pattern>
         <Harmony>
             <name>fm9</name>
         </Harmony>
@@ -64730,7 +64730,7 @@
                 <barre start="0" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-----3</pattern>
+        <pattern>-----[3-O];B1[0-4]</pattern>
         <Harmony>
             <name>fm9(add4)</name>
         </Harmony>
@@ -64754,7 +64754,7 @@
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX6---</pattern>
+        <pattern>XX[6-O]---;B8[3-5]</pattern>
         <Harmony>
             <name>fm9/ab</name>
         </Harmony>
@@ -64780,7 +64780,7 @@
                 <barre start="1" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-3-43</pattern>
+        <pattern>X-[3-O]-[4-O][3-O];B1[1-3]</pattern>
         <Harmony>
             <name>fm9/bb</name>
         </Harmony>
@@ -64804,7 +64804,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--8-8</pattern>
+        <pattern>X--[8-O]-[8-O];B6[1-4]</pattern>
         <Harmony>
             <name>fm9/eb</name>
         </Harmony>
@@ -64827,7 +64827,7 @@
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3---</pattern>
+        <pattern>XX[3-O]---;B4[3-5]</pattern>
         <Harmony>
             <name>fm9b5</name>
         </Harmony>
@@ -64853,7 +64853,7 @@
                 <barre start="3" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3--3</pattern>
+        <pattern>XX[3-O]--[3-O];B1[3-4]</pattern>
         <Harmony>
             <name>fm(add2)</name>
         </Harmony>
@@ -64879,7 +64879,7 @@
                 <barre start="3" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X33--3</pattern>
+        <pattern>X[3-O][3-O]--[3-O];B1[3-4]</pattern>
         <Harmony>
             <name>fm(add2)/c</name>
         </Harmony>
@@ -64903,7 +64903,7 @@
                 <barre start="1" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4---XX</pattern>
+        <pattern>[4-O]---XX;B3[1-3]</pattern>
         <Harmony>
             <name>fm(add4)/ab</name>
         </Harmony>
@@ -64929,7 +64929,7 @@
                 <barre start="3" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3--3</pattern>
+        <pattern>XX[3-O]--[3-O];B1[3-4]</pattern>
         <Harmony>
             <name>fm(add9)</name>
         </Harmony>
@@ -64958,7 +64958,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>1X223X</pattern>
+        <pattern>[1-O]X[2-O][2-O][3-O]X</pattern>
         <Harmony>
             <name>fmaj13</name>
         </Harmony>
@@ -64985,7 +64985,7 @@
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X899--</pattern>
+        <pattern>X[8-O][9-O][9-O]--;B10[4-5]</pattern>
         <Harmony>
             <name>fmaj13#11</name>
         </Harmony>
@@ -65002,7 +65002,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>--3---</pattern>
+        <pattern>--[3-O]---;B1[0-5]</pattern>
         <Harmony>
             <name>fm(add4)</name>
         </Harmony>
@@ -65028,7 +65028,7 @@
                 <barre start="2" end="3">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>1X--33</pattern>
+        <pattern>[1-O]X--[3-O][3-O];B2[2-3]</pattern>
         <Harmony>
             <name>f69</name>
         </Harmony>
@@ -65057,7 +65057,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX321O</pattern>
+        <pattern>XX[3-O][2-O][1-O]O</pattern>
         <Harmony>
             <name>fmaj7</name>
         </Harmony>
@@ -65086,7 +65086,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX32OO</pattern>
+        <pattern>XX[3-O][2-O]OO</pattern>
         <Harmony>
             <name>fmaj7b5</name>
         </Harmony>
@@ -65115,7 +65115,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX331O</pattern>
+        <pattern>XX[3-O][3-O][1-O]O</pattern>
         <Harmony>
             <name>fmaj7(add4)</name>
         </Harmony>
@@ -65144,7 +65144,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X332OO</pattern>
+        <pattern>X[3-O][3-O][2-O]OO</pattern>
         <Harmony>
             <name>fmaj7b5/c</name>
         </Harmony>
@@ -65173,7 +65173,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO321O</pattern>
+        <pattern>XO[3-O][2-O][1-O]O</pattern>
         <Harmony>
             <name>fmaj7/a</name>
         </Harmony>
@@ -65202,7 +65202,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1321O</pattern>
+        <pattern>X[1-O][3-O][2-O][1-O]O</pattern>
         <Harmony>
             <name>fmaj7/bb</name>
         </Harmony>
@@ -65231,7 +65231,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3221O</pattern>
+        <pattern>X[3-O][2-O][2-O][1-O]O</pattern>
         <Harmony>
             <name>fmaj7/c</name>
         </Harmony>
@@ -65261,7 +65261,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X53555</pattern>
+        <pattern>X[5-O][3-O][5-O][5-O][5-O]</pattern>
         <Harmony>
             <name>fmaj7/d</name>
         </Harmony>
@@ -65290,7 +65290,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O3321O</pattern>
+        <pattern>O[3-O][3-O][2-O][1-O]O</pattern>
         <Harmony>
             <name>fmaj7/e</name>
         </Harmony>
@@ -65319,7 +65319,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X321O</pattern>
+        <pattern>[3-O]X[3-O][2-O][1-O]O</pattern>
         <Harmony>
             <name>fmaj7/g</name>
         </Harmony>
@@ -65348,7 +65348,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>1X22OO</pattern>
+        <pattern>[1-O]X[2-O][2-O]OO</pattern>
         <Harmony>
             <name>fmaj7#11</name>
         </Harmony>
@@ -65377,7 +65377,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX322O</pattern>
+        <pattern>XX[3-O][2-O][2-O]O</pattern>
         <Harmony>
             <name>fmaj7#5</name>
         </Harmony>
@@ -65406,7 +65406,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO322O</pattern>
+        <pattern>XO[3-O][2-O][2-O]O</pattern>
         <Harmony>
             <name>fmaj7#5/a</name>
         </Harmony>
@@ -65435,7 +65435,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX331O</pattern>
+        <pattern>XX[3-O][3-O][1-O]O</pattern>
         <Harmony>
             <name>fmaj7sus4</name>
         </Harmony>
@@ -65464,7 +65464,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>1X2O1O</pattern>
+        <pattern>[1-O]X[2-O]O[1-O]O</pattern>
         <Harmony>
             <name>fmaj9</name>
         </Harmony>
@@ -65493,7 +65493,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO3O1O</pattern>
+        <pattern>XO[3-O]O[1-O]O</pattern>
         <Harmony>
             <name>fmaj9/a</name>
         </Harmony>
@@ -65522,7 +65522,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X33O1O</pattern>
+        <pattern>X[3-O][3-O]O[1-O]O</pattern>
         <Harmony>
             <name>fmaj9/c</name>
         </Harmony>
@@ -65543,7 +65543,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6----</pattern>
+        <pattern>X[6-O]----;B5[2-5]</pattern>
         <Harmony>
             <name>fmaj9/eb</name>
         </Harmony>
@@ -65572,7 +65572,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X3O1O</pattern>
+        <pattern>[3-O]X[3-O]O[1-O]O</pattern>
         <Harmony>
             <name>fmaj9/g</name>
         </Harmony>
@@ -65601,7 +65601,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>1X2OOO</pattern>
+        <pattern>[1-O]X[2-O]OOO</pattern>
         <Harmony>
             <name>fmaj9#11</name>
         </Harmony>
@@ -65628,7 +65628,7 @@
                 <barre start="3" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X810--10</pattern>
+        <pattern>X[8-O][10-O]--[10-O];B9[3-4]</pattern>
         <Harmony>
             <name>fm13(maj7)</name>
         </Harmony>
@@ -65655,7 +65655,7 @@
                 <barre start="3" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X810--10</pattern>
+        <pattern>X[8-O][10-O]--[10-O];B9[3-4]</pattern>
         <Harmony>
             <name>fm13(maj7)</name>
         </Harmony>
@@ -65675,7 +65675,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-32---</pattern>
+        <pattern>-[3-O][2-O]---;B1[0-5]</pattern>
         <Harmony>
             <name>fm(#7)</name>
         </Harmony>
@@ -65698,7 +65698,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X2---</pattern>
+        <pattern>[4-O]X[2-O]---;B1[3-5]</pattern>
         <Harmony>
             <name>fm(#7)/ab</name>
         </Harmony>
@@ -65721,7 +65721,7 @@
                 <barre start="0" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-32--3</pattern>
+        <pattern>-[3-O][2-O]--[3-O];B1[0-4]</pattern>
         <Harmony>
             <name>fm(add9)</name>
         </Harmony>
@@ -65744,7 +65744,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>332---</pattern>
+        <pattern>[3-O][3-O][2-O]---;B1[3-5]</pattern>
         <Harmony>
             <name>fm(#7)/g</name>
         </Harmony>
@@ -65767,7 +65767,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X3---</pattern>
+        <pattern>[4-O]X[3-O]---;B1[3-5]</pattern>
         <Harmony>
             <name>fm/ab</name>
         </Harmony>
@@ -65790,7 +65790,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X23---</pattern>
+        <pattern>X[2-O][3-O]---;B1[3-5]</pattern>
         <Harmony>
             <name>fm/b</name>
         </Harmony>
@@ -65810,7 +65810,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-3---</pattern>
+        <pattern>X-[3-O]---;B1[1-5]</pattern>
         <Harmony>
             <name>fm/bb</name>
         </Harmony>
@@ -65833,7 +65833,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X33---</pattern>
+        <pattern>X[3-O][3-O]---;B1[3-5]</pattern>
         <Harmony>
             <name>fm/c</name>
         </Harmony>
@@ -65856,7 +65856,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO---</pattern>
+        <pattern>XXO---;B1[3-5]</pattern>
         <Harmony>
             <name>fm/d</name>
         </Harmony>
@@ -65879,7 +65879,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X43---</pattern>
+        <pattern>X[4-O][3-O]---;B1[3-5]</pattern>
         <Harmony>
             <name>fm/db</name>
         </Harmony>
@@ -65902,7 +65902,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX2---</pattern>
+        <pattern>XX[2-O]---;B1[3-5]</pattern>
         <Harmony>
             <name>fm/e</name>
         </Harmony>
@@ -65922,7 +65922,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX----</pattern>
+        <pattern>XX----;B1[2-5]</pattern>
         <Harmony>
             <name>fm/eb</name>
         </Harmony>
@@ -65945,7 +65945,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>233---</pattern>
+        <pattern>[2-O][3-O][3-O]---;B1[3-5]</pattern>
         <Harmony>
             <name>fm/f#</name>
         </Harmony>
@@ -65968,7 +65968,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X3---</pattern>
+        <pattern>[3-O]X[3-O]---;B1[3-5]</pattern>
         <Harmony>
             <name>fm/g</name>
         </Harmony>
@@ -65991,7 +65991,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>233---</pattern>
+        <pattern>[2-O][3-O][3-O]---;B1[3-5]</pattern>
         <Harmony>
             <name>fm/gb</name>
         </Harmony>
@@ -66017,7 +66017,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3-2-</pattern>
+        <pattern>XX[3-O]-[2-O]-;B1[3-5]</pattern>
         <Harmony>
             <name>fm(#5)</name>
         </Harmony>
@@ -66046,7 +66046,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>133XXX</pattern>
+        <pattern>[1-O][3-O][3-O]XXX</pattern>
         <Harmony>
             <name>f5</name>
         </Harmony>
@@ -66075,7 +66075,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1X11</pattern>
+        <pattern>XX[1-O]X[1-O][1-O]</pattern>
         <Harmony>
             <name>f5/eb</name>
         </Harmony>
@@ -66101,7 +66101,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO32--</pattern>
+        <pattern>XO[3-O][2-O]--;B1[4-5]</pattern>
         <Harmony>
             <name>f/a</name>
         </Harmony>
@@ -66128,7 +66128,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX6-6-</pattern>
+        <pattern>XX[6-O]-[6-O]-;B5[3-5]</pattern>
         <Harmony>
             <name>f/ab</name>
         </Harmony>
@@ -66151,7 +66151,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-32--</pattern>
+        <pattern>X-[3-O][2-O]--;B1[1-5]</pattern>
         <Harmony>
             <name>f/bb</name>
         </Harmony>
@@ -66177,7 +66177,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2X2--</pattern>
+        <pattern>X[2-O]X[2-O]--;B1[4-5]</pattern>
         <Harmony>
             <name>f/b</name>
         </Harmony>
@@ -66203,7 +66203,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X332--</pattern>
+        <pattern>X[3-O][3-O][2-O]--;B1[4-5]</pattern>
         <Harmony>
             <name>f/c</name>
         </Harmony>
@@ -66229,7 +66229,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO2--</pattern>
+        <pattern>XXO[2-O]--;B1[4-5]</pattern>
         <Harmony>
             <name>f/d</name>
         </Harmony>
@@ -66255,7 +66255,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X432--</pattern>
+        <pattern>X[4-O][3-O][2-O]--;B1[4-5]</pattern>
         <Harmony>
             <name>f/db</name>
         </Harmony>
@@ -66281,7 +66281,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX22--</pattern>
+        <pattern>XX[2-O][2-O]--;B1[4-5]</pattern>
         <Harmony>
             <name>f/e</name>
         </Harmony>
@@ -66304,7 +66304,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-2--</pattern>
+        <pattern>XX-[2-O]--;B1[2-5]</pattern>
         <Harmony>
             <name>f/eb</name>
         </Harmony>
@@ -66334,7 +66334,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4565</pattern>
+        <pattern>XX[4-O][5-O][6-O][5-O]</pattern>
         <Harmony>
             <name>f/f#</name>
         </Harmony>
@@ -66360,7 +66360,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X32--</pattern>
+        <pattern>[3-O]X[3-O][2-O]--;B1[4-5]</pattern>
         <Harmony>
             <name>f/g</name>
         </Harmony>
@@ -66389,7 +66389,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3221</pattern>
+        <pattern>XX[3-O][2-O][2-O][1-O]</pattern>
         <Harmony>
             <name>f+</name>
         </Harmony>
@@ -66418,7 +66418,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3X221</pattern>
+        <pattern>X[3-O]X[2-O][2-O][1-O]</pattern>
         <Harmony>
             <name>f+/c</name>
         </Harmony>
@@ -66447,7 +66447,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2X221</pattern>
+        <pattern>X[2-O]X[2-O][2-O][1-O]</pattern>
         <Harmony>
             <name>f+/b</name>
         </Harmony>
@@ -66476,7 +66476,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO3221</pattern>
+        <pattern>XO[3-O][2-O][2-O][1-O]</pattern>
         <Harmony>
             <name>f+/a</name>
         </Harmony>
@@ -66502,7 +66502,7 @@
                 <barre start="3" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X43--X</pattern>
+        <pattern>X[4-O][3-O]--X;B2[3-4]</pattern>
         <Harmony>
             <name>f+/c#</name>
         </Harmony>
@@ -66528,7 +66528,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-22-</pattern>
+        <pattern>XX-[2-O][2-O]-;B1[2-5]</pattern>
         <Harmony>
             <name>f+/eb</name>
         </Harmony>
@@ -66557,7 +66557,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO221</pattern>
+        <pattern>XXO[2-O][2-O][1-O]</pattern>
         <Harmony>
             <name>f+/d</name>
         </Harmony>
@@ -66584,7 +66584,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-66-</pattern>
+        <pattern>XX-[6-O][6-O]-;B5[2-5]</pattern>
         <Harmony>
             <name>f+/g</name>
         </Harmony>
@@ -66607,7 +66607,7 @@
                 <barre start="0" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-443--</pattern>
+        <pattern>-[4-O][4-O][3-O]--;B2[0-5]</pattern>
         <Harmony>
             <name>f#</name>
         </Harmony>
@@ -66625,7 +66625,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-----</pattern>
+        <pattern>X-----;B9[1-5]</pattern>
         <Harmony>
             <name>f#11</name>
         </Harmony>
@@ -66654,7 +66654,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX2344</pattern>
+        <pattern>XX[2-O][3-O][4-O][4-O]</pattern>
         <Harmony>
             <name>f#13</name>
         </Harmony>
@@ -66683,7 +66683,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX2343</pattern>
+        <pattern>XX[2-O][3-O][4-O][3-O]</pattern>
         <Harmony>
             <name>f#13b9</name>
         </Harmony>
@@ -66710,7 +66710,7 @@
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X323--</pattern>
+        <pattern>X[3-O][2-O][3-O]--;B4[4-5]</pattern>
         <Harmony>
             <name>f#13#11</name>
         </Harmony>
@@ -66739,7 +66739,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX2344</pattern>
+        <pattern>XX[2-O][3-O][4-O][4-O]</pattern>
         <Harmony>
             <name>f#13/e</name>
         </Harmony>
@@ -66762,7 +66762,7 @@
                 <barre start="0" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-4-44-</pattern>
+        <pattern>-[4-O]-[4-O][4-O]-;B2[0-5]</pattern>
         <Harmony>
             <name>f#13sus4</name>
         </Harmony>
@@ -66791,7 +66791,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>244XXX</pattern>
+        <pattern>[2-O][4-O][4-O]XXX</pattern>
         <Harmony>
             <name>f#5</name>
         </Harmony>
@@ -66821,7 +66821,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O44XXX</pattern>
+        <pattern>O[4-O][4-O]XXX</pattern>
         <Harmony>
             <name>f#5/e</name>
         </Harmony>
@@ -66851,7 +66851,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO46XX</pattern>
+        <pattern>XO[4-O][6-O]XX</pattern>
         <Harmony>
             <name>f#5/a</name>
         </Harmony>
@@ -66875,7 +66875,7 @@
                 <barre start="0" end="2">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>---XXX</pattern>
+        <pattern>---XXX;B4[0-2]</pattern>
         <Harmony>
             <name>f#5/g#</name>
         </Harmony>
@@ -66902,7 +66902,7 @@
                 <barre start="1" end="2">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--67X</pattern>
+        <pattern>X--[6-O][7-O]X;B4[1-2]</pattern>
         <Harmony>
             <name>f#5/c#</name>
         </Harmony>
@@ -66925,7 +66925,7 @@
                 <barre start="1" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-4X--</pattern>
+        <pattern>X-[4-O]X--;B2[1-5]</pattern>
         <Harmony>
             <name>f#5/b</name>
         </Harmony>
@@ -66955,7 +66955,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X546XX</pattern>
+        <pattern>X[5-O][4-O][6-O]XX</pattern>
         <Harmony>
             <name>f#5/d</name>
         </Harmony>
@@ -66982,7 +66982,7 @@
                 <barre start="1" end="2">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O--6XX</pattern>
+        <pattern>O--[6-O]XX;B4[1-2]</pattern>
         <Harmony>
             <name>f#5/e</name>
         </Harmony>
@@ -67011,7 +67011,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4342</pattern>
+        <pattern>XX[4-O][3-O][4-O][2-O]</pattern>
         <Harmony>
             <name>f#6</name>
         </Harmony>
@@ -67040,7 +67040,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4X342</pattern>
+        <pattern>X[4-O]X[3-O][4-O][2-O]</pattern>
         <Harmony>
             <name>f#6/c#</name>
         </Harmony>
@@ -67067,7 +67067,7 @@
                 <barre start="2" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X9--99</pattern>
+        <pattern>X[9-O]--[9-O][9-O];B8[2-3]</pattern>
         <Harmony>
             <name>f#69</name>
         </Harmony>
@@ -67093,7 +67093,7 @@
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-34-</pattern>
+        <pattern>XX-[3-O][4-O]-;B2[2-5]</pattern>
         <Harmony>
             <name>f#6/e</name>
         </Harmony>
@@ -67122,7 +67122,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXX342</pattern>
+        <pattern>XXX[3-O][4-O][2-O]</pattern>
         <Harmony>
             <name>f#6/a#</name>
         </Harmony>
@@ -67142,7 +67142,7 @@
                 <barre start="0" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-4-3--</pattern>
+        <pattern>-[4-O]-[3-O]--;B2[0-5]</pattern>
         <Harmony>
             <name>f#7</name>
         </Harmony>
@@ -67171,7 +67171,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2X23OX</pattern>
+        <pattern>[2-O]X[2-O][3-O]OX</pattern>
         <Harmony>
             <name>f#7(add4)</name>
         </Harmony>
@@ -67200,7 +67200,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX23O2</pattern>
+        <pattern>XX[2-O][3-O]O[2-O]</pattern>
         <Harmony>
             <name>f#7(add4)/e</name>
         </Harmony>
@@ -67229,7 +67229,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2X234X</pattern>
+        <pattern>[2-O]X[2-O][3-O][4-O]X</pattern>
         <Harmony>
             <name>f#7(add13)</name>
         </Harmony>
@@ -67252,7 +67252,7 @@
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2X2---</pattern>
+        <pattern>[2-O]X[2-O]---;B3[3-5]</pattern>
         <Harmony>
             <name>f#7b13</name>
         </Harmony>
@@ -67281,7 +67281,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2X231X</pattern>
+        <pattern>[2-O]X[2-O][3-O][1-O]X</pattern>
         <Harmony>
             <name>f#7b5</name>
         </Harmony>
@@ -67310,7 +67310,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX2323</pattern>
+        <pattern>XX[2-O][3-O][2-O][3-O]</pattern>
         <Harmony>
             <name>f#7(b9b5)</name>
         </Harmony>
@@ -67340,7 +67340,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX455X</pattern>
+        <pattern>XX[4-O][5-O][5-O]X</pattern>
         <Harmony>
             <name>f#7(b5no3)</name>
         </Harmony>
@@ -67367,7 +67367,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4-5-</pattern>
+        <pattern>XX[4-O]-[5-O]-;B3[3-5]</pattern>
         <Harmony>
             <name>f#7b9</name>
         </Harmony>
@@ -67397,7 +67397,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX45OO</pattern>
+        <pattern>XX[4-O][5-O]OO</pattern>
         <Harmony>
             <name>f#7b5sus4</name>
         </Harmony>
@@ -67426,7 +67426,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX2323</pattern>
+        <pattern>XX[2-O][3-O][2-O][3-O]</pattern>
         <Harmony>
             <name>f#7(b13b9)</name>
         </Harmony>
@@ -67450,7 +67450,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX2---</pattern>
+        <pattern>XX[2-O]---;B3[3-5]</pattern>
         <Harmony>
             <name>f#7(b9#5)</name>
         </Harmony>
@@ -67477,7 +67477,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>6X-6-X</pattern>
+        <pattern>[6-O]X-[6-O]-X;B5[2-4]</pattern>
         <Harmony>
             <name>f#7b9/a#</name>
         </Harmony>
@@ -67504,7 +67504,7 @@
                 <barre start="1" end="2">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--65X</pattern>
+        <pattern>X--[6-O][5-O]X;B4[1-2]</pattern>
         <Harmony>
             <name>f#7(no3)/c#</name>
         </Harmony>
@@ -67527,7 +67527,7 @@
                 <barre start="1" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--3-3</pattern>
+        <pattern>X--[3-O]-[3-O];B2[1-4]</pattern>
         <Harmony>
             <name>f#7b9/b</name>
         </Harmony>
@@ -67557,7 +67557,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX465X</pattern>
+        <pattern>XX[4-O][6-O][5-O]X</pattern>
         <Harmony>
             <name>f#7(no3)</name>
         </Harmony>
@@ -67587,7 +67587,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>6X465X</pattern>
+        <pattern>[6-O]X[4-O][6-O][5-O]X</pattern>
         <Harmony>
             <name>f#7/a#</name>
         </Harmony>
@@ -67607,7 +67607,7 @@
                 <barre start="1" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--3--</pattern>
+        <pattern>X--[3-O]--;B2[1-5]</pattern>
         <Harmony>
             <name>f#7/b</name>
         </Harmony>
@@ -67630,7 +67630,7 @@
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4-3--</pattern>
+        <pattern>X[4-O]-[3-O]--;B2[2-5]</pattern>
         <Harmony>
             <name>f#7/c#</name>
         </Harmony>
@@ -67653,7 +67653,7 @@
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-3--</pattern>
+        <pattern>XX-[3-O]--;B2[2-5]</pattern>
         <Harmony>
             <name>f#7/e</name>
         </Harmony>
@@ -67676,7 +67676,7 @@
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X-3--</pattern>
+        <pattern>[3-O]X-[3-O]--;B2[2-5]</pattern>
         <Harmony>
             <name>f#7/g</name>
         </Harmony>
@@ -67699,7 +67699,7 @@
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X-3--</pattern>
+        <pattern>[4-O]X-[3-O]--;B2[2-5]</pattern>
         <Harmony>
             <name>f#7/g#</name>
         </Harmony>
@@ -67728,7 +67728,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2X233X</pattern>
+        <pattern>[2-O]X[2-O][3-O][3-O]X</pattern>
         <Harmony>
             <name>f#+7</name>
         </Harmony>
@@ -67757,7 +67757,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2X231X</pattern>
+        <pattern>[2-O]X[2-O][3-O][1-O]X</pattern>
         <Harmony>
             <name>f#7#11</name>
         </Harmony>
@@ -67783,7 +67783,7 @@
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-33-</pattern>
+        <pattern>XX-[3-O][3-O]-;B2[2-5]</pattern>
         <Harmony>
             <name>f#7#5</name>
         </Harmony>
@@ -67809,7 +67809,7 @@
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-33-</pattern>
+        <pattern>XX-[3-O][3-O]-;B2[2-5]</pattern>
         <Harmony>
             <name>f#7#5/e</name>
         </Harmony>
@@ -67832,7 +67832,7 @@
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2X2---</pattern>
+        <pattern>[2-O]X[2-O]---;B3[3-5]</pattern>
         <Harmony>
             <name>f#7(b9#5)</name>
         </Harmony>
@@ -67859,7 +67859,7 @@
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X989--</pattern>
+        <pattern>X[9-O][8-O][9-O]--;B10[4-5]</pattern>
         <Harmony>
             <name>f#7(#9#5)</name>
         </Harmony>
@@ -67885,7 +67885,7 @@
                 <barre start="3" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X----5</pattern>
+        <pattern>X----[5-O];B2[1-2];B3[3-4]</pattern>
         <Harmony>
             <name>f#7(#9#5)/b</name>
         </Harmony>
@@ -67914,7 +67914,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1233X</pattern>
+        <pattern>X[1-O][2-O][3-O][3-O]X</pattern>
         <Harmony>
             <name>f#7#5/a#</name>
         </Harmony>
@@ -67944,7 +67944,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4355</pattern>
+        <pattern>XX[4-O][3-O][5-O][5-O]</pattern>
         <Harmony>
             <name>f#7#9</name>
         </Harmony>
@@ -67971,7 +67971,7 @@
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X989--</pattern>
+        <pattern>X[9-O][8-O][9-O]--;B10[4-5]</pattern>
         <Harmony>
             <name>f#7(b13#9)</name>
         </Harmony>
@@ -68001,7 +68001,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4X355</pattern>
+        <pattern>X[4-O]X[3-O][5-O][5-O]</pattern>
         <Harmony>
             <name>f#7#9/c#</name>
         </Harmony>
@@ -68020,7 +68020,7 @@
                 <barre start="1" end="3">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>------</pattern>
+        <pattern>------;B2[0-5];B4[1-3]</pattern>
         <Harmony>
             <name>f#7sus4</name>
         </Harmony>
@@ -68047,7 +68047,7 @@
                 <barre start="2" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>6X--5X</pattern>
+        <pattern>[6-O]X--[5-O]X;B4[2-3]</pattern>
         <Harmony>
             <name>f#7sus4/a#</name>
         </Harmony>
@@ -68070,7 +68070,7 @@
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4-4--</pattern>
+        <pattern>X[4-O]-[4-O]--;B2[2-5]</pattern>
         <Harmony>
             <name>f#7sus4/c#</name>
         </Harmony>
@@ -68093,7 +68093,7 @@
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O4-4--</pattern>
+        <pattern>O[4-O]-[4-O]--;B2[2-5]</pattern>
         <Harmony>
             <name>f#7sus4/e</name>
         </Harmony>
@@ -68116,7 +68116,7 @@
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X-4--</pattern>
+        <pattern>[4-O]X-[4-O]--;B2[2-5]</pattern>
         <Harmony>
             <name>f#7sus4/g#</name>
         </Harmony>
@@ -68146,7 +68146,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4354</pattern>
+        <pattern>XX[4-O][3-O][5-O][4-O]</pattern>
         <Harmony>
             <name>f#9</name>
         </Harmony>
@@ -68172,7 +68172,7 @@
                 <barre start="1" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-2-22</pattern>
+        <pattern>X-[2-O]-[2-O][2-O];B1[1-3]</pattern>
         <Harmony>
             <name>f#9/a#</name>
         </Harmony>
@@ -68196,7 +68196,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O98---</pattern>
+        <pattern>O[9-O][8-O]---;B9[3-5]</pattern>
         <Harmony>
             <name>f#9/e</name>
         </Harmony>
@@ -68222,7 +68222,7 @@
                 <barre start="2" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X-3-4</pattern>
+        <pattern>[4-O]X-[3-O]-[4-O];B2[2-4]</pattern>
         <Harmony>
             <name>f#9/g#</name>
         </Harmony>
@@ -68252,7 +68252,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4576</pattern>
+        <pattern>XX[4-O][5-O][7-O][6-O]</pattern>
         <Harmony>
             <name>f#(b5)</name>
         </Harmony>
@@ -68279,7 +68279,7 @@
                 <barre start="3" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X98--10</pattern>
+        <pattern>X[9-O][8-O]--[10-O];B9[3-4]</pattern>
         <Harmony>
             <name>f#9b13</name>
         </Harmony>
@@ -68308,7 +68308,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2X231X</pattern>
+        <pattern>[2-O]X[2-O][3-O][1-O]X</pattern>
         <Harmony>
             <name>f#9b5</name>
         </Harmony>
@@ -68335,7 +68335,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X9-99-</pattern>
+        <pattern>X[9-O]-[9-O][9-O]-;B8[2-5]</pattern>
         <Harmony>
             <name>f#9#11</name>
         </Harmony>
@@ -68364,7 +68364,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX2334</pattern>
+        <pattern>XX[2-O][3-O][3-O][4-O]</pattern>
         <Harmony>
             <name>f#9#5</name>
         </Harmony>
@@ -68388,7 +68388,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX--5-</pattern>
+        <pattern>XX--[5-O]-;B4[2-5]</pattern>
         <Harmony>
             <name>f#9sus4</name>
         </Harmony>
@@ -68417,7 +68417,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4324</pattern>
+        <pattern>XX[4-O][3-O][2-O][4-O]</pattern>
         <Harmony>
             <name>f#add2</name>
         </Harmony>
@@ -68446,7 +68446,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1X122</pattern>
+        <pattern>X[1-O]X[1-O][2-O][2-O]</pattern>
         <Harmony>
             <name>f#add2/a#</name>
         </Harmony>
@@ -68475,7 +68475,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X443X4</pattern>
+        <pattern>X[4-O][4-O][3-O]X[4-O]</pattern>
         <Harmony>
             <name>f#add2/c#</name>
         </Harmony>
@@ -68505,7 +68505,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>6X457X</pattern>
+        <pattern>[6-O]X[4-O][5-O][7-O]X</pattern>
         <Harmony>
             <name>f#(b5)/a</name>
         </Harmony>
@@ -68534,7 +68534,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4324</pattern>
+        <pattern>XX[4-O][3-O][2-O][4-O]</pattern>
         <Harmony>
             <name>f#add9</name>
         </Harmony>
@@ -68563,7 +68563,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX43O2</pattern>
+        <pattern>XX[4-O][3-O]O[2-O]</pattern>
         <Harmony>
             <name>f#add4</name>
         </Harmony>
@@ -68593,7 +68593,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X9101110X</pattern>
+        <pattern>X[9-O][10-O][11-O][10-O]X</pattern>
         <Harmony>
             <name>f#dim</name>
         </Harmony>
@@ -68622,7 +68622,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1212</pattern>
+        <pattern>XX[1-O][2-O][1-O][2-O]</pattern>
         <Harmony>
             <name>f#dim7</name>
         </Harmony>
@@ -68651,7 +68651,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO1212</pattern>
+        <pattern>XO[1-O][2-O][1-O][2-O]</pattern>
         <Harmony>
             <name>f#dim7/a</name>
         </Harmony>
@@ -68674,7 +68674,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--2-2</pattern>
+        <pattern>X--[2-O]-[2-O];B1[1-4]</pattern>
         <Harmony>
             <name>f#dim7/bb</name>
         </Harmony>
@@ -68703,7 +68703,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3424X</pattern>
+        <pattern>X[3-O][4-O][2-O][4-O]X</pattern>
         <Harmony>
             <name>f#dim7/c</name>
         </Harmony>
@@ -68727,7 +68727,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--11-11</pattern>
+        <pattern>X--[11-O]-[11-O];B10[1-4]</pattern>
         <Harmony>
             <name>f#dim7/g</name>
         </Harmony>
@@ -68756,7 +68756,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO421X</pattern>
+        <pattern>XO[4-O][2-O][1-O]X</pattern>
         <Harmony>
             <name>f#dim/a</name>
         </Harmony>
@@ -68782,7 +68782,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-42-2</pattern>
+        <pattern>X-[4-O][2-O]-[2-O];B1[1-4]</pattern>
         <Harmony>
             <name>f#dim/bb</name>
         </Harmony>
@@ -68811,7 +68811,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3421X</pattern>
+        <pattern>X[3-O][4-O][2-O][1-O]X</pattern>
         <Harmony>
             <name>f#dim/c</name>
         </Harmony>
@@ -68840,7 +68840,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1212</pattern>
+        <pattern>XX[1-O][2-O][1-O][2-O]</pattern>
         <Harmony>
             <name>f#dim/d#</name>
         </Harmony>
@@ -68869,7 +68869,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX2212</pattern>
+        <pattern>XX[2-O][2-O][1-O][2-O]</pattern>
         <Harmony>
             <name>f#dim/e</name>
         </Harmony>
@@ -68898,7 +68898,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X421X</pattern>
+        <pattern>[3-O]X[4-O][2-O][1-O]X</pattern>
         <Harmony>
             <name>f#dim/g</name>
         </Harmony>
@@ -68918,7 +68918,7 @@
                 <barre start="0" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-44---</pattern>
+        <pattern>-[4-O][4-O]---;B2[0-5]</pattern>
         <Harmony>
             <name>f#m</name>
         </Harmony>
@@ -68947,7 +68947,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X442OO</pattern>
+        <pattern>X[4-O][4-O][2-O]OO</pattern>
         <Harmony>
             <name>f#m11</name>
         </Harmony>
@@ -68976,7 +68976,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2O22OO</pattern>
+        <pattern>[2-O]O[2-O][2-O]OO</pattern>
         <Harmony>
             <name>f#m11(no5)</name>
         </Harmony>
@@ -69005,7 +69005,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2X122X</pattern>
+        <pattern>[2-O]X[1-O][2-O][2-O]X</pattern>
         <Harmony>
             <name>f#m6</name>
         </Harmony>
@@ -69034,7 +69034,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4244</pattern>
+        <pattern>XX[4-O][2-O][4-O][4-O]</pattern>
         <Harmony>
             <name>f#m69</name>
         </Harmony>
@@ -69057,7 +69057,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO1---</pattern>
+        <pattern>XO[1-O]---;B2[3-5]</pattern>
         <Harmony>
             <name>f#m6/a</name>
         </Harmony>
@@ -69083,7 +69083,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X44-4-</pattern>
+        <pattern>X[4-O][4-O]-[4-O]-;B2[3-5]</pattern>
         <Harmony>
             <name>f#m6/c#</name>
         </Harmony>
@@ -69106,7 +69106,7 @@
                 <barre start="0" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-O-4-O</pattern>
+        <pattern>-O-[4-O]-O;B2[0-4]</pattern>
         <Harmony>
             <name>f#m11b5</name>
         </Harmony>
@@ -69129,7 +69129,7 @@
                 <barre start="0" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-O-4-O</pattern>
+        <pattern>-O-[4-O]-O;B2[0-4]</pattern>
         <Harmony>
             <name>f#m11b5</name>
         </Harmony>
@@ -69152,7 +69152,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1---</pattern>
+        <pattern>XX[1-O]---;B2[3-5]</pattern>
         <Harmony>
             <name>f#m6/d#</name>
         </Harmony>
@@ -69169,7 +69169,7 @@
                 <barre start="0" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-4----</pattern>
+        <pattern>-[4-O]----;B2[0-5]</pattern>
         <Harmony>
             <name>f#m7</name>
         </Harmony>
@@ -69198,7 +69198,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X442OO</pattern>
+        <pattern>X[4-O][4-O][2-O]OO</pattern>
         <Harmony>
             <name>f#m7(add4)</name>
         </Harmony>
@@ -69221,7 +69221,7 @@
                 <barre start="2" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2X---4</pattern>
+        <pattern>[2-O]X---[4-O];B2[2-4]</pattern>
         <Harmony>
             <name>f#m7(add9)</name>
         </Harmony>
@@ -69245,7 +69245,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4---</pattern>
+        <pattern>XX[4-O]---;B5[3-5]</pattern>
         <Harmony>
             <name>f#m7b5</name>
         </Harmony>
@@ -69269,7 +69269,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO4---</pattern>
+        <pattern>XO[4-O]---;B5[3-5]</pattern>
         <Harmony>
             <name>f#m7b5/a</name>
         </Harmony>
@@ -69293,7 +69293,7 @@
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X24---</pattern>
+        <pattern>X[2-O][4-O]---;B5[3-5]</pattern>
         <Harmony>
             <name>f#m7b5/b</name>
         </Harmony>
@@ -69317,7 +69317,7 @@
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X34---</pattern>
+        <pattern>X[3-O][4-O]---;B5[3-5]</pattern>
         <Harmony>
             <name>f#m7b5/c</name>
         </Harmony>
@@ -69341,7 +69341,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X54---</pattern>
+        <pattern>X[5-O][4-O]---;B5[3-5]</pattern>
         <Harmony>
             <name>f#m7b5/d</name>
         </Harmony>
@@ -69365,7 +69365,7 @@
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O34---</pattern>
+        <pattern>O[3-O][4-O]---;B5[3-5]</pattern>
         <Harmony>
             <name>f#m7b5/e</name>
         </Harmony>
@@ -69389,7 +69389,7 @@
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X4---</pattern>
+        <pattern>[3-O]X[4-O]---;B5[3-5]</pattern>
         <Harmony>
             <name>f#m7b5/g</name>
         </Harmony>
@@ -69418,7 +69418,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2X22XX</pattern>
+        <pattern>[2-O]X[2-O][2-O]XX</pattern>
         <Harmony>
             <name>f#m7(no5)</name>
         </Harmony>
@@ -69442,7 +69442,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X4---</pattern>
+        <pattern>[4-O]X[4-O]---;B5[3-5]</pattern>
         <Harmony>
             <name>f#m7b5/g#</name>
         </Harmony>
@@ -69465,7 +69465,7 @@
                 <barre start="2" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2X---3</pattern>
+        <pattern>[2-O]X---[3-O];B2[2-4]</pattern>
         <Harmony>
             <name>f#m7b9</name>
         </Harmony>
@@ -69495,7 +69495,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4553</pattern>
+        <pattern>XX[4-O][5-O][5-O][3-O]</pattern>
         <Harmony>
             <name>f#m7(b9b5)</name>
         </Harmony>
@@ -69515,7 +69515,7 @@
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO----</pattern>
+        <pattern>XO----;B2[2-5]</pattern>
         <Harmony>
             <name>f#m7/a</name>
         </Harmony>
@@ -69544,7 +69544,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX442O</pattern>
+        <pattern>XX[4-O][4-O][2-O]O</pattern>
         <Harmony>
             <name>f#7sus4</name>
         </Harmony>
@@ -69573,7 +69573,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX442O</pattern>
+        <pattern>XX[4-O][4-O][2-O]O</pattern>
         <Harmony>
             <name>f#7sus4</name>
         </Harmony>
@@ -69590,7 +69590,7 @@
                 <barre start="1" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-----</pattern>
+        <pattern>X-----;B2[1-5]</pattern>
         <Harmony>
             <name>f#m7/b</name>
         </Harmony>
@@ -69610,7 +69610,7 @@
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4----</pattern>
+        <pattern>X[4-O]----;B2[2-5]</pattern>
         <Harmony>
             <name>f#m7/c#</name>
         </Harmony>
@@ -69631,7 +69631,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X5----</pattern>
+        <pattern>X[5-O]----;B2[2-5]</pattern>
         <Harmony>
             <name>f#m7/d</name>
         </Harmony>
@@ -69651,7 +69651,7 @@
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX----</pattern>
+        <pattern>XX----;B2[2-5]</pattern>
         <Harmony>
             <name>f#m7/e</name>
         </Harmony>
@@ -69681,7 +69681,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4254</pattern>
+        <pattern>XX[4-O][2-O][5-O][4-O]</pattern>
         <Harmony>
             <name>f#m9</name>
         </Harmony>
@@ -69711,7 +69711,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX7998</pattern>
+        <pattern>XX[7-O][9-O][9-O][8-O]</pattern>
         <Harmony>
             <name>f#m9b5</name>
         </Harmony>
@@ -69734,7 +69734,7 @@
                 <barre start="1" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-4--4</pattern>
+        <pattern>X-[4-O]--[4-O];B2[1-4]</pattern>
         <Harmony>
             <name>f#m(add2)/b</name>
         </Harmony>
@@ -69757,7 +69757,7 @@
                 <barre start="2" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O4---4</pattern>
+        <pattern>O[4-O]---[4-O];B2[2-4]</pattern>
         <Harmony>
             <name>f#m9/e</name>
         </Harmony>
@@ -69786,7 +69786,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X242OO</pattern>
+        <pattern>X[2-O][4-O][2-O]OO</pattern>
         <Harmony>
             <name>f#m(add4)/b</name>
         </Harmony>
@@ -69809,7 +69809,7 @@
                 <barre start="0" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-44--4</pattern>
+        <pattern>-[4-O][4-O]--[4-O];B2[0-4]</pattern>
         <Harmony>
             <name>f#m(add2)</name>
         </Harmony>
@@ -69835,7 +69835,7 @@
                 <barre start="4" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2O44--</pattern>
+        <pattern>[2-O]O[4-O][4-O]--;B2[4-5]</pattern>
         <Harmony>
             <name>f#m(add4)</name>
         </Harmony>
@@ -69858,7 +69858,7 @@
                 <barre start="0" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-44--4</pattern>
+        <pattern>-[4-O][4-O]--[4-O];B2[0-4]</pattern>
         <Harmony>
             <name>f#m(add9)</name>
         </Harmony>
@@ -69887,7 +69887,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2X332X</pattern>
+        <pattern>[2-O]X[3-O][3-O][2-O]X</pattern>
         <Harmony>
             <name>f#maj7</name>
         </Harmony>
@@ -69914,7 +69914,7 @@
                 <barre start="3" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO4--4</pattern>
+        <pattern>XO[4-O]--[4-O];B2[3-4]</pattern>
         <Harmony>
             <name>f#m(add2)/a</name>
         </Harmony>
@@ -69943,7 +69943,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X332X</pattern>
+        <pattern>[4-O]X[3-O][3-O][2-O]X</pattern>
         <Harmony>
             <name>f#maj7/g#</name>
         </Harmony>
@@ -69972,7 +69972,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2X331X</pattern>
+        <pattern>[2-O]X[3-O][3-O][1-O]X</pattern>
         <Harmony>
             <name>f#maj7#11</name>
         </Harmony>
@@ -70002,7 +70002,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X98109X</pattern>
+        <pattern>X[9-O][8-O][10-O][9-O]X</pattern>
         <Harmony>
             <name>f#maj9</name>
         </Harmony>
@@ -70027,7 +70027,7 @@
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-----</pattern>
+        <pattern>X-----;B4[1-2];B6[3-5]</pattern>
         <Harmony>
             <name>f#maj7/c#</name>
         </Harmony>
@@ -70057,7 +70057,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X3344</pattern>
+        <pattern>[4-O]X[3-O][3-O][4-O][4-O]</pattern>
         <Harmony>
             <name>f#maj9/g#</name>
         </Harmony>
@@ -70086,7 +70086,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X432X</pattern>
+        <pattern>[4-O]X[4-O][3-O][2-O]X</pattern>
         <Harmony>
             <name>f#maj9#11</name>
         </Harmony>
@@ -70106,7 +70106,7 @@
                 <barre start="0" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-43---</pattern>
+        <pattern>-[4-O][3-O]---;B2[0-5]</pattern>
         <Harmony>
             <name>f#m(#7)</name>
         </Harmony>
@@ -70129,7 +70129,7 @@
                 <barre start="0" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-43--4</pattern>
+        <pattern>-[4-O][3-O]--[4-O];B2[0-4]</pattern>
         <Harmony>
             <name>f#m(add9)</name>
         </Harmony>
@@ -70155,7 +70155,7 @@
                 <barre start="3" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO3--4</pattern>
+        <pattern>XO[3-O]--[4-O];B2[3-4]</pattern>
         <Harmony>
             <name>f#m(add9)/a</name>
         </Harmony>
@@ -70178,7 +70178,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO4---</pattern>
+        <pattern>XO[4-O]---;B2[3-5]</pattern>
         <Harmony>
             <name>f#m/a</name>
         </Harmony>
@@ -70198,7 +70198,7 @@
                 <barre start="1" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-4---</pattern>
+        <pattern>X-[4-O]---;B2[1-5]</pattern>
         <Harmony>
             <name>f#m/b</name>
         </Harmony>
@@ -70221,7 +70221,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X34---</pattern>
+        <pattern>X[3-O][4-O]---;B2[3-5]</pattern>
         <Harmony>
             <name>f#m/c</name>
         </Harmony>
@@ -70244,7 +70244,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X44---</pattern>
+        <pattern>X[4-O][4-O]---;B2[3-5]</pattern>
         <Harmony>
             <name>f#m/c#</name>
         </Harmony>
@@ -70267,7 +70267,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO---</pattern>
+        <pattern>XXO---;B2[3-5]</pattern>
         <Harmony>
             <name>f#m/d</name>
         </Harmony>
@@ -70290,7 +70290,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1---</pattern>
+        <pattern>XX[1-O]---;B2[3-5]</pattern>
         <Harmony>
             <name>f#m/d#</name>
         </Harmony>
@@ -70310,7 +70310,7 @@
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX----</pattern>
+        <pattern>XX----;B2[2-5]</pattern>
         <Harmony>
             <name>f#m/e</name>
         </Harmony>
@@ -70333,7 +70333,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3---</pattern>
+        <pattern>XX[3-O]---;B2[3-5]</pattern>
         <Harmony>
             <name>f#m/e#</name>
         </Harmony>
@@ -70356,7 +70356,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3---</pattern>
+        <pattern>XX[3-O]---;B2[3-5]</pattern>
         <Harmony>
             <name>f#m/f</name>
         </Harmony>
@@ -70379,7 +70379,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X4---</pattern>
+        <pattern>[3-O]X[4-O]---;B2[3-5]</pattern>
         <Harmony>
             <name>f#m/g</name>
         </Harmony>
@@ -70402,7 +70402,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X4---</pattern>
+        <pattern>[4-O]X[4-O]---;B2[3-5]</pattern>
         <Harmony>
             <name>f#m/g#</name>
         </Harmony>
@@ -70428,7 +70428,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4-3-</pattern>
+        <pattern>XX[4-O]-[3-O]-;B2[3-5]</pattern>
         <Harmony>
             <name>f#m(#5)</name>
         </Harmony>
@@ -70457,7 +70457,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>244XXX</pattern>
+        <pattern>[2-O][4-O][4-O]XXX</pattern>
         <Harmony>
             <name>f#5</name>
         </Harmony>
@@ -70483,7 +70483,7 @@
                 <barre start="4" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXX4--</pattern>
+        <pattern>XXX[4-O]--;B2[4-5]</pattern>
         <Harmony>
             <name>f#5/b</name>
         </Harmony>
@@ -70513,7 +70513,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X46XX</pattern>
+        <pattern>[4-O]X[4-O][6-O]XX</pattern>
         <Harmony>
             <name>f#5/g#</name>
         </Harmony>
@@ -70543,7 +70543,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>6X467X</pattern>
+        <pattern>[6-O]X[4-O][6-O][7-O]X</pattern>
         <Harmony>
             <name>f#/a#</name>
         </Harmony>
@@ -70566,7 +70566,7 @@
                 <barre start="1" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-43--</pattern>
+        <pattern>X-[4-O][3-O]--;B2[1-5]</pattern>
         <Harmony>
             <name>f#/b</name>
         </Harmony>
@@ -70595,7 +70595,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X343XX</pattern>
+        <pattern>X[3-O][4-O][3-O]XX</pattern>
         <Harmony>
             <name>f#/c</name>
         </Harmony>
@@ -70621,7 +70621,7 @@
                 <barre start="4" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X443--</pattern>
+        <pattern>X[4-O][4-O][3-O]--;B2[4-5]</pattern>
         <Harmony>
             <name>f#/c#</name>
         </Harmony>
@@ -70647,7 +70647,7 @@
                 <barre start="4" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO3--</pattern>
+        <pattern>XXO[3-O]--;B2[4-5]</pattern>
         <Harmony>
             <name>f#/d</name>
         </Harmony>
@@ -70673,7 +70673,7 @@
                 <barre start="4" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O443--</pattern>
+        <pattern>O[4-O][4-O][3-O]--;B2[4-5]</pattern>
         <Harmony>
             <name>f#/e</name>
         </Harmony>
@@ -70700,7 +70700,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX33--</pattern>
+        <pattern>XX[3-O][3-O]--;B2[4-5]</pattern>
         <Harmony>
             <name>f#/f</name>
         </Harmony>
@@ -70726,7 +70726,7 @@
                 <barre start="4" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X43--</pattern>
+        <pattern>[3-O]X[4-O][3-O]--;B2[4-5]</pattern>
         <Harmony>
             <name>f#/g</name>
         </Harmony>
@@ -70752,7 +70752,7 @@
                 <barre start="4" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X43--</pattern>
+        <pattern>[4-O]X[4-O][3-O]--;B2[4-5]</pattern>
         <Harmony>
             <name>f#/g#</name>
         </Harmony>
@@ -70781,7 +70781,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4332</pattern>
+        <pattern>XX[4-O][3-O][3-O][2-O]</pattern>
         <Harmony>
             <name>f#+</name>
         </Harmony>
@@ -70810,7 +70810,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO332</pattern>
+        <pattern>XXO[3-O][3-O][2-O]</pattern>
         <Harmony>
             <name>f#+/d</name>
         </Harmony>
@@ -70839,7 +70839,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1O332</pattern>
+        <pattern>X[1-O]O[3-O][3-O][2-O]</pattern>
         <Harmony>
             <name>f#+/a#</name>
         </Harmony>
@@ -70865,7 +70865,7 @@
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-33-</pattern>
+        <pattern>XX-[3-O][3-O]-;B2[2-5]</pattern>
         <Harmony>
             <name>f#+/e</name>
         </Harmony>
@@ -70891,7 +70891,7 @@
                 <barre start="4" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX44--</pattern>
+        <pattern>XX[4-O][4-O]--;B2[4-5]</pattern>
         <Harmony>
             <name>f#sus</name>
         </Harmony>
@@ -70915,7 +70915,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-1111--</pattern>
+        <pattern>X-[11-O][11-O]--;B9[1-5]</pattern>
         <Harmony>
             <name>f#sus2</name>
         </Harmony>
@@ -70944,7 +70944,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4424</pattern>
+        <pattern>XX[4-O][4-O][2-O][4-O]</pattern>
         <Harmony>
             <name>f#sus2add4</name>
         </Harmony>
@@ -70973,7 +70973,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1X122</pattern>
+        <pattern>X[1-O]X[1-O][2-O][2-O]</pattern>
         <Harmony>
             <name>f#sus2/a#</name>
         </Harmony>
@@ -71002,7 +71002,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4424</pattern>
+        <pattern>XX[4-O][4-O][2-O][4-O]</pattern>
         <Harmony>
             <name>f#sus4sus2(add4)</name>
         </Harmony>
@@ -71031,7 +71031,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4424</pattern>
+        <pattern>XX[4-O][4-O][2-O][4-O]</pattern>
         <Harmony>
             <name>f#(add2sus4)</name>
         </Harmony>
@@ -71061,7 +71061,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>6X46OX</pattern>
+        <pattern>[6-O]X[4-O][6-O]OX</pattern>
         <Harmony>
             <name>f#sus/a#</name>
         </Harmony>
@@ -71087,7 +71087,7 @@
                 <barre start="4" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X444--</pattern>
+        <pattern>X[4-O][4-O][4-O]--;B2[4-5]</pattern>
         <Harmony>
             <name>f#sus/c#</name>
         </Harmony>
@@ -71114,7 +71114,7 @@
                 <barre start="2" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6--7X</pattern>
+        <pattern>X[6-O]--[7-O]X;B4[2-3]</pattern>
         <Harmony>
             <name>f#sus/d#</name>
         </Harmony>
@@ -71137,7 +71137,7 @@
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-4--</pattern>
+        <pattern>XX-[4-O]--;B2[2-5]</pattern>
         <Harmony>
             <name>f#sus/e</name>
         </Harmony>
@@ -71163,7 +71163,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX33--</pattern>
+        <pattern>XX[3-O][3-O]--;B1[4-5]</pattern>
         <Harmony>
             <name>fsus</name>
         </Harmony>
@@ -71186,7 +71186,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-333--</pattern>
+        <pattern>-[3-O][3-O][3-O]--;B1[0-5]</pattern>
         <Harmony>
             <name>fsus4</name>
         </Harmony>
@@ -71212,7 +71212,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3O--</pattern>
+        <pattern>XX[3-O]O--;B1[4-5]</pattern>
         <Harmony>
             <name>fsus2</name>
         </Harmony>
@@ -71241,7 +71241,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3OO1</pattern>
+        <pattern>XX[3-O]OO[1-O]</pattern>
         <Harmony>
             <name>f(#4sus2)</name>
         </Harmony>
@@ -71267,7 +71267,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO3O--</pattern>
+        <pattern>XO[3-O]O--;B1[4-5]</pattern>
         <Harmony>
             <name>fsus2/a</name>
         </Harmony>
@@ -71293,7 +71293,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1XO--</pattern>
+        <pattern>X[1-O]XO--;B1[4-5]</pattern>
         <Harmony>
             <name>fsus2/bb</name>
         </Harmony>
@@ -71322,7 +71322,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1O11</pattern>
+        <pattern>XX[1-O]O[1-O][1-O]</pattern>
         <Harmony>
             <name>fsus2/eb</name>
         </Harmony>
@@ -71348,7 +71348,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X33O--</pattern>
+        <pattern>X[3-O][3-O]O--;B1[4-5]</pattern>
         <Harmony>
             <name>fsus2/c</name>
         </Harmony>
@@ -71378,7 +71378,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO563</pattern>
+        <pattern>XXO[5-O][6-O][3-O]</pattern>
         <Harmony>
             <name>fsus2/d</name>
         </Harmony>
@@ -71407,7 +71407,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3313</pattern>
+        <pattern>XX[3-O][3-O][1-O][3-O]</pattern>
         <Harmony>
             <name>fsus4add2</name>
         </Harmony>
@@ -71437,7 +71437,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX5563</pattern>
+        <pattern>XX[5-O][5-O][6-O][3-O]</pattern>
         <Harmony>
             <name>fsus2/g</name>
         </Harmony>
@@ -71463,7 +71463,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O33O--</pattern>
+        <pattern>O[3-O][3-O]O--;B1[4-5]</pattern>
         <Harmony>
             <name>fsus2/e</name>
         </Harmony>
@@ -71492,7 +71492,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3313</pattern>
+        <pattern>XX[3-O][3-O][1-O][3-O]</pattern>
         <Harmony>
             <name>f(add2sus4)</name>
         </Harmony>
@@ -71521,7 +71521,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3313</pattern>
+        <pattern>XX[3-O][3-O][1-O][3-O]</pattern>
         <Harmony>
             <name>f(add9sus4)</name>
         </Harmony>
@@ -71547,7 +71547,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO33--</pattern>
+        <pattern>XO[3-O][3-O]--;B1[4-5]</pattern>
         <Harmony>
             <name>fsus/a</name>
         </Harmony>
@@ -71570,7 +71570,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-33--</pattern>
+        <pattern>X-[3-O][3-O]--;B1[1-5]</pattern>
         <Harmony>
             <name>fsus/bb</name>
         </Harmony>
@@ -71596,7 +71596,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X333--</pattern>
+        <pattern>X[3-O][3-O][3-O]--;B1[4-5]</pattern>
         <Harmony>
             <name>fsus/c</name>
         </Harmony>
@@ -71619,7 +71619,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-3--</pattern>
+        <pattern>XX-[3-O]--;B1[2-5]</pattern>
         <Harmony>
             <name>fsus/eb</name>
         </Harmony>
@@ -71645,7 +71645,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X33--</pattern>
+        <pattern>[3-O]X[3-O][3-O]--;B1[4-5]</pattern>
         <Harmony>
             <name>fsus/g</name>
         </Harmony>
@@ -71674,7 +71674,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XOX213</pattern>
+        <pattern>XOX[2-O][1-O][3-O]</pattern>
         <Harmony>
             <name>fsus2no2add9/a</name>
         </Harmony>
@@ -71703,7 +71703,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>32OOO3</pattern>
+        <pattern>[3-O][2-O]OOO[3-O]</pattern>
         <Harmony>
             <name>g</name>
         </Harmony>
@@ -71729,7 +71729,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>323O--</pattern>
+        <pattern>[3-O][2-O][3-O]O--;B1[4-5]</pattern>
         <Harmony>
             <name>g11</name>
         </Harmony>
@@ -71755,7 +71755,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3XO2--</pattern>
+        <pattern>[3-O]XO[2-O]--;B1[4-5]</pattern>
         <Harmony>
             <name>g11sus4</name>
         </Harmony>
@@ -71781,7 +71781,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3XO2--</pattern>
+        <pattern>[3-O]XO[2-O]--;B1[4-5]</pattern>
         <Harmony>
             <name>g11sus4</name>
         </Harmony>
@@ -71811,7 +71811,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3455</pattern>
+        <pattern>XX[3-O][4-O][5-O][5-O]</pattern>
         <Harmony>
             <name>g13</name>
         </Harmony>
@@ -71841,7 +71841,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3455</pattern>
+        <pattern>XX[3-O][4-O][5-O][5-O]</pattern>
         <Harmony>
             <name>g13/f</name>
         </Harmony>
@@ -71871,7 +71871,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3454</pattern>
+        <pattern>XX[3-O][4-O][5-O][4-O]</pattern>
         <Harmony>
             <name>g13b9</name>
         </Harmony>
@@ -71901,7 +71901,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO3455</pattern>
+        <pattern>XO[3-O][4-O][5-O][5-O]</pattern>
         <Harmony>
             <name>g13/a</name>
         </Harmony>
@@ -71930,7 +71930,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X342O</pattern>
+        <pattern>[3-O]X[3-O][4-O][2-O]O</pattern>
         <Harmony>
             <name>g13#11</name>
         </Harmony>
@@ -71959,7 +71959,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X321O</pattern>
+        <pattern>[3-O]X[3-O][2-O][1-O]O</pattern>
         <Harmony>
             <name>g13sus4</name>
         </Harmony>
@@ -71988,7 +71988,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3XO233</pattern>
+        <pattern>[3-O]XO[2-O][3-O][3-O]</pattern>
         <Harmony>
             <name>gadd2</name>
         </Harmony>
@@ -72017,7 +72017,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO233</pattern>
+        <pattern>XXO[2-O][3-O][3-O]</pattern>
         <Harmony>
             <name>gadd2/d</name>
         </Harmony>
@@ -72047,7 +72047,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>355XXX</pattern>
+        <pattern>[3-O][5-O][5-O]XXX</pattern>
         <Harmony>
             <name>g5</name>
         </Harmony>
@@ -72076,7 +72076,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XOOO33</pattern>
+        <pattern>XOOO[3-O][3-O]</pattern>
         <Harmony>
             <name>g5/a</name>
         </Harmony>
@@ -72106,7 +72106,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X25XXX</pattern>
+        <pattern>X[2-O][5-O]XXX</pattern>
         <Harmony>
             <name>g5/b</name>
         </Harmony>
@@ -72135,7 +72135,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1OO33</pattern>
+        <pattern>X[1-O]OO[3-O][3-O]</pattern>
         <Harmony>
             <name>g5/bb</name>
         </Harmony>
@@ -72159,7 +72159,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3---</pattern>
+        <pattern>XX[3-O]---;B4[3-5]</pattern>
         <Harmony>
             <name>g13(b9b5)</name>
         </Harmony>
@@ -72188,7 +72188,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3OO33</pattern>
+        <pattern>X[3-O]OO[3-O][3-O]</pattern>
         <Harmony>
             <name>g5/c</name>
         </Harmony>
@@ -72217,7 +72217,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXOO33</pattern>
+        <pattern>XXOO[3-O][3-O]</pattern>
         <Harmony>
             <name>g5/d</name>
         </Harmony>
@@ -72243,7 +72243,7 @@
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4OO--</pattern>
+        <pattern>X[4-O]OO--;B3[4-5]</pattern>
         <Harmony>
             <name>g5/db</name>
         </Harmony>
@@ -72272,7 +72272,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX2O33</pattern>
+        <pattern>XX[2-O]O[3-O][3-O]</pattern>
         <Harmony>
             <name>g5/e</name>
         </Harmony>
@@ -72301,7 +72301,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1O33</pattern>
+        <pattern>XX[1-O]O[3-O][3-O]</pattern>
         <Harmony>
             <name>g5/eb</name>
         </Harmony>
@@ -72330,7 +72330,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3O33</pattern>
+        <pattern>XX[3-O]O[3-O][3-O]</pattern>
         <Harmony>
             <name>g5/f</name>
         </Harmony>
@@ -72356,7 +72356,7 @@
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4O--</pattern>
+        <pattern>XX[4-O]O--;B3[4-5]</pattern>
         <Harmony>
             <name>g5/f#</name>
         </Harmony>
@@ -72385,7 +72385,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3XOO23</pattern>
+        <pattern>[3-O]XOO[2-O][3-O]</pattern>
         <Harmony>
             <name>g5#11</name>
         </Harmony>
@@ -72414,7 +72414,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X2OOO</pattern>
+        <pattern>[3-O]X[2-O]OOO</pattern>
         <Harmony>
             <name>g6</name>
         </Harmony>
@@ -72443,7 +72443,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3XOO3O</pattern>
+        <pattern>[3-O]XOO[3-O]O</pattern>
         <Harmony>
             <name>g6(no3)</name>
         </Harmony>
@@ -72472,7 +72472,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3XO2OO</pattern>
+        <pattern>[3-O]XO[2-O]OO</pattern>
         <Harmony>
             <name>g69</name>
         </Harmony>
@@ -72495,7 +72495,7 @@
                 <barre start="1" end="3">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X---33</pattern>
+        <pattern>X---[3-O][3-O];B2[1-3]</pattern>
         <Harmony>
             <name>g69/b</name>
         </Harmony>
@@ -72524,7 +72524,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO2OO3</pattern>
+        <pattern>XO[2-O]OO[3-O]</pattern>
         <Harmony>
             <name>g6/a</name>
         </Harmony>
@@ -72553,7 +72553,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3XO2OO</pattern>
+        <pattern>[3-O]XO[2-O]OO</pattern>
         <Harmony>
             <name>g6(add2)</name>
         </Harmony>
@@ -72582,7 +72582,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2OOOO</pattern>
+        <pattern>X[2-O]OOOO</pattern>
         <Harmony>
             <name>g6/b</name>
         </Harmony>
@@ -72611,7 +72611,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X241O</pattern>
+        <pattern>[3-O]X[2-O][4-O][1-O]O</pattern>
         <Harmony>
             <name>g6(add4)</name>
         </Harmony>
@@ -72641,7 +72641,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO453</pattern>
+        <pattern>XXO[4-O][5-O][3-O]</pattern>
         <Harmony>
             <name>g6/d</name>
         </Harmony>
@@ -72664,7 +72664,7 @@
                 <barre start="0" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-444--</pattern>
+        <pattern>-[4-O][4-O][4-O]--;B2[0-5]</pattern>
         <Harmony>
             <name>g6sus4</name>
         </Harmony>
@@ -72693,7 +72693,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX2OO3</pattern>
+        <pattern>XX[2-O]OO[3-O]</pattern>
         <Harmony>
             <name>g6/e</name>
         </Harmony>
@@ -72722,7 +72722,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2X2OOO</pattern>
+        <pattern>[2-O]X[2-O]OOO</pattern>
         <Harmony>
             <name>g6/f#</name>
         </Harmony>
@@ -72751,7 +72751,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>1X2OO3</pattern>
+        <pattern>[1-O]X[2-O]OO[3-O]</pattern>
         <Harmony>
             <name>g6/f</name>
         </Harmony>
@@ -72780,7 +72780,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>32OOO1</pattern>
+        <pattern>[3-O][2-O]OOO[1-O]</pattern>
         <Harmony>
             <name>g7</name>
         </Harmony>
@@ -72810,7 +72810,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X345X</pattern>
+        <pattern>[3-O]X[3-O][4-O][5-O]X</pattern>
         <Harmony>
             <name>g7(add13)</name>
         </Harmony>
@@ -72836,7 +72836,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>32OO--</pattern>
+        <pattern>[3-O][2-O]OO--;B1[4-5]</pattern>
         <Harmony>
             <name>g7(add4)</name>
         </Harmony>
@@ -72862,7 +72862,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>42OO--</pattern>
+        <pattern>[4-O][2-O]OO--;B1[4-5]</pattern>
         <Harmony>
             <name>g7(add4)/g#</name>
         </Harmony>
@@ -72891,7 +72891,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X344X</pattern>
+        <pattern>[3-O]X[3-O][4-O][4-O]X</pattern>
         <Harmony>
             <name>g7b13</name>
         </Harmony>
@@ -72920,7 +72920,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X342X</pattern>
+        <pattern>[3-O]X[3-O][4-O][2-O]X</pattern>
         <Harmony>
             <name>g7b5</name>
         </Harmony>
@@ -72944,7 +72944,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X10-10--</pattern>
+        <pattern>X[10-O]-[10-O]--;B9[2-5]</pattern>
         <Harmony>
             <name>g7(b9b5)</name>
         </Harmony>
@@ -72974,7 +72974,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>9X9108X</pattern>
+        <pattern>[9-O]X[9-O][10-O][8-O]X</pattern>
         <Harmony>
             <name>g7b5/db</name>
         </Harmony>
@@ -73001,7 +73001,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X10-1011-</pattern>
+        <pattern>X[10-O]-[10-O][11-O]-;B9[2-5]</pattern>
         <Harmony>
             <name>g7(#9b5)</name>
         </Harmony>
@@ -73030,7 +73030,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2XO21</pattern>
+        <pattern>X[2-O]XO[2-O][1-O]</pattern>
         <Harmony>
             <name>g7b5/b</name>
         </Harmony>
@@ -73060,7 +73060,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX5667</pattern>
+        <pattern>XX[5-O][6-O][6-O][7-O]</pattern>
         <Harmony>
             <name>g7b5sus4</name>
         </Harmony>
@@ -73089,7 +73089,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3434</pattern>
+        <pattern>XX[3-O][4-O][3-O][4-O]</pattern>
         <Harmony>
             <name>g7b9</name>
         </Harmony>
@@ -73119,7 +73119,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3454</pattern>
+        <pattern>XX[3-O][4-O][5-O][4-O]</pattern>
         <Harmony>
             <name>g7(b9add13)</name>
         </Harmony>
@@ -73142,7 +73142,7 @@
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X3---</pattern>
+        <pattern>[3-O]X[3-O]---;B4[3-5]</pattern>
         <Harmony>
             <name>g7(b13b9)</name>
         </Harmony>
@@ -73171,7 +73171,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X231O3</pattern>
+        <pattern>X[2-O][3-O][1-O]O[3-O]</pattern>
         <Harmony>
             <name>g7b9/b</name>
         </Harmony>
@@ -73200,7 +73200,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3434</pattern>
+        <pattern>XX[3-O][4-O][3-O][4-O]</pattern>
         <Harmony>
             <name>g7b9/f</name>
         </Harmony>
@@ -73223,7 +73223,7 @@
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3---</pattern>
+        <pattern>XX[3-O]---;B4[3-5]</pattern>
         <Harmony>
             <name>g7(b9#5)</name>
         </Harmony>
@@ -73247,7 +73247,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X10-10--</pattern>
+        <pattern>X[10-O]-[10-O]--;B9[2-5]</pattern>
         <Harmony>
             <name>g7(#11b9)</name>
         </Harmony>
@@ -73270,7 +73270,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3XO---</pattern>
+        <pattern>[3-O]XO---;B1[3-5]</pattern>
         <Harmony>
             <name>g7b9sus4</name>
         </Harmony>
@@ -73299,7 +73299,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X3O33</pattern>
+        <pattern>[3-O]X[3-O]O[3-O][3-O]</pattern>
         <Harmony>
             <name>g7(no3)</name>
         </Harmony>
@@ -73322,7 +73322,7 @@
                 <barre start="2" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO-4--</pattern>
+        <pattern>XO-[4-O]--;B3[2-5]</pattern>
         <Harmony>
             <name>g7/a</name>
         </Harmony>
@@ -73351,7 +73351,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2OOO1</pattern>
+        <pattern>X[2-O]OOO[1-O]</pattern>
         <Harmony>
             <name>g7/b</name>
         </Harmony>
@@ -73380,7 +73380,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1OOO1</pattern>
+        <pattern>X[1-O]OOO[1-O]</pattern>
         <Harmony>
             <name>g7/bb</name>
         </Harmony>
@@ -73409,7 +73409,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3OOO1</pattern>
+        <pattern>X[3-O]OOO[1-O]</pattern>
         <Harmony>
             <name>g7/c</name>
         </Harmony>
@@ -73438,7 +73438,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXOOO1</pattern>
+        <pattern>XXOOO[1-O]</pattern>
         <Harmony>
             <name>g7/d</name>
         </Harmony>
@@ -73467,7 +73467,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1OO1</pattern>
+        <pattern>XX[1-O]OO[1-O]</pattern>
         <Harmony>
             <name>g7/eb</name>
         </Harmony>
@@ -73496,7 +73496,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3OO1</pattern>
+        <pattern>XX[3-O]OO[1-O]</pattern>
         <Harmony>
             <name>g7/f</name>
         </Harmony>
@@ -73525,7 +73525,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X342X</pattern>
+        <pattern>[3-O]X[3-O][4-O][2-O]X</pattern>
         <Harmony>
             <name>g7#11</name>
         </Harmony>
@@ -73554,7 +73554,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X344X</pattern>
+        <pattern>[3-O]X[3-O][4-O][4-O]X</pattern>
         <Harmony>
             <name>g7#5</name>
         </Harmony>
@@ -73577,7 +73577,7 @@
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X3---</pattern>
+        <pattern>[3-O]X[3-O]---;B4[3-5]</pattern>
         <Harmony>
             <name>g7(b9#5)</name>
         </Harmony>
@@ -73603,7 +73603,7 @@
                 <barre start="4" end="5">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X34--</pattern>
+        <pattern>[3-O]X[3-O][4-O]--;B4[4-5]</pattern>
         <Harmony>
             <name>g7(#9#5)</name>
         </Harmony>
@@ -73632,7 +73632,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2344X</pattern>
+        <pattern>X[2-O][3-O][4-O][4-O]X</pattern>
         <Harmony>
             <name>g7#5/b</name>
         </Harmony>
@@ -73658,7 +73658,7 @@
                 <barre start="2" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-44-</pattern>
+        <pattern>XX-[4-O][4-O]-;B3[2-5]</pattern>
         <Harmony>
             <name>g7#5/f</name>
         </Harmony>
@@ -73687,7 +73687,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X3OO1</pattern>
+        <pattern>[3-O]X[3-O]OO[1-O]</pattern>
         <Harmony>
             <name>g7(no5)</name>
         </Harmony>
@@ -73716,7 +73716,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4344X</pattern>
+        <pattern>X[4-O][3-O][4-O][4-O]X</pattern>
         <Harmony>
             <name>g7(#11#5)</name>
         </Harmony>
@@ -73745,7 +73745,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3344X</pattern>
+        <pattern>X[3-O][3-O][4-O][4-O]X</pattern>
         <Harmony>
             <name>g7#5/c</name>
         </Harmony>
@@ -73772,7 +73772,7 @@
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X10910--</pattern>
+        <pattern>X[10-O][9-O][10-O]--;B11[4-5]</pattern>
         <Harmony>
             <name>g7(#9#5)</name>
         </Harmony>
@@ -73802,7 +73802,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX5466</pattern>
+        <pattern>XX[5-O][4-O][6-O][6-O]</pattern>
         <Harmony>
             <name>g7#9</name>
         </Harmony>
@@ -73829,7 +73829,7 @@
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X10910--</pattern>
+        <pattern>X[10-O][9-O][10-O]--;B11[4-5]</pattern>
         <Harmony>
             <name>g7(b13#9)</name>
         </Harmony>
@@ -73855,7 +73855,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3XOO--</pattern>
+        <pattern>[3-O]XOO--;B1[4-5]</pattern>
         <Harmony>
             <name>g7sus4</name>
         </Harmony>
@@ -73876,7 +73876,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-12---</pattern>
+        <pattern>X-[12-O]---;B10[1-5]</pattern>
         <Harmony>
             <name>g7sus2</name>
         </Harmony>
@@ -73899,7 +73899,7 @@
                 <barre start="1" end="3">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-----4</pattern>
+        <pattern>-----[4-O];B3[0-4];B5[1-3]</pattern>
         <Harmony>
             <name>g7b9sus4</name>
         </Harmony>
@@ -73925,7 +73925,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XOOO--</pattern>
+        <pattern>XOOO--;B1[4-5]</pattern>
         <Harmony>
             <name>g7sus4/a</name>
         </Harmony>
@@ -73951,7 +73951,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X3O--</pattern>
+        <pattern>[3-O]X[3-O]O--;B1[4-5]</pattern>
         <Harmony>
             <name>g7(sus4no5)</name>
         </Harmony>
@@ -73975,7 +73975,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X-5--</pattern>
+        <pattern>[4-O]X-[5-O]--;B3[2-5]</pattern>
         <Harmony>
             <name>g7sus4/ab</name>
         </Harmony>
@@ -74001,7 +74001,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3OO--</pattern>
+        <pattern>X[3-O]OO--;B1[4-5]</pattern>
         <Harmony>
             <name>g7sus4/c</name>
         </Harmony>
@@ -74025,7 +74025,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X109---</pattern>
+        <pattern>X[10-O][9-O]---;B10[3-5]</pattern>
         <Harmony>
             <name>g9</name>
         </Harmony>
@@ -74051,7 +74051,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXOO--</pattern>
+        <pattern>XXOO--;B1[4-5]</pattern>
         <Harmony>
             <name>g7sus4/d</name>
         </Harmony>
@@ -74077,7 +74077,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3O--</pattern>
+        <pattern>XX[3-O]O--;B1[4-5]</pattern>
         <Harmony>
             <name>g7sus4/f</name>
         </Harmony>
@@ -74107,7 +74107,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3445</pattern>
+        <pattern>XX[3-O][4-O][4-O][5-O]</pattern>
         <Harmony>
             <name>g9b13</name>
         </Harmony>
@@ -74136,7 +74136,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX32O3</pattern>
+        <pattern>XX[3-O][2-O]O[3-O]</pattern>
         <Harmony>
             <name>g9/f</name>
         </Harmony>
@@ -74165,7 +74165,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X322X</pattern>
+        <pattern>[3-O]X[3-O][2-O][2-O]X</pattern>
         <Harmony>
             <name>g9(b5no3)</name>
         </Harmony>
@@ -74189,7 +74189,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX9---</pattern>
+        <pattern>XX[9-O]---;B10[3-5]</pattern>
         <Harmony>
             <name>g9/b</name>
         </Harmony>
@@ -74218,7 +74218,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3O2O1</pattern>
+        <pattern>X[3-O]O[2-O]O[1-O]</pattern>
         <Harmony>
             <name>g9/c</name>
         </Harmony>
@@ -74247,7 +74247,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X342X</pattern>
+        <pattern>[3-O]X[3-O][4-O][2-O]X</pattern>
         <Harmony>
             <name>g9b5</name>
         </Harmony>
@@ -74271,7 +74271,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>10X9---</pattern>
+        <pattern>[10-O]X[9-O]---;B10[3-5]</pattern>
         <Harmony>
             <name>g9/d</name>
         </Harmony>
@@ -74295,7 +74295,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO9---</pattern>
+        <pattern>XO[9-O]---;B10[3-5]</pattern>
         <Harmony>
             <name>g9/a</name>
         </Harmony>
@@ -74322,7 +74322,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X10-1010-</pattern>
+        <pattern>X[10-O]-[10-O][10-O]-;B9[2-5]</pattern>
         <Harmony>
             <name>g9#11</name>
         </Harmony>
@@ -74352,7 +74352,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3445</pattern>
+        <pattern>XX[3-O][4-O][4-O][5-O]</pattern>
         <Harmony>
             <name>g9#5</name>
         </Harmony>
@@ -74379,7 +74379,7 @@
                 <barre start="3" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3--5</pattern>
+        <pattern>XX[3-O]--[5-O];B4[3-4]</pattern>
         <Harmony>
             <name>g9#5/f</name>
         </Harmony>
@@ -74402,7 +74402,7 @@
                 <barre start="1" end="3">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-----5</pattern>
+        <pattern>-----[5-O];B3[0-4];B5[1-3]</pattern>
         <Harmony>
             <name>g9sus4</name>
         </Harmony>
@@ -74431,7 +74431,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3XO2O3</pattern>
+        <pattern>[3-O]XO[2-O]O[3-O]</pattern>
         <Harmony>
             <name>gadd2</name>
         </Harmony>
@@ -74460,7 +74460,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XOO2O3</pattern>
+        <pattern>XOO[2-O]O[3-O]</pattern>
         <Harmony>
             <name>gadd2/a</name>
         </Harmony>
@@ -74489,7 +74489,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2O2O3</pattern>
+        <pattern>X[2-O]O[2-O]O[3-O]</pattern>
         <Harmony>
             <name>gadd2/b</name>
         </Harmony>
@@ -74518,7 +74518,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3X2O3</pattern>
+        <pattern>X[3-O]X[2-O]O[3-O]</pattern>
         <Harmony>
             <name>gadd2/c</name>
         </Harmony>
@@ -74547,7 +74547,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO2O3</pattern>
+        <pattern>XXO[2-O]O[3-O]</pattern>
         <Harmony>
             <name>gadd2/d</name>
         </Harmony>
@@ -74576,7 +74576,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX22O3</pattern>
+        <pattern>XX[2-O][2-O]O[3-O]</pattern>
         <Harmony>
             <name>gadd2/e</name>
         </Harmony>
@@ -74605,7 +74605,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>32OO13</pattern>
+        <pattern>[3-O][2-O]OO[1-O][3-O]</pattern>
         <Harmony>
             <name>gadd4</name>
         </Harmony>
@@ -74634,7 +74634,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2XO2O3</pattern>
+        <pattern>[2-O]XO[2-O]O[3-O]</pattern>
         <Harmony>
             <name>gadd2/f#</name>
         </Harmony>
@@ -74660,7 +74660,7 @@
                 <barre start="3" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3XO--3</pattern>
+        <pattern>[3-O]XO--[3-O];B2[3-4]</pattern>
         <Harmony>
             <name>g(#4)/c#</name>
         </Harmony>
@@ -74690,7 +74690,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO5O3</pattern>
+        <pattern>XXO[5-O]O[3-O]</pattern>
         <Harmony>
             <name>gadd4/d</name>
         </Harmony>
@@ -74719,7 +74719,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3XO3O3</pattern>
+        <pattern>[3-O]XO[3-O]O[3-O]</pattern>
         <Harmony>
             <name>g(#9)</name>
         </Harmony>
@@ -74748,7 +74748,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3XO3O3</pattern>
+        <pattern>[3-O]XO[3-O]O[3-O]</pattern>
         <Harmony>
             <name>g(#9)</name>
         </Harmony>
@@ -74777,7 +74777,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2OO13</pattern>
+        <pattern>X[2-O]OO[1-O][3-O]</pattern>
         <Harmony>
             <name>gadd4/b</name>
         </Harmony>
@@ -74806,7 +74806,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3XO2O3</pattern>
+        <pattern>[3-O]XO[2-O]O[3-O]</pattern>
         <Harmony>
             <name>gadd9</name>
         </Harmony>
@@ -74835,7 +74835,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XOO2O3</pattern>
+        <pattern>XOO[2-O]O[3-O]</pattern>
         <Harmony>
             <name>gadd9/a</name>
         </Harmony>
@@ -74864,7 +74864,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3OOO3</pattern>
+        <pattern>X[3-O]OOO[3-O]</pattern>
         <Harmony>
             <name>gadd4/c</name>
         </Harmony>
@@ -74893,7 +74893,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2O2O3</pattern>
+        <pattern>X[2-O]O[2-O]O[3-O]</pattern>
         <Harmony>
             <name>gadd9/b</name>
         </Harmony>
@@ -74922,7 +74922,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO2O3</pattern>
+        <pattern>XXO[2-O]O[3-O]</pattern>
         <Harmony>
             <name>gadd9/d</name>
         </Harmony>
@@ -74951,7 +74951,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>12OO1X</pattern>
+        <pattern>[1-O][2-O]OO[1-O]X</pattern>
         <Harmony>
             <name>gadd4/f</name>
         </Harmony>
@@ -74980,7 +74980,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX32O3</pattern>
+        <pattern>XX[3-O][2-O]O[3-O]</pattern>
         <Harmony>
             <name>gadd9/f</name>
         </Harmony>
@@ -75007,7 +75007,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-54-5</pattern>
+        <pattern>X-[5-O][4-O]-[5-O];B3[1-4]</pattern>
         <Harmony>
             <name>gadd9/c</name>
         </Harmony>
@@ -75036,7 +75036,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3XO3O3</pattern>
+        <pattern>[3-O]XO[3-O]O[3-O]</pattern>
         <Harmony>
             <name>g(#9)</name>
         </Harmony>
@@ -75065,7 +75065,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3XO3O3</pattern>
+        <pattern>[3-O]XO[3-O]O[3-O]</pattern>
         <Harmony>
             <name>g(#9)</name>
         </Harmony>
@@ -75094,7 +75094,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXX323</pattern>
+        <pattern>XXX[3-O][2-O][3-O]</pattern>
         <Harmony>
             <name>gdim</name>
         </Harmony>
@@ -75123,7 +75123,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX2323</pattern>
+        <pattern>XX[2-O][3-O][2-O][3-O]</pattern>
         <Harmony>
             <name>gdim7</name>
         </Harmony>
@@ -75152,7 +75152,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO2323</pattern>
+        <pattern>XO[2-O][3-O][2-O][3-O]</pattern>
         <Harmony>
             <name>gdim/a</name>
         </Harmony>
@@ -75182,7 +75182,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX6656</pattern>
+        <pattern>XX[6-O][6-O][5-O][6-O]</pattern>
         <Harmony>
             <name>gdim7/ab</name>
         </Harmony>
@@ -75205,7 +75205,7 @@
                 <barre start="1" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--3-3</pattern>
+        <pattern>X--[3-O]-[3-O];B2[1-4]</pattern>
         <Harmony>
             <name>gdim7/b</name>
         </Harmony>
@@ -75234,7 +75234,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X12O2O</pattern>
+        <pattern>X[1-O][2-O]O[2-O]O</pattern>
         <Harmony>
             <name>gdim7/bb</name>
         </Harmony>
@@ -75261,7 +75261,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX53--</pattern>
+        <pattern>XX[5-O][3-O]--;B2[4-5]</pattern>
         <Harmony>
             <name>gdim(#7)</name>
         </Harmony>
@@ -75285,7 +75285,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--6-6</pattern>
+        <pattern>X--[6-O]-[6-O];B5[1-4]</pattern>
         <Harmony>
             <name>gdim7/d</name>
         </Harmony>
@@ -75315,7 +75315,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4535X</pattern>
+        <pattern>X[4-O][5-O][3-O][5-O]X</pattern>
         <Harmony>
             <name>gdim7/db</name>
         </Harmony>
@@ -75344,7 +75344,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>112O2X</pattern>
+        <pattern>[1-O][1-O][2-O]O[2-O]X</pattern>
         <Harmony>
             <name>gdim7/f</name>
         </Harmony>
@@ -75373,7 +75373,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX2323</pattern>
+        <pattern>XX[2-O][3-O][2-O][3-O]</pattern>
         <Harmony>
             <name>gdim7/fb</name>
         </Harmony>
@@ -75402,7 +75402,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X12O2O</pattern>
+        <pattern>X[1-O][2-O]O[2-O]O</pattern>
         <Harmony>
             <name>gdim/bb</name>
         </Harmony>
@@ -75428,7 +75428,7 @@
                 <barre start="2" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3-3-3</pattern>
+        <pattern>X[3-O]-[3-O]-[3-O];B2[2-4]</pattern>
         <Harmony>
             <name>gdim/c</name>
         </Harmony>
@@ -75452,7 +75452,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--6-6</pattern>
+        <pattern>X--[6-O]-[6-O];B5[1-4]</pattern>
         <Harmony>
             <name>gdim/d</name>
         </Harmony>
@@ -75482,7 +75482,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4532X</pattern>
+        <pattern>X[4-O][5-O][3-O][2-O]X</pattern>
         <Harmony>
             <name>gdim/db</name>
         </Harmony>
@@ -75511,7 +75511,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX2323</pattern>
+        <pattern>XX[2-O][3-O][2-O][3-O]</pattern>
         <Harmony>
             <name>gdim/e</name>
         </Harmony>
@@ -75540,7 +75540,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3323</pattern>
+        <pattern>XX[3-O][3-O][2-O][3-O]</pattern>
         <Harmony>
             <name>gdim/f</name>
         </Harmony>
@@ -75563,7 +75563,7 @@
                 <barre start="0" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-443--</pattern>
+        <pattern>-[4-O][4-O][3-O]--;B2[0-5]</pattern>
         <Harmony>
             <name>gb</name>
         </Harmony>
@@ -75592,7 +75592,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2X234X</pattern>
+        <pattern>[2-O]X[2-O][3-O][4-O]X</pattern>
         <Harmony>
             <name>gb13</name>
         </Harmony>
@@ -75621,7 +75621,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>21111X</pattern>
+        <pattern>[2-O][1-O][1-O][1-O][1-O]X</pattern>
         <Harmony>
             <name>gb13b5</name>
         </Harmony>
@@ -75650,7 +75650,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX2343</pattern>
+        <pattern>XX[2-O][3-O][4-O][3-O]</pattern>
         <Harmony>
             <name>gb13b9</name>
         </Harmony>
@@ -75673,7 +75673,7 @@
                 <barre start="0" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-3-34-</pattern>
+        <pattern>-[3-O]-[3-O][4-O]-;B2[0-5]</pattern>
         <Harmony>
             <name>gb13#11</name>
         </Harmony>
@@ -75702,7 +75702,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>244XXX</pattern>
+        <pattern>[2-O][4-O][4-O]XXX</pattern>
         <Harmony>
             <name>gb5</name>
         </Harmony>
@@ -75731,7 +75731,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2X132X</pattern>
+        <pattern>[2-O]X[1-O][3-O][2-O]X</pattern>
         <Harmony>
             <name>gb6</name>
         </Harmony>
@@ -75749,7 +75749,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-----</pattern>
+        <pattern>X-----;B9[1-5]</pattern>
         <Harmony>
             <name>gb11</name>
         </Harmony>
@@ -75776,7 +75776,7 @@
                 <barre start="2" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X9--99</pattern>
+        <pattern>X[9-O]--[9-O][9-O];B8[2-3]</pattern>
         <Harmony>
             <name>gb69</name>
         </Harmony>
@@ -75800,7 +75800,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X9--9-</pattern>
+        <pattern>X[9-O]--[9-O]-;B8[2-5]</pattern>
         <Harmony>
             <name>gb69#11</name>
         </Harmony>
@@ -75830,7 +75830,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>345XXX</pattern>
+        <pattern>[3-O][4-O][5-O]XXX</pattern>
         <Harmony>
             <name>g(b5)</name>
         </Harmony>
@@ -75860,7 +75860,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX6646</pattern>
+        <pattern>XX[6-O][6-O][4-O][6-O]</pattern>
         <Harmony>
             <name>gb6/ab</name>
         </Harmony>
@@ -75889,7 +75889,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4434X</pattern>
+        <pattern>X[4-O][4-O][3-O][4-O]X</pattern>
         <Harmony>
             <name>gb6/db</name>
         </Harmony>
@@ -75909,7 +75909,7 @@
                 <barre start="0" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-4-3--</pattern>
+        <pattern>-[4-O]-[3-O]--;B2[0-5]</pattern>
         <Harmony>
             <name>gb7</name>
         </Harmony>
@@ -75938,7 +75938,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX431O</pattern>
+        <pattern>XX[4-O][3-O][1-O]O</pattern>
         <Harmony>
             <name>gb7b5</name>
         </Harmony>
@@ -75967,7 +75967,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1232O</pattern>
+        <pattern>X[1-O][2-O][3-O][2-O]O</pattern>
         <Harmony>
             <name>gb7/bb</name>
         </Harmony>
@@ -75996,7 +75996,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX2323</pattern>
+        <pattern>XX[2-O][3-O][2-O][3-O]</pattern>
         <Harmony>
             <name>gb7b9</name>
         </Harmony>
@@ -76023,7 +76023,7 @@
                 <barre start="1" end="2">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--656</pattern>
+        <pattern>X--[6-O][5-O][6-O];B4[1-2]</pattern>
         <Harmony>
             <name>gb7/db</name>
         </Harmony>
@@ -76050,7 +76050,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X9-910-</pattern>
+        <pattern>X[9-O]-[9-O][10-O]-;B8[2-5]</pattern>
         <Harmony>
             <name>gb7(#9b5)</name>
         </Harmony>
@@ -76079,7 +76079,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX132O</pattern>
+        <pattern>XX[1-O][3-O][2-O]O</pattern>
         <Harmony>
             <name>gb7/eb</name>
         </Harmony>
@@ -76108,7 +76108,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX232O</pattern>
+        <pattern>XX[2-O][3-O][2-O]O</pattern>
         <Harmony>
             <name>gb7/fb</name>
         </Harmony>
@@ -76137,7 +76137,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2X231X</pattern>
+        <pattern>[2-O]X[2-O][3-O][1-O]X</pattern>
         <Harmony>
             <name>gb7#11</name>
         </Harmony>
@@ -76163,7 +76163,7 @@
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-33-</pattern>
+        <pattern>XX-[3-O][3-O]-;B2[2-5]</pattern>
         <Harmony>
             <name>gb7#5</name>
         </Harmony>
@@ -76186,7 +76186,7 @@
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2X2---</pattern>
+        <pattern>[2-O]X[2-O]---;B3[3-5]</pattern>
         <Harmony>
             <name>gb7b9#5</name>
         </Harmony>
@@ -76213,7 +76213,7 @@
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X989--</pattern>
+        <pattern>X[9-O][8-O][9-O]--;B10[4-5]</pattern>
         <Harmony>
             <name>gb7(#9#5)</name>
         </Harmony>
@@ -76243,7 +76243,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4355</pattern>
+        <pattern>XX[4-O][3-O][5-O][5-O]</pattern>
         <Harmony>
             <name>gb7#9</name>
         </Harmony>
@@ -76262,7 +76262,7 @@
                 <barre start="1" end="3">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>------</pattern>
+        <pattern>------;B2[0-5];B4[1-3]</pattern>
         <Harmony>
             <name>gb7sus4</name>
         </Harmony>
@@ -76292,7 +76292,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4354</pattern>
+        <pattern>XX[4-O][3-O][5-O][4-O]</pattern>
         <Harmony>
             <name>gb9</name>
         </Harmony>
@@ -76319,7 +76319,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X9-99-</pattern>
+        <pattern>X[9-O]-[9-O][9-O]-;B8[2-5]</pattern>
         <Harmony>
             <name>gb9b5</name>
         </Harmony>
@@ -76348,7 +76348,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX2334</pattern>
+        <pattern>XX[2-O][3-O][3-O][4-O]</pattern>
         <Harmony>
             <name>gb9#5</name>
         </Harmony>
@@ -76372,7 +76372,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>9X8---</pattern>
+        <pattern>[9-O]X[8-O]---;B9[3-5]</pattern>
         <Harmony>
             <name>gb9/db</name>
         </Harmony>
@@ -76399,7 +76399,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X9-99-</pattern>
+        <pattern>X[9-O]-[9-O][9-O]-;B8[2-5]</pattern>
         <Harmony>
             <name>gb9#11</name>
         </Harmony>
@@ -76426,7 +76426,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X98-9-</pattern>
+        <pattern>X[9-O][8-O]-[9-O]-;B6[3-5]</pattern>
         <Harmony>
             <name>gbadd2</name>
         </Harmony>
@@ -76455,7 +76455,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4X324</pattern>
+        <pattern>X[4-O]X[3-O][2-O][4-O]</pattern>
         <Harmony>
             <name>gbadd2/db</name>
         </Harmony>
@@ -76476,7 +76476,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X---7-</pattern>
+        <pattern>X---[7-O]-;B6[1-5]</pattern>
         <Harmony>
             <name>gbadd2/eb</name>
         </Harmony>
@@ -76500,7 +76500,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-9-7-</pattern>
+        <pattern>X-[9-O]-[7-O]-;B6[1-5]</pattern>
         <Harmony>
             <name>gbadd4/eb</name>
         </Harmony>
@@ -76523,7 +76523,7 @@
                 <barre start="1" end="4">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>--8---</pattern>
+        <pattern>--[8-O]---;B6[0-5];B9[1-4]</pattern>
         <Harmony>
             <name>gbadd9/bb</name>
         </Harmony>
@@ -76546,7 +76546,7 @@
                 <barre start="1" end="4">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>--8---</pattern>
+        <pattern>--[8-O]---;B6[0-5];B9[1-4]</pattern>
         <Harmony>
             <name>gbadd2/bb</name>
         </Harmony>
@@ -76575,7 +76575,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4X324</pattern>
+        <pattern>X[4-O]X[3-O][2-O][4-O]</pattern>
         <Harmony>
             <name>gbadd9/db</name>
         </Harmony>
@@ -76604,7 +76604,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4312</pattern>
+        <pattern>XX[4-O][3-O][1-O][2-O]</pattern>
         <Harmony>
             <name>gb(#4)</name>
         </Harmony>
@@ -76633,7 +76633,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3324</pattern>
+        <pattern>XX[3-O][3-O][2-O][4-O]</pattern>
         <Harmony>
             <name>gbadd2/f</name>
         </Harmony>
@@ -76662,7 +76662,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4324</pattern>
+        <pattern>XX[4-O][3-O][2-O][4-O]</pattern>
         <Harmony>
             <name>gbadd9</name>
         </Harmony>
@@ -76691,7 +76691,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX421X</pattern>
+        <pattern>XX[4-O][2-O][1-O]X</pattern>
         <Harmony>
             <name>gbdim</name>
         </Harmony>
@@ -76721,7 +76721,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4545</pattern>
+        <pattern>XX[4-O][5-O][4-O][5-O]</pattern>
         <Harmony>
             <name>gbdim7</name>
         </Harmony>
@@ -76744,7 +76744,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--2-2</pattern>
+        <pattern>X--[2-O]-[2-O];B1[1-4]</pattern>
         <Harmony>
             <name>gbdim/bb</name>
         </Harmony>
@@ -76773,7 +76773,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3312</pattern>
+        <pattern>XX[3-O][3-O][1-O][2-O]</pattern>
         <Harmony>
             <name>gb(b5)/f</name>
         </Harmony>
@@ -76796,7 +76796,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4---</pattern>
+        <pattern>XX[4-O]---;B2[3-5]</pattern>
         <Harmony>
             <name>gbm</name>
         </Harmony>
@@ -76822,7 +76822,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4-4-</pattern>
+        <pattern>XX[4-O]-[4-O]-;B2[3-5]</pattern>
         <Harmony>
             <name>gbm6</name>
         </Harmony>
@@ -76848,7 +76848,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO4-4-</pattern>
+        <pattern>XO[4-O]-[4-O]-;B2[3-5]</pattern>
         <Harmony>
             <name>gbm6/a</name>
         </Harmony>
@@ -76871,7 +76871,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2X1---</pattern>
+        <pattern>[2-O]X[1-O]---;B2[3-5]</pattern>
         <Harmony>
             <name>gbm6/db</name>
         </Harmony>
@@ -76888,7 +76888,7 @@
                 <barre start="0" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-4----</pattern>
+        <pattern>-[4-O]----;B2[0-5]</pattern>
         <Harmony>
             <name>gbm7</name>
         </Harmony>
@@ -76914,7 +76914,7 @@
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2X22--</pattern>
+        <pattern>[2-O]X[2-O][2-O]--;B3[4-5]</pattern>
         <Harmony>
             <name>gbmaj13</name>
         </Harmony>
@@ -76937,7 +76937,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO4---</pattern>
+        <pattern>XO[4-O]---;B2[3-5]</pattern>
         <Harmony>
             <name>gbm/a</name>
         </Harmony>
@@ -76960,7 +76960,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X4---</pattern>
+        <pattern>[4-O]X[4-O]---;B2[3-5]</pattern>
         <Harmony>
             <name>gbm/ab</name>
         </Harmony>
@@ -76983,7 +76983,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X4---</pattern>
+        <pattern>[3-O]X[4-O]---;B2[3-5]</pattern>
         <Harmony>
             <name>gbm/g</name>
         </Harmony>
@@ -77006,7 +77006,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X44---</pattern>
+        <pattern>X[4-O][4-O]---;B2[3-5]</pattern>
         <Harmony>
             <name>gbm/db</name>
         </Harmony>
@@ -77026,7 +77026,7 @@
                 <barre start="0" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-4---4</pattern>
+        <pattern>-[4-O]---[4-O];B2[0-4]</pattern>
         <Harmony>
             <name>gbm9</name>
         </Harmony>
@@ -77055,7 +77055,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4321</pattern>
+        <pattern>XX[4-O][3-O][2-O][1-O]</pattern>
         <Harmony>
             <name>gbmaj7</name>
         </Harmony>
@@ -77084,7 +77084,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>243XXX</pattern>
+        <pattern>[2-O][4-O][3-O]XXX</pattern>
         <Harmony>
             <name>gbmaj7(no3)</name>
         </Harmony>
@@ -77106,7 +77106,7 @@
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>------</pattern>
+        <pattern>------;B4[0-2];B6[3-5]</pattern>
         <Harmony>
             <name>gbmaj7/ab</name>
         </Harmony>
@@ -77129,7 +77129,7 @@
                 <barre start="0" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>--33-4</pattern>
+        <pattern>--[3-O][3-O]-[4-O];B2[0-4]</pattern>
         <Harmony>
             <name>gbmaj11</name>
         </Harmony>
@@ -77155,7 +77155,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-432-</pattern>
+        <pattern>X-[4-O][3-O][2-O]-;B1[1-5]</pattern>
         <Harmony>
             <name>gbmaj7/bb</name>
         </Harmony>
@@ -77179,7 +77179,7 @@
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X44---</pattern>
+        <pattern>X[4-O][4-O]---;B6[3-5]</pattern>
         <Harmony>
             <name>gbmaj7/db</name>
         </Harmony>
@@ -77202,7 +77202,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>--432-</pattern>
+        <pattern>--[4-O][3-O][2-O]-;B1[0-5]</pattern>
         <Harmony>
             <name>gbmaj7/f</name>
         </Harmony>
@@ -77228,7 +77228,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2X43--</pattern>
+        <pattern>[2-O]X[4-O][3-O]--;B1[4-5]</pattern>
         <Harmony>
             <name>gbmaj7#11</name>
         </Harmony>
@@ -77257,7 +77257,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO331</pattern>
+        <pattern>XXO[3-O][3-O][1-O]</pattern>
         <Harmony>
             <name>gbmaj7#5/d</name>
         </Harmony>
@@ -77280,7 +77280,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3---</pattern>
+        <pattern>XX[3-O]---;B2[3-5]</pattern>
         <Harmony>
             <name>gbm(#7)</name>
         </Harmony>
@@ -77310,7 +77310,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4364</pattern>
+        <pattern>XX[4-O][3-O][6-O][4-O]</pattern>
         <Harmony>
             <name>gbmaj9</name>
         </Harmony>
@@ -77333,7 +77333,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4-3-2-</pattern>
+        <pattern>[4-O]-[3-O]-[2-O]-;B1[1-5]</pattern>
         <Harmony>
             <name>gbmaj9/ab</name>
         </Harmony>
@@ -77353,7 +77353,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>--4-2-</pattern>
+        <pattern>--[4-O]-[2-O]-;B1[0-5]</pattern>
         <Harmony>
             <name>gbmaj9/f</name>
         </Harmony>
@@ -77374,7 +77374,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>---66-</pattern>
+        <pattern>---[6-O][6-O]-;B4[0-5]</pattern>
         <Harmony>
             <name>gbmaj9(no3)/ab</name>
         </Harmony>
@@ -77400,7 +77400,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX43--</pattern>
+        <pattern>XX[4-O][3-O]--;B1[4-5]</pattern>
         <Harmony>
             <name>gbmaj9(#4)</name>
         </Harmony>
@@ -77426,7 +77426,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3-4-</pattern>
+        <pattern>XX[3-O]-[4-O]-;B2[3-5]</pattern>
         <Harmony>
             <name>gbm(add13)</name>
         </Harmony>
@@ -77452,7 +77452,7 @@
                 <barre start="4" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X43--</pattern>
+        <pattern>[4-O]X[4-O][3-O]--;B2[4-5]</pattern>
         <Harmony>
             <name>gb/ab</name>
         </Harmony>
@@ -77475,7 +77475,7 @@
                 <barre start="1" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-43--</pattern>
+        <pattern>X-[4-O][3-O]--;B2[1-5]</pattern>
         <Harmony>
             <name>gb/b</name>
         </Harmony>
@@ -77502,7 +77502,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX8-7-</pattern>
+        <pattern>XX[8-O]-[7-O]-;B6[3-5]</pattern>
         <Harmony>
             <name>gb/bb</name>
         </Harmony>
@@ -77531,7 +77531,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X343XX</pattern>
+        <pattern>X[3-O][4-O][3-O]XX</pattern>
         <Harmony>
             <name>gb/c</name>
         </Harmony>
@@ -77554,7 +77554,7 @@
                 <barre start="1" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-43--</pattern>
+        <pattern>X-[4-O][3-O]--;B2[1-5]</pattern>
         <Harmony>
             <name>gb</name>
         </Harmony>
@@ -77580,7 +77580,7 @@
                 <barre start="4" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO3--</pattern>
+        <pattern>XXO[3-O]--;B2[4-5]</pattern>
         <Harmony>
             <name>gb/d</name>
         </Harmony>
@@ -77606,7 +77606,7 @@
                 <barre start="4" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X443--</pattern>
+        <pattern>X[4-O][4-O][3-O]--;B2[4-5]</pattern>
         <Harmony>
             <name>gb/db</name>
         </Harmony>
@@ -77629,7 +77629,7 @@
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-3--</pattern>
+        <pattern>XX-[3-O]--;B2[2-5]</pattern>
         <Harmony>
             <name>gb/e</name>
         </Harmony>
@@ -77658,7 +77658,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1322</pattern>
+        <pattern>XX[1-O][3-O][2-O][2-O]</pattern>
         <Harmony>
             <name>gb/eb</name>
         </Harmony>
@@ -77684,7 +77684,7 @@
                 <barre start="4" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX33--</pattern>
+        <pattern>XX[3-O][3-O]--;B2[4-5]</pattern>
         <Harmony>
             <name>gb/f</name>
         </Harmony>
@@ -77707,7 +77707,7 @@
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-3--</pattern>
+        <pattern>XX-[3-O]--;B2[2-5]</pattern>
         <Harmony>
             <name>gb/fb</name>
         </Harmony>
@@ -77736,7 +77736,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4332</pattern>
+        <pattern>XX[4-O][3-O][3-O][2-O]</pattern>
         <Harmony>
             <name>gb+</name>
         </Harmony>
@@ -77765,7 +77765,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXX332</pattern>
+        <pattern>XXX[3-O][3-O][2-O]</pattern>
         <Harmony>
             <name>gb+/bb</name>
         </Harmony>
@@ -77794,7 +77794,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3X332</pattern>
+        <pattern>X[3-O]X[3-O][3-O][2-O]</pattern>
         <Harmony>
             <name>gb+/c</name>
         </Harmony>
@@ -77823,7 +77823,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO332</pattern>
+        <pattern>XXO[3-O][3-O][2-O]</pattern>
         <Harmony>
             <name>gb+/d</name>
         </Harmony>
@@ -77852,7 +77852,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3332</pattern>
+        <pattern>XX[3-O][3-O][3-O][2-O]</pattern>
         <Harmony>
             <name>gb+/f</name>
         </Harmony>
@@ -77878,7 +77878,7 @@
                 <barre start="4" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX44--</pattern>
+        <pattern>XX[4-O][4-O]--;B2[4-5]</pattern>
         <Harmony>
             <name>gbsus</name>
         </Harmony>
@@ -77907,7 +77907,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X442X</pattern>
+        <pattern>[4-O]X[4-O][4-O][2-O]X</pattern>
         <Harmony>
             <name>gbsus/ab</name>
         </Harmony>
@@ -77931,7 +77931,7 @@
                 <barre start="1" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>6---XX</pattern>
+        <pattern>[6-O]---XX;B4[1-3]</pattern>
         <Harmony>
             <name>gbsus/bb</name>
         </Harmony>
@@ -77955,7 +77955,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-1111--</pattern>
+        <pattern>X-[11-O][11-O]--;B9[1-5]</pattern>
         <Harmony>
             <name>gbsus2</name>
         </Harmony>
@@ -77984,7 +77984,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1X122</pattern>
+        <pattern>X[1-O]X[1-O][2-O][2-O]</pattern>
         <Harmony>
             <name>gbsus2/bb</name>
         </Harmony>
@@ -78008,7 +78008,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-1011--</pattern>
+        <pattern>X-[10-O][11-O]--;B9[1-5]</pattern>
         <Harmony>
             <name>gb(#4sus2)</name>
         </Harmony>
@@ -78029,7 +78029,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-55---</pattern>
+        <pattern>-[5-O][5-O]---;B3[0-5]</pattern>
         <Harmony>
             <name>gm</name>
         </Harmony>
@@ -78058,7 +78058,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X331X</pattern>
+        <pattern>[3-O]X[3-O][3-O][1-O]X</pattern>
         <Harmony>
             <name>gm11</name>
         </Harmony>
@@ -78081,7 +78081,7 @@
                 <barre start="2" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX--1-</pattern>
+        <pattern>XX--[1-O]-;B3[2-5]</pattern>
         <Harmony>
             <name>gm11/f</name>
         </Harmony>
@@ -78110,7 +78110,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1OO11</pattern>
+        <pattern>X[1-O]OO[1-O][1-O]</pattern>
         <Harmony>
             <name>gm11/bb</name>
         </Harmony>
@@ -78131,7 +78131,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X----5</pattern>
+        <pattern>X----[5-O];B3[1-4]</pattern>
         <Harmony>
             <name>gm11/c</name>
         </Harmony>
@@ -78158,7 +78158,7 @@
                 <barre start="2" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6--8X</pattern>
+        <pattern>X[6-O]--[8-O]X;B5[2-3]</pattern>
         <Harmony>
             <name>gm11b5/db</name>
         </Harmony>
@@ -78187,7 +78187,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X333O</pattern>
+        <pattern>[3-O]X[3-O][3-O][3-O]O</pattern>
         <Harmony>
             <name>gm13</name>
         </Harmony>
@@ -78209,7 +78209,7 @@
                 <barre start="1" end="4">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>------</pattern>
+        <pattern>------;B3[0-5];B5[1-4]</pattern>
         <Harmony>
             <name>gm6</name>
         </Harmony>
@@ -78239,7 +78239,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX5355</pattern>
+        <pattern>XX[5-O][3-O][5-O][5-O]</pattern>
         <Harmony>
             <name>gm69</name>
         </Harmony>
@@ -78265,7 +78265,7 @@
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X122--</pattern>
+        <pattern>X[1-O][2-O][2-O]--;B3[4-5]</pattern>
         <Harmony>
             <name>gm69/bb</name>
         </Harmony>
@@ -78292,7 +78292,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO5-5-</pattern>
+        <pattern>XO[5-O]-[5-O]-;B3[3-5]</pattern>
         <Harmony>
             <name>gm6/a</name>
         </Harmony>
@@ -78315,7 +78315,7 @@
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X12---</pattern>
+        <pattern>X[1-O][2-O]---;B3[3-5]</pattern>
         <Harmony>
             <name>gm6/bb</name>
         </Harmony>
@@ -78344,7 +78344,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO33O</pattern>
+        <pattern>XXO[3-O][3-O]O</pattern>
         <Harmony>
             <name>gm6/d</name>
         </Harmony>
@@ -78367,7 +78367,7 @@
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX2---</pattern>
+        <pattern>XX[2-O]---;B3[3-5]</pattern>
         <Harmony>
             <name>gm6/e</name>
         </Harmony>
@@ -78390,7 +78390,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX--3-</pattern>
+        <pattern>XX--[3-O]-;B1[2-5]</pattern>
         <Harmony>
             <name>gm6/f</name>
         </Harmony>
@@ -78413,7 +78413,7 @@
                 <barre start="2" end="4">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X---X</pattern>
+        <pattern>[3-O]X---X;B3[2-4]</pattern>
         <Harmony>
             <name>gm7</name>
         </Harmony>
@@ -78434,7 +78434,7 @@
                 <barre start="0" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-5---5</pattern>
+        <pattern>-[5-O]---[5-O];B3[0-4]</pattern>
         <Harmony>
             <name>gm7(add2)</name>
         </Harmony>
@@ -78455,7 +78455,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6----</pattern>
+        <pattern>X[6-O]----;B3[2-5]</pattern>
         <Harmony>
             <name>gm7/eb</name>
         </Harmony>
@@ -78484,7 +78484,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X331X</pattern>
+        <pattern>[3-O]X[3-O][3-O][1-O]X</pattern>
         <Harmony>
             <name>gm7(add4)</name>
         </Harmony>
@@ -78513,7 +78513,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>1X331X</pattern>
+        <pattern>[1-O]X[3-O][3-O][1-O]X</pattern>
         <Harmony>
             <name>gm7(add4)/f</name>
         </Harmony>
@@ -78542,7 +78542,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X332X</pattern>
+        <pattern>[3-O]X[3-O][3-O][2-O]X</pattern>
         <Harmony>
             <name>gm7b5</name>
         </Harmony>
@@ -78571,7 +78571,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1332X</pattern>
+        <pattern>X[1-O][3-O][3-O][2-O]X</pattern>
         <Harmony>
             <name>gm7b5/bb</name>
         </Harmony>
@@ -78600,7 +78600,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3X323</pattern>
+        <pattern>X[3-O]X[3-O][2-O][3-O]</pattern>
         <Harmony>
             <name>gm7b5/c</name>
         </Harmony>
@@ -78625,7 +78625,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-----</pattern>
+        <pattern>X-----;B5[1-2];B6[3-5]</pattern>
         <Harmony>
             <name>gm7b5/d</name>
         </Harmony>
@@ -78652,7 +78652,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X45-6-</pattern>
+        <pattern>X[4-O][5-O]-[6-O]-;B3[3-5]</pattern>
         <Harmony>
             <name>gm7b5/db</name>
         </Harmony>
@@ -78675,7 +78675,7 @@
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>1X2---</pattern>
+        <pattern>[1-O]X[2-O]---;B3[3-5]</pattern>
         <Harmony>
             <name>gm7b5/f</name>
         </Harmony>
@@ -78701,7 +78701,7 @@
                 <barre start="2" end="3">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X--4X</pattern>
+        <pattern>[3-O]X--[4-O]X;B3[2-3]</pattern>
         <Harmony>
             <name>gm7b6</name>
         </Harmony>
@@ -78721,7 +78721,7 @@
                 <barre start="2" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1----</pattern>
+        <pattern>X[1-O]----;B3[2-5]</pattern>
         <Harmony>
             <name>gm7/bb</name>
         </Harmony>
@@ -78738,7 +78738,7 @@
                 <barre start="1" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-----</pattern>
+        <pattern>X-----;B3[1-5]</pattern>
         <Harmony>
             <name>gm7/c</name>
         </Harmony>
@@ -78759,7 +78759,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO----</pattern>
+        <pattern>XO----;B3[2-5]</pattern>
         <Harmony>
             <name>gm7/a</name>
         </Harmony>
@@ -78780,7 +78780,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X5----</pattern>
+        <pattern>X[5-O]----;B3[2-5]</pattern>
         <Harmony>
             <name>gm7/d</name>
         </Harmony>
@@ -78800,7 +78800,7 @@
                 <barre start="2" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX----</pattern>
+        <pattern>XX----;B3[2-5]</pattern>
         <Harmony>
             <name>gm7/f</name>
         </Harmony>
@@ -78826,7 +78826,7 @@
                 <barre start="2" end="3">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X--4X</pattern>
+        <pattern>[3-O]X--[4-O]X;B3[2-3]</pattern>
         <Harmony>
             <name>gm7#5</name>
         </Harmony>
@@ -78847,7 +78847,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--5--</pattern>
+        <pattern>X--[5-O]--;B3[1-5]</pattern>
         <Harmony>
             <name>gm7sus4/c</name>
         </Harmony>
@@ -78865,7 +78865,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>---5--</pattern>
+        <pattern>---[5-O]--;B3[0-5]</pattern>
         <Harmony>
             <name>gm7sus4</name>
         </Harmony>
@@ -78894,7 +78894,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X33XX</pattern>
+        <pattern>[3-O]X[3-O][3-O]XX</pattern>
         <Harmony>
             <name>gm7(no5)</name>
         </Harmony>
@@ -78915,7 +78915,7 @@
                 <barre start="0" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-5---5</pattern>
+        <pattern>-[5-O]---[5-O];B3[0-4]</pattern>
         <Harmony>
             <name>gm9</name>
         </Harmony>
@@ -78933,7 +78933,7 @@
                 <barre start="0" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-----5</pattern>
+        <pattern>-----[5-O];B3[0-4]</pattern>
         <Harmony>
             <name>gm9(add4)</name>
         </Harmony>
@@ -78962,7 +78962,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X332X</pattern>
+        <pattern>[3-O]X[3-O][3-O][2-O]X</pattern>
         <Harmony>
             <name>gm9b5</name>
         </Harmony>
@@ -78983,7 +78983,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X----5</pattern>
+        <pattern>X----[5-O];B3[1-4]</pattern>
         <Harmony>
             <name>gm9/c</name>
         </Harmony>
@@ -79007,7 +79007,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X5---5</pattern>
+        <pattern>X[5-O]---[5-O];B3[2-4]</pattern>
         <Harmony>
             <name>gm9/d</name>
         </Harmony>
@@ -79031,7 +79031,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX---5</pattern>
+        <pattern>XX---[5-O];B3[2-4]</pattern>
         <Harmony>
             <name>gm9/f</name>
         </Harmony>
@@ -79055,7 +79055,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO---5</pattern>
+        <pattern>XO---[5-O];B3[2-4]</pattern>
         <Harmony>
             <name>gm9/a</name>
         </Harmony>
@@ -79079,7 +79079,7 @@
                 <barre start="2" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2X---5</pattern>
+        <pattern>[2-O]X---[5-O];B3[2-4]</pattern>
         <Harmony>
             <name>gm9/f#</name>
         </Harmony>
@@ -79100,7 +79100,7 @@
                 <barre start="0" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>---5-5</pattern>
+        <pattern>---[5-O]-[5-O];B3[0-4]</pattern>
         <Harmony>
             <name>gm9sus4</name>
         </Harmony>
@@ -79127,7 +79127,7 @@
                 <barre start="3" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X65--5</pattern>
+        <pattern>X[6-O][5-O]--[5-O];B3[3-4]</pattern>
         <Harmony>
             <name>gm(add9)/eb</name>
         </Harmony>
@@ -79154,7 +79154,7 @@
                 <barre start="3" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX5--5</pattern>
+        <pattern>XX[5-O]--[5-O];B3[3-4]</pattern>
         <Harmony>
             <name>gm(add2)</name>
         </Harmony>
@@ -79181,7 +79181,7 @@
                 <barre start="3" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X5X--5</pattern>
+        <pattern>X[5-O]X--[5-O];B3[3-4]</pattern>
         <Harmony>
             <name>gm(add2)/d</name>
         </Harmony>
@@ -79210,7 +79210,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1O233</pattern>
+        <pattern>X[1-O]O[2-O][3-O][3-O]</pattern>
         <Harmony>
             <name>gm(add2)/bb</name>
         </Harmony>
@@ -79240,7 +79240,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX5536</pattern>
+        <pattern>XX[5-O][5-O][3-O][6-O]</pattern>
         <Harmony>
             <name>gm(add4)</name>
         </Harmony>
@@ -79264,7 +79264,7 @@
                 <barre start="0" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-55--5</pattern>
+        <pattern>-[5-O][5-O]--[5-O];B3[0-4]</pattern>
         <Harmony>
             <name>gm(add9)</name>
         </Harmony>
@@ -79287,7 +79287,7 @@
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>13O---</pattern>
+        <pattern>[1-O][3-O]O---;B3[3-5]</pattern>
         <Harmony>
             <name>gm(add4)/f</name>
         </Harmony>
@@ -79314,7 +79314,7 @@
                 <barre start="3" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X5X--5</pattern>
+        <pattern>X[5-O]X--[5-O];B3[3-4]</pattern>
         <Harmony>
             <name>gm(add9)/d</name>
         </Harmony>
@@ -79338,7 +79338,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX---5</pattern>
+        <pattern>XX---[5-O];B3[2-4]</pattern>
         <Harmony>
             <name>gm(add9)/f</name>
         </Harmony>
@@ -79368,7 +79368,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X445X</pattern>
+        <pattern>[3-O]X[4-O][4-O][5-O]X</pattern>
         <Harmony>
             <name>gmaj13</name>
         </Harmony>
@@ -79397,7 +79397,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO343</pattern>
+        <pattern>XXO[3-O][4-O][3-O]</pattern>
         <Harmony>
             <name>g-(#5)</name>
         </Harmony>
@@ -79427,7 +79427,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX5677</pattern>
+        <pattern>XX[5-O][6-O][7-O][7-O]</pattern>
         <Harmony>
             <name>gmaj13#11</name>
         </Harmony>
@@ -79447,7 +79447,7 @@
                 <barre start="1" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3---3-</pattern>
+        <pattern>[3-O]---[3-O]-;B2[1-5]</pattern>
         <Harmony>
             <name>g69</name>
         </Harmony>
@@ -79476,7 +79476,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3XOOO2</pattern>
+        <pattern>[3-O]XOOO[2-O]</pattern>
         <Harmony>
             <name>gmaj7</name>
         </Harmony>
@@ -79506,7 +79506,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X445X</pattern>
+        <pattern>[3-O]X[4-O][4-O][5-O]X</pattern>
         <Harmony>
             <name>gmaj7(add13)</name>
         </Harmony>
@@ -79535,7 +79535,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>33OOO2</pattern>
+        <pattern>[3-O][3-O]OOO[2-O]</pattern>
         <Harmony>
             <name>gmaj7(add4)</name>
         </Harmony>
@@ -79564,7 +79564,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3OOO2</pattern>
+        <pattern>X[3-O]OOO[2-O]</pattern>
         <Harmony>
             <name>gmaj7/c</name>
         </Harmony>
@@ -79594,7 +79594,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO5432</pattern>
+        <pattern>XO[5-O][4-O][3-O][2-O]</pattern>
         <Harmony>
             <name>gmaj7/a</name>
         </Harmony>
@@ -79623,7 +79623,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2OOO2</pattern>
+        <pattern>X[2-O]OOO[2-O]</pattern>
         <Harmony>
             <name>gmaj7/b</name>
         </Harmony>
@@ -79652,7 +79652,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3XO3X2</pattern>
+        <pattern>[3-O]XO[3-O]X[2-O]</pattern>
         <Harmony>
             <name>gmaj7#9</name>
         </Harmony>
@@ -79681,7 +79681,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXOOO2</pattern>
+        <pattern>XXOOO[2-O]</pattern>
         <Harmony>
             <name>gmaj7/d</name>
         </Harmony>
@@ -79710,7 +79710,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3XOO32</pattern>
+        <pattern>[3-O]XOO[3-O][2-O]</pattern>
         <Harmony>
             <name>gmaj7(no3)</name>
         </Harmony>
@@ -79739,7 +79739,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2OO32</pattern>
+        <pattern>X[2-O]OO[3-O][2-O]</pattern>
         <Harmony>
             <name>gmaj7(no3)/b</name>
         </Harmony>
@@ -79768,7 +79768,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3XO32</pattern>
+        <pattern>X[3-O]XO[3-O][2-O]</pattern>
         <Harmony>
             <name>gmaj7(no3)/c</name>
         </Harmony>
@@ -79797,7 +79797,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXOO32</pattern>
+        <pattern>XXOO[3-O][2-O]</pattern>
         <Harmony>
             <name>gmaj7(no3)/d</name>
         </Harmony>
@@ -79826,7 +79826,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2XOO32</pattern>
+        <pattern>[2-O]XOO[3-O][2-O]</pattern>
         <Harmony>
             <name>gmaj7(no3)/f#</name>
         </Harmony>
@@ -79855,7 +79855,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O2OOO2</pattern>
+        <pattern>O[2-O]OOO[2-O]</pattern>
         <Harmony>
             <name>gmaj7/e</name>
         </Harmony>
@@ -79884,7 +79884,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>22OOO2</pattern>
+        <pattern>[2-O][2-O]OOO[2-O]</pattern>
         <Harmony>
             <name>gmaj7/f#</name>
         </Harmony>
@@ -79910,7 +79910,7 @@
                 <barre start="4" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X44--</pattern>
+        <pattern>[3-O]X[4-O][4-O]--;B2[4-5]</pattern>
         <Harmony>
             <name>gmaj7#11</name>
         </Harmony>
@@ -79936,7 +79936,7 @@
                 <barre start="4" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X44--</pattern>
+        <pattern>[3-O]X[4-O][4-O]--;B2[4-5]</pattern>
         <Harmony>
             <name>gmaj7#4</name>
         </Harmony>
@@ -79959,7 +79959,7 @@
                 <barre start="2" end="4">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X---X</pattern>
+        <pattern>[3-O]X---X;B4[2-4]</pattern>
         <Harmony>
             <name>gmaj7#5</name>
         </Harmony>
@@ -79988,7 +79988,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO4443</pattern>
+        <pattern>XO[4-O][4-O][4-O][3-O]</pattern>
         <Harmony>
             <name>gmaj7#5/a</name>
         </Harmony>
@@ -80018,7 +80018,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX5532</pattern>
+        <pattern>XX[5-O][5-O][3-O][2-O]</pattern>
         <Harmony>
             <name>gmaj7sus4</name>
         </Harmony>
@@ -80047,7 +80047,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2O232</pattern>
+        <pattern>X[2-O]O[2-O][3-O][2-O]</pattern>
         <Harmony>
             <name>gmaj7sus2/b</name>
         </Harmony>
@@ -80074,7 +80074,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX5-4-</pattern>
+        <pattern>XX[5-O]-[4-O]-;B3[3-5]</pattern>
         <Harmony>
             <name>gm(b6)</name>
         </Harmony>
@@ -80103,7 +80103,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3XO2O2</pattern>
+        <pattern>[3-O]XO[2-O]O[2-O]</pattern>
         <Harmony>
             <name>gmaj9</name>
         </Harmony>
@@ -80129,7 +80129,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3XO-3-</pattern>
+        <pattern>[3-O]XO-[3-O]-;B2[3-5]</pattern>
         <Harmony>
             <name>gmaj9(no3)</name>
         </Harmony>
@@ -80158,7 +80158,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XOOOO2</pattern>
+        <pattern>XOOOO[2-O]</pattern>
         <Harmony>
             <name>gmaj9/a</name>
         </Harmony>
@@ -80188,7 +80188,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X24OO5</pattern>
+        <pattern>X[2-O][4-O]OO[5-O]</pattern>
         <Harmony>
             <name>gmaj9/b</name>
         </Harmony>
@@ -80217,7 +80217,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>22O2O3</pattern>
+        <pattern>[2-O][2-O]O[2-O]O[3-O]</pattern>
         <Harmony>
             <name>gmaj9/f#</name>
         </Harmony>
@@ -80246,7 +80246,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO2O2</pattern>
+        <pattern>XXO[2-O]O[2-O]</pattern>
         <Harmony>
             <name>gmaj9/d</name>
         </Harmony>
@@ -80273,7 +80273,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X10-1110-</pattern>
+        <pattern>X[10-O]-[11-O][10-O]-;B9[2-5]</pattern>
         <Harmony>
             <name>gmaj9#11</name>
         </Harmony>
@@ -80294,7 +80294,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-54---</pattern>
+        <pattern>-[5-O][4-O]---;B3[0-5]</pattern>
         <Harmony>
             <name>gm(#7)</name>
         </Harmony>
@@ -80324,7 +80324,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO5322</pattern>
+        <pattern>XO[5-O][3-O][2-O][2-O]</pattern>
         <Harmony>
             <name>gm(#7)/a</name>
         </Harmony>
@@ -80348,7 +80348,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>654---</pattern>
+        <pattern>[6-O][5-O][4-O]---;B3[3-5]</pattern>
         <Harmony>
             <name>gm(#7)/bb</name>
         </Harmony>
@@ -80368,7 +80368,7 @@
                 <barre start="1" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-4---</pattern>
+        <pattern>X-[4-O]---;B3[1-5]</pattern>
         <Harmony>
             <name>gm(#7)/c</name>
         </Harmony>
@@ -80391,7 +80391,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3---</pattern>
+        <pattern>XX[3-O]---;B2[3-5]</pattern>
         <Harmony>
             <name>gm(#7)/f#</name>
         </Harmony>
@@ -80415,7 +80415,7 @@
                 <barre start="0" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-54--5</pattern>
+        <pattern>-[5-O][4-O]--[5-O];B3[0-4]</pattern>
         <Harmony>
             <name>gm(add9)</name>
         </Harmony>
@@ -80441,7 +80441,7 @@
                 <barre start="2" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3X-33-</pattern>
+        <pattern>[3-O]X-[3-O][3-O]-;B2[2-5]</pattern>
         <Harmony>
             <name>gm(add13)</name>
         </Harmony>
@@ -80465,7 +80465,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO5---</pattern>
+        <pattern>XO[5-O]---;B3[3-5]</pattern>
         <Harmony>
             <name>gm/a</name>
         </Harmony>
@@ -80489,7 +80489,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>455---</pattern>
+        <pattern>[4-O][5-O][5-O]---;B3[3-5]</pattern>
         <Harmony>
             <name>gm/ab</name>
         </Harmony>
@@ -80512,7 +80512,7 @@
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1O---</pattern>
+        <pattern>X[1-O]O---;B3[3-5]</pattern>
         <Harmony>
             <name>gm/bb</name>
         </Harmony>
@@ -80533,7 +80533,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-5---</pattern>
+        <pattern>X-[5-O]---;B3[1-5]</pattern>
         <Harmony>
             <name>gm/c</name>
         </Harmony>
@@ -80556,7 +80556,7 @@
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO---</pattern>
+        <pattern>XXO---;B3[3-5]</pattern>
         <Harmony>
             <name>gm/d</name>
         </Harmony>
@@ -80585,7 +80585,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4O333</pattern>
+        <pattern>X[4-O]O[3-O][3-O][3-O]</pattern>
         <Harmony>
             <name>gm/db</name>
         </Harmony>
@@ -80608,7 +80608,7 @@
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX2---</pattern>
+        <pattern>XX[2-O]---;B3[3-5]</pattern>
         <Harmony>
             <name>gm/e</name>
         </Harmony>
@@ -80631,7 +80631,7 @@
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1---</pattern>
+        <pattern>XX[1-O]---;B3[3-5]</pattern>
         <Harmony>
             <name>gm/eb</name>
         </Harmony>
@@ -80651,7 +80651,7 @@
                 <barre start="2" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX----</pattern>
+        <pattern>XX----;B3[2-5]</pattern>
         <Harmony>
             <name>gm/f</name>
         </Harmony>
@@ -80674,7 +80674,7 @@
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4---</pattern>
+        <pattern>XX[4-O]---;B3[3-5]</pattern>
         <Harmony>
             <name>gm/f#</name>
         </Harmony>
@@ -80697,7 +80697,7 @@
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4---</pattern>
+        <pattern>XX[4-O]---;B3[3-5]</pattern>
         <Harmony>
             <name>gm/gb</name>
         </Harmony>
@@ -80724,7 +80724,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX5-4-</pattern>
+        <pattern>XX[5-O]-[4-O]-;B3[3-5]</pattern>
         <Harmony>
             <name>gm(#5)</name>
         </Harmony>
@@ -80753,7 +80753,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3XOO13</pattern>
+        <pattern>[3-O]XOO[1-O][3-O]</pattern>
         <Harmony>
             <name>gmsus4</name>
         </Harmony>
@@ -80780,7 +80780,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO55--</pattern>
+        <pattern>XO[5-O][5-O]--;B3[4-5]</pattern>
         <Harmony>
             <name>gmsus4/a</name>
         </Harmony>
@@ -80809,7 +80809,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2OO33</pattern>
+        <pattern>X[2-O]OO[3-O][3-O]</pattern>
         <Harmony>
             <name>g5/b</name>
         </Harmony>
@@ -80838,7 +80838,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3OO33</pattern>
+        <pattern>X[3-O]OO[3-O][3-O]</pattern>
         <Harmony>
             <name>g5/c</name>
         </Harmony>
@@ -80867,7 +80867,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3OO3</pattern>
+        <pattern>XX[3-O]OO[3-O]</pattern>
         <Harmony>
             <name>gno5/f</name>
         </Harmony>
@@ -80894,7 +80894,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO54--</pattern>
+        <pattern>XO[5-O][4-O]--;B3[4-5]</pattern>
         <Harmony>
             <name>g/a</name>
         </Harmony>
@@ -80921,7 +80921,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X54--</pattern>
+        <pattern>[4-O]X[5-O][4-O]--;B3[4-5]</pattern>
         <Harmony>
             <name>g/ab</name>
         </Harmony>
@@ -80950,7 +80950,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2OOO3</pattern>
+        <pattern>X[2-O]OOO[3-O]</pattern>
         <Harmony>
             <name>g/b</name>
         </Harmony>
@@ -80979,7 +80979,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X1OOO3</pattern>
+        <pattern>X[1-O]OOO[3-O]</pattern>
         <Harmony>
             <name>g/bb</name>
         </Harmony>
@@ -81008,7 +81008,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3OOO3</pattern>
+        <pattern>X[3-O]OOO[3-O]</pattern>
         <Harmony>
             <name>g/c</name>
         </Harmony>
@@ -81037,7 +81037,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXOOO3</pattern>
+        <pattern>XXOOO[3-O]</pattern>
         <Harmony>
             <name>g/d</name>
         </Harmony>
@@ -81064,7 +81064,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X454--</pattern>
+        <pattern>X[4-O][5-O][4-O]--;B3[4-5]</pattern>
         <Harmony>
             <name>g/db</name>
         </Harmony>
@@ -81091,7 +81091,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X654--</pattern>
+        <pattern>X[6-O][5-O][4-O]--;B3[4-5]</pattern>
         <Harmony>
             <name>g/d#</name>
         </Harmony>
@@ -81120,7 +81120,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4OOO3</pattern>
+        <pattern>X[4-O]OOO[3-O]</pattern>
         <Harmony>
             <name>g/c#</name>
         </Harmony>
@@ -81149,7 +81149,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O2OOO3</pattern>
+        <pattern>O[2-O]OOO[3-O]</pattern>
         <Harmony>
             <name>g/e</name>
         </Harmony>
@@ -81178,7 +81178,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1OO3</pattern>
+        <pattern>XX[1-O]OO[3-O]</pattern>
         <Harmony>
             <name>g/eb</name>
         </Harmony>
@@ -81207,7 +81207,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>12OOO3</pattern>
+        <pattern>[1-O][2-O]OOO[3-O]</pattern>
         <Harmony>
             <name>g/f</name>
         </Harmony>
@@ -81233,7 +81233,7 @@
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX44--</pattern>
+        <pattern>XX[4-O][4-O]--;B3[4-5]</pattern>
         <Harmony>
             <name>g/f#</name>
         </Harmony>
@@ -81262,7 +81262,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4XOOO3</pattern>
+        <pattern>[4-O]XOOO[3-O]</pattern>
         <Harmony>
             <name>g/g#</name>
         </Harmony>
@@ -81292,7 +81292,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX5443</pattern>
+        <pattern>XX[5-O][4-O][4-O][3-O]</pattern>
         <Harmony>
             <name>g+</name>
         </Harmony>
@@ -81321,7 +81321,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X21OO3</pattern>
+        <pattern>X[2-O][1-O]OO[3-O]</pattern>
         <Harmony>
             <name>g+/b</name>
         </Harmony>
@@ -81350,7 +81350,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X31OO3</pattern>
+        <pattern>X[3-O][1-O]OO[3-O]</pattern>
         <Harmony>
             <name>g+/c</name>
         </Harmony>
@@ -81379,7 +81379,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX1OO3</pattern>
+        <pattern>XX[1-O]OO[3-O]</pattern>
         <Harmony>
             <name>g+/d#</name>
         </Harmony>
@@ -81408,7 +81408,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>1X1OOX</pattern>
+        <pattern>[1-O]X[1-O]OOX</pattern>
         <Harmony>
             <name>g+/f</name>
         </Harmony>
@@ -81438,7 +81438,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO443</pattern>
+        <pattern>XXO[4-O][4-O][3-O]</pattern>
         <Harmony>
             <name>g+/d</name>
         </Harmony>
@@ -81462,7 +81462,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-665--</pattern>
+        <pattern>-[6-O][6-O][5-O]--;B4[0-5]</pattern>
         <Harmony>
             <name>g#</name>
         </Harmony>
@@ -81491,7 +81491,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>32OO2X</pattern>
+        <pattern>[3-O][2-O]OO[2-O]X</pattern>
         <Harmony>
             <name>g(#11)</name>
         </Harmony>
@@ -81521,7 +81521,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X456X</pattern>
+        <pattern>[4-O]X[4-O][5-O][6-O]X</pattern>
         <Harmony>
             <name>g#13</name>
         </Harmony>
@@ -81551,7 +81551,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>466XXX</pattern>
+        <pattern>[4-O][6-O][6-O]XXX</pattern>
         <Harmony>
             <name>g#5</name>
         </Harmony>
@@ -81581,7 +81581,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX5443</pattern>
+        <pattern>XX[5-O][4-O][4-O][3-O]</pattern>
         <Harmony>
             <name>gaug</name>
         </Harmony>
@@ -81611,7 +81611,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X354X</pattern>
+        <pattern>[4-O]X[3-O][5-O][4-O]X</pattern>
         <Harmony>
             <name>g#6</name>
         </Harmony>
@@ -81632,7 +81632,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-6-5--</pattern>
+        <pattern>-[6-O]-[5-O]--;B4[0-5]</pattern>
         <Harmony>
             <name>g#7</name>
         </Harmony>
@@ -81662,7 +81662,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X453X</pattern>
+        <pattern>[4-O]X[4-O][5-O][3-O]X</pattern>
         <Harmony>
             <name>g#7b5</name>
         </Harmony>
@@ -81692,7 +81692,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX4545</pattern>
+        <pattern>XX[4-O][5-O][4-O][5-O]</pattern>
         <Harmony>
             <name>g#7(b9b5)</name>
         </Harmony>
@@ -81719,7 +81719,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX6-7-</pattern>
+        <pattern>XX[6-O]-[7-O]-;B5[3-5]</pattern>
         <Harmony>
             <name>g#7b9</name>
         </Harmony>
@@ -81746,7 +81746,7 @@
                 <barre start="0" end="2">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-6-XXX</pattern>
+        <pattern>-[6-O]-XXX;B4[0-2]</pattern>
         <Harmony>
             <name>g#7(no3)</name>
         </Harmony>
@@ -81770,7 +81770,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X4---</pattern>
+        <pattern>[4-O]X[4-O]---;B5[3-5]</pattern>
         <Harmony>
             <name>g#7(b9#5)</name>
         </Harmony>
@@ -81793,7 +81793,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3---2</pattern>
+        <pattern>X[3-O]---[2-O];B1[2-4]</pattern>
         <Harmony>
             <name>g#7/b#</name>
         </Harmony>
@@ -81814,7 +81814,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--5--</pattern>
+        <pattern>X--[5-O]--;B4[1-5]</pattern>
         <Harmony>
             <name>g#7/c#</name>
         </Harmony>
@@ -81837,7 +81837,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX---2</pattern>
+        <pattern>XX---[2-O];B1[2-4]</pattern>
         <Harmony>
             <name>g#7/d#</name>
         </Harmony>
@@ -81861,7 +81861,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-5--</pattern>
+        <pattern>XX-[5-O]--;B4[2-5]</pattern>
         <Harmony>
             <name>g#7/f#</name>
         </Harmony>
@@ -81888,7 +81888,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-55-</pattern>
+        <pattern>XX-[5-O][5-O]-;B4[2-5]</pattern>
         <Harmony>
             <name>g#7#5</name>
         </Harmony>
@@ -81918,7 +81918,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3455X</pattern>
+        <pattern>X[3-O][4-O][5-O][5-O]X</pattern>
         <Harmony>
             <name>g#7#5/b#</name>
         </Harmony>
@@ -81942,7 +81942,7 @@
                 <barre start="3" end="5">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X4---</pattern>
+        <pattern>[4-O]X[4-O]---;B5[3-5]</pattern>
         <Harmony>
             <name>g#7(b9#5)</name>
         </Harmony>
@@ -81969,7 +81969,7 @@
                 <barre start="4" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X111011--</pattern>
+        <pattern>X[11-O][10-O][11-O]--;B12[4-5]</pattern>
         <Harmony>
             <name>g#7(#9#5)</name>
         </Harmony>
@@ -81999,7 +81999,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX6577</pattern>
+        <pattern>XX[6-O][5-O][7-O][7-O]</pattern>
         <Harmony>
             <name>g#7#9</name>
         </Harmony>
@@ -82019,7 +82019,7 @@
                 <barre start="1" end="3">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>------</pattern>
+        <pattern>------;B4[0-5];B6[1-3]</pattern>
         <Harmony>
             <name>g#7sus4</name>
         </Harmony>
@@ -82043,7 +82043,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6-6--</pattern>
+        <pattern>X[6-O]-[6-O]--;B4[2-5]</pattern>
         <Harmony>
             <name>g#7sus4/d#</name>
         </Harmony>
@@ -82073,7 +82073,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX6576</pattern>
+        <pattern>XX[6-O][5-O][7-O][6-O]</pattern>
         <Harmony>
             <name>g#9</name>
         </Harmony>
@@ -82103,7 +82103,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X453X</pattern>
+        <pattern>[4-O]X[4-O][5-O][3-O]X</pattern>
         <Harmony>
             <name>g#9b5</name>
         </Harmony>
@@ -82133,7 +82133,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X432X</pattern>
+        <pattern>[4-O]X[4-O][3-O][2-O]X</pattern>
         <Harmony>
             <name>g#9sus4</name>
         </Harmony>
@@ -82163,7 +82163,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX643X</pattern>
+        <pattern>XX[6-O][4-O][3-O]X</pattern>
         <Harmony>
             <name>g#dim</name>
         </Harmony>
@@ -82192,7 +82192,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2O1OX</pattern>
+        <pattern>X[2-O]O[1-O]OX</pattern>
         <Harmony>
             <name>g#dim/b</name>
         </Harmony>
@@ -82216,7 +82216,7 @@
                 <barre start="1" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X--4-4</pattern>
+        <pattern>X--[4-O]-[4-O];B3[1-4]</pattern>
         <Harmony>
             <name>g#dim/c</name>
         </Harmony>
@@ -82246,7 +82246,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO434</pattern>
+        <pattern>XXO[4-O][3-O][4-O]</pattern>
         <Harmony>
             <name>g#dim/d</name>
         </Harmony>
@@ -82275,7 +82275,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO1O1</pattern>
+        <pattern>XXO[1-O]O[1-O]</pattern>
         <Harmony>
             <name>g#dim7</name>
         </Harmony>
@@ -82305,7 +82305,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO6767</pattern>
+        <pattern>XO[6-O][7-O][6-O][7-O]</pattern>
         <Harmony>
             <name>g#dim7/a</name>
         </Harmony>
@@ -82326,7 +82326,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-66---</pattern>
+        <pattern>-[6-O][6-O]---;B4[0-5]</pattern>
         <Harmony>
             <name>g#m</name>
         </Harmony>
@@ -82355,7 +82355,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X442X</pattern>
+        <pattern>[4-O]X[4-O][4-O][2-O]X</pattern>
         <Harmony>
             <name>g#m11</name>
         </Harmony>
@@ -82382,7 +82382,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX6-6-</pattern>
+        <pattern>XX[6-O]-[6-O]-;B4[3-5]</pattern>
         <Harmony>
             <name>g#m6</name>
         </Harmony>
@@ -82400,7 +82400,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-6----</pattern>
+        <pattern>-[6-O]----;B4[0-5]</pattern>
         <Harmony>
             <name>g#m7</name>
         </Harmony>
@@ -82429,7 +82429,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X442X</pattern>
+        <pattern>[4-O]X[4-O][4-O][2-O]X</pattern>
         <Harmony>
             <name>g#m7(add4)</name>
         </Harmony>
@@ -82453,7 +82453,7 @@
                 <barre start="3" end="5">3</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X23---</pattern>
+        <pattern>X[2-O][3-O]---;B4[3-5]</pattern>
         <Harmony>
             <name>g#m6/b</name>
         </Harmony>
@@ -82482,7 +82482,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X442X</pattern>
+        <pattern>[4-O]X[4-O][4-O][2-O]X</pattern>
         <Harmony>
             <name>g#m7(add11)</name>
         </Harmony>
@@ -82505,7 +82505,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3---3</pattern>
+        <pattern>X[3-O]---[3-O];B1[2-4]</pattern>
         <Harmony>
             <name>g#maj7/b#</name>
         </Harmony>
@@ -82534,7 +82534,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X443X</pattern>
+        <pattern>[4-O]X[4-O][4-O][3-O]X</pattern>
         <Harmony>
             <name>g#m7b5</name>
         </Harmony>
@@ -82558,7 +82558,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>6X6---</pattern>
+        <pattern>[6-O]X[6-O]---;B4[3-5]</pattern>
         <Harmony>
             <name>g#m/a#</name>
         </Harmony>
@@ -82587,7 +82587,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X4443X</pattern>
+        <pattern>X[4-O][4-O][4-O][3-O]X</pattern>
         <Harmony>
             <name>g#m7b5/c#</name>
         </Harmony>
@@ -82616,7 +82616,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2O1O2</pattern>
+        <pattern>X[2-O]O[1-O]O[2-O]</pattern>
         <Harmony>
             <name>g#m7b5/b</name>
         </Harmony>
@@ -82645,7 +82645,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO1O2</pattern>
+        <pattern>XXO[1-O]O[2-O]</pattern>
         <Harmony>
             <name>g#m7b5/d</name>
         </Harmony>
@@ -82665,7 +82665,7 @@
                 <barre start="2" end="5">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2----</pattern>
+        <pattern>X[2-O]----;B4[2-5]</pattern>
         <Harmony>
             <name>g#m7/b</name>
         </Harmony>
@@ -82695,7 +82695,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>4X44XX</pattern>
+        <pattern>[4-O]X[4-O][4-O]XX</pattern>
         <Harmony>
             <name>g#m7(no5)</name>
         </Harmony>
@@ -82715,7 +82715,7 @@
                 <barre start="2" end="5">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3----</pattern>
+        <pattern>X[3-O]----;B4[2-5]</pattern>
         <Harmony>
             <name>g#m7/c</name>
         </Harmony>
@@ -82744,7 +82744,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O211O2</pattern>
+        <pattern>O[2-O][1-O][1-O]O[2-O]</pattern>
         <Harmony>
             <name>g#m7/e</name>
         </Harmony>
@@ -82762,7 +82762,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-----</pattern>
+        <pattern>X-----;B4[1-5]</pattern>
         <Harmony>
             <name>g#m7/c#</name>
         </Harmony>
@@ -82783,7 +82783,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X6----</pattern>
+        <pattern>X[6-O]----;B4[2-5]</pattern>
         <Harmony>
             <name>g#m7/d#</name>
         </Harmony>
@@ -82812,7 +82812,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3O1O2</pattern>
+        <pattern>X[3-O]O[1-O]O[2-O]</pattern>
         <Harmony>
             <name>g#m7b5/b#</name>
         </Harmony>
@@ -82833,7 +82833,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX----</pattern>
+        <pattern>XX----;B4[2-5]</pattern>
         <Harmony>
             <name>g#m7/f#</name>
         </Harmony>
@@ -82857,7 +82857,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX---6</pattern>
+        <pattern>XX---[6-O];B4[2-4]</pattern>
         <Harmony>
             <name>g#m9</name>
         </Harmony>
@@ -82884,7 +82884,7 @@
                 <barre start="2" end="3">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX--66</pattern>
+        <pattern>XX--[6-O][6-O];B4[2-3]</pattern>
         <Harmony>
             <name>g#m9(add13)</name>
         </Harmony>
@@ -82908,7 +82908,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXX---</pattern>
+        <pattern>XXX---;B4[3-5]</pattern>
         <Harmony>
             <name>g#m/b</name>
         </Harmony>
@@ -82929,7 +82929,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-6---</pattern>
+        <pattern>X-[6-O]---;B4[1-5]</pattern>
         <Harmony>
             <name>g#m/c#</name>
         </Harmony>
@@ -82953,7 +82953,7 @@
                 <barre start="2" end="4">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX---6</pattern>
+        <pattern>XX---[6-O];B4[2-4]</pattern>
         <Harmony>
             <name>g#m9/f#</name>
         </Harmony>
@@ -82977,7 +82977,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X66---</pattern>
+        <pattern>X[6-O][6-O]---;B4[3-5]</pattern>
         <Harmony>
             <name>g#m/d#</name>
         </Harmony>
@@ -83000,7 +83000,7 @@
                 <barre start="3" end="5">4</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX3---</pattern>
+        <pattern>XX[3-O]---;B4[3-5]</pattern>
         <Harmony>
             <name>g#m/f</name>
         </Harmony>
@@ -83021,7 +83021,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX----</pattern>
+        <pattern>XX----;B4[2-5]</pattern>
         <Harmony>
             <name>g#m/f#</name>
         </Harmony>
@@ -83051,7 +83051,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX6888</pattern>
+        <pattern>XX[6-O][8-O][8-O][8-O]</pattern>
         <Harmony>
             <name>g#maj7</name>
         </Harmony>
@@ -83081,7 +83081,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XO6544</pattern>
+        <pattern>XO[6-O][5-O][4-O][4-O]</pattern>
         <Harmony>
             <name>g#/a</name>
         </Harmony>
@@ -83111,7 +83111,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>8X689X</pattern>
+        <pattern>[8-O]X[6-O][8-O][9-O]X</pattern>
         <Harmony>
             <name>g#/b#</name>
         </Harmony>
@@ -83135,7 +83135,7 @@
                 <barre start="1" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X-65--</pattern>
+        <pattern>X-[6-O][5-O]--;B4[1-5]</pattern>
         <Harmony>
             <name>g#/c#</name>
         </Harmony>
@@ -83159,7 +83159,7 @@
                 <barre start="3" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX5---</pattern>
+        <pattern>XX[5-O]---;B4[3-5]</pattern>
         <Harmony>
             <name>g#m(#7)/g</name>
         </Harmony>
@@ -83186,7 +83186,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X565--</pattern>
+        <pattern>X[5-O][6-O][5-O]--;B4[4-5]</pattern>
         <Harmony>
             <name>g#/d</name>
         </Harmony>
@@ -83213,7 +83213,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X665--</pattern>
+        <pattern>X[6-O][6-O][5-O]--;B4[4-5]</pattern>
         <Harmony>
             <name>g#/d#</name>
         </Harmony>
@@ -83237,7 +83237,7 @@
                 <barre start="2" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX-5--</pattern>
+        <pattern>XX-[5-O]--;B4[2-5]</pattern>
         <Harmony>
             <name>g#/f#</name>
         </Harmony>
@@ -83267,7 +83267,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XX6554</pattern>
+        <pattern>XX[6-O][5-O][5-O][4-O]</pattern>
         <Harmony>
             <name>g#+</name>
         </Harmony>
@@ -83291,7 +83291,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-666--</pattern>
+        <pattern>-[6-O][6-O][6-O]--;B4[0-5]</pattern>
         <Harmony>
             <name>g#sus</name>
         </Harmony>
@@ -83321,7 +83321,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3X554</pattern>
+        <pattern>X[3-O]X[5-O][5-O][4-O]</pattern>
         <Harmony>
             <name>g#+/b#</name>
         </Harmony>
@@ -83345,7 +83345,7 @@
                 <barre start="0" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>-555--</pattern>
+        <pattern>-[5-O][5-O][5-O]--;B3[0-5]</pattern>
         <Harmony>
             <name>gsus</name>
         </Harmony>
@@ -83374,7 +83374,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3XO233</pattern>
+        <pattern>[3-O]XO[2-O][3-O][3-O]</pattern>
         <Harmony>
             <name>gsus2</name>
         </Harmony>
@@ -83403,7 +83403,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3XO213</pattern>
+        <pattern>[3-O]XO[2-O][1-O][3-O]</pattern>
         <Harmony>
             <name>gsus2add4</name>
         </Harmony>
@@ -83432,7 +83432,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XOO213</pattern>
+        <pattern>XOO[2-O][1-O][3-O]</pattern>
         <Harmony>
             <name>gsus2add4/a</name>
         </Harmony>
@@ -83461,7 +83461,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2O213</pattern>
+        <pattern>X[2-O]O[2-O][1-O][3-O]</pattern>
         <Harmony>
             <name>gsus2add4/b</name>
         </Harmony>
@@ -83490,7 +83490,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XOO233</pattern>
+        <pattern>XOO[2-O][3-O][3-O]</pattern>
         <Harmony>
             <name>gsus2/a</name>
         </Harmony>
@@ -83516,7 +83516,7 @@
                 <barre start="3" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3XO--3</pattern>
+        <pattern>[3-O]XO--[3-O];B2[3-4]</pattern>
         <Harmony>
             <name>g(#4sus2)</name>
         </Harmony>
@@ -83542,7 +83542,7 @@
                 <barre start="3" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3XO--3</pattern>
+        <pattern>[3-O]XO--[3-O];B2[3-4]</pattern>
         <Harmony>
             <name>g(#4sus2)</name>
         </Harmony>
@@ -83571,7 +83571,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2O233</pattern>
+        <pattern>X[2-O]O[2-O][3-O][3-O]</pattern>
         <Harmony>
             <name>gsus2/b</name>
         </Harmony>
@@ -83600,7 +83600,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3O233</pattern>
+        <pattern>X[3-O]O[2-O][3-O][3-O]</pattern>
         <Harmony>
             <name>gsus2/c</name>
         </Harmony>
@@ -83629,7 +83629,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XXO233</pattern>
+        <pattern>XXO[2-O][3-O][3-O]</pattern>
         <Harmony>
             <name>gsus2/d</name>
         </Harmony>
@@ -83658,7 +83658,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>O2O233</pattern>
+        <pattern>O[2-O]O[2-O][3-O][3-O]</pattern>
         <Harmony>
             <name>gsus2/e</name>
         </Harmony>
@@ -83687,7 +83687,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>1XO233</pattern>
+        <pattern>[1-O]XO[2-O][3-O][3-O]</pattern>
         <Harmony>
             <name>gsus2/f</name>
         </Harmony>
@@ -83716,7 +83716,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>2XO233</pattern>
+        <pattern>[2-O]XO[2-O][3-O][3-O]</pattern>
         <Harmony>
             <name>gsus2/f#</name>
         </Harmony>
@@ -83742,7 +83742,7 @@
                 <barre start="3" end="4">2</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3XO--3</pattern>
+        <pattern>[3-O]XO--[3-O];B2[3-4]</pattern>
         <Harmony>
             <name>g(#11sus2)</name>
         </Harmony>
@@ -83771,7 +83771,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>33OO34</pattern>
+        <pattern>[3-O][3-O]OO[3-O][4-O]</pattern>
         <Harmony>
             <name>g(b9sus4)</name>
         </Harmony>
@@ -83800,7 +83800,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3XOO13</pattern>
+        <pattern>[3-O]XOO[1-O][3-O]</pattern>
         <Harmony>
             <name>gsus4</name>
         </Harmony>
@@ -83829,7 +83829,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3XO213</pattern>
+        <pattern>[3-O]XO[2-O][1-O][3-O]</pattern>
         <Harmony>
             <name>gsus4sus2(add4)</name>
         </Harmony>
@@ -83858,7 +83858,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3XO213</pattern>
+        <pattern>[3-O]XO[2-O][1-O][3-O]</pattern>
         <Harmony>
             <name>g(add2sus4)</name>
         </Harmony>
@@ -83887,7 +83887,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>XOOO13</pattern>
+        <pattern>XOOO[1-O][3-O]</pattern>
         <Harmony>
             <name>gsus/a</name>
         </Harmony>
@@ -83916,7 +83916,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>3XO213</pattern>
+        <pattern>[3-O]XO[2-O][1-O][3-O]</pattern>
         <Harmony>
             <name>g(add9sus4)</name>
         </Harmony>
@@ -83945,7 +83945,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>43OO1X</pattern>
+        <pattern>[4-O][3-O]OO[1-O]X</pattern>
         <Harmony>
             <name>gsus/ab</name>
         </Harmony>
@@ -83974,7 +83974,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X2OO13</pattern>
+        <pattern>X[2-O]OO[1-O][3-O]</pattern>
         <Harmony>
             <name>gsus/b</name>
         </Harmony>
@@ -84003,7 +84003,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X3OO13</pattern>
+        <pattern>X[3-O]OO[1-O][3-O]</pattern>
         <Harmony>
             <name>gsus/c</name>
         </Harmony>
@@ -84030,7 +84030,7 @@
                 <barre start="4" end="5">1</barre>
             </fretDiagram>
         </FretDiagram>
-        <pattern>X555--</pattern>
+        <pattern>X[5-O][5-O][5-O]--;B3[4-5]</pattern>
         <Harmony>
             <name>gsus/d</name>
         </Harmony>
@@ -84059,7 +84059,7 @@
                 </string>
             </fretDiagram>
         </FretDiagram>
-        <pattern>1XOO13</pattern>
+        <pattern>[1-O]XOO[1-O][3-O]</pattern>
         <Harmony>
             <name>gsus/f</name>
         </Harmony>

--- a/src/engraving/dom/fret.h
+++ b/src/engraving/dom/fret.h
@@ -247,6 +247,7 @@ public:
     static FretDiagram* makeFromHarmonyOrFretDiagram(const EngravingItem* harmonyOrFretDiagram);
 
     bool isInFretBox() const;
+    bool isCustom(const String& harmonyNameForCompare) const;
 
     friend class FretUndoData;
 
@@ -282,7 +283,7 @@ private:
     FretDiagram(Segment* parent = nullptr);
     FretDiagram(const FretDiagram&);
 
-    void readHarmonyToDiagramFile(const muse::io::path_t& filePath);
+    void readHarmonyToDiagramFile(const muse::io::path_t& filePath) const;
 
     void initDefaultValues();
 

--- a/src/engraving/dom/harmony.cpp
+++ b/src/engraving/dom/harmony.cpp
@@ -775,18 +775,14 @@ void Harmony::endEditTextual(EditData& ed)
     bool textChanged = ted != nullptr && ted->oldXmlText != harmonyName();
 
     if (textChanged) {
-        if (configuration()->autoUpdateFretboardDiagrams()) {
-            Segment* parentSegment = getParentSeg();
-            if (parentSegment) {
-                EngravingItem* fretDiagramItem = parentSegment->findAnnotation(ElementType::FRET_DIAGRAM, track(), track());
-                if (fretDiagramItem) {
-                    FretDiagram* fretDiagram = toFretDiagram(fretDiagramItem);
-
-                    UndoStack* undo = score()->undoStack();
-                    undo->reopen();
-                    score()->undo(new FretDataChange(fretDiagram, s));
-                    score()->endCmd();
-                }
+        FretDiagram* fretDiagram = explicitParent()->isFretDiagram() ? toFretDiagram(explicitParent()) : nullptr;
+        bool isFretDiagramCustom = fretDiagram ? fretDiagram->isCustom(ted->oldXmlText) : false;
+        if (fretDiagram && configuration()->autoUpdateFretboardDiagrams()) {
+            if (!isFretDiagramCustom) {
+                UndoStack* undo = score()->undoStack();
+                undo->reopen();
+                score()->undo(new FretDataChange(fretDiagram, s));
+                score()->endCmd();
             }
         }
 

--- a/src/engraving/dom/property.cpp
+++ b/src/engraving/dom/property.cpp
@@ -271,7 +271,7 @@ static constexpr PropertyMetaData propertyList[] = {
     { Pid::FRET_OFFSET,             true,  "fretOffset",            P_TYPE::INT,                PropertyGroup::POSITION,        DUMMY_QT_TR_NOOP("propertyName", "fret offset") },
     { Pid::FRET_NUM_POS,            true,  "fretNumPos",            P_TYPE::INT,                PropertyGroup::POSITION,        DUMMY_QT_TR_NOOP("propertyName", "fret number position") },
     { Pid::ORIENTATION,             true,  "orientation",           P_TYPE::ORIENTATION,        PropertyGroup::APPEARANCE,      DUMMY_QT_TR_NOOP("propertyName", "orientation") },
-    { Pid::FRET_SHOW_FINGERINGS,     true,  "fretShowFingering",     P_TYPE::BOOL       ,        PropertyGroup::APPEARANCE,      DUMMY_QT_TR_NOOP("propertyName", "fretShowFingering") },
+    { Pid::FRET_SHOW_FINGERINGS,    true,  "fretShowFingering",     P_TYPE::BOOL       ,        PropertyGroup::APPEARANCE,      DUMMY_QT_TR_NOOP("propertyName", "fretShowFingering") },
     { Pid::FRET_FINGERING,          true,  "fretFingering",         P_TYPE::INT_VEC,            PropertyGroup::APPEARANCE,      DUMMY_QT_TR_NOOP("propertyName", "fretFingering") },
 
     { Pid::HARMONY_VOICE_LITERAL,   true,  "harmonyVoiceLiteral",   P_TYPE::BOOL,               PropertyGroup::APPEARANCE,      DUMMY_QT_TR_NOOP("propertyName", "harmony voice literal") },

--- a/src/engraving/style/style.cpp
+++ b/src/engraving/style/style.cpp
@@ -591,6 +591,8 @@ void MStyle::read(XmlReader& e, compat::ReadChordListHook* readChordListHook)
             } else {
                 set(Sid::chordStyle, TConv::fromXml(val, ChordStylePreset::STANDARD));
             }
+        } else if (tag == "fretFrets" && m_version < 460) {
+            e.skipCurrentElement();
         } else if (!readProperties(e)) {
             e.unknown();
         }

--- a/src/engraving/style/styledef.cpp
+++ b/src/engraving/style/styledef.cpp
@@ -437,7 +437,7 @@ const std::array<StyleDef::StyleValue, size_t(Sid::STYLES)> StyleDef::styleValue
     styleDef(fretMag,                                    PropertyValue(1.0)),
     styleDef(fretPlacement,                              PlacementV::ABOVE),
     styleDef(fretStrings,                                6),
-    styleDef(fretFrets,                                  5),
+    styleDef(fretFrets,                                  4),
     styleDef(fretNut,                                    true),
     styleDef(fretDotSize,                                PropertyValue(1.0)), // DEPRECATED
     styleDef(fretDotSpatiumSize,                         Spatium(0.5)),

--- a/src/importexport/musicxml/tests/data/testChordSymbols2_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testChordSymbols2_ref.mscx
@@ -142,6 +142,7 @@
             <sigD>4</sigD>
             </TimeSig>
           <FretDiagram>
+            <frets>5</frets>
             <eid>K_K</eid>
             <fretDiagram>
               <string no="0">
@@ -205,6 +206,7 @@
         <eid>O_O</eid>
         <voice>
           <FretDiagram>
+            <frets>5</frets>
             <eid>P_P</eid>
             <fretDiagram>
               <string no="0">

--- a/tools/harmony_to_diagram/parse_mscx.py
+++ b/tools/harmony_to_diagram/parse_mscx.py
@@ -1,0 +1,210 @@
+from lxml import etree as ET
+import argparse
+import copy
+
+def extract_fret_harmony_pairs(mscx_path):
+    tree = ET.parse(mscx_path)
+    root = tree.getroot()
+
+    elements = []
+
+    for parent in root.iter():
+        children = list(parent)
+        for i in range(len(children) - 1):
+            first = children[i]
+            second = children[i + 1]
+
+            if (first.tag == "FretDiagram" and second.tag == "Harmony") or \
+               (first.tag == "Harmony" and second.tag == "FretDiagram"):
+                elements.append(first)
+                elements.append(second)
+
+    pairs = []
+    i = 0
+    while i < len(elements) - 1:
+        if elements[i].tag == "FretDiagram" and elements[i + 1].tag == "Harmony":
+            pairs.append((elements[i], elements[i + 1]))
+            i += 2
+        elif elements[i].tag == "Harmony" and elements[i + 1].tag == "FretDiagram":
+            pairs.append((elements[i + 1], elements[i]))
+            i += 2
+        else:
+            i += 1
+
+    return pairs
+
+def remove_barre_overlapping_dots(fret_elem, offset):
+    strings = fret_elem.findall("string")
+
+    for barre in fret_elem.findall("barre"):
+        start = int(barre.get("start", -1))
+        end = int(barre.get("end", -1))
+        fret = int(barre.text.strip()) + offset
+
+        for string in strings:
+            string_no = int(string.get("no", -1))
+            dot = string.find("dot")
+            if dot is not None and start <= string_no <= end:
+                dot_fret = int(dot.get("fret", -1)) + offset
+                if dot_fret == fret:
+                    string.remove(dot)
+
+def extract_pattern_from_fretdiagram(fret_elem):
+    strings_count = 6
+    offset_elem = fret_elem.getparent().find("fretOffset")
+    offset = int(offset_elem.text) if offset_elem is not None else 0
+
+    pattern = ['-' for _ in range(strings_count)]
+    barre_parts = []
+
+    for string_elem in fret_elem.findall("string"):
+        string_no = int(string_elem.get("no", -1))
+        if not (0 <= string_no < strings_count):
+            continue
+
+        marker = string_elem.find("marker")
+        dot_elems = string_elem.findall("dot")
+        dot_descriptions = []
+
+        if marker is not None and not dot_elems:
+            marker_type = marker.text.strip().lower()
+            if marker_type == "cross":
+                pattern[string_no] = "X"
+            elif marker_type == "circle" or marker_type == "o":
+                pattern[string_no] = "O"
+
+        elif dot_elems:
+            for dot_elem in dot_elems:
+                fret = int(dot_elem.get("fret", -1))
+                dot_type = dot_elem.text.strip().lower() if dot_elem.text else "normal"
+
+                type_char = "O"
+                if dot_type == "cross":
+                    type_char = "X"
+                elif dot_type == "square":
+                    type_char = "S"
+                elif dot_type == "triangle":
+                    type_char = "T"
+
+                if fret >= 0:
+                    dot_descriptions.append("%d-%s" % (fret + offset, type_char))
+
+            if dot_descriptions:
+                pattern[string_no] = "[" + ",".join(dot_descriptions) + "]"
+
+    for barre_elem in fret_elem.findall("barre"):
+        start = int(barre_elem.get("start", -1))
+        end = int(barre_elem.get("end", -1))
+        barre_fret_text = barre_elem.text.strip()
+
+        if not barre_fret_text.isdigit() or not (0 <= start < strings_count):
+            continue
+
+        if end == -1:
+            end = strings_count - 1
+        if end < start or end >= strings_count:
+            continue
+
+        barre_fret = int(barre_fret_text) + offset
+
+        for i in range(start, end + 1):
+            current = pattern[i]
+            if current.startswith("[") and current.endswith("]"):
+                inner = current[1:-1]
+                new_inner = []
+                for dot_str in inner.split(","):
+                    parts = dot_str.strip().split("-")
+                    if len(parts) != 2:
+                        continue
+                    try:
+                        fret_val = int(parts[0])
+                    except ValueError:
+                        continue
+                    if fret_val != barre_fret:
+                        new_inner.append(dot_str)
+                if new_inner:
+                    pattern[i] = "[" + ",".join(new_inner) + "]"
+                else:
+                    pattern[i] = "-"
+            elif current == str(barre_fret):
+                pattern[i] = "-"
+
+        barre_parts.append("B%d[%d-%d]" % (barre_fret, start, end))
+
+    base_pattern = ''.join(pattern)
+    if barre_parts:
+        base_pattern += ';' + ';'.join(barre_parts)
+
+    return base_pattern
+
+def get_harmony_name(harmony_elem):
+    name_elem = harmony_elem.find("name")
+    return name_elem.text.strip().lower() if name_elem is not None and name_elem.text else "unknown"
+
+def build_output_xml(pairs):
+    data_elem = ET.Element("Data")
+
+    for fret_elem, harmony_elem in pairs:
+        name = get_harmony_name(harmony_elem)
+
+        htd = ET.SubElement(data_elem, "HarmonyToDiagram")
+        fret_diagram_elem = ET.SubElement(htd, "FretDiagram")
+
+        for child in fret_elem:
+            if child.tag == "eid":
+                continue
+            elif child.tag == "fretDiagram":
+                fret = copy.deepcopy(child)
+
+                offset_elem = fret_elem.getparent().find("fretOffset")
+                offset = int(offset_elem.text) if offset_elem is not None else 0
+                remove_barre_overlapping_dots(fret, offset)
+
+                fret_diagram_elem.append(fret)
+
+                pattern = extract_pattern_from_fretdiagram(fret)
+                pattern_elem = ET.SubElement(htd, "pattern")
+                pattern_elem.text = pattern
+
+            elif child.tag == "string" and fret_elem.find("fretDiagram") is not None and child not in fret_elem.find("fretDiagram"):
+                continue
+            else:
+                fret_diagram_elem.append(copy.deepcopy(child))
+
+        harmony_out = ET.SubElement(htd, "Harmony")
+        name_elem = ET.SubElement(harmony_out, "name")
+        name_elem.text = name
+
+    return data_elem
+
+def indent(elem, level=0):
+    i = "\n" + level * "    "
+    if len(elem):
+        if not elem.text or not elem.text.strip():
+            elem.text = i + "    "
+        for child in elem:
+            indent(child, level + 1)
+        if not elem[-1].tail or not elem[-1].tail.strip():
+            elem[-1].tail = i
+    if level and (not elem.tail or not elem.tail.strip()):
+        elem.tail = i
+    return elem
+
+def main():
+    # Example: python2 parse_mscx.py --in "/path/to/file.mscx" --out /path/to/result.xml
+    parser = argparse.ArgumentParser(description="Extract Harmony and FretDiagram pairs from .mscx and output XML.")
+    parser.add_argument('--in', dest='input_file', required=True, help='Path to the input .mscx file')
+    parser.add_argument('--out', dest='output_file', required=True, help='Path to the output .xml file')
+    args = parser.parse_args()
+
+    pairs = extract_fret_harmony_pairs(args.input_file)
+    root_elem = build_output_xml(pairs)
+    indent(root_elem)
+
+    tree = ET.ElementTree(root_elem)
+    tree.write(args.output_file, encoding="utf-8", xml_declaration=True)
+
+    print("Finished")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Resolves: #28398
Resolves: #28632
Includes: #28442

The idea is that when harmonies change and we try to update a diagram, we check whether the diagram is custom - and if it is, we don’t auto-update it.

The check for 'custom' works as follows:
- If any of these properties were changed, we treat the diagram as custom:
   - Turning 'Show fingerings' on and adding at least one fingering
   - Changing 'Strings'
   - Changing 'Visible frets'
   - Changing 'Fret number'
   - Changing 'Show nut'
- If the user has manually edited the diagram, we also treat it as custom.
   - The main challenge here is detecting whether the user made changes. To do this, we take the diagram, generate a pattern from it, find all matching harmonies for that pattern (in harmony_to_diagram.xml) - and if the current harmony is not in the list of matches, we assume the diagram was modified and is therefore custom.