### PR TITLE
Fix barline scaling in parts

### DIFF
--- a/src/engraving/dom/barline.cpp
+++ b/src/engraving/dom/barline.cpp
@@ -491,7 +491,7 @@ void BarLine::calcY()
         }
     }
 
-    double spatium1 = staffType1->spatium();
+    double spatium1 = staffType1->getScaledSpatium(style().spatium());
     double lineDistance = staffType1->lineDistance().val() * spatium1;
     double offset = staffType1->yoffset().val() * spatium1;
     double lineWidth = style().styleS(Sid::staffLineWidth).val() * spatium1 * .5;
@@ -504,7 +504,7 @@ void BarLine::calcY()
         // as it may be scalled diferently
         const Staff* staff2 = score()->staff(staffIdx2);
         const StaffType* staffType2 = staff2 ? staff2->staffType(tick) : staffType1;
-        double spatium2 = staffType2->spatium();
+        double spatium2 = staffType2->getScaledSpatium(style().spatium());
         double lineDistance2 = staffType2->lineDistance().val() * spatium2;
         double startStaffY = system->staff(staffIdx1)->y();
 
@@ -534,7 +534,7 @@ void BarLine::calcY()
                     to = BARLINE_SPAN_1LINESTAFF_TO;
                 }
             }
-            double spatium1Next = staffType1Next->spatium();
+            double spatium1Next = staffType1Next->getScaledSpatium(style().spatium());
             double lineDistanceNext = staffType1Next->lineDistance().val() * spatium1Next;
             double offsetNext = staffType1Next->yoffset().val() * spatium1Next;
             double lineWidthNext = style().styleS(Sid::staffLineWidth).val() * spatium1Next * .5;

--- a/src/engraving/dom/stafftype.cpp
+++ b/src/engraving/dom/stafftype.cpp
@@ -1093,9 +1093,9 @@ const MStyle& StaffType::style() const
 //   spatium
 //---------------------------------------------------------
 
-double StaffType::spatium() const
+double StaffType::getScaledSpatium(double sp) const
 {
-    return style().spatium() * (isSmall() ? style().styleD(Sid::smallStaffMag) : 1.0) * userMag();
+    return sp * (isSmall() ? style().styleD(Sid::smallStaffMag) : 1.0) * userMag();
 }
 
 //=========================================================

--- a/src/engraving/dom/stafftype.h
+++ b/src/engraving/dom/stafftype.h
@@ -217,7 +217,7 @@ public:
     void setColor(const Color& val) { m_color = val; }
     Spatium yoffset() const { return m_yoffset; }
     void setYoffset(Spatium val) { m_yoffset = val; }
-    double spatium() const;
+    double getScaledSpatium(double sp) const;
 
     void setStemless(bool val) { m_stemless = val; }
     bool stemless() const { return m_stemless; }


### PR DESCRIPTION
Resolves: #28799 

This was caused by the value of "Page settings > Staff space (sp)" being different in the main score and part.
