### PR TITLE
Nullcheck return of createAnchors

### DIFF
--- a/src/engraving/dom/spanner.cpp
+++ b/src/engraving/dom/spanner.cpp
@@ -1104,6 +1104,9 @@ Segment* Spanner::startSegment() const
         Measure* measure = mmRest ? score()->tick2measureMM(startTick) : score()->tick2measure(startTick);
         if (measure) {
             TimeTickAnchor* anchor = EditTimeTickAnchors::createTimeTickAnchor(measure, startTick - measure->tick(), track2staff(trackIdx));
+            IF_ASSERT_FAILED(anchor) {
+                return nullptr;
+            }
             EditTimeTickAnchors::updateLayout(measure);
             return anchor->segment();
         }


### PR DESCRIPTION
Resolves: #30856

This is a hotfix for the patch. Should fix the crash in release mode, and fail the assertion in debug mode.

TODO: The true problem lies in `Chord::scanChildren`. All of these scanChildren functions are very weird and should probably be removed entirely. They are basically copies of scanElements except they just return the list of children. But if that's the case a) they should be called getChildren cause they are not doing any operation on the children themselves, b) they should be implemented using the scanElement methods, not copypasting their code.