### PR TITLE
[4.6.3] Treat `$n` as page number style and `$:copyright:` as copyright style

### DIFF
--- a/src/engraving/dom/page.cpp
+++ b/src/engraving/dom/page.cpp
@@ -406,16 +406,7 @@ TextBlock Page::replaceTextMacros(const TextBlock& tb) const
                     if (no > 0) {
                         const String pageNumberString = String::number(no);
                         const CharFormat pageNumberFormat = formatForMacro(String('$' + nc));
-                        // If the default format equals the format for this macro, we don't need to create a new fragment...
-                        if (defaultFormat == pageNumberFormat) {
-                            newFragments.back().text += pageNumberString;
-                            break;
-                        }
-                        TextFragment pageNumberFragment(pageNumberString);
-                        pageNumberFragment.format = pageNumberFormat;
-                        newFragments.emplace_back(pageNumberFragment);
-                        newFragments.emplace_back(TextFragment());    // Start next fragment
-                        newFragments.back().format = defaultFormat;   // reset to default for next fragment
+                        appendFormattedString(newFragments, pageNumberString, defaultFormat, pageNumberFormat);
                     }
                 }
                 break;
@@ -424,16 +415,7 @@ TextBlock Page::replaceTextMacros(const TextBlock& tb) const
                     size_t no = score()->npages() + score()->pageNumberOffset();
                     const String numberOfPagesString = String::number(no);
                     const CharFormat pageNumberFormat = formatForMacro(String('$' + nc));
-                    // If the default format equals the format for this macro, we don't need to create a new fragment...
-                    if (defaultFormat == pageNumberFormat) {
-                        newFragments.back().text += numberOfPagesString;
-                        break;
-                    }
-                    TextFragment numberOfPagesFragment(numberOfPagesString);
-                    numberOfPagesFragment.format = pageNumberFormat;
-                    newFragments.emplace_back(numberOfPagesFragment);
-                    newFragments.emplace_back(TextFragment());    // Start next fragment
-                    newFragments.back().format = defaultFormat;   // reset to default for next fragment
+                    appendFormattedString(newFragments, numberOfPagesString, defaultFormat, pageNumberFormat);
                 }
                 break;
                 case 'i': // not on first page
@@ -490,16 +472,7 @@ TextBlock Page::replaceTextMacros(const TextBlock& tb) const
                 {
                     const String copyrightString = score()->metaTag(u"copyright");
                     const CharFormat copyrightFormat = formatForMacro(String('$' + nc));
-                    // If the default format equals the format for this macro, we don't need to create a new fragment...
-                    if (defaultFormat == copyrightFormat) {
-                        newFragments.back().text += copyrightString;
-                        break;
-                    }
-                    TextFragment copyrightFragment(copyrightString);
-                    copyrightFragment.format = copyrightFormat;
-                    newFragments.emplace_back(copyrightFragment);
-                    newFragments.emplace_back(TextFragment());    // Start next fragment
-                    newFragments.back().format = defaultFormat;   // reset to default for next fragment
+                    appendFormattedString(newFragments, copyrightString, defaultFormat, copyrightFormat);
                 }
                 break;
                 case 'v':
@@ -538,17 +511,7 @@ TextBlock Page::replaceTextMacros(const TextBlock& tb) const
                         if (tag == u"copyright") {
                             const String copyrightString = score()->metaTag(tag);
                             const CharFormat copyrightFormat = formatForMacro(String(u"$:" + tag + u":"));
-                            // If the default format equals the format for this macro, we don't need to create a new fragment...
-                            if (defaultFormat == copyrightFormat) {
-                                newFragments.back().text += copyrightString;
-                                i = k - 1;
-                                break;
-                            }
-                            TextFragment copyrightFragment(copyrightString);
-                            copyrightFragment.format = copyrightFormat;
-                            newFragments.emplace_back(copyrightFragment);
-                            newFragments.emplace_back(TextFragment());    // Start next fragment
-                            newFragments.back().format = defaultFormat;   // reset to default for next fragment
+                            appendFormattedString(newFragments, copyrightString, defaultFormat, copyrightFormat);
                         } else {
                             newFragments.back().text += score()->metaTag(tag);
                         }
@@ -590,6 +553,25 @@ const CharFormat Page::formatForMacro(const String& s) const
         format.setFontFamily(style().styleSt(Sid::pageNumberFontFace));
     }
     return format;
+}
+
+//---------------------------------------------------------
+//   appendFormattedString
+//---------------------------------------------------------
+
+void Page::appendFormattedString(std::list<TextFragment>& fragments, const String& string, const CharFormat& defaultFormat,
+                                 const CharFormat& newFormat) const
+{
+    // If the default format equals the format for this macro, we don't need to create a new fragment...
+    if (defaultFormat == newFormat) {
+        fragments.back().text += string;
+        return;
+    }
+    TextFragment newFragment(string);
+    newFragment.format = newFormat;
+    fragments.emplace_back(newFragment);
+    fragments.emplace_back(TextFragment());    // Start next fragment
+    fragments.back().format = defaultFormat;   // reset to default for next fragment
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/page.h
+++ b/src/engraving/dom/page.h
@@ -96,6 +96,8 @@ private:
     void doRebuildBspTree();
     TextBlock replaceTextMacros(const TextBlock&) const;
     const CharFormat formatForMacro(const String&) const;
+    void appendFormattedString(std::list<TextFragment>& fragments, const String& string, const CharFormat& defaultFormat,
+                               const CharFormat& newFormat) const;
 
     std::vector<System*> m_systems;
     page_idx_t m_no = 0;                        // page number


### PR DESCRIPTION
Same as #30512 but for 4.6.3