### PR TITLE
Fix Textstream::operator<<(double) format

### DIFF
--- a/src/framework/global/serialization/textstream.cpp
+++ b/src/framework/global/serialization/textstream.cpp
@@ -101,7 +101,11 @@ TextStream& TextStream::operator<<(double val)
     || (!defined(__APPLE__) && defined(_LIBCPP_VERSION) && _LIBCPP_VERSION >= 14000) \
     || (defined(_GLIBCXX_RELEASE) && _GLIBCXX_RELEASE >= 11)
     std::array<char, 24> buf{};
-    const auto [last, ec] = std::to_chars(buf.data(), buf.data() + buf.size(), val);
+
+    // emulate std::stringstream default behavior
+    constexpr auto format = std::chars_format::general;
+    constexpr int precision = 6;
+    const auto [last, ec] = std::to_chars(buf.data(), buf.data() + buf.size(), val, format, precision);
     IF_ASSERT_FAILED(ec == std::errc {}) {
         return *this;
     }


### PR DESCRIPTION
`std::to_chars` has different output than `std::stringstream` by default. This breaks tests on windows (and other platforms with a sufficiently recent std lib)

Broken by me in #28952

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
