### PR TITLE
Support for positioning a popup view to the left or right

### DIFF
--- a/src/framework/uicomponents/qml/Muse/UiComponents/StyledPopupView.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/StyledPopupView.qml
@@ -56,7 +56,7 @@ PopupView {
     closePolicies: PopupView.CloseOnPressOutsideParent
 
     x: root.isPlacementVertical ? (root.parent.width / 2) - (root.width / 2) : root.parent.width
-    y: root.isPlacementeVertical ? root.parent.height : (root.parent.height / 2) - (root.height / 2)
+    y: root.isPlacementVertical ? root.parent.height : (root.parent.height / 2) - (root.height / 2)
 
     onOpened: {
         if (!(openPolicies & PopupView.NoActivateFocus) && content.navigationSection) {

--- a/src/framework/uicomponents/qml/Muse/UiComponents/StyledPopupView.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/StyledPopupView.qml
@@ -46,13 +46,17 @@ PopupView {
 
     property alias useDropShadow: content.useDropShadow
 
+    property bool isPlacementVertical: (root.placementPolicies === PopupView.Default)
+                                        || (root.placementPolicies === PopupView.PreferAbove)
+                                        || (root.placementPolicies === PopupView.PreferBelow)
+
     contentWidth: 240
     contentHeight: content.contentBodyHeight
 
     closePolicies: PopupView.CloseOnPressOutsideParent
 
-    x: (root.parent.width / 2) - (root.width / 2)
-    y: root.parent.height
+    x: root.isPlacementVertical ? (root.parent.width / 2) - (root.width / 2) : root.parent.width
+    y: root.isPlacementeVertical ? root.parent.height : (root.parent.height / 2) - (root.height / 2)
 
     onOpened: {
         if (!(openPolicies & PopupView.NoActivateFocus) && content.navigationSection) {
@@ -76,7 +80,8 @@ PopupView {
 
         showArrow: root.showArrow
         arrowX: root.arrowX
-        opensUpward: root.opensUpward
+        arrowY: root.arrowY
+        popupPosition: root.popupPosition
         isOpened: root.isOpened
 
         enabled: root.isOpened

--- a/src/framework/uicomponents/qml/Muse/UiComponents/StyledPopupView.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/StyledPopupView.qml
@@ -46,9 +46,9 @@ PopupView {
 
     property alias useDropShadow: content.useDropShadow
 
-    property bool isPlacementVertical: (root.placementPolicies === PopupView.Default)
-                                        || (root.placementPolicies === PopupView.PreferAbove)
-                                        || (root.placementPolicies === PopupView.PreferBelow)
+    property bool isPlacementVertical:  (root.placementPolicies === PopupView.Default)
+                                        || (root.placementPolicies & PopupView.PreferAbove)
+                                        || (root.placementPolicies & PopupView.PreferBelow)
 
     contentWidth: 240
     contentHeight: content.contentBodyHeight

--- a/src/framework/uicomponents/qml/Muse/UiComponents/internal/PopupContent.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/internal/PopupContent.qml
@@ -41,7 +41,10 @@ FocusScope {
 
     property bool showArrow: false
     property int arrowX: 0
-    property bool opensUpward: false
+    property int arrowY: 0
+
+    property int popupPosition: PopupPosition.Bottom
+
     property bool isOpened: false
     property bool useDropShadow: true
 
@@ -132,15 +135,33 @@ FocusScope {
         Canvas {
             id: arrow
 
-            height: root.padding
-            width: root.padding * 2
+            height: root.popupPosition & PopupPosition.Vertical
+                ? root.padding
+                : 2 * root.padding;
+            width: root.popupPosition & PopupPosition.Vertical
+                ? 2 * root.padding
+                : root.padding;
 
             visible: root.showArrow && arrow.height > 0
             enabled: root.showArrow
 
-            x: root.arrowX - arrow.width / 2 - root.padding
-            y: root.opensUpward ? parent.y + parent.height - height - contentBorder.border.width
-                                : -height + contentBorder.border.width
+            x: {
+                if (root.popupPosition & PopupPosition.Vertical) {
+                    return root.arrowX - arrow.width / 2 - root.padding;
+                } else if (root.popupPosition & PopupPosition.Left) {
+                    return parent.x + parent.width - width - contentBackground.border.width
+                } else if (root.popupPosition & PopupPosition.Right)
+                    return -width + contentBackground.border.width
+            }
+
+            y: {
+                if (root.popupPosition & PopupPosition.Top) {
+                    return parent.y + parent.height - height - contentBackground.border.width
+                } else if (root.popupPosition & PopupPosition.Bottom) {
+                    return -height + contentBackground.border.width
+                } else if (root.popupPosition & PopupPosition.Horizontal)
+                    return root.arrowY - arrow.height / 2 - root.padding;
+            }
 
             onPaint: {
                 var ctx = getContext("2d");
@@ -151,13 +172,21 @@ FocusScope {
                 ctx.strokeStyle = contentBorder.border.color
                 ctx.beginPath();
 
-                if (root.opensUpward) {
+                if (root.popupPosition & PopupPosition.Top) {
                     ctx.moveTo(0, 0);
                     ctx.lineTo(width / 2, height - 1);
                     ctx.lineTo(width, 0);
-                } else {
+                } else if (root.popupPosition & PopupPosition.Bottom) {
                     ctx.moveTo(0, height);
                     ctx.lineTo(width / 2, 1);
+                    ctx.lineTo(width, height);
+                } else if (root.popupPosition & PopupPosition.Left) {
+                    ctx.moveTo(0, 0);
+                    ctx.lineTo(width, height / 2);
+                    ctx.lineTo(0, height);
+                } else if (root.popupPosition & PopupPosition.Right) {
+                    ctx.moveTo(width, 0);
+                    ctx.lineTo(0, height / 2);
                     ctx.lineTo(width, height);
                 }
 
@@ -167,7 +196,7 @@ FocusScope {
 
             Connections {
                 target: root
-                function onOpensUpwardChanged() { arrow.requestPaint() }
+                function onPopupPositionChanged() { arrow.requestPaint() }
             }
 
             Connections {

--- a/src/framework/uicomponents/qml/Muse/UiComponents/internal/StyledDropdownView.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/internal/StyledDropdownView.qml
@@ -131,7 +131,7 @@ DropdownView {
 
         showArrow: root.showArrow
         arrowX: root.arrowX
-        opensUpward: root.opensUpward
+        popupPosition: root.popupPosition
         isOpened: root.isOpened
 
         onCloseRequested: {

--- a/src/framework/uicomponents/qml/Muse/UiComponents/internal/StyledMenu.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/internal/StyledMenu.qml
@@ -174,7 +174,7 @@ MenuView {
         margins: 0
 
         showArrow: root.showArrow
-        opensUpward: root.opensUpward
+        popupPosition: root.popupPosition
         isOpened: root.isOpened
 
         animationEnabled: false //! NOTE disabled - because trouble with simultaneous opening of submenu

--- a/src/framework/uicomponents/uicomponentsmodule.cpp
+++ b/src/framework/uicomponents/uicomponentsmodule.cpp
@@ -123,6 +123,8 @@ void UiComponentsModule::registerUiTypes()
                                                      QLatin1String("Do not create objects of type SelectionMode"));
 
     qmlRegisterUncreatableType<ToolBarItemType>("Muse.UiComponents", 1, 0, "ToolBarItemType", "Cannot create a ToolBarItemType");
+    qmlRegisterUncreatableType<PopupPosition>("Muse.UiComponents", 1, 0, "PopupPosition",
+                                              QLatin1String("Do not create objects of type PopupPosition"));
 
     auto ui = ioc()->resolve<ui::IUiEngine>(moduleName());
     if (ui) {

--- a/src/framework/uicomponents/view/menuview.cpp
+++ b/src/framework/uicomponents/view/menuview.cpp
@@ -81,7 +81,7 @@ void MenuView::updateGeometry()
     QRectF anchorRect = anchorGeometry();
     QRectF viewRect = viewGeometry();
 
-    setOpensUpward(false);
+    setPopupPosition(PopupPosition::Bottom);
     setCascadeAlign(Qt::AlignmentFlag::AlignRight);
 
     auto movePos = [this, &viewRect](qreal x, qreal y) {
@@ -112,7 +112,7 @@ void MenuView::updateGeometry()
             if (anchorRect.top() < newY) {
                 // move to the top of the parent
                 movePos(m_globalPos.x(), newY);
-                setOpensUpward(true);
+                setPopupPosition(PopupPosition::Top);
             } else {
                 // move to the right of the parent and move to top to an area that doesn't fit
                 movePos(parentTopLeft.x() + parent->width(), m_globalPos.y() - (viewRect.bottom() - anchorRect.bottom()));
@@ -138,7 +138,7 @@ void MenuView::updateGeometry()
 
 void MenuView::updateContentPosition()
 {
-    if (opensUpward()) {
+    if (popupPosition() == PopupPosition::Top) {
         contentItem()->setY(padding());
     } else {
         contentItem()->setY(-padding());

--- a/src/framework/uicomponents/view/popupview.cpp
+++ b/src/framework/uicomponents/view/popupview.cpp
@@ -840,38 +840,22 @@ void PopupView::updateGeometry()
         moveBelow();
     } else if ((preferAbove || placementDefault) && canFitAbove) {
         moveAbove();
-    } else if ((preferLeft || placementDefault) && canFitLeft) {
+    } else if (preferLeft && canFitLeft) {
         moveLeft();
-    } else if ((preferRight || placementDefault) && canFitRight) {
+    } else if (preferRight && canFitRight) {
         moveRight();
-    } else if (!canFitBelow && (preferBelow || placementDefault)) {
-        if (canFitAbove) {
-            moveAbove();
-        } else {
-            // move to the right of the parent and move to top to an area that doesn't fit
-            movePos(parentTopLeft.x() + parent->width(), m_globalPos.y() - (viewRect.bottom() - anchorRect.bottom()) + padding());
-        }
-    } else if (!canFitAbove && (preferAbove || placementDefault)) {
-        if (canFitBelow) {
-            moveBelow();
-        } else {
-            // move to the left of the parent and move to bottom to an area that doesn't fit
-            movePos(parentTopLeft.x() - (viewRect.right() - anchorRect.right()) + padding(), m_globalPos.y() + parent->height());
-        }
-    } else if (!canFitLeft && (preferLeft || placementDefault)) {
-        if (canFitRight) {
-            moveRight();
-        } else {
-            // move to the top of the parent and move to right to an area that doesn't fit
-            movePos(m_globalPos.x() + parentTopLeft.x() + padding(), parentTopLeft.y() - (viewRect.bottom() - anchorRect.bottom()));
-        }
-    } else if (!canFitRight && (preferRight || placementDefault)) {
-        if (canFitLeft) {
-            moveLeft();
-        } else {
-            // move to the bottom of the parent and move to left to an area that doesn't fit
-            movePos(m_globalPos.x() - (viewRect.right() - anchorRect.right()) + padding(), parentTopLeft.y() + parent->height());
-        }
+    } else if (!canFitBelow && canFitAbove && (preferBelow || placementDefault)) {
+        moveAbove();
+    } else if (!canFitAbove && canFitBelow && (preferAbove || placementDefault)) {
+        moveBelow();
+    } else if (!canFitLeft && canFitRight && preferLeft) {
+        moveRight();
+    } else if (!canFitRight && canFitLeft && preferRight) {
+        moveLeft();
+    } else {
+        // move to the right of the parent and move to top to an area that doesn't fit
+        movePos(parentTopLeft.x() + parent->width(), m_globalPos.y() - (viewRect.bottom() - anchorRect.bottom()) + padding());
+        setPopupPosition(PopupPosition::Right);
     }
 
     if (viewRect.left() < anchorRect.left()) {

--- a/src/framework/uicomponents/view/popupview.h
+++ b/src/framework/uicomponents/view/popupview.h
@@ -44,6 +44,23 @@ class INavigationControl;
 }
 
 namespace muse::uicomponents {
+class PopupPosition
+{
+    Q_GADGET
+
+public:
+    enum Type: int {
+        Left = 0x01,
+        Right = 0x02,
+        Horizontal = 0x03,
+        Bottom = 0x04,
+        Top = 0x08,
+        Vertical = 0x0C,
+    };
+
+    Q_ENUM(Type)
+};
+
 class PopupView : public QObject, public QQmlParserStatus, public Injectable, public async::Asyncable
 {
     Q_OBJECT
@@ -66,8 +83,10 @@ class PopupView : public QObject, public QQmlParserStatus, public Injectable, pu
     Q_PROPERTY(PlacementPolicies placementPolicies READ placementPolicies WRITE setPlacementPolicies NOTIFY placementPoliciesChanged)
 
     Q_PROPERTY(QQuickItem * anchorItem READ anchorItem WRITE setAnchorItem NOTIFY anchorItemChanged)
-    Q_PROPERTY(bool opensUpward READ opensUpward NOTIFY opensUpwardChanged)
+    Q_PROPERTY(PopupPosition::Type popupPosition READ popupPosition WRITE setPopupPosition NOTIFY popupPositionChanged)
+
     Q_PROPERTY(int arrowX READ arrowX WRITE setArrowX NOTIFY arrowXChanged)
+    Q_PROPERTY(int arrowY READ arrowY WRITE setArrowY NOTIFY arrowYChanged)
 
     Q_PROPERTY(bool isOpened READ isOpened NOTIFY isOpenedChanged)
     Q_PROPERTY(OpenPolicies openPolicies READ openPolicies WRITE setOpenPolicies NOTIFY openPoliciesChanged)
@@ -128,7 +147,9 @@ public:
         Default = 0x00000000,
         PreferBelow = 0x00000001,
         PreferAbove = 0x00000002,
-        IgnoreFit = 0x00000003
+        PreferLeft = 0x00000004,
+        PreferRight = 0x00000008,
+        IgnoreFit = 0x0000000F,
     };
     Q_DECLARE_FLAGS(PlacementPolicies, PlacementPolicy)
     Q_FLAG(PlacementPolicies)
@@ -174,8 +195,9 @@ public:
     bool alwaysOnTop() const;
     QVariantMap ret() const;
 
-    bool opensUpward() const;
+    PopupPosition::Type popupPosition() const;
     int arrowX() const;
+    int arrowY() const;
     int padding() const;
     bool showArrow() const;
     QQuickItem* anchorItem() const;
@@ -204,8 +226,9 @@ public slots:
     void setAlwaysOnTop(bool alwaysOnTop);
     void setRet(QVariantMap ret);
 
-    void setOpensUpward(bool opensUpward);
+    void setPopupPosition(PopupPosition::Type position);
     void setArrowX(int arrowX);
+    void setArrowY(int arrowY);
     void setPadding(int padding);
     void setShowArrow(bool showArrow);
     void setAnchorItem(QQuickItem* anchorItem);
@@ -238,8 +261,9 @@ signals:
     void aboutToClose(QQuickCloseEvent* closeEvent);
     void closed(bool force);
 
-    void opensUpwardChanged(bool opensUpward);
+    void popupPositionChanged(PopupPosition::Type position);
     void arrowXChanged(int arrowX);
+    void arrowYChanged(int arrowY);
     void paddingChanged(int padding);
     void showArrowChanged(bool showArrow);
     void anchorItemChanged(QQuickItem* anchorItem);
@@ -320,8 +344,9 @@ protected:
     bool m_resizable = false;
     bool m_alwaysOnTop = false;
     QVariantMap m_ret;
-    bool m_opensUpward = false;
+    PopupPosition::Type m_popupPosition = PopupPosition::Bottom;
     int m_arrowX = 0;
+    int m_arrowY = 0;
     int m_padding = 0;
     bool m_showArrow = false;
 


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/9141

<!-- Add a short description of and motivation for the changes here -->

This PR supports positioning the popup to the left or right of the parent component. This is based on a design request for the Audacity project to place a volume tooltip on the left of the meter slider. Additionally, the playback meter flyout should be placed so that it does not hide the meter's content.

<img width="490" height="463" alt="image" src="https://github.com/user-attachments/assets/c02a8f68-7d18-4be2-ae9a-6fb3d6056bf1" />

<img width="734" height="1069" alt="image" src="https://github.com/user-attachments/assets/48b2f22c-6811-4178-b9dc-68b4fdd2f507" />

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
