### PR TITLE
Fix elements collide after set to invisible

### DIFF
--- a/src/engraving/dom/chord.cpp
+++ b/src/engraving/dom/chord.cpp
@@ -841,6 +841,23 @@ bool Chord::allNotesTiedToNext() const
     return true;
 }
 
+bool Chord::allElementsInvisible() const
+{
+    for (EngravingObject* child : scanChildren()) {
+        if (toEngravingItem(child)->visible()) {
+            return false;
+        }
+    }
+
+    for (Chord* grace : m_graceNotes) {
+        if (!grace->allElementsInvisible()) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 //---------------------------------------------------------
 //   processSiblings
 //---------------------------------------------------------

--- a/src/engraving/dom/chord.cpp
+++ b/src/engraving/dom/chord.cpp
@@ -1552,6 +1552,7 @@ PropertyValue Chord::getProperty(Pid propertyId) const
     case Pid::STEM_DIRECTION:  return PropertyValue::fromValue<DirectionV>(stemDirection());
     case Pid::PLAY: return isChordPlayable();
     case Pid::COMBINE_VOICE: return PropertyValue::fromValue<AutoOnOff>(combineVoice());
+    case Pid::VISIBLE: return true; // Chord cannot be set invisible, only its elements can
     default:
         return ChordRest::getProperty(propertyId);
     }

--- a/src/engraving/dom/chord.h
+++ b/src/engraving/dom/chord.h
@@ -359,6 +359,7 @@ public:
     StartEndSlurs& startEndSlurs() { return m_startEndSlurs; }
 
     bool allNotesTiedToNext() const;
+    bool allElementsInvisible() const;
 
 private:
 

--- a/src/engraving/editing/edit.cpp
+++ b/src/engraving/editing/edit.cpp
@@ -6430,23 +6430,6 @@ static bool chordHasVisibleNote(const Chord* chord)
     return false;
 }
 
-static bool chordHasVisibleChild(const Chord* chord)
-{
-    for (EngravingObject* child : chord->scanChildren()) {
-        if (toEngravingItem(child)->visible()) {
-            return true;
-        }
-    }
-
-    for (const Chord* graceNote : chord->graceNotes()) {
-        if (chordHasVisibleChild(graceNote)) {
-            return true;
-        }
-    }
-
-    return false;
-}
-
 static void undoChangeOrnamentVisibility(Ornament* ornament, bool visible);
 
 static void undoChangeNoteVisibility(Note* note, bool visible)
@@ -6498,9 +6481,9 @@ static void undoChangeNoteVisibility(Note* note, bool visible)
         ElementType::LEDGER_LINE, // temporary objects, impossible to change visibility
     };
 
