### PR TITLE
Fix spacing inconsistency for multivoice measures made of full rests

### DIFF
--- a/src/engraving/dom/segment.cpp
+++ b/src/engraving/dom/segment.cpp
@@ -2604,7 +2604,18 @@ void Segment::createShape(staff_idx_t staffIdx)
             setVisible(true);
             if (e->isRest() && toRest(e)->isFullMeasureRest() && measure()->hasVoices(e->staffIdx())) {
                 // A full measure rest in a measure with multiple voices must be ignored
-                continue;
+                // Unless the measure is made of *only* full rests
+                bool isAllFullRests = true;
+                for (track_idx_t track = strack; track < etrack; ++track) {
+                    EngravingItem* element = m_elist[track];
+                    if (element && !(element->isRest() && toRest(element)->isFullMeasureRest())) {
+                        isAllFullRests = false;
+                        break;
+                    }
+                }
+                if (!isAllFullRests) {
+                    continue;
+                }
             }
             if (e->isMMRest() || (e->isMeasureRepeat() && toMeasureRepeat(e)->numMeasures() > 1)) {
                 continue;


### PR DESCRIPTION
Resolves: measures with multiple voices made of all full rests are narrower than the others.
<img width="1280" height="344" alt="image" src="https://github.com/user-attachments/assets/85ce3e5f-11a8-4fcf-a59b-4196d441a623" />

Happens because in multivoice situations the bounding box of full rests is ignored, because it's assumed that the spacing will be determined by the notes in the other voices and the full rest would just uselessly encroach with it. The only exception is when all voices contain just a full rest.
