### PR TITLE
Don't sum top and bottom gap of frames

### DIFF
--- a/src/engraving/compat/engravingcompat.cpp
+++ b/src/engraving/compat/engravingcompat.cpp
@@ -25,6 +25,7 @@
 #include "dom/marker.h"
 #include "dom/system.h"
 #include "engraving/dom/beam.h"
+#include "engraving/dom/box.h"
 #include "engraving/dom/chord.h"
 #include "engraving/dom/instrument.h"
 #include "engraving/dom/masterscore.h"
@@ -43,6 +44,7 @@ void EngravingCompat::doPreLayoutCompatIfNeeded(MasterScore* score)
     if (mscVersion < 460) {
         resetMarkerLeftFontSize(score);
         resetRestVerticalOffsets(score);
+        adjustVBoxDistances(score);
     }
 
     if (mscVersion < 440) {
@@ -205,6 +207,20 @@ void EngravingCompat::resetRestVerticalOffsets(MasterScore* masterScore)
                         }
                     }
                 }
+            }
+        }
+    }
+}
+
+void EngravingCompat::adjustVBoxDistances(MasterScore* masterScore)
+{
+    for (Score* score : masterScore->scoreList()) {
+        for (MeasureBase* mb = score->first(); mb; mb = mb->next()) {
+            MeasureBase* nextmb = mb->next();
+            if (mb->isVBoxBase() && nextmb && nextmb->isVBoxBase()) {
+                VBox* first = toVBox(mb);
+                VBox* second = toVBox(nextmb);
+                first->setBottomGap(first->bottomGap() + second->topGap()); // Because pre-4.6 these used to be added
             }
         }
     }

--- a/src/engraving/compat/engravingcompat.cpp
+++ b/src/engraving/compat/engravingcompat.cpp
@@ -218,8 +218,8 @@ void EngravingCompat::adjustVBoxDistances(MasterScore* masterScore)
         for (MeasureBase* mb = score->first(); mb; mb = mb->next()) {
             MeasureBase* nextmb = mb->next();
             if (mb->isVBoxBase() && nextmb && nextmb->isVBoxBase()) {
-                VBox* first = toVBox(mb);
-                VBox* second = toVBox(nextmb);
+                VBox* first = static_cast<VBox*>(mb);
+                VBox* second = static_cast<VBox*>(nextmb);
                 first->setBottomGap(first->bottomGap() + second->topGap()); // Because pre-4.6 these used to be added
             }
         }

--- a/src/engraving/compat/engravingcompat.h
+++ b/src/engraving/compat/engravingcompat.h
@@ -39,6 +39,7 @@ private:
     static void migrateDynamicPosOnVocalStaves(MasterScore* masterScore);
     static void resetMarkerLeftFontSize(MasterScore* masterScore);
     static void resetRestVerticalOffsets(MasterScore* masterScore);
+    static void adjustVBoxDistances(MasterScore* masterScore);
 
     static bool relayoutUserModifiedCrossStaffBeams(MasterScore* score);
     static bool resetHookHeightSign(MasterScore* masterScore);

--- a/src/engraving/dom/box.cpp
+++ b/src/engraving/dom/box.cpp
@@ -842,9 +842,6 @@ PropertyValue FBox::propertyDefault(Pid propertyId) const
     case Pid::TOP_GAP:
     case Pid::BOTTOM_GAP:
         return 4.0;
-    case Pid::TOP_MARGIN:
-    case Pid::BOTTOM_MARGIN:
-        return 2.0;
     case Pid::FRET_FRAME_DIAGRAMS_ORDER:
         return PropertyValue();
     default:

--- a/src/engraving/dom/box.cpp
+++ b/src/engraving/dom/box.cpp
@@ -842,6 +842,9 @@ PropertyValue FBox::propertyDefault(Pid propertyId) const
     case Pid::TOP_GAP:
     case Pid::BOTTOM_GAP:
         return 4.0;
+    case Pid::TOP_MARGIN:
+    case Pid::BOTTOM_MARGIN:
+        return 2.0;
     case Pid::FRET_FRAME_DIAGRAMS_ORDER:
         return PropertyValue();
     default:

--- a/src/engraving/rendering/score/systemlayout.cpp
+++ b/src/engraving/rendering/score/systemlayout.cpp
@@ -2671,7 +2671,9 @@ double SystemLayout::minDistance(const System* top, const System* bottom, const 
     } else if (!topVBox && bottomVBox) {
         return std::max(bottomVBox->absoluteFromSpatium(bottomVBox->topGap()), top->minBottom());
     } else if (topVBox && bottomVBox) {
-        return bottomVBox->absoluteFromSpatium(bottomVBox->topGap()) + topVBox->absoluteFromSpatium(topVBox->bottomGap());
+        double largestGap = std::max(bottomVBox->absoluteFromSpatium(bottomVBox->topGap()),
+                                     topVBox->absoluteFromSpatium(topVBox->bottomGap()));
+        return largestGap;
     }
 
     if (top->staves().empty() || bottom->staves().empty()) {

--- a/src/framework/audio/worker/audioworkermodule.cpp
+++ b/src/framework/audio/worker/audioworkermodule.cpp
@@ -22,6 +22,7 @@
 
 #include "audioworkermodule.h"
 
+#include "internal/audiobuffer.h"
 #include "internal/audioengine.h"
 #include "internal/workerplayback.h"
 #include "internal/workerchannelcontroller.h"


### PR DESCRIPTION
Resolves: #28755 

Simple fix, with an added compatibility pass that ensures pre-460 scores retain the same result.

Additionally, a small layout improvement (temporarily) to the Fretboard diagram legend to account for top and bottom margin
<img width="854" height="299" alt="image" src="https://github.com/user-attachments/assets/e6c3ded8-794d-4c5e-bdae-1d11d9d2439c" />
