### PR TITLE
Workaround debug assert failure "coreIndex >= 0"

### DIFF
--- a/src/framework/uicomponents/qml/Muse/UiComponents/ListItemBlank.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/ListItemBlank.qml
@@ -19,9 +19,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import QtQuick 2.15
+import QtQuick
 
-import Muse.Ui 1.0
+import Muse.Ui
 
 FocusableControl {
     id: root
@@ -29,7 +29,10 @@ FocusableControl {
     property string hint
 
     property bool isSelected: false
-    property alias radius: root.background.radius
+    // HACK: Workaround debug assert failure "coreIndex >= 0" (https://bugreports.qt.io/browse/QTBUG-124476)
+    //property alias radius: background.radius
+    property double radius: 0
+    background.radius: radius
 
     property color normalColor: "transparent"
     property color hoverHitColor: ui.theme.buttonColor

--- a/src/framework/uicomponents/qml/Muse/UiComponents/internal/StyledDropdownView.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/internal/StyledDropdownView.qml
@@ -222,7 +222,6 @@ DropdownView {
                 width: root.contentWidth
 
                 normalColor: root.itemColor
-                radius: 0
 
                 isSelected: model.index === root.currentIndex
 

--- a/src/notation/qml/MuseScore/NotationScene/internal/EditStyle/ComboBoxDropdown.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/EditStyle/ComboBoxDropdown.qml
@@ -84,7 +84,6 @@ ComboBox {
             width: comboDropdown.contentWidth
 
             normalColor: ui.theme.buttonColor
-            radius: 0
 
             isSelected: model.index === comboDropdown.currentIndex
 


### PR DESCRIPTION
This appears to be a Qt bug which is triggered by a property alias pointing to a property of an item which is referenced via another property alias. (https://bugreports.qt.io/browse/QTBUG-124476)

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
