### PR TITLE
Fix #28795: MacOS pop-up windows open lower on screen every time

### DIFF
--- a/src/notation/view/widgets/editpitch.cpp
+++ b/src/notation/view/widgets/editpitch.cpp
@@ -56,9 +56,11 @@ EditPitch::EditPitch(QWidget* parent, int midiCode)
     tableWidget->setCurrentCell(tableWidget->rowCount() - 1 - (midiCode / 12), midiCode % 12);
 }
 
-//---------------------------------------------------------
-//   hideEvent
-//---------------------------------------------------------
+void EditPitch::showEvent(QShowEvent* event)
+{
+    WidgetStateStore::restoreGeometry(this);
+    QWidget::showEvent(event);
+}
 
 void EditPitch::hideEvent(QHideEvent* ev)
 {
@@ -85,8 +87,6 @@ void EditPitch::setup()
 {
     setupUi(this);
     setWindowFlags(this->windowFlags() & ~Qt::WindowContextHelpButtonHint);
-
-    WidgetStateStore::restoreGeometry(this);
 
     //! NOTE: It is necessary for the correct start of navigation in the dialog
     setFocus();

--- a/src/notation/view/widgets/editpitch.h
+++ b/src/notation/view/widgets/editpitch.h
@@ -19,8 +19,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef MU_NOTATION_EDITPITCH_H
-#define MU_NOTATION_EDITPITCH_H
+#pragma once
 
 #include "ui_editpitch.h"
 
@@ -44,11 +43,10 @@ private slots:
     void reject() override { done(-1); }                               // return an invalid pitch MIDI code
 
 private:
+    virtual void showEvent(QShowEvent*) override;
     virtual void hideEvent(QHideEvent*) override;
     bool eventFilter(QObject* obj, QEvent* event) override;
 
     void setup();
 };
 }
-
-#endif // MU_NOTATION_EDITPITCH_H

--- a/src/notation/view/widgets/editstaff.cpp
+++ b/src/notation/view/widgets/editstaff.cpp
@@ -100,8 +100,6 @@ EditStaff::EditStaff(QWidget* parent)
     WidgetUtils::setWidgetIcon(minPitchPSelect, IconCode::Code::EDIT);
     WidgetUtils::setWidgetIcon(maxPitchPSelect, IconCode::Code::EDIT);
 
-    WidgetStateStore::restoreGeometry(this);
-
     //! NOTE: It is necessary for the correct start of navigation in the dialog
     setFocus();
 }
@@ -175,6 +173,12 @@ void EditStaff::setStaff(Staff* s, const Fraction& tick)
     updateStaffType(*stt);
     updateInstrument();
     updateNextPreviousButtons();
+}
+
+void EditStaff::showEvent(QShowEvent* event)
+{
+    WidgetStateStore::restoreGeometry(this);
+    QDialog::showEvent(event);
 }
 
 void EditStaff::hideEvent(QHideEvent* ev)

--- a/src/notation/view/widgets/editstaff.h
+++ b/src/notation/view/widgets/editstaff.h
@@ -20,8 +20,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef MU_NOTATION_EDITSTAFF_H
-#define MU_NOTATION_EDITSTAFF_H
+#pragma once
 
 #include <QDialog>
 
@@ -52,6 +51,7 @@ public:
     EditStaff(QWidget* parent = nullptr);
 
 private:
+    void showEvent(QShowEvent*) override;
     void hideEvent(QHideEvent*) override;
     void apply();
     void setStaff(mu::engraving::Staff*, const mu::engraving::Fraction& tick);
@@ -112,5 +112,3 @@ private:
     EditStaffType* editStaffTypeDialog = nullptr;
 };
 }
-
-#endif

--- a/src/notation/view/widgets/editstafftype.cpp
+++ b/src/notation/view/widgets/editstafftype.cpp
@@ -171,8 +171,6 @@ EditStaffType::EditStaffType(QWidget* parent)
 
     addToTemplates->setVisible(false);
 
-    WidgetStateStore::restoreGeometry(this);
-
     //! NOTE: It is necessary for the correct start of navigation in the dialog
     setFocus();
 }
