### PR TITLE
Fix out of date padding table for parts

### DIFF
--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -167,9 +167,6 @@ Score::Score(const modularity::ContextPtr& iocCtx)
     m_rootItem = new RootItem(this);
     m_rootItem->init();
 
-    //! NOTE Looks like a bug, `minimumPaddingUnit` is set using the default style's spatium value
-    //! and does not change if the style or the spatium of this score is changed
-    m_paddingTable.setMinimumPaddingUnit(0.1 * style().spatium());
     createPaddingTable();
 
     m_shadowNote = new ShadowNote(this);

--- a/src/engraving/engravingproject.cpp
+++ b/src/engraving/engravingproject.cpp
@@ -124,6 +124,7 @@ Ret EngravingProject::doSetupMasterScore(bool forceMode)
     for (Score* s : m_masterScore->scoreList()) {
         s->setPlaylistDirty();
         s->setLayoutAll();
+        s->createPaddingTable();
     }
 
     m_masterScore->updateChannel();

--- a/src/engraving/rendering/paddingtable.cpp
+++ b/src/engraving/rendering/paddingtable.cpp
@@ -27,11 +27,9 @@
 
 using namespace mu::engraving;
 
-void PaddingTable::initPaddingTable()
+void PaddingTable::initPaddingTable(double minPadUnit)
 {
     PaddingTable& table = *this;
-
-    double minPadUnit = minimumPaddingUnit();
 
     for (size_t i=0; i < TOT_ELEMENT_TYPES; ++i) {
         for (size_t j=0; j < TOT_ELEMENT_TYPES; ++j) {
@@ -42,14 +40,14 @@ void PaddingTable::initPaddingTable()
 
 void PaddingTable::createTable(const MStyle& style)
 {
-    initPaddingTable();
-
-    PaddingTable& table = *this;
-
-    const double minPadUnit = minimumPaddingUnit();
     const double spatium = style.spatium();
+    const double minPadUnit = 0.1 * spatium;
+    initPaddingTable(minPadUnit);
+
     const double ledgerPad = 0.25 * spatium;
     const double ledgerLength = style.styleMM(Sid::ledgerLineLength);
+
+    PaddingTable& table = *this;
 
     // NOTE: we don't set note-note padding to minNoteDistance
     // because there are cases when they should be allowed to get closer.
@@ -292,16 +290,17 @@ ParenPaddingTablePtr ParenPaddingTable::getPaddingTable(const EngravingItem* par
         ASSERT_X("Not a valid parenthesised type")
     }
 
-    table->setMinimumPaddingUnit(0.1 * parent->style().spatium());
+    const double spatium = parent->style().spatium();
+    const double minPadUnit = 0.1 * spatium;
+    table->initPaddingTable(minPadUnit);
+
     table->createTable(parent->style());
 
     return table;
 }
 
-void ParenPaddingTable::initPaddingTable()
+void ParenPaddingTable::initPaddingTable(double minPadUnit)
 {
-    const double minPadUnit = minimumPaddingUnit();
-
     for (size_t i = 0; i < TOT_ELEMENT_TYPES; ++i) {
         m_parenBefore[i] = minPadUnit;
         m_parenAfter[i]  = minPadUnit;

--- a/src/engraving/rendering/paddingtable.h
+++ b/src/engraving/rendering/paddingtable.h
@@ -43,15 +43,10 @@ struct PaddingVector : std::array<T, TOT_ELEMENT_TYPES>
 struct PaddingTable : public PaddingVector<PaddingVector<double> >
 {
 public:
-
-    void setMinimumPaddingUnit(double val) { m_minimumPaddingUnit = val; }
-    double minimumPaddingUnit() const { return m_minimumPaddingUnit; }
-
     void createTable(const MStyle& style);
 
 private:
-    void initPaddingTable();
-    double m_minimumPaddingUnit = 0.0;
+    void initPaddingTable(double minPadUnit);
 };
 
 struct ParenPaddingTable
@@ -59,21 +54,15 @@ struct ParenPaddingTable
 public:
     virtual ~ParenPaddingTable() = default;
 
-    void setMinimumPaddingUnit(double val) { m_minimumPaddingUnit = val; }
-    double minimumPaddingUnit() const { return m_minimumPaddingUnit; }
-
     virtual void createTable(const MStyle& style) = 0;
     double padding(ElementType type1, ElementType type2);
 
     static ParenPaddingTablePtr getPaddingTable(const EngravingItem* parent);
 
 protected:
-    void initPaddingTable();
+    void initPaddingTable(double minPadUnit);
     PaddingVector<double> m_parenBefore;
     PaddingVector<double> m_parenAfter;
-
-private:
-    double m_minimumPaddingUnit = 0.0;
 };
 
 struct NoteParenPaddingTable : public ParenPaddingTable {


### PR DESCRIPTION
Resolves: #26240 

We were missing a `createPaddingTable` call for parts. The result was that the last time the padding table was updated for the part was _before_ the style was loaded (hence it was out of date on first opening the file, but was updating itself when a style change was triggered). We probably never noticed because it's more rare for parts to have non-default spatium and non-default spacing settings. Good thing we fixed this.

Bonus cleanup while I was at it for the minimum padding unit inside the padding table class (which made no sense to be a class member and especially to be set in the score constructor).