-    for (Chord* chord : chords) {
-        for (EngravingObject* obj : chord->linkList()) {
-            Chord* linkedChord = toChord(obj);
+    for (const Chord* chord : chords) {
+        for (const EngravingObject* obj : chord->linkList()) {
+            const Chord* linkedChord = toChord(obj);
             chordHasVisibleNote_ = chordHasVisibleNote(linkedChord);
             for (EngravingObject* child : linkedChord->scanChildren()) {
                 const ElementType type = child->type();
@@ -6520,10 +6503,6 @@ static void undoChangeNoteVisibility(Note* note, bool visible)
                 } else {
                     child->undoChangeProperty(Pid::VISIBLE, chordHasVisibleNote_);
                 }
-            }
-            bool visibleChild = chordHasVisibleChild(linkedChord);
-            if (!visibleChild) {
-                linkedChord->undoChangeProperty(Pid::VISIBLE, visibleChild);
             }
         }
     }

--- a/src/engraving/rendering/score/restlayout.cpp
+++ b/src/engraving/rendering/score/restlayout.cpp
@@ -493,7 +493,7 @@ InterruptionPoints RestLayout::computeInterruptionPoints(const Measure* measure,
     track_idx_t sTrack = staffIdx * VOICES;
     track_idx_t eTrack = sTrack + VOICES;
 
-    // Gap rests interrupt all voices
+    // Compute all-voices interruptions
     for (const Segment* segment = measure->first(SegmentType::ChordRest); segment; segment = segment->next(SegmentType::ChordRest)) {
         for (track_idx_t track = sTrack; track < eTrack; ++track) {
             EngravingItem* item = segment->element(track);
@@ -505,7 +505,8 @@ InterruptionPoints RestLayout::computeInterruptionPoints(const Measure* measure,
             // doing it and way too fragile, because it means that any logic that may move one rest can break the "merging".
             // A more solid way of merging rests would be to *delete* the second voice rests, i.e. turn them into gap rests [M.S.].
             const bool hasMergedRest = item->isRest() && !toRest(item)->ldata()->mergedRests.empty();
-            if (gapRest || hasMergedRest || !item->visible()) {
+            const bool invisible = item->isRest() ? !item->visible() : toChord(item)->allElementsInvisible();
+            if (gapRest || hasMergedRest || invisible) {
                 for (voice_idx_t voice = 0; voice < VOICES; ++voice) {
                     interruptionPointSets[voice].insert(segment->rtick());
                     interruptionPointSets[voice].insert(segment->rtick() + segment->ticks());

--- a/src/engraving/rw/read460/tread.cpp
+++ b/src/engraving/rw/read460/tread.cpp
@@ -2535,6 +2535,13 @@ bool TRead::readProperties(Chord* ch, XmlReader& e, ReadContext& ctx)
     } else {
         return false;
     }
+
+    if (!ch->visible()) {
+        // By convention, the chord can't be set to invisible (only its elements can).
+        // If it was written and read as invisible that was an error so we fix it here.
+        ch->setVisible(true);
+    }
+
     return true;
 }
 

--- a/src/engraving/rw/write/twrite.cpp
+++ b/src/engraving/rw/write/twrite.cpp
@@ -391,9 +391,6 @@ void TWrite::writeProperty(const EngravingItem* item, XmlWriter& xml, Pid pid, b
     if (item->isStyled(pid)) {
         return;
     }
-    if (pid == Pid::VISIBLE && item->isChord()) {
-        return; // We don't use VISIBLE property for Chord, only for their elements
-    }
     PropertyValue p = item->getProperty(pid);
     if (!p.isValid()) {
         LOGD("%s invalid property %d <%s>", item->typeName(), int(pid), propertyName(pid));

--- a/src/engraving/rw/write/twrite.cpp
+++ b/src/engraving/rw/write/twrite.cpp
@@ -391,6 +391,9 @@ void TWrite::writeProperty(const EngravingItem* item, XmlWriter& xml, Pid pid, b
     if (item->isStyled(pid)) {
         return;
     }
+    if (pid == Pid::VISIBLE && item->isChord()) {
+        return; // We don't use VISIBLE property for Chord, only for their elements
+    }
     PropertyValue p = item->getProperty(pid);
     if (!p.isValid()) {
         LOGD("%s invalid property %d <%s>", item->typeName(), int(pid), propertyName(pid));

--- a/src/importexport/musicxml/tests/data/testLyricVisibility_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testLyricVisibility_ref.mscx
@@ -110,7 +110,6 @@
             </TimeSig>
           <Chord>
             <eid>I_I</eid>
-            <visible>0</visible>
             <durationType>half</durationType>
             <Lyrics>
               <eid>J_J</eid>
@@ -186,7 +185,6 @@
         <voice>
           <Chord>
             <eid>X_X</eid>
-            <visible>0</visible>
             <durationType>half</durationType>
             <Lyrics>
               <eid>Y_Y</eid>


### PR DESCRIPTION
Resolves: #30355

The bug originated in #29837. I think we've established an implicit convention that the Chord is never set visible/invisible, only its invidivual elements are. Allowing the Chord to be set invisible caused it to not be added to the segment shape and go out of sync with the visibility of its individual elements. I've now made a different solution to the problem the original PR was solving and also prevented the property to be read/written altogether.