### PR TITLE
Fix #27709: proper sync of selections in score and layout panel

### DIFF
--- a/src/instrumentsscene/view/layoutpaneltreemodel.h
+++ b/src/instrumentsscene/view/layoutpaneltreemodel.h
@@ -147,6 +147,7 @@ private:
 
     void updateSelectedRows();
     void onScoreChanged(const mu::engraving::ScoreChanges& changes = {});
+    void updateScoreSelection() const;
 
     void clear();
     void deleteItems();
@@ -199,5 +200,7 @@ private:
     MoveParams m_activeDragMoveParams;
 
     muse::ID m_systemStaffToSelect;
+
+    bool m_blockSelectionChangedEvents = false;
 };
 }


### PR DESCRIPTION


Resolves: #27709

When choosing row in layout panel, check if selection matches the one that's currently in the score. If it doesn't match - clear selection of the one in score without propagating that change back to layout panel


- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
