### PR TITLE
fw/global: Fix assertion macros

### DIFF
--- a/src/framework/global/thirdparty/kors_logger/src/log_base.h
+++ b/src/framework/global/thirdparty/kors_logger/src/log_base.h
@@ -54,11 +54,15 @@ SOFTWARE.
 #define LOGN if (0) LOGD_T(LOG_TAG) // compiling, but no output
 
 //! Useful macros
-#define DO_ASSERT_X(cond, msg) \
-    if (!(cond)) { \
-        LOGE() << "ASSERT FAILED:    " << msg << "    " << __FILE__ << ":" << __LINE__; \
-        assert(cond); \
-    } \
+#define DO_ASSERT_X_IMPL(cond, msg, var_name) \
+    { \
+        const auto var_name = (cond); \
+        if (!(var_name)) { \
+            LOGE() << "ASSERT FAILED:    " << msg << "    " << __FILE__ << ":" << __LINE__; \
+            assert(var_name); \
+        } \
+    }
+#define DO_ASSERT_X(cond, msg) DO_ASSERT_X_IMPL(cond, msg, UNIQUE_VAR_NAME(__do_assert_))
 
 #define DO_ASSERT(cond) DO_ASSERT_X(cond, #cond)
 #define ASSERT_X(msg) DO_ASSERT_X(false, msg)
@@ -71,7 +75,7 @@ SOFTWARE.
     const auto var_name = (cond); \
     if (!(var_name)) { \
         LOGE() << "ASSERT FAILED:    " << msg << "    " << __FILE__ << ":" << __LINE__; \
-        assert(cond); \
+        assert(var_name); \
     } \
     if (!(var_name))
 


### PR DESCRIPTION
They evaluated `cond` twice in debug-enabled builds. PR #28935 fixed this for release builds.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
