### PR TITLE
Fix #29454 corruption when modifying second staff

### DIFF
--- a/src/notation/inotationparts.h
+++ b/src/notation/inotationparts.h
@@ -72,6 +72,7 @@ public:
                             InsertMode mode = InsertMode::Before) = 0;
 
     virtual bool appendStaff(Staff* staff, const muse::ID& destinationPartId) = 0;
+    virtual bool appendStaffLinkedToMaster(Staff* staff, Staff* masterSourceStaff, const muse::ID& destinationPartId) = 0;
     virtual bool appendLinkedStaff(Staff* staff, const muse::ID& sourceStaffId, const muse::ID& destinationPartId) = 0;
 
     virtual void insertPart(Part* part, size_t index) = 0;

--- a/src/notation/internal/masternotationparts.cpp
+++ b/src/notation/internal/masternotationparts.cpp
@@ -145,9 +145,8 @@ bool MasterNotationParts::appendStaff(Staff* staff, const ID& destinationPartId)
 
     for (const INotationPartsPtr& parts : excerptsParts()) {
         Staff* excerptStaff = staff->clone();
-        if (parts->appendStaff(excerptStaff, destinationPartId)) {
-            excerptStaff->linkTo(staff);
-        } else {
+        if (!parts->appendStaffLinkedToMaster(excerptStaff, staff, destinationPartId)) {
+            excerptStaff->undoUnlink();
             delete excerptStaff;
         }
     }

--- a/src/notation/internal/masternotationparts.h
+++ b/src/notation/internal/masternotationparts.h
@@ -40,6 +40,7 @@ public:
     void removeStaves(const muse::IDList& stavesIds) override;
 
     bool appendStaff(Staff* staff, const muse::ID& destinationPartId) override;
+    bool appendStaffLinkedToMaster(Staff*, Staff*, const muse::ID&) override { return false; }
     bool appendLinkedStaff(Staff* staff, const muse::ID& sourceStaffId, const muse::ID& destinationPartId) override;
 
     void replaceInstrument(const InstrumentKey& instrumentKey, const Instrument& newInstrument,

--- a/src/notation/internal/notationparts.cpp
+++ b/src/notation/internal/notationparts.cpp
@@ -611,6 +611,29 @@ bool NotationParts::appendStaff(Staff* staff, const ID& destinationPartId)
     return true;
 }
 
+bool NotationParts::appendStaffLinkedToMaster(Staff* staff, Staff* masterSourceStaff, const muse::ID& destinationPartId)
+{
+    TRACEFUNC;
+
+    IF_ASSERT_FAILED(staff && masterSourceStaff) {
+        return false;
+    }
+
+    Part* destinationPart = partModifiable(destinationPartId);
+    if (!destinationPart) {
+        return false;
+    }
+
+    startEdit(TranslatableString("undoableAction", "Add staff"));
+
+    doAppendStaff(staff, destinationPart, /*createRests*/ false);
+    score()->undo(new mu::engraving::Link(staff, masterSourceStaff));
+
+    mu::engraving::Excerpt::cloneStaff2(masterSourceStaff, staff, Fraction(0, 1), score()->endTick());
+
+    return true;
+}
+
 bool NotationParts::appendLinkedStaff(Staff* staff, const muse::ID& sourceStaffId, const muse::ID& destinationPartId)
 {
     TRACEFUNC;

--- a/src/notation/internal/notationparts.h
+++ b/src/notation/internal/notationparts.h
@@ -66,6 +66,7 @@ public:
     void moveStaves(const muse::IDList& sourceStavesIds, const muse::ID& destinationStaffId, InsertMode mode = InsertMode::Before) override;
 
     bool appendStaff(Staff* staff, const muse::ID& destinationPartId) override;
+    bool appendStaffLinkedToMaster(Staff* staff, Staff* masterSourceStaff, const muse::ID& destinationPartId) override;
     bool appendLinkedStaff(Staff* staff, const muse::ID& sourceStaffId, const muse::ID& destinationPartId) override;
 
     void insertPart(Part* part, size_t index) override;


### PR DESCRIPTION
Resolves: #29454 

When adding a new stave to the instrument, the operation was done independently in the score and in each part. The staves themselves were then linked across score and parts, but the contained full-measure rests were not. As a result, newly entered notes or rests were entered and synced correctly, but operations made on the exising rests (such as shortening the full-measure rest by selecting it and pressing a duration key) were not synced, which resulted in rests of wrong durations overfilling the measure in the part and causing the corruption.

The solution is to avoid adding the new stave independently in each part, but rather adding it to the main score and then doing a full clone of it the same way we do when creating parts.

EDIT Also worth clarifying: a file that's already corrupted, or even just saved after adding the new stave, cannot be fixed, cause all the links will be missing. This PR prevents the corruption from happening on new files.