### PR TITLE
[4.6.0} Fix MSVC compiler warning

### DIFF
--- a/src/framework/audio/common/audiotypes.h
+++ b/src/framework/audio/common/audiotypes.h
@@ -466,7 +466,7 @@ struct InputProcessingProgress {
         int64_t total = 0;
     };
 
-    enum Status : uint8_t {
+    enum Status : unsigned int {
         Undefined = 0,
         Started,
         Processing,


### PR DESCRIPTION
reg.: 'muse::audio::InputProcessingProgress::StatusInfo': 'this' pointer for member 'muse::audio::InputProcessingProgress::StatusInfo::errorText' may not be aligned 8 as expected by the constructor (C4315)

This change does waste a couple bytes though...

Same as #29421