### PR TITLE
Only start edit mode when clicking on already single-selected element

### DIFF
--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -797,7 +797,7 @@ void NotationViewInputController::mousePress_considerSelect(const ClickContext& 
         return;
     }
 
-    m_hitElementWasAlreadySelected = ctx.hitElement->selected();
+    m_hitElementWasAlreadySingleSelected = ctx.hitElement == viewInteraction()->selection()->element();
 
     if (ctx.event->button() == Qt::LeftButton) {
         if (ctx.event->modifiers() & Qt::ControlModifier) {
@@ -1193,7 +1193,7 @@ void NotationViewInputController::handleLeftClickRelease(const QPointF& releaseP
         }
     }
 
-    if (!m_hitElementWasAlreadySelected) {
+    if (!m_hitElementWasAlreadySingleSelected) {
         return;
     }
 

--- a/src/notation/view/notationviewinputcontroller.h
+++ b/src/notation/view/notationviewinputcontroller.h
@@ -235,7 +235,7 @@ private:
 
     const mu::engraving::EngravingItem* m_prevSelectedElement = nullptr;
 
-    bool m_hitElementWasAlreadySelected = false;
+    bool m_hitElementWasAlreadySingleSelected = false;
     bool m_shouldSelectOnLeftClickRelease = false;
     bool m_shouldStartEditOnLeftClickRelease = false;
 };


### PR DESCRIPTION
Not just already selected, but specifically single-selected.

Resolves: https://github.com/musescore/MuseScore/issues/29272