### PR TITLE
fix #29955: [TablEdit import] set instrument ID

### DIFF
--- a/src/importexport/tabledit/internal/importtef.cpp
+++ b/src/importexport/tabledit/internal/importtef.cpp
@@ -560,6 +560,15 @@ void TablEdit::createRepeats()
     }
 }
 
+static void setInstrumentIDs(const std::vector<Part*>& parts)
+{
+    for (Part* part : parts) {
+        for (const auto& pair : part->instruments()) {
+            pair.second->updateInstrumentId();
+        }
+    }
+}
+
 void TablEdit::createScore()
 {
     createProperties();
@@ -571,6 +580,7 @@ void TablEdit::createScore()
     createRepeats();
     createTexts();
     createLinkedTabs();
+    setInstrumentIDs(score->parts());
 }
 
 void TablEdit::createTempo()

--- a/src/importexport/tabledit/tests/data/bass.mscx
+++ b/src/importexport/tabledit/tests/data/bass.mscx
@@ -56,9 +56,10 @@
           </StaffType>
         </Staff>
       <trackName>Bass</trackName>
-      <Instrument>
+      <Instrument id="bass">
         <longName>Bass</longName>
         <trackName></trackName>
+        <instrumentId>voice.bass</instrumentId>
         <StringData>
           <frets>25</frets>
           <string>28</string>

--- a/src/importexport/tabledit/tests/data/chord_C_D.mscx
+++ b/src/importexport/tabledit/tests/data/chord_C_D.mscx
@@ -55,9 +55,10 @@
           </StaffType>
         </Staff>
       <trackName>Guitar Standard</trackName>
-      <Instrument>
+      <Instrument id="cavaquinho">
         <longName>Guitar Standard</longName>
         <trackName></trackName>
+        <instrumentId>pluck.guitar</instrumentId>
         <StringData>
           <frets>25</frets>
           <string>40</string>

--- a/src/importexport/tabledit/tests/data/dynamic.mscx
+++ b/src/importexport/tabledit/tests/data/dynamic.mscx
@@ -56,9 +56,10 @@
           </StaffType>
         </Staff>
       <trackName>Guitar Standard</trackName>
-      <Instrument>
+      <Instrument id="cavaquinho">
         <longName>Guitar Standard</longName>
         <trackName></trackName>
+        <instrumentId>pluck.guitar</instrumentId>
         <StringData>
           <frets>25</frets>
           <string>40</string>

--- a/src/importexport/tabledit/tests/data/grace_1.mscx
+++ b/src/importexport/tabledit/tests/data/grace_1.mscx
@@ -56,9 +56,10 @@
           </StaffType>
         </Staff>
       <trackName>Guitar Standard</trackName>
-      <Instrument>
+      <Instrument id="cavaquinho">
         <longName>Guitar Standard</longName>
         <trackName></trackName>
+        <instrumentId>pluck.guitar</instrumentId>
         <StringData>
           <frets>25</frets>
           <string>40</string>

--- a/src/importexport/tabledit/tests/data/guitar.mscx
+++ b/src/importexport/tabledit/tests/data/guitar.mscx
@@ -56,9 +56,10 @@
           </StaffType>
         </Staff>
       <trackName>Guitar Standard</trackName>
-      <Instrument>
+      <Instrument id="cavaquinho">
         <longName>Guitar Standard</longName>
         <trackName></trackName>
+        <instrumentId>pluck.guitar</instrumentId>
         <StringData>
           <frets>25</frets>
           <string>40</string>

--- a/src/importexport/tabledit/tests/data/guitar_bass.mscx
+++ b/src/importexport/tabledit/tests/data/guitar_bass.mscx
@@ -55,9 +55,10 @@
           </StaffType>
         </Staff>
       <trackName>Guitar Standard</trackName>
-      <Instrument>
+      <Instrument id="cavaquinho">
         <longName>Guitar Standard</longName>
         <trackName></trackName>
