### PR TITLE
More handbells symbols

### DIFF
--- a/src/engraving/dom/playtechannotation.cpp
+++ b/src/engraving/dom/playtechannotation.cpp
@@ -56,6 +56,12 @@ PlayTechAnnotation* PlayTechAnnotation::clone() const
     return new PlayTechAnnotation(*this);
 }
 
+bool PlayTechAnnotation::isHandbellsSymbol() const
+{
+    return static_cast<int>(m_techniqueType) >= static_cast<int>(PlayingTechniqueType::HandbellsSwing)
+           && static_cast<int>(m_techniqueType) <= static_cast<int>(PlayingTechniqueType::HandbellsDamp);
+}
+
 PropertyValue PlayTechAnnotation::getProperty(Pid id) const
 {
     switch (id) {

--- a/src/engraving/dom/playtechannotation.h
+++ b/src/engraving/dom/playtechannotation.h
@@ -41,6 +41,9 @@ public:
 
     PlayTechAnnotation* clone() const override;
 
+    bool isHandbellsSymbol() const;
+    bool isEditable() const override { return !isHandbellsSymbol(); }
+
 private:
 
     PropertyValue getProperty(Pid id) const override;

--- a/src/engraving/dom/textbase.cpp
+++ b/src/engraving/dom/textbase.cpp
@@ -886,6 +886,7 @@ Font TextFragment::font(const TextBase* t) const
     if (format.fontFamily() == "ScoreText") {
         if (t->isDynamic()
             || t->isStringTunings()
+            || t->isPlayTechAnnotation()
             || t->textStyleType() == TextStyleType::OTTAVA
             || t->textStyleType() == TextStyleType::HARP_PEDAL_DIAGRAM
             || t->textStyleType() == TextStyleType::TUPLET

--- a/src/engraving/rendering/score/tlayout.cpp
+++ b/src/engraving/rendering/score/tlayout.cpp
@@ -4596,6 +4596,27 @@ void TLayout::layoutPlayTechAnnotation(const PlayTechAnnotation* item, PlayTechA
     LAYOUT_CALL_ITEM(item);
     layoutBaseTextBase(item, ldata);
 
+    if (item->isHandbellsSymbol()) {
+        Chord* chord = nullptr;
+        Segment* seg = item->segment();
+        track_idx_t sTrack = staff2track(item->staffIdx());
+        track_idx_t eTrack = sTrack + VOICES;
+        for (track_idx_t track = sTrack; track < eTrack; ++track) {
+            if (seg->element(track) && seg->element(track)->isChord()) {
+                chord = toChord(seg->element(track));
+                break;
+            }
+        }
+        double center = 0.0;
+        if (chord) {
+            Note* refNote = item->placeAbove() ? chord->upNote() : chord->downNote();
+            center = 0.5 * refNote->width() + refNote->x() + chord->x();
+        } else {
+            center = 0.5 * item->score()->noteHeadWidth();
+        }
+        ldata->setPosX(center - 0.5 * (ldata->bbox().right() - ldata->bbox().left()));
+    }
+
     if (item->autoplace()) {
         const Segment* s = toSegment(item->explicitParent());
         const Measure* m = s->measure();

--- a/src/engraving/types/types.h
+++ b/src/engraving/types/types.h
@@ -926,6 +926,13 @@ enum class PlayingTechniqueType : signed char {
     Overdrive,
     Harmonics,
     JazzTone,
+    // Handbells
+    HandbellsSwing,
+    HandbellsSwingUp,
+    HandbellsSwingDown,
+    HandbellsEcho1,
+    HandbellsEcho2,
+    HandbellsDamp
 };
 
 enum class GradualTempoChangeType : signed char {

--- a/src/engraving/types/typesconv.cpp
+++ b/src/engraving/types/typesconv.cpp
@@ -3147,11 +3147,11 @@ const std::array<ArticulationTextTypeItem, 10> ARTICULATIONTEXT_TYPES = { {
     { ArticulationTextType::POP,    "Pop",  String(u"P"),    muse::TranslatableString("engraving/sym", "Pop") },
     // Handbells
     { ArticulationTextType::LV,     "LV",   String(u"LV"),   muse::TranslatableString("engraving/sym", "Let vibrate") },
-    { ArticulationTextType::R,      "R",    String(u"P"),    muse::TranslatableString("engraving/sym", "Ring") },
+    { ArticulationTextType::R,      "R",    String(u"R"),    muse::TranslatableString("engraving/sym", "Ring") },
     { ArticulationTextType::TD,     "TD",   String(u"TD"),   muse::TranslatableString("engraving/sym", "Thumb damp") },
     { ArticulationTextType::BD,     "BD",   String(u"BD"),   muse::TranslatableString("engraving/sym", "Brush damp") },
     { ArticulationTextType::RT,     "RT",   String(u"RT"),   muse::TranslatableString("engraving/sym", "Ring touch") },
-    { ArticulationTextType::PL,     "PL",   String(u"Pl"),   muse::TranslatableString("engraving/sym", "Pluck") },
+    { ArticulationTextType::PL,     "PL",   String(u"PL"),   muse::TranslatableString("engraving/sym", "Pluck") },
     { ArticulationTextType::SB,     "SB",   String(u"SB"),   muse::TranslatableString("engraving/sym", "Singing bell") },
     { ArticulationTextType::VIB,    "VIB",  String(u"vib."), muse::TranslatableString("engraving/sym", "Vibrate") },
 } };

--- a/src/engraving/types/typesconv.cpp
+++ b/src/engraving/types/typesconv.cpp
@@ -2036,6 +2036,15 @@ static const std::vector<Item<PlayingTechniqueType> > PLAY_TECH_TYPES = {
     { PlayingTechniqueType::Overdrive,     "overdrive",      muse::TranslatableString("engraving/playtechtype", "Overdrive") },
     { PlayingTechniqueType::Harmonics,     "harmonics",      muse::TranslatableString("engraving/playtechtype", "Harmonics") },
     { PlayingTechniqueType::JazzTone,      "jazz_tone",      muse::TranslatableString("engraving/playtechtype", "Jazz tone") },
+    // Handbells
+    { PlayingTechniqueType::HandbellsSwing, "handbells_swing", muse::TranslatableString("engraving/playtechtype", "Swing") },
+    { PlayingTechniqueType::HandbellsSwingUp, "handbells_swing_up",
+      muse::TranslatableString("engraving/playtechtype", "Swing up") },
+    { PlayingTechniqueType::HandbellsSwingDown, "handbells_swing_down",
+      muse::TranslatableString("engraving/playtechtype", "Swing down") },
+    { PlayingTechniqueType::HandbellsEcho1, "handbells_echo_1", muse::TranslatableString("engraving/playtechtype", "Echo") },
+    { PlayingTechniqueType::HandbellsEcho2, "handbells_echo_2", muse::TranslatableString("engraving/playtechtype", "Echo") },
+    { PlayingTechniqueType::HandbellsDamp, "handbells_damp", muse::TranslatableString("engraving/playtechtype", "Damp") },
 };
 
 const muse::TranslatableString& TConv::userName(PlayingTechniqueType v)

--- a/src/palette/internal/palettecreator.cpp
+++ b/src/palette/internal/palettecreator.cpp
@@ -2040,6 +2040,23 @@ PalettePtr PaletteCreator::newHandbellsPalette(bool defaultPalette)
         ArticulationTextType::VIB,
     };
 
+    struct HandbellsPlayTechInfo {
+        const char* xmlText;
+        PlayingTechniqueType playTechType;
+    };
+
+    static const std::vector<HandbellsPlayTechInfo> standardHandbellsPlayTech {
+        { "<sym>handbellsSwingUp</sym>",   PlayingTechniqueType::HandbellsSwingUp, },
+        { "<sym>handbellsSwingDown</sym>",   PlayingTechniqueType::HandbellsSwingDown, },
+        { "<sym>handbellsEcho1</sym>",   PlayingTechniqueType::HandbellsEcho1, },
+        { "<sym>handbellsDamp3</sym>",   PlayingTechniqueType::HandbellsDamp, },
+    };
+
+    static const std::vector<HandbellsPlayTechInfo> additionalHandbellsPlayTech {
+        { "<sym>handbellsSwing</sym>",   PlayingTechniqueType::HandbellsSwing, },
+        { "<sym>handbellsEcho2</sym>",   PlayingTechniqueType::HandbellsEcho2, },
+    };
+
     if (defaultPalette) {
         for (SymId symId : standardHandbellsArticSymbols) {
             auto artic = Factory::makeArticulation(gpaletteScore->dummy()->chord());
@@ -2053,11 +2070,25 @@ PalettePtr PaletteCreator::newHandbellsPalette(bool defaultPalette)
             artic->setTextType(textType);
             sp->appendElement(artic, artic->subtypeUserName(), 1.1);
         }
+
+        for (const HandbellsPlayTechInfo& info : standardHandbellsPlayTech) {
+            auto element = makeElement<PlayTechAnnotation>(gpaletteScore);
+            element->setXmlText(info.xmlText);
+            element->setTechniqueType(info.playTechType);
+            sp->appendElement(element, TConv::userName(info.playTechType));
+        }
     } else {
         for (SymId symId : additionalHandbellsArticSymbols) {
             auto artic = Factory::makeArticulation(gpaletteScore->dummy()->chord());
             artic->setSymId(symId);
             sp->appendElement(artic, artic->subtypeUserName());
+        }
+
+        for (const HandbellsPlayTechInfo& info : additionalHandbellsPlayTech) {
+            auto element = makeElement<PlayTechAnnotation>(gpaletteScore);
+            element->setXmlText(info.xmlText);
+            element->setTechniqueType(info.playTechType);
+            sp->appendElement(element, TConv::userName(info.playTechType));
         }
     }
 


### PR DESCRIPTION
These symbols, unlike the ones I've introduced before, don't attach to a specific chord but can be anchored to any point in time, so they can't be treated as articulations. Instead, they need to be treated as playing techniques (for which we already have a dedicated type that's used for other instruments too), with the only difference that they contain a symbol rather than plain text.