### PR TITLE
Feature 18055: another take on clickable url in pdf

### DIFF
--- a/src/engraving/dom/textbase.cpp
+++ b/src/engraving/dom/textbase.cpp
@@ -65,6 +65,50 @@ namespace mu::engraving {
 static const char* FALLBACK_SYMBOL_FONT = "Bravura";
 static const char* FALLBACK_SYMBOLTEXT_FONT = "Bravura Text";
 
+static const std::regex URL_PATTERN(
+    R"((https?://[a-zA-Z0-9.-]+(?:/[a-zA-Z0-9._~:/?#[\]@!$&'()*+,;=-]*)?))");
+
+static const char* LINK_STYLE = "color: blue; text-decoration: underline;";
+
+static void replaceAll(std::string& s, char from, const char* to, size_t toLen)
+{
+    size_t pos = 0;
+    while ((pos = s.find(from, pos)) != std::string::npos) {
+        s.replace(pos, 1, to);
+        pos += toLen;
+    }
+}
+
+static std::string htmlEscape(const std::string& input)
+{
+    std::string result = input;
+    replaceAll(result, '&', "&amp;", 5);
+    replaceAll(result, '<', "&lt;", 4);
+    replaceAll(result, '>', "&gt;", 4);
+    replaceAll(result, '"', "&quot;", 6);
+    replaceAll(result, '\'', "&#39;", 5);
+    return result;
+}
+
+static String convertUrlsToLinks(const String& text)
+{
+    std::string input = text.toStdString();
+    std::string result;
+    std::sregex_iterator it(input.begin(), input.end(), URL_PATTERN);
+    std::sregex_iterator end;
+    size_t lastPos = 0;
+
+    for (; it != end; ++it) {
+        result += htmlEscape(input.substr(lastPos, it->position() - lastPos));
+        const std::string& url = (*it)[0].str();
+        result += "<a href=\"" + url + "\" style=\"" + LINK_STYLE + "\">" + htmlEscape(url) + "</a>";
+        lastPos = it->position() + it->length();
+    }
+    result += htmlEscape(input.substr(lastPos));
+
+    return String::fromStdString(result);
+}
+
 //---------------------------------------------------------
 //   isSorted
 /// return true if (r1,c1) is at or before (r2,c2)
@@ -789,6 +833,7 @@ int TextCursor::position(int row, int column) const
 TextFragment::TextFragment(const String& s)
 {
     text = s;
+    updateHtml();
 }
 
 TextFragment::TextFragment(TextCursor* cursor, const String& s)
@@ -802,6 +847,7 @@ TextFragment::TextFragment(const TextFragment& f)
     text = f.text;
     format = f.format;
     pos = f.pos;
+    htmlText = f.htmlText;
 }
 
 TextFragment& TextFragment::operator =(const TextFragment& f)
@@ -809,6 +855,7 @@ TextFragment& TextFragment::operator =(const TextFragment& f)
     text = f.text;
     format = f.format;
     pos = f.pos;
+    htmlText = f.htmlText;
     return *this;
 }
 
@@ -830,8 +877,10 @@ TextFragment TextFragment::split(int column)
                 if (idx < text.size()) {
                     f.text = text.mid(idx);
                     text   = text.left(idx);
+                    updateHtml();
                 }
             }
+            f.updateHtml();
             return f;
         }
         ++idx;
@@ -840,6 +889,7 @@ TextFragment TextFragment::split(int column)
         }
         ++col;
     }
+    f.updateHtml();
     return f;
 }
 
