### PR TITLE
Fix #17753:  Option to form melismas along slurs and ties when writing lyrics

### DIFF
--- a/src/notation/inotationconfiguration.h
+++ b/src/notation/inotationconfiguration.h
@@ -157,6 +157,10 @@ public:
     virtual void setStartNoteInputAtSelectedNoteRestWhenPressingMidiKey(bool value) = 0;
     virtual muse::async::Notification startNoteInputAtSelectedNoteRestWhenPressingMidiKeyChanged() const = 0;
 
+    virtual bool lyricsFormMelismaAtSlurTies() const = 0;
+    virtual void setLyricsFormMelismaAtSlurTies(bool value) = 0;
+    virtual muse::async::Notification lyricsFormMelismaAtSlurTiesChanged() const = 0;
+
     virtual bool isAutomaticallyPanEnabled() const = 0;
     virtual void setIsAutomaticallyPanEnabled(bool enabled) = 0;
 

--- a/src/notation/internal/notationconfiguration.cpp
+++ b/src/notation/internal/notationconfiguration.cpp
@@ -77,6 +77,7 @@ static const Settings::Key ADD_ACCIDENTAL_ARTICULATIONS_DOTS_TO_NEXT_NOTE_ENTERE
 static const Settings::Key IS_MIDI_INPUT_ENABLED(module_name, "io/midi/enableInput");
 static const Settings::Key START_NOTE_INPUT_AT_SELECTED_NOTE_REST_WHEN_PRESSING_MIDI_KEY(module_name,
                                                                                          "score/startNoteInputAtSelectionWhenPressingMidiKey");
+static const Settings::Key LYRICS_FORM_MELISMA_AT_SLUR_TIES(module_name, "score/lyricsFormMelismaAtSlurTies");
 static const Settings::Key USE_MIDI_INPUT_WRITTEN_PITCH(module_name, "io/midi/useWrittenPitch");
 static const Settings::Key IS_AUTOMATICALLY_PAN_ENABLED(module_name, "application/playback/panPlayback");
 static const Settings::Key PLAYBACK_SMOOTH_PANNING(module_name, "application/playback/smoothPan");
@@ -272,6 +273,11 @@ void NotationConfiguration::init()
     settings()->setDefaultValue(START_NOTE_INPUT_AT_SELECTED_NOTE_REST_WHEN_PRESSING_MIDI_KEY, Val(true));
     settings()->valueChanged(START_NOTE_INPUT_AT_SELECTED_NOTE_REST_WHEN_PRESSING_MIDI_KEY).onReceive(this, [this](const Val&) {
         m_startNoteInputAtSelectedNoteRestWhenPressingMidiKeyChanged.notify();
+    });
+
+    settings()->setDefaultValue(LYRICS_FORM_MELISMA_AT_SLUR_TIES, Val(false));
+    settings()->valueChanged(LYRICS_FORM_MELISMA_AT_SLUR_TIES).onReceive(this, [this](const Val&) {
+        m_lyricsFormMelismaAtSlurTiesChanged.notify();
     });
 
     settings()->setDefaultValue(IS_AUTOMATICALLY_PAN_ENABLED, Val(true));
@@ -882,6 +888,21 @@ void NotationConfiguration::setStartNoteInputAtSelectedNoteRestWhenPressingMidiK
 async::Notification NotationConfiguration::startNoteInputAtSelectedNoteRestWhenPressingMidiKeyChanged() const
 {
     return m_startNoteInputAtSelectedNoteRestWhenPressingMidiKeyChanged;
+}
+
+bool NotationConfiguration::lyricsFormMelismaAtSlurTies() const
+{
+    return settings()->value(LYRICS_FORM_MELISMA_AT_SLUR_TIES).toBool();
+}
+
+void NotationConfiguration::setLyricsFormMelismaAtSlurTies(bool value)
+{
+    settings()->setSharedValue(LYRICS_FORM_MELISMA_AT_SLUR_TIES, Val(value));
+}
+
+async::Notification NotationConfiguration::lyricsFormMelismaAtSlurTiesChanged() const
+{
+    return m_lyricsFormMelismaAtSlurTiesChanged;
 }
 
 bool NotationConfiguration::isAutomaticallyPanEnabled() const

