### PR TITLE
Fix #29925: Use default panel visibilities when resetting workspace

### DIFF
--- a/src/framework/dockwindow/view/dockwindow.cpp
+++ b/src/framework/dockwindow/view/dockwindow.cpp
@@ -483,7 +483,7 @@ void DockWindow::addPanelAsTab(DockPanelView* panel, DockPanelView* destinationP
 {
     registerDock(panel);
 
-    if (panel->isVisible()) {
+    if (panel->defaultVisibility()) {
         destinationPanel->addPanelAsTab(panel);
         destinationPanel->setCurrentTabIndex(0);
     }


### PR DESCRIPTION
Resolves: #29925

- The Palettes panel is the first to be re-added on reset. Here we call `DockWindow::addDock` and use `defaultVisibility`
- Subsequent panels are added with `addPanelAsTab`. This method uses `isVisible` instead of `defaultVisibility`

Looks like we need to bring other panels in-line with the first added panel (use `defaultVisibility` in `addPanelAsTab`)