### PR TITLE
Get ChordRest segment when pasting FretDiagram, not TimeTick

### DIFF
--- a/src/engraving/rw/read460/read460.cpp
+++ b/src/engraving/rw/read460/read460.cpp
@@ -647,7 +647,9 @@ bool Read460::pasteStaff(XmlReader& e, Segment* dst, staff_idx_t dstStaff, Fract
 
                     Fraction tick = doScale ? (ctx.tick() - dstTick) * scale + dstTick : ctx.tick();
                     Measure* m = score->tick2measure(tick);
-                    Segment* seg = m->undoGetChordRestOrTimeTickSegment(tick);
+                    Segment* seg = el->isFretDiagram()
+                                   ? m->undoGetSegment(SegmentType::ChordRest, tick)
+                                   : m->undoGetChordRestOrTimeTickSegment(tick);
                     el->setParent(seg);
 
                     // be sure to paste the element in the destination track;


### PR DESCRIPTION
Resolves: #29590

When pasting, all the ChordRest segments in the destination area get removed (but the TimeTick segments don't). They then get recreated when the actual notes are pasted, but segment annotations (including fret diagrams) are read _before_ notes, so when we call `undoGetChordRestOrTimeTickSegment` we only find TimeTick segments (and fret diagrams can only accept ChordRest segments). Solution is to trivially just restrict the get-segment call to ChordRest type for fret diagrams.