### PR TITLE
Allow FilePicker's button customization

### DIFF
--- a/src/framework/uicomponents/qml/Muse/UiComponents/FilePicker.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/FilePicker.qml
@@ -41,6 +41,9 @@ Item {
     property alias filter: filePickerModel.filter
     property alias dir: filePickerModel.dir
 
+    property int buttonType: FlatButton.IconOnly
+    property int orientation: Qt.Vertical
+
     property NavigationPanel navigation: null
     property int navigationRowOrderStart: 0
     property int navigationColumnOrderStart: 0
@@ -88,6 +91,10 @@ Item {
             id: button
             Layout.alignment: Qt.AlignVCenter
             icon: IconCode.OPEN_FILE
+
+            text: qsTrc("ui", "Browse")
+            buttonType: root.buttonType
+            orientation: root.orientation
 
             navigation.name: "FilePickerButton"
             navigation.panel: root.navigation

--- a/src/framework/uicomponents/qml/Muse/UiComponents/FlatButton.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/FlatButton.qml
@@ -213,7 +213,7 @@ FocusScope {
                 iconCode: root.icon
                 font: root.iconFont
                 color: root.iconColor
-                visible: !isEmpty
+                visible: !isEmpty && buttonType != FlatButton.TextOnly
             }
 
             StyledTextLabel {
@@ -224,7 +224,7 @@ FocusScope {
                 textFormat: root.textFormat
                 wrapMode: Text.Wrap
                 maximumLineCount: root.maximumLineCount
-                visible: !isEmpty
+                visible: !isEmpty && buttonType != FlatButton.IconOnly
             }
         }
     }


### PR DESCRIPTION
Right now FilePicker displays only a flat button with a directory icon - it's not customizable. This PR exposes button so it can be customized.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