@@ -283,6 +281,16 @@ Ret EditStaffType::loadScore(mu::engraving::MasterScore* score, const muse::io::
     score->update();
 
     return score->sanityCheck();
+}
+
+//---------------------------------------------------------
+//   showEvent
+//---------------------------------------------------------
+
+void EditStaffType::showEvent(QShowEvent* ev)
+{
+    WidgetStateStore::restoreGeometry(this);
+    QDialog::showEvent(ev);
 }
 
 //---------------------------------------------------------

--- a/src/notation/view/widgets/editstafftype.h
+++ b/src/notation/view/widgets/editstafftype.h
@@ -47,6 +47,7 @@ class EditStaffType : public QDialog, private Ui::EditStaffType, public muse::In
 
     mu::engraving::StaffType staffType;
 
+    virtual void showEvent(QShowEvent*);
     virtual void hideEvent(QHideEvent*);
     void blockSignals(bool block);
 

--- a/src/notation/view/widgets/editstringdata.cpp
+++ b/src/notation/view/widgets/editstringdata.cpp
@@ -64,8 +64,6 @@ EditStringData::EditStringData(QWidget* parent, const std::vector<instrString>& 
 
     init();
 
-    WidgetStateStore::restoreGeometry(this);
-
     //! NOTE: It is necessary for the correct start of navigation in the dialog
     setFocus();
 
@@ -82,9 +80,11 @@ int EditStringData::frets() const
     return _frets;
 }
 
-//---------------------------------------------------------
-//   hideEvent
-//---------------------------------------------------------
+void EditStringData::showEvent(QShowEvent* event)
+{
+    WidgetStateStore::restoreGeometry(this);
+    QDialog::showEvent(event);
+}
 
 void EditStringData::hideEvent(QHideEvent* ev)
 {

--- a/src/notation/view/widgets/editstringdata.h
+++ b/src/notation/view/widgets/editstringdata.h
@@ -19,8 +19,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef MU_NOTATION_EDITSTRINGDATA_H
-#define MU_NOTATION_EDITSTRINGDATA_H
+#pragma once
 
 #include <QDialog>
 
@@ -61,7 +60,8 @@ private:
     void init();
     void initStringsData();
 
-    virtual void hideEvent(QHideEvent*) override;
+    void showEvent(QShowEvent*) override;
+    void hideEvent(QHideEvent*) override;
     bool eventFilter(QObject* obj, QEvent* event) override;
 
     QString openColumnAccessibleText(const QTableWidgetItem* item) const;
@@ -77,5 +77,3 @@ private:
     Instrument* m_instrument = nullptr;
 };
 }
-
-#endif // MU_NOTATION_EDITSTRINGDATA_H

--- a/src/notation/view/widgets/editstyle.cpp
+++ b/src/notation/view/widgets/editstyle.cpp
@@ -1283,8 +1283,6 @@ EditStyle::EditStyle(QWidget* parent)
     });
 
     adjustPagesStackSize(0);
-
-    WidgetStateStore::restoreGeometry(this);
 }
 
 //---------------------------------------------------------
@@ -1297,6 +1295,8 @@ void EditStyle::showEvent(QShowEvent* ev)
     pageList->setFocus();
     globalContext()->currentNotation()->undoStack()->prepareChanges(muse::TranslatableString("undoableAction", "Edit style"));
     buttonApplyToAllParts->setEnabled(globalContext()->currentNotation()->style()->canApplyToAllParts());
+
+    WidgetStateStore::restoreGeometry(this);
     QWidget::showEvent(ev);
 }
 

--- a/src/notation/view/widgets/measureproperties.cpp
+++ b/src/notation/view/widgets/measureproperties.cpp
@@ -71,8 +71,6 @@ MeasurePropertiesDialog::MeasurePropertiesDialog(QWidget* parent)
     WidgetUtils::setWidgetIcon(previousButton, IconCode::Code::ARROW_LEFT);
     WidgetUtils::setWidgetIcon(nextButton, IconCode::Code::ARROW_RIGHT);
 
-    WidgetStateStore::restoreGeometry(this);
-
     //! NOTE: It is necessary for the correct start of navigation in the dialog
     setFocus();
 
@@ -346,6 +344,12 @@ void MeasurePropertiesDialog::apply()
 
     m_notation->interaction()->select({ m_measure }, mu::engraving::SelectType::SINGLE, 0);
     m_notation->notationChanged().notify();
