### PR TITLE
Draft: Implement #9640: Sticky header in MixerPanel

### DIFF
--- a/src/framework/uicomponents/qml/Muse/UiComponents/RowWithStickyHeader.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/RowWithStickyHeader.qml
@@ -1,0 +1,91 @@
+import QtQuick 2.15
+import Muse.Ui 1.0
+import Muse.UiComponents 1.0
+
+Item {
+    id: root
+
+    // Public properties
+    property string headerTitle: ""
+    property bool headerVisible: true
+    property int headerWidth: 98
+    property int headerHeight: implicitHeight - spacingAbove - spacingBelow
+    property real spacingAbove: 4
+    property real spacingBelow: 4
+    property var model: undefined
+    property Component delegateComponent
+
+    // Sticky header functionality
+    property Item parentFlickable: null
+
+    // Layout properties
+    property int spacing: 1 // for separators
+
+    // Size calculation
+    width: (headerVisible ? headerWidth + 30 : 0) + sectionContentList.width + (model ? model.count * spacing : 0)
+    height: spacingAbove + sectionContentList.contentHeight + spacingBelow
+
+    // Sticky header
+    StyledTextLabel {
+        id: stickyHeader
+
+        visible: root.headerVisible
+
+        // Sticky positioning - follows the flickable's contentX
+        x: root.parentFlickable ?
+           Math.max(0, Math.min(root.parentFlickable.contentX,
+                                root.width - (root.headerWidth + 30))) : 0
+
+        y: root.spacingAbove
+
+        width: root.headerWidth + 30
+        height: root.headerHeight
+
+        z: 10 // Keep above other content
+
+        leftPadding: 12
+        rightPadding: 12
+        horizontalAlignment: Qt.AlignRight
+        text: root.headerTitle
+
+        // Background to make header opaque during scrolling
+        Rectangle {
+            anchors.fill: parent
+            anchors.margins: -1
+            color: ui.theme.backgroundPrimaryColor
+            border.width: 1
+            border.color: ui.theme.strokeColor
+            z: -1
+        }
+    }
+
+    // Content list positioned after header
+    ListView {
+        id: sectionContentList
+
+        x: root.headerVisible ? root.headerWidth + 30 + root.spacing : 0
+        y: root.spacingAbove
+
+        width: contentItem.childrenRect.width
+        height: Math.max(1, contentHeight) // HACK: if the height is 0, the listview won't create any delegates
+        contentHeight: contentItem.childrenRect.height
+
+        interactive: false
+        orientation: Qt.Horizontal
+        spacing: root.spacing // for separators (will be rendered in MixerPanel.qml)
+
+        model: root.model
+        delegate: root.delegateComponent
+    }
+
+    // Update header position when parent flickable scrolls
+    Connections {
+        target: root.parentFlickable
+        function onContentXChanged() {
+            if (root.parentFlickable && root.headerVisible) {
+                stickyHeader.x = Math.max(0, Math.min(root.parentFlickable.contentX,
+                                                    root.width - (root.headerWidth + 30)))
+            }
+        }
+    }
+}

--- a/src/playback/playback.qrc
+++ b/src/playback/playback.qrc
@@ -27,5 +27,6 @@
         <file>qml/MuseScore/Playback/internal/SoundFlag/MuseSoundsParams.qml</file>
         <file>qml/MuseScore/Playback/internal/SoundFlag/ParamsGridView.qml</file>
         <file>qml/MuseScore/Playback/internal/AudioProcessingProgressBar.qml</file>
+        <file>qml/MuseScore/Playback/internal/MixerRow.qml</file>
     </qresource>
 </RCC>

--- a/src/playback/qml/MuseScore/Playback/MixerPanel.qml
+++ b/src/playback/qml/MuseScore/Playback/MixerPanel.qml
@@ -174,10 +174,38 @@ ColumnLayout {
 
             spacing: prv.channelItemWidth
 
+            SeparatorLine {
+                id: firstSeparator
+                orientation: Qt.Vertical
+            }
+
+
             Repeater {
-                model: contextMenuModel.labelsSectionVisible ? mixerPanelModel.count + 1 : mixerPanelModel.count
+                model: mixerPanelModel.count
+                // model: contextMenuModel.labelsSectionVisible ? mixerPanelModel.count : mixerPanelModel.count
 
                 SeparatorLine { orientation: Qt.Vertical }
+            }
+        }
+
+
+        Rectangle {
+            id: headerBackgroundRect
+            width: prv.headerWidth
+            height: parent.height
+            visible: contextMenuModel.labelsSectionVisible
+            color: ui.theme.backgroundSecondaryColor
+        }
+
+        Connections {
+            target: flickable
+            function onContentXChanged() {
+                if (flickable) {
+                    var flickableX = Math.max(0, flickable.contentX)
+                    firstSeparator.x = flickableX
+                    headerBackgroundRect.x = flickableX
+
+                }
             }
         }
 
