### PR TITLE
Ignore timeTick segment when spacing clef

### DIFF
--- a/src/engraving/rendering/score/horizontalspacing.cpp
+++ b/src/engraving/rendering/score/horizontalspacing.cpp
@@ -652,7 +652,11 @@ void HorizontalSpacing::moveRightAlignedSegments(std::vector<SegmentPosition>& p
 
         if (x != DBL_MAX) {
             placedSegments[i].xPosInSystemCoords = x;
-            double nextSegX = placedSegments[i + 1].xPosInSystemCoords;
+            SegmentPosition& nextSegPos = placedSegments[i + 1];
+            for (size_t j = i + 2; nextSegPos.ignoreForSpacing && j < placedSegments.size(); ++j) {
+                nextSegPos = placedSegments[j];
+            }
+            double nextSegX = nextSegPos.xPosInSystemCoords;
             Segment* prevCRSeg = segment->prev(SegmentType::ChordRest);
             if (prevCRSeg) {
                 prevCRSeg->addWidthOffset(-nextSegX + x);


### PR DESCRIPTION
Resolves: #29698

Turns out that the staff size has nothing to do with the issue (I could reproduce it also with default size). It was just about a very sneaky interaction between clef spacing and TimeTick segments.