### PR TITLE
fw/global: Cleanup WinInteractiveHelper

### DIFF
--- a/src/appshell/qml/DevTools/Interactive/InteractiveTests.qml
+++ b/src/appshell/qml/DevTools/Interactive/InteractiveTests.qml
@@ -180,6 +180,16 @@ Rectangle {
         FlatButton {
             width: 200
             navigation.panel: navPanel
+            navigation.row: 6
+            text: "Open MuseHub"
+            onClicked: {
+                api.launcher.openApp("musehub://?from=musescore")
+            }
+        }
+
+        FlatButton {
+            width: 200
+            navigation.panel: navPanel
             navigation.row: 7
             text: "Question"
             onClicked: testModel.question()

--- a/src/framework/global/CMakeLists.txt
+++ b/src/framework/global/CMakeLists.txt
@@ -230,6 +230,7 @@ else()
         set(MODULE_SRC ${MODULE_SRC}
             ${CMAKE_CURRENT_LIST_DIR}/internal/platform/win/wininteractivehelper.cpp
             ${CMAKE_CURRENT_LIST_DIR}/internal/platform/win/wininteractivehelper.h
+            ${CMAKE_CURRENT_LIST_DIR}/platform/win/async.h
             ${CMAKE_CURRENT_LIST_DIR}/platform/win/waitabletimer.h
         )
         list(APPEND MODULE_LINK

--- a/src/framework/global/internal/platform/win/wininteractivehelper.cpp
+++ b/src/framework/global/internal/platform/win/wininteractivehelper.cpp
@@ -24,31 +24,18 @@
 #include <winrt/Windows.System.h>
 #include <winrt/Windows.Foundation.h>
 
+#include "platform/win/async.h"
+#include "types/uri.h"
+
 using namespace muse;
 using namespace muse::async;
 
+using namespace winrt;
+using namespace Windows::System;
+
 async::Promise<Ret> WinInteractiveHelper::openApp(const Uri& uri)
 {
-    return Promise<Ret>([&uri](auto resolve, auto reject) {
-        using namespace winrt::Windows;
-        using namespace winrt::Windows::System;
+    const Windows::Foundation::Uri wUri(winrt::to_hstring(uri.toString()));
 
-        std::string sUri = uri.toString();
-        std::wstring wsUri = std::wstring(sUri.begin(), sUri.end());
-
-        Foundation::Uri wUri(wsUri.c_str());
-
-        auto asyncOperation = Launcher::LaunchUriAsync(wUri);
-        asyncOperation.Completed([=](Foundation::IAsyncOperation<bool> const&,
-                                     Foundation::AsyncStatus const asyncStatus) {
-            if (asyncStatus == Foundation::AsyncStatus::Error) {
-                Ret ret = make_ret(Ret::Code::InternalError);
-                (void)reject(ret.code(), ret.text());
-            } else {
-                (void)resolve(make_ok());
-            }
-        });
-
-        return Promise<Ret>::Result::unchecked();
-    });
+    return toPromise<Ret>(Launcher::LaunchUriAsync(wUri));
 }

--- a/src/framework/global/internal/platform/win/wininteractivehelper.h
+++ b/src/framework/global/internal/platform/win/wininteractivehelper.h
@@ -19,22 +19,19 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef MU_FRAMEWORK_WININTERACTIVEHELPER_H
-#define MU_FRAMEWORK_WININTERACTIVEHELPER_H
+#pragma once
 
-#include "io/path.h"
 #include "types/ret.h"
-#include "types/uri.h"
 
 #include "async/asyncable.h"
 #include "async/promise.h"
 
 namespace muse {
+class Uri;
+
 class WinInteractiveHelper : public async::Asyncable
 {
 public:
     static async::Promise<Ret> openApp(const Uri& uri);
 };
 }
-
-#endif // MU_FRAMEWORK_WININTERACTIVEHELPER_H

--- a/src/framework/global/platform/win/async.h
+++ b/src/framework/global/platform/win/async.h
@@ -1,0 +1,60 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2025 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <type_traits>
+
+#include <winrt/windows.foundation.h>
+
+#include "global/async/promise.h"
+#include "global/types/ret.h"
+
+namespace muse::async {
+template<typename T, typename U, typename Fn,
+         std::enable_if_t<std::is_convertible_v<std::invoke_result_t<Fn, U>, T>, int> = 0>
+Promise<T> toPromise(winrt::Windows::Foundation::IAsyncOperation<U> asyncOp, Fn&& transformResult)
+{
+    using winrt::Windows::Foundation::IAsyncOperation;
+    using winrt::Windows::Foundation::AsyncStatus;
+
+    return Promise<T>([&](auto resolve, auto reject) {
+        asyncOp.Completed([=](const IAsyncOperation<U>& sender, const AsyncStatus status) {
+            if (status != AsyncStatus::Completed) {
+                Ret ret = make_ret(Ret::Code::InternalError);
+                (void)reject(ret.code(), ret.text());
+                return;
+            }
+
+            (void)resolve(transformResult(sender.GetResults()));
+        });
+
+        return Promise<T>::Result::unchecked();
+    }, PromiseType::AsyncByBody);
+}
+
+template<typename T, typename U,
+         std::enable_if_t<std::is_constructible_v<T, U>, int> = 0>
+Promise<T> toPromise(winrt::Windows::Foundation::IAsyncOperation<U> asyncOp)
+{
+    return toPromise<T>(asyncOp, [](auto&& u) -> T { return T { std::forward<decltype(u)>(u) }; });
+}
+}

--- a/src/framework/ui/view/qmllauncher.cpp
+++ b/src/framework/ui/view/qmllauncher.cpp
@@ -34,6 +34,12 @@ bool QmlLauncher::open(const QString& uri)
     return true;
 }
 
+bool QmlLauncher::openApp(const QString& uri)
+{
+    interactive()->openApp(Uri(uri));
+    return true;
+}
+
 bool QmlLauncher::openUrl(const QString& url)
 {
     return interactive()->openUrl(QUrl(url));

--- a/src/framework/ui/view/qmllauncher.h
+++ b/src/framework/ui/view/qmllauncher.h
@@ -19,8 +19,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef MUSE_UI_QMLLAUNCHER_H
-#define MUSE_UI_QMLLAUNCHER_H
+#pragma once
 
 #include <QObject>
 
@@ -38,8 +37,7 @@ public:
     QmlLauncher(QObject* parent, const modularity::ContextPtr& iocCtx);
 
     Q_INVOKABLE bool open(const QString& uri);
+    Q_INVOKABLE bool openApp(const QString& uri);
     Q_INVOKABLE bool openUrl(const QString& url);
 };
 }
-
-#endif // MUSE_UI_QMLLAUNCHER_H


### PR DESCRIPTION
I noticed a few defects in this class while looking into #28779.
- `std::wstring(begin, end)` doesn't convert charsets. `winrt::to_hstring` does.
- The `bool` result of `Launcher::LaunchUriAsync` was ignored (it's still unused, but at least it's now being converted to `Ret` and returned)

I've also factored out the `IAsyncOperation<T> -> Promise<T>` conversion to a utility function.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
