### PR TITLE
Feature #23662: Auto-scroll mixer to selected instrument

### DIFF
--- a/src/appshell/qml/Preferences/AudioMidiPreferencesPage.qml
+++ b/src/appshell/qml/Preferences/AudioMidiPreferencesPage.qml
@@ -84,12 +84,16 @@ PreferencesPage {
 
         MixerSection {
             muteHiddenInstruments: audioMidiModel.muteHiddenInstruments
+            focusSelectedInstrument: audioMidiModel.focusSelectedInstrument
 
             navigation.section: root.navigationSection
             navigation.order: root.navigationOrderStart + 3
 
             onMuteHiddenInstrumentsChangeRequested: function(mute) {
                 audioMidiModel.muteHiddenInstruments = mute
+            }
+            onFocusSelectedInstrumentInMixerChangeRequested: function (checked) {
+                audioMidiModel.focusSelectedInstrument = checked
             }
         }
 

--- a/src/appshell/qml/Preferences/internal/MixerSection.qml
+++ b/src/appshell/qml/Preferences/internal/MixerSection.qml
@@ -30,8 +30,10 @@ BaseSection {
     title: qsTrc("appshell/preferences", "Mixer")
 
     property alias muteHiddenInstruments: muteHiddenInstrumentsCheckBox.checked
+    property alias focusSelectedInstrument: focusSelectedInstrumentCheckBox.checked
 
     signal muteHiddenInstrumentsChangeRequested(bool mute)
+    signal focusSelectedInstrumentInMixerChangeRequested(bool checked)
 
     CheckBox {
         id: muteHiddenInstrumentsCheckBox
@@ -45,6 +47,21 @@ BaseSection {
 
         onClicked: {
             root.muteHiddenInstrumentsChangeRequested(!checked)
+        }
+    }
+
+    CheckBox {
+        id: focusSelectedInstrumentCheckBox
+
+        width: parent.width
+
+        text: qsTrc("appshell/preferences", "Automatically scroll Mixer panel to show the instrument selected in the Score")
+
+        navigation.name: "FocusSelectedInstrumentInMixerCheckbox"
+        navigation.panel: root.navigation
+
+        onClicked: {
+            root.focusSelectedInstrumentInMixerChangeRequested(!checked)
         }
     }
 }

--- a/src/appshell/view/preferences/audiomidipreferencesmodel.cpp
+++ b/src/appshell/view/preferences/audiomidipreferencesmodel.cpp
@@ -100,6 +100,10 @@ void AudioMidiPreferencesModel::init()
         emit muteHiddenInstrumentsChanged(mute);
     });
 
+    playbackConfiguration()->focusSelectedInstrumentChanged().onReceive(this, [this](bool mute) {
+        emit focusSelectedInstrumentChanged(mute);
+    });
+
     playbackConfiguration()->shouldShowOnlineSoundsProcessingErrorChanged().onNotify(this, [this]() {
         emit shouldShowOnlineSoundsProcessingErrorChanged();
     });
@@ -207,6 +211,20 @@ void AudioMidiPreferencesModel::setMuteHiddenInstruments(bool mute)
     }
 
     playbackConfiguration()->setMuteHiddenInstruments(mute);
+}
+
+bool AudioMidiPreferencesModel::focusSelectedInstrument() const
+{
+    return playbackConfiguration()->focusSelectedInstrument();
+}
+
+void AudioMidiPreferencesModel::setFocusSelectedInstrument(bool checked)
+{
+    if (checked == focusSelectedInstrument()) {
+        return;
+    }
+
+    playbackConfiguration()->setFocusSelectedInstrument(checked);
 }
 
 bool AudioMidiPreferencesModel::shouldShowOnlineSoundsProcessingError() const

--- a/src/appshell/view/preferences/audiomidipreferencesmodel.h
+++ b/src/appshell/view/preferences/audiomidipreferencesmodel.h
@@ -49,6 +49,8 @@ class AudioMidiPreferencesModel : public QObject, public muse::Injectable, publi
     Q_PROPERTY(bool useMIDI20Output READ useMIDI20Output WRITE setUseMIDI20Output NOTIFY useMIDI20OutputChanged)
 
     Q_PROPERTY(bool muteHiddenInstruments READ muteHiddenInstruments WRITE setMuteHiddenInstruments NOTIFY muteHiddenInstrumentsChanged)
