### PR TITLE
Fix #30604: Implement double duration for smaller note values

### DIFF
--- a/src/engraving/editing/cmd.cpp
+++ b/src/engraving/editing/cmd.cpp
@@ -4490,6 +4490,15 @@ void Score::cmdPadNoteIncreaseTAB()
     case DurationType::V_128TH:
         padToggle(Pad::NOTE64);
         break;
+    case DurationType::V_256TH:
+        padToggle(Pad::NOTE128);
+        break;
+    case DurationType::V_512TH:
+        padToggle(Pad::NOTE256);
+        break;
+    case DurationType::V_1024TH:
+        padToggle(Pad::NOTE512);
+        break;
     default:
         break;
     }


### PR DESCRIPTION
Resolves: #30604

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
