### PR TITLE
[API] Expose an element's children

### DIFF
--- a/src/engraving/api/v1/scoreelement.cpp
+++ b/src/engraving/api/v1/scoreelement.cpp
@@ -76,7 +76,8 @@ qreal ScoreElement::spatium() const
 
 QQmlListProperty<ScoreElement> ScoreElement::children()
 {
-    return wrapContainerProperty<ScoreElement>(this, e->children());
+    const EngravingObjectList& children = e->scanChildren();
+    return wrapContainerProperty<ScoreElement>(this, children);
 }
 
 //---------------------------------------------------------

--- a/src/engraving/api/v1/scoreelement.cpp
+++ b/src/engraving/api/v1/scoreelement.cpp
@@ -227,25 +227,17 @@ void ScoreElement::scanElements(QJSValue func, bool all)
         return;
     }
 
-    struct CallbackContext {
-        QJSValue callback;
-        QJSEngine* engine;
-        Ownership ownership;
-    };
-
-    CallbackContext ctx{ func, qmlEngine(this), ownership() };
-
     auto wrapper = [](void* data, mu::engraving::EngravingItem* item) {
-        auto* ctx = static_cast<CallbackContext*>(data);
-        if (!ctx->callback.isCallable()) {
+        auto* callback = static_cast<QJSValue*>(data);
+        if (!callback->isCallable()) {
             return;
         }
 
         QJSValueList args;
-        args << ctx->engine->toScriptValue(wrap(item, ctx->ownership));
-        ctx->callback.call(args);
+        args << wrap(item); //ctx->engine->toScriptValue(wrap(item, ctx->ownership));
+        callback->call(args);
     };
-    e->scanElements(&ctx, wrapper, all);
+    e->scanElements(&func, wrapper, all);
 }
 
 //---------------------------------------------------------

--- a/src/engraving/api/v1/scoreelement.cpp
+++ b/src/engraving/api/v1/scoreelement.cpp
@@ -74,10 +74,9 @@ qreal ScoreElement::spatium() const
     return e->isEngravingItem() ? toEngravingItem(e)->spatium() : e->score()->style().spatium();
 }
 
-QQmlListProperty<ScoreElement> ScoreElement::children()
+QQmlListProperty<ScoreElement> ScoreElement::children(bool includeInvisible)
 {
-    const EngravingObjectList& children = e->scanChildren();
-    return wrapContainerProperty<ScoreElement>(this, children);
+    return wrapContainerProperty<ScoreElement>(this, e->getChildren(includeInvisible));
 }
 
 //---------------------------------------------------------

--- a/src/engraving/api/v1/scoreelement.cpp
+++ b/src/engraving/api/v1/scoreelement.cpp
@@ -221,33 +221,6 @@ void ScoreElement::reset(mu::engraving::Pid pid)
     }
 }
 
-void ScoreElement::scanElements(QJSValue func, bool all)
-{
-    if (!func.isCallable()) {
-        return;
-    }
-
-    struct CallbackContext {
-        QJSValue callback;
-        QJSEngine* engine;
-        Ownership ownership;
-    };
-
-    CallbackContext ctx{ func, qmlEngine(this), ownership() };
-
-    auto wrapper = [](void* data, mu::engraving::EngravingItem* item) {
-        auto* ctx = static_cast<CallbackContext*>(data);
-        if (!ctx->callback.isCallable()) {
-            return;
-        }
-
-        QJSValueList args;
-        args << ctx->engine->toScriptValue(wrap(item, ctx->ownership));
-        ctx->callback.call(args);
-    };
-    e->scanElements(&ctx, wrapper, all);
-}
-
 //---------------------------------------------------------
 //   wrap
 ///   \cond PLUGIN_API \private \endcond

--- a/src/engraving/api/v1/scoreelement.cpp
+++ b/src/engraving/api/v1/scoreelement.cpp
@@ -76,7 +76,9 @@ qreal ScoreElement::spatium() const
 
 QQmlListProperty<ScoreElement> ScoreElement::children(bool includeInvisible)
 {
-    return wrapContainerProperty<ScoreElement>(this, e->getChildren(includeInvisible));
+    static std::vector<engraving::EngravingItem*> list;
+    list = e->getChildren(includeInvisible);
+    return wrapContainerProperty<ScoreElement>(this, list);
 }
 
 //---------------------------------------------------------

--- a/src/engraving/api/v1/scoreelement.cpp
+++ b/src/engraving/api/v1/scoreelement.cpp
@@ -227,17 +227,25 @@ void ScoreElement::scanElements(QJSValue func, bool all)
         return;
     }
 
+    struct CallbackContext {
+        QJSValue callback;
+        QJSEngine* engine;
+        Ownership ownership;
+    };
+
+    CallbackContext ctx{ func, qmlEngine(this), ownership() };
+
     auto wrapper = [](void* data, mu::engraving::EngravingItem* item) {
-        auto* callback = static_cast<QJSValue*>(data);
-        if (!callback->isCallable()) {
+        auto* ctx = static_cast<CallbackContext*>(data);
+        if (!ctx->callback.isCallable()) {
             return;
         }
 
         QJSValueList args;
-        args << wrap(item); //ctx->engine->toScriptValue(wrap(item, ctx->ownership));
-        callback->call(args);
+        args << ctx->engine->toScriptValue(wrap(item, ctx->ownership));
+        ctx->callback.call(args);
     };
-    e->scanElements(&func, wrapper, all);
+    e->scanElements(&ctx, wrapper, all);
 }
 
 //---------------------------------------------------------

