### PR TITLE
Restore and improve diagram ordering

### DIFF
--- a/src/engraving/dom/box.cpp
+++ b/src/engraving/dom/box.cpp
@@ -752,7 +752,7 @@ void FBox::init()
     for (size_t i = 0; i < oldDiagramsNames.size(); ++i) {
         String oldName = oldDiagramsNames[i];
         if (!muse::contains(diagramsNamesInScore, oldName)) {
-            score()->undoRemoveElement(oldDiagrams[i]);
+            score()->undo(new RemoveFretDiagramFromFretBox(oldDiagrams[i]));
         }
     }
 
@@ -801,6 +801,17 @@ void FBox::add(EngravingItem* e)
         return;
     }
     e->added();
+}
+
+void FBox::addAtIdx(FretDiagram* fretDiagram, size_t idx)
+{
+    if (idx < m_el.size()) {
+        m_el.insert(m_el.begin() + idx, fretDiagram);
+    } else {
+        m_el.push_back(fretDiagram);
+    }
+
+    fretDiagram->added();
 }
 
 PropertyValue FBox::getProperty(Pid propertyId) const

--- a/src/engraving/dom/box.cpp
+++ b/src/engraving/dom/box.cpp
@@ -803,10 +803,6 @@ void FBox::addAtIdx(FretDiagram* fretDiagram, size_t idx)
     harmony->setFlag(ElementFlag::MOVABLE, false);
     harmony->setFlag(ElementFlag::ON_STAFF, false);
 
-    if (!fretDiagram->eid().isValid()) {
-        fretDiagram->assignNewEID();
-    }
-
     if (idx < m_el.size()) {
         m_el.insert(m_el.begin() + idx, fretDiagram);
     } else {

--- a/src/engraving/dom/box.h
+++ b/src/engraving/dom/box.h
@@ -222,6 +222,7 @@ private:
 
     void updateDiagramsOrder(const StringList& currentDiagrams);
     void updateInvisibleDiagrams(const StringList& currentDiagrams);
+    size_t computeInsertionIdx(const String& nameOfDiagramBeforeThis);
 
     double m_textScale = 0.0;
     double m_diagramScale = 0.0;

--- a/src/engraving/dom/box.h
+++ b/src/engraving/dom/box.h
@@ -189,6 +189,7 @@ public:
     void init();
 
     void add(EngravingItem*) override;
+    void addAtIdx(FretDiagram* fretDiagram, size_t idx);
 
     double textScale() const { return m_textScale; }
     double diagramScale() const { return m_diagramScale; }

--- a/src/engraving/dom/fret.cpp
+++ b/src/engraving/dom/fret.cpp
@@ -1346,10 +1346,6 @@ FretDiagram* FretDiagram::makeFromHarmonyOrFretDiagram(const EngravingItem* harm
         }
     }
 
-    if (fretDiagram) {
-        fretDiagram->setTrack(muse::nidx);
-    }
-
     return fretDiagram;
 }
 

--- a/src/engraving/dom/measurebase.h
+++ b/src/engraving/dom/measurebase.h
@@ -206,12 +206,12 @@ protected:
 
     Fraction m_len  { Fraction(0, 1) };    // actual length of measure
 
+    ElementList m_el;                     // Measure(/tick) relative -elements: with defined start time
+                                          // but outside the staff
 private:
     MeasureBase* m_next = nullptr;
     MeasureBase* m_prev = nullptr;
 
-    ElementList m_el;                     // Measure(/tick) relative -elements: with defined start time
-                                          // but outside the staff
     Fraction m_tick = Fraction(0, 1);
     int m_no = 0;                         // Measure number, counting from zero
     int m_noOffset = 0;                   // Offset to measure number

--- a/src/engraving/dom/undo.cpp
+++ b/src/engraving/dom/undo.cpp
@@ -3591,3 +3591,20 @@ void RemoveFretDiagramFromFretBox::undo(EditData*)
     FBox* fbox = toFBox(m_fretDiagram->parent());
     fbox->addAtIdx(m_fretDiagram, m_idx);
 }
+
+AddFretDiagramToFretBox::AddFretDiagramToFretBox(FretDiagram* f, size_t idx)
+    : m_fretDiagram(f), m_idx(idx)
+{
+}
+
+void AddFretDiagramToFretBox::redo(EditData*)
+{
+    FBox* fbox = toFBox(m_fretDiagram->parent());
+    fbox->addAtIdx(m_fretDiagram, m_idx);
+}
+
+void AddFretDiagramToFretBox::undo(EditData*)
+{
+    FBox* fbox = toFBox(m_fretDiagram->parent());
+    fbox->remove(m_fretDiagram);
+}

--- a/src/engraving/dom/undo.cpp
+++ b/src/engraving/dom/undo.cpp
@@ -3571,3 +3571,23 @@ void FretLinkHarmony::redo(EditData*)
         m_fretDiagram->linkHarmony(m_harmony);
     }
 }
