### PR TITLE
Fix build with latest Windows SDK

### DIFF
--- a/src/framework/audio/CMakeLists.txt
+++ b/src/framework/audio/CMakeLists.txt
@@ -287,7 +287,8 @@ else ()
         find_library(CoreAudio NAMES CoreAudio)
         set(MODULE_LINK ${MODULE_LINK} ${AudioToolbox} ${CoreAudio})
     elseif (OS_IS_WIN)
-        set(MODULE_LINK ${MODULE_LINK} winmm mmdevapi mfplat)
+        set(MODULE_LINK ${MODULE_LINK} winmm mmdevapi mfplat
+            WindowsApp) # needed for C++/WinRT
     elseif (OS_IS_LIN)
         find_package(ALSA REQUIRED)
         set(MODULE_INCLUDE_PRIVATE ${MODULE_INCLUDE_PRIVATE} ${ALSA_INCLUDE_DIRS} )

--- a/src/framework/global/CMakeLists.txt
+++ b/src/framework/global/CMakeLists.txt
@@ -232,7 +232,9 @@ else()
             ${CMAKE_CURRENT_LIST_DIR}/internal/platform/win/wininteractivehelper.h
             ${CMAKE_CURRENT_LIST_DIR}/platform/win/waitabletimer.h
         )
-        list(APPEND MODULE_LINK Winmm) # needed for timeBeginPeriod
+        list(APPEND MODULE_LINK
+            WindowsApp # needed for C++/WinRT
+            Winmm) # needed for timeBeginPeriod
     endif()
 endif()
 


### PR DESCRIPTION
We need to link to WindowsApp.lib when we use the C++/WinRT language projection.[^1]

[^1]: https://learn.microsoft.com/en-us/windows/uwp/cpp-and-winrt-apis/get-started#linking

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
