### PR TITLE
Fix measure number too far from  bracket

### DIFF
--- a/src/engraving/rendering/score/measurenumberlayout.cpp
+++ b/src/engraving/rendering/score/measurenumberlayout.cpp
@@ -122,11 +122,14 @@ void MeasureNumberLayout::layoutMeasureNumberBase(MeasureNumberBase* item, Measu
 
     TextLayout::layoutBaseTextBase1(item, ldata);
 
+    staff_idx_t effectiveStaffIdx = item->effectiveStaffIdx();
+    Staff* staff = item->score()->staff(effectiveStaffIdx);
+
     if (item->placeBelow()) {
         double yoff = ldata->bbox().height();
 
         // If there is only one line, the barline spans outside the staff lines, so the default position is not correct.
-        if (item->staff()->constStaffType(item->measure()->tick())->lines() == 1) {
+        if (staff && staff->lines(item->tick()) == 1) {
             yoff += 2.0 * item->spatium();
         } else {
             yoff += item->staff()->staffHeight();
@@ -137,8 +140,6 @@ void MeasureNumberLayout::layoutMeasureNumberBase(MeasureNumberBase* item, Measu
         double yoff = 0.0;
 
         // If there is only one line, the barline spans outside the staff lines, so the default position is not correct.
-        staff_idx_t effectiveStaffIdx = item->effectiveStaffIdx();
-        Staff* staff = item->score()->staff(effectiveStaffIdx);
         if (staff && staff->lines(item->tick()) == 1) {
             yoff -= 2.0 * item->spatium();
         }


### PR DESCRIPTION
Follow up to #30771, now also works properly when measure numbers are below the staff

Actually in that case it doesn't collide with the bracket, like described in #30707 and fixed in #30771, but is too far away from it
before:
<img width="181" height="341" alt="image" src="https://github.com/user-attachments/assets/0de570ce-aca7-4f49-8261-2e857bd2c705" />
after
<img width="110" height="182" alt="image" src="https://github.com/user-attachments/assets/d26dcab0-7b8c-4363-87e7-3503ae87c315" />

Resolves: #30707 (sort of, an unknown part of it)
