### PR TITLE
Add .midi extension support to macOS Info.plist

### DIFF
--- a/buildscripts/packaging/macOS/Info.plist.in
+++ b/buildscripts/packaging/macOS/Info.plist.in
@@ -273,6 +273,7 @@
 			<key>CFBundleTypeExtensions</key>
 			<array>
 				<string>mid</string>
+				<string>midi</string>
 			</array>
 			<key>CFBundleTypeMIMETypes</key>
 			<array>


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/28744

Another experiment with GitHub Copilot agent mode in VS Code... and it seems to have worked well. 