### PR TITLE
[4.6.4] Use ALSA by default on Linux

### DIFF
--- a/src/framework/audio/internal/audioconfiguration.cpp
+++ b/src/framework/audio/internal/audioconfiguration.cpp
@@ -71,7 +71,7 @@ void AudioConfiguration::init()
     });
 
 #if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
-    settings()->setDefaultValue(AUDIO_API_KEY, Val("PipeWire"));
+    settings()->setDefaultValue(AUDIO_API_KEY, Val("ALSA Audio"));
 #endif
     settings()->valueChanged(AUDIO_API_KEY).onReceive(nullptr, [this](const Val&) {
         m_currentAudioApiChanged.notify();


### PR DESCRIPTION
We've been getting a lot of reports from Linux users that they have no audio when using PipeWire. So we've decided to switch back to ALSA as the default API (until we fix this issue), while keeping PipeWire available in Preferences. @rtbo FYI