### PR TITLE
tests: Silence gMock warnings

### DIFF
--- a/src/framework/accessibility/tests/accessibilitycontroller_tests.cpp
+++ b/src/framework/accessibility/tests/accessibilitycontroller_tests.cpp
@@ -20,7 +20,6 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include <gmock/gmock.h>
-#include <gtest/gtest.h>
 
 #include <memory>
 
@@ -45,10 +44,11 @@
 
 class QEvent;
 
-using ::testing::Return;
 using ::testing::_;
-using ::testing::SaveArg;
 using ::testing::DoAll;
+using ::testing::NiceMock;
+using ::testing::Return;
+using ::testing::SaveArg;
 
 using namespace muse;
 using namespace muse::accessibility;
@@ -63,13 +63,13 @@ public:
 
         m_controller->setAccesibilityEnabled(true);
 
-        m_mainWindow = std::make_shared<muse::ui::MainWindowMock>();
+        m_mainWindow = std::make_shared<NiceMock<muse::ui::MainWindowMock> >();
         m_controller->mainWindow.set(m_mainWindow);
 
-        m_application = std::make_shared<ApplicationMock>();
+        m_application = std::make_shared<NiceMock<ApplicationMock> >();
         m_controller->application.set(m_application);
 
-        m_configuration = std::make_shared<AccessibilityConfigurationMock>();
+        m_configuration = std::make_shared<NiceMock<AccessibilityConfigurationMock> >();
         m_controller->configuration.set(m_configuration);
     }
 

--- a/src/framework/audioplugins/tests/knownaudiopluginsregistertest.cpp
+++ b/src/framework/audioplugins/tests/knownaudiopluginsregistertest.cpp
@@ -19,8 +19,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
-#include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 #include "global/serialization/json.h"
 
@@ -30,6 +29,7 @@
 #include "mocks/audiopluginsconfigurationmock.h"
 
 using ::testing::_;
+using ::testing::NiceMock;
 using ::testing::Return;
 
 using namespace muse;
