### PR TITLE
Allow T on list selection

### DIFF
--- a/src/engraving/editing/edit.cpp
+++ b/src/engraving/editing/edit.cpp
@@ -2113,6 +2113,7 @@ void Score::cmdAddTie(bool addToChord)
         // if no note to re-use, create one
         NoteVal nval(note->noteVal());
         if (!n) {
+            m_is.setDuration(note->chord()->durationType());
             n = addPitch(nval, addFlag);
             if (staffMove != 0) {
                 undo(new ChangeChordStaffMove(n->chord(), staffMove));
@@ -2189,7 +2190,7 @@ Tie* Score::cmdToggleTie()
         } else {
             Note* tieNote = searchTieNote(n);
             tieNoteList[i] = tieNote;
-            if (tieNote) {
+            if (tieNote || n->chord()->hasFollowingJumpItem()) {
                 someHaveExistingNextNoteToTieTo = true;
             } else {
                 allHaveExistingNextNoteToTieTo = false;


### PR DESCRIPTION
Resolves: #27905

Allows T to work on list selections outside note entry.  Works only on single chord selections as shown below. 
(Would be cool to add multiple staves support later on)
 


https://github.com/user-attachments/assets/524ffb4a-b8b3-4570-a7aa-599d0a11b370

Another option would be to add a tied note to the next chord without overwriting. 

Third option would be to only allow cases where next chordRest is rest only. (see discussion in #27905)




