### PR TITLE
Fix stafftype issues

### DIFF
--- a/src/engraving/dom/staff.cpp
+++ b/src/engraving/dom/staff.cpp
@@ -1284,11 +1284,14 @@ void Staff::init(const InstrumentTemplate* t, const StaffType* staffType, int ci
 void Staff::init(const Staff* s)
 {
     m_id                = s->m_id;
+
+    setStaffType(Fraction(0, 1), s->m_staffTypeList.staffType(Fraction(0, 1)));
     for (const auto& stPair : s->m_staffTypeList.staffTypeChanges()) {
         const StaffType& st = stPair.second;
         StaffType newStaffType(st);
         setStaffType(Fraction::fromTicks(stPair.first), newStaffType);
     }
+
     setDefaultClefType(s->defaultClefType());
     m_barLineFrom       = s->m_barLineFrom;
     m_barLineTo         = s->m_barLineTo;

--- a/src/engraving/tests/chordsymbol_data/no-system-ref.mscx
+++ b/src/engraving/tests/chordsymbol_data/no-system-ref.mscx
@@ -236,7 +236,7 @@
           <eid>Y_Y</eid>
           <linkedTo>C_C</linkedTo>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Flute</trackName>
@@ -351,7 +351,7 @@
           <eid>l_l</eid>
           <linkedTo>D_D</linkedTo>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Alto Saxophone</trackName>

--- a/src/engraving/tests/links_data/testPickupLinkedStaff-ref.mscx
+++ b/src/engraving/tests/links_data/testPickupLinkedStaff-ref.mscx
@@ -81,6 +81,7 @@
         <eid>D_D</eid>
         <linkedTo>C_C</linkedTo>
         <StaffType group="pitched">
+          <name>stdNormal</name>
           </StaffType>
         <defaultClef>G8vb</defaultClef>
         </Staff>

--- a/src/engraving/tests/parts_data/part-all-appendmeasures.mscx
+++ b/src/engraving/tests/parts_data/part-all-appendmeasures.mscx
@@ -1133,7 +1133,7 @@
           <eid>zC_zC</eid>
           <linkedTo>C_C</linkedTo>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Alto</trackName>
@@ -1886,7 +1886,7 @@
           <eid>sE_sE</eid>
           <linkedTo>D_D</linkedTo>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Tenor</trackName>

--- a/src/engraving/tests/parts_data/part-all-insertmeasures.mscx
+++ b/src/engraving/tests/parts_data/part-all-insertmeasures.mscx
@@ -1133,7 +1133,7 @@
           <eid>3C_3C</eid>
           <linkedTo>C_C</linkedTo>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Alto</trackName>
@@ -1884,7 +1884,7 @@
           <eid>wE_wE</eid>
           <linkedTo>D_D</linkedTo>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Tenor</trackName>

--- a/src/engraving/tests/parts_data/part-all-parts.mscx
+++ b/src/engraving/tests/parts_data/part-all-parts.mscx
@@ -1114,7 +1114,7 @@
           <eid>wC_wC</eid>
           <linkedTo>C_C</linkedTo>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Alto</trackName>
@@ -1856,7 +1856,7 @@
           <eid>nE_nE</eid>
           <linkedTo>D_D</linkedTo>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Tenor</trackName>

--- a/src/engraving/tests/parts_data/part-all-uappendmeasures.mscx
+++ b/src/engraving/tests/parts_data/part-all-uappendmeasures.mscx
@@ -1114,7 +1114,7 @@
           <eid>zC_zC</eid>
           <linkedTo>C_C</linkedTo>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Alto</trackName>
@@ -1856,7 +1856,7 @@
           <eid>sE_sE</eid>
           <linkedTo>D_D</linkedTo>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Tenor</trackName>

--- a/src/engraving/tests/parts_data/part-all-uinsertmeasures.mscx
+++ b/src/engraving/tests/parts_data/part-all-uinsertmeasures.mscx
@@ -1114,7 +1114,7 @@
           <eid>3C_3C</eid>
           <linkedTo>C_C</linkedTo>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Alto</trackName>
@@ -1856,7 +1856,7 @@
           <eid>wE_wE</eid>
           <linkedTo>D_D</linkedTo>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Tenor</trackName>

--- a/src/engraving/tests/parts_data/part-breath-add.mscx
+++ b/src/engraving/tests/parts_data/part-breath-add.mscx
@@ -847,7 +847,7 @@
         <Staff>
           <eid>6B_6B</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Alto</trackName>
@@ -1292,7 +1292,7 @@
         <Staff>
           <eid>ID_ID</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Tenor</trackName>

--- a/src/engraving/tests/parts_data/part-breath-del.mscx
+++ b/src/engraving/tests/parts_data/part-breath-del.mscx
@@ -843,7 +843,7 @@
         <Staff>
           <eid>5B_5B</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Alto</trackName>
@@ -1288,7 +1288,7 @@
         <Staff>
           <eid>HD_HD</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Tenor</trackName>

--- a/src/engraving/tests/parts_data/part-breath-parts.mscx
+++ b/src/engraving/tests/parts_data/part-breath-parts.mscx
@@ -842,7 +842,7 @@
           <eid>8B_8B</eid>
           <linkedTo>C_C</linkedTo>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Alto</trackName>
@@ -1327,7 +1327,7 @@
           <eid>MD_MD</eid>
           <linkedTo>D_D</linkedTo>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Tenor</trackName>

--- a/src/engraving/tests/parts_data/part-breath-uadd.mscx
+++ b/src/engraving/tests/parts_data/part-breath-uadd.mscx
@@ -843,7 +843,7 @@
         <Staff>
           <eid>5B_5B</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Alto</trackName>
@@ -1288,7 +1288,7 @@
         <Staff>
           <eid>HD_HD</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Tenor</trackName>

--- a/src/engraving/tests/parts_data/part-breath-udel.mscx
+++ b/src/engraving/tests/parts_data/part-breath-udel.mscx
@@ -847,7 +847,7 @@
         <Staff>
           <eid>6B_6B</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Alto</trackName>
@@ -1292,7 +1292,7 @@
         <Staff>
           <eid>ID_ID</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Tenor</trackName>

--- a/src/engraving/tests/parts_data/part-breath-uradd.mscx
+++ b/src/engraving/tests/parts_data/part-breath-uradd.mscx
@@ -847,7 +847,7 @@
         <Staff>
           <eid>6B_6B</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Alto</trackName>
@@ -1292,7 +1292,7 @@
         <Staff>
           <eid>ID_ID</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Tenor</trackName>

--- a/src/engraving/tests/parts_data/part-breath-urdel.mscx
+++ b/src/engraving/tests/parts_data/part-breath-urdel.mscx
@@ -843,7 +843,7 @@
         <Staff>
           <eid>5B_5B</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Alto</trackName>
@@ -1288,7 +1288,7 @@
         <Staff>
           <eid>HD_HD</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Tenor</trackName>

--- a/src/engraving/tests/parts_data/part-chordline-add.mscx
+++ b/src/engraving/tests/parts_data/part-chordline-add.mscx
@@ -847,7 +847,7 @@
         <Staff>
           <eid>6B_6B</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Alto</trackName>
@@ -1292,7 +1292,7 @@
         <Staff>
           <eid>ID_ID</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Tenor</trackName>

--- a/src/engraving/tests/parts_data/part-chordline-del.mscx
+++ b/src/engraving/tests/parts_data/part-chordline-del.mscx
@@ -838,7 +838,7 @@
         <Staff>
           <eid>4B_4B</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Alto</trackName>
@@ -1282,7 +1282,7 @@
         <Staff>
           <eid>GD_GD</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Tenor</trackName>

--- a/src/engraving/tests/parts_data/part-chordline-parts.mscx
+++ b/src/engraving/tests/parts_data/part-chordline-parts.mscx
@@ -828,7 +828,7 @@
           <eid>5B_5B</eid>
           <linkedTo>C_C</linkedTo>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Alto</trackName>
@@ -1301,7 +1301,7 @@
           <eid>HD_HD</eid>
           <linkedTo>D_D</linkedTo>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Tenor</trackName>

--- a/src/engraving/tests/parts_data/part-chordline-uadd.mscx
+++ b/src/engraving/tests/parts_data/part-chordline-uadd.mscx
@@ -843,7 +843,7 @@
         <Staff>
           <eid>5B_5B</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Alto</trackName>
@@ -1288,7 +1288,7 @@
         <Staff>
           <eid>HD_HD</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Tenor</trackName>

--- a/src/engraving/tests/parts_data/part-chordline-udel.mscx
+++ b/src/engraving/tests/parts_data/part-chordline-udel.mscx
@@ -842,7 +842,7 @@
         <Staff>
           <eid>5B_5B</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Alto</trackName>
@@ -1286,7 +1286,7 @@
         <Staff>
           <eid>HD_HD</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Tenor</trackName>

--- a/src/engraving/tests/parts_data/part-chordline-uradd.mscx
+++ b/src/engraving/tests/parts_data/part-chordline-uradd.mscx
@@ -847,7 +847,7 @@
         <Staff>
           <eid>6B_6B</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Alto</trackName>
@@ -1292,7 +1292,7 @@
         <Staff>
           <eid>ID_ID</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Tenor</trackName>

--- a/src/engraving/tests/parts_data/part-chordline-urdel.mscx
+++ b/src/engraving/tests/parts_data/part-chordline-urdel.mscx
@@ -838,7 +838,7 @@
         <Staff>
           <eid>4B_4B</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Alto</trackName>
@@ -1282,7 +1282,7 @@
         <Staff>
           <eid>GD_GD</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Tenor</trackName>

--- a/src/engraving/tests/parts_data/part-empty-parts.mscx
+++ b/src/engraving/tests/parts_data/part-empty-parts.mscx
@@ -829,7 +829,7 @@
           <eid>5B_5B</eid>
           <linkedTo>C_C</linkedTo>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Alto</trackName>
@@ -1303,7 +1303,7 @@
           <eid>HD_HD</eid>
           <linkedTo>D_D</linkedTo>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Tenor</trackName>

--- a/src/engraving/tests/parts_data/part-fingering-add.mscx
+++ b/src/engraving/tests/parts_data/part-fingering-add.mscx
@@ -847,7 +847,7 @@
         <Staff>
           <eid>6B_6B</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Alto</trackName>
@@ -1292,7 +1292,7 @@
         <Staff>
           <eid>ID_ID</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Tenor</trackName>

--- a/src/engraving/tests/parts_data/part-fingering-del.mscx
+++ b/src/engraving/tests/parts_data/part-fingering-del.mscx
@@ -848,7 +848,7 @@
         <Staff>
           <eid>6B_6B</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Alto</trackName>
@@ -1303,7 +1303,7 @@
         <Staff>
           <eid>KD_KD</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Tenor</trackName>

--- a/src/engraving/tests/parts_data/part-fingering-parts.mscx
+++ b/src/engraving/tests/parts_data/part-fingering-parts.mscx
@@ -839,7 +839,7 @@
           <eid>7B_7B</eid>
           <linkedTo>C_C</linkedTo>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Alto</trackName>
@@ -1325,7 +1325,7 @@
           <eid>LD_LD</eid>
           <linkedTo>D_D</linkedTo>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Tenor</trackName>

--- a/src/engraving/tests/parts_data/part-fingering-uadd.mscx
+++ b/src/engraving/tests/parts_data/part-fingering-uadd.mscx
@@ -843,7 +843,7 @@
         <Staff>
           <eid>5B_5B</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Alto</trackName>
@@ -1288,7 +1288,7 @@
         <Staff>
           <eid>HD_HD</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Tenor</trackName>

--- a/src/engraving/tests/parts_data/part-fingering-udel.mscx
+++ b/src/engraving/tests/parts_data/part-fingering-udel.mscx
@@ -853,7 +853,7 @@
         <Staff>
           <eid>7B_7B</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Alto</trackName>
@@ -1308,7 +1308,7 @@
         <Staff>
           <eid>LD_LD</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Tenor</trackName>

--- a/src/engraving/tests/parts_data/part-fingering-uradd.mscx
+++ b/src/engraving/tests/parts_data/part-fingering-uradd.mscx
@@ -847,7 +847,7 @@
         <Staff>
           <eid>6B_6B</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Alto</trackName>
@@ -1292,7 +1292,7 @@
         <Staff>
           <eid>ID_ID</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Tenor</trackName>

--- a/src/engraving/tests/parts_data/part-fingering-urdel.mscx
+++ b/src/engraving/tests/parts_data/part-fingering-urdel.mscx
@@ -848,7 +848,7 @@
         <Staff>
           <eid>6B_6B</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Alto</trackName>
@@ -1303,7 +1303,7 @@
         <Staff>
           <eid>KD_KD</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Tenor</trackName>

--- a/src/engraving/tests/parts_data/part-image-add.mscx
+++ b/src/engraving/tests/parts_data/part-image-add.mscx
@@ -848,7 +848,7 @@
         <Staff>
           <eid>6B_6B</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Alto</trackName>
@@ -1293,7 +1293,7 @@
         <Staff>
           <eid>ID_ID</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Tenor</trackName>

--- a/src/engraving/tests/parts_data/part-image-del.mscx
+++ b/src/engraving/tests/parts_data/part-image-del.mscx
@@ -844,7 +844,7 @@
         <Staff>
           <eid>5B_5B</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Alto</trackName>
@@ -1302,7 +1302,7 @@
         <Staff>
           <eid>JD_JD</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Tenor</trackName>

--- a/src/engraving/tests/parts_data/part-image-parts.mscx
+++ b/src/engraving/tests/parts_data/part-image-parts.mscx
@@ -842,7 +842,7 @@
           <eid>7B_7B</eid>
           <linkedTo>C_C</linkedTo>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Alto</trackName>
@@ -1329,7 +1329,7 @@
           <eid>LD_LD</eid>
           <linkedTo>D_D</linkedTo>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Tenor</trackName>

--- a/src/engraving/tests/parts_data/part-image-uadd.mscx
+++ b/src/engraving/tests/parts_data/part-image-uadd.mscx
@@ -843,7 +843,7 @@
         <Staff>
           <eid>5B_5B</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Alto</trackName>
@@ -1288,7 +1288,7 @@
         <Staff>
           <eid>HD_HD</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Tenor</trackName>

--- a/src/engraving/tests/parts_data/part-image-udel.mscx
+++ b/src/engraving/tests/parts_data/part-image-udel.mscx
@@ -856,7 +856,7 @@
         <Staff>
           <eid>7B_7B</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Alto</trackName>
@@ -1314,7 +1314,7 @@
         <Staff>
           <eid>LD_LD</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Tenor</trackName>

--- a/src/engraving/tests/parts_data/part-image-uradd.mscx
+++ b/src/engraving/tests/parts_data/part-image-uradd.mscx
@@ -848,7 +848,7 @@
         <Staff>
           <eid>6B_6B</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Alto</trackName>
@@ -1293,7 +1293,7 @@
         <Staff>
           <eid>ID_ID</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Tenor</trackName>

--- a/src/engraving/tests/parts_data/part-image-urdel.mscx
+++ b/src/engraving/tests/parts_data/part-image-urdel.mscx
@@ -844,7 +844,7 @@
         <Staff>
           <eid>5B_5B</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Alto</trackName>
@@ -1302,7 +1302,7 @@
         <Staff>
           <eid>JD_JD</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Tenor</trackName>

--- a/src/engraving/tests/parts_data/part-measure-repeat-add.mscx
+++ b/src/engraving/tests/parts_data/part-measure-repeat-add.mscx
@@ -860,7 +860,7 @@
         <Staff>
           <eid>8B_8B</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Alto</trackName>
@@ -1305,7 +1305,7 @@
         <Staff>
           <eid>KD_KD</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Tenor</trackName>

--- a/src/engraving/tests/parts_data/part-measure-repeat-del.mscx
+++ b/src/engraving/tests/parts_data/part-measure-repeat-del.mscx
@@ -865,7 +865,7 @@
         <Staff>
           <eid>+B_+B</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Alto</trackName>
@@ -1311,7 +1311,7 @@
         <Staff>
           <eid>MD_MD</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Tenor</trackName>

--- a/src/engraving/tests/parts_data/part-measure-repeat-parts.mscx
+++ b/src/engraving/tests/parts_data/part-measure-repeat-parts.mscx
@@ -867,7 +867,7 @@
           <eid>/B_/B</eid>
           <linkedTo>C_C</linkedTo>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Alto</trackName>
@@ -1351,7 +1351,7 @@
           <eid>ND_ND</eid>
           <linkedTo>D_D</linkedTo>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Tenor</trackName>

--- a/src/engraving/tests/parts_data/part-measure-repeat-uadd.mscx
+++ b/src/engraving/tests/parts_data/part-measure-repeat-uadd.mscx
@@ -843,7 +843,7 @@
         <Staff>
           <eid>5B_5B</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Alto</trackName>
@@ -1288,7 +1288,7 @@
         <Staff>
           <eid>HD_HD</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Tenor</trackName>

--- a/src/engraving/tests/parts_data/part-measure-repeat-udel.mscx
+++ b/src/engraving/tests/parts_data/part-measure-repeat-udel.mscx
@@ -872,7 +872,7 @@
         <Staff>
           <eid>/B_/B</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Alto</trackName>
@@ -1318,7 +1318,7 @@
         <Staff>
           <eid>ND_ND</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Tenor</trackName>

--- a/src/engraving/tests/parts_data/part-measure-repeat-uradd.mscx
+++ b/src/engraving/tests/parts_data/part-measure-repeat-uradd.mscx
@@ -860,7 +860,7 @@
         <Staff>
           <eid>8B_8B</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Alto</trackName>
@@ -1305,7 +1305,7 @@
         <Staff>
           <eid>KD_KD</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Tenor</trackName>

--- a/src/engraving/tests/parts_data/part-measure-repeat-urdel.mscx
+++ b/src/engraving/tests/parts_data/part-measure-repeat-urdel.mscx
@@ -865,7 +865,7 @@
         <Staff>
           <eid>+B_+B</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Alto</trackName>
@@ -1311,7 +1311,7 @@
         <Staff>
           <eid>MD_MD</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Tenor</trackName>

--- a/src/engraving/tests/parts_data/part-symbol-add.mscx
+++ b/src/engraving/tests/parts_data/part-symbol-add.mscx
@@ -847,7 +847,7 @@
         <Staff>
           <eid>6B_6B</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Alto</trackName>
@@ -1292,7 +1292,7 @@
         <Staff>
           <eid>ID_ID</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Tenor</trackName>

--- a/src/engraving/tests/parts_data/part-symbol-del.mscx
+++ b/src/engraving/tests/parts_data/part-symbol-del.mscx
@@ -843,7 +843,7 @@
         <Staff>
           <eid>5B_5B</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Alto</trackName>
@@ -1292,7 +1292,7 @@
         <Staff>
           <eid>ID_ID</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Tenor</trackName>

--- a/src/engraving/tests/parts_data/part-symbol-parts.mscx
+++ b/src/engraving/tests/parts_data/part-symbol-parts.mscx
@@ -833,7 +833,7 @@
           <eid>6B_6B</eid>
           <linkedTo>C_C</linkedTo>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Alto</trackName>
@@ -1312,7 +1312,7 @@
           <eid>JD_JD</eid>
           <linkedTo>D_D</linkedTo>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Tenor</trackName>

--- a/src/engraving/tests/parts_data/part-symbol-uadd.mscx
+++ b/src/engraving/tests/parts_data/part-symbol-uadd.mscx
@@ -843,7 +843,7 @@
         <Staff>
           <eid>5B_5B</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Alto</trackName>
@@ -1288,7 +1288,7 @@
         <Staff>
           <eid>HD_HD</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Tenor</trackName>

--- a/src/engraving/tests/parts_data/part-symbol-udel.mscx
+++ b/src/engraving/tests/parts_data/part-symbol-udel.mscx
@@ -847,7 +847,7 @@
         <Staff>
           <eid>6B_6B</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Alto</trackName>
@@ -1296,7 +1296,7 @@
         <Staff>
           <eid>JD_JD</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Tenor</trackName>

--- a/src/engraving/tests/parts_data/part-symbol-uradd.mscx
+++ b/src/engraving/tests/parts_data/part-symbol-uradd.mscx
@@ -847,7 +847,7 @@
         <Staff>
           <eid>6B_6B</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Alto</trackName>
@@ -1292,7 +1292,7 @@
         <Staff>
           <eid>ID_ID</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Tenor</trackName>

--- a/src/engraving/tests/parts_data/part-symbol-urdel.mscx
+++ b/src/engraving/tests/parts_data/part-symbol-urdel.mscx
@@ -843,7 +843,7 @@
         <Staff>
           <eid>5B_5B</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Alto</trackName>
@@ -1292,7 +1292,7 @@
         <Staff>
           <eid>ID_ID</eid>
           <StaffType group="pitched">
-            <name>stdNormal</name>
+            <name>Standard</name>
             </StaffType>
           </Staff>
         <trackName>Tenor</trackName>


### PR DESCRIPTION
Resolves: #29144 

The first `StaffType` isn't included in `StaffTypeList::staffTypeChanges` so must be copied separately
