### PR TITLE
Don't snap hairpins to non-autoplace elements

### DIFF
--- a/src/engraving/dom/hairpin.cpp
+++ b/src/engraving/dom/hairpin.cpp
@@ -309,7 +309,8 @@ EngravingItem* HairpinSegment::findElementToSnapBefore(bool ignoreInvisible) con
     auto intervals = score()->spannerMap().findOverlapping(startTick.ticks(), startTick.ticks());
     for (auto interval : intervals) {
         Spanner* spanner = interval.value;
-        bool isValidHairpin = spanner->isHairpin() && !spanner->segmentsEmpty() && spanner->visible() && spanner != thisHairpin;
+        bool isValidHairpin = spanner->isHairpin() && !spanner->segmentsEmpty() && spanner != thisHairpin
+                              && (spanner->addToSkyline() || !ignoreInvisible);
         if (!isValidHairpin) {
             continue;
         }
@@ -366,7 +367,7 @@ TextBase* HairpinSegment::findStartDynamicOrExpression(bool ignoreInvisible) con
             if (!item->isDynamic() && !item->isExpression()) {
                 continue;
             }
-            if (ignoreInvisible && !item->visible()) {
+            if (ignoreInvisible && !item->addToSkyline()) {
                 continue;
             }
             bool endsMatch = item->track() == hairpin()->track()
@@ -420,7 +421,7 @@ TextBase* HairpinSegment::findEndDynamicOrExpression(bool ignoreInvisible) const
             if (!item->isDynamic() && !item->isExpression()) {
                 continue;
             }
-            if (ignoreInvisible && !item->visible()) {
+            if (ignoreInvisible && !item->addToSkyline()) {
                 continue;
             }
             bool endsMatch = item->track() == hairpin()->track()


### PR DESCRIPTION
Elements with autoplace disabled should not affect the position of other elements.
VTest difference intentional, albeit an ugly example

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
