### PR TITLE
Let TextInput{Field,Area} take focus even in non-focusable popup

### DIFF
--- a/src/framework/uicomponents/qml/Muse/UiComponents/TextInputArea.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/TextInputArea.qml
@@ -21,6 +21,7 @@
  */
 import QtQuick 2.15
 import QtQuick.Controls 2.15
+import QtQuick.Window
 
 import Muse.Ui 1.0
 import Muse.UiComponents 1.0
@@ -57,6 +58,12 @@ FocusScope {
     }
 
     function ensureActiveFocus() {
+        if (Window.window && Window.window.objectName.includes("PopupWindow_QQuickView")) {
+            // See also PopupWindow_QQuickView::eventFilter
+            Window.window.flags &= ~Qt.WindowDoesNotAcceptFocus
+            Window.window.requestActivate()
+        }
+
         if (!root.activeFocus) {
             root.forceActiveFocus()
         }

--- a/src/framework/uicomponents/qml/Muse/UiComponents/TextInputField.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/TextInputField.qml
@@ -22,6 +22,7 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.3
+import QtQuick.Window
 
 import Muse.Ui 1.0
 import Muse.UiComponents 1.0
@@ -77,6 +78,12 @@ FocusScope {
     }
 
     function ensureActiveFocus() {
+        if (Window.window && Window.window.objectName.includes("PopupWindow_QQuickView")) {
+            // See also PopupWindow_QQuickView::eventFilter
+            Window.window.flags &= ~Qt.WindowDoesNotAcceptFocus
+            Window.window.requestActivate()
+        }
+
         if (!root.activeFocus) {
             root.forceActiveFocus()
         }

--- a/src/framework/uicomponents/view/popupwindow/popupwindow_qquickview.cpp
+++ b/src/framework/uicomponents/view/popupwindow/popupwindow_qquickview.cpp
@@ -271,18 +271,27 @@ void PopupWindow_QQuickView::setTakeFocusOnClick(bool takeFocusOnClick)
 bool PopupWindow_QQuickView::eventFilter(QObject* watched, QEvent* event)
 {
     if (watched == m_view) {
-        if (event->type() == QEvent::Hide) {
+        switch (event->type()) {
+        case QEvent::Hide:
             if (m_onHidden) {
                 m_onHidden();
             }
-        }
-
-        if (event->type() == QEvent::FocusIn) {
+            break;
+        case QEvent::FocusIn:
             m_view->rootObject()->forceActiveFocus();
-        }
-
-        if (m_takeFocusOnClick && event->type() == QEvent::MouseButtonPress) {
-            forceActiveFocus();
+            break;
+        case QEvent::FocusOut:
+            if (!m_takeFocusOnClick) {
+                // Undo what's done in TextInput{Field,Area}.qml ensureActiveFocus
+                m_view->setFlag(Qt::WindowDoesNotAcceptFocus);
+            }
+            break;
+        case QEvent::MouseButtonPress:
+            if (m_takeFocusOnClick) {
+                forceActiveFocus();
+            }
+            break;
+        default: break;
         }
     }
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/29318