### PR TITLE
Show localized Piano Keyboard key names

### DIFF
--- a/src/notation/view/pianokeyboard/pianokeyboardview.cpp
+++ b/src/notation/view/pianokeyboard/pianokeyboardview.cpp
@@ -266,13 +266,13 @@ void PianoKeyboardView::paintWhiteKeys(QPainter* painter, const QRectF& viewport
 
             int octaveNumber = (key / 12) - 1;
 
-            QString octaveLabel = "C" + QString::number(octaveNumber);
-            octaveLabel = muse::qtrc("global/pitchName", octaveLabel.toStdString().c_str());
+            std::string octaveLabel = "C" + std::to_string(octaveNumber);
+            QString octaveLabelTr = muse::qtrc("global/pitchName", octaveLabel.c_str());
             QRect octaveLabelRect(left, top, right - left, bottom - top - bottomOffset);
 
             painter->setPen(backgroundColor);
             painter->setFont(m_octaveLabelsFont);
-            painter->drawText(octaveLabelRect, Qt::AlignHCenter | Qt::AlignBottom, octaveLabel);
+            painter->drawText(octaveLabelRect, Qt::AlignHCenter | Qt::AlignBottom, octaveLabelTr);
         }
 
         painter->translate(-rect.topLeft());


### PR DESCRIPTION
Partially resolves: #30167 (Part 2)

The C piano keys in the Piano Keyboard panel are always shown in standard pitch notation.

Display the notes with respect to locale by using the strings from `global/pitchName`.

Piano keyboard with Romanian locale:

<img width="722" height="142" alt="Image" src="https://github.com/user-attachments/assets/715a3ad0-2316-4173-b61d-ce30452d2b94" />

Piano keyboard with German locale:

<img width="727" height="137" alt="Image" src="https://github.com/user-attachments/assets/cb312cd5-bdb2-47b5-bd79-75298e1ff27a" />

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
