### PR TITLE
[4.6.1] Fix #28234: play notes while dragging with mouse

### DIFF
--- a/src/notation/view/notationviewinputcontroller.h
+++ b/src/notation/view/notationviewinputcontroller.h
@@ -232,10 +232,15 @@ private:
         Qt::DropAction dropAction = Qt::DropAction::CopyAction;
         QObject* source = nullptr;
     };
+
     bool dropEvent(const DragMoveEvent& event, const QMimeData* mimeData = nullptr);
+
+    std::vector<int> pitchesBeingDragged() const;
+
     DragMoveEvent m_lastDragMoveEvent;
 
     const mu::engraving::EngravingItem* m_prevSelectedElement = nullptr;
+    std::vector<const mu::engraving::EngravingItem*> m_notesBeingDragged;
 
     bool m_hitElementWasAlreadySingleSelected = false;
     bool m_shouldSelectOnLeftClickRelease = false;


### PR DESCRIPTION
Ports: https://github.com/musescore/MuseScore/pull/30177