### PR TITLE
Text layout refactor

### DIFF
--- a/src/engraving/dom/textbase.h
+++ b/src/engraving/dom/textbase.h
@@ -37,6 +37,10 @@ namespace mu::engraving {
 class TextBase;
 class TextBlock;
 
+static constexpr double SUBSCRIPT_SIZE     = 0.6;
+static constexpr double SUBSCRIPT_OFFSET   = 0.5;  // of x-height
+static constexpr double SUPERSCRIPT_OFFSET = -0.9; // of x-height
+
 //---------------------------------------------------------
 //   FrameType
 //---------------------------------------------------------
@@ -250,7 +254,6 @@ public:
     bool operator ==(const TextBlock& x) const { return m_fragments == x.m_fragments; }
     bool operator !=(const TextBlock& x) const { return m_fragments != x.m_fragments; }
     void draw(muse::draw::Painter*, const TextBase*) const;
-    void layout(const TextBase*);
     const std::list<TextFragment>& fragments() const { return m_fragments; }
     std::list<TextFragment>& fragments() { return m_fragments; }
     std::list<TextFragment> fragmentsWithoutEmpty();
@@ -273,6 +276,7 @@ public:
     double y() const { return m_y; }
     void setY(double val) { m_y = val; }
     double lineSpacing() const { return m_lineSpacing; }
+    void setLineSpacing(double val) { m_lineSpacing = val; }
     String text(int, int, bool = false) const;
     bool eol() const { return m_eol; }
     void setEol(bool val) { m_eol = val; }
@@ -280,7 +284,6 @@ public:
 
 private:
     void simplify();
-    double musicSymbolBaseLineAdjust(const TextBase* t, const TextFragment& f, const std::list<TextFragment>::iterator fi);
 
     std::list<TextFragment> m_fragments;
     double m_y = 0.0;

--- a/src/engraving/rendering/score/dynamicslayout.cpp
+++ b/src/engraving/rendering/score/dynamicslayout.cpp
@@ -23,6 +23,7 @@
 #include "dynamicslayout.h"
 #include "layoutcontext.h"
 #include "tlayout.h"
+#include "textlayout.h"
 
 #include "../dom/hairpin.h"
 #include "../dom/staff.h"
@@ -66,7 +67,7 @@ void DynamicsLayout::doLayoutDynamic(Dynamic* item, Dynamic::LayoutData* ldata, 
     AlignH userPosition = item->getProperty(Pid::POSITION).value<AlignH>();
     AlignH hPos = item->centerOnNotehead() ? AlignH::HCENTER : item->position();
     item->setPosition(hPos);
-    TLayout::layoutBaseTextBase(item, ldata);
+    TextLayout::layoutBaseTextBase(item, ldata);
     item->setPosition(userPosition);
 
     const Segment* s = item->segment();

--- a/src/engraving/rendering/score/guitarbendlayout.cpp
+++ b/src/engraving/rendering/score/guitarbendlayout.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "tlayout.h"
+#include "textlayout.h"
 #include "guitarbendlayout.h"
 
 #include "../../dom/chord.h"
@@ -484,7 +485,7 @@ void GuitarBendLayout::layoutTabStaff(GuitarBendSegment* item, LayoutContext& ct
     GuitarBendText* guitarBendText = item->bendText();
     guitarBendText->setParent(item);
     guitarBendText->setXmlText(bend->ldata()->bendDigit());
-    TLayout::layoutBaseTextBase(toTextBase(guitarBendText), ctx);
+    TextLayout::layoutBaseTextBase(toTextBase(guitarBendText), ctx);
     double verticalTextPad = 0.2 * spatium;
     PointF centering(-0.5 * guitarBendText->width(),
                      (bend->isReleaseBend() ? verticalTextPad : -(guitarBendText->height() + verticalTextPad)));

--- a/src/engraving/rendering/score/harmonylayout.cpp
+++ b/src/engraving/rendering/score/harmonylayout.cpp
@@ -23,6 +23,7 @@
 #include "harmonylayout.h"
 #include "rendering/score/parenthesislayout.h"
 #include "tlayout.h"
+#include "textlayout.h"
 
 #include "dom/fret.h"
 #include "dom/harmony.h"
@@ -87,7 +88,7 @@ PointF HarmonyLayout::calculateBoundingRect(const Harmony* item, Harmony::Layout
     double newPosY = 0.0;
 
     if (item->ldata()->renderItemList().empty()) {
-        TLayout::layoutBaseTextBase1(item, ldata);
+        TextLayout::layoutBaseTextBase1(item, ldata);
 
         if (alignToFretDiagram) {
             newPosY = ldata->pos().y();

--- a/src/engraving/rendering/score/lyricslayout.cpp
+++ b/src/engraving/rendering/score/lyricslayout.cpp
@@ -34,6 +34,7 @@
 #include "dom/system.h"
 
 #include "tlayout.h"
+#include "textlayout.h"
 #include "autoplace.h"
 
 using namespace mu;
@@ -73,7 +74,7 @@ void LyricsLayout::layout(Lyrics* item, LayoutContext& ctx)
 {
     if (!item->explicitParent()) {   // palette & clone trick
         item->setPos(PointF());
-        TLayout::layoutBaseTextBase1(item, ctx);
+        TextLayout::layoutBaseTextBase1(item, ctx);
         return;
     }
 
@@ -150,8 +151,8 @@ void LyricsLayout::layout(Lyrics* item, LayoutContext& ctx)
     ChordRest* cr = item->chordRest();
     double x = o.x() - cr->x();
 
-    TLayout::layoutBaseTextBase1(item, ctx);
-    TLayout::computeTextHighResShape(item, ldata);
+    TextLayout::layoutBaseTextBase1(item, ctx);
+    TextLayout::computeTextHighResShape(item, ldata);
 
     double centerAdjust = 0.0;
     double leftAdjust   = 0.0;

--- a/src/engraving/rendering/score/markerlayout.cpp
+++ b/src/engraving/rendering/score/markerlayout.cpp
@@ -23,6 +23,7 @@
 #include "markerlayout.h"
 #include "layoutcontext.h"
 #include "tlayout.h"
+#include "textlayout.h"
 #include "autoplace.h"
 
 #include "../dom/marker.h"
@@ -60,7 +61,7 @@ void MarkerLayout::doLayoutMarker(Marker* item, TextBase::LayoutData* ldata, Lay
                   && !item->symbolString().empty() ? AlignH::HCENTER : item->getProperty(Pid::POSITION).value<AlignH>();
     item->setPosition(hPos);
 
-    TLayout::layoutBaseTextBase(item, ldata);
+    TextLayout::layoutBaseTextBase(item, ldata);
 
     // Adjust for barline
     bool rightMarker = item->isRightMarker();

--- a/src/engraving/rendering/score/measurenumberlayout.cpp
+++ b/src/engraving/rendering/score/measurenumberlayout.cpp
@@ -23,6 +23,7 @@
 #include "measurenumberlayout.h"
 #include "measurelayout.h"
 #include "tlayout.h"
+#include "textlayout.h"
 
 #include "dom/measure.h"
 #include "dom/score.h"
@@ -119,7 +120,7 @@ void MeasureNumberLayout::layoutMeasureNumberBase(MeasureNumberBase* item, Measu
 {
     ldata->setPos(PointF());
 
-    TLayout::layoutBaseTextBase1(item, ldata);
+    TextLayout::layoutBaseTextBase1(item, ldata);
 
     if (item->placeBelow()) {
         double yoff = ldata->bbox().height();

--- a/src/engraving/rendering/score/rendering.cmake
+++ b/src/engraving/rendering/score/rendering.cmake
@@ -81,6 +81,8 @@ set(RENDERING_SCORE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/restlayout.h
     ${CMAKE_CURRENT_LIST_DIR}/boxlayout.cpp
     ${CMAKE_CURRENT_LIST_DIR}/boxlayout.h
+    ${CMAKE_CURRENT_LIST_DIR}/textlayout.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/textlayout.h
 
     ${CMAKE_CURRENT_LIST_DIR}/passbase.cpp
     ${CMAKE_CURRENT_LIST_DIR}/passbase.h

--- a/src/engraving/rendering/score/scorerenderer.cpp
+++ b/src/engraving/rendering/score/scorerenderer.cpp
@@ -29,6 +29,7 @@
 
 #include "tdraw.h"
 #include "tlayout.h"
+#include "textlayout.h"
 #include "chordlayout.h"
 #include "layoutcontext.h"
 #include "scorelayout.h"
@@ -83,11 +84,11 @@ void ScoreRenderer::layoutText1(TextBase* item, bool base)
 {
     LayoutContext ctx(item->score());
     if (base) {
-        TLayout::layoutBaseTextBase1(item, ctx);
+        TextLayout::layoutBaseTextBase1(item, ctx);
     } else if (Harmony::classof(item)) {
         TLayout::layoutHarmony(static_cast<Harmony*>(item), static_cast<Harmony*>(item)->mutldata(), ctx);
     } else {
-        TLayout::layoutBaseTextBase1(item, ctx);
+        TextLayout::layoutBaseTextBase1(item, ctx);
     }
 }
 

--- a/src/engraving/rendering/score/tappinglayout.cpp
+++ b/src/engraving/rendering/score/tappinglayout.cpp
@@ -23,6 +23,7 @@
 #include "slurtielayout.h"
 #include "tappinglayout.h"
 #include "tlayout.h"
+#include "textlayout.h"
 
 #include "dom/chord.h"
 #include "dom/slur.h"
@@ -97,7 +98,7 @@ void TappingLayout::layoutLeftHandTapping(Tapping* item, Tapping::LayoutData* ld
         text->setXmlText("T");
         text->setFrameType(FrameType::CIRCLE);
         text->setAlign(Align(AlignH::LEFT, AlignV::BASELINE));
-        TLayout::layoutBaseTextBase(text, ctx);
+        TextLayout::layoutBaseTextBase(text, ctx);
         // Move the circle up very slightly to look better centered on the T
         text->mutldata()->frame.translate(0.0, -0.02 * text->height());
     }
@@ -217,6 +218,6 @@ void TappingLayout::layoutRightHandTapping(Tapping* item, Tapping::LayoutData* l
         text->setTrack(item->track());
         text->setXmlText("T");
         text->setAlign(Align(AlignH::LEFT, AlignV::BASELINE));
-        TLayout::layoutBaseTextBase(text, ctx);
+        TextLayout::layoutBaseTextBase(text, ctx);
     }
 }

--- a/src/engraving/rendering/score/textlayout.cpp
+++ b/src/engraving/rendering/score/textlayout.cpp
@@ -1,0 +1,350 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2025 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "textlayout.h"
+#include "tlayout.h"
+#include "dom/box.h"
+#include "dom/page.h"
+#include "dom/staff.h"
+#include "dom/textlinebase.h"
+#include "types/typesconv.h"
+
+using namespace mu::engraving::rendering::score;
+using namespace mu::engraving;
+using namespace muse::draw;
+
+void TextLayout::layoutBaseTextBase(const TextBase* item, TextBase::LayoutData* ldata)
+{
+    IF_ASSERT_FAILED(item->explicitParent()) {
+        return;
+    }
+
+    ldata->setPos(PointF());
+
+    if (item->placeBelow()) {
+        ldata->setPosY(item->staff() ? item->staff()->staffHeight(item->tick()) : 0.0);
+    }
+
+    layoutBaseTextBase1(item, ldata);
+}
+
+void TextLayout::layoutBaseTextBase(TextBase* item, LayoutContext&)
+{
+    layoutBaseTextBase(item, item->mutldata());
+}
+
+void TextLayout::layoutBaseTextBase1(const TextBase* item, TextBase::LayoutData* ldata)
+{
+    if (item->explicitParent() && item->layoutToParentWidth()) {
+        LD_CONDITION(item->parentItem()->ldata()->isSetBbox());
+    }
+
+    if (ldata->layoutInvalid) {
+        item->createBlocks(ldata);
+    }
+
+    double y = 0.0;
+
+    double maxBlockWidth = -DBL_MAX;
+    // adjust the bounding box for the text item
+    for (size_t i = 0; i < ldata->blocks.size(); ++i) {
+        TextBlock& t = ldata->blocks[i];
+        layoutTextBlock(&t, item);
+        y += t.lineSpacing();
+        t.setY(y);
+        maxBlockWidth = std::max(maxBlockWidth, t.boundingRect().width());
+    }
+
+    Shape shape;
+    textHorizontalLayout(item, shape, maxBlockWidth, ldata);
+
+    RectF bb = shape.bbox();
+
+    double yoff = 0;
+    double h    = 0;
+    if (item->explicitParent()) {
+        if (item->layoutToParentWidth()) {
+            if (item->explicitParent()->isTBox()) {
+                // hack: vertical alignment is always TOP
+                const_cast<TextBase*>(item)->setAlign({ item->align().horizontal, AlignV::TOP });
+            } else if (item->explicitParent()->isBox()) {
+                // consider inner margins of frame
+                Box* b = toBox(item->explicitParent());
+                yoff = b->topMargin() * DPMM;
+
+                if (b->height() < bb.bottom()) {
+                    h = b->height() / 2 + bb.height();
+                } else {
+                    h  = b->height() - yoff - b->bottomMargin() * DPMM;
+                }
+            } else if (item->explicitParent()->isPage()) {
+                Page* p = toPage(item->explicitParent());
+                h = p->height() - p->tm() - p->bm();
+                yoff = p->tm();
+            } else if (item->explicitParent()->isMeasure()) {
+            } else {
+                h  = item->parentItem()->height();
+            }
+        }
+    } else {
+        ldata->setPos(PointF());
+    }
+
+    if (item->align() == AlignV::BOTTOM) {
+        yoff += h - bb.bottom();
+    } else if (item->align() == AlignV::VCENTER) {
+        yoff +=  (h - (bb.top() + bb.bottom())) * .5;
+    } else if (item->align() == AlignV::BASELINE) {
+        yoff += h * .5 - ldata->blocks.front().lineSpacing();
+    } else {
+        yoff += -bb.top();
+    }
+
+    for (TextBlock& t : ldata->blocks) {
+        t.setY(t.y() + yoff);
+    }
+
+    shape.translateY(yoff);
+    ldata->setShape(shape);
+
+    if (item->hasFrame()) {
+        item->layoutFrame(ldata);
+    }
+
+    if (!item->isDynamic() && !(item->explicitParent() && item->parent()->isBox())) {
+        computeTextHighResShape(item, ldata);
+    }
+}
+
+void TextLayout::layoutBaseTextBase1(TextBase* item, const LayoutContext&)
+{
+    layoutBaseTextBase1(item, item->mutldata());
+}
+
+void TextLayout::computeTextHighResShape(const TextBase* item, TextBase::LayoutData* ldata)
+{
+    Shape& shape = ldata->highResShape.mut_value();
+    shape.clear();
+    shape.elements().reserve(item->xmlText().size());
+
+    for (const TextBlock& block : ldata->blocks) {
+        double y = block.y();
+        for (const TextFragment& fragment : block.fragments()) {
+            FontMetrics fontMetrics = FontMetrics(fragment.font(item));
+            double x = fragment.pos.x();
+            size_t textSize = fragment.text.size();
+            for (size_t i = 0; i < textSize; ++i) {
+                Char character = fragment.text.at(i);
+                RectF characterBoundingRect = fontMetrics.tightBoundingRect(fragment.text.at(i));
+                characterBoundingRect.translate(x, y);
+                shape.add(characterBoundingRect);
+                if (i + 1 < textSize) {
+                    x += fontMetrics.horizontalAdvance(character);
+                }
+            }
+        }
+    }
+
+    ldata->highResShape = shape;
+}
+
+void TextLayout::textHorizontalLayout(const TextBase* item, Shape& shape, double maxBlockWidth, TextBase::LayoutData* ldata)
+{
+    double leftMargin = 0.0;
+    double layoutWidth = 0;
+    EngravingItem* parent = item->parentItem();
+    if (parent && item->layoutToParentWidth()) {
+        layoutWidth = parent->width();
+        switch (parent->type()) {
+        case ElementType::HBOX:
+        case ElementType::VBOX:
+        case ElementType::TBOX: {
+            Box* b = toBox(parent);
+            layoutWidth -= ((b->leftMargin() + b->rightMargin()) * DPMM);
+            leftMargin = b->leftMargin() * DPMM;
+        }
+        break;
+        case ElementType::PAGE: {
+            Page* p = toPage(parent);
+            layoutWidth -= (p->lm() + p->rm());
+            leftMargin = p->lm();
+        }
+        break;
+            break;
+        default:
+            ASSERT_X("Lay out to parent width only valid for items with page or frame as parent");
+        }
+    }
+
+    // Position and alignment
+    for (size_t i = 0; i < ldata->blocks.size(); ++i) {
+        TextBlock& textBlock = ldata->blocks[i];
+        double xAdj = leftMargin - textBlock.boundingRect().left();
+
+        // Set position relative to reference point
+        AlignH position = item->position();
+        if (position == AlignH::HCENTER) {
+            xAdj += (layoutWidth - maxBlockWidth) * .5;
+        } else if (position == AlignH::RIGHT) {
+            xAdj += layoutWidth - maxBlockWidth;
+        }
+
+        double diff = maxBlockWidth - textBlock.boundingRect().width();
+        if (muse::RealIsNull(diff)) {
+            // This is the longest line, don't align
+            for (TextFragment& f : textBlock.fragments()) {
+                f.pos.rx() += xAdj;
+            }
+            textBlock.shape().translate(PointF(xAdj, 0.0));
+            shape.add(textBlock.shape().translated(PointF(0.0, textBlock.y())));
+            continue;
+        }
+        // Align relative to the longest line
+        AlignH alignH = item->align().horizontal;
+        if (alignH == AlignH::HCENTER) {
+            xAdj += diff * 0.5;
+        } else if (alignH == AlignH::RIGHT) {
+            xAdj += diff;
+        }
+
+        for (TextFragment& fragment : textBlock.fragments()) {
+            fragment.pos.rx() += xAdj;
+        }
+        textBlock.shape().translate(PointF(xAdj, 0.0));
+        shape.add(textBlock.shape().translated(PointF(0.0, textBlock.y())));
+    }
+}
+
+void TextLayout::layoutTextBlock(TextBlock* item, const TextBase* t)
+{
+    std::list<TextFragment>& fragments = item->fragments();
+    Shape& shape = item->shape();
+    shape.clear();
+    double x      = 0.0;
+    double lineSpacing = 0.0;
+
+    if (fragments.empty()) {
+        FontMetrics fm = t->fontMetrics();
+        shape.add(RectF(0.0, -fm.ascent(), 1.0, fm.descent()), t);
+        lineSpacing = fm.lineSpacing();
+    } else if (fragments.size() == 1 && fragments.front().text.isEmpty()) {
+        auto fi = fragments.begin();
+        TextFragment& f = *fi;
+        f.pos.setX(x);
+        FontMetrics fm(f.font(t));
+        if (f.format.valign() != VerticalAlignment::AlignNormal) {
+            double voffset = fm.xHeight() / SUBSCRIPT_SIZE;   // use original height
+            if (f.format.valign() == VerticalAlignment::AlignSubScript) {
+                voffset *= SUBSCRIPT_OFFSET;
+            } else {
+                voffset *= SUPERSCRIPT_OFFSET;
+            }
+
+            f.pos.setY(voffset);
+        } else {
+            f.pos.setY(0.0);
+        }
+
+        RectF temp(0.0, -fm.ascent(), 1.0, fm.descent());
+        shape.add(temp, t);
+        lineSpacing = std::max(lineSpacing, fm.lineSpacing());
+    } else {
+        const auto fiLast = --fragments.end();
+        for (auto fi = fragments.begin(); fi != fragments.end(); ++fi) {
+            TextFragment& f = *fi;
+            f.pos.setX(x);
+            Font fragmentFont = f.font(t);
+            FontMetrics fm(fragmentFont);
+            if (f.format.valign() != VerticalAlignment::AlignNormal) {
+                double voffset = fm.xHeight() / SUBSCRIPT_SIZE;           // use original height
+                if (f.format.valign() == VerticalAlignment::AlignSubScript) {
+                    voffset *= SUBSCRIPT_OFFSET;
+                } else {
+                    voffset *= SUPERSCRIPT_OFFSET;
+                }
+                f.pos.setY(voffset);
+            } else {
+                f.pos.setY(0.0);
+            }
+
+            // Optimization: don't calculate character position
+            // for the next fragment if there is no next fragment
+            if (fi != fiLast) {
+                const double w  = fm.width(f.text);
+                x += w;
+            }
+
+            double yOffset = musicSymbolBaseLineAdjust(item, t, f, fi);
+            f.pos.ry() -= yOffset;
+
+            RectF textBRect = fm.tightBoundingRect(f.text).translated(f.pos);
+            bool useDynamicSymShape = fragmentFont.type() == Font::Type::MusicSymbol && t->isDynamic();
+            if (useDynamicSymShape) {
+                const Dynamic* dyn = toDynamic(t);
+                SymId symId = TConv::symId(dyn->dynamicType());
+                if (symId != SymId::noSym) {
+                    shape.add(dyn->symShapeWithCutouts(symId).translated(f.pos));
+                } else {
+                    shape.add(textBRect, t);
+                }
+            } else {
+                shape.add(textBRect, t);
+            }
+            if (fragmentFont.type() == Font::Type::MusicSymbol || fragmentFont.type() == Font::Type::MusicSymbolText) {
+                // SEMI-HACK: Music fonts can have huge linespacing because of tall symbols, so instead of using the
+                // font linespacing value we just use the height of the individual fragment with some added margin
+
+                lineSpacing = std::max(lineSpacing, 1.25 * (shape.bbox().height() - shape.bbox().bottom()) + yOffset);
+            } else {
+                lineSpacing = std::max(lineSpacing, fm.lineSpacing());
+            }
+        }
+    }
+
+    // Apply style/custom line spacing
+    lineSpacing *= t->textLineSpacing();
+    item->setLineSpacing(lineSpacing);
+}
+
+double TextLayout::musicSymbolBaseLineAdjust(const TextBlock* block, const TextBase* t, const TextFragment& f,
+                                             const std::list<TextFragment>::iterator fi)
+{
+    Font fragmentFont = f.font(t);
+    FontMetrics fm(fragmentFont);
+    const bool adjustSymbol = fragmentFont.type() == Font::Type::MusicSymbolText && t->isMarker();
+    if (!adjustSymbol) {
+        return 0.0;
+    }
+
+    // Align the x-height of the coda symbol to half the x-height of the surrounding text
+    Font refFont;
+    if (block->fragments().size() == 1) {
+        refFont = t->font();
+    } else {
+        TextFragment& refFragment = fi != block->fragments().begin() ? *(std::prev(fi)) : *(std::next(fi));
+        refFont = refFragment.font(t);
+    }
+    FontMetrics refFm(refFont);
+
+    const double middle = (fm.tightBoundingRect(f.text).height() / 2) - fm.tightBoundingRect(f.text).bottom();
+    const double refXHeight = refFm.capHeight() / 2;
+    return refXHeight - middle;
+}

--- a/src/engraving/rendering/score/textlayout.h
+++ b/src/engraving/rendering/score/textlayout.h
@@ -1,0 +1,44 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2025 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "layoutcontext.h"
+#include "dom/textbase.h"
+
+namespace mu::engraving::rendering::score {
+class TextLayout
+{
+public:
+    static void layoutBaseTextBase(const TextBase* item, TextBase::LayoutData* data);
+    static void layoutBaseTextBase(TextBase* item, LayoutContext& ctx);
+    static void layoutBaseTextBase1(const TextBase* item, TextBase::LayoutData* data);
+    static void layoutBaseTextBase1(TextBase* item, const LayoutContext& ctx);
+
+    static void computeTextHighResShape(const TextBase* item, TextBase::LayoutData* ldata);
+    static void layoutTextBlock(TextBlock* item, const TextBase* t);
+private:
+    static void textHorizontalLayout(const TextBase* item, Shape& shape, double maxBlockWidth, TextBase::LayoutData* ldata);
+    static double musicSymbolBaseLineAdjust(const TextBlock* block, const TextBase* t, const TextFragment& f,
+                                            const std::list<TextFragment>::iterator fi);
+};
+}

--- a/src/engraving/rendering/score/tlayout.cpp
+++ b/src/engraving/rendering/score/tlayout.cpp
@@ -174,6 +174,7 @@
 #include "measurenumberlayout.h"
 #include "parenthesislayout.h"
 #include "restlayout.h"
+#include "textlayout.h"
 
 using namespace muse;
 using namespace muse::draw;
@@ -953,7 +954,7 @@ void TLayout::layoutArticulation(Articulation* item, Articulation::LayoutData* l
         text->setParent(item);
         text->setSelected(item->selected());
 
-        layoutBaseTextBase(item->text(), item->text()->mutldata());
+        TextLayout::layoutBaseTextBase(item->text(), item->text()->mutldata());
     }
 
     fillArticulationShape(item, ldata);
@@ -1753,7 +1754,7 @@ void TLayout::layoutCapo(const Capo* item, Capo::LayoutData* ldata, const Layout
         }
     }
 
-    TLayout::layoutBaseTextBase(item, ldata);
+    TextLayout::layoutBaseTextBase(item, ldata);
 
     if (item->autoplace()) {
         const Segment* s = item->segment();
@@ -1827,7 +1828,7 @@ void TLayout::layoutExpression(const Expression* item, Expression::LayoutData* l
     const_cast<Expression*>(item)->setPlacementBasedOnVoiceAssignment(item->style().styleV(
                                                                           Sid::dynamicsHairpinVoiceBasedPlacement).value<DirectionV>());
 
-    TLayout::layoutBaseTextBase(item, ldata);
+    TextLayout::layoutBaseTextBase(item, ldata);
 
     const Segment* segment = item->segment();
 
@@ -2224,7 +2225,7 @@ void TLayout::layoutFiguredBass(const FiguredBass* item, FiguredBass::LayoutData
     ldata->setPos(PointF(0.0, y));
 
     // BOUNDING BOX and individual item layout (if required)
-    TLayout::layoutBaseTextBase1(item, ldata);  // prepare structs and data expected by Text methods
+    TextLayout::layoutBaseTextBase1(item, ldata);  // prepare structs and data expected by Text methods
     // if element could be parsed into items, layout each element
     // Items list will be empty in edit mode (see FiguredBass::startEdit).
     // TODO: consider disabling specific layout in case text style is changed (tid() != TextStyleName::FIGURED_BASS).
@@ -2257,7 +2258,7 @@ void TLayout::layoutFingering(const Fingering* item, Fingering::LayoutData* ldat
     }
     ldata->setIsSkipDraw(false);
 
-    TLayout::layoutBaseTextBase(item, ldata);
+    TextLayout::layoutBaseTextBase(item, ldata);
     ldata->setPosY(0.0); // handle placement below
 
     if (item->autoplace()) {
@@ -3172,7 +3173,7 @@ void TLayout::layoutHammerOnPullOffSegment(HammerOnPullOffSegment* item, LayoutC
 
 void TLayout::layoutHammerOnPullOffText(HammerOnPullOffText* item, LayoutContext& ctx)
 {
-    layoutBaseTextBase(item, ctx);
+    TextLayout::layoutBaseTextBase(item, ctx);
 }
 
 void TLayout::fillHairpinSegmentShape(const HairpinSegment* item, HairpinSegment::LayoutData* ldata)
@@ -3198,7 +3199,7 @@ void TLayout::layoutHarpPedalDiagram(const HarpPedalDiagram* item, HarpPedalDiag
     LAYOUT_CALL_ITEM(item);
     const_cast<HarpPedalDiagram*>(item)->updateDiagramText();
 
-    layoutBaseTextBase(item, ldata);
+    TextLayout::layoutBaseTextBase(item, ldata);
 
     if (item->autoplace()) {
         const Segment* s = toSegment(item->explicitParent());
@@ -3299,7 +3300,7 @@ void TLayout::layoutImage(const Image* item, Image::LayoutData* ldata)
 void TLayout::layoutInstrumentChange(const InstrumentChange* item, InstrumentChange::LayoutData* ldata)
 {
     LAYOUT_CALL_ITEM(item);
-    layoutBaseTextBase(item, ldata);
+    TextLayout::layoutBaseTextBase(item, ldata);
 
     if (item->autoplace()) {
         const Segment* s = toSegment(item->explicitParent());
@@ -3321,7 +3322,7 @@ void TLayout::layoutInstrumentName(const InstrumentName* item, InstrumentName::L
 //        return;
 //    }
 
-    layoutBaseTextBase(item, ldata);
+    TextLayout::layoutBaseTextBase(item, ldata);
 }
 
 void TLayout::layoutJump(const Jump* item, Jump::LayoutData* ldata)
@@ -3329,7 +3330,7 @@ void TLayout::layoutJump(const Jump* item, Jump::LayoutData* ldata)
     LAYOUT_CALL_ITEM(item);
     LD_CONDITION(item->parentItem()->ldata()->isSetBbox());
 
-    layoutBaseTextBase(item, ldata);
+    TextLayout::layoutBaseTextBase(item, ldata);
 
     AlignH position = item->position();
 
@@ -4379,7 +4380,7 @@ void TLayout::layoutPlayCountText(PlayCountText* item, TextBase::LayoutData* lda
     BarLine* bl = item->barline();
     Segment* seg = item->segment();
 
-    layoutBaseTextBase(item, ldata);
+    TextLayout::layoutBaseTextBase(item, ldata);
 
     // Avoid incoming barlines from above
     double xAdj = 0.0;
@@ -4396,7 +4397,7 @@ void TLayout::layoutPlayCountText(PlayCountText* item, TextBase::LayoutData* lda
 void TLayout::layoutPlayTechAnnotation(const PlayTechAnnotation* item, PlayTechAnnotation::LayoutData* ldata)
 {
     LAYOUT_CALL_ITEM(item);
-    layoutBaseTextBase(item, ldata);
+    TextLayout::layoutBaseTextBase(item, ldata);
 
     if (item->isHandbellsSymbol()) {
         Chord* chord = nullptr;
@@ -4453,7 +4454,7 @@ void TLayout::layoutRasgueadoSegment(RasgueadoSegment* item, LayoutContext& ctx)
 void TLayout::layoutRehearsalMark(const RehearsalMark* item, RehearsalMark::LayoutData* ldata)
 {
     LAYOUT_CALL_ITEM(item);
-    layoutBaseTextBase(item, ldata);
+    TextLayout::layoutBaseTextBase(item, ldata);
 
     const Segment* s = item->segment();
 
@@ -5131,7 +5132,7 @@ void TLayout::layoutStaffState(const StaffState* item, StaffState::LayoutData* l
 void TLayout::layoutStaffText(const StaffText* item, StaffText::LayoutData* ldata)
 {
     LAYOUT_CALL_ITEM(item);
-    layoutBaseTextBase(item, ldata);
+    TextLayout::layoutBaseTextBase(item, ldata);
 
     if (item->autoplace()) {
         const Segment* s = toSegment(item->explicitParent());
@@ -5309,7 +5310,7 @@ void TLayout::layoutStemSlash(const StemSlash* item, StemSlash::LayoutData* ldat
 void TLayout::layoutSticking(const Sticking* item, Sticking::LayoutData* ldata)
 {
     LAYOUT_CALL_ITEM(item);
-    layoutBaseTextBase(item, ldata);
+    TextLayout::layoutBaseTextBase(item, ldata);
 
     AlignH itemPosition =  item->position();
     if (itemPosition != AlignH::LEFT) {
@@ -5348,7 +5349,7 @@ void TLayout::layoutStringTunings(StringTunings* item, LayoutContext& ctx)
     LAYOUT_CALL_ITEM(item);
     item->updateText();
 
-    TLayout::layoutBaseTextBase(item, ctx);
+    TextLayout::layoutBaseTextBase(item, ctx);
 
     if (item->noStringVisible()) {
         double spatium = item->spatium();
@@ -5507,7 +5508,7 @@ void TLayout::layoutSystemDivider(const SystemDivider* item, SystemDivider::Layo
 void TLayout::layoutSystemText(const SystemText* item, SystemText::LayoutData* ldata)
 {
     LAYOUT_CALL_ITEM(item);
-    layoutBaseTextBase(item, ldata);
+    TextLayout::layoutBaseTextBase(item, ldata);
 
     if (item->autoplace() && item->explicitParent()) {
         const Segment* s = toSegment(item->explicitParent());
@@ -5601,7 +5602,7 @@ void TLayout::layoutTempoText(const TempoText* item, TempoText::LayoutData* ldat
 
     ldata->disconnectSnappedItems();
 
-    layoutBaseTextBase(item, ldata);
+    TextLayout::layoutBaseTextBase(item, ldata);
 
     if (!item->autoplace()) {
         return;
@@ -5642,214 +5643,6 @@ void TLayout::layoutTempoText(const TempoText* item, TempoText::LayoutData* ldat
     Autoplace::autoplaceSegmentElement(item, ldata);
 }
 
-void TLayout::layoutTextBase(TextBase* item, LayoutContext& ctx)
-{
-    LAYOUT_CALL_ITEM(item);
-    layoutItem(item, ctx);
-}
-
-void TLayout::layoutBaseTextBase(const TextBase* item, TextBase::LayoutData* ldata)
-{
-    IF_ASSERT_FAILED(item->explicitParent()) {
-        return;
-    }
-
-    ldata->setPos(PointF());
-
-    if (item->placeBelow()) {
-        ldata->setPosY(item->staff() ? item->staff()->staffHeight(item->tick()) : 0.0);
-    }
-
-    layoutBaseTextBase1(item, ldata);
-}
-
-void TLayout::layoutBaseTextBase(TextBase* item, LayoutContext&)
-{
-    layoutBaseTextBase(item, item->mutldata());
-}
-
-static void textHorizontalLayout(const TextBase* item, Shape& shape, double maxBlockWidth, TextBase::LayoutData* ldata)
-{
-    double leftMargin = 0.0;
-    double layoutWidth = 0;
-    EngravingItem* parent = item->parentItem();
-    if (parent && item->layoutToParentWidth()) {
-        layoutWidth = parent->width();
-        switch (parent->type()) {
-        case ElementType::HBOX:
-        case ElementType::VBOX:
-        case ElementType::TBOX: {
-            Box* b = toBox(parent);
-            layoutWidth -= ((b->leftMargin() + b->rightMargin()) * DPMM);
-            leftMargin = b->leftMargin() * DPMM;
-        }
-        break;
-        case ElementType::PAGE: {
-            Page* p = toPage(parent);
-            layoutWidth -= (p->lm() + p->rm());
-            leftMargin = p->lm();
-        }
-        break;
-            break;
-        default:
-            ASSERT_X("Lay out to parent width only valid for items with page or frame as parent");
-        }
-    }
-
-    // Position and alignment
-    for (size_t i = 0; i < ldata->blocks.size(); ++i) {
-        TextBlock& textBlock = ldata->blocks[i];
-        double xAdj = leftMargin - textBlock.boundingRect().left();
-
-        // Set position relative to reference point
-        AlignH position = item->position();
-        if (position == AlignH::HCENTER) {
-            xAdj += (layoutWidth - maxBlockWidth) * .5;
-        } else if (position == AlignH::RIGHT) {
-            xAdj += layoutWidth - maxBlockWidth;
-        }
-
-        double diff = maxBlockWidth - textBlock.boundingRect().width();
-        if (muse::RealIsNull(diff)) {
-            // This is the longest line, don't align
-            for (TextFragment& f : textBlock.fragments()) {
-                f.pos.rx() += xAdj;
-            }
-            textBlock.shape().translate(PointF(xAdj, 0.0));
-            shape.add(textBlock.shape().translated(PointF(0.0, textBlock.y())));
-            continue;
-        }
-        // Align relative to the longest line
-        AlignH alignH = item->align().horizontal;
-        if (alignH == AlignH::HCENTER) {
-            xAdj += diff * 0.5;
-        } else if (alignH == AlignH::RIGHT) {
-            xAdj += diff;
-        }
-
-        for (TextFragment& fragment : textBlock.fragments()) {
-            fragment.pos.rx() += xAdj;
-        }
-        textBlock.shape().translate(PointF(xAdj, 0.0));
-        shape.add(textBlock.shape().translated(PointF(0.0, textBlock.y())));
-    }
-}
-
-void TLayout::layoutBaseTextBase1(const TextBase* item, TextBase::LayoutData* ldata)
-{
-    if (item->explicitParent() && item->layoutToParentWidth()) {
-        LD_CONDITION(item->parentItem()->ldata()->isSetBbox());
-    }
-
-    if (ldata->layoutInvalid) {
-        item->createBlocks(ldata);
-    }
-
-    double y = 0.0;
-
-    double maxBlockWidth = -DBL_MAX;
-    // adjust the bounding box for the text item
-    for (size_t i = 0; i < ldata->blocks.size(); ++i) {
-        TextBlock& t = ldata->blocks[i];
-        t.layout(item);
-        y += t.lineSpacing();
-        t.setY(y);
-        maxBlockWidth = std::max(maxBlockWidth, t.boundingRect().width());
-    }
-
-    Shape shape;
-    textHorizontalLayout(item, shape, maxBlockWidth, ldata);
-
-    RectF bb = shape.bbox();
-
-    double yoff = 0;
-    double h    = 0;
-    if (item->explicitParent()) {
-        if (item->layoutToParentWidth()) {
-            if (item->explicitParent()->isTBox()) {
-                // hack: vertical alignment is always TOP
-                const_cast<TextBase*>(item)->setAlign({ item->align().horizontal, AlignV::TOP });
-            } else if (item->explicitParent()->isBox()) {
-                // consider inner margins of frame
-                Box* b = toBox(item->explicitParent());
-                yoff = b->topMargin() * DPMM;
-
-                if (b->height() < bb.bottom()) {
-                    h = b->height() / 2 + bb.height();
-                } else {
-                    h  = b->height() - yoff - b->bottomMargin() * DPMM;
-                }
-            } else if (item->explicitParent()->isPage()) {
-                Page* p = toPage(item->explicitParent());
-                h = p->height() - p->tm() - p->bm();
-                yoff = p->tm();
-            } else if (item->explicitParent()->isMeasure()) {
-            } else {
-                h  = item->parentItem()->height();
-            }
-        }
-    } else {
-        ldata->setPos(PointF());
-    }
-
-    if (item->align() == AlignV::BOTTOM) {
-        yoff += h - bb.bottom();
-    } else if (item->align() == AlignV::VCENTER) {
-        yoff +=  (h - (bb.top() + bb.bottom())) * .5;
-    } else if (item->align() == AlignV::BASELINE) {
-        yoff += h * .5 - ldata->blocks.front().lineSpacing();
-    } else {
-        yoff += -bb.top();
-    }
-
-    for (TextBlock& t : ldata->blocks) {
-        t.setY(t.y() + yoff);
-    }
-
-    shape.translateY(yoff);
-    ldata->setShape(shape);
-
-    if (item->hasFrame()) {
-        item->layoutFrame(ldata);
-    }
-
-    if (!item->isDynamic() && !(item->explicitParent() && item->parent()->isBox())) {
-        computeTextHighResShape(item, ldata);
-    }
-}
-
-void TLayout::computeTextHighResShape(const TextBase* item, TextBase::LayoutData* ldata)
-{
-    Shape& shape = ldata->highResShape.mut_value();
-    shape.clear();
-    shape.elements().reserve(item->xmlText().size());
-
-    for (const TextBlock& block : ldata->blocks) {
-        double y = block.y();
-        for (const TextFragment& fragment : block.fragments()) {
-            FontMetrics fontMetrics = FontMetrics(fragment.font(item));
-            double x = fragment.pos.x();
-            size_t textSize = fragment.text.size();
-            for (size_t i = 0; i < textSize; ++i) {
-                Char character = fragment.text.at(i);
-                RectF characterBoundingRect = fontMetrics.tightBoundingRect(fragment.text.at(i));
-                characterBoundingRect.translate(x, y);
-                shape.add(characterBoundingRect);
-                if (i + 1 < textSize) {
-                    x += fontMetrics.horizontalAdvance(character);
-                }
-            }
-        }
-    }
-
-    ldata->highResShape = shape;
-}
-
-void TLayout::layoutBaseTextBase1(TextBase* item, const LayoutContext&)
-{
-    layoutBaseTextBase1(item, item->mutldata());
-}
-
 Shape TLayout::textLineBaseSegmentShape(const TextLineBaseSegment* item)
 {
     LAYOUT_CALL_ITEM(item);
@@ -5881,7 +5674,7 @@ void TLayout::layoutText(const Text* item, Text::LayoutData* ldata)
         LD_CONDITION(item->parentItem()->ldata()->isSetBbox());
     }
 
-    layoutBaseTextBase(item, ldata);
+    TextLayout::layoutBaseTextBase(item, ldata);
 }
 
 void TLayout::layoutTextLine(TextLine* item, LayoutContext& ctx)

--- a/src/engraving/rendering/score/tlayout.h
+++ b/src/engraving/rendering/score/tlayout.h
@@ -341,13 +341,6 @@ public:
     static void layoutTappingHalfSlur(TappingHalfSlur* item);
     static void layoutTempoText(const TempoText* item, TempoText::LayoutData* ldata);
 
-    static void layoutTextBase(TextBase* item, LayoutContext& ctx);                 // factory
-    static void layoutBaseTextBase(const TextBase* item, TextBase::LayoutData* data); // base class
-    static void layoutBaseTextBase(TextBase* item, LayoutContext& ctx);  // base class
-    static void layoutBaseTextBase1(TextBase* item, const LayoutContext& ctx);  // base class
-    static void layoutBaseTextBase1(const TextBase* item, TextBase::LayoutData* data);
-    static void computeTextHighResShape(const TextBase* item, TextBase::LayoutData* ldata);
-
     static void layoutText(const Text* item, Text::LayoutData* ldata);
 
     static void layoutTextLine(TextLine* item, LayoutContext& ctx);

--- a/src/engraving/rendering/single/singlelayout.cpp
+++ b/src/engraving/rendering/single/singlelayout.cpp
@@ -100,6 +100,7 @@
 #include "dom/utils.h"
 
 #include "rendering/score/tlayout.h"
+#include "rendering/score/textlayout.h"
 #include "rendering/score/tremololayout.h"
 #include "rendering/score/chordlayout.h"
 #include "rendering/score/slurtielayout.h"
@@ -1990,7 +1991,7 @@ void SingleLayout::layout1TextBase(const TextBase* item, const Context&, TextBas
     // adjust the bounding box for the text item
     for (size_t i = 0; i < ldata->rows(); ++i) {
         TextBlock& t = ldata->blocks[i];
-        t.layout(item);
+        TextLayout::layoutTextBlock(&t, item);
         const RectF* r = &t.boundingRect();
 
         if (r->height() == 0) {


### PR DESCRIPTION
To be merged after https://github.com/musescore/MuseScore/pull/30719.
This moves `TextBase` layout code to its own file. It also moves `TextBlock` layout code out of the DOM.