### PR TITLE
fixed #29780: Plugin shortcut is not saved after MSS restart. 4.6

### DIFF
--- a/src/framework/extensions/extensionsmodule.cpp
+++ b/src/framework/extensions/extensionsmodule.cpp
@@ -123,11 +123,7 @@ void ExtensionsModule::onInit(const IApplication::RunMode& mode)
 
     m_configuration->init();
     m_actionController->init();
-
-    if (mode == IApplication::RunMode::ConsoleApp) {
-        m_provider->reloadExtensions();
-        m_extensionsLoaded = true;
-    }
+    m_provider->reloadExtensions();
 
 #ifdef MUSE_MODULE_DIAGNOSTICS
     auto pr = ioc()->resolve<muse::diagnostics::IDiagnosticsPathsRegister>(moduleName());
@@ -138,12 +134,4 @@ void ExtensionsModule::onInit(const IApplication::RunMode& mode)
         pr->reg("plugins (legacy): userPath", m_configuration->pluginsUserPath());
     }
 #endif
-}
-
-void ExtensionsModule::onDelayedInit()
-{
-    if (!m_extensionsLoaded) {
-        m_provider->reloadExtensions();
-        m_extensionsLoaded = true;
-    }
 }

--- a/src/framework/extensions/extensionsmodule.h
+++ b/src/framework/extensions/extensionsmodule.h
@@ -42,7 +42,6 @@ public:
     void resolveImports() override;
     void registerApi() override;
     void onInit(const IApplication::RunMode& mode) override;
-    void onDelayedInit() override;
 
 private:
 
@@ -50,6 +49,5 @@ private:
     std::shared_ptr<ExtensionsProvider> m_provider;
     std::shared_ptr<ExtensionsActionController> m_actionController;
     std::shared_ptr<ExtensionsExecPointsRegister> m_execPointsRegister;
-    bool m_extensionsLoaded = false;
 };
 }

--- a/src/framework/shortcuts/shortcutsmodule.cpp
+++ b/src/framework/shortcuts/shortcutsmodule.cpp
@@ -120,7 +120,6 @@ void ShortcutsModule::onInit(const IApplication::RunMode& mode)
 
     m_configuration->init();
     m_shortcutsController->init();
-    m_shortcutsRegister->init();
     m_midiRemote->init();
 
 #ifdef MUSE_MODULE_DIAGNOSTICS
@@ -131,4 +130,13 @@ void ShortcutsModule::onInit(const IApplication::RunMode& mode)
         pr->reg("midiMappingUserAppDataPath", m_configuration->midiMappingUserAppDataPath());
     }
 #endif
+}
+
+void ShortcutsModule::onAllInited(const IApplication::RunMode& mode)
+{
+    if (mode != IApplication::RunMode::GuiApp) {
+        return;
+    }
+
+    m_shortcutsRegister->init();
 }

--- a/src/framework/shortcuts/shortcutsmodule.h
+++ b/src/framework/shortcuts/shortcutsmodule.h
@@ -42,6 +42,7 @@ public:
     void registerResources() override;
     void registerUiTypes() override;
     void onInit(const IApplication::RunMode& mode) override;
+    void onAllInited(const IApplication::RunMode& mode) override;
 
 private:
 


### PR DESCRIPTION
see https://github.com/musescore/MuseScore/pull/29796