### PR TITLE
fixed position of menu

### DIFF
--- a/src/framework/ui/internal/uiengine.cpp
+++ b/src/framework/ui/internal/uiengine.cpp
@@ -27,6 +27,8 @@
 #include <QStringList>
 #include <QDir>
 #include <QQmlContext>
+#include <QEventLoop>
+#include <QTimer>
 
 #include "global/types/color.h"
 #include "graphicsapiprovider.h"
@@ -263,4 +265,13 @@ GraphicsApi UiEngine::graphicsApi() const
 QString UiEngine::graphicsApiName() const
 {
     return GraphicsApiProvider::graphicsApiName();
+}
+
+void UiEngine::sleep(int msec)
+{
+    QEventLoop loop;
+    QTimer::singleShot(msec, [&loop]() {
+        loop.quit();
+    });
+    loop.exec();
 }

--- a/src/framework/ui/internal/uiengine.h
+++ b/src/framework/ui/internal/uiengine.h
@@ -96,6 +96,9 @@ public:
     bool isEffectsAllowed() const;
     bool isSystemDragSupported() const;
 
+    // dev
+    Q_INVOKABLE void sleep(int msec);
+
 public slots:
     void setRootItem(QQuickItem* rootItem);
 

--- a/src/framework/uicomponents/qml/Muse/UiComponents/StyledMenuLoader.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/StyledMenuLoader.qml
@@ -134,6 +134,9 @@ Loader {
 
         menu.closeSubMenu()
 
+        menu.model = model
+        menu.calculateSize()
+
         if (x !== -1) {
             menu.x = x
         }
@@ -141,10 +144,6 @@ Loader {
         if (y !== -1) {
             menu.y = y
         }
-
-        menu.model = model
-
-        Qt.callLater(menu.calculateSize)
     }
 
     Timer {

--- a/src/framework/uicomponents/qml/Muse/UiComponents/internal/StyledMenu.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/internal/StyledMenu.qml
@@ -55,10 +55,16 @@ MenuView {
         return focused
     }
 
+    property Component menuMetricsComponent: Component {
+        MenuMetrics{}
+    }
+
     function calculateSize() {
-        var menuMetricsComponent = Qt.createComponent("MenuMetrics.qml");
         root.menuMetrics = menuMetricsComponent.createObject(root)
         root.menuMetrics.calculate(model)
+
+        // for debuging
+        //ui.sleep(1000)
 
         //! NOTE: Due to the fact that the view has a dynamic delegate,
         //  the height calculation occurs with an error
@@ -84,6 +90,9 @@ MenuView {
         root.contentWidth = root.menuMetrics.itemWidth
         root.contentHeight = Math.min(itemHeight * itemsCount + sepCount * prv.separatorHeight +
                                       prv.viewVerticalMargin * 2, anchorItemHeight - padding * 2)
+
+        // for debuging
+        // ui.sleep(1000)
 
         x = 0
         y = parent.height


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/30569 

If you insert delays, you will see that the menu first appears above the desired position, then jumps to the desired position, because of this it visually looks like a glitch 
