### PR TITLE
Rename parameter in PitchWheelRenderer constructor

### DIFF
--- a/src/engraving/compat/midi/pitchwheelrenderer.cpp
+++ b/src/engraving/compat/midi/pitchwheelrenderer.cpp
@@ -4,8 +4,8 @@
 
 using namespace mu::engraving;
 
-PitchWheelRenderer::PitchWheelRenderer(PitchWheelSpecs wheelSpec)
-    : _wheelSpec(wheelSpec)
+PitchWheelRenderer::PitchWheelRenderer(PitchWheelSpecs wheelSpecParam)
+    : _wheelSpec(wheelSpecParam)
 {}
 
 void PitchWheelRenderer::addPitchWheelFunction(const PitchWheelFunction& function, uint32_t channel, staff_idx_t staffIdx,


### PR DESCRIPTION
Rename input to avoid clash with global:

<img width="499" height="125" alt="Screenshot From 2025-10-09 03-13-58" src="https://github.com/user-attachments/assets/bb62467c-1a2e-4875-ac96-4ea6228f1bee" />

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