--- a/src/notation/internal/notationconfiguration.h
+++ b/src/notation/internal/notationconfiguration.h
@@ -161,6 +161,10 @@ public:
     void setStartNoteInputAtSelectedNoteRestWhenPressingMidiKey(bool value) override;
     muse::async::Notification startNoteInputAtSelectedNoteRestWhenPressingMidiKeyChanged() const override;
 
+    bool lyricsFormMelismaAtSlurTies() const override;
+    void setLyricsFormMelismaAtSlurTies(bool value) override;
+    muse::async::Notification lyricsFormMelismaAtSlurTiesChanged() const override;
+
     bool isAutomaticallyPanEnabled() const override;
     void setIsAutomaticallyPanEnabled(bool enabled) override;
 
@@ -304,6 +308,7 @@ private:
     muse::async::Notification m_useNoteInputCursorInInputByDurationChanged;
     muse::async::Notification m_isMidiInputEnabledChanged;
     muse::async::Notification m_startNoteInputAtSelectedNoteRestWhenPressingMidiKeyChanged;
+    muse::async::Notification m_lyricsFormMelismaAtSlurTiesChanged;
 
     muse::async::Notification m_defaultZoomChanged;
     muse::async::Notification m_mouseZoomPrecisionChanged;

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -6641,6 +6641,7 @@ void NotationInteraction::navigateToLyrics(bool back, bool moveOnly, bool end)
     mu::engraving::PropertyFlags fFlags = lyrics->propertyFlags(mu::engraving::Pid::FONT_STYLE);
     mu::engraving::TextStyleType styleType = lyrics->textStyleType();
 
+    mu::engraving::ChordRest* lastSlurredOrTiedCR = lyrics->chordRest();
     mu::engraving::Segment* nextSegment = segment;
     if (back) {
         // search prev chord
@@ -6659,6 +6660,43 @@ void NotationInteraction::navigateToLyrics(bool back, bool moveOnly, bool end)
             }
         }
     } else {
+        // if in a slur or tie, and configured to move lyrics along them, move to the end of it
+        if (configuration()->lyricsFormMelismaAtSlurTies()) {
+            // check if at start of slur
+            if (lastSlurredOrTiedCR->isChord()) {
+                auto slurredChord = toChord(lastSlurredOrTiedCR);
+
+                // if at start of slur, find the shortest slur and proceed to the end of it
+                if (slurredChord->startEndSlurs().startDown || slurredChord->startEndSlurs().startUp) {
+                    auto spanners = score()->spannerMap().findOverlapping(slurredChord->tick().ticks(), slurredChord->endTick().ticks());
+                    Spanner* spannerToFollow = nullptr;
+                    for (auto& spanner : spanners) {
+                        if (spanner.value->startCR() == slurredChord && spanner.value->isSlur()) {
+                            if (!spannerToFollow
+                                || (spannerToFollow->ticks() > spanner.value->ticks())
+                                ) {
+                                spannerToFollow = spanner.value;
+                            }
+                        }
+                    }
+                    if (spannerToFollow) {
+                        lastSlurredOrTiedCR = spannerToFollow->endCR();
+                    }
+                }
+            }
+
+            // check if have tie - if so, proceed until no more ties
+            if (lastSlurredOrTiedCR->isChord()) {
+                auto tiedChord = toChord(lastSlurredOrTiedCR);
+                while (tiedChord->nextTiedChord()) {
+                    tiedChord = tiedChord->nextTiedChord();
+                }
+                lastSlurredOrTiedCR = toChordRest(tiedChord);
+            }
+
+            nextSegment = lastSlurredOrTiedCR->segment();
+        }
+
         // search next chord
         while ((nextSegment = nextSegment->next1(mu::engraving::SegmentType::ChordRest))) {
             EngravingItem* el = nextSegment->element(track);
@@ -6695,6 +6733,16 @@ void NotationInteraction::navigateToLyrics(bool back, bool moveOnly, bool end)
             }
             segment = segment->prev1(mu::engraving::SegmentType::ChordRest);
         }
