### PR TITLE
Fix crash in SVG export with tapping

### DIFF
--- a/src/engraving/rendering/score/tdraw.cpp
+++ b/src/engraving/rendering/score/tdraw.cpp
@@ -2984,11 +2984,12 @@ void TDraw::draw(const Tapping* item, muse::draw::Painter* painter)
     painter->setPen(item->curColor());
     if (item->ldata()->symId != SymId::noSym) {
         item->drawSymbol(item->ldata()->symId, painter);
-    } else {
-        TappingText* text = item->text();
+    } else if (TappingText* text = item->text()) {
         painter->translate(text->pos());
         drawTextBase(text, painter);
         painter->translate(-text->pos());
+    } else {
+        assert(false && "Drawing Tapping item without text or symbol");
     }
 }
 

--- a/src/importexport/imagesexport/internal/svgwriter.cpp
+++ b/src/importexport/imagesexport/internal/svgwriter.cpp
@@ -240,6 +240,12 @@ Ret SvgWriter::write(INotationPtr notation, io::IODevice& destinationDevice, con
             continue;
         }
 
+        // Match BspTree::items, which checks for bbox intersection
+        // and empty RectF intersects with nothing
+        if (element->ldata()->bbox().isEmpty()) {
+            continue;
+        }
+
         mu::engraving::ElementType type = element->type();
         switch (type) { // In future sub-type code, this switch() grows, and eType gets used
         case mu::engraving::ElementType::STAFF_LINES: // Handled in the 1st pass above


### PR DESCRIPTION
It was calling `TDraw::draw(const Tapping* item, …)` on a `Tapping` with neither a symbol nor Text but only a TappingHalfSlur. In that case, the half slur is drawn via `TDraw::draw(const SlurSegment* item, …)`, and the `Tapping` itself is not drawn at all because its bbox is empty, and elements with empty bbox are normally filtered out for drawing by `BspTree::items`, which checks for `bbox` intersection with the viewport rect, and empty RectF never intersects.

Added a similar bbox check in SVG export, and added a very light safety check in TDraw as well.

Resolves: https://github.com/musescore/MuseScore/issues/29257