### PR TITLE
ValueList customization

### DIFF
--- a/src/framework/uicomponents/qml/Muse/UiComponents/internal/ValueListHeaderItem.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/internal/ValueListHeaderItem.qml
@@ -34,6 +34,8 @@ Item {
     property bool isSorterEnabled: false
     property int sortOrder: Qt.AscendingOrder
 
+    property int headerCapitalization: Font.AllUppercase
+
     property alias navigation: navCtrl
 
     signal clicked()
@@ -79,7 +81,7 @@ Item {
 
             text: headerTitle
             horizontalAlignment: Text.AlignLeft
-            font.capitalization: Font.AllUppercase
+            font.capitalization: root.headerCapitalization
             opacity: ui.theme.buttonOpacityNormal
         }
 

--- a/src/framework/uicomponents/qml/Muse/UiComponents/internal/ValueListItem.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/internal/ValueListItem.qml
@@ -40,15 +40,36 @@ ListItemBlank {
 
     property bool readOnly: false
 
+    property bool drawZebra: true
+    property int keyColumnWidth: 0
+    property bool isKeyEditable: false
+    property bool startEditByDoubleClick: false
+
     property alias spacing: row.spacing
     property real sideMargin: 0
     property real valueItemWidth: 126
 
+    signal keyEdited(string newKey)
+    signal valueEdited(string newValue)
+    signal escapeEdit()
+
     height: 34
 
-    normalColor: (index % 2 == 0) ? ui.theme.backgroundSecondaryColor : ui.theme.backgroundPrimaryColor
+    normalColor: drawZebra ? ( (index % 2 == 0) ? ui.theme.backgroundSecondaryColor : ui.theme.backgroundPrimaryColor ) : ui.theme.backgroundPrimaryColor
 
-    navigation.accessible.name: titleLabel.text + ": " + (Boolean(loader.item) ? loader.item.accessibleName : "")
+    navigation.accessible.name: root.item[keyRoleName] + ": " + (Boolean(valueLoader.item) ? valueLoader.item.accessibleName : "")
+
+    navigation.onTriggered: {
+        if (isKeyEditable) {
+            keyLoader.item.startEdit(keyLoader.item.val)
+        }
+    }
+
+    navigation.onActiveChanged: {
+        if (isKeyEditable) {
+            keyLoader.item.escaped()
+        }
+    }
 
     QtObject {
         id: privateProperties
@@ -80,30 +101,74 @@ ListItemBlank {
 
         anchors.fill: parent
 
-        Row {
+        RowLayout {
             Layout.alignment: Qt.AlignLeft | Qt.AlignVCenter
-            Layout.fillWidth: true
+            Layout.fillWidth: root.keyColumnWidth != 0 ? false : true
+            Layout.preferredWidth: root.keyColumnWidth != 0 ? root.keyColumnWidth : -1
             Layout.leftMargin: root.sideMargin
 
-            spacing: 18
+            spacing: icon.iconCode == IconCode.NONE ? 0 : 18
 
             StyledIconLabel {
+                id: icon
                 iconCode: Boolean(root.item[iconRoleName]) ? root.item[iconRoleName] : IconCode.NONE
             }
 
-            StyledTextLabel {
-                id: titleLabel
-                text: root.item[keyRoleName]
-                horizontalAlignment: Text.AlignLeft
+            Loader {
+                id: keyLoader
+
+                property var val: root.item[keyRoleName]
+
+                Layout.alignment: Qt.AlignVCenter | Qt.AlignLeft
+                Layout.fillHeight: true
+                Layout.fillWidth: true
+
+                sourceComponent: root.isKeyEditable ? textComp : titleLabelComp
+
+                onLoaded: {
+                    keyLoader.item.val = keyLoader.val
+                }
+
+                onValChanged: {
+                    if (keyLoader.item) {
+                        keyLoader.item.val = keyLoader.val
+                    }
+                }
+
+                Connections {
+                    target: keyLoader.item
+                    function onChanged(newVal) {
+                        root.item[keyRoleName] = newVal
+                        listItem.keyEdited(newVal)
+                    }
+                }
+            }
+
+            Component {
+                id: titleLabelComp
+
+                StyledTextLabel {
+                    id: titleLabel
+
+                    property string val
+
+                    text: val
+
+                    horizontalAlignment: Text.AlignLeft
+                }
             }
         }
 
         Loader {
-            id: loader
+            id: valueLoader
             property var val: root.item[valueRoleName]
+            property NavigationPanel navPanel: root.navigation.panel
+            property int navRow: root.navigation.row
+            property int navColumn: 1
 
-            Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
-            Layout.preferredWidth: root.valueItemWidth
+            Layout.alignment: root.keyColumnWidth != 0 ? (Qt.AlignLeft | Qt.AlignVCenter) : (Qt.AlignRight | Qt.AlignVCenter)
+            Layout.preferredWidth: root.keyColumnWidth != 0 ? -1 : root.valueItemWidth
+            Layout.fillWidth: root.keyColumnWidth != 0 ? true : false
             Layout.rightMargin: root.sideMargin
 
             enabled: root.item[valueEnabledRoleName] !== undefined ? root.item[valueEnabledRoleName] : true
@@ -111,36 +176,94 @@ ListItemBlank {
             sourceComponent: !root.readOnly ? privateProperties.componentByType(root.item[valueTypeRole]) : readOnlyComponent
 
             onLoaded: {
-                loader.item.val = loader.val
+                valueLoader.item.val = valueLoader.val
 
                 if (privateProperties.isNumberComponent() && !root.readOnly) {
                     if (Boolean(root.item[minValueRoleName])) {
-                        loader.item.minValue = root.item[minValueRoleName]
+                        valueLoader.item.minValue = root.item[minValueRoleName]
                     }
 
                     if (Boolean(root.item[maxValueRoleName])) {
-                        loader.item.maxValue = root.item[maxValueRoleName]
+                        valueLoader.item.maxValue = root.item[maxValueRoleName]
                     }
                 }
+
+                valueLoader.item.navPanel = valueLoader.navPanel
+                valueLoader.item.navRow = valueLoader.navRow
+                valueLoader.item.navColumn = valueLoader.navColumn
             }
 
             onValChanged: {
-                if (loader.item) {
-                    loader.item.val = loader.val
+                if (valueLoader.item) {
+                    valueLoader.item.val = valueLoader.val
                 }
             }
 
             Connections {
-                target: loader.item
+                target: valueLoader.item
                 function onChanged(newVal) {
                     root.item[valueRoleName] = newVal
+                    listItem.valueEdited(newVal)
                 }
             }
         }
     }
 
+    SeparatorLine {
+        anchors.bottom: row.bottom
+
+        visible: !root.drawZebra
+    }
+
     Component {
         id: textComp
+
+        Loader {
+            id: textLoader
+            property var val
+            signal changed(var newVal)
+            signal startEdit(var val)
+            signal escaped()
+
+            property bool isKey: parent && parent === keyLoader
+
+            property NavigationPanel navPanel: !isKey ? root.navigation.panel : null
+            property int navRow: !isKey ? root.navigation.row : 0
+            property int navColumn: !isKey ? 1 : 0
+
+            sourceComponent: root.startEditByDoubleClick ? doubleClickTextComp : singleClickTextComp
+
+            onLoaded: {
+                textLoader.item.val = textLoader.val ?? ""
+
+                textLoader.item.navPanel = textLoader.navPanel
+                textLoader.item.navRow = textLoader.navRow
+                textLoader.item.navColumn = textLoader.navColumn
+            }
+
+            onValChanged: {
+                if (textLoader.item) {
+                    textLoader.item.val = textLoader.val
+                }
+            }
+
+            onStartEdit: function(val) {
+                textLoader.item.startEdit(val)
+            }
+
+            onEscaped: {
+                textLoader.item.escaped()
+            }
+
+            Connections {
+                target: textLoader.item
+                function onChanged(newVal) { textLoader.changed(newVal) }
+            }
+        }
+    }
+
+    Component {
+        id: singleClickTextComp
 
         TextInputField {
             id: textControl
@@ -149,15 +272,156 @@ ListItemBlank {
             signal changed(string newVal)
 
             property string accessibleName: navigation.accessible.name
+            property NavigationPanel navPanel: null
+            property int navRow: 0
+            property int navColumn: 0
 
-            navigation.panel: root.navigation.panel
-            navigation.row: root.navigation.row
-            navigation.column: 1
+            navigation.panel: navPanel
+            navigation.row: navRow
+            navigation.column: navColumn
 
             currentText: val
 
             onTextChanged: function(newTextValue) {
                 textControl.changed(newTextValue)
+            }
+        }
+    }
+
+    Component {
+        id: doubleClickTextComp
+
+        Item {
+            id: doubleClickItem
+
+            height: root.height
+            width: 10
+
+            property string val
+            property string accessibleName: navigation.accessible.name
+            property NavigationPanel navPanel
+            property int navRow
+            property int navColumn
+
+            signal changed(string newVal)
+            signal startEdit(var val)
+            signal escaped()
+
+            onStartEdit: function(val) {
+                valueEditLoader.edit(val)
+            }
+
+            onEscaped: {
+                valueEditLoader.escaped()
+            }
+
+            NavigationFocusBorder {
+                navigationCtrl: NavigationControl {
+                    id: valueNavCtrl
+                    enabled: doubleClickItem.enabled && doubleClickItem.visible
+                    panel: doubleClickItem.navPanel
+                    row: doubleClickItem.navRow
+                    column: doubleClickItem.navColumn
+
+                    onTriggered: {
+                        valueEditLoader.edit(doubleClickItem.val)
+                        root.clicked(mouseArea)
+                    }
+
+                    onActiveChanged: {
+                        if (!active) {
+                            valueEditLoader.escaped()
+                        }
+                    }
+                }
+
+                anchors.topMargin: 1
+                anchors.bottomMargin: 1
+            }
+
+            StyledTextLabel {
+                id: valueLabel
+
+                anchors.fill: parent
+                horizontalAlignment: Text.AlignLeft
+
+                visible: !valueEditLoader.isEditState
+
+                text: doubleClickItem.val
+            }
+
+            MouseArea {
+                anchors.fill: valueLabel
+
+                acceptedButtons: Qt.LeftButton
+                hoverEnabled: true
+                propagateComposedEvents: true
+
+                onDoubleClicked: (mouse) => {
+                    mouse.accepted = true
+                    valueEditLoader.edit(doubleClickItem.val)
+                }
+            }
+
+            Loader {
+                id: valueEditLoader
+
+                anchors.fill: valueLabel
+
+                property bool isEditState: false
+                sourceComponent: valueEditLoader.isEditState ? valueEditComp : null
+
+                function edit(text) {
+                    valueEditLoader.isEditState = true
+                    valueEditLoader.item.currentText = text
+                    valueEditLoader.item.newValue = text
+                    valueEditLoader.item.visible = true
+                    valueEditLoader.item.ensureActiveFocus()
+                }
+
+                function escaped() {
+                    valueEditLoader.item.escaped()
+                }
+            }
+
+            Component {
+                id: valueEditComp
+
+                TextInputField {
+                    id: valueEdit
+
+                    anchors.fill: parent
+
+                    property string newValue: ""
+
+                    background.color: "transparent"
+                    background.border.width: 0
+                    inputField.color: valueLabel.color
+                    textSidePadding: 0
+                    visible: false
+
+                    onTextChanged: function (text) {
+                        valueEdit.newValue = text
+                    }
+
+                    onAccepted: {
+                        doubleClickItem.changed(valueEdit.newValue)
+                        valueEditLoader.isEditState = false
+                    }
+
+                    onEscaped: {
+                        valueEditLoader.isEditState = false
+                    }
+
+                    onFocusChanged: {
+                        if (!valueEdit.focus) {
+                            valueEdit.visible = false
+                            valueEditLoader.isEditState = false
+                            valueEdit.accepted()
+                            doubleClickItem.changed(valueEdit.newValue)
+                        }
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/9619

Added customizability to the ValueList:
1.  Draw table without zebra coloring
2. Ability to color the header
3. Ability to make table headers capitalized or not
4. Ability to edit both keys and values (and added appropriate navigation
5. Ability to edit on double click
6. Ability to set 1st column width (so it doesn't have to be splitted 1:1)

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)

For QA:
- on MuseScore Studio side there should not be any difference in these preferences: Shortcuts, Advanced, MIDI mappings