### PR TITLE
Fix #28924: Note input stuck after closing dialogs

### DIFF
--- a/src/framework/uicomponents/view/internal/platform/macos/macospopupviewclosecontroller.mm
+++ b/src/framework/uicomponents/view/internal/platform/macos/macospopupviewclosecontroller.mm
@@ -68,7 +68,12 @@ bool MacOSPopupViewCloseController::nativeEventFilter(const QByteArray& eventTyp
 
 void MacOSPopupViewCloseController::initWindowMinimizedObserver()
 {
-    WId wid = parentItem()->window()->winId();
+    const QQuickWindow* qWindow = parentItem() ? parentItem()->window() : nullptr;
+    if (!qWindow) {
+        return;
+    }
+
+    WId wid = qWindow->winId();
     NSView* nsView = (__bridge NSView*)reinterpret_cast<void*>(wid);
     NSWindow* nsWindow = [nsView window];
 

--- a/src/framework/uicomponents/view/internal/popupviewclosecontroller.cpp
+++ b/src/framework/uicomponents/view/internal/popupviewclosecontroller.cpp
@@ -87,14 +87,14 @@ void PopupViewCloseController::setWindow(QWindow* window)
     m_popupWindow = window;
 }
 
-void PopupViewCloseController::setIsCloseOnPressOutsideParent(bool arg)
+void PopupViewCloseController::setCloseOnPressOutsideParent(bool arg)
 {
-    m_isCloseOnPressOutsideParent = arg;
+    m_closeOnPressOutsideParent = arg;
 }
 
-void PopupViewCloseController::setCanClosed(bool arg)
+void PopupViewCloseController::setCanClose(bool arg)
 {
-    m_canClosed = arg;
+    m_canClose = arg;
 }
 
 muse::async::Notification PopupViewCloseController::closeNotification() const
@@ -111,7 +111,9 @@ bool PopupViewCloseController::eventFilter(QObject* watched, QEvent* event)
     } else if (QEvent::FocusOut == event->type() && watched == popupWindow()) {
         doFocusOut(QCursor::pos());
     } else if (QEvent::Close == event->type() && watched == popupWindow()) {
-        if (!m_canClosed) {
+        if (m_canClose) {
+            notifyAboutClose();
+        } else {
             event->ignore();
         }
     }
@@ -121,7 +123,7 @@ bool PopupViewCloseController::eventFilter(QObject* watched, QEvent* event)
 
 void PopupViewCloseController::onApplicationStateChanged(Qt::ApplicationState state)
 {
-    if (!m_active || !m_isCloseOnPressOutsideParent) {
+    if (!m_active || !m_closeOnPressOutsideParent) {
         return;
     }
 
@@ -132,7 +134,7 @@ void PopupViewCloseController::onApplicationStateChanged(Qt::ApplicationState st
 
 void PopupViewCloseController::doFocusOut(const QPointF& mousePos)
 {
-    if (m_isCloseOnPressOutsideParent) {
+    if (m_closeOnPressOutsideParent) {
         if (!isMouseWithinBoundaries(mousePos)) {
             notifyAboutClose();
         }

--- a/src/framework/uicomponents/view/internal/popupviewclosecontroller.h
+++ b/src/framework/uicomponents/view/internal/popupviewclosecontroller.h
@@ -54,8 +54,8 @@ public:
     QWindow* popupWindow() const;
     void setWindow(QWindow* window);
 
-    void setIsCloseOnPressOutsideParent(bool arg);
-    void setCanClosed(bool arg);
+    void setCloseOnPressOutsideParent(bool arg);
+    void setCanClose(bool arg);
 
     async::Notification closeNotification() const;
 
@@ -80,8 +80,8 @@ private:
     QQuickItem* m_parentItem = nullptr;
     QWindow* m_popupWindow = nullptr;
 
-    bool m_isCloseOnPressOutsideParent = false;
-    bool m_canClosed = true;
+    bool m_closeOnPressOutsideParent = false;
+    bool m_canClose = true;
 
     async::Notification m_closeNotification;
 };

--- a/src/framework/uicomponents/view/popupview.cpp
+++ b/src/framework/uicomponents/view/popupview.cpp
@@ -183,12 +183,17 @@ void PopupView::initCloseController()
 
     m_closeController->setParentItem(parentItem());
     m_closeController->setWindow(window());
-    m_closeController->setCloseOnPressOutsideParent(m_closePolicies & ClosePolicy::CloseOnPressOutsideParent);
-    m_closeController->setCanClose(!m_closePolicies.testFlag(ClosePolicy::NoAutoClose));
+
+    if (!isDialog()) {
+        m_closeController->setCloseOnPressOutsideParent(m_closePolicies & ClosePolicy::CloseOnPressOutsideParent);
+        m_closeController->setCanClose(!m_closePolicies.testFlag(ClosePolicy::NoAutoClose));
+    }
 
     m_closeController->closeNotification().onNotify(this, [this]() {
         close(true);
     });
+
+    m_closeController->setActive(true);
 }
 
 void PopupView::componentComplete()
@@ -281,12 +286,8 @@ void PopupView::doOpen()
 
     m_globalPos = QPointF(); // invalidate
 
-    if (!isDialog()) {
-        if (!m_closeController) {
-            initCloseController();
-        }
-
-        m_closeController->setActive(true);
+    if (!m_closeController) {
+        initCloseController();
     }
 
     qApp->installEventFilter(this);

--- a/src/framework/uicomponents/view/popupview.cpp
+++ b/src/framework/uicomponents/view/popupview.cpp
@@ -183,8 +183,8 @@ void PopupView::initCloseController()
 
     m_closeController->setParentItem(parentItem());
     m_closeController->setWindow(window());
-    m_closeController->setIsCloseOnPressOutsideParent(m_closePolicies & ClosePolicy::CloseOnPressOutsideParent);
-    m_closeController->setCanClosed(!m_closePolicies.testFlag(ClosePolicy::NoAutoClose));
+    m_closeController->setCloseOnPressOutsideParent(m_closePolicies & ClosePolicy::CloseOnPressOutsideParent);
+    m_closeController->setCanClose(!m_closePolicies.testFlag(ClosePolicy::NoAutoClose));
 
     m_closeController->closeNotification().onNotify(this, [this]() {
         close(true);
@@ -312,7 +312,7 @@ void PopupView::close(bool force)
     }
 
     if (m_closeController) {
-        m_closeController->setCanClosed(true);
+        m_closeController->setCanClose(true);
         m_closeController->setActive(false);
     }
 
@@ -497,7 +497,7 @@ void PopupView::setClosePolicies(ClosePolicies closePolicies)
     m_closePolicies = closePolicies;
 
     if (m_closeController) {
-        m_closeController->setIsCloseOnPressOutsideParent(closePolicies & ClosePolicy::CloseOnPressOutsideParent);
+        m_closeController->setCloseOnPressOutsideParent(closePolicies & ClosePolicy::CloseOnPressOutsideParent);
     }
 
     emit closePoliciesChanged(closePolicies);


### PR DESCRIPTION
Resolves: #28924

As I mentioned [here](https://github.com/musescore/MuseScore/issues/28924#issuecomment-3120645984) this bug was introduced with #27776 but I don't think that's the cause of the issue. I suspect the underlying problem may go back to #17268 where we decided to never activate the close controller for dialogs.

This PR includes a minor refactor and re-activates the close controller for dialogs (while skipping some close policies that should not be applied to dialogs). 