### PR TITLE
Fix #29925: Use default panel visibilities when resetting workspace [4.6.1 port]

### DIFF
--- a/src/framework/dockwindow/view/dockwindow.cpp
+++ b/src/framework/dockwindow/view/dockwindow.cpp
@@ -483,7 +483,7 @@ void DockWindow::addPanelAsTab(DockPanelView* panel, DockPanelView* destinationP
 {
     registerDock(panel);
 
-    if (panel->isVisible()) {
+    if (panel->defaultVisibility()) {
         destinationPanel->addPanelAsTab(panel);
         destinationPanel->setCurrentTabIndex(0);
     }


### PR DESCRIPTION
Ports: #30096
Resolves: #29925