### PR TITLE
Avoid temporary construction in symbolString

### DIFF
--- a/src/engraving/dom/marker.cpp
+++ b/src/engraving/dom/marker.cpp
@@ -297,14 +297,14 @@ std::vector<LineF> Marker::dragAnchorLines() const
 String Marker::symbolString() const
 {
     // Returns the coda/segno symbol if present
-    constexpr static std::array REPEAT_SYMBOL_NAMES {
-        u"<sym>coda</sym>",
-        u"<sym>codaSquare</sym>",
-        u"<sym>codaJapanes</sym>",
-        u"<sym>segno</sym>",
-        u"<sym>segnoSerpent1</sym>",
-        u"<sym>segnoSerpent2</sym>",
-        u"<sym>segnoJapanese</sym>",
+    const static std::array REPEAT_SYMBOL_NAMES {
+        String(u"<sym>coda</sym>"),
+        String(u"<sym>codaSquare</sym>"),
+        String(u"<sym>codaJapanes</sym>"),
+        String(u"<sym>segno</sym>"),
+        String(u"<sym>segnoSerpent1</sym>"),
+        String(u"<sym>segnoSerpent2</sym>"),
+        String(u"<sym>segnoJapanese</sym>"),
     };
 
     for (const String& sym : REPEAT_SYMBOL_NAMES) {


### PR DESCRIPTION
<!-- Add a short description of and motivation for the changes here -->
I have been working with version 4.6.0 beta in preparation for building the final 4.6.0 release for Fedora when the time comes.  I saw this in the build log:
```
/builddir/build/BUILD/musescore-4.6.0-build/MuseScore-4.6.0-beta/src/engraving/dom/marker.cpp: In member function ‘mu::engraving::String mu::engraving::Marker::symbolString() const’:
/builddir/build/BUILD/musescore-4.6.0-build/MuseScore-4.6.0-beta/src/engraving/dom/marker.cpp:317:24: warning: loop variable ‘sym’ of type ‘const mu::engraving::String&’ {aka ‘const muse::String&’} binds to a temporary constructed from type ‘const std::array<const char16_t*, 7>::value_type’ {aka ‘const char16_t* const’} [-Wrange-loop-construct]
  317 |     for (const String& sym : REPEAT_SYMBOL_NAMES) {
      |                        ^~~
/builddir/build/BUILD/musescore-4.6.0-build/MuseScore-4.6.0-beta/src/engraving/dom/marker.cpp:317:24: note: use non-reference type ‘const mu::engraving::String’ {aka ‘const muse::String’} to make the copy explicit or ‘const char16_t* const&’ to prevent copying
```

`REPEAT_SYMBOL_NAMES` does not contain `String` objects, so every time `symbolString` is called, a temporary `String` must be created on each iteration of the loop.  This patch, instead, creates an array of `String` objects, no later than the first time `symbolString` is called, permitting an efficient loop over the array and eliminating the compiler warning in passing.  I have disassembled versions of `symbolString` before and after this change, as built on an `x86_64` Fedora Rawhide machine, should anybody be interested in seeing them.  The main loop is shorter after applying this patch, although there is more code in total due to the explicit array initialization.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
