### PR TITLE
GitHub Actions: update to macos-26

### DIFF
--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -49,7 +49,7 @@ env:
 
 jobs:
   macos_universal:
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
     - name: Cancel Previous Runs
       uses: styfle/cancel-workflow-action@0.12.1


### PR DESCRIPTION
Just because we can (since a couple of minutes); shouldn't make any difference since we are already using the macOS 26 _SDK_.