### PR TITLE
Fix windows portable apps build

### DIFF
--- a/buildscripts/ci/windows/build.bat
+++ b/buildscripts/ci/windows/build.bat
@@ -46,10 +46,10 @@ ECHO "Finished copy dependencies"
 SET "JACK_DIR=C:\Program Files (x86)\Jack"
 SET "PATH=%JACK_DIR%;%PATH%"
 
-SET MUSESCORE_BUILD_CONFIGURATION="app"
-IF %BUILD_WIN_PORTABLE% == ON ( 
+SET "MUSESCORE_BUILD_CONFIGURATION=app"
+IF %BUILD_WIN_PORTABLE% == ON (
     SET INSTALL_DIR=../build.install/App/MuseScore
-    SET MUSESCORE_BUILD_CONFIGURATION="app-portable"
+    SET "MUSESCORE_BUILD_CONFIGURATION=app-portable"
 )
 
 bash ./buildscripts/ci/tools/make_revision_env.sh 

--- a/buildscripts/ci/windows/setup.bat
+++ b/buildscripts/ci/windows/setup.bat
@@ -26,9 +26,6 @@ IF %TARGET_PROCESSOR_BITS% == 32 (
 where /q git
 IF ERRORLEVEL 1 ( choco install -y git.install )
 
-where /q wget
-IF ERRORLEVEL 1 ( choco install -y wget )
-
 where /q 7z
 IF ERRORLEVEL 1 ( choco install -y 7zip.install )
 
@@ -38,23 +35,23 @@ MKDIR %TEMP_DIR%
 
 :: Install dependencies
 ECHO "=== Install dependencies ==="
-CALL "wget.exe" -q --show-progress --no-check-certificate "https://s3.amazonaws.com/utils.musescore.org/musescore_dependencies_win32.7z" -O %TEMP_DIR%\musescore_dependencies_win32.7z
+CALL "curl.exe" -f -o %TEMP_DIR%\musescore_dependencies_win32.7z "https://s3.amazonaws.com/utils.musescore.org/musescore_dependencies_win32.7z"
 CALL "7z" x -y %TEMP_DIR%\musescore_dependencies_win32.7z "-o%TEMP_DIR%\musescore_dependencies_win32"
 SET JACK_DIR="C:\Program Files (x86)\Jack"
 XCOPY %TEMP_DIR%\musescore_dependencies_win32\dependencies\Jack %JACK_DIR% /E /I /Y
-SET PATH=%JACK_DIR%;%PATH% 
+SET PATH=%JACK_DIR%;%PATH%
 
-CALL "wget.exe" -q --show-progress --no-check-certificate "https://s3.amazonaws.com/utils.musescore.org/dependencies.7z" -O  %TEMP_DIR%\dependencies.7z
+CALL "curl.exe" -f -o %TEMP_DIR%\dependencies.7z "https://s3.amazonaws.com/utils.musescore.org/dependencies.7z"
 CALL "7z" x -y %TEMP_DIR%\dependencies.7z "-oC:\musescore_dependencies"
 
 IF %BUILD_WIN_PORTABLE% == ON (
 ECHO "=== Installing PortableApps.com Tools ==="
 :: portableappslauncher is a vanilla installation of PortableApps.com Launcher https://portableapps.com/apps/development/portableapps.com_launcher
-CALL "wget.exe" --no-check-certificate "https://s3.amazonaws.com/utils.musescore.org/portableappslauncher.zip" -O %TEMP_DIR%\portableappslauncher.zip
+CALL "curl.exe" -f -o %TEMP_DIR%\portableappslauncher.zip "https://s3.amazonaws.com/utils.musescore.org/portableappslauncher.zip"
 CALL "7z" x -y %TEMP_DIR%\portableappslauncher.zip "-oC:\portableappslauncher"
 
 :: portableappsinstaller is a vanilla installation of PortableApps.com Installer https://portableapps.com/apps/development/portableapps.com_installer
-CALL "wget.exe" --no-check-certificate "https://s3.amazonaws.com/utils.musescore.org/portableappsinstaller.zip" -O %TEMP_DIR%\portableappsinstaller.zip
+CALL "curl.exe" -f -o %TEMP_DIR%\portableappsinstaller.zip "https://s3.amazonaws.com/utils.musescore.org/portableappsinstaller.zip"
 CALL "7z" x -y %TEMP_DIR%\portableappsinstaller.zip "-oC:\portableappsinstaller"
 )
 


### PR DESCRIPTION
Resolves: #30199

The `MUSESCORE_BUILD_CONFIGURATION` variable contained quotation marks which caused the `BUILD_CONFIGURATION STREQUAL "APP-PORTABLE"` branch in SetupConfigure.cmake to never be taken. This caused the necessary files from `buildscripts/packaging/windows/PortableApps` to never be installed by CMake. The PortableApps launcher generator then didn't recognize the install folder as a portable app. And what does the generator executable then do? Show a super handy dialog! This is where CI got stuck for 5.5h.
The super handy dialog in question:
<img width="499" height="388" alt="image" src="https://github.com/user-attachments/assets/be2d5856-63e0-460e-a768-010b6839a251" />

Bonus change: Use builtin curl.exe instead of fetching wget with choco (which tends to be flaky recently)

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
