### PR TITLE
Fix #23121: Eliminate delay for dock tab context menus

### DIFF
--- a/src/framework/dockwindow/qml/Muse/Dock/DockPanelTab.qml
+++ b/src/framework/dockwindow/qml/Muse/Dock/DockPanelTab.qml
@@ -68,25 +68,6 @@ StyledTabButton {
             anchors.verticalCenter: parent.verticalCenter
             visible: root.isCurrent
 
-            Connections {
-                target: root
-
-                function onIsCurrentChanged() {
-                    timer.running = true
-                }
-            }
-
-            Timer {
-                id: timer
-
-                interval: 150
-                repeat: false
-
-                onTriggered: {
-                    contextMenuButton.enabled = root.isCurrent
-                }
-            }
-
             navigation.panel: root.navigation.panel
             navigation.order: root.navigation.order + 1
 


### PR DESCRIPTION
Resolves: #23121

The changes from #29463 mean that this delay timer is no longer necessary