### PR TITLE
Fix null reference error on New Score dialog (QML)

### DIFF
--- a/src/project/qml/MuseScore/Project/internal/NewScore/ChooseInstrumentsAndTemplatesPage.qml
+++ b/src/project/qml/MuseScore/Project/internal/NewScore/ChooseInstrumentsAndTemplatesPage.qml
@@ -72,7 +72,9 @@ Item {
     }
 
     function focusOnSelected() {
-        pageLoader.item.navigation.requestActive()
+        if (pageLoader.item) {
+            pageLoader.item.navigation.requestActive()
+        }
     }
 
     Component.onCompleted: {


### PR DESCRIPTION
Resolves: #29246

When `Create from template` is the active tab on the New Score dialog initially when it appears, `onCurrentItemChanged` is called before `pageLoader` has had a chance to load a component. So when `root.focusOnSelected()` is called from `onCurrentItemChanged`, a null reference exception occurs. `focusOnSelected()` is later called also by `onNavigationActivateRequested` in `NewScoreDialog.qml` when `pageLoader` has loaded a component.

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
