### PR TITLE
Fix MSVC compiler warnings

### DIFF
--- a/src/framework/audio/thirdparty/stb/stb_vorbis.c
+++ b/src/framework/audio/thirdparty/stb/stb_vorbis.c
@@ -4699,7 +4699,7 @@ static int go_to_page_before(stb_vorbis *f, unsigned int limit_offset)
 // better).
 static int seek_to_sample_coarse(stb_vorbis *f, uint32 sample_number)
 {
-   ProbedPage left, right, mid;
+   ProbedPage left, right, mid = {};
    int i, start_seg_with_known_loc, end_pos, page_start;
    uint32 delta, stream_length, padding, last_sample_limit;
    double offset = 0.0, bytes_per_sample = 0.0;


### PR DESCRIPTION
* reg.: '=': conversion from 'int' to 'uint32', signed/unsigned mismatch (C4245)
* reg.: declaration of 'n|m' hides function parameter (C4457)
* reg.: potentially uninitialized local variable 'mid' used (C4701)

All in stb_vorbis.c, a recently updated third party module. I didn't find a place to disable those warnings for just that module...