### PR TITLE
Fix measure number collides with bracket

### DIFF
--- a/src/engraving/rendering/score/measurenumberlayout.cpp
+++ b/src/engraving/rendering/score/measurenumberlayout.cpp
@@ -136,7 +136,9 @@ void MeasureNumberLayout::layoutMeasureNumberBase(MeasureNumberBase* item, Measu
         double yoff = 0.0;
 
         // If there is only one line, the barline spans outside the staff lines, so the default position is not correct.
-        if (item->staff()->constStaffType(item->measure()->tick())->lines() == 1) {
+        staff_idx_t effectiveStaffIdx = item->effectiveStaffIdx();
+        Staff* staff = item->score()->staff(effectiveStaffIdx);
+        if (staff && staff->lines(item->tick()) == 1) {
             yoff -= 2.0 * item->spatium();
         }
 


### PR DESCRIPTION
Resolves: #30707

Should use effectiveStaffIdx as opposed to checking its "original" staff because staves may be hidden in between.
