### PR TITLE
Fix saving of uncompressed scores in OneDrive

### DIFF
--- a/src/framework/global/io/internal/filesystem.cpp
+++ b/src/framework/global/io/internal/filesystem.cpp
@@ -21,9 +21,10 @@
  */
 #include "filesystem.h"
 
-#include <QFileInfo>
 #include <QDir>
 #include <QDirIterator>
+#include <QDirListing>
+#include <QFileInfo>
 
 #ifdef Q_OS_WIN
 #include <windows.h>
@@ -56,42 +57,31 @@ Ret FileSystem::remove(const io::path_t& path_, bool onlyIfEmpty)
     return make_ret(Err::NoError);
 }
 
-Ret FileSystem::clear(const io::path_t& path_)
+Ret FileSystem::clear(const io::path_t& path)
 {
-    QString path = path_.toQString();
-    if (!QFileInfo::exists(path)) {
+    const QString qPath = path.toQString();
+    if (!QFileInfo::exists(qPath)) {
         return true;
     }
 
-    Ret ret = make_ret(Err::NoError);
-    QDirIterator di(path, QDir::AllEntries | QDir::Hidden | QDir::System | QDir::NoDotAndDotDot);
-    while (di.hasNext()) {
-        di.next();
-        const QFileInfo& fi = di.fileInfo();
-        const QString& filePath = di.filePath();
-        if (fi.isDir() && !fi.isSymLink()) {
-            ret = removeDir(filePath); // recursive
-        } else {
-            bool ok = QFile::remove(filePath);
-            if (!ok) { // Read-only files prevent directory deletion on Windows, retry with Write permission.
-                const QFile::Permissions permissions = QFile::permissions(filePath);
-                if (!(permissions & QFile::WriteUser)) {
-                    ok = QFile::setPermissions(filePath, permissions | QFile::WriteUser)
-                         && QFile::remove(filePath);
-                }
+    using ItFlag = QDirListing::IteratorFlag;
+    for (const auto& dirEntry : QDirListing{ qPath, ItFlag::IncludeHidden }) {
+        if (dirEntry.isDir() && !dirEntry.isSymLink()) {
+            const Ret didRemove = removeDir(dirEntry.filePath());
+            if (!didRemove) {
+                return didRemove;
             }
 
-            if (!ok) {
-                ret = make_ret(Err::FSRemoveError);
-            }
+            continue;
         }
 
-        if (!ret) {
-            break;
+        const Ret didRemove = removeFile(dirEntry.filePath());
+        if (!didRemove) {
+            return didRemove;
         }
     }
 
-    return ret;
+    return make_ok();
 }
 
 Ret FileSystem::copy(const io::path_t& src, const io::path_t& dst, bool replace)
@@ -310,29 +300,67 @@ RetVal<io::paths_t> FileSystem::scanFiles(const io::path_t& rootDir, const std::
     return result;
 }
 
-Ret FileSystem::removeFile(const io::path_t& path) const
+Ret FileSystem::removeFile(const io::path_t& path)
 {
     QFile file(path.toQString());
     if (!file.remove()) {
-        return make_ret(Err::FSRemoveError);
+        // Read-only files prevent directory deletion on Windows, retry with Write permission.
+        LOGW() << "Failed to delete file. Setting write permission and trying again...";
+        if (!file.setPermissions(file.permissions() | QFile::WriteUser)) {
+            LOGE() << "Failed to set write permission for file";
+            return make_ret(Err::FSRemoveError);
+        }
+        if (!file.remove()) {
+            LOGE() << "Second delete attempt failed";
+            return make_ret(Err::FSRemoveError);
+        }
+
+        return make_ok();
     }
 
-    return make_ret(Err::NoError);
+    return make_ok();
 }
 
-Ret FileSystem::removeDir(const io::path_t& path, bool onlyIfEmpty) const
+Ret FileSystem::removeDir(const io::path_t& path, const bool onlyIfEmpty)
 {
-    QDir dir(path.toQString());
+    const QString qPath = path.toQString();
+    QDir dir(qPath);
 
-    if (onlyIfEmpty && !dir.isEmpty()) {
+    if (!onlyIfEmpty) {
+        // clear directory for deletion
+        const Ret didClear = clear(path);
+        if (!didClear) {
+            LOGE() << "Failed to clear directory for deletion";
+
+            return didClear;
+        }
+    }
+
+    if (!dir.isEmpty()) {
         return make_ret(Err::FSDirNotEmptyError);
     }
 
-    if (!dir.removeRecursively()) {
-        return make_ret(Err::FSRemoveError);
+    const QString dirName = dir.dirName();
+    if (!dir.cdUp()) {
+        return make_ret(Err::FSNotExist);
     }
 
-    return make_ret(Err::NoError);
+    if (!dir.rmdir(dirName)) {
+        // OneDrive removes delete permission on Windows. try again with write permission
+        LOGW() << "Failed to delete directory. Setting write permission and trying again...";
+        if (!QFile::setPermissions(qPath, QFile::permissions(qPath) | QFile::WriteUser)) {
+            LOGE() << "Failed to set write permission for directory";
+            return make_ret(Err::FSRemoveError);
+        }
+        if (!dir.rmdir(dirName)) {
+            LOGE() << "Second delete attempt failed";
+            return make_ret(Err::FSRemoveError);
+        }
+
+        return make_ok();
+    }
+
+    return make_ok();
 }
 
 Ret FileSystem::copyRecursively(const io::path_t& src, const io::path_t& dst) const

--- a/src/framework/global/io/internal/filesystem.h
+++ b/src/framework/global/io/internal/filesystem.h
@@ -60,8 +60,8 @@ public:
     Ret isWritable(const path_t& filePath) const override;
 
 private:
-    Ret removeFile(const io::path_t& path) const;
-    Ret removeDir(const io::path_t& path, bool onlyIfEmpty = false) const;
+    Ret removeFile(const io::path_t& path);
+    Ret removeDir(const io::path_t& path, bool onlyIfEmpty = false);
     Ret copyRecursively(const io::path_t& src, const io::path_t& dst) const;
 };
 }


### PR DESCRIPTION
Resolves: #29052

OneDrive removes the delete permission for some reason. The `clear()` method already dealt with this for files by retrying with the write permission explicitly set. This solution does the same when removing directories.
Drive-by cleanups:
- use `clear()` instead of `removeRecursively()`
  - "This function is meant for removing a small application-internal directory (such as a temporary directory), but not user-visible directories."[^1]
- use `QDirListing` instead of `QDirIterator`
  - "This class is deprecated and may be removed in a Qt release. Use QDirListing instead."[^2]
- move retry logic to `removeFile` and `removeDir`

<!-- -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)

[^1]: https://doc.qt.io/qt-6/qdir.html#removeRecursively
[^2]: https://doc.qt.io/qt-6/qdiriterator.html#details