### PR TITLE
Fix MSVC compiler warning

### DIFF
--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -6496,9 +6496,9 @@ static void undoChangeNoteVisibility(Note* note, bool visible)
                     child->undoChangeProperty(Pid::VISIBLE, chordHasVisibleNote_);
                 }
             }
-            bool visible = chordHasVisibleChild(linkedChord);
-            if (!visible) {
-                linkedChord->undoChangeProperty(Pid::VISIBLE, visible);
+            bool visibleChild = chordHasVisibleChild(linkedChord);
+            if (!visibleChild) {
+                linkedChord->undoChangeProperty(Pid::VISIBLE, visibleChild);
             }
         }
     }


### PR DESCRIPTION
reg.: declaration of 'visible' hides function parameter (C4457)