### PR TITLE
Fix #27317: color inversion incorrectly affecting palettes (4.6)

### DIFF
--- a/src/engraving/dom/engravingitem.cpp
+++ b/src/engraving/dom/engravingitem.cpp
@@ -2430,7 +2430,7 @@ bool EngravingItem::colorsInversionEnabled() const
     return m_colorsInversionEnabled;
 }
 
-void EngravingItem::setColorsInverionEnabled(bool enabled)
+void EngravingItem::setColorsInversionEnabled(bool enabled)
 {
     m_colorsInversionEnabled = enabled;
 }

--- a/src/engraving/dom/engravingitem.h
+++ b/src/engraving/dom/engravingitem.h
@@ -494,7 +494,7 @@ public:
     double styleP(Sid idx) const;
 
     bool colorsInversionEnabled() const;
-    void setColorsInverionEnabled(bool enabled);
+    void setColorsInversionEnabled(bool enabled);
 
     virtual void setParenthesesMode(const ParenthesesMode& v, bool addToLinked = true, bool generated = false);
     ParenthesesMode parenthesesMode() const;

--- a/src/notation/utilities/engravingitempreviewpainter.cpp
+++ b/src/notation/utilities/engravingitempreviewpainter.cpp
@@ -25,6 +25,9 @@
 #include "engraving/dom/actionicon.h"
 #include "engraving/style/defaultstyle.h"
 #include "engraving/dom/masterscore.h"
+#include "engraving/dom/spanner.h"
+#include "engraving/dom/textlinebase.h"
+#include "engraving/dom/text.h"
 
 using namespace mu::notation;
 using namespace mu::engraving;
@@ -75,7 +78,18 @@ void EngravingItemPreviewPainter::paintItem(mu::engraving::EngravingItem* elemen
         const Color frameColorBackup = item->getProperty(Pid::FRAME_FG_COLOR).value<Color>();
         const bool colorsInversionEnabledBackup = item->colorsInversionEnabled();
 
-        item->setColorsInverionEnabled(ctx->colorsInversionEnabled);
+        item->setColorsInversionEnabled(ctx->colorsInversionEnabled);
+
+        if (item->isTextLineBaseSegment()) {
+            TextLineBaseSegment* tls = item_cast<TextLineBaseSegment*>(item);
+            tls->text()->setColorsInversionEnabled(ctx->colorsInversionEnabled);
+            tls->endText()->setColorsInversionEnabled(ctx->colorsInversionEnabled);
+        }
+
+        if (item->isSpannerSegment()) {
+            SpannerSegment* ss = item_cast<SpannerSegment*>(item);
+            ss->spanner()->setColorsInversionEnabled(ctx->colorsInversionEnabled);
+        }
 
         if (!ctx->useElementColors) {
             const Color color = ctx->color;
@@ -85,9 +99,20 @@ void EngravingItemPreviewPainter::paintItem(mu::engraving::EngravingItem* elemen
 
         engravingRender()->drawItem(item, painter);
 
-        item->setColorsInverionEnabled(colorsInversionEnabledBackup);
+        item->setColorsInversionEnabled(colorsInversionEnabledBackup);
         item->setProperty(Pid::COLOR, colorBackup);
         item->setProperty(Pid::FRAME_FG_COLOR, frameColorBackup);
+
+        if (item->isTextLineBaseSegment()) {
+            TextLineBaseSegment* tls = item_cast<TextLineBaseSegment*>(item);
+            tls->text()->setColorsInversionEnabled(colorsInversionEnabledBackup);
+            tls->endText()->setColorsInversionEnabled(colorsInversionEnabledBackup);
+        }
+
+        if (item->isSpannerSegment()) {
+            SpannerSegment* ss = item_cast<SpannerSegment*>(item);
+            ss->spanner()->setColorsInversionEnabled(colorsInversionEnabledBackup);
+        }
 
         painter->restore();
     };

--- a/src/palette/view/drumsetpanelview.cpp
+++ b/src/palette/view/drumsetpanelview.cpp
@@ -153,7 +153,7 @@ void DrumsetPanelView::updateColors()
     }
 
     options.useElementColors = true;
-    options.colorsInverionsEnabled = true;
+    options.colorsInversionEnabled = true;
 
     widget->setPaintOptions(options);
 

--- a/src/palette/view/widgets/palettewidget.cpp
+++ b/src/palette/view/widgets/palettewidget.cpp
@@ -1097,7 +1097,7 @@ void PaletteWidget::paintEvent(QPaintEvent* /*event*/)
         params.color = configuration()->elementsColor();
 
         params.useElementColors = m_paintOptions.useElementColors;
-        params.colorsInversionEnabled = m_paintOptions.colorsInverionsEnabled;
+        params.colorsInversionEnabled = m_paintOptions.colorsInversionEnabled;
 
         notation::EngravingItemPreviewPainter::paintItem(el.get(), params);
 

--- a/src/palette/view/widgets/palettewidget.h
+++ b/src/palette/view/widgets/palettewidget.h
@@ -167,7 +167,7 @@ public:
         muse::draw::Color selectionColor;
         muse::draw::Color linesColor;
         bool useElementColors = false;
-        bool colorsInverionsEnabled = false;
+        bool colorsInversionEnabled = false;
     };
 
     const PaintOptions& paintOptions() const;


### PR DESCRIPTION
Resolves: #27317

Cherry-pick of #27642 for 4.6.0 branch.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [ ] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
