### PR TITLE
Add missing fretboard layout call

### DIFF
--- a/src/engraving/rendering/score/systemlayout.cpp
+++ b/src/engraving/rendering/score/systemlayout.cpp
@@ -1090,6 +1090,7 @@ void SystemLayout::layoutFretDiagrams(const ElementsToLayout& elements, System* 
             continue;
         }
 
+        TLayout::layoutFretDiagram(fd, fd->mutldata(), ctx);
         Autoplace::autoplaceSegmentElement(fd, fd->mutldata());
         fretItemsAlign.push_back(fd);
         fretHarmonyPositions.insert({ fd->tick(), fd->staffIdx() });


### PR DESCRIPTION
Resolves: 

https://github.com/user-attachments/assets/e78ea1fc-f8a0-4d62-bbf1-246fe389ea1a

Same issue as https://github.com/musescore/MuseScore/pull/30262 but for fret diagrams