+        <instrumentId>pluck.guitar</instrumentId>
         <StringData>
           <frets>25</frets>
           <string>40</string>
@@ -108,9 +109,10 @@
           </StaffType>
         </Staff>
       <trackName>Acoustic Bass</trackName>
-      <Instrument>
+      <Instrument id="acoustic-bass">
         <longName>Acoustic Bass</longName>
         <trackName></trackName>
+        <instrumentId>pluck.bass.acoustic</instrumentId>
         <StringData>
           <frets>25</frets>
           <string>28</string>

--- a/src/importexport/tabledit/tests/data/guitar_drop_D.mscx
+++ b/src/importexport/tabledit/tests/data/guitar_drop_D.mscx
@@ -56,9 +56,10 @@
           </StaffType>
         </Staff>
       <trackName>Guitar Standard</trackName>
-      <Instrument>
+      <Instrument id="cavaquinho">
         <longName>Guitar Standard</longName>
         <trackName></trackName>
+        <instrumentId>pluck.guitar</instrumentId>
         <StringData>
           <frets>25</frets>
           <string>38</string>

--- a/src/importexport/tabledit/tests/data/guitar_new_standard_tuning.mscx
+++ b/src/importexport/tabledit/tests/data/guitar_new_standard_tuning.mscx
@@ -56,9 +56,10 @@
           </StaffType>
         </Staff>
       <trackName>Guitar Standard</trackName>
-      <Instrument>
+      <Instrument id="cavaquinho">
         <longName>Guitar Standard</longName>
         <trackName></trackName>
+        <instrumentId>pluck.guitar</instrumentId>
         <StringData>
           <frets>25</frets>
           <string>36</string>

--- a/src/importexport/tabledit/tests/data/key_signatures.mscx
+++ b/src/importexport/tabledit/tests/data/key_signatures.mscx
@@ -56,9 +56,10 @@
           </StaffType>
         </Staff>
       <trackName>Guitar Standard</trackName>
-      <Instrument>
+      <Instrument id="cavaquinho">
         <longName>Guitar Standard</longName>
         <trackName></trackName>
+        <instrumentId>pluck.guitar</instrumentId>
         <StringData>
           <frets>25</frets>
           <string>40</string>

--- a/src/importexport/tabledit/tests/data/key_signatures_2.mscx
+++ b/src/importexport/tabledit/tests/data/key_signatures_2.mscx
@@ -56,9 +56,10 @@
           </StaffType>
         </Staff>
       <trackName>Guitar Standard</trackName>
-      <Instrument>
+      <Instrument id="cavaquinho">
         <longName>Guitar Standard</longName>
         <trackName></trackName>
+        <instrumentId>pluck.guitar</instrumentId>
         <StringData>
           <frets>25</frets>
           <string>40</string>
@@ -109,9 +110,10 @@
           </StaffType>
         </Staff>
       <trackName>Acoustic Guitar (steel)</trackName>
-      <Instrument>
+      <Instrument id="cavaquinho">
         <longName>Acoustic Guitar (steel)</longName>
         <trackName></trackName>
+        <instrumentId>pluck.guitar</instrumentId>
         <StringData>
           <frets>25</frets>
           <string>40</string>

--- a/src/importexport/tabledit/tests/data/metadata.mscx
+++ b/src/importexport/tabledit/tests/data/metadata.mscx
@@ -57,9 +57,10 @@
           </StaffType>
         </Staff>
       <trackName>Acoustic Guitar (steel)</trackName>
-      <Instrument>
+      <Instrument id="cavaquinho">
         <longName>Acoustic Guitar (steel)</longName>
         <trackName></trackName>
+        <instrumentId>pluck.guitar</instrumentId>
         <StringData>
           <frets>25</frets>
           <string>40</string>

--- a/src/importexport/tabledit/tests/data/multi_track_rests.mscx
+++ b/src/importexport/tabledit/tests/data/multi_track_rests.mscx
@@ -55,9 +55,10 @@
           </StaffType>
         </Staff>
       <trackName>Guitar Standard</trackName>
