### PR TITLE
Re-enable LPF in fluid synth

### DIFF
--- a/src/framework/audio/thirdparty/fluidsynth/fluidsynth-2.3.3/src/synth/fluid_voice.c
+++ b/src/framework/audio/thirdparty/fluidsynth/fluidsynth-2.3.3/src/synth/fluid_voice.c
@@ -197,11 +197,7 @@ static void fluid_voice_initialize_rvoice(fluid_voice_t *voice, fluid_real_t out
     fluid_voice_update_modenv(voice, FALSE, FLUID_VOICE_ENVFINISHED,
                               0xffffffff, 0.0f, 0.0f, -1.0f, 1.0f);
 
-#ifdef ENABLE_DEFAULT_COMPRESSION
     param[0].i = FLUID_IIR_LOWPASS;
-#else
-    param[0].i = FLUID_IIR_DISABLED;
-#endif
     param[1].i = 0;
     fluid_iir_filter_init(&voice->rvoice->resonant_filter, param);
 


### PR DESCRIPTION
(cherry picked from commit 3749ef0ea4069a489a7adbfd79cfe6d2fdd0c98a)

Resolves: #19859
Resolves: #24779
Resolves: #13963

This PR re-enables the low pass filter, which was disabled in #10731 (presumably to fix other issues).
This PR is a rebase of the closed PR #16448, originally authored by @handrok.

Regarding https://github.com/musescore/MuseScore/issues/19859#issuecomment-1801894975:
> When I tested [#16448](https://github.com/musescore/MuseScore/pull/16448) there was a problem with Piano: on high dynamics (ff, fff) the tone didn't get any brighter as in MS3 (low pass filter didn't react on dynamic changes) [@RomanPudashkin](https://github.com/RomanPudashkin) says that PR should be reworked (rebase is not enough)

I suspect the issue at that time might not have been the filter itself, but rather that the appropriate samples were not being used for different dynamics.

I believe this sample selection issue was resolved between v4.3 and v4.4. While I haven't pinpointed the exact commit, I can clearly hear the difference, and the v4.4.0 release notes state: "Dynamics now use optimal playback parameters (varies depending on sound technology) for more realistic playback," which seems relevant.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
