### PR TITLE
[MEI] mark title to be on first page

### DIFF
--- a/src/importexport/mei/internal/meiexporter.cpp
+++ b/src/importexport/mei/internal/meiexporter.cpp
@@ -389,6 +389,7 @@ bool MeiExporter::writePgHead(const VBox* vBox)
     m_currentNode = m_currentNode.append_child();
 
     libmei::PgHead pgHead;
+    pgHead.SetFunc(libmei::PGFUNC_first);
     pgHead.Write(m_currentNode);
 
     std::list<std::pair<libmei::Rend, String> > cells[CellCount];

--- a/src/importexport/mei/tests/data/accid-01.mei
+++ b/src/importexport/mei/tests/data/accid-01.mei
@@ -20,7 +20,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Untitled score</rend>
                         <lb />

--- a/src/importexport/mei/tests/data/accid-02.mei
+++ b/src/importexport/mei/tests/data/accid-02.mei
@@ -20,7 +20,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Untitled score</rend>
                         <lb />

--- a/src/importexport/mei/tests/data/arpeg-01.mei
+++ b/src/importexport/mei/tests/data/arpeg-01.mei
@@ -20,7 +20,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Untitled score</rend>
                         <lb />

--- a/src/importexport/mei/tests/data/artic-01.mei
+++ b/src/importexport/mei/tests/data/artic-01.mei
@@ -20,7 +20,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Untitled score</rend>
                         <lb />

--- a/src/importexport/mei/tests/data/beam-01.mei
+++ b/src/importexport/mei/tests/data/beam-01.mei
@@ -20,7 +20,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Beam default</rend>
                         <lb />

--- a/src/importexport/mei/tests/data/beam-02.mei
+++ b/src/importexport/mei/tests/data/beam-02.mei
@@ -20,7 +20,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Beam with custom grouping</rend>
                         <lb />

--- a/src/importexport/mei/tests/data/beam-03.mei
+++ b/src/importexport/mei/tests/data/beam-03.mei
@@ -20,7 +20,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Untitled score</rend>
                         <lb />

--- a/src/importexport/mei/tests/data/breaks-01.mei
+++ b/src/importexport/mei/tests/data/breaks-01.mei
@@ -20,7 +20,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Ach Gott und Herr</rend>
                      </rend>

--- a/src/importexport/mei/tests/data/breath-01.mei
+++ b/src/importexport/mei/tests/data/breath-01.mei
@@ -20,7 +20,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Breaths and caesuras</rend>
                         <lb />

--- a/src/importexport/mei/tests/data/btrem-01.mei
+++ b/src/importexport/mei/tests/data/btrem-01.mei
@@ -20,7 +20,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Single Tremolos</rend>
                      </rend>

--- a/src/importexport/mei/tests/data/chord-label-01.mei
+++ b/src/importexport/mei/tests/data/chord-label-01.mei
@@ -20,7 +20,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Absolute chord labels</rend>
                         <lb />

--- a/src/importexport/mei/tests/data/clef-01.mei
+++ b/src/importexport/mei/tests/data/clef-01.mei
@@ -17,7 +17,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Clefs Test</rend>
                      </rend>

--- a/src/importexport/mei/tests/data/color-01.mei
+++ b/src/importexport/mei/tests/data/color-01.mei
@@ -20,7 +20,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Untitled score</rend>
                         <lb />

--- a/src/importexport/mei/tests/data/cross-staff-01.mei
+++ b/src/importexport/mei/tests/data/cross-staff-01.mei
@@ -20,7 +20,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Cross-staff</rend>
                         <lb />

--- a/src/importexport/mei/tests/data/dir-01.mei
+++ b/src/importexport/mei/tests/data/dir-01.mei
@@ -20,7 +20,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Untitled score</rend>
                         <lb />

--- a/src/importexport/mei/tests/data/dynamic-01.mei
+++ b/src/importexport/mei/tests/data/dynamic-01.mei
@@ -20,7 +20,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Dynamics</rend>
                         <lb />

--- a/src/importexport/mei/tests/data/ending-01.mei
+++ b/src/importexport/mei/tests/data/ending-01.mei
@@ -20,7 +20,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Endings</rend>
                         <lb />

--- a/src/importexport/mei/tests/data/fermata-01.mei
+++ b/src/importexport/mei/tests/data/fermata-01.mei
@@ -20,7 +20,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Fermatas </rend>
                         <lb />

--- a/src/importexport/mei/tests/data/fig-bass-01.mei
+++ b/src/importexport/mei/tests/data/fig-bass-01.mei
@@ -20,7 +20,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Untitled score</rend>
                         <lb />

