### PR TITLE
Improve score writing performance by ~30%

### DIFF
--- a/src/engraving/dom/textbase.cpp
+++ b/src/engraving/dom/textbase.cpp
@@ -1696,7 +1696,7 @@ String TextBlock::text(int col1, int len, bool withFormat) const
                 if (f.format.fontFamily() == "ScoreText" && withFormat) {
                     s += toSymbolXml(c);
                 } else {
-                    s += XmlWriter::escapeSymbol(c.unicode());
+                    s += String::toXmlEscaped(c.unicode());
                 }
             }
             if (!c.isHighSurrogate()) {

--- a/src/engraving/infrastructure/eid.cpp
+++ b/src/engraving/infrastructure/eid.cpp
@@ -19,28 +19,32 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+#include "eid.h"
+
 #include <string>
 #include <random>
 
-#include <logger.h>
-
-#include "eid.h"
+#include "global/log.h"
 
 using namespace mu::engraving;
 
 static constexpr char SEPARATOR = '_';
 
-static std::string int64ToBase64Str(uint64_t n)
+static char* toBase64Chars(char* const first, char* const last, uint64_t n)
 {
     static constexpr char CHARS[65] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
-    std::stringstream ss;
+    IF_ASSERT_FAILED(static_cast<size_t>(last - first) >= EID::MAX_UINT64_BASE64_SIZE) {
+        return first;
+    }
+
+    char* it = first;
     do {
-        ss << CHARS[n & 63];
-        n = n >> 6;
+        *it++ = CHARS[n % 64];
+        n = n / 64;
     } while (n != 0);
 
-    return ss.str();
+    return it;
 }
 
 static constexpr uint64_t charToInt(char c)
@@ -128,11 +132,26 @@ static uint64_t base64StrToInt64(const std::string& s)
     return result;
 }
 
+char* EID::toChars(char* const first, char* const last) const
+{
+    IF_ASSERT_FAILED(static_cast<size_t>(last - first) >= MAX_STR_SIZE) {
+        return first;
+    }
+
+    char* it = toBase64Chars(first, last, m_first);
+    *it++ = SEPARATOR;
+    it = toBase64Chars(it, last, m_second);
+
+    return it;
+}
+
 std::string EID::toStdString() const
 {
-    std::stringstream ss;
-    ss << int64ToBase64Str(m_first) << SEPARATOR << int64ToBase64Str(m_second);
-    return ss.str();
+    std::string base64Repr(MAX_STR_SIZE, char {});
+    const char* last = toChars(base64Repr.data(), base64Repr.data() + base64Repr.size());
+    base64Repr.resize(last - base64Repr.data());
+
+    return base64Repr;
 }
 
 EID EID::fromStdString(const std::string& s)

--- a/src/engraving/infrastructure/eid.h
+++ b/src/engraving/infrastructure/eid.h
@@ -19,27 +19,29 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef MU_ENGRAVING_EID_H
-#define MU_ENGRAVING_EID_H
+#pragma once
 
-#include <bitset>
 #include <cstdint>
 #include <string>
 #include <string_view>
 
 #include "global/logstream.h"
 
