### PR TITLE
[Linux/BSD] specify QGuiApplication::setDesktopFileName without .desktop extension

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -140,7 +140,7 @@ int main(int argc, char** argv)
 #ifndef MUSE_APP_INSTALL_SUFFIX
 #define MUSE_APP_INSTALL_SUFFIX ""
 #endif
-    QGuiApplication::setDesktopFileName("org.musescore.MuseScore" + QString(MUSE_APP_INSTALL_SUFFIX) + ".desktop");
+    QGuiApplication::setDesktopFileName("org.musescore.MuseScore" MUSE_APP_INSTALL_SUFFIX);
 #endif
 
 #if (defined (_MSCVER) || defined (_MSC_VER))


### PR DESCRIPTION
Since Qt 6.5 (?), it needs to be specified without the .desktop extension. Otherwise there is a warning like in https://github.com/musescore/MuseScore/issues/28631.