### PR TITLE
Fix crash in debug mode

### DIFF
--- a/src/framework/global/thirdparty/kors_async/async/internal/channelimpl.h
+++ b/src/framework/global/thirdparty/kors_async/async/internal/channelimpl.h
@@ -112,7 +112,7 @@ private:
                 }
 
                 if (r) {
-                    assert(mode != Asyncable::Mode::SetOnce && "callback is already setted");
+                    assert(mode != Asyncable::Mode::SetOnce && "callback is already set");
                     if (mode == Asyncable::Mode::SetOnce) {
                         return needIncrement;
                     }

--- a/src/notation/view/abstractnotationpaintview.cpp
+++ b/src/notation/view/abstractnotationpaintview.cpp
@@ -133,7 +133,7 @@ void AbstractNotationPaintView::initNavigatorOrientation()
 {
     configuration()->canvasOrientation().ch.onReceive(this, [this](muse::Orientation) {
         moveCanvasToPosition(PointF(0, 0));
-    });
+    }, async::Asyncable::Mode::SetReplace);
 }
 
 void AbstractNotationPaintView::moveCanvasToCenter()
@@ -708,7 +708,7 @@ void AbstractNotationPaintView::onNotationSetup()
 
     uiConfiguration()->currentThemeChanged().onNotify(this, [this]() {
         scheduleRedraw();
-    });
+    }, async::Asyncable::Mode::SetReplace);
 
     engravingConfiguration()->debuggingOptionsChanged().onNotify(this, [this]() {
         scheduleRedraw();


### PR DESCRIPTION
Crashes on simply creating a new score (like from the treble clef template) or opening an existing score