### PR TITLE
Restore old system layout when layout break reached

### DIFF
--- a/src/engraving/rendering/score/systemlayout.cpp
+++ b/src/engraving/rendering/score/systemlayout.cpp
@@ -339,6 +339,7 @@ System* SystemLayout::collectSystem(LayoutContext& ctx)
                     prevMeasureState.restoreMeasure();
                     MeasureLayout::layoutMeasureElements(m, ctx);
                     BeamLayout::restoreBeams(m, ctx);
+                    SystemLayout::restoreOldSystemLayout(m->system(), ctx);
                     if (m == nm || !m->noBreak()) {
                         break;
                     }


### PR DESCRIPTION
Resolves: Chord symbols in first measure after a system break not being autoplaced

https://github.com/user-attachments/assets/bd113fde-9c89-41e3-a377-426bf6a27fce

