### PR TITLE
Fix and simplify layout if all staves invisible

### DIFF
--- a/src/engraving/dom/measure.cpp
+++ b/src/engraving/dom/measure.cpp
@@ -604,7 +604,7 @@ bool Measure::showMeasureNumberOnStaff(staff_idx_t staffIdx)
         return false;
     }
 
-    return showMeasureNumber() && score()->staff(staffIdx)->shouldShowMeasureNumbers();
+    return showMeasureNumber() && score()->staff(staffIdx)->shouldShowMeasureNumbers() && !score()->allStavesInvisible();
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -5832,6 +5832,17 @@ size_t Score::visibleStavesCount() const
     return count;
 }
 
+bool Score::allStavesInvisible() const
+{
+    for (const Staff* staff : m_staves) {
+        if (staff->show()) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 ShadowNote* Score::shadowNote() const
 {
     return m_shadowNote;

--- a/src/engraving/dom/score.h
+++ b/src/engraving/dom/score.h
@@ -458,6 +458,7 @@ public:
     const std::vector<Staff*>& staves() const { return m_staves; }
     size_t nstaves() const { return m_staves.size(); }
     size_t visibleStavesCount() const;
+    bool allStavesInvisible() const;
     size_t ntracks() const { return m_staves.size() * VOICES; }
 
     staff_idx_t staffIdx(const Staff*) const;

--- a/src/engraving/rendering/score/horizontalspacing.cpp
+++ b/src/engraving/rendering/score/horizontalspacing.cpp
@@ -48,6 +48,10 @@ double HorizontalSpacing::computeSpacingForFullSystem(System* system, double str
 {
     TRACEFUNC;
 
+    if (system->score()->allStavesInvisible()) {
+        return 0.0;
+    }
+
     HorizontalSpacingContext ctx;
     ctx.system = system;
     ctx.spatium = system->spatium();
@@ -85,6 +89,10 @@ double HorizontalSpacing::computeSpacingForFullSystem(System* system, double str
 double HorizontalSpacing::updateSpacingForLastAddedMeasure(System* system, bool startOfContinuousLayoutRegion)
 {
     TRACEFUNC;
+
+    if (system->score()->allStavesInvisible()) {
+        return 0.0;
+    }
 
     HorizontalSpacingContext ctx;
     ctx.system = system;

--- a/src/engraving/rendering/score/layoutcontext.cpp
+++ b/src/engraving/rendering/score/layoutcontext.cpp
@@ -229,6 +229,14 @@ const Staff* DomAccessor::staff(staff_idx_t idx) const
     return score()->staff(idx);
 }
 
+bool DomAccessor::allStavesInvisible() const
+{
+    IF_ASSERT_FAILED(score()) {
+        return false;
+    }
+    return score()->allStavesInvisible();
+}
+
 size_t DomAccessor::ntracks() const
 {
     IF_ASSERT_FAILED(score()) {

--- a/src/engraving/rendering/score/layoutcontext.h
+++ b/src/engraving/rendering/score/layoutcontext.h
@@ -156,6 +156,7 @@ public:
     size_t nstaves() const;
     const std::vector<Staff*>& staves() const;
     const Staff* staff(staff_idx_t idx) const;
+    bool allStavesInvisible() const;
 
     size_t ntracks() const;
 

--- a/src/engraving/rendering/score/measurelayout.cpp
+++ b/src/engraving/rendering/score/measurelayout.cpp
@@ -956,6 +956,10 @@ void MeasureLayout::layoutMeasure(MeasureBase* currentMB, LayoutContext& ctx)
         return;
     }
 
+    if (ctx.dom().allStavesInvisible()) {
+        return;
+    }
+
     // Check if requested cross-staff is possible
     // This must happen before cmdUpdateNotes
     checkStaffMoveValidity(measure, ctx);

--- a/src/engraving/rendering/score/systemlayout.cpp
+++ b/src/engraving/rendering/score/systemlayout.cpp
@@ -350,7 +350,7 @@ System* SystemLayout::collectSystem(LayoutContext& ctx)
         }
     }
 
-    if (system->staves().empty()) {
+    if (ctx.dom().allStavesInvisible()) {
         // Edge case. Can only happen if all instruments have been deleted.
         return system;
     }


### PR DESCRIPTION
Resolves: #30578

Second part of the fix (this should NOT be ported to 4.6.4). Please merge #30713 first.

Part of the issue results from the fact that, when all staves are hidden, some (but not all) layout steps are skipped, and as a result the horizontal spacing logic computes garbage (in fact we also get an assertion failure when trying to justify the empty system). It's worth introducing some more checks to make sure that in this edge case we skip all the unnecessary calculations and, in the case of horizontal spacing, just return zero.