### PR TITLE
[4.6.4] fixed #29556: Bottom submenus do not open on second monitor 

### DIFF
--- a/src/framework/uicomponents/view/popupview.cpp
+++ b/src/framework/uicomponents/view/popupview.cpp
@@ -166,6 +166,8 @@ void PopupView::init()
         }
     });
 
+    resolveParentWindow();
+
     emit windowChanged();
 }
 
@@ -237,8 +239,6 @@ void PopupView::doOpen()
     }
 
     beforeOpen();
-
-    resolveParentWindow();
 
     updateGeometry();
 


### PR DESCRIPTION
see https://github.com/musescore/MuseScore/pull/31077