### PR TITLE
Fix note select color

### DIFF
--- a/src/engraving/rendering/score/tlayout.cpp
+++ b/src/engraving/rendering/score/tlayout.cpp
@@ -4049,11 +4049,8 @@ void TLayout::layoutNote(const Note* item, Note::LayoutData* ldata)
         } else {
             const_cast<Note*>(item)->setFretString(tab->fretString(std::fabs(item->fret()), item->string(), item->deadNote()));
 
-            if (item->negativeFretUsed()) {
-                auto note = toNote(item);
-                if (!note->deadNote()) {
-                    const_cast<Note*>(item)->setFretString(u"-" + item->fretString());
-                }
+            if (item->negativeFretUsed() && !item->deadNote()) {
+                const_cast<Note*>(item)->setFretString(u"-" + item->fretString());
             }
 
             if (item->displayFret() == Note::DisplayFretOption::ArtificialHarmonic) {


### PR DESCRIPTION
Broken by https://github.com/musescore/MuseScore/pull/29020; the color would not be set anymore for non-tab staves

Plus a small cleanup in tlayout: `toNote(item)` makes no sense because `item` is already `Note*`

Resolves: https://github.com/musescore/MuseScore/issues/30972