### PR TITLE
Remove colon from "Audio API"

### DIFF
--- a/src/appshell/qml/Preferences/internal/AudioApiSection.qml
+++ b/src/appshell/qml/Preferences/internal/AudioApiSection.qml
@@ -41,7 +41,7 @@ BaseSection {
 
             property int initialIndex: -1
 
-            title: qsTrc("appshell/preferences", "Audio API:")
+            title: qsTrc("appshell/preferences", "Audio API")
             columnWidth: root.columnWidth
 
             visible: root.audioApiList.length > 1


### PR DESCRIPTION
Remove colon from "Audio API"
This colon shouldn't be here because all colons have been removed from Preferences in the master. See this PR: https://github.com/musescore/MuseScore/pull/29518.

Greetings,
Grzegorz

Resolves: #NNNNN <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