+}
+
+void MeasurePropertiesDialog::showEvent(QShowEvent* event)
+{
+    WidgetStateStore::restoreGeometry(this);
+    QDialog::showEvent(event);
 }
 
 void MeasurePropertiesDialog::hideEvent(QHideEvent* event)

--- a/src/notation/view/widgets/measureproperties.h
+++ b/src/notation/view/widgets/measureproperties.h
@@ -20,8 +20,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef __MEASUREPROPERTIES_H__
-#define __MEASUREPROPERTIES_H__
+#pragma once
 
 #include <QDialog>
 
@@ -63,6 +62,7 @@ private:
     bool stemless(int staffIdx);
     void setMeasure(mu::engraving::Measure* measure);
 
+    void showEvent(QShowEvent*) override;
     void hideEvent(QHideEvent*) override;
 
     mu::engraving::Measure* m_measure = nullptr;
@@ -71,4 +71,3 @@ private:
     std::shared_ptr<INotation> m_notation;
 };
 }
-#endif

--- a/src/notation/view/widgets/pagesettings.cpp
+++ b/src/notation/view/widgets/pagesettings.cpp
@@ -53,8 +53,6 @@ PageSettings::PageSettings(QWidget* parent)
         inchButton->setChecked(true);
     }
 
-    WidgetStateStore::restoreGeometry(this);
-
     for (int i = 0; i < QPageSize::LastPageSize; ++i) {
         pageGroup->addItem(QPageSize::name(QPageSize::PageSizeId(i)), i);
     }
@@ -100,6 +98,8 @@ void PageSettings::showEvent(QShowEvent* event)
 {
     globalContext()->currentNotation()->undoStack()->prepareChanges(muse::TranslatableString("undoableAction", "Edit page settings"));
     updateValues();
+
+    WidgetStateStore::restoreGeometry(this);
     QWidget::showEvent(event);
 }
 

--- a/src/notation/view/widgets/selectdialog.cpp
+++ b/src/notation/view/widgets/selectdialog.cpp
@@ -70,8 +70,6 @@ SelectDialog::SelectDialog(QWidget* parent)
 
     connect(buttonBox, &QDialogButtonBox::clicked, this, &SelectDialog::buttonClicked);
 
-    WidgetStateStore::restoreGeometry(this);
-
     //! NOTE: It is necessary for the correct start of navigation in the dialog
     setFocus();
 }
@@ -189,6 +187,16 @@ void SelectDialog::buttonClicked(QAbstractButton* button)
     default:
         break;
     }
+}
+
+//---------------------------------------------------------
+//   showEvent
+//---------------------------------------------------------
+
+void SelectDialog::showEvent(QShowEvent* event)
+{
+    WidgetStateStore::restoreGeometry(this);
+    QDialog::showEvent(event);
 }
 
 //---------------------------------------------------------

--- a/src/notation/view/widgets/selectdialog.h
+++ b/src/notation/view/widgets/selectdialog.h
@@ -19,8 +19,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef MU_NOTATION_SELECTDIALOG_H
-#define MU_NOTATION_SELECTDIALOG_H
+#pragma once
 
 #include "ui_selectdialog.h"
 
@@ -55,7 +54,8 @@ private slots:
     void buttonClicked(QAbstractButton* button);
 
 private:
-    virtual void hideEvent(QHideEvent*);
+    void showEvent(QShowEvent*) override;
+    void hideEvent(QHideEvent*) override;
 
     INotationPtr currentNotation() const;
     INotationInteractionPtr currentNotationInteraction() const;
@@ -68,5 +68,4 @@ private:
 
     const EngravingItem* m_element = nullptr;
 };
-} // namespace Ms
-#endif
+}

--- a/src/notation/view/widgets/selectnotedialog.cpp
+++ b/src/notation/view/widgets/selectnotedialog.cpp
@@ -98,8 +98,6 @@ SelectNoteDialog::SelectNoteDialog(QWidget* parent)
 
     connect(buttonBox, &QDialogButtonBox::clicked, this, &SelectNoteDialog::buttonClicked);
 
-    WidgetStateStore::restoreGeometry(this);
-
     //! NOTE: It is necessary for the correct start of navigation in the dialog
     setFocus();
 }
