### PR TITLE
Ensure chord list in property panel is updated after click reset button

### DIFF
--- a/src/inspector/models/notation/frames/fretframe/fretframechordssettingsmodel.cpp
+++ b/src/inspector/models/notation/frames/fretframe/fretframechordssettingsmodel.cpp
@@ -60,6 +60,7 @@ void FretFrameChordsSettingsModel::requestElements()
 void FretFrameChordsSettingsModel::loadProperties()
 {
     loadProperties({ Pid::FRET_FRAME_DIAGRAMS_ORDER });
+    m_chordListModel->load();
 }
 
 void FretFrameChordsSettingsModel::resetProperties()


### PR DESCRIPTION
Resolves: reset button updates the score but not the chord list in property panel.

[Screencast from 2025-08-29 16-37-48.webm](https://github.com/user-attachments/assets/da2f7e41-b0f9-4550-816b-110f93171b3f)
