### PR TITLE
Add missing harmony layout call

### DIFF
--- a/src/engraving/playback/playbackmodel.cpp
+++ b/src/engraving/playback/playbackmodel.cpp
@@ -458,7 +458,7 @@ void PlaybackModel::processSegment(const int tickPositionOffset, const Segment* 
         }
 
         const Harmony* chordSymbol = findChordSymbol(item);
-        if (!chordSymbol || !chordSymbol->play()) {
+        if (!chordSymbol) {
             continue;
         }
 
@@ -475,10 +475,11 @@ void PlaybackModel::processSegment(const int tickPositionOffset, const Segment* 
             continue;
         }
 
-        const PlaybackContextPtr ctx = playbackCtx(trackId);
-
-        m_renderer.renderChordSymbol(chordSymbol, tickPositionOffset, profile, ctx,
-                                     m_playbackDataMap[trackId].originEvents);
+        if (chordSymbol->play()) {
+            const PlaybackContextPtr ctx = playbackCtx(trackId);
+            m_renderer.renderChordSymbol(chordSymbol, tickPositionOffset, profile, ctx,
+                                         m_playbackDataMap[trackId].originEvents);
+        }
 
         collectChangesTracks(trackId, trackChanges);
     }

--- a/src/engraving/rendering/score/systemlayout.cpp
+++ b/src/engraving/rendering/score/systemlayout.cpp
@@ -1023,6 +1023,7 @@ void SystemLayout::layoutHarmonies(const std::vector<Harmony*> harmonies, System
             continue;
         }
 
+        TLayout::layoutHarmony(h, h->mutldata(), ctx);
         autoplaceHarmony(h);
         harmonyItemsAlign.push_back(h);
         harmonyPositions.insert({ h->tick(), h->staffIdx() });


### PR DESCRIPTION
Resolves: #30211
If this call isn't made, harmonies outside of the layout range aren't laid out (and their y position reset) but are vertically aligned.

Also fixes a playback bug - when chord's play property is set to off, that change needs to trigger the track being added to the changes.