### PR TITLE
Allow adding frames to palette

### DIFF
--- a/src/engraving/dom/box.cpp
+++ b/src/engraving/dom/box.cpp
@@ -62,6 +62,24 @@ static const String FRET_BOX_DIAGRAMS_SEPARATOR = u",";
 Box::Box(const ElementType& type, System* parent)
     : MeasureBase(type, parent)
 {
+    m_iconFont = Font(configuration()->iconsFontFamily(), Font::Type::Icon);
+    m_iconFont.setPointSizeF(UI_ICONS_DEFAULT_FONT_SIZE);
+    switch (type) {
+    case ElementType::FBOX:
+        m_iconCode = 0xF491;
+        break;
+    case ElementType::HBOX:
+        m_iconCode = 0xEF6D;
+        break;
+    case ElementType::TBOX:
+        m_iconCode = 0xEF6E;
+        break;
+    case ElementType::VBOX:
+        m_iconCode = 0xEF6C;
+        break;
+    default:
+        break;
+    }
 }
 
 //---------------------------------------------------------

--- a/src/engraving/dom/box.h
+++ b/src/engraving/dom/box.h
@@ -25,6 +25,8 @@
 #include "measurebase.h"
 #include "property.h"
 
+#include "draw/types/font.h"
+
 namespace mu::engraving {
 //---------------------------------------------------------
 //   Box
@@ -88,6 +90,10 @@ public:
     bool canBeExcludedFromOtherParts() const override { return true; }
     void manageExclusionFromParts(bool exclude) override;
 
+    // For use in palettes
+    char16_t iconCode() const { return m_iconCode; }
+    const muse::draw::Font& iconFont() const { return m_iconFont; }
+
 private:
     Spatium m_boxWidth;         // only valid for HBox
     Spatium m_boxHeight;        // only valid for VBox
@@ -100,6 +106,9 @@ private:
     double m_topMargin = 0.0;
     double m_bottomMargin = 0.0;
     bool m_isAutoSizeEnabled = true;
+
+    char16_t m_iconCode = 0;
+    muse::draw::Font m_iconFont;
 };
 
 //---------------------------------------------------------

--- a/src/engraving/rendering/single/singledraw.cpp
+++ b/src/engraving/rendering/single/singledraw.cpp
@@ -38,6 +38,7 @@
 #include "dom/barline.h"
 #include "dom/beam.h"
 #include "dom/bend.h"
+#include "dom/box.h"
 #include "dom/bracket.h"
 #include "dom/breath.h"
 
