### PR TITLE
Text style popup position fixes

### DIFF
--- a/src/engraving/dom/textedit.h
+++ b/src/engraving/dom/textedit.h
@@ -73,6 +73,7 @@ class TextEditUndoCommand : public UndoCommand
 public:
     UNDO_TYPE(CommandType::TextEdit)
     UNDO_NAME("TextEdit")
+    UNDO_CHANGED_OBJECTS({ m_cursor.text() })
 
     TextEditUndoCommand(const TextCursor& tc)
         : m_cursor(tc) {}

--- a/src/framework/ui/view/interactiveprovider.cpp
+++ b/src/framework/ui/view/interactiveprovider.cpp
@@ -102,7 +102,7 @@ async::Promise<Color> InteractiveProvider::selectColor(const Color& color, const
 
         dlg->setCurrentColor(color.toQColor());
 
-        QObject::connect(dlg, &QFileDialog::finished, [this, dlg, resolve, reject](int result) {
+        QObject::connect(dlg, &QColorDialog::finished, [this, dlg, resolve, reject](int result) {
             dlg->deleteLater();
 
             m_isSelectColorOpened = false;

--- a/src/framework/uicomponents/qml/Muse/UiComponents/ExpandableBlankSection.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/ExpandableBlankSection.qml
@@ -84,15 +84,13 @@ FocusScope {
         Item {
             id: expandButton
 
-            anchors.verticalCenter: parent.verticalCenter
-
             Layout.preferredWidth: expandButtonIcon.font.pixelSize
             Layout.preferredHeight: expandButtonIcon.font.pixelSize
 
             StyledIconLabel {
                 id: expandButtonIcon
 
-                anchors.verticalCenter: parent.verticalCenter
+                anchors.centerIn: parent
 
                 rotation: root.isExpanded ? 0 : -90
 

--- a/src/inspector/models/text/textstylepopupmodel.cpp
+++ b/src/inspector/models/text/textstylepopupmodel.cpp
@@ -47,3 +47,18 @@ TextSettingsModel* TextStylePopupModel::textSettingsModel() const
 {
     return m_textSettingsModel;
 }
+
+void TextStylePopupModel::updateItemRect()
+{
+    QRect rect;
+    if (m_item) {
+        // See also `EditModeRenderer::drawTextBase`
+        const double m = m_item->spatium();
+        rect = fromLogical(m_item->canvasBoundingRect().adjusted(-m, -m, m, m)).toQRect();
+    }
+
+    if (m_itemRect != rect) {
+        m_itemRect = rect;
+        emit itemRectChanged(rect);
+    }
+}

--- a/src/inspector/models/text/textstylepopupmodel.h
+++ b/src/inspector/models/text/textstylepopupmodel.h
@@ -43,6 +43,7 @@ public:
     Q_INVOKABLE void init() override;
 
 private:
+    void updateItemRect() override;
     bool ignoreTextEditingChanges() const override { return false; }
 
     TextSettingsModel* m_textSettingsModel = nullptr;

--- a/src/inspector/models/text/textstylepopupmodel.h
+++ b/src/inspector/models/text/textstylepopupmodel.h
@@ -43,6 +43,8 @@ public:
     Q_INVOKABLE void init() override;
 
 private:
+    bool ignoreTextEditingChanges() const override { return false; }
+
     TextSettingsModel* m_textSettingsModel = nullptr;
 
     ElementRepositoryService* m_elementRepositoryService = nullptr;

--- a/src/inspector/view/qml/MuseScore/Inspector/InspectorSectionDelegate.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/InspectorSectionDelegate.qml
@@ -54,7 +54,7 @@ ExpandableBlank {
     navigation.panel: root.navigationPanel
     navigation.row: 0
 
-    title: root.sectionModel?.title
+    title: root.sectionModel?.title ?? ""
 
     headerAccessory: contentItem?.headerAccessory
 

--- a/src/inspector/view/qml/MuseScore/Inspector/score/ScoreAppearanceInspectorView.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/score/ScoreAppearanceInspectorView.qml
@@ -53,7 +53,7 @@ InspectorSectionView {
                 navigation.panel: root.navigationPanel
                 navigation.row: root.navigationRow(1)
 
-                checked: root.model?.hideEmptyStaves
+                checked: root.model?.hideEmptyStaves ?? false
                 onClicked: {
                     if (root.model) {
                         root.model.hideEmptyStaves = !checked

--- a/src/inspector/view/qml/MuseScore/Inspector/text/textstylepopup/TextStylePopup.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/text/textstylepopup/TextStylePopup.qml
@@ -27,10 +27,11 @@ import Muse.Ui 1.0
 import Muse.UiComponents 1.0
 
 import MuseScore.Inspector 1.0
+import MuseScore.NotationScene 1.0
 
 import "../../common"
 
-StyledPopupView {
+AbstractElementPopup {
     id: root
 
     //! Note: the navigation order does not match the order of the components in the file
@@ -43,8 +44,8 @@ StyledPopupView {
     readonly property int controlSpacing: 12
     readonly property int rowSpacing: 8
 
-    contentWidth: contentRow.width
-    contentHeight: contentRow.height
+    contentWidth: contentRow.implicitWidth
+    contentHeight: contentRow.implicitHeight
 
     margins: root.controlSpacing
 
@@ -53,22 +54,12 @@ StyledPopupView {
     focusPolicies: PopupView.DefaultFocus & ~PopupView.ClickFocus
     placementPolicies: PopupView.PreferAbove
 
-    signal elementRectChanged(var elementRect)
+    model: TextStylePopupModel {
+        id: textStyleModel
+    }
 
     function updatePosition() {
         root.x = 0
-    }
-
-    TextStylePopupModel {
-        id: textStyleModel
-
-        onItemRectChanged: function (rect) {
-            root.elementRectChanged(rect);
-        }
-    }
-
-    Component.onCompleted: {
-        textStyleModel.init();
     }
 
     RowLayout {

--- a/src/notation/notationmodule.cpp
+++ b/src/notation/notationmodule.cpp
@@ -213,7 +213,7 @@ void NotationModule::registerUiTypes()
     qmlRegisterType<PianoKeyboardView>("MuseScore.NotationScene", 1, 0, "PianoKeyboardView");
     qmlRegisterType<PianoKeyboardPanelContextMenuModel>("MuseScore.NotationScene", 1, 0, "PianoKeyboardPanelContextMenuModel");
 
-    qmlRegisterUncreatableType<AbstractElementPopupModel>("MuseScore.NotationScene", 1, 0, "Notation",
+    qmlRegisterUncreatableType<AbstractElementPopupModel>("MuseScore.NotationScene", 1, 0, "AbstractElementPopupModel",
                                                           "Not creatable as it is an enum type");
     qmlRegisterType<HarpPedalPopupModel>("MuseScore.NotationScene", 1, 0, "HarpPedalPopupModel");
     qmlRegisterType<CapoSettingsModel>("MuseScore.NotationScene", 1, 0, "CapoSettingsModel");

--- a/src/notation/notationscene.qrc
+++ b/src/notation/notationscene.qrc
@@ -36,6 +36,7 @@
         <file>qml/MuseScore/NotationScene/internal/NoteInputBarCustomisePopup.qml</file>
         <file>qml/MuseScore/NotationScene/PianoKeyboardPanel.qml</file>
         <file>qml/MuseScore/NotationScene/internal/EditStyle/RestOffsetSelector.qml</file>
+        <file>qml/MuseScore/NotationScene/AbstractElementPopup.qml</file>
         <file>qml/MuseScore/NotationScene/internal/ElementPopupLoader.qml</file>
         <file>qml/MuseScore/NotationScene/internal/HarpPedalPopup.qml</file>
         <file>qml/MuseScore/NotationScene/internal/CapoPopup.qml</file>

--- a/src/notation/qml/MuseScore/NotationScene/AbstractElementPopup.qml
+++ b/src/notation/qml/MuseScore/NotationScene/AbstractElementPopup.qml
@@ -5,7 +5,7 @@
  * MuseScore Studio
  * Music Composition & Notation
  *
- * Copyright (C) 2024 MuseScore Limited
+ * Copyright (C) 2025 MuseScore Limited
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -19,39 +19,23 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import QtQuick 2.15
+import QtQuick
 
-import Muse.Ui 1.0
-import Muse.UiComponents 1.0
+import Muse.Ui
+import Muse.UiComponents
 
-import MuseScore.Playback 1.0
+import MuseScore.NotationScene
 
-AbstractElementPopup {
+StyledPopupView {
     id: root
 
-    property NavigationSection notationViewNavigationSection
-    property int navigationOrderStart
-    property int navigationOrderEnd
+    required property AbstractElementPopupModel model
+    
+    readonly property rect elementRect: model.itemRect
 
-    contentWidth: content.width
-    contentHeight: content.height
+    function updatePosition() {}
 
-    function updatePosition() {
-        root.x = (root.parent.width / 2) - (root.width / 2) + root.margins
-    }
-
-    Rectangle {
-        id: content
-
-        width: 300
-        height: stub.implicitHeight
-
-        color: ui.theme.backgroundSecondaryColor
-
-        StyledTextLabel {
-            id: stub
-            anchors.centerIn: parent
-            text: "Sound Flags Stub"
-        }
+    Component.onCompleted: {
+        model.init()
     }
 }

--- a/src/notation/qml/MuseScore/NotationScene/NotationView.qml
+++ b/src/notation/qml/MuseScore/NotationScene/NotationView.qml
@@ -158,15 +158,12 @@ FocusScope {
                         contextMenuLoader.close()
                     }
 
-                    onShowElementPopupRequested: function (popupType, elementRect) {
-                        popUpLoader.openProperties = {
-                            popupType: popupType,
-                            elementRect: elementRect
-                        };
+                    onShowElementPopupRequested: function (popupType) {
+                        popUpLoader.updateShow(popupType);
                     }
 
                     onHideElementPopupRequested: {
-                        popUpLoader.openProperties = null;
+                        popUpLoader.updateShow(AbstractElementPopupModel.TYPE_UNDEFINED);
                     }
 
                     onViewportChanged: {
@@ -190,31 +187,34 @@ FocusScope {
                         notationViewNavigationSection: navSec
                         navigationOrderStart: notationView.navigationPanel.order + 1
 
-                        property var openProperties: null
+                        property int popupType: AbstractElementPopupModel.TYPE_UNDEFINED
                         property bool updateShowScheduled: false
 
-                        onOpenPropertiesChanged: {
+                        function updateShow(popupType) {
+                            this.popupType = popupType;
                             if (!updateShowScheduled) {
-                                Qt.callLater(updateShow)
+                                Qt.callLater(doUpdateShow)
                                 updateShowScheduled = true;
                             }
                         }
 
-                        function updateShow() {
-                            if (openProperties) {
-                                show(openProperties.popupType, openProperties.elementRect);
+                        function doUpdateShow() {
+                            if (popupType !== AbstractElementPopupModel.TYPE_UNDEFINED) {
+                                show(popupType);
                             } else {
                                 close();
                             }
 
-                            popUpLoader.updateShowScheduled = false;
+                            updateShowScheduled = false;
                         }
 
                         onOpened: function(popupType) {
                             paintView.onElementPopupIsOpenChanged(popupType)
                         }
 
-                        onClosed: paintView.onElementPopupIsOpenChanged()
+                        onClosed: {
+                            paintView.onElementPopupIsOpenChanged(AbstractElementPopupModel.TYPE_UNDEFINED)
+                        }
                     }
 
                     NotationRegionsBeingProcessedView {

--- a/src/notation/qml/MuseScore/NotationScene/internal/CapoPopup.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/CapoPopup.qml
@@ -26,7 +26,7 @@ import Muse.Ui 1.0
 import Muse.UiComponents 1.0
 import MuseScore.NotationScene 1.0
 
-StyledPopupView {
+AbstractElementPopup {
     id: root
 
     property alias notationViewNavigationSection: capoSettingsNavPanel.section
@@ -39,7 +39,9 @@ StyledPopupView {
     placementPolicies: PopupView.PreferRight
     showArrow: false
 
-    signal elementRectChanged(var elementRect)
+    model: CapoSettingsModel {
+        id: capoModel
+    }
 
     function updatePosition() {
         var h = Math.max(root.contentHeight, capoModel.capoIsOn ? 360 : 160)
@@ -54,18 +56,6 @@ StyledPopupView {
         width: 294
 
         spacing: 12
-
-        CapoSettingsModel {
-            id: capoModel
-
-            onItemRectChanged: function(rect) {
-                root.elementRectChanged(rect)
-            }
-        }
-
-        Component.onCompleted: {
-            capoModel.init()
-        }
 
         NavigationPanel {
             id: capoSettingsNavPanel

--- a/src/notation/qml/MuseScore/NotationScene/internal/DynamicPopup.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/DynamicPopup.qml
@@ -5,7 +5,7 @@ import Muse.Ui 1.0
 import Muse.UiComponents 1.0
 import MuseScore.NotationScene 1.0
 
-StyledPopupView {
+AbstractElementPopup {
     id: root
 
     property NavigationSection notationViewNavigationSection: null
@@ -26,9 +26,8 @@ StyledPopupView {
     focusPolicies: PopupView.DefaultFocus & ~PopupView.ClickFocus
     placementPolicies: PopupView.PreferBelow
 
-    signal elementRectChanged(var elementRect)
-
-    function updatePosition() {
+    model: DynamicPopupModel {
+        id: dynamicModel
     }
 
     RowLayout {
@@ -36,18 +35,6 @@ StyledPopupView {
 
         width: 208
         spacing: 1
-
-        DynamicPopupModel {
-            id: dynamicModel
-
-            onItemRectChanged: function(rect) {
-                root.elementRectChanged(rect)
-            }
-        }
-
-        Component.onCompleted: {
-            dynamicModel.init()
-        }
 
         NavigationPanel {
             id: dynamicsNavPanel

--- a/src/notation/qml/MuseScore/NotationScene/internal/HarpPedalPopup.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/HarpPedalPopup.qml
@@ -27,7 +27,7 @@ import Muse.Ui 1.0
 import Muse.UiComponents 1.0
 import MuseScore.NotationScene 1.0
 
-StyledPopupView {
+AbstractElementPopup {
     id: root
     property variant pedalState: harpModel.pedalState
 
@@ -43,7 +43,9 @@ StyledPopupView {
     placementPolicies: PopupView.PreferAbove
     showArrow: false
 
-    signal elementRectChanged(var elementRect)
+    model: HarpPedalPopupModel {
+        id: harpModel
+    }
 
     function updatePosition() {
         const marginFromElement = 12
@@ -101,18 +103,6 @@ StyledPopupView {
         flow: GridLayout.TopToBottom
         columnSpacing: 10
         rowSpacing: 10
-
-        HarpPedalPopupModel {
-            id: harpModel
-
-            onItemRectChanged: function(rect) {
-                root.elementRectChanged(rect)
-            }
-        }
-
-        Component.onCompleted: {
-            harpModel.init()
-        }
 
         NavigationPanel {
             id: pedalSettingsNavPanel

--- a/src/notation/qml/MuseScore/NotationScene/internal/PartialTiePopup.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/PartialTiePopup.qml
@@ -28,7 +28,7 @@ import Muse.Ui 1.0
 import Muse.UiComponents 1.0
 import MuseScore.NotationScene 1.0
 
-StyledPopupView {
+AbstractElementPopup {
     id: root
     margins: 0
 
@@ -46,7 +46,13 @@ StyledPopupView {
         partialTiePopupModel.onClosed()
     }
 
-    signal elementRectChanged(var elementRect)
+    model: PartialTiePopupModel {
+        id: partialTiePopupModel
+
+        onItemsChanged: function() {
+            tieMenuList.model = partialTiePopupModel.items
+        }
+    }
 
     function updatePosition() {
         const opensUp = partialTiePopupModel.tieDirection
@@ -59,27 +65,11 @@ StyledPopupView {
         tieMenuList.calculateWidth()
     }
 
-    Component.onCompleted: {
-        partialTiePopupModel.init()
-    }
-
     Column {
         id: content
         width: tieMenuList.width
         height: tieMenuList.height
         spacing: 0
-
-        PartialTiePopupModel {
-            id: partialTiePopupModel
-
-            onItemRectChanged: function(rect) {
-                root.elementRectChanged(rect)
-            }
-
-            onItemsChanged: function() {
-                tieMenuList.model = partialTiePopupModel.items
-            }
-        }
 
         StyledListView {
             id: tieMenuList

--- a/src/notation/qml/MuseScore/NotationScene/internal/ShadowNotePopup.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/ShadowNotePopup.qml
@@ -26,7 +26,7 @@ import Muse.Ui 1.0
 import Muse.UiComponents 1.0
 import MuseScore.NotationScene 1.0
 
-StyledPopupView {
+AbstractElementPopup {
     id: root
 
     property NavigationSection notationViewNavigationSection: null
@@ -45,7 +45,9 @@ StyledPopupView {
     padding: 0 // The popup will "steal" mouse events if the padding overlaps with the shadow note area
     margins: 3
 
-    signal elementRectChanged(var elementRect)
+    model: ShadowNotePopupModel {
+        id: shadowNotePopupModel
+    }
 
     function updatePosition() {
         root.x = root.parent.width * 1.5
@@ -62,16 +64,7 @@ StyledPopupView {
             return null
         }
 
-        ShadowNotePopupModel {
-            id: shadowNotePopupModel
-
-            onItemRectChanged: function(rect) {
-                root.elementRectChanged(rect)
-            }
-        }
-
         Component.onCompleted: {
-            shadowNotePopupModel.init()
             contentLoader.sourceComponent = contentLoader.contentByType(shadowNotePopupModel.currentPopupType)
         }
 

--- a/src/notation/qml/MuseScore/NotationScene/internal/StaffVisibilityPopup.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/StaffVisibilityPopup.qml
@@ -27,7 +27,7 @@ import Muse.Ui
 import Muse.UiComponents
 import MuseScore.NotationScene
 
-StyledPopupView {
+AbstractElementPopup {
     id: root
 
     property alias notationViewNavigationSection: staffVisibilityNavPanel.section
@@ -41,7 +41,9 @@ StyledPopupView {
 
     placementPolicies: PopupView.PreferBelow
 
-    signal elementRectChanged(var elementRect)
+    model: StaffVisibilityPopupModel {
+        id: popupModel
+    }
 
     function updatePosition() {
         root.y = root.parent.height + 4; // 4 for spacing
@@ -57,13 +59,6 @@ StyledPopupView {
             if (event.type === NavigationEvent.Escape) {
                 root.close();
             }
-        }
-    }
-
-    StaffVisibilityPopupModel {
-        id: popupModel
-        onItemRectChanged: function (rect) {
-            root.elementRectChanged(rect);
         }
     }
 

--- a/src/notation/qml/MuseScore/NotationScene/internal/StringTuningsPopup.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/StringTuningsPopup.qml
@@ -26,7 +26,7 @@ import Muse.Ui 1.0
 import Muse.UiComponents 1.0
 import MuseScore.NotationScene 1.0
 
-StyledPopupView {
+AbstractElementPopup {
     id: root
 
     property alias notationViewNavigationSection: navPanel.section
@@ -39,7 +39,9 @@ StyledPopupView {
     placementPolicies: PopupView.PreferRight
     showArrow: false
 
-    signal elementRectChanged(var elementRect)
+    model: StringTuningsSettingsModel {
+        id: stringTuningsModel
+    }
 
     function updatePosition() {
         var h = Math.max(root.contentHeight, 360)
@@ -53,18 +55,6 @@ StyledPopupView {
         width: 272
 
         spacing: 12
-
-        StringTuningsSettingsModel {
-            id: stringTuningsModel
-
-            onItemRectChanged: function(rect) {
-                root.elementRectChanged(rect)
-            }
-        }
-
-        Component.onCompleted: {
-            stringTuningsModel.init()
-        }
 
         NavigationPanel {
             id: navPanel

--- a/src/notation/qml/MuseScore/NotationScene/qmldir
+++ b/src/notation/qml/MuseScore/NotationScene/qmldir
@@ -14,4 +14,5 @@ UndoHistoryPanel 1.0 UndoHistoryPanel.qml
 PianoKeyboardPanel 1.0 PianoKeyboardPanel.qml
 PercussionPanel 1.0 PercussionPanel.qml
 PercussionPanelPadSwapDialog 1.0 PercussionPanelPadSwapDialog.qml
-EditPercussionPanelShortcutDialog 1.0 EditPercussionPanelShortcutDialog
+EditPercussionPanelShortcutDialog 1.0 EditPercussionPanelShortcutDialog.qml
+AbstractElementPopup 1.0 AbstractElementPopup.qml

--- a/src/notation/tests/mocks/controlledviewmock.h
+++ b/src/notation/tests/mocks/controlledviewmock.h
@@ -55,9 +55,9 @@ public:
     MOCK_METHOD(void, showContextMenu, (const ElementType&, const QPointF&), (override));
     MOCK_METHOD(void, hideContextMenu, (), (override));
 
-    MOCK_METHOD(void, showElementPopup, (const ElementType&, const muse::RectF&), (override));
-    MOCK_METHOD(void, hideElementPopup, (const ElementType& elementType), (override));
-    MOCK_METHOD(void, toggleElementPopup, (const ElementType&, const muse::RectF&), (override));
+    MOCK_METHOD(void, showElementPopup, (const ElementType&), (override));
+    MOCK_METHOD(void, hideElementPopup, (const ElementType&), (override));
+    MOCK_METHOD(void, toggleElementPopup, (const ElementType&), (override));
 
     MOCK_METHOD(bool, elementPopupIsOpen, (const ElementType&), (const, override));
 

--- a/src/notation/view/abstractelementpopupmodel.cpp
+++ b/src/notation/view/abstractelementpopupmodel.cpp
@@ -47,10 +47,10 @@ static const QMap<mu::engraving::ElementType, PopupModelType> ELEMENT_POPUP_TYPE
     { mu::engraving::ElementType::LYRICS, PopupModelType::TYPE_TEXT },
     { mu::engraving::ElementType::FIGURED_BASS, PopupModelType::TYPE_TEXT },
     { mu::engraving::ElementType::TEMPO_TEXT, PopupModelType::TYPE_TEXT },
+    { mu::engraving::ElementType::PLAY_COUNT_TEXT, PopupModelType::TYPE_TEXT },
     { mu::engraving::ElementType::TIE_SEGMENT, PopupModelType::TYPE_PARTIAL_TIE },
     { mu::engraving::ElementType::PARTIAL_TIE_SEGMENT, PopupModelType::TYPE_PARTIAL_TIE },
     { mu::engraving::ElementType::SHADOW_NOTE, PopupModelType::TYPE_SHADOW_NOTE },
-    { mu::engraving::ElementType::PLAY_COUNT_TEXT, PopupModelType::TYPE_TEXT }
 };
 
 static const QHash<PopupModelType, mu::engraving::ElementTypeSet> POPUP_DEPENDENT_ELEMENT_TYPES = {
@@ -62,6 +62,7 @@ static const QHash<PopupModelType, mu::engraving::ElementTypeSet> POPUP_DEPENDEN
     { PopupModelType::TYPE_DYNAMIC, { mu::engraving::ElementType::DYNAMIC } },
     { PopupModelType::TYPE_TEXT,
       { mu::engraving::ElementType::TEXT,
+        mu::engraving::ElementType::STAFF_TEXT,
         mu::engraving::ElementType::SYSTEM_TEXT,
         mu::engraving::ElementType::EXPRESSION,
         mu::engraving::ElementType::REHEARSAL_MARK,

--- a/src/notation/view/abstractelementpopupmodel.cpp
+++ b/src/notation/view/abstractelementpopupmodel.cpp
@@ -251,7 +251,7 @@ void AbstractElementPopupModel::init()
     m_item = selection->element();
 
     undoStack->changesChannel().onReceive(this, [this] (const ScoreChanges& changes) {
-        if (changes.isTextEditing) {
+        if (ignoreTextEditingChanges() && changes.isTextEditing) {
             return;
         }
 

--- a/src/notation/view/abstractelementpopupmodel.h
+++ b/src/notation/view/abstractelementpopupmodel.h
@@ -75,6 +75,7 @@ signals:
 
 protected:
     virtual void updateItemRect();
+    virtual bool ignoreTextEditingChanges() const { return true; }
 
     muse::PointF fromLogical(muse::PointF point) const;
     muse::RectF fromLogical(muse::RectF rect) const;

--- a/src/notation/view/abstractnotationpaintview.cpp
+++ b/src/notation/view/abstractnotationpaintview.cpp
@@ -583,7 +583,7 @@ void AbstractNotationPaintView::hideContextMenu()
     }
 }
 
-void AbstractNotationPaintView::showElementPopup(const ElementType& elementType, const RectF& elementRect)
+void AbstractNotationPaintView::showElementPopup(const ElementType& elementType)
 {
     TRACEFUNC;
 
@@ -594,7 +594,7 @@ void AbstractNotationPaintView::showElementPopup(const ElementType& elementType,
     }
 
     m_currentElementPopupType = modelType;
-    emit showElementPopupRequested(modelType, fromLogical(elementRect).toQRectF());
+    emit showElementPopupRequested(modelType);
 }
 
 void AbstractNotationPaintView::hideElementPopup(const ElementType& elementType)
@@ -614,14 +614,14 @@ void AbstractNotationPaintView::hideElementPopup(const ElementType& elementType)
     }
 }
 
-void AbstractNotationPaintView::toggleElementPopup(const ElementType& elementType, const RectF& elementRect)
+void AbstractNotationPaintView::toggleElementPopup(const ElementType& elementType)
 {
     if (m_currentElementPopupType != PopupModelType::TYPE_UNDEFINED) {
         hideElementPopup(elementType);
         return;
     }
 
-    showElementPopup(elementType, elementRect);
+    showElementPopup(elementType);
 }
 
 bool AbstractNotationPaintView::elementPopupIsOpen(const ElementType& elementType) const

--- a/src/notation/view/abstractnotationpaintview.h
+++ b/src/notation/view/abstractnotationpaintview.h
@@ -123,9 +123,9 @@ public:
     void showContextMenu(const ElementType& elementType, const QPointF& pos) override;
     void hideContextMenu() override;
 
-    void showElementPopup(const ElementType& elementType, const muse::RectF& elementRect) override;
+    void showElementPopup(const ElementType& elementType) override;
     void hideElementPopup(const ElementType& elementType = ElementType::INVALID) override;
-    void toggleElementPopup(const ElementType& elementType, const muse::RectF& elementRect) override;
+    void toggleElementPopup(const ElementType& elementType) override;
 
     bool elementPopupIsOpen(const ElementType& elementType) const override;
 
@@ -155,7 +155,7 @@ signals:
     void showContextMenuRequested(int elementType, const QPointF& viewPos);
     void hideContextMenuRequested();
 
-    void showElementPopupRequested(mu::notation::PopupModelType modelType, const QRectF& elementRect);
+    void showElementPopupRequested(mu::notation::PopupModelType modelType);
     void hideElementPopupRequested();
     void isPopupOpenChanged(bool isPopupOpen);
 

--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -148,7 +148,7 @@ void NotationViewInputController::onNotationChanged()
         m_view->hideElementPopup();
 
         if (AbstractElementPopupModel::hasElementEditPopup(selectedItem)) {
-            m_view->showElementPopup(type, selectedItem->canvasBoundingRect());
+            m_view->showElementPopup(type);
         }
     });
 
@@ -164,13 +164,13 @@ void NotationViewInputController::onNotationChanged()
         if (AbstractElementPopupModel::hasTextStylePopup(item)) {
             bool needToSeeStaffWhileEnteringText = item->isLyrics() || item->isFingering() || item->isSticking() || item->isHarmony();
             if (!needToSeeStaffWhileEnteringText || !item->empty()) {
-                m_view->showElementPopup(item->type(), item->canvasBoundingRect());
+                m_view->showElementPopup(item->type());
                 return;
             }
         }
 
         if (item->isDynamic()) {
-            m_view->showElementPopup(item->type(), item->canvasBoundingRect());
+            m_view->showElementPopup(item->type());
             return;
         }
 
@@ -189,7 +189,7 @@ void NotationViewInputController::onNotationChanged()
 
         const TextBase* item = notation->interaction()->editedText();
         if (AbstractElementPopupModel::hasTextStylePopup(item) && item->cursor()->hasSelection()) {
-            m_view->showElementPopup(item->type(), item->canvasBoundingRect());
+            m_view->showElementPopup(item->type());
         }
     });
 
@@ -964,7 +964,7 @@ void NotationViewInputController::updateTextCursorPosition()
         const TextBase* item = viewInteraction()->editedText();
         if (AbstractElementPopupModel::hasTextStylePopup(item)
             && (!item->isLyrics() || !item->empty())) {
-            m_view->showElementPopup(item->type(), item->canvasBoundingRect());
+            m_view->showElementPopup(item->type());
         }
     }
 }
@@ -1635,7 +1635,7 @@ void NotationViewInputController::togglePopupForItemIfSupports(const EngravingIt
     ElementType type = item->type();
 
     if (AbstractElementPopupModel::hasElementEditPopup(item)) {
-        m_view->toggleElementPopup(type, item->canvasBoundingRect());
+        m_view->toggleElementPopup(type);
     }
 }
 
@@ -1647,9 +1647,7 @@ void NotationViewInputController::updateShadowNotePopupVisibility(bool forceHide
         return;
     }
 
-    RectF noteHeadRect = shadowNote->symBbox(shadowNote->noteheadSymbol());
-    noteHeadRect.translate(shadowNote->canvasPos().x(), shadowNote->canvasPos().y());
-    m_view->showElementPopup(ElementType::SHADOW_NOTE, noteHeadRect);
+    m_view->showElementPopup(ElementType::SHADOW_NOTE);
 }
 
 EngravingItem* NotationViewInputController::resolveStartPlayableElement() const

--- a/src/notation/view/notationviewinputcontroller.h
+++ b/src/notation/view/notationviewinputcontroller.h
@@ -74,9 +74,9 @@ public:
     virtual void showContextMenu(const ElementType& elementType, const QPointF& pos) = 0;
     virtual void hideContextMenu() = 0;
 
-    virtual void showElementPopup(const ElementType& elementType, const muse::RectF& elementRect) = 0;
+    virtual void showElementPopup(const ElementType& elementType) = 0;
     virtual void hideElementPopup(const ElementType& elementType = ElementType::INVALID) = 0;
-    virtual void toggleElementPopup(const ElementType& elementType, const muse::RectF& elementRect) = 0;
+    virtual void toggleElementPopup(const ElementType& elementType) = 0;
 
     virtual bool elementPopupIsOpen(const ElementType& elementType) const = 0;
 

--- a/src/playback/qml/MuseScore/Playback/SoundFlagPopup.qml
+++ b/src/playback/qml/MuseScore/Playback/SoundFlagPopup.qml
@@ -25,11 +25,12 @@ import QtQuick.Layouts 1.15
 import Muse.Ui 1.0
 import Muse.UiComponents 1.0
 
+import MuseScore.NotationScene 1.0
 import MuseScore.Playback 1.0
 
 import "internal/SoundFlag"
 
-StyledPopupView {
+AbstractElementPopup {
     id: root
 
     property alias notationViewNavigationSection: navPanel.section
@@ -48,7 +49,9 @@ StyledPopupView {
     placementPolicies: PopupView.PreferAbove
     isContentReady: soundFlagModel.inited
 
-    signal elementRectChanged(var elementRect)
+    model: SoundFlagSettingsModel {
+        id: soundFlagModel
+    }
 
     function updatePosition() {
         root.x = (root.parent.width / 2) - (root.width / 2) + root.margins
@@ -60,18 +63,6 @@ StyledPopupView {
         width: 294
 
         spacing: 12
-
-        SoundFlagSettingsModel {
-            id: soundFlagModel
-
-            onIconRectChanged: function(rect) {
-                root.elementRectChanged(rect)
-            }
-        }
-
-        Component.onCompleted: {
-            soundFlagModel.init()
-        }
 
         RowLayout {
             width: parent.width


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/29627

The pre-last commit is a somewhat significant refactor. QA note: it is important to retest all in-score element popups, i.e. the percussion shadow note popup, capo, string tunings, harp pedals, text style, dynamics, sound flags, partial ties, empty staves visibility. 