--- a/src/importexport/mei/tests/data/fingering-01.mei
+++ b/src/importexport/mei/tests/data/fingering-01.mei
@@ -21,7 +21,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Le Pianiste virtuose (excerpt)</rend>
                      </rend>

--- a/src/importexport/mei/tests/data/gliss-01.mei
+++ b/src/importexport/mei/tests/data/gliss-01.mei
@@ -20,7 +20,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Glissando test</rend>
                      </rend>

--- a/src/importexport/mei/tests/data/gracenote-01.mei
+++ b/src/importexport/mei/tests/data/gracenote-01.mei
@@ -20,7 +20,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Grace notes</rend>
                         <lb />

--- a/src/importexport/mei/tests/data/gracenote-02.mei
+++ b/src/importexport/mei/tests/data/gracenote-02.mei
@@ -20,7 +20,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Untitled score</rend>
                         <lb />

--- a/src/importexport/mei/tests/data/hairpin-01.mei
+++ b/src/importexport/mei/tests/data/hairpin-01.mei
@@ -20,7 +20,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Hairpins</rend>
                         <lb />

--- a/src/importexport/mei/tests/data/harp-01.mei
+++ b/src/importexport/mei/tests/data/harp-01.mei
@@ -20,7 +20,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Harp pedals test</rend>
                      </rend>

--- a/src/importexport/mei/tests/data/jump-01.mei
+++ b/src/importexport/mei/tests/data/jump-01.mei
@@ -20,7 +20,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Jumps</rend>
                         <lb />

--- a/src/importexport/mei/tests/data/jump-02.mei
+++ b/src/importexport/mei/tests/data/jump-02.mei
@@ -20,7 +20,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Jumps</rend>
                         <lb />

--- a/src/importexport/mei/tests/data/key-signature-01.mei
+++ b/src/importexport/mei/tests/data/key-signature-01.mei
@@ -20,7 +20,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Untitled score</rend>
                         <lb />

--- a/src/importexport/mei/tests/data/label-01.mei
+++ b/src/importexport/mei/tests/data/label-01.mei
@@ -17,7 +17,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Very long instrument names</rend>
                      </rend>

--- a/src/importexport/mei/tests/data/laissez-vibrer-01.mei
+++ b/src/importexport/mei/tests/data/laissez-vibrer-01.mei
@@ -20,7 +20,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Laissez vibrer test</rend>
                      </rend>

--- a/src/importexport/mei/tests/data/lyric-01.mei
+++ b/src/importexport/mei/tests/data/lyric-01.mei
@@ -20,7 +20,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Lyric</rend>
                         <lb />

--- a/src/importexport/mei/tests/data/lyric-02.mei
+++ b/src/importexport/mei/tests/data/lyric-02.mei
@@ -20,7 +20,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Untitled score</rend>
                         <lb />

--- a/src/importexport/mei/tests/data/lyric-03.mei
+++ b/src/importexport/mei/tests/data/lyric-03.mei
@@ -20,7 +20,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Untitled score</rend>
                         <lb />

--- a/src/importexport/mei/tests/data/lyric-04.mei
+++ b/src/importexport/mei/tests/data/lyric-04.mei
@@ -17,7 +17,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Ups and downs</rend>
                      </rend>

--- a/src/importexport/mei/tests/data/measure-01.mei
+++ b/src/importexport/mei/tests/data/measure-01.mei
@@ -20,7 +20,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Untitled score</rend>
                         <lb />

--- a/src/importexport/mei/tests/data/measure-02.mei
+++ b/src/importexport/mei/tests/data/measure-02.mei
@@ -20,7 +20,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Untitled score</rend>
                         <lb />

--- a/src/importexport/mei/tests/data/measure-repeat-01.mei
+++ b/src/importexport/mei/tests/data/measure-repeat-01.mei
@@ -20,7 +20,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Bar repeats</rend>
                      </rend>

--- a/src/importexport/mei/tests/data/metadata-01.mei
+++ b/src/importexport/mei/tests/data/metadata-01.mei
@@ -25,7 +25,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Metadata test</rend>
                         <lb />

--- a/src/importexport/mei/tests/data/midi-01.mei
+++ b/src/importexport/mei/tests/data/midi-01.mei
@@ -20,7 +20,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">MIDI test</rend>
                      </rend>

--- a/src/importexport/mei/tests/data/mordent-01.mei
+++ b/src/importexport/mei/tests/data/mordent-01.mei
@@ -20,7 +20,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Untitled score</rend>
                         <lb />

--- a/src/importexport/mei/tests/data/octave-01.mei
+++ b/src/importexport/mei/tests/data/octave-01.mei
@@ -20,7 +20,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Untitled score</rend>
                         <lb />

--- a/src/importexport/mei/tests/data/ornam-01.mei
+++ b/src/importexport/mei/tests/data/ornam-01.mei
@@ -20,7 +20,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Untitled score</rend>
                         <lb />