-#include "../types/types.h"
-
 namespace mu::engraving {
 class EID
 {
 public:
+    // max size of base64 string of 64-bit int is ceil(log(2^64) / log(64)) = 11
+    static constexpr size_t MAX_UINT64_BASE64_SIZE = 11;
+    // 2 * uint64_t as base64 + separator
+    static constexpr size_t MAX_STR_SIZE = 2 * MAX_UINT64_BASE64_SIZE + 1;
+
     bool isValid() const { return m_first != INVALID || m_second != INVALID; }
 
     inline bool operator ==(const EID& other) const { return m_first == other.m_first && m_second == other.m_second; }
     inline bool operator !=(const EID& other) const { return m_first != other.m_first || m_second != other.m_second; }
 
+    char* toChars(char* first, char* last) const;
     std::string toStdString() const;
     static EID fromStdString(const std::string& v);
     static EID fromStdString(const std::string_view& v);
@@ -78,5 +80,3 @@ inline muse::logger::Stream& operator<<(muse::logger::Stream& s, const mu::engra
     s << v.toStdString();
     return s;
 }
-
-#endif // MU_ENGRAVING_EID_H

--- a/src/engraving/rw/write/twrite.cpp
+++ b/src/engraving/rw/write/twrite.cpp
@@ -454,7 +454,12 @@ void TWrite::writeItemEid(const EngravingObject* item, XmlWriter& xml, WriteCont
     if (!eid.isValid()) {
         eid = item->assignNewEID();
     }
-    xml.tag("eid", eid.toStdString());
+
+    std::array<char, EID::MAX_STR_SIZE> buf{};
+    const char* last = eid.toChars(buf.data(), buf.data() + buf.size());
+    const auto size = static_cast<size_t>(last - buf.data());
+
+    xml.tag("eid", AsciiStringView { buf.data(), size });
 }
 
 void TWrite::writeItemLink(const EngravingObject* item, XmlWriter& xml, WriteContext& ctx)
@@ -467,7 +472,7 @@ void TWrite::writeItemLink(const EngravingObject* item, XmlWriter& xml, WriteCon
     if (mainElement != item) {
         EID eidOfMainElement = mainElement->eid();
         DO_ASSERT(eidOfMainElement.isValid());
-        xml.tag("linkedTo", mainElement->eid().toStdString());
+        xml.tag("linkedTo", eidOfMainElement.toStdString());
     }
 }
 

--- a/src/engraving/rw/xmlwriter.cpp
+++ b/src/engraving/rw/xmlwriter.cpp
@@ -353,6 +353,6 @@ void XmlWriter::comment(const String& text)
 
 String XmlWriter::xmlString(const String& s)
 {
-    return XmlStreamWriter::escapeString(s);
+    return s.toXmlEscaped();
 }
 }

--- a/src/framework/global/serialization/textstream.cpp
+++ b/src/framework/global/serialization/textstream.cpp
@@ -20,7 +20,15 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include "textstream.h"
-#include <sstream>
+
+#include <array>
+#include <charconv>
+
+#include "global/io/iodevice.h"
+#include "global/types/bytearray.h"
+#include "global/types/string.h"
+
+#include "global/log.h"
 
 using namespace muse;
 
@@ -29,6 +37,7 @@ static constexpr int TEXTSTREAM_BUFFERSIZE = 16384;
 TextStream::TextStream(io::IODevice* device)
     : m_device(device)
 {
+    m_buf.reserve(TEXTSTREAM_BUFFERSIZE);
 }
 
 TextStream::~TextStream()
@@ -44,7 +53,7 @@ void TextStream::setDevice(io::IODevice* device)
 void TextStream::flush()
 {
     if (m_device && m_device->isOpen()) {
-        m_device->write(m_buf);
+        m_device->write(m_buf.data(), m_buf.size());
         m_buf.clear();
     }
 }
@@ -55,59 +64,81 @@ TextStream& TextStream::operator<<(char ch)
     return *this;
 }
 
-TextStream& TextStream::operator<<(int val)
+TextStream& TextStream::operator<<(const int32_t val)
 {
-    std::stringstream ss;
-    ss << val;
-    write(ss.str().c_str(), ss.str().size());
+    // ceil(log_10(2^31)) = 10 (+ sign)
+    std::array<char, 11> buf{};
+    const auto [last, ec] = std::to_chars(buf.data(), buf.data() + buf.size(), val);
+    IF_ASSERT_FAILED(ec == std::errc {}) {
+        return *this;
+    }
+
+    write(buf.data(), static_cast<size_t>(last - buf.data()));
+
     return *this;
 }
 
-TextStream& TextStream::operator<<(unsigned int val)
+TextStream& TextStream::operator<<(const uint32_t val)
 {
-    std::stringstream ss;
-    ss << val;
-    write(ss.str().c_str(), ss.str().size());
+    // ceil(log_10(2^32)) = 10
+    std::array<char, 10> buf{};
+    const auto [last, ec] = std::to_chars(buf.data(), buf.data() + buf.size(), val);
+    IF_ASSERT_FAILED(ec == std::errc {}) {
+        return *this;
+    }
+
+    write(buf.data(), static_cast<size_t>(last - buf.data()));
     return *this;
 }
 
 TextStream& TextStream::operator<<(double val)
 {
+    // macOS: requires macOS 13.3 at runtime
+    // linux: requires at least libstdc++ 11 (we compile with libstdc++ 10) or libc++ 14
+#if !defined(Q_OS_MAC) && (defined(_MSC_VER) \
+    || (defined(_LIBCPP_VERSION) && _LIBCPP_VERSION >= 14000) \
+    || (defined(_GLIBCXX_RELEASE) && _GLIBCXX_RELEASE >= 11))
+    std::array<char, 24> buf{};
+    const auto [last, ec] = std::to_chars(buf.data(), buf.data() + buf.size(), val);
+    IF_ASSERT_FAILED(ec == std::errc {}) {
+        return *this;
+    }
+    write(buf.data(), static_cast<size_t>(last - buf.data()));
+#else
     std::stringstream ss;
     ss << val;
-    write(ss.str().c_str(), ss.str().size());
+    std::string buf = ss.str();
+    write(buf.data(), buf.size());
+#endif
+
     return *this;
 }
 
