### PR TITLE
Fix #22615: Colours for bends and vibrato

### DIFF
--- a/src/engraving/dom/guitarbend.cpp
+++ b/src/engraving/dom/guitarbend.cpp
@@ -61,7 +61,7 @@ LineSegment* GuitarBend::createLineSegment(System* parent)
 {
     GuitarBendSegment* seg = new GuitarBendSegment(this, parent);
     seg->setTrack(track());
-    seg->setColor(color());
+    seg->setColor(lineColor());
     return seg;
 }
 
@@ -301,6 +301,10 @@ bool GuitarBend::setProperty(Pid propertyId, const PropertyValue& v)
         break;
     case Pid::BEND_END_TIME_FACTOR:
         setEndTimeFactor(v.toReal());
+        break;
+    case Pid::COLOR:
+        setColor(v.value<Color>());
+        setLineColor(v.value<Color>());
         break;
     default:
         return SLine::setProperty(propertyId, v);
@@ -601,7 +605,7 @@ EngravingObject* GuitarBendSegment::propertyDelegate(Pid id) const
     case Pid::APPEARANCE_LINKED_TO_MASTER:
         return guitarBend();
     default:
-        return nullptr;
+        return LineSegment::propertyDelegate(id);
     }
 }
 
@@ -698,7 +702,7 @@ LineSegment* GuitarBendHold::createLineSegment(System* parent)
 {
     GuitarBendHoldSegment* seg = new GuitarBendHoldSegment(this, parent);
     seg->setTrack(track());
-    seg->setColor(color());
+    seg->setColor(lineColor());
     return seg;
 }
 

--- a/src/engraving/dom/line.cpp
+++ b/src/engraving/dom/line.cpp
@@ -1006,7 +1006,7 @@ bool SLine::setProperty(Pid id, const PropertyValue& v)
         m_diagonal = v.toBool();
         break;
     case Pid::COLOR:
-        m_lineColor = v.value<Color>();
+        setLineColor(v.value<Color>());
         break;
     case Pid::LINE_WIDTH:
         if (v.type() == P_TYPE::MILLIMETRE) {

--- a/src/engraving/dom/trill.cpp
+++ b/src/engraving/dom/trill.cpp
@@ -398,12 +398,10 @@ bool Trill::setProperty(Pid propertyId, const PropertyValue& val)
         break;
     case Pid::COLOR:
         setColor(val.value<Color>());
-        [[fallthrough]];
-    default:
-        if (!SLine::setProperty(propertyId, val)) {
-            return false;
-        }
+        setLineColor(val.value<Color>());
         break;
+    default:
+        return SLine::setProperty(propertyId, val);
     }
     triggerLayout();
     return true;

--- a/src/engraving/dom/vibrato.cpp
+++ b/src/engraving/dom/vibrato.cpp
@@ -137,7 +137,7 @@ LineSegment* Vibrato::createLineSegment(System* parent)
 {
     VibratoSegment* seg = new VibratoSegment(this, parent);
     seg->setTrack(track());
-    seg->setColor(color());
+    seg->setColor(lineColor());
     seg->initElementStyle(&vibratoSegmentStyle);
     return seg;
 }
@@ -212,12 +212,10 @@ bool Vibrato::setProperty(Pid propertyId, const PropertyValue& val)
         break;
     case Pid::COLOR:
         setColor(val.value<Color>());
-        [[fallthrough]];
-    default:
-        if (!SLine::setProperty(propertyId, val)) {
-            return false;
-        }
+        setLineColor(val.value<Color>());
         break;
+    default:
+        return SLine::setProperty(propertyId, val);
     }
     triggerLayout();
     return true;


### PR DESCRIPTION
Resolves: #22615
Closes: #25943

I think this issue has evolved a bit since #25943 was opened. The changes here bring bends and vibrato in-line with trills where the colours are set/saved/recalled as expected (see #22852).

The changes here don't seem to interfere with `GuitarBend::curColor`. Critical/warning colours are still displayed in the Score tab, while the "true" colour is always displayed in the Publish tab.