### PR TITLE
Fix resource lock bug in ShortcutsRegister

### DIFF
--- a/src/appshell_web/internal/appshellconfiguration.cpp
+++ b/src/appshell_web/internal/appshellconfiguration.cpp
@@ -21,19 +21,8 @@
  */
 #include "appshellconfiguration.h"
 
-#include <QJsonArray>
-#include <QJsonDocument>
-
-#include "settings.h"
-
-#include "multiinstances/resourcelockguard.h"
-
-#include "log.h"
-
 using namespace muse;
-using namespace mu;
 using namespace mu::appshell;
-using namespace mu::notation;
 
 static const std::string module_name("appshell");
 

--- a/src/framework/shortcuts/internal/shortcutsregister.cpp
+++ b/src/framework/shortcuts/internal/shortcutsregister.cpp
@@ -82,7 +82,7 @@ void ShortcutsRegister::reload(bool onlyDef)
 
         if (!onlyDef) {
             //! NOTE The user shortcut file may change, so we need to lock it
-            mi::ReadResourceLockGuard(multiInstancesProvider(), SHORTCUTS_RESOURCE_NAME);
+            mi::ReadResourceLockGuard guard(multiInstancesProvider(), SHORTCUTS_RESOURCE_NAME);
             ok = readFromFile(m_shortcuts, userPath);
         } else {
             ok = false;
@@ -331,7 +331,7 @@ Ret ShortcutsRegister::setShortcuts(const ShortcutList& shortcuts)
 
 void ShortcutsRegister::resetShortcuts()
 {
-    mi::WriteResourceLockGuard(multiInstancesProvider(), SHORTCUTS_RESOURCE_NAME);
+    mi::WriteResourceLockGuard guard(multiInstancesProvider(), SHORTCUTS_RESOURCE_NAME);
     fileSystem()->remove(configuration()->shortcutsUserAppDataPath());
 
     reload();
@@ -341,7 +341,7 @@ bool ShortcutsRegister::writeToFile(const ShortcutList& shortcuts, const io::pat
 {
     TRACEFUNC;
 
-    mi::WriteResourceLockGuard(multiInstancesProvider(), SHORTCUTS_RESOURCE_NAME);
+    mi::WriteResourceLockGuard guard(multiInstancesProvider(), SHORTCUTS_RESOURCE_NAME);
 
     deprecated::XmlWriter writer(path);
 
@@ -424,7 +424,7 @@ ShortcutList ShortcutsRegister::shortcutsForSequence(const std::string& sequence
 
 Ret ShortcutsRegister::importFromFile(const io::path_t& filePath)
 {
-    mi::ReadResourceLockGuard(multiInstancesProvider(), SHORTCUTS_RESOURCE_NAME);
+    mi::ReadResourceLockGuard guard(multiInstancesProvider(), SHORTCUTS_RESOURCE_NAME);
 
     Ret ret = fileSystem()->copy(filePath, configuration()->shortcutsUserAppDataPath(), true);
     if (!ret) {


### PR DESCRIPTION
Clangd warning:

> Object destroyed immediately after creation; did you mean to name the object?