@@ -209,6 +207,16 @@ void SelectNoteDialog::buttonClicked(QAbstractButton* button)
     default:
         break;
     }
+}
+
+//---------------------------------------------------------
+//   showEvent
+//---------------------------------------------------------
+
+void SelectNoteDialog::showEvent(QShowEvent* event)
+{
+    WidgetStateStore::restoreGeometry(this);
+    QDialog::showEvent(event);
 }
 
 //---------------------------------------------------------

--- a/src/notation/view/widgets/selectnotedialog.h
+++ b/src/notation/view/widgets/selectnotedialog.h
@@ -19,8 +19,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef MU_NOTATION_SELECTNOTEDIALOG_H
-#define MU_NOTATION_SELECTNOTEDIALOG_H
+#pragma once
 
 #include "ui_selectnotedialog.h"
 
@@ -53,7 +52,8 @@ private slots:
     void buttonClicked(QAbstractButton* button);
 
 private:
-    virtual void hideEvent(QHideEvent*);
+    void showEvent(QShowEvent*) override;
+    void hideEvent(QHideEvent*) override;
 
     INotationPtr currentNotation() const;
     INotationInteractionPtr currentNotationInteraction() const;
@@ -65,5 +65,3 @@ private:
     const mu::engraving::Note* m_note = nullptr;
 };
 }
-
-#endif // MU_NOTATION_SELECTNOTEDIALOG_H

--- a/src/notation/view/widgets/stafftextpropertiesdialog.cpp
+++ b/src/notation/view/widgets/stafftextpropertiesdialog.cpp
@@ -83,13 +83,17 @@ StaffTextPropertiesDialog::StaffTextPropertiesDialog(QWidget* parent)
     connect(swingSixteenth, &QRadioButton::toggled, this, &StaffTextPropertiesDialog::setSwingControls);
 
     connect(this, &QDialog::accepted, this, &StaffTextPropertiesDialog::saveValues);
-
-    muse::ui::WidgetStateStore::restoreGeometry(this);
 }
 
 StaffTextPropertiesDialog::~StaffTextPropertiesDialog()
 {
     delete m_staffText;
+}
+
+void StaffTextPropertiesDialog::showEvent(QShowEvent* event)
+{
+    muse::ui::WidgetStateStore::restoreGeometry(this);
+    QDialog::showEvent(event);
 }
 
 void StaffTextPropertiesDialog::hideEvent(QHideEvent* event)

--- a/src/notation/view/widgets/stafftextpropertiesdialog.h
+++ b/src/notation/view/widgets/stafftextpropertiesdialog.h
@@ -19,8 +19,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef MU_NOTATION_STAFFTEXTPROPERTIESDIALOG_H
-#define MU_NOTATION_STAFFTEXTPROPERTIESDIALOG_H
+#pragma once
 
 #include "ui_stafftextpropertiesdialog.h"
 
@@ -47,6 +46,7 @@ private slots:
     void setSwingControls(bool);
 
 private:
+    void showEvent(QShowEvent*) override;
     void hideEvent(QHideEvent*) override;
 
     INotationUndoStackPtr undoStack() const;
@@ -55,5 +55,3 @@ private:
     engraving::StaffTextBase* m_staffText = nullptr;
 };
 }
-
-#endif // MU_NOTATION_STAFFTEXTPROPERTIESDIALOG_H

--- a/src/notation/view/widgets/transposedialog.cpp
+++ b/src/notation/view/widgets/transposedialog.cpp
@@ -63,8 +63,6 @@ TransposeDialog::TransposeDialog(QWidget* parent)
 
     connect(this, &TransposeDialog::accepted, this, &TransposeDialog::apply);
 
-    WidgetStateStore::restoreGeometry(this);
-
     //! NOTE: It is necessary for the correct start of navigation in the dialog
     setFocus();
 }
@@ -169,6 +167,16 @@ TransposeDirection TransposeDialog::direction() const
         return TransposeDirection::UNKNOWN;
     }
     return TransposeDirection::UP;
+}
+
+//---------------------------------------------------------
+//   showEvent
+//---------------------------------------------------------
+
+void TransposeDialog::showEvent(QShowEvent* event)
+{
+    WidgetStateStore::restoreGeometry(this);
+    QDialog::showEvent(event);
 }
 
 //---------------------------------------------------------

