### PR TITLE
Add disambiguation for None strings

### DIFF
--- a/src/inspector/models/notation/tuplets/tupletsettingsmodel.cpp
+++ b/src/inspector/models/notation/tuplets/tupletsettingsmodel.cpp
@@ -64,9 +64,9 @@ QVariantList TupletSettingsModel::possibleNumberTypes() const
     using Type = mu::engraving::TupletNumberType;
 
     QVariantList types {
-        object(Type::SHOW_NUMBER, muse::qtrc("inspector", "Number")),
-        object(Type::SHOW_RELATION, muse::qtrc("inspector", "Ratio")),
-        object(Type::NO_TEXT, muse::qtrc("inspector", "None"))
+        object(Type::SHOW_NUMBER, muse::qtrc("inspector", "Number", "tuplet number type")),
+        object(Type::SHOW_RELATION, muse::qtrc("inspector", "Ratio", "tuplet number type")),
+        object(Type::NO_TEXT, muse::qtrc("inspector", "None", "tuplet number type"))
     };
 
     return types;
@@ -77,9 +77,9 @@ QVariantList TupletSettingsModel::possibleBracketTypes() const
     using Type = mu::engraving::TupletBracketType;
 
     QVariantList types {
-        object(Type::AUTO_BRACKET, muse::qtrc("inspector", "Auto")),
-        object(Type::SHOW_BRACKET, muse::qtrc("inspector", "Bracket"), Icon::TUPLET_NUMBER_WITH_BRACKETS),
-        object(Type::SHOW_NO_BRACKET, muse::qtrc("inspector", "None"), Icon::TUPLET_NUMBER_ONLY)
+        object(Type::AUTO_BRACKET, muse::qtrc("inspector", "Auto", "tuplet bracket type")),
+        object(Type::SHOW_BRACKET, muse::qtrc("inspector", "Bracket", "tuplet bracket type"), Icon::TUPLET_NUMBER_WITH_BRACKETS),
+        object(Type::SHOW_NO_BRACKET, muse::qtrc("inspector", "None", "tuplet bracket type"), Icon::TUPLET_NUMBER_ONLY)
     };
 
     return types;

