### PR TITLE
Fix #28379: Hairpin not being selected by opt+Left

### DIFF
--- a/src/engraving/dom/navigate.cpp
+++ b/src/engraving/dom/navigate.cpp
@@ -989,7 +989,7 @@ EngravingItem* Score::prevElement()
             if (previousElement->type() != ElementType::VBOX
                 && previousElement->type() != ElementType::HBOX
                 && previousElement->type() != ElementType::TBOX
-                && previousElement->type() == ElementType::FBOX) {
+                && previousElement->type() != ElementType::FBOX) {
                 return previousElement;
             }
 

--- a/src/engraving/dom/segment.cpp
+++ b/src/engraving/dom/segment.cpp
@@ -2273,14 +2273,19 @@ EngravingItem* Segment::prevElement(staff_idx_t activeStaff)
             }
         }
 
-        EngravingItem* prev = nullptr;
+        EngravingItem* prevAnnotation = nullptr;
         if (e->explicitParent() == this) {
-            prev = prevAnnotation(e);
+            prevAnnotation = this->prevAnnotation(e);
+        }
+        if (prevAnnotation) {
+            return prevAnnotation;
+        } else if (const Segment* prevSeg = prev1()) {
+            const Spanner* s = prevSeg->lastSpanner(activeStaff);
+            if (s) {
+                return s->spannerSegments().back();
+            }
         }
 
-        if (prev) {
-            return prev;
-        }
         if (notChordRestType()) {
             EngravingItem* lastEl = lastElementOfSegment(activeStaff);
             if (lastEl) {


### PR DESCRIPTION
Resolves: #28379

There are a few ways to approach this (e.g. we could use `Dynamic::leftHairpin`) but the solution I've gone for here is to mirror some missing logic that we already have in `Segment:nextElement`.

This issue highlights a problem we have with `nextElement`/`prevElement`. It certainly feels like there's a solution out there that prevents the need for this mirroring/duplication (probably quite a big/risky undertaking though).