### PR TITLE
Correct French translation for Sopranissimo Sax description

### DIFF
--- a/share/locale/instruments_fr.ts
+++ b/share/locale/instruments_fr.ts
@@ -4269,7 +4269,7 @@
         <source>Saxophone in B♭ (an octave above the soprano).</source>
         <comment>sopranissimo-saxophone description</comment>
         <extracomment>description for Sopranissimo Saxophone; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names</extracomment>
-        <translation>Saxophone en Si♭ (une octave plus grave que le soprano).</translation>
+        <translation>Saxophone en Si♭ (une octave plus aigüe que le soprano).</translation>
     </message>
     <message>
         <location filename="../instruments/instrumentsxml.h" line="1566"/>


### PR DESCRIPTION
Resolves: N/A

In French, the description of the Sopranissimo saxophone was wrong (sounding an octave _lower_ than the Soprano saxophone instead of _higher_). This corrects it

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [ ] ~~The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)~~ (N/A)
- [x] There are no unnecessary changes
- [ ] ~~The code compiles and runs on my machine, preferably after each commit individually~~ (N/A)
- [ ] ~~I created a unit test or vtest to verify the changes I made (if applicable)~~ (N/A)
