### PR TITLE
Fix #30701: Ensure top corners are rounded in Percussion Panel notation preview

### DIFF
--- a/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
+++ b/src/notation/qml/MuseScore/NotationScene/PercussionPanel.qml
@@ -287,6 +287,7 @@ Item {
                         panelMode: percModel.currentPanelMode
                         useNotationPreview: percModel.useNotationPreview
                         notationPreviewNumStaffLines: percModel.notationPreviewNumStaffLines
+                        notationPreviewBackgroundColor: percModel.notationPreviewBackgroundColor
 
                         // When swapping, only show the outline for the swap origin  and the swap target...
                         showEditOutline: percModel.currentPanelMode === PanelMode.EDIT_LAYOUT

--- a/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPad.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPad.qml
@@ -35,6 +35,7 @@ DropArea {
     property int panelMode: -1
     property bool useNotationPreview: false
     property int notationPreviewNumStaffLines: 0
+    property color notationPreviewBackgroundColor: Qt.transparent
     property bool showEditOutline: false
 
     property alias totalBorderWidth: padLoader.anchors.margins
@@ -203,6 +204,7 @@ DropArea {
                     panelMode: root.panelMode
                     useNotationPreview: root.useNotationPreview
                     notationPreviewNumStaffLines: root.notationPreviewNumStaffLines
+                    notationPreviewBackgroundColor: root.notationPreviewBackgroundColor
 
                     footerHeight: prv.footerHeight
 

--- a/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPadContent.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/PercussionPanelPadContent.qml
@@ -33,6 +33,7 @@ Column {
     property int panelMode: -1
     property bool useNotationPreview: false
     property alias notationPreviewNumStaffLines: notationPreview.numStaffLines
+    property color notationPreviewBackgroundColor: Qt.transparent
 
     property alias footerHeight: footerArea.height
 
@@ -50,6 +51,16 @@ Column {
         }
 
         menuLoader.show(pos, root.padModel.contextMenuItems)
+    }
+
+    QtObject {
+        id: prv
+
+        readonly property var currentColor: root.useNotationPreview ? root.notationPreviewBackgroundColor : ui.theme.accentColor
+
+        readonly property var currentOpacityNormal: root.useNotationPreview ? 0.9 : ui.theme.buttonOpacityNormal
+        readonly property var currentOpacityHover: root.useNotationPreview ? 0.7 : ui.theme.buttonOpacityHover
+        readonly property var currentOpacityHit: root.useNotationPreview ? 1.0 : ui.theme.buttonOpacityHit
     }
 
     Item {
@@ -98,15 +109,13 @@ Column {
         }
 
         RoundedRectangle {
-            id: padNameBackground
+            id: padBackground
 
-            visible: !root.useNotationPreview
+            color: Utils.colorWithAlpha(prv.currentColor, prv.currentOpacityNormal)
 
             anchors.fill: parent
             topLeftRadius: root.cornerRadius
             topRightRadius: root.cornerRadius
-
-            color: Utils.colorWithAlpha(ui.theme.accentColor, ui.theme.buttonOpacityNormal)
         }
 
         StyledTextLabel {
@@ -142,24 +151,16 @@ Column {
                 name: "MOUSE_HOVERED"
                 when: mouseArea.containsMouse && !mouseArea.pressed && !root.padSwapActive
                 PropertyChanges {
-                    target: padNameBackground
-                    color: Utils.colorWithAlpha(ui.theme.accentColor, ui.theme.buttonOpacityHover)
-                }
-                PropertyChanges {
-                    target: notationPreview
-                    opacity: 0.7
+                    target: padBackground
+                    color: Utils.colorWithAlpha(prv.currentColor, prv.currentOpacityHover)
                 }
             },
             State {
                 name: "MOUSE_HIT"
                 when: mouseArea.pressed || root.padSwapActive
                 PropertyChanges {
-                    target: padNameBackground
-                    color: Utils.colorWithAlpha(ui.theme.accentColor, ui.theme.buttonOpacityHit)
-                }
-                PropertyChanges {
-                    target: notationPreview
-                    opacity: 1.0
+                    target: padBackground
+                    color: Utils.colorWithAlpha(prv.currentColor, prv.currentOpacityHit)
                 }
             }
         ]

--- a/src/notation/view/paintedengravingitem.cpp
+++ b/src/notation/view/paintedengravingitem.cpp
@@ -109,7 +109,5 @@ void PaintedEngravingItem::paintNotationPreview(muse::draw::Painter& painter, qr
 
     params.numStaffLines = m_numStaffLines;
 
-    painter.fillRect(params.rect, configuration()->noteBackgroundColor());
-
     EngravingItemPreviewPainter::paintPreview(m_item.get(), params);
 }

--- a/src/notation/view/percussionpanel/percussionpanelmodel.cpp
+++ b/src/notation/view/percussionpanel/percussionpanelmodel.cpp
@@ -109,15 +109,15 @@ void PercussionPanelModel::setCurrentPanelMode(const PanelMode::Mode& panelMode)
 
 bool PercussionPanelModel::useNotationPreview() const
 {
-    return configuration()->percussionPanelUseNotationPreview();
+    return notationConfiguration()->percussionPanelUseNotationPreview();
 }
 
 void PercussionPanelModel::setUseNotationPreview(bool useNotationPreview)
 {
-    if (configuration()->percussionPanelUseNotationPreview() == useNotationPreview) {
+    if (notationConfiguration()->percussionPanelUseNotationPreview() == useNotationPreview) {
         return;
     }
-    configuration()->setPercussionPanelUseNotationPreview(useNotationPreview);
+    notationConfiguration()->setPercussionPanelUseNotationPreview(useNotationPreview);
 }
 
 int PercussionPanelModel::notationPreviewNumStaffLines() const
@@ -130,6 +130,12 @@ int PercussionPanelModel::notationPreviewNumStaffLines() const
     const Staff* staff = inputState.staff();
 
     return staff ? staff->lines(inputState.tick()) : 0;
+}
+
+QColor PercussionPanelModel::notationPreviewBackgroundColor() const
+{
+    const muse::Color color = engravingConfiguration()->noteBackgroundColor();
+    return color.toQColor();
 }
 
 PercussionPanelPadListModel* PercussionPanelModel::padListModel() const
@@ -351,8 +357,8 @@ void PercussionPanelModel::setUpConnections()
         });
     }
 
-    configuration()->percussionPanelUseNotationPreviewChanged().onNotify(this, [this]() {
-        const bool useNotationPreview = configuration()->percussionPanelUseNotationPreview();
+    notationConfiguration()->percussionPanelUseNotationPreviewChanged().onNotify(this, [this]() {
+        const bool useNotationPreview = notationConfiguration()->percussionPanelUseNotationPreview();
         emit useNotationPreviewChanged(useNotationPreview);
     });
 }
@@ -508,7 +514,7 @@ void PercussionPanelModel::writePitch(int pitch, const NoteAddingMode& addingMod
         return;
     }
 
-    interaction()->noteInput()->startNoteInput(configuration()->defaultNoteInputMethod(), /*focusNotation*/ false);
+    interaction()->noteInput()->startNoteInput(notationConfiguration()->defaultNoteInputMethod(), /*focusNotation*/ false);
 
     NoteInputParams params;
     params.drumPitch = pitch;

--- a/src/notation/view/percussionpanel/percussionpanelmodel.h
+++ b/src/notation/view/percussionpanel/percussionpanelmodel.h
@@ -57,7 +57,9 @@ class PercussionPanelModel : public QObject, public muse::Injectable, public mus
     muse::Inject<mu::playback::IPlaybackController> playbackController = { this };
     muse::Inject<muse::musesampler::IMuseSamplerInfo> museSampler;
     muse::Inject<IInstrumentsRepository> instrumentsRepository = { this };
-    muse::Inject<INotationConfiguration> configuration = { this };
+
+    muse::Inject<INotationConfiguration> notationConfiguration = { this };
+    muse::Inject<engraving::IEngravingConfiguration> engravingConfiguration = { this };
 
     Q_OBJECT
 
@@ -68,6 +70,7 @@ class PercussionPanelModel : public QObject, public muse::Injectable, public mus
     Q_PROPERTY(PanelMode::Mode currentPanelMode READ currentPanelMode WRITE setCurrentPanelMode NOTIFY currentPanelModeChanged)
     Q_PROPERTY(bool useNotationPreview READ useNotationPreview WRITE setUseNotationPreview NOTIFY useNotationPreviewChanged)
     Q_PROPERTY(int notationPreviewNumStaffLines READ notationPreviewNumStaffLines NOTIFY notationPreviewNumStaffLinesChanged)
+    Q_PROPERTY(QColor notationPreviewBackgroundColor READ notationPreviewBackgroundColor CONSTANT)
 
     Q_PROPERTY(PercussionPanelPadListModel * padListModel READ padListModel NOTIFY padListModelChanged)
 
@@ -86,6 +89,7 @@ public:
     void setUseNotationPreview(bool useNotationPreview);
 
     int notationPreviewNumStaffLines() const;
+    QColor notationPreviewBackgroundColor() const;
 
     PercussionPanelPadListModel* padListModel() const;
 


### PR DESCRIPTION
Resolves: #30701

This bug was caused by #28365 when we took away the `EffectOpacityMask`. The solution proposed here is to stop drawing the background with `PaintedEngravingItem` and instead use the existing `padNameBackground` (now just `padBackground`) for both pad names and notation preview modes.

These changes will also come in handy if/when we implement score inversion in the percussion panel.