### PR TITLE
Reset Score::printing after Paint::paintScore

### DIFF
--- a/src/engraving/rendering/score/paint.cpp
+++ b/src/engraving/rendering/score/paint.cpp
@@ -68,8 +68,10 @@ void Paint::paintScore(Painter* painter, Score* score, const IScoreRenderer::Pai
 
     // Setup score draw system
     mu::engraving::MScore::pixelRatio = mu::engraving::DPI / DEVICE_DPI;
-    score->setPrinting(opt.isPrinting);
     mu::engraving::MScore::pdfPrinting = opt.isPrinting;
+
+    const bool wasPrinting = score->printing();
+    score->setPrinting(opt.isPrinting);
 
     // Setup page counts
     int fromPage = opt.fromPage >= 0 ? opt.fromPage : 0;
@@ -173,6 +175,8 @@ void Paint::paintScore(Painter* painter, Score* score, const IScoreRenderer::Pai
             }
         }
     }
+
+    score->setPrinting(wasPrinting);
 }
 
 SizeF Paint::pageSizeInch(const Score* score)


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/14970
Resolves: https://github.com/musescore/MuseScore/issues/25917

If `Score::printing` remains true after painting the Navigator, then the `canHitElement` lambda inside `NotationInteraction::hitElements` will return false when invisible elements or SoundFlags are clicked.