### PR TITLE
print: Remove color mode override

### DIFF
--- a/src/print/internal/printprovider.cpp
+++ b/src/print/internal/printprovider.cpp
@@ -52,7 +52,6 @@ Ret PrintProvider::printNotation(INotationPtr notation)
         LOGD() << "unable to clear printer margins";
     }
 
-    printerDev.setColorMode(QPrinter::Color);
     printerDev.setDocName(notation->projectWorkTitleAndPartName());
     printerDev.setOutputFormat(QPrinter::NativeFormat);
     printerDev.setFromTo(1, painting->pageCount());


### PR DESCRIPTION
Resolves: #30515

I was in this area of the code somewhat recently (while experimenting with a Windows print provider[^2]), so I immediately had an idea which line could be causing the behavior mentioned in the issue. However, I couldn't verify the fix because none of my printers support the system color setting.

The call to `QPrinter::setColorMode` seems unnecessary (it stems from the initial commit[^1])

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)

[^1]: https://github.com/musescore/MuseScore/blame/v3.6.2/mscore/file.cpp#L1831
[^2]: https://github.com/juli27/MuseScore/tree/modernizePrintingWindows