### PR TITLE
Embed label in ToggleButton component

### DIFF
--- a/src/appshell/qml/DevTools/Gallery/GeneralComponentsGallery.qml
+++ b/src/appshell/qml/DevTools/Gallery/GeneralComponentsGallery.qml
@@ -714,6 +714,8 @@ Rectangle {
         ToggleButton {
             id: toggleButton
 
+            text: checked ? "On" : "Off"
+
             onToggled: {
                 checked = !checked
             }

--- a/src/appshell/qml/Preferences/PercussionPreferencesPage.qml
+++ b/src/appshell/qml/Preferences/PercussionPreferencesPage.qml
@@ -141,37 +141,17 @@ PreferencesPage {
             navigation.section: root.navigationSection
             navigation.order: autoShowSection.navigation.order + 1
 
-            Row {
-                id: useLegacyToggleRow
+            ToggleButton {
+                id: useLegacyToggle
 
-                height: useLegacyToggle.height
-                width: parent.width
+                text: qsTrc("notation/percussion", "Use legacy percussion panel")
+                checked: !percussionPreferencesModel.useNewPercussionPanel
 
-                spacing: 6
+                navigation.name: "UseLegacyPercussionPanel"
+                navigation.panel: legacyToggleSection.navigation
 
-                ToggleButton {
-                    id: useLegacyToggle
-
-                    checked: !percussionPreferencesModel.useNewPercussionPanel
-
-                    navigation.name: "UseLegacyPercussionPanel"
-                    navigation.panel: legacyToggleSection.navigation
-
-                    onToggled: {
-                        percussionPreferencesModel.useNewPercussionPanel = !percussionPreferencesModel.useNewPercussionPanel
-                    }
-                }
-
-                StyledTextLabel {
-                    id: legacyToggleInfo
-
-                    height: parent.height
-
-                    horizontalAlignment: Text.AlignLeft
-                    verticalAlignment: Text.AlignVCenter
-
-                    wrapMode: Text.Wrap
-                    text: qsTrc("notation/percussion", "Use legacy percussion panel")
+                onToggled: {
+                    percussionPreferencesModel.useNewPercussionPanel = !percussionPreferencesModel.useNewPercussionPanel
                 }
             }
         }

--- a/src/appshell/qml/Preferences/internal/NoteInput/MidiInputSection.qml
+++ b/src/appshell/qml/Preferences/internal/NoteInput/MidiInputSection.qml
@@ -42,34 +42,18 @@ BaseSection {
     signal advanceToNextNoteChangeRequested(bool advance)
     signal delayBetweenNotesChangeRequested(int delay)
 
-    Row {
+    ToggleButton {
+        id: enableMidiInputToggle
         width: parent.width
-        height: enableMidiInputToggle.height
 
-        spacing: 6
+        text: qsTrc("appshell/preferences", "Enable MIDI input")
 
-        ToggleButton {
-            id: enableMidiInputToggle
+        navigation.name: "EnableMidiInputToggle"
+        navigation.panel: root.navigation
+        navigation.row: 0
 
-            navigation.name: "EnableMidiInputToggle"
-            navigation.panel: root.navigation
-            navigation.row: 0
-
-            navigation.accessible.name: enableMidiInputLabel.text
-
-            onToggled: {
-                root.midiInputEnabledChangeRequested(!checked)
-            }
-        }
-
-        StyledTextLabel {
-            id: enableMidiInputLabel
-
-            anchors.verticalCenter: parent.verticalCenter
-            horizontalAlignment: Text.AlignLeft
-            wrapMode: Text.Wrap
-
-            text: qsTrc("appshell/preferences", "Enable MIDI input")
+        onToggled: {
+            root.midiInputEnabledChangeRequested(!checked)
         }
     }
 

--- a/src/appshell/qml/Preferences/internal/NoteInput/NotePreviewSection.qml
+++ b/src/appshell/qml/Preferences/internal/NoteInput/NotePreviewSection.qml
@@ -52,34 +52,18 @@ BaseSection {
 
     title: qsTrc("appshell/preferences", "Note preview")
 
-    Row {
+    ToggleButton {
+        id: playNotesToggle
         width: parent.width
-        height: playNotesToggle.height
 
-        spacing: 6
+        text: qsTrc("appshell/preferences", "Hear playback when adding, editing, and selecting notes")
 
-        ToggleButton {
-            id: playNotesToggle
+        navigation.name: "PlayNotesToggle"
+        navigation.panel: root.navigation
+        navigation.row: 0
 
-            navigation.name: "PlayNotesToggle"
-            navigation.panel: root.navigation
-            navigation.row: 0
-
-            navigation.accessible.name: playNotesBoxLabel.text
-
-            onToggled: {
-                root.playNotesWhenEditingChangeRequested(!checked)
-            }
-        }
-
-        StyledTextLabel {
-            id: playNotesBoxLabel
-
-            anchors.verticalCenter: parent.verticalCenter
-            horizontalAlignment: Text.AlignLeft
-            wrapMode: Text.Wrap
-
-            text: qsTrc("appshell/preferences", "Hear playback when adding, editing, and selecting notes")
+        onToggled: {
+            root.playNotesWhenEditingChangeRequested(!checked)
         }
     }
 

--- a/src/inspector/view/qml/MuseScore/Inspector/common/PropertyToggle.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/common/PropertyToggle.qml
@@ -25,38 +25,17 @@ import QtQuick.Layouts 1.15
 import Muse.UiComponents 1.0
 import MuseScore.Inspector 1.0
 
-RowLayout {
-    id: root
-
-    width: parent.width
-
+ToggleButton {
     required property PropertyItem propertyItem
-    property alias label: label
-    property alias text: label.text
-    property alias navigation: toggle.navigation
 
     visible: propertyItem && propertyItem.isVisible
     enabled: propertyItem && propertyItem.isEnabled
 
-    spacing: 4
+    checked: propertyItem && Boolean(propertyItem.value)
 
-    ToggleButton {
-        id: toggle
-
-        checked: root.propertyItem && Boolean(root.propertyItem.value)
-
-        onToggled: {
-            if (root.propertyItem) {
-                root.propertyItem.value = !checked
-            }
+    onToggled: {
+        if (propertyItem) {
+            propertyItem.value = !checked
         }
-    }
-
-    StyledTextLabel {
-        id: label
-
-        Layout.fillWidth: true
-
-        horizontalAlignment: Text.AlignLeft
     }
 }

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/fretdiagrams/FretDiagramSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/fretdiagrams/FretDiagramSettings.qml
@@ -84,6 +84,7 @@ Item {
 
             PropertyToggle {
                 id: showFingerings
+                width: parent.width
 
                 text: qsTrc("inspector", "Show fingerings")
                 propertyItem: root.model ? root.model.showFingerings : null

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/rests/RestBeamSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/rests/RestBeamSettings.qml
@@ -38,8 +38,8 @@ FocusableItem {
     property NavigationPanel navigationPanel: null
     property int navigationRowStart: 1
 
-    implicitHeight: beamTypeSection.height
-    width: parent.width
+    implicitWidth: beamTypeSection.implicitWidth
+    implicitHeight: beamTypeSection.implicitHeight
 
     BeamTypeSelector {
         id: beamTypeSection

--- a/src/inspector/view/qml/MuseScore/Inspector/notation/rests/RestSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/notation/rests/RestSettings.qml
@@ -51,8 +51,7 @@ Column {
 
     RestBeamSettings {
         id: restBeamSettings
-        
-        height: implicitHeight
+        width: parent.width
 
         model: root.beamModel
 
@@ -62,6 +61,7 @@ Column {
 
     PropertyToggle {
         id: alignWithOtherRests
+        width: parent.width
 
         navigation.name: "Align with other rests"
         navigation.panel: root.navigationPanel

--- a/src/inspector/view/qml/MuseScore/Inspector/parts/PartsSettings.qml
+++ b/src/inspector/view/qml/MuseScore/Inspector/parts/PartsSettings.qml
@@ -59,6 +59,7 @@ InspectorSectionView {
 
             PropertyToggle {
                 id: positionLinkedToMasterToggle
+                width: parent.width
 
                 navigation.name: "Position linked to score"
                 navigation.panel: root.navigationPanel
@@ -70,10 +71,11 @@ InspectorSectionView {
 
             PropertyToggle {
                 id: appearanceLinkedToMasterToggle
+                width: parent.width
 
                 navigation.name: "Style / appearance linked to score"
                 navigation.panel: root.navigationPanel
-                navigation.row: positionLinkedToMasterToggle.navigationRow + 1
+                navigation.row: positionLinkedToMasterToggle.navigation.row + 1
 
                 propertyItem: root.model ? root.model.appearanceLinkedToMaster : null
                 text: qsTrc("inspector", "Style/appearance")
@@ -81,12 +83,13 @@ InspectorSectionView {
 
             PropertyToggle {
                 id: textLinkedToMasterToggle
+                width: parent.width
 
                 visible: root.model ? root.model.showTextLinkingOption : false
 
                 navigation.name: "Text linked to score"
                 navigation.panel: root.navigationPanel
-                navigation.row: appearanceLinkedToMasterToggle.navigationRow + 1
+                navigation.row: appearanceLinkedToMasterToggle.navigation.row + 1
 
                 propertyItem: root.model ? root.model.textLinkedToMaster : null
                 text: qsTrc("inspector", "Text")
@@ -104,7 +107,7 @@ InspectorSectionView {
 
             navigation.name: "Exclude from other parts"
             navigation.panel: root.navigationPanel
-            navigation.row: root.navigationRowStart
+            navigation.row: textLinkedToMasterToggle.navigation.row + 1
 
             text: root.model && root.model.isMasterScore
                   ? qsTrc("inspector", "Exclude from parts")

--- a/src/notation/qml/MuseScore/NotationScene/SelectionFilterPanel.qml
+++ b/src/notation/qml/MuseScore/NotationScene/SelectionFilterPanel.qml
@@ -154,41 +154,20 @@ Item {
                         }
                     }
 
-                    Row {
-                        id: singleNotesToggleRow
+                    ToggleButton {
+                        Layout.fillWidth: true
 
-                        height: singleNotesToggle.height
-                        width: parent.width
+                        text: qsTrc("notation", "Include single notes")
+                        checked: notesInChordModel.includeSingleNotes
 
-                        spacing: notesInChordSection.spacing
+                        navigation.name: "SingleNotesToggle"
+                        navigation.panel: notesInChordSection.navigation
+                        navigation.row: 100
 
-                        ToggleButton {
-                            id: singleNotesToggle
-
-                            checked: notesInChordModel.includeSingleNotes
-
-                            navigation.name: "SingleNotesToggle"
-                            navigation.panel: notesInChordSection.navigation
-                            navigation.row: 100
-
-                            onToggled: {
-                                notesInChordModel.includeSingleNotes = !notesInChordModel.includeSingleNotes
-                            }
-                        }
-
-                        StyledTextLabel {
-                            id: singleNotesInfo
-
-                            height: parent.height
-
-                            horizontalAlignment: Text.AlignLeft
-                            verticalAlignment: Text.AlignVCenter
-
-                            wrapMode: Text.Wrap
-                            text: qsTrc("notation", "Include single notes")
+                        onToggled: {
+                            notesInChordModel.includeSingleNotes = !notesInChordModel.includeSingleNotes
                         }
                     }
-
                 }
             }
 

--- a/src/notation/qml/MuseScore/NotationScene/internal/CapoPopup.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/CapoPopup.qml
@@ -165,36 +165,19 @@ AbstractElementPopup {
 
                 model: capoModel.strings
 
-                Item {
-                    height: toggleBtn.height
-                    width: (content.width / 2 - content.columnsSpacing / applyToStringsGrid.columns)
+                ToggleButton {
+                    Layout.preferredWidth: (content.width - applyToStringsGrid.columnSpacing) / 2
 
-                    ToggleButton {
-                        id: toggleBtn
+                    navigation.name: "String" + model.index + "Control"
+                    navigation.panel: capoSettingsNavPanel
+                    navigation.row: applyToStringsGrid.navigationRowStart + model.index
+                    navigation.accessible.name: applyToLabel.text + " " + text
 
-                        anchors.left: parent.left
-                        anchors.top: parent.top
+                    text: qsTrc("notation", "String %1").arg(model.index + 1)
+                    checked: modelData.applyCapo
 
-                        navigation.name: "String" + model.index + "Control"
-                        navigation.panel: capoSettingsNavPanel
-                        navigation.row: applyToStringsGrid.navigationRowStart + model.index
-                        navigation.accessible.name: applyToLabel.text + " " + stringLabel.text
-
-                        checked: modelData.applyCapo
-
-                        onToggled: {
-                            capoModel.toggleCapoForString(model.index)
-                        }
-                    }
-
-                    StyledTextLabel {
-                        id: stringLabel
-
-                        anchors.left: toggleBtn.right
-                        anchors.leftMargin: 4
-                        anchors.verticalCenter: parent.verticalCenter
-
-                        text: qsTrc("notation", "String %1").arg(model.index + 1)
+                    onToggled: {
+                        capoModel.toggleCapoForString(model.index)
                     }
                 }
             }

--- a/src/notation/qml/MuseScore/NotationScene/internal/EditStyle/ClefKeyTimeSigPage.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/EditStyle/ClefKeyTimeSigPage.qml
@@ -485,7 +485,7 @@ StyledFlickable {
             component CourtesyShowAndParenToggle: GridLayout {
                 required property StyleItem showStyleItem
                 required property StyleItem parensStyleItem
-                property alias text: toggleText.text
+                property alias text: toggleButton.text
 
                 flow: GridLayout.TopToBottom
 
@@ -495,30 +495,19 @@ StyledFlickable {
                 width: parent.width
                 rowSpacing: 8
 
-                RowLayout {
+                ToggleButton {
+                    id: toggleButton
+
                     Layout.row: 0
                     Layout.column: 0
                     Layout.maximumWidth: 232
                     Layout.preferredWidth: 232
-                    Layout.fillWidth: false
-                    ToggleButton {
-                        id: toggleButton
-                        checked: showStyleItem.value === true
-                        onToggled: {
-                            showStyleItem.value = !showStyleItem.value
-                        }
-                    }
 
-                    StyledTextLabel {
-                        id: toggleText
-                        Layout.alignment: Qt.AlignLeft
-                        horizontalAlignment: Text.AlignLeft
-                        Layout.maximumWidth: 232 - toggleButton.width
-                        Layout.preferredWidth: 232 - toggleButton.width
-                        wrapMode: Text.Wrap
+                    checked: showStyleItem.value === true
+                    onToggled: {
+                        showStyleItem.value = !showStyleItem.value
                     }
                 }
-
 
                 CheckBox {
                     id: parensCheckbox

--- a/src/notation/qml/MuseScore/NotationScene/internal/EditStyle/HammerOnPullOffTappingPage.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/EditStyle/HammerOnPullOffTappingPage.qml
@@ -53,40 +53,26 @@ StyledFlickable {
                 spacing: 10
 
                 StyledTextLabel {
+                    Layout.fillWidth: true
                     text: qsTrc("notation/editstyle/hammeronpulloff", "Show ‘H’ and ‘P’ symbols on")
+                    horizontalAlignment: Text.AlignLeft
                 }
 
-                RowLayout {
-                    spacing: 6
-
-                    ToggleButton {
-                        checked: hopoPage.showOnStandardStaves.value === true
-                        onToggled: {
-                            hopoPage.showOnStandardStaves.value = !hopoPage.showOnStandardStaves.value
-                        }
-                    }
-
-                    StyledTextLabel {
-                        Layout.fillWidth: true
-                        horizontalAlignment: Text.AlignLeft
-                        text: qsTrc("notation/editstyle/hammeronpulloff", "Standard staves")
+                ToggleButton {
+                    Layout.fillWidth: true
+                    text: qsTrc("notation/editstyle/hammeronpulloff", "Standard staves")
+                    checked: hopoPage.showOnStandardStaves.value === true
+                    onToggled: {
+                        hopoPage.showOnStandardStaves.value = !hopoPage.showOnStandardStaves.value
                     }
                 }
 
-                RowLayout {
-                    spacing: 6
-
-                    ToggleButton {
-                        checked: hopoPage.showOnTabStaves.value === true
-                        onToggled: {
-                            hopoPage.showOnTabStaves.value = !hopoPage.showOnTabStaves.value
-                        }
-                    }
-
-                    StyledTextLabel {
-                        Layout.fillWidth: true
-                        horizontalAlignment: Text.AlignLeft
-                        text: qsTrc("notation/editstyle/hammeronpulloff", "Tablature staves")
+                ToggleButton {
+                    Layout.fillWidth: true
+                    text: qsTrc("notation/editstyle/hammeronpulloff", "Tablature staves")
+                    checked: hopoPage.showOnTabStaves.value === true
+                    onToggled: {
+                        hopoPage.showOnTabStaves.value = !hopoPage.showOnTabStaves.value
                     }
                 }
             }

--- a/src/notation/qml/MuseScore/NotationScene/internal/EditStyle/RepeatBarlinesSection.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/EditStyle/RepeatBarlinesSection.qml
@@ -28,7 +28,6 @@ import MuseScore.NotationScene 1.0
 import Muse.UiComponents 1.0
 import Muse.Ui 1.0
 
-
 Rectangle {
     id: root
     anchors.fill: parent
@@ -42,22 +41,12 @@ Rectangle {
         width: parent.width
         spacing: 12
 
-        RowLayout {
-            id: beforeSigChangesToggle
-
-            ToggleButton {
-                id: toggleButton
-                checked: repeatBarlinesSectionModel.barlineBeforeSigChange.value === true
-                onToggled: {
-                    repeatBarlinesSectionModel.barlineBeforeSigChange.value = !repeatBarlinesSectionModel.barlineBeforeSigChange.value
-                }
-            }
-
-            StyledTextLabel {
-                id : toggleText
-                text: qsTrc("notation/editstyle/barlines", "Show barline before key and time signature changes")
-                Layout.fillWidth: true
-                horizontalAlignment: Text.AlignLeft
+        ToggleButton {
+            Layout.fillWidth: true
+            text: qsTrc("notation/editstyle/barlines", "Show barline before key and time signature changes")
+            checked: repeatBarlinesSectionModel.barlineBeforeSigChange.value === true
+            onToggled: {
+                repeatBarlinesSectionModel.barlineBeforeSigChange.value = !repeatBarlinesSectionModel.barlineBeforeSigChange.value
             }
         }
 

--- a/src/notation/qml/MuseScore/NotationScene/internal/EditStyle/RepeatPage.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/EditStyle/RepeatPage.qml
@@ -150,18 +150,12 @@ Rectangle {
                 width: parent.width
                 spacing: 12
 
-                RowLayout {
-                    ToggleButton {
-                        checked: repeatPlayCountTextModel.repeatPlayCountShow.value === true
-                        onToggled: {
-                            repeatPlayCountTextModel.repeatPlayCountShow.value = !repeatPlayCountTextModel.repeatPlayCountShow.value
-                        }
-                    }
-
-                    StyledTextLabel {
-                        Layout.fillWidth: true
-                        horizontalAlignment: Text.AlignLeft
-                        text: qsTrc("notation/editstyle/repeatplaycount", "Automatically show text at repeat barlines")
+                ToggleButton {
+                    Layout.fillWidth: true
+                    text: qsTrc("notation/editstyle/repeatplaycount", "Automatically show text at repeat barlines")
+                    checked: repeatPlayCountTextModel.repeatPlayCountShow.value === true
+                    onToggled: {
+                        repeatPlayCountTextModel.repeatPlayCountShow.value = !repeatPlayCountTextModel.repeatPlayCountShow.value
                     }
                 }
 

--- a/src/notation/qml/MuseScore/NotationScene/internal/EditStyle/StyleToggle.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/EditStyle/StyleToggle.qml
@@ -27,23 +27,11 @@ import MuseScore.NotationScene 1.0
 import Muse.UiComponents 1.0
 import Muse.Ui 1.0
 
-RowLayout {
-    id: root
-
-    spacing: 6
-
+ToggleButton {
     required property StyleItem styleItem
-    property alias text : label.text
 
-    ToggleButton {
-        checked: root.styleItem.value === true
-        onToggled: {
-            root.styleItem.value = !root.styleItem.value
-        }
-    }
-
-    StyledTextLabel {
-        id: label
-        horizontalAlignment: Text.AlignLeft
+    checked: styleItem.value === true
+    onToggled: {
+        styleItem.value = !styleItem.value
     }
 }

--- a/src/notation/qml/MuseScore/NotationScene/internal/EditStyle/StyleToggleWithImage.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/EditStyle/StyleToggleWithImage.qml
@@ -27,13 +27,13 @@ import Muse.UiComponents 1.0
 import Muse.Ui 1.0
 
 ColumnLayout {
-    id: column
+    id: root
 
     required property StyleItem styleItem
     required property string imageON
     required property string imageOFF
 
-    property alias text: toggleText.text
+    property alias text: toggleButton.text
 
     RowLayout {
         spacing: 15
@@ -47,23 +47,13 @@ ColumnLayout {
             source: toggleButton.checked ? imageON : imageOFF
         }
 
-        RowLayout {
-            id: toggle
+        ToggleButton {
+            id: toggleButton
 
-            ToggleButton {
-                id: toggleButton
-                checked: styleItem.value === true
-                onToggled: {
-                    styleItem.value = !styleItem.value
-                }
-            }
-
-            StyledTextLabel {
-                id : toggleText
-                Layout.fillWidth: true
-                horizontalAlignment: Text.AlignLeft
+            checked: root.styleItem.value === true
+            onToggled: {
+                root.styleItem.value = !root.styleItem.value
             }
         }
     }
-
 }


### PR DESCRIPTION
In literally all places where ToggleButton is used, it is combined with a text label. This commit reduces code duplication by embedding the label in the ToggleButton component, just like with CheckBox. It also makes the text clickable, and adds a subtle toggle slide animation.

Resolves: https://github.com/musescore/MuseScore/issues/23857
Closes: https://github.com/musescore/MuseScore/pull/25862