### PR TITLE
fix instrument change export

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
@@ -7952,9 +7952,13 @@ void ExportMusicXml::writeInstrumentChange(const InstrumentChange* instrChange)
     writeInstrumentDetails(instr, m_score->style().styleB(Sid::concertPitch));
 
     m_xml.startElement("sound");
-    m_xml.startElement("instrument-change");
-    scoreInstrument(m_xml, static_cast<int>(partNr) + 1, instNr + 1, instr->trackName(), instr);
-    m_xml.endElement();
+    if (!instr->musicXmlId().empty()) {
+        m_xml.startElementRaw(String("instrument-change %1").arg(instrId(partNr, instNr)));
+        m_xml.tag("instrument-sound", instr->musicXmlId());
+        m_xml.endElement();
+    } else {
+        m_xml.tagRaw(String("instrument-change %1").arg(instrId(partNr, instNr)));        
+    }
     m_xml.endElement();
 }
 

--- a/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
@@ -7953,11 +7953,11 @@ void ExportMusicXml::writeInstrumentChange(const InstrumentChange* instrChange)
 
     m_xml.startElement("sound");
     if (!instr->musicXmlId().empty()) {
-        m_xml.startElementRaw(String("instrument-change %1").arg(instrId(partNr + 1, instNr + 1)));
+        m_xml.startElementRaw(String(u"instrument-change %1").arg(instrId(partNr + 1, instNr + 1)));
         m_xml.tag("instrument-sound", instr->musicXmlId());
         m_xml.endElement();
     } else {
-        m_xml.tagRaw(String("instrument-change %1").arg(instrId(partNr + 1, instNr + 1)));
+        m_xml.tagRaw(String(u"instrument-change %1").arg(instrId(partNr + 1, instNr + 1)));
     }
     m_xml.endElement();
 }

--- a/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
@@ -6475,8 +6475,6 @@ static bool commonAnnotations(ExportMusicXml* exp, const EngravingItem* e, staff
         return false;
     }
 
