### PR TITLE
Activate default section and panel on escape

### DIFF
--- a/src/framework/ui/internal/navigationcontroller.cpp
+++ b/src/framework/ui/internal/navigationcontroller.cpp
@@ -981,7 +981,19 @@ void NavigationController::onEscape()
     activeCtrl->setActive(false);
 
     if (m_defaultNavigationControl) {
-        doActivateControl(m_defaultNavigationControl);
+        INavigationPanel* defaultPanel = m_defaultNavigationControl->panel();
+        if (!defaultPanel) {
+            return;
+        }
+
+        INavigationSection* defaultSection = defaultPanel->section();
+        if (!defaultSection) {
+            return;
+        }
+
+        onActiveRequested(defaultSection, defaultPanel, m_defaultNavigationControl, true);
+    } else {
+        m_navigationChanged.notify();
     }
 }
 


### PR DESCRIPTION
Resolves: #NNNNN <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

Ensures the correct panel and section are set when falling back to the default navigation.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
