### PR TITLE
engraving/api: Improve Enum performance

### DIFF
--- a/src/engraving/api/v1/enums.cpp
+++ b/src/engraving/api/v1/enums.cpp
@@ -22,6 +22,8 @@
 
 #include "enums.h"
 
+#include <QVariant>
+
 #include "log.h"
 
 using namespace mu::engraving::apiv1;
@@ -42,8 +44,11 @@ void Enum::add(const QMetaEnum& _enum)
         return;
     }
 
+    QVariantHash enumValues;
     const int nkeys = _enum.keyCount();
     for (int i = 0; i < nkeys; ++i) {
-        insert(_enum.key(i), _enum.value(i));
+        enumValues.insert(_enum.key(i), _enum.value(i));
     }
+
+    insert(enumValues);
 }

--- a/src/engraving/api/v1/qmlpluginapi.h
+++ b/src/engraving/api/v1/qmlpluginapi.h
@@ -19,9 +19,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
-#ifndef MU_ENGRAVING_APIV1_QMLPLUGINAPI_H
-#define MU_ENGRAVING_APIV1_QMLPLUGINAPI_H
+#pragma once
 
 #include <QQuickItem>
 
@@ -55,8 +53,10 @@ class Score;
     Q_PROPERTY(mu::engraving::apiv1::Enum * qmlName READ get_##cppName CONSTANT) \
     static Enum* cppName; \
     static Enum* get_##cppName() { \
-        if (!cppName) \
-        cppName = wrapEnum<enumName>(); \
+        if (!cppName) { \
+            cppName = wrapEnum<enumName>(); \
+            cppName->freeze(); \
+        } \
         return cppName; \
     }
 
@@ -67,6 +67,7 @@ class Score;
         if (!cppName) { \
             cppName = wrapEnum<enumName1>(); \
             cppName->add(QMetaEnum::fromType<enumName2>()); \
+            cppName->freeze(); \
         } \
         return cppName; \
     }
@@ -351,7 +352,6 @@ private:
     muse::async::Notification m_closeRequested;
 };
 
+#undef DECLARE_API_ENUM2
 #undef DECLARE_API_ENUM
 }
-
-#endif


### PR DESCRIPTION
Resolves: #28248 (pending confirmation)
Resolves: https://github.com/musescore/MuseScore/issues/28666

From the Qt documentation of [`QQmlPropertyMap::insert(values)`](https://doc.qt.io/qt-6/qqmlpropertymap.html#insert):
> This method is substantially faster than calling insert(key, value) many times in a row.

Creating the Enum instance for the enormous `SymId `enum took ~4.5s on my machine. Now it only takes ~7.5ms.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
