### PR TITLE
Qt 6.9 migration fixes

### DIFF
--- a/src/framework/uicomponents/qml/Muse/UiComponents/ContextMenuLoader.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/ContextMenuLoader.qml
@@ -35,6 +35,7 @@ Item {
     //  next(depending on the limitation) to the pressed position.
     width: 0
     height: 0
+    visible: false
 
     function show(position: point, items) {
         if (!items) {

--- a/src/framework/uicomponents/qml/Muse/UiComponents/ContextMenuLoader.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/ContextMenuLoader.qml
@@ -26,6 +26,7 @@ Item {
 
     // Useful for static context menus
     property var items: []
+    property alias parentWindow: contextMenuLoader.parentWindow
 
     signal handleMenuItem(string itemId)
     signal opened()

--- a/src/framework/uicomponents/qml/Muse/UiComponents/StyledDropdown.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/StyledDropdown.qml
@@ -37,6 +37,8 @@ Item {
 
     property int currentIndex: -1
 
+    property alias parentWindow: dropdownLoader.parentWindow
+
     property alias background: backgroundItem
     property alias itemColor: dropdownLoader.itemColor
 

--- a/src/framework/uicomponents/qml/Muse/UiComponents/StyledMenuLoader.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/StyledMenuLoader.qml
@@ -37,6 +37,7 @@ Loader {
     property StyledMenu menu: loader.item as StyledMenu
     property Item menuAnchorItem: null
     property bool hasSiblingMenus: false
+    property var parentWindow: null
 
     property alias isMenuOpened: loader.active
 
@@ -64,6 +65,8 @@ Loader {
         focusPolicies: PopupView.NoFocus
 
         accessibleName: loader.accessibleName
+
+        parentWindow: loader.parentWindow
 
         onHandleMenuItem: function(itemId) {
             itemMenu.close()

--- a/src/framework/uicomponents/qml/Muse/UiComponents/internal/StyledDropdownLoader.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/internal/StyledDropdownLoader.qml
@@ -25,6 +25,8 @@ import QtQuick.Window 2.15
 Loader {
     id: loader
 
+    property var parentWindow: null
+
     property string textRole: ""
     property string valueRole: ""
 
@@ -73,6 +75,7 @@ Loader {
         itemColor: loader.itemColor
         background.color: loader.backgroundColor
 
+        parentWindow: loader.parentWindow
         accessibleWindow: loader.Window.window
 
         onHandleItem: function(index, value) {

--- a/src/framework/uicomponents/qml/Muse/UiComponents/internal/StyledMenu.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/internal/StyledMenu.qml
@@ -251,7 +251,7 @@ MenuView {
 
         Component.onCompleted: {
             var menuLoaderComponent = Qt.createComponent("../StyledMenuLoader.qml");
-            root.subMenuLoader = menuLoaderComponent.createObject(root)
+            root.subMenuLoader = menuLoaderComponent.createObject(root.window)
             root.subMenuLoader.menuAnchorItem = root.anchorItem
             root.subMenuLoader.hasSiblingMenus = root.hasSiblingMenus
 

--- a/src/framework/uicomponents/view/popupview.cpp
+++ b/src/framework/uicomponents/view/popupview.cpp
@@ -135,6 +135,7 @@ void PopupView::init()
     m_window = new PopupWindow_QQuickView(muse::iocCtxForQmlEngine(engine), this);
     m_window->init(engine, isDialog(), frameless());
     m_window->setOnHidden([this]() { onHidden(); });
+    m_window->setParentWindow(m_parentWindow);
     m_window->setContent(m_component, m_contentItem);
     m_window->setTakeFocusOnClick(m_focusPolicies & FocusPolicy::ClickFocus);
 
@@ -744,16 +745,29 @@ void PopupView::setErrCode(Ret::Code code)
 
 QWindow* PopupView::parentWindow() const
 {
-    return m_window->parentWindow();
+    return m_parentWindow;
 }
 
 void PopupView::setParentWindow(QWindow* window)
 {
-    m_window->setParentWindow(window);
+    if (m_parentWindow == window) {
+        return;
+    }
+
+    if (m_window) {
+        m_window->setParentWindow(window);
+    }
+    m_parentWindow = window;
+
+    emit parentWindowChanged();
 }
 
 void PopupView::resolveParentWindow()
 {
+    if (m_parentWindow) {
+        return;
+    }
+
     if (QQuickItem* parent = parentItem()) {
         if (QWindow* window = parent->window()) {
             setParentWindow(window);

--- a/src/framework/uicomponents/view/popupview.h
+++ b/src/framework/uicomponents/view/popupview.h
@@ -73,6 +73,7 @@ class PopupView : public QObject, public QQmlParserStatus, public Injectable, pu
     Q_PROPERTY(int contentHeight READ contentHeight WRITE setContentHeight NOTIFY contentHeightChanged)
 
     Q_PROPERTY(QWindow * window READ window NOTIFY windowChanged)
+    Q_PROPERTY(QWindow * parentWindow READ parentWindow WRITE setParentWindow NOTIFY parentWindowChanged FINAL)
 
     //! NOTE Local, related parent
     Q_PROPERTY(qreal x READ localX WRITE setLocalX NOTIFY xChanged)
@@ -273,6 +274,8 @@ signals:
 
     void isContentReadyChanged();
 
+    void parentWindowChanged();
+
 protected:
     virtual bool isDialog() const;
     void classBegin() override;
@@ -312,6 +315,7 @@ protected:
 
     QQmlEngine* engine() const;
 
+    QWindow* m_parentWindow = nullptr;
     IPopupWindow* m_window = nullptr;
 
     QQmlComponent* m_component = nullptr;


### PR DESCRIPTION
Fixes made to the framework during Audacity migration to Qt 6.9


<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
