### PR TITLE
Implement #27869: Recall transpose options

### DIFF
--- a/src/notation/view/widgets/transposedialog.cpp
+++ b/src/notation/view/widgets/transposedialog.cpp
@@ -60,6 +60,7 @@ TransposeDialog::TransposeDialog(QWidget* parent)
     setEnableTransposeChordNames(hasChordNames);
 
     setKey(firstPitchedStaffKey());
+    restorePreviousSettings();
 
     connect(this, &TransposeDialog::accepted, this, &TransposeDialog::apply);
 
@@ -124,6 +125,35 @@ TransposeMode TransposeDialog::mode() const
     return chromaticBox->isChecked()
            ? (transposeByKey->isChecked() ? TransposeMode::TO_KEY : TransposeMode::BY_INTERVAL)
            : TransposeMode::DIATONICALLY;
+}
+
+void TransposeDialog::setMode(TransposeMode& mode)
+{
+    // revert the logic of getter
+    switch (mode) {
+    case TransposeMode::TO_KEY: {
+        chromaticBox->setChecked(true);
+        diatonicBox->setChecked(false);
+        transposeByKey->setChecked(true);
+        transposeByInterval->setChecked(false);
+        break;
+    }
+    case TransposeMode::BY_INTERVAL: {
+        chromaticBox->setChecked(true);
+        diatonicBox->setChecked(false);
+        transposeByKey->setChecked(false);
+        transposeByInterval->setChecked(true);
+        break;
+    }
+    case TransposeMode::DIATONICALLY: {
+        chromaticBox->setChecked(false);
+        diatonicBox->setChecked(true);
+        break;
+    }
+    default:
+    {
+    }
+    }
 }
 
 //---------------------------------------------------------
@@ -206,7 +236,7 @@ INotationSelectionPtr TransposeDialog::selection() const
 
 void TransposeDialog::apply()
 {
-    TransposeOptions options;
+    TransposeOptions& options = lastUsedOptions();
 
     options.mode = mode();
     options.direction = direction();
@@ -292,4 +322,52 @@ void TransposeDialog::setKey(Key k)
 bool TransposeDialog::useDoubleSharpsFlats() const
 {
     return accidentalOptions->currentIndex() == 1;
+}
+
+void TransposeDialog::setDirection(TransposeDirection direction)
+{
+    switch (mode()) {
+    case TransposeMode::TO_KEY: {
+        if (direction == TransposeDirection::CLOSEST) {
+            closestKey->setChecked(true);
+        } else {
+            upKey->setChecked(direction == TransposeDirection::UP);
+        }
+        break;
+    }
+    case TransposeMode::BY_INTERVAL: {
+        upInterval->setChecked(direction == TransposeDirection::UP);
+        break;
+    }
+    case TransposeMode::DIATONICALLY: {
+        upDiatonic->setChecked(direction == TransposeDirection::UP);
+        break;
+    }
+    default: {
+    }
+    }
+}
+
+void TransposeDialog::setInterval(int interval)
+{
+    if (chromaticBox->isChecked()) {
+        intervalList->setCurrentIndex(interval);
+    } else {
+        degreeList->setCurrentIndex(interval - 1);
+    }
+}
+
+void TransposeDialog::restorePreviousSettings()
+{
+    TransposeOptions& options = lastUsedOptions();
+
+    setMode(options.mode);
+    setDirection(options.direction);
+    setInterval(options.interval);
+}
+
+TransposeOptions& TransposeDialog::lastUsedOptions()
+{
+    static TransposeOptions options;
+    return options;
 }

--- a/src/notation/view/widgets/transposedialog.h
+++ b/src/notation/view/widgets/transposedialog.h
@@ -37,6 +37,7 @@ class TransposeDialog : public QDialog, Ui::TransposeDialogBase, public muse::In
     muse::Inject<context::IGlobalContext> context = { this };
 
 public:
+
     TransposeDialog(QWidget* parent = 0);
 
 private slots:
@@ -64,8 +65,20 @@ private:
     int transposeInterval() const;
     TransposeDirection direction() const;
     TransposeMode mode() const;
+
+    void setMode(TransposeMode& mode);
+
     void setKey(Key k);
     bool useDoubleSharpsFlats() const;
+
+    void setDirection(TransposeDirection direction);
+
+    void setInterval(int interval);
+
+
+    void restorePreviousSettings();
+
+    static TransposeOptions& lastUsedOptions();
 
     bool m_allSelected = false;
 };


### PR DESCRIPTION
Resolves: #27869

* Stores TransposeOptions as static variable of TransposeDialog.
* When applying transpose, saves used options to that static variable
* Only applies to mode, direction and interval (there is more complex logic in initialization for other fields)



- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
