### PR TITLE
Fix missing accidentals in MuseScore Legacy chord symbols

### DIFF
--- a/src/engraving/rendering/score/harmonylayout.cpp
+++ b/src/engraving/rendering/score/harmonylayout.cpp
@@ -805,7 +805,6 @@ void HarmonyLayout::renderActionAcc(Harmony* item, Harmony::LayoutData* ldata, H
     String text = cs.isValid() ? cs.value : c;
     muse::draw::Font font = cs.isValid() ? ldata->fontList.value()[cs.fontIdx] : ldata->fontList.value().front();
     font.setPointSizeF(font.pointSizeF() * harmonyCtx.scale);
-    font.setNoFontMerging(true);
 
     TextSegment* ts = new TextSegment(text, font, harmonyCtx.x(), harmonyCtx.y(), harmonyCtx.hAlign);
     harmonyCtx.renderItemList.push_back(ts);
@@ -916,7 +915,6 @@ void HarmonyLayout::renderActionSet(Harmony* item, Harmony::LayoutData* ldata, c
 
 void HarmonyLayout::renderActionMove(Harmony* item, const RenderActionMovePtr& a, HarmonyRenderCtx& harmonyCtx)
 {
-    const FontMetrics fm = FontMetrics(item->font());
     const double scale = (a->scaled() ? harmonyCtx.scale : 1.0) * item->mag();
     harmonyCtx.pos = harmonyCtx.pos + a->vec() * FontMetrics::capHeight(item->font()) * scale;
 }


### PR DESCRIPTION
Resolves: #30727
I'm not entirely sure why I turned fontmerging off here. It doesn't seem to cause any problems with the new music text font accidentals.
