### PR TITLE
Avoid argument shadowing in SplitJoinMeasure::joinMeasures()

### DIFF
--- a/src/engraving/editing/splitjoinmeasure.cpp
+++ b/src/engraving/editing/splitjoinmeasure.cpp
@@ -315,29 +315,29 @@ void SplitJoinMeasure::joinMeasures(MasterScore* score, const Fraction& tick1, c
                 if (TimeSig* insTimeSig = toTimeSig(insMSeg->element(staffIdx * VOICES))) {
                     TimeSig* lts = nullptr;
                     for (EngravingObject* l : insTimeSig->linkList()) {
-                        Score* score = l->score();
+                        Score* currentScore = l->score();
                         TimeSig* timeSig = toTimeSig(l);
                         Segment* tSeg = timeSig->segment();
                         track_idx_t track = timeSig->track();
-                        Measure* sNext = next ? score->tick2measure(next->tick()) : nullptr;
+                        Measure* sNext = next ? currentScore->tick2measure(next->tick()) : nullptr;
                         Segment* nextTSeg = sNext ? sNext->undoGetSegmentR(SegmentType::TimeSig, Fraction(0, 1)) : nullptr;
                         if (sNext && !nextTSeg->element(track)) {
                             TimeSig* nsig = Factory::copyTimeSig(*timeSig);
-                            nsig->setScore(score);
+                            nsig->setScore(currentScore);
                             nsig->setTrack(track);
                             nsig->setParent(nextTSeg);
 
-                            score->doUndoAddElement(nsig);
+                            currentScore->doUndoAddElement(nsig);
 
                             if (!lts) {
                                 lts = nsig;
                             } else {
-                                score->undo(new Link(lts, nsig));
+                                currentScore->undo(new Link(lts, nsig));
                             }
                         }
-                        score->doUndoRemoveElement(timeSig);
+                        currentScore->doUndoRemoveElement(timeSig);
                         if (tSeg->empty()) {
-                            score->doUndoRemoveElement(tSeg);
+                            currentScore->doUndoRemoveElement(tSeg);
                         }
                     }
                 }


### PR DESCRIPTION
The function already takes an argument named score leading to this one shadowing the argument.

<img width="477" height="130" alt="image" src="https://github.com/user-attachments/assets/847c82b7-1796-4565-87a4-a7ad440a492a" />

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