+    }
+
+    if (!nextSegment) {
+        // end of the score - add melisma line if have jumped ahead for slur/tie and have written lyrics
+        if (fromLyrics == lyrics && lastSlurredOrTiedCR != lyrics->chordRest()) {
+            score()->startCmd(TranslatableString("undoableAction", "Navigate to lyrics"));
+            lyrics->undoChangeProperty(mu::engraving::Pid::LYRIC_TICKS, lastSlurredOrTiedCR->endTick() - lyrics->chordRest()->endTick());
+            score()->endCmd();
+        }
+        return;
     }
 
     ChordRest* cr = toChordRest(nextSegment->element(track));
@@ -6754,6 +6802,11 @@ void NotationInteraction::navigateToLyrics(bool back, bool moveOnly, bool end)
         }
     }
 
+    // add melisma line if have jumped ahead for slur/tie and have written lyrics
+    if (fromLyrics == lyrics && lastSlurredOrTiedCR != lyrics->chordRest()) {
+        lyrics->undoChangeProperty(mu::engraving::Pid::LYRIC_TICKS, lastSlurredOrTiedCR->endTick() - lyrics->chordRest()->endTick());
+    }
+
     if (newLyrics) {
         score()->undoAddElement(nextLyrics);
     }
@@ -6800,8 +6853,43 @@ void NotationInteraction::navigateToNextSyllable()
     PropertyFlags fFlags = lyrics->propertyFlags(Pid::FONT_STYLE);
     mu::engraving::TextStyleType styleType = lyrics->textStyleType();
 
+    // check if at start of slur
+    ChordRest* lastSlurredOrTiedCR = initialCR;
+    if (configuration()->lyricsFormMelismaAtSlurTies()) {
+        if (lastSlurredOrTiedCR->isChord()) {
+            auto slurredChord = toChord(lastSlurredOrTiedCR);
+
+            // if at start of slur, find the shortest slur and proceed to the end of it
+            if (slurredChord->startEndSlurs().startDown || slurredChord->startEndSlurs().startUp) {
+                auto spanners = score()->spannerMap().findOverlapping(slurredChord->tick().ticks(), slurredChord->endTick().ticks());
+                Spanner* spannerToFollow = nullptr;
+                for (auto& spanner : spanners) {
+                    if (spanner.value->startCR() == slurredChord && spanner.value->isSlur()) {
+                        if (!spannerToFollow
+                            || (spannerToFollow->ticks() > spanner.value->ticks())
+                            ) {
+                            spannerToFollow = spanner.value;
+                        }
+                    }
+                }
+                if (spannerToFollow) {
+                    lastSlurredOrTiedCR = spannerToFollow->endCR();
+                }
+            }
+        }
+
+        // check if have tie - if so, proceed until no more ties
+        if (lastSlurredOrTiedCR->isChord()) {
+            auto tiedChord = toChord(lastSlurredOrTiedCR);
+            while (tiedChord->nextTiedChord()) {
+                tiedChord = tiedChord->nextTiedChord();
+            }
+            lastSlurredOrTiedCR = toChordRest(tiedChord);
+        }
+    }
+
     // search next chord
