### PR TITLE
[10664-widen_tab_inuput_cursor] Fix #10664 - widen input cursor on tablature

### DIFF
--- a/src/notation/internal/notationnoteinput.cpp
+++ b/src/notation/internal/notationnoteinput.cpp
@@ -751,7 +751,9 @@ muse::RectF NotationNoteInput::cursorRect() const
         return {};
     }
 
-    constexpr int sideMargin = 4;
+    const bool isTabStaff = staff->isTabStaff(inputState.tick());
+
+    const int sideMargin = isTabStaff ? 12 : 4;
     constexpr int skylineMargin = 20;
 
     RectF segmentContentRect = segment->contentRect();
@@ -770,12 +772,10 @@ muse::RectF NotationNoteInput::cursorRect() const
     y += yOffset;
 
     int instrumentStringsCount = static_cast<int>(staff->part()->instrument()->stringData()->strings());
-    if (staff->isTabStaff(inputState.tick()) && inputStateStringsCount >= 0 && inputStateStringsCount <= instrumentStringsCount) {
+    if (isTabStaff && inputStateStringsCount >= 0 && inputStateStringsCount <= instrumentStringsCount) {
         h = lineDist;
         y += staffType->physStringToYOffset(inputStateStringsCount) * spatium;
         y -= (staffType->onLines() ? lineDist * 0.5 : lineDist);
-        x -= 2 * sideMargin;
-        w += 4 * sideMargin;
     } else {
         h = (lines - 1) * lineDist + 2 * skylineMargin;
         y -= skylineMargin;


### PR DESCRIPTION

Resolves: https://github.com/musescore/MuseScore/issues/10664

The input cursor for the tablature was smaller than in MU3.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [N/A] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [N/A] I created a unit test or vtest to verify the changes I made (if applicable)
