### PR TITLE
Adds option to not enter Note Input Mode on Keyboard input (#21399)

### DIFF
--- a/src/appshell/qml/Preferences/NoteInputPreferencesPage.qml
+++ b/src/appshell/qml/Preferences/NoteInputPreferencesPage.qml
@@ -47,6 +47,7 @@ PreferencesPage {
             defaultNoteInputMethod: noteInputModel.defaultNoteInputMethod
             addAccidentalDotsArticulationsToNextNoteEntered: noteInputModel.addAccidentalDotsArticulationsToNextNoteEntered
             useNoteInputCursorInInputByDuration: noteInputModel.useNoteInputCursorInInputByDuration
+            enterNoteInputModeOnKeyboardEntry: noteInputModel.enterNoteInputModeOnKeyboardEntry
 
             navigation.section: root.navigationSection
             navigation.order: root.navigationOrderStart + 1
@@ -61,6 +62,10 @@ PreferencesPage {
 
             onUseNoteInputCursorInInputByDurationChangeRequested: function(use) {
                 noteInputModel.useNoteInputCursorInInputByDuration = use
+            }
+
+            onEnterNoteInputModeOnKeyboardEntryChangeRequested: function(use) {
+                noteInputModel.enterNoteInputModeOnKeyboardEntry = use
             }
         }
 

--- a/src/appshell/qml/Preferences/internal/NoteInput/NoteInputSection.qml
+++ b/src/appshell/qml/Preferences/internal/NoteInput/NoteInputSection.qml
@@ -37,10 +37,12 @@ BaseSection {
 
     property bool addAccidentalDotsArticulationsToNextNoteEntered: true
     property bool useNoteInputCursorInInputByDuration: false
+    property bool enterNoteInputModeOnKeyboardEntry: false
 
     signal defaultNoteInputMethodChangeRequested(int method)
     signal addAccidentalDotsArticulationsToNextNoteEnteredChangeRequested(bool add)
     signal useNoteInputCursorInInputByDurationChangeRequested(bool use)
+    signal enterNoteInputModeOnKeyboardEntryChangeRequested(bool use)
 
     ComboBoxWithTitle {
         id: defaultNoteInputMethodDropdown
@@ -93,6 +95,25 @@ BaseSection {
 
         onValueEdited: function(newIndex, newValue) {
             root.useNoteInputCursorInInputByDurationChangeRequested(newIndex === 1)
+        }
+    }
+
+    ComboBoxWithTitle {
+        title: qsTrc("appshell/preferences", "Enter Note Input Mode on keyboard note entry")
+
+        navigation.name: "EnterNoteInputOnKeyboardEntryDropdown"
+        navigation.panel: root.navigation
+        navigation.row: 2
+
+        model: [
+            { text: qsTrc("appshell/preferences", "Yes"), value: 0 },
+            { text: qsTrc("appshell/preferences", "No"), value: 1 },
+        ]
+
+        currentIndex: root.enterNoteInputModeOnKeyboardEntry ? 1 : 0
+
+        onValueEdited: function(newIndex, newValue) {
+            root.enterNoteInputModeOnKeyboardEntryChangeRequested(newIndex === 1)
         }
     }
 }

--- a/src/appshell/view/preferences/noteinputpreferencesmodel.cpp
+++ b/src/appshell/view/preferences/noteinputpreferencesmodel.cpp
@@ -45,6 +45,10 @@ void NoteInputPreferencesModel::load()
         emit useNoteInputCursorInInputByDurationChanged(useNoteInputCursorInInputByDuration());
     });
 
+    notationConfiguration()->enterNoteInputModeOnKeyboardEntryChanged().onNotify(this, [this]() {
+        emit enterNoteInputModeOnKeyboardEntryChanged(enterNoteInputModeOnKeyboardEntry());
+    });
+
     notationConfiguration()->isMidiInputEnabledChanged().onNotify(this, [this]() {
         emit midiInputEnabledChanged(midiInputEnabled());
     });
@@ -149,6 +153,11 @@ bool NoteInputPreferencesModel::useNoteInputCursorInInputByDuration() const
     return notationConfiguration()->useNoteInputCursorInInputByDuration();
 }
 
