### PR TITLE
Don't clone staff type change if it doesn't belong to current staff

### DIFF
--- a/src/engraving/dom/excerpt.cpp
+++ b/src/engraving/dom/excerpt.cpp
@@ -1535,7 +1535,7 @@ void Excerpt::cloneStaff2(Staff* srcStaff, Staff* dstStaff, const Fraction& star
             if (oldEl->isLayoutBreak()) {
                 continue;
             }
-            if (oldEl->systemFlag() && dstStaffIdx != 0) {
+            if ((oldEl->systemFlag() && dstStaffIdx != 0) || (!oldEl->systemFlag() && oldEl->staffIdx() != srcStaffIdx)) {
                 continue;
             }
             bool alreadyCloned = oldEl->systemFlag() && oldEl->findLinkedInScore(score);
@@ -1544,7 +1544,7 @@ void Excerpt::cloneStaff2(Staff* srcStaff, Staff* dstStaff, const Fraction& star
             }
             EngravingItem* newEl = oldEl->linkedClone();
             newEl->setParent(nm);
-            newEl->setTrack(0);
+            newEl->setStaffIdx(oldEl->systemFlag() ? 0 : dstStaffIdx);
             newEl->setScore(score);
             newEl->styleChanged();
             addElement(newEl);


### PR DESCRIPTION
Resolves: #30109

This bit of code seemed to have an underlying assumption that all measure-attached elements are also system objects. Which is probably true for all of them except staff type changes.