### PR TITLE
Fix text shown twice in TupletCenteringSelector

### DIFF
--- a/src/notation/qml/MuseScore/NotationScene/internal/EditStyle/TupletCenteringSelector.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/EditStyle/TupletCenteringSelector.qml
@@ -56,7 +56,8 @@ Rectangle {
             delegate: FlatRadioButton {
                 width: 140
                 height: 65
-                text: modelData.text
+
+                navigation.accessible.name: modelData.text
 
                 Column {
                     anchors.centerIn: parent


### PR DESCRIPTION
Resolves: #29030

My suggestion from https://github.com/musescore/MuseScore/pull/27051#discussion_r2225561731 didn't work well together with https://github.com/musescore/MuseScore/pull/28812