### PR TITLE
Prevents previous lyrics from being overwritten with following lyrics.

### DIFF
--- a/share/plugins/lilyrics/lilyrics.qml
+++ b/share/plugins/lilyrics/lilyrics.qml
@@ -10,6 +10,7 @@ import Muse.UiComponents
 
 MuseScore {
     version: "1.3" // 11 - August - 2025 // Adds saving lyrics in the plugin's text field
+                                         // Display a hyphen between two syllables of the same word
     title: "Lilypond Lyrics"
     categoryCode: "lyrics"
     thumbnailName: "lilyrics.png"
@@ -616,7 +617,6 @@ MuseScore {
         onScreenVerse=spinVerse.value;
     }
 
-
     function deleteLyrics() {
         var track=(spinStaff.value-1)*4+spinVoice.value-1;
         var verse=spinVerse.value-1;
@@ -656,7 +656,6 @@ MuseScore {
         }
     }
 
-
     function pasteLyrics(s) {
         var skipTies=checkTie.checked;
         var track=(spinStaff.value-1)*4+spinVoice.value-1;
@@ -664,7 +663,10 @@ MuseScore {
         var placement=comboPos.currentIndex;
         var spaceString="--SPACE--";
         var sinalefa=sinalefas[comboElision.currentIndex];
-        //var s = textLily.text;
+
+        // Makes the hyphen between words visible
+        s = s.replace(/([^\s-]+)-([^\s-]+)/g, "$1 - $2");
+
         var spaces=findSpaces(s);
         var linkDictionary = {};
         s=s.trim();
@@ -698,6 +700,14 @@ MuseScore {
                 var syl=Lyrics.SINGLE;
                 if (index<list.length) w=list[index];
                 if (w==spaceString) w=" ";
+
+                // Management of the hyphen for syllabic liaison
+                if (index > 0 && list[index - 1] == "-") {
+                    syl = Lyrics.END;
+                } else if (index + 1 < list.length && list[index + 1] == "-") {
+                    syl = Lyrics.BEGIN;
+                }
+
                 if (index+1<list.length && list[index+1]=="--") {
                     insideMelisma=false;
                     if (insideWord) syl=Lyrics.MIDDLE;
@@ -807,8 +817,6 @@ MuseScore {
         curScore.selection.clear();
     }
 
-
-
     /********** Functions on condensed format **********/
 
     function condenseLyrics(s) {
@@ -881,6 +889,4 @@ MuseScore {
         s=s.trim();
         return s;
     }
-
 }
-

--- a/share/plugins/lilyrics/lilyrics.qml
+++ b/share/plugins/lilyrics/lilyrics.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import QtQuick.Controls
+import Qt.labs.settings 1.0
 
 import MuseScore 3.0
 import Muse.Ui
@@ -8,8 +9,7 @@ import Muse.UiComponents
 // Inspired by roblyric, by Robbie Matthews
 
 MuseScore {
-    version: "1.2" // 21 - June - 2022
-    description: qsTr("Apply lyrics in lilypond format.")
+    version: "1.3" // 11 - August - 2025 // Adds saving lyrics in the plugin's text field
     title: "Lilypond Lyrics"
     categoryCode: "lyrics"
     thumbnailName: "lilyrics.png"
@@ -32,6 +32,12 @@ MuseScore {
     property var onScreenStaves: []
     property var onScreenVoice: null
     property var onScreenVerse: null
+
+    // Added persistent lyrics saving
+    Settings {
+        id: lyricsSettings
+        property string lastLyrics: ""
+    }
 
     onRun: {}
 
@@ -89,7 +95,12 @@ MuseScore {
                     wrapMode: TextEdit.WrapAnywhere
                     textFormat: TextEdit.PlainText
                     selectByMouse: true
-                    text: ""
+                    // Patch : text saved/restored
+                    text: lyricsSettings.lastLyrics
+
+                    onTextChanged: {
+                        lyricsSettings.lastLyrics = text
+                    }
                 }
             }
         }
@@ -246,7 +257,6 @@ MuseScore {
             }
         }
 
-
         // CANCEL
         FlatButton {
             id : buttonCancel
@@ -260,7 +270,6 @@ MuseScore {
                 quit()
             }
         }
-
 
         /******************************************
         *********** Bottom bar controls ***********
@@ -391,6 +400,11 @@ MuseScore {
                 width: 36
             }
         }
+    }
+
+    // Patch : restore text when opening plugin
+    Component.onCompleted: {
+        textLily.text = lyricsSettings.lastLyrics
     }
 
     /*********************************************


### PR DESCRIPTION
This change allows you to save written lyrics in the Lilypond Lyrics plugin interface, preventing them from being overwritten if you add new lyrics later. The plugin detects lyrics and saves them each time you open a score with a sung part.

@igorkorsukov, Is my PR ready to be merged ??