### PR TITLE
Rearrange chord symbols capitalization options

### DIFF
--- a/src/notation/qml/MuseScore/NotationScene/internal/EditStyle/ChordSymbolsPage.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/EditStyle/ChordSymbolsPage.qml
@@ -169,27 +169,27 @@ StyledFlickable {
                     title: qsTrc("notation/editstyle/chordsymbols", "Spelling")
 
                     RowLayout {
-                        spacing: 6
+                        spacing: 12
                         anchors.fill: parent
 
-                        RadioButtonGroup {
-                            id: spellingRadioButtonGroup
-                            Layout.fillWidth: true
-                            model: chordSymbolsModel.possibleChordSymbolSpellings()
+                        ButtonGroup { id: spellingButtonGroup }
 
+                        Repeater {
+                            model: chordSymbolsModel.possibleChordSymbolSpellings()
                             delegate: RoundedRadioButton {
                                 height: 30
                                 checked: modelData.value === chordSymbolsModel.chordSymbolSpelling.value
                                 text: modelData.text ? modelData.text : ""
-
                                 onToggled: {
                                     chordSymbolsModel.chordSymbolSpelling.value = modelData.value
                                 }
+                                ButtonGroup.group: spellingButtonGroup
+                                Layout.alignment: Qt.AlignVCenter
                             }
                         }
 
                         FlatButton {
-                            Layout.alignment: Qt.AlignTop | Qt.AlignRight
+                            Layout.alignment: Qt.AlignVCenter
                             icon: IconCode.UNDO
                             enabled: !chordSymbolsModel.chordSymbolSpelling.isDefault
                             onClicked: chordSymbolsModel.chordSymbolSpelling.value = chordSymbolsModel.chordSymbolSpelling.defaultValue
@@ -206,24 +206,13 @@ StyledFlickable {
                         Layout.fillWidth: true
 
                         RowLayout {
-                            spacing: 6
+                            spacing: 8
                             Layout.fillWidth: true
 
-                            Item {
-                                Layout.preferredWidth: 450
-                                implicitHeight: children.length === 1 ? children[0].implicitHeight : 0
-
-                                CheckBox {
-                                    id: capitaliseCheckBox
-                                    text: qsTrc("notation/editstyle/chordsymbols", "Automatically capitalize note names")
-
-                                    checked: chordSymbolsModel.automaticCapitalization && Boolean(chordSymbolsModel.automaticCapitalization.value)
-                                    onClicked: {
-                                        if (chordSymbolsModel.automaticCapitalization) {
-                                            chordSymbolsModel.automaticCapitalization.value = !checked
-                                        }
-                                    }
-                                }
+                            StyleToggle {
+                                Layout.preferredWidth: 460
+                                styleItem: chordSymbolsModel.automaticCapitalization
+                                text: qsTrc("notation/editstyle/chordsymbols", "Automatically capitalize note names")
                             }
 
                             FlatButton {
@@ -234,22 +223,32 @@ StyledFlickable {
                             }
                         }
 
-                        CheckBox {
-                            text: qsTrc("notation/editstyle/chordsymbols", "Lowercase minor chords")
-                            checked: chordSymbolsModel.lowerCaseMinorChords.value === true
-                            onClicked: chordSymbolsModel.lowerCaseMinorChords.value = !chordSymbolsModel.lowerCaseMinorChords.value
-                        }
+                        ColumnLayout {
+                            spacing: 8
+                            Layout.fillWidth: true
 
-                        CheckBox {
-                            text: qsTrc("notation/editstyle/chordsymbols", "Lowercase bass notes")
-                            checked: chordSymbolsModel.lowerCaseBassNotes.value === true
-                            onClicked: chordSymbolsModel.lowerCaseBassNotes.value = !chordSymbolsModel.lowerCaseBassNotes.value
-                        }
+                            CheckBox {
+                                text: qsTrc("notation/editstyle/chordsymbols", "Lowercase minor chords")
+                                checked: chordSymbolsModel.lowerCaseMinorChords.value === true
+                                enabled: chordSymbolsModel.automaticCapitalization.value === true
+                                onClicked: chordSymbolsModel.lowerCaseMinorChords.value = !chordSymbolsModel.lowerCaseMinorChords.value
+                            }
 
-                        CheckBox {
-                            text: qsTrc("notation/editstyle/chordsymbols", "All caps note names")
-                            checked: chordSymbolsModel.allCapsNoteNames.value === true
-                            onClicked: chordSymbolsModel.allCapsNoteNames.value = !chordSymbolsModel.allCapsNoteNames.value
+                            CheckBox {
+                                text: qsTrc("notation/editstyle/chordsymbols", "Lowercase bass notes")
+                                checked: chordSymbolsModel.lowerCaseBassNotes.value === true
+                                enabled: chordSymbolsModel.automaticCapitalization.value === true
+                                onClicked: chordSymbolsModel.lowerCaseBassNotes.value = !chordSymbolsModel.lowerCaseBassNotes.value
+                            }
+
+                            CheckBox {
+                                text: qsTrc("notation/editstyle/chordsymbols", "All caps (for Solfeggio and French)")
+                                checked: chordSymbolsModel.allCapsNoteNames.value === true
+                                enabled: chordSymbolsModel.automaticCapitalization.value === true &&
+                                        (chordSymbolsModel.chordSymbolSpelling.value === 3 ||
+                                         chordSymbolsModel.chordSymbolSpelling.value === 4)
+                                onClicked: chordSymbolsModel.allCapsNoteNames.value = !chordSymbolsModel.allCapsNoteNames.value
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Resolves: #30539

Rearrange the capitalization options such that they have more space for non-English languages to fit.

<img width="667" height="326" alt="image" src="https://github.com/user-attachments/assets/6eda8d77-1cff-44ef-94dc-6f7e0ed579f8" />

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