-    Segment* nextSegment = segment;
+    Segment* nextSegment = lastSlurredOrTiedCR->segment();
     while ((nextSegment = nextSegment->next1(SegmentType::ChordRest))) {
         EngravingItem* el = nextSegment->element(track);
         if (!el || !el->isChord()) {

--- a/src/notation/tests/mocks/notationconfigurationmock.h
+++ b/src/notation/tests/mocks/notationconfigurationmock.h
@@ -147,6 +147,10 @@ public:
     MOCK_METHOD(void, setStartNoteInputAtSelectedNoteRestWhenPressingMidiKey, (bool), (override));
     MOCK_METHOD(muse::async::Notification, startNoteInputAtSelectedNoteRestWhenPressingMidiKeyChanged, (), (const, override));
 
+    MOCK_METHOD(bool, lyricsFormMelismaAtSlurTies, (), (const, override));
+    MOCK_METHOD(void, setLyricsFormMelismaAtSlurTies, (bool), (override));
+    MOCK_METHOD(muse::async::Notification, lyricsFormMelismaAtSlurTiesChanged, (), (const, override));
+
     MOCK_METHOD(bool, isAutomaticallyPanEnabled, (), (const, override));
     MOCK_METHOD(void, setIsAutomaticallyPanEnabled, (bool), (override));
 

--- a/src/preferences/qml/MuseScore/Preferences/CMakeLists.txt
+++ b/src/preferences/qml/MuseScore/Preferences/CMakeLists.txt
@@ -105,6 +105,7 @@ qt_add_qml_module(preferences_qml
         internal/MixerSection.qml
         internal/MusicXmlSection.qml
         internal/NoteInput/FretboardDiagramsSection.qml
+        internal/NoteInput/LyricsSection.qml
         internal/NoteInput/MidiInputSection.qml
         internal/NoteInput/NoteColorsSection.qml
         internal/NoteInput/NoteInputSection.qml

--- a/src/preferences/qml/MuseScore/Preferences/NoteInputPreferencesPage.qml
+++ b/src/preferences/qml/MuseScore/Preferences/NoteInputPreferencesPage.qml
@@ -193,5 +193,20 @@ PreferencesPage {
                 noteInputModel.warnGuitarBends = warn
             }
         }
+
+        SeparatorLine {}
+
+        LyricsSection {
+            width: parent.width
+
+            lyricsFormMelismaAtSlurTies: noteInputModel.lyricsFormMelismaAtSlurTies
+
+            navigation.section: root.navigationSection
+            navigation.order: root.navigationOrderStart + 7
+
+            onLyricsFormMelismaAtSlurTiesChangeRequested: function(update) {
+                noteInputModel.lyricsFormMelismaAtSlurTies = update
+            }
+        }
     }
 }

--- a/src/preferences/qml/MuseScore/Preferences/internal/NoteInput/LyricsSection.qml
+++ b/src/preferences/qml/MuseScore/Preferences/internal/NoteInput/LyricsSection.qml
@@ -1,0 +1,53 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2025 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import QtQuick 2.15
+
+import Muse.UiComponents 1.0
+
+import "../../internal"
+
+BaseSection {
+    id: root
+
+    property bool lyricsFormMelismaAtSlurTies: true
+
+    signal lyricsFormMelismaAtSlurTiesChangeRequested(bool update)
+
+    title: qsTrc("appshell/preferences", "Lyrics")
+
+    CheckBox {
+        id: updateBox
+        width: parent.width
+
+        text: qsTrc("appshell/preferences", "Automatically form melisma at slurs and ties when writing lyrics")
+
+        checked: root.lyricsFormMelismaAtSlurTies
+
+        navigation.name: "LyricsFormMelismaAtSlurTies"
+        navigation.panel: root.navigation
+        navigation.row: 0
+
+        onClicked: {
+            root.lyricsFormMelismaAtSlurTiesChangeRequested(!root.lyricsFormMelismaAtSlurTies)
+        }
+    }
+}

--- a/src/preferences/qml/MuseScore/Preferences/noteinputpreferencesmodel.cpp
+++ b/src/preferences/qml/MuseScore/Preferences/noteinputpreferencesmodel.cpp
@@ -106,6 +106,10 @@ void NoteInputPreferencesModel::load()
     engravingConfiguration()->autoUpdateFretboardDiagramsChanged().onReceive(this, [this](bool value) {
         emit autoUpdateFretboardDiagramsChanged(value);
     });