-    bool instrChangeHandled = false;
-
     // note: the instrument change details are handled in ExportMusicXml::writeMeasureTracks,
     // optionally writing the associated staff text is done below
     if (e->isTempoText()) {
@@ -6494,8 +6492,6 @@ static bool commonAnnotations(ExportMusicXml* exp, const EngravingItem* e, staff
         exp->rehearsal(toRehearsalMark(e), sstaff);
     } else if (e->isSystemText()) {
         exp->systemText(toStaffTextBase(e), sstaff);
-    } else {
-        return instrChangeHandled;
     }
 
     return true;

--- a/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
@@ -7598,8 +7598,8 @@ static void partList(XmlWriter& xml, Score* score, MusicXmlInstrumentMap& instrM
     size_t staffCount = 0;                               // count sum of # staves in parts
     const auto& parts = score->parts();
     int partGroupEnd[MAX_PART_GROUPS];                // staff where part group ends (bracketSpan is in staves, not parts)
-    for (int i = 0; i < MAX_PART_GROUPS; i++) {
-        partGroupEnd[i] = -1;
+    for (int &i : partGroupEnd) {
+        i = -1;
     }
     for (size_t idx = 0; idx < parts.size(); ++idx) {
         const Part* part = parts.at(idx);

--- a/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
@@ -7113,7 +7113,7 @@ void ExportMusicXml::identification(XmlWriter& xml, Score const* const score)
 //  findPartGroupNumber
 //---------------------------------------------------------
 
-static int findPartGroupNumber(int* partGroupEnd)
+static int findPartGroupNumber(std::array<int, MAX_PART_GROUPS> partGroupEnd)
 {
     // find part group number
     for (int number = 0; number < MAX_PART_GROUPS; ++number) {

--- a/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
@@ -6989,23 +6989,20 @@ void ExportMusicXml::keysigTimesig(const Measure* m, const Part* p)
                 }
             }
         }
-        for (staff_idx_t i = 1; i < nstaves; i++) {
-            // return here if it's a key change because of an instrument change
-            if (keysigs.at(i)->forInstrumentChange()) {
-                LOGD("keysigs for instrument change");
-                return;
-            }
-        }
 
         // write the keysigs
         //LOGD(" singleKey %d", singleKey);
         if (singleKey) {
             // keysig applies to all staves
-            keysig(keysigs.at(0), p->staff(0)->clef(m->tick()), 0, keysigs.at(0)->visible());
+            if (!keysigs.at(0)->forInstrumentChange()) {
+                keysig(keysigs.at(0), p->staff(0)->clef(m->tick()), 0, keysigs.at(0)->visible());
+            }
         } else {
             // staff-specific keysigs
             for (staff_idx_t st : muse::keys(keysigs)) {
-                keysig(keysigs.at(st), p->staff(st)->clef(m->tick()), st + 1, keysigs.at(st)->visible());
+                if (!keysigs.at(st)->forInstrumentChange()) {
+                    keysig(keysigs.at(st), p->staff(st)->clef(m->tick()), st + 1, keysigs.at(st)->visible());
+                }
             }
         }
     } else {

--- a/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
@@ -7594,7 +7594,7 @@ static void partList(XmlWriter& xml, Score* score, MusicXmlInstrumentMap& instrM
     size_t staffCount = 0;                               // count sum of # staves in parts
     const auto& parts = score->parts();
     int partGroupEnd[MAX_PART_GROUPS];                // staff where part group ends (bracketSpan is in staves, not parts)
-    for (int &i : partGroupEnd) {
+    for (int& i : partGroupEnd) {
         i = -1;
     }
     for (size_t idx = 0; idx < parts.size(); ++idx) {
@@ -7957,7 +7957,7 @@ void ExportMusicXml::writeInstrumentChange(const InstrumentChange* instrChange)
         m_xml.tag("instrument-sound", instr->musicXmlId());
         m_xml.endElement();
     } else {
-        m_xml.tagRaw(String("instrument-change %1").arg(instrId(partNr + 1, instNr + 1)));        
+        m_xml.tagRaw(String("instrument-change %1").arg(instrId(partNr + 1, instNr + 1)));
     }
     m_xml.endElement();
 }

--- a/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
@@ -7953,11 +7953,11 @@ void ExportMusicXml::writeInstrumentChange(const InstrumentChange* instrChange)
 
     m_xml.startElement("sound");
     if (!instr->musicXmlId().empty()) {
-        m_xml.startElementRaw(String("instrument-change %1").arg(instrId(partNr, instNr)));
+        m_xml.startElementRaw(String("instrument-change %1").arg(instrId(partNr + 1, instNr + 1)));
         m_xml.tag("instrument-sound", instr->musicXmlId());
         m_xml.endElement();
     } else {
-        m_xml.tagRaw(String("instrument-change %1").arg(instrId(partNr, instNr)));        
+        m_xml.tagRaw(String("instrument-change %1").arg(instrId(partNr + 1, instNr + 1)));        
     }
     m_xml.endElement();
 }

--- a/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
@@ -7591,12 +7591,10 @@ static void findPitchesUsed(const Part* part, pitchSet& set)
 static void partList(XmlWriter& xml, Score* score, MusicXmlInstrumentMap& instrMap)
 {
     xml.startElement("part-list");
-    size_t staffCount = 0;                               // count sum of # staves in parts
+    size_t staffCount = 0;                          // count sum of # staves in parts
     const auto& parts = score->parts();
-    int partGroupEnd[MAX_PART_GROUPS];                // staff where part group ends (bracketSpan is in staves, not parts)
-    for (int& i : partGroupEnd) {
-        i = -1;
-    }
+    std::array<int, MAX_PART_GROUPS> partGroupEnd;  // staff where part group ends (bracketSpan is in staves, not parts)
+    partGroupEnd.fill(-1);
     for (size_t idx = 0; idx < parts.size(); ++idx) {
         const Part* part = parts.at(idx);
         bool bracketFound = false;

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -1782,8 +1782,8 @@ void MusicXmlParserPass2::initPartState(const String& partId)
     for (int i = 0; i < MAX_NUMBER_LEVEL; ++i) {
         m_trills[i] = 0;
     }
-    for (int i = 0; i < MAX_NUMBER_LEVEL; ++i) {
-        m_glissandi[i][0] = m_glissandi[i][1] = 0;
+    for (auto &i : m_glissandi) {
+        i[0] = i[1] = 0;
     }
     m_pedalContinue = 0;
     m_harmony = 0;
@@ -4350,9 +4350,9 @@ void MusicXmlInferredFingering::roundTick(Measure* measure)
 {
     measure->computeTicks();
     int gcdTicks = Fraction(1, 1).ticks();
-    for (auto s = measure->segments().begin(); s != measure->segments().end(); ++s) {
-        if ((*s).isChordRestType()) {
-            gcdTicks = std::gcd(gcdTicks, (*s).ticks().ticks());
+    for (auto &s : measure->segments()) {
+        if (s.isChordRestType()) {
+            gcdTicks = std::gcd(gcdTicks, s.ticks().ticks());
         }
     }
     if (!gcdTicks || gcdTicks == Fraction(1, 1).ticks() || !(m_tick.ticks() % gcdTicks)) {

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -1782,7 +1782,7 @@ void MusicXmlParserPass2::initPartState(const String& partId)
     for (int i = 0; i < MAX_NUMBER_LEVEL; ++i) {
         m_trills[i] = 0;
     }
-    for (auto &i : m_glissandi) {
+    for (auto& i : m_glissandi) {
         i[0] = i[1] = 0;
     }
     m_pedalContinue = 0;
@@ -4350,7 +4350,7 @@ void MusicXmlInferredFingering::roundTick(Measure* measure)
 {
     measure->computeTicks();
     int gcdTicks = Fraction(1, 1).ticks();
-    for (auto &s : measure->segments()) {
+    for (auto& s : measure->segments()) {
         if (s.isChordRestType()) {
             gcdTicks = std::gcd(gcdTicks, s.ticks().ticks());
         }

--- a/src/importexport/musicxml/tests/data/testChangeTranspose-no-diatonic_ref.xml
+++ b/src/importexport/musicxml/tests/data/testChangeTranspose-no-diatonic_ref.xml
@@ -115,10 +115,8 @@
           </transpose>
         </attributes>
       <sound>
-        <instrument-change>
-          <score-instrument id="P1-I2">
-            <instrument-name>B♭ Clarinet</instrument-name>
-            </score-instrument>
+        <instrument-change id="P1-I2">
+          <instrument-sound>wind.reed.clarinet.bflat</instrument-sound>
           </instrument-change>
         </sound>
       <direction placement="above">

--- a/src/importexport/musicxml/tests/data/testChangeTranspose.xml
+++ b/src/importexport/musicxml/tests/data/testChangeTranspose.xml
@@ -115,10 +115,8 @@
           </transpose>
         </attributes>
       <sound>
-        <instrument-change>
-          <score-instrument id="P1-I2">
-            <instrument-name>B♭ Clarinet</instrument-name>
-            </score-instrument>
+        <instrument-change id="P1-I2">
+          <instrument-sound>wind.reed.clarinet.bflat</instrument-sound>
           </instrument-change>
         </sound>
       <direction placement="above">

--- a/src/importexport/musicxml/tests/data/testInstrumentChangeMIDIportExport_ref.xml
+++ b/src/importexport/musicxml/tests/data/testInstrumentChangeMIDIportExport_ref.xml
@@ -1069,10 +1069,8 @@
           </part-abbreviation-display>
         </print>
       <sound>
-        <instrument-change>
-          <score-instrument id="P15-I2">
-            <instrument-name>Voice</instrument-name>
-            </score-instrument>
+        <instrument-change id="P15-I2">
+          <instrument-sound>voice.vocals</instrument-sound>
           </instrument-change>
         </sound>
       <direction placement="above">

--- a/src/importexport/musicxml/tests/data/testMultiInstrumentPart1.xml
+++ b/src/importexport/musicxml/tests/data/testMultiInstrumentPart1.xml
@@ -92,10 +92,8 @@
           </part-abbreviation-display>
         </print>
       <sound>
-        <instrument-change>
-          <score-instrument id="P1-I2">
-            <instrument-name>Flute</instrument-name>
-            </score-instrument>
+        <instrument-change id="P1-I2">
+          <instrument-sound>wind.flutes.flute</instrument-sound>
           </instrument-change>
         </sound>
       <direction placement="above">

--- a/src/importexport/musicxml/tests/data/testMultiInstrumentPart2.xml
+++ b/src/importexport/musicxml/tests/data/testMultiInstrumentPart2.xml
@@ -116,10 +116,8 @@
           </part-abbreviation-display>
         </print>
       <sound>
-        <instrument-change>
-          <score-instrument id="P1-I2">
-            <instrument-name>Flute</instrument-name>
-            </score-instrument>
+        <instrument-change id="P1-I2">
+          <instrument-sound>wind.flutes.flute</instrument-sound>
           </instrument-change>
         </sound>
       <direction placement="above">
@@ -270,10 +268,8 @@
           </part-abbreviation-display>
         </print>
       <sound>
-        <instrument-change>
-          <score-instrument id="P2-I2">
-            <instrument-name>C Trumpet</instrument-name>
-            </score-instrument>
+        <instrument-change id="P2-I2">
+          <instrument-sound>brass.trumpet.c</instrument-sound>
           </instrument-change>
         </sound>
       <direction placement="above">

--- a/src/importexport/musicxml/tests/data/testMultiInstrumentPart3_ref.xml
+++ b/src/importexport/musicxml/tests/data/testMultiInstrumentPart3_ref.xml
@@ -187,10 +187,8 @@
           </transpose>
         </attributes>
       <sound>
-        <instrument-change>
-          <score-instrument id="P1-I2">
-            <instrument-name>B♭ Clarinet</instrument-name>
-            </score-instrument>
+        <instrument-change id="P1-I2">
+          <instrument-sound>wind.reed.clarinet.bflat</instrument-sound>
           </instrument-change>
         </sound>
       <direction placement="above">


### PR DESCRIPTION
Resolves: #29535

Fixes the wrong structure of `<instrument-change>` and exports now the instrument key change together with the transposition.