@@ -1163,10 +1213,13 @@ void TextBlock::insert(TextCursor* cursor, const String& s)
             }
         } else {
             i->text.insert(ridx, s);
+            i->updateHtml();
         }
     } else {
         if (!m_fragments.empty() && m_fragments.back().format == *cursor->format()) {
-            m_fragments.back().text.append(s);
+            TextFragment& fragmentIt = m_fragments.back();
+            fragmentIt.text.append(s);
+            fragmentIt.updateHtml();
         } else {
             m_fragments.push_back(TextFragment(cursor, s));
         }
@@ -1246,9 +1299,11 @@ String TextBlock::remove(int column, TextCursor* cursor)
                 if (it->text.at(i).isSurrogate()) {
                     s = it->text.mid(idx, 2);
                     it->text.remove(idx, 2);
+                    it->updateHtml();
                 } else {
                     s = it->text.mid(idx, 1);
                     it->text.remove(idx, 1);
+                    it->updateHtml();
                 }
                 if (it->text.isEmpty()) {
                     m_fragments.erase(it);
@@ -1284,6 +1339,7 @@ void TextBlock::simplify()
     for (; i != m_fragments.end(); ++i) {
         while (i != m_fragments.end() && (i->format == f->format)) {
             f->text.append(i->text);
+            f->updateHtml();
             i = m_fragments.erase(i);
         }
         if (i == m_fragments.end()) {
@@ -1322,6 +1378,7 @@ String TextBlock::remove(int start, int n, TextCursor* cursor)
                 }
                 --n;
                 if (n == 0) {
+                    i->updateHtml();
                     insertEmptyFragmentIfNeeded(cursor);           // without this, cursorRect can't calculate the y position of the cursor correctly
                     return s;
                 }
@@ -1334,6 +1391,7 @@ String TextBlock::remove(int start, int n, TextCursor* cursor)
             ++col;
         }
         if (inc) {
+            i->updateHtml();
             ++i;
         }
     }
@@ -1451,6 +1509,15 @@ void TextFragment::changeFormat(FormatId id, const FormatValue& data)
     format.setFormatValue(id, data);
 }
 
+void TextFragment::updateHtml()
+{
+    if (std::regex_search(text.toStdString(), URL_PATTERN)) {
+        htmlText = convertUrlsToLinks(text);
+    } else {
+        htmlText.reset();
+    }
+}
+
 //---------------------------------------------------------
 //   split
 //---------------------------------------------------------
@@ -1470,6 +1537,7 @@ TextBlock TextBlock::split(int column, TextCursor* cursor)
                         tf.format = it->format;
                         tl.m_fragments.push_back(tf);
                         it->text = it->text.left(idx);
+                        it->updateHtml();
                         ++it;
                     }
                 }

--- a/src/engraving/dom/textbase.h
+++ b/src/engraving/dom/textbase.h
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include <optional>
 #include <variant>
 
 #include "draw/fontmetrics.h"
@@ -229,6 +230,7 @@ public:
     mutable CharFormat format;
     PointF pos;                    // y is relative to TextBlock->y()
     mutable String text;
+    std::optional<String> htmlText;
 
     TextFragment() = default;
     TextFragment(const String& s);
@@ -244,6 +246,8 @@ public:
     double calculatedFontSize(const TextBase*) const;
     int columns() const;
     void changeFormat(FormatId id, const FormatValue& data);
+
+    void updateHtml();
 
 private:
     void resolveFallback(muse::draw::Font::Type fontType, const muse::draw::FontMetrics& fm, String& family) const;

--- a/src/engraving/rendering/editmode/editmoderenderer.cpp
+++ b/src/engraving/rendering/editmode/editmoderenderer.cpp
@@ -289,5 +289,9 @@ void EditModeRenderer::draw(const TextBlock& textBlock, const TextBase* item, mu
 void EditModeRenderer::draw(const TextFragment& textFragment, const TextBase* item, muse::draw::Painter* painter)
 {
     painter->setFont(textFragment.font(item));
-    painter->drawText(textFragment.pos, textFragment.text);
+    if (textFragment.htmlText && painter->canDrawHtml()) {
+        painter->drawHtml(textFragment.pos, *textFragment.htmlText);
+    } else {
+        painter->drawText(textFragment.pos, textFragment.text);
+    }
 }

--- a/src/engraving/rendering/score/paintdebugger.cpp
+++ b/src/engraving/rendering/score/paintdebugger.cpp
@@ -186,6 +186,16 @@ void PaintDebugger::drawText(const RectF& rect, int flags, const String& text)
     m_real->drawText(rect, flags, text);
 }
 
