### PR TITLE
Fix frame height not working

### DIFF
--- a/src/inspector/models/notation/frames/verticalframesettingsmodel.h
+++ b/src/inspector/models/notation/frames/verticalframesettingsmodel.h
@@ -19,10 +19,11 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef MU_INSPECTOR_VERTICALFRAMESETTINGSMODEL_H
-#define MU_INSPECTOR_VERTICALFRAMESETTINGSMODEL_H
+#pragma once
 
 #include "models/abstractinspectormodel.h"
+
+#include "engraving/dom/property.h"
 
 namespace mu::inspector {
 class VerticalFrameSettingsModel : public AbstractInspectorModel
@@ -56,6 +57,8 @@ public:
 
 private:
     void createProperties() override;
+    void onFrameHeightSet(const mu::engraving::Pid pid, const QVariant& newValue);
+    void onFrameHeightReset(const mu::engraving::Pid pid);
     void requestElements() override;
     void loadProperties() override;
     void resetProperties() override;
@@ -76,5 +79,3 @@ private:
     PropertyItem* m_paddingToNotationBelow = nullptr;
 };
 }
-
-#endif // MU_INSPECTOR_VERTICALFRAMESETTINGSMODEL_H


### PR DESCRIPTION
Resolves: #20584 

This PR overrides the `onPropertyValueChanged` and `onPropertyValueReset` functions on the `height` property of vertical frames so as to also turn the `BOX_AUTOSIZE` property off/on.

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