@@ -191,6 +192,8 @@ void SingleDraw::drawItem(const EngravingItem* item, Painter* painter, const Pai
     case ElementType::EXPRESSION:   draw(item_cast<const Expression*>(item), painter, opt);
         break;
 
+    case ElementType::FBOX:         draw(item_cast<const Box*>(item), painter, opt);
+        break;
     case ElementType::FERMATA:      draw(item_cast<const Fermata*>(item), painter, opt);
         break;
     case ElementType::FIGURED_BASS: draw(item_cast<const FiguredBass*>(item), painter, opt);
@@ -222,6 +225,8 @@ void SingleDraw::drawItem(const EngravingItem* item, Painter* painter, const Pai
     case ElementType::HARMONIC_MARK_SEGMENT: draw(item_cast<const HarmonicMarkSegment*>(item), painter, opt);
         break;
     case ElementType::HARMONY:      draw(item_cast<const Harmony*>(item), painter, opt);
+        break;
+    case ElementType::HBOX:         draw(item_cast<const Box*>(item), painter, opt);
         break;
     case ElementType::HOOK:         draw(item_cast<const Hook*>(item), painter, opt);
         break;
@@ -318,6 +323,8 @@ void SingleDraw::drawItem(const EngravingItem* item, Painter* painter, const Pai
 
     case ElementType::TAPPING:              draw(item_cast<const Tapping*>(item), painter, opt);
         break;
+    case ElementType::TBOX:                 draw(item_cast<const Box*>(item), painter, opt);
+        break;
     case ElementType::TEMPO_TEXT:           draw(item_cast<const TempoText*>(item), painter, opt);
         break;
     case ElementType::TEXT:                 draw(item_cast<const Text*>(item), painter, opt);
@@ -341,6 +348,8 @@ void SingleDraw::drawItem(const EngravingItem* item, Painter* painter, const Pai
     case ElementType::TUPLET:               draw(item_cast<const Tuplet*>(item), painter, opt);
         break;
 
+    case ElementType::VBOX:                 draw(item_cast<const Box*>(item), painter, opt);
+        break;
     case ElementType::VIBRATO_SEGMENT:      draw(item_cast<const VibratoSegment*>(item), painter, opt);
         break;
     case ElementType::VOLTA_SEGMENT:        draw(item_cast<const VoltaSegment*>(item), painter, opt);
@@ -950,6 +959,14 @@ void SingleDraw::draw(const Bend* item, Painter* painter, const PaintOptions& op
         x = x2;
         y = y2;
     }
+}
+
+void SingleDraw::draw(const Box* item, Painter* painter, const PaintOptions&)
+{
+    TRACE_DRAW_ITEM;
+    const Box::LayoutData* ldata = item->ldata();
+    painter->setFont(item->iconFont());
+    painter->drawText(ldata->bbox(), muse::draw::AlignCenter, Char(item->iconCode()));
 }
 
 void SingleDraw::draw(const Bracket* item, Painter* painter, const PaintOptions& opt)

--- a/src/engraving/rendering/single/singledraw.h
+++ b/src/engraving/rendering/single/singledraw.h
@@ -43,6 +43,7 @@ class BagpipeEmbellishment;
 class BarLine;
 class Beam;
 class Bend;
+class Box;
 class Bracket;
 class Breath;
 
@@ -183,6 +184,7 @@ private:
     static void draw(const BarLine* item, muse::draw::Painter* painter, const PaintOptions& opt);
     static void draw(const Beam* item, muse::draw::Painter* painter, const PaintOptions& opt);
     static void draw(const Bend* item, muse::draw::Painter* painter, const PaintOptions& opt);
+    static void draw(const Box* item, muse::draw::Painter* painter, const PaintOptions& opt);
     static void draw(const Bracket* item, muse::draw::Painter* painter, const PaintOptions& opt);
     static void draw(const Breath* item, muse::draw::Painter* painter, const PaintOptions& opt);
 

--- a/src/engraving/rendering/single/singlelayout.cpp
+++ b/src/engraving/rendering/single/singlelayout.cpp
@@ -38,6 +38,7 @@
 #include "dom/actionicon.h"
 #include "dom/ambitus.h"
 #include "dom/articulation.h"
+#include "dom/box.h"
 #include "dom/bagpembell.h"
 #include "dom/barline.h"
 #include "dom/bend.h"
@@ -148,6 +149,8 @@ void SingleLayout::layoutItem(EngravingItem* item)
         break;
     case ElementType::EXPRESSION:   layout(toExpression(item), ctx);
         break;
+    case ElementType::FBOX:         layout(toBox(item), ctx);
+        break;
     case ElementType::FERMATA:      layout(toFermata(item), ctx);
         break;
     case ElementType::FINGERING:    layout(toFingering(item), ctx);
@@ -167,6 +170,8 @@ void SingleLayout::layoutItem(EngravingItem* item)
     case ElementType::HAMMER_ON_PULL_OFF: layout(toHammerOnPullOff(item), ctx);
         break;
     case ElementType::HARP_DIAGRAM: layout(toHarpPedalDiagram(item), ctx);
+        break;
+    case ElementType::HBOX:         layout(toBox(item), ctx);
         break;
     case ElementType::IMAGE:        layout(toImage(item), ctx);
         break;
@@ -226,6 +231,8 @@ void SingleLayout::layoutItem(EngravingItem* item)
         break;
     case ElementType::TAPPING:      layout(toTapping(item), ctx);
         break;
+    case ElementType::TBOX:         layout(toBox(item), ctx);
+        break;
     case ElementType::TEMPO_TEXT:   layout(toTempoText(item), ctx);
         break;
     case ElementType::TEXT:         layout(toText(item), ctx);
@@ -241,6 +248,8 @@ void SingleLayout::layoutItem(EngravingItem* item)
     case ElementType::TREMOLOBAR:   layout(toTremoloBar(item), ctx);
         break;
     case ElementType::TRILL:        layout(toTrill(item), ctx);
+        break;
+    case ElementType::VBOX:         layout(toBox(item), ctx);
         break;
     case ElementType::VIBRATO:      layout(toVibrato(item), ctx);
         break;
@@ -716,6 +725,12 @@ void SingleLayout::layout(Bend* item, const Context&)
     bb.adjust(-lw, -lw, lw, lw);
     ldata->setBbox(bb);
     ldata->setPos(0.0, 0.0);
+}
+
+void SingleLayout::layout(Box* item, const Context&)
+{
+    FontMetrics fontMetrics(item->iconFont());
+    item->setbbox(fontMetrics.boundingRect(Char(item->iconCode())));
 }
 
 void SingleLayout::layout(Bracket* item, const Context& ctx)

--- a/src/engraving/rendering/single/singlelayout.h
+++ b/src/engraving/rendering/single/singlelayout.h
@@ -41,6 +41,7 @@ class Articulation;
 class BagpipeEmbellishment;
 class BarLine;
 class Bend;
+class Box;
 class Bracket;
 class Breath;
 
@@ -165,6 +166,7 @@ public:
     static void layout(BagpipeEmbellishment* item, const Context& ctx);
     static void layout(BarLine* item, const Context& ctx);
     static void layout(Bend* item, const Context& ctx);
+    static void layout(Box* item, const Context& ctx); // Boxes share layout method
     static void layout(Bracket* item, const Context& ctx);
     static void layout(Breath* item, const Context&);
 

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -1396,10 +1396,6 @@ bool NotationInteraction::isOutgoingDragElementAllowed(const EngravingItem* elem
     switch (element->type()) {
     case ElementType::MEASURE:
     case ElementType::NOTE:
-    case ElementType::VBOX:
-    case ElementType::HBOX:
-    case ElementType::TBOX:
-    case ElementType::FBOX:
     // TODO: Bends & NoteLines can't be copy-dragged until corresponding SingleLayout::layout and SingleDraw::draw methods have been implemented
     case ElementType::GUITAR_BEND:
     case ElementType::GUITAR_BEND_SEGMENT:

--- a/src/palette/internal/palettecell.cpp
+++ b/src/palette/internal/palettecell.cpp
@@ -25,6 +25,7 @@
 #include "mimedatautils.h"
 
 #include "engraving/dom/actionicon.h"
+#include "engraving/dom/box.h"
 #include "engraving/dom/engravingitem.h"
 #include "engraving/dom/factory.h"
 #include "engraving/dom/fret.h"
@@ -341,7 +342,24 @@ PaletteCellPtr PaletteCell::fromElementMimeData(const QByteArray& data)
         }
     }
 
-    const String name = (element->isFretDiagram()) ? toFretDiagram(element.get())->harmonyPlainText() : element->translatedTypeUserName();
+    String name = (element->isFretDiagram()) ? toFretDiagram(element.get())->harmonyPlainText() : element->translatedTypeUserName();
+    if (element->isBox()) {
+        Text* t = nullptr;
+        if (element->isTBox()) {
+            t = toTBox(element.get())->text();
+        } else {
+            for (EngravingItem* e : toBox(element.get())->el()) {
+                if (e->isText()) {
+                    t = toText(e);
+                    break;
+                }
+            }
+        }
+        String text = t ? t->plainText().simplified() : String();
+        if (!text.empty()) {
+            name = String("%1: %2").arg(name, text);
+        }
+    }
 
     return std::make_shared<PaletteCell>(element, name);
 }


### PR DESCRIPTION
Now that frames can be dropped directly to the score, we can allow adding customised frames to palettes.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
