### PR TITLE
Fix issue with "Decrease duration" and "Increase duration" in the History panel

### DIFF
--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -5636,9 +5636,9 @@ void NotationInteraction::increaseDecreaseDuration(int steps, bool stepByDots)
         return;
     }
 
-    startEdit(steps >= 0
-              ? TranslatableString("undoableAction", "Increase duration")
-              : TranslatableString("undoableAction", "Decrease duration"));
+    startEdit(steps > 0 // negative: increase, positive: decrease
+              ? TranslatableString("undoableAction", "Decrease duration")
+              : TranslatableString("undoableAction", "Increase duration"));
     score()->cmdIncDecDuration(steps, stepByDots);
     apply();
 }


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/26733

Simple version of https://github.com/musescore/MuseScore/pull/26738

This had been included in 4.5, but not yet in master, because we were hoping to use https://github.com/musescore/MuseScore/pull/26738, but that's proving to be more complicated and risky than it's worth.