### PR TITLE
Fix using sccache

### DIFF
--- a/buildscripts/cmake/SetupCompilerCache.cmake
+++ b/buildscripts/cmake/SetupCompilerCache.cmake
@@ -23,7 +23,7 @@ if (CMAKE_C_COMPILER_LAUNCHER OR CMAKE_CXX_COMPILER_LAUNCHER)
     return()
 endif()
 
-find_program(COMPILER_CACHE_PROGRAM ccache sccache buildcache)
+find_program(COMPILER_CACHE_PROGRAM NAMES ccache sccache buildcache)
 if (NOT COMPILER_CACHE_PROGRAM)
     message(STATUS "No compiler cache program found")
     return()


### PR DESCRIPTION
Resolves: (no issue reported)

Previously `sccache` was ignored due to incorrect syntax. Correct syntax is: 
```
find_program (
          <VAR>
          name | NAMES name1 [name2 ...]
          ...
```

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
