### PR TITLE
Move chord symbol rendering into layout class

### DIFF
--- a/src/engraving/dom/chordrest.cpp
+++ b/src/engraving/dom/chordrest.cpp
@@ -288,8 +288,6 @@ EngravingItem* ChordRest::drop(EditData& data)
             interval.flip();
             score()->undoTransposeHarmony(harmony, interval);
         }
-        // render
-        harmony->render();
     }
     // fall through
     case ElementType::TEXT:

--- a/src/engraving/dom/cmd.cpp
+++ b/src/engraving/dom/cmd.cpp
@@ -3366,7 +3366,6 @@ void Score::cmdAddParentheses(EngravingItem* el)
         Harmony* h = toHarmony(el);
         h->setLeftParen(!h->leftParen());
         h->setRightParen(!h->rightParen());
-        h->render();
     } else if (el->type() == ElementType::TIMESIG) {
         TimeSig* ts = toTimeSig(el);
         ts->setLargeParentheses(true);

--- a/src/engraving/dom/excerpt.cpp
+++ b/src/engraving/dom/excerpt.cpp
@@ -956,14 +956,10 @@ static MeasureBase* cloneMeasure(MeasureBase* mb, Score* score, const Score* osc
                         ns->add(ne);
                         // for chord symbols,
                         // re-render with new style settings
-                        if (ne->isHarmony()) {
-                            Harmony* h = toHarmony(ne);
-                            h->render();
-                        } else if (ne->isFretDiagram()) {
+                        if (ne->isFretDiagram()) {
                             Harmony* h = toHarmony(toFretDiagram(ne)->harmony());
                             if (h) {
                                 processLinkedClone(h, score, strack);
-                                h->render();
                             }
                         }
                     }

--- a/src/engraving/dom/harmony.cpp
+++ b/src/engraving/dom/harmony.cpp
@@ -1582,10 +1582,6 @@ Sid Harmony::getPropertyStyle(Pid pid) const
 
 double Harmony::mag() const
 {
-    if (m_userMag.has_value()) {
-        return m_userMag.value();
-    }
-
     return EngravingItem::mag();
 }
 

--- a/src/engraving/dom/harmony.h
+++ b/src/engraving/dom/harmony.h
@@ -232,8 +232,6 @@ public:
     PropertyValue propertyDefault(Pid id) const override;
 
     double mag() const override;
-    void setUserMag(double m) { m_userMag = m; }
-    const std::optional<double>& userMag() const { return m_userMag; }
 
     double bassScale() const { return m_bassScale; }
     void setBassScale(double v) { m_bassScale = v; }
@@ -282,7 +280,6 @@ private:
     NoteCaseType m_rootCase = NoteCaseType::AUTO;
     NoteCaseType m_bassCase = NoteCaseType::AUTO;        // case as typed
 
-    std::optional<double> m_userMag;
     double m_bassScale = 1.0;
 };
 } // namespace mu::engraving

--- a/src/engraving/dom/harmony.h
+++ b/src/engraving/dom/harmony.h
@@ -82,34 +82,6 @@ private:
     bool m_hAlign = true;
 };
 
-//---------------------------------------------------------
-//   HarmonyRenderCtx
-//---------------------------------------------------------
-
-struct HarmonyRenderCtx {
-    PointF pos = PointF();
-    std::vector<TextSegment*> textList;
-
-    // Reset every single chord
-    bool hAlign = true;
-
-    // Reset every render() call
-    std::stack<PointF> stack;
-    int tpc = Tpc::TPC_INVALID;
-    NoteSpellingType noteSpelling = NoteSpellingType::STANDARD;
-    NoteCaseType noteCase = NoteCaseType::AUTO;
-    double scale = 1.0;
-
-    double x() const { return pos.x(); }
-    double y() const { return pos.y(); }
-
-    void setx(double v) { pos.setX(v); }
-    void movex(double v) { pos.setX(pos.x() + v); }
-    void sety(double v) { pos.setY(v); }
-    void movey(double v) { pos.setY(pos.y() + v); }
-};
-
-struct RenderAction;
 class HDegree;
 
 //---------------------------------------------------------
@@ -233,8 +205,6 @@ public:
 
     const ParsedChord* parsedForm() const;                                             // WILL BE DEPRECATED AFTER RelaizedHarmony IS UPDATED
 
-    const std::vector<TextSegment*>& textList() const { return m_textList; }
-
     void afterRead();
     void render();
 
@@ -263,6 +233,7 @@ public:
 
     double mag() const override;
     void setUserMag(double m) { m_userMag = m; }
+    const std::optional<double>& userMag() const { return m_userMag; }
 
     double bassScale() const { return m_bassScale; }
     void setBassScale(double v) { m_bassScale = v; }
@@ -271,11 +242,18 @@ public:
 
     Color curColor() const override;
 
+    bool doNotStackModifiers() const { return m_doNotStackModifiers; }
+
+    NoteCaseType rootRenderCase(HarmonyInfo* info) const;
+    NoteCaseType bassRenderCase() const;
+
     struct LayoutData : public TextBase::LayoutData {
-        ld_field<double> harmonyHeight = { "[Harmony] harmonyHeight", 0.0 };           // used for calculating the height is frame while editing.
+        ld_field<double> harmonyHeight = { "[Harmony] harmonyHeight", 0.0 };    // used for calculating the height is frame while editing.
         ld_field<std::vector<LineF> > polychordDividerLines = { "[Harmony] polychordDividerLine", std::vector<LineF>() };
         ld_field<double> polychordDividerOffset = { "[Harmony] polychordDividerOffset", 0.0 };
         ld_field<double> baseline = { "[Harmony] baseline", 0.0 };
+        ld_field<std::vector<muse::draw::Font> > fontList = "[Harmony] fontList";          // temp values used in render()
+        ld_field<std::vector<TextSegment*> > textList = "[Harmony] textList";              // rendered chord
     };
     DECLARE_LAYOUTDATA_METHODS(Harmony)
 
