### PR TITLE
Remove ToursService::initTours() and clean up

### DIFF
--- a/src/framework/stubs/tours/toursconfigurationstub.cpp
+++ b/src/framework/stubs/tours/toursconfigurationstub.cpp
@@ -31,8 +31,3 @@ muse::String ToursConfigurationStub::lastShownTourIdForEvent(const String&) cons
 void ToursConfigurationStub::setLastShownTourIdForEvent(const String&, const String&)
 {
 }
-
-muse::io::path_t ToursConfigurationStub::toursFilePath() const
-{
-    return "";
-}

--- a/src/framework/stubs/tours/toursconfigurationstub.h
+++ b/src/framework/stubs/tours/toursconfigurationstub.h
@@ -30,7 +30,5 @@ class ToursConfigurationStub : public IToursConfiguration
 public:
     String lastShownTourIdForEvent(const String& eventCode) const override;
     void setLastShownTourIdForEvent(const String& eventCode, const String& tourId) override;
-
-    io::path_t toursFilePath() const override;
 };
 }

--- a/src/framework/tours/internal/toursconfiguration.cpp
+++ b/src/framework/tours/internal/toursconfiguration.cpp
@@ -23,10 +23,6 @@
 
 #include "settings.h"
 
-#include "global/configreader.h"
-
-#include "log.h"
-
 using namespace muse;
 using namespace muse::tours;
 using namespace muse::async;
@@ -66,11 +62,6 @@ void ToursConfiguration::setLastShownTourIdForEvent(const String& eventCode, con
     }
 
     settings()->setSharedValue(UI_LAST_SHOWN_TOURS_KEY, Val(allLastShownTours.join(u",").toStdString()));
-}
-
-io::path_t ToursConfiguration::toursFilePath() const
-{
-    return ":/resources/tours.json";
 }
 
 StringList ToursConfiguration::lastShownTours() const

--- a/src/framework/tours/internal/toursconfiguration.h
+++ b/src/framework/tours/internal/toursconfiguration.h
@@ -22,28 +22,19 @@
 
 #pragma once
 
-#include "io/path.h"
-
 #include "modularity/ioc.h"
