### PR TITLE
fix color handling on imported text

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -3585,6 +3585,7 @@ void MusicXmlParserDirection::direction(const String& partId,
 
             if (m_color.isValid()) {
                 t->setColor(m_color);
+                t->setPropertyFlags(Pid::COLOR, PropertyFlags::UNSTYLED);
             }
 
             if (configuration()->importLayout()) {

--- a/src/importexport/musicxml/tests/data/testStringmute_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testStringmute_ref.mscx
@@ -156,6 +156,7 @@
           <PlayTechAnnotation>
             <playTechType>mute</playTechType>
             <eid>Q_Q</eid>
+            <color r="69" g="0" b="84" a="255"/>
             <text><sym>stringsMuteOn</sym></text>
             </PlayTechAnnotation>
           <Chord>
@@ -206,6 +207,7 @@
           <PlayTechAnnotation>
             <playTechType>open</playTechType>
             <eid>a_a</eid>
+            <color r="253" g="169" b="51" a="255"/>
             <text><sym>stringsMuteOff</sym></text>
             </PlayTechAnnotation>
           <Chord>


### PR DESCRIPTION
Important fix I noticed with #29263: colors on imported text was shown but not saved.