### PR TITLE
[4.6.3] CI. Backend. Fonts override fix

### DIFF
--- a/buildscripts/ci/backend/docker/setup.sh
+++ b/buildscripts/ci/backend/docker/setup.sh
@@ -103,7 +103,7 @@ cd fonts-main
 
 echo "Installing Google Fonts..."
 mkdir -p "$FONTS_DIR"
-find . -type f \( -iname "*.ttf" -o -iname "*.otf" \) -print0 | xargs -0 -r mv -t "$FONTS_DIR"
+find . -type f \( -iname "*.ttf" -o -iname "*.otf" \) -print0 | xargs -0 -r mv -n -t "$FONTS_DIR"
 
 echo "Installing Fonts Cache..."
 fc-cache -f -v


### PR DESCRIPTION
```
#8 207.8 + xargs -0 -r mv -t /root/.local/share/fonts
#8 207.9 mv: will not overwrite just-created '/root/.local/share/fonts/NotoSansNKo-Regular.ttf' with './ofl/notosansnko_todelist/NotoSansNKo-Regular.ttf'
#8 208.0 mv: will not overwrite just-created '/root/.local/share/fonts/OpenSans-Italic[wdth,wght].ttf' with './axisregistry/tests/data/OpenSans-Italic[wdth,wght].ttf'
#8 208.0 mv: will not overwrite just-created '/root/.local/share/fonts/OpenSans[wdth,wght].ttf' with './axisregistry/tests/data/OpenSans[wdth,wght].ttf'
#8 ERROR: process "/bin/sh -c bash -ex setup.sh" did not complete successfully: exit code: 123
```