### PR TITLE
Some experiments regarding Fonts with no measurable character dimensions

### DIFF
--- a/src/engraving/rendering/score/tlayout.cpp
+++ b/src/engraving/rendering/score/tlayout.cpp
@@ -6029,7 +6029,8 @@ void TLayout::layoutBaseTextBase1(const TextBase* item, TextBase::LayoutData* ld
     shape.translateY(yoff);
     ldata->setShape(shape);
 
-    if (item->hasFrame()) {
+    // Layout a frame, or at least make the layout valid in some strange-font cases ...
+    if (item->hasFrame() || (!item->plainText().isEmpty() && !ldata->isValid() && !ldata->isSkipDraw())) {
         item->layoutFrame(ldata);
     }
 


### PR DESCRIPTION
Resolves: #19252

Some texts with zero-width and -heigh bounding boxes may not display unless contained e. g. in a frame. 
In this change, during the layout process, if is checked whether there is an invalid layout computed for a non-empty text, and in this case a frame is constructed (which will *not* render a frame, but provides for a valid shape in the end result). 

Compare the left staff text with a zero-width frame: 
<img width="990" height="1028" alt="grafik" src="https://github.com/user-attachments/assets/049edc5b-3730-456c-a867-89b1bf4ede6d" />

The right staff text has no frame: 
<img width="990" height="1028" alt="grafik" src="https://github.com/user-attachments/assets/a87bb053-1529-41bf-b88c-e24f19bfa165" />

In MuseScore 4.5.2 this renders as such: 
<img width="919" height="600" alt="grafik" src="https://github.com/user-attachments/assets/8a42ea60-a32e-4511-a830-2234b013d3c3" />

For creating an automated test case I would need to understand whether the _ Saxy_  font can easily be included as to create a test case ... probably not though. 8^(

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
