### PR TITLE
Fix crash when pressing key while dynamics handle selected

### DIFF
--- a/src/engraving/dom/dynamic.cpp
+++ b/src/engraving/dom/dynamic.cpp
@@ -21,7 +21,7 @@
  */
 #include "dynamic.h"
 
-#include "../editing/undo.h"
+#include "../editing/textedit.h"
 #include "../types/typesconv.h"
 
 #include "dynamichairpingroup.h"
@@ -595,8 +595,8 @@ String Dynamic::screenReaderInfo() const
 
 bool Dynamic::isEditAllowed(EditData& ed) const
 {
-    if (ed.key == Key_Tab) {
-        return false;
+    if (!dynamic_cast<TextEditData*>(ed.getData(this).get())) {
+        return EngravingItem::isEditAllowed(ed);
     }
 
     return TextBase::isEditAllowed(ed);


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/30229

TextBase methods love `static_cast<TextEditData*>(ed.getData(this).get())`, but that’s a bit of a problem when it’s actually only `ElementEditData`, as is the case when a dynamic is in grip edit mode.