### PR TITLE
Fix #16644: Repeat last note/chord after inputting a rest

### DIFF
--- a/src/engraving/dom/segment.cpp
+++ b/src/engraving/dom/segment.cpp
@@ -451,6 +451,17 @@ Segment* Segment::prev1WithElemsOnStaff(staff_idx_t staffIdx, SegmentType segTyp
     return prev;
 }
 
+Segment* Segment::prev1WithElemsOnTrack(track_idx_t trackIdx, SegmentType segType) const
+{
+    Segment* prev = prev1(segType);
+
+    while (prev && !prev->hasElements(trackIdx, trackIdx)) {
+        prev = prev->prev1(segType);
+    }
+
+    return prev;
+}
+
 Segment* Segment::prev1enabled() const
 {
     Segment* s = prev1();

--- a/src/engraving/dom/segment.h
+++ b/src/engraving/dom/segment.h
@@ -164,6 +164,7 @@ public:
 
     Segment* prev1() const;
     Segment* prev1WithElemsOnStaff(staff_idx_t staffIdx, SegmentType segType = SegmentType::ChordRest) const;
+    Segment* prev1WithElemsOnTrack(track_idx_t trackIdx, SegmentType segType = SegmentType::ChordRest) const;
     Segment* prev1enabled() const;
     Segment* prev1MM() const;
     Segment* prev1MMenabled() const;


### PR DESCRIPTION
Resolves: #16644<!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
This PR allow to repeat (R command) last note/chord after inputting a rest:
- If the selected element is a rest and there is only one element selected the app looks for the previous note and then repeats it

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
