### PR TITLE
Add option to always display pitch in SPN

### DIFF
--- a/src/appshell/qml/Preferences/NoteInputPreferencesPage.qml
+++ b/src/appshell/qml/Preferences/NoteInputPreferencesPage.qml
@@ -47,6 +47,7 @@ PreferencesPage {
             defaultNoteInputMethod: noteInputModel.defaultNoteInputMethod
             addAccidentalDotsArticulationsToNextNoteEntered: noteInputModel.addAccidentalDotsArticulationsToNextNoteEntered
             useNoteInputCursorInInputByDuration: noteInputModel.useNoteInputCursorInInputByDuration
+            pitchNotationSPN: noteInputModel.pitchNotationSPN
 
             navigation.section: root.navigationSection
             navigation.order: root.navigationOrderStart + 1
@@ -61,6 +62,10 @@ PreferencesPage {
 
             onUseNoteInputCursorInInputByDurationChangeRequested: function(use) {
                 noteInputModel.useNoteInputCursorInInputByDuration = use
+            }
+
+            onPitchNotationSPNChangeRequested: function(spnPitch) {
+                noteInputModel.pitchNotationSPN = spnPitch
             }
         }
 

--- a/src/appshell/qml/Preferences/internal/NoteInput/NoteInputSection.qml
+++ b/src/appshell/qml/Preferences/internal/NoteInput/NoteInputSection.qml
@@ -37,10 +37,12 @@ BaseSection {
 
     property bool addAccidentalDotsArticulationsToNextNoteEntered: true
     property bool useNoteInputCursorInInputByDuration: false
+    property alias pitchNotationSPN: pitchNotationSPNCheckBox.checked
 
     signal defaultNoteInputMethodChangeRequested(int method)
     signal addAccidentalDotsArticulationsToNextNoteEnteredChangeRequested(bool add)
     signal useNoteInputCursorInInputByDurationChangeRequested(bool use)
+    signal pitchNotationSPNChangeRequested(bool spnPitch)
 
     ComboBoxWithTitle {
         id: defaultNoteInputMethodDropdown
@@ -93,6 +95,21 @@ BaseSection {
 
         onValueEdited: function(newIndex, newValue) {
             root.useNoteInputCursorInInputByDurationChangeRequested(newIndex === 1)
+        }
+    }
+
+    CheckBox {
+        id: pitchNotationSPNCheckBox
+        width: parent.width
+
+        text: qsTrc("appshell/preferences", "Always display pitch names in Scientific Pitch Notation")
+
+        navigation.name: "PitchNotationSPNCheckBox"
+        navigation.panel: root.navigation
+        navigation.row: 3
+
+        onClicked: {
+            root.pitchNotationSPNChangeRequested(!checked)
         }
     }
 }

--- a/src/appshell/view/preferences/noteinputpreferencesmodel.cpp
+++ b/src/appshell/view/preferences/noteinputpreferencesmodel.cpp
@@ -45,6 +45,10 @@ void NoteInputPreferencesModel::load()
         emit useNoteInputCursorInInputByDurationChanged(useNoteInputCursorInInputByDuration());
     });
 
+    engravingConfiguration()->pitchNotationSPNChanged().onNotify(this, [this]() {
+        emit pitchNotationSPNChanged(pitchNotationSPN());
+    });
+
     notationConfiguration()->isMidiInputEnabledChanged().onNotify(this, [this]() {
         emit midiInputEnabledChanged(midiInputEnabled());
     });
@@ -149,6 +153,11 @@ bool NoteInputPreferencesModel::useNoteInputCursorInInputByDuration() const
     return notationConfiguration()->useNoteInputCursorInInputByDuration();
 }
 
+bool NoteInputPreferencesModel::pitchNotationSPN() const
+{
+    return engravingConfiguration()->pitchNotationSPN();
+}
+
 bool NoteInputPreferencesModel::midiInputEnabled() const
 {
     return notationConfiguration()->isMidiInputEnabled();
@@ -249,6 +258,15 @@ void NoteInputPreferencesModel::setUseNoteInputCursorInInputByDuration(bool valu
     }
 
     notationConfiguration()->setUseNoteInputCursorInInputByDuration(value);
+}
+
+void NoteInputPreferencesModel::setPitchNotationSPN(bool value)
+{
+    if (value == pitchNotationSPN()) {
+        return;
+    }
+
+    engravingConfiguration()->setPitchNotationSPN(value);
 }
 
 void NoteInputPreferencesModel::setMidiInputEnabled(bool value)

