### PR TITLE
[4.6.1] Fix #30122: Export MP3: File for the first part in score has no sound

### DIFF
--- a/src/framework/audio/worker/internal/sequenceplayer.cpp
+++ b/src/framework/audio/worker/internal/sequenceplayer.cpp
@@ -73,7 +73,9 @@ void SequencePlayer::seek(const secs_t newPosition, const bool flushSound)
     ONLY_AUDIO_WORKER_THREAD;
 
     m_flushSoundOnSeek = flushSound;
-    m_clock->seek(secsToMicrosecs(newPosition));
+    msecs_t newPos = secsToMicrosecs(newPosition);
+    m_clock->seek(newPos);
+    seekAllTracks(newPos);
     m_flushSoundOnSeek = true;
 }
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/30122
Resolves: https://github.com/musescore/MuseScore/issues/30179