### PR TITLE
Extend full width Edit Style ColumnLayout

### DIFF
--- a/src/notationscene/qml/MuseScore/NotationScene/styledialog/AccidentalsPage.qml
+++ b/src/notationscene/qml/MuseScore/NotationScene/styledialog/AccidentalsPage.qml
@@ -28,7 +28,7 @@ import Muse.UiComponents
 StyledFlickable {
     id: root
 
-    contentWidth: root.width
+    contentWidth: contentLayout.implicitWidth
     contentHeight: contentLayout.implicitHeight
 
     AccidentalsPageModel {
@@ -42,28 +42,38 @@ StyledFlickable {
 
         StyledGroupBox {
             Layout.fillWidth: true
+            Layout.minimumWidth: accidentalsPaddingLayout.implicitWidth + 24
             title: qsTrc("notation/editstyle/accidentals", "Accidentals")
 
-            StyleSpinboxWithReset {
-                styleItem: accidentalsPageModel.bracketedAccidentalPadding
-                label: qsTrc("notation/editstyle/accidentals", "Padding inside parentheses:")
+            ColumnLayout {
+                id: accidentalsPaddingLayout
+                width: parent.width
+                spacing: 12
 
-                suffix: qsTrc("global", "sp")
-                decimals: 3
-                step: 0.1
-                min: -10.0
-                max: 10.0
+                StyleSpinboxWithReset {
+                    styleItem: accidentalsPageModel.bracketedAccidentalPadding
+                    label: qsTrc("notation/editstyle/accidentals", "Padding inside parentheses:")
 
-                labelAreaWidth: -1
-                controlAreaWidth: spinBoxWidth
+                    suffix: qsTrc("global", "sp")
+                    decimals: 3
+                    step: 0.1
+                    min: -10.0
+                    max: 10.0
+
+                    labelAreaWidth: -1
+                    controlAreaWidth: spinBoxWidth
+                }
             }
         }
 
         StyledGroupBox {
             Layout.fillWidth: true
+            Layout.minimumWidth: multipleAccidentalsLayout.implicitWidth + 24
             title: qsTrc("notation/editstyle/accidentals", "Multiple accidentals in chords")
 
             ColumnLayout {
+                id: multipleAccidentalsLayout
+                width: parent.width
                 spacing: 12
 
                 StyleToggleWithImage {

--- a/src/notationscene/qml/MuseScore/NotationScene/styledialog/BendsPage.qml
+++ b/src/notationscene/qml/MuseScore/NotationScene/styledialog/BendsPage.qml
@@ -45,10 +45,11 @@ StyledFlickable {
 
         StyledGroupBox {
             Layout.fillWidth: true
-            Layout.minimumWidth: 500
+            Layout.minimumWidth: bendsLayout.implicitWidth + 24
             title: qsTrc("notation/editstyle/bends", "Bends")
 
             ColumnLayout {
+                id: bendsLayout
                 spacing: 8
                 width: parent.width
 
@@ -158,10 +159,11 @@ StyledFlickable {
 
         StyledGroupBox {
             Layout.fillWidth: true
-            Layout.minimumWidth: 500
+            Layout.minimumWidth: divesLayout.implicitWidth + 24
             title: qsTrc("notation/editstyle/bends", "Dives")
 
             ColumnLayout {
+                id: divesLayout
                 spacing: 8
                 width: parent.width
 
@@ -284,10 +286,11 @@ StyledFlickable {
 
         StyledGroupBox {
             Layout.fillWidth: true
-            Layout.minimumWidth: 500
+            Layout.minimumWidth: graceNoteLayout.implicitWidth + 24
             title: qsTrc("notation/editstyle/bends", "Grace note bends/dives on tablature")
 
             ColumnLayout {
+                id: graceNoteLayout
                 spacing: 12
                 width: parent.width
 
@@ -328,11 +331,13 @@ StyledFlickable {
 
         StyledGroupBox {
             Layout.fillWidth: true
-            Layout.minimumWidth: 500
+            Layout.minimumWidth: intervalLayout.implicitWidth + 24
             title: qsTrc("notation/editstyle/bends", "Interval labels")
 
             RowLayout {
+                id: intervalLayout
                 spacing: 12
+                width: parent.width
 
                 RadioButtonGroup {
                     Layout.fillWidth: false

--- a/src/notationscene/qml/MuseScore/NotationScene/styledialog/ChordSymbolsPage.qml
+++ b/src/notationscene/qml/MuseScore/NotationScene/styledialog/ChordSymbolsPage.qml
@@ -33,7 +33,7 @@ import MuseScore.NotationScene
 StyledFlickable {
     id: root
 
-    contentWidth: root.width
+    contentWidth: column.width
     contentHeight: column.height
 
     ChordSymbolsPageModel {
@@ -115,12 +115,13 @@ StyledFlickable {
 
         StyledGroupBox {
             Layout.fillWidth: true
-            Layout.minimumWidth: 500
+            Layout.minimumWidth: presetLayout.implicitWidth + 24
             title: qsTrc("notation/editstyle/chordsymbols", "Preset")
 
             ColumnLayout {
+                id: presetLayout
                 spacing: 12
-                anchors.fill: parent
+                width: parent.width
 
                 // TODO - replace with StyledDropdown once this whole dialog is written in QML
                 ComboBoxDropdown {
@@ -157,12 +158,13 @@ StyledFlickable {
 
         StyledGroupBox {
             Layout.fillWidth: true
-            Layout.minimumWidth: 500
+            Layout.minimumWidth: appearanceLayout.implicitWidth + 24
             title: qsTrc("notation/editstyle/chordsymbols", "Appearance")
 
             ColumnLayout {
+                id: appearanceLayout
                 spacing: 12
-                anchors.fill: parent
+                width: parent.width
 
                 FlatButton {
                     text: qsTrc("notation", "Edit chord symbol text style")
@@ -603,12 +605,13 @@ StyledFlickable {
 
         StyledGroupBox {
             Layout.fillWidth: true
-            Layout.minimumWidth: 500
+            Layout.minimumWidth: alignmentLayout.implicitWidth + 24
             title: qsTrc("notation/editstyle/chordsymbols", "Alignment")
 
             ColumnLayout {
+                id: alignmentLayout
                 spacing: 12
-                anchors.fill: parent
+                width: parent.width
 
                 RowLayout {
                     spacing: 6
@@ -666,12 +669,13 @@ StyledFlickable {
 
         StyledGroupBox {
             Layout.fillWidth: true
-            Layout.minimumWidth: 500
+            Layout.minimumWidth: positioningLayout.implicitWidth + 24
             title: qsTrc("notation/editstyle/chordsymbols", "Positioning")
 
             ColumnLayout {
+                id: positioningLayout
                 spacing: 12
-                anchors.fill: parent
+                width: parent.width
 
                 RowLayout {
                     spacing: 6
@@ -770,11 +774,12 @@ StyledFlickable {
 
         StyledGroupBox {
             Layout.fillWidth: true
-            Layout.minimumWidth: 500
+            Layout.minimumWidth: playbackLayout.implicitWidth + 24
             title: qsTrc("notation/editstyle/chordsymbols", "Playback")
 
             GridLayout {
-                anchors.fill: parent
+                id: playbackLayout
+                width: parent.width
                 rowSpacing: 12
                 columnSpacing: 6
                 columns: 3
@@ -857,10 +862,11 @@ StyledFlickable {
 
         StyledGroupBox {
             Layout.fillWidth: true
-            Layout.minimumWidth: 500
+            Layout.minimumWidth: capoLayout.implicitWidth + 24
             title: qsTrc("notation/editstyle/chordsymbols", "Capo")
 
             ColumnLayout {
+                id: capoLayout
                 spacing: 12
                 width: parent.width
 

--- a/src/notationscene/qml/MuseScore/NotationScene/styledialog/ClefKeyTimeSigPage.qml
+++ b/src/notationscene/qml/MuseScore/NotationScene/styledialog/ClefKeyTimeSigPage.qml
@@ -33,7 +33,7 @@ import MuseScore.NotationScene
 StyledFlickable {
     id: root
 
-    contentWidth: root.width
+    contentWidth: column.width
     contentHeight: column.height
 
     ClefKeyTimeSigPageModel {
@@ -74,10 +74,11 @@ StyledFlickable {
 
         StyledGroupBox {
             Layout.fillWidth: true
-            Layout.minimumWidth: 500
+            Layout.minimumWidth: clefsLayout.implicitWidth + 24
             title: qsTrc("notation/editstyle/timesignatures", "Clefs")
 
             ColumnLayout {
+                id: clefsLayout
                 width: parent.width
                 spacing: 10
 

--- a/src/notationscene/qml/MuseScore/NotationScene/styledialog/FretboardsPage.qml
+++ b/src/notationscene/qml/MuseScore/NotationScene/styledialog/FretboardsPage.qml
@@ -30,7 +30,7 @@ import MuseScore.NotationScene
 StyledFlickable {
     id: root
 
-    contentWidth: root.width
+    contentWidth: groupBox.implicitWidth
     contentHeight: groupBox.implicitHeight
 
     readonly property real controlAreaWidth: 204

--- a/src/notationscene/qml/MuseScore/NotationScene/styledialog/HammerOnPullOffTappingPage.qml
+++ b/src/notationscene/qml/MuseScore/NotationScene/styledialog/HammerOnPullOffTappingPage.qml
@@ -35,7 +35,7 @@ StyledFlickable {
 
     signal goToTextStylePage(string s)
 
-    contentWidth: root.width
+    contentWidth: column.width
     contentHeight: column.height
 
     HammerOnPullOffTappingPageModel {
@@ -49,10 +49,11 @@ StyledFlickable {
 
         StyledGroupBox {
             Layout.fillWidth: true
-            Layout.minimumWidth: 500
+            Layout.minimumWidth: visibilityLayout.implicitWidth + 24
             title: qsTrc("notation/editstyle/hammeronpulloff", "Visibility")
 
             ColumnLayout {
+                id: visibilityLayout
                 width: parent.width
                 spacing: 10
 
@@ -84,10 +85,11 @@ StyledFlickable {
 
         StyledGroupBox {
             Layout.fillWidth: true
-            Layout.minimumWidth: 500
+            Layout.minimumWidth: caseRow.implicitWidth + 24
             title: qsTrc("notation/editstyle/hammeronpulloff", "Case")
 
             Row {
+                id: caseRow
                 width: parent.width
                 spacing: 8
 
@@ -126,10 +128,11 @@ StyledFlickable {
 
         StyledGroupBox {
             Layout.fillWidth: true
-            Layout.minimumWidth: 500
+            Layout.minimumWidth: alignmentLayout.implicitWidth + 24
             title: qsTrc("notation/editstyle/hammeronpulloff", "Alignment")
 
             ColumnLayout {
+                id: alignmentLayout
                 width: parent.width
                 spacing: 10
 
@@ -153,10 +156,11 @@ StyledFlickable {
 
         StyledGroupBox {
             Layout.fillWidth: true
-            Layout.minimumWidth: 500
+            Layout.minimumWidth: consecutiveLayout.implicitWidth + 24
             title: qsTrc("notation/editstyle/hammeronpulloff", "Consecutive hammer-ons/pull-offs")
 
             ColumnLayout {
+                id: consecutiveLayout
                 width: parent.width
                 spacing: 8
 
@@ -187,10 +191,11 @@ StyledFlickable {
 
         StyledGroupBox {
             Layout.fillWidth: true
-            Layout.minimumWidth: 500
+            Layout.minimumWidth: lhTappingLayout.implicitWidth + 24
             title: qsTrc("notation/editstyle/hammeronpulloff", "Left-hand tapping")
 
             ColumnLayout {
+                id: lhTappingLayout
                 width: parent.width
                 spacing: 8
 
@@ -391,10 +396,11 @@ StyledFlickable {
 
         StyledGroupBox {
             Layout.fillWidth: true
-            Layout.minimumWidth: 500
+            Layout.minimumWidth: rhTappingLayout.implicitWidth + 24
             title: qsTrc("notation/editstyle/hammeronpulloff", "Right-hand tapping")
 
             ColumnLayout {
+                id: rhTappingLayout
                 width: parent.width
                 spacing: 12
 

--- a/src/notationscene/qml/MuseScore/NotationScene/styledialog/MeasureNumbersPage.qml
+++ b/src/notationscene/qml/MuseScore/NotationScene/styledialog/MeasureNumbersPage.qml
@@ -35,7 +35,7 @@ StyledFlickable {
 
     signal goToTextStylePage(int index)
 
-    contentWidth: root.width
+    contentWidth: column.width
     contentHeight: column.height
 
     MeasureNumbersPageModel {
@@ -49,10 +49,11 @@ StyledFlickable {
 
         StyledGroupBox {
             Layout.fillWidth: true
-            Layout.minimumWidth: 500
+            Layout.minimumWidth: measureNumbersLayout.implicitWidth + 24
             title: qsTrc("notation/editstyle/voltas", "Measure numbers")
 
             ColumnLayout {
+                id: measureNumbersLayout
                 width: parent.width
                 spacing: 12
 
@@ -115,10 +116,11 @@ StyledFlickable {
         StyledGroupBox {
             enabled: barNumbersModel.showMeasureNumber.value === true
             Layout.fillWidth: true
-            Layout.minimumWidth: 500
+            Layout.minimumWidth: frequencyLayout.implicitWidth + 24
             title: qsTrc("notation/editstyle/voltas", "Frequency")
 
             ColumnLayout {
+                id: frequencyLayout
                 width: parent.width
                 spacing: 8
 
@@ -162,10 +164,11 @@ StyledFlickable {
         StyledGroupBox {
             enabled: barNumbersModel.showMeasureNumber.value === true
             Layout.fillWidth: true
-            Layout.minimumWidth: 500
+            Layout.minimumWidth: positionLayout.implicitWidth + 24
             title: qsTrc("notation/editstyle/voltas", "Position")
 
             ColumnLayout {
+                id: positionLayout
                 width:parent.width
                 spacing: 12
 
@@ -316,10 +319,11 @@ StyledFlickable {
 
         StyledGroupBox {
             Layout.fillWidth: true
-            Layout.minimumWidth: 500
+            Layout.minimumWidth: mmRestLayout.implicitWidth + 24
             title: qsTrc("notation/editstyle/voltas", "Measure number range at multimeasure rests")
 
             ColumnLayout {
+                id: mmRestLayout
                 width: parent.width
                 spacing: 12
 

--- a/src/notationscene/qml/MuseScore/NotationScene/styledialog/SlursAndTiesPage.qml
+++ b/src/notationscene/qml/MuseScore/NotationScene/styledialog/SlursAndTiesPage.qml
@@ -28,7 +28,7 @@ import Muse.UiComponents
 StyledFlickable {
     id: root
 
-    contentWidth: root.width
+    contentWidth: contentLayout.implicitWidth
     contentHeight: contentLayout.implicitHeight
 
     SlursAndTiesPageModel {

--- a/src/notationscene/qml/MuseScore/NotationScene/styledialog/VoltasPage.qml
+++ b/src/notationscene/qml/MuseScore/NotationScene/styledialog/VoltasPage.qml
@@ -43,11 +43,13 @@ StyledFlickable {
 
         StyledGroupBox {
             Layout.fillWidth: true
-            Layout.minimumWidth: 500
+            Layout.minimumWidth: voltasLayout.implicitWidth + 24
             title: qsTrc("notation/editstyle/voltas", "Voltas")
 
             ColumnLayout {
+                id: voltasLayout
                 spacing: 12
+                width: parent.width
 
                 RowLayout {
                     spacing: 8
@@ -132,11 +134,13 @@ StyledFlickable {
 
         StyledGroupBox {
             Layout.fillWidth: true
-            Layout.minimumWidth: 500
+            Layout.minimumWidth: alignmentLayout.implicitWidth + 24
             title: qsTrc("notation/editstyle/voltas", "Alignment")
 
             ColumnLayout {
+                id: alignmentLayout
                 spacing: 12
+                width: parent.width
 
                 RowLayout {
                     spacing: 16


### PR DESCRIPTION
Resolves: #30541

Extend the ColumnLayout to full page width for the following pages:
- Measure numbers
- Clefs, keys
- Accidentals
- Slurs & ties
- Hammer-ons/Pull-offs
- Chord symbols
- Fretboard diagrams

<img width="1441" height="406" alt="image" src="https://github.com/user-attachments/assets/5d1b6e0e-426b-4605-a341-442607bfcbf9" />

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
