### PR TITLE
Don't add incomplete slurs when importing MusicXML

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -8181,9 +8181,17 @@ static void addSlur(const Notation& notation, SlurStack& slurs, ChordRest* cr, c
         } else if (slurs[slurNo].isStop()) {
             // slur start when slur already stopped: wrap up
             Slur* newSlur = slurs[slurNo].slur();
+            newSlur->setTrack(track);
             newSlur->setTick(Fraction::fromTicks(tick));
             newSlur->setStartElement(cr);
+            newSlur->setTick2(newSlur->endElement()->tick());
             slurs[slurNo] = SlurDesc();
+            if (newSlur->ticks().negative()) {
+                logger->logError(String(u"slur end is before slur start"), xmlreader);
+                delete newSlur;
+                return;
+            }
+            score->addElement(newSlur);
         } else {
             // slur start for new slur: init
             Slur* newSlur = Factory::createSlur(score->dummy());
@@ -8220,7 +8228,6 @@ static void addSlur(const Notation& notation, SlurStack& slurs, ChordRest* cr, c
             newSlur->setTrack(track);
             newSlur->setTrack2(track);
             slurs[slurNo].start(newSlur);
-            score->addElement(newSlur);
         }
     } else if (slurType == u"stop") {
         if (slurs[slurNo].isStart()) {
@@ -8232,6 +8239,7 @@ static void addSlur(const Notation& notation, SlurStack& slurs, ChordRest* cr, c
             }
             newSlur->setEndElement(cr);
             slurs[slurNo] = SlurDesc();
+            score->addElement(newSlur);
         } else if (slurs[slurNo].isStop()) {
             // slur stop when slur already stopped: report error
             logger->logError(String(u"ignoring duplicate slur stop"), xmlreader);
@@ -8239,7 +8247,6 @@ static void addSlur(const Notation& notation, SlurStack& slurs, ChordRest* cr, c
             // slur stop for new slur: init
             Slur* newSlur = Factory::createSlur(score->dummy());
             if (!(cr->isGrace())) {
-                newSlur->setTick2(Fraction::fromTicks(tick));
                 newSlur->setTrack2(track);
             }
             newSlur->setEndElement(cr);

--- a/src/importexport/musicxml/tests/data/testBackupRoundingError_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testBackupRoundingError_ref.mscx
@@ -1581,6 +1581,14 @@
             <eid>/D_/D</eid>
             <small>1</small>
             <durationType>eighth</durationType>
+            <Spanner type="Slur">
+              <prev>
+                <location>
+                  <staves>1</staves>
+                  <fractions>-11/12</fractions>
+                  </location>
+                </prev>
+              </Spanner>
             <Articulation>
               <subtype>articStaccatoAbove</subtype>
               <eid>AE_AE</eid>
@@ -2395,12 +2403,23 @@
             <eid>JG_JG</eid>
             <small>1</small>
             <durationType>quarter</durationType>
+            <Spanner type="Slur">
+              <Slur>
+                <eid>KG_KG</eid>
+                </Slur>
+              <next>
+                <location>
+                  <staves>-1</staves>
+                  <fractions>11/12</fractions>
+                  </location>
+                </next>
+              </Spanner>
             <StemDirection>up</StemDirection>
             <Note>
-              <eid>KG_KG</eid>
+              <eid>LG_LG</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>LG_LG</eid>
+                <eid>MG_MG</eid>
                 </Accidental>
               <pitch>62</pitch>
               <tpc>16</tpc>
@@ -2408,16 +2427,16 @@
             </Chord>
           <Fermata>
             <subtype>fermataAbove</subtype>
-            <eid>MG_MG</eid>
+            <eid>NG_NG</eid>
             </Fermata>
           <Chord>
-            <eid>NG_NG</eid>
+            <eid>OG_OG</eid>
             <durationType>half</durationType>
             <StemDirection>up</StemDirection>
             <Note>
-              <eid>OG_OG</eid>
+              <eid>PG_PG</eid>
               <Fingering>
-                <eid>PG_PG</eid>
+                <eid>QG_QG</eid>
                 <text>2</text>
                 </Fingering>
               <pitch>25</pitch>
@@ -2425,7 +2444,7 @@
               </Note>
             </Chord>
           <Rest>
-            <eid>QG_QG</eid>
+            <eid>RG_RG</eid>
             <visible>0</visible>
             <durationType>quarter</durationType>
             </Rest>
@@ -2434,41 +2453,41 @@
             </location>
           <Symbol>
             <name>fClef</name>
-            <eid>RG_RG</eid>
+            <eid>SG_SG</eid>
             </Symbol>
           <location>
             <fractions>1/12</fractions>
             </location>
           <BarLine>
             <subtype>end</subtype>
-            <eid>SG_SG</eid>
+            <eid>TG_TG</eid>
             </BarLine>
           </voice>
         <voice>
           <Chord>
-            <eid>TG_TG</eid>
+            <eid>UG_UG</eid>
             <dots>1</dots>
             <durationType>half</durationType>
             <StemDirection>down</StemDirection>
             <Note>
-              <eid>UG_UG</eid>
+              <eid>VG_VG</eid>
               <Accidental>
                 <subtype>accidentalSharp</subtype>
-                <eid>VG_VG</eid>
+                <eid>WG_WG</eid>
                 </Accidental>
               <pitch>25</pitch>
               <tpc>21</tpc>
               </Note>
             </Chord>
           <Chord>
-            <eid>WG_WG</eid>
+            <eid>XG_XG</eid>
             <durationType>quarter</durationType>
             <StemDirection>up</StemDirection>
             <Note>
-              <eid>XG_XG</eid>
+              <eid>YG_YG</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>YG_YG</eid>
+                <eid>ZG_ZG</eid>
                 </Accidental>
               <pitch>38</pitch>
               <tpc>16</tpc>
@@ -2476,37 +2495,37 @@
             </Chord>
           <Fermata>
             <subtype>fermataBelow</subtype>
-            <eid>ZG_ZG</eid>
+            <eid>aG_aG</eid>
             </Fermata>
           <Chord>
-            <eid>aG_aG</eid>
+            <eid>bG_bG</eid>
             <durationType>half</durationType>
             <StemDirection>down</StemDirection>
             <Note>
-              <eid>bG_bG</eid>
+              <eid>cG_cG</eid>
               <Accidental>
                 <subtype>accidentalSharp</subtype>
-                <eid>cG_cG</eid>
+                <eid>dG_dG</eid>
                 </Accidental>
               <pitch>41</pitch>
               <tpc>25</tpc>
               </Note>
             <Note>
-              <eid>dG_dG</eid>
+              <eid>eG_eG</eid>
               <Accidental>
                 <subtype>accidentalNatural</subtype>
-                <eid>eG_eG</eid>
+                <eid>fG_fG</eid>
                 </Accidental>
               <pitch>67</pitch>
               <tpc>15</tpc>
               </Note>
             <Arpeggio>
-              <eid>fG_fG</eid>
+              <eid>gG_gG</eid>
               <subtype>0</subtype>
               </Arpeggio>
             </Chord>
           <Rest>
-            <eid>gG_gG</eid>
+            <eid>hG_hG</eid>
             <visible>0</visible>
             <durationType>half</durationType>
             </Rest>


### PR DESCRIPTION
Resolves: #28889 
This PR ensures only slurs with valid start and end tags are added to the score. It also allows us to add slurs with end tags which come before the start tags in the XML but not the music [as per the spec](https://www.w3.org/2021/06/musicxml40/musicxml-reference/data-types/start-stop-continue/).