### PR TITLE
Use % for tuplet 'Maximum slope' style setting

### DIFF
--- a/src/notationscene/widgets/editstyle.cpp
+++ b/src/notationscene/widgets/editstyle.cpp
@@ -533,7 +533,7 @@ EditStyle::EditStyle(QWidget* parent)
         { StyleId::tupletDirection,         false, tupletDirection,         resetTupletDirection },
         { StyleId::tupletNumberType,        false, tupletNumberType,        resetTupletNumberType },
         { StyleId::tupletBracketType,       false, tupletBracketType,       resetTupletBracketType },
-        { StyleId::tupletMaxSlope,          false, tupletMaxSlope,          resetTupletMaxSlope },
+        { StyleId::tupletMaxSlope,          true,  tupletMaxSlope,          resetTupletMaxSlope },
         { StyleId::tupletOutOfStaff,        false, tupletOutOfStaff,        0 },
         { StyleId::tupletUseSymbols,        false, tupletUseSymbols,        resetTupletUseSymbols },
         { StyleId::tupletExtendToEndOfDuration, false, tupletExtendToEndOfDuration, 0 },

--- a/src/notationscene/widgets/editstyle.ui
+++ b/src/notationscene/widgets/editstyle.ui
@@ -6106,16 +6106,16 @@
                      <bool>false</bool>
                     </property>
                     <property name="suffix">
-                     <string extracomment="spatium unit">sp</string>
+                     <string notr="true">%</string>
                     </property>
                     <property name="maximum">
-                     <double>1.000000000000000</double>
+                     <double>100.000000000000000</double>
                     </property>
                     <property name="singleStep">
-                     <double>0.050000000000000</double>
+                     <double>5</double>
                     </property>
-                    <property name="value">
-                     <double>0.500000000000000</double>
+                    <property name="decimals">
+                     <number>0</number>
                     </property>
                    </widget>
                   </item>


### PR DESCRIPTION
The 'Maximum value' value is currently falsely displayed as a spatium value in the UI, even though internally it's treated as a `double`.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
