### PR TITLE
Don't add duplicate chord symbols and fret diagrams to skyline

### DIFF
--- a/src/engraving/rendering/score/systemlayout.cpp
+++ b/src/engraving/rendering/score/systemlayout.cpp
@@ -1038,21 +1038,6 @@ void SystemLayout::layoutHarmonies(const std::vector<Harmony*> harmonies, System
 
 void SystemLayout::layoutFretDiagrams(const ElementsToLayout& elements, System* system, LayoutContext& ctx)
 {
-    auto addFretHarmonyToSkyline = [system](std::vector<EngravingItem*> fretDiagramsOrHarmony) -> void {
-        for (EngravingItem* item : fretDiagramsOrHarmony) {
-            if (!item->isFretDiagram()) {
-                continue;
-            }
-            FretDiagram* fretDiag = toFretDiagram(item);
-            if (Harmony* harmony = fretDiag->harmony()) {
-                SkylineLine& skl = system->staff(fretDiag->staffIdx())->skyline().north();
-                Segment* s = fretDiag->segment();
-                Shape harmShape = harmony->ldata()->shape().translated(harmony->pos() + fretDiag->pos() + s->pos() + s->measure()->pos());
-                skl.add(harmShape);
-            }
-        }
-    };
-
     if (!ctx.conf().styleB(Sid::verticallyAlignChordSymbols)) {
         for (FretDiagram* fretDiag : elements.fretDiagrams) {
             Autoplace::autoplaceSegmentElement(fretDiag, fretDiag->mutldata());
@@ -1115,8 +1100,6 @@ void SystemLayout::layoutFretDiagrams(const ElementsToLayout& elements, System* 
 
     layoutHarmonies(harmonyItemsAlign, system, ctx);
 
-    addFretHarmonyToSkyline(fretItemsAlign);
-
     // autoplace everything else
     for (EngravingItem* item : fretOrHarmonyItemsNoAlign) {
         if (item->isFretDiagram()) {
@@ -1129,8 +1112,6 @@ void SystemLayout::layoutFretDiagrams(const ElementsToLayout& elements, System* 
             autoplaceHarmony(item);
         }
     }
-
-    addFretHarmonyToSkyline(fretOrHarmonyItemsNoAlign);
 }
 
 void SystemLayout::layoutSystemElements(System* system, LayoutContext& ctx)
@@ -2030,6 +2011,14 @@ void SystemLayout::restoreOldSystemLayout(System* system, LayoutContext& ctx)
     }
 
     layoutTiesAndBends(elements, ctx);
+
+    // Remove stale items from the skyline
+    for (EngravingItem* i : elements.fretDiagrams) {
+        removeElementFromSkyline(i, system);
+    }
+    for (EngravingItem* i : elements.harmonies) {
+        removeElementFromSkyline(i, system);
+    }
 
     bool hasFretDiagram = elements.fretDiagrams.size() > 0;
     if (hasFretDiagram) {
@@ -2948,6 +2937,17 @@ double SystemLayout::minDistance(const System* top, const System* bottom, const 
         dist = std::max(dist, sld);
     }
     return dist;
+}
+
+void SystemLayout::removeElementFromSkyline(EngravingItem* element, const System* system)
+{
+    Skyline& skyline = system->staff(element->staffIdx())->skyline();
+    bool isAbove = element->isArticulationFamily() ? toArticulation(element)->up() : element->placeAbove();
+    SkylineLine& skylineLine = isAbove ? skyline.north() : skyline.south();
+
+    skylineLine.remove_if([element](ShapeElement& shapeEl) {
+        return element == shapeEl.item();
+    });
 }
 
 void SystemLayout::updateSkylineForElement(EngravingItem* element, const System* system, double yMove)

--- a/src/engraving/rendering/score/systemlayout.h
+++ b/src/engraving/rendering/score/systemlayout.h
@@ -86,6 +86,7 @@ public:
     static void centerBigTimeSigsAcrossStaves(const System* system);
 
     static void updateSkylineForElement(EngravingItem* element, const System* system, double yMove);
+    static void removeElementFromSkyline(EngravingItem* element, const System* system);
 
     static void layoutSystemLockIndicators(System* system, LayoutContext& ctx);
 


### PR DESCRIPTION
Resolves: #30350 

I don't think this solution is ideal as `remove_if` is inefficient and something we try to avoid where possible. This is maybe a prompt to have a look at `restoreOldSystemLayout` more closely in future.