### PR TITLE
fixed #29556: Bottom submenus do not open on second monitor

### DIFF
--- a/src/framework/uicomponents/view/windowview.cpp
+++ b/src/framework/uicomponents/view/windowview.cpp
@@ -78,6 +78,8 @@ void WindowView::init()
         }
     });
 
+    resolveParentWindow();
+
     emit windowChanged();
 }
 
@@ -158,7 +160,6 @@ void WindowView::doOpen()
         return;
     }
 
-    resolveParentWindow();
     updateGeometry();
 
     beforeOpen();


### PR DESCRIPTION
was StyledMenuLoader open -> StyledMenuLoader update -> StyledMenu calculateSize -> call anchorGeometry -> use parent window (not inited) -> StyledMenu open (init parent window)

before [this change](https://github.com/musescore/MuseScore/pull/30831/files#diff-249b8ea3c7a05029b5fa327b8dce09aac6b875487213c060b37ae0998ac3d4c8L150) StyledMenu calculateSize was called after StyledMenu open

Resolves: #29556
