### PR TITLE
Fix #29880 font size of 1 after save if size is changed in part of text

### DIFF
--- a/src/engraving/dom/textbase.h
+++ b/src/engraving/dom/textbase.h
@@ -99,7 +99,7 @@ public:
     double fontSize() const { return m_fontSize; }
     String fontFamily() const { return m_fontFamily; }
     void setValign(VerticalAlignment val) { m_valign = val; }
-    void setFontSize(double val) { m_fontSize = muse::RealIsEqualOrLess(val, 0.0) ? 1.0 : val; } // Font Size 0 will cause a crash
+    void setFontSize(double val) { m_fontSize = val; }
     void setFontFamily(const String& val) { m_fontFamily = val; }
 
     FormatValue formatValue(FormatId) const;


### PR DESCRIPTION
Resolves: #29880

Note: the problem is not limited to lyrics. Any text with a part of it set to a different size will become 1pt size after save/reload. The issue was introduced in https://github.com/musescore/MuseScore/pull/28890.