### PR TITLE
Remove unused autoplaceVerticalAlignRange style option

### DIFF
--- a/share/styles/MuseJazz.mss
+++ b/share/styles/MuseJazz.mss
@@ -358,7 +358,6 @@
     <dynamicsPosAbove x="0" y="-2"/>
     <dynamicsPosBelow x="0" y="4"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-3.5"/>
     <textLinePosBelow x="0" y="3.5"/>

--- a/share/templates/01-General/01-Treble_Clef/score_style.mss
+++ b/share/templates/01-General/01-Treble_Clef/score_style.mss
@@ -510,7 +510,6 @@
     <dynamicsPosAbove x="0" y="-1.0"/>
     <dynamicsPosBelow x="0" y="2.0"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/share/templates/01-General/02-Bass_Clef/score_style.mss
+++ b/share/templates/01-General/02-Bass_Clef/score_style.mss
@@ -510,7 +510,6 @@
     <dynamicsPosAbove x="0" y="-1.0"/>
     <dynamicsPosBelow x="0" y="2.0"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/share/templates/01-General/03-Grand_Staff/score_style.mss
+++ b/share/templates/01-General/03-Grand_Staff/score_style.mss
@@ -510,7 +510,6 @@
     <dynamicsPosAbove x="0" y="-1.0"/>
     <dynamicsPosBelow x="0" y="2.0"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/share/templates/02-Choral/01-SATB/score_style.mss
+++ b/share/templates/02-Choral/01-SATB/score_style.mss
@@ -510,7 +510,6 @@
     <dynamicsPosAbove x="0" y="-1.0"/>
     <dynamicsPosBelow x="0" y="2.0"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/share/templates/02-Choral/02-SATB_+_Organ/score_style.mss
+++ b/share/templates/02-Choral/02-SATB_+_Organ/score_style.mss
@@ -510,7 +510,6 @@
     <dynamicsPosAbove x="0" y="-1.0"/>
     <dynamicsPosBelow x="0" y="2.0"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/share/templates/02-Choral/03-SATB_+_Piano/score_style.mss
+++ b/share/templates/02-Choral/03-SATB_+_Piano/score_style.mss
@@ -510,7 +510,6 @@
     <dynamicsPosAbove x="0" y="-1.0"/>
     <dynamicsPosBelow x="0" y="2.0"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/share/templates/02-Choral/04-SATB_Closed_Score/score_style.mss
+++ b/share/templates/02-Choral/04-SATB_Closed_Score/score_style.mss
@@ -512,7 +512,6 @@
     <dynamicsPosAbove x="0" y="-1.0"/>
     <dynamicsPosBelow x="0" y="2.0"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/share/templates/02-Choral/05-SATB_Closed_Score_+_Organ/score_style.mss
+++ b/share/templates/02-Choral/05-SATB_Closed_Score_+_Organ/score_style.mss
@@ -512,7 +512,6 @@
     <dynamicsPosAbove x="0" y="-1.0"/>
     <dynamicsPosBelow x="0" y="2.0"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/share/templates/02-Choral/06-SATB_Closed_Score_+_Piano/score_style.mss
+++ b/share/templates/02-Choral/06-SATB_Closed_Score_+_Piano/score_style.mss
@@ -512,7 +512,6 @@
     <dynamicsPosAbove x="0" y="-1.0"/>
     <dynamicsPosBelow x="0" y="2.0"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/share/templates/02-Choral/07-Voice_+_Piano/score_style.mss
+++ b/share/templates/02-Choral/07-Voice_+_Piano/score_style.mss
@@ -512,7 +512,6 @@
     <dynamicsPosAbove x="0" y="-1.0"/>
     <dynamicsPosBelow x="0" y="2.0"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/share/templates/02-Choral/08-Barbershop_Quartet_(Men)/score_style.mss
+++ b/share/templates/02-Choral/08-Barbershop_Quartet_(Men)/score_style.mss
@@ -512,7 +512,6 @@
     <dynamicsPosAbove x="0" y="-1.0"/>
     <dynamicsPosBelow x="0" y="2.0"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/share/templates/02-Choral/09-Barbershop_Quartet_(Women)/score_style.mss
+++ b/share/templates/02-Choral/09-Barbershop_Quartet_(Women)/score_style.mss
@@ -512,7 +512,6 @@
     <dynamicsPosAbove x="0" y="-1.0"/>
     <dynamicsPosBelow x="0" y="2.0"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/share/templates/02-Choral/10-Liturgical_Unmetrical/score_style.mss
+++ b/share/templates/02-Choral/10-Liturgical_Unmetrical/score_style.mss
@@ -512,7 +512,6 @@
     <dynamicsPosAbove x="0" y="-1.0"/>
     <dynamicsPosBelow x="0" y="2.0"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/share/templates/02-Choral/11-Liturgical_Unmetrical_+_Organ/score_style.mss
+++ b/share/templates/02-Choral/11-Liturgical_Unmetrical_+_Organ/score_style.mss
@@ -512,7 +512,6 @@
     <dynamicsPosAbove x="0" y="-1.0"/>
     <dynamicsPosBelow x="0" y="2.0"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/share/templates/03-Chamber_Music/01-String_Quartet/score_style.mss
