### PR TITLE
Inspector popups opening fix

### DIFF
--- a/src/framework/uicomponents/view/popupview.cpp
+++ b/src/framework/uicomponents/view/popupview.cpp
@@ -348,9 +348,9 @@ PopupView::ClosePolicies PopupView::closePolicies() const
     return m_closePolicies;
 }
 
-PopupView::Placement PopupView::placement() const
+PopupView::PlacementPolicies PopupView::placementPolicies() const
 {
-    return m_placement;
+    return m_placementPolicies;
 }
 
 bool PopupView::activateParentOnClose() const
@@ -503,14 +503,14 @@ void PopupView::setClosePolicies(ClosePolicies closePolicies)
     emit closePoliciesChanged(closePolicies);
 }
 
-void PopupView::setPlacement(Placement placement)
+void PopupView::setPlacementPolicies(muse::uicomponents::PopupView::PlacementPolicies placementPolicies)
 {
-    if (m_placement == placement) {
+    if (m_placementPolicies == placementPolicies) {
         return;
     }
 
-    m_placement = placement;
-    emit placementChanged(placement);
+    m_placementPolicies = placementPolicies;
+    emit placementPoliciesChanged(placementPolicies);
 }
 
 void PopupView::setObjectId(QString objectId)
@@ -789,14 +789,15 @@ void PopupView::updateGeometry()
         viewRect.moveTopLeft(m_globalPos);
     };
 
-    bool canFitAbove = viewRect.height() < parentTopLeft.y();
-    bool canFitBelow = viewRect.bottom() < anchorRect.bottom();
+    bool ignoreFit = m_placementPolicies.testFlag(PlacementPolicy::IgnoreFit);
+    bool canFitAbove = !ignoreFit ? viewRect.height() < parentTopLeft.y() : true;
+    bool canFitBelow = !ignoreFit ? viewRect.bottom() < anchorRect.bottom() : true;
 
