### PR TITLE
[4.6.0] Fix #29534: Fretboard diagram plays after deleting

### DIFF
--- a/src/engraving/dom/measure.cpp
+++ b/src/engraving/dom/measure.cpp
@@ -2006,6 +2006,10 @@ bool Measure::visible(staff_idx_t staffIdx) const
 bool Measure::stemless(staff_idx_t staffIdx) const
 {
     const Staff* staff = score()->staff(staffIdx);
+    if (!staff) {
+        return false;
+    }
+
     return staff->stemless(tick()) || m_mstaves[staffIdx]->stemless() || staff->staffType(tick())->stemless();
 }
 

--- a/src/engraving/dom/undo.cpp
+++ b/src/engraving/dom/undo.cpp
@@ -125,6 +125,11 @@ static std::vector<EngravingObject*> compoundObjects(EngravingObject* object)
         for (Note* compoundNote : note->compoundNotes()) {
             objects.push_back(compoundNote);
         }
+    } else if (object->isFretDiagram()) {
+        const FretDiagram* fret = toFretDiagram(object);
+        if (fret->harmony()) {
+            objects.push_back(fret->harmony());
+        }
     }
 
     objects.push_back(object);
@@ -1246,6 +1251,11 @@ bool RemoveElement::isFiltered(UndoCommand::Filter f, const EngravingItem* targe
         break;
     }
     return false;
+}
+
+std::vector<EngravingObject*> RemoveElement::objectItems() const
+{
+    return compoundObjects(element);
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/undo.h
+++ b/src/engraving/dom/undo.h
@@ -851,8 +851,9 @@ public:
 
     bool isFiltered(UndoCommand::Filter f, const EngravingItem* target) const override;
 
+    std::vector<EngravingObject*> objectItems() const override;
+
     UNDO_TYPE(CommandType::RemoveElement)
-    UNDO_CHANGED_OBJECTS({ element })
 };
 
 class AddSystemLock : public UndoCommand


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/29534