### PR TITLE
Fix #22671: Add support for nested tuplets in MusicXML

### DIFF
--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass1.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass1.cpp
@@ -2758,7 +2758,8 @@ void MusicXmlParserPass1::measure(const String& partId,
     Fraction mTime;   // current time stamp within measure
     Fraction mDura;   // current total measure duration
     vod.newMeasure();
-    MusicXmlTupletStates tupletStates;
+    MusicXmlNestedTupletStates nestedTupletStates;  // Tuplet state for each voice in the current part
+    VoiceNestedTupletsTimeMod nesTuplets;         // Current tuplet for each voice in the current part
 
     while (m_e.readNextStartElement()) {
         if (m_e.name() == "attributes") {
@@ -2770,7 +2771,7 @@ void MusicXmlParserPass1::measure(const String& partId,
             Fraction dura;
             Fraction missingCurr;
             // note: chord and grace note handling done in note()
-            note(partId, cTime + mTime, missingPrev, dura, missingCurr, vod, tupletStates);
+            note(partId, cTime + mTime, missingPrev, dura, missingCurr, vod, nestedTupletStates, nesTuplets);
             if (missingPrev.isValid()) {
                 mTime += missingPrev;
             }
@@ -2888,6 +2889,9 @@ void MusicXmlParserPass1::measure(const String& partId,
            muPrintable(partId), muPrintable(number), muPrintable(mdur.print()), mdur.ticks());
      */
     m_parts[partId].addMeasureNumberAndDuration(number, mdur);
+
+    // delete tuplets
+    nesTuplets.clear();
 
     addError(checkAtEndElement(m_e, u"measure"));
 }
@@ -3318,23 +3322,59 @@ void MusicXmlParserPass1::handleOctaveShift(const Fraction& cTime,
  Parse the /score-partwise/part/measure/note/notations node.
  */
 
-void MusicXmlParserPass1::notations(MusicXmlStartStop& tupletStartStop)
+void MusicXmlParserPass1::notations(MusicXmlStartStop& tupletStartStop, unsigned int& numberOfStartsOrStops,
+                                    NestedTupletsTimeMod& tupletsTimeMod, const Fraction timeModNote)
 {
     //_logger->logDebugTrace("MusicXmlParserPass1::note", &_e);
+    numberOfStartsOrStops = 0;
+    tupletsTimeMod.clear();
 
     while (m_e.readNextStartElement()) {
         if (m_e.name() == "tuplet") {
             String tupletType = m_e.attribute("type");
 
-            // ignore possible children (currently not supported)
-            m_e.skipCurrentElement();
-
             if (tupletType == u"start") {
                 tupletStartStop = MusicXmlStartStop::START;
+                ++numberOfStartsOrStops;
             } else if (tupletType == u"stop") {
                 tupletStartStop = MusicXmlStartStop::STOP;
+                ++numberOfStartsOrStops;
             } else if (!tupletType.empty() && tupletType != u"start" && tupletType != u"stop") {
                 m_logger->logError(String(u"unknown tuplet type '%1'").arg(tupletType), &m_e);
+            }
+
+            if (tupletStartStop == MusicXmlStartStop::START) {
+                int tupletActualNumber= 0;
+                int tupletNormalNumber = 0;
+
+                while (m_e.readNextStartElement()) {
+                    if (m_e.name() == "tuplet-actual") {
+                        while (m_e.readNextStartElement()) {
+                            if (m_e.name() == "tuplet-number") {
+                                tupletActualNumber = m_e.readInt();
+                            }
+                        }
+                    } else if (m_e.name() == "tuplet-normal") {
+                        while (m_e.readNextStartElement()) {
+                            if (m_e.name() == "tuplet-number") {
+                                tupletNormalNumber = m_e.readInt();
+                            }
+                        }
+                    }
+                    // ignore possible children
+                    m_e.skipCurrentElement();
+                }
+
+                if ((tupletActualNumber > 0) && (tupletNormalNumber > 0)) {
+                    tupletsTimeMod[numberOfStartsOrStops] = Fraction(tupletNormalNumber, tupletActualNumber);
+                }
+                // Tuplet number one may not have the information because it' is in't in previous note
+                else if (numberOfStartsOrStops == 1) {
+                    tupletsTimeMod[numberOfStartsOrStops] = timeModNote;
+                }
+            } else {
+                // ignore possible children
+                m_e.skipCurrentElement();
             }
         } else {
             m_e.skipCurrentElement();              // skip but don't log
@@ -3379,7 +3419,8 @@ void MusicXmlParserPass1::note(const String& partId,
                                Fraction& dura,
                                Fraction& missingCurr,
                                VoiceOverlapDetector& vod,
-                               MusicXmlTupletStates& tupletStates)
+                               MusicXmlNestedTupletStates& nestedTupletStates,
+                               VoiceNestedTupletsTimeMod& nesTuplets)
 {
     //_logger->logDebugTrace("MusicXmlParserPass1::note", &_e);
 
@@ -3399,6 +3440,8 @@ void MusicXmlParserPass1::note(const String& partId,
     String voice = u"1";
     String instrId;
     MusicXmlStartStop tupletStartStop { MusicXmlStartStop::NONE };
+    unsigned int numberOfStartsOrStops = 0;
+    NestedTupletsTimeMod tupletsTimeMod;
 
     MusicXmlNoteDuration mnd(m_divs, m_logger, this);
 
@@ -3427,7 +3470,7 @@ void MusicXmlParserPass1::note(const String& partId,
             m_parts[partId].hasLyrics(true);
             m_e.skipCurrentElement();
         } else if (m_e.name() == "notations") {
-            notations(tupletStartStop);
+            notations(tupletStartStop, numberOfStartsOrStops, tupletsTimeMod, mnd.timeMod());
         } else if (m_e.name() == "notehead") {
             m_e.skipCurrentElement();        // skip but don't log
         } else if (m_e.name() == "pitch") {
@@ -3498,9 +3541,36 @@ void MusicXmlParserPass1::note(const String& partId,
 
     if (!chord && !grace) {
         // do tuplet
-        Fraction timeMod = mnd.timeMod();
-        MusicXmlTupletState& tupletState = tupletStates[voice];
-        tupletState.determineTupletAction(mnd.duration(), timeMod, tupletStartStop, mnd.normalType(), missingPrev, missingCurr);
+        MusicXmlNestedTupletState& nestedTupletState = nestedTupletStates[voice];
+
+        if (tupletStartStop == MusicXmlStartStop::START) {
+            unsigned int tupletDepth = nestedTupletState.currentTupletDepth();
+            Fraction realTimeMod;
+
+            for (unsigned int i = 1; i <= numberOfStartsOrStops; ++i) {
+                ++tupletDepth;
+                nesTuplets[voice][tupletDepth] = tupletsTimeMod[i];
+                realTimeMod = nesTuplets[voice][tupletDepth];
+
+                nestedTupletState.determineTupletAction(mnd.duration(), realTimeMod, tupletStartStop,
+                                                        mnd.normalType(), missingPrev, missingCurr);
+            }
+        } else if (tupletStartStop == MusicXmlStartStop::STOP) {
+            unsigned int tupletDepth;
+            Fraction realTimeMod;
+
+            for (unsigned int i = numberOfStartsOrStops; i > 0; --i) {
+                tupletDepth = nestedTupletState.currentTupletDepth();
+                realTimeMod = nesTuplets[voice][tupletDepth];
+                nestedTupletState.determineTupletAction(mnd.duration(), realTimeMod, tupletStartStop,
+                                                        mnd.normalType(), missingPrev, missingCurr);
+            }
+        } else {
+            unsigned int tupletDepth = nestedTupletState.currentTupletDepth();
+            Fraction realTimeMod = nesTuplets[voice][tupletDepth];
+            nestedTupletState.determineTupletAction(mnd.duration(), realTimeMod, tupletStartStop, mnd.normalType(), missingPrev,
+                                                    missingCurr);
+        }
     }
 
     // store result

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass1.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass1.cpp
@@ -2892,7 +2892,6 @@ void MusicXmlParserPass1::measure(const String& partId,
 
     // delete tuplets
     nesTuplets.clear();
-
     addError(checkAtEndElement(m_e, u"measure"));
 }
 
@@ -3330,6 +3329,10 @@ void MusicXmlParserPass1::notations(MusicXmlStartStop& tupletStartStop, unsigned
     tupletsTimeMod.clear();
 
     while (m_e.readNextStartElement()) {
+        if (m_e.isStartElement()) {
+        }
+        if (m_e.isEndElement()) {
+        }
         if (m_e.name() == "tuplet") {
             String tupletType = m_e.attribute("type");
 
@@ -3545,31 +3548,30 @@ void MusicXmlParserPass1::note(const String& partId,
 
         if (tupletStartStop == MusicXmlStartStop::START) {
             unsigned int tupletDepth = nestedTupletState.currentTupletDepth();
-            Fraction realTimeMod;
+            Fraction currentTupletTimeMod;
 
             for (unsigned int i = 1; i <= numberOfStartsOrStops; ++i) {
                 ++tupletDepth;
                 nesTuplets[voice][tupletDepth] = tupletsTimeMod[i];
-                realTimeMod = nesTuplets[voice][tupletDepth];
-
-                nestedTupletState.determineTupletAction(mnd.duration(), realTimeMod, tupletStartStop,
+                currentTupletTimeMod = nesTuplets[voice][tupletDepth];
+                nestedTupletState.determineTupletAction(mnd.duration(), mnd.timeMod(), currentTupletTimeMod, tupletStartStop,
                                                         mnd.normalType(), missingPrev, missingCurr);
             }
         } else if (tupletStartStop == MusicXmlStartStop::STOP) {
             unsigned int tupletDepth;
-            Fraction realTimeMod;
+            Fraction currentTupletTimeMod;
 
             for (unsigned int i = numberOfStartsOrStops; i > 0; --i) {
                 tupletDepth = nestedTupletState.currentTupletDepth();
-                realTimeMod = nesTuplets[voice][tupletDepth];
-                nestedTupletState.determineTupletAction(mnd.duration(), realTimeMod, tupletStartStop,
+                currentTupletTimeMod = nesTuplets[voice][tupletDepth];
+                nestedTupletState.determineTupletAction(mnd.duration(), mnd.timeMod(), currentTupletTimeMod, tupletStartStop,
                                                         mnd.normalType(), missingPrev, missingCurr);
             }
         } else {
             unsigned int tupletDepth = nestedTupletState.currentTupletDepth();
-            Fraction realTimeMod = nesTuplets[voice][tupletDepth];
-            nestedTupletState.determineTupletAction(mnd.duration(), realTimeMod, tupletStartStop, mnd.normalType(), missingPrev,
-                                                    missingCurr);
+            Fraction currentTupletTimeMod = nesTuplets[voice][tupletDepth];
+            nestedTupletState.determineTupletAction(mnd.duration(), mnd.timeMod(), currentTupletTimeMod, tupletStartStop,
+                                                    mnd.normalType(), missingPrev, missingCurr);
         }
     }
 

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass1.h
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass1.h
@@ -56,6 +56,9 @@ struct PageFormat {
 typedef std::pair<int, int> StartStop;
 typedef std::vector<StartStop> StartStopList;
 
+using NestedTupletsTimeMod = std::map<unsigned int, engraving::Fraction>;
+using VoiceNestedTupletsTimeMod = std::map<muse::String, NestedTupletsTimeMod>;
+
 //---------------------------------------------------------
 //   MusicXmlOctaveShiftDesc
 //---------------------------------------------------------
@@ -166,9 +169,11 @@ public:
     void directionType(const engraving::Fraction cTime, std::vector<MusicXmlOctaveShiftDesc>& starts,
                        std::vector<MusicXmlOctaveShiftDesc>& stops);
     void handleOctaveShift(const engraving::Fraction& cTime, const muse::String& type, short size, MusicXmlOctaveShiftDesc& desc);
-    void notations(MusicXmlStartStop& tupletStartStop);
+    void notations(MusicXmlStartStop& tupletStartStop, unsigned int& numberOfStartsOrStops, NestedTupletsTimeMod& tupletsTimeMod,
+                   const engraving::Fraction timeModNote);
     void note(const muse::String& partId, const engraving::Fraction& cTime, engraving::Fraction& missingPrev, engraving::Fraction& dura,
-              engraving::Fraction& missingCurr, VoiceOverlapDetector& vod, MusicXmlTupletStates& tupletStates);
+              engraving::Fraction& missingCurr, VoiceOverlapDetector& vod, MusicXmlNestedTupletStates& nestedTupletStates,
+              VoiceNestedTupletsTimeMod& nesTuplets);
     void notePrintSpacingNo(engraving::Fraction& dura);
     engraving::Fraction calcTicks(const int& intTicks, const int& _divisions, const muse::XmlStreamReader* xmlReader);
     engraving::Fraction calcTicks(const int& intTicks) { return calcTicks(intTicks, m_divs, &m_e); }

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.cpp
@@ -9647,25 +9647,25 @@ void MusicXmlParserNotations::tuplet(const Fraction noteTimeMod, const unsigned 
 
     // set bracket, leave at default if unspecified
     if (tupletBracket == u"yes") {
-        m_tupletDesc.bracket = TupletBracketType::SHOW_BRACKET;
+        m_tupletDescList[tupletNumber].bracket = TupletBracketType::SHOW_BRACKET;
     } else if (tupletBracket == u"no") {
-        m_tupletDesc.bracket = TupletBracketType::SHOW_NO_BRACKET;
+        m_tupletDescList[tupletNumber].bracket = TupletBracketType::SHOW_NO_BRACKET;
     }
 
     // set number, default is "actual" (=NumberType::SHOW_NUMBER)
     if (tupletShowNumber == u"both") {
-        m_tupletDesc.shownumber = TupletNumberType::SHOW_RELATION;
+        m_tupletDescList[tupletNumber].shownumber = TupletNumberType::SHOW_RELATION;
     } else if (tupletShowNumber == u"none") {
-        m_tupletDesc.shownumber = TupletNumberType::NO_TEXT;
+        m_tupletDescList[tupletNumber].shownumber = TupletNumberType::NO_TEXT;
     } else {
-        m_tupletDesc.shownumber = TupletNumberType::SHOW_NUMBER;
+        m_tupletDescList[tupletNumber].shownumber = TupletNumberType::SHOW_NUMBER;
     }
 
     // set number and bracket placement
     if (tupletPlacement == u"above") {
-        m_tupletDesc.direction = DirectionV::UP;
+        m_tupletDescList[tupletNumber].direction = DirectionV::UP;
     } else if (tupletPlacement == u"below") {
-        m_tupletDesc.direction = DirectionV::DOWN;
+        m_tupletDescList[tupletNumber].direction = DirectionV::DOWN;
     } else if (tupletPlacement.empty()) {
         // ignore
     } else {

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.h
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.h
@@ -343,7 +343,12 @@ using MusicXmlTieMap = std::map<TieLocation, engraving::Tie*>;
 class MusicXmlParserNotations
 {
 public:
-    using MusicXmlTupletDescList = std::map<unsigned int, std::pair <MusicXmlTupletDesc, engraving::Fraction> >;
+    struct TupletDescInformation {
+        MusicXmlTupletDesc tupletDescription;
+        engraving::Fraction tupletTimeMod;
+    };
+    using MusicXmlTupletDescList = std::map<unsigned int, TupletDescInformation>;
+
     MusicXmlParserNotations(muse::XmlStreamReader& e, engraving::Score* score, MusicXmlLogger* logger, MusicXmlParserPass2& pass2);
     void parse(const engraving::Fraction noteTimeMod, unsigned int& tupletsProcessed);
     void addToScore(engraving::ChordRest* const cr, engraving::Note* const note, const engraving::Fraction& tick, SlurStack& slurs,

--- a/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.h
+++ b/src/importexport/musicxml/internal/musicxml/import/importmusicxmlpass2.h
@@ -73,6 +73,7 @@ namespace mu::iex::musicxml {
 using GraceChordList = std::vector<engraving::Chord*>;
 using FiguredBassList = std::vector<engraving::FiguredBass*>;
 using Tuplets = std::map<muse::String, engraving::Tuplet*>;
+using NestedTuplets = std::map<muse::String, std::map<unsigned int, engraving::Tuplet*> >;
 using Beams = std::map<muse::String, engraving::Beam*>;
 
 //---------------------------------------------------------
@@ -342,14 +343,15 @@ using MusicXmlTieMap = std::map<TieLocation, engraving::Tie*>;
 class MusicXmlParserNotations
 {
 public:
+    using MusicXmlTupletDescList = std::map<unsigned int, std::pair <MusicXmlTupletDesc, engraving::Fraction> >;
     MusicXmlParserNotations(muse::XmlStreamReader& e, engraving::Score* score, MusicXmlLogger* logger, MusicXmlParserPass2& pass2);
-    void parse();
+    void parse(const engraving::Fraction noteTimeMod, unsigned int& tupletsProcessed);
     void addToScore(engraving::ChordRest* const cr, engraving::Note* const note, const engraving::Fraction& tick, SlurStack& slurs,
                     engraving::Glissando* glissandi[MAX_NUMBER_LEVEL][2], MusicXmlSpannerMap& spanners, TrillStack& trills,
                     MusicXmlTieMap& ties, std::vector<engraving::Note*>& unstartedTieNotes, std::vector<engraving::Note*>& unendedTieNotes,
                     ArpeggioMap& arpMap, DelayedArpMap& delayedArps);
     muse::String errors() const { return m_errors; }
-    MusicXmlTupletDesc tupletDesc() const { return m_tupletDesc; }
+    MusicXmlTupletDescList tupletDescList() const { return m_tupletDescList; }
     bool hasTremolo() const { return m_hasTremolo; }
     muse::String tremoloType() const { return m_tremoloType; }
     muse::String tremoloSmufl() const { return m_tremoloSmufl; }
@@ -375,14 +377,14 @@ private:
     void technical();
     void otherTechnical();
     void tied();
-    void tuplet();
+    void tuplet(const engraving::Fraction noteTimeMod, const unsigned int tupletNumber);
     void otherNotation();
     muse::XmlStreamReader& m_e;
     MusicXmlParserPass2& m_pass2;
     engraving::Score* m_score = nullptr;                         // the score
     MusicXmlLogger* m_logger = nullptr;                              // the error logger
     muse::String m_errors;                    // errors to present to the user
-    MusicXmlTupletDesc m_tupletDesc;
+    MusicXmlTupletDescList m_tupletDescList;
     engraving::Color m_dynamicsColor;
     muse::String m_dynamicsPlacement;
     engraving::StringList m_dynamicsList;
@@ -464,8 +466,8 @@ private:
     engraving::Note* note(const muse::String& partId, engraving::Measure* measure, const engraving::Fraction sTime,
                           const engraving::Fraction prevTime, engraving::Fraction& missingPrev, engraving::Fraction& dura,
                           engraving::Fraction& missingCurr, muse::String& currentVoice, GraceChordList& gcl, size_t& gac, Beams& currBeams,
-                          FiguredBassList& fbl, int& alt, MusicXmlTupletStates& tupletStates, Tuplets& tuplets, ArpeggioMap& arpMap,
-                          DelayedArpMap& delayedArps);
+                          FiguredBassList& fbl, int& alt, MusicXmlNestedTupletStates& nestedTupletStates, NestedTuplets& nesTuplets,
+                          ArpeggioMap& arpMap, DelayedArpMap& delayedArps);
     void notePrintSpacingNo(engraving::Fraction& dura);
     engraving::FiguredBassItem* figure(const int idx, const bool paren, engraving::FiguredBass* parent);
     engraving::FiguredBass* figuredBass();

--- a/src/importexport/musicxml/internal/musicxml/import/musicxmltupletstate.cpp
+++ b/src/importexport/musicxml/internal/musicxml/import/musicxmltupletstate.cpp
@@ -44,6 +44,11 @@ void MusicXmlTupletState::determineTupletFractionAndFullDuration(const Fraction 
     fraction = duration;
     fullDuration = Fraction(1, 1);
 
+    if (duration == Fraction(0, 1)) {
+        LOGD("Error: Fraction 0");
+        return;
+    }
+
     // move denominator's powers of 2 from fraction to fullDuration
     while (fraction.denominator() % 2 == 0) {
         fraction *= 2;
@@ -140,7 +145,6 @@ bool MusicXmlTupletState::isTupletFilled(const TDuration normalType, const Fract
     if (normalType.isValid()) {
         int matchedNormalType  = int(normalType.type());
         int matchedNormalCount = actualNotes;
-
         // match the types
         matchTypeAndCount(matchedNormalType, matchedNormalCount);
         // ... result scenario (1)
@@ -166,6 +170,15 @@ bool MusicXmlTupletState::isTupletFilled(const TDuration normalType, const Fract
          */
     }
     return res;
+}
+
+//---------------------------------------------------------
+//   currentTupletDuration
+//---------------------------------------------------------
+
+Fraction MusicXmlTupletState::currentTupletDuration()
+{
+    return duration;
 }
 
 //---------------------------------------------------------
@@ -288,15 +301,26 @@ MusicXmlTupletFlags MusicXmlTupletState::determineTupletAction(const Fraction no
                                                                const Fraction timeMod,
                                                                const MusicXmlStartStop tupletStartStop,
                                                                const TDuration normalType,
+                                                               const bool falseTuplet,
                                                                Fraction& missingPreviousDuration,
                                                                Fraction& missingCurrentDuration,
-                                                               Fraction& durationWhenStopped)
+                                                               bool& isImplicit)
 {
     const int actNotes = timeMod.denominator();
     const int norNotes = timeMod.numerator();
     MusicXmlTupletFlags res = MusicXmlTupletFlag::NONE;
-    durationWhenStopped = Fraction(1, 1);
-    LOGI() << "tpacebes devolvemos res NONE";
+
+    // check for unexpected termination of previous tuplet
+    if (inTuplet && !falseTuplet && timeMod == Fraction(1, 1)) {
+        // recover by simply stopping the current tuplet first
+        if (!isTupletFilled(normalType, timeMod)) {
+            missingPreviousDuration = missingTupletDuration(duration);
+            //LOGD("tuplet incomplete, missing %s", muPrintable(missingPreviousDuration.print()));
+        }
+        // Duration when ended
+        *this = {};
+        res |= MusicXmlTupletFlag::STOP_PREVIOUS;
+    }
 
     // check for obvious errors
     if (inTuplet && tupletStartStop == MusicXmlStartStop::START) {
@@ -306,24 +330,28 @@ MusicXmlTupletFlags MusicXmlTupletState::determineTupletAction(const Fraction no
             missingPreviousDuration = missingTupletDuration(duration);
             //LOGD("tuplet incomplete, missing %s", muPrintable(missingPreviousDuration.print()));
         }
-        // Duration when ended
-        durationWhenStopped = duration;
         *this = {};
         res |= MusicXmlTupletFlag::STOP_PREVIOUS;
     }
 
+    // We have been already stopped and we are asked again to stop. Therefore we should communicate
     if (tupletStartStop == MusicXmlStartStop::STOP && !inTuplet) {
         LOGD("tuplet stop but no tuplet started");           // TODO
+        *this = {};
+        res |= MusicXmlTupletFlag::STOP_CURRENT;
+
         // recovery handled later (automatically, no special case needed)
     }
 
     // Tuplet are either started by the tuplet start
     // or when the time modification is first found.
+    // and it's not a false Tuplet
     if (!inTuplet) {
         if (tupletStartStop == MusicXmlStartStop::START
-            || (!inTuplet && (actNotes != 1 || norNotes != 1))) {
+            || (!falseTuplet && (actNotes != 1 || norNotes != 1))) {
             if (tupletStartStop != MusicXmlStartStop::START) {
                 implicit = true;
+                isImplicit = true;
             } else {
                 implicit = false;
             }
@@ -342,8 +370,6 @@ MusicXmlTupletFlags MusicXmlTupletState::determineTupletAction(const Fraction no
         res |= MusicXmlTupletFlag::ADD_CHORD;
     }
 
-    LOGI() << "tpacebes determineTupletAction duration durationTupleta es " << durationWhenStopped.toString();
-
     // Tuplets are stopped by the tuplet stop
     // or when the tuplet is filled completely
     // (either with knowledge of the normal type
@@ -353,14 +379,12 @@ MusicXmlTupletFlags MusicXmlTupletState::determineTupletAction(const Fraction no
 
     if (inTuplet) {
         if (tupletStartStop == MusicXmlStartStop::STOP
-            || (implicit && isTupletFilled(normalType, timeMod))) {
+            || (implicit && isTupletFilled(normalType, timeMod))
+            ) {
             if (actNotes > norNotes && !isTupletFilled(normalType, timeMod)) {
                 missingCurrentDuration = missingTupletDuration(duration);
                 LOGD("current tuplet incomplete, missing %s", muPrintable(missingCurrentDuration.toString()));
             }
-
-            // Duration when ended
-            durationWhenStopped = duration;
             *this = {};
             res |= MusicXmlTupletFlag::STOP_CURRENT;
         }
@@ -374,72 +398,144 @@ MusicXmlTupletFlags MusicXmlTupletState::determineTupletAction(const Fraction no
 //---------------------------------------------------------
 
 MusicXmlTupletFlags MusicXmlNestedTupletState::determineTupletAction(const engraving::Fraction noteDuration,
-                                                                     const engraving::Fraction timeMod,
+                                                                     const engraving::Fraction noteTimeMod,
+                                                                     const engraving::Fraction currentTupletTimeMod,
                                                                      const MusicXmlStartStop tupletStartStop,
                                                                      const engraving::TDuration normalType,
                                                                      engraving::Fraction& missingPreviousDuration,
                                                                      engraving::Fraction& missingCurrentDuration)
 {
     MusicXmlTupletFlags tupletAction;
-    Fraction tupletDurationWhenStopped = Fraction(1, 1);
-    bool newImplicitTupletStart = false;
+    MusicXmlTupletState tupletState;
+    bool isImplicit = false;
+    Fraction originalMissingPreviousDuration = missingPreviousDuration;
+    Fraction originanMissingCurrentDuration = missingCurrentDuration;
+    bool forcedStopPrevious = false;
+    Fraction timeModTupletAction = workingTimeMode(noteTimeMod, currentTupletTimeMod);
+    // bool falseTuplet = ((noteTimeMod != Fraction(1, 1)) && (currentTupletTimeMod == Fraction(1, 1)));
+    bool falseTuplet = (currentTupletTimeMod == Fraction(1, 1));
 
-    // Check if this is an implicit Tuplet if needed.
-    // We could only deal with implicit tuplets when there aren't any tuplet yet (no nested implicit tuplets)
-    // There is no way to differentiate between a "middle" note in a tuplet and the start of a new implicit tuplet
-    if ((tupletStartStop != MusicXmlStartStop::START) && (tupletStartStop != MusicXmlStartStop::STOP)
-        && (m_tupletNestingDepth == 0) & !m_tupletCurrentDepthIsImplicit) {
-        // We check if there is a new implicit start
-        MusicXmlTupletFlags checkTupletAction;
-        MusicXmlTupletState checkTupletState;
-        checkTupletAction = checkTupletState.determineTupletAction(noteDuration, timeMod, tupletStartStop, normalType,
-                                                                   missingPreviousDuration, missingCurrentDuration,
-                                                                   tupletDurationWhenStopped);
+    // Check if we should create a new depth of tuplets or not
+    tupletAction = tupletState.determineTupletAction(noteDuration, timeModTupletAction, tupletStartStop, normalType, falseTuplet,
+                                                     missingPreviousDuration, missingCurrentDuration, isImplicit);
 
-        // If we should start a new tuplet and there isn't a START is an implicit Start
-        m_tupletCurrentDepthIsImplicit = (checkTupletAction & MusicXmlTupletFlag::START_NEW);
-        newImplicitTupletStart = m_tupletCurrentDepthIsImplicit;
-    }
+    if (((m_tupletNestingDepth == 0) && (isImplicit || (tupletStartStop == MusicXmlStartStop::START)))
+        || ((m_tupletNestingDepth > 0) && (tupletStartStop == MusicXmlStartStop::START))) {
+        // Destroy previous tuplet if necessary
+        if ((m_tupletNestingDepth > 0) && !falseTuplet && isTupletFull(m_tupletNestingDepth)) {
+            // End previous tuplet
+            m_measureTupletStates.erase(m_tupletNestingDepth);
+            --m_tupletNestingDepth;
+            m_tupletFormerNestingDepth = m_tupletNestingDepth + 1;
 
-    if (((m_tupletCurrentDepthIsImplicit) && (newImplicitTupletStart)) || (tupletStartStop == MusicXmlStartStop::START)) {
+            // We should return a STOP_PREVIOUS
+            forcedStopPrevious = true;
+        }
+        // A new tuplet must be created
         ++m_tupletNestingDepth;
         m_tupletFormerNestingDepth = m_tupletNestingDepth - 1;
-
-        // Adding a new tuplet State
-        MusicXmlTupletState tupletState;
-        m_measureTupletStates[m_tupletNestingDepth] = std::make_pair(tupletState, timeMod);
+        m_measureTupletStates[m_tupletNestingDepth].tupletTimeMod = timeModTupletAction;
+        if (m_tupletNestingDepth == 1) {
+            m_measureTupletStates[m_tupletNestingDepth].tupletFullSize = noteDuration * noteTimeMod.denominator();
+        } else {
+            m_measureTupletStates[m_tupletNestingDepth].tupletFullSize = m_measureTupletStates[m_tupletNestingDepth - 1].tupletFullSize
+                                                                         / m_measureTupletStates[m_tupletNestingDepth
+                                                                                                 - 1].tupletTimeMod.denominator();
+        }
     }
 
     if (m_tupletNestingDepth == 0) {
         tupletAction = MusicXmlTupletFlag::NONE;
-    } else {
-        tupletAction = m_measureTupletStates[m_tupletNestingDepth].first.determineTupletAction(noteDuration, timeMod, tupletStartStop,
-                                                                                               normalType, missingPreviousDuration,
-                                                                                               missingCurrentDuration,
-                                                                                               tupletDurationWhenStopped);
+    }
+    // No start and depth --> Let's update the former tupletstate
+    else {
+        // Recovering original values;
+        missingPreviousDuration = originalMissingPreviousDuration;
+        missingCurrentDuration = originanMissingCurrentDuration;
 
-        if ((tupletAction & MusicXmlTupletFlag::STOP_CURRENT) || (tupletAction & MusicXmlTupletFlag::STOP_PREVIOUS)) {
-            m_measureTupletStates.erase(m_tupletNestingDepth);
-            // End of implicit Tuplet
-            m_tupletCurrentDepthIsImplicit = false;
-            --m_tupletNestingDepth;
-            m_tupletFormerNestingDepth = m_tupletNestingDepth + 1;
+        // Keep the ratio 1/1 if this is current tuplet timeMod
+        Fraction tupletTimeMod = workingTimeMode(timeModTupletAction, m_measureTupletStates[m_tupletNestingDepth].tupletTimeMod);
 
-            // We add the length of the current tuplet to te parent (if there is a parent)
-            if (m_tupletNestingDepth > 0) {
-                Fraction ignoredMissingPreviousDuration;
-                Fraction ignoredMissingCurrentDuration;
-                Fraction ignoredtupletDurationWhenStopped;
+        // We should update the existing tuplet
+        tupletAction = m_measureTupletStates[m_tupletNestingDepth].tupletState.determineTupletAction(noteDuration,
+                                                                                                     tupletTimeMod,
+                                                                                                     tupletStartStop,
+                                                                                                     normalType, falseTuplet,
+                                                                                                     missingPreviousDuration,
+                                                                                                     missingCurrentDuration, isImplicit);
+    }
 
-                MusicXmlTupletFlags ignoredTupletAction = m_measureTupletStates[m_tupletNestingDepth].first.determineTupletAction(
-                    tupletDurationWhenStopped + missingCurrentDuration, m_measureTupletStates[m_tupletNestingDepth].second,
-                    MusicXmlStartStop::NONE, normalType, ignoredMissingPreviousDuration, ignoredMissingCurrentDuration,
-                    ignoredtupletDurationWhenStopped);
-            }
+    // We should add this duration to the parents if it's not the start of a new tuplet or if not asked to stop the previous tuplet (and start a new one)
+    if ((tupletAction & MusicXmlTupletFlag::ADD_CHORD) && !(tupletAction & MusicXmlTupletFlag::START_NEW)
+        && !(tupletAction & MusicXmlTupletFlag::STOP_PREVIOUS)) {
+        for (int i = (m_tupletNestingDepth - 1); i > 0; --i) {
+            MusicXmlTupletFlags ignoredTupletAction;
+            MusicXmlTupletState ignoredTupletState;
+            bool ignoredIsImplicit = false;
+            Fraction ignoredMissingPreviousDuration = Fraction(0, 1);
+            Fraction ignoredMissingCurrentDuration = Fraction(0, 1);
+            Fraction localTimeModTupletAction = (noteTimeMod == Fraction(1, 1) ? noteTimeMod : m_measureTupletStates[i].tupletTimeMod);
+            bool localFalseTuplet = ((noteTimeMod != Fraction(1, 1)) && (m_measureTupletStates[i].tupletTimeMod == Fraction(1, 1)));
+
+            // We should update the existing tuplet
+            ignoredTupletAction = m_measureTupletStates[i].tupletState.determineTupletAction(noteDuration,
+                                                                                             localTimeModTupletAction,
+                                                                                             MusicXmlStartStop::NONE,
+                                                                                             normalType, localFalseTuplet,
+                                                                                             ignoredMissingPreviousDuration,
+                                                                                             ignoredMissingCurrentDuration,
+                                                                                             ignoredIsImplicit);
         }
     }
 
+    // Delete current depoth
+    if ((tupletAction & MusicXmlTupletFlag::STOP_CURRENT) || (tupletAction & MusicXmlTupletFlag::STOP_PREVIOUS)) {
+        m_measureTupletStates.erase(m_tupletNestingDepth);
+        --m_tupletNestingDepth;
+        m_tupletFormerNestingDepth = m_tupletNestingDepth + 1;
+    }
+
+    // Add the flag
+    if (forcedStopPrevious) {
+        tupletAction |= MusicXmlTupletFlag::STOP_PREVIOUS;
+    }
     return tupletAction;
+}
+
+//---------------------------------------------------------
+//   workingTimeMode
+//---------------------------------------------------------
+
+Fraction MusicXmlNestedTupletState::workingTimeMode(const engraving::Fraction noteTimeMod,
+                                                    const engraving::Fraction currentTupletTimeMod)
+{
+    return (noteTimeMod == Fraction(1, 1) || (currentTupletTimeMod == Fraction(0, 1))) ? noteTimeMod : currentTupletTimeMod;
+}
+
+//---------------------------------------------------------
+//   isTupletFull
+//---------------------------------------------------------
+
+bool MusicXmlNestedTupletState::isTupletFull(unsigned int depth)
+{
+    if (m_measureTupletStates[depth].tupletTimeMod == Fraction(1, 1)) {
+        return false;
+    } else {
+        return m_measureTupletStates[depth].tupletState.currentTupletDuration() >= m_measureTupletStates[depth].tupletFullSize;
+    }
+}
+
+//---------------------------------------------------------
+//   tupletTimeMod
+//---------------------------------------------------------
+
+Fraction MusicXmlNestedTupletState::tupletTimeMod(const unsigned int tupletDepth)
+{
+    if (tupletDepth > m_tupletNestingDepth) {
+        return Fraction(0, 1);
+    } else {
+        return m_measureTupletStates[tupletDepth].tupletTimeMod;
+    }
 }
 
 //---------------------------------------------------------

--- a/src/importexport/musicxml/internal/musicxml/import/musicxmltupletstate.h
+++ b/src/importexport/musicxml/internal/musicxml/import/musicxmltupletstate.h
@@ -19,10 +19,10 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 #pragma once
 
 #include "global/types/flags.h"
+
 #include "engraving/types/fraction.h"
 
 namespace mu::engraving {
@@ -45,8 +45,9 @@ class MusicXmlTupletState
 public:
     MusicXmlTupletFlags determineTupletAction(const engraving::Fraction noteDuration, const engraving::Fraction timeMod,
                                               const MusicXmlStartStop tupletStartStop, const engraving::TDuration normalType,
-                                              engraving::Fraction& missingPreviousDuration, engraving::Fraction& missingCurrentDuration,
-                                              engraving::Fraction& durationWhenStopped);
+                                              const bool falseTuplet, engraving::Fraction& missingPreviousDuration,
+                                              engraving::Fraction& missingCurrentDuration, bool& isImplicit);
+    engraving::Fraction currentTupletDuration();
     static void determineTupletFractionAndFullDuration(const engraving::Fraction duration, engraving::Fraction& fraction,
                                                        engraving::Fraction& fullDuration);
     static engraving::Fraction missingTupletDuration(const engraving::Fraction duration);
@@ -61,8 +62,8 @@ private:
     int actualNotes = 1;
     int normalNotes = 1;
     engraving::Fraction duration{ 0, 1 };
-    int smallestNoteType = 0;       // smallest note type in the tuplet
-    int smallestNoteCount = 0;       // number of smallest notes in the tuplet
+    int smallestNoteType = 0;   // smallest note type in the tuplet
+    int smallestNoteCount = 0;   // number of smallest notes in the tuplet
 };
 
 using MusicXmlTupletStates = std::map<muse::String, MusicXmlTupletState>;
@@ -70,17 +71,26 @@ using MusicXmlTupletStates = std::map<muse::String, MusicXmlTupletState>;
 class MusicXmlNestedTupletState
 {
 public:
-    MusicXmlTupletFlags determineTupletAction(const engraving::Fraction noteDuration, const engraving::Fraction timeMod,
-                                              const MusicXmlStartStop tupletStartStop, const engraving::TDuration normalType,
-                                              engraving::Fraction& missingPreviousDuration, engraving::Fraction& missingCurrentDuration);
+    MusicXmlTupletFlags determineTupletAction(const engraving::Fraction noteDuration, const engraving::Fraction globalTimeMod,
+                                              const engraving::Fraction localTimeMod, const MusicXmlStartStop tupletStartStop,
+                                              const engraving::TDuration normalType, engraving::Fraction& missingPreviousDuration,
+                                              engraving::Fraction& missingCurrentDuration);
+    engraving::Fraction tupletTimeMod(const unsigned int tupletDepth);
     unsigned int currentTupletDepth();
     unsigned int formerTupletDepth();
 
 private:
+    bool isTupletFull(unsigned int depth);
+    engraving::Fraction workingTimeMode(const engraving::Fraction noteTimeMod, const engraving::Fraction currentTupletTimeMod);
     unsigned int m_tupletNestingDepth = 0;
     unsigned int m_tupletFormerNestingDepth = 0;
-    bool m_tupletCurrentDepthIsImplicit = false;
-    std::map <unsigned int, std::pair<MusicXmlTupletState, engraving::Fraction> > m_measureTupletStates;
+    struct TupletInformation {
+        MusicXmlTupletState tupletState;
+        engraving::Fraction tupletTimeMod;
+        engraving::Fraction tupletFullSize;
+    };
+    // Tuplet State, Tuplet TimeMod, Tuplet
+    std::map <unsigned int, TupletInformation> m_measureTupletStates;
 };
 
 using MusicXmlNestedTupletStates = std::map<muse::String, MusicXmlNestedTupletState>;

--- a/src/importexport/musicxml/internal/musicxml/import/musicxmltupletstate.h
+++ b/src/importexport/musicxml/internal/musicxml/import/musicxmltupletstate.h
@@ -19,10 +19,10 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
 #pragma once
 
 #include "global/types/flags.h"
-
 #include "engraving/types/fraction.h"
 
 namespace mu::engraving {
@@ -45,7 +45,8 @@ class MusicXmlTupletState
 public:
     MusicXmlTupletFlags determineTupletAction(const engraving::Fraction noteDuration, const engraving::Fraction timeMod,
                                               const MusicXmlStartStop tupletStartStop, const engraving::TDuration normalType,
-                                              engraving::Fraction& missingPreviousDuration, engraving::Fraction& missingCurrentDuration);
+                                              engraving::Fraction& missingPreviousDuration, engraving::Fraction& missingCurrentDuration,
+                                              engraving::Fraction& durationWhenStopped);
     static void determineTupletFractionAndFullDuration(const engraving::Fraction duration, engraving::Fraction& fraction,
                                                        engraving::Fraction& fullDuration);
     static engraving::Fraction missingTupletDuration(const engraving::Fraction duration);
@@ -59,9 +60,28 @@ private:
     bool implicit = false;
     int actualNotes = 1;
     int normalNotes = 1;
-    engraving::Fraction duration { 0, 1 };
-    int smallestNoteType = 0;   // smallest note type in the tuplet
-    int smallestNoteCount = 0;   // number of smallest notes in the tuplet
+    engraving::Fraction duration{ 0, 1 };
+    int smallestNoteType = 0;       // smallest note type in the tuplet
+    int smallestNoteCount = 0;       // number of smallest notes in the tuplet
 };
+
 using MusicXmlTupletStates = std::map<muse::String, MusicXmlTupletState>;
+
+class MusicXmlNestedTupletState
+{
+public:
+    MusicXmlTupletFlags determineTupletAction(const engraving::Fraction noteDuration, const engraving::Fraction timeMod,
+                                              const MusicXmlStartStop tupletStartStop, const engraving::TDuration normalType,
+                                              engraving::Fraction& missingPreviousDuration, engraving::Fraction& missingCurrentDuration);
+    unsigned int currentTupletDepth();
+    unsigned int formerTupletDepth();
+
+private:
+    unsigned int m_tupletNestingDepth = 0;
+    unsigned int m_tupletFormerNestingDepth = 0;
+    bool m_tupletCurrentDepthIsImplicit = false;
+    std::map <unsigned int, std::pair<MusicXmlTupletState, engraving::Fraction> > m_measureTupletStates;
+};
+
+using MusicXmlNestedTupletStates = std::map<muse::String, MusicXmlNestedTupletState>;
 }


### PR DESCRIPTION
Resolves: #22671<!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
- This PR is able to deal with nested tuplets when importing nested tuplets in MusicXML
- It has been tested with the following Score: [musescore-22671-test.zip](https://github.com/user-attachments/files/23344743/musescore-22671-test.zip)

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
