### PR TITLE
Return localized note name in tpcUserName

### DIFF
--- a/src/engraving/dom/note.cpp
+++ b/src/engraving/dom/note.cpp
@@ -836,7 +836,7 @@ String Note::tpcUserName(int tpc, int pitch, bool explicitAccidental, bool full)
 
     const String octaveStr = String::number(((pitch - static_cast<int>(tpc2alter(tpc))) / PITCH_DELTA_OCTAVE) - 1);
 
-    return pitchStr + u" " + octaveStr;
+    return pitchStr + octaveStr;
 }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Partially resolves: #30167 (Part 3)

Show note+octave names using the default locale name from `global/pitchName` strings.

This fixes the status bar display of note names. Example with Romanian locale:

<img width="572" height="22" alt="image" src="https://github.com/user-attachments/assets/09c95b64-da87-474d-93d0-2c7f00451596" />

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
