### PR TITLE
Make `StyleDef` member variables private.

### DIFF
--- a/src/engraving/style/styledef.h
+++ b/src/engraving/style/styledef.h
@@ -2046,11 +2046,16 @@ struct StyleDef
 {
 public:
     struct StyleValue {
+    private:
         Sid _idx;
         muse::AsciiStringView _name;         // xml name for read()/write()
         PropertyValue _defaultValue;
 
     public:
+        StyleValue(Sid idx, muse::AsciiStringView name, PropertyValue defaultValue)
+            : _idx(idx), _name(name), _defaultValue(defaultValue)
+        {}
+
         Sid  styleIdx() const { return _idx; }
         int idx() const { return int(_idx); }
         const muse::AsciiStringView& name() const { return _name; }


### PR DESCRIPTION
Resolves: #30919

The data members of `StyleDef` appear to have been inadvertently made public. This PR corrects that.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
