### PR TITLE
[4.6.1] Fix #30082: When sub-menus in mixer are overlapping they can be un-selectable or cause a crash

### DIFF
--- a/src/framework/uicomponents/qml/Muse/UiComponents/internal/StyledMenu.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/internal/StyledMenu.qml
@@ -256,8 +256,7 @@ MenuView {
             root.subMenuLoader.hasSiblingMenus = root.hasSiblingMenus
 
             root.subMenuLoader.handleMenuItem.connect(function(itemId) {
-                Qt.callLater(root.handleMenuItem, itemId)
-                root.subMenuLoader.close()
+                root.handleMenuItem(itemId)
             })
 
             root.subMenuLoader.opened.connect(function(itemId) {


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/30082