### PR TITLE
Feature #27869: clickable url in pdf

### DIFF
--- a/src/engraving/dom/textbase.h
+++ b/src/engraving/dom/textbase.h
@@ -216,6 +216,9 @@ class TextFragment
 public:
     muse::GlobalInject<IEngravingFontsProvider> engravingFonts;
 
+private:
+    static const QRegularExpression urlPattern;
+
 public:
     mutable CharFormat format;
     PointF pos;                    // y is relative to TextBlock->y()
@@ -232,9 +235,13 @@ public:
 
     TextFragment split(int column);
     void draw(muse::draw::Painter*, const TextBase*) const;
+    void drawWithUrl(QPainter* qp, const TextBase*) const;
+
     muse::draw::Font font(const TextBase*) const;
     int columns() const;
     void changeFormat(FormatId id, const FormatValue& data);
+private:
+    static QString convertUrlsToLinks(const QString& text);
 };
 
 //---------------------------------------------------------

--- a/src/engraving/rendering/score/paintdebugger.cpp
+++ b/src/engraving/rendering/score/paintdebugger.cpp
@@ -238,3 +238,8 @@ void PaintDebugger::setClipping(bool enable)
 {
     m_real->setClipping(enable);
 }
+
+QPainter* PaintDebugger::getQPainter()
+{
+    return nullptr;
+}

--- a/src/engraving/rendering/score/paintdebugger.h
+++ b/src/engraving/rendering/score/paintdebugger.h
@@ -86,6 +86,8 @@ public:
     void setMask(const muse::RectF& background, const std::vector<muse::RectF>& maskRects) override;
     void setClipping(bool enable) override;
 
+    QPainter* getQPainter() override;
+
 private:
     muse::draw::IPaintProviderPtr m_real = nullptr;
 

--- a/src/framework/draw/bufferedpaintprovider.cpp
+++ b/src/framework/draw/bufferedpaintprovider.cpp
@@ -355,6 +355,11 @@ void BufferedPaintProvider::setClipping(bool enable)
     UNUSED(enable);
 }
 
+QPainter* BufferedPaintProvider::getQPainter()
+{
+    return nullptr;
+}
+
 DrawDataPtr BufferedPaintProvider::drawData() const
 {
     return m_buf;

--- a/src/framework/draw/bufferedpaintprovider.h
+++ b/src/framework/draw/bufferedpaintprovider.h
@@ -88,6 +88,8 @@ public:
     void setMask(const RectF& background, const std::vector<RectF>& maskRects) override;
     void setClipping(bool enable) override;
 
+    QPainter* getQPainter() override;
+
     // ---
 
     DrawDataPtr drawData() const;

--- a/src/framework/draw/internal/qpainterprovider.cpp
+++ b/src/framework/draw/internal/qpainterprovider.cpp
@@ -382,3 +382,8 @@ void QPainterProvider::setClipping(bool enable)
 {
     m_painter->setClipping(enable);
 }
+
+QPainter* QPainterProvider::getQPainter()
+{
+    return m_painter;
+}

--- a/src/framework/draw/internal/qpainterprovider.h
+++ b/src/framework/draw/internal/qpainterprovider.h
@@ -90,6 +90,8 @@ public:
     void setMask(const RectF& background, const std::vector<RectF>& maskRects) override;
     void setClipping(bool enable) override;
 
+    QPainter* getQPainter() override;
+
 protected:
     QPainter* m_painter = nullptr;
 

--- a/src/framework/draw/ipaintprovider.h
+++ b/src/framework/draw/ipaintprovider.h
@@ -91,6 +91,11 @@ public:
     virtual void setClipRect(const RectF& rect) = 0;
     virtual void setMask(const RectF& background, const std::vector<RectF>& maskRects) = 0;
     virtual void setClipping(bool enable) = 0;
+
+    // We cannot implement writing clickable url into pdf without
+    // directly passing QPainter to QTextDocument::drawContents,
+    // so we need to expose QPainter
+    virtual QPainter* getQPainter() = 0;
 };
 
 using IPaintProviderPtr = std::shared_ptr<IPaintProvider>;

--- a/src/framework/draw/painter.cpp
+++ b/src/framework/draw/painter.cpp
@@ -552,3 +552,8 @@ void Painter::setClipping(bool enable)
 {
     m_provider->setClipping(enable);
 }
+
+QPainter* Painter::getQPainter() const
+{
+    return m_provider->getQPainter();
+}

--- a/src/framework/draw/painter.h
+++ b/src/framework/draw/painter.h
@@ -160,6 +160,8 @@ public:
     void setMask(const RectF& background, const std::vector<RectF>& maskRects);
     void setClipping(bool enable);
 
+    QPainter* getQPainter() const;
+
     //! NOTE Provider for tests.
     //! We're not ready to use DI (ModuleIoC) here yet
     static IPaintProviderPtr extended;


### PR DESCRIPTION
Resolves: #27869
Implements writing URLs into PDF via wrapping text into `QTextDocument`
and using its `::drawContents` method.

As of September 2025 it's the only known method to write URLs to PDF.

(Url regex is not fully-featured, isn't intended for long urls with queries)


- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
