### PR TITLE
Create debug option for showing gap rests

### DIFF
--- a/src/appshell/view/appmenumodel.cpp
+++ b/src/appshell/view/appmenumodel.cpp
@@ -527,6 +527,7 @@ MenuItem* AppMenuModel::makeDiagnosticsMenu()
             makeMenuItem("show-skylines"),
             makeMenuItem("show-system-bounding-rects"),
             makeMenuItem("show-element-masks"),
+            makeMenuItem("show-gap-rests"),
             makeMenuItem("show-line-attach-points"),
             makeMenuItem("mark-empty-staff-visibility-overrides"),
             makeMenuItem("mark-corrupted-measures"),

--- a/src/engraving/dom/rest.cpp
+++ b/src/engraving/dom/rest.cpp
@@ -440,7 +440,7 @@ void Rest::scanElements(void* data, void (* func)(void*, EngravingItem*), bool a
     for (NoteDot* dot : m_dots) {
         dot->scanElements(data, func, all);
     }
-    if (!isGap()) {
+    if (!isGap() || debugDrawGap()) {
         func(data, this);
     }
 }
@@ -746,6 +746,11 @@ bool Rest::shouldNotBeDrawn() const
     }
 
     return false;
+}
+
+bool Rest::debugDrawGap() const
+{
+    return configuration()->debuggingOptions().showGapRests;
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/rest.h
+++ b/src/engraving/dom/rest.h
@@ -128,6 +128,7 @@ public:
     String screenReaderInfo() const override;
 
     bool shouldNotBeDrawn() const;
+    bool debugDrawGap() const;
 
     RestVerticalClearance& verticalClearance() { return m_verticalClearance; }
 

--- a/src/engraving/iengravingconfiguration.h
+++ b/src/engraving/iengravingconfiguration.h
@@ -109,6 +109,7 @@ public:
         bool showLineAttachPoints = false;
         bool markEmptyStaffVisibilityOverrides = false;
         bool markCorruptedMeasures = true;
+        bool showGapRests = false;
 
         bool anyEnabled() const
         {
@@ -122,6 +123,7 @@ public:
                    || showLineAttachPoints
                    || markEmptyStaffVisibilityOverrides
                    || markCorruptedMeasures
+                   || showGapRests
             ;
         }
     };

