### PR TITLE
engraving: Rename Pid::SUBTYPE

### DIFF
--- a/src/engraving/api/v1/elements.h
+++ b/src/engraving/api/v1/elements.h
@@ -192,9 +192,6 @@ class EngravingItem : public apiv1::ScoreElement
     /// \since MuseScore 4.6
     Q_PROPERTY(bool addToSkyline READ addToSkyline)
 
-    /// Unlike the name might suggest, this property no longer returns the subtype and is scarcely used.
-    /// Named 'subtype' prior to MuseScore 4.6
-    API_PROPERTY(subType,                 SUBTYPE)
     API_PROPERTY_READ_ONLY_T(bool, selected, SELECTED)
     API_PROPERTY_READ_ONLY_T(bool, generated, GENERATED)
     /// EngravingItem color. See https://doc.qt.io/qt-5/qml-color.html
@@ -527,6 +524,9 @@ class EngravingItem : public apiv1::ScoreElement
     ///\since MuseScore 4.6
     API_PROPERTY_T(bool, mmRestNumberVisible, MMREST_NUMBER_VISIBLE)
 
+    /// For measure repeats: The number of measures to repeat.
+    ///\since MuseScore 4.6
+    API_PROPERTY(measureRepeatNumber,  MEASURE_REPEAT_NUMBER)
     /// For measure repeats: The position of the number.
     ///\since MuseScore 4.6
     API_PROPERTY(measureRepeatNumberPos,  MEASURE_REPEAT_NUMBER_POS)

--- a/src/engraving/dom/dynamic.cpp
+++ b/src/engraving/dom/dynamic.cpp
@@ -453,8 +453,6 @@ PropertyValue Dynamic::getProperty(Pid propertyId) const
         return m_dynamicType;
     case Pid::VELOCITY:
         return velocity();
