### PR TITLE
Fix #30248: Inserting frames before frames

### DIFF
--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -2506,11 +2506,11 @@ void NotationInteraction::applyPaletteElementToList(EngravingItem* element, bool
     }
 
     if (isMeasureAnchoredElement) {
-        // we add the following measure-based items to each measure containing selected items
-        std::vector<Measure*> measuresWithSelectedContent;
+        // find the MeasureBase of each selected item - apply the drop there...
+        std::vector<MeasureBase*> measuresWithSelectedContent;
         for (EngravingItem* e : sel.elements()) {
-            Measure* m = e->findMeasure();
-            if (!m) {
+            MeasureBase* mb = e->findMeasureBase();
+            if (!mb) {
                 continue;
             }
             if (elementType == ElementType::MARKER && e->isBarLine()
@@ -2518,15 +2518,13 @@ void NotationInteraction::applyPaletteElementToList(EngravingItem* element, bool
                 && toBarLine(e)->segment()->segmentType() != SegmentType::StartRepeatBarLine) {
                 // exception: markers are anchored to the start of a measure,
                 // so when the user selects an end barline we take the next measure
-                m = m->nextMeasureMM() ? m->nextMeasureMM() : m;
+                mb = mb->nextMeasureMM() ? mb->nextMeasureMM() : mb;
             }
-            if (muse::contains(measuresWithSelectedContent, m)) {
+            if (muse::contains(measuresWithSelectedContent, mb)) {
                 continue;
             }
-            measuresWithSelectedContent.push_back(m);
-            const RectF r = m->staffPageBoundingRect(e->staff()->idx());
-            const PointF pt = r.center() + m->system()->page()->pos();
-            applyDropPaletteElement(score, m, element, modifiers, pt);
+            measuresWithSelectedContent.push_back(mb);
+            applyDropPaletteElement(score, mb, element, modifiers);
             if (elementType == ElementType::BRACKET) {
                 break;
             }
@@ -2547,9 +2545,7 @@ void NotationInteraction::applyPaletteElementToRange(EngravingItem* element, boo
     if (elementType == ElementType::BAR_LINE || isMeasureAnchoredElement) {
         Measure* last = sel.endSegment() ? sel.endSegment()->measure() : nullptr;
         for (Measure* m = sel.startSegment()->measure(); m; m = m->nextMeasureMM()) {
-            const RectF r = m->staffPageBoundingRect(sel.staffStart());
-            const PointF pt = r.center() + m->system()->page()->pos();
-            applyDropPaletteElement(score, m, element, modifiers, pt);
+            applyDropPaletteElement(score, m, element, modifiers);
             if (m == last || elementType == ElementType::BRACKET) {
                 break;
             }


### PR DESCRIPTION
Resolves: #30248

We could take this a step further and flag other nearby frames as targets when dragging frames around (see image). I'd say this is an adventure for another time though.

<img width="1512" height="982" alt="Screenshot 2025-10-03 at 16 48 45" src="https://github.com/user-attachments/assets/24720f17-d516-4a2e-89e1-51c7499c0301" />
...

Note that this PR removes the "position" (`pt`) logic when dropping measure-anchored elements. This has mostly been made redundant since #21543 and related PRs - the drop target is set in our `prepareDrop` methods meaning we shouldn't rely on positions anymore.

I'll try to find some time in the near future to see if this parameter can be phased out completely.