### PR TITLE
fixed #29556: Bottom submenus do not open on second monitor

### DIFF
--- a/src/framework/uicomponents/qml/Muse/UiComponents/StyledMenuLoader.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/StyledMenuLoader.qml
@@ -72,7 +72,7 @@ Loader {
 
         onOpenPrevMenu: {
            Qt.callLater(loader.openPrevMenu)
-        }  
+        }
 
         onOpenNextMenu: {
             Qt.callLater(loader.openNextMenu)
@@ -144,7 +144,7 @@ Loader {
 
         menu.model = model
 
-        menu.calculateSize()
+        Qt.callLater(menu.calculateSize)
     }
 
     Timer {


### PR DESCRIPTION
Resolves: #29556
