### PR TITLE
Fix #29620: Fix copyright text fields

### DIFF
--- a/src/framework/uicomponents/qml/Muse/UiComponents/TextInputArea.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/TextInputArea.qml
@@ -177,9 +177,16 @@ FocusScope {
                         return
                     }
 
-                    if (event.key === Qt.Key_Escape) {
+                    switch (event.key) {
+                    case Qt.Key_Escape:
+                    case Qt.Key_Space:
+                    case Qt.Key_Return:
+                    case Qt.Key_Enter: {
                         event.accepted = true
                         return
+                    }
+                    default:
+                        break
                     }
 
                     if (textInputModel.isShortcutAllowedOverride(event.key, event.modifiers)) {


### PR DESCRIPTION
Resolves: #29620

This appears to have been caused by some changes in Qt 6.9.2. The fix I'm proposing here is to accept shortcut overrides of the keys in question, preventing the events from propagating. Currently TextInputArea is solely used for our copyright fields, so this fix should be pretty safe/contained.