### PR TITLE
Fix double subcribe in NotationProject

### DIFF
--- a/src/project/internal/notationproject.cpp
+++ b/src/project/internal/notationproject.cpp
@@ -345,10 +345,6 @@ Ret NotationProject::createNew(const ProjectCreateOptions& projectOptions)
     // Load template if present
     if (!projectOptions.templatePath.empty()) {
         Ret ret = loadTemplate(projectOptions);
-        if (ret) {
-            listenIfNeedSaveChanges();
-        }
-
         return ret;
     }
 


### PR DESCRIPTION
Subscription is already done by `load`, called by `loadTemplate`