### PR TITLE
[4.6.0] Fix #30111: fix crash during audio plugin registration

### DIFF
--- a/src/framework/audio/main/audiomodule.cpp
+++ b/src/framework/audio/main/audiomodule.cpp
@@ -185,10 +185,16 @@ void AudioModule::onInit(const IApplication::RunMode& mode)
             pr->reg("soundfonts", p);
         }
     }
+
+    m_audioInited = true;
 }
 
 void AudioModule::onDeinit()
 {
+    if (!m_audioInited) {
+        return;
+    }
+
     m_mainPlayback->deinit();
     m_rpcTimer.stop();
 

--- a/src/framework/audio/main/audiomodule.h
+++ b/src/framework/audio/main/audiomodule.h
@@ -77,6 +77,8 @@ private:
     std::shared_ptr<rpc::GeneralRpcChannel> m_rpcChannel;
 
     std::shared_ptr<IAudioDriverController> m_audioDriverController;
+
+    bool m_audioInited = false;
 };
 }
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/30111