### PR TITLE
Partial slurs input fix

### DIFF
--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -2846,7 +2846,7 @@ void NotationInteraction::doAddSlur(const Slur* slurTemplate)
         bool firstCrTrill = firstItem && firstItem->isChord() && toChord(firstItem)->isTrillCueNote();
         bool secondCrTrill = secondItem && secondItem->isChord() && toChord(secondItem)->isTrillCueNote();
 
-        if (firstItem && !(firstCrTrill || secondCrTrill)) {
+        if (firstItem && secondItem && (firstItem->isChordRest() || secondItem->isChordRest()) && !(firstCrTrill || secondCrTrill)) {
             doAddSlur(firstItem, secondItem, slurTemplate);
         }
     }


### PR DESCRIPTION
Resolves: #28641
Allow inputting partial slurs by list selection when the start/end note is not directly adjacent to the repeat object. eg.
<img width="380" alt="Screenshot 2025-07-01 at 15 51 32" src="https://github.com/user-attachments/assets/db2c610a-d22f-416f-bca3-9564be886d86" />
<img width="304" alt="Screenshot 2025-07-01 at 15 51 58" src="https://github.com/user-attachments/assets/369edd20-4ac4-489d-babc-899c1fe62a51" />
