### PR TITLE
Remove empty segments without pushing the action to undo stack

### DIFF
--- a/src/engraving/dom/excerpt.cpp
+++ b/src/engraving/dom/excerpt.cpp
@@ -1617,7 +1617,8 @@ void Excerpt::cloneStaff2(Staff* srcStaff, Staff* dstStaff, const Fraction& star
         for (Segment& seg : nm->segments()) {
             seg.checkEmpty();
             if (seg.empty()) {
-                score->doUndoRemoveElement(&seg);
+                nm->remove(&seg);
+                delete &seg;
             }
         }
         if (!nm->hasVoices(dstStaffIdx, nm->tick(), nm->ticks())) {

--- a/src/engraving/dom/excerpt.cpp
+++ b/src/engraving/dom/excerpt.cpp
@@ -1614,12 +1614,16 @@ void Excerpt::cloneStaff2(Staff* srcStaff, Staff* dstStaff, const Fraction& star
                 }
             }
         }
+        std::vector<Segment*> emptySegments;
         for (Segment& seg : nm->segments()) {
             seg.checkEmpty();
             if (seg.empty()) {
-                nm->remove(&seg);
-                delete &seg;
+                emptySegments.push_back(&seg);
             }
+        }
+        for (Segment* seg : emptySegments) {
+            nm->remove(seg);
+            delete seg;
         }
         if (!nm->hasVoices(dstStaffIdx, nm->tick(), nm->ticks())) {
             promoteGapRestsToRealRests(nm, dstStaffIdx);


### PR DESCRIPTION
The creation of the new segments is done via `Measure::getSegment` without adding it to the undo stack, so we can't instead add to the undo stack the removal of the empty ones, cause we're making the operation asymmetrical. We should add both or none, and I think none is the simpler option here.

Resolves: #30149
