### PR TITLE
Remove use of private Qt function in navigableappmenumodel.cpp

### DIFF
--- a/src/appshell/view/navigableappmenumodel.cpp
+++ b/src/appshell/view/navigableappmenumodel.cpp
@@ -25,44 +25,37 @@
 #include <QWindow>
 #include <QKeyEvent>
 
-#include <private/qkeymapper_p.h>
-
 #include "log.h"
 
 using namespace mu::appshell;
 using namespace muse::ui;
 using namespace muse::uicomponents;
 
-QSet<int> convertToSet(QList<int> keys)
-{
-    return QSet<int>(keys.cbegin(), keys.cend());
-}
-
-QSet<int> convertToSet(QList<QKeyCombination> keys)
-{
-    QSet<int> keyset;
-    for (const auto& key : keys) {
-        keyset << key.toCombined();
-    }
-    return keyset;
-}
-
 QSet<int> possibleKeys(QKeyEvent* keyEvent)
 {
-    QKeyEvent* correctedKeyEvent = keyEvent;
-    //! NOTE: correct work only with alt modifier
-    correctedKeyEvent->setModifiers(Qt::AltModifier);
+    QSet<int> keyset;
 
-    auto keys = QKeyMapper::possibleKeys(correctedKeyEvent);
-    return convertToSet(keys);
+    int key = keyEvent->key();
+    Qt::KeyboardModifiers mods = keyEvent->modifiers();
+
+    if (key != Qt::Key_unknown) {
+        keyset << (key | mods);
+    } else if (!keyEvent->text().isEmpty()) {
+        keyset << (int(keyEvent->text().at(0).unicode()) | mods);
+    }
+
+    return keyset;
 }
 
 QSet<int> possibleKeys(const QChar& keySymbol)
 {
-    QKeyEvent fakeKey(QKeyEvent::KeyRelease, Qt::Key_unknown, Qt::AltModifier, keySymbol);
-    auto keys = QKeyMapper::possibleKeys(&fakeKey);
+    QSet<int> keyset;
 
-    return convertToSet(keys);
+    if (!keySymbol.isNull()) {
+        keyset << int(keySymbol.unicode());
+    }
+
+    return keyset;
 }
 
 NavigableAppMenuModel::NavigableAppMenuModel(QObject* parent)


### PR DESCRIPTION
This PR removes the use of the private Qt function QKeyMapper::possibleKeys() in navigableappmenumodel.cpp and replaces it with a public-API-compatible implementation.

Using private Qt functions can create significant issues for both developers and the community: it prevents building Audacity from public Qt headers, introduces potential [breakage when updating Qt](https://github.com/musescore/MuseScore/issues/23980), and makes it harder for contributors to build and test changes. By relying solely on public Qt APIs, we maintain compatibility, ensure a smoother developer experience, and reduce the risk of future maintenance problems.

This change preserves the original functionality while keeping the code fully compliant with publicly available Qt headers, supporting both current and future contributors.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
