### PR TITLE
Fix crash on large time sigs

### DIFF
--- a/src/engraving/rendering/score/systemlayout.cpp
+++ b/src/engraving/rendering/score/systemlayout.cpp
@@ -3026,6 +3026,9 @@ void SystemLayout::centerBigTimeSigsAcrossStaves(const System* system)
                     continue;
                 }
                 staff_idx_t thisStaffIdx = timeSig->effectiveStaffIdx();
+                if (thisStaffIdx == muse::nidx) {
+                    continue;
+                }
                 staff_idx_t nextStaffIdx = thisStaffIdx;
                 for (staff_idx_t idx = thisStaffIdx + 1; idx < nstaves; ++idx) {
                     TimeSig* nextTimeSig = toTimeSig(segment.element(staff2track(idx)));


### PR DESCRIPTION
Resolves: #30871

`muse::nidx` is an acceptable return value of `effectiveStaffIdx` so it must be checked for.