### PR TITLE
Ignore dots from slur-style barrés when writing diagrams

### DIFF
--- a/src/engraving/dom/fret.cpp
+++ b/src/engraving/dom/fret.cpp
@@ -432,7 +432,7 @@ void FretDiagram::setDot(int string, int fret, bool add /*= false*/, FretDotType
 void FretDiagram::addDotForDotStyleBarre(int string, int fret)
 {
     if (m_dots[string].empty()) {
-        m_dots[string].push_back(FretItem::Dot(fret, FretDotType::NORMAL));
+        m_dots[string].push_back(FretItem::Dot(fret, FretDotType::NORMAL, /*isPartOfSlurBarre*/ true));
     }
 }
 
@@ -779,10 +779,24 @@ String FretDiagram::patternFromDiagram(const FretDiagram* diagram)
         }
 
         const auto it = dotsMap.find(i);
-        if (it != dotsMap.end() && !it->second.empty()) {
+        std::vector<FretItem::Dot> dotList;
+        if (it != dotsMap.end()) {
+            const std::vector<FretItem::Dot>& dots = it->second;
+            for (const FretItem::Dot& dot : dots) {
+                if (!dot.isPartOfSlurBarre) { // Don't write dot if part of slur barré
+                    dotList.push_back(dot);
+                }
+            }
+        }
+
+        if (!dotList.empty()) {
             const auto& dotList = it->second;
             StringList dotDescriptions;
             for (const auto& dot : dotList) {
+                if (dot.isPartOfSlurBarre) {
+                    continue;
+                }
+
                 int actualFret = dot.fret + offset;
                 Char typeChar = u'O';
 

--- a/src/engraving/dom/fret.h
+++ b/src/engraving/dom/fret.h
@@ -69,10 +69,11 @@ public:
         int fingering = 0;     // NOTE:JT - possible future feature?
 
         Dot() = default;
-        Dot(int f, FretDotType t = FretDotType::NORMAL)
-            : fret(f), dtype(t) {}
+        Dot(int f, FretDotType t = FretDotType::NORMAL, bool isPartOfSlurBarre = false)
+            : fret(f), dtype(t), isPartOfSlurBarre(isPartOfSlurBarre) {}
 
         bool exists() const { return fret > 0; }
+        bool isPartOfSlurBarre = false;
     };
 
     struct Marker {

--- a/src/engraving/rw/write/twrite.cpp
+++ b/src/engraving/rw/write/twrite.cpp
@@ -1387,7 +1387,7 @@ void TWrite::write(const FretDiagram* item, XmlWriter& xml, WriteContext& ctx)
 
             bool dotExists = false;
             for (auto const& d : allDots) {
-                if (d.exists()) {
+                if (d.exists() && !d.isPartOfSlurBarre) { // Don't write dot if part of slur barré (will be generate during layout)
                     dotExists = true;
                     break;
                 }


### PR DESCRIPTION
Resolves: #29974

Because if we include them the resulting pattern will have additional dots that don't match with the database anymore.