### PR TITLE
Prevent double time signature on redo

### DIFF
--- a/src/engraving/rendering/score/measurelayout.cpp
+++ b/src/engraving/rendering/score/measurelayout.cpp
@@ -819,7 +819,7 @@ void MeasureLayout::createMultiMeasureRestsIfNeed(MeasureBase* currentMB, Layout
 {
     LAYOUT_CALL() << LAYOUT_ITEM_INFO(currentMB);
 
-    if (!currentMB->isMeasure()) {
+    if (!currentMB->isMeasure() || ctx.dom().nstaves() == 0) {
         return;
     }
 

--- a/src/engraving/rendering/score/modifydom.cpp
+++ b/src/engraving/rendering/score/modifydom.cpp
@@ -273,7 +273,7 @@ void ModifyDom::sortMeasureSegments(Measure* measure, LayoutContext& ctx)
         return ClefToBarlinePosition::AUTO;
     };
 
-    MeasureBase* nextMb = measure->nextMM();
+    MeasureBase* nextMb = measure ? measure->nextMM() : nullptr;
 
     if (!nextMb || !nextMb->isMeasure()) {
         return;


### PR DESCRIPTION
Resolves: #27787 

The root cause of this was that we were creating multimeasure rests (and all their segments) in empty scores. These segments somehow ended up being added to measure which had been removed from the score.
