### PR TITLE
Remove children from skyline when clearing old system

### DIFF
--- a/src/engraving/rendering/score/systemlayout.cpp
+++ b/src/engraving/rendering/score/systemlayout.cpp
@@ -2954,7 +2954,7 @@ void SystemLayout::removeElementFromSkyline(EngravingItem* element, const System
     SkylineLine& skylineLine = isAbove ? skyline.north() : skyline.south();
 
     skylineLine.remove_if([element](ShapeElement& shapeEl) {
-        return element == shapeEl.item();
+        return element == shapeEl.item() || element == shapeEl.item()->parentItem();
     });
 }
 


### PR DESCRIPTION
Resolves: #30709 
The affected all chord symbols. There were stale parentheses left in the skyline which need to be removed.