### PR TITLE
Fix MSVC compiler warning

### DIFF
--- a/src/framework/audio/common/audiotypes.h
+++ b/src/framework/audio/common/audiotypes.h
@@ -466,7 +466,7 @@ struct InputProcessingProgress {
         int64_t total = 0;
     };
 
-    enum Status : uint8_t {
+    enum Status : unsigned int {
         Undefined = 0,
         Started,
         Processing,


### PR DESCRIPTION
reg.: 'muse::audio::InputProcessingProgress::StatusInfo': 'this' pointer for member 'muse::audio::InputProcessingProgress::StatusInfo::errorText' may not be aligned 8 as expected by the constructor (C4315)

This change does waste a couple bytes though, but see the discussion at https://github.com/musescore/MuseScore/commit/8e2f5b011f9dda0048407d9d45fc5c0e0bd06d30#r164425654 ff.