### PR TITLE
fw/ui: Save custom colors of QColorDialog in settings

### DIFF
--- a/src/framework/ui/internal/uiconfiguration.cpp
+++ b/src/framework/ui/internal/uiconfiguration.cpp
@@ -29,11 +29,12 @@
 #include "settings.h"
 #include "themeconverter.h"
 
-#include <QScreen>
 #include <QFontDatabase>
+#include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
-#include <QJsonArray>
+#include <QScreen>
+#include <QSettings>
 
 #ifdef Q_OS_WIN
 #include <QOperatingSystemVersion>
@@ -43,12 +44,14 @@
 
 #include "log.h"
 
+using namespace Qt::Literals;
 using namespace muse;
 using namespace muse::ui;
 using namespace muse::async;
 
 static const Settings::Key UI_THEMES_KEY("ui", "ui/application/themes");
 static const Settings::Key UI_CURRENT_THEME_CODE_KEY("ui", "ui/application/currentThemeCode");
+static const Settings::Key UI_CUSTOM_COLORS_KEY("ui", "ui/application/customColors");
 static const Settings::Key UI_FOLLOW_SYSTEM_THEME_KEY("ui", "ui/application/followSystemTheme");
 static const Settings::Key UI_FONT_FAMILY_KEY("ui", "ui/theme/fontFamily");
 static const Settings::Key UI_FONT_SIZE_KEY("ui", "ui/theme/fontSize");
@@ -64,11 +67,30 @@ static const int FLICKABLE_MAX_VELOCITY = 4000;
 
 static const int TOOLTIP_DELAY = 500;
 
+// read custom colors saved by Qt < 6.9
+// see: https://github.com/qt/qtbase/blob/v6.2.4/src/gui/kernel/qplatformdialoghelper.cpp#L292-L302
+static std::vector<Val> readLegacyCustomColors()
+{
+    constexpr size_t customColorCount = 16;
+
+    QSettings settings(QSettings::UserScope, u"QtProject"_s);
+    std::vector<Val> legacyValues(customColorCount, Val(QColorConstants::White));
+    for (size_t i = 0; i < customColorCount; ++i) {
+        const QVariant value = settings.value(u"Qt/customColors/"_s + QString::number(i));
+        if (value.isValid()) {
+            legacyValues[i] = Val(QColor::fromRgb(value.toUInt()));
+        }
+    }
+
+    return legacyValues;
+}
+
 void UiConfiguration::init()
 {
     m_config = ConfigReader::read(":/configs/ui.cfg");
 
     settings()->setDefaultValue(UI_CURRENT_THEME_CODE_KEY, Val(LIGHT_THEME_CODE));
+    settings()->setDefaultValue(UI_CUSTOM_COLORS_KEY, Val(readLegacyCustomColors()));
     settings()->setDefaultValue(UI_FOLLOW_SYSTEM_THEME_KEY, Val(false));
     settings()->setDefaultValue(UI_FONT_FAMILY_KEY, Val(defaultFontFamily()));
     settings()->setDefaultValue(UI_FONT_SIZE_KEY, Val(defaultFontSize()));
@@ -905,4 +927,28 @@ int UiConfiguration::flickableMaxVelocity() const
 int UiConfiguration::tooltipDelay() const
 {
     return TOOLTIP_DELAY;
+}
+
+std::vector<QColor> UiConfiguration::colorDialogCustomColors() const
+{
+    const ValList colorVals = settings()->value(UI_CUSTOM_COLORS_KEY).toList();
+
+    std::vector<QColor> customColors;
+    customColors.reserve(colorVals.size());
+    for (const auto& colorVal : colorVals) {
+        customColors.push_back(colorVal.toQColor());
+    }
+
+    return customColors;
+}
+
+void UiConfiguration::setColorDialogCustomColors(const std::vector<QColor>& customColors)
+{
+    ValList colorVals;
+    colorVals.reserve(customColors.size());
+    for (const auto& color: customColors) {
+        colorVals.emplace_back(color);
+    }
+
+    settings()->setLocalValue(UI_CUSTOM_COLORS_KEY, Val(colorVals));
 }

--- a/src/framework/ui/internal/uiconfiguration.h
+++ b/src/framework/ui/internal/uiconfiguration.h
@@ -131,6 +131,9 @@ public:
 
     int tooltipDelay() const override;
 
+    std::vector<QColor> colorDialogCustomColors() const override;
+    void setColorDialogCustomColors(const std::vector<QColor>&) override;
+
 private:
     void initThemes();
     void correctUserFontIfNeeded();

--- a/src/framework/ui/iuiconfiguration.h
+++ b/src/framework/ui/iuiconfiguration.h
@@ -24,6 +24,8 @@
 
 #include <optional>
 
+#include <QColor>
+
 #include "modularity/imoduleinterface.h"
 
 #include "global/types/retval.h"
@@ -124,5 +126,8 @@ public:
     virtual int flickableMaxVelocity() const = 0;
 
     virtual int tooltipDelay() const = 0;
+
+    virtual std::vector<QColor> colorDialogCustomColors() const = 0;
+    virtual void setColorDialogCustomColors(const std::vector<QColor>&) = 0;
 };
 }

--- a/src/framework/ui/tests/mocks/uiconfigurationmock.h
+++ b/src/framework/ui/tests/mocks/uiconfigurationmock.h
@@ -108,5 +108,8 @@ public:
     MOCK_METHOD(int, flickableMaxVelocity, (), (const, override));
 
     MOCK_METHOD(int, tooltipDelay, (), (const, override));
+
+    MOCK_METHOD(std::vector<QColor>, colorDialogCustomColors, (), (const, override));
+    MOCK_METHOD(void, setColorDialogCustomColors, (const std::vector<QColor>&), (override));
 };
 }

--- a/src/framework/ui/view/interactiveprovider.h
+++ b/src/framework/ui/view/interactiveprovider.h
@@ -19,8 +19,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef MUSE_UI_INTERACTIVEPROVIDER_H
-#define MUSE_UI_INTERACTIVEPROVIDER_H
+#pragma once
 
 #include <QObject>
 #include <QVariant>
@@ -30,6 +29,7 @@
 #include "global/async/asyncable.h"
 
 #include "modularity/ioc.h"
+#include "ui/iuiconfiguration.h"
 #include "../iinteractiveprovider.h"
 #include "../iinteractiveuriregister.h"
 #include "../imainwindow.h"
@@ -56,6 +56,7 @@ class InteractiveProvider : public QObject, public IInteractiveProvider, public 
 {
     Q_OBJECT
 
+    Inject<IUiConfiguration> config = { this };
     Inject<IInteractiveUriRegister> uriRegister = { this };
     Inject<IMainWindow> mainWindow = { this };
     Inject<muse::extensions::IExtensionsProvider> extensionsProvider = { this };
@@ -149,5 +150,3 @@ private:
     bool m_isSelectColorOpened = false;
 };
 }
-
-#endif // MUSE_UI_INTERACTIVEPROVIDER_H


### PR DESCRIPTION
Resolves: #30273

Save & restore the custom colors of the `QColorDialog`. Qt versions before 6.9 saved these per user in a `QSettings` instance under the organization name "QtProject". This functionality must be replaced by client code (us). Legacy values are read and used as default values.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