+bool NoteInputPreferencesModel::enterNoteInputModeOnKeyboardEntry() const
+{
+    return notationConfiguration()->enterNoteInputModeOnKeyboardEntry();
+}
+
 bool NoteInputPreferencesModel::midiInputEnabled() const
 {
     return notationConfiguration()->isMidiInputEnabled();
@@ -249,6 +258,15 @@ void NoteInputPreferencesModel::setUseNoteInputCursorInInputByDuration(bool valu
     }
 
     notationConfiguration()->setUseNoteInputCursorInInputByDuration(value);
+}
+
+void NoteInputPreferencesModel::setEnterNoteInputModeOnKeyboardEntry(bool value)
+{
+    if (value == enterNoteInputModeOnKeyboardEntry()) {
+        return;
+    }
+
+    notationConfiguration()->setEnterNoteInputModeOnKeyboardEntry(value);
 }
 
 void NoteInputPreferencesModel::setMidiInputEnabled(bool value)

--- a/src/appshell/view/preferences/noteinputpreferencesmodel.h
+++ b/src/appshell/view/preferences/noteinputpreferencesmodel.h
@@ -44,6 +44,8 @@ class NoteInputPreferencesModel : public QObject, public muse::Injectable, publi
         bool addAccidentalDotsArticulationsToNextNoteEntered READ addAccidentalDotsArticulationsToNextNoteEntered WRITE setAddAccidentalDotsArticulationsToNextNoteEntered NOTIFY addAccidentalDotsArticulationsToNextNoteEnteredChanged)
     Q_PROPERTY(
         bool useNoteInputCursorInInputByDuration READ useNoteInputCursorInInputByDuration WRITE setUseNoteInputCursorInInputByDuration NOTIFY useNoteInputCursorInInputByDurationChanged)
