### PR TITLE
Fix score corruption on create new excerpt

### DIFF
--- a/src/engraving/rendering/score/measurelayout.cpp
+++ b/src/engraving/rendering/score/measurelayout.cpp
@@ -950,12 +950,9 @@ void MeasureLayout::layoutMeasure(MeasureBase* currentMB, LayoutContext& ctx)
     Measure* measure = toMeasure(currentMB);
 
     measure->moveTicks(ctx.state().tick() - measure->tick());
+    ctx.mutState().setTick(ctx.state().tick() + measure->ticks());
 
     if (ctx.conf().isLinearMode() && (measure->tick() < ctx.state().startTick() || measure->tick() > ctx.state().endTick())) {
-        // needed to reset segment widths if they can change after measure width is computed
-        //for (Segment& s : measure->segments())
-        //      s.createShapes();
-        ctx.mutState().setTick(ctx.state().tick() + measure->ticks());
         return;
     }
 
@@ -1097,8 +1094,6 @@ void MeasureLayout::layoutMeasure(MeasureBase* currentMB, LayoutContext& ctx)
 
     measure->computeTicks(); // Must be called *after* Segment::createShapes() because it relies on the
     // Segment::visible() property, which is determined by Segment::createShapes().
-
-    ctx.mutState().setTick(ctx.state().tick() + measure->ticks());
 }
 
 void MeasureLayout::updateGraceNotes(Measure* measure, LayoutContext& ctx)

--- a/src/engraving/tests/parts_tests.cpp
+++ b/src/engraving/tests/parts_tests.cpp
@@ -295,6 +295,30 @@ TEST_F(Engraving_PartsTests, createPart1)
     testPartCreation(u"part-empty");
 }
 
+TEST_F(Engraving_PartsTests, createEmptyPart)
+{
+    String sourceFileName = u"part-empty";
+    MasterScore* score = ScoreRW::readScore(PARTS_DATA_DIR + sourceFileName + u".mscx");
+    ASSERT_TRUE(score);
+    EXPECT_TRUE(ScoreComp::saveCompareScore(score, sourceFileName + u"-1.mscx", PARTS_DATA_DIR + sourceFileName + u".mscx"));
+
+    TestUtils::createEmptyPart(score);
+
+    // Check that measures have correct ticks set
+    for (Excerpt* excerpt : score->excerpts()) {
+        Score* excerptScore = excerpt->excerptScore();
+        EXPECT_TRUE(excerptScore);
+        for (MeasureBase* mb = excerptScore->first(); mb; mb = mb->next()) {
+            if (mb->isMeasure()) {
+                EXPECT_GT(mb->ticks(), Fraction(0, 1));
+            }
+            if (mb->prev()) {
+                EXPECT_EQ(mb->prev()->endTick(), mb->tick());
+            }
+        }
+    }
+}
+
 TEST_F(Engraving_PartsTests, createPart2)
 {
     testPartCreation(u"part-all");

--- a/src/engraving/tests/utils/testutils.cpp
+++ b/src/engraving/tests/utils/testutils.cpp
@@ -49,6 +49,22 @@ Score* TestUtils::createPart(MasterScore* masterScore, size_t partNumber)
     return nscore;
 }
 
+Score* TestUtils::createEmptyPart(MasterScore* masterScore)
+{
+    Score* nscore = masterScore->createScore();
+
+    Excerpt* ex = new Excerpt(masterScore);
+    ex->setExcerptScore(nscore);
+
+    Excerpt::createExcerpt(ex);
+
+    masterScore->excerpts().push_back(ex);
+    masterScore->setExcerptsChanged(true);
+
+    EXPECT_TRUE(nscore);
+    return nscore;
+}
+
 void TestUtils::createParts(MasterScore* masterScore, size_t numberOfParts)
 {
     EXPECT_TRUE(numberOfParts > 0);

--- a/src/engraving/tests/utils/testutils.h
+++ b/src/engraving/tests/utils/testutils.h
@@ -29,6 +29,7 @@ class TestUtils
 {
 public:
     static Score* createPart(MasterScore* masterScore, size_t partNumber = 0);
+    static Score* createEmptyPart(MasterScore* masterScore);
     static void createParts(MasterScore* masterScore, size_t numberOfParts);
 };
 }


### PR DESCRIPTION
Resolves: #30915

Was caused by https://github.com/musescore/MuseScore/pull/30715, in particular a missing call to `ctx.mutState().setTick`. Turns out that creating a custom part, i.e. one that has initially no part or stave, wasn't covered by any unit test, so I've added one.