--- a/src/inspector/view/qml/MuseScore/Inspector/common/FrameSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/common/FrameSettings.qml
@@ -54,9 +54,9 @@ Column {
         navigationRowStart: root.navigationRowStart
 
         model: [
-            { text: qsTrc("inspector", "None"), value: TextTypes.FRAME_TYPE_NONE, titleRole: qsTrc("inspector", "None") },
-            { iconCode: IconCode.FRAME_SQUARE, value: TextTypes.FRAME_TYPE_SQUARE, titleRole: qsTrc("inspector", "Rectangle") },
-            { iconCode: IconCode.FRAME_CIRCLE, value: TextTypes.FRAME_TYPE_CIRCLE, titleRole: qsTrc("inspector", "Circle") }
+            { text: qsTrc("inspector", "None", "text frame type"), value: TextTypes.FRAME_TYPE_NONE, titleRole: qsTrc("inspector", "None", "text frame type") },
+            { iconCode: IconCode.FRAME_SQUARE, value: TextTypes.FRAME_TYPE_SQUARE, titleRole: qsTrc("inspector", "Rectangle", "text frame type") },
+            { iconCode: IconCode.FRAME_CIRCLE, value: TextTypes.FRAME_TYPE_CIRCLE, titleRole: qsTrc("inspector", "Circle", "text frame type") }
         ]
     }
 

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/accidentals/AccidentalSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/accidentals/AccidentalSettings.qml
@@ -53,9 +53,9 @@ Column {
         navigationRowStart: root.navigationRowStart
 
         model: [
-            { text: qsTrc("inspector", "None"), value: AccidentalTypes.BRACKET_TYPE_NONE },
-            { iconCode: IconCode.BRACKET_PARENTHESES, value: AccidentalTypes.BRACKET_TYPE_PARENTHESIS, title: qsTrc("inspector", "Parentheses") },
-            { iconCode: IconCode.BRACKET_PARENTHESES_SQUARE, value: AccidentalTypes.BRACKET_TYPE_SQUARE, title: qsTrc("inspector", "Brackets") }
+            { text: qsTrc("inspector", "None", "bracket type"), value: AccidentalTypes.BRACKET_TYPE_NONE },
+            { iconCode: IconCode.BRACKET_PARENTHESES, value: AccidentalTypes.BRACKET_TYPE_PARENTHESIS, title: qsTrc("inspector", "Parentheses", "bracket type") },
+            { iconCode: IconCode.BRACKET_PARENTHESES_SQUARE, value: AccidentalTypes.BRACKET_TYPE_SQUARE, title: qsTrc("inspector", "Brackets", "bracket type") }
         ]
     }
 

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/keysignatures/KeySignatureSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/keysignatures/KeySignatureSettings.qml
@@ -63,19 +63,19 @@ Column {
         navigationRowStart: root.navigationRowStart + 2
 
         model: [
-            { text: qsTrc("inspector", "Unknown"), value: KeySignatureTypes.MODE_UNKNOWN },
-            { text: qsTrc("inspector", "None"), value: KeySignatureTypes.MODE_NONE },
+            { text: qsTrc("inspector", "Unknown", "key signature mode"), value: KeySignatureTypes.MODE_UNKNOWN },
+            { text: qsTrc("inspector", "None", "key signature mode"), value: KeySignatureTypes.MODE_NONE },
             //: mode of a key signature, not an interval
             { text: qsTrc("inspector", "Major", "key signature mode"), value: KeySignatureTypes.MODE_MAJOR },
             //: mode of a key signature, not an interval
             { text: qsTrc("inspector", "Minor", "key signature mode"), value: KeySignatureTypes.MODE_MINOR },
-            { text: qsTrc("inspector", "Dorian"), value: KeySignatureTypes.MODE_DORIAN },
-            { text: qsTrc("inspector", "Phrygian"), value: KeySignatureTypes.MODE_PHRYGIAN },
-            { text: qsTrc("inspector", "Lydian"), value: KeySignatureTypes.MODE_LYDIAN },
-            { text: qsTrc("inspector", "Mixolydian"), value: KeySignatureTypes.MODE_MIXOLYDIAN },
-            { text: qsTrc("inspector", "Aeolian"), value: KeySignatureTypes.MODE_AEOLIAN },
-            { text: qsTrc("inspector", "Ionian"), value: KeySignatureTypes.MODE_IONIAN },
-            { text: qsTrc("inspector", "Locrian"), value: KeySignatureTypes.MODE_LOCRIAN }
+            { text: qsTrc("inspector", "Dorian", "key signature mode"), value: KeySignatureTypes.MODE_DORIAN },
+            { text: qsTrc("inspector", "Phrygian", "key signature mode"), value: KeySignatureTypes.MODE_PHRYGIAN },
+            { text: qsTrc("inspector", "Lydian", "key signature mode"), value: KeySignatureTypes.MODE_LYDIAN },
+            { text: qsTrc("inspector", "Mixolydian", "key signature mode"), value: KeySignatureTypes.MODE_MIXOLYDIAN },
+            { text: qsTrc("inspector", "Aeolian", "key signature mode"), value: KeySignatureTypes.MODE_AEOLIAN },
+            { text: qsTrc("inspector", "Ionian", "key signature mode"), value: KeySignatureTypes.MODE_IONIAN },
+            { text: qsTrc("inspector", "Locrian", "key signature mode"), value: KeySignatureTypes.MODE_LOCRIAN }
         ]
     }
 }

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/notes/BeamSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/notes/BeamSettings.qml
@@ -93,9 +93,9 @@ FocusableItem {
                     width: parent.width
 
                     model: [
-                        { text: qsTrc("inspector", "None"), value: Beam.FEATHERING_NONE, title: qsTrc("inspector", "None") },
-                        { iconCode: IconCode.BEAM_FEATHERED_DECELERATE, value: Beam.FEATHERED_DECELERATE, title: qsTrc("inspector", "Decelerate") },
-                        { iconCode: IconCode.BEAM_FEATHERED_ACCELERATE, value: Beam.FEATHERED_ACCELERATE, title: qsTrc("inspector", "Accelerate") }
+                        { text: qsTrc("inspector", "None", "beam feathering type"), value: Beam.FEATHERING_NONE, title: qsTrc("inspector", "None", "beam feathering type") },
+                        { iconCode: IconCode.BEAM_FEATHERED_DECELERATE, value: Beam.FEATHERED_DECELERATE, title: qsTrc("inspector", "Decelerate", "beam feathering type") },
+                        { iconCode: IconCode.BEAM_FEATHERED_ACCELERATE, value: Beam.FEATHERED_ACCELERATE, title: qsTrc("inspector", "Accelerate", "beam feathering type") }
                     ]
 
                     delegate: FlatRadioButton {


### PR DESCRIPTION
Resolves: #24903

Disambiguation of context is necessary in some languages (e.g. Italian) that use noun genders.

The strings need to be translated differently in each context, so add a disambiguation parameter.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
