### PR TITLE
Don't restore window as minimised

### DIFF
--- a/src/framework/dockwindow/thirdparty/KDDockWidgets/src/LayoutSaver.cpp
+++ b/src/framework/dockwindow/thirdparty/KDDockWidgets/src/LayoutSaver.cpp
@@ -248,7 +248,7 @@ bool LayoutSaver::restoreLayout(const QByteArray &data)
 
         if (!(d->m_restoreOptions & InternalRestoreOption::SkipMainWindowGeometry)) {
             d->deserializeWindowGeometry(mw, mainWindow->window()); // window(), as the MainWindow can be embedded
-            if (mw.windowState != Qt::WindowNoState) {
+            if (mw.windowState != Qt::WindowNoState && mw.windowState != Qt::WindowMinimized) {
                 if (auto w = mainWindow->windowHandle()) {
                     w->setWindowState(mw.windowState);
                 }

--- a/src/framework/dockwindow/view/dockwindow.cpp
+++ b/src/framework/dockwindow/view/dockwindow.cpp
@@ -251,12 +251,10 @@ void DockWindow::loadPage(const QString& uri, const QVariantMap& params)
     if (isFirstOpening) {
         async::Async::call(this, [this, notifyAboutPageLoaded]() {
             if (!m_hasGeometryBeenRestored
-                || (m_mainWindow->windowHandle()->windowStates() & QWindow::FullScreen)) {
+                || (m_mainWindow->windowHandle()->windowStates() & Qt::WindowFullScreen)) {
                 //! NOTE: show window as maximized if no geometry has been restored
                 //! or if the user had closed app in FullScreen mode
                 m_mainWindow->windowHandle()->showMaximized();
-            } else {
-                m_mainWindow->windowHandle()->setVisible(true);
             }
 
             notifyAboutPageLoaded();


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/30388

Unminimising a window turns out to be difficult, if you want that the geometry is preserved when the window filled the whole screen before being minimised. Qt considers a window that happens to fill the whole screen as “maximised”; it seems that when unminimising a window, either using `show` or `setVisibility(AutomaticVisibility)`, Qt wants it to return to a “normal” state, which is not a maximised state, so the window is made a bit smaller (and it’s ugly). 
A plain call to `window->setWindowStates(states & ~Minimised)` seems to do exactly nothing.

Instead of trying to unminimise the window, we just make sure it never gets into a minimised state at all, during geometry restoration.