-TextStream& TextStream::operator<<(signed long int val)
+TextStream& TextStream::operator<<(const int64_t val)
 {
-    std::stringstream ss;
-    ss << val;
-    write(ss.str().c_str(), ss.str().size());
+    // ceil(log_10(2^63)) = 20 (+ sign)
+    std::array<char, 21> buf{};
+    const auto [last, ec] = std::to_chars(buf.data(), buf.data() + buf.size(), val);
+    IF_ASSERT_FAILED(ec == std::errc {}) {
+        return *this;
+    }
+
+    write(buf.data(), static_cast<size_t>(last - buf.data()));
+
     return *this;
 }
 
-TextStream& TextStream::operator<<(unsigned long int val)
+TextStream& TextStream::operator<<(const uint64_t val)
 {
-    std::stringstream ss;
-    ss << val;
-    write(ss.str().c_str(), ss.str().size());
-    return *this;
-}
+    // ceil(log_10(2^64)) = 20
+    std::array<char, 20> buf{};
+    const auto [last, ec] = std::to_chars(buf.data(), buf.data() + buf.size(), val);
+    IF_ASSERT_FAILED(ec == std::errc {}) {
+        return *this;
+    }
 
-TextStream& TextStream::operator<<(signed long long val)
-{
-    std::stringstream ss;
-    ss << val;
-    write(ss.str().c_str(), ss.str().size());
-    return *this;
-}
+    write(buf.data(), static_cast<size_t>(last - buf.data()));
 
-TextStream& TextStream::operator<<(unsigned long long val)
-{
-    std::stringstream ss;
-    ss << val;
-    write(ss.str().c_str(), ss.str().size());
     return *this;
 }
 
@@ -147,7 +178,7 @@ TextStream& TextStream::operator<<(const String& s)
 
 void TextStream::write(const char* ch, size_t len)
 {
-    m_buf.push_back(reinterpret_cast<const uint8_t*>(ch), len);
+    m_buf.insert(m_buf.end(), reinterpret_cast<const uint8_t*>(ch), reinterpret_cast<const uint8_t*>(ch + len));
     if (m_device && m_buf.size() > TEXTSTREAM_BUFFERSIZE) {
         flush();
     }

--- a/src/framework/global/serialization/textstream.cpp
+++ b/src/framework/global/serialization/textstream.cpp
@@ -113,13 +113,12 @@ TextStream& TextStream::operator<<(unsigned long long val)
 
 TextStream& TextStream::operator<<(const char* s)
 {
-    write(s, std::strlen(s));
-    return *this;
+    return operator<<(std::string_view { s });
 }
 
-TextStream& TextStream::operator<<(const std::string& str)
+TextStream& TextStream::operator<<(const std::string_view str)
 {
-    write(str.c_str(), str.size());
+    write(str.data(), str.size());
     return *this;
 }
 
@@ -136,12 +135,6 @@ TextStream& TextStream::operator<<(const QString& s)
 TextStream& TextStream::operator<<(const ByteArray& b)
 {
     write(reinterpret_cast<const char*>(b.constData()), b.size());
-    return *this;
-}
-
-TextStream& TextStream::operator<<(const AsciiStringView& s)
-{
-    write(s.ascii(), s.size());
     return *this;
 }
 

--- a/src/framework/global/serialization/textstream.h
+++ b/src/framework/global/serialization/textstream.h
@@ -21,17 +21,22 @@
  */
 #pragma once
 
+#include <cstdint>
 #include <string_view>
-
-#include "../io/iodevice.h"
-#include "../types/bytearray.h"
-#include "../types/string.h"
+#include <vector>
 
 #ifndef NO_QT_SUPPORT
 #include <QString>
 #endif
 
 namespace muse {
+class ByteArray;
+class String;
+
+namespace io {
+class IODevice;
+}
+
 class TextStream
 {
 public:
@@ -44,13 +49,11 @@ public:
     void flush();
 
     TextStream& operator<<(char ch);
-    TextStream& operator<<(int val);
-    TextStream& operator<<(unsigned int val);
-    TextStream& operator<<(double val);
-    TextStream& operator<<(signed long int val);
-    TextStream& operator<<(unsigned long int val);
-    TextStream& operator<<(signed long long val);
-    TextStream& operator<<(unsigned long long val);
+    TextStream& operator<<(int32_t);
+    TextStream& operator<<(uint32_t);
+    TextStream& operator<<(double);
+    TextStream& operator<<(int64_t);
+    TextStream& operator<<(uint64_t);
     TextStream& operator<<(const char* s);
     TextStream& operator<<(std::string_view);
     TextStream& operator<<(const ByteArray& b);
@@ -63,6 +66,6 @@ public:
 private:
     void write(const char* ch, size_t len);
     io::IODevice* m_device = nullptr;
-    ByteArray m_buf;
+    std::vector<uint8_t> m_buf;
 };
 }

--- a/src/framework/global/serialization/textstream.h
+++ b/src/framework/global/serialization/textstream.h
@@ -19,8 +19,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef MUSE_GLOBAL_TEXTSTREAM_H
-#define MUSE_GLOBAL_TEXTSTREAM_H
+#pragma once
+
+#include <string_view>
 
 #include "../io/iodevice.h"
 #include "../types/bytearray.h"
@@ -51,9 +52,8 @@ public:
     TextStream& operator<<(signed long long val);
     TextStream& operator<<(unsigned long long val);
     TextStream& operator<<(const char* s);
-    TextStream& operator<<(const std::string& s);
+    TextStream& operator<<(std::string_view);
     TextStream& operator<<(const ByteArray& b);
-    TextStream& operator<<(const AsciiStringView& s);
     TextStream& operator<<(const String& s);
 
 #ifndef NO_QT_SUPPORT
@@ -66,5 +66,3 @@ private:
     ByteArray m_buf;
 };
 }
