### PR TITLE
Add missing #include directives

### DIFF
--- a/src/appshell/internal/startupscenario.cpp
+++ b/src/appshell/internal/startupscenario.cpp
@@ -23,6 +23,7 @@
 #include "startupscenario.h"
 
 #include <QCoreApplication>
+#include <QTimer>
 
 #include "async/async.h"
 #include "network/networkerrors.h"

--- a/src/framework/ui/view/internal/widgetdialogadapter.cpp
+++ b/src/framework/ui/view/internal/widgetdialogadapter.cpp
@@ -22,6 +22,7 @@
 #include "widgetdialogadapter.h"
 
 #include <QGuiApplication>
+#include <QKeyEvent>
 
 #include "log.h"
 


### PR DESCRIPTION
As requested in  https://github.com/musescore/MuseScore/pull/29591, this change is for the 4.6.0 branch.

I tried a test build of MuseScore 4.6.0 alpha on a Fedora Rawhide machine, with Qt 6.9.1. The build failed in two places due to dereferencing an incomplete type. Adding these #include directives leads to a successful build.
<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
