### PR TITLE
Remove extra rule for Ekmelos

### DIFF
--- a/src/engraving/rendering/score/tdraw.cpp
+++ b/src/engraving/rendering/score/tdraw.cpp
@@ -642,13 +642,6 @@ static void drawDots(const BarLine* item, Painter* painter, double x)
         y1l = st->doty1() * spatium;
         y2l = st->doty2() * spatium;
 
-        // workaround to make external fonts work correctly with repeatDots
-        if (item->score()->engravingFont()->name() == "Ekmelos") { // not the other ones from the Ekmelos family though (EkmelosXXedo)
-            double offset = 0.5 * item->style().spatium() * item->mag();
-            y1l += offset;
-            y2l += offset;
-        }
-
         //adjust for staffType offset
         double stYOffset = item->staffOffsetY();
         y1l += stYOffset;


### PR DESCRIPTION
With release of version v2.59 the position of the repeat dot has been fixed in https://github.com/tr-igem/ekmelos/issues/8, so we can remove this additional offset finally for the next release.

Relates to #28155 and #28157.