-    case Pid::SUBTYPE:
-        return int(m_dynamicType);
     case Pid::VELO_CHANGE:
         if (isVelocityChangeAvailable()) {
             return changeInVelocity();
@@ -494,9 +492,6 @@ bool Dynamic::setProperty(Pid propertyId, const PropertyValue& v)
         break;
     case Pid::VELOCITY:
         m_velocity = v.toInt();
-        break;
-    case Pid::SUBTYPE:
-        m_dynamicType = v.value<DynamicType>();
         break;
     case Pid::VELO_CHANGE:
         if (isVelocityChangeAvailable()) {

--- a/src/engraving/dom/measurerepeat.cpp
+++ b/src/engraving/dom/measurerepeat.cpp
@@ -143,7 +143,7 @@ PropertyValue MeasureRepeat::propertyDefault(Pid propertyId) const
 PropertyValue MeasureRepeat::getProperty(Pid propertyId) const
 {
     switch (propertyId) {
-    case Pid::SUBTYPE:
+    case Pid::MEASURE_REPEAT_NUMBER:
         return numMeasures();
     case Pid::MEASURE_REPEAT_NUMBER_POS:
         return numberPos();
@@ -159,8 +159,8 @@ PropertyValue MeasureRepeat::getProperty(Pid propertyId) const
 bool MeasureRepeat::setProperty(Pid propertyId, const PropertyValue& v)
 {
     switch (propertyId) {
-    case Pid::SUBTYPE:
-        setNumMeasures(v.toInt());
+    case Pid::MEASURE_REPEAT_NUMBER:
+        setNumMeasures(v.value<int>());
         break;
     case Pid::MEASURE_REPEAT_NUMBER_POS:
         setNumberPos(v.toDouble());

--- a/src/engraving/dom/property.cpp
+++ b/src/engraving/dom/property.cpp
@@ -59,7 +59,6 @@ struct PropertyMetaData {
 #define DUMMY_QT_TR_NOOP(x, y) y
 /* *INDENT-OFF* */
 static constexpr PropertyMetaData propertyList[] = {
-    { Pid::SUBTYPE,                 false, "subtype",               P_TYPE::INT,                PropertyGroup::APPEARANCE,      DUMMY_QT_TR_NOOP("propertyName", "subtype") },
     { Pid::SELECTED,                false, "selected",              P_TYPE::BOOL,               PropertyGroup::NONE,      DUMMY_QT_TR_NOOP("propertyName", "selected") },
     { Pid::GENERATED,               false, "generated",             P_TYPE::BOOL,               PropertyGroup::NONE,            DUMMY_QT_TR_NOOP("propertyName", "generated") },
     { Pid::COLOR,                   false, "color",                 P_TYPE::COLOR,              PropertyGroup::APPEARANCE,      DUMMY_QT_TR_NOOP("propertyName", "color") },
@@ -247,8 +246,9 @@ static constexpr PropertyMetaData propertyList[] = {
     { Pid::MMREST_NUMBER_OFFSET,    false, "mmRestNumberOffset",    P_TYPE::SPATIUM,            PropertyGroup::APPEARANCE,      DUMMY_QT_TR_NOOP("propertyName", "vertical offset of multimeasure rest number") },
     { Pid::MMREST_NUMBER_VISIBLE,   false, "mmRestNumberVisible",   P_TYPE::BOOL,               PropertyGroup::APPEARANCE,      DUMMY_QT_TR_NOOP("propertyName", "visibility of multimeasure rest number") },
 
+    { Pid::MEASURE_REPEAT_NUMBER,     false, "subtype",                P_TYPE::INT,             PropertyGroup::APPEARANCE,      DUMMY_QT_TR_NOOP("propertyName", "subtype") },
     { Pid::MEASURE_REPEAT_NUMBER_POS, false, "measureRepeatNumberPos", P_TYPE::SPATIUM,         PropertyGroup::APPEARANCE,      DUMMY_QT_TR_NOOP("propertyName", "vertical position of measure repeat number") },
-    { Pid::REPEAT_COUNT,            true,  "repeatCount",             P_TYPE::INT,              PropertyGroup::APPEARANCE,      DUMMY_QT_TR_NOOP("propertyName", "repeat count") },
+    { Pid::REPEAT_COUNT,              true,  "repeatCount",            P_TYPE::INT,             PropertyGroup::APPEARANCE,      DUMMY_QT_TR_NOOP("propertyName", "repeat count") },
 
     { Pid::USER_STRETCH,            false, "stretch",               P_TYPE::REAL,               PropertyGroup::NONE      ,      DUMMY_QT_TR_NOOP("propertyName", "stretch") },
     { Pid::NO_OFFSET,               true,  "noOffset",              P_TYPE::INT,                PropertyGroup::APPEARANCE,      DUMMY_QT_TR_NOOP("propertyName", "numbering offset") },

--- a/src/engraving/dom/property.h
+++ b/src/engraving/dom/property.h
@@ -69,7 +69,6 @@ enum class PropertyFlags : char {
 //------------------------------------------------------------------------
 
 enum class Pid {
-    SUBTYPE,
     SELECTED,
     GENERATED,
     COLOR,
@@ -252,6 +251,7 @@ enum class Pid {
     MMREST_NUMBER_POS,
     MMREST_NUMBER_OFFSET,
     MMREST_NUMBER_VISIBLE,
+    MEASURE_REPEAT_NUMBER,
     MEASURE_REPEAT_NUMBER_POS,
     REPEAT_COUNT,
 

--- a/src/engraving/rw/write/twrite.cpp
+++ b/src/engraving/rw/write/twrite.cpp
@@ -2310,7 +2310,7 @@ void TWrite::write(const MeasureNumber* item, XmlWriter& xml, WriteContext& ctx)
 void TWrite::write(const MeasureRepeat* item, XmlWriter& xml, WriteContext& ctx)
 {
     xml.startElement(item);
-    writeProperty(item, xml, Pid::SUBTYPE);
+    writeProperty(item, xml, Pid::MEASURE_REPEAT_NUMBER);
     writeProperties(static_cast<const Rest*>(item), xml, ctx);
     writeItems(item->el(), xml, ctx);
     xml.endElement();


### PR DESCRIPTION
- unused for Dynamic elements
- only remaining use is for MeasureRepeat elements
  - rename to MEASURE_REPEAT_NUMBER to better fit its purpose
- also rename the newly added subType API property
  - added in #28386 
  - might be good to have this in 4.6, but otherwise i'd have to make it backwards compatible.

<!-- -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