+++ b/share/templates/03-Chamber_Music/01-String_Quartet/score_style.mss
@@ -512,7 +512,6 @@
     <dynamicsPosAbove x="0" y="-1.0"/>
     <dynamicsPosBelow x="0" y="2.0"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/share/templates/03-Chamber_Music/02-Wind_Quartet/score_style.mss
+++ b/share/templates/03-Chamber_Music/02-Wind_Quartet/score_style.mss
@@ -512,7 +512,6 @@
     <dynamicsPosAbove x="0" y="-1.0"/>
     <dynamicsPosBelow x="0" y="2.0"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/share/templates/03-Chamber_Music/03-Wind_Quintet/score_style.mss
+++ b/share/templates/03-Chamber_Music/03-Wind_Quintet/score_style.mss
@@ -512,7 +512,6 @@
     <dynamicsPosAbove x="0" y="-1.0"/>
     <dynamicsPosBelow x="0" y="2.0"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/share/templates/03-Chamber_Music/04-Saxophone_Quartet/score_style.mss
+++ b/share/templates/03-Chamber_Music/04-Saxophone_Quartet/score_style.mss
@@ -512,7 +512,6 @@
     <dynamicsPosAbove x="0" y="-1.0"/>
     <dynamicsPosBelow x="0" y="2.0"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/share/templates/03-Chamber_Music/05-Brass_Quartet/score_style.mss
+++ b/share/templates/03-Chamber_Music/05-Brass_Quartet/score_style.mss
@@ -512,7 +512,6 @@
     <dynamicsPosAbove x="0" y="-1.0"/>
     <dynamicsPosBelow x="0" y="2.0"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/share/templates/03-Chamber_Music/06-Brass_Quintet/score_style.mss
+++ b/share/templates/03-Chamber_Music/06-Brass_Quintet/score_style.mss
@@ -512,7 +512,6 @@
     <dynamicsPosAbove x="0" y="-1.0"/>
     <dynamicsPosBelow x="0" y="2.0"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/share/templates/04-Solo/01-Guitar/score_style.mss
+++ b/share/templates/04-Solo/01-Guitar/score_style.mss
@@ -510,7 +510,6 @@
     <dynamicsPosAbove x="0" y="-1.0"/>
     <dynamicsPosBelow x="0" y="2.0"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/share/templates/04-Solo/02-Guitar_+_Tablature/score_style.mss
+++ b/share/templates/04-Solo/02-Guitar_+_Tablature/score_style.mss
@@ -510,7 +510,6 @@
     <dynamicsPosAbove x="0" y="-1.0"/>
     <dynamicsPosBelow x="0" y="2.0"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/share/templates/04-Solo/03-Guitar_Tablature/score_style.mss
+++ b/share/templates/04-Solo/03-Guitar_Tablature/score_style.mss
@@ -510,7 +510,6 @@
     <dynamicsPosAbove x="0" y="-1.0"/>
     <dynamicsPosBelow x="0" y="2.0"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/share/templates/04-Solo/04-Piano/score_style.mss
+++ b/share/templates/04-Solo/04-Piano/score_style.mss
@@ -510,7 +510,6 @@
     <dynamicsPosAbove x="0" y="-1.0"/>
     <dynamicsPosBelow x="0" y="2.0"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/share/templates/05-Jazz/01-Jazz_Lead_Sheet/score_style.mss
+++ b/share/templates/05-Jazz/01-Jazz_Lead_Sheet/score_style.mss
@@ -510,7 +510,6 @@
     <dynamicsPosAbove x="0" y="-1.0"/>
     <dynamicsPosBelow x="0" y="2.0"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/share/templates/05-Jazz/02-Big_Band/score_style.mss
+++ b/share/templates/05-Jazz/02-Big_Band/score_style.mss
@@ -510,7 +510,6 @@
     <dynamicsPosAbove x="0" y="-1.0"/>
     <dynamicsPosBelow x="0" y="2.0"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/share/templates/05-Jazz/03-Jazz_Combo/score_style.mss
+++ b/share/templates/05-Jazz/03-Jazz_Combo/score_style.mss
@@ -510,7 +510,6 @@
     <dynamicsPosAbove x="0" y="-1.0"/>
     <dynamicsPosBelow x="0" y="2.0"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/share/templates/06-Popular/01-Rock_Band/score_style.mss
+++ b/share/templates/06-Popular/01-Rock_Band/score_style.mss
@@ -510,7 +510,6 @@
     <dynamicsPosAbove x="0" y="-1.0"/>
     <dynamicsPosBelow x="0" y="2.0"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/share/templates/06-Popular/02-Bluegrass_Band/score_style.mss
+++ b/share/templates/06-Popular/02-Bluegrass_Band/score_style.mss
@@ -510,7 +510,6 @@
     <dynamicsPosAbove x="0" y="-1.0"/>
     <dynamicsPosBelow x="0" y="2.0"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/share/templates/07-Band_and_Percussion/01-Concert_Band/score_style.mss
+++ b/share/templates/07-Band_and_Percussion/01-Concert_Band/score_style.mss
@@ -510,7 +510,6 @@
     <dynamicsPosAbove x="0" y="-1.0"/>
     <dynamicsPosBelow x="0" y="2.0"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/share/templates/07-Band_and_Percussion/02-Small_Concert_Band/score_style.mss
