### PR TITLE
Layout panel: remove popupAnchorItem and scrolling stuff

### DIFF
--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/LayoutPanel.qml
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/LayoutPanel.qml
@@ -249,7 +249,6 @@ Item {
                             item: model ? model.itemRole : null
 
                             sideMargin: contentColumn.sideMargin
-                            popupAnchorItem: root
 
                             navigation.name: model ? model.itemRole.title : "LayoutPanelItemDelegate"
                             navigation.panel: layoutPanelTreeView.navigationTreePanel
@@ -281,24 +280,6 @@ Item {
 
                             onRemoveSelectionRequested: {
                                 treeModel.removeSelectedRows()
-                            }
-
-                            property real contentYBackup: 0
-
-                            onPopupOpened: function(popupX, popupY, popupHeight) {
-                                contentYBackup = layoutPanelTreeView.flickableItem.contentY
-                                var mappedPopupY = mapToItem(layoutPanelTreeView.flickableItem, popupX, popupY).y
-
-                                if (mappedPopupY + popupHeight < layoutPanelTreeView.flickableItem.height - contentColumn.sideMargin) {
-                                    return
-                                }
-
-                                var hiddenPopupPartHeight = Math.abs(layoutPanelTreeView.flickableItem.height - (mappedPopupY + popupHeight))
-                                layoutPanelTreeView.flickableItem.contentY += hiddenPopupPartHeight + contentColumn.sideMargin
-                            }
-
-                            onPopupClosed: {
-                                layoutPanelTreeView.flickableItem.contentY = contentYBackup
                             }
 
                             onChangeVisibilityOfSelectedRowsRequested: function(visible) {

--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/LayoutPanelItemDelegate.qml
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/LayoutPanelItemDelegate.qml
@@ -43,14 +43,9 @@ FocusableControl {
 
     property int sideMargin: 0
 
-    property var popupAnchorItem: null
-
     signal clicked(var mouse)
     signal doubleClicked(var mouse)
     signal removeSelectionRequested()
-
-    signal popupOpened(var popupX, var popupY, var popupHeight)
-    signal popupClosed()
 
     signal changeVisibilityOfSelectedRowsRequested(bool visible)
     signal changeVisibilityRequested(var index, bool visible)
@@ -147,12 +142,7 @@ FocusableControl {
 
             openedPopup.load(item)
 
-            openedPopup.opened.connect(function() {
-                root.popupOpened(openedPopup.x, openedPopup.y, openedPopup.height)
-            })
-
             openedPopup.closed.connect(function() {
-                root.popupClosed()
                 sourceComponent = null
             })
 
@@ -170,8 +160,6 @@ FocusableControl {
         id: instrumentSettingsComp
 
         InstrumentSettingsPopup {
-            anchorItem: popupAnchorItem
-
             onReplaceInstrumentRequested: {
                 // The popup would close when the dialog to select the new
                 // instrument is shown; when it closes, it is unloaded, i.e.
@@ -193,17 +181,13 @@ FocusableControl {
     Component {
         id: staffSettingsComp
 
-        StaffSettingsPopup {
-            anchorItem: popupAnchorItem
-        }
+        StaffSettingsPopup {}
     }
 
     Component {
         id: systemObjectsLayerSettingsComp
 
-        SystemObjectsLayerSettingsPopup {
-            anchorItem: popupAnchorItem
-        }
+        SystemObjectsLayerSettingsPopup {}
     }
 
     VisibilityControls {


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/29948

This is of course a bit of a non-solution, but I still wanted to publish it, in case I don't find anything better tonight, and because to me it seems not even necessarily bad for UX, so I wanted to give people the chance to try it out.