### PR TITLE
Fix #27058: Mute settings are broken in parts whose instruments were deleted and then restored with Undo

### DIFF
--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -700,6 +700,8 @@ void MasterNotation::updateExcerpts()
             excerptNotation->notation()->elements()->msScore()->doLayout();
         }
 
+        initNotationSoloMuteState(excerptNotation->notation());
+
         updatedExcerpts.push_back(excerptNotation);
     }
 

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -1286,7 +1286,11 @@ void PlaybackController::onTrackNewlyAdded(const InstrumentTrackId& instrumentTr
             if (notation == m_notation || notation->soloMuteState()->trackSoloMuteStateExists(instrumentTrackId)) {
                 continue;
             }
-            const INotationSoloMuteState::SoloMuteState soloMuteState = { /*mute*/ true, /*solo*/ false };
+
+            const Part* part = notation->parts()->part(instrumentTrackId.partId);
+            const bool shouldMute = !part || !part->show();
+
+            const INotationSoloMuteState::SoloMuteState soloMuteState = { shouldMute, /*solo*/ false };
             notation->soloMuteState()->setTrackSoloMuteState(instrumentTrackId, soloMuteState);
         }
     }


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/27058