@@ -44,8 +44,8 @@ protected:
     void SetUp() override
     {
         m_knownPlugins = std::make_shared<KnownAudioPluginsRegister>(modularity::globalCtx());
-        m_fileSystem = std::make_shared<FileSystemMock>();
-        m_configuration = std::make_shared<AudioPluginsConfigurationMock>();
+        m_fileSystem = std::make_shared<NiceMock<FileSystemMock> >();
+        m_configuration = std::make_shared<NiceMock<AudioPluginsConfigurationMock> >();
 
         m_knownPlugins->fileSystem.set(m_fileSystem);
         m_knownPlugins->configuration.set(m_configuration);

--- a/src/framework/audioplugins/tests/registeraudiopluginsscenariotest.cpp
+++ b/src/framework/audioplugins/tests/registeraudiopluginsscenariotest.cpp
@@ -19,8 +19,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
-#include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 #include "audioplugins/internal/registeraudiopluginsscenario.h"
 
@@ -36,6 +35,7 @@
 #include "translation.h"
 
 using ::testing::_;
+using ::testing::NiceMock;
 using ::testing::Return;
 using ::testing::ReturnRef;
 
@@ -51,15 +51,15 @@ protected:
     void SetUp() override
     {
         m_scenario = std::make_shared<RegisterAudioPluginsScenario>(modularity::globalCtx());
-        m_globalConfiguration = std::make_shared<GlobalConfigurationMock>();
+        m_globalConfiguration = std::make_shared<NiceMock<GlobalConfigurationMock> >();
         m_interactive = std::make_shared<InteractiveMock>();
         m_process = std::make_shared<ProcessMock>();
-        m_scannerRegister = std::make_shared<AudioPluginsScannerRegisterMock>();
-        m_knownPlugins = std::make_shared<KnownAudioPluginsRegisterMock>();
-        m_scanners = { std::make_shared<AudioPluginsScannerMock>() };
-        m_metaReaderRegister = std::make_shared<AudioPluginMetaReaderRegisterMock>();
+        m_scannerRegister = std::make_shared<NiceMock<AudioPluginsScannerRegisterMock> >();
+        m_knownPlugins = std::make_shared<NiceMock<KnownAudioPluginsRegisterMock> >();
+        m_scanners = { std::make_shared<NiceMock<AudioPluginsScannerMock> >() };
+        m_metaReaderRegister = std::make_shared<NiceMock<AudioPluginMetaReaderRegisterMock> >();
 
-        const auto metaReaderMock = std::make_shared<AudioPluginMetaReaderMock>();
+        const auto metaReaderMock = std::make_shared<NiceMock<AudioPluginMetaReaderMock> >();
         m_metaReaders = { metaReaderMock };
 
         m_scenario->globalConfiguration.set(m_globalConfiguration);

--- a/src/framework/update/tests/updateservice_tests.cpp
+++ b/src/framework/update/tests/updateservice_tests.cpp
@@ -19,13 +19,12 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
-#include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
 #include <QIODevice>
 
 using ::testing::_;
+using ::testing::NiceMock;
 using ::testing::Return;
 
 #include "framework/network/networktypes.h"
@@ -53,17 +52,17 @@ public:
     {
         m_service = new AppUpdateService(muse::modularity::globalCtx());
 
-        m_configuration = std::make_shared<UpdateConfigurationMock>();
+        m_configuration = std::make_shared<NiceMock<UpdateConfigurationMock> >();
         m_service->configuration.set(m_configuration);
 
-        m_networkManagerCreator = std::make_shared<muse::network::NetworkManagerCreatorMock>();
+        m_networkManagerCreator = std::make_shared<NiceMock<muse::network::NetworkManagerCreatorMock> >();
         m_service->networkManagerCreator.set(m_networkManagerCreator);
 
         m_networkManager = std::make_shared<muse::network::NetworkManagerMock>();
         ON_CALL(*m_networkManagerCreator, makeNetworkManager())
         .WillByDefault(Return(m_networkManager));
 
-        m_systemInfoMock = std::make_shared<SystemInfoMock>();
+        m_systemInfoMock = std::make_shared<NiceMock<SystemInfoMock> >();
         m_service->systemInfo.set(m_systemInfoMock);
 
         ON_CALL(*m_systemInfoMock, productType())

--- a/src/notation/tests/notationviewinputcontroller_tests.cpp
+++ b/src/notation/tests/notationviewinputcontroller_tests.cpp
@@ -19,8 +19,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
-#include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
 #include "mocks/controlledviewmock.h"
@@ -35,6 +33,7 @@
 #include "notation/view/notationviewinputcontroller.h"
 
 using ::testing::_;
+using ::testing::NiceMock;
 using ::testing::Return;
 using ::testing::ReturnRef;
 
@@ -50,13 +49,13 @@ public:
 
     void SetUp() override
     {
-        m_interaction = std::make_shared<NotationInteractionMock>();
+        m_interaction = std::make_shared<NiceMock<NotationInteractionMock> >();
 
-        m_selection = std::make_shared<NotationSelectionMock>();
+        m_selection = std::make_shared<NiceMock<NotationSelectionMock> >();
         ON_CALL(*m_interaction, selection())
         .WillByDefault(Return(m_selection));
 
-        m_selectionRange = std::make_shared<NotationSelectionRangeMock>();
+        m_selectionRange = std::make_shared<NiceMock<NotationSelectionRangeMock> >();
         ON_CALL(*m_selection, range())
         .WillByDefault(Return(m_selectionRange));
 
@@ -68,10 +67,10 @@ public:
 
         m_controller = new NotationViewInputController(&m_view, muse::modularity::globalCtx());
 
-        m_configuration = std::make_shared<NotationConfigurationMock>();
+        m_configuration = std::make_shared<NiceMock<NotationConfigurationMock> >();
         m_controller->configuration.set(m_configuration);
 
-        m_playbackController = std::make_shared<playback::PlaybackControllerMock>();
+        m_playbackController = std::make_shared<NiceMock<playback::PlaybackControllerMock> >();
         m_controller->playbackController.set(m_playbackController);
 
         setNoWaylandForLinux();
@@ -84,12 +83,12 @@ public:
     }
 
     NotationViewInputController* m_controller = nullptr;
-    ControlledViewMock m_view;
+    NiceMock<ControlledViewMock> m_view;
     std::shared_ptr<NotationConfigurationMock> m_configuration;
     std::shared_ptr<NotationInteractionMock> m_interaction;
     std::shared_ptr<NotationSelectionMock> m_selection;
     std::shared_ptr<NotationSelectionRangeMock> m_selectionRange;
-    std::shared_ptr<playback::PlaybackControllerMock > m_playbackController;
+    std::shared_ptr<playback::PlaybackControllerMock> m_playbackController;
     playback::IPlaybackController::PlayParams m_playParams;
 
     mutable QList<QInputEvent*> m_events;

--- a/src/project/tests/templatesrepositorytest.cpp
+++ b/src/project/tests/templatesrepositorytest.cpp
@@ -19,8 +19,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
-#include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 #include "project/internal/templatesrepository.h"
 
@@ -31,10 +30,9 @@
 #include <QJsonDocument>
 #include <QJsonArray>
 
-using ::testing::_;
+using ::testing::NiceMock;
 using ::testing::Return;
 
-using namespace mu;
 using namespace mu::project;
 using namespace mu::notation;
 using namespace muse;
@@ -46,9 +44,9 @@ protected:
     void SetUp() override
     {
         m_repository = std::make_shared<TemplatesRepository>();
-        m_msczReader = std::make_shared<MsczReaderMock>();
-        m_fileSystem = std::make_shared<FileSystemMock>();
-        m_configuration = std::make_shared<ProjectConfigurationMock>();
+        m_msczReader = std::make_shared<NiceMock<MsczReaderMock> >();
+        m_fileSystem = std::make_shared<NiceMock<FileSystemMock> >();
+        m_configuration = std::make_shared<NiceMock<ProjectConfigurationMock> >();
 
         m_repository->configuration.set(m_configuration);
         m_repository->mscReader.set(m_msczReader);
@@ -177,13 +175,13 @@ TEST_F(Project_TemplatesRepositoryTest, Templates)
         expectedTemplates << buildTemplate("My templates", otherTemplatePath, true /*isCustom*/);
     }
 
-    for (const Template& templ : expectedTemplates) {
+    for (const Template& templ : std::as_const(expectedTemplates)) {
         ON_CALL(*m_msczReader, readMeta(templ.meta.filePath))
         .WillByDefault(Return(RetVal<ProjectMeta>::make_ok(templ.meta)));
     }
 
     // [WHEN] Get templates meta
-    RetVal<Templates> templates = m_repository->templates();
+    const RetVal<Templates> templates = m_repository->templates();
 
     // [THEN] Successfully got templates meta
     EXPECT_TRUE(templates.ret);


### PR DESCRIPTION
Wrap mocks with uninteresting mock calls in a `::testing::NiceMock`
https://google.github.io/googletest/gmock_cook_book.html#NiceStrictNaggy

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
