### PR TITLE
Deep refactor of elements anchor-editing behaviour

### DIFF
--- a/src/engraving/dom/anchors.cpp
+++ b/src/engraving/dom/anchors.cpp
@@ -39,7 +39,7 @@ namespace mu::engraving {
  * EditTimeTickAnchors
  * ************************************/
 
-void EditTimeTickAnchors::updateAnchors(const EngravingItem* item, track_idx_t track)
+void EditTimeTickAnchors::updateAnchors(const EngravingItem* item)
 {
     if (!item->allowTimeAnchor()) {
         item->score()->hideAnchors();
@@ -56,7 +56,7 @@ void EditTimeTickAnchors::updateAnchors(const EngravingItem* item, track_idx_t t
         return;
     }
 
-    staff_idx_t staff = track2staff(track);
+    staff_idx_t staff = item->staffIdx();
     Measure* startOneBefore = startMeasure->prevMeasure();
     for (MeasureBase* mb = startOneBefore ? startOneBefore : startMeasure; mb && mb->tick() <= endMeasure->tick(); mb = mb->next()) {
         if (!mb->isMeasure()) {
@@ -72,6 +72,8 @@ void EditTimeTickAnchors::updateAnchors(const EngravingItem* item, track_idx_t t
 
     score->setShowAnchors(ShowAnchors(voiceIdx, staff, startTickMainRegion, endTickMainRegion, startTickExtendedRegion,
                                       endTickExtendedRegion));
+
+    item->triggerLayout();
 }
 
 void EditTimeTickAnchors::updateAnchors(Measure* measure, staff_idx_t staffIdx)

--- a/src/engraving/dom/anchors.cpp
+++ b/src/engraving/dom/anchors.cpp
@@ -147,7 +147,7 @@ void EditTimeTickAnchors::updateLayout(Measure* measure)
     MeasureLayout::layoutTimeTickAnchors(measure, ctx);
 }
 
-void EditTimeTickAnchors::moveElementAnchors(EngravingItem* element, KeyboardKey key, KeyboardModifier mod)
+void MoveElementAnchors::moveElementAnchors(EngravingItem* element, KeyboardKey key, KeyboardModifier mod)
 {
     Segment* segment = element->parentItem() && element->parentItem()->isSegment() ? toSegment(element->parentItem()) : nullptr;
     if (!segment) {
@@ -172,11 +172,11 @@ void EditTimeTickAnchors::moveElementAnchors(EngravingItem* element, KeyboardKey
     }
 
     moveSegment(element, /*forward*/ key == Key_Right);
-    updateAnchors(element);
+    EditTimeTickAnchors::updateAnchors(element);
     checkMeasureBoundariesAndMoveIfNeed(element);
 }
 
-bool EditTimeTickAnchors::canAnchorToEndOfPrevious(const EngravingItem* element)
+bool MoveElementAnchors::canAnchorToEndOfPrevious(const EngravingItem* element)
 {
     switch (element->type()) {
     case ElementType::HARMONY:
@@ -188,7 +188,7 @@ bool EditTimeTickAnchors::canAnchorToEndOfPrevious(const EngravingItem* element)
     }
 }
 
-void EditTimeTickAnchors::checkMeasureBoundariesAndMoveIfNeed(EngravingItem* element)
+void MoveElementAnchors::checkMeasureBoundariesAndMoveIfNeed(EngravingItem* element)
 {
     Segment* curSeg = toSegment(element->parent());
     Fraction curTick = curSeg->tick();
@@ -206,7 +206,8 @@ void EditTimeTickAnchors::checkMeasureBoundariesAndMoveIfNeed(EngravingItem* ele
     if (needMoveToPrevious) {
         newSeg = prevMeasure->findSegment(SegmentType::TimeTick, curSeg->tick());
         if (!newSeg) {
-            TimeTickAnchor* anchor = createTimeTickAnchor(prevMeasure, curTick - prevMeasure->tick(), element->staffIdx());
+            TimeTickAnchor* anchor = EditTimeTickAnchors::createTimeTickAnchor(prevMeasure, curTick - prevMeasure->tick(),
+                                                                               element->staffIdx());
             EditTimeTickAnchors::updateLayout(prevMeasure);
             newSeg = anchor->segment();
         }
@@ -222,7 +223,7 @@ void EditTimeTickAnchors::checkMeasureBoundariesAndMoveIfNeed(EngravingItem* ele
     }
 }
 
-void EditTimeTickAnchors::moveSegment(EngravingItem* element, bool forward)
+void MoveElementAnchors::moveSegment(EngravingItem* element, bool forward)
 {
     if (canAnchorToEndOfPrevious(element)) {
         bool cachedAnchorToEndOfPrevious = element->getProperty(Pid::ANCHOR_TO_END_OF_PREVIOUS).toBool();

--- a/src/engraving/dom/anchors.cpp
+++ b/src/engraving/dom/anchors.cpp
@@ -149,10 +149,6 @@ void EditTimeTickAnchors::updateLayout(Measure* measure)
 
 void EditTimeTickAnchors::moveElementAnchors(EngravingItem* element, KeyboardKey key, KeyboardModifier mod)
 {
-    IF_ASSERT_FAILED(element && element->allowTimeAnchor()) {
-        return;
-    }
-
     Segment* segment = element->parentItem() && element->parentItem()->isSegment() ? toSegment(element->parentItem()) : nullptr;
     if (!segment) {
         return;
@@ -185,6 +181,7 @@ bool EditTimeTickAnchors::canAnchorToEndOfPrevious(const EngravingItem* element)
     switch (element->type()) {
     case ElementType::HARMONY:
     case ElementType::FRET_DIAGRAM:
+    case ElementType::REHEARSAL_MARK:
         return false;
     default:
         return true;
@@ -227,10 +224,12 @@ void EditTimeTickAnchors::checkMeasureBoundariesAndMoveIfNeed(EngravingItem* ele
 
 void EditTimeTickAnchors::moveSegment(EngravingItem* element, bool forward)
 {
-    bool cachedAnchorToEndOfPrevious = element->getProperty(Pid::ANCHOR_TO_END_OF_PREVIOUS).toBool();
-    element->undoResetProperty(Pid::ANCHOR_TO_END_OF_PREVIOUS);
-    if (cachedAnchorToEndOfPrevious && forward) {
-        return;
+    if (canAnchorToEndOfPrevious(element)) {
+        bool cachedAnchorToEndOfPrevious = element->getProperty(Pid::ANCHOR_TO_END_OF_PREVIOUS).toBool();
+        element->undoResetProperty(Pid::ANCHOR_TO_END_OF_PREVIOUS);
+        if (cachedAnchorToEndOfPrevious && forward) {
+            return;
+        }
     }
 
     Segment* curSeg = toSegment(element->parentItem());

--- a/src/engraving/dom/anchors.h
+++ b/src/engraving/dom/anchors.h
@@ -45,6 +45,8 @@ public:
     static void moveSegment(EngravingItem* element, Segment* newSeg, Fraction tickDiff);
     static void checkMeasureBoundariesAndMoveIfNeed(EngravingItem* element);
 
+    static void moveElementAnchorsOnDrag(EngravingItem* element, EditData& ed);
+
 private:
     static bool canAnchorToEndOfPrevious(const EngravingItem* element);
     static void moveSegment(EngravingItem* element, bool forward);
@@ -56,6 +58,7 @@ private:
     static void doMoveSegment(FretDiagram* element, Segment* newSeg, Fraction tickDiff);
 
     static void moveSnappedItems(EngravingItem* element, Segment* newSeg, Fraction tickDiff);
+    static void rebaseOffsetOnMoveSegment(EngravingItem* element, const PointF& curOffset, Segment* newSeg, Segment* oldSeg);
 };
 
 class TimeTickAnchor : public EngravingItem

--- a/src/engraving/dom/anchors.h
+++ b/src/engraving/dom/anchors.h
@@ -42,11 +42,20 @@ class MoveElementAnchors
 {
 public:
     static void moveElementAnchors(EngravingItem* element, KeyboardKey key, KeyboardModifier mod);
+    static void moveSegment(EngravingItem* element, Segment* newSeg, Fraction tickDiff);
+    static void checkMeasureBoundariesAndMoveIfNeed(EngravingItem* element);
 
 private:
     static bool canAnchorToEndOfPrevious(const EngravingItem* element);
-    static void checkMeasureBoundariesAndMoveIfNeed(EngravingItem* element);
     static void moveSegment(EngravingItem* element, bool forward);
+    static Segment* getNewSegment(EngravingItem* element, Segment* curSeg, bool forward);
+
+    static void doMoveSegment(EngravingItem* element, Segment* newSeg, Fraction tickDiff);
+    static void doMoveSegment(FiguredBass* element, Segment* newSeg, Fraction tickDiff);
+    static void doMoveSegment(Harmony* element, Segment* newSeg, Fraction tickDiff);
+    static void doMoveSegment(FretDiagram* element, Segment* newSeg, Fraction tickDiff);
+
+    static void moveSnappedItems(EngravingItem* element, Segment* newSeg, Fraction tickDiff);
 };
 
 class TimeTickAnchor : public EngravingItem

--- a/src/engraving/dom/anchors.h
+++ b/src/engraving/dom/anchors.h
@@ -32,7 +32,7 @@ class Factory;
 class EditTimeTickAnchors
 {
 public:
-    static void updateAnchors(const EngravingItem* item, track_idx_t track);
+    static void updateAnchors(const EngravingItem* item);
     static void updateAnchors(Measure* measure, staff_idx_t staffIdx);
     static TimeTickAnchor* createTimeTickAnchor(Measure* measure, Fraction relTick, staff_idx_t staffIdx);
     static void updateLayout(Measure* measure);

--- a/src/engraving/dom/anchors.h
+++ b/src/engraving/dom/anchors.h
@@ -36,7 +36,11 @@ public:
     static void updateAnchors(Measure* measure, staff_idx_t staffIdx);
     static TimeTickAnchor* createTimeTickAnchor(Measure* measure, Fraction relTick, staff_idx_t staffIdx);
     static void updateLayout(Measure* measure);
+};
 
+class MoveElementAnchors
+{
+public:
     static void moveElementAnchors(EngravingItem* element, KeyboardKey key, KeyboardModifier mod);
 
 private:

--- a/src/engraving/dom/anchors.h
+++ b/src/engraving/dom/anchors.h
@@ -36,6 +36,13 @@ public:
     static void updateAnchors(Measure* measure, staff_idx_t staffIdx);
     static TimeTickAnchor* createTimeTickAnchor(Measure* measure, Fraction relTick, staff_idx_t staffIdx);
     static void updateLayout(Measure* measure);
+
+    static void moveElementAnchors(EngravingItem* element, KeyboardKey key, KeyboardModifier mod);
+
+private:
+    static bool canAnchorToEndOfPrevious(const EngravingItem* element);
+    static void checkMeasureBoundariesAndMoveIfNeed(EngravingItem* element);
+    static void moveSegment(EngravingItem* element, bool forward);
 };
 
 class TimeTickAnchor : public EngravingItem

--- a/src/engraving/dom/dynamic.cpp
+++ b/src/engraving/dom/dynamic.cpp
@@ -577,13 +577,13 @@ String Dynamic::screenReaderInfo() const
 }
 }
 
-bool Dynamic::isTextualEditAllowed(EditData& ed) const
+bool Dynamic::isEditAllowed(EditData& ed) const
 {
     if (ed.key == Key_Tab) {
         return false;
     }
 
-    return TextBase::isTextualEditAllowed(ed);
+    return TextBase::isEditAllowed(ed);
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/dynamic.cpp
+++ b/src/engraving/dom/dynamic.cpp
@@ -344,6 +344,24 @@ int Dynamic::dynamicVelocity(DynamicType t)
     return DYN_LIST[int(t)].velocity;
 }
 
+void Dynamic::startEdit(EditData& ed)
+{
+    if (ed.curGrip != Grip::NO_GRIP) {
+        EngravingItem::startEdit(ed);
+    } else {
+        TextBase::startEdit(ed);
+    }
+}
+
+void Dynamic::endEdit(EditData& ed)
+{
+    if (cursor() && cursor()->editing()) {
+        TextBase::endEdit(ed);
+    } else {
+        EngravingItem::endEdit(ed);
+    }
+}
+
 TranslatableString Dynamic::subtypeUserName() const
 {
     if (dynamicType() == DynamicType::OTHER) {

--- a/src/engraving/dom/dynamic.h
+++ b/src/engraving/dom/dynamic.h
@@ -112,6 +112,8 @@ public:
 
     bool hasVoiceAssignmentProperties() const override { return true; }
 
+    void startEdit(EditData&) override;
+    void endEdit(EditData&) override;
     int gripsCount() const override;
     std::vector<PointF> gripsPositions(const EditData& = EditData()) const override;
     void editDrag(EditData& editData) override;

--- a/src/engraving/dom/dynamic.h
+++ b/src/engraving/dom/dynamic.h
@@ -117,7 +117,7 @@ public:
     void editDrag(EditData& editData) override;
     void endEditDrag(EditData&) override;
 
-    bool isTextualEditAllowed(EditData&) const override;
+    bool isEditAllowed(EditData&) const override;
 
     Hairpin* leftHairpin() const { return m_leftHairpin; }
     Hairpin* rightHairpin() const { return m_rightHairpin; }

--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -4289,7 +4289,7 @@ Hairpin* Score::addHairpinToDynamicOnGripDrag(Dynamic* dynamic, bool isLeftGrip,
     constexpr double spacingFactor = 0.5;
 
     // Ensure time tick segments are created
-    EditTimeTickAnchors::updateAnchors(dynamic, track);
+    EditTimeTickAnchors::updateAnchors(dynamic);
 
     // Find segment of type ChordRest or TimeTick near cursor postion
     dragPosition(pos, &staffIndex, &seg, spacingFactor, /*allowTimeAnchor*/ true);

--- a/src/engraving/dom/editdata.h
+++ b/src/engraving/dom/editdata.h
@@ -249,7 +249,6 @@ public:
     PointF moveDelta;           ///< Mouse offset from the start of mouse move
     bool hRaster = false;
     bool vRaster = false;
-    bool editTextualProperties = true;
     bool isHairpinDragCreatedFromDynamic = false;
 
     int key = 0;

--- a/src/engraving/dom/editdata.h
+++ b/src/engraving/dom/editdata.h
@@ -252,7 +252,6 @@ public:
     bool isHairpinDragCreatedFromDynamic = false;
 
     int key = 0;
-    bool isKeyRelease = false;
     KeyboardModifiers modifiers  { /*0*/ };   // '0' initialized via default constructor, doing it here too results in compiler warning with Qt 5.15
     String s;
     String preeditString;

--- a/src/engraving/dom/engravingitem.cpp
+++ b/src/engraving/dom/engravingitem.cpp
@@ -2102,7 +2102,6 @@ void EngravingItem::startDrag(EditData& ed)
     eed->e = this;
     eed->pushProperty(Pid::OFFSET);
     eed->pushProperty(Pid::AUTOPLACE);
-    eed->initOffset = offset();
     ed.addData(eed);
     if (ed.modifiers & AltModifier) {
         setAutoplace(false);
@@ -2122,9 +2121,7 @@ RectF EngravingItem::drag(EditData& ed)
 
     const RectF r0(canvasBoundingRect());
 
-    const ElementEditDataPtr eed = ed.getData(this);
-
-    const PointF offset0 = ed.moveDelta + eed->initOffset;
+    const PointF offset0 = ed.evtDelta + offset();
     double x = offset0.x();
     double y = offset0.y();
 

--- a/src/engraving/dom/engravingitem.h
+++ b/src/engraving/dom/engravingitem.h
@@ -777,7 +777,6 @@ class ElementEditData
 public:
     EngravingItem* e = nullptr;
     std::list<PropertyData> propertyData;
-    PointF initOffset;   ///< for dragging: difference between actual offset and editData.moveDelta
 
     virtual ~ElementEditData() = default;
     void pushProperty(Pid pid)

--- a/src/engraving/dom/figuredbass.cpp
+++ b/src/engraving/dom/figuredbass.cpp
@@ -702,14 +702,14 @@ Sid FiguredBass::getPropertyStyle(Pid id) const
     return EngravingItem::getPropertyStyle(id);
 }
 
-void FiguredBass::startEditTextual(EditData& ed)
+void FiguredBass::startEdit(EditData& ed)
 {
     clearItems();
     renderer()->layoutText1(this);   // re-layout without F.B.-specific formatting.
-    TextBase::startEditTextual(ed);
+    TextBase::startEdit(ed);
 }
 
-bool FiguredBass::isTextualEditAllowed(EditData& ed) const
+bool FiguredBass::isEditAllowed(EditData& ed) const
 {
     if (isTextNavigationKey(ed.key, ed.modifiers)) {
         return false;
@@ -719,12 +719,12 @@ bool FiguredBass::isTextualEditAllowed(EditData& ed) const
         return false;
     }
 
-    return TextBase::isTextualEditAllowed(ed);
+    return TextBase::isEditAllowed(ed);
 }
 
-void FiguredBass::endEditTextual(EditData& ed)
+void FiguredBass::endEdit(EditData& ed)
 {
-    TextBase::endEditTextual(ed);
+    TextBase::endEdit(ed);
     regenerateText();
 }
 

--- a/src/engraving/dom/figuredbass.cpp
+++ b/src/engraving/dom/figuredbass.cpp
@@ -772,47 +772,6 @@ void FiguredBass::regenerateText()
     score()->endCmd();
 }
 
-void FiguredBass::undoMoveSegment(Segment* newSeg, Fraction tickDiff)
-{
-    Segment* oldSeg = segment();
-
-    TextBase::undoMoveSegment(newSeg, tickDiff);
-
-    track_idx_t startTrack = staff2track(staffIdx());
-    track_idx_t endTrack = startTrack + VOICES;
-
-    // Shorten this if needed
-    if (newSeg->tick() > oldSeg->tick()) {
-        FiguredBass* nextFB = nullptr;
-        Fraction endTick = newSeg->tick() + m_ticks;
-        for (Segment* seg = newSeg->next1(Segment::CHORD_REST_OR_TIME_TICK_TYPE); seg && seg->tick() <= endTick;
-             seg = seg->next1(Segment::CHORD_REST_OR_TIME_TICK_TYPE)) {
-            nextFB = toFiguredBass(seg->findAnnotation(ElementType::FIGURED_BASS, startTrack, endTrack));
-            if (nextFB) {
-                break;
-            }
-        }
-        if (nextFB) {
-            setTicks(nextFB->tick() - newSeg->tick());
-        }
-    }
-
-    // Shorten previous if needed
-    if (newSeg->tick() < oldSeg->tick()) {
-        FiguredBass* prevFB = nullptr;
-        for (Segment* seg = newSeg->prev1(Segment::CHORD_REST_OR_TIME_TICK_TYPE); seg && seg->measure()->isAfterOrEqual(newSeg->measure());
-             seg = seg->prev1(Segment::CHORD_REST_OR_TIME_TICK_TYPE)) {
-            prevFB = (FiguredBass*)(seg->findAnnotation(ElementType::FIGURED_BASS, startTrack, endTrack));
-            if (prevFB) {
-                break;
-            }
-        }
-        if (prevFB) {
-            prevFB->setTicks(std::min(prevFB->ticks(), newSeg->tick() - prevFB->tick()));
-        }
-    }
-}
-
 //---------------------------------------------------------
 //   setSelected /setVisible
 //

--- a/src/engraving/dom/figuredbass.h
+++ b/src/engraving/dom/figuredbass.h
@@ -273,9 +273,9 @@ public:
 
     void setSelected(bool f) override;
     void setVisible(bool f) override;
-    void startEditTextual(EditData& ed) override;
-    bool isTextualEditAllowed(EditData&) const override;
-    void endEditTextual(EditData&) override;
+    void startEdit(EditData& ed) override;
+    bool isEditAllowed(EditData&) const override;
+    void endEdit(EditData&) override;
     void regenerateText();
 
     void undoMoveSegment(Segment* newSeg, Fraction tickDiff) override;

--- a/src/engraving/dom/figuredbass.h
+++ b/src/engraving/dom/figuredbass.h
@@ -278,8 +278,6 @@ public:
     void endEdit(EditData&) override;
     void regenerateText();
 
-    void undoMoveSegment(Segment* newSeg, Fraction tickDiff) override;
-
     bool onNote() const { return m_onNote; }
     void setOnNote(bool val) { m_onNote = val; }
     Segment* segment() const { return (Segment*)(explicitParent()); }

--- a/src/engraving/dom/fret.cpp
+++ b/src/engraving/dom/fret.cpp
@@ -975,32 +975,7 @@ RectF FretDiagram::drag(EditData& ed)
 {
     RectF result = EngravingItem::drag(ed);
 
-    Segment* segment = explicitParent() ? toSegment(parent()) : nullptr;
-    if (!segment) {
-        return result;
-    }
-
-    ElementEditDataPtr eed = ed.getData(this);
-    if (!eed) {
-        return result;
-    }
-
-    EditTimeTickAnchors::updateAnchors(this);
-
-    KeyboardModifiers km = ed.modifiers;
-    if (km & (ShiftModifier | ControlModifier)) {
-        return result;
-    }
-
-    staff_idx_t si = staffIdx();
-    Segment* newSeg = nullptr;     // don't prefer any segment while dragging, just snap to the closest
-    static constexpr double spacingFactor = 0.5;
-    score()->dragPosition(canvasPos(), &si, &newSeg, spacingFactor, allowTimeAnchor());
-    if (newSeg && (newSeg != segment || staffIdx() != si)) {
-        MoveElementAnchors::moveSegment(this, newSeg, newSeg->tick() - segment->tick());
-        PointF offsetShift = newSeg->pagePos() - segment->pagePos();
-        eed->initOffset -= offsetShift;
-    }
+    MoveElementAnchors::moveElementAnchorsOnDrag(this, ed);
 
     return result;
 }

--- a/src/engraving/dom/fret.h
+++ b/src/engraving/dom/fret.h
@@ -249,6 +249,8 @@ public:
     bool isInFretBox() const;
     bool isCustom(const String& harmonyNameForCompare) const;
 
+    bool allowTimeAnchor() const { return true; }
+
     friend class FretUndoData;
 
     struct FingeringItem {

--- a/src/engraving/dom/fret.h
+++ b/src/engraving/dom/fret.h
@@ -224,10 +224,10 @@ public:
     void add(EngravingItem*) override;
     void remove(EngravingItem*) override;
 
+    RectF drag(EditData&) override;
     bool acceptDrop(EditData&) const override;
     EngravingItem* drop(EditData&) override;
 
-    void endEditDrag(EditData& editData) override;
     void scanElements(void* data, void (* func)(void*, EngravingItem*), bool all=true) override;
 
     PropertyValue getProperty(Pid propertyId) const override;
@@ -249,7 +249,7 @@ public:
     bool isInFretBox() const;
     bool isCustom(const String& harmonyNameForCompare) const;
 
-    bool allowTimeAnchor() const { return true; }
+    bool allowTimeAnchor() const { return explicitParent() && parent()->isSegment(); }
 
     friend class FretUndoData;
 

--- a/src/engraving/dom/harmony.cpp
+++ b/src/engraving/dom/harmony.cpp
@@ -637,7 +637,7 @@ NoteCaseType Harmony::bassRenderCase() const
 //   startEdit
 //---------------------------------------------------------
 
-void Harmony::startEditTextual(EditData& ed)
+void Harmony::startEdit(EditData& ed)
 {
     if (!ldata()->textList().empty()) {
         // convert chord symbol to plain text
@@ -653,10 +653,10 @@ void Harmony::startEditTextual(EditData& ed)
     renderer()->layoutText1(this, true);
     triggerLayout();
 
-    TextBase::startEditTextual(ed);
+    TextBase::startEdit(ed);
 }
 
-bool Harmony::isTextualEditAllowed(EditData& ed) const
+bool Harmony::isEditAllowed(EditData& ed) const
 {
     if (isTextNavigationKey(ed.key, ed.modifiers)) {
         return false;
@@ -675,20 +675,20 @@ bool Harmony::isTextualEditAllowed(EditData& ed) const
         return true;
     }
 
-    return TextBase::isTextualEditAllowed(ed);
+    return TextBase::isEditAllowed(ed);
 }
 
 //---------------------------------------------------------
 //   edit
 //---------------------------------------------------------
 
-bool Harmony::editTextual(EditData& ed)
+bool Harmony::edit(EditData& ed)
 {
     if (!isEditAllowed(ed)) {
         return false;
     }
 
-    bool rv = TextBase::editTextual(ed);
+    bool rv = TextBase::edit(ed);
 
     // layout as text, without position reset
     renderer()->layoutText1(this, true);
@@ -726,7 +726,7 @@ bool Harmony::editTextual(EditData& ed)
 //   endEdit
 //---------------------------------------------------------
 
-void Harmony::endEditTextual(EditData& ed)
+void Harmony::endEdit(EditData& ed)
 {
     // get plain text
     String s = plainText();
@@ -763,7 +763,7 @@ void Harmony::endEditTextual(EditData& ed)
     // disable spell check
     m_isMisspelled = false;
 
-    TextBase::endEditTextual(ed);
+    TextBase::endEdit(ed);
 
     TextEditData* ted = dynamic_cast<TextEditData*>(ed.getData(this).get());
     bool textChanged = ted != nullptr && ted->oldXmlText != harmonyName();

--- a/src/engraving/dom/harmony.cpp
+++ b/src/engraving/dom/harmony.cpp
@@ -1585,27 +1585,6 @@ double Harmony::mag() const
     return EngravingItem::mag();
 }
 
-void Harmony::undoMoveSegment(Segment* newSeg, Fraction tickDiff)
-{
-    IF_ASSERT_FAILED(parentItem()->isSegment()) {
-        return;
-    }
-
-    if (newSeg->isTimeTickType()) {
-        Measure* measure = newSeg->measure();
-        Segment* chordRestSegAtSameTick = measure->undoGetSegment(SegmentType::ChordRest, newSeg->tick());
-        newSeg = chordRestSegAtSameTick;
-    }
-
-    Segment* oldSegment = toSegment(parent());
-    TextBase::undoMoveSegment(newSeg, tickDiff);
-
-    oldSegment->checkEmpty();
-    if (oldSegment->empty()) {
-        score()->undoRemoveElement(oldSegment);
-    }
-}
-
 HarmonyInfo::HarmonyInfo(const HarmonyInfo& h)
 {
     m_id = h.m_id;

--- a/src/engraving/dom/harmony.h
+++ b/src/engraving/dom/harmony.h
@@ -236,8 +236,6 @@ public:
     double bassScale() const { return m_bassScale; }
     void setBassScale(double v) { m_bassScale = v; }
 
-    void undoMoveSegment(Segment* newSeg, Fraction tickDiff) override;
-
     Color curColor() const override;
 
     bool doNotStackModifiers() const { return m_doNotStackModifiers; }

--- a/src/engraving/dom/harmony.h
+++ b/src/engraving/dom/harmony.h
@@ -186,10 +186,10 @@ public:
     const RealizedHarmony& getRealizedHarmony() const;
 
     bool isEditable() const override { return !isInFretBox(); }
-    void startEditTextual(EditData&) override;
-    bool isTextualEditAllowed(EditData&) const override;
-    bool editTextual(EditData&) override;
-    void endEditTextual(EditData&) override;
+    void startEdit(EditData&) override;
+    bool isEditAllowed(EditData&) const override;
+    bool edit(EditData&) override;
+    void endEdit(EditData&) override;
 
     bool isPlayable() const override;
 

--- a/src/engraving/dom/line.cpp
+++ b/src/engraving/dom/line.cpp
@@ -899,8 +899,7 @@ void LineSegment::undoMoveStartEndAndSnappedItems(bool moveStart, bool moveEnd, 
         Fraction tickDiff = s1->tick() - thisLine->tick();
         if (EngravingItem* itemSnappedBefore = ldata()->itemSnappedBefore()) {
             if (itemSnappedBefore->isTextBase()) {
-                // Let the TextBase manage the move
-                toTextBase(itemSnappedBefore)->undoMoveSegment(s1, tickDiff);
+                MoveElementAnchors::moveSegment(itemSnappedBefore, s1, tickDiff);
             } else if (itemSnappedBefore->isLineSegment()) {
                 toLineSegment(itemSnappedBefore)->line()->undoMoveEnd(tickDiff);
                 thisLine->undoMoveStart(tickDiff);
@@ -913,8 +912,7 @@ void LineSegment::undoMoveStartEndAndSnappedItems(bool moveStart, bool moveEnd, 
         Fraction tickDiff = s2->tick() - thisLine->tick2();
         if (EngravingItem* itemSnappedAfter = thisLine->backSegment()->ldata()->itemSnappedAfter()) {
             if (itemSnappedAfter->isTextBase()) {
-                // Let the TextBase manage the move
-                toTextBase(itemSnappedAfter)->undoMoveSegment(s2, tickDiff);
+                MoveElementAnchors::moveSegment(itemSnappedAfter, s2, tickDiff);
             } else if (itemSnappedAfter->isLineSegment()) {
                 toLineSegment(itemSnappedAfter)->line()->undoMoveStart(tickDiff);
                 thisLine->undoMoveEnd(tickDiff);

--- a/src/engraving/dom/line.cpp
+++ b/src/engraving/dom/line.cpp
@@ -214,7 +214,7 @@ void LineSegment::startEditDrag(EditData& ed)
         setAutoplace(false);
     }
 
-    updateAnchors(ed);
+    EditTimeTickAnchors::updateAnchors(this);
 }
 
 bool LineSegment::isEditAllowed(EditData& ed) const
@@ -801,16 +801,9 @@ void LineSegment::editDrag(EditData& ed)
         }
     }
 
-    updateAnchors(ed);
+    EditTimeTickAnchors::updateAnchors(this);
 
     triggerLayout();
-}
-
-void LineSegment::updateAnchors(EditData& ed) const
-{
-    if (line()->allowTimeAnchor()) {
-        EditTimeTickAnchors::updateAnchors(this);
-    }
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/line.cpp
+++ b/src/engraving/dom/line.cpp
@@ -235,18 +235,6 @@ bool LineSegment::edit(EditData& ed)
     LineSegment* ls       = 0;
     SpannerSegmentType st = spannerSegmentType();   // may change later
     SLine* l              = line();
-    track_idx_t track = l->track();
-    track_idx_t track2 = l->track2();      // assumed to be same as track
-
-    if (ed.key == KeyboardKey::Key_Shift) {
-        if (ed.isKeyRelease) {
-            score()->hideAnchors();
-        } else {
-            EditTimeTickAnchors::updateAnchors(this, moveStart ? track : track2);
-        }
-        triggerLayout();
-        return true;
-    }
 
     if (!isEditAllowed(ed)) {
         return false;
@@ -279,7 +267,7 @@ bool LineSegment::edit(EditData& ed)
 
         undoMoveStartEndAndSnappedItems(moveStart, moveEnd, s1, s2);
 
-        EditTimeTickAnchors::updateAnchors(this, moveStart ? track : track2);
+        EditTimeTickAnchors::updateAnchors(this);
     }
     break;
     case Spanner::Anchor::NOTE:
@@ -821,7 +809,7 @@ void LineSegment::editDrag(EditData& ed)
 void LineSegment::updateAnchors(EditData& ed) const
 {
     if (line()->allowTimeAnchor()) {
-        EditTimeTickAnchors::updateAnchors(this, ed.curGrip == Grip::START ? line()->track() : line()->track2());
+        EditTimeTickAnchors::updateAnchors(this);
     }
 }
 

--- a/src/engraving/dom/line.h
+++ b/src/engraving/dom/line.h
@@ -45,7 +45,6 @@ class LineSegment : public SpannerSegment
     OBJECT_ALLOCATOR(engraving, LineSegment)
 protected:
     virtual void editDrag(EditData&) override;
-    void updateAnchors(EditData& ed) const;
     virtual bool isEditAllowed(EditData&) const override;
     virtual bool edit(EditData&) override;
     std::vector<LineF> gripAnchorLines(Grip) const override;

--- a/src/engraving/dom/rehearsalmark.cpp
+++ b/src/engraving/dom/rehearsalmark.cpp
@@ -77,35 +77,9 @@ bool RehearsalMark::isEditAllowed(EditData& ed) const
     return TextBase::isEditAllowed(ed);
 }
 
-void RehearsalMark::editDrag(EditData& ed)
+RectF RehearsalMark::drag(EditData& ed)
 {
-    return EngravingItem::editDrag(ed);
-}
-
-bool RehearsalMark::moveSegment(const EditData& ed)
-{
-    assert(hasParentSegment());
-
-    bool forward = ed.key == Key_Right;
-
-    Segment* curSeg = toSegment(parent());
-    IF_ASSERT_FAILED(curSeg) {
-        return false;
-    }
-
-    Measure* newMeas = forward ? curSeg->measure()->nextMeasureMM() : curSeg->measure()->prevMeasureMM();
-    if (!newMeas) {
-        return false;
-    }
-
-    Segment* newSeg = newMeas->first(SegmentType::ChordRest);
-    IF_ASSERT_FAILED(newSeg) {
-        return false;
-    }
-
-    undoMoveSegment(newSeg, newSeg->tick() - curSeg->tick());
-
-    return true;
+    return EngravingItem::drag(ed);
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/rehearsalmark.cpp
+++ b/src/engraving/dom/rehearsalmark.cpp
@@ -79,6 +79,7 @@ bool RehearsalMark::isEditAllowed(EditData& ed) const
 
 RectF RehearsalMark::drag(EditData& ed)
 {
+    // Not TextBase::drag because we don't allow reanchoring on drag
     return EngravingItem::drag(ed);
 }
 

--- a/src/engraving/dom/rehearsalmark.h
+++ b/src/engraving/dom/rehearsalmark.h
@@ -45,8 +45,7 @@ public:
 
     bool isEditAllowed(EditData&) const override;
     bool allowTimeAnchor() const override { return false; }
-    void editDrag(EditData& ed) override;
-    bool moveSegment(const EditData& ed) override;
+    RectF drag(EditData& ed) override;
 
     RehearsalMark* clone() const override { return new RehearsalMark(*this); }
 

--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -1638,7 +1638,7 @@ void Score::addElement(EngravingItem* element)
     }
 
     if (element->isTextBase() && toTextBase(element)->hasParentSegment()) {
-        toTextBase(element)->checkMeasureBoundariesAndMoveIfNeed();
+        MoveElementAnchors::checkMeasureBoundariesAndMoveIfNeed(element);
     }
 
     element->triggerLayout();

--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -1110,6 +1110,9 @@ std::vector<System*> Score::searchSystem(const PointF& pos, const System* prefer
     size_t n = sl.size();
     for (size_t i = 0; i < n; ++i) {
         System* s = sl.at(i);
+        if (!s->firstMeasure()) {
+            continue;
+        }
         System* ns = 0;                   // next system row
         size_t ii = i + 1;
         for (; ii < n; ++ii) {

--- a/src/engraving/dom/textbase.cpp
+++ b/src/engraving/dom/textbase.cpp
@@ -2594,7 +2594,7 @@ String TextBase::accessibleInfo() const
     String s = plainText().simplified();
     if (s.size() > 20) {
         s.truncate(20);
-        s += u"ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€šÃ‚Â¦";
+        s += u"…";
     }
     return String(u"%1: %2").arg(rez, s);
 }

--- a/src/engraving/dom/textbase.cpp
+++ b/src/engraving/dom/textbase.cpp
@@ -3284,7 +3284,7 @@ void TextBase::editDrag(EditData& ed)
         return;
     }
 
-    EditTimeTickAnchors::updateAnchors(this, track());
+    EditTimeTickAnchors::updateAnchors(this);
 
     KeyboardModifiers km = ed.modifiers;
     if (km & (ShiftModifier | ControlModifier)) {
@@ -3350,16 +3350,6 @@ bool TextBase::editNonTextual(EditData& ed)
         return EngravingItem::edit(ed);
     }
 
-    if (ed.key == Key_Shift) {
-        if (ed.isKeyRelease) {
-            score()->hideAnchors();
-        } else {
-            EditTimeTickAnchors::updateAnchors(this, track());
-        }
-        triggerLayout();
-        return true;
-    }
-
     if (!isEditAllowed(ed)) {
         return false;
     }
@@ -3382,7 +3372,7 @@ bool TextBase::editNonTextual(EditData& ed)
     bool moveSeg = shiftMod && (ed.key == Key_Left || ed.key == Key_Right);
     if (moveSeg) {
         bool moved = moveSegment(ed);
-        EditTimeTickAnchors::updateAnchors(this, track());
+        EditTimeTickAnchors::updateAnchors(this);
         checkMeasureBoundariesAndMoveIfNeed();
         return moved;
     }

--- a/src/engraving/dom/textbase.cpp
+++ b/src/engraving/dom/textbase.cpp
@@ -3240,32 +3240,7 @@ RectF TextBase::drag(EditData& ed)
 {
     RectF result = EngravingItem::drag(ed);
 
-    Segment* segment = explicitParent() ? toSegment(parent()) : nullptr;
-    if (!segment) {
-        return result;
-    }
-
-    ElementEditDataPtr eed = ed.getData(this);
-    if (!eed) {
-        return result;
-    }
-
-    EditTimeTickAnchors::updateAnchors(this);
-
-    KeyboardModifiers km = ed.modifiers;
-    if (km & (ShiftModifier | ControlModifier)) {
-        return result;
-    }
-
-    staff_idx_t si = staffIdx();
-    Segment* newSeg = nullptr;     // don't prefer any segment while dragging, just snap to the closest
-    static constexpr double spacingFactor = 0.5;
-    score()->dragPosition(canvasPos(), &si, &newSeg, spacingFactor, allowTimeAnchor());
-    if (newSeg && (newSeg != segment || staffIdx() != si)) {
-        MoveElementAnchors::moveSegment(this, newSeg, newSeg->tick() - segment->tick());
-        PointF offsetShift = newSeg->pagePos() - segment->pagePos();
-        shiftInitOffset(ed, offsetShift);
-    }
+    MoveElementAnchors::moveElementAnchorsOnDrag(this, ed);
 
     return result;
 }
@@ -3276,30 +3251,6 @@ void TextBase::endDrag(EditData& ed)
         return;
     }
     EngravingItem::endDrag(ed);
-}
-
-void TextBase::shiftInitOffset(EditData& ed, const PointF& offsetShift)
-{
-    ElementEditDataPtr eedThis = ed.getData(this);
-    eedThis->initOffset -= offsetShift;
-
-    if (EngravingItem* itemBefore = ldata()->itemSnappedBefore()) {
-        if (itemBefore->isTextBase()) {
-            ElementEditDataPtr eedBefore = ed.getData(itemBefore);
-            if (eedBefore) {
-                eedBefore->initOffset -= offsetShift;
-            }
-        }
-    }
-
-    if (EngravingItem* itemAfter = ldata()->itemSnappedAfter()) {
-        if (itemAfter->isTextBase()) {
-            ElementEditDataPtr eedAfter = ed.getData(itemAfter);
-            if (eedAfter) {
-                eedAfter->initOffset -= offsetShift;
-            }
-        }
-    }
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/textbase.cpp
+++ b/src/engraving/dom/textbase.cpp
@@ -3236,23 +3236,25 @@ void TextBase::initTextStyleType(TextStyleType tid)
     }
 }
 
-void TextBase::editDrag(EditData& ed)
+RectF TextBase::drag(EditData& ed)
 {
+    RectF result = EngravingItem::drag(ed);
+
     Segment* segment = explicitParent() ? toSegment(parent()) : nullptr;
     if (!segment) {
-        return EngravingItem::editDrag(ed);
+        return result;
     }
 
     ElementEditDataPtr eed = ed.getData(this);
     if (!eed) {
-        return;
+        return result;
     }
 
     EditTimeTickAnchors::updateAnchors(this);
 
     KeyboardModifiers km = ed.modifiers;
     if (km & (ShiftModifier | ControlModifier)) {
-        return;
+        return result;
     }
 
     staff_idx_t si = staffIdx();
@@ -3264,6 +3266,8 @@ void TextBase::editDrag(EditData& ed)
         PointF offsetShift = newSeg->pagePos() - segment->pagePos();
         shiftInitOffset(ed, offsetShift);
     }
+
+    return result;
 }
 
 void TextBase::endDrag(EditData& ed)

--- a/src/engraving/dom/textbase.h
+++ b/src/engraving/dom/textbase.h
@@ -346,7 +346,6 @@ public:
     virtual bool allowTimeAnchor() const override { return hasParentSegment(); }
     virtual void startEdit(EditData&) override;
     virtual bool isEditAllowed(EditData&) const override;
-    virtual bool supportsNonTextualEdit() const;
     virtual bool edit(EditData&) override;
     virtual void editCut(EditData&) override;
     virtual void editCopy(EditData&) override;
@@ -507,14 +506,6 @@ protected:
     TextBase(const ElementType& type, EngravingItem* parent, ElementFlags);
     TextBase(const TextBase&);
 
-    virtual void startEditTextual(EditData&);
-    virtual void startEditNonTextual(EditData&);
-    virtual bool editTextual(EditData&);
-    virtual bool editNonTextual(EditData&);
-    virtual void endEditNonTextual(EditData&);
-    virtual void endEditTextual(EditData&);
-    virtual bool isNonTextualEditAllowed(EditData&) const;
-    virtual bool isTextualEditAllowed(EditData&) const;
     bool nudge(const EditData& ed);
 
     virtual bool moveSegment(const EditData&);

--- a/src/engraving/dom/textbase.h
+++ b/src/engraving/dom/textbase.h
@@ -354,9 +354,6 @@ public:
     virtual void endDrag(EditData&) override;
     void movePosition(EditData&, TextCursor::MoveOperation);
 
-    virtual void undoMoveSegment(Segment* newSeg, Fraction tickDiff);
-    void checkMeasureBoundariesAndMoveIfNeed();
-
     bool deleteSelectedText(EditData&);
 
     void selectAll(TextCursor*);
@@ -508,8 +505,6 @@ protected:
 
     bool nudge(const EditData& ed);
 
-    virtual bool moveSegment(const EditData&);
-    void moveSnappedItems(Segment* newSeg, Fraction tickDiff) const;
     void shiftInitOffset(EditData& ed, const PointF& offsetShift);
 
     void insertSym(EditData& ed, SymId id);

--- a/src/engraving/dom/textbase.h
+++ b/src/engraving/dom/textbase.h
@@ -350,7 +350,7 @@ public:
     virtual void editCut(EditData&) override;
     virtual void editCopy(EditData&) override;
     virtual void endEdit(EditData&) override;
-    virtual void editDrag(EditData&) override;
+    virtual RectF drag(EditData&) override;
     virtual void endDrag(EditData&) override;
     void movePosition(EditData&, TextCursor::MoveOperation);
 

--- a/src/engraving/dom/textbase.h
+++ b/src/engraving/dom/textbase.h
@@ -343,7 +343,6 @@ public:
     void setAnchorToEndOfPrevious(bool v) { m_anchorToEndOfPrevious = v; }
 
     bool hasParentSegment() const { return explicitParent() && parent()->isSegment(); }
-    virtual bool needStartEditingAfterSelecting() const override { return hasParentSegment(); }
     virtual bool allowTimeAnchor() const override { return hasParentSegment(); }
     virtual void startEdit(EditData&) override;
     virtual bool isEditAllowed(EditData&) const override;

--- a/src/engraving/dom/textbase.h
+++ b/src/engraving/dom/textbase.h
@@ -505,8 +505,6 @@ protected:
 
     bool nudge(const EditData& ed);
 
-    void shiftInitOffset(EditData& ed, const PointF& offsetShift);
-
     void insertSym(EditData& ed, SymId id);
     void prepareFormat(const String& token, TextCursor& cursor);
     bool prepareFormat(const String& token, CharFormat& format);

--- a/src/engraving/dom/textedit.cpp
+++ b/src/engraving/dom/textedit.cpp
@@ -105,7 +105,7 @@ void TextBase::editInsertText(TextCursor* cursor, const String& s)
 //   startEdit
 //---------------------------------------------------------
 
-void TextBase::startEditTextual(EditData& ed)
+void TextBase::startEdit(EditData& ed)
 {
     std::shared_ptr<TextEditData> ted = std::make_shared<TextEditData>(this);
     ted->e = this;
@@ -135,7 +135,7 @@ void TextBase::startEditTextual(EditData& ed)
 //   endEdit
 //---------------------------------------------------------
 
-void TextBase::endEditTextual(EditData& ed)
+void TextBase::endEdit(EditData& ed)
 {
     TextEditData* ted = static_cast<TextEditData*>(ed.getData(this).get());
     IF_ASSERT_FAILED(ted && ted->cursor()) {
@@ -285,7 +285,7 @@ void TextBase::insertText(EditData& ed, const String& s)
     score()->undo(new InsertText(cursor, s), &ed);
 }
 
-bool TextBase::isTextualEditAllowed(EditData& ed) const
+bool TextBase::isEditAllowed(EditData& ed) const
 {
     // Keep this method closely in sync with TextBase::edit()!
 
@@ -409,7 +409,7 @@ bool TextBase::isTextualEditAllowed(EditData& ed) const
 //   edit
 //---------------------------------------------------------
 
-bool TextBase::editTextual(EditData& ed)
+bool TextBase::edit(EditData& ed)
 {
     // Keep this method closely in sync with TextBase::isEditAllowed()!
 

--- a/src/engraving/dom/undo.cpp
+++ b/src/engraving/dom/undo.cpp
@@ -525,7 +525,7 @@ void UndoStack::undo(EditData* ed)
 {
     LOG_UNDO() << "called";
     // Are we currently editing text?
-    if (ed && ed->editTextualProperties && ed->element && ed->element->isTextBase()) {
+    if (ed && ed->element && ed->element->isTextBase()) {
         TextEditData* ted = dynamic_cast<TextEditData*>(ed->getData(ed->element).get());
         if (ted && ted->startUndoIdx == m_currentIndex) {
             // No edits to undo, so do nothing

--- a/src/engraving/rendering/editmode/editmoderenderer.cpp
+++ b/src/engraving/rendering/editmode/editmoderenderer.cpp
@@ -166,7 +166,7 @@ void EditModeRenderer::drawBarline(BarLine* item, muse::draw::Painter* painter, 
 
 void EditModeRenderer::drawDynamic(Dynamic* item, muse::draw::Painter* painter, EditData& ed, double currentViewScaling)
 {
-    if (ed.editTextualProperties) {
+    if (item->cursor() && item->cursor()->editing()) {
         drawTextBase(item, painter, ed, currentViewScaling);
         return;
     }

--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -149,7 +149,7 @@ public:
     virtual bool textEditingAllowed(const EngravingItem* element) const = 0;
     virtual void startEditText(EngravingItem* element, const muse::PointF& elementPos = muse::PointF()) = 0;
     virtual void editText(QInputMethodEvent* event) = 0;
-    virtual void endEditText(bool startNonTextualEdit = true) = 0;
+    virtual void endEditText() = 0;
     virtual void changeTextCursorPosition(const muse::PointF& newCursorPos) = 0;
     virtual void selectText(mu::engraving::SelectTextType type) = 0;
     virtual const TextBase* editedText() const = 0;

--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -176,6 +176,7 @@ public:
 
     // Anchors edit
     virtual void updateTimeTickAnchors(QKeyEvent* event) = 0;
+    virtual void moveElementAnchors(QKeyEvent* event) = 0;
 
     virtual void splitSelectedMeasure() = 0;
     virtual void joinSelectedMeasures() = 0;

--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -174,6 +174,9 @@ public:
     virtual void editElement(QKeyEvent* event) = 0;
     virtual void endEditElement() = 0;
 
+    // Anchors edit
+    virtual void updateTimeTickAnchors(QKeyEvent* event) = 0;
+
     virtual void splitSelectedMeasure() = 0;
     virtual void joinSelectedMeasures() = 0;
 

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -4748,7 +4748,8 @@ void NotationInteraction::updateTimeTickAnchors(QKeyEvent* event)
         score()->hideAnchors();
     }
 
-    apply();
+    score()->update();
+    notifyAboutNotationChanged();
 }
 
 void NotationInteraction::moveElementAnchors(QKeyEvent* event)

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -971,7 +971,7 @@ void NotationInteraction::doSelect(const std::vector<EngravingItem*>& elements, 
     TRACEFUNC;
 
     if (needEndTextEditing(elements)) {
-        endEditText(/*startNonTextualEdit*/ false);
+        endEditText();
     } else if (needEndElementEditing(elements)) {
         endEditElement();
     }
@@ -4376,7 +4376,7 @@ bool NotationInteraction::handleKeyPress(QKeyEvent* event)
     return true;
 }
 
-void NotationInteraction::endEditText(bool startNonTextualEdit)
+void NotationInteraction::endEditText()
 {
     if (!isTextEditingStarted()) {
         return;
@@ -4385,11 +4385,6 @@ void NotationInteraction::endEditText(bool startNonTextualEdit)
     TextBase* editedElement = toTextBase(m_editData.element);
     doEndEditElement();
     notifyAboutTextEditingEnded(editedElement);
-
-    // When textual edit is finished, non-textual edit can still happen, so we need to start the non-textual edit mode here
-    if (startNonTextualEdit && editedElement->supportsNonTextualEdit()) {
-        startEditElement(editedElement, false);
-    }
 
     notifyAboutTextEditingChanged();
     notifyAboutSelectionChangedIfNeed();
@@ -6449,7 +6444,7 @@ void NotationInteraction::navigateToLyrics(bool back, bool moveOnly, bool end)
         return;
     }
 
-    endEditText(/*startNonTextualEdit*/ false);
+    endEditText();
 
     // look for the lyrics we are moving from; may be the current lyrics or a previous one
     // if we are skipping several chords with spaces
@@ -6599,7 +6594,7 @@ void NotationInteraction::navigateToNextSyllable()
         return;
     }
 
-    endEditText(/*startNonTextualEdit*/ false);
+    endEditText();
 
     // look for the lyrics we are moving from; may be the current lyrics or a previous one
     // we are extending with several dashes
@@ -6843,7 +6838,7 @@ void NotationInteraction::navigateToLyricsVerse(MoveDirection direction)
         }
     }
 
-    endEditText(/*startNonTextualEdit*/ false);
+    endEditText();
 
     lyrics = cr->lyrics(verse, placement);
     if (!lyrics) {
@@ -7437,7 +7432,7 @@ void NotationInteraction::addMelisma()
     FontStyle fStyle = lyrics->fontStyle();
     PropertyFlags fFlags = lyrics->propertyFlags(Pid::FONT_STYLE);
     Fraction endTick = segment->tick(); // a previous melisma cannot extend beyond this point
-    endEditText(/*startNonTextualEdit*/ false);
+    endEditText();
 
     // search next chord
     Segment* nextSegment = segment;
@@ -7642,7 +7637,7 @@ void NotationInteraction::addLyricsVerse()
     mu::engraving::FontStyle fStyle = oldLyrics->fontStyle();
     mu::engraving::PropertyFlags fFlags = oldLyrics->propertyFlags(mu::engraving::Pid::FONT_STYLE);
 
-    endEditText(/*startNonTextualEdit*/ false);
+    endEditText();
 
     score()->startCmd(TranslatableString("undoableAction", "Add lyrics verse"));
     int newVerse = oldLyrics->no() + 1;

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -4657,14 +4657,6 @@ void NotationInteraction::editElement(QKeyEvent* event)
     m_editData.key = event->key();
     m_editData.s = event->text();
 
-    bool isShiftRelease = event->type() == QKeyEvent::Type::KeyRelease;
-    if (isShiftRelease) {
-        m_editData.isKeyRelease = true;
-        resetAnchorLines();
-    } else {
-        m_editData.isKeyRelease = false;
-    }
-
     // Brackets may be deleted and replaced
     bool isBracket = m_editData.element->isBracket();
     const mu::engraving::System* system = nullptr;
@@ -4707,16 +4699,14 @@ void NotationInteraction::editElement(QKeyEvent* event)
 
         apply();
 
-        if (!isShiftRelease) {
-            if (isGripEditStarted()) {
-                if (m_editData.element->isDynamic() && !m_editData.isStartEndGrip()) {
-                    updateDragAnchorLines();
-                } else {
-                    updateGripAnchorLines();
-                }
-            } else if (isElementEditStarted()) {
+        if (isGripEditStarted()) {
+            if (m_editData.element->isDynamic() && !m_editData.isStartEndGrip()) {
                 updateDragAnchorLines();
+            } else {
+                updateGripAnchorLines();
             }
+        } else if (isElementEditStarted()) {
+            updateDragAnchorLines();
         }
     } else {
         rollback();

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -4222,7 +4222,7 @@ bool NotationInteraction::isTextSelected() const
 
 bool NotationInteraction::isTextEditingStarted() const
 {
-    return m_editData.element && m_editData.element->isTextBase() && m_editData.editTextualProperties;
+    return m_editData.element && m_editData.element->isTextBase();
 }
 
 bool NotationInteraction::textEditingAllowed(const EngravingItem* element) const
@@ -4244,7 +4244,6 @@ void NotationInteraction::startEditText(EngravingItem* element, const PointF& cu
         m_editData.element = element;
     }
 
-    m_editData.editTextualProperties = true;
     m_editData.startMove = bindCursorPosToText(cursorPos, m_editData.element);
     m_editData.element->startEdit(m_editData);
 
@@ -4504,7 +4503,6 @@ void NotationInteraction::startEditGrip(EngravingItem* element, mu::engraving::G
 
     m_editData.element = element;
     m_editData.curGrip = grip;
-    m_editData.editTextualProperties = false;
 
     updateGripAnchorLines();
     m_editData.element->startEdit(m_editData);
@@ -4573,7 +4571,6 @@ void NotationInteraction::startEditElement(EngravingItem* element, bool editText
     if (element->isTextBase() && editTextualProperties) {
         startEditText(element);
     } else if (element->isEditable()) {
-        m_editData.editTextualProperties = false;
         element->startEdit(m_editData);
         m_editData.element = element;
     }
@@ -4710,7 +4707,7 @@ void NotationInteraction::editElement(QKeyEvent* event)
                 } else {
                     updateGripAnchorLines();
                 }
-            } else if (isElementEditStarted() && !m_editData.editTextualProperties) {
+            } else if (isElementEditStarted()) {
                 updateDragAnchorLines();
             }
         }

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -4762,6 +4762,18 @@ void NotationInteraction::updateTimeTickAnchors(QKeyEvent* event)
     apply();
 }
 
+void NotationInteraction::moveElementAnchors(QKeyEvent* event)
+{
+    EngravingItem* element = selection()->element();
+    IF_ASSERT_FAILED(element) {
+        return;
+    }
+
+    EditTimeTickAnchors::moveElementAnchors(element, KeyboardKey(event->key()), keyboardModifier(event->modifiers()));
+
+    apply();
+}
+
 void NotationInteraction::doEndEditElement()
 {
     if (m_editData.element) {

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -4768,6 +4768,8 @@ void NotationInteraction::moveElementAnchors(QKeyEvent* event)
         return;
     }
 
+    startEdit(TranslatableString("undoableAction", "Move element anchors"));
+
     MoveElementAnchors::moveElementAnchors(element, KeyboardKey(event->key()), keyboardModifier(event->modifiers()));
 
     apply();

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -4748,7 +4748,7 @@ void NotationInteraction::endEditElement()
 void NotationInteraction::updateTimeTickAnchors(QKeyEvent* event)
 {
     EngravingItem* selectedElement = m_selection->element();
-    if (selectedElement && selectedElement->allowTimeAnchor() && event->type() == QKeyEvent::Type::KeyPress) {
+    if (selectedElement && selectedElement->allowTimeAnchor() && event->type() == QKeyEvent::Type::KeyPress && !isTextEditingStarted()) {
         EditTimeTickAnchors::updateAnchors(selectedElement);
     } else {
         score()->hideAnchors();

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -3544,6 +3544,12 @@ void NotationInteraction::drawGripPoints(muse::draw::Painter* painter)
     }
 
     mu::engraving::EngravingItem* editedElement = m_editData.element;
+    if (!editedElement) {
+        EngravingItem* selectedElement = m_selection->element();
+        if (selectedElement && selectedElement->isDynamic()) {
+            editedElement = selectedElement;
+        }
+    }
 
     if (editedElement && editedElement->isDynamic()) {
         toDynamic(editedElement)->findAdjacentHairpins();
@@ -4222,7 +4228,8 @@ bool NotationInteraction::isTextSelected() const
 
 bool NotationInteraction::isTextEditingStarted() const
 {
-    return m_editData.element && m_editData.element->isTextBase();
+    EngravingItem* element = m_editData.element;
+    return element && element->isTextBase() && toTextBase(element)->cursor() && toTextBase(element)->cursor()->editing();
 }
 
 bool NotationInteraction::textEditingAllowed(const EngravingItem* element) const

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -4705,7 +4705,7 @@ void NotationInteraction::editElement(QKeyEvent* event)
             } else {
                 updateGripAnchorLines();
             }
-        } else if (isElementEditStarted()) {
+        } else if (isElementEditStarted() && !m_editData.element->isTextBase()) {
             updateDragAnchorLines();
         }
     } else {
@@ -4744,8 +4744,10 @@ void NotationInteraction::updateTimeTickAnchors(QKeyEvent* event)
     EngravingItem* selectedElement = m_selection->element();
     if (selectedElement && selectedElement->allowTimeAnchor() && event->type() == QKeyEvent::Type::KeyPress && !isTextEditingStarted()) {
         EditTimeTickAnchors::updateAnchors(selectedElement);
+        updateDragAnchorLines();
     } else {
         score()->hideAnchors();
+        resetAnchorLines();
     }
 
     score()->update();
@@ -4764,6 +4766,8 @@ void NotationInteraction::moveElementAnchors(QKeyEvent* event)
     MoveElementAnchors::moveElementAnchors(element, KeyboardKey(event->key()), keyboardModifier(event->modifiers()));
 
     apply();
+
+    updateDragAnchorLines();
 }
 
 void NotationInteraction::doEndEditElement()

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -4750,6 +4750,18 @@ void NotationInteraction::endEditElement()
     notifyAboutNotationChanged();
 }
 
+void NotationInteraction::updateTimeTickAnchors(QKeyEvent* event)
+{
+    EngravingItem* selectedElement = m_selection->element();
+    if (selectedElement && selectedElement->allowTimeAnchor() && event->type() == QKeyEvent::Type::KeyPress) {
+        EditTimeTickAnchors::updateAnchors(selectedElement);
+    } else {
+        score()->hideAnchors();
+    }
+
+    apply();
+}
+
 void NotationInteraction::doEndEditElement()
 {
     if (m_editData.element) {

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -4768,7 +4768,7 @@ void NotationInteraction::moveElementAnchors(QKeyEvent* event)
         return;
     }
 
-    EditTimeTickAnchors::moveElementAnchors(element, KeyboardKey(event->key()), keyboardModifier(event->modifiers()));
+    MoveElementAnchors::moveElementAnchors(element, KeyboardKey(event->key()), keyboardModifier(event->modifiers()));
 
     apply();
 }

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -158,7 +158,7 @@ public:
     bool textEditingAllowed(const EngravingItem* element) const override;
     void startEditText(EngravingItem* element, const muse::PointF& cursorPos = muse::PointF()) override;
     void editText(QInputMethodEvent* event) override;
-    void endEditText(bool startNonTextualEdit = true) override;
+    void endEditText() override;
     void changeTextCursorPosition(const muse::PointF& newCursorPos) override;
     void selectText(mu::engraving::SelectTextType type) override;
     const TextBase* editedText() const override;

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -180,6 +180,9 @@ public:
     void editElement(QKeyEvent* event) override;
     void endEditElement() override;
 
+    // Anchors edit
+    void updateTimeTickAnchors(QKeyEvent* event) override;
+
     // Measure
     void splitSelectedMeasure() override;
     void joinSelectedMeasures() override;

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -182,6 +182,7 @@ public:
 
     // Anchors edit
     void updateTimeTickAnchors(QKeyEvent* event) override;
+    void moveElementAnchors(QKeyEvent* event) override;
 
     // Measure
     void splitSelectedMeasure() override;

--- a/src/notation/tests/mocks/notationinteractionmock.h
+++ b/src/notation/tests/mocks/notationinteractionmock.h
@@ -114,7 +114,7 @@ public:
     MOCK_METHOD(bool, textEditingAllowed, (const EngravingItem*), (const, override));
     MOCK_METHOD(void, startEditText, (EngravingItem*, const muse::PointF&), (override));
     MOCK_METHOD(void, editText, (QInputMethodEvent*), (override));
-    MOCK_METHOD(void, endEditText, (bool), (override));
+    MOCK_METHOD(void, endEditText, (), (override));
     MOCK_METHOD(void, changeTextCursorPosition, (const muse::PointF&), (override));
     MOCK_METHOD(void, selectText, (mu::engraving::SelectTextType), (override));
     MOCK_METHOD(const TextBase*, editedText, (), (const, override));

--- a/src/notation/tests/mocks/notationinteractionmock.h
+++ b/src/notation/tests/mocks/notationinteractionmock.h
@@ -136,6 +136,8 @@ public:
     MOCK_METHOD(void, editElement, (QKeyEvent*), (override));
     MOCK_METHOD(void, endEditElement, (), (override));
 
+    MOCK_METHOD(void, updateTimeTickAnchors, (QKeyEvent*), (override));
+
     MOCK_METHOD(void, splitSelectedMeasure, (), (override));
     MOCK_METHOD(void, joinSelectedMeasures, (), (override));
 

--- a/src/notation/tests/mocks/notationinteractionmock.h
+++ b/src/notation/tests/mocks/notationinteractionmock.h
@@ -137,6 +137,7 @@ public:
     MOCK_METHOD(void, endEditElement, (), (override));
 
     MOCK_METHOD(void, updateTimeTickAnchors, (QKeyEvent*), (override));
+    MOCK_METHOD(void, moveElementAnchors, (QKeyEvent*), (override));
 
     MOCK_METHOD(void, splitSelectedMeasure, (), (override));
     MOCK_METHOD(void, joinSelectedMeasures, (), (override));

--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -1213,8 +1213,7 @@ bool NotationViewInputController::shortcutOverrideEvent(QKeyEvent* event)
     }
 
     if (anchorEditingKeysFound(event)) {
-        EngravingItem* element = viewInteraction()->selection()->element();
-        return element && element->allowTimeAnchor();
+        return true;
     }
 
     return tryPercussionShortcut(event);

--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -1227,11 +1227,15 @@ bool NotationViewInputController::shortcutOverrideEvent(QKeyEvent* event)
 void NotationViewInputController::keyPressEvent(QKeyEvent* event)
 {
     auto key = event->key();
+
     if (startTextEditingAllowed() && (event->key() == Qt::Key_Return || event->key() == Qt::Key_Enter)) {
         dispatcher()->dispatch("edit-text");
         event->accept();
     } else if (viewInteraction()->isElementEditStarted()) {
         viewInteraction()->editElement(event);
+        if (key == Qt::Key_Shift) {
+            viewInteraction()->updateTimeTickAnchors(event);
+        }
     } else if (key == Qt::Key_Shift) {
         updateShadowNotePopupVisibility();
         viewInteraction()->updateTimeTickAnchors(event);

--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -1221,6 +1221,7 @@ void NotationViewInputController::keyPressEvent(QKeyEvent* event)
         viewInteraction()->editElement(event);
     } else if (event->key() == Qt::Key_Shift) {
         updateShadowNotePopupVisibility();
+        viewInteraction()->updateTimeTickAnchors(event);
     }
 
     updateShadowNotePopupVisibility(/*forceHide*/ true);
@@ -1234,6 +1235,7 @@ void NotationViewInputController::keyReleaseEvent(QKeyEvent* event)
 
     viewInteraction()->editElement(event);
     updateShadowNotePopupVisibility(/*forceHide*/ true);
+    viewInteraction()->updateTimeTickAnchors(event);
 }
 
 void NotationViewInputController::inputMethodEvent(QInputMethodEvent* event)

--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -1132,10 +1132,6 @@ void NotationViewInputController::handleLeftClickRelease(const QPointF& releaseP
     if (interaction->isTextEditingStarted()) {
         return;
     }
-
-    if (interaction->textEditingAllowed(ctx.element)) {
-        interaction->startEditText(ctx.element, m_mouseDownInfo.logicalBeginPoint);
-    }
 }
 
 void NotationViewInputController::mouseDoubleClickEvent(QMouseEvent* event)

--- a/src/notation/view/notationviewinputcontroller.h
+++ b/src/notation/view/notationviewinputcontroller.h
@@ -197,6 +197,8 @@ private:
     bool startTextEditingAllowed() const;
     void updateTextCursorPosition();
 
+    bool anchorEditingKeysFound(QKeyEvent* event) const;
+
     bool tryPercussionShortcut(QKeyEvent* event);
 
     EngravingItem* resolveStartPlayableElement() const;


### PR DESCRIPTION
Resolves: #27580
Resolves: #24052 

This refactoring became necessary for a few key reasons:

- Managing the anchor-editing behaviour within `TextBase::edit` required to have two separate edit modes for TextBase elements, namely a "textual" edit mode (where the text itself is being edited) and a "non textual" mode (where other things, such as the anchoring, get edited). It also made it necessary for most TextBase element to set `needStartEditingAfterSelecting = true`. Both things have been known to cause various issues.
- It made it impossible to extend the behaviour to non-text-based elements, such as FretDiagram, without moving the logic all the way up to EngravingItem.

This PR does a few relevant things.
- The keyboard combination for anchor editing (shift+left/right) is captured in NotationViewInputController then handled in NotationInteraction and passed to a new dedicated MoveElementAnchors class. 
- All the anchoring logic that was previously managed in the edit methods by several elements is now managed by MoveElementAnchors.
- The distinction between textualEdit and nonTextualEdit for TextBase elements has been removed. Now the only edit mode for text elements is the textual edit (as it used to be before my first anchors work).

