### PR TITLE
Improve padding for TextStyleProperty

### DIFF
--- a/src/engraving/compat/dummyelement.h
+++ b/src/engraving/compat/dummyelement.h
@@ -25,7 +25,7 @@
 #include "../dom/engravingitem.h"
 
 namespace mu::engraving {
-enum class Pid : int;
+enum class Pid : short;
 
 class RootItem;
 }

--- a/src/engraving/dom/engravingitem.h
+++ b/src/engraving/dom/engravingitem.h
@@ -71,7 +71,7 @@ class AccessibleItem;
 typedef std::shared_ptr<AccessibleItem> AccessibleItemPtr;
 #endif
 
-enum class Pid;
+enum class Pid : short;
 class StaffType;
 
 //---------------------------------------------------------

--- a/src/engraving/dom/engravingobject.h
+++ b/src/engraving/dom/engravingobject.h
@@ -200,7 +200,7 @@ class ShadowNote;
 
 class LinkedObjects;
 
-enum class Pid : int;
+enum class Pid : short;
 enum class PropertyFlags : char;
 
 using EngravingObjectList = std::vector<EngravingObject*>;

--- a/src/engraving/dom/location.h
+++ b/src/engraving/dom/location.h
@@ -29,7 +29,7 @@
 namespace mu::engraving {
 class EngravingItem;
 
-enum class Pid;
+enum class Pid : short;
 
 //---------------------------------------------------------
 //   Location

--- a/src/engraving/dom/property.h
+++ b/src/engraving/dom/property.h
@@ -68,7 +68,7 @@ enum class PropertyFlags : char {
 //   EngravingItem Properties
 //------------------------------------------------------------------------
 
-enum class Pid {
+enum class Pid : short {
     SUBTYPE,
     SELECTED,
     GENERATED,

--- a/src/engraving/rw/read400/tread.h
+++ b/src/engraving/rw/read400/tread.h
@@ -160,7 +160,7 @@ class Tuplet;
 class Vibrato;
 class Volta;
 
-enum class Pid;
+enum class Pid : short;
 }
 
 namespace mu::engraving::read400 {

--- a/src/engraving/rw/read410/tread.h
+++ b/src/engraving/rw/read410/tread.h
@@ -164,7 +164,7 @@ class Tuplet;
 class Vibrato;
 class Volta;
 
-enum class Pid;
+enum class Pid : short;
 }
 
 namespace mu::engraving::compat {

--- a/src/engraving/style/styledef.h
+++ b/src/engraving/style/styledef.h
@@ -53,7 +53,7 @@ namespace mu::engraving {
 //---------------------------------------------------------
 
 BEGIN_QT_REGISTERED_ENUM(Sid)
-enum class Sid {
+enum class Sid : short {
     ///.\{
     NOSTYLE = -1,
 


### PR DESCRIPTION
Saves 8*1146 bytes of memory

and also saving 2 bytes per use of `Pid`