+    Q_PROPERTY(
+        bool focusSelectedInstrument READ focusSelectedInstrument WRITE setFocusSelectedInstrument NOTIFY focusSelectedInstrumentChanged)
 
     Q_PROPERTY(
         bool shouldShowOnlineSoundsProcessingError READ shouldShowOnlineSoundsProcessingError WRITE setShouldShowOnlineSoundsProcessingError NOTIFY shouldShowOnlineSoundsProcessingErrorChanged)
@@ -89,6 +91,7 @@ public:
     bool useMIDI20Output() const;
 
     bool muteHiddenInstruments() const;
+    bool focusSelectedInstrument() const;
 
     bool shouldShowOnlineSoundsProcessingError() const;
     bool autoProcessOnlineSoundsInBackground() const;
@@ -100,6 +103,7 @@ public slots:
     void setUseMIDI20Output(bool use);
 
     void setMuteHiddenInstruments(bool mute);
+    void setFocusSelectedInstrument(bool checked);
 
     void setShouldShowOnlineSoundsProcessingError(bool value);
     void setAutoProcessOnlineSoundsInBackground(bool value);
@@ -116,6 +120,7 @@ signals:
     void useMIDI20OutputChanged();
 
     void muteHiddenInstrumentsChanged(bool mute);
+    void focusSelectedInstrumentChanged(bool mute);
 
     void shouldShowOnlineSoundsProcessingErrorChanged();
     void autoProcessOnlineSoundsInBackgroundChanged();

--- a/src/playback/internal/playbackconfiguration.cpp
+++ b/src/playback/internal/playbackconfiguration.cpp
@@ -61,6 +61,7 @@ static const Settings::Key ONLINE_SOUNDS_SHOW_ERROR(moduleName, "playback/online
 static const Settings::Key ONLINE_SOUNDS_SHOW_PROGRESS_BAR_MODE(moduleName, "playback/onlineSounds/showProgressBarMode");
 
 static const Settings::Key MUTE_HIDDEN_INSTRUMENTS(moduleName, "playback/mixer/muteHiddenInstruments");
+static const Settings::Key FOCUS_SELECTED_INSTRUMENT(moduleName, "playback/mixer/focusSelectedInstrument");
 
 static const Settings::Key DEFAULT_SOUND_PROFILE_FOR_NEW_PROJECTS(moduleName, "playback/profiles/defaultProfileName");
 static const SoundProfileName BASIC_PROFILE_NAME(u"MuseScore Basic");
@@ -128,6 +129,11 @@ void PlaybackConfiguration::init()
     settings()->setDefaultValue(MUTE_HIDDEN_INSTRUMENTS, Val(true));
     settings()->valueChanged(MUTE_HIDDEN_INSTRUMENTS).onReceive(nullptr, [this](const Val& mute) {
         m_muteHiddenInstrumentsChanged.send(mute.toBool());
+    });
+
+    settings()->setDefaultValue(FOCUS_SELECTED_INSTRUMENT, Val(true));
+    settings()->valueChanged(FOCUS_SELECTED_INSTRUMENT).onReceive(nullptr, [this](const Val& checked) {
+        m_focusSelectedInstrumentChanged.send(checked.toBool());
     });
 
     settings()->setDefaultValue(DEFAULT_SOUND_PROFILE_FOR_NEW_PROJECTS, Val(fallbackSoundProfileStr().toStdString()));
@@ -301,6 +307,21 @@ void PlaybackConfiguration::setMuteHiddenInstruments(bool mute)
 muse::async::Channel<bool> PlaybackConfiguration::muteHiddenInstrumentsChanged() const
 {
     return m_muteHiddenInstrumentsChanged;
+}
+
+bool PlaybackConfiguration::focusSelectedInstrument() const
+{
+    return settings()->value(FOCUS_SELECTED_INSTRUMENT).toBool();
+}
+
+void PlaybackConfiguration::setFocusSelectedInstrument(bool mute)
+{
+    settings()->setSharedValue(FOCUS_SELECTED_INSTRUMENT, Val(mute));
+}
+
+muse::async::Channel<bool> PlaybackConfiguration::focusSelectedInstrumentChanged() const
+{
+    return m_focusSelectedInstrumentChanged;
 }
 
 const SoundProfileName& PlaybackConfiguration::basicSoundProfileName() const

--- a/src/playback/internal/playbackconfiguration.h
+++ b/src/playback/internal/playbackconfiguration.h
@@ -75,6 +75,10 @@ public:
     void setMuteHiddenInstruments(bool mute) override;
     muse::async::Channel<bool> muteHiddenInstrumentsChanged() const override;
 
+    bool focusSelectedInstrument() const override;
+    void setFocusSelectedInstrument(bool mute) override;
+    muse::async::Channel<bool> focusSelectedInstrumentChanged() const override;
+
     const SoundProfileName& basicSoundProfileName() const override;
     const SoundProfileName& museSoundsProfileName() const override;
     const SoundProfileName& compatMuseSoundsProfileName() const override;
@@ -117,6 +121,7 @@ private:
     muse::async::Channel<MixerSectionType, bool> m_isMixerSectionVisibleChanged;
 
     muse::async::Channel<bool> m_muteHiddenInstrumentsChanged;
+    muse::async::Channel<bool> m_focusSelectedInstrumentChanged;
 };
 }
 

