### PR TITLE
Refactor showMeasureNumber to always default to auto mode

### DIFF
--- a/src/engraving/dom/measure.cpp
+++ b/src/engraving/dom/measure.cpp
@@ -619,9 +619,9 @@ bool Measure::showMeasureNumber()
         return true;
     case MeasureNumberMode::HIDE:
         return false;
+    default:
+        return showMeasureNumberInAutoMode();
     }
-
-    return showMeasureNumberInAutoMode();
 }
 
 //---------------------------------------------------------


### PR DESCRIPTION
This addresses a few warnings, there are multiple ways issues like this could be addressed so starting slow to see what's preferred.

<img width="637" height="370" alt="image" src="https://github.com/user-attachments/assets/d8166de2-5355-4150-8766-5e9d9f64526d" />
Technically there isn't an issue here and it's more a case of the compilers not properly detecting that the switch is exhaustive, but still it's good to utilize a style that creates less noise.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
