### PR TITLE
Don't recreate entire staff shape on beam layout

### DIFF
--- a/src/engraving/rendering/score/beamlayout.cpp
+++ b/src/engraving/rendering/score/beamlayout.cpp
@@ -875,8 +875,6 @@ void BeamLayout::layoutNonCrossBeams(ChordRest* cr, LayoutContext& ctx)
         if (beamCR->isRest() && beamCR->vStaffIdx() == beam->staffIdx()) {
             verticalAdjustBeamedRests(toRest(beamCR), beam, ctx);
         }
-
-        beamCR->segment()->createShape(beamCR->staffIdx());
     }
 }
 
@@ -935,6 +933,8 @@ void BeamLayout::verticalAdjustBeamedRests(Rest* rest, Beam* beam, LayoutContext
     }
 
     TLayout::layoutBeam(beam, ctx);
+
+    rest->segment()->createShape(rest->vStaffIdx());
 }
 
 void BeamLayout::checkCrossPosAndStemConsistency(Beam* beam, LayoutContext& ctx)

--- a/src/engraving/rendering/score/beamtremololayout.cpp
+++ b/src/engraving/rendering/score/beamtremololayout.cpp
@@ -311,6 +311,14 @@ void BeamTremoloLayout::extendStem(const BeamBase::LayoutData* ldata, Chord* cho
     if (chord->stemSlash()) {
         TLayout::layoutStemSlash(chord->stemSlash(), chord->stemSlash()->mutldata(), ctx.conf());
     }
+
+    // Update stem shape
+    Stem* stem = chord->stem();
+    for (ShapeElement& shapeEl : chord->segment()->staffShape(chord->vStaffIdx()).elements()) {
+        if (shapeEl.item() == stem) {
+            shapeEl = ShapeElement(stem->ldata()->bbox().translated(stem->pos() + chord->pos()), stem);
+        }
+    }
 }
 
 bool BeamTremoloLayout::isBeamInsideStaff(int yPos, int staffLines, bool allowFloater)


### PR DESCRIPTION
Resolves: #30104

The issue happens because, when recreating the shape, the grace-note-after gets added into a wrong position. Unfortunately correcting that position causes problems elsewhere, because of the particular way that grace notes after work. So the only solution is to avoid recreating the shape during beam layout (and only update the stem, which is what may actually change). It's a good thing to do because it's also an efficiency improvement, but it isn't a particularly strong fix for the issue itself, which may happen again if the shape gets recreated from any other part of the code. This can only be fixed when we reimplement grace notes better and get rid of the grace-note-after concept entirely.