+
+RemoveFretDiagramFromFretBox::RemoveFretDiagramFromFretBox(FretDiagram* f)
+    : m_fretDiagram(f)
+{
+    FBox* fbox = toFBox(f->parent());
+    const ElementList& el = fbox->el();
+    m_idx = muse::indexOf(el, m_fretDiagram);
+}
+
+void RemoveFretDiagramFromFretBox::redo(EditData*)
+{
+    FBox* fbox = toFBox(m_fretDiagram->parent());
+    fbox->remove(m_fretDiagram);
+}
+
+void RemoveFretDiagramFromFretBox::undo(EditData*)
+{
+    FBox* fbox = toFBox(m_fretDiagram->parent());
+    fbox->addAtIdx(m_fretDiagram, m_idx);
+}

--- a/src/engraving/dom/undo.h
+++ b/src/engraving/dom/undo.h
@@ -1842,6 +1842,24 @@ public:
     UNDO_CHANGED_OBJECTS({ m_fretDiagram })
 };
 
+class AddFretDiagramToFretBox : public UndoCommand
+{
+    OBJECT_ALLOCATOR(engraving, RemoveFretDiagramFromFretBox)
+
+    FretDiagram* m_fretDiagram = nullptr;
+    size_t m_idx = muse::nidx;
+
+    void redo(EditData*) override;
+    void undo(EditData*) override;
+
+public:
+    AddFretDiagramToFretBox(FretDiagram* f, size_t idx);
+
+    UNDO_TYPE(CommandType::RemoveFretDiagramFromFretBox)
+    UNDO_NAME("RemoveFretDiagramFromFretBox")
+    UNDO_CHANGED_OBJECTS({ m_fretDiagram })
+};
+
 class MoveTremolo : public UndoCommand
 {
     OBJECT_ALLOCATOR(engraving, MoveTremolo)

--- a/src/engraving/dom/undo.h
+++ b/src/engraving/dom/undo.h
@@ -160,6 +160,7 @@ enum class CommandType : signed char {
     FretBarre,
     FretClear,
     FretLinkHarmony,
+    RemoveFretDiagramFromFretBox,
 
     // Harmony
     TransposeHarmony,
@@ -1820,6 +1821,24 @@ public:
 
     UNDO_TYPE(CommandType::FretLinkHarmony)
     UNDO_NAME("FretLinkHarmony")
+    UNDO_CHANGED_OBJECTS({ m_fretDiagram })
+};
+
+class RemoveFretDiagramFromFretBox : public UndoCommand
+{
+    OBJECT_ALLOCATOR(engraving, RemoveFretDiagramFromFretBox)
+
+    FretDiagram* m_fretDiagram = nullptr;
+    size_t m_idx = muse::nidx;
+
+    void redo(EditData*) override;
+    void undo(EditData*) override;
+
+public:
+    RemoveFretDiagramFromFretBox(FretDiagram* f);
+
+    UNDO_TYPE(CommandType::RemoveFretDiagramFromFretBox)
+    UNDO_NAME("RemoveFretDiagramFromFretBox")
     UNDO_CHANGED_OBJECTS({ m_fretDiagram })
 };
 

--- a/src/inspector/models/notation/frames/fretframe/fretframechorditem.cpp
+++ b/src/inspector/models/notation/frames/fretframe/fretframechorditem.cpp
@@ -28,21 +28,6 @@ FretFrameChordItem::FretFrameChordItem(QObject* parent)
 {
 }
 
-QString FretFrameChordItem::id() const
-{
-    return m_id;
-}
-
-void FretFrameChordItem::setId(const QString& id)
-{
-    if (m_id == id) {
-        return;
-    }
-
-    m_id = id;
-    emit idChanged();
-}
-
 QString FretFrameChordItem::title() const
 {
     return m_title;

--- a/src/inspector/models/notation/frames/fretframe/fretframechorditem.h
+++ b/src/inspector/models/notation/frames/fretframe/fretframechorditem.h
@@ -35,9 +35,6 @@ class FretFrameChordItem : public muse::uicomponents::SelectableItemListModel::I
 public:
     explicit FretFrameChordItem(QObject* parent = nullptr);
 
-    QString id() const;
-    void setId(const QString& id);
-
     QString title() const;
     void setTitle(const QString& title);
 

--- a/src/inspector/models/notation/frames/fretframe/fretframechordlistmodel.cpp
+++ b/src/inspector/models/notation/frames/fretframe/fretframechordlistmodel.cpp
@@ -62,7 +62,6 @@ void FretFrameChordListModel::load()
     for (EngravingItem* element : m_fretBox->orderedElements(true /*includeInvisible*/)) {
         FretDiagram* diagram = toFretDiagram(element);
         auto chordItem = new FretFrameChordItem(this);
-        chordItem->setId(QString::fromStdString(diagram->eid().toStdString()));
         chordItem->setTitle(harmonyName(diagram->harmony()));
 
         chordItem->setIsVisible(!muse::contains(invisibleDiagrams, diagram->harmony()->harmonyName().toLower()));


### PR DESCRIPTION
Resolves: see video ⬇️. Diagram is reinserted last on undo delete chord from score. This was a known problem introduced by my other fixes in #29346. I've now implemented some logic which allows to remember in the position of a diagram when inserting or removing it.

[Screencast from 2025-08-28 18-59-47.webm](https://github.com/user-attachments/assets/3cfb8e80-3f0d-4d1a-948f-e654c92ac0b2)
