### PR TITLE
Fix corruption when range-deleting measure repeat and measure after

### DIFF
--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -3703,6 +3703,8 @@ void Score::deleteRangeAtTrack(std::vector<ChordRest*>& crsToSelect, const track
         }
 
         if (e->isMeasureRepeat()) {
+            // MeasureRepeat has its own special handling, so it is skipped here
+            foundDeselected(toDurationElement(e));
             deleteItem(e);
             continue;
         }


### PR DESCRIPTION
Resolves: #30055

Known issue: the full-measure rest resulting from the deleted measure repeat is not selected, but that's too much work for this late hour.