### PR TITLE
Fix: restore double-click for Header/Footer dialog and reduce EditStyle dialog delay

### DIFF
--- a/src/notation/view/widgets/editstyle.cpp
+++ b/src/notation/view/widgets/editstyle.cpp
@@ -228,11 +228,22 @@ static void fillDynamicHairpinComboBox(QComboBox* comboBox)
 EditStyle::EditStyle(QWidget* parent)
     : QDialog(parent), muse::Injectable(muse::iocCtxForQWidget(this))
 {
-    //! NOTE: suppress all accessibility events causing a long delay when opening the dialog (massive spam from setupUi)
-    accessibilityController()->setIgnoreQtAccessibilityEvents(true);
-    DEFER {
-        accessibilityController()->setIgnoreQtAccessibilityEvents(false);
+   // RAII class to block accessibility events temporarily
+    class AccessibilityBlocker {
+    public:
+        AccessibilityBlocker() {
+            accessibilityController()->setIgnoreQtAccessibilityEvents(true);
+        }
+        ~AccessibilityBlocker() {
+            accessibilityController()->setIgnoreQtAccessibilityEvents(false);
+        }
     };
+
+    AccessibilityBlocker blocker; // events suppressed within this scope
+
+    // Dialog UI setup
+    setupUi(this);
+
 
     setObjectName("EditStyle");
     setupUi(this);


### PR DESCRIPTION
This PR fixes two issues in MuseScore 4:

Double-clicking a header or footer no longer opens the Header/Footer dialog (regression from MuseScore 3).

Long delay (>5 seconds) when opening the dialog from the menu (Format → Style → Header/Footer) caused by excessive Qt accessibility events during UI setup.