+++ b/share/templates/07-Band_and_Percussion/02-Small_Concert_Band/score_style.mss
@@ -510,7 +510,6 @@
     <dynamicsPosAbove x="0" y="-1.0"/>
     <dynamicsPosBelow x="0" y="2.0"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/share/templates/07-Band_and_Percussion/03-Brass_Band/score_style.mss
+++ b/share/templates/07-Band_and_Percussion/03-Brass_Band/score_style.mss
@@ -510,7 +510,6 @@
     <dynamicsPosAbove x="0" y="-1.0"/>
     <dynamicsPosBelow x="0" y="2.0"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/share/templates/07-Band_and_Percussion/04-Marching_Band/score_style.mss
+++ b/share/templates/07-Band_and_Percussion/04-Marching_Band/score_style.mss
@@ -510,7 +510,6 @@
     <dynamicsPosAbove x="0" y="-1.0"/>
     <dynamicsPosBelow x="0" y="2.0"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/share/templates/07-Band_and_Percussion/05-Small_Marching_Band/score_style.mss
+++ b/share/templates/07-Band_and_Percussion/05-Small_Marching_Band/score_style.mss
@@ -510,7 +510,6 @@
     <dynamicsPosAbove x="0" y="-1.0"/>
     <dynamicsPosBelow x="0" y="2.0"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/share/templates/07-Band_and_Percussion/06-Battery_Percussion/score_style.mss
+++ b/share/templates/07-Band_and_Percussion/06-Battery_Percussion/score_style.mss
@@ -510,7 +510,6 @@
     <dynamicsPosAbove x="0" y="-1.0"/>
     <dynamicsPosBelow x="0" y="2.0"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/share/templates/07-Band_and_Percussion/07-Large_Pit_Percussion/score_style.mss
+++ b/share/templates/07-Band_and_Percussion/07-Large_Pit_Percussion/score_style.mss
@@ -510,7 +510,6 @@
     <dynamicsPosAbove x="0" y="-1.0"/>
     <dynamicsPosBelow x="0" y="2.0"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/share/templates/07-Band_and_Percussion/08-Small_Pit_Percussion/score_style.mss
+++ b/share/templates/07-Band_and_Percussion/08-Small_Pit_Percussion/score_style.mss
@@ -510,7 +510,6 @@
     <dynamicsPosAbove x="0" y="-1.0"/>
     <dynamicsPosBelow x="0" y="2.0"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/share/templates/07-Band_and_Percussion/09-European_Concert_Band/score_style.mss
+++ b/share/templates/07-Band_and_Percussion/09-European_Concert_Band/score_style.mss
@@ -510,7 +510,6 @@
     <dynamicsPosAbove x="0" y="-1.0"/>
     <dynamicsPosBelow x="0" y="2.0"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/share/templates/08-Orchestral/01-Classical_Orchestra/score_style.mss
+++ b/share/templates/08-Orchestral/01-Classical_Orchestra/score_style.mss
@@ -510,7 +510,6 @@
     <dynamicsPosAbove x="0" y="-1.0"/>
     <dynamicsPosBelow x="0" y="2.0"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/share/templates/08-Orchestral/02-Symphony_Orchestra/score_style.mss
+++ b/share/templates/08-Orchestral/02-Symphony_Orchestra/score_style.mss
@@ -510,7 +510,6 @@
     <dynamicsPosAbove x="0" y="-1.0"/>
     <dynamicsPosBelow x="0" y="2.0"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/share/templates/08-Orchestral/03-String_Orchestra/score_style.mss
+++ b/share/templates/08-Orchestral/03-String_Orchestra/score_style.mss
@@ -510,7 +510,6 @@
     <dynamicsPosAbove x="0" y="-1.0"/>
     <dynamicsPosBelow x="0" y="2.0"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/data/styles/legacy-style-defaults-v1.mss
+++ b/src/engraving/data/styles/legacy-style-defaults-v1.mss
@@ -451,7 +451,6 @@
     <dynamicsPosAbove x="0" y="-3"/>
     <dynamicsPosBelow x="0" y="4"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/data/styles/legacy-style-defaults-v2.mss
+++ b/src/engraving/data/styles/legacy-style-defaults-v2.mss
@@ -451,7 +451,6 @@
     <dynamicsPosAbove x="0" y="-3"/>
     <dynamicsPosBelow x="0" y="4"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/data/styles/legacy-style-defaults-v3.mss
+++ b/src/engraving/data/styles/legacy-style-defaults-v3.mss
@@ -450,7 +450,6 @@
     <dynamicsPosAbove x="0" y="-3"/>
     <dynamicsPosBelow x="0" y="4"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/data/styles/legacy-style-defaults-v302.mss
+++ b/src/engraving/data/styles/legacy-style-defaults-v302.mss
@@ -484,7 +484,6 @@
     <dynamicsPosAbove x="0" y="-1.5"/>
     <dynamicsPosBelow x="0" y="2.5"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/data/styles/legacy-style-defaults-v450.mss
+++ b/src/engraving/data/styles/legacy-style-defaults-v450.mss
@@ -622,7 +622,6 @@
     <snapToDynamics>1</snapToDynamics>
     <centerOnNotehead>1</centerOnNotehead>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/rendering/score/layoutcontext.h
+++ b/src/engraving/rendering/score/layoutcontext.h
@@ -131,8 +131,6 @@ public:
 
     bool firstSystemIndent() const { return styleB(Sid::enableIndentationOnFirstSystem); }
 
