### PR TITLE
Use score inversion foreground color for engraving elements

### DIFF
--- a/src/engraving/dom/engravingitem.cpp
+++ b/src/engraving/dom/engravingitem.cpp
@@ -677,6 +677,9 @@ Color EngravingItem::curColor(bool isVisible, Color normalColor, const rendering
     }
 
     if (opt.invertColors) {
+        if (normalColor == configuration()->defaultColor()) {
+            return configuration()->scoreInversionColor();
+        }
         return normalColor.inverted();
     }
 


### PR DESCRIPTION
Default-colored elements will now use EngravingConfiguration::scoreInversionColor in score colors inversion mode. That’s a light-grey instead of white, which makes it a bit less intense to look at.