### PR TITLE
Fix #26717: Switch dock tab on mouse release (instead of press)

### DIFF
--- a/src/framework/dockwindow/internal/docktabbar.cpp
+++ b/src/framework/dockwindow/internal/docktabbar.cpp
@@ -37,28 +37,48 @@ bool DockTabBar::event(QEvent* event)
         doubleClicked(mouseEvent->pos());
         return true;
     }
-    case QEvent::MouseButtonPress: {
-        QQuickItem* tabBar = tabBarQmlItem();
-        if (tabBar) {
-            QMouseEvent* mouseEvent = static_cast<QMouseEvent*>(event);
-            QPoint localPos = mouseEvent->pos();
-
-            int tabIndex = tabAt(localPos);
-            if (tabIndex < 0) {
-                return true;
-            }
-
-            tabBar->setProperty("currentIndex", tabIndex);
-            TabBar::onMousePress(localPos);
-        }
-
-        break;
+    case QEvent::MouseButtonPress:
+    case QEvent::MouseButtonRelease: {
+        QMouseEvent* mouseEvent = static_cast<QMouseEvent*>(event);
+        onMousePressRelease(mouseEvent);
+        return true;
     }
     default:
         break;
     }
 
     return KDDockWidgets::TabBarQuick::event(event);
+}
+
+void DockTabBar::onMousePressRelease(const QMouseEvent* mouseEvent)
+{
+    QQuickItem* tabBar = tabBarQmlItem();
+    if (!mouseEvent || !tabBar) {
+        return;
+    }
+
+    const QPoint localPos = mouseEvent->pos();
+
+    int tabIndex = tabAt(localPos);
+    if (tabIndex < 0) {
+        return;
+    }
+
+    switch (mouseEvent->type()) {
+    case QEvent::MouseButtonPress: {
+        m_indexOfPressedTab = tabIndex;
+        TabBar::onMousePress(localPos);
+        break;
+    }
+    case QEvent::MouseButtonRelease: {
+        if (tabIndex == m_indexOfPressedTab) {
+            tabBar->setProperty("currentIndex", tabIndex);
+        }
+        m_indexOfPressedTab = -1;
+        break;
+    }
+    default: UNREACHABLE;
+    }
 }
 
 void DockTabBar::doubleClicked(const QPoint& pos) const

--- a/src/framework/dockwindow/internal/docktabbar.h
+++ b/src/framework/dockwindow/internal/docktabbar.h
@@ -40,9 +40,11 @@ public:
 
 private:
     bool event(QEvent* event) override;
+    void onMousePressRelease(const QMouseEvent* mouseEvent);
     bool isPositionDraggable(QPoint localPos) const override;
 
     QQuickItem* m_draggableMouseArea = nullptr;
+    int m_indexOfPressedTab = -1;
 };
 }
 


### PR DESCRIPTION
Resolves: #26717

I hoped this would simply be a case of properly intercepting/accepting the QEvent but that doesn't appear to work. Instead the solution I've gone for here is to only switch tabs once the mouse has been released.