### PR TITLE
Enable Unity builds for uicomponents

### DIFF
--- a/src/framework/uicomponents/CMakeLists.txt
+++ b/src/framework/uicomponents/CMakeLists.txt
@@ -122,8 +122,6 @@ if(QT_SUPPORT)
     list(APPEND MODULE_LINK Qt::Widgets Qt::Quick)
 endif()
 
-set(MODULE_USE_UNITY OFF)
-
 setup_module()
 
 qt_add_shaders(${MODULE} "${MODULE}_shaders"


### PR DESCRIPTION
~It does cause one (pretty minor) vtest failure though and requires a minor change to a third party (freetype) source file (and its CMakeLists.txt), which likely is the cause for the vtest failure~