### PR TITLE
Fix #27056: wrong layout ordering when excerpt exists

### DIFF
--- a/src/instrumentsscene/view/layoutpaneltreemodel.cpp
+++ b/src/instrumentsscene/view/layoutpaneltreemodel.cpp
@@ -94,7 +94,6 @@ LayoutPanelTreeModel::LayoutPanelTreeModel(QObject* parent)
 void LayoutPanelTreeModel::onMasterNotationChanged()
 {
     m_masterNotation = context()->currentMasterNotation();
-    initPartOrders();
 }
 
 void LayoutPanelTreeModel::onNotationChanged()
@@ -116,6 +115,11 @@ void LayoutPanelTreeModel::onNotationChanged()
     }
 
     m_notationChangedWhileLoadingWasBlocked = false;
+}
+
+bool LayoutPanelTreeModel::isMasterScore() const
+{
+    return m_notation && m_notation->isMaster();
 }
 
 LayoutPanelTreeModel::~LayoutPanelTreeModel()
@@ -161,24 +165,7 @@ bool LayoutPanelTreeModel::shouldShowSystemObjectLayers() const
 {
     // Only show system object staves in master score
     // TODO: extend system object staves logic to parts
-    return m_notation && m_notation->isMaster();
-}
-
-void LayoutPanelTreeModel::initPartOrders()
-{
-    m_sortedPartIdList.clear();
-
-    if (!m_masterNotation) {
-        return;
-    }
-
-    for (const IExcerptNotationPtr& excerpt : m_masterNotation->excerpts()) {
-        NotationKey key = notationToKey(excerpt->notation());
-
-        for (const Part* part : excerpt->notation()->parts()->partList()) {
-            m_sortedPartIdList[key] << part->id();
-        }
-    }
+    return isMasterScore();
 }
 
 void LayoutPanelTreeModel::onBeforeChangeNotation()
@@ -194,8 +181,6 @@ void LayoutPanelTreeModel::onBeforeChangeNotation()
             partIdList << item->id();
         }
     }
-
-    m_sortedPartIdList[notationToKey(m_notation)] = partIdList;
 }
 
 void LayoutPanelTreeModel::setLoadingBlocked(bool blocked)
@@ -401,7 +386,11 @@ void LayoutPanelTreeModel::load()
     m_rootItem = new RootTreeItem(m_masterNotation, m_notation, this);
 
     async::NotifyList<const Part*> masterParts = m_masterNotation->parts()->partList();
-    sortParts(masterParts);
+    async::NotifyList<const Part*> excerptParts = m_notation->parts()->partList();
+    // For master score we should use score's order, for others - custom
+    if (!isMasterScore()) {
+        sortParts(masterParts, excerptParts);
+    }
 
     const bool showSystemObjectLayers = shouldShowSystemObjectLayers();
     const std::vector<Staff*>& systemObjectStaves = m_masterNotation->notation()->parts()->systemObjectStaves();
@@ -442,30 +431,32 @@ void LayoutPanelTreeModel::load()
     emit isAddingAvailableChanged(true);
 }
 
-void LayoutPanelTreeModel::sortParts(notation::PartList& parts)
+void LayoutPanelTreeModel::sortParts(notation::PartList& parts, notation::PartList& referenceParts)
 {
-    NotationKey key = notationToKey(m_notation);
+    // First collect ids of referenceParts to use in sorting further
 
-    if (!m_sortedPartIdList.contains(key)) {
-        return;
+    std::vector<ID> referenceIdOrder;
+    referenceParts.reserve(referenceParts.size());
+
+    for (const Part* part : referenceParts) {
+        referenceIdOrder.push_back(part->id());
     }
 
-    const QList<muse::ID>& sortedPartIdList = m_sortedPartIdList[key];
+    // Now we can define ordering function based on reference order
+    auto comparator = [&referenceIdOrder] (const Part* partA, const Part* partB) {
+        const ID& idA = partA->id();
+        const ID& idB = partB->id();
 
-    std::sort(parts.begin(), parts.end(), [&sortedPartIdList](const Part* part1, const Part* part2) {
-        int index1 = sortedPartIdList.indexOf(part1->id());
-        int index2 = sortedPartIdList.indexOf(part2->id());
+        auto itA = std::find(referenceIdOrder.begin(), referenceIdOrder.end(), idA);
+        auto itB = std::find(referenceIdOrder.begin(), referenceIdOrder.end(), idB);
 
-        if (index1 < 0) {
-            index1 = std::numeric_limits<int>::max();
-        }
+        auto idxA = std::distance(referenceIdOrder.begin(), itA);
+        auto idxB = std::distance(referenceIdOrder.begin(), itB);
 
-        if (index2 < 0) {
-            index2 = std::numeric_limits<int>::max();
-        }
+        return idxA < idxB;
+    };
 
-        return index1 < index2;
-    });
+    std::stable_sort(parts.begin(), parts.end(), comparator);
 }
 
 void LayoutPanelTreeModel::setLayoutPanelVisible(bool visible)
@@ -661,7 +652,6 @@ void LayoutPanelTreeModel::endActiveDrag()
     setLoadingBlocked(false);
 
     updateSystemObjectLayers();
-    initPartOrders();
 }
 
 void LayoutPanelTreeModel::changeVisibilityOfSelectedRows(bool visible)
@@ -991,7 +981,7 @@ void LayoutPanelTreeModel::updateIsAddingSystemMarkingsAvailable()
 {
     bool addingSysMarkAvailable = false;
 
-    if (!isAddingAvailable() || !m_notation->isMaster()) {
+    if (!isAddingAvailable() || !isMasterScore()) {
         addingSysMarkAvailable = false;
     } else {
         int systemLayerCount = 0;

--- a/src/instrumentsscene/view/layoutpaneltreemodel.h
+++ b/src/instrumentsscene/view/layoutpaneltreemodel.h
@@ -135,13 +135,14 @@ private:
     void onMasterNotationChanged();
     void onNotationChanged();
 
+    bool isMasterScore() const;
+
     bool shouldShowSystemObjectLayers() const;
 
-    void initPartOrders();
     void onBeforeChangeNotation();
     void setLoadingBlocked(bool blocked);
 
-    void sortParts(notation::PartList& parts);
+    static void sortParts(notation::PartList& parts, notation::PartList& referenceParts);
 
     void setupPartsConnections();
     void setupStavesConnections(const muse::ID& partId);
@@ -189,7 +190,6 @@ private:
     std::shared_ptr<muse::async::Asyncable> m_partsNotifyReceiver = nullptr;
 
     using NotationKey = QString;
-    QHash<NotationKey, QList<muse::ID> > m_sortedPartIdList;
 
     bool m_layoutPanelVisible = true;
     bool m_scoreChanged = false;


### PR DESCRIPTION
Resolves: #27056

`LayoutPanelTreeModel` receives masterParts that are already sorted as they are in score. So there is no need to try to reorder them based on some other criteria. 

(Though I'm not completely sure about it, so please let me know if I've missed something)

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
