### PR TITLE
Feature #13920: zig-zag tablature staff

### DIFF
--- a/src/engraving/dom/staff.h
+++ b/src/engraving/dom/staff.h
@@ -188,6 +188,7 @@ public:
     int lines(const Fraction&) const;
     void setLines(const Fraction&, int lines);
     double lineDistance(const Fraction&) const;
+    double effectiveLineDistance(const Fraction&) const;
 
     bool isLinesInvisible(const Fraction&) const;
     void setIsLinesInvisible(const Fraction&, bool val);

--- a/src/engraving/dom/stafftype.cpp
+++ b/src/engraving/dom/stafftype.cpp
@@ -209,6 +209,7 @@ bool StaffType::operator==(const StaffType& st) const
     equal &= (m_showTabFingering == st.m_showTabFingering);
     equal &= (m_useNumbers == st.m_useNumbers);
     equal &= (m_showBackTied == st.m_showBackTied);
+    equal &= (m_zigzagFretNumbers == st.m_zigzagFretNumbers);
     equal &= (m_durationBoxH == st.m_durationBoxH);
     equal &= (m_durationBoxY == st.m_durationBoxY);
     equal &= (m_durationFont == st.m_durationFont);
@@ -746,7 +747,7 @@ Spatium StaffType::physStringToYOffset(int strg) const
     }
     // if TAB upside down, flip around top line
     yOffset = m_upsideDown ? (double)(m_lines - 1) - yOffset : yOffset;
-    return yOffset * m_lineDistance;
+    return yOffset * lineDistance();
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/stafftype.h
+++ b/src/engraving/dom/stafftype.h
@@ -195,6 +195,7 @@ public:
     int stepOffset() const { return m_stepOffset; }
     void setLineDistance(const Spatium& val) { m_lineDistance = val; }
     Spatium lineDistance() const { return m_lineDistance; }
+
     void setGenClef(bool val) { m_genClef = val; }
     bool genClef() const { return m_genClef; }
     void setShowBarlines(bool val) { m_showBarlines = val; }
@@ -278,6 +279,7 @@ public:
     bool  fretUseTextStyle() const { return m_fretUseTextStyle; }
     TextStyleType fretTextStyle() const { return m_fretTextStyle; }
     size_t fretPresetIdx() const { return m_fretPresetIdx; }
+    bool  zigzagFretNumbers() const { return m_zigzagFretNumbers; }
 
     // properties setters (setting some props invalidates metrics)
     void  setDurationFontName(const String&);
@@ -302,6 +304,7 @@ public:
     void  setFretTextStyle(const TextStyleType& val);
     void  setFretPresetIdx(size_t idx);
     void  setFretPreset(const String& str);
+    void  setZigzagFretNumbers(const bool val) { m_zigzagFretNumbers = val; }
 
     bool isTabStaff() const { return m_group == StaffGroup::TAB; }
     bool isDrumStaff() const { return m_group == StaffGroup::PERCUSSION; }
@@ -378,6 +381,7 @@ private:
     bool m_showTabFingering = false;        // Allow fingering in tablature staff (true) or not (false)
     bool m_useNumbers = true;               // true: use numbers ('0' - ...) for frets | false: use letters ('a' - ...)
     bool m_showBackTied = true;             // whether back-tied notes are shown or not
+    bool m_zigzagFretNumbers = false;       // whether fret numbers are arranged in zig-zag pattern to save vertical space
 
     // TAB: internally managed variables
     // Note: values in RASTER UNITS are independent from score scaling and

--- a/src/engraving/rendering/score/chordlayout.cpp
+++ b/src/engraving/rendering/score/chordlayout.cpp
@@ -363,11 +363,56 @@ void ChordLayout::layoutTablature(Chord* item, LayoutContext& ctx)
     const Staff* st    = item->staff();
     const StaffType* tab = st->staffTypeForElement(item);
     double lineDist    = tab->lineDistance().val() * _spatium;
