### PR TITLE
fixed #29557: Alt+arrow navigation gets stuck on Fretboard diagram frame

### DIFF
--- a/src/engraving/dom/box.h
+++ b/src/engraving/dom/box.h
@@ -207,6 +207,8 @@ public:
     Grip defaultGrip() const override;
     std::vector<PointF> gripsPositions(const EditData&) const override;
 
+    bool needStartEditingAfterSelecting() const override { return false; }
+
     void undoReorderElements(const StringList& newOrder);
     const StringList& diagramsOrder() const { return m_diagramsOrder; }
 


### PR DESCRIPTION
Resolves: #29557