-    VerticalAlignRange verticalAlignRange() const { return style().value(Sid::autoplaceVerticalAlignRange).value<VerticalAlignRange>(); }
-
 private:
     const Score* score() const;
     const LayoutOptions& options() const;

--- a/src/engraving/style/styledef.cpp
+++ b/src/engraving/style/styledef.cpp
@@ -757,7 +757,6 @@ const std::array<StyleDef::StyleValue, size_t(Sid::STYLES)> StyleDef::styleValue
     styleDef(snapToDynamics,                             true),
     styleDef(centerOnNotehead,                           true),
     styleDef(dynamicsMinDistance,                        Spatium(0.5)),
-    styleDef(autoplaceVerticalAlignRange,                int(VerticalAlignRange::SYSTEM)),
 
     styleDef(textLinePlacement,                          PlacementV::ABOVE),
     styleDef(textLinePosAbove,                           PointF(.0, -1.0)),

--- a/src/engraving/style/styledef.h
+++ b/src/engraving/style/styledef.h
@@ -774,7 +774,6 @@ enum class Sid {
     snapToDynamics,
     centerOnNotehead,
     dynamicsMinDistance,
-    autoplaceVerticalAlignRange,
 
     textLinePlacement,
     textLinePosAbove,
@@ -2020,14 +2019,6 @@ enum class Sid {
 END_QT_REGISTERED_ENUM(Sid)
 
 using StyleIdSet = std::unordered_set<Sid>;
-
-//---------------------------------------------------------
-//   VerticalAlignRange
-//---------------------------------------------------------
-
-enum class VerticalAlignRange : unsigned char {
-    SEGMENT, MEASURE, SYSTEM
-};
 
 //---------------------------------------------------------
 //   StyledProperty

--- a/src/engraving/tests/hideemptystaves_data/compat450/score_style.mss
+++ b/src/engraving/tests/hideemptystaves_data/compat450/score_style.mss
@@ -622,7 +622,6 @@
     <snapToDynamics>1</snapToDynamics>
     <centerOnNotehead>1</centerOnNotehead>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/tests/playback/playbackeventsrenderer_data/TwoNotes_Discrete_Harp_Glissando/score_style.mss
+++ b/src/engraving/tests/playback/playbackeventsrenderer_data/TwoNotes_Discrete_Harp_Glissando/score_style.mss
@@ -544,7 +544,6 @@
     <snapToDynamics>1</snapToDynamics>
     <centerOnNotehead>1</centerOnNotehead>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/tests/playback/playbackeventsrenderer_data/chord_arpeggio/score_style.mss
+++ b/src/engraving/tests/playback/playbackeventsrenderer_data/chord_arpeggio/score_style.mss
@@ -512,7 +512,6 @@
     <dynamicsPosAbove x="0" y="-1.5"/>
     <dynamicsPosBelow x="0" y="2.5"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/tests/playback/playbackeventsrenderer_data/chord_arpeggio_bracket/score_style.mss
+++ b/src/engraving/tests/playback/playbackeventsrenderer_data/chord_arpeggio_bracket/score_style.mss
@@ -512,7 +512,6 @@
     <dynamicsPosAbove x="0" y="-1.5"/>
     <dynamicsPosBelow x="0" y="2.5"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/tests/playback/playbackeventsrenderer_data/chord_arpeggio_down/score_style.mss
+++ b/src/engraving/tests/playback/playbackeventsrenderer_data/chord_arpeggio_down/score_style.mss
@@ -512,7 +512,6 @@
     <dynamicsPosAbove x="0" y="-1.5"/>
     <dynamicsPosBelow x="0" y="2.5"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/tests/playback/playbackeventsrenderer_data/chord_arpeggio_straight_down/score_style.mss
+++ b/src/engraving/tests/playback/playbackeventsrenderer_data/chord_arpeggio_straight_down/score_style.mss
@@ -512,7 +512,6 @@
     <dynamicsPosAbove x="0" y="-1.5"/>
     <dynamicsPosBelow x="0" y="2.5"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/tests/playback/playbackeventsrenderer_data/chord_arpeggio_straight_up/score_style.mss
+++ b/src/engraving/tests/playback/playbackeventsrenderer_data/chord_arpeggio_straight_up/score_style.mss
@@ -512,7 +512,6 @@
     <dynamicsPosAbove x="0" y="-1.5"/>
     <dynamicsPosBelow x="0" y="2.5"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/tests/playback/playbackeventsrenderer_data/chord_arpeggio_up/score_style.mss
+++ b/src/engraving/tests/playback/playbackeventsrenderer_data/chord_arpeggio_up/score_style.mss
@@ -512,7 +512,6 @@
     <dynamicsPosAbove x="0" y="-1.5"/>
     <dynamicsPosBelow x="0" y="2.5"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/tests/playback/playbackeventsrenderer_data/single_chord_tremolo/score_style.mss
+++ b/src/engraving/tests/playback/playbackeventsrenderer_data/single_chord_tremolo/score_style.mss
@@ -512,7 +512,6 @@
     <dynamicsPosAbove x="0" y="-1.5"/>
     <dynamicsPosBelow x="0" y="2.5"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/tests/playback/playbackeventsrenderer_data/single_note_acciaccatura/score_style.mss
+++ b/src/engraving/tests/playback/playbackeventsrenderer_data/single_note_acciaccatura/score_style.mss
@@ -512,7 +512,6 @@
     <dynamicsPosAbove x="0" y="-1.5"/>
     <dynamicsPosBelow x="0" y="2.5"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/tests/playback/playbackeventsrenderer_data/single_note_acciaccatura_chord/score_style.mss
+++ b/src/engraving/tests/playback/playbackeventsrenderer_data/single_note_acciaccatura_chord/score_style.mss
@@ -533,7 +533,6 @@
     <dynamicsPosAbove x="0" y="-1.5"/>
     <dynamicsPosBelow x="0" y="2.5"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/tests/playback/playbackeventsrenderer_data/single_note_appoggiatura_chord_post/score_style.mss
+++ b/src/engraving/tests/playback/playbackeventsrenderer_data/single_note_appoggiatura_chord_post/score_style.mss
@@ -533,7 +533,6 @@
     <dynamicsPosAbove x="0" y="-1.5"/>
     <dynamicsPosBelow x="0" y="2.5"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/tests/playback/playbackeventsrenderer_data/single_note_appoggiatura_post/score_style.mss
+++ b/src/engraving/tests/playback/playbackeventsrenderer_data/single_note_appoggiatura_post/score_style.mss
@@ -512,7 +512,6 @@
     <dynamicsPosAbove x="0" y="-1.5"/>
     <dynamicsPosBelow x="0" y="2.5"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/tests/playback/playbackeventsrenderer_data/single_note_inverted_turn/score_style.mss
+++ b/src/engraving/tests/playback/playbackeventsrenderer_data/single_note_inverted_turn/score_style.mss
@@ -510,7 +510,6 @@
     <dynamicsPosAbove x="0" y="-1.5"/>
     <dynamicsPosBelow x="0" y="2.5"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/tests/playback/playbackeventsrenderer_data/single_note_inverted_turn_slash_variation/score_style.mss
+++ b/src/engraving/tests/playback/playbackeventsrenderer_data/single_note_inverted_turn_slash_variation/score_style.mss
@@ -510,7 +510,6 @@
     <dynamicsPosAbove x="0" y="-1.5"/>
     <dynamicsPosBelow x="0" y="2.5"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/tests/playback/playbackeventsrenderer_data/single_note_lower_mordent/score_style.mss
+++ b/src/engraving/tests/playback/playbackeventsrenderer_data/single_note_lower_mordent/score_style.mss
@@ -512,7 +512,6 @@
     <dynamicsPosAbove x="0" y="-1.5"/>
     <dynamicsPosBelow x="0" y="2.5"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/tests/playback/playbackeventsrenderer_data/single_note_multi_acciaccatura/score_style.mss
+++ b/src/engraving/tests/playback/playbackeventsrenderer_data/single_note_multi_acciaccatura/score_style.mss
@@ -512,7 +512,6 @@
     <dynamicsPosAbove x="0" y="-1.5"/>
     <dynamicsPosBelow x="0" y="2.5"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/tests/playback/playbackeventsrenderer_data/single_note_multi_appoggiatura_post/score_style.mss
+++ b/src/engraving/tests/playback/playbackeventsrenderer_data/single_note_multi_appoggiatura_post/score_style.mss
@@ -512,7 +512,6 @@
     <dynamicsPosAbove x="0" y="-1.5"/>
     <dynamicsPosBelow x="0" y="2.5"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/tests/playback/playbackeventsrenderer_data/single_note_no_articulations/score_style.mss
+++ b/src/engraving/tests/playback/playbackeventsrenderer_data/single_note_no_articulations/score_style.mss
@@ -510,7 +510,6 @@
     <dynamicsPosAbove x="0" y="-1.5"/>
     <dynamicsPosBelow x="0" y="2.5"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/tests/playback/playbackeventsrenderer_data/single_note_regular_turn/score_style.mss
+++ b/src/engraving/tests/playback/playbackeventsrenderer_data/single_note_regular_turn/score_style.mss
@@ -510,7 +510,6 @@
     <dynamicsPosAbove x="0" y="-1.5"/>
     <dynamicsPosBelow x="0" y="2.5"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/tests/playback/playbackeventsrenderer_data/single_note_tenuto_accent/score_style.mss
+++ b/src/engraving/tests/playback/playbackeventsrenderer_data/single_note_tenuto_accent/score_style.mss
@@ -508,7 +508,6 @@
     <dynamicsPosAbove x="0" y="-1.5"/>
     <dynamicsPosBelow x="0" y="2.5"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/tests/playback/playbackeventsrenderer_data/single_note_tremolo/score_style.mss
+++ b/src/engraving/tests/playback/playbackeventsrenderer_data/single_note_tremolo/score_style.mss
@@ -512,7 +512,6 @@
     <dynamicsPosAbove x="0" y="-1.5"/>
     <dynamicsPosBelow x="0" y="2.5"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/tests/playback/playbackeventsrenderer_data/single_note_trill_baroque/score_style.mss
+++ b/src/engraving/tests/playback/playbackeventsrenderer_data/single_note_trill_baroque/score_style.mss
@@ -510,7 +510,6 @@
     <dynamicsPosAbove x="0" y="-3"/>
     <dynamicsPosBelow x="0" y="4"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/tests/playback/playbackeventsrenderer_data/single_note_trill_default_tempo/score_style.mss
+++ b/src/engraving/tests/playback/playbackeventsrenderer_data/single_note_trill_default_tempo/score_style.mss
@@ -510,7 +510,6 @@
     <dynamicsPosAbove x="0" y="-1.5"/>
     <dynamicsPosBelow x="0" y="2.5"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/tests/playback/playbackeventsrenderer_data/single_note_unexpandable_trill/score_style.mss
+++ b/src/engraving/tests/playback/playbackeventsrenderer_data/single_note_unexpandable_trill/score_style.mss
@@ -510,7 +510,6 @@
     <dynamicsPosAbove x="0" y="-1.5"/>
     <dynamicsPosBelow x="0" y="2.5"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/tests/playback/playbackeventsrenderer_data/single_note_upper_mordent/score_style.mss
+++ b/src/engraving/tests/playback/playbackeventsrenderer_data/single_note_upper_mordent/score_style.mss
@@ -512,7 +512,6 @@
     <dynamicsPosAbove x="0" y="-1.5"/>
     <dynamicsPosBelow x="0" y="2.5"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/tests/playback/playbackeventsrenderer_data/two_chords_tremolo/score_style.mss
+++ b/src/engraving/tests/playback/playbackeventsrenderer_data/two_chords_tremolo/score_style.mss
@@ -512,7 +512,6 @@
     <dynamicsPosAbove x="0" y="-1.5"/>
     <dynamicsPosBelow x="0" y="2.5"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/tests/playback/playbackeventsrenderer_data/two_notes_continuous_glissando/score_style.mss
+++ b/src/engraving/tests/playback/playbackeventsrenderer_data/two_notes_continuous_glissando/score_style.mss
@@ -622,7 +622,6 @@
     <snapToDynamics>1</snapToDynamics>
     <centerOnNotehead>1</centerOnNotehead>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/tests/playback/playbackeventsrenderer_data/two_notes_continuous_glissando_no_play/score_style.mss
+++ b/src/engraving/tests/playback/playbackeventsrenderer_data/two_notes_continuous_glissando_no_play/score_style.mss
@@ -512,7 +512,6 @@
     <dynamicsPosAbove x="0" y="-1.5"/>
     <dynamicsPosBelow x="0" y="2.5"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/tests/playback/playbackeventsrenderer_data/two_notes_discrete_glissando/score_style.mss
+++ b/src/engraving/tests/playback/playbackeventsrenderer_data/two_notes_discrete_glissando/score_style.mss
@@ -512,7 +512,6 @@
     <dynamicsPosAbove x="0" y="-1.5"/>
     <dynamicsPosBelow x="0" y="2.5"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/tests/playback/playbackeventsrenderer_data/whole_measure_rest/score_style.mss
+++ b/src/engraving/tests/playback/playbackeventsrenderer_data/whole_measure_rest/score_style.mss
@@ -510,7 +510,6 @@
     <dynamicsPosAbove x="0" y="-1.5"/>
     <dynamicsPosBelow x="0" y="2.5"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/tests/playback/playbackmodel_data/da_capo_al_coda/score_style.mss
+++ b/src/engraving/tests/playback/playbackmodel_data/da_capo_al_coda/score_style.mss
@@ -512,7 +512,6 @@
     <dynamicsPosAbove x="0" y="-1.5"/>
     <dynamicsPosBelow x="0" y="2.5"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/tests/playback/playbackmodel_data/da_capo_al_fine/score_style.mss
+++ b/src/engraving/tests/playback/playbackmodel_data/da_capo_al_fine/score_style.mss
@@ -512,7 +512,6 @@
     <dynamicsPosAbove x="0" y="-1.5"/>
     <dynamicsPosBelow x="0" y="2.5"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/tests/playback/playbackmodel_data/dal_segno_al_coda/score_style.mss
+++ b/src/engraving/tests/playback/playbackmodel_data/dal_segno_al_coda/score_style.mss
@@ -512,7 +512,6 @@
     <dynamicsPosAbove x="0" y="-1.5"/>
     <dynamicsPosBelow x="0" y="2.5"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/tests/playback/playbackmodel_data/dal_segno_al_fine/score_style.mss
+++ b/src/engraving/tests/playback/playbackmodel_data/dal_segno_al_fine/score_style.mss
@@ -512,7 +512,6 @@
     <dynamicsPosAbove x="0" y="-1.5"/>
     <dynamicsPosBelow x="0" y="2.5"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/tests/playback/playbackmodel_data/dynamics/score_style.mss
+++ b/src/engraving/tests/playback/playbackmodel_data/dynamics/score_style.mss
@@ -548,7 +548,6 @@
     <snapToDynamics>1</snapToDynamics>
     <centerOnNotehead>1</centerOnNotehead>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/tests/playback/playbackmodel_data/metronome_4_4/score_style.mss
+++ b/src/engraving/tests/playback/playbackmodel_data/metronome_4_4/score_style.mss
@@ -512,7 +512,6 @@
     <dynamicsPosAbove x="0" y="-1.5"/>
     <dynamicsPosBelow x="0" y="2.5"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/tests/playback/playbackmodel_data/metronome_6_4_with_repeat/score_style.mss
+++ b/src/engraving/tests/playback/playbackmodel_data/metronome_6_4_with_repeat/score_style.mss
@@ -512,7 +512,6 @@
     <dynamicsPosAbove x="0" y="-1.5"/>
     <dynamicsPosBelow x="0" y="2.5"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/tests/playback/playbackmodel_data/multi_measure_repeat/score_style.mss
+++ b/src/engraving/tests/playback/playbackmodel_data/multi_measure_repeat/score_style.mss
@@ -532,7 +532,6 @@
     <dynamicsPosAbove x="0" y="-1.5"/>
     <dynamicsPosBelow x="0" y="2.5"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/tests/playback/playbackmodel_data/pizz_to_arco/score_style.mss
+++ b/src/engraving/tests/playback/playbackmodel_data/pizz_to_arco/score_style.mss
@@ -512,7 +512,6 @@
     <dynamicsPosAbove x="0" y="-1.5"/>
     <dynamicsPosBelow x="0" y="2.5"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/tests/playback/playbackmodel_data/playback_setup_instruments/score_style.mss
+++ b/src/engraving/tests/playback/playbackmodel_data/playback_setup_instruments/score_style.mss
@@ -512,7 +512,6 @@
     <dynamicsPosAbove x="0" y="-1.5"/>
     <dynamicsPosBelow x="0" y="2.5"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/tests/playback/playbackmodel_data/repeat_and_tremolo/score_style.mss
+++ b/src/engraving/tests/playback/playbackmodel_data/repeat_and_tremolo/score_style.mss
@@ -551,7 +551,6 @@
     <snapToDynamics>1</snapToDynamics>
     <centerOnNotehead>1</centerOnNotehead>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/tests/playback/playbackmodel_data/repeat_range/score_style.mss
+++ b/src/engraving/tests/playback/playbackmodel_data/repeat_range/score_style.mss
@@ -512,7 +512,6 @@
     <dynamicsPosAbove x="0" y="-1.5"/>
     <dynamicsPosBelow x="0" y="2.5"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/tests/playback/playbackmodel_data/repeat_with_2_voltas/score_style.mss
+++ b/src/engraving/tests/playback/playbackmodel_data/repeat_with_2_voltas/score_style.mss
@@ -512,7 +512,6 @@
     <dynamicsPosAbove x="0" y="-1.5"/>
     <dynamicsPosBelow x="0" y="2.5"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/tests/playback/playbackmodel_data/single_measure_repeat/score_style.mss
+++ b/src/engraving/tests/playback/playbackmodel_data/single_measure_repeat/score_style.mss
@@ -530,7 +530,6 @@
     <dynamicsPosAbove x="0" y="-1.5"/>
     <dynamicsPosBelow x="0" y="2.5"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/tests/playback/playbackmodel_data/spanners/score_style.mss
+++ b/src/engraving/tests/playback/playbackmodel_data/spanners/score_style.mss
@@ -548,7 +548,6 @@
     <snapToDynamics>1</snapToDynamics>
     <centerOnNotehead>1</centerOnNotehead>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/tests/playback/playbackmodel_data/tempo_changes_during_notes/score_style.mss
+++ b/src/engraving/tests/playback/playbackmodel_data/tempo_changes_during_notes/score_style.mss
@@ -551,7 +551,6 @@
     <snapToDynamics>1</snapToDynamics>
     <centerOnNotehead>1</centerOnNotehead>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/tests/tempomap_data/absolute_tempo_80_to_120_bpm/score_style.mss
+++ b/src/engraving/tests/tempomap_data/absolute_tempo_80_to_120_bpm/score_style.mss
@@ -512,7 +512,6 @@
     <dynamicsPosAbove x="0" y="-1.5"/>
     <dynamicsPosBelow x="0" y="2.5"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/tests/tempomap_data/custom_tempo_80_bpm/score_style.mss
+++ b/src/engraving/tests/tempomap_data/custom_tempo_80_bpm/score_style.mss
@@ -512,7 +512,6 @@
     <dynamicsPosAbove x="0" y="-1.5"/>
     <dynamicsPosBelow x="0" y="2.5"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/tests/tempomap_data/default_tempo/score_style.mss
+++ b/src/engraving/tests/tempomap_data/default_tempo/score_style.mss
@@ -512,7 +512,6 @@
     <dynamicsPosAbove x="0" y="-1.5"/>
     <dynamicsPosBelow x="0" y="2.5"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/tests/tempomap_data/gradual_tempo_change_accelerando/score_style.mss
+++ b/src/engraving/tests/tempomap_data/gradual_tempo_change_accelerando/score_style.mss
@@ -512,7 +512,6 @@
     <dynamicsPosAbove x="0" y="-1.5"/>
     <dynamicsPosBelow x="0" y="2.5"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/tests/tempomap_data/gradual_tempo_change_doesnt_overwrite_other_tempo/score_style.mss
+++ b/src/engraving/tests/tempomap_data/gradual_tempo_change_doesnt_overwrite_other_tempo/score_style.mss
@@ -527,7 +527,6 @@
     <dynamicsPosAbove x="0" y="-1.5"/>
     <dynamicsPosBelow x="0" y="2.5"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/engraving/tests/tempomap_data/gradual_tempo_change_rallentando/score_style.mss
+++ b/src/engraving/tests/tempomap_data/gradual_tempo_change_rallentando/score_style.mss
@@ -512,7 +512,6 @@
     <dynamicsPosAbove x="0" y="-1.5"/>
     <dynamicsPosBelow x="0" y="2.5"/>
     <dynamicsMinDistance>0.5</dynamicsMinDistance>
-    <autoplaceVerticalAlignRange>2</autoplaceVerticalAlignRange>
     <textLinePlacement>0</textLinePlacement>
     <textLinePosAbove x="0" y="-1"/>
     <textLinePosBelow x="0" y="1"/>

--- a/src/notation/view/widgets/editstyle.cpp
+++ b/src/notation/view/widgets/editstyle.cpp
@@ -620,7 +620,6 @@ EditStyle::EditStyle(QWidget* parent)
         { StyleId::rehearsalMarkPosBelow,    false, rehearsalMarkPosBelow,      resetRehearsalMarkPosBelow },
         { StyleId::rehearsalMarkMinDistance, false, rehearsalMarkMinDistance,   resetRehearsalMarkMinDistance },
 
-        { StyleId::autoplaceVerticalAlignRange, false, autoplaceVerticalAlignRange, resetAutoplaceVerticalAlignRange },
         { StyleId::minVerticalDistance,         false, minVerticalDistance,         resetMinVerticalDistance },
 
         { StyleId::textLinePlacement,           false, textLinePlacement,           resetTextLinePlacement },
@@ -753,11 +752,6 @@ EditStyle::EditStyle(QWidget* parent)
         cb->addItem(muse::qtrc("notation/editstyle", "Above"), int(PlacementV::ABOVE));
         cb->addItem(muse::qtrc("notation/editstyle", "Below"), int(PlacementV::BELOW));
     }
-
-    autoplaceVerticalAlignRange->clear();
-    autoplaceVerticalAlignRange->addItem(muse::qtrc("notation/editstyle", "Segment"), int(VerticalAlignRange::SEGMENT));
-    autoplaceVerticalAlignRange->addItem(muse::qtrc("notation/editstyle", "Measure"), int(VerticalAlignRange::MEASURE));
-    autoplaceVerticalAlignRange->addItem(muse::qtrc("notation/editstyle", "System"),  int(VerticalAlignRange::SYSTEM));
 
     tupletNumberType->clear();
     tupletNumberType->addItem(muse::qtrc("notation/editstyle", "Number"), int(TupletNumberType::SHOW_NUMBER));
@@ -1321,10 +1315,6 @@ void EditStyle::retranslate()
         cb->setItemText(0, muse::qtrc("notation/editstyle", "Above"));
         cb->setItemText(1, muse::qtrc("notation/editstyle", "Below"));
     }