-    double stemX       = 0.5 * headWidth;
+    double stemX       = StemLayout::tabStemPosX() * _spatium;
     int ledgerLines = 0;
     double llY         = 0.0;
 
     size_t numOfNotes  = item->notes().size();
+
+    // Check if some of notes need repositioning for zigzag layout
+    std::vector<char> notePositions; // L / C / R
+    constexpr char LEFT = 'L';
+    constexpr char CENTER = 'C';
+    constexpr char RIGHT = 'R';
+    bool hasZigzagAdjustments = false;
+    double rightHeadWidth = 0.0;
+    if (tab->zigzagFretNumbers()) {
+
+        int prevNoteString = 1000; // just a very large value
+        for (size_t i = 0; i < numOfNotes; ++i) {
+            Note *note = item->notes().at(i);
+            char position;
+            // notes in TAB are always sorted by string from highest num (lowest pitch) to lowest num (highest pitch)
+            if (note->string() + 1  != prevNoteString || notePositions.empty()) {
+                position = CENTER;
+            } else {
+                switch (notePositions.back()) {
+                    case LEFT: {
+                        position = RIGHT;
+                        break;
+                    }
+                    case RIGHT: {
+                        position = LEFT;
+                        break;
+                    };
+                    case CENTER: {
+                        position = RIGHT;
+                        notePositions.back() = LEFT;
+                        break;
+                    }
+                    default: {
+                        position = CENTER;
+                    };
+                }
+            }
+            prevNoteString = note->string();
+            notePositions.push_back(position);
+            if (position != CENTER) {
+                hasZigzagAdjustments = true;
+            }
+        }
+    }
+
     double minY        = 1000.0;                 // just a very large value
     for (size_t i = 0; i < numOfNotes; ++i) {
         Note* note = item->notes().at(i);
@@ -379,8 +424,38 @@ void ChordLayout::layoutTablature(Chord* item, LayoutContext& ctx)
         if (headWidth < fretWidth) {
             headWidth = fretWidth;
         }
-        // centre fret string on stem
-        double x = stemX - fretWidth * 0.5;
+        // centre fret string on stem, or apply zig-zag alignment
+        double x;
+        if (tab->zigzagFretNumbers()) {
+            // Apply zig-zag positioning with proper alignment
+            // Positions were already prepared above
+
+            assert(notePositions.size() == item->notes().size());
+            char position = notePositions[i];
+            switch (position) {
+                case LEFT: {
+                    x = stemX - fretWidth;
+                    break;
+                }
+                case RIGHT: {
+                    x = stemX;
+                    if (fretWidth > rightHeadWidth) {
+                        rightHeadWidth = fretWidth;
+                    }
+                    break;
+                }
+                case CENTER: {
+                    x = stemX - fretWidth * 0.5;
+                    break;
+                }
+                default: ;
+            }
+
+        } else {
+            // Standard centered positioning
+            x = stemX - fretWidth * 0.5;
+        }
+
         double y = note->fixed() ? note->line() * lineDist / 2 : tab->physStringToYOffset(note->string()).toAbsolute(_spatium);
         note->setPos(x, y);
         if (y < minY) {
@@ -459,14 +534,26 @@ void ChordLayout::layoutTablature(Chord* item, LayoutContext& ctx)
 
     // horiz. spacing: leave half width at each side of the (potential) stem
     double halfHeadWidth = headWidth * 0.5;
-    if (lll < stemX - halfHeadWidth) {
-        lll = stemX - halfHeadWidth;
+
+    // Account for zig-zag offsets in spacing calculations
+    double extraSpacing = 0.0;
+    if (tab->zigzagFretNumbers() && hasZigzagAdjustments) {
+        // Add extra spacing for the zig-zag offsets (only when notes span both even and odd strings)
+        extraSpacing = 0.5 * _spatium;
     }
-    if (rrr < stemX + halfHeadWidth) {
-        rrr = stemX + halfHeadWidth;
+
+    if (lll < stemX - halfHeadWidth - extraSpacing) {
+        lll = stemX - halfHeadWidth - extraSpacing;
+    }
+    if (rrr < stemX + halfHeadWidth + extraSpacing) {
+        rrr = stemX + halfHeadWidth + extraSpacing;
     }
     // align dots to the widest fret mark (not needed in all TAB styles, but harmless anyway)
-    item->setDotPosX(headWidth);
+    if (tab->zigzagFretNumbers() && hasZigzagAdjustments) {
+        item->setDotPosX(stemX + rightHeadWidth);
+    } else {
+        item->setDotPosX(headWidth);
+    }
 
     if (item->shouldHaveStem()) {
         // if stem is required but missing, add it;

--- a/src/engraving/rendering/score/chordlayout.cpp
+++ b/src/engraving/rendering/score/chordlayout.cpp
@@ -377,32 +377,31 @@ void ChordLayout::layoutTablature(Chord* item, LayoutContext& ctx)
     bool hasZigzagAdjustments = false;
     double rightHeadWidth = 0.0;
     if (tab->zigzagFretNumbers()) {
-
         int prevNoteString = 1000; // just a very large value
         for (size_t i = 0; i < numOfNotes; ++i) {
-            Note *note = item->notes().at(i);
+            Note* note = item->notes().at(i);
             char position;
             // notes in TAB are always sorted by string from highest num (lowest pitch) to lowest num (highest pitch)
-            if (note->string() + 1  != prevNoteString || notePositions.empty()) {
+            if (note->string() + 1 != prevNoteString || notePositions.empty()) {
                 position = CENTER;
             } else {
                 switch (notePositions.back()) {
-                    case LEFT: {
-                        position = RIGHT;
-                        break;
-                    }
-                    case RIGHT: {
-                        position = LEFT;
-                        break;
-                    };
-                    case CENTER: {
-                        position = RIGHT;
-                        notePositions.back() = LEFT;
-                        break;
-                    }
-                    default: {
-                        position = CENTER;
-                    };
+                case LEFT: {
+                    position = RIGHT;
+                    break;
+                }
+                case RIGHT: {
+                    position = LEFT;
+                    break;
+                };
+                case CENTER: {
+                    position = RIGHT;
+                    notePositions.back() = LEFT;
+                    break;
+                }
+                default: {
+                    position = CENTER;
+                };
                 }
             }
             prevNoteString = note->string();
@@ -433,24 +432,23 @@ void ChordLayout::layoutTablature(Chord* item, LayoutContext& ctx)
             assert(notePositions.size() == item->notes().size());
             char position = notePositions[i];
             switch (position) {
-                case LEFT: {
-                    x = stemX - fretWidth;
-                    break;
-                }
-                case RIGHT: {
-                    x = stemX;
-                    if (fretWidth > rightHeadWidth) {
-                        rightHeadWidth = fretWidth;
-                    }
-                    break;
-                }
-                case CENTER: {
-                    x = stemX - fretWidth * 0.5;
-                    break;
-                }
-                default: ;
+            case LEFT: {
+                x = stemX - fretWidth;
+                break;
             }
-
+            case RIGHT: {
+                x = stemX;
+                if (fretWidth > rightHeadWidth) {
+                    rightHeadWidth = fretWidth;
+                }
+                break;
+            }
+            case CENTER: {
+                x = stemX - fretWidth * 0.5;
+                break;
+            }
+            default:;
+            }
         } else {
             // Standard centered positioning
             x = stemX - fretWidth * 0.5;

--- a/src/engraving/rendering/score/horizontalspacing.cpp
+++ b/src/engraving/rendering/score/horizontalspacing.cpp
@@ -1510,7 +1510,13 @@ void HorizontalSpacing::computeNotePadding(const Note* note, const EngravingItem
     }
 
     if (!note->fretString().empty() && item2->isNote()) { // This is a TAB fret mark
-        static constexpr double tabFretPaddingIncrease = 1.5; // TODO: style?
+        double tabFretPaddingIncrease = 1.5; // TODO: style?
+
+        // Increase padding further for zig-zag tablature mode
+        if (note->staff() && note->staff()->staffTypeForElement(note)->zigzagFretNumbers()) {
+            tabFretPaddingIncrease = 6.0; // Larger spacing for zig-zag offset
+        }
+
         padding *= tabFretPaddingIncrease;
     }
 

--- a/src/engraving/rw/read460/tread.cpp
+++ b/src/engraving/rw/read460/tread.cpp
@@ -4010,6 +4010,8 @@ void TRead::read(StaffType* t, XmlReader& e, ReadContext& ctx)
             t->setUseNumbers(e.readBool());
         } else if (tag == "showBackTied") {           // must be after reading "slashStyle"/"stemless" prop, as in older
             t->setShowBackTied(e.readBool());            // scores, this prop was lacking and controlled by "slashStyle"
+        } else if (tag == "zigzagFretNumbers") {
+            t->setZigzagFretNumbers(e.readBool());
         } else {
             e.unknown();
         }

--- a/src/engraving/rw/write/twrite.cpp
+++ b/src/engraving/rw/write/twrite.cpp
@@ -3062,6 +3062,7 @@ void TWrite::write(const StaffType* item, XmlWriter& xml, WriteContext& ctx)
         if (item->showBackTied() != !item->stemless()) {
             xml.tag("showBackTied",  item->showBackTied());
         }
+        xml.tag("zigzagFretNumbers", item->zigzagFretNumbers(), false);
     }
     xml.endElement();
 }

--- a/src/notationscene/widgets/editstafftype.cpp
+++ b/src/notationscene/widgets/editstafftype.cpp
@@ -151,6 +151,8 @@ EditStaffType::EditStaffType(const muse::modularity::ContextPtr& ctx, QWidget* p
     connect(linesThroughRadio, &QRadioButton::toggled, this, &EditStaffType::updatePreview);
     connect(onLinesRadio,      &QRadioButton::toggled, this, &EditStaffType::updatePreview);
     connect(showTabFingering,  &QCheckBox::toggled, this, &EditStaffType::updatePreview);
+    connect(zigzagFretNumbers, &QCheckBox::toggled, this, &EditStaffType::tabZigzagToggled);
+
     connect(upsideDown,        &QCheckBox::toggled, this, &EditStaffType::updatePreview);
     connect(numbersRadio,      &QCheckBox::toggled, this, &EditStaffType::updatePreview);
 
@@ -329,6 +331,7 @@ void EditStaffType::setValues()
     {
         upsideDown->setChecked(staffType.upsideDown());
         showTabFingering->setChecked(staffType.showTabFingering());
+        zigzagFretNumbers->setChecked(staffType.zigzagFretNumbers());
 
         textStyleRadioButton->setChecked(staffType.fretUseTextStyle());
         presetRadioButton->setChecked(!staffType.fretUseTextStyle());
@@ -550,6 +553,7 @@ void EditStaffType::setFromDlg()
         staffType.setShowRests(showRests->isChecked());
         staffType.setUpsideDown(upsideDown->isChecked());
         staffType.setShowTabFingering(showTabFingering->isChecked());
+        staffType.setZigzagFretNumbers(zigzagFretNumbers->isChecked());
         staffType.setUseNumbers(numbersRadio->isChecked());
         //note values
         staffType.setStemsDown(stemBelowRadio->isChecked());
@@ -587,6 +591,7 @@ void EditStaffType::blockSignals(bool block)
 
     upsideDown->blockSignals(block);
     showTabFingering->blockSignals(block);
+    zigzagFretNumbers->blockSignals(block);
 
     textStyleRadioButton->blockSignals(block);
     presetRadioButton->blockSignals(block);
@@ -693,6 +698,29 @@ void EditStaffType::tabStemThroughCompatibility(bool checked)
     minimShortRadio->setEnabled(enab);
     stemAboveRadio->setEnabled(enab);
     stemBelowRadio->setEnabled(enab);
+}
+
+//---------------------------------------------------------
+//   Tabulature "zigzag" toggled
+//---------------------------------------------------------
+
+void EditStaffType::tabZigzagToggled(bool checked)
+{
+    tabZigzagCompatibility(checked);
+    updatePreview();
+}
+
+//---------------------------------------------------------
+//   Tabulature "zigzag" compatibility
+//
+//    Adjusts line distance when zigzag is toggled
+//---------------------------------------------------------
+
+void EditStaffType::tabZigzagCompatibility(bool checked)
+{
+    static constexpr double zigzagCoefficient = 0.82;
+    double val = lineDistance->value();
+    lineDistance->setValue(checked ? val * zigzagCoefficient : val / zigzagCoefficient);
 }
 
 //---------------------------------------------------------

--- a/src/notationscene/widgets/editstafftype.h
+++ b/src/notationscene/widgets/editstafftype.h
@@ -61,6 +61,7 @@ private slots:
     void tabStemThroughToggled(bool checked);
     void tabMinimShortToggled(bool checked);
     void tabStemsToggled(bool checked);
+    void tabZigzagToggled(bool checked);
     void updatePreview();
 
     void savePresets();
@@ -81,6 +82,7 @@ private:
 
     void enablePresets();
     void enableTextStyles();
+    void tabZigzagCompatibility(bool checked);
 
     std::vector<QString> textStyleNames() const;
     engraving::TextStyleType getTextStyle(const QString& name) const;

--- a/src/notationscene/widgets/editstafftype.ui
+++ b/src/notationscene/widgets/editstafftype.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>663</width>
-    <height>736</height>
+    <height>792</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -36,7 +36,7 @@
         <string>STANDARD STAFF</string>
        </property>
        <property name="alignment">
-        <set>Qt::AlignCenter</set>
+        <set>Qt::AlignmentFlag::AlignCenter</set>
        </property>
        <property name="buddy">
         <cstring>name</cstring>
@@ -48,7 +48,7 @@
        <item>
         <spacer name="horizontalSpacer_3">
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -68,7 +68,7 @@
        <item>
         <spacer name="horizontalSpacer_2">
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -85,7 +85,7 @@
        <item>
         <spacer name="horizontalSpacer_4">
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -165,7 +165,7 @@
        <item>
         <spacer name="horizontalSpacer_5">
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -208,10 +208,10 @@
      <item>
       <widget class="QStackedWidget" name="stack">
        <property name="frameShape">
-        <enum>QFrame::NoFrame</enum>
+        <enum>QFrame::Shape::NoFrame</enum>
        </property>
        <property name="frameShadow">
-        <enum>QFrame::Plain</enum>
+        <enum>QFrame::Shadow::Plain</enum>
        </property>
        <property name="lineWidth">
         <number>0</number>
@@ -323,7 +323,7 @@
          <item>
           <spacer name="verticalSpacer_2">
            <property name="orientation">
-            <enum>Qt::Vertical</enum>
+            <enum>Qt::Orientation::Vertical</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -380,7 +380,7 @@
          <item>
           <spacer name="verticalSpacer_3">
            <property name="orientation">
-            <enum>Qt::Vertical</enum>
+            <enum>Qt::Orientation::Vertical</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -409,7 +409,7 @@
               <item>
                <spacer name="horizontalSpacer_9">
                 <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
+                 <enum>Qt::Orientation::Horizontal</enum>
                 </property>
                 <property name="sizeHint" stdset="0">
                  <size>
@@ -711,6 +711,30 @@
                  </layout>
                 </item>
                 <item>
+                 <layout class="QHBoxLayout" name="horizontalLayout_zigzag">
+                  <item>
+                   <widget class="QCheckBox" name="zigzagFretNumbers">
+                    <property name="text">
+                     <string>Use zig-zag number layout (space saving)</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <spacer name="horizontalSpacer_zigzag">
+                    <property name="orientation">
+                     <enum>Qt::Orientation::Horizontal</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>40</width>
+                      <height>20</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                 </layout>
+                </item>
+                <item>
                  <layout class="QHBoxLayout" name="horizontalLayout_3">
                   <item>
                    <widget class="QCheckBox" name="showTabFingering">
@@ -722,7 +746,7 @@
                   <item>
                    <spacer name="horizontalSpacer_6">
                     <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
+                     <enum>Qt::Orientation::Horizontal</enum>
                     </property>
                     <property name="sizeHint" stdset="0">
                      <size>
@@ -752,7 +776,7 @@
                      <string>Font:</string>
                     </property>
                     <property name="textFormat">
-                     <enum>Qt::PlainText</enum>
+                     <enum>Qt::TextFormat::PlainText</enum>
                     </property>
                     <property name="buddy">
                      <cstring>durFontName</cstring>
@@ -768,10 +792,10 @@
                      <string>Size:</string>
                     </property>
                     <property name="textFormat">
-                     <enum>Qt::PlainText</enum>
+                     <enum>Qt::TextFormat::PlainText</enum>
                     </property>
                     <property name="alignment">
-                     <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                     <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
                     </property>
                     <property name="buddy">
                      <cstring>durFontSize</cstring>
@@ -800,10 +824,10 @@
                      <string>Vertical offset:</string>
                     </property>
                     <property name="textFormat">
-                     <enum>Qt::PlainText</enum>
+                     <enum>Qt::TextFormat::PlainText</enum>
                     </property>
                     <property name="alignment">
-                     <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                     <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
                     </property>
                     <property name="buddy">
                      <cstring>durY</cstring>
@@ -828,10 +852,10 @@
                 <item>
                  <widget class="QFrame" name="frame_4">
                   <property name="frameShape">
-                   <enum>QFrame::NoFrame</enum>
+                   <enum>QFrame::Shape::NoFrame</enum>
                   </property>
                   <property name="frameShadow">
-                   <enum>QFrame::Plain</enum>
+                   <enum>QFrame::Shadow::Plain</enum>
                   </property>
                   <layout class="QHBoxLayout" name="horizontalLayout_5">
                    <property name="leftMargin">
@@ -858,7 +882,7 @@
                       <string>Shown as:</string>
                      </property>
                      <property name="textFormat">
-                      <enum>Qt::PlainText</enum>
+                      <enum>Qt::TextFormat::PlainText</enum>
                      </property>
                      <property name="buddy">
                       <cstring>noteValuesNone</cstring>
@@ -901,7 +925,7 @@
                    <item>
                     <spacer name="horizontalSpacer_13">
                      <property name="orientation">
-                      <enum>Qt::Horizontal</enum>
+                      <enum>Qt::Orientation::Horizontal</enum>
                      </property>
                      <property name="sizeHint" stdset="0">
                       <size>
@@ -917,10 +941,10 @@
                 <item>
                  <widget class="QFrame" name="frame_5">
                   <property name="frameShape">
-                   <enum>QFrame::NoFrame</enum>
+                   <enum>QFrame::Shape::NoFrame</enum>
                   </property>
                   <property name="frameShadow">
-                   <enum>QFrame::Plain</enum>
+                   <enum>QFrame::Shadow::Plain</enum>
                   </property>
                   <layout class="QHBoxLayout" name="horizontalLayout_5_2">
                    <property name="leftMargin">
@@ -1000,7 +1024,7 @@
                    <item>
                     <spacer name="horizontalSpacer_13_2">
                      <property name="orientation">
-                      <enum>Qt::Horizontal</enum>
+                      <enum>Qt::Orientation::Horizontal</enum>
                      </property>
                      <property name="sizeHint" stdset="0">
                       <size>
@@ -1016,10 +1040,10 @@
                 <item>
                  <widget class="QFrame" name="frame_6">
                   <property name="frameShape">
-                   <enum>QFrame::NoFrame</enum>
+                   <enum>QFrame::Shape::NoFrame</enum>
                   </property>
                   <property name="frameShadow">
-                   <enum>QFrame::Plain</enum>
+                   <enum>QFrame::Shadow::Plain</enum>
                   </property>
                   <layout class="QHBoxLayout" name="horizontalLayout_17">
                    <property name="leftMargin">
@@ -1073,7 +1097,7 @@
                    <item>
                     <spacer name="horizontalSpacer_11">
                      <property name="orientation">
-                      <enum>Qt::Horizontal</enum>
+                      <enum>Qt::Orientation::Horizontal</enum>
                      </property>
                      <property name="sizeHint" stdset="0">
                       <size>
@@ -1089,10 +1113,10 @@
                 <item>
                  <widget class="QFrame" name="frame_7">
                   <property name="frameShape">
-                   <enum>QFrame::NoFrame</enum>
+                   <enum>QFrame::Shape::NoFrame</enum>
                   </property>
                   <property name="frameShadow">
-                   <enum>QFrame::Plain</enum>
+                   <enum>QFrame::Shadow::Plain</enum>
                   </property>
                   <layout class="QHBoxLayout" name="horizontalLayout_15">
                    <property name="leftMargin">
@@ -1146,7 +1170,7 @@
                    <item>
                     <spacer name="horizontalSpacer_10">
                      <property name="orientation">
-                      <enum>Qt::Horizontal</enum>
+                      <enum>Qt::Orientation::Horizontal</enum>
                      </property>
                      <property name="sizeHint" stdset="0">
                       <size>
@@ -1162,10 +1186,10 @@
                 <item>
                  <widget class="QFrame" name="frame_8">
                   <property name="frameShape">
-                   <enum>QFrame::NoFrame</enum>
+                   <enum>QFrame::Shape::NoFrame</enum>
                   </property>
                   <property name="frameShadow">
-                   <enum>QFrame::Plain</enum>
+                   <enum>QFrame::Shadow::Plain</enum>
                   </property>
                   <layout class="QHBoxLayout" name="horizontalLayout_18">
                    <property name="leftMargin">
@@ -1241,7 +1265,7 @@
                    <item>
                     <spacer name="horizontalSpacer_14">
                      <property name="orientation">
-                      <enum>Qt::Horizontal</enum>
+                      <enum>Qt::Orientation::Horizontal</enum>
                      </property>
                      <property name="sizeHint" stdset="0">
                       <size>
@@ -1269,7 +1293,7 @@
                   <item>
                    <spacer name="horizontalSpacer_12">
                     <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
+                     <enum>Qt::Orientation::Horizontal</enum>
                     </property>
                     <property name="sizeHint" stdset="0">
                      <size>
@@ -1346,7 +1370,7 @@
           <string>Template:</string>
          </property>
          <property name="textFormat">
-          <enum>Qt::PlainText</enum>
+          <enum>Qt::TextFormat::PlainText</enum>
          </property>
          <property name="buddy">
           <cstring>templateCombo</cstring>
@@ -1366,7 +1390,7 @@
        <item>
         <spacer name="horizontalSpacer_16">
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -1398,7 +1422,7 @@
      <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Orientation::Horizontal</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -1411,10 +1435,10 @@
      <item>
       <widget class="QDialogButtonBox" name="buttonBox">
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Orientation::Horizontal</enum>
        </property>
        <property name="standardButtons">
-        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+        <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Ok</set>
        </property>
       </widget>
      </item>
@@ -1460,6 +1484,7 @@
   <tabstop>linesThroughRadio</tabstop>
   <tabstop>linesBrokenRadio</tabstop>
   <tabstop>showTabFingering</tabstop>
+  <tabstop>zigzagFretNumbers</tabstop>
   <tabstop>noteValuesSymb</tabstop>
   <tabstop>noteValuesStems</tabstop>
   <tabstop>valuesRepeatNever</tabstop>
@@ -1518,8 +1543,8 @@
   </connection>
  </connections>
  <buttongroups>
+  <buttongroup name="NumLettersButtGroup"/>
   <buttongroup name="OnAboveLinesButtGroup"/>
   <buttongroup name="ContinuousBrokenLinesbuttGroup"/>
-  <buttongroup name="NumLettersButtGroup"/>
  </buttongroups>
 </ui>


### PR DESCRIPTION

Resolves: #13920

* Zigzag option in Staff options -> Advanced options
* Lines are condensed when staff is set to zigzag
* All layouts and note interaction are adapted
* "Trivial" chords (only odd or even strings) are not zigzagged for readability


- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
