### PR TITLE
Add missing #include

### DIFF
--- a/src/framework/audio/worker/audioworkermodule.cpp
+++ b/src/framework/audio/worker/audioworkermodule.cpp
@@ -22,6 +22,7 @@
 
 #include "audioworkermodule.h"
 
+#include "internal/audiobuffer.h"
 #include "internal/audioengine.h"
 #include "internal/workerplayback.h"
 #include "internal/workerchannelcontroller.h"


### PR DESCRIPTION
Otherwise it doesn't build on Windows (non-unity build) and says the type is unknown
