### PR TITLE
Fix Mac crash on exit

### DIFF
--- a/src/framework/audio/engine/internal/enginecontroller.cpp
+++ b/src/framework/audio/engine/internal/enginecontroller.cpp
@@ -142,6 +142,8 @@ void EngineController::deinit()
     m_playback->deinit();
     m_rpcController->deinit();
     m_audioEngine->deinit();
+    m_playback.reset();
+    m_rpcController.reset();
 }
 
 OutputSpec EngineController::outputSpec() const

--- a/src/framework/audio/engine/internal/engineplayback.cpp
+++ b/src/framework/audio/engine/internal/engineplayback.cpp
@@ -54,6 +54,16 @@ void EnginePlayback::deinit()
 
     m_sequences.clear();
 
+    // Explicitly disconnect and clear all channel members before
+    // async_disconnectAll() and before the destructor runs. This ensures
+    // subscribers are disconnected while they're still alive, not during IoC
+    // teardown when some may already be destroyed.
+    m_masterOutputParamsChanged = async::Channel<AudioOutputParams>();
+    m_outputParamsChanged = async::Channel<TrackSequenceId, TrackId, AudioOutputParams>();
+    m_inputParamsChanged = async::Channel<TrackSequenceId, TrackId, AudioInputParams>();
+    m_trackRemoved = async::Channel<TrackSequenceId, TrackId>();
+    m_trackAdded = async::Channel<TrackSequenceId, TrackId>();
+
     async_disconnectAll();
 }
 

--- a/src/framework/audio/engine/internal/enginerpccontroller.cpp
+++ b/src/framework/audio/engine/internal/enginerpccontroller.cpp
@@ -641,6 +641,7 @@ void EngineRpcController::deinit()
     playback()->trackRemoved().disconnect(this);
     playback()->inputParamsChanged().disconnect(this);
     playback()->outputParamsChanged().disconnect(this);
+    playback()->masterOutputParamsChanged().disconnect(this);
 
     for (const Method& m : m_usedMethods) {
         channel()->onMethod(m, nullptr);

--- a/src/framework/audio/main/internal/startaudiocontroller.cpp
+++ b/src/framework/audio/main/internal/startaudiocontroller.cpp
@@ -299,6 +299,13 @@ void StartAudioController::stopAudioProcessing()
         audioDriver()->close();
     }
 #ifndef Q_OS_WASM
+    // Must call deinit() before stopping worker, so disconnect messages can
+    // still be processed on the worker thread
+    if (m_engineController) {
+        m_engineController->deinit();
+        m_engineController.reset();
+    }
+
     if (m_worker && m_worker->isRunning()) {
         m_worker->stop();
     }


### PR DESCRIPTION
Currently, if the Mac app is shutdown (eg ⌘Q) then it crashes.

