### PR TITLE
Added new FilePicker type

### DIFF
--- a/src/framework/uicomponents/qml/Muse/UiComponents/FilePicker.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/FilePicker.qml
@@ -31,7 +31,8 @@ Item {
     enum PickerType {
         File,
         Directory,
-        MultipleDirectories
+        MultipleDirectories,
+        Any
     }
     property int pickerType: FilePicker.PickerType.File
 
@@ -118,6 +119,14 @@ Item {
                 case FilePicker.PickerType.MultipleDirectories:{
                     var selectedDirectories = filePickerModel.selectMultipleDirectories(root.path)
                     root.pathEdited(selectedDirectories)
+                    break
+                }
+                case FilePicker.PickerType.Any:{
+                    var selectedAny = filePickerModel.selectAny()
+                    if (Boolean(selectedAny)) {
+                        root.pathEdited(selectedAny)
+                    }
+
                     break
                 }
                 }

--- a/src/framework/uicomponents/view/filepickermodel.cpp
+++ b/src/framework/uicomponents/view/filepickermodel.cpp
@@ -84,6 +84,22 @@ QString FilePickerModel::selectMultipleDirectories(const QString& selectedDirect
     return result.join(";");
 }
 
+QString FilePickerModel::selectAny()
+{
+    std::vector<std::string> filter;
+    for (const QString& nameFilter : m_filter) {
+        filter.push_back(nameFilter.toStdString());
+    }
+
+    io::path_t file = interactive()->selectSavingFileSync(m_title.toStdString(), m_dir, filter);
+
+    if (!file.empty()) {
+        m_dir = io::dirpath(file).toQString();
+    }
+
+    return file.toQString();
+}
+
 void FilePickerModel::setTitle(const QString& title)
 {
     if (title == m_title) {

--- a/src/framework/uicomponents/view/filepickermodel.h
+++ b/src/framework/uicomponents/view/filepickermodel.h
@@ -48,6 +48,7 @@ public:
     Q_INVOKABLE QString selectFile();
     Q_INVOKABLE QString selectDirectory();
     Q_INVOKABLE QString selectMultipleDirectories(const QString& selectedDirectoriesStr);
+    Q_INVOKABLE QString selectAny();
 
 public slots:
     void setTitle(const QString& title);


### PR DESCRIPTION
Adds new FilePicker type enabling to select both a file or a directory (and entering new/non-existing filename manually if needed)

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
