### PR TITLE
Make "Disable version checking" visible as an Advanced preference

### DIFF
--- a/src/project/internal/projectconfiguration.cpp
+++ b/src/project/internal/projectconfiguration.cpp
@@ -123,7 +123,9 @@ void ProjectConfiguration::init()
     });
     settings()->setDefaultValue(SHOW_CLOUD_IS_NOT_AVAILABLE_WARNING, Val(true));
 
+    settings()->setDescription(DISABLE_VERSION_CHECKING, muse::trc("project", "Disable version checking of score files"));
     settings()->setDefaultValue(DISABLE_VERSION_CHECKING, Val(false));
+    settings()->setCanBeManuallyEdited(DISABLE_VERSION_CHECKING, true);
 
     settings()->setDefaultValue(CREATE_BACKUP_BEFORE_SAVING, Val(true));
     settings()->setDescription(CREATE_BACKUP_BEFORE_SAVING, muse::trc("project",


### PR DESCRIPTION
rather than hiding it completly (in DevTools and for development builds only) and keeping it a secret setting known to only a handfull people.
(that setting exists in 4.2.1 and 4.3.x (via #20907) and 4.4.0 and later (via #20906))

Actually this does not really disable the version __checking__ (which still happens and gets warned about) but rather the __denial__ to load a newer score file version.
Maybe we should rename it accordingly.
Maybe it should even default to `true` for developement builds.

Whether opening the score works or does not work or even crashes is an entirely different issue, but being an Advanced setting should make it hidden enough ;-)

Resolves: #20899