### PR TITLE
Speed up scrolling further for Qt 6.9.1

### DIFF
--- a/src/appshell/qml/DevTools/Gallery/GeneralComponentsGallery.qml
+++ b/src/appshell/qml/DevTools/Gallery/GeneralComponentsGallery.qml
@@ -39,7 +39,7 @@ Rectangle {
         order: 4
     }
 
-    Flickable {
+    StyledFlickable {
         id: flickableWrapper
 
         anchors.fill: parent

--- a/src/framework/ui/internal/uiconfiguration.cpp
+++ b/src/framework/ui/internal/uiconfiguration.cpp
@@ -55,7 +55,11 @@ static const Settings::Key UI_MUSICAL_FONT_SIZE_KEY("ui", "ui/theme/musicalFontS
 
 static const QString WINDOW_GEOMETRY_KEY("window");
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
+static const int FLICKABLE_MAX_VELOCITY = 4000;
+#else
 static const int FLICKABLE_MAX_VELOCITY = 1500;
+#endif
 
 static const int TOOLTIP_DELAY = 500;
 


### PR DESCRIPTION
Resolves: #28966

This PR sets `maximumFlickVelocity` to 4000 for Qt 6.9.1. Also replaces `Flickable` with `StyledFlickable` for the UI Component Gallery under DevTools for consistency and to add scrollbars to it.

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
