### PR TITLE
Refactor some Handbells articulations as playing techiques

### DIFF
--- a/src/engraving/dom/articulation.cpp
+++ b/src/engraving/dom/articulation.cpp
@@ -609,7 +609,7 @@ void Articulation::computeCategories()
     m_categories.setFlag(ArticulationCategory::HANDBELLS,
                          (static_cast<int>(m_symId) >= static_cast<int>(SymId::handbellsBelltree)
                           && static_cast<int>(m_symId) <= static_cast<int>(SymId::handbellsTableSingleBell))
-                         || (static_cast<int>(m_textType) >= static_cast<int>(ArticulationTextType::LV)
+                         || (static_cast<int>(m_textType) >= static_cast<int>(ArticulationTextType::TD)
                              && static_cast<int>(m_textType) <= static_cast<int>(ArticulationTextType::VIB))
                          );
 }

--- a/src/engraving/dom/playtechannotation.cpp
+++ b/src/engraving/dom/playtechannotation.cpp
@@ -49,6 +49,7 @@ PlayingTechniqueType PlayTechAnnotation::techniqueType() const
 void PlayTechAnnotation::setTechniqueType(const PlayingTechniqueType techniqueType)
 {
     m_techniqueType = techniqueType;
+    resetProperty(Pid::TEXT_STYLE);
 }
 
 PlayTechAnnotation* PlayTechAnnotation::clone() const
@@ -59,7 +60,7 @@ PlayTechAnnotation* PlayTechAnnotation::clone() const
 bool PlayTechAnnotation::isHandbellsSymbol() const
 {
     return static_cast<int>(m_techniqueType) >= static_cast<int>(PlayingTechniqueType::HandbellsSwing)
-           && static_cast<int>(m_techniqueType) <= static_cast<int>(PlayingTechniqueType::HandbellsDamp);
+           && static_cast<int>(m_techniqueType) <= static_cast<int>(PlayingTechniqueType::HandbellsR);
 }
 
 PropertyValue PlayTechAnnotation::getProperty(Pid id) const
