### PR TITLE
Fix iterator bugs in score layout code

### DIFF
--- a/src/engraving/rendering/score/accidentalslayout.cpp
+++ b/src/engraving/rendering/score/accidentalslayout.cpp
@@ -627,35 +627,37 @@ void AccidentalsLayout::computeCompactOrdering(std::vector<Accidental*>& acciden
             }
         }
 
-        auto startIter = pickFromTop ? accidentalsToPlace.begin() : --accidentalsToPlace.end();
-        auto endIter = pickFromTop ? accidentalsToPlace.end() : --accidentalsToPlace.begin();
-        auto moveIter = [pickFromTop](auto& iter) {
-            pickFromTop ? ++iter : --iter;
-        };
-
-        auto iter = startIter;
-        while (iter != endIter) {
-            Accidental* acc2 = *iter;
-            if ((pickFromTop && acc2->line() < acc->line()) || (!pickFromTop && acc2->line() > acc->line())) {
-                moveIter(iter);
-                continue;
-            }
-            if (canFitInSameColumn(acc, acc2, ctx)) {
-                if (acc2->ldata()->octaves.value().size() > 0) {
-                    moveIter(iter);
+        const auto fitOthersIntoColumn = [&](const auto startIter, const auto endIter) {
+            auto iter = startIter;
+            while (iter != endIter) {
+                Accidental* acc2 = *iter;
+                if ((pickFromTop && acc2->line() < acc->line()) || (!pickFromTop && acc2->line() > acc->line())) {
+                    ++iter;
                     continue;
                 }
-                foundOneThatFits = true;
-                accidentalsPlaced.push_back(acc2);
-                acc = acc2;
-                if (acc2 == bottomAcc) {
-                    hitBottom = true;
+                if (canFitInSameColumn(acc, acc2, ctx)) {
+                    if (acc2->ldata()->octaves.value().size() > 0) {
+                        ++iter;
+                        continue;
+                    }
+                    foundOneThatFits = true;
+                    accidentalsPlaced.push_back(acc2);
+                    acc = acc2;
+                    if (acc2 == bottomAcc) {
+                        hitBottom = true;
+                    }
+                    ++iter;
+                    accidentalsToPlace.remove(acc2);
+                    continue;
                 }
-                moveIter(iter);
-                accidentalsToPlace.remove(acc2);
-                continue;
+                ++iter;
             }
-            moveIter(iter);
+        };
+
+        if (pickFromTop) {
+            fitOthersIntoColumn(accidentalsToPlace.begin(), accidentalsToPlace.end());
+        } else {
+            fitOthersIntoColumn(accidentalsToPlace.rbegin(), accidentalsToPlace.rend());
         }
 
         if (ctx.keepSecondsTogether()) {

--- a/src/engraving/rendering/score/harmonylayout.cpp
+++ b/src/engraving/rendering/score/harmonylayout.cpp
@@ -600,7 +600,6 @@ void HarmonyLayout::render(Harmony* item, Harmony::LayoutData* ldata, const std:
     harmonyCtx.scale = noteMag;
 
     for (const RenderActionPtr& a : renderList) {
-        a->print();
         renderAction(item, ldata, a, harmonyCtx, ctx);
     }
 }

--- a/src/engraving/rendering/score/measurelayout.cpp
+++ b/src/engraving/rendering/score/measurelayout.cpp
@@ -876,7 +876,9 @@ void MeasureLayout::createMultiMeasureRestsIfNeed(MeasureBase* currentMB, Layout
 void MeasureLayout::removeMMRestElements(Measure* mmRestMeasure)
 {
     // Removed linked clones that were created for the mmRest measure
-    for (EngravingItem* item : mmRestMeasure->el()) {
+    // copy because we're removing elements
+    const ElementList elements = mmRestMeasure->el();
+    for (EngravingItem* item : elements) {
         item->undoUnlink();
         mmRestMeasure->score()->doUndoRemoveElement(item);
     }


### PR DESCRIPTION
This should resolve most issues uncovered by #29508 

1. Issue
    https://github.com/musescore/MuseScore/blob/1bad6282151f6b37386f8d0470681511634afeb1/src/engraving/rendering/score/accidentalslayout.cpp#L630-L631    `--accidentalsToPlace.begin()` is obviously wrong, `--accidentalsToPlace.end()` is wrong when `accidentalsToPlace` is empty. Fixed by moving the while loop into a generic lambda and using either regular or reverse iterators.
2. Issue
    https://github.com/musescore/MuseScore/blob/1bad6282151f6b37386f8d0470681511634afeb1/src/engraving/rendering/score/measurelayout.cpp#L879-L882 good ol' "removing while iterating"

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
