### PR TITLE
Reduce test log output (part 2)

### DIFF
--- a/src/braille/internal/braille.cpp
+++ b/src/braille/internal/braille.cpp
@@ -68,6 +68,13 @@
 #include "louis.h"
 #include "braillecode.h"
 
+#define BRAILLE_TRACE_ENABLED 0
+#if BRAILLE_TRACE_ENABLED
+#define BRAILLE_TRACE LOGD
+#else
+#define BRAILLE_TRACE LOGN
+#endif
+
 namespace mu::engraving {
 // Max lyrics num
 #define MAX_LYRICS_NUM                  16
@@ -829,7 +836,7 @@ bool Braille::write(QIODevice& device)
         }
 
         for (size_t i = 0; i < nrStaves; ++i) {
-            LOGD() << "Measure " << mb->no() + 1 << " Staff " << i;
+            BRAILLE_TRACE() << "Measure " << mb->no() + 1 << " Staff " << i;
 
             measureBraille[i] = brailleMeasure(m, static_cast<int>(i)).toUtf8();
 
@@ -838,7 +845,7 @@ bool Braille::write(QIODevice& device)
             }
         }
 
-        LOGD() << "Current measure max len: " << currentMeasureMaxLength;
+        BRAILLE_TRACE() << "Current measure max len: " << currentMeasureMaxLength;
         // TODO handle better the case when the size of the current measure
         // by itself is larger than the MAX_CHARS_PER_LINE. The measure will
         // have to be split on multiple lines based on specific rules

--- a/src/importexport/capella/internal/capella.cpp
+++ b/src/importexport/capella/internal/capella.cpp
@@ -396,7 +396,7 @@ Fraction TupletFractionCap(int tupletNotesSpanned, bool tuplettrp, bool tupletpr
     if (tuplettrp) {
         dd = dd * 3;
     }
-    LOG_TUPLETS("Tuplet Fraction: %d / %d", nn, dd);
+    CAPELLA_TRACE("Tuplet Fraction: %d / %d", nn, dd);
     return Fraction(nn, dd);
 }
 
@@ -504,8 +504,8 @@ static bool findChordRests(BasicDrawObj const* const o, Score* score, const int 
             break;
         }
     }
