### PR TITLE
Refine behaviour of Alt+click to paste range

### DIFF
--- a/src/engraving/dom/anchors.cpp
+++ b/src/engraving/dom/anchors.cpp
@@ -80,7 +80,7 @@ void EditTimeTickAnchors::updateAnchors(const EngravingItem* item)
     item->triggerLayout();
 }
 
-void EditTimeTickAnchors::updateAnchors(Measure* measure, staff_idx_t staffIdx)
+void EditTimeTickAnchors::updateAnchors(Measure* measure, staff_idx_t staffIdx, const std::set<Fraction>& additionalAnchorRelTicks)
 {
     Fraction startTick = Fraction(0, 1);
     Fraction endTick = measure->ticks();
@@ -88,7 +88,7 @@ void EditTimeTickAnchors::updateAnchors(Measure* measure, staff_idx_t staffIdx)
     Fraction timeSig = measure->timesig();
     Fraction halfDivision = Fraction(1, 2 * timeSig.denominator());
 
-    std::set<Fraction> anchorTicks;
+    std::set<Fraction> anchorTicks { additionalAnchorRelTicks };
     for (Fraction tick = startTick; tick <= endTick; tick += halfDivision) {
         anchorTicks.insert(tick);
     }

--- a/src/engraving/dom/anchors.h
+++ b/src/engraving/dom/anchors.h
@@ -20,8 +20,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef MU_ENGRAVING_ANCHORS_H
-#define MU_ENGRAVING_ANCHORS_H
+#pragma once
 
 #include "engravingitem.h"
 #include "score.h"
@@ -33,7 +32,7 @@ class EditTimeTickAnchors
 {
 public:
     static void updateAnchors(const EngravingItem* item);
-    static void updateAnchors(Measure* measure, staff_idx_t staffIdx);
+    static void updateAnchors(Measure* measure, staff_idx_t staffIdx, const std::set<Fraction>& additionalAnchorRelTicks = {});
     static TimeTickAnchor* createTimeTickAnchor(Measure* measure, Fraction relTick, staff_idx_t staffIdx);
     static void updateLayout(Measure* measure);
 };
@@ -90,5 +89,4 @@ public:
     };
     DECLARE_LAYOUTDATA_METHODS(TimeTickAnchor)
 };
-} // namespace mu::engraving
-#endif // MU_ENGRAVING_ANCHORS_H
+}

