### PR TITLE
Speed up score loading even further

### DIFF
--- a/src/framework/draw/types/font.h
+++ b/src/framework/draw/types/font.h
@@ -50,7 +50,7 @@ public:
         //! NOTE: Case insensitive comparison
         inline bool operator==(const FontFamily& o) const
         {
-            return m_id.toLower() == o.id().toLower();
+            return m_id.isEqualIgnoreCase(o.m_id);
         }
 
     private:

--- a/src/framework/global/types/string.cpp
+++ b/src/framework/global/types/string.cpp
@@ -387,6 +387,20 @@ void String::reserve(size_t i)
     mutStr().reserve(i);
 }
 
+bool String::isEqualIgnoreCase(const String& s) const
+{
+    const std::u16string_view a { constStr() };
+    const std::u16string_view b { s.constStr() };
+
+    if (a.size() != b.size()) {
+        return false;
+    }
+
+    return std::equal(a.begin(), a.end(), b.begin(), [](const char16_t c1, const char16_t c2) {
+        return Char::toLower(c1) == Char::toLower(c2);
+    });
+}
+
 bool String::operator ==(const AsciiStringView& s) const
 {
     if (size() != s.size()) {

--- a/src/framework/global/types/string.h
+++ b/src/framework/global/types/string.h
@@ -228,6 +228,8 @@ public:
     inline bool operator ==(const String& s) const { return constStr() == s.constStr(); }
     inline bool operator !=(const String& s) const { return !operator ==(s); }
 
+    bool isEqualIgnoreCase(const String& s) const;
+
     bool operator ==(const AsciiStringView& s) const;
     inline bool operator !=(const AsciiStringView& s) const { return !operator ==(s); }
     inline bool operator ==(const char16_t* s) const { return constStr() == s; }


### PR DESCRIPTION
Speeds up loading (actually initial layout) of the big Beethoven 9th score.

before:
```
  Function                                Module      Inclusive  Exclusive
--------------------------------------------------------------------------
  muse::draw::FontsEngine::fontFace       MuseScore4  7185.24    89.85
     muse::draw::FontDataKey::operator==  MuseScore4  7062.12    144.74
```
after:
```
  Function                            Module      Inclusive  Exclusive
----------------------------------------------------------------------
  muse::draw::FontsEngine::fontFace   MuseScore4  365.65     77.90
     muse::String::isEqualIgnoreCase  MuseScore4  265.19     66.73
```

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