-#include "iglobalconfiguration.h"
-
-#include "tourstypes.h"
 
 #include "itoursconfiguration.h"
 
 namespace muse::tours {
 class ToursConfiguration : public IToursConfiguration, public Injectable
 {
-    Inject<IGlobalConfiguration> globalConfiguration = { this };
-
 public:
     ToursConfiguration(const modularity::ContextPtr& iocCtx)
         : Injectable(iocCtx) {}
 
     String lastShownTourIdForEvent(const String& eventCode) const override;
     void setLastShownTourIdForEvent(const String& eventCode, const String& tourId) override;
-
-    io::path_t toursFilePath() const override;
 
 private:
     StringList lastShownTours() const;

--- a/src/framework/tours/internal/toursservice.cpp
+++ b/src/framework/tours/internal/toursservice.cpp
@@ -21,17 +21,7 @@
  */
 #include "toursservice.h"
 
-#include "io/file.h"
-#include "serialization/json.h"
-
-#include "log.h"
-
 using namespace muse::tours;
-
-void ToursService::init()
-{
-    initTours();
-}
 
 void ToursService::registerTour(const String& eventCode, const Tour& tour)
 {
@@ -58,76 +48,4 @@ void ToursService::onEvent(const String& eventCode)
     toursProvider()->showTour(tour);
 
     toursConfiguration()->setLastShownTourIdForEvent(eventCode, tour.id);
-}
-
-void ToursService::initTours()
-{
-    io::path_t filePath = toursConfiguration()->toursFilePath();
-    std::unordered_map<String, Tour> result;
-
-    ByteArray data;
-    Ret ret = io::File::readFile(filePath, data);
-    if (!ret) {
-        LOGE() << "failed read file: " << filePath << ", err: " << ret.toString();
-        return;
-    }
-
-    std::string err;
-    JsonObject obj = JsonDocument::fromJson(data, &err).rootObject();
-    if (!err.empty()) {
-        LOGE() << "failed parse file: " << filePath << ", err: " << err;
-        return;
-    }
-
-    QString languageCode = languagesConfiguration()->currentLanguageCode().val;
-    std::string locale = QLocale(languageCode).bcp47Name().toStdString();
-
-    for (const std::string& eventCode : obj.keys()) {
-        Tour tour;
-
-        JsonObject tourObj = obj.value(eventCode).toObject();
-        tour.id = tourObj.value("id").toString();
-
-        JsonArray steps = tourObj.value("steps").toArray();
-        if (steps.empty()) {
-            continue;
-        }
-
-        for (size_t itemIdx = 0; itemIdx < steps.size(); ++itemIdx) {
-            JsonObject itemObj = steps.at(itemIdx).toObject();
-            if (itemObj.empty()) {
-                continue;
-            }
-
-            TourStep step;
-            step.previewImageOrGifUrl = itemObj.value("previewImageOrGifUrl").toString();
-            step.videoExplanationUrl = itemObj.value("video_explanation_url").toString();
-            step.controlUri = Uri(itemObj.value("control_uri").toString());
-
-            JsonObject itemLocaleObj = itemObj.value("locale").toObject();
-
-            if (!itemLocaleObj.contains(locale)) {
-                static const std::string DEFAULT_LOCALE = "en";
-                locale = DEFAULT_LOCALE;
-
-                if (!itemLocaleObj.contains(locale)) {
-                    LOGE() << "failed parse, no tour content";
-                    return;
-                }
-            }
-
-            JsonObject itemCurrentLocaleObj = itemLocaleObj.value(locale).toObject();
-
-            step.title = itemCurrentLocaleObj.value("title").toString();
-            step.description = itemCurrentLocaleObj.value("description").toString();
-
-            tour.steps.emplace_back(step);
-        }
-
-        if (!tour.steps.empty()) {
-            result.insert({ String::fromStdString(eventCode), tour });
-        }
-    }
-
-    m_eventsMap = result;
 }

--- a/src/framework/tours/internal/toursservice.h
+++ b/src/framework/tours/internal/toursservice.h
@@ -26,7 +26,6 @@
 
 #include "modularity/ioc.h"
 #include "iinteractive.h"
-#include "languages/ilanguagesconfiguration.h"
 #include "itoursprovider.h"
 #include "itoursconfiguration.h"
 
@@ -38,21 +37,16 @@ class ToursService : public IToursService, public Injectable, public async::Asyn
     Inject<IInteractive> interactive = { this };
     Inject<IToursProvider> toursProvider = { this };
     Inject<IToursConfiguration> toursConfiguration = { this };
-    Inject<languages::ILanguagesConfiguration> languagesConfiguration = { this };
 
 public:
     ToursService(const muse::modularity::ContextPtr& ctx)
         : Injectable(ctx) {}
-
-    void init();
 
     void registerTour(const String& eventCode, const Tour& tour) override;
 
     void onEvent(const String& eventCode) override;
 
 private:
-    void initTours();
-
     std::unordered_map<String /*eventCode*/, Tour> m_eventsMap;
 };
 }

--- a/src/framework/tours/itoursconfiguration.h
+++ b/src/framework/tours/itoursconfiguration.h
@@ -23,7 +23,6 @@
 #pragma once
 
 #include "types/string.h"
-#include "io/path.h"
 
 #include "modularity/imoduleinterface.h"
 
@@ -39,7 +38,5 @@ public:
 
     virtual String lastShownTourIdForEvent(const String& eventCode) const = 0;
     virtual void setLastShownTourIdForEvent(const String& eventCode, const String& tourId) = 0;
-
-    virtual io::path_t toursFilePath() const = 0;
 };
 }

--- a/src/framework/tours/toursmodule.cpp
+++ b/src/framework/tours/toursmodule.cpp
@@ -64,12 +64,3 @@ void ToursModule::registerUiTypes()
 {
     qmlRegisterType<ToursProviderModel>("Muse.Tours", 1, 0, "ToursProviderModel");
 }
-
-void ToursModule::onInit(const IApplication::RunMode& mode)
-{
-    if (mode != IApplication::RunMode::GuiApp) {
-        return;
-    }
-
-    m_service->init();
-}

--- a/src/framework/tours/toursmodule.h
+++ b/src/framework/tours/toursmodule.h
@@ -37,7 +37,6 @@ public:
     void registerExports() override;
     void registerResources() override;
     void registerUiTypes() override;
-    void onInit(const IApplication::RunMode& mode) override;
 
 private:
     std::shared_ptr<ToursService> m_service;


### PR DESCRIPTION
Resolves: #29010

Per [Eism's comment](https://github.com/musescore/MuseScore/issues/29010#issuecomment-3139380588) in the issue, ToursService::initTours can be removed.

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
