### PR TITLE
Fix staves/systems being pushed down by 'inactive' measure numbers

### DIFF
--- a/src/engraving/rendering/score/systemlayout.cpp
+++ b/src/engraving/rendering/score/systemlayout.cpp
@@ -1339,9 +1339,10 @@ void SystemLayout::collectElementsToLayout(Measure* measure, ElementsToLayout& e
 
     System* system = elements.system;
     for (size_t staffIdx = 0; staffIdx < ctx.dom().nstaves(); ++staffIdx) {
-        MeasureNumber* mno = measure->measureNumber(staffIdx);
-        if (mno) {
-            elements.measureNumbers.push_back(mno);
+        if (measure->showMeasureNumberOnStaff(staffIdx)) {
+            if (MeasureNumber* mno = measure->measureNumber(staffIdx)) {
+                elements.measureNumbers.push_back(mno);
+            }
         }
 
         if (!system->staff(staffIdx)->show()) {


### PR DESCRIPTION
Caused by 86b668e67bc8dacee3ba64c5b70111d95f0b4e72. See investigation at https://github.com/musescore/MuseScore/issues/30406.

Resolves: https://github.com/musescore/MuseScore/issues/30406

Porting https://github.com/musescore/MuseScore/pull/30411 to master