### PR TITLE
Don't show measure number if all staves invisible

### DIFF
--- a/src/engraving/dom/measure.cpp
+++ b/src/engraving/dom/measure.cpp
@@ -604,7 +604,7 @@ bool Measure::showMeasureNumberOnStaff(staff_idx_t staffIdx)
         return false;
     }
 
-    return showMeasureNumber() && score()->staff(staffIdx)->shouldShowMeasureNumbers();
+    return showMeasureNumber() && score()->staff(staffIdx)->shouldShowMeasureNumbers() && !score()->allStavesInvisible();
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -5832,6 +5832,17 @@ size_t Score::visibleStavesCount() const
     return count;
 }
 
+bool Score::allStavesInvisible() const
+{
+    for (const Staff* staff : m_staves) {
+        if (staff->show()) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 ShadowNote* Score::shadowNote() const
 {
     return m_shadowNote;

--- a/src/engraving/dom/score.h
+++ b/src/engraving/dom/score.h
@@ -458,6 +458,7 @@ public:
     const std::vector<Staff*>& staves() const { return m_staves; }
     size_t nstaves() const { return m_staves.size(); }
     size_t visibleStavesCount() const;
+    bool allStavesInvisible() const;
     size_t ntracks() const { return m_staves.size() * VOICES; }
 
     staff_idx_t staffIdx(const Staff*) const;


### PR DESCRIPTION
Resolves: #30578

This is the safe part of the fix which should be ported to 4.6.4. A second part to the fix is coming which should only be merged to master. (https://github.com/musescore/MuseScore/pull/30715)