### PR TITLE
fixed #29370: Crash when opening Edit workspaces dialog with VoiceOver enabled. 4.6

### DIFF
--- a/src/framework/workspace/qml/Muse/Workspace/internal/WorkspacesTopPanel.qml
+++ b/src/framework/workspace/qml/Muse/Workspace/internal/WorkspacesTopPanel.qml
@@ -52,7 +52,6 @@ Column {
 
     AccessibleItem {
         id: accessibleInfo
-        accessibleParent: root.navigationPanel.accessible
         visualItem: root
         role: MUAccessible.ListItem
         name: descriptionLabel.text + " " + root.firstWorkspaceTitle


### PR DESCRIPTION
see https://github.com/musescore/MuseScore/pull/29584