### PR TITLE
fixed #29162: Shift+arrow selection of text broken in Linux

### DIFF
--- a/src/framework/uicomponents/view/popupwindow/popupwindow_qquickview.cpp
+++ b/src/framework/uicomponents/view/popupwindow/popupwindow_qquickview.cpp
@@ -87,16 +87,16 @@ void PopupWindow_QQuickView::init(QQmlEngine* engine, bool isDialogMode, bool is
     }
     // popup
     else {
-        Qt::WindowFlags flags(
-#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
-            Qt::Popup // Popups can't be Qt::Tool on Linux Wayland, or they can't be relatvely positioned.
-#else
-            Qt::Tool
-#endif
-            | Qt::FramelessWindowHint            // Without border
-            | Qt::NoDropShadowWindowHint         // Without system shadow
-            | Qt::BypassWindowManagerHint        // Otherwise, it does not work correctly on Gnome (Linux) when resizing)
-            );
+        Qt::WindowFlags flags;
+        if (qGuiApp->platformName().contains("wayland")) {
+            flags = Qt::Popup;
+        } else {
+            flags = Qt::Tool;
+        }
+
+        flags |= Qt::FramelessWindowHint           // Without border
+                 | Qt::NoDropShadowWindowHint      // Without system shadow
+                 | Qt::BypassWindowManagerHint;    // Otherwise, it does not work correctly on Gnome (Linux) when resizing)
 
         m_view->setFlags(flags);
         m_view->setColor(QColor(Qt::transparent));


### PR DESCRIPTION
Now it doesn't work only if the user manually sets wayland on Linux

Resolves: [29162](https://github.com/musescore/MuseScore/issues/29162)
