### PR TITLE
Enable fractional scaling on Linux

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -119,12 +119,7 @@ int main(int argc, char** argv)
     }
 #endif
 
-//! NOTE: For unknown reasons, Linux scaling for 1 is defined as 1.003 in fractional scaling.
-//!       Because of this, some elements are drawn with a shift on the score.
-//!       Let's make a Linux hack and round values above 0.75(see RoundPreferFloor)
-#ifdef Q_OS_LINUX
-    QGuiApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::RoundPreferFloor);
-#elif defined(Q_OS_WIN)
+#ifdef Q_OS_WIN
     QGuiApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
 #endif
 


### PR DESCRIPTION
#10285 broke fractional scaling on Linux. This was noticed a year and a half later in https://github.com/musescore/MuseScore/pull/10285#discussion_r1423393942. I have the same issue today on Fedora 42 (KDE Plasma 6.4.3). My system scaling factor is set to 165%, and all Qt applications work fine except MuseScore. MuseScore is (erroneously) scaled down to 100%, making the UI text unusably small on my display.

Simply removing this old workaround resolves the problem for me. With the workaround removed, Qt6's built-in HiDPI works great and the application looks and feels normal. When the workaround was introduced, the following comments were written:

> NOTE: For unknown reasons, Linux scaling for 1 is defined as 1.003 in fractional scaling. Because of this, some elements are drawn with a shift on the score.

and

> you can verify it yourself by adjusting the value and opening any score, the rendering of elements occurs with a shift.

I couldn't duplicate this problem after this PR. I opened several scores, but I didn't see any shift occurring when rendering elements. Whatever reason was behind this workaround over 3 years ago no longer seems to apply to Qt6 on modern KDE today.

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