--- a/src/notation/view/widgets/transposedialog.h
+++ b/src/notation/view/widgets/transposedialog.h
@@ -20,8 +20,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef MU_NOTATION_TRANSPOSEDIALOG_H
-#define MU_NOTATION_TRANSPOSEDIALOG_H
+#pragma once
 
 #include "ui_transposedialog.h"
 
@@ -48,6 +47,7 @@ private slots:
     void apply();
 
 private:
+    void showEvent(QShowEvent*) override;
     void hideEvent(QHideEvent*) override;
 
     INotationPtr notation() const;
@@ -70,5 +70,3 @@ private:
     bool m_allSelected = false;
 };
 }
-
-#endif // MU_NOTATION_TRANSPOSEDIALOG_H

--- a/src/notation/view/widgets/tupletdialog.cpp
+++ b/src/notation/view/widgets/tupletdialog.cpp
@@ -39,7 +39,6 @@ TupletDialog::TupletDialog(QWidget* parent)
     setObjectName("TupletDialog");
     setupUi(this);
     setWindowFlags(this->windowFlags() & ~Qt::WindowContextHelpButtonHint);
-    WidgetStateStore::restoreGeometry(this);
 
     connect(buttonBox, &QDialogButtonBox::clicked, this, &TupletDialog::bboxClicked);
 
@@ -96,9 +95,11 @@ TupletBracketType TupletDialog::bracketType() const
     return TupletBracketType::AUTO_BRACKET;
 }
 
-//---------------------------------------------------------
-//   hideEvent
-//---------------------------------------------------------
+void TupletDialog::showEvent(QShowEvent* event)
+{
+    WidgetStateStore::restoreGeometry(this);
+    QDialog::showEvent(event);
+}
 
 void TupletDialog::hideEvent(QHideEvent* event)
 {

--- a/src/notation/view/widgets/tupletdialog.h
+++ b/src/notation/view/widgets/tupletdialog.h
@@ -19,8 +19,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef MU_NOTATION_TUPLETDIALOG_H
-#define MU_NOTATION_TUPLETDIALOG_H
+#pragma once
 
 #include "ui_tupletdialog.h"
 
@@ -36,7 +35,8 @@ class TupletDialog : public QDialog, Ui::TupletDialog, public muse::Injectable
     muse::Inject<context::IGlobalContext> globalContext = { this };
     muse::Inject<muse::actions::IActionsDispatcher> dispatcher = { this };
 
-    virtual void hideEvent(QHideEvent*);
+    void showEvent(QShowEvent*) override;
+    void hideEvent(QHideEvent*) override;
 
 public:
     TupletDialog(QWidget* parent = nullptr);
@@ -55,5 +55,3 @@ private slots:
     void bboxClicked(QAbstractButton* button);
 };
 }
-
-#endif // MU_NOTATION_TUPLETDIALOG_H

--- a/src/palette/view/widgets/masterpalette.cpp
+++ b/src/palette/view/widgets/masterpalette.cpp
@@ -157,8 +157,6 @@ MasterPalette::MasterPalette(QWidget* parent)
     connect(treeWidget, &QTreeWidget::currentItemChanged, this, &MasterPalette::currentChanged);
     connect(treeWidget, &QTreeWidget::itemClicked, this, &MasterPalette::clicked);
     retranslate(true);
-
-    WidgetStateStore::restoreGeometry(this);
 }
 
 //---------------------------------------------------------
@@ -218,6 +216,12 @@ void MasterPalette::clicked(QTreeWidgetItem* item, int)
 //---------------------------------------------------------
 //   closeEvent
 //---------------------------------------------------------
+
+void MasterPalette::showEvent(QShowEvent* event)
+{
+    WidgetStateStore::restoreGeometry(this);
+    TopLevelDialog::showEvent(event);
+}
 
 void MasterPalette::closeEvent(QCloseEvent* event)
 {

--- a/src/palette/view/widgets/masterpalette.h
+++ b/src/palette/view/widgets/masterpalette.h
@@ -20,8 +20,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef __MASTERPALETTE_H__
-#define __MASTERPALETTE_H__
+#pragma once
 
 #include "ui_masterpalette.h"
 
@@ -56,6 +55,7 @@ private slots:
     void clicked(QTreeWidgetItem*, int);
 
     void changeEvent(QEvent* event) override;
+    void showEvent(QShowEvent*) override;
     void closeEvent(QCloseEvent* event) override;
 
 private:
@@ -71,6 +71,4 @@ private:
     int m_idxAllSymbols = -1;
     QHash<int, SymbolDialog*> m_symbolWidgets;
 };