--- a/src/engraving/rendering/score/restlayout.cpp
+++ b/src/engraving/rendering/score/restlayout.cpp
@@ -36,6 +36,13 @@ namespace mu::engraving::rendering::score {
 void RestLayout::layoutRest(const Rest* item, Rest::LayoutData* ldata, const LayoutContext& ctx)
 {
     if (item->isGap()) {
+        if (item->debugDrawGap()) {
+            ldata->sym = item->getSymbol(item->durationType().type(), 16, 5);
+            fillShape(item, ldata, ctx.conf());
+            ldata->setPos(PointF(0.0, 10 * item->spatium()));
+        } else {
+            ldata->reset();
+        }
         return;
     }
 
@@ -641,7 +648,7 @@ void RestLayout::fillShape(const Rest* item, Rest::LayoutData* ldata)
 {
     Shape shape(Shape::Type::Composite);
 
-    if (!item->isGap() && !item->shouldNotBeDrawn()) {
+    if ((!item->isGap() || item->debugDrawGap()) && !item->shouldNotBeDrawn()) {
         shape.add(ChordLayout::chordRestShape(item));
         shape.add(item->symBbox(ldata->sym), item);
         for (const NoteDot* dot : item->dotList()) {

--- a/src/engraving/rendering/score/tdraw.cpp
+++ b/src/engraving/rendering/score/tdraw.cpp
@@ -2441,6 +2441,12 @@ void TDraw::draw(const RehearsalMark* item, Painter* painter, const PaintOptions
 void TDraw::draw(const Rest* item, Painter* painter, const PaintOptions& opt)
 {
     TRACE_DRAW_ITEM;
+
+    if (item->isGap()) {
+        drawDebugGapRest(item, painter);
+        return;
+    }
+
     if (item->shouldNotBeDrawn()) {
         return;
     }
@@ -2454,6 +2460,16 @@ void TDraw::draw(const Rest* item, Painter* painter, const PaintOptions& opt)
     } else {
         item->drawSymbol(ldata->sym, painter);
     }
+}
+
+void TDraw::drawDebugGapRest(const Rest* item, muse::draw::Painter* painter)
+{
+    IF_ASSERT_FAILED(item->debugDrawGap()) {
+        return;
+    }
+
+    painter->setPen(Color::RED);
+    item->drawSymbol(item->ldata()->sym, painter);
 }
 
 //! NOTE May be removed later (should be only single mode)

--- a/src/engraving/rendering/score/tdraw.h
+++ b/src/engraving/rendering/score/tdraw.h
@@ -276,6 +276,7 @@ private:
     static void draw(const RasgueadoSegment* item, muse::draw::Painter* painter, const PaintOptions& opt);
     static void draw(const RehearsalMark* item, muse::draw::Painter* painter, const PaintOptions& opt);
     static void draw(const Rest* item, muse::draw::Painter* painter, const PaintOptions& opt);
+    static void drawDebugGapRest(const Rest* item, muse::draw::Painter* painter);
 
     static void draw(const ShadowNote* item, muse::draw::Painter* painter, const PaintOptions& opt);
     static void draw(const SlurSegment* item, muse::draw::Painter* painter, const PaintOptions& opt);

--- a/src/engraving/tests/environment.cpp
+++ b/src/engraving/tests/environment.cpp
@@ -56,6 +56,9 @@ static muse::testing::SuiteEnvironment engraving_se(
     ON_CALL(*configurator, isAccessibleEnabled()).WillByDefault(::testing::Return(false));
     ON_CALL(*configurator, defaultColor()).WillByDefault(::testing::Return(muse::draw::Color::BLACK));
 
+    mu::engraving::IEngravingConfiguration::DebuggingOptions debugOpt {};
+    ON_CALL(*configurator, debuggingOptions()).WillByDefault(::testing::ReturnRef(debugOpt));
+
     muse::modularity::globalIoc()->unregister<mu::engraving::IEngravingConfiguration>("utests");
     muse::modularity::globalIoc()->registerExport<mu::engraving::IEngravingConfiguration>("utests", configurator);
 },

--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -334,6 +334,8 @@ public:
     virtual muse::async::Channel<ShowItemRequest> showItemRequested() const = 0;
 
     virtual void setGetViewRectFunc(const std::function<muse::RectF()>& func) = 0;
+
+    virtual void toggleDebugShowGapRests() = 0;
 };
 
 using INotationInteractionPtr = std::shared_ptr<INotationInteraction>;

--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -75,7 +75,8 @@ const std::unordered_map<ActionCode, bool EngravingDebuggingOptions::*> Notation
     { "show-element-masks", &EngravingDebuggingOptions::showElementMasks },
     { "show-line-attach-points", &EngravingDebuggingOptions::showLineAttachPoints },
     { "mark-empty-staff-visibility-overrides", &EngravingDebuggingOptions::markEmptyStaffVisibilityOverrides },
-    { "mark-corrupted-measures", &EngravingDebuggingOptions::markCorruptedMeasures }
+    { "mark-corrupted-measures", &EngravingDebuggingOptions::markCorruptedMeasures },
+    { "show-gap-rests", &EngravingDebuggingOptions::showGapRests }
 };
 
 //! NOTE Just for more readable
@@ -558,8 +559,12 @@ void NotationActionController::init()
     for (auto& [code, member] : engravingDebuggingActions) {
         dispatcher()->reg(this, code, [this, member = member]() {
             EngravingDebuggingOptions options = engravingConfiguration()->debuggingOptions();
+            bool showGapRests = options.showGapRests;
             options.*member = !(options.*member);
             engravingConfiguration()->setDebuggingOptions(options);
+            if (options.showGapRests != showGapRests) {
+                currentNotation()->interaction()->toggleDebugShowGapRests();
+            }
         });
     }
     dispatcher()->reg(this, "check-for-score-corruptions", [this] { checkForScoreCorruptions(); });

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -8264,6 +8264,14 @@ void NotationInteraction::showItem(const mu::engraving::EngravingItem* el, int s
     m_showItemRequested.send(request);
 }
 
+void NotationInteraction::toggleDebugShowGapRests()
+{
+    // Doesn't perform any action on the score, just triggers the necessary relayout
+    startEdit(TranslatableString("debugOption", "Toggle show gap rests"));
+    score()->setLayoutAll();
+    apply();
+}
+
 muse::async::Channel<NotationInteraction::ShowItemRequest> NotationInteraction::showItemRequested() const
 {
     return m_showItemRequested;

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -338,6 +338,8 @@ public:
 
     void setGetViewRectFunc(const std::function<muse::RectF()>& func) override;
 
+    void toggleDebugShowGapRests() override;
+
 private:
     mu::engraving::Score* score() const;
     void onScoreInited();

--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -2698,6 +2698,13 @@ const UiActionList NotationUiActions::s_engravingDebuggingActions = {
              TranslatableString("action", "Mark corrupted measures"),
              Checkable::Yes
              ),
+    UiAction("show-gap-rests",
+             mu::context::UiCtxProjectOpened,
+             mu::context::CTX_NOTATION_OPENED,
+             TranslatableString("action", "Show gap rests"),
+             TranslatableString("action", "Show gap rests"),
+             Checkable::Yes
+             ),
     UiAction("check-for-score-corruptions",
              mu::context::UiCtxProjectOpened,
              mu::context::CTX_NOTATION_OPENED,

--- a/src/notation/tests/mocks/notationinteractionmock.h
+++ b/src/notation/tests/mocks/notationinteractionmock.h
@@ -287,5 +287,6 @@ public:
     MOCK_METHOD(muse::async::Channel<ShowItemRequest>, showItemRequested, (), (const, override));
 
     MOCK_METHOD(void, setGetViewRectFunc, (const std::function<muse::RectF()>&), (override));
+    MOCK_METHOD(void, toggleDebugShowGapRests, (), (override));
 };
 }


### PR DESCRIPTION
Gap rests have always been problematic for several reasons, but one of the main reasons is that they can never be seen so it always takes a _lot_ of time to debug anything that goes wrong with them.

The implementation of this option is a bit ugly because, unlike all other debug painting options which just draw things on top of the notation, this needs to draw an actual score element that is normally not drawn. This also implies some changes to the layout code (because if we need to draw gap rests we also need to lay them out, or at least give them a bounding rectangle and set them in some position, otherwise they won't be drawn), which in turns requires to trigger a relayout when this option is toggled on. Not very nice, I'll admit, but worth it I think, given how useful this can be.

<img width="2039" height="1677" alt="image" src="https://github.com/user-attachments/assets/b2f30fce-e5a7-493d-8d41-f5aa3cdb9352" />