+
+    notationConfiguration()->lyricsFormMelismaAtSlurTiesChanged().onNotify(this, [this]() {
+        emit lyricsFormMelismaAtSlurTiesChanged(lyricsFormMelismaAtSlurTies());
+    });
 }
 
 QVariantList NoteInputPreferencesModel::noteInputMethods() const
@@ -396,4 +400,18 @@ void NoteInputPreferencesModel::setAutoUpdateFretboardDiagrams(bool value)
     }
 
     engravingConfiguration()->setAutoUpdateFretboardDiagrams(value);
+}
+
+bool NoteInputPreferencesModel::lyricsFormMelismaAtSlurTies() const
+{
+    return notationConfiguration()->lyricsFormMelismaAtSlurTies();
+}
+
+void NoteInputPreferencesModel::setLyricsFormMelismaAtSlurTies(bool value)
+{
+    if (value == lyricsFormMelismaAtSlurTies()) {
+        return;
+    }
+
+    notationConfiguration()->setLyricsFormMelismaAtSlurTies(value);
 }

--- a/src/preferences/qml/MuseScore/Preferences/noteinputpreferencesmodel.h
+++ b/src/preferences/qml/MuseScore/Preferences/noteinputpreferencesmodel.h
@@ -43,41 +43,58 @@ class NoteInputPreferencesModel : public QObject, public muse::Injectable, publi
     Q_PROPERTY(
         int defaultNoteInputMethod READ defaultNoteInputMethod WRITE setDefaultNoteInputMethod NOTIFY defaultNoteInputMethodChanged)
     Q_PROPERTY(
-        bool addAccidentalDotsArticulationsToNextNoteEntered READ addAccidentalDotsArticulationsToNextNoteEntered WRITE setAddAccidentalDotsArticulationsToNextNoteEntered NOTIFY addAccidentalDotsArticulationsToNextNoteEnteredChanged)
+        bool addAccidentalDotsArticulationsToNextNoteEntered READ addAccidentalDotsArticulationsToNextNoteEntered WRITE
+        setAddAccidentalDotsArticulationsToNextNoteEntered NOTIFY addAccidentalDotsArticulationsToNextNoteEnteredChanged)
     Q_PROPERTY(
-        bool useNoteInputCursorInInputByDuration READ useNoteInputCursorInInputByDuration WRITE setUseNoteInputCursorInInputByDuration NOTIFY useNoteInputCursorInInputByDurationChanged)
+        bool useNoteInputCursorInInputByDuration READ useNoteInputCursorInInputByDuration WRITE setUseNoteInputCursorInInputByDuration
+        NOTIFY useNoteInputCursorInInputByDurationChanged)
 
     Q_PROPERTY(bool midiInputEnabled READ midiInputEnabled WRITE setMidiInputEnabled NOTIFY midiInputEnabledChanged)
     Q_PROPERTY(
-        bool startNoteInputAtSelectedNoteRestWhenPressingMidiKey READ startNoteInputAtSelectedNoteRestWhenPressingMidiKey WRITE setStartNoteInputAtSelectedNoteRestWhenPressingMidiKey NOTIFY startNoteInputAtSelectedNoteRestWhenPressingMidiKeyChanged)
+        bool startNoteInputAtSelectedNoteRestWhenPressingMidiKey READ startNoteInputAtSelectedNoteRestWhenPressingMidiKey WRITE
+        setStartNoteInputAtSelectedNoteRestWhenPressingMidiKey NOTIFY startNoteInputAtSelectedNoteRestWhenPressingMidiKeyChanged)
     Q_PROPERTY(
-        bool advanceToNextNoteOnKeyRelease READ advanceToNextNoteOnKeyRelease WRITE setAdvanceToNextNoteOnKeyRelease NOTIFY advanceToNextNoteOnKeyReleaseChanged)
+        bool advanceToNextNoteOnKeyRelease READ advanceToNextNoteOnKeyRelease WRITE setAdvanceToNextNoteOnKeyRelease NOTIFY
+        advanceToNextNoteOnKeyReleaseChanged)
     Q_PROPERTY(
-        bool colorNotesOutsideOfUsablePitchRange READ colorNotesOutsideOfUsablePitchRange WRITE setColorNotesOutsideOfUsablePitchRange NOTIFY colorNotesOutsideOfUsablePitchRangeChanged)
+        bool colorNotesOutsideOfUsablePitchRange READ colorNotesOutsideOfUsablePitchRange WRITE setColorNotesOutsideOfUsablePitchRange
+        NOTIFY colorNotesOutsideOfUsablePitchRangeChanged)
     Q_PROPERTY(
         bool warnGuitarBends READ warnGuitarBends WRITE setWarnGuitarBends NOTIFY warnGuitarBendsChanged)
     Q_PROPERTY(
-        int delayBetweenNotesInRealTimeModeMilliseconds READ delayBetweenNotesInRealTimeModeMilliseconds WRITE setDelayBetweenNotesInRealTimeModeMilliseconds NOTIFY delayBetweenNotesInRealTimeModeMillisecondsChanged)
+        int delayBetweenNotesInRealTimeModeMilliseconds READ delayBetweenNotesInRealTimeModeMilliseconds WRITE
+        setDelayBetweenNotesInRealTimeModeMilliseconds NOTIFY delayBetweenNotesInRealTimeModeMillisecondsChanged)
 
     Q_PROPERTY(bool playNotesWhenEditing READ playNotesWhenEditing WRITE setPlayNotesWhenEditing NOTIFY playNotesWhenEditingChanged)
     Q_PROPERTY(
-        bool playPreviewNotesInInputByDuration READ playPreviewNotesInInputByDuration WRITE setPlayPreviewNotesInInputByDuration NOTIFY playPreviewNotesInInputByDurationChanged)
+        bool playPreviewNotesInInputByDuration READ playPreviewNotesInInputByDuration WRITE setPlayPreviewNotesInInputByDuration NOTIFY
+        playPreviewNotesInInputByDurationChanged)
     Q_PROPERTY(
-        int notePlayDurationMilliseconds READ notePlayDurationMilliseconds WRITE setNotePlayDurationMilliseconds NOTIFY notePlayDurationMillisecondsChanged)
+        int notePlayDurationMilliseconds READ notePlayDurationMilliseconds WRITE setNotePlayDurationMilliseconds NOTIFY
+        notePlayDurationMillisecondsChanged)
     Q_PROPERTY(bool playChordWhenEditing READ playChordWhenEditing WRITE setPlayChordWhenEditing NOTIFY playChordWhenEditingChanged)
     Q_PROPERTY(
-        bool playChordSymbolWhenEditing READ playChordSymbolWhenEditing WRITE setPlayChordSymbolWhenEditing NOTIFY playChordSymbolWhenEditingChanged)
+        bool playChordSymbolWhenEditing READ playChordSymbolWhenEditing WRITE setPlayChordSymbolWhenEditing NOTIFY
+        playChordSymbolWhenEditingChanged)
     Q_PROPERTY(
-        bool playPreviewNotesWithScoreDynamics READ playPreviewNotesWithScoreDynamics WRITE setPlayPreviewNotesWithScoreDynamics NOTIFY playPreviewNotesWithScoreDynamicsChanged)
+        bool playPreviewNotesWithScoreDynamics READ playPreviewNotesWithScoreDynamics WRITE setPlayPreviewNotesWithScoreDynamics NOTIFY
+        playPreviewNotesWithScoreDynamicsChanged)
     Q_PROPERTY(bool playNotesOnMidiInput READ playNotesOnMidiInput WRITE setPlayNotesOnMidiInput NOTIFY playNotesOnMidiInputChanged)
     Q_PROPERTY(
-        bool useMidiVelocityAndDurationDuringNoteInput READ useMidiVelocityAndDurationDuringNoteInput WRITE setUseMidiVelocityAndDurationDuringNoteInput NOTIFY useMidiVelocityAndDurationDuringNoteInputChanged)
+        bool useMidiVelocityAndDurationDuringNoteInput READ useMidiVelocityAndDurationDuringNoteInput WRITE
+        setUseMidiVelocityAndDurationDuringNoteInput NOTIFY useMidiVelocityAndDurationDuringNoteInputChanged)
 
     Q_PROPERTY(
-        bool dynamicsApplyToAllVoices READ dynamicsApplyToAllVoices WRITE setDynamicsApplyToAllVoices NOTIFY dynamicsApplyToAllVoicesChanged FINAL)
+        bool dynamicsApplyToAllVoices READ dynamicsApplyToAllVoices WRITE setDynamicsApplyToAllVoices NOTIFY dynamicsApplyToAllVoicesChanged
+        FINAL)
 
     Q_PROPERTY(
-        bool autoUpdateFretboardDiagrams READ autoUpdateFretboardDiagrams WRITE setAutoUpdateFretboardDiagrams NOTIFY autoUpdateFretboardDiagramsChanged FINAL)
+        bool autoUpdateFretboardDiagrams READ autoUpdateFretboardDiagrams WRITE setAutoUpdateFretboardDiagrams NOTIFY
+        autoUpdateFretboardDiagramsChanged FINAL)
+
+    Q_PROPERTY(
+        bool lyricsFormMelismaAtSlurTies READ lyricsFormMelismaAtSlurTies WRITE setLyricsFormMelismaAtSlurTies NOTIFY
+        lyricsFormMelismaAtSlurTiesChanged FINAL)
 
     muse::Inject<muse::shortcuts::IShortcutsConfiguration> shortcutsConfiguration = { this };
     muse::Inject<notation::INotationConfiguration> notationConfiguration = { this };
