### PR TITLE
Preserve grace note when entering new note over existing one

### DIFF
--- a/src/engraving/dom/chord.h
+++ b/src/engraving/dom/chord.h
@@ -207,6 +207,7 @@ public:
     const std::vector<Chord*>& graceNotes() const { return m_graceNotes; }
     std::vector<Chord*>& graceNotes() { return m_graceNotes; }
     std::vector<Chord*> allGraceChordsOfMainChord();
+    void removeAllGraceNotes() { m_graceNotes.clear(); }
 
     GraceNotesGroup& graceNotesBefore(bool filterUnplayable = false) const;
     GraceNotesGroup& graceNotesAfter(bool filterUnplayable = false) const;

--- a/src/engraving/dom/cmd.cpp
+++ b/src/engraving/dom/cmd.cpp
@@ -1127,6 +1127,12 @@ Segment* Score::setNoteRest(Segment* segment, track_idx_t track, NoteVal nval, F
                 chord->setTicks(d.fraction());
                 chord->setStemDirection(stemDirection);
                 chord->add(note);
+                if (cr && cr->isChord()) {
+                    std::vector<Chord*> graceNotes = toChord(cr)->graceNotes();
+                    for (Chord* grace : graceNotes) {
+                        undoChangeParent(grace, chord, chord->staffIdx());
+                    }
+                }
                 note->setNval(nval, tick);
                 if (forceAccidental) {
                     int tpc = style().styleB(Sid::concertPitch) ? nval.tpc1 : nval.tpc2;

--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -433,6 +433,10 @@ ChordRest* Score::addClone(ChordRest* cr, const Fraction& tick, const TDuration&
     newcr->setTicks(d.isMeasure() ? cr->measure()->ticks() : d.fraction());
     newcr->setTuplet(cr->tuplet());
     newcr->setSelected(false);
+    if (newcr->isChord()) {
+        muse::DeleteAll(toChord(newcr)->graceNotes());
+        toChord(newcr)->removeAllGraceNotes();
+    }
 
     undoAddCR(newcr, cr->measure(), tick);
     return newcr;


### PR DESCRIPTION
Resolves: #19878
Resolves: #29675

The main issue is that the grace note wasn't preserved, but was instead cloned to all the subsequent chords. This messed up the HOPO (but a normal slur would have the same problem) cause it didn't know anymore what its start- and end-notes are. Fixing the grace note interaction seems to fix the HOPO problem as well.
