### PR TITLE
Chord symbol autoplace fixes

### DIFF
--- a/src/engraving/rendering/score/alignmentlayout.cpp
+++ b/src/engraving/rendering/score/alignmentlayout.cpp
@@ -200,7 +200,7 @@ double AlignmentLayout::yOpticalCenter(const EngravingItem* item)
     case ElementType::HARMONY: {
         EngravingItem* parentItem = toHarmony(item)->parentItem();
         if (parentItem && parentItem->isFretDiagram()) {
-            curY += parentItem->pos().y();
+            curY += parentItem->pos().y() + item->height();
         }
         break;
     }

--- a/src/engraving/rendering/score/harmonylayout.cpp
+++ b/src/engraving/rendering/score/harmonylayout.cpp
@@ -55,7 +55,8 @@ void HarmonyLayout::layoutHarmony(Harmony* item, Harmony::LayoutData* ldata,
     auto calculateBoundingRect = [](const Harmony* item, Harmony::LayoutData* ldata, const LayoutContext& ctx) -> PointF
     {
         const double ypos = (item->placeBelow() && item->staff()) ? item->staff()->staffHeight(item->tick()) : 0.0;
-        const FretDiagram* fd = (item->explicitParent() && item->explicitParent()->isFretDiagram())
+        const EngravingItem* parent = item->explicitParent() ? toEngravingItem(item->explicitParent()) : nullptr;
+        const FretDiagram* fd = (parent && parent->isFretDiagram() && parent->visible())
                                 ? toFretDiagram(item->explicitParent())
                                 : nullptr;
 

--- a/src/engraving/rendering/score/systemlayout.cpp
+++ b/src/engraving/rendering/score/systemlayout.cpp
@@ -1088,7 +1088,7 @@ void SystemLayout::layoutSystemElements(System* system, LayoutContext& ctx)
             AlignmentLayout::alignItemsForSystem(fretItems, system);
         }
 
-        layoutHarmonies(elementsToLayout.harmonies, system, false, ctx);
+        layoutHarmonies(elementsToLayout.harmonies, system, true, ctx);
 
         for (FretDiagram* fretDiag : elementsToLayout.fretDiagrams) {
             if (Harmony* harmony = fretDiag->harmony()) {


### PR DESCRIPTION
Resolves: #28047 

Also fixes alignment of chord symbols attached to fretboard diagrams