### PR TITLE
FIx close Preferences dialog due to missing negation

### DIFF
--- a/src/framework/shortcuts/internal/midiremote.cpp
+++ b/src/framework/shortcuts/internal/midiremote.cpp
@@ -203,7 +203,7 @@ bool MidiRemote::writeMidiMappings(const MidiMappingList& midiMappings) const
 
     writer.endElement();
 
-    return mappingsFile.hasError();
+    return !mappingsFile.hasError();
 }
 
 void MidiRemote::writeMidiMapping(XmlStreamWriter& writer, const MidiControlsMapping& midiMapping) const

--- a/src/framework/shortcuts/internal/shortcutsregister.cpp
+++ b/src/framework/shortcuts/internal/shortcutsregister.cpp
@@ -369,7 +369,7 @@ bool ShortcutsRegister::writeToFile(const ShortcutList& shortcuts, const io::pat
 
     writer.endElement();
 
-    return file.hasError();
+    return !file.hasError();
 }
 
 void ShortcutsRegister::writeShortcut(XmlStreamWriter& writer, const Shortcut& shortcut) const


### PR DESCRIPTION
Writing shortcuts and midi mappings files incorrectly returned false on 
success, which prevented the Preferences dialog from closing when 
pressing OK.

Resolves: https://github.com/musescore/MuseScore/issues/31064