### PR TITLE
Feature #18055: Clickable urls in PDF export

### DIFF
--- a/src/engraving/dom/textbase.cpp
+++ b/src/engraving/dom/textbase.cpp
@@ -40,8 +40,6 @@
 #include "accessibility/accessibleitem.h"
 #endif
 
-#include <QTextDocument>
-
 #include "anchors.h"
 #include "barline.h"
 #include "box.h"

--- a/src/engraving/dom/textbase.cpp
+++ b/src/engraving/dom/textbase.cpp
@@ -68,13 +68,13 @@ static constexpr double superScriptOffset = -0.9; // of x-height
 static const char* FALLBACK_SYMBOL_FONT = "Bravura";
 static const char* FALLBACK_SYMBOLTEXT_FONT = "Bravura Text";
 
-const QRegularExpression TextFragment::urlPattern = QRegularExpression(
+static const QRegularExpression URL_PATTERN = QRegularExpression(
     R"((https?://[a-zA-Z0-9.-]+(?:/[a-zA-Z0-9._~:/?#[\]@!$&'()*+,;=-]*)?))");
 
 QString convertUrlsToLinks(const QString& text)
 {
     QString result = text.toHtmlEscaped();
-    result.replace(TextFragment::urlPattern, R"(<a href="\1" style="color: blue; text-decoration: underline;">\1</a>)");
+    result.replace(URL_PATTERN, R"(<a href="\1" style="color: blue; text-decoration: underline;">\1</a>)");
 
     return result;
 }
@@ -862,7 +862,7 @@ bool TextFragment::operator ==(const TextFragment& f) const
 void TextFragment::draw(Painter* p, const TextBase* t) const
 {
     auto qp = p->getQPainter();
-    if (qp && text.toQString().contains(urlPattern)) {
+    if (qp && text.toQString().contains(URL_PATTERN)) {
         drawWithUrl(qp, t);
         return;
     }

--- a/src/engraving/dom/textbase.cpp
+++ b/src/engraving/dom/textbase.cpp
@@ -40,6 +40,8 @@
 #include "accessibility/accessibleitem.h"
 #endif
 
+#include <QTextDocument>
+
 #include "anchors.h"
 #include "barline.h"
 #include "box.h"
@@ -65,6 +67,17 @@ static constexpr double superScriptOffset = -0.9; // of x-height
 
 static const char* FALLBACK_SYMBOL_FONT = "Bravura";
 static const char* FALLBACK_SYMBOLTEXT_FONT = "Bravura Text";
+
+const QRegularExpression TextFragment::urlPattern = QRegularExpression(
+    R"((https?://[a-zA-Z0-9.-]+(?:/[a-zA-Z0-9._~:/?#[\]@!$&'()*+,;=-]*)?))");
+
+QString convertUrlsToLinks(const QString& text)
+{
+    QString result = text.toHtmlEscaped();
+    result.replace(TextFragment::urlPattern, R"(<a href="\1" style="color: blue; text-decoration: underline;">\1</a>)");
+
+    return result;
+}
 
 //---------------------------------------------------------
 //   isSorted
@@ -848,6 +861,12 @@ bool TextFragment::operator ==(const TextFragment& f) const
 
 void TextFragment::draw(Painter* p, const TextBase* t) const
 {
+    auto qp = p->getQPainter();
+    if (qp && text.toQString().contains(urlPattern)) {
+        drawWithUrl(qp, t);
+        return;
+    }
+
     Font f(font(t));
     f.setPointSizeF(f.pointSizeF() * MScore::pixelRatio);
 #ifndef Q_OS_MACOS
@@ -856,6 +875,33 @@ void TextFragment::draw(Painter* p, const TextBase* t) const
     p->setFont(f);
     p->drawText(pos, text);
 #endif
+}
+
+// WARNING: this function directly operates with QPainter instead of working with Painter class
+void TextFragment::drawWithUrl(QPainter* qp, const TextBase* t) const
+{
+    QTextDocument doc;
+
+    // Set font
+    QFont f = font(t).toQFont();
+    float fontScalingFactor = qp->device()->logicalDpiX() / 72.;
+    f.setPixelSize(f.pointSizeF() * MScore::pixelRatio * fontScalingFactor);
+    doc.setDefaultFont(f);
+    doc.setUseDesignMetrics(true);
+
+    // Convert URLs to HTML links
+    QString htmlText = convertUrlsToLinks(text);
+    doc.setHtml(htmlText);
+
+    // Set document properties
+    doc.setTextWidth(-1); // No wrapping
+    doc.setDocumentMargin(0);
+
+    // Draw the document
+    qp->save();
+    qp->translate(pos.toQPointF());
+    doc.drawContents(qp);
+    qp->restore();
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/textbase.cpp
+++ b/src/engraving/dom/textbase.cpp
@@ -69,7 +69,7 @@ static const char* FALLBACK_SYMBOLTEXT_FONT = "Bravura Text";
 static const std::regex URL_PATTERN(
     R"((https?://[a-zA-Z0-9.-]+(?:/[a-zA-Z0-9._~:/?#[\]@!$&'()*+,;=-]*)?))");
 
-std::string htmlEscape(const String& text)
+static std::string htmlEscape(const String& text)
 {
     std::string result = text.toStdString();
 
@@ -107,7 +107,7 @@ std::string htmlEscape(const String& text)
     return result;
 }
 
-String convertUrlsToLinks(const String& text)
+static String convertUrlsToLinks(const String& text)
 {
     std::string result = htmlEscape(text);
     result = std::regex_replace(result, URL_PATTERN,
@@ -905,7 +905,7 @@ void TextFragment::draw(Painter* p, const TextBase* t) const
 #else
     p->setFont(f);
     if (p->canDrawHtml() && std::regex_search(text.toStdString(), URL_PATTERN)) {
-        p->drawTextWithUrl(pos, convertUrlsToLinks(text));
+        p->drawHtml(pos, convertUrlsToLinks(text));
     } else {
         p->drawText(pos, text);
     }

--- a/src/engraving/dom/textbase.h
+++ b/src/engraving/dom/textbase.h
@@ -215,6 +215,7 @@ class TextFragment
 {
 public:
     muse::GlobalInject<IEngravingFontsProvider> engravingFonts;
+    static const QRegularExpression urlPattern;
 
 public:
     mutable CharFormat format;
@@ -232,6 +233,8 @@ public:
 
     TextFragment split(int column);
     void draw(muse::draw::Painter*, const TextBase*) const;
+    void drawWithUrl(QPainter* qp, const TextBase*) const;
+
     muse::draw::Font font(const TextBase*) const;
     int columns() const;
     void changeFormat(FormatId id, const FormatValue& data);

--- a/src/engraving/dom/textbase.h
+++ b/src/engraving/dom/textbase.h
@@ -33,8 +33,6 @@
 #include "property.h"
 #include "../types/types.h"
 
-class QPainter;
-
 namespace mu::engraving {
 class TextBase;
 class TextBlock;

--- a/src/engraving/dom/textbase.h
+++ b/src/engraving/dom/textbase.h
@@ -234,7 +234,6 @@ public:
 
     TextFragment split(int column);
     void draw(muse::draw::Painter*, const TextBase*) const;
-    void drawWithUrl(QPainter* qp, const TextBase*) const;
 
     muse::draw::Font font(const TextBase*) const;
     int columns() const;

--- a/src/engraving/dom/textbase.h
+++ b/src/engraving/dom/textbase.h
@@ -215,7 +215,6 @@ class TextFragment
 {
 public:
     muse::GlobalInject<IEngravingFontsProvider> engravingFonts;
-    static const QRegularExpression urlPattern;
 
 public:
     mutable CharFormat format;

--- a/src/engraving/dom/textbase.h
+++ b/src/engraving/dom/textbase.h
@@ -33,6 +33,8 @@
 #include "property.h"
 #include "../types/types.h"
 
+class QPainter;
+
 namespace mu::engraving {
 class TextBase;
 class TextBlock;

--- a/src/engraving/rendering/score/paintdebugger.cpp
+++ b/src/engraving/rendering/score/paintdebugger.cpp
@@ -238,3 +238,8 @@ void PaintDebugger::setClipping(bool enable)
 {
     m_real->setClipping(enable);
 }
+
+QPainter* PaintDebugger::getQPainter()
+{
+    return nullptr;
+}

--- a/src/engraving/rendering/score/paintdebugger.cpp
+++ b/src/engraving/rendering/score/paintdebugger.cpp
@@ -191,11 +191,10 @@ void PaintDebugger::drawTextWorkaround(const Font& f, const PointF& pos, const S
     m_real->drawTextWorkaround(f, pos, text);
 }
 
-bool PaintDebugger::canDrawHtml() { return false; }
+bool PaintDebugger::canDrawHtml() const { return false; }
 
-void PaintDebugger::drawHtml(const muse::PointF& point, const muse::String& htmlText)
+void PaintDebugger::drawHtml(const PointF&, const String&)
 {
-    //
 }
 
 void PaintDebugger::drawSymbol(const PointF& point, char32_t ucs4Code)
@@ -244,9 +243,4 @@ void PaintDebugger::setMask(const RectF& background, const std::vector<RectF>& m
 void PaintDebugger::setClipping(bool enable)
 {
     m_real->setClipping(enable);
-}
-
-QPainter* PaintDebugger::getQPainter()
-{
-    return nullptr;
 }

--- a/src/engraving/rendering/score/paintdebugger.cpp
+++ b/src/engraving/rendering/score/paintdebugger.cpp
@@ -191,6 +191,13 @@ void PaintDebugger::drawTextWorkaround(const Font& f, const PointF& pos, const S
     m_real->drawTextWorkaround(f, pos, text);
 }
 
+bool PaintDebugger::canDrawHtml() { return false; }
+
+void PaintDebugger::drawHtml(const muse::PointF& point, const muse::String& htmlText)
+{
+    //
+}
+
 void PaintDebugger::drawSymbol(const PointF& point, char32_t ucs4Code)
 {
     m_real->drawSymbol(point, ucs4Code);

--- a/src/engraving/rendering/score/paintdebugger.h
+++ b/src/engraving/rendering/score/paintdebugger.h
@@ -86,6 +86,8 @@ public:
     void setMask(const muse::RectF& background, const std::vector<muse::RectF>& maskRects) override;
     void setClipping(bool enable) override;
 
+    QPainter* getQPainter() override;
+
 private:
     muse::draw::IPaintProviderPtr m_real = nullptr;
 

--- a/src/engraving/rendering/score/paintdebugger.h
+++ b/src/engraving/rendering/score/paintdebugger.h
@@ -23,6 +23,7 @@
 #define MU_ENGRAVING_PAINTDEBUGGER_DEV_H
 
 #include "draw/ipaintprovider.h"
+#include "gtest/internal/gtest-string.h"
 
 namespace mu::engraving::rendering::score {
 class PaintDebugger : public muse::draw::IPaintProvider
@@ -69,6 +70,10 @@ public:
     void drawText(const muse::PointF& point, const muse::String& text) override;
     void drawText(const muse::RectF& rect, int flags, const muse::String& text) override;
     void drawTextWorkaround(const muse::draw::Font& f, const muse::PointF& pos, const muse::String& text) override;
+
+    bool canDrawHtml() override;
+
+    void drawHtml(const muse::PointF& point, const muse::String& htmlText) override;
 
     void drawSymbol(const muse::PointF& point, char32_t ucs4Code) override;
 

--- a/src/engraving/rendering/score/paintdebugger.h
+++ b/src/engraving/rendering/score/paintdebugger.h
@@ -23,7 +23,6 @@
 #define MU_ENGRAVING_PAINTDEBUGGER_DEV_H
 
 #include "draw/ipaintprovider.h"
-#include "gtest/internal/gtest-string.h"
 
 namespace mu::engraving::rendering::score {
 class PaintDebugger : public muse::draw::IPaintProvider
@@ -71,7 +70,7 @@ public:
     void drawText(const muse::RectF& rect, int flags, const muse::String& text) override;
     void drawTextWorkaround(const muse::draw::Font& f, const muse::PointF& pos, const muse::String& text) override;
 
-    bool canDrawHtml() override;
+    bool canDrawHtml() const override;
 
     void drawHtml(const muse::PointF& point, const muse::String& htmlText) override;
 
@@ -90,8 +89,6 @@ public:
     void setClipRect(const muse::RectF& rect) override;
     void setMask(const muse::RectF& background, const std::vector<muse::RectF>& maskRects) override;
     void setClipping(bool enable) override;
-
-    QPainter* getQPainter() override;
 
 private:
     muse::draw::IPaintProviderPtr m_real = nullptr;

--- a/src/framework/draw/bufferedpaintprovider.cpp
+++ b/src/framework/draw/bufferedpaintprovider.cpp
@@ -355,6 +355,11 @@ void BufferedPaintProvider::setClipping(bool enable)
     UNUSED(enable);
 }
 
+QPainter* BufferedPaintProvider::getQPainter()
+{
+    return nullptr;
+}
+
 DrawDataPtr BufferedPaintProvider::drawData() const
 {
     return m_buf;

--- a/src/framework/draw/bufferedpaintprovider.cpp
+++ b/src/framework/draw/bufferedpaintprovider.cpp
@@ -306,7 +306,7 @@ void BufferedPaintProvider::drawTextWorkaround(const Font& f, const PointF& pos,
     drawText(pos, text);
 }
 
-bool BufferedPaintProvider::canDrawHtml()
+bool BufferedPaintProvider::canDrawHtml() const
 {
     return false;
 }
@@ -363,11 +363,6 @@ void BufferedPaintProvider::setMask(const RectF& background, const std::vector<R
 void BufferedPaintProvider::setClipping(bool enable)
 {
     UNUSED(enable);
-}
-
-QPainter* BufferedPaintProvider::getQPainter()
-{
-    return nullptr;
 }
 
 DrawDataPtr BufferedPaintProvider::drawData() const

--- a/src/framework/draw/bufferedpaintprovider.cpp
+++ b/src/framework/draw/bufferedpaintprovider.cpp
@@ -306,6 +306,16 @@ void BufferedPaintProvider::drawTextWorkaround(const Font& f, const PointF& pos,
     drawText(pos, text);
 }
 
+bool BufferedPaintProvider::canDrawHtml()
+{
+    return false;
+}
+
+void BufferedPaintProvider::drawHtml(const PointF& point, const String& htmlText)
+{
+    //
+}
+
 void BufferedPaintProvider::drawSymbol(const PointF& point, char32_t ucs4Code)
 {
     drawText(point, String::fromUcs4(&ucs4Code, 1));

--- a/src/framework/draw/bufferedpaintprovider.h
+++ b/src/framework/draw/bufferedpaintprovider.h
@@ -72,7 +72,7 @@ public:
     void drawText(const RectF& rect, int flags, const String& text) override;
     void drawTextWorkaround(const Font& f, const PointF& pos, const String& text) override;
 
-    bool canDrawHtml() override;
+    bool canDrawHtml() const override;
     void drawHtml(const PointF& point, const String& htmlText) override;
 
     void drawSymbol(const PointF& point, char32_t ucs4Code) override;
@@ -90,8 +90,6 @@ public:
     void setClipRect(const RectF& rect) override;
     void setMask(const RectF& background, const std::vector<RectF>& maskRects) override;
     void setClipping(bool enable) override;
-
-    QPainter* getQPainter() override;
 
     // ---
 

--- a/src/framework/draw/bufferedpaintprovider.h
+++ b/src/framework/draw/bufferedpaintprovider.h
@@ -88,6 +88,8 @@ public:
     void setMask(const RectF& background, const std::vector<RectF>& maskRects) override;
     void setClipping(bool enable) override;
 
+    QPainter* getQPainter() override;
+
     // ---
 
     DrawDataPtr drawData() const;

--- a/src/framework/draw/bufferedpaintprovider.h
+++ b/src/framework/draw/bufferedpaintprovider.h
@@ -72,6 +72,9 @@ public:
     void drawText(const RectF& rect, int flags, const String& text) override;
     void drawTextWorkaround(const Font& f, const PointF& pos, const String& text) override;
 
+    bool canDrawHtml() override;
+    void drawHtml(const PointF& point, const String& htmlText) override;
+
     void drawSymbol(const PointF& point, char32_t ucs4Code) override;
 
     void drawPixmap(const PointF& p, const Pixmap& pm) override;

--- a/src/framework/draw/internal/qpainterprovider.cpp
+++ b/src/framework/draw/internal/qpainterprovider.cpp
@@ -326,9 +326,13 @@ void QPainterProvider::drawHtml(const PointF& point, const String& htmlText)
     doc.setTextWidth(-1); // No wrapping
     doc.setDocumentMargin(0);
 
+    // Calculate baseline offset
+    QFontMetricsF fm(f);
+    qreal baselineOffset = fm.ascent();
+
     // Draw the document
     m_painter->save();
-    m_painter->translate(point.toQPointF());
+    m_painter->translate(point.toQPointF().x(), point.toQPointF().y() - baselineOffset);
     doc.drawContents(m_painter);
     m_painter->restore();
 }

--- a/src/framework/draw/internal/qpainterprovider.cpp
+++ b/src/framework/draw/internal/qpainterprovider.cpp
@@ -303,7 +303,7 @@ void QPainterProvider::drawTextWorkaround(const Font& f, const PointF& pos, cons
     m_painter->restore();
 }
 
-bool QPainterProvider::canDrawHtml()
+bool QPainterProvider::canDrawHtml() const
 {
     return true;
 }
@@ -319,6 +319,7 @@ void QPainterProvider::drawHtml(const PointF& point, const String& htmlText)
     doc.setDefaultFont(f);
     doc.setUseDesignMetrics(true);
 
+    // Set contents
     doc.setHtml(htmlText);
 
     // Set document properties
@@ -410,9 +411,4 @@ void QPainterProvider::setMask(const RectF& background, const std::vector<RectF>
 void QPainterProvider::setClipping(bool enable)
 {
     m_painter->setClipping(enable);
-}
-
-QPainter* QPainterProvider::getQPainter()
-{
-    return m_painter;
 }

--- a/src/framework/draw/internal/qpainterprovider.cpp
+++ b/src/framework/draw/internal/qpainterprovider.cpp
@@ -382,3 +382,8 @@ void QPainterProvider::setClipping(bool enable)
 {
     m_painter->setClipping(enable);
 }
+
+QPainter* QPainterProvider::getQPainter()
+{
+    return m_painter;
+}

--- a/src/framework/draw/internal/qpainterprovider.cpp
+++ b/src/framework/draw/internal/qpainterprovider.cpp
@@ -303,6 +303,35 @@ void QPainterProvider::drawTextWorkaround(const Font& f, const PointF& pos, cons
     m_painter->restore();
 }
 
+bool QPainterProvider::canDrawHtml()
+{
+    return true;
+}
+
+void QPainterProvider::drawHtml(const PointF& point, const String& htmlText)
+{
+    QTextDocument doc;
+
+    // Set font
+    QFont f = font().toQFont();
+    float fontScalingFactor = m_painter->device()->logicalDpiX() / 72.;
+    f.setPixelSize(f.pointSizeF() * fontScalingFactor);
+    doc.setDefaultFont(f);
+    doc.setUseDesignMetrics(true);
+
+    doc.setHtml(htmlText);
+
+    // Set document properties
+    doc.setTextWidth(-1); // No wrapping
+    doc.setDocumentMargin(0);
+
+    // Draw the document
+    m_painter->save();
+    m_painter->translate(point.toQPointF());
+    doc.drawContents(m_painter);
+    m_painter->restore();
+}
+
 void QPainterProvider::drawSymbol(const PointF& point, char32_t ucs4Code)
 {
     static QHash<char32_t, QString> cache;

--- a/src/framework/draw/internal/qpainterprovider.h
+++ b/src/framework/draw/internal/qpainterprovider.h
@@ -76,6 +76,9 @@ public:
     void drawText(const RectF& rect, int flags, const String& text) override;
     void drawTextWorkaround(const Font& f, const PointF& pos, const String& text) override;
 
+    bool canDrawHtml() override;
+    void drawHtml(const PointF& point, const String& htmlText) override;
+
     void drawSymbol(const PointF& point, char32_t ucs4Code) override;
 
     void drawPixmap(const PointF& point, const Pixmap& pm) override;

--- a/src/framework/draw/internal/qpainterprovider.h
+++ b/src/framework/draw/internal/qpainterprovider.h
@@ -76,7 +76,7 @@ public:
     void drawText(const RectF& rect, int flags, const String& text) override;
     void drawTextWorkaround(const Font& f, const PointF& pos, const String& text) override;
 
-    bool canDrawHtml() override;
+    bool canDrawHtml() const override;
     void drawHtml(const PointF& point, const String& htmlText) override;
 
     void drawSymbol(const PointF& point, char32_t ucs4Code) override;
@@ -92,8 +92,6 @@ public:
     void setClipRect(const RectF& rect) override;
     void setMask(const RectF& background, const std::vector<RectF>& maskRects) override;
     void setClipping(bool enable) override;
-
-    QPainter* getQPainter() override;
 
 protected:
     QPainter* m_painter = nullptr;

--- a/src/framework/draw/internal/qpainterprovider.h
+++ b/src/framework/draw/internal/qpainterprovider.h
@@ -90,6 +90,8 @@ public:
     void setMask(const RectF& background, const std::vector<RectF>& maskRects) override;
     void setClipping(bool enable) override;
 
+    QPainter* getQPainter() override;
+
 protected:
     QPainter* m_painter = nullptr;
 

--- a/src/framework/draw/ipaintprovider.h
+++ b/src/framework/draw/ipaintprovider.h
@@ -33,6 +33,8 @@
 #include "types/transform.h"
 #include "types/painterpath.h"
 
+class QPainter;
+
 namespace muse::draw {
 class Painter;
 class IPaintProvider
@@ -91,6 +93,11 @@ public:
     virtual void setClipRect(const RectF& rect) = 0;
     virtual void setMask(const RectF& background, const std::vector<RectF>& maskRects) = 0;
     virtual void setClipping(bool enable) = 0;
+
+    // We cannot implement writing clickable url into pdf without
+    // directly passing QPainter to QTextDocument::drawContents,
+    // so we need to expose QPainter
+    virtual QPainter* getQPainter() = 0;
 };
 
 using IPaintProviderPtr = std::shared_ptr<IPaintProvider>;

--- a/src/framework/draw/ipaintprovider.h
+++ b/src/framework/draw/ipaintprovider.h
@@ -78,6 +78,9 @@ public:
     virtual void drawText(const RectF& rect, int flags, const String& text) = 0;
     virtual void drawTextWorkaround(const Font& f, const PointF& pos, const String& text) = 0; // see Painter::drawTextWorkaround .h file
 
+    virtual bool canDrawHtml() = 0;
+    virtual void drawHtml(const PointF& point, const String& htmlText) = 0;
+
     virtual void drawSymbol(const PointF& point, char32_t ucs4Code) = 0;
 
     virtual void drawPixmap(const PointF& point, const Pixmap& pm) = 0;

--- a/src/framework/draw/ipaintprovider.h
+++ b/src/framework/draw/ipaintprovider.h
@@ -33,8 +33,6 @@
 #include "types/transform.h"
 #include "types/painterpath.h"
 
-class QPainter;
-
 namespace muse::draw {
 class Painter;
 class IPaintProvider
@@ -78,7 +76,7 @@ public:
     virtual void drawText(const RectF& rect, int flags, const String& text) = 0;
     virtual void drawTextWorkaround(const Font& f, const PointF& pos, const String& text) = 0; // see Painter::drawTextWorkaround .h file
 
-    virtual bool canDrawHtml() = 0;
+    virtual bool canDrawHtml() const = 0;
     virtual void drawHtml(const PointF& point, const String& htmlText) = 0;
 
     virtual void drawSymbol(const PointF& point, char32_t ucs4Code) = 0;
@@ -96,11 +94,6 @@ public:
     virtual void setClipRect(const RectF& rect) = 0;
     virtual void setMask(const RectF& background, const std::vector<RectF>& maskRects) = 0;
     virtual void setClipping(bool enable) = 0;
-
-    // We cannot implement writing clickable url into pdf without
-    // directly passing QPainter to QTextDocument::drawContents,
-    // so we need to expose QPainter
-    virtual QPainter* getQPainter() = 0;
 };
 
 using IPaintProviderPtr = std::shared_ptr<IPaintProvider>;

--- a/src/framework/draw/painter.cpp
+++ b/src/framework/draw/painter.cpp
@@ -552,3 +552,8 @@ void Painter::setClipping(bool enable)
 {
     m_provider->setClipping(enable);
 }
+
+QPainter* Painter::getQPainter() const
+{
+    return m_provider->getQPainter();
+}

--- a/src/framework/draw/painter.cpp
+++ b/src/framework/draw/painter.cpp
@@ -29,7 +29,6 @@
 #endif
 
 #include "log.h"
-#include "musesampler/internal/apitypes.h"
 
 using namespace muse;
 using namespace muse::draw;
@@ -429,7 +428,7 @@ void Painter::drawText(const PointF& point, const String& text)
     }
 }
 
-void Painter::drawTextWithUrl(const PointF& point, const String& htmlText)
+void Painter::drawHtml(const PointF& point, const String& htmlText)
 {
     m_provider->drawHtml(point, htmlText);
 }

--- a/src/framework/draw/painter.cpp
+++ b/src/framework/draw/painter.cpp
@@ -29,6 +29,7 @@
 #endif
 
 #include "log.h"
+#include "musesampler/internal/apitypes.h"
 
 using namespace muse;
 using namespace muse::draw;
@@ -428,6 +429,11 @@ void Painter::drawText(const PointF& point, const String& text)
     }
 }
 
+void Painter::drawTextWithUrl(const PointF& point, const String& htmlText)
+{
+    m_provider->drawHtml(point, htmlText);
+}
+
 void Painter::drawText(const RectF& rect, int flags, const String& text)
 {
     m_provider->drawText(rect, flags, text);
@@ -553,7 +559,7 @@ void Painter::setClipping(bool enable)
     m_provider->setClipping(enable);
 }
 
-QPainter* Painter::getQPainter() const
+bool Painter::canDrawHtml() const
 {
-    return m_provider->getQPainter();
+    return m_provider->canDrawHtml();
 }

--- a/src/framework/draw/painter.h
+++ b/src/framework/draw/painter.h
@@ -128,7 +128,7 @@ public:
 
     void drawText(const PointF& point, const String& text);
 
-    void drawTextWithUrl(const PointF& point, const String& htmlText);
+    void drawHtml(const PointF& point, const String& htmlText);
 
     inline void drawText(double x, double y, const String& text);
 

--- a/src/framework/draw/painter.h
+++ b/src/framework/draw/painter.h
@@ -160,6 +160,8 @@ public:
     void setMask(const RectF& background, const std::vector<RectF>& maskRects);
     void setClipping(bool enable);
 
+    QPainter* getQPainter() const;
+
     //! NOTE Provider for tests.
     //! We're not ready to use DI (ModuleIoC) here yet
     static IPaintProviderPtr extended;

--- a/src/framework/draw/painter.h
+++ b/src/framework/draw/painter.h
@@ -127,6 +127,9 @@ public:
     void drawArc(const RectF& rect, int a, int alen);
 
     void drawText(const PointF& point, const String& text);
+
+    void drawTextWithUrl(const PointF& point, const String& htmlText);
+
     inline void drawText(double x, double y, const String& text);
 
     void drawText(const RectF& rect, int flags, const String& text);
@@ -160,7 +163,7 @@ public:
     void setMask(const RectF& background, const std::vector<RectF>& maskRects);
     void setClipping(bool enable);
 
-    QPainter* getQPainter() const;
+    bool canDrawHtml() const;
 
     //! NOTE Provider for tests.
     //! We're not ready to use DI (ModuleIoC) here yet


### PR DESCRIPTION
Resolves: #18055
Implements writing URLs into PDF via wrapping text into `QTextDocument`
and using its `::drawContents` method.

As of September 2025 it's the only known method to write URLs to PDF.

(Url regex is not fully-featured, isn't intended for long urls with queries)


- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