@@ -284,28 +262,6 @@ private:
 
     const std::vector<const ChordDescription*> parseHarmony(const String& s, bool syntaxOnly = false);
     const ChordDescription* parseSingleHarmony(const String& s, HarmonyInfo* info, bool syntaxOnly = false);
-
-    NoteCaseType rootRenderCase(HarmonyInfo* info) const;
-    NoteCaseType bassRenderCase() const;
-
-    // TODO - move harmony rendering into a layout class
-    void renderSingleHarmony(HarmonyInfo* info, HarmonyRenderCtx& ctx);
-    void renderRomanNumeral();
-    void render(const String&, HarmonyRenderCtx& ctx);
-    void render(SymId, HarmonyRenderCtx& ctx);
-    void render(const std::list<RenderActionPtr>& renderList, HarmonyRenderCtx& ctx, int tpc,
-                NoteSpellingType noteSpelling = NoteSpellingType::STANDARD, NoteCaseType noteCase = NoteCaseType::AUTO,
-                double noteMag = 1.0);
-    void renderAction(const RenderActionPtr& a, HarmonyRenderCtx& ctx);
-    void renderActionSet(const RenderActionSetPtr& a, HarmonyRenderCtx& ctx);
-    void renderActionMove(const RenderActionMovePtr& a, HarmonyRenderCtx& ctx);
-    void renderActionMoveXHeight(const RenderActionMoveXHeightPtr& a, HarmonyRenderCtx& ctx);
-    void renderActionPush(HarmonyRenderCtx& ctx);
-    void renderActionPop(const RenderActionPopPtr& a, HarmonyRenderCtx& ctx);
-    void renderActionNote(HarmonyRenderCtx& ctx);
-    void renderActionAcc(HarmonyRenderCtx& ctx);
-    void renderActionAlign(HarmonyRenderCtx& ctx);
-    void renderActionScale(const RenderActionScalePtr& a, HarmonyRenderCtx& ctx);
 
     Sid getPropertyStyle(Pid) const override;
 
@@ -317,8 +273,6 @@ private:
     mutable RealizedHarmony m_realizedHarmony;           // the realized harmony used for playback
 
     std::vector<HDegree> m_degreeList;
-    std::vector<muse::draw::Font> m_fontList;            // temp values used in render()
-    std::vector<TextSegment*> m_textList;                // rendered chord
 
     bool m_leftParen = false;
     bool m_rightParen = false;                           // include opening and/or closing parenthesis

--- a/src/engraving/dom/undo.cpp
+++ b/src/engraving/dom/undo.cpp
@@ -1768,7 +1768,6 @@ void TransposeHarmony::flip(EditData*)
     }
 
     m_harmony->setXmlText(m_harmony->harmonyName());
-    m_harmony->render();
     m_harmony->triggerLayout();
     m_interval.flip();
 }
@@ -1794,7 +1793,6 @@ void TransposeHarmonyDiatonic::flip(EditData*)
     }
 
     m_harmony->setXmlText(m_harmony->harmonyName());
-    m_harmony->render();
     m_harmony->triggerLayout();
 
     m_interval *= -1;