-    LOGD("findChordRests o %p nNotes %d score %p track %d tick %d cr1 %p cr2 %p",
-         o, o->nNotes, score, track, tick.ticks(), cr1, cr2);
+    CAPELLA_TRACE("findChordRests o %p nNotes %d score %p track %d tick %d cr1 %p cr2 %p",
+                  o, o->nNotes, score, track, tick.ticks(), cr1, cr2);
 
     if (!(cr1 && cr2)) {
         LOGD("first or second anchor for BasicDrawObj not found (tick %d type %d track %d first %p second %p)",
@@ -557,7 +557,7 @@ static Fraction readCapVoice(Score* score, CapVoice* cvoice, int staffIdx, const
         switch (no->type()) {
         case CapellaNoteObjectType::REST:
         {
-            LOGD("     <Rest>");
+            CAPELLA_TRACE("     <Rest>");
             Measure* m = score->getCreateMeasure(tick);
             RestObj* o = static_cast<RestObj*>(no);
             Fraction ticks  = o->ticks();
@@ -583,8 +583,8 @@ static Fraction readCapVoice(Score* score, CapVoice* cvoice, int staffIdx, const
                     Fraction nn = ((o->tupletTicks.isZero()) ? (ticks * tupletNotesSpanned) : o->tupletTicks) / f;
                     tuplet->setTicks(nn);
                 }
-                LOG_TUPLETS("Tuplet(R) at %d: tupletDenominator: %d  tri: %d  prolonging: %d  ticks %d objects %lld",
-                            tick.ticks(), o->tupletDenominator, o->tripartite, o->isProlonging, ticks.ticks(), o->objects.size());
+                CAPELLA_TRACE("Tuplet(R) at %d: tupletDenominator: %d  tri: %d  prolonging: %d  ticks %d objects %lld",
+                              tick.ticks(), o->tupletDenominator, o->tripartite, o->isProlonging, ticks.ticks(), o->objects.size());
             }
 
             Fraction ft = m->ticks();
@@ -645,7 +645,7 @@ static Fraction readCapVoice(Score* score, CapVoice* cvoice, int staffIdx, const
         break;
         case CapellaNoteObjectType::CHORD:
         {
-            LOGD("     <Chord>");
+            CAPELLA_TRACE("     <Chord>");
             ChordObj* o = static_cast<ChordObj*>(no);
             Fraction ticks = o->ticks();
             if (o->invisible && ticks.isZero()) {              // get rid of placeholders
@@ -673,8 +673,8 @@ static Fraction readCapVoice(Score* score, CapVoice* cvoice, int staffIdx, const
                     Fraction nn = ((o->tupletTicks.isZero()) ? (ticks * tupletNotesSpanned) : o->tupletTicks) / f;
                     tuplet->setTicks(nn);
                 }
-                LOG_TUPLETS("Tuplet(C) at %d: tupletDenominator: %d  tri: %d  prolonging: %d  ticks %d objects %lld",
-                            tick.ticks(), o->tupletDenominator, o->tripartite, o->isProlonging, ticks.ticks(), o->objects.size());
+                CAPELLA_TRACE("Tuplet(C) at %d: tupletDenominator: %d  tri: %d  prolonging: %d  ticks %d objects %lld",
+                              tick.ticks(), o->tupletDenominator, o->tripartite, o->isProlonging, ticks.ticks(), o->objects.size());
             }
 
             Chord* chord = Factory::createChord(score->dummy()->segment());
@@ -848,11 +848,11 @@ static Fraction readCapVoice(Score* score, CapVoice* cvoice, int staffIdx, const
         break;
         case CapellaNoteObjectType::CLEF:
         {
-            LOGD("     <Clef>");
+            CAPELLA_TRACE("     <Clef>");
             CapClef* o = static_cast<CapClef*>(no);
             ClefType nclef = o->clef();
-            LOGD("%d:%d <Clef> %s line %d oct %d clef %d",
-                 tick.ticks(), staffIdx, o->name(), int(o->line), int(o->oct), int(o->clef()));
+            CAPELLA_TRACE("%d:%d <Clef> %s line %d oct %d clef %d",
+                          tick.ticks(), staffIdx, o->name(), int(o->line), int(o->oct), int(o->clef()));
             if (nclef == ClefType::INVALID || nclef == pclef) {
                 break;
             }
@@ -873,7 +873,7 @@ static Fraction readCapVoice(Score* score, CapVoice* cvoice, int staffIdx, const
         break;
         case CapellaNoteObjectType::KEY:
         {
-            LOGD("   <Key>");
+            CAPELLA_TRACE("   <Key>");
             CapKey* o = static_cast<CapKey*>(no);
             KeySigEvent key = score->staff(staffIdx)->keySigEvent(tick);
             KeySigEvent okey = key;
@@ -904,7 +904,7 @@ static Fraction readCapVoice(Score* score, CapVoice* cvoice, int staffIdx, const
         case CapellaNoteObjectType::METER:
         {
             CapMeter* o = static_cast<CapMeter*>(no);
-            LOGD("     <Meter> tick %d %d/%d", tick.ticks(), o->numerator, 1 << o->log2Denom);
+            CAPELLA_TRACE("     <Meter> tick %d %d/%d", tick.ticks(), o->numerator, 1 << o->log2Denom);
             if (o->log2Denom > 7 || o->log2Denom < 0) {
                 ASSERT_X("illegal fraction");
             }
@@ -939,7 +939,7 @@ static Fraction readCapVoice(Score* score, CapVoice* cvoice, int staffIdx, const
         case CapellaNoteObjectType::IMPL_BARLINE:              // does not exist?
         {
             CapExplicitBarline* o = static_cast<CapExplicitBarline*>(no);
-            LOGD("     <Barline>");
+            CAPELLA_TRACE("     <Barline>");
             Measure* pm = 0;             // the previous measure (the one terminated by this barline)
             if (tick > Fraction(0, 1)) {
                 pm = score->getCreateMeasure(tick - Fraction::fromTicks(1));
@@ -974,7 +974,7 @@ static Fraction readCapVoice(Score* score, CapVoice* cvoice, int staffIdx, const
         }
         break;
         case CapellaNoteObjectType::PAGE_BKGR:
-            LOGD("     <PageBreak>");
+            CAPELLA_TRACE("     <PageBreak>");
             break;
         }
     }
@@ -1016,8 +1016,8 @@ static Fraction readCapVoice(Score* score, CapVoice* cvoice, int staffIdx, const
                              tick.ticks(), track, cr1, cr2);
                     } else {
                         Slur* slur = Factory::createSlur(score->dummy());
-                        LOGD("tick %d track %d cr1 %p cr2 %p -> slur %p",
-                             tick.ticks(), track, cr1, cr2, slur);
+                        CAPELLA_TRACE("tick %d track %d cr1 %p cr2 %p -> slur %p",
+                                      tick.ticks(), track, cr1, cr2, slur);
                         slur->setTick(cr1->tick());
                         slur->setTick2(cr2->tick());
                         slur->setStartElement(cr1);
@@ -1035,8 +1035,8 @@ static Fraction readCapVoice(Score* score, CapVoice* cvoice, int staffIdx, const
                 Text* s = Factory::createText(measure, TextStyleType::TITLE);
                 QString ss = ::rtf2html(QString(to->text));
 
-                // LOGD("string %f:%f w %d ratio %d <%s>",
-                //    to->relPos.x(), to->relPos.y(), to->width, to->yxRatio, qPrintable(ss));
+                // CAPELLA_TRACE("string %f:%f w %d ratio %d <%s>",
+                //               to->relPos.x(), to->relPos.y(), to->width, to->yxRatio, qPrintable(ss));
                 s->setXmlText(ss);
 
                 if (measure->type() != ElementType::VBOX) {
@@ -1192,13 +1192,13 @@ void convertCapella(Score* score, Capella* cap, bool capxMode)
     score->style().set(Sid::maxSystemDistance, Spatium(12));
 
     for (CapSystem* csys : cap->systems) {
-        LOGD("System:");
+        CAPELLA_TRACE("System:");
         for (CapStaff* cstaff : csys->staves) {
             CapStaffLayout* cl = cap->staffLayout(cstaff->iLayout);
-            LOGD("  Staff layout <%s><%s><%s><%s><%s> %d  barline %d-%d mode %d",
-                 qPrintable(cl->descr), qPrintable(cl->name), qPrintable(cl->abbrev),
-                 qPrintable(cl->intermediateName), qPrintable(cl->intermediateAbbrev),
-                 cstaff->iLayout, cl->barlineFrom, cl->barlineTo, cl->barlineMode);
+            CAPELLA_TRACE("  Staff layout <%s><%s><%s><%s><%s> %d  barline %d-%d mode %d",
+                          qPrintable(cl->descr), qPrintable(cl->name), qPrintable(cl->abbrev),
+                          qPrintable(cl->intermediateName), qPrintable(cl->intermediateAbbrev),
+                          cstaff->iLayout, cl->barlineFrom, cl->barlineTo, cl->barlineMode);
         }
     }
 
@@ -1232,7 +1232,7 @@ void convertCapella(Score* score, Capella* cap, bool capxMode)
     Part* part = 0;
     for (int staffIdx = 0; staffIdx < staves; ++staffIdx) {
         CapStaffLayout* cl = cap->staffLayout(staffIdx);
-        // LOGD("MIDI staff %d program %d", staffIdx, cl->sound);
+        // CAPELLA_TRACE("MIDI staff %d program %d", staffIdx, cl->sound);
 
         // create a new part if necessary
         if (needPart(midiPatch, cl->sound, staffIdx, cap->brackets)) {
@@ -1280,7 +1280,7 @@ void convertCapella(Score* score, Capella* cap, bool capxMode)
     }
 
     for (CapBracket cb : cap->brackets) {
-        LOGD("Bracket %d-%d curly %d", cb.from, cb.to, cb.curly);
+        CAPELLA_TRACE("Bracket %d-%d curly %d", cb.from, cb.to, cb.curly);
         Staff* staff = muse::value(score->staves(), cb.from);
         if (staff == 0) {
             LOGD("bad bracket 'from' value");
@@ -1348,7 +1348,7 @@ void convertCapella(Score* score, Capella* cap, bool capxMode)
 
     Fraction systemTick = Fraction(0, 1);
     for (CapSystem* csys : cap->systems) {
-        LOGD("readCapSystem");
+        CAPELLA_TRACE("readCapSystem");
         /*
         if (csys->explLeftIndent > 0) {
               HBox* mb = Factory::createHBox(score);
@@ -1364,7 +1364,7 @@ void convertCapella(Score* score, Capella* cap, bool capxMode)
             //    which means that there is a 1:1 relation between layout/staff
             //
 
-            LOGD("  ReadCapStaff %d/%d", cstaff->numerator, 1 << cstaff->log2Denom);
+            CAPELLA_TRACE("  ReadCapStaff %d/%d", cstaff->numerator, 1 << cstaff->log2Denom);
             int staffIdx = cstaff->iLayout;
             for (CapVoice* cvoice : cstaff->voices) {
                 Fraction tick = readCapVoice(score, cvoice, staffIdx, systemTick, capxMode);
@@ -1460,8 +1460,8 @@ void SlurObj::read()
     nMid      = cap->readByte();
     nDotDist  = cap->readByte();
     nDotWidth = cap->readByte();
-    // LOGD("SlurObj nEnd %d nMid %d nDotDist %d nDotWidth %d",
-    //        nEnd, nMid, nDotDist, nDotWidth);
+    // CAPELLA_TRACE("SlurObj nEnd %d nMid %d nDotDist %d nDotWidth %d",
+    //               nEnd, nMid, nDotDist, nDotWidth);
 }
 
 //---------------------------------------------------------
@@ -1477,7 +1477,7 @@ void TextObj::read()
     cap->read(txt, size);
     txt[size] = 0;
     text = QString(txt);
-    // LOGD("read textObj len %d <%s>", size, txt);
+    // CAPELLA_TRACE("read textObj len %d <%s>", size, txt);
 }
 
 //---------------------------------------------------------
@@ -1491,8 +1491,8 @@ void SimpleTextObj::read()
     align  = cap->readByte();
     _font  = cap->readFont();
     _text  = cap->readQString();
-    // LOGD("read SimpletextObj(%f,%f) len %zd <%s>",
-    //        relPos.x(), relPos.y(), _text.length(), qPrintable(_text));
+    // CAPELLA_TRACE("read SimpletextObj(%f,%f) len %zd <%s>",
+    //               relPos.x(), relPos.y(), _text.length(), qPrintable(_text));
 }
 
 //---------------------------------------------------------
@@ -1506,7 +1506,7 @@ void LineObj::read()
     pt2       = cap->readPoint();
     color     = cap->readColor();
     lineWidth = cap->readByte();
-    // LOGD("LineObj: %f:%f  %f:%f  width %d", pt1.x(), pt1.y(), pt2.x(), pt2.y(), lineWidth);
+    // CAPELLA_TRACE("LineObj: %f:%f  %f:%f  width %d", pt1.x(), pt1.y(), pt2.x(), pt2.y(), lineWidth);
 }
 
 //---------------------------------------------------------
@@ -1561,7 +1561,7 @@ void MetafileObj::read()
     std::vector<char> vEnhMetaFileBits(size);
     char* enhMetaFileBits = vEnhMetaFileBits.data();
     cap->read(enhMetaFileBits, size);
-    // LOGD("MetaFileObj::read %d bytes", size);
+    // CAPELLA_TRACE("MetaFileObj::read %d bytes", size);
 }
 
 //---------------------------------------------------------
@@ -1656,8 +1656,8 @@ void VoltaObj::read()
     unsigned char numbers = cap->readByte();
     from = numbers & 0x0F;
     to = (numbers >> 4) & 0x0F;
-    LOGD("VoltaObj::read x0 %d x1 %d y %d bLeft %d bRight %d bDotted %d allNumbers %d from %d to %d",
-         x0, x1, y, bLeft, bRight, bDotted, allNumbers, from, to);
+    CAPELLA_TRACE("VoltaObj::read x0 %d x1 %d y %d bLeft %d bRight %d bDotted %d allNumbers %d from %d to %d",
+                  x0, x1, y, bLeft, bRight, bDotted, allNumbers, from, to);
 }
 
 //---------------------------------------------------------
@@ -1696,7 +1696,7 @@ QList<BasicDrawObj*> Capella::readDrawObjectArray()
     QList<BasicDrawObj*> ol;
     int n = readUnsigned();         // draw obj array
 
-    // LOGD("readDrawObjectArray %d elements", n);
+    // CAPELLA_TRACE("readDrawObjectArray %d elements", n);
     for (int i = 0; i < n; ++i) {
         CapellaType type = CapellaType(readByte());
 
@@ -1823,8 +1823,8 @@ void BasicDrawObj::read()
     nNotes      = range & 0x0fff;
     background  = range & 0x1000;
     pageRange   = (range >> 13) & 0x7;
-    LOGD("BasicDrawObj::read modeX %d modeY %d distY %d flags %d nRefNote %d nNotes %d background %d pageRange %d",
-         modeX, modeY, distY, flags, nRefNote, nNotes, background, pageRange);
+    CAPELLA_TRACE("BasicDrawObj::read modeX %d modeY %d distY %d flags %d nRefNote %d nNotes %d background %d pageRange %d",
+                  modeX, modeY, distY, flags, nRefNote, nNotes, background, pageRange);
 }
 
 //---------------------------------------------------------
@@ -1880,9 +1880,9 @@ void BasicDurationalObj::read()
     if (c & 0x40) {
         objects = cap->readDrawObjectArray();
     }
-    LOGD("DurationObj ndots %d nodur %d postgr %d bsm %d inv %d notbl %d t %d hsh %d den %d trp %d ispro %d",
-         nDots, noDuration, postGrace, bSmall, invisible, notBlack, int(t), horizontalShift, tupletDenominator, tripartite, isProlonging
-         );
+    CAPELLA_TRACE("DurationObj ndots %d nodur %d postgr %d bsm %d inv %d notbl %d t %d hsh %d den %d trp %d ispro %d",
+                  nDots, noDuration, postGrace, bSmall, invisible, notBlack, int(t), horizontalShift, tupletDenominator, tripartite, isProlonging
+                  );
 }
 
 //---------------------------------------------------------
@@ -2013,8 +2013,8 @@ void ChordObj::read()
             n.explAlteration = 1;
         }
         n.silent = b & 0x80;
-        LOGD("ChordObj::read() note pitch %d explAlt %d head group %d %d alt %d silent %d",
-             n.pitch, n.explAlteration, n.headType, n.headGroup, n.alteration, n.silent);
+        CAPELLA_TRACE("ChordObj::read() note pitch %d explAlt %d head group %d %d alt %d silent %d",
+                      n.pitch, n.explAlteration, n.headType, n.headGroup, n.alteration, n.silent);
         notes.append(n);
     }
 }
@@ -2227,7 +2227,7 @@ QFont Capella::readFont()
         /*QColor color           =*/ readColor();
         QString face             = readQString();
 
-        LOGD("Font <%s> size %d, weight %d", qPrintable(face), lfHeight, lfWeight);
+        CAPELLA_TRACE("Font <%s> size %d, weight %d", qPrintable(face), lfHeight, lfWeight);
         QFont font(face);
         font.setPointSizeF(lfHeight / 1000.0);
         font.setItalic(lfItalic);
@@ -2272,10 +2272,10 @@ void Capella::readStaveLayout(CapStaffLayout* sl, int idx)
     }
     break;
     }
-    LOGD("StaffLayout %d: barlineMode %d noteLines %d", idx, sl->barlineMode, sl->noteLines);
+    CAPELLA_TRACE("StaffLayout %d: barlineMode %d noteLines %d", idx, sl->barlineMode, sl->noteLines);
 
     sl->bSmall      = readByte();
-    LOGD("staff size small %d", sl->bSmall);
+    CAPELLA_TRACE("staff size small %d", sl->bSmall);
 
     sl->topDist      = readInt();
     sl->btmDist      = readInt();
@@ -2289,7 +2289,7 @@ void Capella::readStaveLayout(CapStaffLayout* sl, int idx)
     sl->form = Form(clef & 7);
     sl->line = ClefLine((clef >> 3) & 7);
     sl->oct  = Oct((clef >> 6));
-    LOGD("   clef %x  form %d, line %d, oct %d", clef, int(sl->form), int(sl->line), int(sl->oct));
+    CAPELLA_TRACE("   clef %x  form %d, line %d, oct %d", clef, int(sl->form), int(sl->line), int(sl->oct));
 
     // Schlagzeuginformation
     unsigned char b   = readByte();
@@ -2317,16 +2317,16 @@ void Capella::readStaveLayout(CapStaffLayout* sl, int idx)
     sl->sound  = readInt();
     sl->volume = readInt();
     sl->transp = readInt();
-    LOGD("   sound %d vol %d transp %d", sl->sound, sl->volume, sl->transp);
+    CAPELLA_TRACE("   sound %d vol %d transp %d", sl->sound, sl->volume, sl->transp);
 
     sl->descr              = readQString();
     sl->name               = readQString();
     sl->abbrev             = readQString();
     sl->intermediateName   = readQString();
     sl->intermediateAbbrev = readQString();
-    LOGD("   descr <%s> name <%s>  abbrev <%s> iname <%s> iabbrev <%s>",
-         qPrintable(sl->descr), qPrintable(sl->name), qPrintable(sl->abbrev),
-         qPrintable(sl->intermediateName), qPrintable(sl->intermediateAbbrev));
+    CAPELLA_TRACE("   descr <%s> name <%s>  abbrev <%s> iname <%s> iabbrev <%s>",
+                  qPrintable(sl->descr), qPrintable(sl->name), qPrintable(sl->abbrev),
+                  qPrintable(sl->intermediateName), qPrintable(sl->intermediateAbbrev));
 }
 
 //---------------------------------------------------------
@@ -2337,11 +2337,11 @@ void Capella::readLayout()
 {
     smallLineDist  = double(readInt()) / 100;
     normalLineDist = double(readInt()) / 100;
-    LOGD("Capella::readLayout(): smallLineDist %g normalLineDist %g", smallLineDist, normalLineDist);
+    CAPELLA_TRACE("Capella::readLayout(): smallLineDist %g normalLineDist %g", smallLineDist, normalLineDist);
 
     topDist        = readInt();
     interDist      = readInt();
-    LOGD("Capella::readLayout(): topDist %d", topDist);
+    CAPELLA_TRACE("Capella::readLayout(): topDist %d", topDist);
 
     txtAlign   = readByte();      // Stimmenbezeichnungen 0=links, 1=zentriert, 2=rechts
     adjustVert = readByte();      // 0=nein, 1=außer letzte Seite, 3=alle Seiten
@@ -2361,7 +2361,7 @@ void Capella::readLayout()
     // Musterzeilen
     unsigned nStaveLayouts = readUnsigned();
 
-    // LOGD("%d staves", nStaveLayouts);
+    // CAPELLA_TRACE("%d staves", nStaveLayouts);
 
     for (unsigned iStave = 0; iStave < nStaveLayouts; iStave++) {
         CapStaffLayout* sl = new CapStaffLayout;
@@ -2376,10 +2376,10 @@ void Capella::readLayout()
         cb.from   = readInt();
         cb.to     = readInt();
         cb.curly = readByte();
-        // LOGD("Bracket%d %d-%d curly %d", i, b.from, b.to, b.curly);
+        // CAPELLA_TRACE("Bracket%d %d-%d curly %d", i, b.from, b.to, b.curly);
         brackets.append(cb);
     }
-    // LOGD("Capella::readLayout(): done");
+    // CAPELLA_TRACE("Capella::readLayout(): done");
 }
 
 //---------------------------------------------------------
@@ -2390,7 +2390,7 @@ void Capella::readExtra()
 {
     uchar n = readByte();
     if (n) {
-        LOGD("Capella::readExtra(%d)", n);
+        CAPELLA_TRACE("Capella::readExtra(%d)", n);
         for (int i = 0; i < n; ++i) {
             readByte();
         }
@@ -2407,7 +2407,7 @@ void CapClef::read()
     form            = Form(b & 7);
     line            = ClefLine((b >> 3) & 7);
     oct             = Oct(b >> 6);
-    LOGD("Clef::read form %d line %d oct %d", int(form), int(line), int(oct));
+    CAPELLA_TRACE("Clef::read form %d line %d oct %d", int(form), int(line), int(oct));
 }
 
 //---------------------------------------------------------
@@ -2470,7 +2470,7 @@ void CapMeter::read()
     uchar d   = cap->readByte();
     log2Denom = (d & 0x7f) - 1;
     allaBreve = d & 0x80;
-    LOGD("   Meter %d/%d allaBreve %d", numerator, log2Denom, allaBreve);
+    CAPELLA_TRACE("   Meter %d/%d allaBreve %d", numerator, log2Denom, allaBreve);
     if (log2Denom > 7 || log2Denom < 0) {
         LOGD("   illegal fraction");
         // abort();
@@ -2521,7 +2521,7 @@ void CapExplicitBarline::read()
         throw Capella::Error::BAD_FORMAT;
     }
 
-    LOGD("         Expl.Barline type %d mode %d", int(_type), _barMode);
+    CAPELLA_TRACE("         Expl.Barline type %d mode %d", int(_type), _barMode);
 }
 
 //---------------------------------------------------------
@@ -2530,7 +2530,7 @@ void CapExplicitBarline::read()
 
 void Capella::readVoice(CapStaff* cs, int idx)
 {
-    LOGD("      readVoice %d", idx);
+    CAPELLA_TRACE("      readVoice %d", idx);
 
     if (readChar() != 'C') {
         throw Capella::Error::BAD_VOICE_SIG;
@@ -2548,7 +2548,7 @@ void Capella::readVoice(CapStaff* cs, int idx)
     for (unsigned i = 0; i < nNoteObjs; i++) {
         QColor color       = Qt::black;
         uchar type = readByte();
-        // LOGD("         Voice %d read object idx %d(%d) type %d", idx,  i, nNoteObjs, type);
+        // CAPELLA_TRACE("         Voice %d read object idx %d(%d) type %d", idx,  i, nNoteObjs, type);
         readExtra();
         if ((type != uchar(CapellaNoteObjectType::REST)) && (type != uchar(CapellaNoteObjectType::CHORD))
             && (type != uchar(CapellaNoteObjectType::PAGE_BKGR))) {
@@ -2597,7 +2597,7 @@ void Capella::readVoice(CapStaff* cs, int idx)
         {
             CapExplicitBarline* bl = new CapExplicitBarline(this);
             bl->read();
-            LOGD("append Expl Barline==========");
+            CAPELLA_TRACE("append Expl Barline==========");
             v->objects.append(bl);
         }
         break;
@@ -2624,7 +2624,7 @@ void Capella::readStaff(CapSystem* system)
     uchar d          = readByte();
     staff->log2Denom = (d & 0x7f) - 1;
     staff->allaBreve = d & 0x80;
-    LOGD("   CapStaff meter %d/%d allaBreve %d", staff->numerator, staff->log2Denom, staff->allaBreve);
+    CAPELLA_TRACE("   CapStaff meter %d/%d allaBreve %d", staff->numerator, staff->log2Denom, staff->allaBreve);
     if (staff->log2Denom > 7 || staff->log2Denom < 0) {
         LOGD("   illegal fraction");
         staff->log2Denom = 2;
@@ -2637,7 +2637,7 @@ void Capella::readStaff(CapSystem* system)
     staff->color     = readColor();
     readExtra();
 
-    LOGD("      Staff iLayout %d", staff->iLayout);
+    CAPELLA_TRACE("      Staff iLayout %d", staff->iLayout);
     // Stimmen
     unsigned nVoices = readUnsigned();
     for (unsigned i = 0; i < nVoices; i++) {
@@ -2749,7 +2749,7 @@ void Capella::read(QFile* fp)
         throw Capella::Error::BAD_SIG;
     }
 
-    // LOGD("read Capella file signature <%s>", signature);
+    // CAPELLA_TRACE("read Capella file signature <%s>", signature);
 
     // TODO: test for signature[7] = a-z
 
@@ -2757,7 +2757,7 @@ void Capella::read(QFile* fp)
     keywords = readString();
     comment  = readString();
 
-    // LOGD("author <%s> keywords <%s> comment <%s>", author, keywords, comment);
+    // CAPELLA_TRACE("author <%s> keywords <%s> comment <%s>", author, keywords, comment);
 
     nRel   = readUnsigned();              // 75
     nAbs   = readUnsigned();              // 16
@@ -2766,7 +2766,7 @@ void Capella::read(QFile* fp)
     bAllowCompression = b & 2;
     bPrintLandscape   = b & 16;
 
-    // LOGD("  nRel %d  nAbs %d useRealSize %d compression %d", nRel, nAbs, bUseRealSize, bAllowCompression);
+    // CAPELLA_TRACE("  nRel %d  nAbs %d useRealSize %d compression %d", nRel, nAbs, bUseRealSize, bAllowCompression);
 
     readLayout();
 
@@ -2786,13 +2786,13 @@ void Capella::read(QFile* fp)
     for (unsigned int i = 0; i < n; ++i) {
         /*char* s =*/
         readString();                       // Namen der Galerie-Objekte
-        // LOGD("Galerie: <%s>", s);
+        // CAPELLA_TRACE("Galerie: <%s>", s);
     }
 
-    // LOGD("read backgroundChord");
+    // CAPELLA_TRACE("read backgroundChord");
     backgroundChord = new ChordObj(this);
     backgroundChord->read();                // contains graphic objects on the page background
-    // LOGD("read backgroundChord done");
+    // CAPELLA_TRACE("read backgroundChord done");
     bShowBarCount    = readByte();          // Taktnumerierung zeigen
     barNumberFrame   = readByte();          // 0=kein, 1=Rechteck, 2=Ellipse
     nBarDistX        = readByte();

--- a/src/importexport/capella/internal/capella.h
+++ b/src/importexport/capella/internal/capella.h
@@ -27,11 +27,11 @@
 
 #include "engraving/types/types.h"
 
-//#define DEBUG_CAPELLA_TUPLETS
-#ifdef DEBUG_CAPELLA_TUPLETS
-#define LOG_TUPLETS LOGD
+#define CAPELLA_TRACE_ENABLED 0
+#if CAPELLA_TRACE_ENABLED
+#define CAPELLA_TRACE LOGD
 #else
-#define LOG_TUPLETS LOGN
+#define CAPELLA_TRACE LOGN
 #endif
 
 class QFile;

--- a/src/importexport/capella/internal/capxml.cpp
+++ b/src/importexport/capella/internal/capxml.cpp
@@ -68,7 +68,7 @@ static QFont capxReadFont(XmlReader& e)
         f.setWeight(QFont::Bold);
     }
     f.setItalic(e.asciiAttribute("italic", "false") == "true");
-    // LOGD("capxReadFont family '%s' ps %g w %d it '%s'", qPrintable(family), pointSize, weight, qPrintable(italic));
+    // CAPELLA_TRACE("capxReadFont family '%s' ps %g w %d it '%s'", qPrintable(family), pointSize, weight, qPrintable(italic));
     e.readNext();
     return f;
 }
@@ -117,7 +117,7 @@ static bool qstring2timestep(QString& str, TIMESTEP& tstp)
 void BasicDrawObj::readCapx(XmlReader& e)
 {
     nNotes = e.intAttribute("noteRange", 0);
-    LOGD("nNotes %d", nNotes);
+    CAPELLA_TRACE("nNotes %d", nNotes);
     e.readNext();
 }
 
@@ -176,9 +176,10 @@ void BasicDurationalObj::readCapx(XmlReader& e, unsigned int& fullm)
             e.unknown();
         }
     }
-    LOGD("DurationObj ndots %d nodur %d postgr %d bsm %d inv %d notbl %d t %d hsh %d den %d trp %d ispro %d fullm %d",
-         nDots, noDuration, postGrace, bSmall, invisible, notBlack, int(t), horizontalShift, tupletDenominator, tripartite, isProlonging, fullm
-         );
+    CAPELLA_TRACE("DurationObj ndots %d nodur %d postgr %d bsm %d inv %d notbl %d t %d hsh %d den %d trp %d ispro %d fullm %d",
+                  nDots, noDuration, postGrace, bSmall, invisible, notBlack, int(t), horizontalShift, tupletDenominator, tripartite,
+                  isProlonging, fullm
+                  );
 }
 
 //---------------------------------------------------------
@@ -250,7 +251,7 @@ void CapClef::readCapx(XmlReader& e)
         line = ClefLine::L2;
         oct = Oct::OCT_NULL;
     }
-    LOGD("Clef::read '%s' -> form %d line %d oct %d", qPrintable(clef), int(form), int(line), int(oct));
+    CAPELLA_TRACE("Clef::read '%s' -> form %d line %d oct %d", qPrintable(clef), int(form), int(line), int(oct));
     e.readNext();
 }
 
@@ -261,7 +262,7 @@ void CapClef::readCapx(XmlReader& e)
 void CapKey::readCapx(XmlReader& e)
 {
     signature = e.intAttribute("fifths", 0);
-    LOGD("Key %d", signature);
+    CAPELLA_TRACE("Key %d", signature);
     e.readNext();
 }
 
@@ -320,7 +321,7 @@ static void qstring2timesig(QString& time, uchar& numerator, int& log2Denom, boo
         }
     }
     // TODO: recovery required if decoding the timesig failed ?
-    LOGD("Meter '%s' res %d %d/%d allaBreve %d", qPrintable(time), res, numerator, log2Denom, allaBreve);
+    CAPELLA_TRACE("Meter '%s' res %d %d/%d allaBreve %d", qPrintable(time), res, numerator, log2Denom, allaBreve);
 }
 
 //---------------------------------------------------------
@@ -329,7 +330,7 @@ static void qstring2timesig(QString& time, uchar& numerator, int& log2Denom, boo
 
 void CapMeter::readCapx(XmlReader& e)
 {
-    LOGD("CapMeter::readCapx");
+    CAPELLA_TRACE("CapMeter::readCapx");
     QString time = e.attribute("time");
     qstring2timesig(time, numerator, log2Denom, allaBreve);
     e.readNext();
@@ -455,7 +456,7 @@ static signed char pitchStr2Char(QString& strPitch)
         pitch = -1;
     }
 
-    LOGD("pitchStr2Char: '%s' -> %d", qPrintable(strPitch), pitch);
+    CAPELLA_TRACE("pitchStr2Char: '%s' -> %d", qPrintable(strPitch), pitch);
 
     return static_cast<signed char>(pitch);
 }
@@ -505,8 +506,8 @@ void ChordObj::readCapxNotes(XmlReader& e)
                     e.unknown();
                 }
             }
-            LOGD("ChordObj::readCapxNotes: pitch '%s' altstep '%s' shape '%s'",
-                 qPrintable(pitch), qPrintable(sstep), qPrintable(shape));
+            CAPELLA_TRACE("ChordObj::readCapxNotes: pitch '%s' altstep '%s' shape '%s'",
+                          qPrintable(pitch), qPrintable(sstep), qPrintable(shape));
             int istep = sstep.toInt();
             CNote n;
             n.pitch = pitchStr2Char(pitch);
@@ -538,7 +539,7 @@ void ChordObj::readCapxNotes(XmlReader& e)
             tupletCount = o->nNotes;
             objects.removeOne(o);
             delete o;
-            LOG_TUPLETS("==> Tuplet start, plus %d notes till end", tupletCount);
+            CAPELLA_TRACE("==> Tuplet start, plus %d notes till end", tupletCount);
             return; // we are done, and we modified the iterator, so back out
         }
     }
@@ -583,7 +584,7 @@ void RestObj::readCapx(XmlReader& e)
             tupletCount = o->nNotes;
             objects.removeOne(o);
             delete o;
-            LOG_TUPLETS("      ==> Tuplet start, plus %d notes till end", tupletCount);
+            CAPELLA_TRACE("      ==> Tuplet start, plus %d notes till end", tupletCount);
             return; // we are done, and we modified the iterator, so back out
         }
     }
@@ -607,14 +608,14 @@ void SimpleTextObj::readCapx(XmlReader& e)
     }
     relPos = QPointF(x, y);
     relPos *= 32.0;
-    // LOGD("x %g y %g align %s", x, y, qPrintable(align));
+    // CAPELLA_TRACE("x %g y %g align %s", x, y, qPrintable(align));
     while (e.readNextStartElement()) {
         const AsciiStringView tag(e.name());
         if (tag == "font") {
             _font = capxReadFont(e);
         } else if (tag == "content") {
             _text = e.readText();
-            // LOGD("SimpleTextObj::readCapx: found content '%s'", qPrintable(_text));
+            // CAPELLA_TRACE("SimpleTextObj::readCapx: found content '%s'", qPrintable(_text));
         } else {
             e.unknown();
         }
@@ -676,9 +677,9 @@ void VoltaObj::readCapx(XmlReader& e)
         from = firstNumber;
         to   = (lastNumber == 0) ? firstNumber : lastNumber;
     }
-    LOGD("VoltaObj::read firstNumber %d lastNumber %d", firstNumber, lastNumber);
-    LOGD("VoltaObj::read x0 %d x1 %d y %d bLeft %d bRight %d bDotted %d allNumbers %d from %d to %d",
-         x0, x1, y, bLeft, bRight, bDotted, allNumbers, from, to);
+    CAPELLA_TRACE("VoltaObj::read firstNumber %d lastNumber %d", firstNumber, lastNumber);
+    CAPELLA_TRACE("VoltaObj::read x0 %d x1 %d y %d bLeft %d bRight %d bDotted %d allNumbers %d from %d to %d",
+                  x0, x1, y, bLeft, bRight, bDotted, allNumbers, from, to);
     e.readNext();
 }
 
@@ -696,7 +697,7 @@ void TrillObj::readCapx(XmlReader& e)
     x1 = (int)round(x1d * 32.0);
     y  = (int)round(yd * 32.0);
     // color       -> skipped
-    LOGD("TrillObj::read x0 %d x1 %d y %d trillSign %d", x0, x1, y, trillSign);
+    CAPELLA_TRACE("TrillObj::read x0 %d x1 %d y %d trillSign %d", x0, x1, y, trillSign);
     e.readNext();
 }
 
@@ -867,8 +868,8 @@ void Capella::readCapxVoice(XmlReader& e, CapStaff* cs, int idx)
                         tupletCounter = chord->tupletCount;
                         tupletTicks   = chord->ticks();
                         tupletObj     = chord;  // save the tuplet object for later
-                        LOG_TUPLETS("     ==| (C) start of tuplet with %d notes, ticks %d",
-                                    1 + tupletCounter, tupletTicks.ticks());
+                        CAPELLA_TRACE("     ==| (C) start of tuplet with %d notes, ticks %d",
+                                      1 + tupletCounter, tupletTicks.ticks());
                     } else if (tupletCounter > 0) {
                         if (!tupletObj) {
                             LOGE("     !!! chord with tupletCounter %d without tupletObj", tupletCounter);
@@ -883,10 +884,10 @@ void Capella::readCapxVoice(XmlReader& e, CapStaff* cs, int idx)
                                 chord->tupletEnd = true;
                                 tupletObj->tupletTicks = tupletTicks;      // set total ticks to the tuplet object
                                 tupletObj = nullptr;      // reset tuplet object
-                                LOG_TUPLETS("     ==| end of tuplet, total ticks %d", tupletTicks.ticks());
+                                CAPELLA_TRACE("     ==| end of tuplet, total ticks %d", tupletTicks.ticks());
                             } else {
-                                LOG_TUPLETS("     ==> chord with tupletCounter %d inside tuplet, ticks now %d",
-                                            tupletCounter, tupletTicks.ticks());
+                                CAPELLA_TRACE("     ==> chord with tupletCounter %d inside tuplet, ticks now %d",
+                                              tupletCounter, tupletTicks.ticks());
                             }
                         }
                     }
@@ -898,8 +899,8 @@ void Capella::readCapxVoice(XmlReader& e, CapStaff* cs, int idx)
                         tupletCounter = rest->tupletCount;
                         tupletTicks   = rest->ticks();
                         tupletObj     = rest;  // save the tuplet object for later
-                        LOG_TUPLETS("     ==| (R) start of tuplet with %d notes, ticks %d",
-                                    1 + tupletCounter, tupletTicks.ticks());
+                        CAPELLA_TRACE("     ==| (R) start of tuplet with %d notes, ticks %d",
+                                      1 + tupletCounter, tupletTicks.ticks());
                     } else if (tupletCounter > 0) {
                         if (!tupletObj) {
                             LOGE("     !!! rest with tupletCounter %d without tupletObj", tupletCounter);
@@ -915,10 +916,10 @@ void Capella::readCapxVoice(XmlReader& e, CapStaff* cs, int idx)
                                 rest->tupletEnd = true;
                                 tupletObj->tupletTicks = tupletTicks;      // set total ticks to the tuplet object
                                 tupletObj = nullptr;      // reset tuplet object
-                                LOG_TUPLETS("     ==| end of tuplet, total ticks %d", tupletTicks.ticks());
+                                CAPELLA_TRACE("     ==| end of tuplet, total ticks %d", tupletTicks.ticks());
                             } else {
-                                LOG_TUPLETS("     ==> rest with tupletCounter %d inside tuplet, ticks now %d",
-                                            tupletCounter, tupletTicks.ticks());
+                                CAPELLA_TRACE("     ==> rest with tupletCounter %d inside tuplet, ticks now %d",
+                                              tupletCounter, tupletTicks.ticks());
                             }
                         }
                     }
