### PR TITLE
gp-import: fixed converting stored pitches into bend pitches

### DIFF
--- a/src/importexport/guitarpro/internal/guitarbendimport/bendinfoconverter.cpp
+++ b/src/importexport/guitarpro/internal/guitarbendimport/bendinfoconverter.cpp
@@ -83,6 +83,7 @@ ImportedBendInfo BendInfoConverter::fillBendInfo(const Note* note, const PitchVa
             break;
 
         case pvd::SAME_PITCH_DIFF_TIME:
+        case pvd::INCREASED_PITCH_SAME_TIME:
         {
             if (importedInfo.segments.empty()) {
                 addPrebendOrHold(pitchValues[i]);
@@ -90,15 +91,7 @@ ImportedBendInfo BendInfoConverter::fillBendInfo(const Note* note, const PitchVa
                 BendSegment& lastSegment = importedInfo.segments.back();
                 lastSegment.middleTime = lastSegment.endTime;
                 lastSegment.endTime = pitchValues[i + 1].time;
-            }
-
-            break;
-        }
-
-        case pvd::INCREASED_PITCH_SAME_TIME:
-        {
-            if (importedInfo.segments.empty()) {
-                addPrebendOrHold(pitchValues[i]);
+                lastSegment.endPitch = pitchValues[i + 1].pitch;
             }
 
             break;


### PR DESCRIPTION
in case of pitch values from guitar pro "0-25-50" (if 25 and 50 was on same time) it was treated as slight bend (25 = 1/4 tone) instead of bend (50 = 1/2 tone)