### PR TITLE
Add missing <mutex> header

### DIFF
--- a/src/framework/global/thirdparty/kors_modularity/modularity/ioc.h
+++ b/src/framework/global/thirdparty/kors_modularity/modularity/ioc.h
@@ -25,6 +25,7 @@ SOFTWARE.
 #pragma once
 
 #include <memory>
+#include <mutex>
 #include <shared_mutex>
 #include <string_view>
 


### PR DESCRIPTION
Fixes a build failure observed on Ubuntu 25.10 (g++-13, Qt 6.9.3 Debug build) where `std::unique_lock` is undefined.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
