### PR TITLE
[4.6.1] Fixed a crash when accessing an invalid json object

### DIFF
--- a/src/framework/global/serialization/json.cpp
+++ b/src/framework/global/serialization/json.cpp
@@ -602,22 +602,38 @@ bool JsonObject::isValid() const
 
 bool JsonObject::empty() const
 {
+    if (!isValid()) {
+        return true;
+    }
+
     return object_const(m_data).size() == 0;
 }
 
 size_t JsonObject::size() const
 {
+    if (!isValid()) {
+        return 0;
+    }
+
     return object_const(m_data).size();
 }
 
 bool JsonObject::contains(const std::string& key) const
 {
+    if (!isValid()) {
+        return false;
+    }
+
     const picojson::object& o = object_const(m_data);
     return o.find(key) != o.cend();
 }
 
 JsonValue JsonObject::value(const std::string& key, JsonValue def) const
 {
+    if (!isValid()) {
+        return def;
+    }
+
     const picojson::object& o = object_const(m_data);
     auto it = o.find(key);
     if (it != o.cend()) {


### PR DESCRIPTION
see https://github.com/musescore/MuseScore/pull/30238