### PR TITLE
Fix #28664: Overlapping panels

### DIFF
--- a/src/appshell/internal/applicationuiactions.cpp
+++ b/src/appshell/internal/applicationuiactions.cpp
@@ -313,7 +313,7 @@ bool ApplicationUiActions::actionChecked(const UiAction& act) const
     }
 
     const IDockWindow* window = dockWindowProvider()->window();
-    return window ? window->isDockOpenAndCurrentInFrame(dockName) : false;
+    return window ? window->isDockOpen(dockName) : false;
 }
 
 muse::async::Channel<ActionCodeList> ApplicationUiActions::actionEnabledChanged() const

--- a/src/appshell/view/notationpagemodel.cpp
+++ b/src/appshell/view/notationpagemodel.cpp
@@ -215,7 +215,7 @@ void NotationPageModel::updateDrumsetPanelVisibility()
     }
 
     auto setDrumsetPanelOpen = [this, window](bool open) {
-        if (open == window->isDockOpenAndCurrentInFrame(DRUMSET_PANEL_NAME)) {
+        if (open == window->isDockOpen(DRUMSET_PANEL_NAME)) {
             return;
         }
 
@@ -250,12 +250,12 @@ void NotationPageModel::updatePercussionPanelVisibility()
     //! NOTE: If the user is entering percussion notes with the piano keyboard, we can assume that they
     //! don't want the percussion panel to auto-show...
     const muse::dock::IDockWindow* window = dockWindowProvider()->window();
-    if (!window || window->isDockOpenAndCurrentInFrame(PIANO_KEYBOARD_PANEL_NAME)) {
+    if (!window || window->isDockOpen(PIANO_KEYBOARD_PANEL_NAME)) {
         return;
     }
 
     auto setPercussionPanelOpen = [this, window](bool open) {
-        if (open == window->isDockOpenAndCurrentInFrame(PERCUSSION_PANEL_NAME)) {
+        if (open == window->isDockOpen(PERCUSSION_PANEL_NAME)) {
             return;
         }
 

--- a/src/framework/dockwindow/idockwindow.h
+++ b/src/framework/dockwindow/idockwindow.h
@@ -36,7 +36,7 @@ class IDockWindow
 public:
     virtual ~IDockWindow() = default;
 
-    virtual bool isDockOpenAndCurrentInFrame(const QString& dockName) const = 0;
+    virtual bool isDockOpen(const QString& dockName) const = 0;
     virtual void setDockOpen(const QString& dockName, bool open) = 0;
     virtual void toggleDock(const QString& dockName) = 0;
 

--- a/src/framework/dockwindow/view/dockpageview.cpp
+++ b/src/framework/dockwindow/view/dockpageview.cpp
@@ -205,26 +205,15 @@ DockPanelView* DockPageView::findPanelForTab(const DockPanelView* tab) const
     return nullptr;
 }
 
-bool DockPageView::isDockOpenAndCurrentInFrame(const QString& dockName) const
+bool DockPageView::isDockOpen(const QString& dockName) const
 {
     const DockBase* dock = dockByName(dockName);
-    if (!dock) {
-        return false;
-    }
-
-    const bool isDockOpen = dock && dock->isOpen();
-
-    const DockPanelView* panel = dynamic_cast<const DockPanelView*>(dock);
-    if (panel) {
-        return isDockOpen && panel->isCurrentTabInFrame();
-    }
-
-    return isDockOpen;
+    return dock && dock->isOpen();
 }
 
 void DockPageView::toggleDock(const QString& dockName)
 {
-    setDockOpen(dockName, !isDockOpenAndCurrentInFrame(dockName));
+    setDockOpen(dockName, !isDockOpen(dockName));
 }
 
 void DockPageView::setDockOpen(const QString& dockName, bool open)
@@ -248,7 +237,6 @@ void DockPageView::setDockOpen(const QString& dockName, bool open)
     DockPanelView* destinationPanel = findPanelForTab(panel);
     if (destinationPanel) {
         destinationPanel->addPanelAsTab(panel);
-        panel->makeCurrentTabInFrame();
     } else {
         panel->open();
     }

--- a/src/framework/dockwindow/view/dockpageview.h
+++ b/src/framework/dockwindow/view/dockpageview.h
@@ -95,7 +95,7 @@ public:
     QList<DockPanelView*> findPanelsForDropping(const DockPanelView* panel) const;
     DockPanelView* findPanelForTab(const DockPanelView* tab) const;
 
-    bool isDockOpenAndCurrentInFrame(const QString& dockName) const;
+    bool isDockOpen(const QString& dockName) const;
     void toggleDock(const QString& dockName);
     void setDockOpen(const QString& dockName, bool open);
 

--- a/src/framework/dockwindow/view/dockpanelview.cpp
+++ b/src/framework/dockwindow/view/dockpanelview.cpp
@@ -315,27 +315,3 @@ void DockPanelView::setCurrentTabIndex(int index)
         frame->setCurrentTabIndex(index);
     }
 }
-
-bool DockPanelView::isCurrentTabInFrame() const
-{
-    if (!dockWidget()) {
-        return false;
-    }
-
-    KDDockWidgets::Frame* frame = dockWidget()->frame();
-    return frame && frame->currentDockWidget() == dockWidget();
-}
-
-void DockPanelView::makeCurrentTabInFrame()
-{
-    IF_ASSERT_FAILED(dockWidget()) {
-        return;
-    }
-
-    KDDockWidgets::Frame* frame = dockWidget()->frame();
-    if (!frame) {
-        return;
-    }
-
-    frame->setCurrentDockWidget(dockWidget());
-}

--- a/src/framework/dockwindow/view/dockpanelview.h
+++ b/src/framework/dockwindow/view/dockpanelview.h
@@ -58,9 +58,6 @@ public:
     void addPanelAsTab(DockPanelView* tab);
     void setCurrentTabIndex(int index);
 
-    bool isCurrentTabInFrame() const;
-    void makeCurrentTabInFrame();
-
 public slots:
     void setGroupName(const QString& name);
     void setContextMenuModel(uicomponents::AbstractMenuModel* model);

--- a/src/framework/dockwindow/view/dockwindow.cpp
+++ b/src/framework/dockwindow/view/dockwindow.cpp
@@ -266,9 +266,9 @@ void DockWindow::loadPage(const QString& uri, const QVariantMap& params)
     }
 }
 
