### PR TITLE
Fix #28074: Crash when swapping with clipboard

### DIFF
--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -5254,44 +5254,16 @@ void NotationInteraction::swapSelection()
         return;
     }
 
+    // Store the old selection...
     mu::engraving::Selection& selection = score()->selection();
-    QString mimeType = selection.mimeType();
+    QByteArray oldSelection = selection.mimeData().toQByteArray();
 
-    if (mimeType == mu::engraving::mimeStaffListFormat) { // determine size of clipboard selection
-        const QMimeData* mimeData = this->selection()->qMimeData();
-        QByteArray data = mimeData ? mimeData->data(mu::engraving::mimeStaffListFormat) : QByteArray();
-        mu::engraving::XmlReader reader(data);
-        reader.readNextStartElement();
-
-        Fraction tickLen = Fraction(0, 1);
-        int stavesCount = 0;
-
-        if (reader.name() == "StaffList") {
-            tickLen = mu::engraving::Fraction::fromString(reader.attribute("len"));
-            stavesCount = reader.intAttribute("staves", 0);
-        }
-
-        if (tickLen > mu::engraving::Fraction(0, 1)) { // attempt to extend selection to match clipboard size
-            mu::engraving::Segment* segment = selection.startSegment();
-            mu::engraving::Fraction startTick = selection.tickStart() + tickLen;
-            mu::engraving::Segment* segmentAfter = score()->tick2leftSegment(startTick);
-
-            size_t staffIndex = selection.staffStart() + stavesCount - 1;
-            if (staffIndex >= score()->nstaves()) {
-                staffIndex = score()->nstaves() - 1;
-            }
-
-            startTick = selection.tickStart();
-            mu::engraving::Fraction endTick = startTick + tickLen;
-            selection.extendRangeSelection(segment, segmentAfter, staffIndex, startTick, endTick);
-            selection.update();
-        }
-    }
-
-    QByteArray currentSelectionBackup = selection.mimeData().toQByteArray();
+    // Paste using contents of clipboard...
     pasteSelection();
+
+    // Save old selection to clipboard...
     QMimeData* mimeData = new QMimeData();
-    mimeData->setData(mimeType, currentSelectionBackup);
+    mimeData->setData(selection.mimeType(), oldSelection);
     QApplication::clipboard()->setMimeData(mimeData);
 }
 


### PR DESCRIPTION
Resolves: #28074

This actually has more to do with multi-measure rests than part scores - you can also repro by turning on mmrests in the main score.

In `Selection::staffMimeData` - `seg1` is set to the first segment of our selection (`m_startSegment`), `seg2` is set to the first segment after the selection (`m_endSegment`). Crucially, `seg2` currently refers to a segment covered by the mmrest. When we call `hasElementInTrack` with these segments as parameters, we iterate using `next1MM`. This means we actually _skip over_ the end segment (the loop condition is never met, `seg` goes null, _**kaboom**_). Looks like this is caused by the fact that we use `tick2leftSegment` instead of `tick2leftSegmentMM` in `NotationInteraction::swapSelection`.

For this solution we can actually remove all the messing around with range selections. At some point before MS4 it was decided that, when performing a swap, the range copied _to_ the clipboard should "expand" to match the range already _contained in_ the clipboard. For example, if you had a 4 bar range in the clipboard, performing a swap would aways copy 4 bars into the clipboard (regardless of your current selection range). We've decided that this is not actually the desired behaviour - instead we should think of this as a "swap selection with clipboard". So if you have 4 bars in the clipboard and 1 bar selected, 4 bars will be pasted and 1 bar will be copied.