### PR TITLE
Fix #29333: Pause and select bug with repeats

### DIFF
--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -700,8 +700,9 @@ void PlaybackController::pause(bool select)
 
     currentPlayer()->pause();
 
-    if (select) {
-        selectAtRawTick(m_currentTick);
+    if (select && m_notation) {
+        const Fraction playPositionFrac = Fraction::fromTicks(m_currentTick);
+        interaction()->findAndSelectChordRest(playPositionFrac);
     }
 }
 
@@ -730,21 +731,6 @@ void PlaybackController::resume()
     }
 
     currentPlayer()->resume(delay);
-}
-
-void PlaybackController::selectAtRawTick(const tick_t& rawTick)
-{
-    if (!m_notation) {
-        return;
-    }
-
-    const RetVal<tick_t> playPositionTick = notationPlayback()->playPositionTickByRawTick(rawTick);
-    if (!playPositionTick.ret) {
-        return;
-    }
-
-    const Fraction playPositionFrac = Fraction::fromTicks(playPositionTick.val);
-    interaction()->findAndSelectChordRest(playPositionFrac);
 }
 
 secs_t PlaybackController::playbackStartSecs() const

--- a/src/playback/internal/playbackcontroller.h
+++ b/src/playback/internal/playbackcontroller.h
@@ -172,8 +172,6 @@ private:
     void stop();
     void resume();
 
-    void selectAtRawTick(const muse::midi::tick_t& rawTick);
-
     muse::audio::secs_t playbackStartSecs() const;
     muse::audio::secs_t playbackEndSecs() const;
 


### PR DESCRIPTION
Resolves: #29333

We shouldn't be converting to "play position ticks" here as we're purely dealing with "visual" ticks. After taking this conversion out `selectAtRawTick` looks a bit redundant - so we'll remove this method and call `findAndSelectChordRest` directly.