### PR TITLE
Fix navigator initial scaling

### DIFF
--- a/src/notation/view/notationnavigator.h
+++ b/src/notation/view/notationnavigator.h
@@ -77,8 +77,6 @@ signals:
     void orientationChanged();
 
 private:
-    INotationPtr currentNotation() const;
-
     void initOrientation();
     void initVisible();
 


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/30227

Problem is that `height()` is initially zero, so the scaling is not set. Solution: rescale when the view size changes, rather than when setting the notation view rect (which shouldn’t require rescaling anyway).