### PR TITLE
Fix #28950: Place dynamics popup above if a dynamic is above the staff

### DIFF
--- a/src/notation/qml/MuseScore/NotationScene/internal/DynamicPopup.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/DynamicPopup.qml
@@ -24,7 +24,7 @@ AbstractElementPopup {
     showArrow: false
 
     focusPolicies: PopupView.DefaultFocus & ~PopupView.ClickFocus
-    placementPolicies: PopupView.PreferBelow
+    placementPolicies: dynamicModel.placeAbove ? PopupView.PreferAbove : PopupView.PreferBelow
 
     model: DynamicPopupModel {
         id: dynamicModel

--- a/src/notation/view/internal/dynamicpopupmodel.cpp
+++ b/src/notation/view/internal/dynamicpopupmodel.cpp
@@ -212,3 +212,23 @@ void DynamicPopupModel::addHairpinToDynamic(ItemType itemType)
     interaction->selectAndStartEditIfNeeded(hairpin);
     updateNotation();
 }
+
+void DynamicPopupModel::updateItemRect()
+{
+    bool placeAbove = true;
+    if (m_item) {
+        placeAbove = m_item->placeAbove() || !m_item->hasStaff();
+    }
+
+    AbstractElementPopupModel::updateItemRect();
+
+    if (m_placeAbove != placeAbove) {
+        m_placeAbove = placeAbove;
+        emit placeAboveChanged();
+    }
+}
+
+bool DynamicPopupModel::placeAbove() const
+{
+    return m_placeAbove;
+}

--- a/src/notation/view/internal/dynamicpopupmodel.h
+++ b/src/notation/view/internal/dynamicpopupmodel.h
@@ -35,6 +35,7 @@ class DynamicPopupModel : public AbstractElementPopupModel
 
     Q_PROPERTY(QString fontFamily READ fontFamily CONSTANT)
     Q_PROPERTY(QVariantList pages READ pages NOTIFY pagesChanged)
+    Q_PROPERTY(bool placeAbove READ placeAbove NOTIFY placeAboveChanged)
 
 public:
     explicit DynamicPopupModel(QObject* parent = nullptr);
@@ -60,13 +61,19 @@ public:
     QString fontFamily() const;
     QVariantList pages() const;
 
+    bool placeAbove() const;
+
 signals:
     void pagesChanged();
+    void placeAboveChanged();
 
 private:
     // Represents different pages of the popup, each containing dynamic/hairpin symbols as strings, width, offset and ItemType
     QVariantList m_pages;
 
     QString xmlTextToQString(const std::string& text, engraving::IEngravingFontPtr engravingFont) const;
+
+    void updateItemRect() override;
+    bool m_placeAbove = true;
 };
 } // namespace mu::notation


### PR DESCRIPTION
Resolves: #28950

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