+bool PaintDebugger::canDrawHtml() const
+{
+    return m_real->canDrawHtml();
+}
+
+void PaintDebugger::drawHtml(const PointF& point, const String& htmlText)
+{
+    m_real->drawHtml(point, htmlText);
+}
+
 void PaintDebugger::drawSymbol(const PointF& point, char32_t ucs4Code)
 {
     m_real->drawSymbol(point, ucs4Code);

--- a/src/engraving/rendering/score/paintdebugger.h
+++ b/src/engraving/rendering/score/paintdebugger.h
@@ -70,6 +70,8 @@ public:
 
     void drawText(const muse::PointF& point, const muse::String& text) override;
     void drawText(const muse::RectF& rect, int flags, const muse::String& text) override;
+    bool canDrawHtml() const override;
+    void drawHtml(const muse::PointF& point, const muse::String& htmlText) override;
 
     void drawSymbol(const muse::PointF& point, char32_t ucs4Code) override;
 

--- a/src/engraving/rendering/score/tdraw.cpp
+++ b/src/engraving/rendering/score/tdraw.cpp
@@ -1741,7 +1741,11 @@ void TDraw::draw(const TextBlock& textBlock, const TextBase* item, Painter* pain
 void TDraw::draw(const TextFragment& textFragment, const TextBase* item, muse::draw::Painter* painter)
 {
     painter->setFont(textFragment.font(item));
-    painter->drawText(textFragment.pos, textFragment.text);
+    if (textFragment.htmlText && painter->canDrawHtml()) {
+        painter->drawHtml(textFragment.pos, *textFragment.htmlText);
+    } else {
+        painter->drawText(textFragment.pos, textFragment.text);
+    }
 }
 
 void TDraw::drawTextLineBaseSegment(const TextLineBaseSegment* item, Painter* painter, const PaintOptions& opt)

--- a/src/engraving/rendering/single/singledraw.cpp
+++ b/src/engraving/rendering/single/singledraw.cpp
@@ -1571,7 +1571,11 @@ void SingleDraw::draw(const TextBlock& textBlock, const TextBase* item, muse::dr
 void SingleDraw::draw(const TextFragment& textFragment, const TextBase* item, muse::draw::Painter* painter)
 {
     painter->setFont(textFragment.font(item));
-    painter->drawText(textFragment.pos, textFragment.text);
+    if (textFragment.htmlText && painter->canDrawHtml()) {
+        painter->drawHtml(textFragment.pos, *textFragment.htmlText);
+    } else {
+        painter->drawText(textFragment.pos, textFragment.text);
+    }
 }
 
 static void setDashAndGapLen(const SLine* line, double& dash, double& gap, Pen& pen)

--- a/src/framework/draw/bufferedpaintprovider.cpp
+++ b/src/framework/draw/bufferedpaintprovider.cpp
@@ -305,6 +305,17 @@ void BufferedPaintProvider::drawText(const RectF& rect, int flags, const String&
     editableData().texts.push_back(DrawText { DrawText::Rect, rect, flags, text });
 }
 
+bool BufferedPaintProvider::canDrawHtml() const
+{
+    return false;
+}
+
+void BufferedPaintProvider::drawHtml(const PointF& point, const String& htmlText)
+{
+    UNUSED(point);
+    UNUSED(htmlText);
+}
+
 void BufferedPaintProvider::drawSymbol(const PointF& point, char32_t ucs4Code)
 {
     drawText(point, String::fromUcs4(&ucs4Code, 1));

--- a/src/framework/draw/bufferedpaintprovider.h
+++ b/src/framework/draw/bufferedpaintprovider.h
@@ -73,6 +73,9 @@ public:
     void drawText(const PointF& point, const String& text) override;
     void drawText(const RectF& rect, int flags, const String& text) override;
 
+    bool canDrawHtml() const override;
+    void drawHtml(const PointF& point, const String& htmlText) override;
+
     void drawSymbol(const PointF& point, char32_t ucs4Code) override;
 
     void drawPixmap(const PointF& p, const Pixmap& pm) override;

--- a/src/framework/draw/internal/qpainterprovider.cpp
+++ b/src/framework/draw/internal/qpainterprovider.cpp
@@ -29,6 +29,7 @@
 #include <QPixmapCache>
 #include <QStaticText>
 #include <QPainterPath>
+#include <QTextBlock>
 
 #include "draw/utils/drawlogger.h"
 #include "types/transform.h"
@@ -245,6 +246,34 @@ void QPainterProvider::drawText(const PointF& point, const String& text)
 void QPainterProvider::drawText(const RectF& rect, int flags, const String& text)
 {
     m_painter->drawText(rect.toQRectF(), flags, text);
+}
+
+bool QPainterProvider::canDrawHtml() const
+{
+    return true;
+}
+
+void QPainterProvider::drawHtml(const PointF& point, const String& htmlText)
+{
+    QTextDocument doc;
+
+    QFont f = font().toQFont();
+    double fontScalingFactor = m_painter->device()->logicalDpiX() / 72.0;
+    f.setPixelSize(static_cast<int>(f.pointSizeF() * fontScalingFactor));
+    doc.setDefaultFont(f);
+    doc.setUseDesignMetrics(true);
+    doc.setHtml(htmlText);
+    doc.setTextWidth(-1); // No wrapping
+    doc.setDocumentMargin(0);
+
+    QFontMetricsF fm(f);
+    qreal baselineOffset = fm.ascent();
+
+    QPointF p = point.toQPointF();
+    m_painter->save();
+    m_painter->translate(p.x(), p.y() - baselineOffset);
+    doc.drawContents(m_painter);
+    m_painter->restore();
 }
 
 void QPainterProvider::drawSymbol(const PointF& point, char32_t ucs4Code)

--- a/src/framework/draw/internal/qpainterprovider.h
+++ b/src/framework/draw/internal/qpainterprovider.h
@@ -77,6 +77,9 @@ public:
     void drawText(const PointF& point, const String& text) override;
     void drawText(const RectF& rect, int flags, const String& text) override;
 
+    bool canDrawHtml() const override;
+    void drawHtml(const PointF& point, const String& htmlText) override;
+
     void drawSymbol(const PointF& point, char32_t ucs4Code) override;
 
     void drawPixmap(const PointF& point, const Pixmap& pm) override;

--- a/src/framework/draw/ipaintprovider.h
+++ b/src/framework/draw/ipaintprovider.h
@@ -77,6 +77,9 @@ public:
     virtual void drawText(const PointF& point, const String& text) = 0;
     virtual void drawText(const RectF& rect, int flags, const String& text) = 0;
 
+    virtual bool canDrawHtml() const = 0;
+    virtual void drawHtml(const PointF& point, const String& htmlText) = 0;
+
     virtual void drawSymbol(const PointF& point, char32_t ucs4Code) = 0;
 
     virtual void drawPixmap(const PointF& point, const Pixmap& pm) = 0;

--- a/src/framework/draw/painter.cpp
+++ b/src/framework/draw/painter.cpp
@@ -444,6 +444,21 @@ void Painter::drawText(const PointF& point, const String& text)
     }
 }
 
+bool Painter::canDrawHtml() const
+{
+    return m_provider->canDrawHtml();
+}
+
+void Painter::drawHtml(const PointF& point, const String& htmlText)
+{
+    applyFontSizeScaling();
+
+    m_provider->drawHtml(point, htmlText);
+    if (extended) {
+        extended->drawHtml(point, htmlText);
+    }
+}
+
 void Painter::drawText(const RectF& rect, int flags, const String& text)
 {
     applyFontSizeScaling();

--- a/src/framework/draw/painter.h
+++ b/src/framework/draw/painter.h
@@ -133,6 +133,9 @@ public:
 
     void drawText(const RectF& rect, int flags, const String& text);
 
+    bool canDrawHtml() const;
+    void drawHtml(const PointF& point, const String& htmlText);
+
     void drawSymbol(const PointF& point, char32_t ucs4Code);
 
     void fillRect(const RectF& rect, const Brush& brush);


### PR DESCRIPTION
Resolves: #18055

Another take on #18055 (instead of https://github.com/musescore/MuseScore/pull/30003 ) with url processing moved to TextFragments' forming instead of doing it on each paint operation. Kinda messy, because we have a lot of direct operations with `mutable String text` in fragments. 

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [ ] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [ ] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
