### PR TITLE
Fix #29471: Context menus in undocked panels

### DIFF
--- a/src/framework/dockwindow/qml/Muse/Dock/DockFrame.qml
+++ b/src/framework/dockwindow/qml/Muse/Dock/DockFrame.qml
@@ -95,8 +95,6 @@ Rectangle {
 
         titleBarCpp: root.titleBarCpp
 
-        contextMenuModel: prv.tabsModel.data(prv.tabsModel.index(prv.currentIndex, 0), DockTabsModel.ContextMenu)
-
         navigationPanel: navPanel
         navigationOrder: 1
 
@@ -105,6 +103,18 @@ Rectangle {
         }
 
         titleBarItem: frameModel.titleBar
+
+        function updateContextMenu() {
+            const idx = prv.tabsModel.index(prv.currentIndex, 0);
+            const menuModel = prv.tabsModel.data(idx, DockTabsModel.ContextMenu)
+            titleBar.contextMenuModel = menuModel
+        }
+
+        Connections {
+            target: prv.tabsModel
+            function onDataChanged() { titleBar.updateContextMenu() }
+            function onModelReset() { titleBar.updateContextMenu() }
+        }
     }
 
     DockTabBar {


### PR DESCRIPTION
Resolves: #29471

Addresses an oversight from #29249 - we cant bind `contextMenuModel` like this. The approach used in this solution is largely the same as the one used for toolbar components in DockTabBar.qml.