### PR TITLE
Layout panel: fix disappearing instruments when opening settings popup

### DIFF
--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/LayoutPanelItemDelegate.qml
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/LayoutPanelItemDelegate.qml
@@ -49,7 +49,7 @@ FocusableControl {
     signal doubleClicked(var mouse)
     signal removeSelectionRequested()
 
-    signal popupOpened(var popupX, var popupY, var popupHeight)
+    signal popupOpened(var popup)
     signal popupClosed()
 
     signal changeVisibilityOfSelectedRowsRequested(bool visible)
@@ -148,7 +148,7 @@ FocusableControl {
             openedPopup.load(item)
 
             openedPopup.opened.connect(function() {
-                root.popupOpened(openedPopup.x, openedPopup.y, openedPopup.height)
+                root.popupOpened(openedPopup)
             })
 
             openedPopup.closed.connect(function() {


### PR DESCRIPTION
Reimplement the "scroll to make room for popup" logic

In essence, we're no longer trying to scroll a ListView against its will, because we're now adding a footer to make the ListView happy about the scrolling.

Resolves: https://github.com/musescore/MuseScore/issues/29948