### PR TITLE
missing header

### DIFF
--- a/src/palette/view/widgets/palettewidget.cpp
+++ b/src/palette/view/widgets/palettewidget.cpp
@@ -35,6 +35,7 @@
 #include <QMimeData>
 #include <QResizeEvent>
 #include <QToolTip>
+#include <QWindow>
 
 #include "translation.h"
 #include "types/bytearray.h"


### PR DESCRIPTION
```
src/palette/view/widgets/palettewidget.cpp:
In member function ‘void mu::palette::PaletteWidget::applyElementAtIndex(int, Qt::KeyboardModifiers)’: src/palette/view/widgets/palettewidget.cpp:460:28: error: invalid use of incomplete type ‘class QWindow’
  460 |     mainWindow()->qWindow()->requestActivate();
      |                            ^~
```


- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
