### PR TITLE
fixed #28753: KDDW patch. Ensures stack layout is polished after insertion

### DIFF
--- a/src/framework/dockwindow/thirdparty/KDDockWidgets/src/private/quick/FrameQuick.cpp
+++ b/src/framework/dockwindow/thirdparty/KDDockWidgets/src/private/quick/FrameQuick.cpp
@@ -126,6 +126,10 @@ void FrameQuick::insertDockWidget_impl(DockWidgetBase *dw, int index)
     if (m_tabWidget->insertDockWidget(index, dw, {}, {})) {
         dw->setParent(m_stackLayout);
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 3, 0)
+        m_stackLayout->ensurePolished();
+#endif
+
         QMetaObject::Connection conn = connect(dw, &DockWidgetBase::parentChanged, this, [dw, this] {
             if (dw->parent() != m_stackLayout)
                 removeWidget_impl(dw);


### PR DESCRIPTION
This commit added invalidate for QQuickStackLayout during creation and removed stack rearrangement when new elements are added: https://github.com/qt/qtdeclarative/commit/4de9df2c9ae0ba35ad425d46fc9f2e982e0da404

When restoring the frame geometry, we also set the size for the StackLayout, but because it’s invalidated, rearrangement for the stack is ignored. The solution is to restore the previous behavior — after adding an item, update the StackLayout.

Resolves: #28753
Resolves: #28555
