### PR TITLE
moveElementSelection: only start editing when selected element wants it

### DIFF
--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -1712,8 +1712,6 @@ void NotationActionController::startEditSelectedElement(const ActionData& args)
     if (interaction->textEditingAllowed(element)) {
         PointF cursorPos = !args.empty() ? args.arg<PointF>(0) : PointF();
         interaction->startEditText(element, cursorPos);
-    } else if (element->hasGrips()) {
-        interaction->startEditGrip(element, element->defaultGrip());
     } else {
         interaction->startEditElement(element);
     }

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -4084,8 +4084,8 @@ void NotationInteraction::moveElementSelection(MoveDirection d)
         score()->setPlayNote(true);
     }
 
-    if (toEl->hasGrips()) {
-        startEditGrip(toEl, toEl->defaultGrip());
+    if (toEl->needStartEditingAfterSelecting()) {
+        startEditElement(toEl);
     }
 }
 
@@ -4594,7 +4594,7 @@ bool NotationInteraction::isElementEditStarted() const
 
 void NotationInteraction::startEditElement(EngravingItem* element)
 {
-    if (!element) {
+    if (!element || !element->isEditable()) {
         return;
     }
 
@@ -4604,7 +4604,9 @@ void NotationInteraction::startEditElement(EngravingItem* element)
 
     if (element->isTextBase()) {
         startEditText(element);
-    } else if (element->isEditable()) {
+    } else if (element->hasGrips() && !element->isImage()) {
+        startEditGrip(element, element->defaultGrip());
+    } else {
         element->startEdit(m_editData);
         m_editData.element = element;
     }

--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -898,11 +898,7 @@ void NotationViewInputController::handleLeftClick(const ClickContext& ctx)
     // If it is the only selected element, start editing if needed
     if (ctx.hitElement == viewInteraction()->selection()->element()
         && ctx.hitElement->needStartEditingAfterSelecting()) {
-        if (ctx.hitElement->hasGrips() && !ctx.hitElement->isImage()) {
-            viewInteraction()->startEditGrip(ctx.hitElement, ctx.hitElement->defaultGrip());
-        } else {
-            viewInteraction()->startEditElement(ctx.hitElement);
-        }
+        viewInteraction()->startEditElement(ctx.hitElement);
     }
 
     if (ctx.hitElement->isPlayable()) {


### PR DESCRIPTION
Since https://github.com/musescore/MuseScore/pull/28794/commits/b5dc6004c1d75ef1465641515286a5ac75fdf75e, it would cause text editing to be started, since `Dynamic::defaultGrip` (==`EngravingItem::defaultGrip`) (intentionally) returns NO_GRIP.

Resolves: https://github.com/musescore/MuseScore/issues/29286

(The change in `NotationInteraction::startEditGrip` is not great, but I don't see a better way at the moment)