### PR TITLE
Fix #29064: Crash relating to brackets

### DIFF
--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -5191,8 +5191,6 @@ void NotationInteraction::pasteSelection(const Fraction& scale)
 {
     startEdit(TranslatableString("undoableAction", "Paste"));
 
-    EngravingItem* pastedElement = nullptr;
-
     if (isTextEditingStarted()) {
         const QMimeData* mimeData = QApplication::clipboard()->mimeData();
         if (mimeData->hasFormat(TextEditData::mimeRichTextFormat)) {
@@ -5223,20 +5221,12 @@ void NotationInteraction::pasteSelection(const Fraction& scale)
     } else {
         const QMimeData* mimeData = QApplication::clipboard()->mimeData();
         QMimeDataAdapter ma(mimeData);
-
-        std::vector<EngravingItem*> pastedElements = score()->cmdPaste(&ma, nullptr, scale);
-        if (!pastedElements.empty()) {
-            pastedElement = pastedElements.back();
-        }
+        score()->cmdPaste(&ma, nullptr, scale);
     }
 
     apply();
 
-    if (pastedElement == nullptr) {
-        pastedElement = selection()->element();
-    }
-
-    if (pastedElement) {
+    if (EngravingItem* pastedElement = selection()->element()) {
         selectAndStartEditIfNeeded(pastedElement);
     }
 


### PR DESCRIPTION
Resolves: #29064

Unfortunately it isn't always safe to use `pastedElement` either side of `apply` because `apply` may delete `pastedElement` (indeed this is what happens in this case, a use-after-free). Thankfully a partial revert of #26949 doesn't appear to reintroduce #25792.