### PR TITLE
Crash on reading slurs & ties starting and ending on the same chord

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -8200,6 +8200,7 @@ static void addSlur(const Notation& notation, SlurStack& slurs, ChordRest* cr, N
             newSlur->setTick2(newSlur->endElement()->tick());
             if (newSlur->ticks().negative()) {
                 logger->logError(String(u"slur end is before slur start"), xmlreader);
+                slurs[slurNo] = SlurDesc();
                 delete newSlur;
                 return;
             }


### PR DESCRIPTION
Resolves: Crashes on opening scores exported from Sibelius