@@ -204,6 +232,7 @@ ColumnLayout {
                 spacingAbove: 8
 
                 model: mixerPanelModel
+                flickableArea: flickable
 
                 navigationRowStart: 1
                 needReadChannelName: prv.isPanelActivated
@@ -211,6 +240,7 @@ ColumnLayout {
                 onNavigateControlIndexChanged: function(index) {
                     prv.setNavigateControlIndex(index)
                 }
+
             }
 
             MixerFxSection {
@@ -222,6 +252,7 @@ ColumnLayout {
                 channelItemWidth: prv.channelItemWidth
 
                 model: mixerPanelModel
+                flickableArea: flickable
 
                 navigationRowStart: 100
                 needReadChannelName: prv.isPanelActivated
@@ -241,6 +272,7 @@ ColumnLayout {
                 channelItemWidth: prv.channelItemWidth
 
                 model: mixerPanelModel
+                flickableArea: flickable
 
                 navigationRowStart: 200
                 needReadChannelName: prv.isPanelActivated
@@ -259,6 +291,7 @@ ColumnLayout {
                 channelItemWidth: prv.channelItemWidth
 
                 model: mixerPanelModel
+                flickableArea: flickable
 
                 navigationRowStart: 300
                 needReadChannelName: prv.isPanelActivated
@@ -277,6 +310,7 @@ ColumnLayout {
                 channelItemWidth: prv.channelItemWidth
 
                 model: mixerPanelModel
+                flickableArea: flickable
 
                 navigationRowStart: 400
                 needReadChannelName: prv.isPanelActivated
@@ -297,6 +331,7 @@ ColumnLayout {
                 spacingBelow: -2
 
                 model: mixerPanelModel
+                flickableArea: flickable
 
                 navigationRowStart: 500
                 needReadChannelName: prv.isPanelActivated
@@ -315,6 +350,7 @@ ColumnLayout {
                 channelItemWidth: prv.channelItemWidth
 
                 model: mixerPanelModel
+                flickableArea: flickable
 
                 navigationRowStart: 600
                 needReadChannelName: prv.isPanelActivated
@@ -335,6 +371,7 @@ ColumnLayout {
                 spacingBelow: 0
 
                 model: mixerPanelModel
+                flickableArea: flickable
 
                 navigationRowStart: 700
                 needReadChannelName: prv.isPanelActivated

--- a/src/playback/qml/MuseScore/Playback/internal/MixerPanelSection.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/MixerPanelSection.qml
@@ -45,48 +45,80 @@ Loader {
 
     property bool needReadChannelName: false
 
+    property var flickableArea
+
     default property Component delegateComponent
 
     signal navigateControlIndexChanged(var index)
 
     active: visible
 
-    sourceComponent: Row {
-        width: implicitWidth
-        height: root.spacingAbove + sectionContentList.contentHeight + root.spacingBelow
-        spacing: 1 // for separator (will be rendered in MixerPanel.qml)
+    sourceComponent: MixerRow {
+        flickableArea: root.flickableArea
+        spacingAbove: root.spacingAbove
+        spacingBelow: root.spacingBelow
 
-        StyledTextLabel {
-            visible: root.headerVisible
 
-            anchors.top: parent.top
-            anchors.topMargin: root.spacingAbove
+        header: Component {
+            Item {
+                anchors.top: parent.top
+                width: textLabel.width
+                height: textLabel.height + root.spacingAbove + root.spacingBelow
 
-            width: root.headerWidth
-            height: root.headerHeight
+                StyledTextLabel {
+                    id: textLabel
+                    visible: root.headerVisible
 
-            leftPadding: 12
-            rightPadding: 12
+                    anchors.top: parent.top
+                    anchors.topMargin: root.spacingAbove
 
-            horizontalAlignment: Qt.AlignRight
-            text: root.headerTitle
+                    width: root.headerWidth
+                    height: root.headerHeight
+
+                    leftPadding: 12
+                    rightPadding: 12
+
+                    horizontalAlignment: Qt.AlignRight
+                    text: root.headerTitle
+                    z: 2
+                }
+
+                Rectangle {
+                    id: backgroundRect
+                    anchors.fill: parent
+
+
+                    color: ui.theme.backgroundSecondaryColor
+                    // color: "red"
+                    z: 1
+
+                    MouseArea {
+                        id: mouseBlocker
+                        anchors.fill: parent
+                        propagateComposedEvents: false
+                        hoverEnabled: true
+                    }
+                }
+
+            }
         }
+        body: Component {
+            ListView {
+                id: sectionContentList
 
-        ListView {
-            id: sectionContentList
+                anchors.top: parent.top
+                anchors.topMargin: root.spacingAbove
+                width: contentItem.childrenRect.width
+                height: Math.max(1, contentHeight) // HACK: if the height is 0, the listview won't create any delegates
+                contentHeight: contentItem.childrenRect.height
 
-            anchors.top: parent.top
-            anchors.topMargin: root.spacingAbove
-            width: contentItem.childrenRect.width
-            height: Math.max(1, contentHeight) // HACK: if the height is 0, the listview won't create any delegates
-            contentHeight: contentItem.childrenRect.height
+                interactive: false
+                orientation: Qt.Horizontal
+                spacing: 1 // for separators (will be rendered in MixerPanel.qml)
 
-            interactive: false
-            orientation: Qt.Horizontal
-            spacing: 1 // for separators (will be rendered in MixerPanel.qml)
-
-            model: root.model
-            delegate: delegateComponent
+                model: root.model
+                delegate: delegateComponent
+            }
         }
     }
 }

--- a/src/playback/qml/MuseScore/Playback/internal/MixerRow.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/MixerRow.qml
@@ -1,0 +1,51 @@
+import QtQuick 2.15
+
+import Muse.Ui 1.0
+import Muse.UiComponents 1.0
+import Muse.Audio 1.0
+import MuseScore.Playback 1.0
+
+Row {
+    id: root
+
+    property real spacingAbove: 4
+    property real spacingBelow: 4
+
+    property alias header: headerLoader.sourceComponent
+    property alias body: bodyLoader.sourceComponent
+    property var flickableArea
+
+
+
+
+    width: implicitWidth
+    height: root.spacingAbove + (bodyLoader.status === Loader.Ready ? bodyLoader.item.contentHeight : 0) + root.spacingBelow
+    // height: 150
+
+    spacing: 1 // for separator (will be rendered in MixerPanel.qml)
+
+    // visible: (headerLoader.status === Loader.Ready) && (bodyLoader.status === Loader.ready)
+    visible: true
+
+    Loader {
+        id: headerLoader
+        z: 2
+    }
+
+    Loader {
+        id: bodyLoader
+        z: 1
+    }
+
+    Connections {
+        target: root.flickableArea
+        function onContentXChanged() {
+            if (root.flickableArea && headerLoader.item) {
+                console.log(root.flickableArea.contentX)
+                headerLoader.item.x = Math.max(0, root.flickableArea.contentX)
+            }
+        }
+    }
+
+
+}


### PR DESCRIPTION
It's a draft. You can check it, but please don't merge, it needs cleaning


* Implements per-row sticky logic
* Adds background rectangle with mouseArea to intercept mouse events
* There is some gap where mouse events still fall through, needs further investigation

Resolves: #9640 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

Implements sticky header logic suggested in #9640. 

The implementation has some problems: 
* We have to make background-color rectangles both in MixPanel and in each MixRow's header, otherwise layering is bad 
* It's implemented per-row, but volume slider goes beyond its row. That causes the slider to have higher z-order then previous row's header (see picture where header has red color intentionally)

Maybe it would be better to redo the whole panel so that column header is its own entity (but that would require more complex logic around header row heights) 

<img width="117" height="204" alt="image" src="https://github.com/user-attachments/assets/05d50311-b487-4ae4-8e00-48fdf837af1f" />

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [ ] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [ ] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
