### PR TITLE
Fix stack buffer overflow in accessibleInfo for Ambitus with no tpcs set

### DIFF
--- a/src/engraving/dom/ambitus.cpp
+++ b/src/engraving/dom/ambitus.cpp
@@ -554,6 +554,9 @@ EngravingItem* Ambitus::prevSegmentElement()
 
 String Ambitus::accessibleInfo() const
 {
+    if (m_topTpc == Tpc::TPC_INVALID || m_bottomTpc == Tpc::TPC_INVALID) {
+        return EngravingItem::accessibleInfo();
+    }
     return EngravingItem::accessibleInfo() + u"; "
            + muse::mtrc("engraving", "Top pitch: %1; Bottom pitch: %2")
            .arg(tpc2name(topTpc(), NoteSpellingType::STANDARD, NoteCaseType::AUTO, false) + String::number(topOctave()),


### PR DESCRIPTION
When an Ambitus is created, it has by default no tpcs set. In the layout code, this situation is handled by placing the notes on the top and bottom staff line. The `accessibleInfo` method did not take this situation into account, and called `tpc2name`; the "inner" tpc2name method has a stack buffer overflow when an invalid tpc is passed in.