### PR TITLE
Fix #21780: Ensure title frames are included in parts when creating from template

### DIFF
--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -377,19 +377,20 @@ void MasterNotation::applyOptions(mu::engraving::MasterScore* score, const Score
     createMeasures(score, scoreOptions);
 
     {
-        QString title = score->metaTag(u"workTitle");
-        QString subtitle = score->metaTag(u"subtitle");
-        QString composer = score->metaTag(u"composer");
-        QString lyricist = score->metaTag(u"lyricist");
+        const QString title = score->metaTag(u"workTitle");
+        const QString subtitle = score->metaTag(u"subtitle");
+        const QString composer = score->metaTag(u"composer");
+        const QString lyricist = score->metaTag(u"lyricist");
 
         if (!title.isEmpty() || !subtitle.isEmpty() || !composer.isEmpty() || !lyricist.isEmpty()) {
             mu::engraving::MeasureBase* measure = score->measures()->first();
             if (measure->type() != ElementType::VBOX) {
-                mu::engraving::MeasureBase* nm = nvb ? nvb : Factory::createTitleVBox(score->dummy()->system());
-                nm->setTick(mu::engraving::Fraction(0, 1));
-                nm->setExcludeFromOtherParts(false);
-                nm->setNext(measure);
-                score->measures()->add(nm);
+                if (!nvb) {
+                    nvb = Factory::createTitleVBox(score->dummy()->system());
+                }
+                nvb->setTick(mu::engraving::Fraction(0, 1));
+                nvb->setNext(measure);
+                score->measures()->add(nvb);
             } else if (nvb) {
                 delete nvb;
             }
@@ -420,6 +421,10 @@ void MasterNotation::applyOptions(mu::engraving::MasterScore* score, const Score
             }
         } else if (nvb) {
             delete nvb;
+        }
+
+        if (nvb) {
+            nvb->manageExclusionFromParts(/*exclude*/ false);
         }
     }
 


### PR DESCRIPTION
Resolves: #25795
Resolves: #21780

As mentioned [here](https://github.com/musescore/MuseScore/issues/21780#issuecomment-2733283266) by @MarcSabatella, #21780 seems to have evolved since it was reported.

This PR ensures that the "part management" logic we use for title frames is the same for both custom templates and for title frames created via other means (`manageExclusionFromParts`).