### PR TITLE
[4.6.3] Fix #30460: fix sound preview of playing technique annotations

### DIFF
--- a/src/engraving/playback/playbackeventsrenderer.cpp
+++ b/src/engraving/playback/playbackeventsrenderer.cpp
@@ -354,7 +354,7 @@ void PlaybackEventsRenderer::renderFixedNoteEvent(const Note* note, const mpe::t
     RenderingContext ctx(actualTimestamp,
                          actualDuration,
                          actualDynamicLevel,
-                         0,
+                         note->tick().ticks(),
                          0,
                          ticksFromTempoAndDuration(Constants::DEFAULT_TEMPO.val, actualDuration),
                          Constants::DEFAULT_TEMPO,


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/30460