### PR TITLE
Rewrite createMeasures (fix templates/parts corruption #27499)

### DIFF
--- a/src/engraving/dom/score.h
+++ b/src/engraving/dom/score.h
@@ -549,7 +549,7 @@ public:
 
     ChordRest* addClone(ChordRest* cr, const Fraction& tick, const TDuration& d);
     Rest* setRest(const Fraction& tick, track_idx_t track, const Fraction&, bool useDots, Tuplet* tuplet, bool useFullMeasureRest = true);
-    std::vector<Rest*> setRests(const Fraction& tick, track_idx_t track, const Fraction&, bool useDots, Tuplet* tuplet,
+    std::vector<Rest*> setRests(const Fraction& tick, track_idx_t track, const Fraction& l, bool useDots, Tuplet* tuplet,
                                 bool useFullMeasureRest = true);
 
     void upDown(bool up, UpDownMode);

--- a/src/notation/notationtypes.h
+++ b/src/notation/notationtypes.h
@@ -539,16 +539,15 @@ struct ScoreCreateOptions
     bool withTempo = false;
     Tempo tempo;
 
-    int timesigNumerator = 0;
-    int timesigDenominator = 1;
+    Fraction globalTimesig;
     TimeSigType timesigType = TimeSigType::NORMAL;
 
     Key key = Key::C;
 
+    int totalMeasures = 0;
+
     bool withPickupMeasure = false;
-    int measures = 0;
-    int measureTimesigNumerator = 0;
-    int measureTimesigDenominator = 0;
+    Fraction pickupTimesig;
 
     PartInstrumentList parts;
     ScoreOrder order;

--- a/src/project/view/newscoremodel.cpp
+++ b/src/project/view/newscoremodel.cpp
@@ -88,17 +88,21 @@ ProjectCreateOptions NewScoreModel::parseOptions(const QVariantMap& info) const
 
     QVariantMap timeSignature = info["timeSignature"].toMap();
     scoreOptions.timesigType = static_cast<TimeSigType>(info["timeSignatureType"].toInt());
-    scoreOptions.timesigNumerator = timeSignature["numerator"].toInt();
-    scoreOptions.timesigDenominator = timeSignature["denominator"].toInt();
+
+    const int timesigNumerator = timeSignature["numerator"].toInt();
+    const int timesigDenominator = timeSignature["denominator"].toInt();
+    scoreOptions.globalTimesig = Fraction(timesigNumerator, timesigDenominator);
 
     QVariantMap keySignature = info["keySignature"].toMap();
     scoreOptions.key = static_cast<Key>(keySignature["key"].toInt());
 
     QVariantMap measuresPickup = info["pickupTimeSignature"].toMap();
+    scoreOptions.totalMeasures = info["measureCount"].toInt();
+
     scoreOptions.withPickupMeasure = info["withPickupMeasure"].toBool();
-    scoreOptions.measures = info["measureCount"].toInt();
-    scoreOptions.measureTimesigNumerator = measuresPickup["numerator"].toInt();
-    scoreOptions.measureTimesigDenominator = measuresPickup["denominator"].toInt();
+    const int pickupNumerator = measuresPickup["numerator"].toInt();
+    const int pickupDenominator = measuresPickup["denominator"].toInt();
+    scoreOptions.pickupTimesig = Fraction(pickupNumerator, pickupDenominator);
 
     QVariantList instruments = info["instruments"].toList();
 


### PR DESCRIPTION
Resolves: #27499

Introduced by #19492 but that only seems to have uncovered an existing issue.

I think the problem here is that `createMeasures` uses some really old/outdated logic to link rests (towards the end of the method). I figured we could use `MasterScore::insertMeasure` instead which will call some of our more tried-and-tested linking logic.

This PR also includes a general cleanup/refactor of createMeasures.