### PR TITLE
Fix measure number edits not retained

### DIFF
--- a/src/engraving/api/v1/elements.h
+++ b/src/engraving/api/v1/elements.h
@@ -1786,7 +1786,7 @@ public:
     mu::engraving::Measure* measure() { return toMeasure(e); }
     const mu::engraving::Measure* measure() const { return toMeasure(e); }
 
-    bool showsMeasureNumberInAutoMode() { return measure()->showsMeasureNumberInAutoMode(); }
+    bool showsMeasureNumberInAutoMode() { return measure()->showMeasureNumberInAutoMode(); }
 
     Segment* firstSegment() { return wrap<Segment>(measure()->firstEnabled(), Ownership::SCORE); }
     Segment* lastSegment() { return wrap<Segment>(measure()->last(), Ownership::SCORE); }

--- a/src/engraving/dom/edit.cpp
+++ b/src/engraving/dom/edit.cpp
@@ -3051,7 +3051,7 @@ void Score::deleteItem(EngravingItem* el)
         // If after setting the MeasureNumberMode to AUTO, the measure number still shows,
         // We need to force the measure to hide its measure number.
         case MeasureNumberMode::SHOW:
-            if (mea->showsMeasureNumberInAutoMode()) {
+            if (mea->showMeasureNumberInAutoMode()) {
                 mea->undoChangeProperty(Pid::MEASURE_NUMBER_MODE, static_cast<int>(MeasureNumberMode::HIDE));
             } else {
                 mea->undoChangeProperty(Pid::MEASURE_NUMBER_MODE, static_cast<int>(MeasureNumberMode::AUTO));

--- a/src/engraving/dom/measure.cpp
+++ b/src/engraving/dom/measure.cpp
@@ -186,7 +186,7 @@ Measure::Measure(System* parent)
         m_mstaves.push_back(ms);
     }
     setIrregular(false);
-    m_noMode                = MeasureNumberMode::AUTO;
+    m_measureNumberMode                = MeasureNumberMode::AUTO;
     m_userStretch           = 1.0;
     m_breakMultiMeasureRest = false;
     m_mmRest                = nullptr;
@@ -205,7 +205,7 @@ Measure::Measure(const Measure& m)
     m_timesig     = m.m_timesig;
     m_len          = m.m_len;
     m_repeatCount = m.m_repeatCount;
-    m_noMode      = m.m_noMode;
+    m_measureNumberMode      = m.m_measureNumberMode;
     m_userStretch = m.m_userStretch;
 
     m_mstaves.reserve(m.m_mstaves.size());
@@ -553,7 +553,7 @@ double Measure::tick2pos(Fraction tck) const
 ///    Whether the measure will show measure number(s) when MeasureNumberMode is set to AUTO
 //---------------------------------------------------------
 
-bool Measure::showsMeasureNumberInAutoMode()
+bool Measure::showMeasureNumberInAutoMode()
 {
     // Check whether any measure number should be shown
     if (!style().styleB(Sid::showMeasureNumber)) {
@@ -594,19 +594,31 @@ bool Measure::showsMeasureNumberInAutoMode()
     }
 }
 
+bool Measure::showMeasureNumberOnStaff(staff_idx_t staffIdx)
+{
+    IF_ASSERT_FAILED(staffIdx < score()->nstaves()) {
+        return false;
+    }
+
+    return showMeasureNumber() && score()->staff(staffIdx)->shouldShowMeasureNumbers();
+}
+
 //---------------------------------------------------------
 //   showsMeasureNumber
 ///     Whether the Measure shows a MeasureNumber
 //---------------------------------------------------------
 
-bool Measure::showsMeasureNumber()
+bool Measure::showMeasureNumber()
 {
-    if (m_noMode == MeasureNumberMode::SHOW) {
+    switch (m_measureNumberMode) {
+    case MeasureNumberMode::AUTO:
+        return showMeasureNumberInAutoMode();
+    case MeasureNumberMode::SHOW:
         return true;
-    } else if (m_noMode == MeasureNumberMode::HIDE) {
+    case MeasureNumberMode::HIDE:
         return false;
-    } else {
-        return showsMeasureNumberInAutoMode();
+    default:
+        UNREACHABLE;
     }
 }
 
@@ -2120,7 +2132,7 @@ void Measure::scanElements(void* data, void (* func)(void*, EngravingItem*), boo
 
     for (staff_idx_t staffIdx = 0; staffIdx < nstaves; ++staffIdx) {
         MStaff* ms = m_mstaves[staffIdx];
-        if (ms->measureNumber()) {
+        if (ms->measureNumber() && showMeasureNumberOnStaff(staffIdx)) {
             func(data, ms->measureNumber());
         }
 

--- a/src/engraving/dom/measure.cpp
+++ b/src/engraving/dom/measure.cpp
@@ -617,8 +617,6 @@ bool Measure::showMeasureNumber()
         return true;
     case MeasureNumberMode::HIDE:
         return false;
-    default:
-        UNREACHABLE;
     }
 }
 

--- a/src/engraving/dom/measure.h
+++ b/src/engraving/dom/measure.h
@@ -197,8 +197,8 @@ public:
 
     void createStaves(staff_idx_t);
 
-    MeasureNumberMode measureNumberMode() const { return m_noMode; }
-    void setMeasureNumberMode(MeasureNumberMode v) { m_noMode = v; }
+    MeasureNumberMode measureNumberMode() const { return m_measureNumberMode; }
+    void setMeasureNumberMode(MeasureNumberMode v) { m_measureNumberMode = v; }
 
     Fraction timesig() const { return m_timesig; }
     void setTimesig(const Fraction& f) { m_timesig = f; }
@@ -225,8 +225,9 @@ public:
     Fraction anacrusisOffset() const;
     Fraction maxTicks() const;
 
-    bool showsMeasureNumber();
-    bool showsMeasureNumberInAutoMode();
+    bool showMeasureNumber();
+    bool showMeasureNumberInAutoMode();
+    bool showMeasureNumberOnStaff(staff_idx_t staffIdx);
 
     Chord* findChord(Fraction tick, track_idx_t track) const;
     ChordRest* findChordRest(Fraction tick, track_idx_t track) const;
@@ -407,7 +408,7 @@ private:
 
     int m_repeatCount = 0;      // end repeat marker and repeat count
 
-    MeasureNumberMode m_noMode = MeasureNumberMode::AUTO;
+    MeasureNumberMode m_measureNumberMode = MeasureNumberMode::AUTO;
     bool m_breakMultiMeasureRest = false;
 };
 } // namespace mu::engraving

--- a/src/engraving/dom/staff.cpp
+++ b/src/engraving/dom/staff.cpp
@@ -239,8 +239,7 @@ bool Staff::shouldShowMeasureNumbers() const
     case MeasureNumberPlacement::ON_SYSTEM_OBJECT_STAVES:
     {
         bool isTopStave = score()->staves().front() == this;
-        bool isSystemObjectStaff = muse::contains(score()->systemObjectStaves(), const_cast<Staff*>(this));
-        return (isTopStave && m_showMeasureNumbers != AutoOnOff::OFF) || (isSystemObjectStaff && m_showMeasureNumbers == AutoOnOff::ON);
+        return (isTopStave && m_showMeasureNumbers != AutoOnOff::OFF) || (isSystemObjectStaff() && m_showMeasureNumbers == AutoOnOff::ON);
     }
     case MeasureNumberPlacement::ON_ALL_STAVES:
         return show();

--- a/src/engraving/rendering/score/measurelayout.cpp
+++ b/src/engraving/rendering/score/measurelayout.cpp
@@ -1297,7 +1297,6 @@ void MeasureLayout::layoutPlayCountText(Measure* m, LayoutContext& ctx)
 
 void MeasureLayout::layoutMeasureNumber(Measure* m, LayoutContext& ctx)
 {
-    bool showMeasureNumber = m->showsMeasureNumber();
     MeasureNumberPlacement placementMode = ctx.conf().styleV(Sid::measureNumberPlacementMode).value<MeasureNumberPlacement>();
 
     String stringNum = String::number(m->no() + 1);
@@ -1311,11 +1310,8 @@ void MeasureLayout::layoutMeasureNumber(Measure* m, LayoutContext& ctx)
             break;
         }
 
-        Staff* staff = score->staff(staffIdx);
-        const MStaff* measureStaff = measureStaves[staffIdx];
-        MeasureNumber* measureNumber = measureStaff->measureNumber();
-
-        if (showMeasureNumber && staff->shouldShowMeasureNumbers()) {
+        if (m->showMeasureNumberOnStaff(staffIdx)) {
+            MeasureNumber* measureNumber = measureStaves[staffIdx]->measureNumber();
             if (!measureNumber) {
                 measureNumber = new MeasureNumber(m);
                 measureNumber->setTrack(staff2track(staffIdx));
@@ -1327,9 +1323,6 @@ void MeasureLayout::layoutMeasureNumber(Measure* m, LayoutContext& ctx)
             measureNumber->setXmlText(stringNum);
             measureNumber->setSystemFlag(placementMode != MeasureNumberPlacement::ON_ALL_STAVES);
             TLayout::layoutMeasureNumber(measureNumber, measureNumber->mutldata(), ctx);
-        } else if (measureNumber) {
-            measureNumber->setTrack(staff2track(staffIdx));
-            ctx.mutDom().doUndoRemoveElement(measureNumber);
         }
     }
 }


### PR DESCRIPTION
Resolves: #29594

In my previous implementation, measure numbers that weren't shown were removed from the score, and if they happened to be shown again new ones were created, hence customizations were lost. Now instead of removing measure numbers that don't show we just exclude them from Measure::scanElements.

All other changes are just code cleanup.