--- a/src/importexport/mei/tests/data/page-head-01.mei
+++ b/src/importexport/mei/tests/data/page-head-01.mei
@@ -20,7 +20,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Title of the score<lb />with a second line<lb />and a third one</rend>
                      </rend>

--- a/src/importexport/mei/tests/data/page-head-02.mei
+++ b/src/importexport/mei/tests/data/page-head-02.mei
@@ -20,7 +20,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="left" valign="top">
                         <rend type="instrument_excerpt">Flute part</rend>
                      </rend>

--- a/src/importexport/mei/tests/data/pedal-01.mei
+++ b/src/importexport/mei/tests/data/pedal-01.mei
@@ -20,7 +20,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Untitled score</rend>
                         <lb />

--- a/src/importexport/mei/tests/data/reh-01.mei
+++ b/src/importexport/mei/tests/data/reh-01.mei
@@ -17,7 +17,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Rehearsal</rend>
                      </rend>

--- a/src/importexport/mei/tests/data/roman-numeral-01.mei
+++ b/src/importexport/mei/tests/data/roman-numeral-01.mei
@@ -20,7 +20,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Roman numerals</rend>
                         <lb />

--- a/src/importexport/mei/tests/data/score-01.mei
+++ b/src/importexport/mei/tests/data/score-01.mei
@@ -20,7 +20,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Untitled score</rend>
                         <lb />

--- a/src/importexport/mei/tests/data/score-02.mei
+++ b/src/importexport/mei/tests/data/score-02.mei
@@ -20,7 +20,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Untitled score</rend>
                         <lb />

--- a/src/importexport/mei/tests/data/score-03.mei
+++ b/src/importexport/mei/tests/data/score-03.mei
@@ -20,7 +20,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Staff type properties</rend>
                      </rend>

--- a/src/importexport/mei/tests/data/slur-01.mei
+++ b/src/importexport/mei/tests/data/slur-01.mei
@@ -20,7 +20,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Slurs</rend>
                         <lb />

--- a/src/importexport/mei/tests/data/slur-02.mei
+++ b/src/importexport/mei/tests/data/slur-02.mei
@@ -20,7 +20,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Hypothetical slurs</rend>
                         <lb />

--- a/src/importexport/mei/tests/data/stem-01.mei
+++ b/src/importexport/mei/tests/data/stem-01.mei
@@ -17,7 +17,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Stems</rend>
                      </rend>

--- a/src/importexport/mei/tests/data/tempo-01.mei
+++ b/src/importexport/mei/tests/data/tempo-01.mei
@@ -20,7 +20,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Untitled score</rend>
                         <lb />

--- a/src/importexport/mei/tests/data/tie-01.mei
+++ b/src/importexport/mei/tests/data/tie-01.mei
@@ -20,7 +20,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Ties</rend>
                         <lb />

--- a/src/importexport/mei/tests/data/time-signature-01.mei
+++ b/src/importexport/mei/tests/data/time-signature-01.mei
@@ -20,7 +20,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Time Signatures</rend>
                      </rend>

--- a/src/importexport/mei/tests/data/time-signature-02.mei
+++ b/src/importexport/mei/tests/data/time-signature-02.mei
@@ -20,7 +20,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Untitled score</rend>
                         <lb />

--- a/src/importexport/mei/tests/data/transpose-01.mei
+++ b/src/importexport/mei/tests/data/transpose-01.mei
@@ -20,7 +20,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Untitled score</rend>
                         <lb />

--- a/src/importexport/mei/tests/data/trill-01.mei
+++ b/src/importexport/mei/tests/data/trill-01.mei
@@ -20,7 +20,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">The Art of Trill</rend>
                      </rend>

--- a/src/importexport/mei/tests/data/tuplet-01.mei
+++ b/src/importexport/mei/tests/data/tuplet-01.mei
@@ -17,7 +17,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Tuplet and beam example</rend>
                      </rend>

--- a/src/importexport/mei/tests/data/tuplet-02.mei
+++ b/src/importexport/mei/tests/data/tuplet-02.mei
@@ -17,7 +17,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Tuplet and beam example</rend>
                      </rend>

--- a/src/importexport/mei/tests/data/tuplet-03.mei
+++ b/src/importexport/mei/tests/data/tuplet-03.mei
@@ -17,7 +17,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <pgHead>
+                  <pgHead func="first">
                      <rend halign="center" valign="top">
                         <rend type="title" fontsize="x-large">Tuplet with custom styles</rend>
                      </rend>


### PR DESCRIPTION
Since 5.1 MEI expects a `@func` attribute on `pgHead` to specify on which page it should appear. This PR marks all exported titles to be on the first page only.