### PR TITLE
Correct/simplify fret diagram autoplace logic

### DIFF
--- a/src/engraving/rendering/score/autoplace.cpp
+++ b/src/engraving/rendering/score/autoplace.cpp
@@ -405,18 +405,16 @@ bool Autoplace::itemsShouldIgnoreEachOther(const EngravingItem* itemToAutoplace,
         return type2 != ElementType::KEYSIG;
     }
 
-    if (type1 == ElementType::FRET_DIAGRAM && type2 == ElementType::HARMONY) {
-        const Harmony* h = toHarmony(itemInSkyline);
-        return itemToAutoplace->parent() != h->getParentSeg();
+    if (type1 == ElementType::FRET_DIAGRAM && (type2 == ElementType::FRET_DIAGRAM || type2 == ElementType::HARMONY)) {
+        bool isFretDiagAgainstItsOwnHarmony = itemInSkyline->parentItem() == itemToAutoplace;
+        bool areOnDifferentSegments = itemToAutoplace->findAncestor(ElementType::SEGMENT)
+                                      != itemInSkyline->findAncestor(ElementType::SEGMENT);
+        return isFretDiagAgainstItsOwnHarmony || areOnDifferentSegments;
     }
 
     if ((type1 == ElementType::DYNAMIC || type1 == ElementType::HAIRPIN_SEGMENT)
         && (type2 == ElementType::DYNAMIC || type2 == ElementType::HAIRPIN_SEGMENT)) {
         return true;
-    }
-
-    if (type1 == type2 && type1 == ElementType::FRET_DIAGRAM) {
-        return itemToAutoplace->parent() != itemInSkyline->parent();
     }
 
     if (type1 == type2) {


### PR DESCRIPTION
Resolves: #29894

I should add that the problem is not persistent (fixes itself after relayout) and that it can happen exclusively on the second system. Still, it did point out to some inconsistency in how we deal with fret diagrams in the skyline.

Side notes / things to do later:

- There's a layout call being made even though the element hasn't actually been dropped on the score. We can probably optimize that and remove it.
- Because nothing has changed in the score, the layout range is null (start tick and end tick are both zero), but the first system still gets laid out. This probably should also be optimized.