@@ -958,7 +959,7 @@ static int findStaffIndex(const QString& layout, const QList<CapStaffLayout*>& s
 
 void Capella::readCapxStaff(XmlReader& e, CapSystem* system)
 {
-    LOGD("Capella::readCapxStaff");
+    CAPELLA_TRACE("Capella::readCapxStaff");
     CapStaff* staff = new CapStaff;
     QString layout = e.attribute("layout");
     QString time = e.attribute("defaultTime");
@@ -1138,7 +1139,7 @@ void Capella::readCapxStaveLayout(XmlReader& e, CapStaffLayout* sl, int /*idx*/)
     sl->form = Form(clef & 7);
     sl->line = ClefLine((clef >> 3) & 7);
     sl->oct  = Oct((clef >> 6));
-    // LOGD("   clef %x  form %d, line %d, oct %d", clef, sl->form, sl->line, sl->oct);
+    // CAPELLA_TRACE("   clef %x  form %d, line %d, oct %d", clef, sl->form, sl->line, sl->oct);
 
     // Schlagzeuginformation
     unsigned char b   = 0;   // ?? TODO ?? sl->soundMapIn and sl->soundMapOut are not used
@@ -1166,7 +1167,7 @@ void Capella::readCapxStaveLayout(XmlReader& e, CapStaffLayout* sl, int /*idx*/)
     sl->volume = 0;
     sl->transp = 0;
 
-    LOGD("readCapxStaveLayout");
+    CAPELLA_TRACE("readCapxStaveLayout");
     sl->descr = e.attribute("description");
     while (e.readNextStartElement()) {
         const AsciiStringView tag(e.name());
@@ -1198,10 +1199,10 @@ void Capella::readCapxStaveLayout(XmlReader& e, CapStaffLayout* sl, int /*idx*/)
             e.unknown();
         }
     }
-    LOGD("   descr '%s' name '%s' abbrev '%s'",
-         qPrintable(sl->descr), qPrintable(sl->name), qPrintable(sl->abbrev));
-    LOGD("   sound %d vol %d transp %d", sl->sound, sl->volume, sl->transp);
-    LOGD("readCapxStaveLayout done");
+    CAPELLA_TRACE("   descr '%s' name '%s' abbrev '%s'",
+                  qPrintable(sl->descr), qPrintable(sl->name), qPrintable(sl->abbrev));
+    CAPELLA_TRACE("   sound %d vol %d transp %d", sl->sound, sl->volume, sl->transp);
+    CAPELLA_TRACE("readCapxStaveLayout done");
 }
 
 //---------------------------------------------------------
@@ -1430,7 +1431,7 @@ Err importCapXml(MasterScore* score, const QString& name)
     while (e.readNextStartElement()) {
         if (e.name() == "score") {
             String xmlns = e.attribute("xmlns", u"<none>");       // doesn't work ???
-            LOGD("importCapXml: found score, namespace '%s'", xmlns.toUtf8().constChar());
+            CAPELLA_TRACE("importCapXml: found score, namespace '%s'", xmlns.toUtf8().constChar());
             cf.readCapx(e);
         } else {
             e.unknown();


### PR DESCRIPTION
This PR adds trace log macros to the Braille and Capella modules in order to reduce log spam.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