--- a/src/appshell/view/preferences/noteinputpreferencesmodel.h
+++ b/src/appshell/view/preferences/noteinputpreferencesmodel.h
@@ -44,6 +44,8 @@ class NoteInputPreferencesModel : public QObject, public muse::Injectable, publi
         bool addAccidentalDotsArticulationsToNextNoteEntered READ addAccidentalDotsArticulationsToNextNoteEntered WRITE setAddAccidentalDotsArticulationsToNextNoteEntered NOTIFY addAccidentalDotsArticulationsToNextNoteEnteredChanged)
     Q_PROPERTY(
         bool useNoteInputCursorInInputByDuration READ useNoteInputCursorInInputByDuration WRITE setUseNoteInputCursorInInputByDuration NOTIFY useNoteInputCursorInInputByDurationChanged)
+    Q_PROPERTY(
+        bool pitchNotationSPN READ pitchNotationSPN WRITE setPitchNotationSPN NOTIFY pitchNotationSPNChanged)
 
     Q_PROPERTY(bool midiInputEnabled READ midiInputEnabled WRITE setMidiInputEnabled NOTIFY midiInputEnabledChanged)
     Q_PROPERTY(
@@ -93,6 +95,7 @@ public:
     int defaultNoteInputMethod() const;
     bool addAccidentalDotsArticulationsToNextNoteEntered() const;
     bool useNoteInputCursorInInputByDuration() const;
+    bool pitchNotationSPN() const;
 
     bool midiInputEnabled() const;
     bool startNoteInputAtSelectedNoteRestWhenPressingMidiKey() const;
@@ -119,6 +122,7 @@ public slots:
     void setDefaultNoteInputMethod(int value);
     void setAddAccidentalDotsArticulationsToNextNoteEntered(bool value);
     void setUseNoteInputCursorInInputByDuration(bool value);
+    void setPitchNotationSPN(bool use);
 
     void setMidiInputEnabled(bool value);
     void setStartNoteInputAtSelectedNoteRestWhenPressingMidiKey(bool value);
@@ -145,6 +149,7 @@ signals:
     void defaultNoteInputMethodChanged(int value);
     void addAccidentalDotsArticulationsToNextNoteEnteredChanged(bool value);
     void useNoteInputCursorInInputByDurationChanged(bool value);
+    void pitchNotationSPNChanged(bool value);
 
     void midiInputEnabledChanged(bool value);
     void startNoteInputAtSelectedNoteRestWhenPressingMidiKeyChanged(bool value);

--- a/src/engraving/dom/note.cpp
+++ b/src/engraving/dom/note.cpp
@@ -847,7 +847,9 @@ String Note::tpcUserName(const bool explicitAccidental, bool full) const
 {
     String pitchName = tpcUserName(tpc(), epitch() + ottaveCapoFret(), explicitAccidental, full);
 
-    pitchName = muse::mtrc("global/pitchName", pitchName);
+    if (!configuration()->pitchNotationSPN()) {
+        pitchName = muse::mtrc("global/pitchName", pitchName);
+    }
 
     if (fixed() && headGroup() == NoteHeadGroup::HEAD_SLASH) {
         // see Note::accessibleInfo(), but we return what we have
@@ -872,7 +874,9 @@ String Note::tpcUserName(const bool explicitAccidental, bool full) const
 
     if (!concertPitch() && transposition()) {
         String soundingPitch = tpcUserName(tpc1(), ppitch(), explicitAccidental);
-        soundingPitch = muse::mtrc("global/pitchName", soundingPitch);
+        if (!configuration()->pitchNotationSPN()) {
+            soundingPitch = muse::mtrc("global/pitchName", soundingPitch);
+        }
         return muse::mtrc("engraving", "%1 (sounding as %2%3)").arg(pitchName, soundingPitch, pitchOffset);
     }
     return pitchName + pitchOffset;

--- a/src/engraving/iengravingconfiguration.h
+++ b/src/engraving/iengravingconfiguration.h
@@ -146,6 +146,10 @@ public:
     virtual bool guitarProMultivoiceEnabled() const = 0;
     virtual bool minDistanceForPartialSkylineCalculated() const = 0;
     virtual bool specificSlursLayoutWorkaround() const = 0;
+
+    virtual bool pitchNotationSPN() const = 0;
+    virtual void setPitchNotationSPN(bool use) = 0;
+    virtual muse::async::Notification pitchNotationSPNChanged() const = 0;
 };
 }
 

--- a/src/engraving/internal/engravingconfiguration.cpp
+++ b/src/engraving/internal/engravingconfiguration.cpp
@@ -57,6 +57,8 @@ static const Settings::Key FRETBOARD_DIAGRAMS_AUTO_UPDATE("engraving", "score/fr
 
 static const Settings::Key DO_NOT_SAVE_EIDS_FOR_BACK_COMPAT("engraving", "engraving/compat/doNotSaveEIDsForBackCompat");
 
+static const Settings::Key PITCH_NOTATION_SPN("engraving", "score/pitchNotationSPN");
+
 struct VoiceColor {
     Settings::Key key;
     Color color;
@@ -164,6 +166,11 @@ void EngravingConfiguration::init()
     settings()->setDefaultValue(DO_NOT_SAVE_EIDS_FOR_BACK_COMPAT, Val(false));
     settings()->setDescription(DO_NOT_SAVE_EIDS_FOR_BACK_COMPAT, muse::trc("engraving", "Do not save EIDs"));
     settings()->setCanBeManuallyEdited(DO_NOT_SAVE_EIDS_FOR_BACK_COMPAT, false);
+
+    settings()->setDefaultValue(PITCH_NOTATION_SPN, Val(false));
+    settings()->valueChanged(PITCH_NOTATION_SPN).onReceive(nullptr, [this](const Val&) {
+        m_pitchNotationSPNChanged.notify();
+    });
 }
 
 muse::io::path_t EngravingConfiguration::appDataPath() const
@@ -505,4 +512,19 @@ bool EngravingConfiguration::minDistanceForPartialSkylineCalculated() const
 bool EngravingConfiguration::specificSlursLayoutWorkaround() const
 {
     return guitarProImportExperimental();
+}
+
+bool EngravingConfiguration::pitchNotationSPN() const
+{
+    return settings()->value(PITCH_NOTATION_SPN).toBool();
+}
+
+void EngravingConfiguration::setPitchNotationSPN(bool use)
+{
+    settings()->setSharedValue(PITCH_NOTATION_SPN, Val(use));
+}
+
+muse::async::Notification EngravingConfiguration::pitchNotationSPNChanged() const
+{
+    return m_pitchNotationSPNChanged;
 }

--- a/src/engraving/internal/engravingconfiguration.h
+++ b/src/engraving/internal/engravingconfiguration.h
@@ -127,6 +127,10 @@ public:
     bool minDistanceForPartialSkylineCalculated() const override;
     bool specificSlursLayoutWorkaround() const override;
 
+    bool pitchNotationSPN() const override;
+    void setPitchNotationSPN(bool use) override;
+    muse::async::Notification pitchNotationSPNChanged() const override;
+
 private:
     muse::async::Channel<voice_idx_t, Color> m_voiceColorChanged;
     muse::async::Notification m_scoreInversionChanged;
@@ -138,6 +142,7 @@ private:
     muse::async::Channel<Color> m_unlinkedColorChanged;
     muse::async::Channel<muse::io::path_t> m_defaultStyleFilePathChanged;
     muse::async::Channel<muse::io::path_t> m_partStyleFilePathChanged;
+    muse::async::Notification m_pitchNotationSPNChanged;
 
     muse::ValNt<DebuggingOptions> m_debuggingOptions;
 

--- a/src/engraving/tests/mocks/engravingconfigurationmock.h
+++ b/src/engraving/tests/mocks/engravingconfigurationmock.h
@@ -109,6 +109,10 @@ public:
     MOCK_METHOD(bool, guitarProMultivoiceEnabled, (), (const, override));
     MOCK_METHOD(bool, minDistanceForPartialSkylineCalculated, (), (const, override));
     MOCK_METHOD(bool, specificSlursLayoutWorkaround, (), (const, override));
+
+    MOCK_METHOD(bool, pitchNotationSPN, (), (const, override));
+    MOCK_METHOD(void, setPitchNotationSPN, (bool), (override));
+    MOCK_METHOD(muse::async::Notification, pitchNotationSPNChanged, (), (const, override));
 };
 }
 

