### PR TITLE
Fretboard diagram legend improvements

### DIFF
--- a/src/engraving/rendering/score/tlayout.cpp
+++ b/src/engraving/rendering/score/tlayout.cpp
@@ -1547,7 +1547,7 @@ void TLayout::layoutFBox(const FBox* item, FBox::LayoutData* ldata, const Layout
             double height = fretRect.united(harmonyRect).height();
             maxRowHeight = std::max(maxRowHeight, height);
             maxHarmonyHeight = std::max(maxHarmonyHeight, -harmonyRect.top());
-            harmonyBaseline = std::max(harmonyBaseline, fretDiagram->harmony()->baseLine());
+            harmonyBaseline = std::min(harmonyBaseline, harmonyLdata->pos().y());
         }
 
         rowHeights.push_back(maxRowHeight);
@@ -1596,12 +1596,10 @@ void TLayout::layoutFBox(const FBox* item, FBox::LayoutData* ldata, const Layout
             y += rowHeights[r] + rowGap;
         }
 
-        std::vector<HarmonyRenderItem*> renderItemList = harmony->ldata()->renderItemList.value();
-        double baseline = renderItemList.empty() ? 0.0 : renderItemList.front()->bboxBaseLine() + renderItemList.front()->pos().y();
-
-        double baseLineAdjust = harmony->ldata()->bbox().bottom() - baseline;
-
-        harmony->mutldata()->moveY(-(harmonyBaselines[row]) + baseLineAdjust);
+        double commonBaseline = harmonyBaselines[row];
+        double thisBaseline = harmony->ldata()->pos().y();
+        double baselineOff = commonBaseline - thisBaseline;
+        harmony->mutldata()->moveY(baselineOff);
 
         double fretDiagramX = x;
         double fretDiagramY = y + harmonyHeights[row];

--- a/src/engraving/rendering/score/tlayout.cpp
+++ b/src/engraving/rendering/score/tlayout.cpp
@@ -1512,7 +1512,6 @@ void TLayout::layoutFBox(const FBox* item, FBox::LayoutData* ldata, const Layout
 
         Harmony* harmony = fretDiagram->harmony();
         harmony->mutldata()->setMag(item->textScale());
-        layoutHarmony(harmony, harmony->mutldata(), ctx);
 
         layoutItem(fretDiagram, const_cast<LayoutContext&>(ctx));
 

--- a/src/engraving/rendering/score/tlayout.cpp
+++ b/src/engraving/rendering/score/tlayout.cpp
@@ -1542,12 +1542,11 @@ void TLayout::layoutFBox(const FBox* item, FBox::LayoutData* ldata, const Layout
             RectF fretRect = fretDiagram->ldata()->bbox();
 
             const Harmony::LayoutData* harmonyLdata = fretDiagram->harmony()->ldata();
-            RectF harmonyRect = harmonyLdata->bbox();
-            harmonyRect.moveTo(harmonyLdata->pos());
+            RectF harmonyRect = harmonyLdata->bbox().translated(harmonyLdata->pos());
 
             double height = fretRect.united(harmonyRect).height();
             maxRowHeight = std::max(maxRowHeight, height);
-            maxHarmonyHeight = std::max(maxHarmonyHeight, harmonyRect.height());
+            maxHarmonyHeight = std::max(maxHarmonyHeight, -harmonyRect.top());
             harmonyBaseline = std::max(harmonyBaseline, fretDiagram->harmony()->baseLine());
         }
 
@@ -1573,8 +1572,6 @@ void TLayout::layoutFBox(const FBox* item, FBox::LayoutData* ldata, const Layout
                           ? (width - totalTableWidth) / 2
                           : alignH == AlignH::RIGHT ? width - totalTableWidth : 0.0;
     const double startY = topMargin;
-
-    const double shapeMarginAboveDiagram = ctx.conf().styleMM(Sid::harmonyFretDist).val() * 1.5;
 
     double bottomY = 0.0;
 
@@ -1607,7 +1604,7 @@ void TLayout::layoutFBox(const FBox* item, FBox::LayoutData* ldata, const Layout
         harmony->mutldata()->moveY(-(harmonyBaselines[row]) + baseLineAdjust);
 
         double fretDiagramX = x;
-        double fretDiagramY = y + harmonyHeights[row] + shapeMarginAboveDiagram;
+        double fretDiagramY = y + harmonyHeights[row];
 
         fretDiagram->mutldata()->setPos(PointF(fretDiagramX, fretDiagramY));
 

--- a/src/engraving/rendering/score/tlayout.cpp
+++ b/src/engraving/rendering/score/tlayout.cpp
@@ -2687,7 +2687,7 @@ void TLayout::layoutFretDiagram(const FretDiagram* item, FretDiagram::LayoutData
 
     double shapeMarginAboveDiagram = ldata->fretDist * 1.5;
     double w = ldata->stringDist * (item->strings() - 1) + ldata->markerSize;
-    double h = item->frets() * ldata->fretDist + ldata->stringExtendBottom + shapeMarginAboveDiagram;
+    double h = item->frets() * ldata->fretDist + ldata->stringExtendBottom + 0.5 * ldata->stringLineWidth + shapeMarginAboveDiagram;
     double y = -shapeMarginAboveDiagram;
     double x = -(ldata->markerSize * .5);
 

--- a/src/engraving/rendering/score/tlayout.cpp
+++ b/src/engraving/rendering/score/tlayout.cpp
@@ -1615,7 +1615,11 @@ void TLayout::layoutFBox(const FBox* item, FBox::LayoutData* ldata, const Layout
         bottomY = std::max(bottomY, fretDiagram->mutldata()->bbox().translated(fretDiagram->mutldata()->pos()).bottom());
     }
 
-    double height = std::max(bottomY + bottomMargin, item->minHeight());
+    double height = bottomY + bottomMargin;
+    if (RealIsNull(height)) {
+        height = item->minHeight();
+    }
+
     ldata->setBbox(0.0, 0.0, width, height);
 }
 


### PR DESCRIPTION
Resolves: #29351

- Fixing an error in the height of the box which I had introduced [here](https://github.com/musescore/MuseScore/pull/29152)
- Removing an unnecessary layout call for chord symbols
- Fine correction to the shape of fret diagrams (was missing a half line width from the bottom). This is the cause of almost all the vtest differences btw.
- Improved/simplified calculations of chord symbols vertical positions and alignment (the combination of which was causing them to overshoot the top of the frame). This also makes sure that the 3sp row gap is honored correctly.