### PR TITLE
Remove unnecessary Qt initialization code

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -119,10 +119,6 @@ int main(int argc, char** argv)
     }
 #endif
 
-#ifdef Q_OS_WIN
-    QGuiApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
-#endif
-
     QGuiApplication::styleHints()->setMousePressAndHoldInterval(250);
 
 // Can't use MUSE_APP_TITLE until next major release, because this "application name" is used to determine


### PR DESCRIPTION
As mentioned in https://github.com/musescore/MuseScore/pull/28944#discussion_r2231725976, this code can be removed, because according to https://doc.qt.io/qt-6/qguiapplication.html#setHighDpiScaleFactorRoundingPolicy …

> The default value is [Qt::HighDpiScaleFactorRoundingPolicy::PassThrough](https://doc.qt.io/qt-6/qt.html#HighDpiScaleFactorRoundingPolicy-enum).

I compiled this change successfully on my Fedora 42 system, but I have no Windows development environment to test this on Windows.

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
