### PR TITLE
Fix #27582: Fix removing timeSig from mmRests

### DIFF
--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -1612,6 +1612,13 @@ void Score::cmdRemoveTimeSig(TimeSig* ts)
     if (rs) {
         rScore->undoRemoveElement(rs);
     }
+    // Measure can contain mmRest that can have its own timesig. We need to delete it too
+    if (rm->mmRest()) {
+        Segment* mmRestTimesig = rm->mmRest()->findSegment(SegmentType::TimeSig, s->tick());
+        if (mmRestTimesig) {
+            rScore->undoRemoveElement(mmRestTimesig);
+        }
+    }
 
     Measure* pm = m->prevMeasure();
     Fraction ns(pm ? pm->timesig() : Fraction(4, 4));


### PR DESCRIPTION
* Adds additional check to remove timeSig segment from inside mmRest

Resolves: #27582

Fixes the case where removing time signature that is only followed by multi-measure rests (even if it's 1-measure mmRest) crashes the application

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
