### PR TITLE
Refactor key event handling for accessibility on Linux

### DIFF
--- a/src/framework/accessibility/internal/accessibilitycontroller.cpp
+++ b/src/framework/accessibility/internal/accessibilitycontroller.cpp
@@ -28,7 +28,6 @@
 
 #ifdef Q_OS_LINUX
 #include <QKeyEvent>
-#include <private/qcoreapplication_p.h>
 #endif
 
 #include "accessibleobject.h"
@@ -474,9 +473,8 @@ void AccessibilityController::cancelPreviousReading()
 
 #ifdef Q_OS_LINUX
     //! HACK: it needs for canceling reading the name of previous control on accessibility
-    QKeyEvent* keyEvent = new QKeyEvent(QEvent::KeyPress, Qt::Key_Cancel, Qt::KeyboardModifier::NoModifier, 0, 1, 0);
-    QCoreApplicationPrivate::setEventSpontaneous(keyEvent, true);
-    application()->notify(mainWindow()->qWindow(), keyEvent);
+    QKeyEvent* keyEvent = new QKeyEvent(QEvent::KeyPress, Qt::Key_Cancel, Qt::NoModifier);
+    QCoreApplication::postEvent(mainWindow()->qWindow(), keyEvent);
 #endif
 }
 


### PR DESCRIPTION
The code was making use of internal Qt classes which can easily break when upgrading the framework, but also makes it hard for other to build and contribute as it can't be build from the public headers and instead requires the full Qt source available.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)

Note my goal here is to make sure that Audacity 4.0 does not get rejected from Linux repos because of dependency issues. As such I have only tested that the patch builds on Audacity, but your current guide lines seems to dictate that I submit the change in MuseScore.