### PR TITLE
Fix #28947: Broken percussion note popup

### DIFF
--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -1234,8 +1234,8 @@ void NotationViewInputController::keyPressEvent(QKeyEvent* event)
             viewInteraction()->updateTimeTickAnchors(event);
         }
     } else if (key == Qt::Key_Shift) {
-        updateShadowNotePopupVisibility();
         viewInteraction()->updateTimeTickAnchors(event);
+        updateShadowNotePopupVisibility();
     } else if (isAnchorEditingEvent(event)) {
         viewInteraction()->moveElementAnchors(event);
     }


### PR DESCRIPTION
Resolves: #28947

If I understand correctly, the new call to `updateTimeTickAnchors` causes the score to update, leaving the popup with invalid/outdated info. I do wonder whether this call is completely necessary after the addition of f2e8c3ea2db5086daf410f4a0aa66e5af83b67db - @mike-spa you'll know best!