### PR TITLE
Auto-fit Hammer-on/Pull-off left hand tapping options

### DIFF
--- a/src/notationscene/qml/MuseScore/NotationScene/styledialog/HammerOnPullOffTappingPage.qml
+++ b/src/notationscene/qml/MuseScore/NotationScene/styledialog/HammerOnPullOffTappingPage.qml
@@ -225,20 +225,22 @@ StyledFlickable {
                             Repeater {
                                 id: lhTappingNormalStaveRepeater
                                 model: [
-                                    {title: qsTrc("notation/editstyle/hammeronpulloff", "Half slur"), value: 0 },
-                                    {title: qsTrc("notation/editstyle/hammeronpulloff", "Symbol"), value: 1 },
-                                    {title: qsTrc("notation/editstyle/hammeronpulloff", "Both"), value: 2 },
+                                    { text: qsTrc("notation/editstyle/hammeronpulloff", "Half slur"), value: 0 },
+                                    { text: qsTrc("notation/editstyle/hammeronpulloff", "Symbol"), value: 1 },
+                                    { text: qsTrc("notation/editstyle/hammeronpulloff", "Both"), value: 2 },
                                 ]
 
                                 FlatRadioButton {
-                                    required property string title
+                                    id: lhTappingNormalStaveButton
+
+                                    required text
                                     required property int index
                                     required property int value
 
                                     property int contentWidth: lhTappingNormalStaveMetrics.width + 16
                                     width: lhTappingNormalStaveRow.maxButtonWidth
                                     height: 30
-                                    text: title
+
                                     ButtonGroup.group: lhTappingNormalStaveGroup
                                     checked: hopoPage.lhTappingShowItemsNormalStave.value === value
                                     onToggled: hopoPage.lhTappingShowItemsNormalStave.value = value
@@ -247,7 +249,7 @@ StyledFlickable {
                                         id: lhTappingNormalStaveMetrics
                                         font.family: ui.theme.bodyFont.family
                                         font.pixelSize: ui.theme.bodyFont.pixelSize
-                                        text: title
+                                        text: lhTappingNormalStaveButton.text
                                     }
                                 }
                             }
@@ -316,20 +318,22 @@ StyledFlickable {
                             Repeater {
                                 id: lhTappingTabStaveRepeater
                                 model: [
-                                    {title: qsTrc("notation/editstyle/hammeronpulloff", "Half slur"), value: 0 },
-                                    {title: qsTrc("notation/editstyle/hammeronpulloff", "Symbol"), value: 1 },
-                                    {title: qsTrc("notation/editstyle/hammeronpulloff", "Both"), value: 2 },
+                                    { text: qsTrc("notation/editstyle/hammeronpulloff", "Half slur"), value: 0 },
+                                    { text: qsTrc("notation/editstyle/hammeronpulloff", "Symbol"), value: 1 },
+                                    { text: qsTrc("notation/editstyle/hammeronpulloff", "Both"), value: 2 },
                                 ]
 
                                 FlatRadioButton {
-                                    required property string title
+                                    id: lhTappingTabStaveButton
+
+                                    required text
                                     required property int index
                                     required property int value
 
                                     property int contentWidth: lhTappingTabStaveMetrics.width + 16
                                     width: lhTappingTabStaveRow.maxButtonWidth
                                     height: 30
-                                    text: title
+
                                     ButtonGroup.group: lhTappingTabStaveGroup
                                     checked: hopoPage.lhTappingShowItemsTab.value === value
                                     onToggled: hopoPage.lhTappingShowItemsTab.value = value
@@ -338,7 +342,7 @@ StyledFlickable {
                                         id: lhTappingTabStaveMetrics
                                         font.family: ui.theme.bodyFont.family
                                         font.pixelSize: ui.theme.bodyFont.pixelSize
-                                        text: title
+                                        text: lhTappingTabStaveButton.text
                                     }
                                 }
                             }


### PR DESCRIPTION
Resolves: #30540

Calculate maximum width necessary for ButtonGroup to fit text.

The new calculation makes sure that:
- Text fits regardless of the font size of the UI and correctly adapts to dynamic changes.
- All buttons maintain the same size, the maximum of the group that correctly fits the given translated text.

<img width="559" height="252" alt="image" src="https://github.com/user-attachments/assets/69e98c00-5ff7-4e39-9f79-53feb379acaa" />

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
