### PR TITLE
Improve IPC logging a bit (for cleaner logs)

### DIFF
--- a/src/framework/multiinstances/internal/ipc/ipcchannel.cpp
+++ b/src/framework/multiinstances/internal/ipc/ipcchannel.cpp
@@ -157,13 +157,16 @@ void IpcChannel::setupConnection()
         if (!m_selfSocket->connect(SERVER_NAME)) {
             //! NOTE If it was not possible to connect to the server, then it no there or was, but it was closed.
             //! In this case, we will become a server
+            LOGI() << "starting ipc server";
             m_server = new IpcServer();
             m_server->listen(SERVER_NAME);
         }
         lock.unlock();
 
         //! NOTE Connect to self server
-        m_selfSocket->connect(SERVER_NAME);
+        if (!m_selfSocket->connect(SERVER_NAME)) {
+            LOGE() << "failed to connect to ipc server";
+        }
     }
 }
 

--- a/src/framework/multiinstances/internal/ipc/ipcserver.cpp
+++ b/src/framework/multiinstances/internal/ipc/ipcserver.cpp
@@ -94,7 +94,7 @@ bool IpcServer::listen(const QString& serverName)
         inc.id = QString::fromUtf8(id);
         m_incomingSockets.append(inc);
 
-        LOGI() << "id: " << id;
+        LOGI() << "ipc server: client with id " << id << " has connected";
 
         QObject::connect(socket, &QLocalSocket::readyRead, [socket, this]() {
             onIncomingReadyRead(socket);

--- a/src/framework/multiinstances/internal/ipc/ipcsocket.cpp
+++ b/src/framework/multiinstances/internal/ipc/ipcsocket.cpp
@@ -65,7 +65,6 @@ bool IpcSocket::connect(const QString& serverName)
     m_socket->connectToServer(serverName);
     bool ok = m_socket->waitForConnected(TIMEOUT_MSEC);
     if (!ok) {
-        LOGW() << "failed connect to server";
         return false;
     }
 

--- a/src/framework/multiinstances/internal/multiinstancesprovider.cpp
+++ b/src/framework/multiinstances/internal/multiinstancesprovider.cpp
@@ -70,6 +70,7 @@ void MultiInstancesProvider::init()
 
     m_ipcChannel = new IpcChannel();
     m_selfID = m_ipcChannel->selfID().toStdString();
+    LOGI() << "our instance id is: " << m_selfID;
 
     m_ipcChannel->msgReceived().onReceive(this, [this](const Msg& msg) { onMsg(msg); });
     m_ipcChannel->instancesChanged().onNotify(this, [this]() { m_instancesChanged.notify(); });


### PR DESCRIPTION
Resolves: #28928 

Before:
`22:22:01.265 | WARN  | main_thread     | IpcSocket::connect | failed connect to server`
`22:22:01.265 | WARN  | main_thread     | IpcSocket::connect | failed connect to server`
`22:22:01.267 | INFO  | main_thread     | IpcSocket::connect | success connected to ipc server`
`22:22:01.267 | INFO  | 24216           | <lambda_1>::operator  | id: "6f6464838eb14526bde4aa47a8f4dbd3"`

After:
`21:29:31.433 | INFO  | main_thread     | MultiInstancesProvider::init | our instance id is: 028da3de7a97405d9f63825f8bc24d7c`
`21:29:31.434 | INFO  | main_thread     | IpcChannel::setupConnection | starting ipc server`
`21:29:31.436 | INFO  | main_thread     | IpcSocket::connect | success connected to ipc server`
`21:29:31.436 | INFO  | 25612           | <lambda_1>::operator  | ipc server: client with id "028da3de7a97405d9f63825f8bc24d7c"  has connected`

Screenshots and details are available in the story.

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