-
-    autoplaceVerticalAlignRange->setItemText(0, muse::qtrc("notation/editstyle", "Segment"));
-    autoplaceVerticalAlignRange->setItemText(1, muse::qtrc("notation/editstyle", "Measure"));
-    autoplaceVerticalAlignRange->setItemText(2, muse::qtrc("notation/editstyle", "System"));
 
     tupletNumberType->setItemText(0, muse::qtrc("notation/editstyle", "Number"));
     tupletNumberType->setItemText(1, muse::qtrc("notation/editstyle", "Ratio"));

--- a/src/notation/view/widgets/editstyle.ui
+++ b/src/notation/view/widgets/editstyle.ui
@@ -820,7 +820,7 @@
                   <string>Autoplace</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_11">
-                  <item row="0" column="4">
+                  <item row="0" column="0">
                    <widget class="QLabel" name="minVerticalDistance_label">
                     <property name="text">
                      <string>Min. vertical distance:</string>
@@ -830,7 +830,7 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="0" column="5">
+                  <item row="0" column="1">
                    <widget class="QDoubleSpinBox" name="minVerticalDistance">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
@@ -855,10 +855,7 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="0" column="1">
-                   <widget class="QComboBox" name="autoplaceVerticalAlignRange"/>
-                  </item>
-                  <item row="0" column="7">
+                  <item row="0" column="3">
                    <spacer name="horizontalSpacer_23">
                     <property name="orientation">
                      <enum>Qt::Orientation::Horizontal</enum>
