### PR TITLE
Implement modified version of measure number placement style

### DIFF
--- a/src/engraving/dom/cmd.cpp
+++ b/src/engraving/dom/cmd.cpp
@@ -2595,7 +2595,7 @@ void Score::cmdResetToDefaultLayout()
         Sid::showMeasureNumberOne,
         Sid::measureNumberInterval,
         Sid::measureNumberSystem,
-        Sid::measureNumberAllStaves,
+        Sid::measureNumberPlacementMode,
         Sid::genClef,
         Sid::hideTabClefAfterFirst,
         Sid::genKeysig,

--- a/src/engraving/dom/engravingitem.h
+++ b/src/engraving/dom/engravingitem.h
@@ -411,7 +411,7 @@ public:
     bool systemFlag() const { return flag(ElementFlag::SYSTEM); }
     void setSystemFlag(bool v) const { setFlag(ElementFlag::SYSTEM, v); }
 
-    bool isSystemObjectBelowBottomStaff() const;
+    virtual bool isSystemObjectBelowBottomStaff() const;
 
     bool header() const { return flag(ElementFlag::HEADER); }
     void setHeader(bool v) { setFlag(ElementFlag::HEADER, v); }

--- a/src/engraving/dom/measurenumber.cpp
+++ b/src/engraving/dom/measurenumber.cpp
@@ -58,4 +58,10 @@ MeasureNumber::MeasureNumber(const MeasureNumber& other)
 {
     initElementStyle(&measureNumberStyle);
 }
+
+bool MeasureNumber::isSystemObjectBelowBottomStaff() const
+{
+    return style().styleV(Sid::measureNumberPlacementMode).value<MeasureNumberPlacement>() == MeasureNumberPlacement::BELOW_SYSTEM
+           || EngravingItem::isSystemObjectBelowBottomStaff();
+}
 } // namespace MS

--- a/src/engraving/dom/measurenumber.h
+++ b/src/engraving/dom/measurenumber.h
@@ -40,6 +40,8 @@ public:
     MeasureNumber(const MeasureNumber& other);
 
     virtual MeasureNumber* clone() const override { return new MeasureNumber(*this); }
+
+    bool isSystemObjectBelowBottomStaff() const override;
 };
 } // namespace mu::engraving
 

--- a/src/engraving/dom/staff.cpp
+++ b/src/engraving/dom/staff.cpp
@@ -245,6 +245,8 @@ bool Staff::shouldShowMeasureNumbers() const
     case MeasureNumberPlacement::ON_ALL_STAVES:
         return show();
     }
+
+    return false;
 }
 
 bool Staff::shouldShowPlayCount() const

