### PR TITLE
Fix crash on drag system object layer

### DIFF
--- a/src/instrumentsscene/view/layoutpaneltreemodel.cpp
+++ b/src/instrumentsscene/view/layoutpaneltreemodel.cpp
@@ -632,7 +632,10 @@ bool LayoutPanelTreeModel::moveRows(const QModelIndex& sourceParent, int sourceR
     sourceParentItem->moveChildren(sourceFirstRow, count, destinationParentItem, destinationRow, !m_dragInProgress);
     endMoveRows();
 
-    updateSystemObjectLayers();
+    if (!m_dragInProgress) {
+        updateSystemObjectLayers();
+    }
+
     updateRearrangementAvailability();
 
     return true;


### PR DESCRIPTION
Resolves: #29871

Don't call updateSystemObjectsLayer if drag is in progress, because updateSystemObjectLayers only works if the score is up to date, but the score doesn't get updated while dragging, it only updates at the end of the drag.