### PR TITLE
Parse chord symbol before checking if it's invalid

### DIFF
--- a/src/notation/internal/notationactioncontroller.cpp
+++ b/src/notation/internal/notationactioncontroller.cpp
@@ -2040,7 +2040,7 @@ void NotationActionController::navigateToTextElement(MoveDirection direction, bo
         const Harmony* chordSymbol = editedChordSymbol();
 
         // otherwise, chord symbol will be deleted when navigating away from it
-        const bool canPlay = chordSymbol && !chordSymbol->plainText().empty();
+        const bool canPlay = chordSymbol && !chordSymbol->harmonyName().empty();
 
         currentNotationInteraction()->navigateToNearHarmony(direction, nearNoteOrRest);
 
@@ -2065,7 +2065,7 @@ void NotationActionController::navigateToTextElementByFraction(const Fraction& f
         const Harmony* chordSymbol = editedChordSymbol();
 
         // otherwise, chord symbol will be deleted when navigating away from it
-        const bool canPlay = chordSymbol && !chordSymbol->plainText().empty();
+        const bool canPlay = chordSymbol && !chordSymbol->harmonyName().empty();
 
         currentNotationInteraction()->navigateToHarmony(fraction);
 
@@ -2088,7 +2088,7 @@ void NotationActionController::navigateToTextElementInNearMeasure(MoveDirection 
         const Harmony* chordSymbol = editedChordSymbol();
 
         // otherwise, chord symbol will be deleted when navigating away from it
-        const bool canPlay = chordSymbol && !chordSymbol->plainText().empty();
+        const bool canPlay = chordSymbol && !chordSymbol->harmonyName().empty();
 
         currentNotationInteraction()->navigateToHarmonyInNearMeasure(direction);
 


### PR DESCRIPTION
Resolves: #30888 
The `canPlay` check was happening too early - the chord symbol hadn't been parsed so we didn't know if it was invalid, only if it was blank. `harmonyName` parses the chord symbol, so will also return a blank string if the symbol is invalid.