--- a/src/engraving/rendering/score/harmonylayout.cpp
+++ b/src/engraving/rendering/score/harmonylayout.cpp
@@ -203,7 +203,7 @@ void HarmonyLayout::render(Harmony* item, Harmony::LayoutData* ldata, const Layo
     ldata->fontList.mut_value().clear();
     for (const ChordFont& cf : chordList->fonts) {
         Font ff(item->font());
-        double mag = item->userMag().value_or(cf.mag);
+        double mag = item->mag() * cf.mag;
         ff.setPointSizeF(ff.pointSizeF() * mag);
         if (cf.musicSymbolText) {
             ff.setFamily(cf.family, Font::Type::MusicSymbolText);

--- a/src/engraving/rendering/score/harmonylayout.cpp
+++ b/src/engraving/rendering/score/harmonylayout.cpp
@@ -5,7 +5,7 @@
  * MuseScore Studio
  * Music Composition & Notation
  *
- * Copyright (C) 2023 MuseScore Limited
+ * Copyright (C) 2025 MuseScore Limited
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -25,16 +25,22 @@
 
 #include "dom/fret.h"
 #include "dom/harmony.h"
+#include "draw/fontmetrics.h"
 
+using namespace muse::draw;
 using namespace mu::engraving;
 using namespace mu::engraving::rendering::score;
 
-void HarmonyLayout::layoutHarmony(const Harmony* item, Harmony::LayoutData* ldata,
+void HarmonyLayout::layoutHarmony(Harmony* item, Harmony::LayoutData* ldata,
                                   const LayoutContext& ctx)
 {
     if (!item->explicitParent()) {
         ldata->setPos(0.0, 0.0);
         const_cast<Harmony*>(item)->setOffset(0.0, 0.0);
+    }
+
+    if (!item->cursor()->editing()) {
+        render(item, ldata, ctx);
     }
 
     if (ldata->layoutInvalid) {
@@ -57,7 +63,7 @@ void HarmonyLayout::layoutHarmony(const Harmony* item, Harmony::LayoutData* ldat
         double newPosX = 0.0;
         double newPosY = 0.0;
 
-        if (item->textList().empty()) {
+        if (item->ldata()->textList().empty()) {
             TLayout::layoutBaseTextBase1(item, ldata);
 
             if (fd) {
@@ -68,7 +74,7 @@ void HarmonyLayout::layoutHarmony(const Harmony* item, Harmony::LayoutData* ldat
         } else {
             RectF bb;
             RectF hAlignBox;
-            for (TextSegment* ts : item->textList()) {
+            for (TextSegment* ts : item->ldata()->textList()) {
                 RectF tsBbox = ts->tightBoundingRect().translated(ts->x(), ts->y());
                 bb.unite(tsBbox);
 
@@ -119,7 +125,7 @@ void HarmonyLayout::layoutHarmony(const Harmony* item, Harmony::LayoutData* ldat
                 newPosY = ypos;
             }
 
-            for (TextSegment* ts : item->textList()) {
+            for (TextSegment* ts : item->ldata()->textList()) {
                 ts->setOffset(PointF(xx, yy));
             }
 
@@ -172,4 +178,491 @@ void HarmonyLayout::layoutHarmony(const Harmony* item, Harmony::LayoutData* ldat
     }
 
     ldata->setPos(positionPoint);
+}
+
+//---------------------------------------------------------
+//   render
+//    construct Chord Symbol
+//---------------------------------------------------------
+
+void HarmonyLayout::render(Harmony* item, Harmony::LayoutData* ldata, const LayoutContext& ctx)
+{
+    for (const TextSegment* s : ldata->textList()) {
+        delete s;
+    }
+    ldata->textList.mut_value().clear();
+    if (item->harmonyType() == HarmonyType::ROMAN) {
+        renderRomanNumeral(item, ldata, ctx);
+        return;
+    }
+
+    // Render standard or Nashville chords
+
+    ChordList* chordList = item->score()->chordList();
+
+    ldata->fontList.mut_value().clear();
+    for (const ChordFont& cf : chordList->fonts) {
+        Font ff(item->font());
+        double mag = item->userMag().value_or(cf.mag);
+        ff.setPointSizeF(ff.pointSizeF() * mag);
+        if (cf.musicSymbolText) {
+            ff.setFamily(cf.family, Font::Type::MusicSymbolText);
+        } else if (!(cf.family.isEmpty() || cf.family == "default")) {
+            ff.setFamily(cf.family, Font::Type::Harmony);
+        }
+        ldata->fontList.mut_value().push_back(ff);
+    }
+    if (ldata->fontList.mut_value().empty()) {
+        ldata->fontList.mut_value().push_back(item->font());
+    }
+
+    ldata->polychordDividerLines.reset();
+    HarmonyRenderCtx harmonyCtx;
+
+    // Map of text segments and their final width
+    std::multimap<double, std::vector<TextSegment*> > chordTextSegments;
+
+    for (size_t i = item->chords().size(); i > 0; i--) {
+        harmonyCtx.info = item->chords().at(i - 1);
+        renderSingleHarmony(item, ldata, harmonyCtx, ctx);
+
+        chordTextSegments.emplace(std::pair<double, std::vector<TextSegment*> > { harmonyCtx.x(), harmonyCtx.textList });
+        ldata->textList.mut_value().insert(ldata->textList.mut_value().end(), harmonyCtx.textList.begin(), harmonyCtx.textList.end());
+
+        // Measure divider spacing from lowest baseline and highest cap-height in segments
+        double rootBaseline = harmonyCtx.textList.empty() ? -DBL_MAX : harmonyCtx.textList.front()->y();
+        double bottomBaseline = -DBL_MAX;
+        for (const TextSegment* seg : harmonyCtx.textList) {
+            bottomBaseline = std::max(bottomBaseline, seg->y());
+        }
+
+        double diff = rootBaseline - bottomBaseline;
+        if (bottomBaseline > rootBaseline) {
+            for (TextSegment* seg : harmonyCtx.textList) {
+                seg->movey(diff);
+            }
+        }
+        if (i == item->chords().size()) {
+            // Set baseline for bottom chord
+            ldata->baseline = -diff;
+        }
+
+        double topCapHeight = DBL_MAX;
+        for (const TextSegment* seg : harmonyCtx.textList) {
+            topCapHeight = std::min(topCapHeight, seg->y() - seg->capHeight());
+        }
+
+        harmonyCtx.textList.clear();
+        if (item->chords().size() == 1 || i == 1) {
+            break;
+        }
+
+        assert(!muse::RealIsEqual(topCapHeight, DBL_MAX));
+
+        harmonyCtx.setx(0);
+        harmonyCtx.sety(topCapHeight);
+
+        double lineY = harmonyCtx.y() - ctx.conf().style().styleS(Sid::polychordDividerSpacing).toMM(item->spatium())
+                       - ctx.conf().style().styleS(Sid::polychordDividerThickness).toMM(item->spatium()) / 2;
+        LineF line = LineF(PointF(0.0, lineY), PointF(0.0, lineY));
+        ldata->polychordDividerLines.mut_value().push_back(line);
+
+        harmonyCtx.movey(-ctx.conf().style().styleS(Sid::polychordDividerSpacing).toMM(item->spatium()) * 2.0);
+        harmonyCtx.movey(-ctx.conf().style().styleS(Sid::polychordDividerThickness).toMM(item->spatium()));
+    }
+
+    // Align polychords
+
+    if (item->align() == AlignH::LEFT) {
+        return;
+    }
+
+    double longestLine = 0.0;
+    for (double width : muse::keys(chordTextSegments)) {
+        if (width > longestLine) {
+            longestLine = width;
+        }
+    }
+
+    for (auto& textSegs : chordTextSegments) {
+        double width = textSegs.first;
+        std::vector<TextSegment*>& segs = textSegs.second;
+
+        double diff = longestLine - width;
+
+        if (muse::RealIsNull(diff)) {
+            continue;
+        }
+
+        // For centre align adjust by .5* difference, for right align adjust by full difference
+        if (item->align() == AlignH::HCENTER) {
+            diff *= 0.5;
+        }
+
+        for (TextSegment* seg : segs) {
+            seg->movex(diff);
+        }
+    }
+}
+
+void HarmonyLayout::renderRomanNumeral(Harmony* item, Harmony::LayoutData* ldata, const LayoutContext& ctx)
+{
+    HarmonyRenderCtx harmonyCtx;
+    if (item->chords().empty()) {
+        return;
+    }
+    HarmonyInfo* info = item->chords().front();
+
+    if (item->leftParen()) {
+        render(item, ldata, SymId::csymParensLeftTall, harmonyCtx, ctx);
+    }
+
+    render(item, ldata, info->textName(), harmonyCtx);
+
+    if (item->rightParen()) {
+        render(item, ldata, SymId::csymParensRightTall, harmonyCtx, ctx);
+    }
+}
+
+void HarmonyLayout::renderSingleHarmony(Harmony* item, Harmony::LayoutData* ldata, HarmonyRenderCtx& harmonyCtx,
+                                        const LayoutContext& ctx)
+{
+    harmonyCtx.hAlign = true;
+    HarmonyInfo* info = harmonyCtx.info;
+
+    const MStyle& style = ctx.conf().style();
+
+    int capo = style.styleI(Sid::capoPosition);
+
+    ChordList* chordList = info->chordList();
+    if (!chordList) {
+        return;
+    }
+
+    NoteCaseType rootCase = item->rootRenderCase(info);
+    NoteCaseType bassCase = item->bassRenderCase();
+
+    if (item->leftParen()) {
+        render(item, ldata, SymId::csymParensLeftTall, harmonyCtx, ctx);
+    }
+
+    NoteSpellingType spelling = style.styleV(Sid::chordSymbolSpelling).value<NoteSpellingType>();
+
+    if (item->harmonyType() == HarmonyType::STANDARD && tpcIsValid(info->rootTpc())) {
+        // render root
+        render(item, ldata, chordList->renderListRoot, harmonyCtx, info->rootTpc(), spelling, rootCase);
+        // render extension
+        const ChordDescription* cd = info->getDescription();
+        if (cd) {
+            const bool stackModifiers = style.styleB(Sid::verticallyStackModifiers) && !item->doNotStackModifiers();
+            render(item, ldata, stackModifiers ? cd->renderListStacked : cd->renderList, harmonyCtx, 0);
+        }
+    } else if (item->harmonyType() == HarmonyType::NASHVILLE && tpcIsValid(info->rootTpc())) {
+        // render function
+        render(item, ldata, chordList->renderListFunction, harmonyCtx, info->rootTpc(), spelling, bassCase);
+        double adjust = chordList->nominalAdjust();
+        harmonyCtx.movey(adjust * item->magS() * item->spatium() * .2);
+        // render extension
+        const ChordDescription* cd = info->getDescription();
+        if (cd) {
+            const bool stackModifiers = style.styleB(Sid::verticallyStackModifiers) && !item->doNotStackModifiers();
+            render(item, ldata, stackModifiers ? cd->renderListStacked : cd->renderList, harmonyCtx, 0);
+        }
+    } else {
+        render(item, ldata, info->textName(), harmonyCtx);
+    }
+
+    // render bass
+    if (tpcIsValid(info->bassTpc())) {
+        std::list<RenderActionPtr >& bassNoteChordList
+            = style.styleB(Sid::chordBassNoteStagger) ? chordList->renderListBassOffset : chordList->renderListBass;
+        render(item, ldata, bassNoteChordList, harmonyCtx, info->bassTpc(), spelling, bassCase, item->bassScale());
+    }
+
+    if (tpcIsValid(info->rootTpc()) && capo > 0 && capo < 12) {
+        int tpcOffset[] = { 0, 5, -2, 3, -4, 1, 6, -1, 4, -3, 2, -5 };
+        int capoRootTpc = info->rootTpc() + tpcOffset[capo];
+        int capoBassTpc = info->bassTpc();
+
+        if (tpcIsValid(capoBassTpc)) {
+            capoBassTpc += tpcOffset[capo];
+        }
+
+        /*
+         * For guitarists, avoid x and bb in Root or Bass,
+         * and also avoid E#, B#, Cb and Fb in Root.
+         */
+        if (capoRootTpc < 8 || (tpcIsValid(capoBassTpc) && capoBassTpc < 6)) {
+            capoRootTpc += 12;
+            if (tpcIsValid(capoBassTpc)) {
+                capoBassTpc += 12;
+            }
+        } else if (capoRootTpc > 24 || (tpcIsValid(capoBassTpc) && capoBassTpc > 26)) {
+            capoRootTpc -= 12;
+            if (tpcIsValid(capoBassTpc)) {
+                capoBassTpc -= 12;
+            }
+        }
+
+        render(item, ldata, SymId::csymParensLeftTall, harmonyCtx, ctx);
+        render(item, ldata, chordList->renderListRoot, harmonyCtx, capoRootTpc, spelling, rootCase);
+
+        // render extension
+        const ChordDescription* cd = info->getDescription();
+        if (cd) {
+            const bool stackModifiers = style.styleB(Sid::verticallyStackModifiers) && !item->doNotStackModifiers();
+            render(item, ldata, stackModifiers ? cd->renderListStacked : cd->renderList, harmonyCtx, 0);
+        }
+
+        if (tpcIsValid(capoBassTpc)) {
+            std::list<RenderActionPtr >& bassNoteChordList
+                = style.styleB(Sid::chordBassNoteStagger) ? chordList->renderListBassOffset : chordList->renderListBass;
+            render(item, ldata, bassNoteChordList, harmonyCtx, capoBassTpc, spelling, bassCase, item->bassScale());
+        }
+        render(item, ldata, SymId::csymParensRightTall, harmonyCtx, ctx);
+    }
+
+    if (item->rightParen()) {
+        render(item, ldata, SymId::csymParensRightTall, harmonyCtx, ctx);
+    }
+}
+
+//---------------------------------------------------------
+//   render
+//---------------------------------------------------------
+
+void HarmonyLayout::render(Harmony* item, Harmony::LayoutData* ldata, const String& s, HarmonyRenderCtx& harmonyCtx)
+{
+    if (s.isEmpty()) {
+        return;
+    }
+
+    Font f = item->harmonyType() != HarmonyType::ROMAN ? ldata->fontList.value().front() : item->font();
+    TextSegment* ts = new TextSegment(s, f, harmonyCtx.x(), harmonyCtx.y(), harmonyCtx.hAlign);
+    harmonyCtx.textList.push_back(ts);
+    harmonyCtx.movex(ts->width());
+}
+
+void HarmonyLayout::render(Harmony* item, Harmony::LayoutData* ldata, SymId sym, HarmonyRenderCtx& harmonyCtx, const LayoutContext& ctx)
+{
+    if (sym == SymId::noSym) {
+        return;
+    }
+
+    Font f = item->harmonyType() != HarmonyType::ROMAN ? ldata->fontList.value().front() : item->font();
+    f.setFamily(ctx.conf().style().styleSt(Sid::musicalTextFont), Font::Type::MusicSymbolText);
+
+    String s = ctx.conf().engravingFont()->toString(sym);
+
+    TextSegment* ts = new TextSegment(s, f, harmonyCtx.x(), harmonyCtx.y(), harmonyCtx.hAlign);
+    harmonyCtx.textList.push_back(ts);
+    harmonyCtx.movex(ts->width());
+}
+
+void HarmonyLayout::render(Harmony* item, Harmony::LayoutData* ldata, const std::list<RenderActionPtr>& renderList,
+                           HarmonyRenderCtx& harmonyCtx,
+                           int tpc,
+                           NoteSpellingType noteSpelling,
+                           NoteCaseType noteCase, double noteMag)
+{
+    harmonyCtx.stack = {};
+    harmonyCtx.tpc = tpc;
+    harmonyCtx.noteSpelling = noteSpelling;
+    harmonyCtx.noteCase = noteCase;
+    harmonyCtx.scale = noteMag;
+
+    for (const RenderActionPtr& a : renderList) {
+        renderAction(item, ldata, a, harmonyCtx);
+    }
+}
+
+void HarmonyLayout::renderAction(Harmony* item, Harmony::LayoutData* ldata, const RenderActionPtr& a, HarmonyRenderCtx& harmonyCtx)
+{
+    switch (a->actionType()) {
+    case RenderAction::RenderActionType::SET:
+        renderActionSet(item, ldata, std::static_pointer_cast<RenderActionSet>(a), harmonyCtx);
+        break;
+    case RenderAction::RenderActionType::MOVE:
+        renderActionMove(item, std::static_pointer_cast<RenderActionMove>(a), harmonyCtx);
+        break;
+    case RenderAction::RenderActionType::MOVEXHEIGHT:
+        renderActionMoveXHeight(item, std::static_pointer_cast<RenderActionMoveXHeight>(a), harmonyCtx);
+        break;
+    case RenderAction::RenderActionType::PUSH:
+        renderActionPush(harmonyCtx);
+        break;
+    case RenderAction::RenderActionType::POP:
+        renderActionPop(std::static_pointer_cast<RenderActionPop>(a), harmonyCtx);
+        break;
+    case RenderAction::RenderActionType::NOTE:
+        renderActionNote(item, ldata, harmonyCtx);
+        break;
+    case RenderAction::RenderActionType::ACCIDENTAL:
+        renderActionAcc(item, ldata, harmonyCtx);
+        break;
+    case RenderAction::RenderActionType::STOPHALIGN:
+        renderActionAlign(harmonyCtx);
+        break;
+    case RenderAction::RenderActionType::SCALE:
+        renderActionScale(std::static_pointer_cast<RenderActionScale>(a), harmonyCtx);
+        break;
+    default:
+        LOGD("unknown render action %d", static_cast<int>(a->actionType()));
+    }
+}
+
+void HarmonyLayout::renderActionPush(HarmonyRenderCtx& harmonyCtx)
+{
+    harmonyCtx.stack.push(harmonyCtx.pos);
+}
+
+void HarmonyLayout::renderActionPop(const RenderActionPopPtr& a, HarmonyRenderCtx& harmonyCtx)
+{
+    if (harmonyCtx.stack.empty()) {
+        LOGD("RenderAction::RenderActionType::POP: stack empty");
+        return;
+    }
+
+    PointF pt = harmonyCtx.stack.top();
+    harmonyCtx.stack.pop();
+    harmonyCtx.pos = PointF(a->popX() ? pt.x() : harmonyCtx.x(), a->popY() ? pt.y() : harmonyCtx.y());
+}
+
+void HarmonyLayout::renderActionNote(Harmony* item, Harmony::LayoutData* ldata, HarmonyRenderCtx& harmonyCtx)
+{
+    if (!tpcIsValid(harmonyCtx.tpc)) {
+        return;
+    }
+    const ChordList* chordList = item->score()->chordList();
+    const Staff* st = item->staff();
+    const Key key = st ? st->key(item->tick()) : Key::INVALID;
+
+    String c;
+    AccidentalVal acc;
+
+    if (item->harmonyType() == HarmonyType::STANDARD) {
+        tpc2name(harmonyCtx.tpc, harmonyCtx.noteSpelling, harmonyCtx.noteCase, c, acc);
+    } else if (item->harmonyType() == HarmonyType::NASHVILLE) {
+        String accStr;
+        tpc2Function(harmonyCtx.tpc, key, accStr, c);
+    }
+
+    if (c.empty()) {
+        return;
+    }
+
+    String lookup = u"note" + c;
+    ChordSymbol cs = chordList->symbol(lookup);
+    if (!cs.isValid()) {
+        cs = chordList->symbol(c);
+    }
+    String text = cs.isValid() ? cs.value : c;
+    muse::draw::Font font = cs.isValid() ? ldata->fontList.value()[cs.fontIdx] : ldata->fontList.value().front();
+    font.setPointSizeF(font.pointSizeF() * harmonyCtx.scale);
+
+    TextSegment* ts = new TextSegment(text, font, harmonyCtx.x(), harmonyCtx.y(), harmonyCtx.hAlign);
+    harmonyCtx.textList.push_back(ts);
+    harmonyCtx.movex(ts->width());
+}
+
+void HarmonyLayout::renderActionAcc(Harmony* item, Harmony::LayoutData* ldata, HarmonyRenderCtx& harmonyCtx)
+{
+    if (!tpcIsValid(harmonyCtx.tpc)) {
+        return;
+    }
+    const ChordList* chordList = item->score()->chordList();
+    const Staff* st = item->staff();
+    const Key key = st ? st->key(item->tick()) : Key::INVALID;
+
+    String c;
+    String acc;
+    String context = u"accidental";
+
+    if (item->harmonyType() == HarmonyType::STANDARD) {
+        tpc2name(harmonyCtx.tpc, harmonyCtx.noteSpelling, harmonyCtx.noteCase, c, acc);
+    } else if (item->harmonyType() == HarmonyType::NASHVILLE) {
+        tpc2Function(harmonyCtx.tpc, key, acc, c);
+    }
+
+    if (acc.empty()) {
+        return;
+    }
+
+    // Try to find token & execute renderlist
+    ChordToken tok = chordList->token(acc, ChordTokenClass::ACCIDENTAL);
+    if (tok.isValid()) {
+        for (const RenderActionPtr& a : tok.renderList) {
+            renderAction(item, ldata, a, harmonyCtx);
+        }
+        return;
+    }
+
+    // No valid token, find symbol
+
+    // German spelling - use special symbol for accidental in TPC_B_B
+    // to allow it to be rendered as either Bb or B
+    if (harmonyCtx.tpc == Tpc::TPC_B_B && harmonyCtx.noteSpelling == NoteSpellingType::GERMAN) {
+        context = u"german_B";
+    }
+    String lookup = context + acc;
+    ChordSymbol cs = chordList->symbol(lookup);
+    if (!cs.isValid()) {
+        cs = chordList->symbol(acc);
+    }
+    String text = cs.isValid() ? cs.value : c;
+    muse::draw::Font font = cs.isValid() ? ldata->fontList.value()[cs.fontIdx] : ldata->fontList.value().front();
+    font.setPointSizeF(font.pointSizeF() * harmonyCtx.scale);
+    font.setNoFontMerging(true);
+
+    TextSegment* ts = new TextSegment(text, font, harmonyCtx.x(), harmonyCtx.y(), harmonyCtx.hAlign);
+    harmonyCtx.textList.push_back(ts);
+    harmonyCtx.movex(ts->width());
+}
+
+void HarmonyLayout::renderActionAlign(HarmonyRenderCtx& harmonyCtx)
+{
+    harmonyCtx.hAlign = false;
+}
+
+void HarmonyLayout::renderActionScale(const RenderActionScalePtr& a, HarmonyRenderCtx& harmonyCtx)
+{
+    harmonyCtx.scale *= a->scale();
+}
+
+void HarmonyLayout::renderActionSet(Harmony* item, Harmony::LayoutData* ldata, const RenderActionSetPtr& a, HarmonyRenderCtx& harmonyCtx)
+{
+    const ChordList* chordList = item->score()->chordList();
+    const ChordSymbol cs = chordList->symbol(a->text());
+    const String text = cs.isValid() ? cs.value : a->text();
+    muse::draw::Font font = cs.isValid() ? ldata->fontList.value()[cs.fontIdx] : ldata->fontList.value().front();
+    font.setPointSizeF(font.pointSizeF() * harmonyCtx.scale);
+    if (item->harmonyType() == HarmonyType::NASHVILLE) {
+        double nmag = chordList->nominalMag();
+        font.setPointSizeF(font.pointSizeF() * nmag);
+    }
+
+    TextSegment* ts = new TextSegment(text, font, harmonyCtx.x(), harmonyCtx.y(), harmonyCtx.hAlign);
+    harmonyCtx.movex(ts->width());
+
+    if (a->renderText()) {
+        harmonyCtx.textList.push_back(ts);
+        return;
+    }
+
+    delete ts;
+}
+
+void HarmonyLayout::renderActionMove(Harmony* item, const RenderActionMovePtr& a, HarmonyRenderCtx& harmonyCtx)
+{
+    const FontMetrics fm = FontMetrics(item->font());
+    const double scale = a->scaled() ? harmonyCtx.scale : 1.0;
+    harmonyCtx.pos = harmonyCtx.pos + a->vec() * FontMetrics::capHeight(item->font()) * scale;
+}
+
+void HarmonyLayout::renderActionMoveXHeight(Harmony* item, const RenderActionMoveXHeightPtr& a, HarmonyRenderCtx& harmonyCtx)
+{
+    const int direction = a->up() ? -1 : 1;
+    const double scale = a->scaled() ? harmonyCtx.scale : 1.0;
+    const FontMetrics fm = FontMetrics(item->font());
+    harmonyCtx.movey(direction * fm.xHeight() * scale);
 }

--- a/src/engraving/rendering/score/harmonylayout.h
+++ b/src/engraving/rendering/score/harmonylayout.h
@@ -33,6 +33,52 @@ namespace mu::engraving::rendering::score {
 class HarmonyLayout
 {
 public:
-    static void layoutHarmony(const Harmony* item, Harmony::LayoutData* ldata, const LayoutContext& ctx);
+    static void layoutHarmony(Harmony* item, Harmony::LayoutData* ldata, const LayoutContext& ctx);
+
+private:
+
+    struct HarmonyRenderCtx {
+        PointF pos = PointF();
+        std::vector<TextSegment*> textList;
+
+        // Reset every single chord
+        bool hAlign = true;
+        HarmonyInfo* info = nullptr;
+
+        // Reset every render() call
+        std::stack<PointF> stack;
+        int tpc = Tpc::TPC_INVALID;
+        NoteSpellingType noteSpelling = NoteSpellingType::STANDARD;
+        NoteCaseType noteCase = NoteCaseType::AUTO;
+        double scale = 1.0;
+
+        double x() const { return pos.x(); }
+        double y() const { return pos.y(); }
+
+        void setx(double v) { pos.setX(v); }
+        void movex(double v) { pos.setX(pos.x() + v); }
+        void sety(double v) { pos.setY(v); }
+        void movey(double v) { pos.setY(pos.y() + v); }
+    };
+
+    static void render(Harmony* item, Harmony::LayoutData* ldata, const LayoutContext& ctx);
+    static void renderSingleHarmony(Harmony* item, Harmony::LayoutData* ldata, HarmonyRenderCtx& harmonyCtx, const LayoutContext& ctx);
+    static void renderRomanNumeral(Harmony* item, Harmony::LayoutData* ldata, const LayoutContext& ctx);
+    static void render(Harmony* item, Harmony::LayoutData* ldata, const String& str, HarmonyRenderCtx& harmonyCtx);
+    static void render(Harmony* item, Harmony::LayoutData* ldata, SymId sym, HarmonyRenderCtx& harmonyCtx, const LayoutContext& ctx);
+    static void render(Harmony* item, Harmony::LayoutData* ldata, const std::list<RenderActionPtr>& renderList, HarmonyRenderCtx& ctx,
+                       int tpc, NoteSpellingType noteSpelling = NoteSpellingType::STANDARD, NoteCaseType noteCase = NoteCaseType::AUTO,
+                       double noteMag = 1.0);
+
+    static void renderAction(Harmony* item, Harmony::LayoutData* ldata, const RenderActionPtr& a, HarmonyRenderCtx& harmonyCtx);
+    static void renderActionSet(Harmony* item, Harmony::LayoutData* ldata, const RenderActionSetPtr& a, HarmonyRenderCtx& harmonyCtx);
+    static void renderActionMove(Harmony* item, const RenderActionMovePtr& a, HarmonyRenderCtx& harmonyCtx);
+    static void renderActionMoveXHeight(Harmony* item, const RenderActionMoveXHeightPtr& a, HarmonyRenderCtx& harmonyCtx);
+    static void renderActionPush(HarmonyRenderCtx& harmonyCtx);
+    static void renderActionPop(const RenderActionPopPtr& a, HarmonyRenderCtx& harmonyCtx);
+    static void renderActionNote(Harmony* item, Harmony::LayoutData* ldata, HarmonyRenderCtx& harmonyCtx);
+    static void renderActionAcc(Harmony* item, Harmony::LayoutData* ldata, HarmonyRenderCtx& harmonyCtx);
+    static void renderActionAlign(HarmonyRenderCtx& harmonyCtx);
+    static void renderActionScale(const RenderActionScalePtr& a, HarmonyRenderCtx& harmonyCtx);
 };
 }

--- a/src/engraving/rendering/score/tdraw.cpp
+++ b/src/engraving/rendering/score/tdraw.cpp
@@ -1817,7 +1817,7 @@ void TDraw::draw(const Harmony* item, Painter* painter)
 
     const Harmony::LayoutData* ldata = item->ldata();
 
-    if (item->textList().empty()) {
+    if (ldata->textList().empty()) {
         drawTextBase(item, painter);
         return;
     }
@@ -1846,7 +1846,7 @@ void TDraw::draw(const Harmony* item, Painter* painter)
     painter->setBrush(BrushStyle::NoBrush);
     Color color = item->textColor();
     painter->setPen(color);
-    for (const TextSegment* ts : item->textList()) {
+    for (const TextSegment* ts : ldata->textList()) {
         Font f(ts->font());
         f.setPointSizeF(f.pointSizeF() * MScore::pixelRatio);
 #ifndef Q_OS_MACOS
@@ -1862,7 +1862,7 @@ void TDraw::draw(const Harmony* item, Painter* painter)
         pen.setWidthF(item->style().styleS(Sid::polychordDividerThickness).toMM(item->spatium()));
         pen.setColor(color);
         painter->setPen(pen);
-        for (const LineF& line : ldata->polychordDividerLines.value()) {
+        for (const LineF& line : ldata->polychordDividerLines()) {
             painter->drawLine(line.translated(PointF(0.0, ldata->polychordDividerOffset)));
         }
     }

--- a/src/engraving/rendering/score/tlayout.cpp
+++ b/src/engraving/rendering/score/tlayout.cpp
@@ -1491,7 +1491,7 @@ void TLayout::layoutFBox(const FBox* item, FBox::LayoutData* ldata, const Layout
         fretDiagram->setUserMag(item->diagramScale());
 
         Harmony* harmony = fretDiagram->harmony();
-        harmony->setUserMag(item->textScale());
+        harmony->mutldata()->setMag(item->textScale());
         layoutHarmony(harmony, harmony->mutldata(), ctx);
 
         layoutItem(fretDiagram, const_cast<LayoutContext&>(ctx));

--- a/src/engraving/rendering/score/tlayout.cpp
+++ b/src/engraving/rendering/score/tlayout.cpp
@@ -287,7 +287,7 @@ void TLayout::layoutItem(EngravingItem* item, LayoutContext& ctx)
         layoutHarpPedalDiagram(item_cast<const HarpPedalDiagram*>(item), static_cast<HarpPedalDiagram::LayoutData*>(ldata));
         break;
     case ElementType::HARMONY:
-        layoutHarmony(item_cast<const Harmony*>(item), static_cast<Harmony::LayoutData*>(ldata), ctx);
+        layoutHarmony(item_cast<Harmony*>(item), static_cast<Harmony::LayoutData*>(ldata), ctx);
         break;
     case ElementType::HARMONIC_MARK_SEGMENT: layoutHarmonicMarkSegment(item_cast<HarmonicMarkSegment*>(item), ctx);
         break;
@@ -1492,7 +1492,7 @@ void TLayout::layoutFBox(const FBox* item, FBox::LayoutData* ldata, const Layout
 
         Harmony* harmony = fretDiagram->harmony();
         harmony->setUserMag(item->textScale());
-        harmony->render();
+        layoutHarmony(harmony, harmony->mutldata(), ctx);
 
         layoutItem(fretDiagram, const_cast<LayoutContext&>(ctx));
 
@@ -3403,7 +3403,7 @@ void TLayout::layoutHarmonicMarkSegment(HarmonicMarkSegment* item, LayoutContext
     Autoplace::autoplaceSpannerSegment(item, ldata, ctx.conf().spatium());
 }
 
-void TLayout::layoutHarmony(const Harmony* item, Harmony::LayoutData* ldata, const LayoutContext& ctx)
+void TLayout::layoutHarmony(Harmony* item, Harmony::LayoutData* ldata, const LayoutContext& ctx)
 {
     LAYOUT_CALL_ITEM(item);
     LD_INDEPENDENT;

--- a/src/engraving/rendering/score/tlayout.h
+++ b/src/engraving/rendering/score/tlayout.h
@@ -257,7 +257,7 @@ public:
     static void fillHairpinSegmentShape(const HairpinSegment* item, HairpinSegment::LayoutData* ldata);
     static void layoutHarpPedalDiagram(const HarpPedalDiagram* item, HarpPedalDiagram::LayoutData* ldata);
     static void layoutHarmonicMarkSegment(HarmonicMarkSegment* item, LayoutContext& ctx);
-    static void layoutHarmony(const Harmony* item, Harmony::LayoutData* ldata, const LayoutContext& ctx);
+    static void layoutHarmony(Harmony* item, Harmony::LayoutData* ldata, const LayoutContext& ctx);
     static void layoutHook(const Hook* item, Hook::LayoutData* ldata);
 
     static void layoutImage(const Image* item, Image::LayoutData* ldata);

--- a/src/engraving/rendering/single/singledraw.cpp
+++ b/src/engraving/rendering/single/singledraw.cpp
@@ -1719,12 +1719,11 @@ void SingleDraw::draw(const Harmony* item, Painter* painter)
 {
     TRACE_DRAW_ITEM;
 
-    if (item->textList().empty()) {
+    const Harmony::LayoutData* ldata = item->ldata();
+    if (ldata->textList().empty()) {
         drawTextBase(item, painter);
         return;
     }
-
-    const Harmony::LayoutData* ldata = item->ldata();
 
     if (item->hasFrame()) {
         if (!RealIsNull(item->frameWidth().val())) {
@@ -1750,7 +1749,7 @@ void SingleDraw::draw(const Harmony* item, Painter* painter)
     painter->setBrush(BrushStyle::NoBrush);
     Color color = item->textColor();
     painter->setPen(color);
-    for (const TextSegment* ts : item->textList()) {
+    for (const TextSegment* ts : ldata->textList()) {
         Font f(ts->font());
         f.setPointSizeF(f.pointSizeF() * MScore::pixelRatio);
 #ifndef Q_OS_MACOS

--- a/src/importexport/bb/internal/bb.cpp
+++ b/src/importexport/bb/internal/bb.cpp
@@ -521,7 +521,6 @@ Err importBB(MasterScore* score, const QString& name)
         info->setId(c.extension);
         h->addChord(info);
 
-        h->render();
         s->add(h);
     }
 

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -7860,7 +7860,6 @@ void MusicXmlParserPass2::harmony(const String& partId, Measure* measure, const 
         info->setTextName(textName);
     }
     ha->addChord(info);
-    ha->render();
 
     ha->setVisible(printObject);
     if (placement == u"below") {

--- a/src/importexport/ove/internal/importove.cpp
+++ b/src/importexport/ove/internal/importove.cpp
@@ -2133,7 +2133,6 @@ void OveToMScore::convertHarmonies(Measure* measure, int part, int staff, int tr
         }
 
         harmony->addChord(info);
-        harmony->render();
 
         Segment* s = measure->getSegment(SegmentType::ChordRest, Fraction::fromTicks(absTick));
         s->add(harmony);


### PR DESCRIPTION
Render chord symbol at layout.
To prevent chord symbols being rendered when editing, I've introduced an `editing()` value which is set to true in `startEditTextual` and false in `endEditTextual`. I would like to solve this problem in a similar way to https://github.com/musescore/MuseScore/pull/27976 eventually.