### PR TITLE
Account for continuous panel when playing back in continuous view

### DIFF
--- a/src/notation/view/abstractnotationpaintview.cpp
+++ b/src/notation/view/abstractnotationpaintview.cpp
@@ -927,6 +927,14 @@ bool AbstractNotationPaintView::adjustCanvasPosition(const RectF& logicRect, boo
     TRACEFUNC;
 
     RectF viewRect = viewport();
+    PointF pos = viewRect.topLeft();
+
+    // Account for continuous panel if panning in continuous view
+    qreal continuousPanelWidth = 0;
+    if (notation()->viewMode() == engraving::LayoutMode::LINE) {
+        continuousPanelWidth = m_continuousPanel->width();
+    }
+    viewRect.adjust(continuousPanelWidth, 0, 0, 0);
 
     double viewArea = viewRect.width() * viewRect.height();
     double logicRectArea = logicRect.width() * logicRect.height();
@@ -948,17 +956,16 @@ bool AbstractNotationPaintView::adjustCanvasPosition(const RectF& logicRect, boo
         _scale = 1;
     }
 
-    PointF pos = viewRect.topLeft();
     PointF oldPos = pos;
 
     RectF showRect = logicRect;
 
     if (showRect.left() < viewRect.left()) {
-        pos.setX(showRect.left() - border);
+        pos.setX(showRect.left() - border - continuousPanelWidth);
     } else if (showRect.left() > viewRect.right()) {
         pos.setX(showRect.right() - width() / _scale + border);
     } else if (viewRect.width() >= showRect.width() && showRect.right() > viewRect.right()) {
-        pos.setX(showRect.left() - border);
+        pos.setX(showRect.left() - border - continuousPanelWidth);
     }
 
     if (adjustVertically) {

--- a/src/notation/view/continuouspanel.cpp
+++ b/src/notation/view/continuouspanel.cpp
@@ -109,6 +109,11 @@ void ContinuousPanel::setNotation(INotationPtr notation)
     m_notation = notation;
 }
 
+qreal ContinuousPanel::width() const
+{
+    return m_width;
+}
+
 void ContinuousPanel::paint(Painter& painter, const NotationViewContext& ctx, const engraving::rendering::PaintOptions& opt)
 {
     TRACEFUNC;

--- a/src/notation/view/continuouspanel.h
+++ b/src/notation/view/continuouspanel.h
@@ -67,6 +67,7 @@ public:
         std::function<muse::PointF(const muse::PointF&)> fromLogical;
     };
 
+    qreal width() const;
     void paint(muse::draw::Painter& painter, const NotationViewContext& ctx, const engraving::rendering::PaintOptions& opt);
 
 private:


### PR DESCRIPTION
Resolves: #16173  <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->
Resolves: https://github.com/musescore/MuseScore/issues/29928

<!-- Add a short description of and motivation for the changes here -->
Previously, when playing back music in continuous view mode, the sticky header, the ContinuousPanel, would cover up some of the music; the width of the header was rendered retrievable and the `AbstractNotationPaintView::adjustCanvasPosition` method modified to account for it, which prevents the playback cursor - or the selected element or range, or any other object of focus - from being covered by it.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