@@ -871,7 +868,7 @@
                     </property>
                    </spacer>
                   </item>
-                  <item row="0" column="6">
+                  <item row="0" column="2">
                    <widget class="QToolButton" name="resetMinVerticalDistance">
                     <property name="toolTip">
                      <string>Reset to default</string>
@@ -883,42 +880,6 @@
                      <string notr="true"/>
                     </property>
                    </widget>
-                  </item>
-                  <item row="0" column="0">
-                   <widget class="QLabel" name="label_36">
-                    <property name="text">
-                     <string>Vertical align range:</string>
-                    </property>
-                    <property name="buddy">
-                     <cstring>autoplaceVerticalAlignRange</cstring>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="2">
-                   <widget class="QToolButton" name="resetAutoplaceVerticalAlignRange">
-                    <property name="toolTip">
-                     <string>Reset to default</string>
-                    </property>
-                    <property name="accessibleName">
-                     <string>Reset 'Vertical align range' value</string>
-                    </property>
-                    <property name="text">
-                     <string notr="true"/>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="3">
-                   <spacer name="horizontalSpacer_51">
-                    <property name="orientation">
-                     <enum>Qt::Orientation::Horizontal</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>0</width>
-                      <height>0</height>
-                     </size>
-                    </property>
-                   </spacer>
                   </item>
                  </layout>
                 </widget>


### PR DESCRIPTION
- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x]  Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
