### PR TITLE
Fix MSVC compiler warnings

### DIFF
--- a/src/importexport/guitarpro/internal/guitarbendimport/benddatacollector.cpp
+++ b/src/importexport/guitarpro/internal/guitarbendimport/benddatacollector.cpp
@@ -251,7 +251,7 @@ void BendDataCollector::fillBendDataContext(BendDataContext& bendDataCtx)
                 for (size_t i = 0; i < notesVec.size(); ++i) {
                     Note* n = notesVec[i];
                     if (auto it = notesData.find(n); it != notesData.end()) {
-                        fillBendDataForNote(bendDataCtx, it->second, i);
+                        fillBendDataForNote(bendDataCtx, it->second, static_cast<int>(i));
                     }
                 }
             }

--- a/src/importexport/guitarpro/internal/guitarbendimport/benddatacollector.cpp
+++ b/src/importexport/guitarpro/internal/guitarbendimport/benddatacollector.cpp
@@ -245,7 +245,7 @@ void BendDataCollector::fillBendDataContext(BendDataContext& bendDataCtx)
                 }
             }
 
-            for (auto& [tick, chordInfo] : chunk) {
+            for (auto& [tack, chordInfo] : chunk) {
                 const auto& notesVec  = chordInfo.chord->notes();
                 const auto& notesData = chordInfo.dataByNote;
                 for (size_t i = 0; i < notesVec.size(); ++i) {

--- a/src/notation/view/internal/staffvisibilitypopupmodel.h
+++ b/src/notation/view/internal/staffvisibilitypopupmodel.h
@@ -46,7 +46,7 @@ class StaffVisibilityPopupModel : public AbstractElementPopupModel, public QQmlP
     Q_INTERFACES(QQmlParserStatus)
 
     Q_PROPERTY(EmptyStavesVisibilityModel * emptyStavesVisibilityModel READ emptyStavesVisibilityModel CONSTANT)
-    Q_PROPERTY(int systemIndex READ systemIndex NOTIFY systemIndexChanged)
+    Q_PROPERTY(size_t systemIndex READ systemIndex NOTIFY systemIndexChanged)
 
 public:
     explicit StaffVisibilityPopupModel(QObject* parent = nullptr);
@@ -54,7 +54,7 @@ public:
     Q_INVOKABLE void init() override;
 
     EmptyStavesVisibilityModel* emptyStavesVisibilityModel() const { return m_emptyStavesVisibilityModel.get(); }
-    int systemIndex() const { return m_systemIndex; }
+    size_t systemIndex() const { return m_systemIndex; }
 
 signals:
     void systemIndexChanged();
@@ -64,7 +64,7 @@ private:
     void componentComplete() override {}
 
     std::unique_ptr<EmptyStavesVisibilityModel> m_emptyStavesVisibilityModel = nullptr;
-    int m_systemIndex = 0;
+    size_t m_systemIndex = 0;
 };
 
 class EmptyStavesVisibilityModel : public QAbstractItemModel, public muse::Injectable


### PR DESCRIPTION
* reg.: conversion from 'size_t' to 'int', possible loss of data (C4267)
* reg.: declaration of 'tick' hides previous local declaration (C4465)