### PR TITLE
fixed #29090: Crash after selecting chord in fretboard diagram legend in part

### DIFF
--- a/src/engraving/dom/fret.cpp
+++ b/src/engraving/dom/fret.cpp
@@ -1329,7 +1329,6 @@ FretDiagram* FretDiagram::makeFromHarmonyOrFretDiagram(const EngravingItem* harm
 
         fretDiagram = Factory::createFretDiagram(harmonyOrFretDiagram->score()->dummy()->segment());
 
-        fretDiagram->setTrack(harmony->track());
         fretDiagram->updateDiagram(harmony->plainText());
 
         fretDiagram->linkHarmony(harmony);
@@ -1341,6 +1340,10 @@ FretDiagram* FretDiagram::makeFromHarmonyOrFretDiagram(const EngravingItem* harm
             //! generate from diagram and add harmony
             fretDiagram->add(Factory::createHarmony(harmonyOrFretDiagram->score()->dummy()->segment()));
         }
+    }
+
+    if (fretDiagram) {
+        fretDiagram->setTrack(muse::nidx);
     }
 
     return fretDiagram;


### PR DESCRIPTION
Determining whether an element is on staff depends on the track, if it is valid then the element is on staff, which is not true for elements in the box

Resolves: #29090