### PR TITLE
[MEI] add staff attribute to harm element

### DIFF
--- a/src/importexport/mei/internal/meiconverter.cpp
+++ b/src/importexport/mei/internal/meiconverter.cpp
@@ -1417,6 +1417,9 @@ std::pair<libmei::Harm, libmei::Fb> Convert::fbToMEI(const engraving::FiguredBas
     libmei::Harm meiHarm;
     libmei::Fb meiFb;
 
+    // @staff
+    Convert::staffIdentToMEI(figuredBass, meiHarm);
+
     // @color
     Convert::colorToMEI(figuredBass, meiHarm);
 
@@ -1750,6 +1753,9 @@ libmei::Harm Convert::harmToMEI(const engraving::Harmony* harmony, StringList& m
     if (harmony->propertyFlags(engraving::Pid::PLACEMENT) == engraving::PropertyFlags::UNSTYLED) {
         meiHarm.SetPlace(Convert::placeToMEI(harmony->placement()));
     }
+
+    // @staff
+    Convert::staffIdentToMEI(harmony, meiHarm);
 
     // @color
     Convert::colorToMEI(harmony, meiHarm);

--- a/src/importexport/mei/tests/data/chord-label-01.mei
+++ b/src/importexport/mei/tests/data/chord-label-01.mei
@@ -66,8 +66,8 @@
                            </chord>
                         </layer>
                      </staff>
-                     <harm xml:id="h1bgzmmn" startid="#c16epnbl">E^7</harm>
-                     <harm xml:id="h1fslw0p" startid="#c4pb0j8">Bb/D</harm>
+                     <harm xml:id="h1bgzmmn" staff="1" startid="#c16epnbl">E^7</harm>
+                     <harm xml:id="h1fslw0p" staff="1" startid="#c4pb0j8">Bb/D</harm>
                   </measure>
                   <measure xml:id="m17w9yor" n="2">
                      <staff xml:id="m2s1" n="1">
@@ -98,9 +98,9 @@
                            </chord>
                         </layer>
                      </staff>
-                     <harm xml:id="h5dj6v7" startid="#rezq8rc">EM</harm>
-                     <harm xml:id="hnjtfvy" startid="#c15hduaw">E7</harm>
-                     <harm xml:id="hg8bgbi" startid="#cccssun">not a chord</harm>
+                     <harm xml:id="h5dj6v7" staff="1" startid="#rezq8rc">EM</harm>
+                     <harm xml:id="hnjtfvy" staff="1" startid="#c15hduaw">E7</harm>
+                     <harm xml:id="hg8bgbi" staff="1" startid="#cccssun">not a chord</harm>
                   </measure>
                   <measure xml:id="m9o8nmk" n="3">
                      <staff xml:id="m3s1" n="1">
@@ -141,9 +141,9 @@
                            </note>
                         </layer>
                      </staff>
-                     <harm xml:id="h1dlo6v9" startid="#c944xvj">Bbb</harm>
-                     <harm xml:id="h1uvdsty" startid="#c1lo3mzp">Gb-</harm>
-                     <harm xml:id="h1e83rhs" startid="#n6az5co" place="below">Eb0</harm>
+                     <harm xml:id="h1dlo6v9" staff="1" startid="#c944xvj">Bbb</harm>
+                     <harm xml:id="h1uvdsty" staff="1" startid="#c1lo3mzp">Gb-</harm>
+                     <harm xml:id="h1e83rhs" staff="1" startid="#n6az5co" place="below">Eb0</harm>
                   </measure>
                   <measure xml:id="mjnwqx9" right="end" n="4">
                      <staff xml:id="m4s1" n="1">
@@ -180,9 +180,9 @@
                            </note>
                         </layer>
                      </staff>
-                     <harm xml:id="h1jmd9aa" startid="#c1dl6j78">Db9Maj7</harm>
-                     <harm xml:id="htlcc69" startid="#n11s8pxj" place="below">Bbono5ma7</harm>
-                     <harm xml:id="hp721hh" startid="#nj8l4lr">Bb-Maj7/Db</harm>
+                     <harm xml:id="h1jmd9aa" staff="1" startid="#c1dl6j78">Db9Maj7</harm>
+                     <harm xml:id="htlcc69" staff="1" startid="#n11s8pxj" place="below">Bbono5ma7</harm>
+                     <harm xml:id="hp721hh" staff="1" startid="#nj8l4lr">Bb-Maj7/Db</harm>
                   </measure>
                </section>
             </score>

--- a/src/importexport/mei/tests/data/fig-bass-01.mei
+++ b/src/importexport/mei/tests/data/fig-bass-01.mei
@@ -58,18 +58,18 @@
                            <note xml:id="nyk80vv" dur="4" pname="c" oct="3" />
                         </layer>
                      </staff>
-                     <harm startid="#n1i43w58">
+                     <harm staff="2" startid="#n1i43w58">
                         <fb xml:id="ffz7y2q">
                            <f xml:id="fuej3fi">6</f>
                            <f xml:id="fj4gnll">5</f>
                         </fb>
                      </harm>
-                     <harm startid="#n1rjye5l">
+                     <harm staff="2" startid="#n1rjye5l">
                         <fb xml:id="f1522aas">
                            <f xml:id="f1dnqorw">6#</f>
                         </fb>
                      </harm>
-                     <harm startid="#nyk80vv">
+                     <harm staff="2" startid="#nyk80vv">
                         <fb xml:id="fzp6izt">
                            <f xml:id="f1rg3br9">6b__</f>
                         </fb>
@@ -89,17 +89,17 @@
                            <note xml:id="nmw9hng" dur="4" pname="c" oct="3" />
                         </layer>
                      </staff>
-                     <harm startid="#n1l35gbb">
+                     <harm staff="2" startid="#n1l35gbb">
                         <fb xml:id="fct3c8g">
                            <f xml:id="f1dwv9vp">5bb</f>
                         </fb>
                      </harm>
-                     <harm startid="#nenmw8s">
+                     <harm staff="2" startid="#nenmw8s">
                         <fb xml:id="f16wulbx">
                            <f xml:id="f1so57zl">5##</f>
                         </fb>
                      </harm>
-                     <harm startid="#nmw9hng">
+                     <harm staff="2" startid="#nmw9hng">
                         <fb xml:id="f5kj22w">
                            <f xml:id="f19f8t1u">5h</f>
                         </fb>
@@ -119,7 +119,7 @@
                            <note xml:id="n45ov2a" dur="4" pname="c" oct="3" />
                         </layer>
                      </staff>
-                     <harm startid="#n1kwtmew">
+                     <harm staff="2" startid="#n1kwtmew">
                         <fb xml:id="f1aiqtpi">
                            <f xml:id="f1g0tln2">4+</f>
                         </fb>

--- a/src/importexport/mei/tests/data/roman-numeral-01.mei
+++ b/src/importexport/mei/tests/data/roman-numeral-01.mei
@@ -131,10 +131,10 @@
                            </beam>
                         </layer>
                      </staff>
-                     <harm xml:id="h11isqcg" type="mscore-roman" startid="#cfp4mbz">E.I7{</harm>
-                     <harm xml:id="hqd5b29" type="mscore-roman" startid="#coo81qj">bVII7(b9)</harm>
-                     <harm xml:id="h1ouzwgk" type="mscore-roman" startid="#c1ume9sq">V7(-5)/bIII</harm>
-                     <harm xml:id="h1c6oiqa" type="mscore-roman" startid="#c18zaam0">VI7(b5b4)</harm>
+                     <harm xml:id="h11isqcg" type="mscore-roman" staff="2" startid="#cfp4mbz">E.I7{</harm>
+                     <harm xml:id="hqd5b29" type="mscore-roman" staff="2" startid="#coo81qj">bVII7(b9)</harm>
+                     <harm xml:id="h1ouzwgk" type="mscore-roman" staff="2" startid="#c1ume9sq">V7(-5)/bIII</harm>
+                     <harm xml:id="h1c6oiqa" type="mscore-roman" staff="2" startid="#c18zaam0">VI7(b5b4)</harm>
                   </measure>
                   <measure xml:id="m1msh5yn" n="2">
                      <staff xml:id="m2s1" n="1">
@@ -410,10 +410,10 @@
                            </beam>
                         </layer>
                      </staff>
-                     <harm xml:id="h1874to2" type="mscore-roman" startid="#c1xrr9sz">I.bVI+6</harm>
-                     <harm xml:id="h1v3iy05" type="mscore-roman" startid="#cpqgpn9">v%43(-3)</harm>
-                     <harm xml:id="hwsyu0q" type="mscore-roman" startid="#coj5usf">V7/V</harm>
-                     <harm xml:id="h154c0h8" type="mscore-roman" startid="#c18vo3yk">bI+6(+4)</harm>
+                     <harm xml:id="h1874to2" type="mscore-roman" staff="1" startid="#c1xrr9sz">I.bVI+6</harm>
+                     <harm xml:id="h1v3iy05" type="mscore-roman" staff="1" startid="#cpqgpn9">v%43(-3)</harm>
+                     <harm xml:id="hwsyu0q" type="mscore-roman" staff="1" startid="#coj5usf">V7/V</harm>
+                     <harm xml:id="h154c0h8" type="mscore-roman" staff="1" startid="#c18vo3yk">bI+6(+4)</harm>
                   </measure>
                   <measure xml:id="mx37hco" n="5">
                      <staff xml:id="m5s1" n="1">
@@ -509,10 +509,10 @@
                            </beam>
                         </layer>
                      </staff>
-                     <harm xml:id="h19k4fue" type="mscore-roman" startid="#c1djk3s0">N7(+6)</harm>
-                     <harm xml:id="h1janxng" type="mscore-roman" startid="#coe4rhe">I7(+#6#4)</harm>
-                     <harm xml:id="h974j5y" type="mscore-roman" startid="#c1kk682t">V7(v##6)/III</harm>
-                     <harm xml:id="hjfstls" type="mscore-roman" startid="#c1066e1z">bII7(+#6##3##1)/V/V/V</harm>
+                     <harm xml:id="h19k4fue" type="mscore-roman" staff="2" startid="#c1djk3s0">N7(+6)</harm>
+                     <harm xml:id="h1janxng" type="mscore-roman" staff="2" startid="#coe4rhe">I7(+#6#4)</harm>
+                     <harm xml:id="h974j5y" type="mscore-roman" staff="2" startid="#c1kk682t">V7(v##6)/III</harm>
+                     <harm xml:id="hjfstls" type="mscore-roman" staff="2" startid="#c1066e1z">bII7(+#6##3##1)/V/V/V</harm>
                   </measure>
                   <measure xml:id="m17w0b7o" right="end" n="6">
                      <staff xml:id="m6s1" n="1">
@@ -600,9 +600,9 @@
                         </layer>
                      </staff>
                      <caesura xml:id="ct7c3el" startid="#cg7p1d9" />
-                     <harm xml:id="hpsp4ra" type="mscore-roman" startid="#c18b26o0">V7/V/V</harm>
-                     <harm xml:id="hbo8vux" type="mscore-roman" startid="#c1uxt5we">Fr(+#5)</harm>
-                     <harm xml:id="h1blah3y" type="mscore-roman" startid="#c119yffs">V7|HC}</harm>
+                     <harm xml:id="hpsp4ra" type="mscore-roman" staff="2" startid="#c18b26o0">V7/V/V</harm>
+                     <harm xml:id="hbo8vux" type="mscore-roman" staff="2" startid="#c1uxt5we">Fr(+#5)</harm>
+                     <harm xml:id="h1blah3y" type="mscore-roman" staff="2" startid="#c119yffs">V7|HC}</harm>
                      <caesura xml:id="crg1jce" startid="#c119yffs" />
                   </measure>
                </section>


### PR DESCRIPTION
For figured bass it makes sense to make the connected staff explicit in the MEI export. This PR adds the corresponding value to all harmony elements.