### PR TITLE
Update link to coding rules in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@ Resolves: #NNNNN <!-- Replace `NNNNN` with a GitHub issue number, or a direct li
 - [ ] The title of the PR describes the problem it addresses
 - [ ] Each commit's message describes its purpose and effects, and references the issue it resolves
 - [ ] If changes are extensive, there is a sequence of easily reviewable commits
-- [ ] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
+- [ ] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
 - [ ] There are no unnecessary changes
 - [ ] The code compiles and runs on my machine, preferably after each commit individually
 - [ ] I created a unit test or vtest to verify the changes I made (if applicable)


### PR DESCRIPTION
Update link to coding rules in PR template

Resolves: #30705 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [ ] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](../../muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)