### PR TITLE
[MusicXML] minor improvements for symbols

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/musicxml/export/exportmusicxml.cpp
@@ -6147,12 +6147,15 @@ static void directionMarker(XmlWriter& xml, const Marker* const m, const std::ve
 {
     const MarkerType mtp = getEffectiveMarkerType(m, jumps);
     String words;
+    String smufl;
     String type;
     String sound;
 
     switch (mtp) {
-    case MarkerType::CODA:
     case MarkerType::VARCODA:
+        smufl = u"codaSquare";
+        [[fallthrough]];
+    case MarkerType::CODA:
     case MarkerType::CODETTA:
         type = u"coda";
         if (m->label() == "") {
@@ -6161,8 +6164,10 @@ static void directionMarker(XmlWriter& xml, const Marker* const m, const std::ve
             sound = u"coda=\"" + m->label() + u"\"";
         }
         break;
-    case MarkerType::SEGNO:
     case MarkerType::VARSEGNO:
+        smufl = u"segnoSerpent1";
+        [[fallthrough]];
+    case MarkerType::SEGNO:
         type = u"segno";
         if (m->label() == "") {
             sound = u"segno=\"1\"";
@@ -6201,6 +6206,9 @@ static void directionMarker(XmlWriter& xml, const Marker* const m, const std::ve
         xml.startElement("direction-type");
         String attrs = color2xml(m);
         attrs += ExportMusicXml::positioningAttributes(m);
+        if (!smufl.empty()) {
+            attrs += String(u" smufl=\"%1\"").arg(smufl);
+        }
         if (!type.empty()) {
             xml.tagRaw(type + attrs);
         }

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -4031,6 +4031,9 @@ void MusicXmlParserDirection::directionType(std::vector<MusicXmlSpannerDesc>& st
         } else if (m_e.name() == "segno") {
             m_wordsText += u"<sym>segno</sym>";
             m_e.skipCurrentElement();
+        } else if (m_e.name() == "eyeglasses") {
+            m_wordsText += u"<sym>miscEyeglasses</sym>";
+            m_e.skipCurrentElement();
         } else if (m_e.name() == "symbol") {
             const String smufl = m_e.readText();
             if (!smufl.empty()) {

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -4026,10 +4026,20 @@ void MusicXmlParserDirection::directionType(std::vector<MusicXmlSpannerDesc>& st
         } else if (m_e.name() == "wedge") {
             wedge(type, n, starts, stops);
         } else if (m_e.name() == "coda") {
-            m_wordsText += u"<sym>coda</sym>";
+            const String smufl = m_e.attribute("smufl");
+            if (!smufl.empty()) {
+                m_wordsText += u"<sym>" + smufl + u"</sym>";
+            } else {
+                m_wordsText += u"<sym>coda</sym>";
+            }
             m_e.skipCurrentElement();
         } else if (m_e.name() == "segno") {
-            m_wordsText += u"<sym>segno</sym>";
+            const String smufl = m_e.attribute("smufl");
+            if (!smufl.empty()) {
+                m_wordsText += u"<sym>" + smufl + u"</sym>";
+            } else {
+                m_wordsText += u"<sym>segno</sym>";
+            }
             m_e.skipCurrentElement();
         } else if (m_e.name() == "eyeglasses") {
             m_wordsText += u"<sym>miscEyeglasses</sym>";


### PR DESCRIPTION
Adds import for `eyeglasses` element and extends import and export for special coda and segno glyphs.