### PR TITLE
Fix #28634: Retrograde plugin accounts for starting points across different voices

### DIFF
--- a/src/engraving/api/v1/elements.cpp
+++ b/src/engraving/api/v1/elements.cpp
@@ -289,7 +289,11 @@ void DurationElement::changeCRlen(FractionWrapper* len)
         LOGW("DurationElement::changeCRlen: invalid parameter values: %s", qPrintable(f.toString()));
         return;
     }
-    durationElement()->score()->changeCRlen(toChordRest(durationElement()), f);
+    if (durationElement()->isChord() && toChord(durationElement())->isGrace()) {
+        durationElement()->score()->undoChangeChordRestLen(toChord(durationElement()), f);
+    } else {
+        durationElement()->score()->changeCRlen(toChordRest(durationElement()), f);
+    }
 }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Resolves: #28634

Besides resolving the linked issue, much of the plugin has been simplified and rewritten using the new features of the 4.6 API :)
Hopefully it can provide a good example of how to use them for other developers.

Additionally, one bug in the API has been resolved: The duration of grace notes is now correctly changed when done so via plugin.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
