### PR TITLE
fixed #28819: [macOS] Crash after switching between desktops with opened dialog window

### DIFF
--- a/src/framework/ui/view/interactiveprovider.cpp
+++ b/src/framework/ui/view/interactiveprovider.cpp
@@ -565,7 +565,7 @@ RetVal<InteractiveProvider::OpenData> InteractiveProvider::openWidgetDialog(cons
     fillData(dialog, params);
 
     //! NOTE Will be deleted with the dialog
-    WidgetDialogAdapter* adapter = new WidgetDialogAdapter(dialog, mainWindow()->qWindow());
+    WidgetDialogAdapter* adapter = new WidgetDialogAdapter(dialog);
     adapter->onShow([this, objectId, dialog]() {
         async::Async::call(this, [this, objectId, dialog]() {
             onOpen(ContainerType::QWidgetDialog, objectId, dialog->window());

--- a/src/framework/ui/view/internal/widgetdialogadapter.h
+++ b/src/framework/ui/view/internal/widgetdialogadapter.h
@@ -29,7 +29,7 @@ namespace muse::ui {
 class WidgetDialogAdapter : public QObject
 {
 public:
-    WidgetDialogAdapter(QDialog* parent, QWindow* window, bool staysOnTop = true);
+    WidgetDialogAdapter(QDialog* parent);
 
     WidgetDialogAdapter& onShow(const std::function<void()>& func);
     WidgetDialogAdapter& onHide(const std::function<void()>& func);
@@ -37,13 +37,8 @@ public:
     bool eventFilter(QObject* watched, QEvent* event) override;
 
 private:
-#ifdef Q_OS_MAC
-    void updateStayOnTopHint();
-#endif
 
     QDialog* m_dialog = nullptr;
-    QWindow* m_window = nullptr;
-    bool m_staysOnTop = true;
     std::function<void()> m_onShownCallBack;
     std::function<void()> m_onHideCallBack;
 };

--- a/src/framework/uicomponents/view/topleveldialog.cpp
+++ b/src/framework/uicomponents/view/topleveldialog.cpp
@@ -22,8 +22,6 @@
 
 #include "topleveldialog.h"
 
-#include <QApplication>
-#include <QKeyEvent>
 #include <QWindow>
 
 using namespace muse::uicomponents;
@@ -33,30 +31,8 @@ TopLevelDialog::TopLevelDialog(QWidget* parent)
 {
     setWindowFlag(Qt::WindowContextHelpButtonHint, false);
 
-    // We want some windows to be on top of the main window.
-    // But not on top of all other applications when MuseScore isn't active.
-    // On Windows, we achieve this by setting the transient parent.
-    // On macOS, we have to use a workaround:
-    // When the application becomes active, the windows will get the StayOnTop hint.
-    // and when the application becomes inactive, the hint will be removed.
 #ifdef Q_OS_MAC
-    auto updateStayOnTopHint = [this]() {
-        bool stay = qApp->applicationState() == Qt::ApplicationActive;
-
-        bool wasShown = isVisible();
-        bool wasActive = isActiveWindow();
-
-        setWindowFlag(Qt::WindowStaysOnTopHint, stay);
-        if (wasShown) {
-            if (!wasActive) {
-                setAttribute(Qt::WA_ShowWithoutActivating, true);
-            }
-            show();
-            setAttribute(Qt::WA_ShowWithoutActivating, false);
-        }
-    };
-    updateStayOnTopHint();
-    connect(qApp, &QApplication::applicationStateChanged, this, updateStayOnTopHint);
+    setWindowFlags(Qt::Tool);
 #endif
 }
 
@@ -67,15 +43,6 @@ bool TopLevelDialog::event(QEvent* e)
         windowHandle()->setTransientParent(mainWindow()->qWindow());
     }
 #endif
-
-    if (e->type() == QEvent::ShortcutOverride) {
-        if (QKeyEvent* keyEvent = dynamic_cast<QKeyEvent*>(e)) {
-            if (keyEvent->key() == Qt::Key_Escape && keyEvent->modifiers() == Qt::NoModifier) {
-                close();
-                return true;
-            }
-        }
-    }
 
     return QDialog::event(e);
 }

--- a/src/framework/uicomponents/view/topleveldialog.h
+++ b/src/framework/uicomponents/view/topleveldialog.h
@@ -20,8 +20,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef MUSE_UICOMPONENTS_TOPLEVELDIALOG_H
-#define MUSE_UICOMPONENTS_TOPLEVELDIALOG_H
+#pragma once
 
 #include <QDialog>
 
@@ -41,5 +40,3 @@ protected:
     bool event(QEvent* e) override;
 };
 }
-
-#endif // MUSE_UICOMPONENTS_TOPLEVELDIALOG_H


### PR DESCRIPTION
Resolves: #28819