### PR TITLE
Fix crash when flipping element that's not in edit mode

### DIFF
--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -4529,9 +4529,13 @@ void NotationInteraction::endEditGrip()
 
 void NotationInteraction::updateGripAnchorLines()
 {
+    if (!m_editData.element) {
+        return;
+    }
+
     std::vector<LineF> lines;
-    mu::engraving::Grip anchorLinesGrip = m_editData.curGrip
-                                          == mu::engraving::Grip::NO_GRIP ? m_editData.element->defaultGrip() : m_editData.curGrip;
+    mu::engraving::Grip anchorLinesGrip = m_editData.curGrip == mu::engraving::Grip::NO_GRIP
+                                          ? m_editData.element->defaultGrip() : m_editData.curGrip;
     std::vector<LineF> anchorLines = m_editData.element->gripAnchorLines(anchorLinesGrip);
 
     if (!anchorLines.empty()) {


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/29053

Caused by https://github.com/musescore/MuseScore/commit/12e1a373deae18bc6d578d874323ce1568bd02db.