### PR TITLE
Refactor of runOnSplashScreen

### DIFF
--- a/src/appshell/internal/startupscenario.cpp
+++ b/src/appshell/internal/startupscenario.cpp
@@ -25,6 +25,7 @@
 #include <QCoreApplication>
 
 #include "async/async.h"
+#include "network/networkerrors.h"
 #include "translation.h"
 #include "log.h"
 
@@ -94,50 +95,45 @@ muse::async::Promise<muse::Ret> StartupScenario::runOnSplashScreen()
         registerAudioPlugins();
 
         if (multiInstancesProvider()->instances().size() != 1) {
-            const Ret ret = muse::make_ret(Ret::Code::Cancel);
+            const Ret ret = muse::make_ret(Ret::Code::Ok);
             return resolve(ret);
         }
 
         // Calculate the total number of expected update checks (TODO: check the
         // connection before trying any of this)...
-        static size_t totalChecksExpected = 0;
 
         const bool canCheckAppUpdate = appUpdateScenario() && appUpdateScenario()->needCheckForUpdate();
-        if (canCheckAppUpdate) {
-            ++totalChecksExpected;
-        }
-
         const bool canCheckMuseSoundsUpdate = museSoundsUpdateScenario() && museSoundsUpdateScenario()->needCheckForUpdate();
-        if (canCheckMuseSoundsUpdate) {
-            ++totalChecksExpected;
-        }
-
         //! NOTE: A MuseSampler update check also exists but we run it later (see onStartupPageOpened)...
+        m_totalChecksExpected = size_t(canCheckAppUpdate) + size_t(canCheckMuseSoundsUpdate);
 
-        if (totalChecksExpected == 0) {
+        if (m_totalChecksExpected == 0) {
             const Ret ret = muse::make_ret(Ret::Code::Ok);
             return resolve(ret);
         }
 
+        m_totalChecksReceived = 0;
+
         // Resolve once all checks are completed...
         const auto onUpdateCheckCompleted = [this, resolve](){
-            static size_t totalChecksReceived = 0;
-            IF_ASSERT_FAILED(m_updateCheckInProgress && totalChecksReceived < totalChecksExpected) {
-                m_updateCheckInProgress = false;
-                return;
+            if (!m_updateChecksInProgress) {
+                return; // Already resolved or timed out...
             }
 
-            ++totalChecksReceived;
+            ++m_totalChecksReceived;
 
-            if (totalChecksReceived == totalChecksExpected) {
-                m_updateCheckInProgress = false;
-                const Ret ret = muse::make_ret(Ret::Code::Ok);
-                (void)resolve(ret);
+            if (m_totalChecksReceived < m_totalChecksExpected) {
+                return; // Not ready to resolve yet...
             }
+
+            m_updateChecksInProgress = false;
+
+            const Ret ret = muse::make_ret(Ret::Code::Ok);
+            (void)resolve(ret);
         };
 
         // Asynchronously start the checks once we know the total number of expected checks...
-        m_updateCheckInProgress = true;
+        m_updateChecksInProgress = true;
         async::Async::call(this, [this, onUpdateCheckCompleted, canCheckAppUpdate, canCheckMuseSoundsUpdate]() {
             if (canCheckAppUpdate) {
                 muse::async::Promise<Ret> promise = appUpdateScenario()->checkForUpdate(/*manual*/ false);
@@ -155,11 +151,15 @@ muse::async::Promise<muse::Ret> StartupScenario::runOnSplashScreen()
 
         // Timeout if the checks take too long...
         QTimer::singleShot(CHECK_FOR_UPDATES_TIMEOUT, [this, resolve]() {
-            if (m_updateCheckInProgress) {
-                LOGE() << "Update checks timed out...";
-                const Ret ret = muse::make_ret(Ret::Code::Cancel);
-                (void)resolve(ret);
+            if (!m_updateChecksInProgress) {
+                return;
             }
+
+            m_updateChecksInProgress = false;
+
+            LOGE() << "Update checks timed out...";
+            const Ret ret = network::make_ret(network::Err::Timeout);
+            (void)resolve(ret);
         });
 
         return muse::async::Promise<Ret>::dummy_result();

--- a/src/appshell/internal/startupscenario.h
+++ b/src/appshell/internal/startupscenario.h
@@ -91,7 +91,9 @@ private:
     project::ProjectFile m_startupScoreFile;
     bool m_startupCompleted = false;
 
-    bool m_updateCheckInProgress = false;
+    bool m_updateChecksInProgress = false;
+    size_t m_totalChecksExpected = 0;
+    size_t m_totalChecksReceived = 0;
 };
 }
 


### PR DESCRIPTION
The main idea here is to prevent `resolve` being called twice by adding `m_updateChecksInProgress = false` to the timeout lambda.