### PR TITLE
Add possibility to get new plugins paths

### DIFF
--- a/src/framework/audioplugins/internal/registeraudiopluginsscenario.cpp
+++ b/src/framework/audioplugins/internal/registeraudiopluginsscenario.cpp
@@ -49,7 +49,7 @@ void RegisterAudioPluginsScenario::init()
     }
 }
 
-Ret RegisterAudioPluginsScenario::registerNewPlugins()
+io::paths_t RegisterAudioPluginsScenario::scanForNewPluginPaths() const
 {
     TRACEFUNC;
 
@@ -63,6 +63,17 @@ Ret RegisterAudioPluginsScenario::registerNewPlugins()
                 newPluginPaths.push_back(path);
             }
         }
+    }
+
+    return newPluginPaths;
+}
+
+Ret RegisterAudioPluginsScenario::registerNewPlugins(io::paths_t newPluginPaths)
+{
+    TRACEFUNC;
+
+    if (newPluginPaths.empty()) {
+        newPluginPaths = scanForNewPluginPaths();
     }
 
     if (newPluginPaths.empty()) {

--- a/src/framework/audioplugins/internal/registeraudiopluginsscenario.h
+++ b/src/framework/audioplugins/internal/registeraudiopluginsscenario.h
@@ -50,7 +50,8 @@ public:
 
     void init();
 
-    Ret registerNewPlugins() override;
+    io::paths_t scanForNewPluginPaths() const override;
+    Ret registerNewPlugins(io::paths_t newPluginPaths = {}) override;
     Ret registerPlugin(const io::path_t& pluginPath) override;
     Ret registerFailedPlugin(const io::path_t& pluginPath, int failCode) override;
 

--- a/src/framework/audioplugins/iregisteraudiopluginsscenario.h
+++ b/src/framework/audioplugins/iregisteraudiopluginsscenario.h
@@ -35,7 +35,8 @@ class IRegisterAudioPluginsScenario : MODULE_EXPORT_INTERFACE
 public:
     virtual ~IRegisterAudioPluginsScenario() = default;
 
-    virtual Ret registerNewPlugins() = 0;
+    virtual io::paths_t scanForNewPluginPaths() const = 0;
+    virtual Ret registerNewPlugins(io::paths_t newPluginPaths = {}) = 0;
     virtual Ret registerPlugin(const io::path_t& pluginPath) = 0;
     virtual Ret registerFailedPlugin(const io::path_t& pluginPath, int failCode) = 0;
 };


### PR DESCRIPTION
Added function returning paths to newly found plugins


- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
