### PR TITLE
Fix #28914: Crash relating to selection filter and measure duration

### DIFF
--- a/src/engraving/dom/measure.cpp
+++ b/src/engraving/dom/measure.cpp
@@ -1925,6 +1925,23 @@ void Measure::adjustToLen(Fraction nf, bool appendRestsIfNecessary)
             }
         }
     }
+
+    Selection& sel = score()->selection();
+    if (!sel.isRange()) {
+        return;
+    }
+    // If the selection started and/or ended inside this measure, we should pass it
+    // updated start/end segments...
+    const Segment* oldStart = sel.startSegment();
+    if (oldStart && sel.startMeasureBase() == this) {
+        Segment* newStart = this->tick2segment(oldStart->tick());
+        sel.setStartSegment(newStart ? newStart : first());
+    }
+    const Segment* oldEnd = sel.endSegment();
+    if (oldEnd && sel.endMeasureBase() == this) {
+        Segment* newEnd = this->tick2segment(oldEnd->tick());
+        sel.setEndSegment(newEnd ? newEnd : last()->next1());
+    }
 }
 
 //---------------------------------------------------------

--- a/src/notation/view/selectionfilter/notesinchordselectionfiltermodel.cpp
+++ b/src/notation/view/selectionfilter/notesinchordselectionfiltermodel.cpp
@@ -218,6 +218,9 @@ void NotesInChordSelectionFilterModel::updateTopNoteIdx()
 
     for (track_idx_t track = startTrack; track < endTrack; ++track) {
         for (Segment* seg = startSeg; seg != endSeg; seg = seg->next1MM()) {
+            IF_ASSERT_FAILED(seg && seg->tick() < endSeg->tick()) {
+                break;
+            }
             const EngravingItem* e = seg->element(track);
             if (!seg->enabled() || !e || !e->isChord()) {
                 continue;


### PR DESCRIPTION
Resolves: #28914

### Explainer

In `MeasurePropertiesDialog::apply`:

1.  The duration of a measure is changed
2. We call `undoStack()->commitChanges()`, triggering a `selectionChanged` notification
3. `NotesInChordSelectionFilterModel::updateTopNoteIdx` is called

At this point, our range selection is in an intermediate/invalid state - `rangeEndSegment` still refers to the old end segment before we changed the duration of the measure. This means that the end condition of the inner loop is never met, we eventually hit a null segment, and the program crashes.

If we can avoid the crash, we'll go back to `MeasurePropertiesDialog::apply`:
1. We call `NotationInteraction::select` on the updated measure
2. `selectionChanged` is triggered
3. `NotesInChordSelectionFilterModel::updateTopNoteIdx` is called again, this time with a valid range selection state

### Solution

These changes include a null check on each iteration of the inner loop as a failsafe. To prevent interation all the way to the score during the intermediate state, we'll check that the tick of the current segment hasn't surpassed the tick of the old end segment.