### PR TITLE
Fix #24871: Clicking measure numbers in palette

### DIFF
--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -2297,6 +2297,7 @@ bool NotationInteraction::applyPaletteElement(mu::engraving::EngravingItem* elem
     switch (element->type()) {
     case ElementType::MARKER:
     case ElementType::JUMP:
+    case ElementType::MEASURE_NUMBER:
     case ElementType::SPACER:
     case ElementType::VBOX:
     case ElementType::HBOX:


### PR DESCRIPTION
Resolves: #24871

Another reminder that we should try to clean up and unify our `drop`/`apply` methods as much as we can...