### PR TITLE
Use breve rests with ledger lines glyph when appropriate

### DIFF
--- a/src/engraving/dom/rest.cpp
+++ b/src/engraving/dom/rest.cpp
@@ -248,10 +248,10 @@ SymId Rest::getSymbol(DurationType type, int line, int lines) const
     case DurationType::V_LONG:
         return SymId::restLonga;
     case DurationType::V_BREVE:
-        return SymId::restDoubleWhole;
+        return (line < 0 || line >= lines) ? SymId::restDoubleWholeLegerLine : SymId::restDoubleWhole;
     case DurationType::V_MEASURE:
         if (ticks() >= Fraction(2, 1)) {
-            return SymId::restDoubleWhole;
+            return (line < 0 || line >= lines) ? SymId::restDoubleWholeLegerLine : SymId::restDoubleWhole;
         }
     // fall through
     case DurationType::V_WHOLE:


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/25230
Replaces: #25248