### PR TITLE
Fix #29221: Only show welcome dialog in one instance of MuseScore Studio

### DIFF
--- a/src/appshell/internal/startupscenario.cpp
+++ b/src/appshell/internal/startupscenario.cpp
@@ -327,7 +327,8 @@ void StartupScenario::onStartupPageOpened(StartupModeType modeType)
         configuration()->setWelcomeDialogLastShownIndex(-1); // reset
     }
 
-    if (configuration()->welcomeDialogShowOnStartup() && !museSoundsUpdateScenario()->hasUpdate()) {
+    const size_t numInstances = multiInstancesProvider()->instances().size();
+    if (numInstances == 1 && configuration()->welcomeDialogShowOnStartup() && !museSoundsUpdateScenario()->hasUpdate()) {
         showWelcomeDialog();
     }
 


### PR DESCRIPTION
Resolves: #29221