### PR TITLE
[4.6.1] Fix IncrementalPropertyControl decimal separator

### DIFF
--- a/src/framework/uicomponents/qml/Muse/UiComponents/IncrementalPropertyControl.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/IncrementalPropertyControl.qml
@@ -150,7 +150,7 @@ Item {
         anchors.top: parent.top
         anchors.bottom: parent.bottom
 
-        currentText: ui.df.formatReal(root.currentValue ? root.currentValue : 0.0, decimals)
+        currentText: Qt.locale().toString(root.currentValue ? root.currentValue : 0.0, 'f', decimals)
 
         navigation.accessible.role: MUAccessible.SpinBox
         navigation.accessible.value: currentValue + (measureUnitsSymbol !== "" ? " " + measureUnitsSymbol : "")


### PR DESCRIPTION
Resolves: #30297

Respect system locale when displaying the decimal separator: dot or comma.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
