### PR TITLE
Add fret min distance to style page

### DIFF
--- a/src/notation/qml/MuseScore/NotationScene/internal/EditStyle/FretboardsPage.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/EditStyle/FretboardsPage.qml
@@ -59,6 +59,13 @@ StyledFlickable {
             }
 
             StyleSpinboxWithReset {
+                styleItem: fretboardsPage.fretMinDistance
+                label: qsTrc("notation", "Autoplace min. distance:")
+                suffix: qsTrc("global", "sp")
+                controlAreaWidth: root.controlAreaWidth
+            }
+
+            StyleSpinboxWithReset {
                 styleItem: fretboardsPage.fretMag
                 label: qsTrc("notation", "Scale:")
                 inPercentage: true

--- a/src/notation/view/styledialog/fretboardspagemodel.cpp
+++ b/src/notation/view/styledialog/fretboardspagemodel.cpp
@@ -27,6 +27,7 @@ using namespace mu::notation;
 FretboardsPageModel::FretboardsPageModel(QObject* parent)
     : AbstractStyleDialogModel(parent, {
     StyleId::fretY,
+    StyleId::fretMinDistance,
     StyleId::fretMag,
     StyleId::fretOrientation,
     StyleId::fretNutThickness,
@@ -45,6 +46,7 @@ FretboardsPageModel::FretboardsPageModel(QObject* parent)
 }
 
 StyleItem* FretboardsPageModel::fretY() const { return styleItem(StyleId::fretY); }
+StyleItem* FretboardsPageModel::fretMinDistance() const { return styleItem(StyleId::fretMinDistance); }
 StyleItem* FretboardsPageModel::fretMag() const { return styleItem(StyleId::fretMag); }
 StyleItem* FretboardsPageModel::fretOrientation() const { return styleItem(StyleId::fretOrientation); }
 StyleItem* FretboardsPageModel::fretNutThickness() const { return styleItem(StyleId::fretNutThickness); }

--- a/src/notation/view/styledialog/fretboardspagemodel.h
+++ b/src/notation/view/styledialog/fretboardspagemodel.h
@@ -30,6 +30,7 @@ class FretboardsPageModel : public AbstractStyleDialogModel
     Q_OBJECT
 
     Q_PROPERTY(StyleItem * fretY READ fretY CONSTANT)
+    Q_PROPERTY(StyleItem * fretMinDistance READ fretMinDistance CONSTANT)
     Q_PROPERTY(StyleItem * fretMag READ fretMag CONSTANT)
     Q_PROPERTY(StyleItem * fretOrientation READ fretOrientation CONSTANT)
     Q_PROPERTY(StyleItem * fretNutThickness READ fretNutThickness CONSTANT)
@@ -48,6 +49,7 @@ public:
     explicit FretboardsPageModel(QObject* parent = nullptr);
 
     StyleItem* fretY() const;
+    StyleItem* fretMinDistance() const;
     StyleItem* fretMag() const;
     StyleItem* fretOrientation() const;
     StyleItem* fretNutThickness() const;


### PR DESCRIPTION
Adds "Autoplace min. distance" for fretboard diagrams
<img width="433" height="160" alt="Screenshot 2025-09-24 at 11 51 21" src="https://github.com/user-attachments/assets/caadbd43-e646-43f1-885f-0884afe947e2" />
