### PR TITLE
Fix extra space in bass note slash

### DIFF
--- a/src/engraving/dom/chordlist.cpp
+++ b/src/engraving/dom/chordlist.cpp
@@ -1707,7 +1707,6 @@ const std::list<RenderActionPtr >& ParsedChord::renderList(const ChordList* cl, 
             // Jazz superscript
             if (superScriptModifier) {
                 // Set scale
-                LOGI() << "SCALE: " << cl->stackedModifierMag();
                 m_renderList.emplace_back(new RenderActionScale(cl->stackedModifierMag()));
                 // Move to x-height
                 m_renderList.emplace_back(new RenderActionPush());

--- a/src/engraving/rendering/score/harmonylayout.cpp
+++ b/src/engraving/rendering/score/harmonylayout.cpp
@@ -500,7 +500,7 @@ void HarmonyLayout::renderSingleHarmony(Harmony* item, Harmony::LayoutData* ldat
 
     // render bass
     if (tpcIsValid(info->bassTpc())) {
-        std::list<RenderActionPtr >& bassNoteChordList
+        std::list<RenderActionPtr > bassNoteChordList
             = style.styleB(Sid::chordBassNoteStagger) ? chordList->renderListBassOffset : chordList->renderListBass;
 
         static const std::wregex PATTERN_69 = std::wregex(L"6[,/]?9");

--- a/src/engraving/rw/read460/tread.cpp
+++ b/src/engraving/rw/read460/tread.cpp
@@ -4348,9 +4348,6 @@ bool TRead::readProperties(TextBase* t, XmlReader& e, ReadContext& ctx)
 {
     const AsciiStringView tag(e.name());
     for (Pid i : TextBasePropertyId) {
-        if (i == Pid::POSITION && tag == propertyName(i)) {
-            LOGI() << "read pos";
-        }
         if (TRead::readProperty(t, tag, e, ctx, i)) {
             return true;
         }


### PR DESCRIPTION
Resolves: 
<img width="2274" height="374" alt="image" src="https://github.com/user-attachments/assets/3c48b12d-4b11-41b0-9985-21e50fa3def5" />

We are adding this list in some circumstances so this needs to be a copy not a reference.