### PR TITLE
[4.6.2] Don't mask bar lines for inactive measure numbers

### DIFF
--- a/src/engraving/dom/measure.cpp
+++ b/src/engraving/dom/measure.cpp
@@ -553,7 +553,7 @@ double Measure::tick2pos(Fraction tck) const
 ///    Whether the measure will show measure number(s) when MeasureNumberMode is set to AUTO
 //---------------------------------------------------------
 
-bool Measure::showMeasureNumberInAutoMode()
+bool Measure::showMeasureNumberInAutoMode() const
 {
     // Check whether any measure number should be shown
     if (!style().styleB(Sid::showMeasureNumber)) {
@@ -594,7 +594,7 @@ bool Measure::showMeasureNumberInAutoMode()
     }
 }
 
-bool Measure::showMeasureNumberOnStaff(staff_idx_t staffIdx)
+bool Measure::showMeasureNumberOnStaff(staff_idx_t staffIdx) const
 {
     IF_ASSERT_FAILED(staffIdx < score()->nstaves()) {
         return false;
@@ -608,7 +608,7 @@ bool Measure::showMeasureNumberOnStaff(staff_idx_t staffIdx)
 ///     Whether the Measure shows a MeasureNumber
 //---------------------------------------------------------
 
-bool Measure::showMeasureNumber()
+bool Measure::showMeasureNumber() const
 {
     switch (m_measureNumberMode) {
     case MeasureNumberMode::AUTO:

--- a/src/engraving/dom/measure.h
+++ b/src/engraving/dom/measure.h
@@ -225,9 +225,9 @@ public:
     Fraction anacrusisOffset() const;
     Fraction maxTicks() const;
 
-    bool showMeasureNumber();
-    bool showMeasureNumberInAutoMode();
-    bool showMeasureNumberOnStaff(staff_idx_t staffIdx);
+    bool showMeasureNumber() const;
+    bool showMeasureNumberInAutoMode() const;
+    bool showMeasureNumberOnStaff(staff_idx_t staffIdx) const;
 
     Chord* findChord(Fraction tick, track_idx_t track) const;
     ChordRest* findChordRest(Fraction tick, track_idx_t track) const;

--- a/src/engraving/rendering/score/masklayout.cpp
+++ b/src/engraving/rendering/score/masklayout.cpp
@@ -195,19 +195,22 @@ std::vector<TextBase*> MaskLayout::collectAllSystemText(const System* system)
         if (!mb->isMeasure()) {
             continue;
         }
-        for (const MStaff* mstaff : toMeasure(mb)->mstaves()) {
-            if (MeasureNumber* measureNumber = mstaff->measureNumber()) {
-                allText.push_back(measureNumber);
+        const Measure* measure = toMeasure(mb);
+        for (staff_idx_t i = 0; i < measure->mstaves().size(); ++i) {
+            if (measure->showMeasureNumberOnStaff(i)) {
+                if (MeasureNumber* measureNumber = measure->measureNumber(i)) {
+                    allText.push_back(measureNumber);
+                }
             }
         }
-        for (EngravingItem* item : toMeasure(mb)->el()) {
+        for (EngravingItem* item : measure->el()) {
             const SysStaff* staff = system ? system->staff(item->staffIdx()) : nullptr;
             const bool staffVisible = staff && staff->show();
             if ((item->isMarker() || item->isJump()) && item->visible() && staffVisible) {
                 allText.push_back(toTextBase(item));
             }
         }
-        for (const Segment& s : toMeasure(mb)->segments()) {
+        for (const Segment& s : measure->segments()) {
             if (!s.isType(Segment::CHORD_REST_OR_TIME_TICK_TYPE) || !s.enabled()) {
                 continue;
             }


### PR DESCRIPTION
Follow-up to e9438fb540c33cda226f80b02efc03f5d37b16d8

Resolves: https://github.com/musescore/MuseScore/issues/30429