### PR TITLE
Fix grace note after bend bugs

### DIFF
--- a/src/engraving/dom/engravingitem.cpp
+++ b/src/engraving/dom/engravingitem.cpp
@@ -1050,6 +1050,7 @@ void EngravingItem::add(EngravingItem* e)
     switch (e->type()) {
     case ElementType::PARENTHESIS: {
         Parenthesis* p = toParenthesis(e);
+        p->setVisible(visible());
         if (p->direction() == DirectionH::LEFT) {
             m_leftParenthesis = p;
         } else if (p->direction() == DirectionH::RIGHT) {

--- a/src/engraving/dom/note.cpp
+++ b/src/engraving/dom/note.cpp
@@ -3157,8 +3157,11 @@ PropertyValue Note::propertyDefault(Pid propertyId) const
     case Pid::TPC1:
         return PropertyValue();
     case Pid::VISIBLE:
-        if (staffType() && staffType()->isTabStaff() && bendBack()) {
-            return false;
+        if (staffType() && staffType()->isTabStaff()) {
+            GuitarBend* bend = bendBack();
+            if (bend && !bend->isFullRelease()) {
+                return false;
+            }
         }
         return EngravingItem::propertyDefault(propertyId);
     case Pid::COLOR: {

--- a/src/engraving/dom/stringdata.cpp
+++ b/src/engraving/dom/stringdata.cpp
@@ -509,6 +509,9 @@ void StringData::sortChordNotes(std::map<int, Note*>& sortedNotes, const Chord* 
         if (note->displayFret() != Note::DisplayFretOption::NoHarmonic) {
             continue;
         }
+        if (note->bendFor() || note->bendBack()) {
+            continue;
+        }
 
         int string = note->string();
         int noteFret = note->fret();

--- a/src/engraving/rendering/score/parenthesislayout.cpp
+++ b/src/engraving/rendering/score/parenthesislayout.cpp
@@ -54,7 +54,7 @@ void ParenthesisLayout::layoutParentheses(const EngravingItem* parent, const Lay
         layoutParenthesis(parent->rightParen(), parent->rightParen()->mutldata(), ctx);
     }
 
-    bool itemAddToSkyline = parent->addToSkyline();
+    bool itemAddToSkyline = parent->autoplace() && !parent->ldata()->isSkipDraw();
     Shape dummyItemShape = parent->shape();
     dummyItemShape.remove_if([](ShapeElement& shapeEl) {
         return shapeEl.item() && shapeEl.item()->isParenthesis();


### PR DESCRIPTION
Resolves: #29075

Points 1 & 2 from the related issue are fixed. Point 3 is not a bug and is not related to the other two, it's just that Musescore enforces that the end note of a bend must be on the same string as the start of the bend (otherwise it's not a bend). Changing string is possible at the start of the bend (and it will cause all the subsequent ones to change too).