### PR TITLE
Update french translation

### DIFF
--- a/share/locale/musescore_fr.ts
+++ b/share/locale/musescore_fr.ts
@@ -26320,7 +26320,7 @@ Remarque : Maitriser MuseScore est disponible principalement en anglais (Certain
     <message>
         <location filename="../../src/notation/view/selectionfilter/elementsselectionfiltermodel.cpp" line="91"/>
         <source>Grace notes</source>
-        <translation>Fioritures</translation>
+        <translation>Appoggiatures</translation>
     </message>
     <message>
         <location filename="../../src/notation/view/selectionfilter/notesinchordselectionfiltermodel.cpp" line="149"/>
@@ -28369,7 +28369,7 @@ a échoué.</translation>
     <message>
         <location filename="../../src/palette/internal/palettecreator.cpp" line="1103"/>
         <source>Grace notes</source>
-        <translation>Fioritures</translation>
+        <translation>Appogiatures</translation>
     </message>
     <message>
         <location filename="../../src/palette/internal/palettecreator.cpp" line="1124"/>
@@ -28884,7 +28884,7 @@ a échoué.</translation>
     <message>
         <location filename="../../src/palette/internal/palettecreator.cpp" line="1892"/>
         <source>Keyboard</source>
-        <translation>Clavier</translation>
+        <translation>Pédalier</translation>
     </message>
     <message>
         <location filename="../../src/palette/internal/palettecreator.cpp" line="1957"/>


### PR DESCRIPTION
Update french translation

"Clavier" -> "Pédalier"
"Fioritures" -> "Appogiatures". Because in french, the translation of grace note is appogiatures and not fioritures. The "fioritures" are the ornaments and the grace note.

<img width="300" height="978" alt="Capture d'écran 2025-09-08 174621" src="https://github.com/user-attachments/assets/bbf1c86d-de55-4464-ae5c-efabd2422279" />