### PR TITLE
Check for presence of Qt private headers

### DIFF
--- a/src/appshell/CMakeLists.txt
+++ b/src/appshell/CMakeLists.txt
@@ -140,6 +140,19 @@ if (NOT OS_IS_MAC)
 
     # we use QKeyMapper to fix https://github.com/musescore/MuseScore/issues/10181
     set(MODULE_INCLUDE_PRIVATE ${Qt6Gui_PRIVATE_INCLUDE_DIRS} )
+
+    get_target_property(QT_GUI_INCLUDE_DIRS Qt::Gui INTERFACE_INCLUDE_DIRECTORIES)
+    set(QT_PRIVATE_HEADER_FOUND FALSE)
+    foreach(dir IN LISTS QT_GUI_INCLUDE_DIRS)
+        file(GLOB PRIVATE_HEADER "${dir}/QtGui/*/QtGui/private/*.h")
+        if (PRIVATE_HEADER)
+            set(QT_PRIVATE_HEADER_FOUND TRUE)
+            break()
+        endif()
+    endforeach()
+    if (NOT QT_PRIVATE_HEADER_FOUND)
+        message(FATAL_ERROR "Qt private headers not found. Ensure your Qt installation includes private headers.")
+    endif()
 endif(NOT OS_IS_MAC)
 
 if (QT_SUPPORT)


### PR DESCRIPTION
Resolves: #30345

Adds a CMake check for QtGui private headers and fails early if they are missing. This ensures developers are notified immediately when building modules that rely on Qt private APIs, avoiding build errors later.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
