### PR TITLE
Add new lyric in separate undo command

### DIFF
--- a/buildscripts/ci/macos/build.sh
+++ b/buildscripts/ci/macos/build.sh
@@ -35,6 +35,8 @@ while [[ "$#" -gt 0 ]]; do
     shift
 done
 
+export MUSESCORE_DIAGNOSTICS_CRASHPAD_CLIENT=OFF
+
 if [ -z "$BUILD_NUMBER" ]; then echo "error: not set BUILD_NUMBER"; exit 1; fi
 
 BUILD_MODE=$(cat $ARTIFACTS_DIR/env/build_mode.env)
@@ -59,6 +61,7 @@ MUSESCORE_REVISION=$MUSESCORE_REVISION \
 MUSESCORE_CRASHREPORT_URL=$CRASH_REPORT_URL \
 MUSESCORE_BUILD_VST_MODULE="ON" \
 MUSESCORE_BUILD_WEBSOCKET="ON" \
+MUSESCORE_DIAGNOSTICS_CRASHPAD_CLIENT=$MUSESCORE_DIAGNOSTICS_CRASHPAD_CLIENT \
 bash ./ninja_build.sh -t install
 
 bash ./buildscripts/ci/tools/make_release_channel_env.sh -c $MUSE_APP_BUILD_MODE

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -7686,6 +7686,9 @@ void NotationInteraction::addMelisma()
         prevPartialLyricsLine->undoMoveEnd(tickDiff);
         prevPartialLyricsLine->triggerLayout();
     }
+    score()->endCmd();
+
+    score()->startCmd(TranslatableString("undoableAction", "Enter lyrics extension line"));
     if (newLyrics) {
         score()->undoAddElement(toLyrics);
     }

--- a/src/palette/internal/palettecompat.cpp
+++ b/src/palette/internal/palettecompat.cpp
@@ -150,8 +150,8 @@ void PaletteCompat::migrateOldPaletteCellIfNeeded(PaletteCell* cell, Score* pale
         Marker* marker = toMarker(item);
         Marker* newMarker = marker->clone();
 
-        AsciiStringView s(newMarker->label().toStdString());
-        MarkerType mt = TConv::fromXml(s, MarkerType::USER);
+        std::string label = newMarker->label().toStdString();
+        MarkerType mt = TConv::fromXml(label, MarkerType::USER);
         newMarker->setMarkerType(mt);
 
         cell->element.reset(newMarker);


### PR DESCRIPTION
Resolves: #30187 

When rolling back the undo command which added the empty text in `endEditText()` at the top of `addMelisma()` we were also rolling back any property changes made in the command between L7631 and L7692. Adding the next lyric needs to happen in a separate command.