### PR TITLE
Jazz font tweaks

### DIFF
--- a/src/engraving/data/chords/chords_jazz.xml
+++ b/src/engraving/data/chords/chords_jazz.xml
@@ -76,7 +76,7 @@
     <sym code="0x1d12b" name="bb"/>
 
     <sym code="0xE87C" name="dslash"/>
-    <sym code="0xE874" name="-"/>
+    <sym value="-" name="-"/>
     <sym code="0xe186" name="+"/>
     </font>
 
@@ -222,12 +222,12 @@
 
   <token>
     <name>o</name>
-    <render>sc:0.5 :push :mx circle :popy sc:2</render>
+    <render>sc:0.8 :push :mx circle :popy sc:1.25</render>
     </token>
 
   <token>
     <name>0</name>
-    <render>sc:0.5 :push :mx oslash :popy sc:2</render>
+    <render>sc:0.8 :push :mx oslash :popy sc:1.25</render>
     </token>
 
   <token>


### PR DESCRIPTION
Resolves: #29770

This fixes the '-' symbol when using the jazz chord style, and enlarges the 'o' and 'ø' symbols.
<img width="1028" height="155" alt="Screenshot 2025-09-10 at 10 51 55" src="https://github.com/user-attachments/assets/e1268e7c-50af-4abf-a4cc-786b8e9be1d6" />
