### PR TITLE
Missing includes

### DIFF
--- a/src/framework/ui/view/internal/widgetdialogadapter.h
+++ b/src/framework/ui/view/internal/widgetdialogadapter.h
@@ -22,6 +22,8 @@
 #pragma once
 
 #include <QObject>
+#include <QDialog>
+#include <QWindow>
 
 namespace muse::ui {
 class WidgetDialogAdapter : public QObject

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -34,6 +34,8 @@
 #include "translation.h"
 #include "log.h"
 
+#include <QGuiApplication>
+
 using namespace mu;
 using namespace muse;
 using namespace muse::io;


### PR DESCRIPTION
>src/framework/ui/view/internal/widgetdialogadapter.cpp:97
>:21: error: cannot initialize object parameter of type 'QObject'
> with an expression of type 'muse::ui::WidgetDialogAdapter'
>   97 |     return QObject::eventFilter(watched, event);
>      |                     ^~~~~~~~~~~

>src/framework/ui/view/internal/widgetdialogadapter.cpp:86
>:37: error: member access into incomplete type 'QWindow'
>   86 |             m_dialog->windowHandle()->setTransientParent(m_window);
>      |                                     ^
>/usr/include/qt6/QtGui/qwindowdefs.h:19:7: note: forward declaration of 'QWindow'
>   19 | class QWindow;
>      |       ^

>src/notation/internal/notationactioncontroller.cpp:2236:5
>2: error: use of undeclared identifier 'QGuiApplication'; did you mean 'QApplication'?
> 2236 |     QGuiApplication::applicationState() == Qt::ApplicationActive;
>      |     ^~~~~~~~~~~~~~~
>      |     QApplication

See https://bugs.gentoo.org/958259#c33

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