<details><summary>Example backtrace</summary>
<pre>
* thread #2, name = 'main', queue = 'com.apple.main-thread', stop reason = signal SIGABRT
  * frame #0: 0x0000000191d8a388 libsystem_kernel.dylib`__pthread_kill + 8
    frame #1: 0x0000000191dc3848 libsystem_pthread.dylib`pthread_kill + 296
    frame #2: 0x0000000191ccc9e4 libsystem_c.dylib`abort + 124
    frame #3: 0x0000000191d79384 libc++abi.dylib`abort_message + 132
    frame #4: 0x0000000191d67cd8 libc++abi.dylib`demangling_terminate_handler() + 316
    frame #5: 0x00000001919ecde4 libobjc.A.dylib`_objc_terminate() + 172
    frame #6: 0x0000000191d78698 libc++abi.dylib`std::__terminate(void (*)()) + 16
    frame #7: 0x0000000191d7863c libc++abi.dylib`std::terminate() + 108
    frame #8: 0x0000000100010264 .mscore-wrapped`__clang_call_terminate + 16
    frame #9: 0x00000001005768ec .mscore-wrapped`kors::async::ChannelImpl<muse::audio::AudioOutputParams>::~ChannelImpl(this=0x00000001372086b8) at channelimpl.h:451:9
    frame #10: 0x0000000100573940 .mscore-wrapped`kors::async::ChannelImpl<muse::audio::AudioOutputParams>::~ChannelImpl(this=0x00000001372086b8) at channelimpl.h:450:5
    frame #11: 0x0000000100581514 .mscore-wrapped`kors::async::Channel<muse::audio::AudioOutputParams>::Data::~Data(this=0x00000001372086b8) at channel.h:42:12
    frame #12: 0x00000001005814dc .mscore-wrapped`kors::async::Channel<muse::audio::AudioOutputParams>::Data::~Data(this=0x00000001372086b8) at channel.h:42:12
    frame #13: 0x00000001005814ac .mscore-wrapped`std::__1::allocator<kors::async::Channel<muse::audio::AudioOutputParams>::Data>::destroy[abi:se190102](this=0x000000016fdfd2c7, __p=0x00000001372086b8) at allocator.h:168:87
    frame #14: 0x000000010058147c .mscore-wrapped`void std::__1::allocator_traits<std::__1::allocator<kors::async::Channel<muse::audio::AudioOutputParams>::Data>>::destroy[abi:se190102]<kors::async::Channel<muse::audio::AudioOutputParams>::Data, 0>(__a=0x000000016fdfd2c7, __p=0x00000001372086b8) at allocator_traits.h:334:9
    frame #15: 0x0000000100581418 .mscore-wrapped`void std::__1::__shared_ptr_emplace<kors::async::Channel<muse::audio::AudioOutputParams>::Data, std::__1::allocator<kors::async::Channel<muse::audio::AudioOutputParams>::Data>>::__on_zero_shared_impl[abi:se190102]<std::__1::allocator<kors::async::Channel<muse::audio::AudioOutputParams>::Data>, 0>(this=0x00000001372086a0) at shared_ptr.h:285:5
    frame #16: 0x0000000100573524 .mscore-wrapped`std::__1::__shared_ptr_emplace<kors::async::Channel<muse::audio::AudioOutputParams>::Data, std::__1::allocator<kors::async::Channel<muse::audio::AudioOutputParams>::Data>>::__on_zero_shared(this=0x00000001372086a0) at shared_ptr.h:288:78
    frame #17: 0x000000010001aa08 .mscore-wrapped`std::__1::__shared_count::__release_shared[abi:se190102](this=0x00000001372086a0) at shared_ptr.h:158:7
    frame #18: 0x000000010001a9a8 .mscore-wrapped`std::__1::__shared_weak_count::__release_shared[abi:se190102](this=0x00000001372086a0) at shared_ptr.h:187:25
    frame #19: 0x00000001004f6cb8 .mscore-wrapped`std::__1::shared_ptr<kors::async::Channel<muse::audio::AudioOutputParams>::Data>::~shared_ptr[abi:se190102](this=0x00000001372082f0) at shared_ptr.h:670:17
    frame #20: 0x00000001004f6c70 .mscore-wrapped`std::__1::shared_ptr<kors::async::Channel<muse::audio::AudioOutputParams>::Data>::~shared_ptr[abi:se190102](this=0x00000001372082f0) at shared_ptr.h:668:39
    frame #21: 0x00000001004f6c44 .mscore-wrapped`kors::async::Channel<muse::audio::AudioOutputParams>::~Channel(this=0x00000001372082f0) at channel.h:63:24
    frame #22: 0x00000001004f666c .mscore-wrapped`kors::async::Channel<muse::audio::AudioOutputParams>::~Channel(this=0x00000001372082f0) at channel.h:63:24
    frame #23: 0x00000001003a8564 .mscore-wrapped`muse::audio::engine::EnginePlayback::~EnginePlayback(this=0x0000000137208178) at engineplayback.h:41:7
    frame #24: 0x00000001003a21b4 .mscore-wrapped`muse::audio::engine::EnginePlayback::~EnginePlayback(this=0x0000000137208178) at engineplayback.h:41:7
    frame #25: 0x00000001003c27a4 .mscore-wrapped`std::__1::allocator<muse::audio::engine::EnginePlayback>::destroy[abi:se190102](this=0x000000016fdfd477, __p=0x0000000137208178) at allocator.h:168:87
    frame #26: 0x00000001003c276c .mscore-wrapped`void std::__1::allocator_traits<std::__1::allocator<muse::audio::engine::EnginePlayback>>::destroy[abi:se190102]<muse::audio::engine::EnginePlayback, 0>(__a=0x000000016fdfd477, __p=0x0000000137208178) at allocator_traits.h:334:9
    frame #27: 0x00000001003c2708 .mscore-wrapped`void std::__1::__shared_ptr_emplace<muse::audio::engine::EnginePlayback, std::__1::allocator<muse::audio::engine::EnginePlayback>>::__on_zero_shared_impl[abi:se190102]<std::__1::allocator<muse::audio::engine::EnginePlayback>, 0>(this=0x0000000137208160) at shared_ptr.h:285:5
    frame #28: 0x00000001003c0c20 .mscore-wrapped`std::__1::__shared_ptr_emplace<muse::audio::engine::EnginePlayback, std::__1::allocator<muse::audio::engine::EnginePlayback>>::__on_zero_shared(this=0x0000000137208160) at shared_ptr.h:288:78
    frame #29: 0x000000010001aa08 .mscore-wrapped`std::__1::__shared_count::__release_shared[abi:se190102](this=0x0000000137208160) at shared_ptr.h:158:7
    frame #30: 0x000000010001a9a8 .mscore-wrapped`std::__1::__shared_weak_count::__release_shared[abi:se190102](this=0x0000000137208160) at shared_ptr.h:187:25
    frame #31: 0x00000001003bbefc .mscore-wrapped`std::__1::shared_ptr<muse::audio::engine::EnginePlayback>::~shared_ptr[abi:se190102](this=0x0000600002abc1b0) at shared_ptr.h:670:17
    frame #32: 0x000000010038a004 .mscore-wrapped`std::__1::shared_ptr<muse::audio::engine::EnginePlayback>::~shared_ptr[abi:se190102](this=0x0000600002abc1b0) at shared_ptr.h:668:39
    frame #33: 0x00000001003a9b50 .mscore-wrapped`muse::audio::engine::EngineController::~EngineController(this=0x0000600002abc178) at enginecontroller.h:48:7
    frame #34: 0x00000001003a22c4 .mscore-wrapped`muse::audio::engine::EngineController::~EngineController(this=0x0000600002abc178) at enginecontroller.h:48:7
    frame #35: 0x00000001005bf29c .mscore-wrapped`std::__1::allocator<muse::audio::engine::EngineController>::destroy[abi:se190102](this=0x000000016fdfd5e7, __p=0x0000600002abc178) at allocator.h:168:87
    frame #36: 0x00000001005bf264 .mscore-wrapped`void std::__1::allocator_traits<std::__1::allocator<muse::audio::engine::EngineController>>::destroy[abi:se190102]<muse::audio::engine::EngineController, 0>(__a=0x000000016fdfd5e7, __p=0x0000600002abc178) at allocator_traits.h:334:9
    frame #37: 0x00000001005bf200 .mscore-wrapped`void std::__1::__shared_ptr_emplace<muse::audio::engine::EngineController, std::__1::allocator<muse::audio::engine::EngineController>>::__on_zero_shared_impl[abi:se190102]<std::__1::allocator<muse::audio::engine::EngineController>, 0>(this=0x0000600002abc160) at shared_ptr.h:285:5
    frame #38: 0x00000001005bef48 .mscore-wrapped`std::__1::__shared_ptr_emplace<muse::audio::engine::EngineController, std::__1::allocator<muse::audio::engine::EngineController>>::__on_zero_shared(this=0x0000600002abc160) at shared_ptr.h:288:78
    frame #39: 0x000000010001aa08 .mscore-wrapped`std::__1::__shared_count::__release_shared[abi:se190102](this=0x0000600002abc160) at shared_ptr.h:158:7
    frame #40: 0x000000010001a9a8 .mscore-wrapped`std::__1::__shared_weak_count::__release_shared[abi:se190102](this=0x0000600002abc160) at shared_ptr.h:187:25
    frame #41: 0x00000001005be758 .mscore-wrapped`std::__1::shared_ptr<muse::audio::engine::EngineController>::~shared_ptr[abi:se190102](this=0x0000000137213160) at shared_ptr.h:670:17
    frame #42: 0x00000001004ccf68 .mscore-wrapped`std::__1::shared_ptr<muse::audio::engine::EngineController>::~shared_ptr[abi:se190102](this=0x0000000137213160) at shared_ptr.h:668:39
    frame #43: 0x00000001004f7660 .mscore-wrapped`muse::audio::StartAudioController::~StartAudioController(this=0x0000000137213058) at startaudiocontroller.h:42:7
    frame #44: 0x00000001004d3f04 .mscore-wrapped`muse::audio::StartAudioController::~StartAudioController(this=0x0000000137213058) at startaudiocontroller.h:42:7
    frame #45: 0x000000010059986c .mscore-wrapped`std::__1::allocator<muse::audio::StartAudioController>::destroy[abi:se190102](this=0x000000016fdfd757, __p=0x0000000137213058) at allocator.h:168:87
    frame #46: 0x0000000100599834 .mscore-wrapped`void std::__1::allocator_traits<std::__1::allocator<muse::audio::StartAudioController>>::destroy[abi:se190102]<muse::audio::StartAudioController, 0>(__a=0x000000016fdfd757, __p=0x0000000137213058) at allocator_traits.h:334:9
    frame #47: 0x00000001005997d0 .mscore-wrapped`void std::__1::__shared_ptr_emplace<muse::audio::StartAudioController, std::__1::allocator<muse::audio::StartAudioController>>::__on_zero_shared_impl[abi:se190102]<std::__1::allocator<muse::audio::StartAudioController>, 0>(this=0x0000000137213040) at shared_ptr.h:285:5
    frame #48: 0x0000000100599518 .mscore-wrapped`std::__1::__shared_ptr_emplace<muse::audio::StartAudioController, std::__1::allocator<muse::audio::StartAudioController>>::__on_zero_shared(this=0x0000000137213040) at shared_ptr.h:288:78
    frame #49: 0x000000010001aa08 .mscore-wrapped`std::__1::__shared_count::__release_shared[abi:se190102](this=0x0000000137213040) at shared_ptr.h:158:7
    frame #50: 0x000000010001a9a8 .mscore-wrapped`std::__1::__shared_weak_count::__release_shared[abi:se190102](this=0x0000000137213040) at shared_ptr.h:187:25
    frame #51: 0x0000000100054a54 .mscore-wrapped`std::__1::shared_ptr<kors::modularity::IModuleInterface>::~shared_ptr[abi:se190102](this=0x000060000399c830) at shared_ptr.h:670:17
    frame #52: 0x0000000100053950 .mscore-wrapped`std::__1::shared_ptr<kors::modularity::IModuleInterface>::~shared_ptr[abi:se190102](this=0x000060000399c830) at shared_ptr.h:668:39
    frame #53: 0x000000010477b5c0 .mscore-wrapped`kors::modularity::ModulesIoC::Service::~Service(this=0x000060000399c810) at modulesioc.h:235:12
    frame #54: 0x000000010477b590 .mscore-wrapped`kors::modularity::ModulesIoC::Service::~Service(this=0x000060000399c810) at modulesioc.h:235:12
    frame #55: 0x000000010477b560 .mscore-wrapped`std::__1::pair<std::__1::basic_string_view<char, std::__1::char_traits<char>> const, kors::modularity::ModulesIoC::Service>::~pair(this=0x000060000399c800) at pair.h:66:29
    frame #56: 0x000000010477b530 .mscore-wrapped`std::__1::pair<std::__1::basic_string_view<char, std::__1::char_traits<char>> const, kors::modularity::ModulesIoC::Service>::~pair(this=0x000060000399c800) at pair.h:66:29
    frame #57: 0x000000010477b500 .mscore-wrapped`void std::__1::__destroy_at[abi:se190102]<std::__1::pair<std::__1::basic_string_view<char, std::__1::char_traits<char>> const, kors::modularity::ModulesIoC::Service>, 0>(__loc=0x000060000399c800) at construct_at.h:67:11
    frame #58: 0x000000010477b414 .mscore-wrapped`void std::__1::allocator_traits<std::__1::allocator<std::__1::__tree_node<std::__1::__value_type<std::__1::basic_string_view<char, std::__1::char_traits<char>>, kors::modularity::ModulesIoC::Service>, void*>>>::destroy[abi:se190102]<std::__1::pair<std::__1::basic_string_view<char, std::__1::char_traits<char>> const, kors::modularity::ModulesIoC::Service>, void, 0>((null)=0x0000000106436eb8, __p=0x000060000399c800) at allocator_traits.h:339:5
    frame #59: 0x000000010477b394 .mscore-wrapped`std::__1::__tree<std::__1::__value_type<std::__1::basic_string_view<char, std::__1::char_traits<char>>, kors::modularity::ModulesIoC::Service>, std::__1::__map_value_compare<std::__1::basic_string_view<char, std::__1::char_traits<char>>, std::__1::__value_type<std::__1::basic_string_view<char, std::__1::char_traits<char>>, kors::modularity::ModulesIoC::Service>, std::__1::less<std::__1::basic_string_view<char, std::__1::char_traits<char>>>, true>, std::__1::allocator<std::__1::__value_type<std::__1::basic_string_view<char, std::__1::char_traits<char>>, kors::modularity::ModulesIoC::Service>>>::destroy(this=0x0000000106436eb0, __nd=0x000060000399c7e0) at __tree:1541:5
    frame #60: 0x000000010477b360 .mscore-wrapped`std::__1::__tree<std::__1::__value_type<std::__1::basic_string_view<char, std::__1::char_traits<char>>, kors::modularity::ModulesIoC::Service>, std::__1::__map_value_compare<std::__1::basic_string_view<char, std::__1::char_traits<char>>, std::__1::__value_type<std::__1::basic_string_view<char, std::__1::char_traits<char>>, kors::modularity::ModulesIoC::Service>, std::__1::less<std::__1::basic_string_view<char, std::__1::char_traits<char>>>, true>, std::__1::allocator<std::__1::__value_type<std::__1::basic_string_view<char, std::__1::char_traits<char>>, kors::modularity::ModulesIoC::Service>>>::destroy(this=0x0000000106436eb0, __nd=0x000060000399d320) at __tree:1539:5
    frame #61: 0x000000010477b350 .mscore-wrapped`std::__1::__tree<std::__1::__value_type<std::__1::basic_string_view<char, std::__1::char_traits<char>>, kors::modularity::ModulesIoC::Service>, std::__1::__map_value_compare<std::__1::basic_string_view<char, std::__1::char_traits<char>>, std::__1::__value_type<std::__1::basic_string_view<char, std::__1::char_traits<char>>, kors::modularity::ModulesIoC::Service>, std::__1::less<std::__1::basic_string_view<char, std::__1::char_traits<char>>>, true>, std::__1::allocator<std::__1::__value_type<std::__1::basic_string_view<char, std::__1::char_traits<char>>, kors::modularity::ModulesIoC::Service>>>::destroy(this=0x0000000106436eb0, __nd=0x000060000399daa0) at __tree:1538:5
    frame #62: 0x000000010477b360 .mscore-wrapped`std::__1::__tree<std::__1::__value_type<std::__1::basic_string_view<char, std::__1::char_traits<char>>, kors::modularity::ModulesIoC::Service>, std::__1::__map_value_compare<std::__1::basic_string_view<char, std::__1::char_traits<char>>, std::__1::__value_type<std::__1::basic_string_view<char, std::__1::char_traits<char>>, kors::modularity::ModulesIoC::Service>, std::__1::less<std::__1::basic_string_view<char, std::__1::char_traits<char>>>, true>, std::__1::allocator<std::__1::__value_type<std::__1::basic_string_view<char, std::__1::char_traits<char>>, kors::modularity::ModulesIoC::Service>>>::destroy(this=0x0000000106436eb0, __nd=0x000060000399dce0) at __tree:1539:5
    frame #63: 0x000000010477b360 .mscore-wrapped`std::__1::__tree<std::__1::__value_type<std::__1::basic_string_view<char, std::__1::char_traits<char>>, kors::modularity::ModulesIoC::Service>, std::__1::__map_value_compare<std::__1::basic_string_view<char, std::__1::char_traits<char>>, std::__1::__value_type<std::__1::basic_string_view<char, std::__1::char_traits<char>>, kors::modularity::ModulesIoC::Service>, std::__1::less<std::__1::basic_string_view<char, std::__1::char_traits<char>>>, true>, std::__1::allocator<std::__1::__value_type<std::__1::basic_string_view<char, std::__1::char_traits<char>>, kors::modularity::ModulesIoC::Service>>>::destroy(this=0x0000000106436eb0, __nd=0x000060000399eee0) at __tree:1539:5
    frame #64: 0x000000010477b360 .mscore-wrapped`std::__1::__tree<std::__1::__value_type<std::__1::basic_string_view<char, std::__1::char_traits<char>>, kors::modularity::ModulesIoC::Service>, std::__1::__map_value_compare<std::__1::basic_string_view<char, std::__1::char_traits<char>>, std::__1::__value_type<std::__1::basic_string_view<char, std::__1::char_traits<char>>, kors::modularity::ModulesIoC::Service>, std::__1::less<std::__1::basic_string_view<char, std::__1::char_traits<char>>>, true>, std::__1::allocator<std::__1::__value_type<std::__1::basic_string_view<char, std::__1::char_traits<char>>, kors::modularity::ModulesIoC::Service>>>::destroy(this=0x0000000106436eb0, __nd=0x000060000399d920) at __tree:1539:5
    frame #65: 0x000000010462b0d0 .mscore-wrapped`std::__1::__tree<std::__1::__value_type<std::__1::basic_string_view<char, std::__1::char_traits<char>>, kors::modularity::ModulesIoC::Service>, std::__1::__map_value_compare<std::__1::basic_string_view<char, std::__1::char_traits<char>>, std::__1::__value_type<std::__1::basic_string_view<char, std::__1::char_traits<char>>, kors::modularity::ModulesIoC::Service>, std::__1::less<std::__1::basic_string_view<char, std::__1::char_traits<char>>>, true>, std::__1::allocator<std::__1::__value_type<std::__1::basic_string_view<char, std::__1::char_traits<char>>, kors::modularity::ModulesIoC::Service>>>::clear(this=0x0000000106436eb0) at __tree:1572:3
    frame #66: 0x000000010462b098 .mscore-wrapped`std::__1::map<std::__1::basic_string_view<char, std::__1::char_traits<char>>, kors::modularity::ModulesIoC::Service, std::__1::less<std::__1::basic_string_view<char, std::__1::char_traits<char>>>, std::__1::allocator<std::__1::pair<std::__1::basic_string_view<char, std::__1::char_traits<char>> const, kors::modularity::ModulesIoC::Service>>>::clear[abi:se190102](this=0x0000000106436eb0 size=140) at map:1313:58
    frame #67: 0x000000010461e548 .mscore-wrapped`kors::modularity::ModulesIoC::reset(this=0x0000000106436eb0) at modulesioc.h:168:15
    frame #68: 0x000000010461e510 .mscore-wrapped`muse::BaseApplication::removeIoC(this=0x0000000125878818) at baseapplication.cpp:186:37
    frame #69: 0x000000010004ef5c .mscore-wrapped`mu::app::GuiApp::finish(this=0x0000000125878818) at guiapp.cpp:310:5
    frame #70: 0x000000010001070c .mscore-wrapped`main(argc=1, argv=0x000000016fdfebe0) at main.cpp:226:10
    frame #71: 0x0000000191a22b98 dyld`start + 6076