--- a/src/engraving/dom/staff.cpp
+++ b/src/engraving/dom/staff.cpp
@@ -230,13 +230,21 @@ void Staff::undoSetShowMeasureNumbers(bool show)
 
 bool Staff::shouldShowMeasureNumbers() const
 {
-    if (style().styleB(Sid::measureNumberAllStaves)) {
+    MeasureNumberPlacement placementMode = style().styleV(Sid::measureNumberPlacementMode).value<MeasureNumberPlacement>();
+    switch (placementMode) {
+    case MeasureNumberPlacement::ABOVE_SYSTEM:
+        return score()->staves().front() == this;
+    case MeasureNumberPlacement::BELOW_SYSTEM:
+        return score()->staves().back() == this;
+    case MeasureNumberPlacement::ON_SYSTEM_OBJECT_STAVES:
+    {
+        bool isTopStave = score()->staves().front() == this;
+        bool isSystemObjectStaff = muse::contains(score()->systemObjectStaves(), const_cast<Staff*>(this));
+        return (isTopStave && m_showMeasureNumbers != AutoOnOff::OFF) || (isSystemObjectStaff && m_showMeasureNumbers == AutoOnOff::ON);
+    }
+    case MeasureNumberPlacement::ON_ALL_STAVES:
         return show();
     }
-
-    bool isTopStave = score()->staves().front() == this;
-    bool isSystemObjectStaff = muse::contains(score()->systemObjectStaves(), const_cast<Staff*>(this));
-    return (isTopStave && m_showMeasureNumbers != AutoOnOff::OFF) || (isSystemObjectStaff && m_showMeasureNumbers == AutoOnOff::ON);
 }
 
 bool Staff::shouldShowPlayCount() const

--- a/src/engraving/rendering/score/measurelayout.cpp
+++ b/src/engraving/rendering/score/measurelayout.cpp
@@ -1284,6 +1284,7 @@ void MeasureLayout::layoutPlayCountText(Measure* m, LayoutContext& ctx)
 void MeasureLayout::layoutMeasureNumber(Measure* m, LayoutContext& ctx)
 {
     bool showMeasureNumber = m->showsMeasureNumber();
+    MeasureNumberPlacement placementMode = ctx.conf().styleV(Sid::measureNumberPlacementMode).value<MeasureNumberPlacement>();
 
     String stringNum = String::number(m->no() + 1);
 
@@ -1310,7 +1311,7 @@ void MeasureLayout::layoutMeasureNumber(Measure* m, LayoutContext& ctx)
             }
 
             measureNumber->setXmlText(stringNum);
-            measureNumber->setSystemFlag(!score->style().styleB(Sid::measureNumberAllStaves));
+            measureNumber->setSystemFlag(placementMode != MeasureNumberPlacement::ON_ALL_STAVES);
             TLayout::layoutMeasureNumber(measureNumber, measureNumber->mutldata(), ctx);
         } else if (measureNumber) {
             measureNumber->setTrack(staff2track(staffIdx));

--- a/src/engraving/rendering/score/measurenumberlayout.cpp
+++ b/src/engraving/rendering/score/measurenumberlayout.cpp
@@ -32,11 +32,11 @@
 using namespace mu::engraving;
 using namespace mu::engraving::rendering::score;
 
-void MeasureNumberLayout::layoutMeasureNumber(const MeasureNumber* item, MeasureNumber::LayoutData* ldata, const LayoutContext& ctx)
+void MeasureNumberLayout::layoutMeasureNumber(MeasureNumber* item, MeasureNumber::LayoutData* ldata, const LayoutContext& ctx)
 {
     MeasureNumberPlacement placementMode = ctx.conf().styleV(Sid::measureNumberPlacementMode).value<MeasureNumberPlacement>();
     if (placementMode != MeasureNumberPlacement::ON_ALL_STAVES) {
-        const_cast<MeasureNumber*>(item)->setPlacement(PlacementV::ABOVE);
+        item->setPlacement(PlacementV::ABOVE);
     }
 
     layoutMeasureNumberBase(item, ldata);
@@ -93,7 +93,7 @@ void MeasureNumberLayout::layoutMeasureNumber(const MeasureNumber* item, Measure
     checkBarlineCollisions(item, barlineSeg, hPlacement, ldata);
 }
 
-void MeasureNumberLayout::layoutMMRestRange(const MMRestRange* item, MMRestRange::LayoutData* ldata, const LayoutContext& ctx)
+void MeasureNumberLayout::layoutMMRestRange(MMRestRange* item, MMRestRange::LayoutData* ldata, const LayoutContext& ctx)
 {
     layoutMeasureNumberBase(item, ldata);
 
@@ -115,7 +115,7 @@ void MeasureNumberLayout::layoutMMRestRange(const MMRestRange* item, MMRestRange
     }
 }
 
-void MeasureNumberLayout::layoutMeasureNumberBase(const MeasureNumberBase* item, MeasureNumberBase::LayoutData* ldata)
+void MeasureNumberLayout::layoutMeasureNumberBase(MeasureNumberBase* item, MeasureNumberBase::LayoutData* ldata)
 {
     ldata->setPos(PointF());
 
@@ -145,7 +145,7 @@ void MeasureNumberLayout::layoutMeasureNumberBase(const MeasureNumberBase* item,
 
     if (item->isStyled(Pid::OFFSET)) {
         PointF offset = item->propertyDefault(Pid::OFFSET).value<PointF>() * item->staff()->staffMag(item->tick());
-        const_cast<MeasureNumberBase*>(item)->setOffset(offset);
+        item->setOffset(offset);
     }
 }
 

--- a/src/engraving/rendering/score/measurenumberlayout.cpp
+++ b/src/engraving/rendering/score/measurenumberlayout.cpp
@@ -34,6 +34,11 @@ using namespace mu::engraving::rendering::score;
 
 void MeasureNumberLayout::layoutMeasureNumber(const MeasureNumber* item, MeasureNumber::LayoutData* ldata, const LayoutContext& ctx)
 {
+    MeasureNumberPlacement placementMode = ctx.conf().styleV(Sid::measureNumberPlacementMode).value<MeasureNumberPlacement>();
+    if (placementMode != MeasureNumberPlacement::ON_ALL_STAVES) {
+        const_cast<MeasureNumber*>(item)->setPlacement(PlacementV::ABOVE);
+    }
+
     layoutMeasureNumberBase(item, ldata);
 
     const RectF& itemBBox = ldata->bbox();

--- a/src/engraving/rendering/score/measurenumberlayout.h
+++ b/src/engraving/rendering/score/measurenumberlayout.h
@@ -30,11 +30,11 @@ namespace mu::engraving::rendering::score {
 class MeasureNumberLayout
 {
 public:
-    static void layoutMeasureNumber(const MeasureNumber* item, MeasureNumber::LayoutData* ldata, const LayoutContext& ctx);
-    static void layoutMMRestRange(const MMRestRange* item, MMRestRange::LayoutData* ldata, const LayoutContext& ctx);
+    static void layoutMeasureNumber(MeasureNumber* item, MeasureNumber::LayoutData* ldata, const LayoutContext& ctx);
+    static void layoutMMRestRange(MMRestRange* item, MMRestRange::LayoutData* ldata, const LayoutContext& ctx);
 
 private:
-    static void layoutMeasureNumberBase(const MeasureNumberBase* item, MeasureNumberBase::LayoutData* ldata);
+    static void layoutMeasureNumberBase(MeasureNumberBase* item, MeasureNumberBase::LayoutData* ldata);
 
     static const Segment* refBarlineSegment(const MeasureNumber* item, bool alignToBarline, AlignH hPlacement);
     static void checkBarlineCollisions(const MeasureNumber* item, const Segment* barlineSeg, AlignH hPlacement,

--- a/src/engraving/rendering/score/tlayout.cpp
+++ b/src/engraving/rendering/score/tlayout.cpp
@@ -338,7 +338,7 @@ void TLayout::layoutItem(EngravingItem* item, LayoutContext& ctx)
         layoutMarker(item_cast<const Marker*>(item), static_cast<Marker::LayoutData*>(ldata), ctx);
         break;
     case ElementType::MEASURE_NUMBER:
-        layoutMeasureNumber(item_cast<const MeasureNumber*>(item), static_cast<MeasureNumber::LayoutData*>(ldata), ctx);
+        layoutMeasureNumber(item_cast<MeasureNumber*>(item), static_cast<MeasureNumber::LayoutData*>(ldata), ctx);
         break;
     case ElementType::MEASURE_REPEAT:
         layoutMeasureRepeat(item_cast<const MeasureRepeat*>(item), static_cast<MeasureRepeat::LayoutData*>(ldata), ctx);
@@ -347,7 +347,7 @@ void TLayout::layoutItem(EngravingItem* item, LayoutContext& ctx)
         layoutMMRest(item_cast<const MMRest*>(item), static_cast<MMRest::LayoutData*>(ldata), ctx);
         break;
     case ElementType::MMREST_RANGE:
-        layoutMMRestRange(item_cast<const MMRestRange*>(item), static_cast<MMRestRange::LayoutData*>(ldata), ctx);
+        layoutMMRestRange(item_cast<MMRestRange*>(item), static_cast<MMRestRange::LayoutData*>(ldata), ctx);
         break;
     case ElementType::NOTE:
         layoutNote(item_cast<const Note*>(item), static_cast<Note::LayoutData*>(ldata));
@@ -4059,7 +4059,7 @@ void TLayout::layoutBaseMeasureBase(const MeasureBase* item, MeasureBase::Layout
     }
 }
 
-void TLayout::layoutMeasureNumber(const MeasureNumber* item, MeasureNumber::LayoutData* ldata, const LayoutContext& ctx)
+void TLayout::layoutMeasureNumber(MeasureNumber* item, MeasureNumber::LayoutData* ldata, const LayoutContext& ctx)
 {
     MeasureNumberLayout::layoutMeasureNumber(item,  ldata, ctx);
 }
@@ -4279,7 +4279,7 @@ void TLayout::layoutMMRest(const MMRest* item, MMRest::LayoutData* ldata, const 
     ChordLayout::fillShape(item, ldata, ctx.conf());
 }
 
-void TLayout::layoutMMRestRange(const MMRestRange* item, MMRestRange::LayoutData* ldata, const LayoutContext& ctx)
+void TLayout::layoutMMRestRange(MMRestRange* item, MMRestRange::LayoutData* ldata, const LayoutContext& ctx)
 {
     MeasureNumberLayout::layoutMMRestRange(item, ldata, ctx);
 }

--- a/src/engraving/rendering/score/tlayout.h
+++ b/src/engraving/rendering/score/tlayout.h
@@ -285,11 +285,11 @@ public:
     static void layoutMarker(const Marker* item, Marker::LayoutData* ldata, LayoutContext& ctx);
     static void layoutMeasureBase(MeasureBase* item, LayoutContext& ctx); // factory
     static void layoutBaseMeasureBase(const MeasureBase* item, MeasureBase::LayoutData* ldata, const LayoutContext& ctx); // base class
-    static void layoutMeasureNumber(const MeasureNumber* item, MeasureNumber::LayoutData* ldata, const LayoutContext& ctx);
+    static void layoutMeasureNumber(MeasureNumber* item, MeasureNumber::LayoutData* ldata, const LayoutContext& ctx);
     static void layoutMeasureRepeat(const MeasureRepeat* item, MeasureRepeat::LayoutData* ldata, const LayoutContext& ctx);
     static void layoutMeasureRepeatExtender(const MeasureRepeat* item, MeasureRepeat::LayoutData* ldata, const LayoutContext& ctx);
     static void layoutMMRest(const MMRest* item, MMRest::LayoutData* ldata, const LayoutContext& ctx);
-    static void layoutMMRestRange(const MMRestRange* item, MMRestRange::LayoutData* ldata, const LayoutContext& ctx);
+    static void layoutMMRestRange(MMRestRange* item, MMRestRange::LayoutData* ldata, const LayoutContext& ctx);
 
     static void layoutNote(const Note* item, Note::LayoutData* ldata);
     static void fillNoteShape(const Note* item, Note::LayoutData* ldata);

--- a/src/engraving/style/style.cpp
+++ b/src/engraving/style/style.cpp
@@ -232,6 +232,9 @@ bool MStyle::readProperties(XmlReader& e)
             case P_TYPE::PLAY_COUNT_PRESET:
                 set(idx, TConv::fromXml(e.readAsciiText(), RepeatPlayCountPreset::X_N));
                 break;
+            case P_TYPE::MEASURE_NUMBER_PLACEMENT:
+                set(idx, TConv::fromXml(e.readAsciiText(), MeasureNumberPlacement::ABOVE_SYSTEM));
+                break;
             default:
                 ASSERT_X(u"unhandled type " + String::number(int(type)));
             }
@@ -393,8 +396,6 @@ void MStyle::read(XmlReader& e, compat::ReadChordListHook* readChordListHook, in
             set(Sid::chordSymbolAPosAbove, e.readPoint());
         } else if (tag == "chordSymbolPosBelow") { // pre-4.4 typo
             set(Sid::chordSymbolAPosBelow, e.readPoint());
-        } else if (tag == "measureNumberAllStaffs") { // pre-4.4 typo
-            set(Sid::measureNumberAllStaves, e.readBool());
         } else if (tag == "dontHidStavesInFirstSystm") { // pre-3.6.3/4.0 typo
             set(Sid::dontHideStavesInFirstSystem, e.readBool());
         } else if (tag == "firstSystemInsNameVisibility") { // pre-4.4 typo
@@ -616,6 +617,9 @@ void MStyle::read(XmlReader& e, compat::ReadChordListHook* readChordListHook, in
             AlignH hAlign = hPlacement == PlacementH::LEFT ? AlignH::LEFT
                             : hPlacement == PlacementH::CENTER ? AlignH::HCENTER : AlignH::RIGHT;
             set(Sid::mmRestRangeHPlacement, hAlign);
+        } else if (tag == "measureNumberAllStaves" || tag == "measureNumberAllStaffs" /*old typo*/) {
+            bool allStaves = e.readBool();
+            set(Sid::measureNumberPlacementMode, allStaves ? MeasureNumberPlacement::ON_ALL_STAVES : MeasureNumberPlacement::ABOVE_SYSTEM);
         } else if (!readProperties(e)) {
             e.unknown();
         }
@@ -741,6 +745,8 @@ void MStyle::save(XmlWriter& xml, bool optimize)
             xml.tag(st.name(), TConv::toXml(value(idx).value<ParenthesesMode>()));
         } else if (P_TYPE::PLAY_COUNT_PRESET == type) {
             xml.tag(st.name(), TConv::toXml(value(idx).value<RepeatPlayCountPreset>()));
+        } else if (P_TYPE::MEASURE_NUMBER_PLACEMENT == type) {
+            xml.tag(st.name(), TConv::toXml(value(idx).value<MeasureNumberPlacement>()));
         } else {
             PropertyValue val = value(idx);
             //! NOTE for compatibility

--- a/src/engraving/style/styledef.cpp
+++ b/src/engraving/style/styledef.cpp
@@ -464,7 +464,7 @@ const std::array<StyleDef::StyleValue, size_t(Sid::STYLES)> StyleDef::styleValue
     styleDef(showMeasureNumberOne,                       false),
     styleDef(measureNumberInterval,                      PropertyValue(5)),
     styleDef(measureNumberSystem,                        true),
-    styleDef(measureNumberAllStaves,                     false),
+    styleDef(measureNumberPlacementMode,                 MeasureNumberPlacement::ABOVE_SYSTEM),
     styleDef(smallNoteMag,                               PropertyValue(.7)),
     styleDef(scaleRythmicSpacingForSmallNotes,           true),
     styleDef(graceNoteMag,                               PropertyValue(0.7)),

--- a/src/engraving/style/styledef.h
+++ b/src/engraving/style/styledef.h
@@ -475,7 +475,7 @@ enum class Sid {
     showMeasureNumberOne,
     measureNumberInterval,
     measureNumberSystem,
-    measureNumberAllStaves,
+    measureNumberPlacementMode,
 
     smallNoteMag,
     scaleRythmicSpacingForSmallNotes,

--- a/src/engraving/types/propertyvalue.cpp
+++ b/src/engraving/types/propertyvalue.cpp
@@ -184,6 +184,7 @@ QVariant PropertyValue::toQVariant() const
     case P_TYPE::VOICE_ASSIGNMENT: return static_cast<int>(value<VoiceAssignment>());
     case P_TYPE::AUTO_ON_OFF:       return static_cast<int>(value<AutoOnOff>());
     case P_TYPE::AUTO_CUSTOM_HIDE:  return static_cast<int>(value<AutoCustomHide>());
+    case P_TYPE::MEASURE_NUMBER_PLACEMENT: return static_cast<int>(value<MeasureNumberPlacement>());
 
     // Other
     case P_TYPE::GROUPS: {
@@ -303,6 +304,7 @@ PropertyValue PropertyValue::fromQVariant(const QVariant& v, P_TYPE type)
     case P_TYPE::PARENTHESES_MODE:   return PropertyValue(ParenthesesMode(v.toInt()));
     case P_TYPE::PLAY_COUNT_PRESET:   return PropertyValue(RepeatPlayCountPreset(v.toInt()));
     case P_TYPE::MARKER_TYPE:         return PropertyValue(MarkerType(v.toInt()));
+    case P_TYPE::MEASURE_NUMBER_PLACEMENT: return PropertyValue(MeasureNumberPlacement(v.toInt()));
 
     // Other
     case P_TYPE::GROUPS: {

--- a/src/engraving/types/propertyvalue.h
+++ b/src/engraving/types/propertyvalue.h
@@ -126,6 +126,8 @@ enum class P_TYPE : unsigned char {
 
     AUTO_CUSTOM_HIDE,
 
+    MEASURE_NUMBER_PLACEMENT,
+
     // Other
     GROUPS,
 };
@@ -351,6 +353,9 @@ public:
 
     PropertyValue(const MarkerType& v)
         : m_type(P_TYPE::MARKER_TYPE), m_data(make_data<MarkerType>(v)) {}
+
+    PropertyValue(const MeasureNumberPlacement& v)
+        : m_type(P_TYPE::MEASURE_NUMBER_PLACEMENT), m_data(make_data<MeasureNumberPlacement>(v)) {}
 
     bool isValid() const;
 

--- a/src/engraving/types/types.h
+++ b/src/engraving/types/types.h
@@ -431,6 +431,13 @@ constexpr bool operator&(BarLineType t1, BarLineType t2)
     return static_cast<int>(t1) & static_cast<int>(t2);
 }
 
+enum class MeasureNumberPlacement {
+    ABOVE_SYSTEM,
+    BELOW_SYSTEM,
+    ON_SYSTEM_OBJECT_STAVES,
+    ON_ALL_STAVES
+};
+
 // P_TYPE::NOTEHEAD_TYPE
 enum class NoteHeadType : signed char {
     HEAD_AUTO    = -1,

--- a/src/engraving/types/typesconv.cpp
+++ b/src/engraving/types/typesconv.cpp
@@ -3335,3 +3335,20 @@ String TConv::translatedUserName(Key v, bool isAtonal, bool isCustom)
 {
     return userName(v, isAtonal, isCustom).translated();
 }
+
+const std::array<Item<MeasureNumberPlacement>, 4> MEASURE_NUMBER_MODES = { {
+    { MeasureNumberPlacement::ABOVE_SYSTEM,   "above-system" },
+    { MeasureNumberPlacement::BELOW_SYSTEM,   "below-system" },
+    { MeasureNumberPlacement::ON_SYSTEM_OBJECT_STAVES,   "on-so-staves" },
+    { MeasureNumberPlacement::ON_ALL_STAVES,   "on-all-staves" },
+} };
+
+AsciiStringView TConv::toXml(MeasureNumberPlacement v)
+{
+    return findXmlTagByType<MeasureNumberPlacement>(MEASURE_NUMBER_MODES, v);
+}
+
+MeasureNumberPlacement TConv::fromXml(const AsciiStringView& tag, MeasureNumberPlacement def)
+{
+    return findTypeByXmlTag<MeasureNumberPlacement>(MEASURE_NUMBER_MODES, tag, def);
+}

--- a/src/engraving/types/typesconv.h
+++ b/src/engraving/types/typesconv.h
@@ -283,5 +283,8 @@ public:
 
     static AsciiStringView toXml(AutoCustomHide autoOnOff);
     static AutoCustomHide fromXml(const AsciiStringView& str, AutoCustomHide def);
+
+    static AsciiStringView toXml(MeasureNumberPlacement v);
+    static MeasureNumberPlacement fromXml(const AsciiStringView& str, MeasureNumberPlacement def);
 };
 }

--- a/src/instrumentsscene/view/layoutpanelutils.h
+++ b/src/instrumentsscene/view/layoutpanelutils.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "engraving/dom/staff.h"
+#include "engraving/style/style.h"
 #include "engraving/dom/utils.h"
 #include "engraving/types/typesconv.h"
 
@@ -58,9 +59,14 @@ inline SystemObjectGroupsByStaff collectSystemObjectGroups(const std::vector<mu:
         }
     }
 
-    for (mu::engraving::Staff* staff : staves) {
-        SystemObjectGroups& systemObjectGroups = result[staff];
-        systemObjectGroups.push_back(SystemObjectsGroup { mu::engraving::ElementType::MEASURE_NUMBER, {}, staff });
+    const engraving::MStyle& style = staves.front()->style();
+    bool collectMeasureNumbers = style.styleV(engraving::Sid::measureNumberPlacementMode).value<engraving::MeasureNumberPlacement>()
+                                 == engraving::MeasureNumberPlacement::ON_SYSTEM_OBJECT_STAVES;
+    if (collectMeasureNumbers) {
+        for (mu::engraving::Staff* staff : staves) {
+            SystemObjectGroups& systemObjectGroups = result[staff];
+            systemObjectGroups.push_back(SystemObjectsGroup { mu::engraving::ElementType::MEASURE_NUMBER, {}, staff });
+        }
     }
 
     return result;

--- a/src/instrumentsscene/view/systemobjectslayertreeitem.cpp
+++ b/src/instrumentsscene/view/systemobjectslayertreeitem.cpp
@@ -143,7 +143,8 @@ bool SystemObjectsLayerTreeItem::canAcceptDrop(const QVariant&) const
 
 void SystemObjectsLayerTreeItem::onScoreChanged(const mu::engraving::ScoreChanges& changes)
 {
-    if (muse::contains(changes.changedStyleIdSet, Sid::timeSigPlacement)) {
+    if (muse::contains(changes.changedStyleIdSet, Sid::timeSigPlacement)
+        || muse::contains(changes.changedStyleIdSet, Sid::measureNumberPlacementMode)) {
         m_systemObjectGroups = collectSystemObjectGroups(m_staff);
         updateState();
         return;

--- a/src/notation/qml/MuseScore/NotationScene/internal/EditStyle/MeasureNumbersPage.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/EditStyle/MeasureNumbersPage.qml
@@ -219,16 +219,22 @@ StyledFlickable {
                         horizontalAlignment: Text.AlignLeft
                     }
 
-                    RoundedRadioButton {
-                        checked: barNumbersModel.measureNumberAllStaves.value === false
-                        onClicked: barNumbersModel.measureNumberAllStaves.value = false
-                        text: qsTrc("notation/editstyle/voltas", "At system marking positions")
-                    }
+                    RadioButtonGroup {
+                        orientation: ListView.Vertical
+                        spacing: 8
 
-                    RoundedRadioButton {
-                        checked: barNumbersModel.measureNumberAllStaves.value === true
-                        onClicked: barNumbersModel.measureNumberAllStaves.value = true
-                        text: qsTrc("notation/editstyle/voltas", "On all staves")
+                        model:[
+                            { text: qsTrc("notation/editstyle/voltas", "Above system"), value: 0 },
+                            { text: qsTrc("notation/editstyle/voltas", "Below system"), value: 1 },
+                            { text: qsTrc("notation/editstyle/voltas", "At system marking positions"), value: 2 },
+                            { text: qsTrc("notation/editstyle/voltas", "On all staves"), value: 3 },
+                        ]
+
+                        delegate: RoundedRadioButton {
+                            text: modelData.text
+                            checked: barNumbersModel.measureNumberPlacementMode.value === modelData.value
+                            onClicked: barNumbersModel.measureNumberPlacementMode.value = modelData.value
+                        }
                     }
                 }
 

--- a/src/notation/qml/MuseScore/NotationScene/internal/EditStyle/MeasureNumbersPage.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/EditStyle/MeasureNumbersPage.qml
@@ -241,6 +241,7 @@ StyledFlickable {
                 ColumnLayout {
                     width: parent.width
                     spacing: 8
+                    visible: barNumbersModel.measureNumberPlacementMode.value === 3
 
                     StyledTextLabel {
                         text: qsTrc("notation/editstyle/voltas", "Position")

--- a/src/notation/view/styledialog/measurenumberspagemodel.cpp
+++ b/src/notation/view/styledialog/measurenumberspagemodel.cpp
@@ -35,7 +35,7 @@ MeasureNumbersPageModel::MeasureNumbersPageModel(QObject* parent)
                                          StyleId::measureNumberSystem,
                                          StyleId::measureNumberVPlacement,
                                          StyleId::measureNumberHPlacement,
-                                         StyleId::measureNumberAllStaves,
+                                         StyleId::measureNumberPlacementMode,
                                          StyleId::measureNumberPosAbove,
                                          StyleId::measureNumberPosBelow,
                                          StyleId::measureNumberAlternatePosBelow,
@@ -65,7 +65,7 @@ StyleItem* MeasureNumbersPageModel::measureNumberInterval() const { return style
 StyleItem* MeasureNumbersPageModel::measureNumberSystem() const { return styleItem(StyleId::measureNumberSystem); }
 StyleItem* MeasureNumbersPageModel::measureNumberVPlacement() const { return styleItem(StyleId::measureNumberVPlacement); }
 StyleItem* MeasureNumbersPageModel::measureNumberHPlacement() const { return styleItem(StyleId::measureNumberHPlacement); }
-StyleItem* MeasureNumbersPageModel::measureNumberAllStaves() const { return styleItem(StyleId::measureNumberAllStaves); }
+StyleItem* MeasureNumbersPageModel::measureNumberPlacementMode() const { return styleItem(StyleId::measureNumberPlacementMode); }
 
 StyleItem* MeasureNumbersPageModel::measureNumberPosAbove() const
 {

--- a/src/notation/view/styledialog/measurenumberspagemodel.h
+++ b/src/notation/view/styledialog/measurenumberspagemodel.h
@@ -35,7 +35,7 @@ class MeasureNumbersPageModel : public AbstractStyleDialogModel
     Q_PROPERTY(StyleItem * measureNumberSystem READ measureNumberSystem CONSTANT)
     Q_PROPERTY(StyleItem * measureNumberVPlacement READ measureNumberVPlacement CONSTANT)
     Q_PROPERTY(StyleItem * measureNumberHPlacement READ measureNumberHPlacement CONSTANT)
-    Q_PROPERTY(StyleItem * measureNumberAllStaves READ measureNumberAllStaves CONSTANT)
+    Q_PROPERTY(StyleItem * measureNumberPlacementMode READ measureNumberPlacementMode CONSTANT)
     Q_PROPERTY(StyleItem * measureNumberPosAbove READ measureNumberPosAbove NOTIFY measureNumberPosAboveChanged FINAL)
     Q_PROPERTY(StyleItem * measureNumberPosBelow READ measureNumberPosBelow CONSTANT)
     Q_PROPERTY(StyleItem * measureNumberAlignToBarline READ measureNumberAlignToBarline CONSTANT)
@@ -63,7 +63,7 @@ public:
     StyleItem* measureNumberSystem() const;
     StyleItem* measureNumberVPlacement() const;
     StyleItem* measureNumberHPlacement() const;
-    StyleItem* measureNumberAllStaves() const;
+    StyleItem* measureNumberPlacementMode() const;
     StyleItem* measureNumberPosAbove() const;
     StyleItem* measureNumberPosBelow() const;
     StyleItem* measureNumberAlignToBarline() const;


### PR DESCRIPTION
- Adds 'Above system' and 'Below system' options.
- Only includes measure numbers in system markings list if 'At system markings positions' is chosen.
- Only uses Position (above/below) when 'On all staves' is chosen.