-      <Instrument>
+      <Instrument id="cavaquinho">
         <longName>Guitar Standard</longName>
         <trackName></trackName>
+        <instrumentId>pluck.guitar</instrumentId>
         <StringData>
           <frets>25</frets>
           <string>40</string>
@@ -108,9 +109,10 @@
           </StaffType>
         </Staff>
       <trackName>Acoustic Bass</trackName>
-      <Instrument>
+      <Instrument id="acoustic-bass">
         <longName>Acoustic Bass</longName>
         <trackName></trackName>
+        <instrumentId>pluck.bass.acoustic</instrumentId>
         <StringData>
           <frets>25</frets>
           <string>28</string>

--- a/src/importexport/tabledit/tests/data/notes_dotted.mscx
+++ b/src/importexport/tabledit/tests/data/notes_dotted.mscx
@@ -56,9 +56,10 @@
           </StaffType>
         </Staff>
       <trackName>Guitar Standard</trackName>
-      <Instrument>
+      <Instrument id="cavaquinho">
         <longName>Guitar Standard</longName>
         <trackName></trackName>
+        <instrumentId>pluck.guitar</instrumentId>
         <StringData>
           <frets>25</frets>
           <string>40</string>

--- a/src/importexport/tabledit/tests/data/notes_normal.mscx
+++ b/src/importexport/tabledit/tests/data/notes_normal.mscx
@@ -56,9 +56,10 @@
           </StaffType>
         </Staff>
       <trackName>Guitar Standard</trackName>
-      <Instrument>
+      <Instrument id="cavaquinho">
         <longName>Guitar Standard</longName>
         <trackName></trackName>
+        <instrumentId>pluck.guitar</instrumentId>
         <StringData>
           <frets>25</frets>
           <string>40</string>

--- a/src/importexport/tabledit/tests/data/positions.mscx
+++ b/src/importexport/tabledit/tests/data/positions.mscx
@@ -56,9 +56,10 @@
           </StaffType>
         </Staff>
       <trackName>Guitar Standard</trackName>
-      <Instrument>
+      <Instrument id="cavaquinho">
         <longName>Guitar Standard</longName>
         <trackName></trackName>
+        <instrumentId>pluck.guitar</instrumentId>
         <StringData>
           <frets>25</frets>
           <string>40</string>

--- a/src/importexport/tabledit/tests/data/reading_list_1.mscx
+++ b/src/importexport/tabledit/tests/data/reading_list_1.mscx
@@ -56,9 +56,10 @@
           </StaffType>
         </Staff>
       <trackName>Guitar Standard</trackName>
-      <Instrument>
+      <Instrument id="cavaquinho">
         <longName>Guitar Standard</longName>
         <trackName></trackName>
+        <instrumentId>pluck.guitar</instrumentId>
         <StringData>
           <frets>25</frets>
           <string>40</string>

--- a/src/importexport/tabledit/tests/data/rests_dotted.mscx
+++ b/src/importexport/tabledit/tests/data/rests_dotted.mscx
@@ -56,9 +56,10 @@
           </StaffType>
         </Staff>
       <trackName>Guitar Standard</trackName>
-      <Instrument>
+      <Instrument id="cavaquinho">
         <longName>Guitar Standard</longName>
         <trackName></trackName>
+        <instrumentId>pluck.guitar</instrumentId>
         <StringData>
           <frets>25</frets>
           <string>40</string>

--- a/src/importexport/tabledit/tests/data/rests_normal.mscx
+++ b/src/importexport/tabledit/tests/data/rests_normal.mscx
@@ -56,9 +56,10 @@
           </StaffType>
         </Staff>
       <trackName>Guitar Standard</trackName>
-      <Instrument>
+      <Instrument id="cavaquinho">
         <longName>Guitar Standard</longName>
         <trackName></trackName>
