### PR TITLE
Fix crash on remove layout break from mmRest

### DIFF
--- a/src/engraving/editing/edit.cpp
+++ b/src/engraving/editing/edit.cpp
@@ -3022,7 +3022,7 @@ void Score::deleteItem(EngravingItem* el)
             // propagate to original measure
             m = m->mmRestLast();
             for (EngravingItem* e : m->el()) {
-                if (e->isLayoutBreak()) {
+                if (e->isLayoutBreak() && toLayoutBreak(e)->layoutBreakType() == toLayoutBreak(el)->layoutBreakType()) {
                     undoRemoveElement(e);
                     break;
                 }

--- a/src/engraving/rendering/score/measurelayout.cpp
+++ b/src/engraving/rendering/score/measurelayout.cpp
@@ -326,12 +326,15 @@ void MeasureLayout::createMMRest(LayoutContext& ctx, Measure* firstMeasure, Meas
             }
         }
         if (!found) {
-            mmrMeasure->add(e->isLayoutBreak() ? e->clone() : e->linkedClone());
+            EngravingItem* newEl = e->isLayoutBreak() ? e->clone() : e->linkedClone();
+            newEl->setParent(mmrMeasure);
+            ctx.mutDom().doUndoAddElement(newEl);
         }
     }
     for (EngravingItem* e : oldList) {
-        delete e;
+        ctx.mutDom().doUndoRemoveElement(e);
     }
+
     Segment* s = mmrMeasure->undoGetSegmentR(SegmentType::ChordRest, Fraction(0, 1));
     for (size_t staffIdx = 0; staffIdx < ctx.dom().nstaves(); ++staffIdx) {
         track_idx_t track = staffIdx * VOICES;


### PR DESCRIPTION
Resolves: #30451 

It is not ideal that the layout break has to be removed from two places (the multirest measure and the underlying empty measure) so this will need to be cleaned up at some point. For the moment, we can just fix the obvious mistake in the case of more than one layout break element of removing one type from the multirest and a different type from the measure.