### PR TITLE
Add compatibility with FFMPEG 8.0

### DIFF
--- a/src/importexport/videoexport/internal/videoencoder.cpp
+++ b/src/importexport/videoexport/internal/videoencoder.cpp
@@ -126,7 +126,11 @@ bool VideoEncoder::open(const muse::io::path_t& fileName, unsigned width, unsign
         return false;
     }
 #endif
+#if LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(60, 31, 102)
     m_ffmpeg->codecCtx->profile = FF_PROFILE_H264_HIGH;
+#else
+    m_ffmpeg->codecCtx->profile = AV_PROFILE_H264_HIGH;
+#endif
 
     m_ffmpeg->codecCtx->bit_rate = bitrate;
     m_ffmpeg->codecCtx->width = width;


### PR DESCRIPTION
FFMPEG 8.0 removed deprecated FF_PROFILE_*
see https://github.com/FFmpeg/FFmpeg/commit/822432769868
AV_PROFILE was introduced with 6.1 (60.31.102)

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
