### PR TITLE
project: Fix loading of templates

### DIFF
--- a/src/project/internal/mscmetareader.cpp
+++ b/src/project/internal/mscmetareader.cpp
@@ -33,6 +33,33 @@ using namespace muse::io;
 using namespace mu::project;
 using namespace mu::engraving;
 
+// emulates QXmlStreamReader::readElementText(QXmlStreamReader::IncludeChildElements)
+static std::string readTextAndChildrenText(XmlStreamReader& reader)
+{
+    if (!reader.isStartElement()) {
+        return std::string();
+    }
+
+    std::string text;
+    while (true) {
+        switch (reader.readNext()) {
+        case XmlStreamReader::Comment:
+            break;
+        case XmlStreamReader::Characters:
+            text += reader.asciiText();
+            break;
+        case XmlStreamReader::StartElement:
+            text += readTextAndChildrenText(reader);
+            break;
+        case XmlStreamReader::EndElement:
+            return text;
+        default:
+            LOGE() << "Unexpected token: " << reader.tokenString();
+            return text;
+        }
+    }
+}
+
 RetVal<ProjectMeta> MscMetaReader::readMeta(const muse::io::path_t& filePath) const
 {
     MscReader msczReader;
@@ -366,7 +393,8 @@ std::string MscMetaReader::cutXmlTags(const std::string& str) const
 
 QString MscMetaReader::readText(XmlStreamReader& xmlReader) const
 {
-    const std::string str = xmlReader.readBody().toStdString();
+    const std::string str = readTextAndChildrenText(xmlReader);
+
     return formatFromXml(str);
 }
 


### PR DESCRIPTION
Resolves: #31076

`MscMetaReader` did not read the title correctly from boxes. Templates with an empty title are skipped in `TemplatesModel::load`. Broken in 55a5118. `XmlStreamReader::readBody` does something completely different from the now removed `XmlReader::readString(...)`.

Will look into testing this code better later this week. (and also adding tests for the serialization of midi remote mappings and shortcuts)

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
