### PR TITLE
fixed #28520: MuseSounds update dialog appears every time a new score is created

### DIFF
--- a/src/musesounds/internal/musesoundscheckupdatescenario.cpp
+++ b/src/musesounds/internal/musesoundscheckupdatescenario.cpp
@@ -148,7 +148,7 @@ muse::Ret MuseSoundsCheckUpdateScenario::showReleaseInfo(const ReleaseInfo& info
     Ret ret = make_ok();
 
     DEFER {
-        if (ret) {
+        if (ret || ret.code() == static_cast<int>(Ret::Code::Cancel)) {
             setIgnoredUpdate(info.version);
         }
     };


### PR DESCRIPTION
Resolves: #28520
