### PR TITLE
Fix #30343: Actions not working in braille panel

### DIFF
--- a/src/context/internal/uicontextresolver.cpp
+++ b/src/context/internal/uicontextresolver.cpp
@@ -158,14 +158,22 @@ bool UiContextResolver::match(const muse::ui::UiContext& currentCtx, const muse:
         return true;
     }
 
+    UiContext currCtx = currentCtx;
+
+    //! NOTE We are on the braille panel, but we allow all project focused actions because the braille panel is
+    //! just another representation of the project...
+    if (currCtx == context::UiCtxBrailleFocused) {
+        currCtx = context::UiCtxProjectFocused;
+    }
+
     //! NOTE: Context could be unknown if a plugin is currently open, in which case we should return true under
     //! the following circumstances (see issue #24673)...
-    if ((currentCtx == context::UiCtxProjectFocused || currentCtx == context::UiCtxUnknown)
+    if ((currCtx == context::UiCtxProjectFocused || currCtx == context::UiCtxUnknown)
         && actCtx == context::UiCtxProjectOpened && globalContext()->currentNotation()) {
         return true;
     }
 
-    return currentCtx == actCtx;
+    return currCtx == actCtx;
 }
 
 bool UiContextResolver::matchWithCurrent(const UiContext& ctx) const


### PR DESCRIPTION
Resolves: #30343

The addition of `UiCtxBrailleFocused` in 97e3c1593325fec490bc5b176fb2b4c38f698945 seems to be the problem here. Certain actions will now return false when we try to `matchWithCurrent` in `isShortcutContextAllowed`.