### PR TITLE
fix: tremolo articulation mapping for individual string instruments

### DIFF
--- a/src/framework/audio/engine/internal/synthesizers/fluidsynth/soundmapping.h
+++ b/src/framework/audio/engine/internal/synthesizers/fluidsynth/soundmapping.h
@@ -923,7 +923,11 @@ inline const ArticulationMapping& articulationSounds(const mpe::PlaybackSetupDat
         { mpe::ArticulationType::SnapPizzicato, midi::Program(20, 45) },
         { mpe::ArticulationType::Pizzicato, midi::Program(20, 45) },
         { mpe::ArticulationType::PalmMute, midi::Program(20, 45) },
-        { mpe::ArticulationType::Mute, midi::Program(20, 40) }
+        { mpe::ArticulationType::Mute, midi::Program(20, 40) },
+        { mpe::ArticulationType::Tremolo8th, midi::Program(20, 44) },
+        { mpe::ArticulationType::Tremolo16th, midi::Program(20, 44) },
+        { mpe::ArticulationType::Tremolo32nd, midi::Program(20, 44) },
+        { mpe::ArticulationType::Tremolo64th, midi::Program(20, 44) },
     };
 
     static const ArticulationMapping VIOLA_SECTION = {
@@ -941,7 +945,11 @@ inline const ArticulationMapping& articulationSounds(const mpe::PlaybackSetupDat
         { mpe::ArticulationType::SnapPizzicato, midi::Program(30, 45) },
         { mpe::ArticulationType::Pizzicato, midi::Program(30, 45) },
         { mpe::ArticulationType::PalmMute, midi::Program(30, 45) },
-        { mpe::ArticulationType::Mute, midi::Program(30, 41) }
+        { mpe::ArticulationType::Mute, midi::Program(30, 41) },
+        { mpe::ArticulationType::Tremolo8th, midi::Program(30, 44) },
+        { mpe::ArticulationType::Tremolo16th, midi::Program(30, 44) },
+        { mpe::ArticulationType::Tremolo32nd, midi::Program(30, 44) },
+        { mpe::ArticulationType::Tremolo64th, midi::Program(30, 44) },
     };
 
     static const ArticulationMapping VIOLONCELLO_SECTION = {
@@ -959,7 +967,11 @@ inline const ArticulationMapping& articulationSounds(const mpe::PlaybackSetupDat
         { mpe::ArticulationType::SnapPizzicato, midi::Program(40, 45) },
         { mpe::ArticulationType::Pizzicato, midi::Program(40, 45) },
         { mpe::ArticulationType::PalmMute, midi::Program(40, 45) },
-        { mpe::ArticulationType::Mute, midi::Program(40, 49) }
+        { mpe::ArticulationType::Mute, midi::Program(40, 49) },
+        { mpe::ArticulationType::Tremolo8th, midi::Program(40, 44) },
+        { mpe::ArticulationType::Tremolo16th, midi::Program(40, 44) },
+        { mpe::ArticulationType::Tremolo32nd, midi::Program(40, 44) },
+        { mpe::ArticulationType::Tremolo64th, midi::Program(40, 44) },
     };
 
     static const ArticulationMapping CONTRABASS_SECTION = {
@@ -978,6 +990,10 @@ inline const ArticulationMapping& articulationSounds(const mpe::PlaybackSetupDat
         { mpe::ArticulationType::Pizzicato, midi::Program(50, 45) },
         { mpe::ArticulationType::PalmMute, midi::Program(50, 45) },
         { mpe::ArticulationType::Mute, midi::Program(50, 43) },
+        { mpe::ArticulationType::Tremolo8th, midi::Program(50, 44) },
+        { mpe::ArticulationType::Tremolo16th, midi::Program(50, 44) },
+        { mpe::ArticulationType::Tremolo32nd, midi::Program(50, 44) },
+        { mpe::ArticulationType::Tremolo64th, midi::Program(50, 44) },
     };
 
     static const ArticulationMapping BRASS = {

--- a/src/framework/audio/engine/internal/synthesizers/fluidsynth/soundmapping.h
+++ b/src/framework/audio/engine/internal/synthesizers/fluidsynth/soundmapping.h
@@ -944,7 +944,11 @@ inline const ArticulationMapping& articulationSounds(const mpe::PlaybackSetupDat
         { mpe::ArticulationType::SnapPizzicato, midi::Program(20, 45) },
         { mpe::ArticulationType::Pizzicato, midi::Program(20, 45) },
         { mpe::ArticulationType::PalmMute, midi::Program(20, 45) },
-        { mpe::ArticulationType::Mute, midi::Program(20, 40) }
+        { mpe::ArticulationType::Mute, midi::Program(20, 40) },
+        { mpe::ArticulationType::Tremolo8th, midi::Program(20, 44) },
+        { mpe::ArticulationType::Tremolo16th, midi::Program(20, 44) },
+        { mpe::ArticulationType::Tremolo32nd, midi::Program(20, 44) },
+        { mpe::ArticulationType::Tremolo64th, midi::Program(20, 44) },
     };
 
     static const ArticulationMapping VIOLA_SECTION = {
@@ -962,7 +966,11 @@ inline const ArticulationMapping& articulationSounds(const mpe::PlaybackSetupDat
         { mpe::ArticulationType::SnapPizzicato, midi::Program(30, 45) },
         { mpe::ArticulationType::Pizzicato, midi::Program(30, 45) },
         { mpe::ArticulationType::PalmMute, midi::Program(30, 45) },
-        { mpe::ArticulationType::Mute, midi::Program(30, 41) }
+        { mpe::ArticulationType::Mute, midi::Program(30, 41) },
+        { mpe::ArticulationType::Tremolo8th, midi::Program(30, 44) },
+        { mpe::ArticulationType::Tremolo16th, midi::Program(30, 44) },
+        { mpe::ArticulationType::Tremolo32nd, midi::Program(30, 44) },
+        { mpe::ArticulationType::Tremolo64th, midi::Program(30, 44) },
     };
 
     static const ArticulationMapping VIOLONCELLO_SECTION = {
@@ -980,7 +988,11 @@ inline const ArticulationMapping& articulationSounds(const mpe::PlaybackSetupDat
         { mpe::ArticulationType::SnapPizzicato, midi::Program(40, 45) },
         { mpe::ArticulationType::Pizzicato, midi::Program(40, 45) },
         { mpe::ArticulationType::PalmMute, midi::Program(40, 45) },
-        { mpe::ArticulationType::Mute, midi::Program(40, 49) }
+        { mpe::ArticulationType::Mute, midi::Program(40, 49) },
+        { mpe::ArticulationType::Tremolo8th, midi::Program(40, 44) },
+        { mpe::ArticulationType::Tremolo16th, midi::Program(40, 44) },
+        { mpe::ArticulationType::Tremolo32nd, midi::Program(40, 44) },
+        { mpe::ArticulationType::Tremolo64th, midi::Program(40, 44) },
     };
 
     static const ArticulationMapping CONTRABASS_SECTION = {
@@ -999,6 +1011,10 @@ inline const ArticulationMapping& articulationSounds(const mpe::PlaybackSetupDat
         { mpe::ArticulationType::Pizzicato, midi::Program(50, 45) },
         { mpe::ArticulationType::PalmMute, midi::Program(50, 45) },
         { mpe::ArticulationType::Mute, midi::Program(50, 43) },
+        { mpe::ArticulationType::Tremolo8th, midi::Program(50, 44) },
+        { mpe::ArticulationType::Tremolo16th, midi::Program(50, 44) },
+        { mpe::ArticulationType::Tremolo32nd, midi::Program(50, 44) },
+        { mpe::ArticulationType::Tremolo64th, midi::Program(50, 44) },
     };
 
     static const ArticulationMapping BRASS = {


### PR DESCRIPTION
### Summary

Now string instruments correctly select tremolo MIDI presets when using SF2 soundfonts.

- Add missing tremolo articulation mappings to individual VIOLIN, VIOLA, VIOLONCELLO and CONTRABASS in `soundmapping.h`
- Previously only the `*_SECTION` variants had tremolo mappings, so individual instruments fell back to the default arco sound

#### Affected mappings

- VIOLIN: Tremolo8th/16th/32nd/64th to `midi::Program(20, 44)`
- VIOLA: Tremolo8th/16th/32nd/64th to `midi::Program(30, 44)`
- VIOLONCELLO: Tremolo8th/16th/32nd/64th to `midi::Program(40, 44)`
- CONTRABASS: Tremolo8th/16th/32nd/64th to `midi::Program(50, 44)`

Resolves: #21122

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
  - Does not apply because the change only affects configuration entries, no logic code, and there are no existing tests covering these mappings