-    if (placement() == Placement::PreferAbove && canFitAbove) {
+    if (m_placementPolicies.testFlag(PlacementPolicy::PreferBelow) && canFitBelow) {
+        movePos(m_globalPos.x(), parentTopLeft.y() + parent->height());
+    } else if (m_placementPolicies.testFlag(PlacementPolicy::PreferAbove) && canFitAbove) {
         movePos(m_globalPos.x(), parentTopLeft.y() - viewRect.height());
         setOpensUpward(true);
-    } else if (placement() == Placement::PreferBelow && canFitBelow) {
-        movePos(m_globalPos.x(), parentTopLeft.y() + parent->height());
     } else if (!canFitBelow) {
         if (canFitAbove) {
             // move to the top of the parent

--- a/src/framework/uicomponents/view/popupview.h
+++ b/src/framework/uicomponents/view/popupview.h
@@ -63,7 +63,7 @@ class PopupView : public QObject, public QQmlParserStatus, public Injectable, pu
 
     Q_PROPERTY(bool showArrow READ showArrow WRITE setShowArrow NOTIFY showArrowChanged)
     Q_PROPERTY(int padding READ padding WRITE setPadding NOTIFY paddingChanged)
-    Q_PROPERTY(Placement placement READ placement WRITE setPlacement NOTIFY placementChanged)
+    Q_PROPERTY(PlacementPolicies placementPolicies READ placementPolicies WRITE setPlacementPolicies NOTIFY placementPoliciesChanged)
 
     Q_PROPERTY(QQuickItem * anchorItem READ anchorItem WRITE setAnchorItem NOTIFY anchorItemChanged)
     Q_PROPERTY(bool opensUpward READ opensUpward NOTIFY opensUpwardChanged)
@@ -124,12 +124,14 @@ public:
     Q_DECLARE_FLAGS(FocusPolicies, FocusPolicy)
     Q_FLAG(FocusPolicies)
 
-    enum class Placement {
-        Default,
-        PreferBelow,
-        PreferAbove
+    enum class PlacementPolicy {
+        Default = 0x00000000,
+        PreferBelow = 0x00000001,
+        PreferAbove = 0x00000002,
+        IgnoreFit = 0x00000003
     };
-    Q_ENUM(Placement)
+    Q_DECLARE_FLAGS(PlacementPolicies, PlacementPolicy)
+    Q_FLAG(PlacementPolicies)
 
     QQuickItem* parentItem() const;
 
@@ -155,7 +157,7 @@ public:
 
     OpenPolicies openPolicies() const;
     ClosePolicies closePolicies() const;
-    Placement placement() const;
+    PlacementPolicies placementPolicies() const;
 
     bool activateParentOnClose() const;
     FocusPolicies focusPolicies() const;
@@ -192,7 +194,7 @@ public slots:
     void setLocalY(qreal y);
     void setOpenPolicies(muse::uicomponents::PopupView::OpenPolicies openPolicies);
     void setClosePolicies(muse::uicomponents::PopupView::ClosePolicies closePolicies);
-    void setPlacement(muse::uicomponents::PopupView::Placement newPlacement);
+    void setPlacementPolicies(muse::uicomponents::PopupView::PlacementPolicies placementPolicies);
     void setNavigationParentControl(muse::ui::INavigationControl* parentNavigationControl);
     void setObjectId(QString objectId);
     void setTitle(QString title);
@@ -221,7 +223,7 @@ signals:
     void yChanged(qreal y);
     void openPoliciesChanged(muse::uicomponents::PopupView::OpenPolicies openPolicies);
     void closePoliciesChanged(muse::uicomponents::PopupView::ClosePolicies closePolicies);
-    void placementChanged(muse::uicomponents::PopupView::Placement placement);
+    void placementPoliciesChanged(muse::uicomponents::PopupView::PlacementPolicies placementPolicies);
     void navigationParentControlChanged(muse::ui::INavigationControl* navigationParentControl);
     void objectIdChanged(QString objectId);
     void titleChanged(QString title);
@@ -307,7 +309,7 @@ protected:
     ClosePolicies m_closePolicies = { ClosePolicy::CloseOnPressOutsideParent };
     FocusPolicies m_focusPolicies = { FocusPolicy::DefaultFocus };
 
-    Placement m_placement = { Placement::Default };
+    PlacementPolicies m_placementPolicies = { PlacementPolicy::Default };
 
     bool m_activateParentOnClose = true;
     ui::INavigationControl* m_navigationParentControl = nullptr;

--- a/src/inspector/models/inspectorpopupcontroller.cpp
+++ b/src/inspector/models/inspectorpopupcontroller.cpp
@@ -185,7 +185,7 @@ void InspectorPopupController::closePopupIfNeed(const QPointF& mouseGlobalPos)
     }
 
     QRectF globalNotationViewRect = globalRect(m_notationView);
-    QWindow* windowUnderCursor = qGuiApp->topLevelAt(QCursor::pos());
+    QWindow* windowUnderCursor = qGuiApp->topLevelAt(mouseGlobalPos.toPoint());
     if (windowUnderCursor == mainWindow()->qWindow() && globalNotationViewRect.contains(mouseGlobalPos)) {
         return;
     }

--- a/src/inspector/view/qml/MuseScore/Inspector/InspectorForm.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/InspectorForm.qml
@@ -60,11 +60,22 @@ Rectangle {
 
             popupController.visualControl = visualControl
             popupController.popup = newOpenedPopup
+
+            popupController.popup.closed.connect(function() {
+                if (sectionList.contentY + sectionList.height > sectionList.contentHeight) {
+                    var invisibleContentHeight = sectionList.contentY + sectionList.height - sectionList.contentHeight
+                    Qt.callLater(sectionList.ensureContentVisible, -invisibleContentHeight)
+                }
+            })
         }
     }
 
     InspectorPopupController {
         id: popupController
+    }
+
+    Component.onCompleted: {
+        popupController.load()
     }
 
     StyledListView {

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/tremolobars/TremoloBarSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/tremolobars/TremoloBarSettings.qml
@@ -37,7 +37,7 @@ Item {
 
     objectName: "TremoloBarSettings"
 
-    implicitHeight: content.implicitHeight
+    implicitHeight: root.model && root.model.areSettingsAvailable ? content.height : multipleBarsError.implicitHeight
 
     function focusOnFirst() {
         tremoloBarTypeSection.focusOnFirst()
@@ -50,9 +50,10 @@ Item {
 
         spacing: 12
 
+        visible: root.model ? root.model.areSettingsAvailable : false
+
         DropdownPropertyView {
             id: tremoloBarTypeSection
-            visible: root.model ? root.model.areSettingsAvailable : false
 
             titleText: qsTrc("inspector", "Tremolo bar type")
             propertyItem: root.model ? root.model.type : null
@@ -73,7 +74,6 @@ Item {
 
         InspectorPropertyView {
             id: tremoloBarCurve
-            visible: root.model ? root.model.areSettingsAvailable : false
 
             titleText: qsTrc("inspector", "Click to add or remove points")
             propertyItem: root.model ? root.model.curve : null
@@ -104,8 +104,6 @@ Item {
         Item {
             height: childrenRect.height
             width: parent.width
-
-            visible: root.model ? root.model.areSettingsAvailable : false
 
             SpinBoxPropertyView {
                 id: lineThicknessSection
@@ -145,7 +143,8 @@ Item {
     }
 
     StyledTextLabel {
-        anchors.fill: parent
+        id: multipleBarsError
+        width: parent.width
 
         wrapMode: Text.Wrap
         text: qsTrc("inspector", "You have multiple tremolo bars selected. Select a single one to edit its settings.")


### PR DESCRIPTION
Slightly improved #16367

Now popups always open downward. 
The popup won’t be shown until the content is ready.
Before opening, we scroll the view to make sure the popup fits.