### PR TITLE
Fix null staff crash during MusicXML export

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
@@ -7954,7 +7954,11 @@ void ExportMusicXml::writeInstrumentChange(const InstrumentChange* instrChange)
 
     for (KeySig* keySig : instrChange->keySigs()) {
         staff_idx_t st = m_score->staffIdx(part);
-        keysig(keySig, part->staff(st)->clef(instrChange->tick()), m_score->staffIdx(part), keySig->visible());
+        Staff* staff = part->staff(st);
+        if (!staff) {
+            continue;
+        }
+        keysig(keySig, staff->clef(instrChange->tick()), m_score->staffIdx(part), keySig->visible());
     }
     writeInstrumentDetails(instr, m_score->style().styleB(Sid::concertPitch));
 


### PR DESCRIPTION
Example MSCZ that causes a crash when exported to MusicXML: [Kings_Row_Suite_for_Orchestra__Erich_Wolfgang_Korngold.zip](https://github.com/user-attachments/files/19380837/Kings_Row_Suite_for_Orchestra__Erich_Wolfgang_Korngold.zip)

(This file is from #27265, which is about an unrelated problem.)