### PR TITLE
Disable dragging horizontal frame as a whole

### DIFF
--- a/src/engraving/dom/box.cpp
+++ b/src/engraving/dom/box.cpp
@@ -524,6 +524,9 @@ void Box::manageExclusionFromParts(bool exclude)
 
 RectF HBox::drag(EditData& data)
 {
+    if (!isMovable()) {
+        return RectF();
+    }
     RectF r(canvasBoundingRect());
     double diff = data.evtDelta.x();
     double x1   = offset().x() + diff;


### PR DESCRIPTION
This created a strange offset effect that's hardly ever desirable. If people do want to create such effect, they can use Properties > Appearances > Offset.

Closes https://github.com/musescore/MuseScore/issues/29979