### PR TITLE
[4.6.0] fixed #29409: Chord symbols should be "above" their fretboard diagrams in arrangement order

### DIFF
--- a/src/engraving/dom/fret.cpp
+++ b/src/engraving/dom/fret.cpp
@@ -990,6 +990,9 @@ void FretDiagram::add(EngravingItem* e)
 
         m_harmony->setTrack(track());
 
+        //! on the same lavel as diagram
+        m_harmony->setZ(z());
+
         if (m_harmony->harmonyName().empty()) {
             if (s_diagramPatternToHarmoniesMap.empty()) {
                 readHarmonyToDiagramFile(HARMONY_TO_DIAGRAM_FILE_PATH);


### PR DESCRIPTION
see https://github.com/musescore/MuseScore/pull/29638