### PR TITLE
Tool to un-tuplet numbers in the note input bar's tuplet menu

### DIFF
--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -1710,8 +1710,11 @@ void Score::removeElement(EngravingItem* element)
 
 void Score::removeTuplet(Tuplet* destinationTuplet, ChordRest* keptChordRest)
 {
-    // TODO: implement this function
-    
+    cmdDeleteTuplet(destinationTuplet, true);
+    if (keptChordRest->isChord()) {
+        addChord(destinationTuplet->tick(), destinationTuplet->ticks(), toChord(keptChordRest), false, destinationTuplet->tuplet());
+    }
+
     return;
 }
 

--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -1708,6 +1708,13 @@ void Score::removeElement(EngravingItem* element)
     }
 }
 
+void Score::removeTuplet(Tuplet* destinationTuplet, ChordRest* keptChordRest)
+{
+    // TODO: implement this function
+    
+    return;
+}
+
 void Score::doUndoRemoveElement(EngravingItem* element)
 {
     if (element->generated()) {

--- a/src/engraving/dom/score.h
+++ b/src/engraving/dom/score.h
@@ -542,6 +542,7 @@ public:
     MeasureRepeat* addMeasureRepeat(const Fraction& tick, track_idx_t track, int numMeasures);
 
     Tuplet* addTuplet(ChordRest* destinationChordRest, Fraction ratio, TupletNumberType numberType, TupletBracketType bracketType);
+    void removeTuplet(Tuplet* destinationTuplet, ChordRest* keptChordRest);
 
     ChordRest* addClone(ChordRest* cr, const Fraction& tick, const TDuration& d);
     Rest* setRest(const Fraction& tick, track_idx_t track, const Fraction&, bool useDots, Tuplet* tuplet, bool useFullMeasureRest = true);

--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -215,6 +215,7 @@ public:
     virtual void addGraceNotesToSelectedNotes(GraceNoteType type) = 0;
     virtual bool canAddTupletToSelectedChordRests() const = 0;
     virtual void addTupletToSelectedChordRests(const TupletOptions& options) = 0;
+    virtual void removeTupletFromSelectedChordRests() = 0;
     virtual void addBeamToSelectedChordRests(BeamMode mode) = 0;
     virtual void beamSelectedRange() = 0;
 

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -5888,6 +5888,39 @@ void NotationInteraction::addTupletToSelectedChordRests(const TupletOptions& opt
     apply();
 }
 
+void NotationInteraction::removeTupletFromSelectedChordRests()
+{
+    if (selection()->isNone()) {
+        return;
+    }
+
+    startEdit(TranslatableString("undoableAction", "Remove tuplet"));
+
+    // Retrieve tuplets, the first selected ChordRest in each (preference given to chords), and which tuplets are not bottom-layer
+    std::unordered_map<Tuplet*, ChordRest*> bottomTuplets;
+    std::unordered_set<Tuplet*> overlayTuplets;
+    for (ChordRest* chordRest : score()->getSelectedChordRests()) {
+        Tuplet* bottomTuplet = chordRest->tuplet();
+        if (bottomTuplet
+            && (bottomTuplets.find(bottomTuplet) == bottomTuplets.end() || bottomTuplets[bottomTuplet]->type() == ElementType::REST
+                || bottomTuplets[bottomTuplet]->tick() > chordRest->tick())) {
+            bottomTuplets[bottomTuplet] = chordRest;
+            while (bottomTuplet = bottomTuplet->tuplet()) {
+                overlayTuplets.insert(bottomTuplet);
+            }
+        }
+    }
+
+    // For those tuplets which are bottom-layer, remove them and replace with their first element
+    for (std::pair<Tuplet*, ChordRest*> tupletAndChordRest : bottomTuplets) {
+        if (overlayTuplets.find(tupletAndChordRest.first) == overlayTuplets.end()) {
+            score()->removeTuplet(tupletAndChordRest.first, tupletAndChordRest.second);
+        }
+    }
+
+    apply();
+}
+
 void NotationInteraction::addBeamToSelectedChordRests(BeamMode mode)
 {
     if (selection()->isNone()) {

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -228,6 +228,7 @@ public:
     void addGraceNotesToSelectedNotes(GraceNoteType type) override;
     bool canAddTupletToSelectedChordRests() const override;
     void addTupletToSelectedChordRests(const TupletOptions& options) override;
+    void removeTupletFromSelectedChordRests() override;
     void addBeamToSelectedChordRests(BeamMode mode) override;
     void beamSelectedRange() override;
 

--- a/src/notation/tests/mocks/notationinteractionmock.h
+++ b/src/notation/tests/mocks/notationinteractionmock.h
@@ -175,6 +175,7 @@ public:
     MOCK_METHOD(void, addGraceNotesToSelectedNotes, (GraceNoteType), (override));
     MOCK_METHOD(bool, canAddTupletToSelectedChordRests, (), (const, override));
     MOCK_METHOD(void, addTupletToSelectedChordRests, (const TupletOptions&), (override));
+    MOCK_METHOD(void, removeTupletFromSelectedChordRests, (), (override));
     MOCK_METHOD(void, addBeamToSelectedChordRests, (BeamMode), (override));
     MOCK_METHOD(void, beamSelectedRange, (), (override));
 

--- a/src/notationscene/internal/notationactioncontroller.cpp
+++ b/src/notationscene/internal/notationactioncontroller.cpp
@@ -1040,7 +1040,14 @@ void NotationActionController::removeTuplet()
 {
     TRACEFUNC;
 
-    // TODO:  Implement this function
+    auto interaction = currentNotationInteraction();
+    if (!interaction) {
+        return;
+    }
+
+    // tuplet removal not implemented for note input mode
+    interaction->removeTupletFromSelectedChordRests();
+
     return;
 }
 

--- a/src/notationscene/internal/notationactioncontroller.cpp
+++ b/src/notationscene/internal/notationactioncontroller.cpp
@@ -187,6 +187,7 @@ void NotationActionController::init()
     registerAction("septuplet", [this]() { putTuplet(7); }, &Controller::noteOrRestSelected);
     registerAction("octuplet", [this]() { putTuplet(8); }, &Controller::noteOrRestSelected);
     registerAction("nonuplet", [this]() { putTuplet(9); }, &Controller::noteOrRestSelected);
+    registerAction("remove-tuplet", &Controller::removeTuplet, &Controller::noteOrRestSelected);
     registerAction("custom-tuplet", &Controller::putTuplet, &Controller::noteOrRestSelected);
     registerAction("tuplet-dialog", &Controller::openTupletOtherDialog, &Controller::noteOrRestSelected);
 
@@ -1033,6 +1034,14 @@ void NotationActionController::putTuplet(int tupletCount)
     }
 
     putTuplet(options);
+}
+
+void NotationActionController::removeTuplet()
+{
+    TRACEFUNC;
+
+    // TODO:  Implement this function
+    return;
 }
 
 void NotationActionController::doubleNoteInputDuration()

--- a/src/notationscene/internal/notationactioncontroller.h
+++ b/src/notationscene/internal/notationactioncontroller.h
@@ -103,6 +103,7 @@ private:
     void putTuplet(const muse::actions::ActionData& data);
     void putTuplet(const TupletOptions& options);
     void putTuplet(int tupletCount);
+    void removeTuplet();
 
     bool moveSelectionAvailable(MoveSelectionType type) const;
     void moveSelection(MoveSelectionType type, MoveDirection direction);

--- a/src/notationscene/internal/notationuiactions.cpp
+++ b/src/notationscene/internal/notationuiactions.cpp
@@ -1465,6 +1465,12 @@ const UiActionList NotationUiActions::s_actions = {
              TranslatableString("action", "&Nonuplet"),
              TranslatableString("action", "Enter tuplet: nonuplet")
              ),
+    UiAction("remove-tuplet",
+             mu::context::UiCtxProjectOpened,
+             mu::context::CTX_NOTATION_FOCUSED,
+             TranslatableString("action", "Remove t&uplet"),
+             TranslatableString("action", "Remove tuplet")
+             ),
     UiAction("tuplet-dialog",
              mu::context::UiCtxProjectOpened,
              mu::context::CTX_NOTATION_FOCUSED,

--- a/src/notationscene/qml/MuseScore/NotationScene/noteinputbarmodel.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/noteinputbarmodel.cpp
@@ -576,6 +576,7 @@ MenuItemList NoteInputBarModel::makeTupletItems()
         makeMenuItem("septuplet"),
         makeMenuItem("octuplet"),
         makeMenuItem("nonuplet"),
+        makeMenuItem("remove-tuplet"),
         makeMenuItem("tuplet-dialog")
     };
 


### PR DESCRIPTION
Resolves (or, attempts to address):  desire from users (as stated on forums [here](https://musescore.org/en/node/306628) and [here](https://musescore.org/en/node/330440)) to be able to un-tuplet notes that have been made into a tuplet without deleting the tuplet.  I don't know whether feature requests are of interest at the moment; if not, I'm open to taking on bugs as well.

Sometimes while editing, one might have a tuplet with an elaborate chord that one made a tuplet long ago - possibly in a different editing session with a different undo stack - and wish to revert the effects of the tuplet-making without re-writing the chord or having to cut-and-paste.  This tool aims to offer the inverse of the enter tuplet action when possible.  In attempting to be the inverse, it replaces, for example, a triplet of eighth notes with a single quarter note (and not, say, with the first two eighth notes), just as the enter tuplet (3) action turns a quarter note into three eighth notes.  In attempting to be distinct from deletion, it preserves the properties of the chord in the tuplet that the user selects (or the first, if any), as shown in the video below.

https://github.com/user-attachments/assets/2e6f9d90-78cf-4519-aed0-771c51067a84

It does this removal using pre-existing methods of the Score object, and thus _should_, if I understand correctly, be undo- and redo- safe, though I would appreciate feedback on that, as well as on how nested tuplets are handled (it's shown in the video above and that below), and how translation of the string "Remove tuplets" is handled (no translations are present on this branch).

https://github.com/user-attachments/assets/0a566d2c-d1d9-4c50-ae19-914b2d155044

It's unlikely this feature is perfect in its this implementation (as this is my first significant pull request), but it is one I would like to see; as such, I am asking for feedback on any aspect of it.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits (wouldn't say they're extensive)
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually (yes, after each commit)
- [x] I created a unit test or vtest to verify the changes I made (if applicable) (did not make a test, as in so far as I can tell those are largely for visuals - is there a way to make them for functions?
