### PR TITLE
Fix #29980: Crash on horizontal frame resize

### DIFF
--- a/src/engraving/rendering/score/systemlayout.cpp
+++ b/src/engraving/rendering/score/systemlayout.cpp
@@ -1700,6 +1700,9 @@ void SystemLayout::layoutTuplets(const std::vector<ChordRest*>& chordRests, Layo
 void SystemLayout::layoutTiesAndBends(const ElementsToLayout& elementsToLayout, LayoutContext& ctx)
 {
     System* system = elementsToLayout.system;
+    if (elementsToLayout.measures.empty()) {
+        return;
+    }
     Fraction stick = elementsToLayout.measures.front()->tick();
 
     for (Chord* chord : elementsToLayout.chords) {


### PR DESCRIPTION
Quick fix: Safeguarding against empty measures list when recalculating layout

Resolves: #29980

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
