### PR TITLE
[4.6.1] Prevent crash when opening part of a certain score

### DIFF
--- a/src/engraving/rendering/score/autoplace.cpp
+++ b/src/engraving/rendering/score/autoplace.cpp
@@ -233,6 +233,9 @@ void Autoplace::autoplaceSpannerSegment(const SpannerSegment* item, EngravingIte
             ldata->setIsSkipDraw(false);
         }
         const System* system = item->system();
+        IF_ASSERT_FAILED(system) {
+            return;
+        }
         const Skyline& staffSkyline = system->staff(stfIdx)->skyline();
         const SkylineLine& skyline = above ? staffSkyline.north() : staffSkyline.south();
         SkylineLine filteredSkyline = skyline.getFilteredCopy([item](const ShapeElement& shapeEl){


### PR DESCRIPTION
Ports: https://github.com/musescore/MuseScore/pull/30293

Looks a bit like bandaid, but might be good enough for 4.6.1 and until a better solution got found (which @miiizen is working at)