### PR TITLE
fixed #28601: Crash after adding slur and closing score (some scores)

### DIFF
--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -6725,6 +6725,13 @@ void Score::undoAddElement(EngravingItem* element, bool addToLinkedStaves, bool 
             nsp->setTrack2(linkedTrack + diff);
             nsp->setTrack(linkedTrack);
 
+            if (Chord* startChord = toChord(sp->startChord())) {
+                Chord* linkedChord = findLinkedChord(startChord, score->staff(staffIdx));
+                if (linkedChord) {
+                    nsp->setParent(linkedChord->measure()->system());
+                }
+            }
+
             // determine start/end element for slurs
             // this is only necessary if start/end element is
             //   a grace note, otherwise the element can be set to zero


### PR DESCRIPTION
Resolves: #28601

When adding a new spanner, it inherited an old system as its parent, because we cloned it a bit earlier. After that, we didn’t update its parent.
When deleting a part, we didn’t delete the spanner. And later, when deleting the main score, we tried to get the rootItem from the spanner - but it had already been deleted along with the score.