-} // namespace Ms
-
-#endif
+}

--- a/src/palette/view/widgets/specialcharactersdialog.cpp
+++ b/src/palette/view/widgets/specialcharactersdialog.cpp
@@ -492,8 +492,12 @@ SpecialCharactersDialog::SpecialCharactersDialog(QWidget* parent)
         const TextBase* editedText = interaction->editedText();
         setFont(editedText->font());
     }
+}
 
+void SpecialCharactersDialog::showEvent(QShowEvent* event)
+{
     WidgetStateStore::restoreGeometry(this);
+    TopLevelDialog::showEvent(event);
 }
 
 void SpecialCharactersDialog::hideEvent(QHideEvent* event)

--- a/src/palette/view/widgets/specialcharactersdialog.h
+++ b/src/palette/view/widgets/specialcharactersdialog.h
@@ -19,8 +19,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef MU_PALETTE_SPECIALCHARACTERSDIALOG_H
-#define MU_PALETTE_SPECIALCHARACTERSDIALOG_H
+#pragma once
 
 #include "ui_specialcharactersdialog.h"
 
@@ -53,6 +52,7 @@ private slots:
     void populateUnicode();
 
 private:
+    void showEvent(QShowEvent*) override;
     void hideEvent(QHideEvent*) override;
 
     void setFont(const muse::draw::Font& font);
@@ -66,5 +66,3 @@ private:
     QListWidget* m_lwu = nullptr;
 };
 }
-
-#endif // MU_PALETTE_SPECIALCHARACTERSDIALOG_H

--- a/src/palette/view/widgets/timesignaturepropertiesdialog.cpp
+++ b/src/palette/view/widgets/timesignaturepropertiesdialog.cpp
@@ -154,13 +154,17 @@ TimeSignaturePropertiesDialog::TimeSignaturePropertiesDialog(QWidget* parent)
         g = Groups::endings(m_editedTimeSig->sig()); // initialize with default
     }
     groups->setSig(m_editedTimeSig->sig(), g, m_editedTimeSig->numeratorString(), m_editedTimeSig->denominatorString());
-
-    WidgetStateStore::restoreGeometry(this);
 }
 
 TimeSignaturePropertiesDialog::~TimeSignaturePropertiesDialog()
 {
     delete m_editedTimeSig;
+}
+
+void TimeSignaturePropertiesDialog::showEvent(QShowEvent* event)
+{
+    WidgetStateStore::restoreGeometry(this);
+    QDialog::showEvent(event);
 }
 
 void TimeSignaturePropertiesDialog::hideEvent(QHideEvent* event)

--- a/src/palette/view/widgets/timesignaturepropertiesdialog.h
+++ b/src/palette/view/widgets/timesignaturepropertiesdialog.h
@@ -20,8 +20,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef MU_PALETTE_TIMESIGNATUREPROPERTIESDIALOG_H
-#define MU_PALETTE_TIMESIGNATUREPROPERTIESDIALOG_H
+#pragma once
 
 #include "ui_timesignaturepropertiesdialog.h"
 
@@ -49,6 +48,7 @@ private slots:
     void accept() override;
 
 private:
+    void showEvent(QShowEvent*) override;
     void hideEvent(QHideEvent*) override;
 
     mu::notation::INotationPtr notation() const;
@@ -57,5 +57,3 @@ private:
     engraving::TimeSig* m_editedTimeSig = nullptr;
 };
 }
-
-#endif // MU_PALETTE_TIMESIGNATUREPROPERTIESDIALOG_H


### PR DESCRIPTION
The Qt code for setting geometry is too complex to easily understand what's going on, but it turns out that the constructor of a QDialog-based class is just too early to call `restoreGeometry`, and `showEvent` does seem to be the right time.

Resolves: https://github.com/musescore/MuseScore/issues/28795