### PR TITLE
Fix crash on pasting header clef

### DIFF
--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -6995,7 +6995,9 @@ void Score::undoAddElement(EngravingItem* element, bool addToLinkedStaves, bool 
                       element->explicitParent());
             Fraction tick    = segment->tick();
             Measure* m       = score->tick2measure(tick);
-            if ((segment->segmentType() & (SegmentType::EndBarLine | SegmentType::Clef)) && (m->tick() == tick)) {
+            bool addClefToPrevMeasure = segment->isType(SegmentType::Clef) && element->isClef() && !toClef(element)->isHeader();
+            bool addBlToPrevMeasure = segment->isType(SegmentType::EndBarLine);
+            if (m->tick() == tick && (addClefToPrevMeasure || addBlToPrevMeasure)) {
                 m = m->prevMeasure();
             }
             Segment* seg     = m->undoGetSegment(segment->segmentType(), tick);

--- a/src/engraving/rw/write/twrite.cpp
+++ b/src/engraving/rw/write/twrite.cpp
@@ -3444,7 +3444,7 @@ void TWrite::writeSegments(XmlWriter& xml, WriteContext& ctx, track_idx_t strack
         if (fm && fm->isMMRest()) {
             fm = fm->mmRestFirst();
             if (fm) {
-                sseg = fm->first();
+                sseg = fm->first(SegmentType::ChordRest);
             }
         }
     }


### PR DESCRIPTION
Resolves: #28958 

This also prevents clefs, key and time signatures being copied when copying MMRests. They aren't copied when copying regular notation.