### PR TITLE
Reduce horizontal padding for full measure rests

### DIFF
--- a/src/engraving/rendering/score/restlayout.cpp
+++ b/src/engraving/rendering/score/restlayout.cpp
@@ -619,7 +619,7 @@ void RestLayout::checkFullMeasureRestCollisions(const System* system, LayoutCont
 
             const double spatium = fullMeasureRest->spatium();
             const double lineDist = fullMeasureRest->staff()->lineDistance(fullMeasureRest->tick()) * spatium;
-            const double minHorizontalDistance = 4 * spatium;
+            const double minHorizontalDistance = 1.5 * spatium;
             const double minVertClearance = 0.75 * spatium;
 
             bool alignAbove = fullMeasureRest->voice() == 0;


### PR DESCRIPTION
Resolves: #29719

As mentioned by @its-not-nice [here](https://github.com/musescore/MuseScore/issues/29719#issuecomment-3264947368), since version 4.6 full measure rests can tuck inside the other voice's notes, but they need to do so with some horizontal margin on each side, or they would risk getting buried. It doesn't matter what we set that margin to, it will always be possible to construct situations like those shown in the issue where one case falls just above and the other just below the margin thus producing different results.

However, the current margin of 4sp on each side was probably overly cautious. Reducing the margin should make these kind of situations less likely (although, as said, still technically unavoidable).