### PR TITLE
Avoid state reset on paste

### DIFF
--- a/src/engraving/dom/box.cpp
+++ b/src/engraving/dom/box.cpp
@@ -752,7 +752,6 @@ void FBox::init()
 
     DEFER {
         triggerLayout();
-        score()->setNeedLayoutFretBox(true);
     };
 
     clearElements();

--- a/src/engraving/dom/cmd.cpp
+++ b/src/engraving/dom/cmd.cpp
@@ -458,11 +458,6 @@ void Score::update(bool resetCmdState, bool layoutAllParts)
 
     TRACEFUNC;
 
-    if (m_needLayoutFretBox) {
-        relayoutFretBox();
-        m_needLayoutFretBox = false;
-    }
-
     bool updateAll = false;
     {
         MasterScore* ms = masterScore();

--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -7453,25 +7453,6 @@ void Score::rebuildFretBox()
     }
 }
 
-void Score::relayoutFretBox()
-{
-    FBox* fretBox = findFretBox();
-    if (!fretBox) {
-        return;
-    }
-
-    fretBox->triggerLayout();
-
-    for (EngravingObject* linkedObject : fretBox->linkList()) {
-        if (!linkedObject || !linkedObject->isFBox() || linkedObject == fretBox) {
-            continue;
-        }
-
-        FBox* box = toFBox(linkedObject);
-        box->triggerLayout();
-    }
-}
-
 //---------------------------------------------------------
 //   undoAddCR
 //---------------------------------------------------------

--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -493,11 +493,6 @@ void Score::setUpTempoMap()
     m_needSetUpTempoMap = false;
 }
 
-void Score::setNeedLayoutFretBox(bool layout)
-{
-    m_needLayoutFretBox = layout;
-}
-
 //---------------------------------------------------------
 //    fixTicks
 ///    updates tempomap and time sig map for a measure

--- a/src/engraving/dom/score.h
+++ b/src/engraving/dom/score.h
@@ -700,7 +700,6 @@ public:
 
     void setUpTempoMapLater();
     void setUpTempoMap();
-    void setNeedLayoutFretBox(bool layout);
 
     EngravingItem* nextElement();
     EngravingItem* prevElement();
@@ -1094,7 +1093,6 @@ public:
     void updateSystemLocksOnCreateMMRests(Measure* first, Measure* last);
 
     void rebuildFretBox();
-    void relayoutFretBox();
 
     friend class Chord;
 
@@ -1245,7 +1243,6 @@ private:
 
     bool m_isOpen = false;
     bool m_needSetUpTempoMap = true;
-    bool m_needLayoutFretBox = false;
 
     std::map<String, String> m_metaTags;
 

--- a/src/engraving/dom/spanner.cpp
+++ b/src/engraving/dom/spanner.cpp
@@ -1469,6 +1469,11 @@ track_idx_t Spanner::effectiveTrack2() const
 
 void Spanner::triggerLayout() const
 {
+    // Don't trigger layout until the tick is correctly set, otherwise is triggers layout of the entire score
+    if (m_tick.numerator() < 0) {
+        return;
+    }
+
     // Spanners do not have parent even when added to a score, so can't check parent here
     const track_idx_t tr2 = effectiveTrack2();
     score()->setLayout(m_tick, m_tick + m_ticks, staffIdx(), track2staff(tr2), this);

--- a/src/engraving/rw/read400/read400.cpp
+++ b/src/engraving/rw/read400/read400.cpp
@@ -711,7 +711,6 @@ bool Read400::pasteStaff(XmlReader& e, Segment* dst, staff_idx_t dstStaff, Fract
         }
 
         if (score->cmdState().layoutRange()) {
-            score->cmdState().reset();
             score->setLayout(dstTick, dstTick + tickLen, dstStaff, endStaff, dst);
         }
 

--- a/src/engraving/rw/read410/read410.cpp
+++ b/src/engraving/rw/read410/read410.cpp
@@ -737,7 +737,6 @@ bool Read410::pasteStaff(XmlReader& e, Segment* dst, staff_idx_t dstStaff, Fract
         }
 
         if (score->cmdState().layoutRange()) {
-            score->cmdState().reset();
             score->setLayout(dstTick, dstTick + tickLen, dstStaff, endStaff, dst);
         }
 

--- a/src/engraving/rw/read460/read460.cpp
+++ b/src/engraving/rw/read460/read460.cpp
@@ -725,7 +725,6 @@ bool Read460::pasteStaff(XmlReader& e, Segment* dst, staff_idx_t dstStaff, Fract
         }
 
         if (score->cmdState().layoutRange()) {
-            score->cmdState().reset();
             score->setLayout(dstTick, dstTick + tickLen, dstStaff, endStaff, dst);
         }
 

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -2202,16 +2202,6 @@ bool NotationInteraction::dropRange(const QByteArray& data, const PointF& pos, b
     XmlReader e(data);
     score()->pasteStaff(e, segment, staffIdx);
 
-    if (deleteSourceMaterial) {
-        // pasteStaff limits the layout range to just the destination region,
-        // but if the source material was deleted we must also layout the source region.
-        CmdState& cmdState = score()->cmdState();
-        cmdState.setTick(rdd.sourceTick);
-        cmdState.setTick(rdd.sourceTick + rdd.tickLength);
-        cmdState.setStaff(rdd.sourceStaffIdx);
-        cmdState.setStaff(rdd.sourceStaffIdx + rdd.numStaves);
-    }
-
     endDrop();
     apply();
 


### PR DESCRIPTION
Resolves: #27399 

But without the hack introduces in #27411. Looks like the much simpler solution is just for Spanner::triggerLayout to check if the tick is correctly set and if not don't trigger.

Resolves: this issue ⬇️ but without hack introduced in https://github.com/musescore/MuseScore/pull/29139/commits/8c286aaa38d645c385d58587e9b579802217d407.

https://github.com/user-attachments/assets/318117e7-c566-494c-9a9b-2822b72b1ed5

