### PR TITLE
Fix update Fretboard Diagram Legend when changing harmonies and undo/redo

### DIFF
--- a/src/engraving/dom/fret.cpp
+++ b/src/engraving/dom/fret.cpp
@@ -967,6 +967,8 @@ void FretDiagram::unlinkHarmony()
 
     segment()->add(m_harmony);
 
+    score()->rebuildFretBox();
+
     m_harmony = nullptr;
 }
 


### PR DESCRIPTION
Resolves: this ⬇️

https://github.com/user-attachments/assets/9478f7e5-f7c4-4d71-be46-65f2c512ecdd

Also
Resolves: #29146