### PR TITLE
Preserve chord symbol in parts when linked fret diagram deleted

### DIFF
--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -3969,7 +3969,11 @@ void Score::cmdDeleteSelection()
                     FretDiagram* fretDiagram = toFretDiagram(e);
                     Harmony* harmony = fretDiagram->harmony();
                     if (harmony) {
-                        undo(new FretLinkHarmony(fretDiagram, harmony, true /* unlink */));
+                        for (EngravingObject* o: fretDiagram->linkList()) {
+                            FretDiagram* linkedDiagram = toFretDiagram(o);
+                            Harmony* linkedHarmony = linkedDiagram->harmony();
+                            undo(new FretLinkHarmony(linkedDiagram, linkedHarmony, true /* unlink */));
+                        }
                         elSelectedAfterDeletion = harmony;
                     }
                 } else if (e->isHarmony()) {


### PR DESCRIPTION
Resolves: root cause (*I think*) of #29516

https://github.com/user-attachments/assets/ed7a2cc4-cdb9-40a4-bc6a-264f14c8fed3