### PR TITLE
Fix MSVC compiler warnings

### DIFF
--- a/src/engraving/rendering/score/harmonylayout.cpp
+++ b/src/engraving/rendering/score/harmonylayout.cpp
@@ -530,9 +530,7 @@ void HarmonyLayout::renderSingleHarmony(Harmony* item, Harmony::LayoutData* ldat
         render(item, ldata, chordList->renderListRoot, harmonyCtx, ctx, capoRootTpc, spelling, rootCase);
 
         // render extension
-        const ChordDescription* cd = info->getDescription();
         if (cd) {
-            const bool stackModifiers = style.styleB(Sid::verticallyStackModifiers) && !item->doNotStackModifiers();
             render(item, ldata, stackModifiers ? cd->renderListStacked : cd->renderList, harmonyCtx, ctx,  0);
         }
 


### PR DESCRIPTION
reg.: declaration hides previous local declaration (C4456)

Actually a code duplication...