### PR TITLE
fixed #29553: 4.5.2 -> 4.6.0 update: Handbells/Layout palettes are not updated properly

### DIFF
--- a/src/palette/internal/palettecell.cpp
+++ b/src/palette/internal/palettecell.cpp
@@ -239,23 +239,26 @@ bool PaletteCell::read(XmlReader& e, bool pasteMode)
                 e.unknown();
             } else {
                 rw::RWRegister::reader()->readItem(element.get(), e);
-                PaletteCompat::migrateOldPaletteItemIfNeeded(element, gpaletteScore);
-                element->styleChanged();
-
-                if (element->type() == ElementType::ACTION_ICON) {
-                    ActionIcon* icon = toActionIcon(element.get());
-                    const muse::ui::UiAction& action = actionsRegister()->action(icon->actionCode());
-                    if (action.isValid()) {
-                        icon->setAction(icon->actionCode(), static_cast<char16_t>(action.iconCode));
-                    } else {
-                        add = false;
-                    }
-                }
             }
         }
     }
 
     setElementTranslated(translateElement);
+
+    if (element) {
+        PaletteCompat::migrateOldPaletteCellIfNeeded(this, gpaletteScore);
+        element->styleChanged();
+
+        if (element->type() == ElementType::ACTION_ICON) {
+            ActionIcon* icon = toActionIcon(element.get());
+            const muse::ui::UiAction& action = actionsRegister()->action(icon->actionCode());
+            if (action.isValid()) {
+                icon->setAction(icon->actionCode(), static_cast<char16_t>(action.iconCode));
+            } else {
+                add = false;
+            }
+        }
+    }
 
     return add && element;
 }

--- a/src/palette/internal/palettecompat.cpp
+++ b/src/palette/internal/palettecompat.cpp
@@ -195,6 +195,11 @@ void PaletteCompat::addNewItemsIfNeeded(Palette& palette, Score* paletteScore)
         addNewRepeatItems(palette, paletteScore);
         return;
     }
+
+    if (palette.type() == Palette::Type::Layout) {
+        addNewLayoutItems(palette);
+        return;
+    }
 }
 
 void PaletteCompat::removeOldItemsIfNeeded(Palette& palette)
@@ -281,8 +286,7 @@ void PaletteCompat::addNewGuitarItems(Palette& guitarPalette, Score* paletteScor
     }
 
     if (!containsFFrame) {
-        static const qreal FRAME_MAG = 1.25;
-        guitarPalette.appendActionIcon(ActionIconType::FFRAME, "insert-fretframe", FRAME_MAG);
+        guitarPalette.appendActionIcon(ActionIconType::FFRAME, "insert-fretframe", COMPAT_FRAME_MAG);
     }
 }
 
@@ -348,6 +352,26 @@ void PaletteCompat::addNewRepeatItems(Palette& repeatPalette, engraving::Score* 
         marker->setMarkerType(MarkerType::TOCODASYM);
         marker->styleChanged();
         repeatPalette.insertElement(5, marker, TConv::userName(MarkerType::TOCODASYM));
+    }
+}
+
+void PaletteCompat::addNewLayoutItems(Palette& layoutPalette)
+{
+    bool containsFFrame = false;
+    for (const PaletteCellPtr& cell : layoutPalette.cells()) {
+        const ElementPtr element = cell->element;
+        if (!element) {
+            continue;
+        }
+
+        if (element->isActionIcon() && toActionIcon(element.get())->actionType() == ActionIconType::FFRAME) {
+            containsFFrame = true;
+        }
+    }
+
+    if (!containsFFrame) {
+        int defaultPosition = std::min(10, layoutPalette.cellsCount());
+        layoutPalette.insertActionIcon(defaultPosition, ActionIconType::FFRAME, "insert-fretframe", COMPAT_FRAME_MAG);
     }
 }
 

--- a/src/palette/internal/palettecompat.cpp
+++ b/src/palette/internal/palettecompat.cpp
@@ -52,11 +52,20 @@
 using namespace mu::palette;
 using namespace mu::engraving;
 
