### PR TITLE
Stop most keys from triggering actions in the Braille panel

### DIFF
--- a/src/braille/qml/MuseScore/Braille/BrailleView.qml
+++ b/src/braille/qml/MuseScore/Braille/BrailleView.qml
@@ -208,16 +208,38 @@ StyledFlickable {
             id: textInputModel
         }
 
+        Keys.onShortcutOverride: function(event) {
+
+            if (keyMap.get(event.key) === "") {
+                // Not interested in this key. Allow it to undergo normal
+                // shortcut processing (i.e. trigger an action, if it's been
+                // assigned one in Preferences that's valid in this context).
+                return;
+            }
+
+            // Intercept key for use in Keys.onPressed (below). This prevents
+            // it from triggering actions it's assigned to in Preferences.
+            // Note: users can reassign shortcuts to use keys that aren't
+            // blocked. Conclusion: we can block keys here but not actions.
+            event.accepted = true;
+            return;
+        }
+
         Keys.onPressed: function(event) {
-            if (event.key === Qt.Key_Tab) {
+            if (event.key === Qt.Key_Tab
+                    || event.key === Qt.Key_Backtab
+                    || event.key === Qt.Key_F6
+                    || event.key === Qt.Key_QuoteLeft) {
                 //! NOTE: We need to handle Tab key here because https://doc.qt.io/qt-5/qml-qtquick-controls2-textarea.html#tab-focus
                 //!       and we don't use qt navigation system
-                if (textInputModel.handleShortcut(Qt.Key_Tab, Qt.NoModifier)) {
+                if (textInputModel.handleShortcut(event.key, event.modifiers)) {
                     brailleTextArea.focus = false;
                     event.accepted = true;
                     return;
                 }
             }
+
+            // Note: Subsequent keys must be accepted in Keys.onShortcutOverride (above).
 
             if (event.key !== Qt.Key_Shift
                 && event.key !== Qt.Key_Alt


### PR DESCRIPTION
Resolves: #30563

It looks like Qt 6.9.2/3 fixed a bug where `Keys.onPressed` was being called before shortcuts were processed rather than after it. This Qt bug masked a problem in our code, namely that we weren't calling `Keys.onShortcutOverride`. Now that the Qt bug is fixed, we have no choice but to use `Keys.onShortcutOverride`.

@MarcSabatella [mentioned](https://github.com/musescore/MuseScore/issues/30343#issuecomment-3390481797) that the Braille panel has never worked for him on Linux. I'm guessing that's because the Qt bug never existed on Linux. If so, there's a chance that this PR also gets the Braille panel working on Linux, but I don't have a Linux machine to test with right now.