</pre>
</details>

This is an object lifetime ordering issue involving the IoC container. I *think* this is what was happening:
```
1. Application shutdown initiated
2. EngineController::deinit() called
   - m_playback->deinit() called
   - m_rpcController.reset() called
   → EngineRpcController destroyed (not in IoC)
   - m_playback.reset() called
   → Just releases local reference; object still alive in IoC

3. Later: IoC container teardown
   → ~EnginePlayback() destructor runs
   → Member channel destructors run (~ChannelImpl)
   → Channels try to disconnect all receivers
   → Try to call async_disconnect() on EngineRpcController
   → But it was destroyed back in step 2!
   → Attempts to lock destroyed mutex
   → CRASH: "mutex lock failed: Invalid argument"
```

The change here aims to tidy up these destructor flows. At least it fixes the crash on my machine.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)

PS In case useful in the future, the EngineRpcController was identified as the culprit here by adding this bit of temporary logging:
```diff
--- a/src/framework/global/thirdparty/kors_async/async/internal/channelimpl.h
+++ b/src/framework/global/thirdparty/kors_async/async/internal/channelimpl.h
@@ -29,6 +29,7 @@ SOFTWARE.
 #include <cassert>
 #include <algorithm>
 #include <atomic>
+#include <iostream>

 #include "../conf.h"
 #include "../asyncable.h"
@@ -53,6 +54,7 @@ private:
         bool enabled = true;
         Asyncable* receiver = nullptr;
         Callback callback;
+        std::string debugName;
     };

     struct QueueData {
@@ -73,7 +75,14 @@ private:
         {
             for (Receiver* r : recs) {
                 if (r->receiver) {
-                    r->receiver->async_disconnect(conn);
+                    try {
+                        r->receiver->async_disconnect(conn);
+                    } catch (const std::system_error& e) {
+                        // __builtin_debugtrap(); // uncomment to break here in lldb
+                        std::cerr << "[kors_async] async_disconnect failed for receiver=" << r->receiver
+                                  << " type=" << (r->debugName.empty() ? "unknown" : r->debugName)
+                                  << " what=" << e.what() << std::endl;
+                    }
                 }
                 delete r;
             }
@@ -126,6 +135,11 @@ private:
                 // new
                 r = new Receiver();
                 r->receiver = const_cast<Asyncable*>(receiver);
+                try {
+                    r->debugName = typeid(*receiver).name();
+                } catch (...) {
+                    r->debugName = "unknown";
+                }
                 if (r->receiver) {
                     r->receiver->async_connect(conn);
                 }
```