### PR TITLE
Fix BSP tree referencing deleted items

### DIFF
--- a/src/engraving/dom/bsp.cpp
+++ b/src/engraving/dom/bsp.cpp
@@ -105,7 +105,7 @@ void BspTree::initialize(const RectF& rec, int n)
     m_leafCnt    = 0;
 
     m_nodes.resize((1 << (m_depth + 1)) - 1);
-    m_leaves.resize(1LL << m_depth);
+    m_leaves.assign(1LL << m_depth, std::vector<EngravingItem*>());
     initialize(rec, m_depth, 0);
 }
 


### PR DESCRIPTION
The removal of std::fill in https://github.com/musescore/MuseScore/pull/29827/commits/60372224e8f58a4a4c8606fa5bec87b020b94d30#diff-422f6cbc9c97b6c0f0967bd17b5f455279a1f01b7bf0cd593301e7ad2e473a1bL110 was too enthusiastic