### PR TITLE
Fix #28095: Undocked panel content too tall for window

### DIFF
--- a/src/framework/dockwindow/internal/dockbase.cpp
+++ b/src/framework/dockwindow/internal/dockbase.cpp
@@ -698,10 +698,6 @@ void DockBase::applySizeConstraints()
         QRect winRect(window->dragRect().topLeft(), winSize);
 
         window->setGeometry(winRect);
-
-        if (KDDockWidgets::LayoutWidget* layout = window->layoutWidget()) {
-            layout->setLayoutSize(winSize);
-        }
     }
 
     if (!frame || !m_inited) {


### PR DESCRIPTION
Resolves: #28095

This bug was uncovered by #27682 but the code in question goes all the way back to #9764.

The purpose of this code is seemingly to force the "layout" size to the window size but it appears to be having the opposite effect. Instead, the layout size ends up 18px taller than the window holding it.