### PR TITLE
Make setHeaderFooterMacroInfoText build on recent Qt version

### DIFF
--- a/src/notation/view/widgets/editstyle.cpp
+++ b/src/notation/view/widgets/editstyle.cpp
@@ -1389,12 +1389,12 @@ void EditStyle::setHeaderFooterMacroInfoText()
     if (!score->isMaster()) {
         for (const auto& tag : score->masterScore()->metaTags()) {
             toolTipHeaderFooter += "<tr><td>%1</td><td width=\"12\"/><td><i>%2</i></td></tr>"_L1
-                                   .arg(tag.first, tag.second.empty() ? QAnyStringView { "-" } : QAnyStringView { tag.second });
+                                   .arg(tag.first, tag.second.empty() ? u"-"_s : tag.second.toQString());
         }
     }
     for (const auto& tag : score->metaTags()) {
         toolTipHeaderFooter += "<tr><td>%1</td><td width=\"12\"/><td><i>%2</i></td></tr>"_L1
-                               .arg(tag.first, tag.second.empty() ? QAnyStringView { "-" } : QAnyStringView { tag.second });
+                               .arg(tag.first, tag.second.empty() ? u"-"_s : tag.second.toQString());
     }
 
     toolTipHeaderFooter += "</table></body></html>"_L1;


### PR DESCRIPTION
This PR fixes a compilation error that occurs when building MuseScore with Qt 6.8.3.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
