### PR TITLE
Let the Slur parent as dummy

### DIFF
--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -700,7 +700,7 @@ Slur* Score::addSlur(ChordRest* firstChordRest, ChordRest* secondChordRest, cons
         }
     }
 
-    Slur* slur = slurTemplate ? slurTemplate->clone() : Factory::createSlur(firstChordRest->measure()->system());
+    Slur* slur = slurTemplate ? slurTemplate->clone() : Factory::createSlur(score()->dummy());
     slur->setScore(firstChordRest->score());
     slur->setTick(firstChordRest->tick());
     slur->setTick2(secondChordRest->tick());


### PR DESCRIPTION
Resolves: #28601

In our engraving model it doesn't really matter what the parent of a Spanner is, because it's only the SpannerSegment that is graphically represented, not the Spanner. Therefore most Spanners should have their parent set to dummy, which makes everything simpler, avoids problem when cloning, etc.