### PR TITLE
'Minimum distance' property for rests

### DIFF
--- a/src/engraving/rendering/score/beamlayout.cpp
+++ b/src/engraving/rendering/score/beamlayout.cpp
@@ -899,10 +899,10 @@ void BeamLayout::verticalAdjustBeamedRests(Rest* rest, Beam* beam, LayoutContext
     const Shape restShape = rest->shape().translate(rest->pagePos() - rest->offset());
     const double minBeamToRestXDist = up && firstRest ? 0.1 * spatium : 0.0;
 
-    const double restToBeamClearance = up
+    const double lineDistance = rest->staff()->lineDistance(rest->tick()) * spatium;
+    const double restToBeamClearance = rest->minDistance().val() * lineDistance + up
                                        ? beamShape.verticalClearance(restShape, minBeamToRestXDist)
                                        : restShape.verticalClearance(beamShape);
-    const double lineDistance = rest->staff()->lineDistance(rest->tick()) * spatium;
 
     int clearanceInSteps = std::ceil(restToBeamClearance / lineDistance);
     up ? rest->verticalClearance().setAbove(clearanceInSteps) : rest->verticalClearance().setBelow(clearanceInSteps);

--- a/src/engraving/rendering/score/restlayout.cpp
+++ b/src/engraving/rendering/score/restlayout.cpp
@@ -243,7 +243,7 @@ void RestLayout::resolveRestVSChord(std::vector<Rest*>& rests, std::vector<Chord
                 minRestToChordClearance = 0.0;
             }
 
-            double margin = clearance - minRestToChordClearance;
+            double margin = clearance - minRestToChordClearance - rest->minDistance().val() * lineDistance;
             int marginInSteps = floor(margin / lineDistance);
             if (restAbove) {
                 restVerticalClearance.setBelow(marginInSteps);
@@ -320,7 +320,8 @@ void RestLayout::resolveRestVSRest(std::vector<Rest*>& rests, const Staff* staff
         } else {
             clearance = shape2.verticalClearance(shape1);
         }
-        double margin = clearance - minRestToRestClearance;
+        double minDistance = (rest1->minDistance().val() + rest2->minDistance().val()) * lineDistance;
+        double margin = clearance - minRestToRestClearance - minDistance;
         int marginInSteps = floor(margin / lineDistance);
         if (firstAbove) {
             rest1Clearance.setBelow(marginInSteps);
@@ -627,7 +628,7 @@ void RestLayout::checkFullMeasureRestCollisions(const System* system, LayoutCont
             const double spatium = fullMeasureRest->spatium();
             const double lineDist = fullMeasureRest->staff()->lineDistance(fullMeasureRest->tick()) * spatium;
             const double minHorizontalDistance = 4 * spatium;
-            const double minVertClearance = 0.75 * spatium;
+            const double minVertClearance = (fullMeasureRest->minDistance().val() + 0.75) * spatium;
 
             bool alignAbove = fullMeasureRest->voice() == 0;
             double verticalClearance = alignAbove ? restShape.verticalClearance(measureShape, minHorizontalDistance)
@@ -682,8 +683,7 @@ void RestLayout::fillShape(const MMRest* item, MMRest::LayoutData* ldata, const 
 
 int RestLayout::computeNaturalLine(int lines)
 {
-    int line = (lines % 2) ? floor(double(lines) / 2) : ceil(double(lines) / 2);
-    return line;
+    return lines / 2;
 }
 
 int RestLayout::computeVoiceOffset(const Rest* item, Rest::LayoutData* ldata)


### PR DESCRIPTION
This feature adds a purpose to the 'minimum distance' property for rests, controlling their vertical avoidance distance to chords or other rests. The distance is added onto the existing pre-calculated offset:
<img width="300" height="518" alt="grafik" src="https://github.com/user-attachments/assets/3a1a7a5c-0b4a-430f-bc26-664a107b6507" />

Here's an example with a large minimum distance of 2sp. The 'align with other rests' property has also offset the remaining rests in this example:

<img width="300" height="529" alt="grafik" src="https://github.com/user-attachments/assets/e5ec5fcb-f01d-453b-9f1e-8a7cb6972104" />

Crucially, this option allows for negative minimum distances, meaning it's possible to fix rests to a given line using a low minimum distance as well as the 'offset' property. This could improve MusicXML import as seen in #24971.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [x]  The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
