### PR TITLE
VST: Don't link to stdc++fs

### DIFF
--- a/src/framework/vst/CMakeLists.txt
+++ b/src/framework/vst/CMakeLists.txt
@@ -104,13 +104,6 @@ set(MODULE_LINK
     vst_sdk_3
     )
 
-if (OS_IS_LIN)
-    set(MODULE_LINK
-        ${MODULE_LINK}
-        stdc++fs
-        )
-endif()
-
 if (QT_SUPPORT)
     list(APPEND MODULE_LINK Qt::Qml Qt::Widgets)
 endif()


### PR DESCRIPTION
As remarked in https://github.com/flathub/org.musescore.MuseScore/pull/154#discussion_r2383696490, that’s only needed for very old compiler versions.