### PR TITLE
Don't close PopupView when color picker window is opened

### DIFF
--- a/src/framework/uicomponents/view/internal/popupviewclosecontroller.cpp
+++ b/src/framework/uicomponents/view/internal/popupviewclosecontroller.cpp
@@ -125,6 +125,11 @@ void PopupViewCloseController::onApplicationStateChanged(Qt::ApplicationState st
         return;
     }
 
+    // Hack for https://github.com/musescore/MuseScore/issues/29656 on Linux
+    if (interactiveProvider()->isSelectColorOpened()) {
+        return;
+    }
+
     if (state != Qt::ApplicationActive) {
         notifyAboutClose();
     }
@@ -183,6 +188,11 @@ bool PopupViewCloseController::isMouseWithinBoundaries(const QPointF& mousePos) 
         if (childRect.contains(mousePos)) {
             return true;
         }
+    }
+
+    // Hack for https://github.com/musescore/MuseScore/issues/29656
+    if (interactiveProvider()->isSelectColorOpened()) {
+        return true;
     }
 
     return false;


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/29656

This is a bit of a hack, by lack of any better idea.