+        <instrumentId>pluck.guitar</instrumentId>
         <StringData>
           <frets>25</frets>
           <string>40</string>

--- a/src/importexport/tabledit/tests/data/staff_text_1.mscx
+++ b/src/importexport/tabledit/tests/data/staff_text_1.mscx
@@ -56,9 +56,10 @@
           </StaffType>
         </Staff>
       <trackName>Acoustic Guitar (steel)</trackName>
-      <Instrument>
+      <Instrument id="cavaquinho">
         <longName>Acoustic Guitar (steel)</longName>
         <trackName></trackName>
+        <instrumentId>pluck.guitar</instrumentId>
         <StringData>
           <frets>25</frets>
           <string>40</string>

--- a/src/importexport/tabledit/tests/data/staff_text_2.mscx
+++ b/src/importexport/tabledit/tests/data/staff_text_2.mscx
@@ -56,9 +56,10 @@
           </StaffType>
         </Staff>
       <trackName>Acoustic Guitar (steel)</trackName>
-      <Instrument>
+      <Instrument id="cavaquinho">
         <longName>Acoustic Guitar (steel)</longName>
         <trackName></trackName>
+        <instrumentId>pluck.guitar</instrumentId>
         <StringData>
           <frets>25</frets>
           <string>40</string>
@@ -109,9 +110,10 @@
           </StaffType>
         </Staff>
       <trackName>Bass guitar</trackName>
-      <Instrument>
+      <Instrument id="bass-guitar">
         <longName>Bass guitar</longName>
         <trackName></trackName>
+        <instrumentId>pluck.bass</instrumentId>
         <StringData>
           <frets>25</frets>
           <string>50</string>

--- a/src/importexport/tabledit/tests/data/tie_1.mscx
+++ b/src/importexport/tabledit/tests/data/tie_1.mscx
@@ -56,8 +56,9 @@
           </StaffType>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="cavaquinho">
         <trackName></trackName>
+        <instrumentId>pluck.guitar</instrumentId>
         <StringData>
           <frets>25</frets>
           <string>40</string>

--- a/src/importexport/tabledit/tests/data/tie_2.mscx
+++ b/src/importexport/tabledit/tests/data/tie_2.mscx
@@ -56,8 +56,9 @@
           </StaffType>
         </Staff>
       <trackName></trackName>
-      <Instrument>
+      <Instrument id="cavaquinho">
         <trackName></trackName>
+        <instrumentId>pluck.guitar</instrumentId>
         <StringData>
           <frets>25</frets>
           <string>40</string>

--- a/src/importexport/tabledit/tests/data/time_signatures.mscx
+++ b/src/importexport/tabledit/tests/data/time_signatures.mscx
@@ -56,9 +56,10 @@
           </StaffType>
         </Staff>
       <trackName>Guitar Standard</trackName>
-      <Instrument>
+      <Instrument id="cavaquinho">
         <longName>Guitar Standard</longName>
         <trackName></trackName>
+        <instrumentId>pluck.guitar</instrumentId>
         <StringData>
           <frets>25</frets>
           <string>40</string>

--- a/src/importexport/tabledit/tests/data/time_signatures_2.mscx
+++ b/src/importexport/tabledit/tests/data/time_signatures_2.mscx
@@ -56,9 +56,10 @@
           </StaffType>
         </Staff>
       <trackName>Guitar Standard</trackName>
-      <Instrument>
+      <Instrument id="cavaquinho">
         <longName>Guitar Standard</longName>
         <trackName></trackName>
+        <instrumentId>pluck.guitar</instrumentId>
         <StringData>
           <frets>25</frets>
           <string>40</string>
@@ -109,9 +110,10 @@
           </StaffType>
         </Staff>
       <trackName>Acoustic Guitar (steel)</trackName>
-      <Instrument>
+      <Instrument id="cavaquinho">
         <longName>Acoustic Guitar (steel)</longName>
         <trackName></trackName>
