### PR TITLE
Fix #30872: Key signature moves one measure back when changing time signature

### DIFF
--- a/src/engraving/dom/range.cpp
+++ b/src/engraving/dom/range.cpp
@@ -723,6 +723,18 @@ bool TrackList::write(Score* score, const Fraction& tick) const
             ne->setScore(score);
             ne->setTrack(m_track);
             seg->add(ne);
+        } else if (e->isKeySig()) {
+            Segment* seg;
+            // No remains -> Next Measure if it does exist
+            if ((remains == Fraction(0, 1)) && m->nextMeasure()) {
+                seg = m->nextMeasure()->getSegmentR(SegmentType::KeySig, Fraction(0, 1));
+            } else {
+                seg = m->getSegmentR(SegmentType::KeySig, Fraction());
+            }
+            EngravingItem* ne = e->clone();
+            ne->setScore(score);
+            ne->setTrack(m_track);
+            seg->add(ne);
         } else {
             if (!m) {
                 break;
@@ -730,7 +742,7 @@ bool TrackList::write(Score* score, const Fraction& tick) const
             // add the element in its own segment;
             // but KeySig has to be at start of (current) measure
 
-            Segment* seg = m->getSegmentR(Segment::segmentType(e->type()), e->isKeySig() ? Fraction() : m->ticks() - remains);
+            Segment* seg = m->getSegmentR(Segment::segmentType(e->type()), m->ticks() - remains);
             EngravingItem* ne = e->clone();
             ne->setScore(score);
             ne->setTrack(m_track);


### PR DESCRIPTION
Resolves: #30872<!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
- This PR keeps key signature in the right measure when changing time signature 
- Tested with [musescore-30872-testv1.zip](https://github.com/user-attachments/files/23464700/musescore-30872-testv1.zip)

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
