### PR TITLE
Add C Major Scale Generator plugin

### DIFF
--- a/share/extensions/cmajorscale/main.js
+++ b/share/extensions/cmajorscale/main.js
@@ -1,0 +1,79 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2025
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// C Major scale MIDI pitches (C4 to C5)
+const cMajorScale = [60, 62, 64, 65, 67, 69, 71, 72] // C D E F G A B C
+
+function main() {
+    api.log.info("C Major Scale Generator started");
+
+    if (typeof curScore === 'undefined' || !curScore) {
+        api.log.error("No score opened");
+        quit();
+        return;
+    }
+
+    var cursor = curScore.newCursor();
+    if (!cursor) {
+        api.log.error("Could not create cursor");
+        quit();
+        return;
+    }
+
+    curScore.startCmd()
+
+    // Check if there's a selection, otherwise start from beginning
+    cursor.rewind(Cursor.SELECTION_START);
+    if (!cursor.segment) {
+        // No selection, start from the beginning of the score
+        cursor.rewind(Cursor.SCORE_START);
+    }
+
+    // Verify we have a valid position
+    if (!cursor.segment) {
+        api.log.error("Could not position cursor");
+        curScore.endCmd();
+        quit();
+        return;
+    }
+
+    // Get the current track (staff and voice)
+    var startTrack = cursor.track;
+
+    // Set note duration to quarter notes (1/4)
+    cursor.setDuration(1, 4);
+
+    // Generate the C major scale
+    for (var i = 0; i < cMajorScale.length; i++) {
+        cursor.track = startTrack;
+        cursor.addNote(cMajorScale[i], false);
+
+        if (i < cMajorScale.length - 1) {
+            cursor.next();
+        }
+    }
+
+    curScore.endCmd()
+
+    api.log.info("C Major scale generated successfully!");
+    quit();
+}

--- a/share/extensions/cmajorscale/main.qml
+++ b/share/extensions/cmajorscale/main.qml
@@ -1,0 +1,73 @@
+import QtQuick 2.0
+import MuseScore 3.0
+
+MuseScore {
+    title: "C Major Scale Generator"
+    description: "Generates a one-octave C major scale starting at the cursor position"
+    version: "1.0"
+    categoryCode: "composing-arranging-tools"
+    requiresScore: true
+
+    // C Major scale intervals (MIDI pitches relative to C4 = 60)
+    property var cMajorScale: [60, 62, 64, 65, 67, 69, 71, 72]  // C D E F G A B C
+
+    onRun: {
+        if (typeof curScore === 'undefined' || !curScore) {
+            console.log("No score opened")
+            quit()
+            return
+        }
+
+        // Create a cursor first to check validity
+        var cursor = curScore.newCursor()
+        if (!cursor) {
+            console.log("Could not create cursor")
+            quit()
+            return
+        }
+
+        // Start the modification command for undo support
+        curScore.startCmd()
+
+        // Check if there's a selection, otherwise start from beginning
+        cursor.rewind(Cursor.SELECTION_START)
+        if (!cursor.segment) {
+            // No selection, start from the beginning of the score
+            cursor.rewind(Cursor.SCORE_START)
+        }
+
+        // Verify we have a valid position
+        if (!cursor.segment) {
+            console.log("Could not position cursor")
+            curScore.endCmd()
+            quit()
+            return
+        }
+
+        // Get the current track (staff and voice)
+        var startTrack = cursor.track
+
+        // Set note duration to quarter notes (1/4)
+        cursor.setDuration(1, 4)
+
+        // Generate the C major scale
+        for (var i = 0; i < cMajorScale.length; i++) {
+            // Make sure we're on the right track
+            cursor.track = startTrack
+
+            // Add the note (pitch value, addToChord = false)
+            cursor.addNote(cMajorScale[i], false)
+
+            // Move to next position (unless it's the last note)
+            if (i < cMajorScale.length - 1) {
+                cursor.next()
+            }
+        }
+
+        // End the modification command
+        curScore.endCmd()
+
+        console.log("C Major scale generated successfully!")
+        quit()
+    }
+}

--- a/share/extensions/cmajorscale/manifest.json
+++ b/share/extensions/cmajorscale/manifest.json
@@ -1,0 +1,11 @@
+{
+    "uri": "musescore://extensions/cmajorscale",
+    "type": "macros",
+    "title": "C Major Scale Generator",
+    "description": "Generates a one-octave C major scale starting at the cursor position",
+    "category": "composing-arranging-tools",
+    "version": "1.0",
+    "apiversion": 1,
+
+    "path": "main.js"
+}

--- a/share/plugins/cmajorscale.qml
+++ b/share/plugins/cmajorscale.qml
@@ -1,0 +1,60 @@
+import QtQuick 2.0
+import MuseScore 3.0
+
+MuseScore {
+    version: "1.0"
+    description: "Generates a one-octave C major scale starting at the cursor position"
+    title: "C Major Scale Generator"
+    categoryCode: "composing-arranging-tools"
+    requiresScore: true
+
+    // C Major scale intervals (MIDI pitches relative to C4 = 60)
+    property var cMajorScale: [60, 62, 64, 65, 67, 69, 71, 72]  // C D E F G A B C
+
+    onRun: {
+        if (!curScore) {
+            console.log("No score opened")
+            quit()
+            return
+        }
+
+        // Start the modification command for undo support
+        curScore.startCmd()
+
+        // Create a cursor
+        var cursor = curScore.newCursor()
+
+        // Check if there's a selection, otherwise start from beginning
+        cursor.rewind(Cursor.SELECTION_START)
+        if (!cursor.segment) {
+            // No selection, start from the beginning of the score
+            cursor.rewind(Cursor.SCORE_START)
+        }
+
+        // Get the current track (staff and voice)
+        var startTrack = cursor.track
+
+        // Set note duration to quarter notes (1/4)
+        cursor.setDuration(1, 4)
+
+        // Generate the C major scale
+        for (var i = 0; i < cMajorScale.length; i++) {
+            // Make sure we're on the right track
+            cursor.track = startTrack
+
+            // Add the note (pitch value, addToChord = false)
+            cursor.addNote(cMajorScale[i], false)
+
+            // Move to next position (unless it's the last note)
+            if (i < cMajorScale.length - 1) {
+                cursor.next()
+            }
+        }
+
+        // End the modification command
+        curScore.endCmd()
+
+        console.log("C Major scale generated successfully!")
+        quit()
+    }
+}


### PR DESCRIPTION
This plugin generates a one-octave C major scale (C4 to C5) at the cursor position.

Features:
- Modern extension format (JavaScript) in share/extensions/cmajorscale/
- Legacy plugin format (QML) in share/plugins/ for backward compatibility
- Generates 8 quarter notes: C D E F G A B C

Resolves: #NNNNN <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [ ] I signed the [CLA](https://musescore.org/en/cla)
- [ ] The title of the PR describes the problem it addresses
- [ ] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [ ] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [ ] There are no unnecessary changes
- [ ] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
