### PR TITLE
Fix MSVC compiler warning

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
@@ -7896,11 +7896,11 @@ static void writeStaffDetails(XmlWriter& xml, const Part* part, const std::vecto
             bool needWriteLineDistance = !muse::RealIsEqual(lineDistance, 1.0);
             bool needWriteMag = !muse::RealIsEqual(mag, 1.0);
             if (needWriteLineDistance || needWriteMag) {
-                XmlWriter::Attributes attributes;
+                XmlWriter::Attributes scaleAttributes;
                 if (needWriteMag) {
                     attributes.emplace_back(std::make_pair("scale", mag));
                 }
-                xml.element("staff-size", attributes, lineDistance * 100);
+                xml.element("staff-size", scaleAttributes, lineDistance * 100);
             }
 
             xml.endElement();


### PR DESCRIPTION
reg.: declaration of 'attributes' hides previous local declaration (C4456)