### PR TITLE
Style Score/Part tabs like Panel tabs

### DIFF
--- a/src/notation/qml/MuseScore/NotationScene/internal/NotationSwitchButton.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/NotationSwitchButton.qml
@@ -38,8 +38,10 @@ FlatRadioButton {
 
     signal closeRequested()
 
+    readonly property real actualHeight: 34
+
     implicitWidth: Math.min(200, implicitContentWidth)
-    implicitHeight: ListView.view.height
+    implicitHeight: actualHeight + 1 // For separator
 
     padding: 0
 

--- a/src/notation/qml/MuseScore/NotationScene/internal/NotationSwitchPanel.qml
+++ b/src/notation/qml/MuseScore/NotationScene/internal/NotationSwitchPanel.qml
@@ -30,7 +30,7 @@ import MuseScore.NotationScene 1.0
 Rectangle {
     id: root
 
-    height: 26
+    height: 34
     visible: notationsView.count > 0
     color: ui.theme.backgroundSecondaryColor
 


### PR DESCRIPTION
Resolves: #23377
Style Score/Part tabs like Panel tabs. Specifically 3 changes:
1. heights are now consistent
2. background color states are now consistent
3. active score/part tab text is now bold, matching panel active state.
<img width="1278" height="640" alt="Screenshot 2025-10-27 at 10 29 18 AM" src="https://github.com/user-attachments/assets/8315e4b7-5fc3-4eea-b0ba-79ba513c2ea2" />
<img width="1278" height="640" alt="Screenshot 2025-10-27 at 10 30 51 AM" src="https://github.com/user-attachments/assets/bfb71fd6-6d88-45b8-9bb1-302f26a515cd" />


- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
