### PR TITLE
Fix QML warnings

### DIFF
--- a/src/app/internal/guiapp.cpp
+++ b/src/app/internal/guiapp.cpp
@@ -259,12 +259,6 @@ void GuiApp::perform()
         });
     }, Qt::QueuedConnection);
 
-    QObject::connect(engine, &QQmlEngine::warnings, [](const QList<QQmlError>& warnings) {
-        for (const QQmlError& e : warnings) {
-            LOGE() << "error: " << e.toString().toStdString() << "\n";
-        }
-    });
-
     // ====================================================
     // Load Main qml
     // ====================================================

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/lines/internal/GradualTempoChangePositionSettingsTab.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/lines/internal/GradualTempoChangePositionSettingsTab.qml
@@ -53,7 +53,7 @@ FocusableItem {
             enabled: root.model ? !root.model.isSystemObjectBelowBottomStaff : false
 
             navigationPanel: root.navigationPanel
-            navigationRowStart: lineStyleSection.navigationRowEnd + 1
+            navigationRowStart: root.navigationRowStart
         }
 
         SeparatorLine {
@@ -61,7 +61,9 @@ FocusableItem {
         }
 
         StyledTextLabel {
+            width: parent.width
             text: qsTrc("inspector", "Alignment with adjacent tempo text")
+            horizontalAlignment: Text.AlignLeft
         }
 
         PropertyCheckBox {
@@ -70,7 +72,7 @@ FocusableItem {
             propertyItem: root.model ? root.model.snapAfter : null
 
             navigation.panel: root.navigationPanel
-            navigation.row: snapBefore.navigation.row + 1
+            navigation.row: placementSection.navigationRowEnd + 1
         }
     }
 }


### PR DESCRIPTION
Also don't print all QML warnings twice, Qt already prints them perfectly fine, so no need to print them ourselves too.