### PR TITLE
Replace Button arguments with FlatButton in plugins

### DIFF
--- a/share/plugins/intervals/mirror-intervals-3.qml
+++ b/share/plugins/intervals/mirror-intervals-3.qml
@@ -220,7 +220,7 @@ MuseScore {
                     currentIndex = index
                 }
             }
-            Button {
+            FlatButton {
                 id: applyButton
                 text: qsTranslate("PrefsDialogBase", "Apply")
                 onClicked: {
@@ -228,7 +228,7 @@ MuseScore {
                     quit()
                 }
             }
-            Button {
+            FlatButton {
                 id: cancelButton
                 text: qsTranslate("PrefsDialogBase", "Cancel")
                 onClicked: {

--- a/share/plugins/tuning/tuning.qml
+++ b/share/plugins/tuning/tuning.qml
@@ -19,6 +19,7 @@ import QtQuick.Controls
 import QtQuick.Layouts
 
 import MuseScore 3.0
+import Muse.UiComponents 1.0
 import FileIO 3.0
 
 MuseScore {
@@ -1213,8 +1214,9 @@ MuseScore {
                                 }
                             }
                         }
+
                         RowLayout {
-                            Button {
+                            FlatButton {
                                 id: saveButton
                                 text: qsTranslate("PrefsDialogBase", "Save")
                                 onClicked: {
@@ -1222,7 +1224,7 @@ MuseScore {
                                     saveDialog.visible = true
                                 }
                             }
-                            Button {
+                            FlatButton {
                                 id: loadButton
                                 text: qsTranslate("PrefsDialogBase", "Load")
                                 onClicked: {
@@ -1230,14 +1232,14 @@ MuseScore {
                                     loadDialog.visible = true
                                 }
                             }
-                            Button {
+                            FlatButton {
                                 id: undoButton
                                 text: qsTranslate("PrefsDialogBase", "Undo")
                                 onClicked: {
                                     getHistory().undo()
                                 }
                             }
-                            Button {
+                            FlatButton {
                                 id: redoButton
                                 text: qsTranslate("PrefsDialogBase", "Redo")
                                 onClicked: {
@@ -1249,7 +1251,7 @@ MuseScore {
                 }
 
                 RowLayout {
-                    Button {
+                    FlatButton {
                         id: applyButton
                         text: qsTranslate("PrefsDialogBase", "Apply")
                         onClicked: {
@@ -1262,7 +1264,7 @@ MuseScore {
                             }
                         }
                     }
-                    Button {
+                    FlatButton {
                         id: cancelButton
                         text: qsTranslate("PrefsDialogBase", "Cancel")
                         onClicked: {

--- a/share/plugins/tuning_modal/Modal_Tuning.qml
+++ b/share/plugins/tuning_modal/Modal_Tuning.qml
@@ -19,6 +19,7 @@ import QtQuick.Controls
 import QtQuick.Layouts
 
 import MuseScore 3.0
+import Muse.UiComponents 1.0
 import FileIO 3.0
 
 MuseScore {
@@ -1337,8 +1338,9 @@ MuseScore {
                                 }
                             }
                         }
+
                         RowLayout {
-                            Button {
+                            FlatButton {
                                 id: saveButton
                                 text: qsTranslate("PrefsDialogBase", "Save")
                                 onClicked: {
@@ -1347,7 +1349,7 @@ MuseScore {
                                     saveDialog.visible = true
                                 }
                             }
-                            Button {
+                            FlatButton {
                                 id: loadButton
                                 text: qsTranslate("PrefsDialogBase", "Load")
                                 onClicked: {
@@ -1355,14 +1357,14 @@ MuseScore {
                                     loadDialog.visible = true
                                 }
                             }
-                            Button {
+                            FlatButton {
                                 id: undoButton
                                 text: qsTranslate("PrefsDialogBase", "Undo")
                                 onClicked: {
                                     getHistory().undo()
                                 }
                             }
-                            Button {
+                            FlatButton {
                                 id: redoButton
                                 text: qsTranslate("PrefsDialogBase", "Redo")
                                 onClicked: {
@@ -1374,7 +1376,7 @@ MuseScore {
                 }
 
                 RowLayout {
-                    Button {
+                    FlatButton {
                         id: applyButton
                         text: qsTranslate("PrefsDialogBase", "Apply")
                         onClicked: {
@@ -1387,7 +1389,7 @@ MuseScore {
                             }
                         }
                     }
-                    Button {
+                    FlatButton {
                         id: cancelButton
                         text: qsTranslate("PrefsDialogBase", "Cancel")
                         onClicked: {

--- a/share/plugins/tuning_modal/Temperaments.qml
+++ b/share/plugins/tuning_modal/Temperaments.qml
@@ -19,6 +19,7 @@ import QtQuick.Controls
 import QtQuick.Layouts
 
 import MuseScore 3.0
+import Muse.UiComponents 1.0
 import FileIO 3.0
 
 MuseScore {
@@ -1337,8 +1338,9 @@ MuseScore {
                                 }
                             }
                         }
+
                         RowLayout {
-                            Button {
+                            FlatButton {
                                 id: saveButton
                                 text: qsTranslate("PrefsDialogBase", "Save")
                                 onClicked: {
@@ -1347,7 +1349,7 @@ MuseScore {
                                     saveDialog.visible = true
                                 }
                             }
-                            Button {
+                            FlatButton {
                                 id: loadButton
                                 text: qsTranslate("PrefsDialogBase", "Load")
                                 onClicked: {
@@ -1355,14 +1357,14 @@ MuseScore {
                                     loadDialog.visible = true
                                 }
                             }
-                            Button {
+                            FlatButton {
                                 id: undoButton
                                 text: qsTranslate("PrefsDialogBase", "Undo")
                                 onClicked: {
                                     getHistory().undo()
                                 }
                             }
-                            Button {
+                            FlatButton {
                                 id: redoButton
                                 text: qsTranslate("PrefsDialogBase", "Redo")
                                 onClicked: {
@@ -1374,7 +1376,7 @@ MuseScore {
                 }
 
                 RowLayout {
-                    Button {
+                    FlatButton {
                         id: applyButton
                         text: qsTranslate("PrefsDialogBase", "Apply")
                         onClicked: {
@@ -1387,7 +1389,7 @@ MuseScore {
                             }
                         }
                     }
-                    Button {
+                    FlatButton {
                         id: cancelButton
                         text: qsTranslate("PrefsDialogBase", "Cancel")
                         onClicked: {


### PR DESCRIPTION
Replace the qml "button" argument with "FlatButton" for better visual rendering 

- [x] I signed the [CLA] (https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [ ] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)