### PR TITLE
Fix tuplet crash

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -7265,11 +7265,11 @@ Note* MusicXmlParserPass2::note(const String& partId,
                     // create a new tuplet
                     handleTupletStart(cr, tuplet, actualNotes, normalNotes, notations.tupletDesc());
                 }
-                if (tupletAction & MusicXmlTupletFlag::ADD_CHORD) {
+                if (tuplet && tupletAction & MusicXmlTupletFlag::ADD_CHORD) {
                     cr->setTuplet(tuplet);
                     tuplet->add(cr);
                 }
-                if (tupletAction & MusicXmlTupletFlag::STOP_CURRENT) {
+                if (tuplet && tupletAction & MusicXmlTupletFlag::STOP_CURRENT) {
                     if (missingCurr.isValid() && missingCurr > Fraction(0, 1)) {
                         LOGD("add missing %s to current tuplet", muPrintable(missingCurr.toString()));
                         const int track = msTrack + msVoice;


### PR DESCRIPTION
Resolves: #29921 

The crash is caused by a nested tuplet. MuseScore's MusicXML import does not support these and never has (see https://github.com/musescore/MuseScore/issues/22671). This PR prevents the crash, though the resulting file will be corrupted. At least there is then a chance of tidying it up.