@@ -76,7 +77,7 @@ bool PlayTechAnnotation::setProperty(Pid propertyId, const PropertyValue& val)
 {
     switch (propertyId) {
     case Pid::PLAY_TECH_TYPE:
-        m_techniqueType = PlayingTechniqueType(val.toInt());
+        setTechniqueType(PlayingTechniqueType(val.toInt()));
         break;
     default:
         if (!StaffTextBase::setProperty(propertyId, val)) {
@@ -93,7 +94,7 @@ PropertyValue PlayTechAnnotation::propertyDefault(Pid id) const
 {
     switch (id) {
     case Pid::TEXT_STYLE:
-        return TextStyleType::STAFF;
+        return isHandbellsSymbol() ? TextStyleType::ARTICULATION : TextStyleType::STAFF;
     case Pid::PLAY_TECH_TYPE:
         return PlayingTechniqueType::Natural;
     default:

--- a/src/engraving/dom/playtechannotation.h
+++ b/src/engraving/dom/playtechannotation.h
@@ -44,11 +44,11 @@ public:
     bool isHandbellsSymbol() const;
     bool isEditable() const override { return !isHandbellsSymbol(); }
 
-private:
-
     PropertyValue getProperty(Pid id) const override;
     bool setProperty(Pid propertyId, const PropertyValue& val) override;
     PropertyValue propertyDefault(Pid id) const override;
+
+private:
 
     PlayingTechniqueType m_techniqueType = PlayingTechniqueType::Undefined;
 };

--- a/src/engraving/playback/metaparsers/internal/symbolsmetaparser.cpp
+++ b/src/engraving/playback/metaparsers/internal/symbolsmetaparser.cpp
@@ -33,8 +33,6 @@ static mpe::ArticulationType textTypeToArticulationType(ArticulationTextType tex
     case ArticulationTextType::NO_TEXT: return mpe::ArticulationType::Standard;
     case ArticulationTextType::SLAP: return mpe::ArticulationType::Slap;
     case ArticulationTextType::POP: return mpe::ArticulationType::Pop;
-    case ArticulationTextType::LV: return mpe::ArticulationType::LaissezVibrer;
-    case ArticulationTextType::R: return mpe::ArticulationType::Ring;
     case ArticulationTextType::TD: return mpe::ArticulationType::ThumbDamp;
     case ArticulationTextType::BD: return mpe::ArticulationType::BrushDamp;
     case ArticulationTextType::RT: return mpe::ArticulationType::RingTouch;

--- a/src/engraving/types/types.h
+++ b/src/engraving/types/types.h
@@ -948,7 +948,9 @@ enum class PlayingTechniqueType : signed char {
     HandbellsSwingDown,
     HandbellsEcho1,
     HandbellsEcho2,
-    HandbellsDamp
+    HandbellsDamp,
+    HandbellsLV,
+    HandbellsR,
 };
 
 enum class GradualTempoChangeType : signed char {
@@ -1172,8 +1174,6 @@ enum class ArticulationTextType : unsigned char {
     SLAP,
     POP,
     // Handbells
-    LV,
-    R,
     TD,
     BD,
     RT,

--- a/src/engraving/types/typesconv.cpp
+++ b/src/engraving/types/typesconv.cpp
@@ -2093,6 +2093,8 @@ static const std::vector<Item<PlayingTechniqueType> > PLAY_TECH_TYPES = {
     { PlayingTechniqueType::HandbellsEcho1, "handbells_echo_1", muse::TranslatableString("engraving/playtechtype", "Echo") },
     { PlayingTechniqueType::HandbellsEcho2, "handbells_echo_2", muse::TranslatableString("engraving/playtechtype", "Echo") },
     { PlayingTechniqueType::HandbellsDamp, "handbells_damp", muse::TranslatableString("engraving/playtechtype", "Damp") },
+    { PlayingTechniqueType::HandbellsLV, "handbells_lv", muse::TranslatableString("engraving/playtechtype", "Let vibrate") },
+    { PlayingTechniqueType::HandbellsR, "handbells_r", muse::TranslatableString("engraving/playtechtype", "Ring") },
 };
 
 const muse::TranslatableString& TConv::userName(PlayingTechniqueType v)
@@ -3198,17 +3200,15 @@ struct ArticulationTextTypeItem {
     muse::TranslatableString name;
 };
 
-const std::array<ArticulationTextTypeItem, 10> ARTICULATIONTEXT_TYPES = { {
+const std::array<ArticulationTextTypeItem, 9> ARTICULATIONTEXT_TYPES = { {
     // Guitar
     { ArticulationTextType::SLAP,   "Slap", String(u"S"),    muse::TranslatableString("engraving/sym", "Slap") },
     { ArticulationTextType::POP,    "Pop",  String(u"P"),    muse::TranslatableString("engraving/sym", "Pop") },
     // Handbells
-    { ArticulationTextType::LV,     "LV",   String(u"LV"),   muse::TranslatableString("engraving/sym", "Let vibrate") },
-    { ArticulationTextType::R,      "R",    String(u"R"),    muse::TranslatableString("engraving/sym", "Ring") },
     { ArticulationTextType::TD,     "TD",   String(u"TD"),   muse::TranslatableString("engraving/sym", "Thumb damp") },
     { ArticulationTextType::BD,     "BD",   String(u"BD"),   muse::TranslatableString("engraving/sym", "Brush damp") },
     { ArticulationTextType::RT,     "RT",   String(u"RT"),   muse::TranslatableString("engraving/sym", "Ring touch") },
-    { ArticulationTextType::PL,     "PL",   String(u"PL"),   muse::TranslatableString("engraving/sym", "Pluck") },
+    { ArticulationTextType::PL,     "PL",   String(u"Pl"),   muse::TranslatableString("engraving/sym", "Pluck") },
     { ArticulationTextType::SB,     "SB",   String(u"SB"),   muse::TranslatableString("engraving/sym", "Singing bell") },
     { ArticulationTextType::VIB,    "VIB",  String(u"vib."), muse::TranslatableString("engraving/sym", "Vibrate") },
 } };

--- a/src/palette/internal/palettecreator.cpp
+++ b/src/palette/internal/palettecreator.cpp
@@ -2030,8 +2030,6 @@ PalettePtr PaletteCreator::newHandbellsPalette(bool defaultPalette)
     };
 
     static const std::vector<ArticulationTextType> handbellsTextTypes {
-        ArticulationTextType::LV,
-        ArticulationTextType::R,
         ArticulationTextType::TD,
         ArticulationTextType::BD,
         ArticulationTextType::RT,
@@ -2046,10 +2044,12 @@ PalettePtr PaletteCreator::newHandbellsPalette(bool defaultPalette)
     };
 
     static const std::vector<HandbellsPlayTechInfo> standardHandbellsPlayTech {
+        { "R", PlayingTechniqueType::HandbellsR, },
+        { "LV", PlayingTechniqueType::HandbellsLV, },
+        { "<sym>handbellsDamp3</sym>",   PlayingTechniqueType::HandbellsDamp, },
         { "<sym>handbellsSwingUp</sym>",   PlayingTechniqueType::HandbellsSwingUp, },
         { "<sym>handbellsSwingDown</sym>",   PlayingTechniqueType::HandbellsSwingDown, },
         { "<sym>handbellsEcho1</sym>",   PlayingTechniqueType::HandbellsEcho1, },
-        { "<sym>handbellsDamp3</sym>",   PlayingTechniqueType::HandbellsDamp, },
     };
 
     static const std::vector<HandbellsPlayTechInfo> additionalHandbellsPlayTech {
@@ -2073,9 +2073,12 @@ PalettePtr PaletteCreator::newHandbellsPalette(bool defaultPalette)
 
         for (const HandbellsPlayTechInfo& info : standardHandbellsPlayTech) {
             auto element = makeElement<PlayTechAnnotation>(gpaletteScore);
+            element->setProperty(Pid::TEXT_STYLE, TextStyleType::ARTICULATION);
             element->setXmlText(info.xmlText);
             element->setTechniqueType(info.playTechType);
-            sp->appendElement(element, TConv::userName(info.playTechType));
+            sp->appendElement(element, TConv::userName(info.playTechType),
+                              info.playTechType == PlayingTechniqueType::HandbellsLV
+                              || info.playTechType == PlayingTechniqueType::HandbellsR ? 1.1 : 1.0);
         }
     } else {
         for (SymId symId : additionalHandbellsArticSymbols) {
@@ -2086,6 +2089,7 @@ PalettePtr PaletteCreator::newHandbellsPalette(bool defaultPalette)
 
         for (const HandbellsPlayTechInfo& info : additionalHandbellsPlayTech) {
             auto element = makeElement<PlayTechAnnotation>(gpaletteScore);
+            element->setProperty(Pid::TEXT_STYLE, TextStyleType::ARTICULATION);
             element->setXmlText(info.xmlText);
             element->setTechniqueType(info.playTechType);
             sp->appendElement(element, TConv::userName(info.playTechType));


### PR DESCRIPTION
Specifically the R (Ring) and LV (Let vibrate) indications. These were originally implemented as articulations, but we figured they are best treated as a playing techniques (which is basically staff text).