### PR TITLE
[4.6.0] Fix #29056: set correct parent for cue chord

### DIFF
--- a/src/engraving/dom/trill.cpp
+++ b/src/engraving/dom/trill.cpp
@@ -243,6 +243,11 @@ void Trill::computeStartElement()
     Spanner::computeStartElement();
     if (startElement() && startElement()->isChord() && m_ornament) {
         m_ornament->setParent(startElement());
+
+        Chord* cueChord = m_ornament->cueNoteChord();
+        if (cueChord) {
+            cueChord->setParent(toChord(startElement())->segment());
+        }
     }
 }
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/29056