+    Q_PROPERTY(
+        bool enterNoteInputModeOnKeyboardEntry READ enterNoteInputModeOnKeyboardEntry WRITE setEnterNoteInputModeOnKeyboardEntry NOTIFY enterNoteInputModeOnKeyboardEntryChanged)
 
     Q_PROPERTY(bool midiInputEnabled READ midiInputEnabled WRITE setMidiInputEnabled NOTIFY midiInputEnabledChanged)
     Q_PROPERTY(
@@ -93,6 +95,7 @@ public:
     int defaultNoteInputMethod() const;
     bool addAccidentalDotsArticulationsToNextNoteEntered() const;
     bool useNoteInputCursorInInputByDuration() const;
+    bool enterNoteInputModeOnKeyboardEntry() const;
 
     bool midiInputEnabled() const;
     bool startNoteInputAtSelectedNoteRestWhenPressingMidiKey() const;
@@ -119,6 +122,7 @@ public slots:
     void setDefaultNoteInputMethod(int value);
     void setAddAccidentalDotsArticulationsToNextNoteEntered(bool value);
     void setUseNoteInputCursorInInputByDuration(bool value);
+    void setEnterNoteInputModeOnKeyboardEntry(bool value);
 
     void setMidiInputEnabled(bool value);
     void setStartNoteInputAtSelectedNoteRestWhenPressingMidiKey(bool value);
@@ -145,6 +149,7 @@ signals:
     void defaultNoteInputMethodChanged(int value);
     void addAccidentalDotsArticulationsToNextNoteEnteredChanged(bool value);
     void useNoteInputCursorInInputByDurationChanged(bool value);
+    void enterNoteInputModeOnKeyboardEntryChanged(bool value);
 
     void midiInputEnabledChanged(bool value);
     void startNoteInputAtSelectedNoteRestWhenPressingMidiKeyChanged(bool value);

--- a/src/notation/inotationconfiguration.h
+++ b/src/notation/inotationconfiguration.h
@@ -92,6 +92,10 @@ public:
     virtual void setUseNoteInputCursorInInputByDuration(bool use) = 0;
     virtual muse::async::Notification useNoteInputCursorInInputByDurationChanged() const = 0;
 
+    virtual bool enterNoteInputModeOnKeyboardEntry() const = 0;
+    virtual void setEnterNoteInputModeOnKeyboardEntry(bool use) = 0;
+    virtual muse::async::Notification enterNoteInputModeOnKeyboardEntryChanged() const = 0;
+
     virtual int selectionProximity() const = 0;
     virtual void setSelectionProximity(int proximity) = 0;
     virtual muse::async::Channel<int> selectionProximityChanged() const = 0;

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -2254,9 +2254,11 @@ bool NotationActionController::startNoteInputAllowed() const
 
 void NotationActionController::startNoteInput()
 {
-    INotationNoteInputPtr noteInput = currentNotationNoteInput();
-    if (noteInput) {
-        noteInput->startNoteInput(configuration()->defaultNoteInputMethod());
+    if (!configuration()->enterNoteInputModeOnKeyboardEntry()) {
+        INotationNoteInputPtr noteInput = currentNotationNoteInput();
+        if (noteInput) {
+            noteInput->startNoteInput(configuration()->defaultNoteInputMethod());
+        }
     }
 }
 

--- a/src/notation/internal/notationconfiguration.cpp
+++ b/src/notation/internal/notationconfiguration.cpp
@@ -54,6 +54,9 @@ static const Settings::Key NOTE_INPUT_PREVIEW_COLOR(module_name, "ui/canvas/note
 static const Settings::Key USE_NOTE_INPUT_CURSOR_IN_INPUT_BY_DURATION(module_name,
                                                                       "ui/canvas/useNoteInputCursorInInputByDuration");
 
+static const Settings::Key ENTER_NOTE_INPUT_MODE_ON_KEYBOARD_ENTRY(module_name,
+                                                                      "ui/canvas/enterNoteInputModeOnKeyboardEntry");
+
 static const Settings::Key THIN_NOTE_INPUT_CURSOR(module_name, "ui/canvas/thinNoteInputCursor");
 
 static const Settings::Key SELECTION_PROXIMITY(module_name, "ui/canvas/misc/selectionProximity");
@@ -187,6 +190,11 @@ void NotationConfiguration::init()
     settings()->setDefaultValue(USE_NOTE_INPUT_CURSOR_IN_INPUT_BY_DURATION, Val(false));
     settings()->valueChanged(USE_NOTE_INPUT_CURSOR_IN_INPUT_BY_DURATION).onReceive(nullptr, [this](const Val&) {
         m_useNoteInputCursorInInputByDurationChanged.notify();
+    });
+
+    settings()->setDefaultValue(ENTER_NOTE_INPUT_MODE_ON_KEYBOARD_ENTRY, Val(false));
+    settings()->valueChanged(ENTER_NOTE_INPUT_MODE_ON_KEYBOARD_ENTRY).onReceive(nullptr, [this](const Val&) {
+        m_enterNoteInputModeOnKeyboardEntryChanged.notify();
     });
 
     settings()->setDefaultValue(THIN_NOTE_INPUT_CURSOR, Val(false)); // accessible via DevTools/Settings
@@ -649,6 +657,21 @@ void NotationConfiguration::setUseNoteInputCursorInInputByDuration(bool use)
 muse::async::Notification NotationConfiguration::useNoteInputCursorInInputByDurationChanged() const
 {
     return m_useNoteInputCursorInInputByDurationChanged;
+}
+
+bool NotationConfiguration::enterNoteInputModeOnKeyboardEntry() const
+{
+    return settings()->value(ENTER_NOTE_INPUT_MODE_ON_KEYBOARD_ENTRY).toBool();
+}
+
+void NotationConfiguration::setEnterNoteInputModeOnKeyboardEntry(bool use)
+{
+    settings()->setSharedValue(ENTER_NOTE_INPUT_MODE_ON_KEYBOARD_ENTRY, Val(use));
+}
+
+muse::async::Notification NotationConfiguration::enterNoteInputModeOnKeyboardEntryChanged() const
+{
+    return m_enterNoteInputModeOnKeyboardEntryChanged;
 }
 
 int NotationConfiguration::selectionProximity() const

--- a/src/notation/internal/notationconfiguration.h
+++ b/src/notation/internal/notationconfiguration.h
@@ -96,6 +96,10 @@ public:
     void setUseNoteInputCursorInInputByDuration(bool use) override;
     muse::async::Notification useNoteInputCursorInInputByDurationChanged() const override;
 
+    bool enterNoteInputModeOnKeyboardEntry() const override;
+    void setEnterNoteInputModeOnKeyboardEntry(bool use) override;
+    muse::async::Notification enterNoteInputModeOnKeyboardEntryChanged() const override;
+
     int selectionProximity() const override;
     void setSelectionProximity(int proximity) override;
     muse::async::Channel<int> selectionProximityChanged() const override;
@@ -296,6 +300,7 @@ private:
     muse::async::Notification m_defaultNoteInputMethodChanged;
     muse::async::Notification m_addAccidentalDotsArticulationsToNextNoteEnteredChanged;
     muse::async::Notification m_useNoteInputCursorInInputByDurationChanged;
+    muse::async::Notification m_enterNoteInputModeOnKeyboardEntryChanged;
     muse::async::Notification m_isMidiInputEnabledChanged;
     muse::async::Notification m_startNoteInputAtSelectedNoteRestWhenPressingMidiKeyChanged;
 

--- a/src/notation/tests/mocks/notationconfigurationmock.h
+++ b/src/notation/tests/mocks/notationconfigurationmock.h
@@ -82,6 +82,10 @@ public:
     MOCK_METHOD(void, setUseNoteInputCursorInInputByDuration, (bool), (override));
     MOCK_METHOD(muse::async::Notification, useNoteInputCursorInInputByDurationChanged, (), (const, override));
 
+    MOCK_METHOD(bool, enterNoteInputModeOnKeyboardEntry, (), (const, override));
+    MOCK_METHOD(void, setEnterNoteInputModeOnKeyboardEntry, (bool), (override));
+    MOCK_METHOD(muse::async::Notification, enterNoteInputModeOnKeyboardEntryChanged, (), (const, override));
+
     MOCK_METHOD(int, selectionProximity, (), (const, override));
     MOCK_METHOD(void, setSelectionProximity, (int), (override));
     MOCK_METHOD(muse::async::Channel<int>, selectionProximityChanged, (), (const, override));

--- a/src/stubs/notation/notationconfigurationstub.cpp
+++ b/src/stubs/notation/notationconfigurationstub.cpp
@@ -190,6 +190,21 @@ muse::async::Notification NotationConfigurationStub::useNoteInputCursorInInputBy
     return n;
 }
 
+bool NotationConfigurationStub::enterNoteInputModeOnKeyboardEntry() const
+{
+    return false;
+}
+
+void NotationConfigurationStub::setEnterNoteInputModeOnKeyboardEntry(bool)
+{
+}
+
+muse::async::Notification NotationConfigurationStub::enterNoteInputModeOnKeyboardEntryChanged() const
+{
+    static muse::async::Notification n;
+    return n;
+}
+
 int NotationConfigurationStub::selectionProximity() const
 {
     return 1;

--- a/src/stubs/notation/notationconfigurationstub.h
+++ b/src/stubs/notation/notationconfigurationstub.h
@@ -84,6 +84,10 @@ public:
     void setUseNoteInputCursorInInputByDuration(bool use) override;
     muse::async::Notification useNoteInputCursorInInputByDurationChanged() const override;
 
+    bool enterNoteInputModeOnKeyboardEntry() const override;
+    void setEnterNoteInputModeOnKeyboardEntry(bool use) override;
+    muse::async::Notification enterNoteInputModeOnKeyboardEntryChanged() const override;
+
     int selectionProximity() const override;
     void setSelectionProximity(int proximity)  override;
     muse::async::Channel<int> selectionProximityChanged() const override;


### PR DESCRIPTION
Resolves: #21399

Adds a toggle in Preferences to disable automatic entry into 'Mouse Note Input Mode' so that one can still select notes, or drag to navigate with reckless abandon, without having to press escape or `n` to exit the mode.  Not everyone wishes to input notes the same way and while there may be more efficient ways, having the option seems to be a good idea, particularly as this has been brought up on the forums may times.  Here's a couple of posts:

https://musescore.org/en/node/270451
https://musescore.org/en/node/304807
https://musescore.org/en/node/358578

I can't claim to have much familiarity with the code base—nor C++ for that matter—so I've basically duplicated `useNoteInputCursorInInputByDuration` as `enterNoteInputModeOnKeyboardEntry` in all but effect.  This approach may come with unnecessary bloat, as I can't say for sure which bits are 100% required.  Similarly, I'm unsure of the cost of checking `configuration()->enterNoteInputModeOnKeyboardEntry()` every time that one might enter Mouse Note Input Mode, so there may be a less expensive method to achieve the same result.  Any advice or comments would be sincerely appreciated.

- [ ] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [ ] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [ ] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
