### PR TITLE
Fix MSVC compiler warnings

### DIFF
--- a/src/framework/global/serialization/msgpack_forward.h
+++ b/src/framework/global/serialization/msgpack_forward.h
@@ -24,7 +24,7 @@
 namespace kors::msgpack {
 class Packer;
 class UnPacker;
-class Cursor;
+struct Cursor;
 }
 
 namespace muse::msgpack {

--- a/src/framework/global/thirdparty/kors_msgpack/msgpack/msgpack.h
+++ b/src/framework/global/thirdparty/kors_msgpack/msgpack/msgpack.h
@@ -104,7 +104,7 @@ struct Cursor {
     }
 
     inline void next(int64_t bytes = 1) {
-        if (remain() >= bytes) {
+        if (static_cast<int64_t>(remain()) >= bytes) {
             current += bytes;
         } else {
             error = true;

--- a/src/framework/global/thirdparty/kors_msgpack/msgpack/msgpack.h
+++ b/src/framework/global/thirdparty/kors_msgpack/msgpack/msgpack.h
@@ -936,8 +936,6 @@ bool unpack_type(Cursor& cursor, T& value) {
             return unpack_custom(cursor, value);
         }
     }
-
-    return false;
 }
 
 class Packer


### PR DESCRIPTION
* reg.: 'kors::msgpack::Cursor': type name first seen using 'class' now seen using 'struct' (C4099)
* reg.: '>=': signed/unsigned mismatch (C4018)
* reg.: unreachable code (C4702)