-bool DockWindow::isDockOpenAndCurrentInFrame(const QString& dockName) const
+bool DockWindow::isDockOpen(const QString& dockName) const
 {
-    return m_currentPage && m_currentPage->isDockOpenAndCurrentInFrame(dockName);
+    return m_currentPage && m_currentPage->isDockOpen(dockName);
 }
 
 void DockWindow::toggleDock(const QString& dockName)

--- a/src/framework/dockwindow/view/dockwindow.h
+++ b/src/framework/dockwindow/view/dockwindow.h
@@ -81,7 +81,7 @@ public:
     Q_INVOKABLE void loadPage(const QString& uri, const QVariantMap& params);
 
     //! IDockWindow
-    bool isDockOpenAndCurrentInFrame(const QString& dockName) const override;
+    bool isDockOpen(const QString& dockName) const override;
     void toggleDock(const QString& dockName) override;
     void setDockOpen(const QString& dockName, bool open) override;
 


### PR DESCRIPTION
Reverts: 99501cb3de20bc4298f4338c53f53e2c5de29afd
Resolves: #28664
Reopens: #26009

The solution in 99501cb3de20bc4298f4338c53f53e2c5de29afd was a misdiagnosis of the problem. The problem isn’t a failure to call `setCurrentDockWidget` with the mixer panel. We _are_ doing this, it’s just immediately followed by another call to `setCurrentDockWidget` with the widget at index 0 (put a breakpoint in `TabWidgetQuick::setCurrentDockWidget` to see this in action).  

My understanding is that this happens when we load a panel with a toolbar component (currently just the Mixer Panel or Percussion Panel). `DockFrameModel` intercepts this in `event` and emits `tabsChanged`, which eventually this leads to a reset of the `tabs` model in `DockTabBar.qml` (setting `currentIndex` to 0).

We'll simply revert for now for a couple of reasons:
1. [#28664](https://github.com/musescore/MuseScore/issues/28664) is a more severe bug than [#26009](https://github.com/musescore/MuseScore/issues/26009)
2. The "definitive" fix for [#26009](https://github.com/musescore/MuseScore/issues/26009) looks like it could be quite involved