--- a/src/playback/iplaybackconfiguration.h
+++ b/src/playback/iplaybackconfiguration.h
@@ -72,6 +72,10 @@ public:
     virtual void setMuteHiddenInstruments(bool mute) = 0;
     virtual muse::async::Channel<bool> muteHiddenInstrumentsChanged() const = 0;
 
+    virtual bool focusSelectedInstrument() const = 0;
+    virtual void setFocusSelectedInstrument(bool mute) = 0;
+    virtual muse::async::Channel<bool> focusSelectedInstrumentChanged() const = 0;
+
     virtual const SoundProfileName& basicSoundProfileName() const = 0;
     virtual const SoundProfileName& museSoundsProfileName() const = 0;
     virtual const SoundProfileName& compatMuseSoundsProfileName() const = 0;

--- a/src/playback/qml/MuseScore/Playback/MixerPanel.qml
+++ b/src/playback/qml/MuseScore/Playback/MixerPanel.qml
@@ -76,14 +76,34 @@ ColumnLayout {
         }
     }
 
-    function scrollToFocusedItem(focusedIndex) {
-        let targetScrollPosition = (focusedIndex) * (prv.channelItemWidth + 1) // + 1 for separators
+    function scrollToFocusedItem(focusedIndex, smooth = false) {
+        let targetScrollPosition = (focusedIndex) * (prv.channelItemWidth + 1) + prv.headerWidth // + 1 for separators
         let maxContentX = flickable.contentWidth - flickable.width
 
+        console.log("Target scroll position:\t" + targetScrollPosition)
+        console.log("Current scroll position:\t" + flickable.contentX)
+        console.log("Max content X\t\t" + maxContentX)
+
+        let contentX = -1
         if (targetScrollPosition + prv.channelItemWidth > flickable.contentX + flickable.width) {
-            flickable.contentX = Math.min(targetScrollPosition + prv.channelItemWidth - flickable.width, maxContentX)
+            console.log("Scrolling right")
+            contentX = Math.min(targetScrollPosition + prv.channelItemWidth - flickable.width, maxContentX)
         } else if (targetScrollPosition < flickable.contentX) {
-            flickable.contentX = Math.max(targetScrollPosition - prv.channelItemWidth, 0)
+            console.log("Scrolling left: choosing between 0 and " + (targetScrollPosition))
+            contentX = Math.max(targetScrollPosition, 0)
+        }
+
+        if (contentX !== -1) {
+            if (!smooth) {
+                flickable.contentX = contentX
+            } else {
+                scrollAnimation.running = false
+                console.log("From " + flickable.contentX + " to " + contentX)
+                scrollAnimation.from = flickable.contentX
+                scrollAnimation.to = contentX
+                console.log("From " + scrollAnimation.from + " to " + scrollAnimation.to)
+                scrollAnimation.running = true
+            }
         }
     }
 
@@ -116,6 +136,14 @@ ColumnLayout {
                     }
                 })
             }
