### PR TITLE
Fix crash on delete all + close in score with spanners and linked staves

### DIFF
--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -3518,6 +3518,11 @@ void Score::deleteOrShortenOutSpannersFromRange(const Fraction& t1, const Fracti
         ElementType::VIBRATO,
     };
 
+    // undoRemoveElement and undoChangeProperty also handle linked elements, so we need
+    // to make sure each linked group is handled only once if multiple elements per linked
+    // group are found in the range, for example in the case of linked staves.
+    std::unordered_set<EngravingObject*> handledMainElements;
+
     auto spanners = m_spanner.findOverlapping(t1.ticks(), t2.ticks() - 1);
     for (auto i : spanners) {
         Spanner* sp = i.value;
@@ -3525,6 +3530,11 @@ void Score::deleteOrShortenOutSpannersFromRange(const Fraction& t1, const Fracti
         Fraction spEndTick = sp->tick2();
         const bool trackValid = sp->track() >= track1 && sp->track() < track2;
         if (!trackValid || sp->isVolta() || sp->systemFlag()) {
+            continue;
+        }
+
+        if (sp->links() && !handledMainElements.insert(sp->links()->mainElement()).second) {
+            // already handled this linked group
             continue;
         }
 


### PR DESCRIPTION
If multiple spanners from the same linked group would be included in the selection, all of them would be removed (`undo(new RemoveElement(…))`) multiple times, causing double-frees when the UndoStack is cleaned up when closing the score.

Resolves: https://github.com/musescore/MuseScore/issues/28273#issuecomment-3166297722

Steps to reproduce the crash from scratch:
1. Create score
2. Add linked staff
3. Add (e.g.) crescendo to the linked staves
4. Make a (range) selection that includes both linked crescendos and press delete
5. Close score