### PR TITLE
Fix duplicate to coda symbol again

### DIFF
--- a/src/palette/internal/palettecompat.cpp
+++ b/src/palette/internal/palettecompat.cpp
@@ -148,6 +148,11 @@ void PaletteCompat::migrateOldPaletteCellIfNeeded(PaletteCell* cell, Score* pale
 
     if (item->isMarker()) {
         Marker* marker = toMarker(item);
+
+        if (marker->markerType() == MarkerType::TOCODASYM) {
+            return;
+        }
+
         Marker* newMarker = marker->clone();
 
         std::string label = newMarker->label().toStdString();


### PR DESCRIPTION
Resolves: #29328 

This is a temporary fix.
I don't really like the current palette compatibility system. When reading palette files, we always use the most up to date file reader. When the file format changes, we don't get the compatibility we add to previous versions of the reader. We have to add this compatibility manually without breaking the most recent version (which is what happened here). All the issues we've had with with markers in the palette this release have been due to this.

A real fix would be straightforward. I see two options:
- We include 1 file version tag in the palette file. We would then have to migrate and save user's workspace files on every new version
- We add a version tag to each palette cell. This way we don't have to migrate the file every time we do a new release. I'm not sure what the overhead of using a (potentially) different reader for each cell would be.
