### PR TITLE
Fix removing measure numbers

### DIFF
--- a/src/engraving/rendering/score/measurelayout.cpp
+++ b/src/engraving/rendering/score/measurelayout.cpp
@@ -1254,7 +1254,8 @@ void MeasureLayout::layoutMeasureNumber(Measure* m, LayoutContext& ctx)
             measureNumber->setSystemFlag(!score->style().styleB(Sid::measureNumberAllStaves));
             TLayout::layoutMeasureNumber(measureNumber, measureNumber->mutldata(), ctx);
         } else if (measureNumber) {
-            m->remove(measureNumber);
+            measureNumber->setTrack(staff2track(staffIdx));
+            ctx.mutDom().doUndoRemoveElement(measureNumber);
         }
     }
 }


### PR DESCRIPTION
When moving staves, the track of measure numbers is not updated because it's expected to be updated during layout. If we don't update the track before removing the measure number, Measure::remove will reset the wrong pointer.

This was previously addressed in 25a3c07b37573828835e99a7af601159fb6c8e79.