### PR TITLE
fixed #29123: "Scale" property for fretboard diagrams in FD legends is nonfunctional

### DIFF
--- a/src/inspector/models/notation/fretdiagrams/fretdiagramsettingsmodel.cpp
+++ b/src/inspector/models/notation/fretdiagrams/fretdiagramsettingsmodel.cpp
@@ -100,6 +100,8 @@ void FretDiagramSettingsModel::requestElements()
 {
     m_elementList = m_repository->findElementsByType(mu::engraving::ElementType::FRET_DIAGRAM);
 
+    updateIsInFretBox();
+
     emit fretDiagramChanged(fretDiagram());
     emit areSettingsAvailableChanged(areSettingsAvailable());
 }
@@ -266,4 +268,33 @@ void FretDiagramSettingsModel::setCurrentFretDotType(int currentFretDotType)
 
     m_currentFretDotType = newFretDotType;
     emit currentFretDotTypeChanged(currentFretDotType);
+}
+
+void FretDiagramSettingsModel::updateIsInFretBox()
+{
+    bool isInFretBox = false;
+
+    for (mu::engraving::EngravingItem* item : std::as_const(m_elementList)) {
+        if (engraving::toFretDiagram(item)->isInFretBox()) {
+            isInFretBox = true;
+            break;
+        }
+    }
+
+    setIsInFretBox(isInFretBox);
+}
+
+bool FretDiagramSettingsModel::isInFretBox() const
+{
+    return m_isInFretBox;
+}
+
+void FretDiagramSettingsModel::setIsInFretBox(bool isInFretBox)
+{
+    if (m_isInFretBox == isInFretBox) {
+        return;
+    }
+
+    m_isInFretBox = isInFretBox;
+    emit isInFretBoxChanged(isInFretBox);
 }

--- a/src/inspector/models/notation/fretdiagrams/fretdiagramsettingsmodel.h
+++ b/src/inspector/models/notation/fretdiagrams/fretdiagramsettingsmodel.h
@@ -49,6 +49,7 @@ class FretDiagramSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(int currentFretDotType READ currentFretDotType WRITE setCurrentFretDotType NOTIFY currentFretDotTypeChanged)
 
     Q_PROPERTY(bool areSettingsAvailable READ areSettingsAvailable NOTIFY areSettingsAvailableChanged)
+    Q_PROPERTY(bool isInFretBox READ isInFretBox NOTIFY isInFretBoxChanged)
 
     Q_PROPERTY(QVariant fretDiagram READ fretDiagram NOTIFY fretDiagramChanged)
     Q_PROPERTY(PropertyItem * showFingerings READ showFingerings CONSTANT)
@@ -84,6 +85,9 @@ public:
 
     bool areSettingsAvailable() const;
 
+    bool isInFretBox() const;
+    void setIsInFretBox(bool isInFretBox);
+
 public slots:
     void setIsBarreModeOn(bool isBarreModeOn);
     void setIsMultipleDotsModeOn(bool isMultipleDotsModeOn);
@@ -99,7 +103,11 @@ signals:
     void areSettingsAvailableChanged(bool areSettingsAvailable);
     void fingeringsChanged(QStringList fingerings);
 
+    void isInFretBoxChanged(bool isInFretBox);
+
 private:
+    void updateIsInFretBox();
+
     PropertyItem* m_scale = nullptr;
     PropertyItem* m_stringsCount = nullptr;
     PropertyItem* m_fretsCount = nullptr;
@@ -115,6 +123,7 @@ private:
 
     bool m_isBarreModeOn = false;
     bool m_isMultipleDotsModeOn = false;
+    bool m_isInFretBox = false;
     FretDiagramTypes::FretDot m_currentFretDotType = FretDiagramTypes::FretDot::DOT_NORMAL;
 };
 }

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/fretdiagrams/internal/FretAdvancedSettingsTab.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/fretdiagrams/internal/FretAdvancedSettingsTab.qml
@@ -58,6 +58,7 @@ FocusableItem {
 
                 titleText: qsTrc("inspector", "Scale")
                 propertyItem: root.model ? root.model.scale : null
+                enabled: root.model ? !root.model.isInFretBox : false
 
                 measureUnitsSymbol: "%"
                 step: 1


### PR DESCRIPTION
Resolves: #29123