### PR TITLE
Fix courtesy paren layout on linux

### DIFF
--- a/src/engraving/dom/parenthesis.h
+++ b/src/engraving/dom/parenthesis.h
@@ -51,7 +51,7 @@ public:
         ld_field<double> height = { "[Parenthesis] height", 0.0 };
         ld_field<double> midPointThickness = { "[Parenthesis] midPointThickness", 0.0 };
         ld_field<double> endPointThickness = { "[Parenthesis] endPointThickness", PARENTHESIS_END_WIDTH };
-        ld_field<double> shoulderWidth = "[Parenthesis] endPointThickness";
+        ld_field<double> shoulderWidth = { "[Parenthesis] endPointThickness", 0.0 };
         ld_field<SymId> symId = { "[Parenthesis] symId", SymId::noSym };
     };
     DECLARE_LAYOUTDATA_METHODS(Parenthesis);

--- a/src/engraving/rendering/score/parenthesislayout.cpp
+++ b/src/engraving/rendering/score/parenthesislayout.cpp
@@ -259,7 +259,9 @@ void ParenthesisLayout::createPathAndShape(Parenthesis* item, Parenthesis::Layou
     }
 
     // Control width of parentheses. We don't want tall parens to be too wide, nor do we want parens at a small scale to lose their curve too much
-    double shoulderX = ldata->shoulderWidth.has_value() ? ldata->shoulderWidth() : 0.2 * std::pow(height, 0.95) * std::pow(mag, 0.1);
+    double shoulderX = !muse::RealIsNull(ldata->shoulderWidth()) ? ldata->shoulderWidth() : 0.2
+                       * std::pow(height, 0.95) * std::pow(mag, 0.1);
+
     const double minShoulderX = 0.25 * spatium;
     shoulderX = std::max(shoulderX, minShoulderX);
 


### PR DESCRIPTION
Resolves:

<img width="556" height="207" alt="Screenshot 2025-08-27 at 13 39 44" src="https://github.com/user-attachments/assets/c44bd5dd-3a73-441a-ba56-3e743a4c89b9" />

This was an odd one - `ld_field::hasValue` was returning different results for mac and linux, so I decided not to rely on this.
