### PR TITLE
remove colons in preference panels

### DIFF
--- a/src/appshell/qml/Preferences/PercussionPreferencesPage.qml
+++ b/src/appshell/qml/Preferences/PercussionPreferencesPage.qml
@@ -65,7 +65,7 @@ PreferencesPage {
 
                 horizontalAlignment: Text.AlignLeft
                 wrapMode: Text.Wrap
-                text: qsTrc("notation/percussion", "Open the panel automatically:")
+                text: qsTrc("notation/percussion", "Open the panel automatically")
             }
 
             RadioButtonGroup {

--- a/src/appshell/qml/Preferences/PreferencesDialog.qml
+++ b/src/appshell/qml/Preferences/PreferencesDialog.qml
@@ -71,6 +71,10 @@ StyledDialogView {
             }
 
             var pageComponent = Qt.createComponent("../" + pageInfo.path)
+            if (pageComponent.status === Component.Error) {
+                console.error("Failed to load preferences page component:", pageComponent.errorString())
+                continue
+            }
 
             var properties = {
                 navigationSection: root.navigationSection,

--- a/src/appshell/qml/Preferences/internal/AccentColorsSection.qml
+++ b/src/appshell/qml/Preferences/internal/AccentColorsSection.qml
@@ -60,7 +60,7 @@ Row {
         anchors.verticalCenter: parent.verticalCenter
         horizontalAlignment: Qt.AlignLeft
 
-        text: qsTrc("appshell/preferences", "Accent color:")
+        text: qsTrc("appshell/preferences", "Accent color")
     }
 
     AccentColorsList {

--- a/src/appshell/qml/Preferences/internal/AutoSaveSection.qml
+++ b/src/appshell/qml/Preferences/internal/AutoSaveSection.qml
@@ -46,7 +46,7 @@ BaseSection {
             width: root.columnWidth
             anchors.verticalCenter: parent.verticalCenter
 
-            text: qsTrc("appshell/preferences", "Auto save every:")
+            text: qsTrc("appshell/preferences", "Auto save every")
 
             navigation.name: "AutoSaveCheckBox"
             navigation.panel: root.navigation

--- a/src/appshell/qml/Preferences/internal/BrailleAdvancedSection.qml
+++ b/src/appshell/qml/Preferences/internal/BrailleAdvancedSection.qml
@@ -38,7 +38,7 @@ BaseSection {
     signal intervalDirectionChangeRequested(int direction)
 
     ComboBoxWithTitle {
-        title: qsTrc("appshell/preferences", "Braille table for lyrics:")
+        title: qsTrc("appshell/preferences", "Braille table for lyrics")
         columnWidth: root.columnWidth
 
         currentIndex: control.indexOfValue(root.brailleTable)
@@ -54,7 +54,7 @@ BaseSection {
     }
 
     ComboBoxWithTitle {
-        title: qsTrc("appshell/preferences", "Interval direction:")
+        title: qsTrc("appshell/preferences", "Interval direction")
         columnWidth: root.columnWidth
 
         currentIndex: control.indexOfValue(root.intervalDirection)

--- a/src/appshell/qml/Preferences/internal/CharsetsSection.qml
+++ b/src/appshell/qml/Preferences/internal/CharsetsSection.qml
@@ -34,7 +34,7 @@ BaseSection {
     signal overtureCharsetChangeRequested(string charset)
 
     ComboBoxWithTitle {
-        title: qsTrc("appshell/preferences", "Overture import character set:")
+        title: qsTrc("appshell/preferences", "Overture import character set")
         columnWidth: root.columnWidth
 
         currentIndex: control.indexOfValue(root.currentOvertureCharset)

--- a/src/appshell/qml/Preferences/internal/ColorAndWallpaperSection.qml
+++ b/src/appshell/qml/Preferences/internal/ColorAndWallpaperSection.qml
@@ -59,7 +59,7 @@ BaseSection {
             implicitWidth: root.columnWidth
 
             checked: root.useColor
-            text: qsTrc("appshell/preferences", "Color:")
+            text: qsTrc("appshell/preferences", "Color")
 
             navigation.name: "ColorBox"
             navigation.panel: root.navigation
@@ -92,7 +92,7 @@ BaseSection {
             implicitWidth: root.columnWidth
 
             checked: !root.useColor
-            text: qsTrc("appshell/preferences", "Wallpaper:")
+            text: qsTrc("appshell/preferences", "Wallpaper")
 
             navigation.name: "WallpaperBox"
             navigation.panel: root.navigation

--- a/src/appshell/qml/Preferences/internal/CommonAudioApiConfiguration.qml
+++ b/src/appshell/qml/Preferences/internal/CommonAudioApiConfiguration.qml
@@ -50,7 +50,7 @@ Item {
         spacing: 12
 
         ComboBoxWithTitle {
-            title: qsTrc("appshell/preferences", "Audio device:")
+            title: qsTrc("appshell/preferences", "Audio device")
             columnWidth: root.columnWidth
 
             currentIndex: indexOfValue(apiModel.currentDeviceId)
@@ -68,7 +68,7 @@ Item {
         ComboBoxWithTitle {
             id: bufferSize
 
-            title: qsTrc("appshell/preferences", "Buffer size:")
+            title: qsTrc("appshell/preferences", "Buffer size")
             columnWidth: root.columnWidth
 
             currentIndex: indexOfValue(apiModel.bufferSize)
@@ -86,7 +86,7 @@ Item {
         ComboBoxWithTitle {
             id: sampleRate
 
-            title: qsTrc("appshell/preferences", "Sample rate:")
+            title: qsTrc("appshell/preferences", "Sample rate")
             columnWidth: root.columnWidth
 
             currentIndex: indexOfValue(apiModel.sampleRate)

--- a/src/appshell/qml/Preferences/internal/DefaultFilesSection.qml
+++ b/src/appshell/qml/Preferences/internal/DefaultFilesSection.qml
@@ -52,7 +52,7 @@ BaseSection {
             StyledTextLabel {
                 id: titleLabel
                 Layout.preferredWidth: root.columnWidth
-                text: model.title + ":"
+                text: model.title
                 horizontalAlignment: Text.AlignLeft
             }
 

--- a/src/appshell/qml/Preferences/internal/FoldersSection.qml
+++ b/src/appshell/qml/Preferences/internal/FoldersSection.qml
@@ -52,7 +52,7 @@ BaseSection {
             StyledTextLabel {
                 id: titleLabel
                 Layout.preferredWidth: root.columnWidth
-                text: model.title + ":"
+                text: model.title
                 horizontalAlignment: Text.AlignLeft
             }
 

--- a/src/appshell/qml/Preferences/internal/ImportStyleSection.qml
+++ b/src/appshell/qml/Preferences/internal/ImportStyleSection.qml
@@ -77,7 +77,7 @@ BaseSection {
             width: root.columnWidth
             anchors.verticalCenter: parent.verticalCenter
 
-            text: qsTrc("appshell/preferences", "Use style file:")
+            text: qsTrc("appshell/preferences", "Use style file")
             checked: prv.useStyleFile
 
             navigation.name: "UseStyleButton"

--- a/src/appshell/qml/Preferences/internal/MidiDevicesSection.qml
+++ b/src/appshell/qml/Preferences/internal/MidiDevicesSection.qml
@@ -44,7 +44,7 @@ BaseSection {
     ComboBoxWithTitle {
         id: inputDevicesBox
 
-        title: qsTrc("appshell/preferences", "MIDI input:")
+        title: qsTrc("appshell/preferences", "MIDI input")
         currentIndex: indexOfValue(root.inputDeviceId)
         columnWidth: root.columnWidth
 
@@ -60,7 +60,7 @@ BaseSection {
     ComboBoxWithTitle {
         id: outputDevicesBox
 
-        title: qsTrc("appshell/preferences", "MIDI output:")
+        title: qsTrc("appshell/preferences", "MIDI output")
         currentIndex: indexOfValue(root.outputDeviceId)
         columnWidth: root.columnWidth
 

--- a/src/appshell/qml/Preferences/internal/MidiSection.qml
+++ b/src/appshell/qml/Preferences/internal/MidiSection.qml
@@ -36,7 +36,7 @@ BaseSection {
     ComboBoxWithTitle {
         id: shortestNotesBox
 
-        title: qsTrc("appshell/preferences", "Shortest note:")
+        title: qsTrc("appshell/preferences", "Shortest note")
         columnWidth: root.columnWidth
 
         currentIndex: control.indexOfValue(root.currentShortestNote)

--- a/src/appshell/qml/Preferences/internal/MiscellaneousSection.qml
+++ b/src/appshell/qml/Preferences/internal/MiscellaneousSection.qml
@@ -36,7 +36,7 @@ BaseSection {
     IncrementalPropertyControlWithTitle {
         id: selectionProximityControl
 
-        title: qsTrc("appshell/preferences", "Proximity for selecting elements:")
+        title: qsTrc("appshell/preferences", "Proximity for selecting elements")
 
         columnWidth: root.columnWidth
         spacing: root.columnSpacing

--- a/src/appshell/qml/Preferences/internal/NoteInput/MidiInputSection.qml
+++ b/src/appshell/qml/Preferences/internal/NoteInput/MidiInputSection.qml
@@ -123,7 +123,7 @@ BaseSection {
                 id: delayBetweenNotesControl
 
                 enabled: root.midiInputEnabled
-                title: qsTrc("appshell/preferences", "Delay between notes:")
+                title: qsTrc("appshell/preferences", "Delay between notes")
 
                 currentValue: root.delayBetweenNotes
 

--- a/src/appshell/qml/Preferences/internal/NoteInput/NoteInputSection.qml
+++ b/src/appshell/qml/Preferences/internal/NoteInput/NoteInputSection.qml
@@ -45,7 +45,7 @@ BaseSection {
     ComboBoxWithTitle {
         id: defaultNoteInputMethodDropdown
 
-        title: qsTrc("appshell/preferences", "Default input mode:")
+        title: qsTrc("appshell/preferences", "Default input mode")
 
         currentIndex: defaultNoteInputMethodDropdown.indexOfValue(root.defaultNoteInputMethod)
 
@@ -59,7 +59,7 @@ BaseSection {
     }
 
     ComboBoxWithTitle {
-        title: qsTrc("appshell/preferences", "Apply accidentals, augmentation dots, and articulations:")
+        title: qsTrc("appshell/preferences", "Apply accidentals, augmentation dots, and articulations")
 
         navigation.name: "AddAccidentalDotsArticulationsToNextNoteEnteredDropdown"
         navigation.panel: root.navigation
@@ -78,7 +78,7 @@ BaseSection {
     }
 
     ComboBoxWithTitle {
-        title: qsTrc("appshell/preferences", "Input by duration mode cursor:")
+        title: qsTrc("appshell/preferences", "Input by duration mode cursor")
 
         navigation.name: "InputByDurationModeCursorDropdown"
         navigation.panel: root.navigation

--- a/src/appshell/qml/Preferences/internal/NoteInput/NotePreviewSection.qml
+++ b/src/appshell/qml/Preferences/internal/NoteInput/NotePreviewSection.qml
@@ -86,7 +86,7 @@ BaseSection {
     IncrementalPropertyControlWithTitle {
         id: notePlayDurationControl
 
-        title: qsTrc("appshell/preferences", "Playback duration:")
+        title: qsTrc("appshell/preferences", "Playback duration")
 
         enabled: root.playNotesWhenEditing
 

--- a/src/appshell/qml/Preferences/internal/NoteInput/VoiceAssignmentSection.qml
+++ b/src/appshell/qml/Preferences/internal/NoteInput/VoiceAssignmentSection.qml
@@ -36,7 +36,7 @@ BaseSection {
 
     StyledTextLabel {
         width: parent.width
-        text: qsTrc("appshell/preferences", "When entered, dynamics and hairpins should affect:")
+        text: qsTrc("appshell/preferences", "When entered, dynamics and hairpins should affect")
         horizontalAlignment: Text.AlignLeft
     }
 

--- a/src/appshell/qml/Preferences/internal/OnlineSoundsSection.qml
+++ b/src/appshell/qml/Preferences/internal/OnlineSoundsSection.qml
@@ -112,7 +112,7 @@ BaseSection {
         control.width: showProcessingVisualizationComboBox.isOpened && root.autoProcessOnlineSoundsInBackground ?
                            378 : showProcessingVisualizationComboBox.columnWidth
 
-        title: qsTrc("appshell/preferences", "Show processing visualization:")
+        title: qsTrc("appshell/preferences", "Show processing visualization")
 
         columnWidth: root.columnWidth
         currentIndex: showProcessingVisualizationComboBox.indexOfValue(root.progressBarMode)

--- a/src/appshell/qml/Preferences/internal/SaveToCloudSection.qml
+++ b/src/appshell/qml/Preferences/internal/SaveToCloudSection.qml
@@ -45,6 +45,7 @@ BaseSection {
 
     AudioGenerationSettings {
         width: parent.width
+        columnWidth: root.columnWidth
 
         navigationPanel: root.navigation
     }

--- a/src/appshell/qml/Preferences/internal/UiColorsSection.qml
+++ b/src/appshell/qml/Preferences/internal/UiColorsSection.qml
@@ -44,10 +44,10 @@ BaseSection {
 
         Repeater {
             model: [
-                { textRole: qsTrc("appshell/preferences", "Accent color:"), colorRole: ui.theme.accentColor, typeRole: AppearancePreferencesModel.AccentColor},
-                { textRole: qsTrc("appshell/preferences", "Text and icons:"), colorRole: ui.theme.fontPrimaryColor, typeRole: AppearancePreferencesModel.TextAndIconsColor},
-                { textRole: qsTrc("appshell/preferences", "Disabled text:"), colorRole: "#000000", typeRole: AppearancePreferencesModel.DisabledColor},
-                { textRole: qsTrc("appshell/preferences", "Border color:"), colorRole: ui.theme.strokeColor, typeRole: AppearancePreferencesModel.BorderColor}
+                { textRole: qsTrc("appshell/preferences", "Accent color"), colorRole: ui.theme.accentColor, typeRole: AppearancePreferencesModel.AccentColor},
+                { textRole: qsTrc("appshell/preferences", "Text and icons"), colorRole: ui.theme.fontPrimaryColor, typeRole: AppearancePreferencesModel.TextAndIconsColor},
+                { textRole: qsTrc("appshell/preferences", "Disabled text"), colorRole: "#000000", typeRole: AppearancePreferencesModel.DisabledColor},
+                { textRole: qsTrc("appshell/preferences", "Border color"), colorRole: ui.theme.strokeColor, typeRole: AppearancePreferencesModel.BorderColor}
             ]
 
             delegate: Row {

--- a/src/appshell/qml/Preferences/internal/UiFontSection.qml
+++ b/src/appshell/qml/Preferences/internal/UiFontSection.qml
@@ -39,7 +39,7 @@ BaseSection {
     ComboBoxWithTitle {
         id: selectFontControl
 
-        title: qsTrc("appshell/preferences", "Font face:")
+        title: qsTrc("appshell/preferences", "Font face")
         columnWidth: root.columnWidth
 
         navigation.name: "FontFaceBox"
@@ -54,7 +54,7 @@ BaseSection {
     IncrementalPropertyControlWithTitle {
         id: bodyTextSizeControl
 
-        title: qsTrc("appshell/preferences", "Body text size:")
+        title: qsTrc("appshell/preferences", "Body text size")
         columnWidth: root.columnWidth
         control.width: 112
 

--- a/src/appshell/qml/Preferences/internal/ZoomSection.qml
+++ b/src/appshell/qml/Preferences/internal/ZoomSection.qml
@@ -45,7 +45,7 @@ BaseSection {
         ComboBoxWithTitle {
             id: defaultZoomTypesBox
 
-            title: qsTrc("appshell/preferences", "Default zoom:")
+            title: qsTrc("appshell/preferences", "Default zoom")
             columnWidth: root.columnWidth
 
             control.textRole: "title"
@@ -91,7 +91,7 @@ BaseSection {
     IncrementalPropertyControlWithTitle {
         id: mouseZoomPrecisionControl
 
-        title: qsTrc("appshell/preferences", "Mouse zoom precision:")
+        title: qsTrc("appshell/preferences", "Mouse zoom precision")
 
         columnWidth: root.columnWidth
         control.width: 60

--- a/src/appshell/view/preferences/generalpreferencesmodel.cpp
+++ b/src/appshell/view/preferences/generalpreferencesmodel.cpp
@@ -197,7 +197,7 @@ QVariantList GeneralPreferencesModel::startupModes() const
             { "value", static_cast<int>(StartupModeType::StartWithNewScore) },
         },
         QVariantMap {
-            { "title", muse::qtrc("appshell/preferences", "Start with score:") },
+            { "title", muse::qtrc("appshell/preferences", "Start with score") },
             { "value", static_cast<int>(StartupModeType::StartWithScore) },
             { "isStartWithScore", true },
         },

--- a/src/project/qml/MuseScore/Project/AudioGenerationSettings.qml
+++ b/src/project/qml/MuseScore/Project/AudioGenerationSettings.qml
@@ -136,7 +136,7 @@ RadioButtonGroup {
 
             //: `%1` will be replaced with a number input field.
             //: Text before it will appear before that number field, text after will appear after the field.
-            readonly property string text: qsTrc("project/save", "Every: %1 saves")
+            readonly property string text: qsTrc("project/save", "Every %1 saves")
 
             readonly property var textSplit: text.split("%1")
 
@@ -158,7 +158,9 @@ RadioButtonGroup {
                 id: button
 
                 anchors.verticalCenter: parent.verticalCenter
-                width: Math.max(implicitWidth, 80)
+
+                // align spinbox with Autosave spinbox
+                width: 214
 
                 text: numberOfSavesItem.textPart1.trim()
                 checked: settingsModel.timePeriodType === numberOfSavesItem.type

--- a/src/project/qml/MuseScore/Project/AudioGenerationSettings.qml
+++ b/src/project/qml/MuseScore/Project/AudioGenerationSettings.qml
@@ -37,6 +37,8 @@ RadioButtonGroup {
         direction: NavigationPanel.Both
     }
 
+    property real columnWidth: -1
+
     orientation: Qt.Vertical
     spacing: 16
 
@@ -130,7 +132,7 @@ RadioButtonGroup {
 
             width: parent.width
             height: button.implicitHeight
-            spacing: 6
+            spacing: 12
 
             // "Every: %1 saves" needs to be one string for correct translatability. We then split the translated version.
 
@@ -159,8 +161,7 @@ RadioButtonGroup {
 
                 anchors.verticalCenter: parent.verticalCenter
 
-                // align spinbox with Autosave spinbox
-                width: 214
+                width: root.columnWidth > 0 ? root.columnWidth : implicitWidth
 
                 text: numberOfSavesItem.textPart1.trim()
                 checked: settingsModel.timePeriodType === numberOfSavesItem.type


### PR DESCRIPTION
Resolves: #27427. Remove all colons to standardize preference labels. Align spixboxes in Save & publish panel.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