+        <instrumentId>pluck.guitar</instrumentId>
         <StringData>
           <frets>25</frets>
           <string>40</string>

--- a/src/importexport/tabledit/tests/data/triplet_eighths.mscx
+++ b/src/importexport/tabledit/tests/data/triplet_eighths.mscx
@@ -55,9 +55,10 @@
           </StaffType>
         </Staff>
       <trackName>Guitar Standard</trackName>
-      <Instrument>
+      <Instrument id="cavaquinho">
         <longName>Guitar Standard</longName>
         <trackName></trackName>
+        <instrumentId>pluck.guitar</instrumentId>
         <StringData>
           <frets>25</frets>
           <string>40</string>

--- a/src/importexport/tabledit/tests/data/triplet_quarters.mscx
+++ b/src/importexport/tabledit/tests/data/triplet_quarters.mscx
@@ -55,9 +55,10 @@
           </StaffType>
         </Staff>
       <trackName>Guitar Standard</trackName>
-      <Instrument>
+      <Instrument id="cavaquinho">
         <longName>Guitar Standard</longName>
         <trackName></trackName>
+        <instrumentId>pluck.guitar</instrumentId>
         <StringData>
           <frets>25</frets>
           <string>40</string>

--- a/src/importexport/tabledit/tests/data/triplets_mixed.mscx
+++ b/src/importexport/tabledit/tests/data/triplets_mixed.mscx
@@ -55,9 +55,10 @@
           </StaffType>
         </Staff>
       <trackName>Guitar Standard</trackName>
-      <Instrument>
+      <Instrument id="cavaquinho">
         <longName>Guitar Standard</longName>
         <trackName></trackName>
+        <instrumentId>pluck.guitar</instrumentId>
         <StringData>
           <frets>25</frets>
           <string>40</string>

--- a/src/importexport/tabledit/tests/data/voices.mscx
+++ b/src/importexport/tabledit/tests/data/voices.mscx
@@ -56,9 +56,10 @@
           </StaffType>
         </Staff>
       <trackName>Guitar Standard</trackName>
-      <Instrument>
+      <Instrument id="cavaquinho">
         <longName>Guitar Standard</longName>
         <trackName></trackName>
+        <instrumentId>pluck.guitar</instrumentId>
         <StringData>
           <frets>25</frets>
           <string>40</string>

--- a/src/importexport/tabledit/tests/data/voices_multi_part.mscx
+++ b/src/importexport/tabledit/tests/data/voices_multi_part.mscx
@@ -56,9 +56,10 @@
           </StaffType>
         </Staff>
       <trackName>Guitar Standard</trackName>
-      <Instrument>
+      <Instrument id="cavaquinho">
         <longName>Guitar Standard</longName>
         <trackName></trackName>
+        <instrumentId>pluck.guitar</instrumentId>
         <StringData>
           <frets>25</frets>
           <string>40</string>
@@ -109,9 +110,10 @@
           </StaffType>
         </Staff>
       <trackName>Acoustic Guitar (steel)</trackName>
-      <Instrument>
+      <Instrument id="cavaquinho">
         <longName>Acoustic Guitar (steel)</longName>
         <trackName></trackName>
+        <instrumentId>pluck.guitar</instrumentId>
         <StringData>
           <frets>25</frets>
           <string>40</string>

--- a/src/importexport/tabledit/tests/environment.cpp
+++ b/src/importexport/tabledit/tests/environment.cpp
@@ -49,6 +49,6 @@ static muse::testing::SuiteEnvironment importexport_se(
     mu::engraving::MScore::testMode = true;
     mu::engraving::MScore::noGui = true;
 
-    mu::engraving::loadInstrumentTemplates(":/data/instruments.xml");
+    mu::engraving::loadInstrumentTemplates(":/engraving/instruments/instruments.xml");
 }
     );


### PR DESCRIPTION
Resolves: #29955

Set instrument ID similarly to how it is done in GuitarPro import to enable sound when playing.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