+static const qreal COMPAT_FRAME_MAG = 1.25;
+
 static const std::unordered_set<ActionIconType> BENDS_ACTION_TYPES = {
     ActionIconType::STANDARD_BEND,
     ActionIconType::PRE_BEND,
     ActionIconType::GRACE_NOTE_BEND,
     ActionIconType::SLIGHT_BEND
+};
+
+static const std::unordered_set<ActionIconType> BOXES_ACTION_TYPES = {
+    ActionIconType::VFRAME,
+    ActionIconType::HFRAME,
+    ActionIconType::TFRAME,
+    ActionIconType::FFRAME
 };
 
 static const std::unordered_map<String, String> FRET_DIAGRAMS_MIGRATION_MAP = {
@@ -89,9 +98,9 @@ static const std::unordered_map<String, String> FRET_DIAGRAMS_MIGRATION_MAP = {
     { u"X[2-O][1-O][2-O]O[2-O]", u"B7" }
 };
 
-void PaletteCompat::migrateOldPaletteItemIfNeeded(ElementPtr& element, Score* paletteScore)
+void PaletteCompat::migrateOldPaletteCellIfNeeded(PaletteCell* cell, Score* paletteScore)
 {
-    EngravingItem* item = element.get();
+    EngravingItem* item = cell->element.get();
 
     if (item->isArticulation()) {
         const std::set<SymId>& ornamentIds = compat::CompatUtils::ORNAMENT_IDS;
@@ -104,7 +113,7 @@ void PaletteCompat::migrateOldPaletteItemIfNeeded(ElementPtr& element, Score* pa
         Articulation* oldOrnament = toArticulation(item);
         Ornament* newOrnament = Factory::createOrnament((ChordRest*)(paletteScore->dummy()->chord()));
         newOrnament->setSymId(oldOrnament->symId());
-        element.reset(newOrnament);
+        cell->element.reset(newOrnament);
         return;
     }
 
@@ -116,7 +125,7 @@ void PaletteCompat::migrateOldPaletteItemIfNeeded(ElementPtr& element, Score* pa
         } else {
             newExpression->setXmlText(oldExpression->xmlText());
         }
-        element.reset(newExpression);
+        cell->element.reset(newExpression);
         return;
     }
 
@@ -133,7 +142,7 @@ void PaletteCompat::migrateOldPaletteItemIfNeeded(ElementPtr& element, Score* pa
         newPedal->setContinueText(newPedal->propertyDefault(Pid::CONTINUE_TEXT).value<String>());
         newPedal->setEndText(newPedal->propertyDefault(Pid::END_TEXT).value<String>());
 
-        element.reset(newPedal);
+        cell->element.reset(newPedal);
         return;
     }
 
@@ -156,8 +165,12 @@ void PaletteCompat::migrateOldPaletteItemIfNeeded(ElementPtr& element, Score* pa
             newFretDiagram->updateDiagram(harmonyName);
         }
 
-        element.reset(newFretDiagram);
+        cell->element.reset(newFretDiagram);
         return;
+    }
+
+    if (item->isActionIcon() && muse::contains(BOXES_ACTION_TYPES, toActionIcon(item)->actionType())) {
+        cell->mag = COMPAT_FRAME_MAG;
     }
 }
 

--- a/src/palette/internal/palettecompat.h
+++ b/src/palette/internal/palettecompat.h
@@ -21,14 +21,15 @@
  */
 #pragma once
 
-#include "engraving/dom/engravingitem.h"
+#include "engraving/dom/score.h"
+#include "palettecell.h"
 
 namespace mu::palette {
 class Palette;
 class PaletteCompat
 {
 public:
-    static void migrateOldPaletteItemIfNeeded(engraving::ElementPtr& element, engraving::Score* paletteScore);
+    static void migrateOldPaletteCellIfNeeded(PaletteCell* cell, engraving::Score* paletteScore);
     static void addNewItemsIfNeeded(Palette& palette, engraving::Score* paletteScore);
     static void removeOldItemsIfNeeded(Palette& palette);
 

--- a/src/palette/internal/palettecompat.h
+++ b/src/palette/internal/palettecompat.h
@@ -38,6 +38,7 @@ private:
     static void addNewLineItems(Palette& linesPalette);
     static void addNewFretboardDiagramItems(Palette& fretboardDiagramPalette, engraving::Score* paletteScore);
     static void addNewRepeatItems(Palette& repeatPalette, engraving::Score* paletteScore);
+    static void addNewLayoutItems(Palette& layoutPalette);
     static void removeOldItems(Palette& palette);
 };
 }

--- a/src/palette/internal/paletteprovider.cpp
+++ b/src/palette/internal/paletteprovider.cpp
@@ -823,7 +823,13 @@ bool PaletteProvider::addPalette(const QPersistentModelIndex& index)
 
     if (index.model() == m_masterPaletteModel) {
         QMimeData* data = m_masterPaletteModel->mimeData({ QModelIndex(index) });
-        const bool success = m_userPaletteModel->dropMimeData(data, Qt::CopyAction, 0, 0, QModelIndex());
+        QModelIndex dropIndex = m_userPaletteModel->index(0, 0);
+
+        const bool success = m_userPaletteModel->dropMimeData(data, Qt::CopyAction, dropIndex.row(), dropIndex.column(), QModelIndex());
+        if (success) {
+            m_userPaletteModel->setData(dropIndex, true, PaletteTreeModel::VisibleRole);
+        }
+
         data->deleteLater();
         return success;
     }


### PR DESCRIPTION
Resolves: #29553

Except 
> Handbells palette
> The palette doesn't appear in default state (all icons shown). Can be fixed by Reset.