### PR TITLE
fixed #30219: Crash when clicking 'Home' with an open score (MuseScore Studio 4.6, Mac OS)

### DIFF
--- a/src/framework/ui/view/abstractnavigation.cpp
+++ b/src/framework/ui/view/abstractnavigation.cpp
@@ -40,8 +40,17 @@ void AbstractNavigation::classBegin()
 {
 }
 
+bool AbstractNavigation::isComponentCompleted() const
+{
+    return m_isComponentCompleted;
+}
+
 void AbstractNavigation::componentComplete()
 {
+    if (isComponentCompleted()) {
+        return;
+    }
+
     if (m_accessible) {
         m_accessible->setState(IAccessible::State::Enabled, enabled());
         m_accessible->setState(IAccessible::State::Active, active());
@@ -51,6 +60,8 @@ void AbstractNavigation::componentComplete()
     navigationController()->highlightChanged().onNotify(this, [this](){
         emit highlightChanged();
     });
+
+    m_isComponentCompleted = true;
 }
 
 void AbstractNavigation::setName(QString name)

--- a/src/framework/ui/view/abstractnavigation.h
+++ b/src/framework/ui/view/abstractnavigation.h
@@ -87,6 +87,8 @@ public:
 
     // QQmlParserStatus
     void classBegin() override;
+
+    bool isComponentCompleted() const;
     void componentComplete() override;
 
 public slots:
@@ -125,6 +127,8 @@ protected:
     NavigationEvent* m_event = nullptr;
 
     mutable AccessibleItem* m_accessible = nullptr;
+
+    bool m_isComponentCompleted = false;
 };
 }
 

--- a/src/framework/ui/view/navigationcontrol.cpp
+++ b/src/framework/ui/view/navigationcontrol.cpp
@@ -42,6 +42,19 @@ NavigationControl::~NavigationControl()
     }
 }
 
+void NavigationControl::componentComplete()
+{
+    if (isComponentCompleted()) {
+        return;
+    }
+
+    if (m_panel) {
+        m_panel->componentComplete();
+    }
+
+    AbstractNavigation::componentComplete();
+}
+
 QString NavigationControl::name() const
 {
     return AbstractNavigation::name();

--- a/src/framework/ui/view/navigationcontrol.h
+++ b/src/framework/ui/view/navigationcontrol.h
@@ -69,6 +69,8 @@ public:
 
     Q_INVOKABLE void notifyAboutControlWasTriggered();
 
+    void componentComplete() override;
+
 public slots:
     void setPanel(NavigationPanel* panel);
 

--- a/src/framework/ui/view/navigationpanel.cpp
+++ b/src/framework/ui/view/navigationpanel.cpp
@@ -45,6 +45,19 @@ NavigationPanel::~NavigationPanel()
     }
 }
 
+void NavigationPanel::componentComplete()
+{
+    if (isComponentCompleted()) {
+        return;
+    }
+
+    if (m_section) {
+        m_section->componentComplete();
+    }
+
+    AbstractNavigation::componentComplete();
+}
+
 QString NavigationPanel::name() const
 {
     return AbstractNavigation::name();

--- a/src/framework/ui/view/navigationpanel.h
+++ b/src/framework/ui/view/navigationpanel.h
@@ -86,6 +86,8 @@ public:
     Q_INVOKABLE void requestActive(INavigationControl* control = nullptr, bool enableHighlight = false,
                                    ActivationType activationType = ActivationType::None) override;
 
+    void componentComplete() override;
+
 public slots:
     void setSection_property(NavigationSection* section);
     void setSection(INavigationSection* section);


### PR DESCRIPTION
Resolves: #30219

I see many problematic areas in the project (and in audacity) where the previous solution doesn’t fit or is too risky, so I decided to slightly change the initialization in the navigation objects.
Usually, we write the panel in the top of qml file and the content below, but the order of calls is clearly not guaranteed, so the component completed of the content might be called before the panel (which is what happens in our case).
https://doc.qt.io/qt-6/qml-qtqml-component.html#completed-signal