### PR TITLE
Set marker type in palette

### DIFF
--- a/src/palette/internal/palettecompat.cpp
+++ b/src/palette/internal/palettecompat.cpp
@@ -146,6 +146,18 @@ void PaletteCompat::migrateOldPaletteCellIfNeeded(PaletteCell* cell, Score* pale
         return;
     }
 
+    if (item->isMarker()) {
+        Marker* marker = toMarker(item);
+        Marker* newMarker = marker->clone();
+
+        AsciiStringView s(newMarker->label().toStdString());
+        MarkerType mt = TConv::fromXml(s, MarkerType::USER);
+        newMarker->setMarkerType(mt);
+
+        cell->element.reset(newMarker);
+        return;
+    }
+
     if (item->isFretDiagram()) {
         FretDiagram* oldFretDiagram = toFretDiagram(item);
         String oldFretDiagramPattern = FretDiagram::patternFromDiagram(oldFretDiagram);


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/30254
All marker types being set to "Fine" in the repeats palette