@@ -116,6 +133,7 @@ public:
     bool warnGuitarBends() const;
 
     bool autoUpdateFretboardDiagrams() const;
+    bool lyricsFormMelismaAtSlurTies() const;
 
 public slots:
     void setDefaultNoteInputMethod(int value);
@@ -142,6 +160,7 @@ public slots:
     void setWarnGuitarBends(bool value);
 
     void setAutoUpdateFretboardDiagrams(bool value);
+    void setLyricsFormMelismaAtSlurTies(bool value);
 
 signals:
     void defaultNoteInputMethodChanged(int value);
@@ -168,5 +187,6 @@ signals:
     void warnGuitarBendsChanged(bool value);
 
     void autoUpdateFretboardDiagramsChanged(bool value);
+    void lyricsFormMelismaAtSlurTiesChanged(bool value);
 };
 }


### PR DESCRIPTION
Adds an option (on by default) to form a melisma automatically that when writing lyrics to a note with at the start of a slur or tie.

Resolves: #17753  <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->
Does not do so for [29195](https://github.com/musescore/MuseScore/issues/29195), as it does not address the request for slurs/ties and melismas to remain _synchronized_, but does follow their suggestion to make it an option.

<!-- Add a short description of and motivation for the changes here -->
This should make it easier for composers to write vocal music, especially music with long melismas, as one can simply place a slur across the melismatic passage and not need to repeatedly type underscores to produce a melisma over the whole passage.

With the setting active, a melisma is not formed when pressing space (or hyphen) without writing lyrics, preserving navigation.  In the event that a note starts multiple slurs, the shortest is chosen; and a slur is followed first, followed by a tie (such as if a note does not start a slur, but does start a series of ties, the melisma follows that series of ties, and if a slur ends at a tied note, the melisma follows that series of ties, and the slur, and all).  This seemed reasonably consistent with the use of slurs and ties (who ever would place a slur over a subset of tied notes?), and resists placing lyrics on rests even when slurs end on rests, though I anticipate other contributors may suggest or discover further edge cases.


https://github.com/user-attachments/assets/00388c84-baa9-4eab-8ba9-4e822ceb4f25



Tested on Windows 11 and Ubuntu 22.04
<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
