### PR TITLE
Remove "dynamic + hairpin" palette element

### DIFF
--- a/src/palette/internal/palettecell.cpp
+++ b/src/palette/internal/palettecell.cpp
@@ -115,9 +115,6 @@ const char* PaletteCell::translationContext() const
     case ElementType::DYNAMIC:
         return "engraving/dynamictype";
     case ElementType::HAIRPIN:
-        if (name == u"Dynamic + hairpin") {
-            return "palette";
-        }
         return "engraving/hairpintype";
     case ElementType::LAYOUT_BREAK:
         return "engraving/layoutbreaktype";

--- a/src/palette/internal/palettecreator.cpp
+++ b/src/palette/internal/palettecreator.cpp
@@ -1166,16 +1166,6 @@ PalettePtr PaletteCreator::newLinesPalette(bool defaultPalette)
         sp->appendElement(hairpin, hairpin->subtypeUserName());
     }
 
-    auto gabel = Factory::makeHairpin(gpaletteScore->dummy());
-    gabel->setHairpinType(HairpinType::CRESC_HAIRPIN);
-    gabel->setBeginText(u"<sym>dynamicMezzo</sym><sym>dynamicForte</sym>");
-    gabel->setPropertyFlags(Pid::BEGIN_TEXT, PropertyFlags::UNSTYLED);
-    gabel->setBeginTextAlign({ AlignH::LEFT, AlignV::VCENTER });
-    gabel->setPropertyFlags(Pid::BEGIN_TEXT_ALIGN, PropertyFlags::UNSTYLED);
-    gabel->setLen(w);
-    // Keep name in sync with PaletteCell::translationContext()
-    sp->appendElement(gabel, QT_TRANSLATE_NOOP("palette", "Dynamic + hairpin"));
-
     auto volta = makeElement<Volta>(gpaletteScore);
     volta->setVoltaType(Volta::Type::CLOSED);
     volta->setLen(w);


### PR DESCRIPTION
* We don't want dynamics as begin/end text of hairpins anymore (they should be standalone elements)
* It doesn't make much sense to have this specific combination of mf + < (and others not)