### PR TITLE
Remove no-op from getNextValidInputSegment

### DIFF
--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -1163,7 +1163,7 @@ static Segment* getNextValidInputSegment(Segment* segment, track_idx_t track, vo
         }
     }
 
-    for (segment; segment; segment = segment->next(SegmentType::ChordRest)) {
+    for (; segment; segment = segment->next(SegmentType::ChordRest)) {
         if (segment->element(track + voice) || (voice && segment->tick() == nextTick)) {
             break;
         }


### PR DESCRIPTION
Remove unessesery code from loop initilization

<img width="398" height="247" alt="image" src="https://github.com/user-attachments/assets/e03bf200-8271-46b9-a843-184460f88313" />

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
