### PR TITLE
Improve float to int audio conversion (fixes #21330 and #24683)

### DIFF
--- a/src/framework/audio/engine/internal/dsp/audiomathutils.h
+++ b/src/framework/audio/engine/internal/dsp/audiomathutils.h
@@ -61,9 +61,12 @@ inline void multiplySamples(float* buffer, const audioch_t& audioChannelsCount,
 }
 
 template<typename T>
-constexpr T convertFloatSamples(float value)
+constexpr T convertFloatSamples(const float value, const int bits)
 {
-    return static_cast<T>(value * std::numeric_limits<T>::max() - 1);
+    const int64_t max_val = (1LL << (bits - 1)) - 1LL;
+    const float clampedValue = std::clamp(value, -1.0f, 1.0f);
+    const float scaledValue = clampedValue * max_val;
+    return static_cast<T>(std::round(scaledValue));
 }
 }
 

--- a/src/framework/audio/engine/internal/export/flacencoder.cpp
+++ b/src/framework/audio/engine/internal/export/flacencoder.cpp
@@ -110,7 +110,7 @@ size_t FlacEncoder::encode(samples_t samplesPerChannel, const float* input)
     std::vector<FLAC__int32> buff(samplesPerChannel * sizeof(float));
 
     for (size_t i = 0; i < buff.size(); ++i) {
-        buff[i] = static_cast<FLAC__int32>(dsp::convertFloatSamples<FLAC__int16>(input[i]));
+        buff[i] = dsp::convertFloatSamples<FLAC__int32>(input[i], 16);
     }
 
     std::vector<FLAC__int32> intermBuff(stepSize);


### PR DESCRIPTION
Resolves: #21330
Resolves: #24683

* Adds std::clamp to prevent overflow.
* Ensures silence (0.0f) correctly maps to 0.
* Implements correct rounding instead of truncation.
* TargetBits can be specified independently of the container type (would also be useful for converting to 24-bit).

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
