### PR TITLE
fixed recursion with mi msg: METHOD_QUITED

### DIFF
--- a/src/framework/multiinstances/internal/ipc/ipcsocket.cpp
+++ b/src/framework/multiinstances/internal/ipc/ipcsocket.cpp
@@ -128,7 +128,7 @@ void IpcSocket::onDataReceived(const QByteArray& data)
         return;
     }
 
-    if (receivedMsg.method == "METHOD_QUITED") {
+    if (receivedMsg.method == "INSTANCE_CLOSED") {
         m_instances.removeAll(receivedMsg.srcID);
         m_instancesChanged.notify();
     }

--- a/src/framework/multiinstances/internal/multiinstancesprovider.cpp
+++ b/src/framework/multiinstances/internal/multiinstancesprovider.cpp
@@ -52,7 +52,7 @@ static const QString METHOD_SETTINGS_SET_VALUE("SETTINGS_SET_VALUE");
 static const QString METHOD_QUIT("METHOD_QUIT");
 static const QString METHOD_QUIT_WITH_RESTART_LAST_INSTANCE("METHOD_QUIT_WITH_RESTART_LAST_INSTANCE");
 static const QString METHOD_QUIT_WITH_RUNING_INSTALLATION("METHOD_QUIT_WITH_RUNING_INSTALLATION");
-static const QString METHOD_QUITED("METHOD_QUITED");
+static const QString METHOD_INSTANCE_CLOSED("INSTANCE_CLOSED");
 static const QString METHOD_RESOURCE_CHANGED("RESOURCE_CHANGED");
 
 MultiInstancesProvider::~MultiInstancesProvider()
@@ -165,8 +165,8 @@ void MultiInstancesProvider::onMsg(const Msg& msg)
     } else if (msg.method == METHOD_QUIT_WITH_RUNING_INSTALLATION) {
         CHECK_ARGS_COUNT(1);
         dispatcher()->dispatch("quit", ActionData::make_arg2<bool, std::string>(false, msg.args.at(0).toStdString()));
-    } else if (msg.method == METHOD_QUITED && msg.type == ipc::MsgType::Request) {
-        m_ipcChannel->response(METHOD_QUITED, { }, msg.srcID);
+    } else if (msg.method == METHOD_INSTANCE_CLOSED && msg.type == ipc::MsgType::Request) {
+        m_ipcChannel->response(METHOD_INSTANCE_CLOSED, { }, msg.srcID);
     } else if (msg.method == METHOD_RESOURCE_CHANGED) {
         resourceChanged().send(msg.args.at(0).toStdString());
     }
@@ -458,7 +458,7 @@ void MultiInstancesProvider::notifyAboutInstanceWasQuited()
         return;
     }
 
-    m_ipcChannel->broadcast(METHOD_QUITED);
+    m_ipcChannel->broadcast(METHOD_INSTANCE_CLOSED);
 }
 
 void MultiInstancesProvider::quitForAll()


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/30921

There are two problems:

* After trying to exit, for some reason the application did not close, it remained running... - I don’t know the reason and this has not been fixed.
* If an application sends a METHOD_QUITED message and doesn't close, it receives a METHOD_QUITED response, but there's no check to if it's a response, so it sends the response again on response... recursion occurs - this has been fixed.