### PR TITLE
Allow to pass options to the open file dialog

### DIFF
--- a/src/framework/autobot/internal/autobotinteractive.cpp
+++ b/src/framework/autobot/internal/autobotinteractive.cpp
@@ -107,9 +107,9 @@ async::Promise<io::path_t> AutobotInteractive::selectOpeningFile(const std::stri
 }
 
 io::path_t AutobotInteractive::selectOpeningFileSync(const std::string& title, const io::path_t& dir,
-                                                     const std::vector<std::string>& filter)
+                                                     const std::vector<std::string>& filter, const int options)
 {
-    return m_real->selectOpeningFileSync(title, dir, filter);
+    return m_real->selectOpeningFileSync(title, dir, filter, options);
 }
 
 io::path_t AutobotInteractive::selectSavingFileSync(const std::string& title, const io::path_t& dir, const std::vector<std::string>& filter,

--- a/src/framework/autobot/internal/autobotinteractive.h
+++ b/src/framework/autobot/internal/autobotinteractive.h
@@ -74,7 +74,8 @@ public:
     // files
     virtual async::Promise<io::path_t> selectOpeningFile(const std::string& title, const io::path_t& dir,
                                                          const std::vector<std::string>& filter) override;
-    io::path_t selectOpeningFileSync(const std::string& title, const io::path_t& dir, const std::vector<std::string>& filter) override;
+    io::path_t selectOpeningFileSync(const std::string& title, const io::path_t& dir, const std::vector<std::string>& filter,
+                                     const int options = 0) override;
     io::path_t selectSavingFileSync(const std::string& title, const io::path_t& dir, const std::vector<std::string>& filter,
                                     bool confirmOverwrite = true) override;
 

--- a/src/framework/global/iinteractive.h
+++ b/src/framework/global/iinteractive.h
@@ -215,7 +215,8 @@ public:
     // files
     virtual async::Promise<io::path_t> selectOpeningFile(const std::string& title, const io::path_t& dir,
                                                          const std::vector<std::string>& filter) = 0;
-    virtual io::path_t selectOpeningFileSync(const std::string& title, const io::path_t& dir, const std::vector<std::string>& filter) = 0;
+    virtual io::path_t selectOpeningFileSync(const std::string& title, const io::path_t& dir, const std::vector<std::string>& filter,
+                                             const int options = 0) = 0;
     virtual io::path_t selectSavingFileSync(const std::string& title, const io::path_t& path, const std::vector<std::string>& filter,
                                             bool confirmOverwrite = true) = 0;
 

--- a/src/framework/global/internal/interactive.h
+++ b/src/framework/global/internal/interactive.h
@@ -81,7 +81,8 @@ public:
     // files
     async::Promise<io::path_t> selectOpeningFile(const std::string& title, const io::path_t& dir,
                                                  const std::vector<std::string>& filter) override;
-    io::path_t selectOpeningFileSync(const std::string& title, const io::path_t& dir, const std::vector<std::string>& filter) override;
+    io::path_t selectOpeningFileSync(const std::string& title, const io::path_t& dir, const std::vector<std::string>& filter,
+                                     const int options) override;
     io::path_t selectSavingFileSync(const std::string& title, const io::path_t& path, const std::vector<std::string>& filter,
                                     bool confirmOverwrite = true) override;
 

--- a/src/framework/global/tests/mocks/interactivemock.h
+++ b/src/framework/global/tests/mocks/interactivemock.h
@@ -58,7 +58,8 @@ public:
 
     MOCK_METHOD(async::Promise<io::path_t>, selectOpeningFile, (const std::string& title, const io::path_t& dir,
                                                                 const std::vector<std::string>& filter), (override));
-    MOCK_METHOD(io::path_t, selectOpeningFileSync, (const std::string&, const io::path_t&, const std::vector<std::string>&), (override));
+    MOCK_METHOD(io::path_t, selectOpeningFileSync, (const std::string&, const io::path_t&, const std::vector<std::string>&, const int),
+                (override));
     MOCK_METHOD(io::path_t, selectSavingFileSync, (const std::string&, const io::path_t&, const std::vector<std::string>&, bool),
                 (override));
     MOCK_METHOD(io::path_t, selectDirectory, (const std::string&, const io::path_t&), (override));


### PR DESCRIPTION
<!-- Add a short description of and motivation for the changes here -->

With Audacity, we can import files from a vast number of file formats.
If we add all possible extensions the open dialog gets wider and not nice.

<img width="1367" height="472" alt="image" src="https://github.com/user-attachments/assets/867c086d-b4df-4fd6-bc77-80a5b0560718" />

This change allows to pass options to the dialog so we can set `QFileDialog::HideNameFilterDetails` to workaround this issue.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