--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -727,42 +727,15 @@ Measure* Score::pos2measure(const PointF& p, staff_idx_t* rst, int* pitch, Segme
 ///              \b output: new segment for drag position
 //---------------------------------------------------------
 
-void Score::dragPosition(const PointF& p, staff_idx_t* rst, Segment** seg, double spacingFactor, bool allowTimeAnchor) const
+void Score::dragPosition(const PointF& pos, staff_idx_t* rst, Segment** seg, double spacingFactor, bool allowTimeAnchor) const
 {
-    const System* preferredSystem = (*seg) ? (*seg)->system() : nullptr;
-    Measure* m = searchMeasure(p, preferredSystem, spacingFactor);
-    if (m == 0 || m->isMMRest()) {
+    Measure* m = nullptr;
+
+    if (!dragPositionToMeasure(pos, this, &m, rst, spacingFactor)) {
         return;
     }
 
-    System* s = m->system();
-    double y   = p.y() - s->canvasPos().y();
-
-    const staff_idx_t i = s->searchStaff(y, *rst, spacingFactor);
-
-    // search for segment + offset
-    PointF pppp = p - m->canvasPos();
-    track_idx_t strack = staff2track(i);
-    if (!staff(i)) {
-        return;
-    }
-    track_idx_t etrack = staff2track(i + 1);
-
-    SegmentType st = allowTimeAnchor ? Segment::CHORD_REST_OR_TIME_TICK_TYPE : SegmentType::ChordRest;
-    Segment* segment = m->searchSegment(pppp.x(), st, strack, etrack, *seg, spacingFactor);
-    if (segment) {
-        if (segment->isTimeTickType()) {
-            if (Segment* crAtSamePos = m->findSegmentR(SegmentType::ChordRest, segment->rtick())) {
-                // If TimeTick and ChordRest at same position, prefer ChordRest
-                segment = crAtSamePos;
-            }
-        }
-        *rst = i;
-        *seg = segment;
-        return;
-    }
-
-    return;
+    dragPositionToSegment(pos, m, *rst, seg, spacingFactor, allowTimeAnchor);
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/utils.cpp
+++ b/src/engraving/dom/utils.cpp
@@ -1264,6 +1264,63 @@ Fraction actualTicks(Fraction duration, Tuplet* tuplet, Fraction timeStretch)
     return f;
 }
 
+bool dragPositionToMeasure(const PointF& pos, const Score* score,
+                           Measure** measure, staff_idx_t* staffIdx,
+                           const double spacingFactor)
+{
+    const System* preferredSystem = (*measure) ? (*measure)->system() : nullptr;
+
+    Measure* m = score->searchMeasure(pos, preferredSystem, spacingFactor);
+    if (!m) {
+        return false;
+    }
+
+    const System* system = m->system();
+    const double y = pos.y() - system->canvasPos().y();
+    const staff_idx_t i = system->searchStaff(y, *staffIdx, spacingFactor);
+    if (!score->staff(i)) {
+        return false;
+    }
+
+    *measure = m;
+    *staffIdx = i;
+    return true;
+}
+
+bool dragPositionToSegment(const PointF& pos, const Measure* measure, const staff_idx_t staffIdx,
+                           Segment** segment,
+                           const double spacingFactor, const bool allowTimeAnchor)
+{
+    const track_idx_t strack = staffIdx * VOICES;
+    const track_idx_t etrack = strack + VOICES;
+
+    const double x = pos.x() - measure->canvasPos().x();
+    const SegmentType st = allowTimeAnchor ? Segment::CHORD_REST_OR_TIME_TICK_TYPE : SegmentType::ChordRest;
+    Segment* s = measure->searchSegment(x, st, strack, etrack, *segment, spacingFactor);
+    if (!s) {
+        return false;
+    }
+
+    *segment = segmentOrChordRestSegmentAtSameTick(s);
+    return true;
+}
+
+Segment* segmentOrChordRestSegmentAtSameTick(Segment* segment)
+{
+    IF_ASSERT_FAILED(segment) {
+        return nullptr;
+    }
+
+    // If TimeTick and ChordRest segments are at the same tick, prefer ChordRest
+    if (segment->isTimeTickType() && segment->measure()) {
+        if (Segment* crSegAtSameTick = segment->measure()->findSegmentR(SegmentType::ChordRest, segment->rtick())) {
+            return crSegAtSameTick;
+        }
+    }
+
+    return segment;
+}
+
 double yStaffDifference(const System* system1, const System* system2, staff_idx_t staffIdx)
 {
     if (!system1 || !system2) {

--- a/src/engraving/dom/utils.h
+++ b/src/engraving/dom/utils.h
@@ -94,6 +94,12 @@ extern Segment* skipTuplet(Tuplet* tuplet);
 extern SymIdList timeSigSymIdsFromString(const String&, TimeSigStyle timeSigStyle = TimeSigStyle::NORMAL);
 extern Fraction actualTicks(Fraction duration, Tuplet* tuplet, Fraction timeStretch);
 
+extern bool dragPositionToMeasure(const PointF& pos, const Score* score, Measure** measure, staff_idx_t* staffIdx,
+                                  const double spacingFactor = 0.5);
+extern bool dragPositionToSegment(const PointF& pos, const Measure* measure, const staff_idx_t staffIdx, Segment** segment,
+                                  const double spacingFactor = 0.5, const bool allowTimeAnchor = false);
+extern Segment* segmentOrChordRestSegmentAtSameTick(Segment* segment);
+
 extern double yStaffDifference(const System* system1, const System* system2, staff_idx_t staffIdx1);
 
 extern bool allowRemoveWhenRemovingStaves(EngravingItem* item, staff_idx_t startStaff, staff_idx_t endStaff = 0);

--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -109,10 +109,10 @@ public:
     virtual bool startDropSingle(const QByteArray& edata) = 0;
     virtual bool startDropRange(const QByteArray& data) = 0;
     virtual bool startDropRange(const Fraction& sourceTick, const Fraction& tickLength, engraving::staff_idx_t sourceStaffIdx,
-                                size_t numStaves) = 0;
+                                size_t numStaves, bool preserveMeasureAlignment) = 0;
     virtual bool startDropImage(const QUrl& url) = 0;
     virtual bool updateDropSingle(const muse::PointF& pos, Qt::KeyboardModifiers modifiers) = 0; //! NOTE Also may set drop target
-    virtual bool updateDropRange(const muse::PointF& pos) = 0;
+    virtual bool updateDropRange(const muse::PointF& pos, std::optional<bool> preserveMeasureAlignment = std::nullopt) = 0;
     virtual bool dropSingle(const muse::PointF& pos, Qt::KeyboardModifiers modifiers) = 0;
     virtual bool dropRange(const QByteArray& data, const muse::PointF& pos, bool deleteSourceMaterial) = 0;
     virtual void setDropTarget(EngravingItem* item, bool notify = true) = 0;

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -119,11 +119,11 @@ public:
     // Drop
     bool startDropSingle(const QByteArray& edata) override;
     bool startDropRange(const QByteArray& data) override;
-    bool startDropRange(const Fraction& sourceTick, const Fraction& tickLength, engraving::staff_idx_t sourceStaffIdx,
-                        size_t numStaves) override;
+    bool startDropRange(const Fraction& sourceTick, const Fraction& tickLength, engraving::staff_idx_t sourceStaffIdx, size_t numStaves,
+                        bool preserveMeasureAlignment) override;
     bool startDropImage(const QUrl& url) override;
     bool updateDropSingle(const muse::PointF& pos, Qt::KeyboardModifiers modifiers) override;
-    bool updateDropRange(const muse::PointF& pos) override;
+    bool updateDropRange(const muse::PointF& pos, std::optional<bool> preserveMeasureAlignment = std::nullopt) override;
     bool dropSingle(const muse::PointF& pos, Qt::KeyboardModifiers modifiers) override;
     bool dropRange(const QByteArray& data, const muse::PointF& pos, bool deleteSourceMaterial) override;
     void setDropTarget(EngravingItem* item, bool notify = true) override;
@@ -494,6 +494,8 @@ private:
 
         engraving::Fraction tickLength;
         size_t numStaves = 0;
+
+        bool preserveMeasureAlignment = false;
 
         engraving::Segment* targetSegment = nullptr;
         engraving::staff_idx_t targetStaffIdx = 0;

--- a/src/notation/tests/mocks/notationinteractionmock.h
+++ b/src/notation/tests/mocks/notationinteractionmock.h
@@ -74,10 +74,10 @@ public:
 
     MOCK_METHOD(bool, startDropSingle, (const QByteArray&), (override));
     MOCK_METHOD(bool, startDropRange, (const QByteArray&), (override));
-    MOCK_METHOD(bool, startDropRange, (const Fraction&, const Fraction&, engraving::staff_idx_t, size_t), (override));
+    MOCK_METHOD(bool, startDropRange, (const Fraction&, const Fraction&, engraving::staff_idx_t, size_t, bool), (override));
     MOCK_METHOD(bool, startDropImage, (const QUrl&), (override));
     MOCK_METHOD(bool, updateDropSingle, (const muse::PointF&, Qt::KeyboardModifiers), (override));
-    MOCK_METHOD(bool, updateDropRange, (const muse::PointF&), (override));
+    MOCK_METHOD(bool, updateDropRange, (const muse::PointF&, std::optional<bool>), (override));
     MOCK_METHOD(bool, dropSingle, (const muse::PointF&, Qt::KeyboardModifiers), (override));
     MOCK_METHOD(bool, dropRange, (const QByteArray&, const muse::PointF&, bool), (override));
     MOCK_METHOD(void, setDropTarget, (EngravingItem*, bool), (override));

--- a/src/notation/utilities/scorerangeutilities.cpp
+++ b/src/notation/utilities/scorerangeutilities.cpp
@@ -102,7 +102,7 @@ std::vector<ScoreRangeUtilities::RangeSection> ScoreRangeUtilities::splitRangeBy
         const System* currentSegmentSystem = segment->measure()->system();
 
         const Segment* nextSegment = segment->next1MMenabled();
-        while (nextSegment && !nextSegment->isActive()) {
+        while (nextSegment && !nextSegment->visible()) {
             nextSegment = nextSegment->next1MMenabled();
         }
 

--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -778,7 +778,8 @@ bool NotationViewInputController::mousePress_considerStartPasteRangeOnRelease(co
     const engraving::staff_idx_t sourceStaffIdx = range->startStaffIndex();
     const size_t numStaves = range->endStaffIndex() - range->startStaffIndex();
 
-    const bool started = viewInteraction()->startDropRange(sourceTick, tickLength, sourceStaffIdx, numStaves);
+    const bool started = viewInteraction()->startDropRange(sourceTick, tickLength, sourceStaffIdx, numStaves,
+                                                           /*preserveMeasureAlignment=*/ true);
     if (!started) {
         return false;
     }
@@ -1009,7 +1010,13 @@ void NotationViewInputController::mouseMoveEvent(QMouseEvent* event)
     }
     case MouseDownInfo::PasteRangeOnRelease: {
         const PointF logicPos = m_view->toLogical(event->pos());
-        const bool canDrop = viewInteraction()->updateDropRange(logicPos);
+
+        std::optional<bool> preserveMeasureAlignment;
+        if (physicalDragDelta.manhattanLength() > 4) {
+            preserveMeasureAlignment = false;
+        }
+
+        const bool canDrop = viewInteraction()->updateDropRange(logicPos, preserveMeasureAlignment);
         m_view->asItem()->setCursor(canDrop ? Qt::DragCopyCursor : QCursor());
         return;
     }


### PR DESCRIPTION
* When you press the mouse down, the pasted range will initially be placed at the same measure alignment as the source material
* When you then start moving, the position of the mouse becomes the start position for the pasted range.