--- a/src/engraving/api/v1/scoreelement.cpp
+++ b/src/engraving/api/v1/scoreelement.cpp
@@ -74,6 +74,11 @@ qreal ScoreElement::spatium() const
     return e->isEngravingItem() ? toEngravingItem(e)->spatium() : e->score()->style().spatium();
 }
 
+QQmlListProperty<ScoreElement> ScoreElement::children()
+{
+    return wrapContainerProperty<ScoreElement>(this, e->children());
+}
+
 //---------------------------------------------------------
 //   ScoreElement::get
 //---------------------------------------------------------

--- a/src/engraving/api/v1/scoreelement.h
+++ b/src/engraving/api/v1/scoreelement.h
@@ -112,11 +112,6 @@ public:
     Q_INVOKABLE QString userName() const;
     /// Checks whether two variables represent the same object. \since MuseScore 3.3
     Q_INVOKABLE bool is(apiv1::ScoreElement* other) { return other && element() == other->element(); }
-    /// Applies a given function to this element's children
-    /// \param func the function to apply.
-    /// \param all whether to apply the function to children of children.
-    /// \since MuseScore 4.7
-    Q_INVOKABLE void scanElements(QJSValue func, bool all);
 };
 
 //---------------------------------------------------------

--- a/src/engraving/api/v1/scoreelement.h
+++ b/src/engraving/api/v1/scoreelement.h
@@ -69,9 +69,6 @@ class ScoreElement : public QObject
     /// The EID of this element.
     /// \since MuseScore 4.6
     Q_PROPERTY(QString eid READ eid)
-    /// The children of this element. Does not include children of children.
-    /// \since MuseScore 4.7
-    Q_PROPERTY(QQmlListProperty<apiv1::ScoreElement> children READ children)
 
     Ownership m_ownership;
 
@@ -101,8 +98,6 @@ public:
 
     QString eid() const { return QString::fromStdString(element()->eid().toStdString()); }
 
-    QQmlListProperty<apiv1::ScoreElement> children();
-
     QVariant get(mu::engraving::Pid pid) const;
     void set(mu::engraving::Pid pid, const QVariant& val);
     void reset(mu::engraving::Pid pid);
@@ -112,6 +107,10 @@ public:
     Q_INVOKABLE QString userName() const;
     /// Checks whether two variables represent the same object. \since MuseScore 3.3
     Q_INVOKABLE bool is(apiv1::ScoreElement* other) { return other && element() == other->element(); }
+    /// Gets the children of this element. Includes children of children.
+    /// \param includeInvisible Whether invisible elements are included in the list.
+    /// \since MuseScore 4.7
+    Q_INVOKABLE QQmlListProperty<apiv1::ScoreElement> children(bool includeInvisible = true);
 };
 
 //---------------------------------------------------------

--- a/src/engraving/api/v1/scoreelement.h
+++ b/src/engraving/api/v1/scoreelement.h
@@ -34,6 +34,7 @@ class EngravingObject;
 }
 
 namespace mu::engraving::apiv1 {
+class ScoreElement;
 //---------------------------------------------------------
 //   Ownership
 ///   \cond PLUGIN_API \private \endcond
@@ -68,6 +69,9 @@ class ScoreElement : public QObject
     /// The EID of this element.
     /// \since MuseScore 4.6
     Q_PROPERTY(QString eid READ eid)
+    /// The children of this element. Does not include children of children.
+    /// \since MuseScore 4.7
+    Q_PROPERTY(QQmlListProperty<apiv1::ScoreElement> children READ children)
 
     Ownership m_ownership;
 
@@ -96,6 +100,8 @@ public:
     int type() const;
 
     QString eid() const { return QString::fromStdString(element()->eid().toStdString()); }
+
+    QQmlListProperty<apiv1::ScoreElement> children();
 
     QVariant get(mu::engraving::Pid pid) const;
     void set(mu::engraving::Pid pid, const QVariant& val);

--- a/src/engraving/api/v1/scoreelement.h
+++ b/src/engraving/api/v1/scoreelement.h
@@ -112,6 +112,11 @@ public:
     Q_INVOKABLE QString userName() const;
     /// Checks whether two variables represent the same object. \since MuseScore 3.3
     Q_INVOKABLE bool is(apiv1::ScoreElement* other) { return other && element() == other->element(); }
+    /// Applies a given function to this element's children
+    /// \param func the function to apply.
+    /// \param all whether to apply the function to children of children.
+    /// \since MuseScore 4.7
+    Q_INVOKABLE void scanElements(QJSValue func, bool all);
 };
 
 //---------------------------------------------------------


### PR DESCRIPTION
Resolves: #28419

Since #28957 it's easy to expose this to the API. Testing this a few months ago when `std::list` was used led to some unstable results, but now that it's an `std::vector` like the other plugin list properties I haven't encountered any issues.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
