### PR TITLE
Prevent crash on corrupted links when reading files

### DIFF
--- a/src/engraving/rw/read460/tread.cpp
+++ b/src/engraving/rw/read460/tread.cpp
@@ -578,7 +578,16 @@ void TRead::readItemLink(EngravingItem* item, XmlReader& xml, ReadContext& ctx)
     DO_ASSERT(eid.isValid());
     EIDRegister* eidRegister = ctx.score()->masterScore()->eidRegister();
     EngravingObject* mainElement = eidRegister->itemFromEID(eid);
-    DO_ASSERT(mainElement && mainElement->type() == item->type());
+    IF_ASSERT_FAILED(mainElement) {
+        LOGE() << "Link failed: Main linked element not found for " << item->typeName() << " at " << ctx.tick().toString();
+        return;
+    }
+    IF_ASSERT_FAILED(mainElement->type() == item->type()) {
+        LOGE() << "Link failed: Main element type (" << mainElement->typeName() << ") does not match linked item type (" <<
+            item->typeName() << ") at " << ctx.tick().toString();
+        return;
+    }
+
     item->linkTo(mainElement);
 }
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/29339
Resolves crash when reading corrupted links
