### PR TITLE
Don't create mmRest on an irregular measure if it doesn't have a full measure rest

### DIFF
--- a/src/engraving/rendering/score/measurelayout.cpp
+++ b/src/engraving/rendering/score/measurelayout.cpp
@@ -602,6 +602,8 @@ static bool validMMRestMeasure(const LayoutContext& ctx, const Measure* m)
                 if (s->element(track)) {
                     if (!s->element(track)->isRest()) {
                         return false;
+                    } else if (m->isIrregular() && !toRest(s->element(track))->isFullMeasureRest()) {
+                        return false;
                     }
                     restFound = true;
                 }

--- a/src/engraving/rendering/score/measurelayout.cpp
+++ b/src/engraving/rendering/score/measurelayout.cpp
@@ -602,8 +602,11 @@ static bool validMMRestMeasure(const LayoutContext& ctx, const Measure* m)
                 if (s->element(track)) {
                     if (!s->element(track)->isRest()) {
                         return false;
-                    } else if (m->isIrregular() && !toRest(s->element(track))->isFullMeasureRest()) {
-                        return false;
+                    } else {
+                        bool isNonEmptyIrregular = m->isIrregular() && !toRest(s->element(track))->isFullMeasureRest();
+                        if (isNonEmptyIrregular) {
+                            return false;
+                        }
                     }
                     restFound = true;
                 }


### PR DESCRIPTION
Resolves: #28091

The problem is that the pickup measure in Musescore is not really flagged as a pickup measure, it's just a measure that is a) at the beginning of the score, b) shortened, c) excluded from the measure count. This poses a problem in terms of what rules you want to follow for creating mmRests without affecting other unintended cases. 

This solution is what probably makes most sense.