### PR TITLE
fix: dead notes for negative frets config

### DIFF
--- a/src/engraving/rendering/score/tdraw.cpp
+++ b/src/engraving/rendering/score/tdraw.cpp
@@ -2189,7 +2189,7 @@ void TDraw::draw(const Note* item, Painter* painter)
 
     bool negativeFret = item->negativeFretUsed() && item->staff()->isTabStaff(item->tick());
 
-    Color c(negativeFret ? config->criticalColor() : item->curColor());
+    Color c(negativeFret && !item->deadNote() ? config->criticalColor() : item->curColor());
     painter->setPen(c);
     bool tablature = item->staff() && item->staff()->isTabStaff(item->chord()->tick());
 

--- a/src/engraving/rendering/score/tlayout.cpp
+++ b/src/engraving/rendering/score/tlayout.cpp
@@ -4255,7 +4255,10 @@ void TLayout::layoutNote(const Note* item, Note::LayoutData* ldata)
             const_cast<Note*>(item)->setFretString(tab->fretString(std::fabs(item->fret()), item->string(), item->deadNote()));
 
             if (item->negativeFretUsed()) {
-                const_cast<Note*>(item)->setFretString(u"-" + item->fretString());
+                auto note = toNote(item);
+                if (!note->deadNote()) {
+                    const_cast<Note*>(item)->setFretString(u"-" + item->fretString());
+                }
             }
 
             if (item->displayFret() == Note::DisplayFretOption::ArtificialHarmonic) {


### PR DESCRIPTION
When negative frets used, dead notes should not became red and have a minus sign before the x.
