### PR TITLE
When inserting measures into an empty score don't move key sig

### DIFF
--- a/src/engraving/dom/staff.cpp
+++ b/src/engraving/dom/staff.cpp
@@ -1444,8 +1444,12 @@ void Staff::insertTime(const Fraction& tick, const Fraction& len)
     for (auto i = m_keys.lower_bound(tick.ticks()); i != m_keys.end();) {
         KeySigEvent kse = i->second;
         Fraction t = Fraction::fromTicks(i->first);
-        m_keys.erase(i++);
-        kl2[(t + len).ticks()] = kse;
+        if (t + len < score()->endTick()) {
+            m_keys.erase(i++);
+            kl2[(t + len).ticks()] = kse;
+        } else {
+            ++i;
+        }
     }
     m_keys.insert(kl2.begin(), kl2.end());
 


### PR DESCRIPTION
Resolves: #30040 

When creating the new score from the template, we insert new measures at the start of the score and in this process the initial key signature was being pushed all the way to the end. What made this weirder is that it only happens with the Guitar+TAB template (and seemingly not with any other). That turns out to be because that particular file is the only one that explicitely sets a key signature at the start, whereas all other templates leave that empty. No idea why that is, but I'm not going to change/investigate that here. 

Side note: the issue is not related to mmRests, it can be reproduced by just opening the template and adding a transposing instrument.

<img width="847" height="352" alt="Screenshot 2025-09-26 142307" src="https://github.com/user-attachments/assets/06c68440-8724-4cba-8359-a53da75de190" />

