### PR TITLE
Reduce test log output (part 1)

### DIFF
--- a/src/engraving/dom/ambitus.cpp
+++ b/src/engraving/dom/ambitus.cpp
@@ -422,7 +422,7 @@ PropertyValue Ambitus::getProperty(Pid propertyId) const
 {
     switch (propertyId) {
     case Pid::HEAD_GROUP:
-        return int(noteHeadGroup());
+        return noteHeadGroup();
     case Pid::HEAD_TYPE:
         return int(noteHeadType());
     case Pid::MIRROR_HEAD:
@@ -503,7 +503,7 @@ PropertyValue Ambitus::propertyDefault(Pid id) const
 {
     switch (id) {
     case Pid::HEAD_GROUP:
-        return int(NOTEHEADGROUP_DEFAULT);
+        return NOTEHEADGROUP_DEFAULT;
     case Pid::HEAD_TYPE:
         return int(NOTEHEADTYPE_DEFAULT);
     case Pid::MIRROR_HEAD:

--- a/src/engraving/dom/chord.cpp
+++ b/src/engraving/dom/chord.cpp
@@ -1061,7 +1061,7 @@ static void updatePercussionNotes(Chord* c, const Drumset* drumset)
                 //! NOTE May be called too often
                 //LOGW("unmapped drum note %d", pitch);
             } else if (!note->fixed()) {
-                note->undoChangeProperty(Pid::HEAD_GROUP, int(drumset->noteHead(pitch)));
+                note->undoChangeProperty(Pid::HEAD_GROUP, drumset->noteHead(pitch));
                 note->setLine(drumset->line(pitch));
             }
         }
@@ -1835,7 +1835,7 @@ void Chord::setSlash(bool flag, bool stemless)
     size_t ns = m_notes.size();
     for (size_t i = 0; i < ns; ++i) {
         Note* n = m_notes[i];
-        n->undoChangeProperty(Pid::HEAD_GROUP, static_cast<int>(head));
+        n->undoChangeProperty(Pid::HEAD_GROUP, head);
         n->undoChangeProperty(Pid::FIXED, true);
         n->undoChangeProperty(Pid::FIXED_LINE, line);
         n->undoChangeProperty(Pid::PLAY, false);

--- a/src/engraving/dom/note.cpp
+++ b/src/engraving/dom/note.cpp
@@ -1081,7 +1081,7 @@ void Note::updateHeadGroup(const NoteHeadGroup headGroup)
 
     if (links()) {
         for (EngravingObject* scoreElement : *links()) {
-            scoreElement->undoChangeProperty(Pid::HEAD_GROUP, static_cast<int>(group));
+            scoreElement->undoChangeProperty(Pid::HEAD_GROUP, group);
             Note* note = toNote(scoreElement);
 
             if (note->staff() && !note->staff()->isDrumStaff(chord()->tick()) && group == NoteHeadGroup::HEAD_CROSS) {
@@ -1089,7 +1089,7 @@ void Note::updateHeadGroup(const NoteHeadGroup headGroup)
             }
         }
     } else {
-        undoChangeProperty(Pid::HEAD_GROUP, int(group));
+        undoChangeProperty(Pid::HEAD_GROUP, group);
     }
 }
 
@@ -1783,14 +1783,14 @@ EngravingItem* Note::drop(EditData& data)
         if (group != m_headGroup) {
             if (links()) {
                 for (EngravingObject* se : *links()) {
-                    se->undoChangeProperty(Pid::HEAD_GROUP, int(group));
+                    se->undoChangeProperty(Pid::HEAD_GROUP, group);
                     Note* note = toNote(se);
                     if (note->staff() && !note->staff()->isDrumStaff(ch->tick())) {
                         se->undoChangeProperty(Pid::DEAD, group == NoteHeadGroup::HEAD_CROSS);
                     }
                 }
             } else {
-                undoChangeProperty(Pid::HEAD_GROUP, int(group));
+                undoChangeProperty(Pid::HEAD_GROUP, group);
                 if (!staff()->isDrumStaff(ch->tick())) {
                     undoChangeProperty(Pid::DEAD, group == NoteHeadGroup::HEAD_CROSS);
                 }
@@ -2958,7 +2958,7 @@ PropertyValue Note::getProperty(Pid propertyId) const
     case Pid::HEAD_SCHEME:
         return int(headScheme());
     case Pid::HEAD_GROUP:
-        return int(headGroup());
+        return headGroup();
     case Pid::USER_VELOCITY:
         return userVelocity();
     case Pid::TUNING:

--- a/src/engraving/rendering/score/segmentlayout.cpp
+++ b/src/engraving/rendering/score/segmentlayout.cpp
@@ -159,7 +159,7 @@ void SegmentLayout::layoutChordDrumset(const Staff* staff, const Segment& segmen
             if (!drumset->isValid(pitch)) {
                 // LOGD("unmapped drum note %d", pitch);
             } else if (!note->fixed()) {
-                note->undoChangeProperty(Pid::HEAD_GROUP, int(drumset->noteHead(pitch)));
+                note->undoChangeProperty(Pid::HEAD_GROUP, drumset->noteHead(pitch));
                 int line = drumset->line(pitch);
                 note->setLine(line);
 

--- a/src/engraving/rw/write/twrite.cpp
+++ b/src/engraving/rw/write/twrite.cpp
@@ -564,7 +564,7 @@ void TWrite::write(const ActionIcon* item, XmlWriter& xml, WriteContext&)
 void TWrite::write(const Ambitus* item, XmlWriter& xml, WriteContext& ctx)
 {
     xml.startElement(item);
-    xml.tagProperty(Pid::HEAD_GROUP, int(item->noteHeadGroup()), int(Ambitus::NOTEHEADGROUP_DEFAULT));
+    xml.tagProperty(Pid::HEAD_GROUP, item->noteHeadGroup(), Ambitus::NOTEHEADGROUP_DEFAULT);
     xml.tagProperty(Pid::HEAD_TYPE,  int(item->noteHeadType()),  int(Ambitus::NOTEHEADTYPE_DEFAULT));
     xml.tagProperty(Pid::MIRROR_HEAD, int(item->direction()),    int(Ambitus::DIRECTION_DEFAULT));
     xml.tag("hasLine",    item->hasLine(), true);

--- a/src/engraving/tests/barline_data/barline03.mscx
+++ b/src/engraving/tests/barline_data/barline03.mscx
@@ -194,7 +194,6 @@
             <subtype>1</subtype>
             <sigN>4</sigN>
             <sigD>4</sigD>
-            <showCourtesy>0</showCourtesy>
             </TimeSig>
           <Rest>
             <durationType>measure</durationType>
@@ -275,7 +274,6 @@
             <subtype>1</subtype>
             <sigN>4</sigN>
             <sigD>4</sigD>
-            <showCourtesy>0</showCourtesy>
             </TimeSig>
           <Rest>
             <durationType>measure</durationType>
@@ -351,7 +349,6 @@
             <subtype>1</subtype>
             <sigN>4</sigN>
             <sigD>4</sigD>
-            <showCourtesy>0</showCourtesy>
             </TimeSig>
           <Rest>
             <durationType>measure</durationType>
@@ -427,7 +424,6 @@
             <subtype>1</subtype>
             <sigN>4</sigN>
             <sigD>4</sigD>
-            <showCourtesy>0</showCourtesy>
             </TimeSig>
           <Rest>
             <durationType>measure</durationType>

--- a/src/engraving/tests/barline_data/barline04.mscx
+++ b/src/engraving/tests/barline_data/barline04.mscx
@@ -194,7 +194,6 @@
             <subtype>1</subtype>
             <sigN>4</sigN>
             <sigD>4</sigD>
-            <showCourtesy>0</showCourtesy>
             </TimeSig>
           <Rest>
             <durationType>measure</durationType>
@@ -275,7 +274,6 @@
             <subtype>1</subtype>
             <sigN>4</sigN>
             <sigD>4</sigD>
-            <showCourtesy>0</showCourtesy>
             </TimeSig>
           <Rest>
             <durationType>measure</durationType>
@@ -351,7 +349,6 @@
             <subtype>1</subtype>
             <sigN>4</sigN>
             <sigD>4</sigD>
-            <showCourtesy>0</showCourtesy>
             </TimeSig>
           <Rest>
             <durationType>measure</durationType>
@@ -427,7 +424,6 @@
             <subtype>1</subtype>
             <sigN>4</sigN>
             <sigD>4</sigD>
-            <showCourtesy>0</showCourtesy>
             </TimeSig>
           <Rest>
             <durationType>measure</durationType>

--- a/src/engraving/tests/barline_data/barline05.mscx
+++ b/src/engraving/tests/barline_data/barline05.mscx
@@ -194,7 +194,6 @@
             <subtype>1</subtype>
             <sigN>4</sigN>
             <sigD>4</sigD>
-            <showCourtesy>0</showCourtesy>
             </TimeSig>
           <Rest>
             <durationType>measure</durationType>
@@ -294,7 +293,6 @@
             <subtype>1</subtype>
             <sigN>4</sigN>
             <sigD>4</sigD>
-            <showCourtesy>0</showCourtesy>
             </TimeSig>
           <Rest>
             <durationType>measure</durationType>
@@ -392,7 +390,6 @@
             <subtype>1</subtype>
             <sigN>4</sigN>
             <sigD>4</sigD>
-            <showCourtesy>0</showCourtesy>
             </TimeSig>
           <Rest>
             <durationType>measure</durationType>
@@ -490,7 +487,6 @@
             <subtype>1</subtype>
             <sigN>4</sigN>
             <sigD>4</sigD>
-            <showCourtesy>0</showCourtesy>
             </TimeSig>
           <Rest>
             <durationType>measure</durationType>

--- a/src/engraving/tests/note_tests.cpp
+++ b/src/engraving/tests/note_tests.cpp
@@ -230,7 +230,7 @@ TEST_F(Engraving_NoteTests, note)
 
     // headGroup
     for (int i = 0; i < int(NoteHeadGroup::HEAD_GROUPS); ++i) {
-        note->setProperty(Pid::HEAD_GROUP, i);
+        note->setProperty(Pid::HEAD_GROUP, static_cast<NoteHeadGroup>(i));
         n = toNote(ScoreRW::writeReadElement(note));
         EXPECT_EQ(int(n->headGroup()), i);
         delete n;

--- a/src/engraving/tests/splitstaff_data/splitstaff04.mscx
+++ b/src/engraving/tests/splitstaff_data/splitstaff04.mscx
@@ -78,7 +78,6 @@
           <TimeSig>
             <sigN>3</sigN>
             <sigD>4</sigD>
-            <showCourtesy>0</showCourtesy>
             </TimeSig>
           <Rest>
             <durationType>quarter</durationType>

--- a/src/engraving/tests/splitstaff_data/splitstaff05.mscx
+++ b/src/engraving/tests/splitstaff_data/splitstaff05.mscx
@@ -78,7 +78,6 @@
           <TimeSig>
             <sigN>3</sigN>
             <sigD>4</sigD>
-            <showCourtesy>0</showCourtesy>
             </TimeSig>
           <Rest>
             <durationType>quarter</durationType>


### PR DESCRIPTION
This PR gets rid of 2 debug messages
- `14:21:12.132 | DEBUG | main_thread     | XmlReader::unknown | tag in <barline03.mscx> byte offset 5894: showCourtesy`
  - occurs 14 times
- `14:22:03.715 | DEBUG | main_thread     | XmlWriter::tagProperty | property value type mismatch, prop: head`
  - occurs 782 times

<!-- -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
