### PR TITLE
[4.6.0] Crash after selecting multi-measure rest in part and inserting measure from Layout palette

### DIFF
--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -4625,6 +4625,10 @@ MeasureBase* Score::insertMeasure(ElementType type, MeasureBase* beforeMeasure, 
         localInsertMeasureBase = insertBox(type, beforeMeasure, options);
     }
 
+    if (localInsertMeasureBase && options.needDeselectAll) {
+        deselectAll();
+    }
+
     return localInsertMeasureBase;
 }
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/29266