### PR TITLE
[API] Allow hiding individual staves in systems

### DIFF
--- a/src/engraving/api/v1/elements.cpp
+++ b/src/engraving/api/v1/elements.cpp
@@ -493,6 +493,11 @@ bool System::show(int staffIdx)
     return ss ? ss->show() : false;
 }
 
+void System::setHideStaffIfEmpty(int staffIdx, int hide)
+{
+    system()->score()->cmdSetHideStaffIfEmptyOverride(static_cast<staff_idx_t>(staffIdx), system(), AutoOnOff(hide));
+}
+
 void System::setIsLocked(bool locked)
 {
     if (locked == isLocked()) {

--- a/src/engraving/api/v1/elements.h
+++ b/src/engraving/api/v1/elements.h
@@ -1891,6 +1891,12 @@ public:
     /// This can differ from \ref Staff.show (e.g. due to 'hide when empty' rules).
     /// \param staffIdx staff number
     Q_INVOKABLE bool show(int staffIdx);
+    /// Override the staff default behaviour for hiding when empty.
+    /// \param staffIdx staff number
+    /// \param hide controls the new hiding behaviour.
+    /// One of PluginAPI::PluginAPI::AutoOnOff values.
+    /// \since MuseScore 4.7
+    Q_INVOKABLE void setHideStaffIfEmpty(int staffIdx, int hide);
 };
 
 //---------------------------------------------------------


### PR DESCRIPTION
Tested with following test code (when creating a blank grand staff score, hides the bottom staff of the first system):

```qml
import QtQuick 2.0
import MuseScore 3.0

MuseScore {
    title: qsTr("Hide staff if empty")
    description: qsTr("test")

    onRun: {
        try {
			curScore.startCmd("Hide staff if empty")
            curScore.systems[1].setHideStaffIfEmpty(1, AutoOnOff.ON)
            curScore.endCmd()
        } catch (e) {
            // If we encounter an error, rollback all changes
            curScore.endCmd(true)
            curScore.startCmd("Error: " + e.toString())
            var text = newElement(Element.STAFF_TEXT)
            text.text = e.toString()
            var c = curScore.newCursor()
            c.rewind(Cursor.SCORE_START)
            c.track = 0
            c.add(text)
            curScore.endCmd()
        }
        quit()
    }
}
```
---
- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
