### PR TITLE
Don't install ninja and cmake while they are already installed

### DIFF
--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -168,9 +168,10 @@ jobs:
         target: 'desktop'
         arch: 'clang_64'
         modules: 'qt5compat qtnetworkauth qtscxml qtshadertools qtwebsockets'
-    - name: Setup environment
+
+    - name: Download dependencies
       run: |
-        bash ./buildscripts/ci/macos/setup.sh
+        bash ./buildscripts/ci/macos/download_dependencies.sh
 
     - name: Generate _en.ts files
       env:

--- a/buildscripts/ci/linux/setup.sh
+++ b/buildscripts/ci/linux/setup.sh
@@ -168,46 +168,15 @@ else
   echo "Unknown compiler: $COMPILER"
 fi
 
-# CMAKE
-# Get newer CMake (only used cached version if it is the same)
-case "$PACKARCH" in
-  x86_64 | wasm)
-    cmake_version="3.24.0"
-    cmake_dir="$BUILD_TOOLS/cmake/${cmake_version}"
-    if [[ ! -d "$cmake_dir" ]]; then
-      mkdir -p "$cmake_dir"
-      cmake_url="https://cmake.org/files/v${cmake_version%.*}/cmake-${cmake_version}-linux-x86_64.tar.gz"
-      wget -q --show-progress --no-check-certificate -O - "${cmake_url}" | tar --strip-components=1 -xz -C "${cmake_dir}"
-    fi
-    export PATH="$cmake_dir/bin:$PATH"
-    echo export PATH="$cmake_dir/bin:\${PATH}" >> ${ENV_FILE}
-    ;;
-  armv7l | aarch64)
-    $SUDO apt-get install -y --no-install-recommends cmake
-    ;;
-esac
+# CMake
+echo "cmake version"
 cmake --version
 
 # Ninja
-case "$PACKARCH" in
-  x86_64 | wasm)
-    echo "Get Ninja"
-    ninja_dir=$BUILD_TOOLS/Ninja
-    if [[ ! -d "$ninja_dir" ]]; then
-      mkdir -p $ninja_dir
-      wget -q --show-progress -O $ninja_dir/ninja "https://s3.amazonaws.com/utils.musescore.org/build_tools/linux/Ninja/ninja"
-      chmod +x $ninja_dir/ninja
-    fi
-    export PATH="${ninja_dir}:${PATH}"
-    echo export PATH="${ninja_dir}:\${PATH}" >> ${ENV_FILE}
-    ;;
-  armv7l | aarch64)
-    $SUDO apt-get install -y --no-install-recommends ninja-build
-    ;;
-esac
 echo "ninja version"
 ninja --version
 
+# Emscripten
 if [[ "$PACKARCH" == "wasm" ]]; then
   git clone https://github.com/emscripten-core/emsdk.git $BUILD_TOOLS/emsdk
   origin_dir=$(pwd)

--- a/buildscripts/ci/macos/download_dependencies.sh
+++ b/buildscripts/ci/macos/download_dependencies.sh
@@ -5,7 +5,7 @@
 # MuseScore Studio
 # Music Composition & Notation
 #
-# Copyright (C) 2021 MuseScore Limited
+# Copyright (C) 2025 MuseScore Limited
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -18,25 +18,13 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
-echo "Setup macOS build environment"
 
-trap 'echo Setup failed; exit 1' ERR
-
-export MACOSX_DEPLOYMENT_TARGET=10.15
-
-# Install build tools
-echo "Install build tools"
-if ! command -v cmake >/dev/null 2>&1
-then
-    brew install cmake ninja --formula --quiet
-fi
-
-# Download dependencies
 echo "Download dependencies"
+trap 'code=$?; echo "error: Download dependencies: command \`$BASH_COMMAND\` exited with code $code." >&2; exit 1' ERR
 
 wget -q --show-progress -O musescore_deps_macos.tar.gz https://raw.githubusercontent.com/cbjeukendrup/musescore_deps/main/musescore_deps_macos.tar.gz
 mkdir -p $HOME/musescore_deps_macos
 tar xf musescore_deps_macos.tar.gz -C $HOME/musescore_deps_macos
 rm musescore_deps_macos.tar.gz
 
-echo "Setup script done"
+echo "Download dependencies done"

--- a/buildscripts/ci/withoutqt/setup.sh
+++ b/buildscripts/ci/withoutqt/setup.sh
@@ -119,29 +119,13 @@ echo export CXX="/usr/bin/g++-${gcc_version}" >> ${ENV_FILE}
 gcc-${gcc_version} --version
 g++-${gcc_version} --version 
 
-# CMAKE
-# Get newer CMake (only used cached version if it is the same)
-cmake_version="3.16.0"
-cmake_dir="$BUILD_TOOLS/cmake/${cmake_version}"
-if [[ ! -d "$cmake_dir" ]]; then
-  mkdir -p "$cmake_dir"
-  cmake_url="https://cmake.org/files/v${cmake_version%.*}/cmake-${cmake_version}-Linux-x86_64.tar.gz"
-  wget -q --show-progress --no-check-certificate -O - "${cmake_url}" | tar --strip-components=1 -xz -C "${cmake_dir}"
-fi
-echo export PATH="$cmake_dir/bin:\${PATH}" >> ${ENV_FILE}
-$cmake_dir/bin/cmake --version
+# CMake
+echo "cmake version"
+cmake --version
 
 # Ninja
-echo "Get Ninja"
-ninja_dir=$BUILD_TOOLS/Ninja
-if [[ ! -d "$ninja_dir" ]]; then
-  mkdir -p $ninja_dir
-  wget -q --show-progress -O $ninja_dir/ninja "https://s3.amazonaws.com/utils.musescore.org/build_tools/linux/Ninja/ninja"
-  chmod +x $ninja_dir/ninja
-fi
-echo export PATH="${ninja_dir}:\${PATH}" >> ${ENV_FILE}
 echo "ninja version"
-$ninja_dir/ninja --version
+ninja --version
 
 ##########################################################################
 # POST INSTALL


### PR DESCRIPTION
The version of these tools is not very important for us, so it doesn't matter if GitHub Actions bumps them.