### PR TITLE
Improve score loading performance by ~33%

### DIFF
--- a/src/engraving/dom/engravingobject.cpp
+++ b/src/engraving/dom/engravingobject.cpp
@@ -22,11 +22,9 @@
 
 #include "engravingobject.h"
 
-#include <iterator>
-#include <unordered_set>
+#include "global/containers.h"
 
 #include "style/textstyle.h"
-#include "types/translatablestring.h"
 #include "types/typesconv.h"
 
 #include "bracketItem.h"
@@ -42,11 +40,6 @@ using namespace mu::engraving;
 
 namespace mu::engraving {
 ElementStyle const EngravingObject::EMPTY_STYLE;
-
-EngravingObject* EngravingObjectList::at(size_t i) const
-{
-    return *std::next(begin(), i);
-}
 
 EngravingObject::EngravingObject(const ElementType& type, EngravingObject* parent)
     : m_type(type)
@@ -117,6 +110,7 @@ EngravingObject::~EngravingObject()
                               && !this->isType(ElementType::SCORE)
                               && score()->rootItem() && score()->rootItem()->dummy();
 
+        // copy because moveToDummy might modify children
         EngravingObjectList children = m_children;
         for (EngravingObject* c : children) {
             if (canMoveToDummy) {
@@ -223,7 +217,7 @@ void EngravingObject::removeChild(EngravingObject* o)
         return;
     }
     o->m_parent = nullptr;
-    m_children.remove(o);
+    muse::remove(m_children, o);
 }
 
 EngravingObject* EngravingObject::parent() const

--- a/src/engraving/dom/engravingobject.h
+++ b/src/engraving/dom/engravingobject.h
@@ -22,6 +22,8 @@
 
 #pragma once
 
+#include <vector>
+
 #include "global/allocator.h"
 
 #include "../devtools/iengravingelementsprovider.h"
@@ -198,13 +200,7 @@ class LinkedObjects;
 enum class Pid : int;
 enum class PropertyFlags : char;
 
-class EngravingObjectList : public std::list<EngravingObject*>
-{
-    OBJECT_ALLOCATOR(engraving, EngravingObjectList)
-public:
-
-    EngravingObject* at(size_t i) const;
-};
+using EngravingObjectList = std::vector<EngravingObject*>;
 
 class EngravingObject
 {


### PR DESCRIPTION
An easy win for score loading, detected using an external sampling profiler. Closing big scores feels snappier too. See commit message.
Loading the big score in #28952:
- before: ~60s
- after: ~40s

before:
<img width="955" height="100" alt="before" src="https://github.com/user-attachments/assets/d2044bab-2dd5-4150-81c4-f485c8060375" />

after:
<img width="934" height="214" alt="after" src="https://github.com/user-attachments/assets/d623f215-496d-4534-ac76-6efb65b753c8" />

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
