### PR TITLE
Fix #28261: Bug relating to staff type changes & drag/drop

### DIFF
--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -3359,7 +3359,6 @@ void NotationInteraction::setDropRect(const RectF& rect)
     if (edd.dropTarget) {
         edd.dropTarget->setDropTarget(false);
         score()->addRefresh(edd.dropTarget->canvasBoundingRect());
-        edd.dropTarget = nullptr;
     } else if (!m_anchorLines.empty()) {
         RectF rf;
         rf.setTopLeft(m_anchorLines.front().p1());


### PR DESCRIPTION
Resolves: #28261

1. Start a drag of a measure anchored element (`prepareDropMeasureAnchorElement`)
2. `setDropRect` _invalidates the drop target_ (something [inherited from MU3](https://github.com/musescore/MuseScore/pull/11832), likely made redundant after [#21543](https://github.com/musescore/MuseScore/pull/21543))
3. Element is dropped (`doDropStandard`) and `edd.dropTarget` is null

The reason this works for some staff type changes and not others is that, if the drop target is null, we fall back to dropping the element based on a position in the score (`NotationInteraction::dropTarget`). If the staff type change makes the measure significantly smaller - this position "misses" the measure and the fallback fails.