-
-#endif // MUSE_GLOBAL_TEXTSTREAM_H

--- a/src/framework/global/serialization/xmlstreamwriter.cpp
+++ b/src/framework/global/serialization/xmlstreamwriter.cpp
@@ -122,17 +122,17 @@ void XmlStreamWriter::writeValue(const Value& v)
     switch (v.index()) {
     case 0:
         break;
-    case 1: m_impl->stream << std::get<int>(v);
+    case 1: m_impl->stream << int32_t{ std::get<int>(v) };
         break;
-    case 2: m_impl->stream << std::get<unsigned int>(v);
+    case 2: m_impl->stream << uint32_t{ std::get<unsigned int>(v) };
         break;
-    case 3: m_impl->stream << std::get<signed long int>(v);
+    case 3: m_impl->stream << int64_t{ std::get<signed long int>(v) };
         break;
-    case 4: m_impl->stream << std::get<unsigned long int>(v);
+    case 4: m_impl->stream << uint64_t{ std::get<unsigned long int>(v) };
         break;
-    case 5: m_impl->stream << std::get<signed long long>(v);
+    case 5: m_impl->stream << int64_t{ std::get<signed long long>(v) };
         break;
-    case 6: m_impl->stream << std::get<unsigned long long>(v);
+    case 6: m_impl->stream << uint64_t{ std::get<unsigned long long>(v) };
         break;
     case 7: m_impl->stream << std::get<double>(v);
         break;

--- a/src/framework/global/serialization/xmlstreamwriter.h
+++ b/src/framework/global/serialization/xmlstreamwriter.h
@@ -19,14 +19,14 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef MUSE_GLOBAL_XMLSTREAMWRITER_H
-#define MUSE_GLOBAL_XMLSTREAMWRITER_H
+#pragma once
 
-#include <list>
+#include <string>
+#include <string_view>
 #include <variant>
 
-#include "types/string.h"
-#include "io/iodevice.h"
+#include "global/types/string.h"
+#include "global/io/iodevice.h"
 
 namespace muse {
 class TextStream;
@@ -61,9 +61,8 @@ public:
 
     void comment(const String& text);
 
-    static String escapeSymbol(char16_t c);
-    static String escapeString(const AsciiStringView& s);
-    static String escapeString(const String& s);
+    static std::string escapeCodePoint(char32_t);
+    static std::string escapeString(std::string_view);
 
 protected:
     void startElementRaw(const String& name);
@@ -78,5 +77,3 @@ private:
     Impl* m_impl = nullptr;
 };
 }
-
-#endif // MUSE_GLOBAL_XMLSTREAMWRITER_H

--- a/src/framework/global/types/string.h
+++ b/src/framework/global/types/string.h
@@ -437,6 +437,9 @@ public:
 #endif
 
     operator std::string_view() const {
+        if (!m_data) {
+            return std::string_view{};
+        }
         return std::string_view(m_data, m_size);
     }
 


### PR DESCRIPTION
Some small optimizations to score writing performance at the string level. See commit messages for details.
The measurements were made when the attached score was autosaved.
[Test..._Beethoven__Symphony_No._9__Op._125-converted.mscz.zip](https://github.com/user-attachments/files/21442903/Test._Beethoven__Symphony_No._9__Op._125-converted.mscz.zip)
Autosaving took ~11s on my machine. It now takes ~7.5s.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
