### PR TITLE
engraving: Remove unused `EngravingItem::playTick()`

### DIFF
--- a/src/engraving/dom/barline.cpp
+++ b/src/engraving/dom/barline.cpp
@@ -374,25 +374,6 @@ bool BarLine::isBottom() const
 }
 
 //---------------------------------------------------------
-//   playTick
-//---------------------------------------------------------
-
-Fraction BarLine::playTick() const
-{
-    // Play from the start of the measure to the right of the barline, unless this is the last barline in either the entire score or the system,
-    // in which case we should play from the start of the measure to the left of the barline.
-    const auto measure = findMeasure();
-    if (measure) {
-        const auto nextMeasure = findMeasure()->next();
-        if (!nextMeasure || (nextMeasure->system() != measure->system())) {
-            return measure->tick();
-        }
-    }
-
-    return tick();
-}
-
-//---------------------------------------------------------
 //   acceptDrop
 //---------------------------------------------------------
 

--- a/src/engraving/dom/barline.h
+++ b/src/engraving/dom/barline.h
@@ -79,8 +79,7 @@ class BarLine final : public EngravingItem
     DECLARE_CLASSOF(ElementType::BAR_LINE)
 
 public:
-
-    virtual ~BarLine();
+    ~BarLine() override;
 
     BarLine& operator=(const BarLine&) = delete;
 
@@ -91,7 +90,6 @@ public:
     EngravingObjectList scanChildren() const override;
 
     BarLine* clone() const override { return new BarLine(*this); }
-    Fraction playTick() const override;
     PointF canvasPos() const override;      ///< position in canvas coordinates
     PointF pagePos() const override;        ///< position in page coordinates
 

--- a/src/engraving/dom/bracket.cpp
+++ b/src/engraving/dom/bracket.cpp
@@ -57,24 +57,6 @@ Bracket::~Bracket()
 }
 
 //---------------------------------------------------------
-//   playTick
-//---------------------------------------------------------
-
-Fraction Bracket::playTick() const
-{
-    // Brackets always have a tick value of zero, so play from the start of the first measure in the system that the bracket belongs to.
-    const auto sys = system();
-    if (sys) {
-        const auto firstMeasure = sys->firstMeasure();
-        if (firstMeasure) {
-            return firstMeasure->tick();
-        }
-    }
-
-    return tick();
-}
-
-//---------------------------------------------------------
 //   setStaffSpan
 //---------------------------------------------------------
 

--- a/src/engraving/dom/bracket.h
+++ b/src/engraving/dom/bracket.h
@@ -69,8 +69,6 @@ public:
     Measure* measure() const { return m_measure; }
     void setMeasure(Measure* measure) { m_measure = measure; }
 
-    Fraction playTick() const override;
-
     const BracketItem* bi() const { return m_bi; }
 
     bool isEditable() const override;

--- a/src/engraving/dom/engravingitem.cpp
+++ b/src/engraving/dom/engravingitem.cpp
@@ -573,16 +573,6 @@ Fraction EngravingItem::rtick() const
 }
 
 //---------------------------------------------------------
-//   playTick
-//---------------------------------------------------------
-
-Fraction EngravingItem::playTick() const
-{
-    // Play from the element's tick position by default.
-    return tick();
-}
-
-//---------------------------------------------------------
 //   beat
 //---------------------------------------------------------
 

--- a/src/engraving/dom/engravingitem.h
+++ b/src/engraving/dom/engravingitem.h
@@ -256,7 +256,6 @@ public:
 
     virtual Fraction tick() const;
     virtual Fraction rtick() const;
-    virtual Fraction playTick() const;   ///< muse::Returns the tick at which playback should begin when this element is selected. Defaults to the element's own tick position.
 
     Fraction beat() const;
 

--- a/src/engraving/dom/instrumentname.cpp
+++ b/src/engraving/dom/instrumentname.cpp
@@ -122,24 +122,6 @@ void InstrumentName::setInstrumentNameType(InstrumentNameType st)
 }
 
 //---------------------------------------------------------
-//   playTick
-//---------------------------------------------------------
-
-Fraction InstrumentName::playTick() const
-{
-    // Instrument names always have a tick value of zero, so play from the start of the first measure in the system that the instrument name belongs to.
-    const auto sys = system();
-    if (sys) {
-        const auto firstMeasure = sys->firstMeasure();
-        if (firstMeasure) {
-            return firstMeasure->tick();
-        }
-    }
-
-    return tick();
-}
-
-//---------------------------------------------------------
 //   getProperty
 //---------------------------------------------------------
 

--- a/src/engraving/dom/instrumentname.h
+++ b/src/engraving/dom/instrumentname.h
@@ -62,7 +62,6 @@ public:
 
     double largestStaffSpatium() const;
 
-    Fraction playTick() const override;
     bool isEditable() const override { return false; }
     PropertyValue getProperty(Pid propertyId) const override;
     bool setProperty(Pid propertyId, const PropertyValue&) override;


### PR DESCRIPTION
- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
