### PR TITLE
[4.6.0] Fix #29908: Playback position doesn't change after selecting Key signatures or Time signatures 

### DIFF
--- a/src/notation/tests/notationviewinputcontroller_tests.cpp
+++ b/src/notation/tests/notationviewinputcontroller_tests.cpp
@@ -344,7 +344,7 @@ TEST_F(NotationViewInputControllerTests, Mouse_Press_Range_Start_Drag_From_Selec
  * @details User pressed left mouse button on already selected text element
  *          We should change text cursor position
  */
-TEST_F(NotationViewInputControllerTests, DISABLED_Mouse_Press_On_Selected_Text_Element)
+TEST_F(NotationViewInputControllerTests, Mouse_Press_On_Selected_Text_Element)
 {
     //! [GIVEN] There is a test score
     engraving::MasterScore* score = engraving::ScoreRW::readScore(TEST_SCORE_PATH);
@@ -370,11 +370,6 @@ TEST_F(NotationViewInputControllerTests, DISABLED_Mouse_Press_On_Selected_Text_E
     EXPECT_CALL(*m_interaction, setHitElementContext(newContext))
     .Times(1);
 
-    EXPECT_CALL(*m_interaction, hitElementContext())
-    .Times(2)
-    .WillOnce(ReturnRef(oldContext))
-    .WillOnce(ReturnRef(newContext));
-
     //! [GIVEN] There isn't a range selection
     ON_CALL(*m_selection, isRange())
     .WillByDefault(Return(false));
@@ -386,8 +381,8 @@ TEST_F(NotationViewInputControllerTests, DISABLED_Mouse_Press_On_Selected_Text_E
     EXPECT_CALL(m_view, isNoteEnterMode())
     .WillOnce(Return(false));
 
-    EXPECT_CALL(*m_playbackController, isPlaying())
-    .WillOnce(Return(false));
+    ON_CALL(*m_playbackController, isPlaying())
+    .WillByDefault(Return(false));
 
     //! [THEN] We will seek and play selected dynamic, but no select again
     EXPECT_CALL(*m_playbackController, seekElement(newContext.element, FLUSH_SOUND))

--- a/src/notation/tests/notationviewinputcontroller_tests.cpp
+++ b/src/notation/tests/notationviewinputcontroller_tests.cpp
@@ -453,9 +453,6 @@ TEST_F(NotationViewInputControllerTests, Mouse_Press_On_Selected_Non_Text_Elemen
     ON_CALL(*m_selection, elements())
     .WillByDefault(ReturnRef(selectedElements));
 
-    ON_CALL(*m_selection, element())
-    .WillByDefault(Return(selectedElements.front()));
-
     //! [GIVEN] No note enter mode, no playing
     EXPECT_CALL(m_view, isNoteEnterMode())
     .WillOnce(Return(false));
@@ -681,9 +678,6 @@ TEST_F(NotationViewInputControllerTests, Mouse_Press_On_Already_Selected_Element
 
     EXPECT_CALL(*m_interaction, setHitElementContext(newContext))
     .Times(1);
-
-    ON_CALL(*m_selection, element())
-    .WillByDefault(Return(oldContext.element));
 
     std::vector<EngravingItem*> selectedElements = { oldContext.element };
     ON_CALL(*m_selection, elements())

--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -1666,14 +1666,16 @@ EngravingItem* NotationViewInputController::resolveStartPlayableElement() const
         return seekAllowed(hitElement) ? hitElement : nullptr;
     }
 
-    INotationSelectionPtr selection = viewInteraction()->selection();
-    if (!selection->isRange()) {
-        return selection->element();
+    const INotationSelectionPtr selection = viewInteraction()->selection();
+    const std::vector<EngravingItem*>& elements = selection->elements();
+
+    if (!selection->isRange() && !elements.empty()) {
+        return elements.back();
     }
 
     EngravingItem* playbackStartElement = hitElementContext().element;
 
-    for (EngravingItem* element: selection->elements()) {
+    for (EngravingItem* element: elements) {
         if (!element || element == playbackStartElement) {
             continue;
         }


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/29908

Caused by: https://github.com/musescore/MuseScore/pull/28849