### PR TITLE
Fix #29239: Introduce `updateShadowNoteVisibility` function

### DIFF
--- a/src/notation/internal/notationnoteinput.cpp
+++ b/src/notation/internal/notationnoteinput.cpp
@@ -441,6 +441,8 @@ void NotationNoteInput::addNote(const NoteInputParams& params, NoteAddingMode ad
 {
     TRACEFUNC;
 
+    m_interaction->hideShadowNote();
+
     bool addToUpOnCurrentChord = addingMode == NoteAddingMode::CurrentChord;
     bool insertNewChord = addingMode == NoteAddingMode::InsertChord;
 
@@ -470,6 +472,8 @@ void NotationNoteInput::addNote(const NoteInputParams& params, NoteAddingMode ad
 void NotationNoteInput::padNote(const Pad& pad)
 {
     TRACEFUNC;
+
+    m_interaction->hideShadowNote();
 
     startEdit(TranslatableString("undoableAction", "Pad note"));
     score()->padToggle(pad);

--- a/src/notation/view/abstractnotationpaintview.cpp
+++ b/src/notation/view/abstractnotationpaintview.cpp
@@ -25,7 +25,7 @@
 #include <QMimeData>
 
 #include "actions/actiontypes.h"
-
+#include "engraving/dom/shadownote.h"
 #include "log.h"
 
 using namespace mu;
@@ -242,10 +242,7 @@ void AbstractNotationPaintView::onLoadNotation(INotationPtr)
     }
 
     m_notation->notationChanged().onNotify(this, [this]() {
-        if (INotationInteractionPtr interaction = notationInteraction()) {
-            interaction->hideShadowNote();
-        }
-        m_shadowNoteRect = RectF();
+        updateShadowNoteVisibility();
         scheduleRedraw();
     });
 
@@ -431,6 +428,27 @@ void AbstractNotationPaintView::updateLoopMarkers()
     scheduleRedraw();
 }
 
+void AbstractNotationPaintView::updateShadowNoteVisibility()
+{
+    INotationInteractionPtr interaction = notationInteraction();
+    const engraving::ShadowNote* shadowNote = interaction ? interaction->shadowNote() : nullptr;
+    if (!shadowNote || !shadowNote->visible()) {
+        m_shadowNoteRect = RectF();
+        return;
+    }
+
+    if (isNoteEnterMode()) {
+        //! NOTE: The following may actually hide the shadow note
+        //! if cursorPos is no longer valid...
+        const QPointF cursorPos = mapFromGlobal(QCursor::pos());
+        showShadowNote(toLogical(cursorPos));
+    } else {
+        interaction->hideShadowNote();
+        m_shadowNoteRect = RectF();
+        return;
+    }
+}
+
 NotationViewInputController* AbstractNotationPaintView::inputController() const
 {
     return m_inputController.get();
@@ -481,12 +499,8 @@ void AbstractNotationPaintView::onNoteInputStateChanged()
     TRACEFUNC;
 
     setAcceptHoverEvents(isNoteEnterMode());
-
-    if (INotationInteractionPtr interaction = notationInteraction()) {
-        interaction->hideShadowNote();
-        m_shadowNoteRect = RectF();
-        scheduleRedraw();
-    }
+    updateShadowNoteVisibility();
+    scheduleRedraw();
 }
 
 void AbstractNotationPaintView::onShowItemRequested(const INotationInteraction::ShowItemRequest& request)
@@ -522,7 +536,12 @@ void AbstractNotationPaintView::showShadowNote(const PointF& pos)
 {
     TRACEFUNC;
 
-    bool visible = notationInteraction()->showShadowNote(pos);
+    INotationInteractionPtr interaction = notationInteraction();
+    if (!interaction) {
+        return;
+    }
+
+    const bool visible = interaction->showShadowNote(pos);
 
     if (m_shadowNoteRect.isValid()) {
         scheduleRedraw(m_shadowNoteRect);
@@ -533,7 +552,7 @@ void AbstractNotationPaintView::showShadowNote(const PointF& pos)
         }
     }
 
-    RectF shadowNoteRect = fromLogical(notationInteraction()->shadowNoteRect());
+    RectF shadowNoteRect = fromLogical(interaction->shadowNoteRect());
 
     if (shadowNoteRect.isValid()) {
         compensateFloatPart(shadowNoteRect);

--- a/src/notation/view/abstractnotationpaintview.h
+++ b/src/notation/view/abstractnotationpaintview.h
@@ -258,6 +258,7 @@ private:
     void onPlaybackCursorRectChanged();
 
     void updateLoopMarkers();
+    void updateShadowNoteVisibility();
 
     const Page* pageByPoint(const muse::PointF& point) const;
     muse::PointF alignToCurrentPageBorder(const muse::RectF& showRect, const muse::PointF& pos) const;

--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -1355,6 +1355,7 @@ void NotationViewInputController::keyPressEvent(QKeyEvent* event)
     } else if (key == Qt::Key_Shift) {
         viewInteraction()->updateTimeTickAnchors(event);
         updateShadowNotePopupVisibility();
+        return;
     } else if (isAnchorEditingEvent(event)) {
         viewInteraction()->moveElementAnchors(event);
     }


### PR DESCRIPTION
Resolves: #29239

The problem here was two-fold. 

### Problem 1:
1. `updateTimeTickAnchors` is called in `NotationViewInputController::keyPressEvent`
2. `notationChanged` fires in `AbstractNotationPaintView::onLoadNotation`
3. `NotationInteraction::hideShadowNote` is called every time

To resolve this I've introduced an `updateShadowNoteVisibility` function. This will show/hide the shadow note depending on whether the current cursor position _**was**_ visibile, and whether is now over a valid position in the score. The only time we "force" the shadow note to hide is when entering notes with the keyboard.

### Problem 2:
A silly logic error from me in `NotationViewInputController::keyPressEvent`. `updateShadowNotePopupVisibility` is called when shift is pressed/released and then immediately called again with a `forceHide` flag (I'm quite surprised this ever worked at all). Resolved by adding an early return.