### PR TITLE
Fix #15726: Some elements are lost when changing time signature

### DIFF
--- a/src/engraving/dom/range.cpp
+++ b/src/engraving/dom/range.cpp
@@ -1392,10 +1392,10 @@ void ScoreRange::deleteSpacers()
 }
 
 //---------------------------------------------------------
-//   endOfMeasure
+//   endOfMeasureElement
 //---------------------------------------------------------
 
-bool ScoreRange::endOfMeasure(EngravingItem* e) const
+bool ScoreRange::endOfMeasureElement(EngravingItem* e) const
 {
     bool result = false;
 
@@ -1422,7 +1422,7 @@ void ScoreRange::backupJumpsAndMarkers(Segment* first, Segment* last)
         for (EngravingItem* e : m->el()) {
             if (e && (e->isMarker() || e->isJump())) {
                 JumpsMarkersBackup mJMBackup;
-                mJMBackup.sPosition = (endOfMeasure(e) ? m->endTick() : m->tick());
+                mJMBackup.sPosition = (endOfMeasureElement(e) ? m->endTick() : m->tick());
                 mJMBackup.e = e->clone();
                 m_jumpsMarkers.push_back(mJMBackup);
             }
@@ -1451,8 +1451,8 @@ void ScoreRange::restoreJumpsAndMarkers(Score* score, const Fraction& tick) cons
         for (Measure* m = score->tick2measure(tick); m; m = m->nextMeasure()) {
             // Markers: we keep them as long as they are in the measure before the final tick
             // Jumps: we keep them as long as they are in the measure after the start tick
-            if ((endOfMeasure(jmb.e) && jmb.sPosition > m->tick() && jmb.sPosition <= m->endTick())
-                || (!endOfMeasure(jmb.e) && jmb.sPosition >= m->tick() && jmb.sPosition < m->endTick())) {
+            if ((endOfMeasureElement(jmb.e) && jmb.sPosition > m->tick() && jmb.sPosition <= m->endTick())
+                || (!endOfMeasureElement(jmb.e) && jmb.sPosition >= m->tick() && jmb.sPosition < m->endTick())) {
                 addJumpMarker(m, jmb.e);
                 LOGI() << "tpacebes hago restore";
             }

--- a/src/engraving/dom/range.h
+++ b/src/engraving/dom/range.h
@@ -151,11 +151,24 @@ private:
     void backupRepeats(Segment* first, Segment* last);
     void restoreRepeats(Score* score, const Fraction& tick) const;
 
+    struct SpacerBackup
+    {
+        Fraction sPosition;
+        staff_idx_t staffIdx;
+        Spacer* s = nullptr;
+    };
+
     void backupSpacers(Segment* first, Segment* last);
     void restoreSpacers(Score* score, const Fraction& tick) const;
     void deleteSpacers();
 
-    bool endOfMeasure(EngravingItem* e) const;
+    struct JumpsMarkersBackup
+    {
+        Fraction sPosition;
+        EngravingItem* e = nullptr;
+    };
+
+    bool endOfMeasureElement(EngravingItem* e) const;
     void backupJumpsAndMarkers(Segment* first, Segment* last);
     void restoreJumpsAndMarkers(Score* score, const Fraction& tick) const;
     void deleteJumpsAndMarkers();
@@ -164,17 +177,6 @@ private:
 
     friend class TrackList;
 
-    struct SpacerBackup
-    {
-        Fraction sPosition;
-        staff_idx_t staffIdx;
-        Spacer* s = nullptr;
-    };
-    struct JumpsMarkersBackup
-    {
-        Fraction sPosition;
-        EngravingItem* e = nullptr;
-    };
     std::vector<TrackList*> m_tracks;
     std::vector<Tie*> m_startTies;
     std::vector<SpacerBackup> m_spacers;


### PR DESCRIPTION
Resolves: #15726 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
- This PR keeps the follogin elements when changing time signature:
-- Glisando && Bends 
-- Spacers 
-- Jumps and Markers
-- Voltas
- BarLines and Breaks support were included in a [previous PR ](https://github.com/musescore/MuseScore/pull/30499)

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
