### PR TITLE
Revert "Reimplement drop shadows using modern QML components"

### DIFF
--- a/src/framework/audio/qml/Muse/Audio/VolumeSlider.qml
+++ b/src/framework/audio/qml/Muse/Audio/VolumeSlider.qml
@@ -288,39 +288,38 @@ Slider {
             }
         }
 
-        StyledRectangularDropShadow {
-            anchors.fill: handleRect
-
-            blur: 4
-            color: "#33000000"
-            radius: handleRect.radius
-
-        }
-
-        Rectangle {
-            id: handleRect
+        ItemWithDropShadow {
             anchors.fill: parent
-            radius: 2
-            color: "white"
+
+            shadow.color: "#33000000"
+            shadow.radius: 4
+            shadow.verticalOffset: 2
 
             Rectangle {
+                id: handleRect
                 anchors.fill: parent
                 radius: 2
-
-                color: Utils.colorWithAlpha(ui.theme.popupBackgroundColor, 0.1)
-                border.color: Qt.rgba(0, 0, 0, 0.7)
-                border.width: 1
+                color: "white"
 
                 Rectangle {
-                    anchors.verticalCenter: parent.verticalCenter
-                    anchors.left: parent.left
-                    anchors.right: parent.right
-                    anchors.leftMargin: 3
-                    anchors.rightMargin: 3
+                    anchors.fill: parent
+                    radius: 2
 
-                    height: 1
-                    radius: height / 2
-                    color: "#000000"
+                    color: Utils.colorWithAlpha(ui.theme.popupBackgroundColor, 0.1)
+                    border.color: Qt.rgba(0, 0, 0, 0.7)
+                    border.width: 1
+
+                    Rectangle {
+                        anchors.verticalCenter: parent.verticalCenter
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        anchors.leftMargin: 3
+                        anchors.rightMargin: 3
+
+                        height: 1
+                        radius: height / 2
+                        color: "#000000"
+                    }
                 }
             }
         }

--- a/src/framework/dockwindow/qml/Muse/Dock/DockFloatingWindow.qml
+++ b/src/framework/dockwindow/qml/Muse/Dock/DockFloatingWindow.qml
@@ -40,21 +40,19 @@ Item {
     anchors.fill: parent
     anchors.margins: 8 // Needed for the shadow, please sync with DOCK_WINDOW_SHADOW in docktypes.h
 
-    StyledRectangularDropShadow {
-        anchors.fill: background
+    ItemWithDropShadow {
+        anchors.fill: dropArea
+        shadow.radius: root.anchors.margins
 
-        blur: root.anchors.margins
-        radius: background.radius
-    }
+        Rectangle {
+            id: background
+            anchors.fill: parent
 
-    Rectangle {
-        id: background
-        anchors.fill: parent
-
-        color: ui.theme.backgroundPrimaryColor
-        border.color: ui.theme.strokeColor
-        border.width: 1
-        radius: 3
+            color: ui.theme.backgroundPrimaryColor
+            border.color: ui.theme.strokeColor
+            border.width: 1
+            radius: 3
+        }
     }
 
     Item {

--- a/src/framework/uicomponents/qml/Muse/UiComponents/ItemWithDropShadow.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/ItemWithDropShadow.qml
@@ -1,0 +1,52 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ *
+ * MuseScore
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2024 MuseScore BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import QtQuick 2.15
+
+Item {
+    id: root
+
+    default property alias contentData: content.data
+    property alias shadow: theShadow
+
+    implicitWidth: content.implicitWidth
+    implicitHeight: content.implicitHeight
+
+    StyledDropShadow {
+        id: theShadow
+        anchors.fill: contentContainer
+        source: contentContainer
+    }
+
+    Item {
+        id: contentContainer
+
+        readonly property real theMargin: Math.abs(theShadow.horizontalOffset) + Math.abs(theShadow.verticalOffset) + Math.abs(theShadow.radius)
+        anchors.fill: parent
+        anchors.margins: -theMargin
+
+        Item {
+            id: content
+            anchors.fill: parent
+            anchors.margins: contentContainer.theMargin
+        }
+    }
+}

--- a/src/framework/uicomponents/qml/Muse/UiComponents/StyledDialogView.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/StyledDialogView.qml
@@ -91,19 +91,18 @@ DialogView {
             }
         }
 
-        StyledRectangularDropShadow {
-            anchors.fill: contentBackground
-            visible: root.frameless
-            radius: contentBackground.radius
-        }
-
-        Rectangle {
-            id: contentBackground
+        ItemWithDropShadow {
             anchors.fill: parent
-            color: ui.theme.backgroundPrimaryColor
-            radius: root.frameless ? 4 : 0
-            border.width: root.frameless ? 1 : 0
-            border.color: ui.theme.strokeColor
+            shadow.visible: root.frameless
+
+            Rectangle {
+                id: contentBackground
+                anchors.fill: parent
+                color: ui.theme.backgroundPrimaryColor
+                radius: root.frameless ? 4 : 0
+                border.width: root.frameless ? 1 : 0
+                border.color: ui.theme.strokeColor
+            }
         }
 
         Item {

--- a/src/framework/uicomponents/qml/Muse/UiComponents/StyledDropShadow.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/StyledDropShadow.qml
@@ -19,12 +19,13 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import QtQuick
-import QtQuick.Effects
+import QtQuick 2.15
 
-RectangularShadow {
-    offset.x: 0
-    offset.y: 2
-    color: Qt.rgba(0.0, 0.0, 0.0, 0.25)
-    blur: 10
+import Muse.GraphicalEffects 1.0
+
+EffectDropShadow {
+    color: "#40000000"
+    verticalOffset: 4
+    radius: 12
+    samples: 18
 }

--- a/src/framework/uicomponents/qml/Muse/UiComponents/ToggleButton.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/ToggleButton.qml
@@ -74,26 +74,25 @@ FocusScope {
             navigationCtrl: navCtrl
         }
 
-        StyledRectangularDropShadow {
-            anchors.fill: handleRect
-            offset.y: 1
-            blur: 4
-            radius: handleRect.radius
-        }
-
-        Rectangle {
-            id: handleRect
-
+        ItemWithDropShadow {
             readonly property int margins: 2
 
             anchors.verticalCenter: parent.verticalCenter
             x: root.checked ? parent.width - width - margins : margins
+
             width: root.height - margins * 2
             height: width
 
+            shadow.color: "#33000000"
+            shadow.radius: 4
+            shadow.verticalOffset: 1
 
-            radius: width / 2
-            color: "#FFFFFF"
+            Rectangle {
+                anchors.fill: parent
+
+                radius: width / 2
+                color: "#FFFFFF"
+            }
         }
     }
 

--- a/src/framework/uicomponents/qml/Muse/UiComponents/internal/PopupContent.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/internal/PopupContent.qml
@@ -93,22 +93,21 @@ FocusScope {
         opacity: root.animationEnabled ? 0.5 : 1.0
         transformOrigin: Item.Center
 
-        StyledRectangularDropShadow {
-            anchors.fill: contentBackground
-            visible: root.useDropShadow
-
-            blur: root.padding
-            radius: contentBackground.radius
-        }
-
-        Rectangle {
-            id: contentBackground
+        ItemWithDropShadow {
             anchors.fill: parent
+            shadow.radius: root.padding
 
-            color: ui.theme.popupBackgroundColor
-            radius: 4
-            border.width: 1
-            border.color: ui.theme.strokeColor
+            shadow.visible: root.useDropShadow
+
+            Rectangle {
+                id: contentBackground
+                anchors.fill: parent
+
+                color: ui.theme.popupBackgroundColor
+                radius: 4
+                border.width: 1
+                border.color: ui.theme.strokeColor
+            }
         }
 
         Canvas {
@@ -133,7 +132,7 @@ FocusScope {
                 ctx.strokeStyle = contentBackground.border.color
                 ctx.beginPath();
 
-                if (root.opensUpward) {
+                if (opensUpward) {
                     ctx.moveTo(0, 0);
                     ctx.lineTo(width / 2, height - 1);
                     ctx.lineTo(width, 0);

--- a/src/framework/uicomponents/qml/Muse/UiComponents/qmldir
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/qmldir
@@ -18,6 +18,7 @@ GradientRectangle 1.0 GradientRectangle.qml
 GridViewSectional 1.0 GridViewSectional.qml
 IncrementalPropertyControl 1.0 IncrementalPropertyControl.qml
 InfoPanel 1.0 InfoPanel.qml
+ItemWithDropShadow 1.0 ItemWithDropShadow.qml
 ListItemBlank 1.0 ListItemBlank.qml
 MenuButton 1.0 MenuButton.qml
 NavigationFocusBorder 1.0 NavigationFocusBorder.qml
@@ -36,7 +37,7 @@ SelectMultipleDirectoriesDialog 1.0 SelectMultipleDirectoriesDialog.qml
 SeparatorLine 1.0 SeparatorLine.qml
 StyledBusyIndicator 1.0 StyledBusyIndicator.qml
 StyledDialogView 1.0 StyledDialogView.qml
-StyledRectangularDropShadow 1.0 StyledRectangularDropShadow.qml
+StyledDropShadow 1.0 StyledDropShadow.qml
 StyledDropdown 1.0 StyledDropdown.qml
 StyledFlickable 1.0 StyledFlickable.qml
 StyledGridView 1.0 StyledGridView.qml

--- a/src/framework/uicomponents/uicomponents.qrc
+++ b/src/framework/uicomponents/uicomponents.qrc
@@ -20,6 +20,7 @@
         <file>qml/Muse/UiComponents/GridViewSectional.qml</file>
         <file>qml/Muse/UiComponents/IncrementalPropertyControl.qml</file>
         <file>qml/Muse/UiComponents/InfoPanel.qml</file>
+        <file>qml/Muse/UiComponents/ItemWithDropShadow.qml</file>
         <file>qml/Muse/UiComponents/ListItemBlank.qml</file>
         <file>qml/Muse/UiComponents/MenuButton.qml</file>
         <file>qml/Muse/UiComponents/NavigationFocusBorder.qml</file>
@@ -37,7 +38,7 @@
         <file>qml/Muse/UiComponents/SeparatorLine.qml</file>
         <file>qml/Muse/UiComponents/StyledBusyIndicator.qml</file>
         <file>qml/Muse/UiComponents/StyledDialogView.qml</file>
-        <file>qml/Muse/UiComponents/StyledRectangularDropShadow.qml</file>
+        <file>qml/Muse/UiComponents/StyledDropShadow.qml</file>
         <file>qml/Muse/UiComponents/StyledDropdown.qml</file>
         <file>qml/Muse/UiComponents/StyledFlickable.qml</file>
         <file>qml/Muse/UiComponents/StyledGridView.qml</file>

--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/LayoutPanelItemDelegate.qml
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/LayoutPanelItemDelegate.qml
@@ -124,12 +124,12 @@ FocusableControl {
         }
     }
 
-    StyledRectangularDropShadow {
+    StyledDropShadow {
         id: shadow
 
-        anchors.fill: root.background
+        anchors.fill: parent
+        source: background
         visible: false
-        z: -1
     }
 
     Loader {

--- a/src/project/qml/MuseScore/Project/internal/ScoresPage/CloudScoreIndicatorButton.qml
+++ b/src/project/qml/MuseScore/Project/internal/ScoresPage/CloudScoreIndicatorButton.qml
@@ -19,8 +19,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import QtQuick
-import QtQuick.Effects
+import QtQuick 2.15
 
 import Muse.UiComponents 1.0
 import Muse.Ui 1.0
@@ -131,23 +130,24 @@ Item {
         }
     ]
 
-    MultiEffect {
-        anchors.fill: icon
-        source: icon
 
-        shadowEnabled: true
-        shadowVerticalOffset: 1
-        shadowColor: Qt.rgba(0, 0, 0, 0.25)
-        blurMax: 4
-    }
-
-    StyledIconLabel {
-        id: icon
+    ItemWithDropShadow {
         anchors.centerIn: parent
 
-        iconCode: root.isProgress ? IconCode.STOP_FILL : IconCode.CLOUD_FILL
-        font.pixelSize: root.isProgress ? 12 : 14
-        color: "white"
+        implicitWidth: icon.implicitWidth
+        implicitHeight: icon.implicitHeight
+
+        shadow.horizontalOffset: 0
+        shadow.verticalOffset: 1
+        shadow.radius: 4
+
+        StyledIconLabel {
+            id: icon
+
+            iconCode: root.isProgress ? IconCode.STOP_FILL : IconCode.CLOUD_FILL
+            font.pixelSize: root.isProgress ? 12 : 14
+            color: "white"
+        }
     }
 
     MouseArea {


### PR DESCRIPTION
This reverts commit 81831c12f3ed88eea033121e1b4898ffe5aaaeea.

Because this breaks MuseScore startup on Qt 6.2. We’ll bring this solution back after the full transition to Qt 6.9.

#28622