+        }
+
+        onFocusedIndexChanged: {
+            let idx = mixerPanelModel.focusedIndex
+            if (idx === -1) {
+                return
+            }
+            scrollToFocusedItem(idx, true)
         }
     }
 
@@ -344,6 +372,15 @@ ColumnLayout {
                 }
             }
         }
+    }
+
+    NumberAnimation {
+        id: scrollAnimation
+        target: flickable
+        property: "contentX"
+        to: 0
+        duration: 200
+        easing.type: Easing.OutQuad
     }
 
     Column {

--- a/src/playback/view/mixerpanelmodel.h
+++ b/src/playback/view/mixerpanelmodel.h
@@ -51,6 +51,7 @@ class MixerPanelModel : public QAbstractListModel, public muse::async::Asyncable
     Q_PROPERTY(int navigationOrderStart READ navigationOrderStart WRITE setNavigationOrderStart NOTIFY navigationOrderStartChanged)
 
     Q_PROPERTY(int count READ rowCount NOTIFY rowCountChanged)
+    Q_PROPERTY(int focusedIndex READ focusedIndex WRITE setFocusedIndex NOTIFY focusedIndexChanged)
 
 public:
     explicit MixerPanelModel(QObject* parent = nullptr);
@@ -68,9 +69,13 @@ public:
     int navigationOrderStart() const;
     void setNavigationOrderStart(int navigationOrderStart);
 
+    int focusedIndex() const;
+    void setFocusedIndex(int focusedIndex);
+
 signals:
     void navigationSectionChanged();
     void navigationOrderStartChanged();
+    void focusedIndexChanged();
     void rowCountChanged();
 
 private:
@@ -101,6 +106,9 @@ private:
     void loadOutputParams(MixerChannelItem* item, muse::audio::AudioOutputParams&& params);
     void updateOutputResourceItemCount();
 
+    void onNotationChanged();
+    void onScoreSelectionChanged();
+
     project::INotationProjectPtr currentProject() const;
     project::IProjectAudioSettingsPtr audioSettings() const;
     notation::INotationPlaybackPtr notationPlayback() const;
@@ -112,6 +120,11 @@ private:
 
     muse::ui::NavigationSection* m_navigationSection = nullptr;
     int m_navigationOrderStart = 1;
+
+    int m_focusedIndex = -1;
+    notation::INotationInteractionPtr m_notationInteraction = nullptr;
+
+    std::shared_ptr<muse::async::Asyncable> m_scoreSelectionNotifyReceiver = nullptr;
 };
 }
 

--- a/src/stubs/playback/playbackconfigurationstub.cpp
+++ b/src/stubs/playback/playbackconfigurationstub.cpp
@@ -150,6 +150,21 @@ muse::async::Channel<bool> PlaybackConfigurationStub::muteHiddenInstrumentsChang
     return ch;
 }
 
+bool PlaybackConfigurationStub::focusSelectedInstrument() const
+{
+    return false;
+}
+
+void PlaybackConfigurationStub::setFocusSelectedInstrument(bool)
+{
+}
+
+muse::async::Channel<bool> PlaybackConfigurationStub::focusSelectedInstrumentChanged() const
+{
+    static muse::async::Channel<bool> ch;
+    return ch;
+}
+
 const SoundProfileName& PlaybackConfigurationStub::basicSoundProfileName() const
 {
     static const SoundProfileName basic;

--- a/src/stubs/playback/playbackconfigurationstub.h
+++ b/src/stubs/playback/playbackconfigurationstub.h
@@ -65,6 +65,10 @@ public:
     void setMuteHiddenInstruments(bool mute) override;
     muse::async::Channel<bool> muteHiddenInstrumentsChanged() const override;
 
+    bool focusSelectedInstrument() const override;
+    void setFocusSelectedInstrument(bool mute) override;
+    muse::async::Channel<bool> focusSelectedInstrumentChanged() const override;
+
     const SoundProfileName& basicSoundProfileName() const override;
     const SoundProfileName& museSoundsProfileName() const override;
     const SoundProfileName& compatMuseSoundsProfileName() const override;


### PR DESCRIPTION
Resolves: #23662

This is a first iteration of auto-scrolling Mixer panel to the instrument selected in Score panel. 

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
