### PR TITLE
[4.6.0] Fix #28692: Deleting or editing measures corrupts guitar pre-bends

### DIFF
--- a/src/engraving/rendering/score/guitarbendlayout.cpp
+++ b/src/engraving/rendering/score/guitarbendlayout.cpp
@@ -54,6 +54,9 @@ void GuitarBendLayout::updateSegmentsAndLayout(SLine* item, LayoutContext& ctx)
         return;
     }
 
+    item->setTick(startNote->tick());
+    item->setTick2(endNote->tick());
+
     unsigned int segmentsNeeded = system1 == system2 ? 1 : 2;
     size_t segmentCount = item->spannerSegments().size();
     if (segmentCount != segmentsNeeded) {

--- a/src/engraving/rendering/score/tlayout.cpp
+++ b/src/engraving/rendering/score/tlayout.cpp
@@ -2855,6 +2855,15 @@ void TLayout::layoutFretDiagram(const FretDiagram* item, FretDiagram::LayoutData
 void TLayout::layoutGlissando(Glissando* item, LayoutContext& ctx)
 {
     LAYOUT_CALL_ITEM(item);
+
+    if (item->startElement()) {
+        item->setTick(item->startElement()->tick());
+    }
+
+    if (item->endElement()) {
+        item->setTick2(item->endElement()->tick());
+    }
+
     TLayout::layoutLine(const_cast<Glissando*>(item), ctx);
 
     if (item->spannerSegments().empty()) {
@@ -5187,6 +5196,15 @@ void TLayout::layoutNoteAnchoredLine(SLine* item, EngravingItem::LayoutData* lda
 void TLayout::layoutNoteLine(NoteLine* item, LayoutContext& ctx)
 {
     LAYOUT_CALL_ITEM(item);
+
+    if (item->startElement()) {
+        item->setTick(item->startElement()->tick());
+    }
+
+    if (item->endElement()) {
+        item->setTick2(item->endElement()->tick());
+    }
+
     TLayout::layoutLine(item, ctx);
 
     if (item->lineEndPlacement() == NoteLineEndPlacement::OFFSET_ENDS) {


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/28692