### PR TITLE
Fix #29681: Unwanted context menus when changing dock tabs

### DIFF
--- a/src/framework/dockwindow/internal/docktabbar.cpp
+++ b/src/framework/dockwindow/internal/docktabbar.cpp
@@ -69,12 +69,15 @@ void DockTabBar::onMousePressRelease(const QMouseEvent* mouseEvent)
     switch (mouseEvent->type()) {
     case QEvent::MouseButtonPress: {
         m_indexOfPressedTab = tabIndex;
+        m_tabChangedOnClick = false;
         TabBar::onMousePress(localPos);
         break;
     }
     case QEvent::MouseButtonRelease: {
-        if (tabIndex == m_indexOfPressedTab) {
+        const int currentTabIndex = tabBar->property("currentIndex").toInt();
+        if (tabIndex != currentTabIndex && tabIndex == m_indexOfPressedTab) {
             tabBar->setProperty("currentIndex", tabIndex);
+            m_tabChangedOnClick = true;
         }
         m_indexOfPressedTab = -1;
         break;

--- a/src/framework/dockwindow/internal/docktabbar.h
+++ b/src/framework/dockwindow/internal/docktabbar.h
@@ -35,8 +35,13 @@ class DockTabBar : public KDDockWidgets::TabBarQuick
 public:
     explicit DockTabBar(KDDockWidgets::TabWidget* parent = nullptr);
 
+    // The following is a hack (see PR #29794)- revisit this system when updating KDDockWidgets
+    Q_PROPERTY(bool tabChangedOnClick READ tabChangedOnClick CONSTANT)
+
     Q_INVOKABLE void setDraggableMouseArea(QQuickItem* mouseArea);
     Q_INVOKABLE void doubleClicked(const QPoint& pos) const;
+
+    bool tabChangedOnClick() const { return m_tabChangedOnClick; }
 
 private:
     bool event(QEvent* event) override;
@@ -45,6 +50,8 @@ private:
 
     QQuickItem* m_draggableMouseArea = nullptr;
     int m_indexOfPressedTab = -1;
+
+    bool m_tabChangedOnClick = false;
 };
 }
 

--- a/src/framework/dockwindow/qml/Muse/Dock/DockTabBar.qml
+++ b/src/framework/dockwindow/qml/Muse/Dock/DockTabBar.qml
@@ -152,6 +152,15 @@ Rectangle {
         propagateComposedEvents: true
         enabled: root.visible && root.draggingTabsAllowed
         cursorShape: Qt.SizeAllCursor
+
+        onClicked: function(mouse) {
+            if (!root.tabBarCpp) {
+                return
+            }
+            // Hack - if the current tab changed on this click, do not propagate the click event
+            // to the tab's menu button. We don't want the menu to appear when changing tabs.
+            mouse.accepted = root.tabBarCpp.tabChangedOnClick
+        }
     }
 
     Loader {


### PR DESCRIPTION
Resolves: #29681

This PR has gone through a few iterations (see edit history of this comment). My first idea was to modify the Z order of the overlapping mouse areas and use an empty `containmentMask` for the `DockPanelTab` so that it wouldn't steal clicks. This, however, ended up breaking hover events for the tabs.

I also tried a revert of #29470, but that didn't suffice.

So, I've settled on a rebase/remix of @krasko78's #27444 where we "block" the propagation of clicks if we detect a change in tabs.