### PR TITLE
Set lyric text style correctly

### DIFF
--- a/src/engraving/dom/lyrics.cpp
+++ b/src/engraving/dom/lyrics.cpp
@@ -465,12 +465,17 @@ bool Lyrics::setProperty(Pid propertyId, const PropertyValue& v)
             setNeedRemoveInvalidSegments();
         }
         break;
-    case Pid::VERSE:
+    case Pid::VERSE: {
         if (Lyrics* l = prevLyrics(this)) {
             l->setNeedRemoveInvalidSegments();
         }
+        bool followTextStyle = getProperty(Pid::TEXT_STYLE) == propertyDefault(Pid::TEXT_STYLE);
         m_no = v.toInt();
+        if (followTextStyle) {
+            setProperty(Pid::TEXT_STYLE, propertyDefault(Pid::TEXT_STYLE));
+        }
         break;
+    }
     case Pid::AVOID_BARLINES:
         m_avoidBarlines = v.toBool();
         break;

--- a/src/engraving/editing/edit.cpp
+++ b/src/engraving/editing/edit.cpp
@@ -942,7 +942,7 @@ TextBase* Score::addText(TextStyleType type, EngravingItem* destinationElement)
         Lyrics* lyrics = Factory::createLyrics(chordRest);
         lyrics->setTrack(chordRest->track());
         lyrics->setParent(chordRest);
-        lyrics->setNo(no);
+        lyrics->setProperty(Pid::VERSE, no);
 
         textBox = lyrics;
         undoAddElement(textBox);


### PR DESCRIPTION
Resolves: #30510

Setting the lyric's text style automatically at layout was removed in https://github.com/musescore/MuseScore/pull/24935, but we missed a couple of interactions which should change the style.