### PR TITLE
Optimize ContinuousPanel

### DIFF
--- a/src/notation/view/continuouspanel.h
+++ b/src/notation/view/continuouspanel.h
@@ -22,6 +22,8 @@
 
 #pragma once
 
+#include <vector>
+
 #include "modularity/ioc.h"
 #include "notation/inotationconfiguration.h"
 #include "engraving/iengravingconfiguration.h"
@@ -68,19 +70,18 @@ public:
     void paint(muse::draw::Painter& painter, const NotationViewContext& ctx, const engraving::rendering::PaintOptions& opt);
 
 private:
-    qreal styleMM(const mu::engraving::Sid styleId) const;
-    const mu::engraving::Score* score() const;
     void clearCache();
+    void ensureCacheSize(size_t staffCount);
 
     INotationPtr m_notation;
     qreal m_width = 0;
     muse::RectF m_rect;
 
-    mu::engraving::Text* m_cachedText = nullptr;
-    mu::engraving::Text* m_cachedName = nullptr;
-    mu::engraving::Clef* m_cachedClef = nullptr;
-    mu::engraving::KeySig* m_cachedKeySig = nullptr;
-    mu::engraving::TimeSig* m_cachedTimeSig = nullptr;
-    mu::engraving::BarLine* m_cachedBarLine = nullptr;
+    mu::engraving::Text* m_cachedMeasureNumberText = nullptr;
+    std::vector<mu::engraving::Text*> m_cachedStaffNameTexts;
+    std::vector<mu::engraving::Clef*> m_cachedClefs;
+    std::vector<mu::engraving::KeySig*> m_cachedKeySigs;
+    std::vector<mu::engraving::TimeSig*> m_cachedTimeSigs;
+    std::vector<mu::engraving::BarLine*> m_cachedBarLines;
 };
 }


### PR DESCRIPTION
Should make screen redrawing in continuous view a little bit more efficient. Scrolling around should become a tiny bit smoother. On the other hand, no significant performance improvements are expected for editing actions; those namely depend on layout.

Some measurements (of highly questionable quality):

Before:
```
AbstractNotationPaintView::paint                            35.464 ms         336               11915.779 ms      
ContinuousPanel::paint                                      22.052 ms         336               7409.591 ms       
NotationPainting::doPaint                                   12.768 ms         336               4289.977 ms       
```

After first commit:
```
AbstractNotationPaintView::paint                            40.732 ms         385               15681.677 ms      
ContinuousPanel::paint                                      20.413 ms         385               7858.888 ms       
NotationPainting::doPaint                                   19.677 ms         385               7575.621 ms       
```

After:
```
AbstractNotationPaintView::paint                            21.897 ms         751               16444.484 ms      
NotationPainting::doPaint                                   12.790 ms         751               9605.352 ms       
Paint::paintScore                                           12.777 ms         751               9595.585 ms       
Paint::paintItems                                           11.118 ms         751               8349.810 ms       
Paint::paintItem                                            0.022 ms          343730            7513.909 ms       
ContinuousPanel::paint                                      8.473 ms          751               6362.911 ms       
```