### PR TITLE
Fix build failure when !QT_DEBUG

### DIFF
--- a/src/importexport/midi/internal/midiimport/importmidi_tuplet.cpp
+++ b/src/importexport/midi/internal/midiimport/importmidi_tuplet.cpp
@@ -895,9 +895,9 @@ void addTupletEvents(std::multimap<ReducedFraction, TupletData>& tupletEvents,
                 message += QString::number(tiedTuplet.voice) + ", chord voice = ";
                 message += QString::number(midiChord.voice) + ", bar number (from 1) = ";
                 message += QString::number(midiChord.barIndex + 1);
-#endif
                 Q_ASSERT_X(tiedTuplet.voice == midiChord.voice,
                            "MidiTuplet::addTupletEvents", message.toLatin1().data());
+#endif
 
                 for (int j: tiedTuplet.tiedNoteIndexes) {
                     midiChord.notes[j].tuplet = it;


### PR DESCRIPTION
<!-- Add a short description of and motivation for the changes here -->
When I attempted to build version 4.6.1 for Fedora 43, the build failed:
```
In file included from /usr/include/qt6/QtCore/qtypes.h:11,
                 from /usr/include/qt6/QtCore/qcontainerfwd.h:8,
                 from /usr/include/qt6/QtCore/qpair.h:7,
                 from /usr/include/qt6/QtCore/qarraydata.h:8,
                 from /usr/include/qt6/QtCore/qarraydataops.h:8,
                 from /usr/include/qt6/QtCore/qarraydatapointer.h:7,
                 from /usr/include/qt6/QtCore/qlist.h:8,
                 from /usr/include/qt6/QtCore/QList:1,
                 from /builddir/build/BUILD/musescore-4.6.1-build/MuseScore-4.6.1/src/importexport/midi/internal/midiimport/importmidi_key.h:25,
                 from /builddir/build/BUILD/musescore-4.6.1-build/MuseScore-4.6.1/src/importexport/midi/internal/midiimport/importmidi_key.cpp:22,
                 from /builddir/build/BUILD/musescore-4.6.1-build/MuseScore-4.6.1/redhat-linux-build/src/importexport/midi/CMakeFiles/iex_midi.dir/Unity/unity_1_cxx.cxx:4:
/builddir/build/BUILD/musescore-4.6.1-build/MuseScore-4.6.1/src/importexport/midi/internal/midiimport/importmidi_tuplet.cpp: In function ‘void mu::iex::midi::MidiTuplet::addTupletEvents(std::multimap<mu::iex::midi::ReducedFraction, TupletData>&, const std::vector<TupletInfo>&, const std::__cxx11::list<TiedTuplet>&)’:
/builddir/build/BUILD/musescore-4.6.1-build/MuseScore-4.6.1/src/importexport/midi/internal/midiimport/importmidi_tuplet.cpp:900:59: error: ‘message’ was not declared in this scope
  900 |                            "MidiTuplet::addTupletEvents", message.toLatin1().data());
      |                                                           ^~~~~~~
```

Since `message` is defined only if `QT_DEBUG` is defined, move the assertion inside the `#ifdef QT_DEBUG` block as well.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