--- a/src/framework/global/utils.cpp
+++ b/src/framework/global/utils.cpp
@@ -292,7 +292,7 @@ static constexpr const char* flatNotes[] = {
     QT_TRANSLATE_NOOP("global/noteName", "B")
 };
 
-std::string muse::pitchToString(int pitch, bool addoctave, bool useFlats /* = false */)
+std::string muse::pitchToString(int pitch, bool useSPN, bool addoctave, bool useFlats /* = false */)
 {
     if (pitch < 0 || pitch > 127) {
         return std::string();
@@ -303,8 +303,17 @@ std::string muse::pitchToString(int pitch, bool addoctave, bool useFlats /* = fa
     int i = pitch % 12;
     if (addoctave) {
         int octave = (pitch / 12) - 1;
-        std::string key = std::string(source[i]) + std::to_string(octave);
-        return muse::trc("global/pitchName", key.c_str());
+        if (useSPN) {
+            return std::string(source[i]) + std::to_string(octave);
+        } else {
+            std::string key = std::string(source[i]) + std::to_string(octave);
+            return muse::trc("global/pitchName", key.c_str());
+        }
     }
-    return muse::trc("global/noteName", source[i]);
+
+    if (useSPN) {
+        return std::string(source[i]);
+    } else {
+        return muse::trc("global/noteName", source[i]);
+    }
 }

--- a/src/framework/global/utils.h
+++ b/src/framework/global/utils.h
@@ -25,7 +25,7 @@
 #include <string>
 
 namespace muse {
-std::string pitchToString(int pitch, bool addoctave=true, bool useFlats=false);
+std::string pitchToString(int pitch, bool useSPN=false, bool addoctave=true, bool useFlats=false);
 }
 
-#endif // MUSE_GLOBAL_GLOBAL_H
+#endif // MUSE_GLOBAL_UTILS_H

--- a/src/notation/view/pianokeyboard/pianokeyboardview.cpp
+++ b/src/notation/view/pianokeyboard/pianokeyboardview.cpp
@@ -268,7 +268,13 @@ void PianoKeyboardView::paintWhiteKeys(QPainter* painter, const QRectF& viewport
             int octaveNumber = (key / 12) - 1;
 
             std::string octaveLabel = "C" + std::to_string(octaveNumber);
-            QString octaveLabelTr = muse::qtrc("global/pitchName", octaveLabel.c_str());
+            QString octaveLabelTr;
+            if (!engravingConfiguration()->pitchNotationSPN()) {
+                octaveLabelTr = muse::qtrc("global/pitchName", octaveLabel.c_str());
+            } else {
+                octaveLabelTr = QString::fromStdString(octaveLabel);
+            }
+
             QRect octaveLabelRect(left, top, right - left, bottom - top - bottomOffset);
 
             painter->setPen(backgroundColor);

--- a/src/notation/view/pianokeyboard/pianokeyboardview.h
+++ b/src/notation/view/pianokeyboard/pianokeyboardview.h
@@ -26,7 +26,8 @@
 
 #include "uicomponents/view/quickpaintedview.h"
 #include "modularity/ioc.h"
-#include "inotationconfiguration.h"
+#include "notation/inotationconfiguration.h"
+#include "engraving/iengravingconfiguration.h"
 #include "ui/iuiconfiguration.h"
 
 #include "pianokeyboardtypes.h"
@@ -43,7 +44,8 @@ class PianoKeyboardView : public muse::uicomponents::QuickPaintedView, public mu
     Q_PROPERTY(qreal scrollBarPosition READ scrollBarPosition WRITE setScrollBarPosition NOTIFY scrollBarChanged)
     Q_PROPERTY(qreal scrollBarSize READ scrollBarSize NOTIFY scrollBarChanged)
 
-    muse::Inject<INotationConfiguration> configuration = { this };
+    muse::Inject<INotationConfiguration> notationConfiguration = { this };
+    muse::Inject<mu::engraving::IEngravingConfiguration> engravingConfiguration = { this };
     muse::Inject<muse::ui::IUiConfiguration> uiConfiguration = { this };
 
 public:

--- a/src/notation/view/widgets/editpitch.cpp
+++ b/src/notation/view/widgets/editpitch.cpp
@@ -28,6 +28,8 @@
 
 #include "engraving/dom/pitchspelling.h"
 
+#define SPN_PITCH_DISPLAY(wantSPN, pitch) (wantSPN ? muse::String(pitch).remove(u" ") : muse::mtrc("global/pitchName", pitch))
+
 using namespace mu::notation;
 using namespace muse::ui;
 

--- a/src/notation/view/widgets/editpitch.cpp
+++ b/src/notation/view/widgets/editpitch.cpp
@@ -28,7 +28,7 @@
 
 #include "engraving/dom/pitchspelling.h"
 
-#define SPN_PITCH_DISPLAY(wantSPN, pitch) (wantSPN ? muse::String(pitch).remove(u" ") : muse::mtrc("global/pitchName", pitch))
+#define SPN_PITCH_DISPLAY(wantSPN, pitch) (wantSPN ? muse::String(pitch) : muse::mtrc("global/pitchName", pitch))
 
 using namespace mu::notation;
 using namespace muse::ui;

--- a/src/notation/view/widgets/editpitch.cpp
+++ b/src/notation/view/widgets/editpitch.cpp
@@ -95,6 +95,9 @@ void EditPitch::setup()
 
     qApp->installEventFilter(this);
 
+    // Display pitch names according to user preference
+    bool wantSPN = engravingConfiguration()->pitchNotationSPN();
+
     // Populate table with localized pitch names and center them in cells
     static constexpr const char* noteName[] =
     { "C", "C♯", "D", "D♯", "E", "F", "F♯", "G", "G♯", "A", "A♯", "B", "C" };
@@ -114,7 +117,7 @@ void EditPitch::setup()
                     octave = 9 - row;
                 }
                 std::string pitch = std::string(noteName[col]) + std::to_string(octave);
-                item->setText(muse::mtrc("global/pitchName", pitch.c_str()));
+                item->setText(SPN_PITCH_DISPLAY(wantSPN, pitch.c_str()));
                 item->setTextAlignment(Qt::AlignCenter);
             }
         }

--- a/src/notation/view/widgets/editpitch.h
+++ b/src/notation/view/widgets/editpitch.h
@@ -22,15 +22,19 @@
 #pragma once
 
 #include "ui_editpitch.h"
+#include "engraving/iengravingconfiguration.h"
+#include "modularity/ioc.h"
 
 namespace mu::notation {
 //---------------------------------------------------------
 //   EditPitch
 //---------------------------------------------------------
 
-class EditPitch : public QDialog, private Ui::EditPitchBase
+class EditPitch : public QDialog, private Ui::EditPitchBase, public muse::Injectable
 {
     Q_OBJECT
+
+    muse::Inject<mu::engraving::IEngravingConfiguration> engravingConfiguration = { this };
 
 public:
     EditPitch(QWidget* parent);

--- a/src/notation/view/widgets/editstaff.cpp
+++ b/src/notation/view/widgets/editstaff.cpp
@@ -648,7 +648,11 @@ void EditStaff::editStringDataClicked()
 
 QString EditStaff::midiCodeToStr(int midiCode)
 {
-    return QString::fromStdString(muse::pitchToString(midiCode));
+    if (engravingConfiguration()->pitchNotationSPN()) {
+        return QString::fromStdString(muse::pitchToString(midiCode, true));
+    } else {
+        return QString::fromStdString(muse::pitchToString(midiCode, false));
+    }
 }
 
 void EditStaff::showStaffTypeDialog()

--- a/src/notation/view/widgets/editstringdata.cpp
+++ b/src/notation/view/widgets/editstringdata.cpp
@@ -335,5 +335,9 @@ void EditStringData::accept()
 
 QString EditStringData::midiCodeToStr(int midiCode)
 {
-    return QString::fromStdString(muse::pitchToString(midiCode));
+    if (engravingConfiguration()->pitchNotationSPN()) {
+        return QString::fromStdString(muse::pitchToString(midiCode, true));
+    } else {
+        return QString::fromStdString(muse::pitchToString(midiCode, false));
+    }
 }

--- a/src/notation/view/widgets/editstringdata.h
+++ b/src/notation/view/widgets/editstringdata.h
@@ -39,6 +39,7 @@ class EditStringData : public QDialog, private Ui::EditStringDataBase, public mu
     Q_OBJECT
 
     muse::Inject<context::IGlobalContext> globalContext = { this };
+    muse::Inject<mu::engraving::IEngravingConfiguration> engravingConfiguration = { this };
 
 public:
     EditStringData(QWidget* parent = nullptr, const std::vector<engraving::instrString>& strings = {}, int frets = 0);


### PR DESCRIPTION
Partially resolves: https://github.com/musescore/MuseScore/issues/30167 (Part 4)

Add an option in Preferences dialog, under Note input to enable people that are accustomed with Scientific Pitch Notation to always display pitches like in DAWs, instead of localised, traditional names. For example, with the option unchecked, in Romanian, the middle C will be displayed as `do1`, but with the option checked, it will be displayed as `C4`. Default will be language locale.

Setting is called `pitchNotationSPN`, with the key `Settings::Key PITCH_NOTATION_SPN("engraving", "score/pitchNotationSPN");` and is part of `mu::engraving::IEngravingConfiguration`, as this is easier to include and use in all the required locations.

This display preference applies to:
- Select note dialog (EditPitchUI)
- Edit Staff dialog
- Edit String Data dialog
- Piano keyboard
- Status bar

Screenshot from the Preferences dialog with the new option under Note input group:

<img width="680" height="226" alt="image" src="https://github.com/user-attachments/assets/68a9ba01-642d-4ef8-bc83-8ff48b868c39" />

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
