### PR TITLE
Fix #31074: Ensure "don't show again" option is honoured in error dialogs

### DIFF
--- a/src/notation/inotationinteraction.h
+++ b/src/notation/inotationinteraction.h
@@ -335,6 +335,8 @@ public:
 
     virtual void setGetViewRectFunc(const std::function<muse::RectF()>& func) = 0;
 
+    virtual void checkAndShowError() = 0;
+
     virtual void toggleDebugShowGapRests() = 0;
 };
 

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -97,7 +97,6 @@
 #include "engraving/rw/rwregister.h"
 #include "engraving/rw/xmlreader.h"
 
-#include "mscoreerrorscontroller.h"
 #include "notationerrors.h"
 #include "notation.h"
 #include "notationnoteinput.h"
@@ -237,6 +236,8 @@ NotationInteraction::NotationInteraction(Notation* notation, INotationUndoStackP
     m_selectionFilter = std::make_shared<NotationSelectionFilter>(notation, [this]() {
         notifyAboutSelectionChangedIfNeed();
     });
+
+    m_errorsController = std::make_shared<MScoreErrorsController>(iocContext());
 
     m_noteInput->stateChanged().onNotify(this, [this]() {
         if (!m_noteInput->isNoteInputMode()) {
@@ -1379,8 +1380,7 @@ void NotationInteraction::endDrag()
     }
 
     notifyAboutDragChanged();
-
-    MScoreErrorsController(iocContext()).checkAndShowMScoreError();
+    checkAndShowError();
 }
 
 muse::async::Notification NotationInteraction::dragChanged() const
@@ -2079,7 +2079,7 @@ bool NotationInteraction::dropSingle(const PointF& pos, Qt::KeyboardModifiers mo
         notifyAboutDropChanged();
     }
 
-    MScoreErrorsController(iocContext()).checkAndShowMScoreError();
+    checkAndShowError();
 
     return accepted;
 }
@@ -2196,7 +2196,7 @@ bool NotationInteraction::dropRange(const QByteArray& data, const PointF& pos, b
         endDrop();
         notifyAboutDropChanged();
         //MScore::setError(MsError::DEST_TUPLET);
-        //MScoreErrorsController(iocContext()).checkAndShowMScoreError();
+        // checkAndShowError();
         // NOTE: if we show the error popup here it seems that the mouse-release event is missed
         // so the dragged region stays sticked to the mouse and move around. Don't know how to fix it. [M.S.]
         return false;
@@ -2231,7 +2231,7 @@ bool NotationInteraction::dropRange(const QByteArray& data, const PointF& pos, b
     endDrop();
     apply();
 
-    MScoreErrorsController(iocContext()).checkAndShowMScoreError();
+    checkAndShowError();
 
     return true;
 }
@@ -2332,7 +2332,7 @@ bool NotationInteraction::applyPaletteElement(mu::engraving::EngravingItem* elem
 
     setDropTarget(nullptr);
 
-    MScoreErrorsController(iocContext()).checkAndShowMScoreError();
+    checkAndShowError();
 
     return true;
 }
@@ -4870,7 +4870,7 @@ void NotationInteraction::splitSelectedMeasure()
     SplitJoinMeasure::splitMeasure(score()->masterScore(), chordRest->tick());
     apply();
 
-    MScoreErrorsController(iocContext()).checkAndShowMScoreError();
+    checkAndShowError();
 }
 
 void NotationInteraction::joinSelectedMeasures()
@@ -4885,7 +4885,7 @@ void NotationInteraction::joinSelectedMeasures()
     SplitJoinMeasure::joinMeasures(score()->masterScore(), measureRange.startMeasure->tick(), measureRange.endMeasure->tick());
     apply();
 
-    MScoreErrorsController(iocContext()).checkAndShowMScoreError();
+    checkAndShowError();
 }
 
 Ret NotationInteraction::canAddBoxes() const
@@ -5077,7 +5077,7 @@ void NotationInteraction::addBoxes(BoxType boxType, int count, int beforeBoxInde
 void NotationInteraction::copySelection()
 {
     if (!selection()->canCopy()) {
-        MScoreErrorsController(iocContext()).checkAndShowMScoreError();
+        checkAndShowError();
         return;
     }
 
@@ -5224,7 +5224,7 @@ void NotationInteraction::pasteSelection(const Fraction& scale)
         selectAndStartEditIfNeeded(pastedElement);
     }
 
-    MScoreErrorsController(iocContext()).checkAndShowMScoreError();
+    checkAndShowError();
 }
 
 void NotationInteraction::swapSelection()
@@ -5267,7 +5267,7 @@ void NotationInteraction::deleteSelection()
         score()->cmdDeleteSelection();
     }
 
-    MScoreErrorsController(iocContext()).checkAndShowMScoreError();
+    checkAndShowError();
     apply();
     resetHitElementContext();
 }
@@ -5886,7 +5886,7 @@ void NotationInteraction::addIntervalToSelectedNotes(int interval)
 
     if (notes.empty()) {
         MScore::setError(MsError::NO_NOTE_SELECTED);
-        MScoreErrorsController(iocContext()).checkAndShowMScoreError();
+        checkAndShowError();
         return;
     }
 
@@ -8207,4 +8207,12 @@ muse::async::Channel<NotationInteraction::ShowItemRequest> NotationInteraction::
 void NotationInteraction::setGetViewRectFunc(const std::function<RectF()>& func)
 {
     static_cast<NotationNoteInput*>(m_noteInput.get())->setGetViewRectFunc(func);
+}
+
+void NotationInteraction::checkAndShowError()
+{
+    IF_ASSERT_FAILED(m_errorsController) {
+        return;
+    }
+    m_errorsController->checkAndShowMScoreError();
 }

--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -35,6 +35,8 @@
 #include "../iselectinstrumentscenario.h"
 #include "inotationundostack.h"
 
+#include "mscoreerrorscontroller.h"
+
 #include "engraving/dom/engravingitem.h"
 #include "engraving/dom/elementgroup.h"
 #include "engraving/rendering/paintoptions.h"
@@ -336,6 +338,8 @@ public:
 
     void setGetViewRectFunc(const std::function<muse::RectF()>& func) override;
 
+    void checkAndShowError() override;
+
     void toggleDebugShowGapRests() override;
 
 private:
@@ -523,6 +527,8 @@ private:
     muse::async::Notification m_selectionChanged;
 
     std::shared_ptr<NotationSelectionFilter> m_selectionFilter = nullptr;
+
+    std::shared_ptr<MScoreErrorsController> m_errorsController = nullptr;
 
     DragData m_dragData;
     muse::async::Notification m_dragChanged;

--- a/src/notation/internal/notationnoteinput.cpp
+++ b/src/notation/internal/notationnoteinput.cpp
@@ -35,8 +35,6 @@
 #include "engraving/dom/drumset.h"
 #include "engraving/dom/utils.h"
 
-#include "mscoreerrorscontroller.h"
-
 #include "log.h"
 
 using namespace mu::notation;
@@ -464,8 +462,7 @@ void NotationNoteInput::addNote(const NoteInputParams& params, NoteAddingMode ad
     notifyNoteAddedChanged();
     notifyAboutStateChanged();
 
-    MScoreErrorsController(iocContext()).checkAndShowMScoreError();
-
+    m_interaction->checkAndShowError();
     m_interaction->showItem(state().cr());
 }
 
@@ -481,7 +478,7 @@ void NotationNoteInput::padNote(const Pad& pad)
 
     notifyAboutStateChanged();
 
-    MScoreErrorsController(iocContext()).checkAndShowMScoreError();
+    m_interaction->checkAndShowError();
 }
 
 Ret NotationNoteInput::putNote(const PointF& pos, bool replace, bool insert)
@@ -501,7 +498,7 @@ Ret NotationNoteInput::putNote(const PointF& pos, bool replace, bool insert)
     notifyNoteAddedChanged();
     notifyAboutStateChanged();
 
-    MScoreErrorsController(iocContext()).checkAndShowMScoreError();
+    m_interaction->checkAndShowError();
 
     return ret;
 }
@@ -521,7 +518,7 @@ void NotationNoteInput::removeNote(const PointF& pos)
 
     notifyAboutStateChanged();
 
-    MScoreErrorsController(iocContext()).checkAndShowMScoreError();
+    m_interaction->checkAndShowError();
 }
 
 void NotationNoteInput::setInputNote(const NoteInputParams& params)
@@ -646,7 +643,7 @@ void NotationNoteInput::setAccidental(AccidentalType accidentalType)
 
     notifyAboutStateChanged();
 
-    MScoreErrorsController(iocContext()).checkAndShowMScoreError();
+    m_interaction->checkAndShowError();
 }
 
 void NotationNoteInput::setArticulation(SymbolId articulationSymbolId)
@@ -661,7 +658,7 @@ void NotationNoteInput::setArticulation(SymbolId articulationSymbolId)
 
     notifyAboutStateChanged();
 
-    MScoreErrorsController(iocContext()).checkAndShowMScoreError();
+    m_interaction->checkAndShowError();
 }
 
 void NotationNoteInput::setDrumNote(int note)
@@ -870,8 +867,7 @@ void NotationNoteInput::addTie()
     score()->cmdAddTie();
 
     notifyAboutStateChanged();
-
-    MScoreErrorsController(iocContext()).checkAndShowMScoreError();
+    m_interaction->checkAndShowError();
 }
 
 void NotationNoteInput::addLaissezVib()
@@ -882,8 +878,7 @@ void NotationNoteInput::addLaissezVib()
     score()->cmdToggleLaissezVib();
 
     notifyAboutStateChanged();
-
-    MScoreErrorsController(iocContext()).checkAndShowMScoreError();
+    m_interaction->checkAndShowError();
 }
 
 Notification NotationNoteInput::noteAdded() const
@@ -965,8 +960,7 @@ void NotationNoteInput::doubleNoteInputDuration()
     apply();
 
     notifyAboutStateChanged();
-
-    MScoreErrorsController(iocContext()).checkAndShowMScoreError();
+    m_interaction->checkAndShowError();
 }
 
 void NotationNoteInput::halveNoteInputDuration()
@@ -978,6 +972,5 @@ void NotationNoteInput::halveNoteInputDuration()
     apply();
 
     notifyAboutStateChanged();
-
-    MScoreErrorsController(iocContext()).checkAndShowMScoreError();
+    m_interaction->checkAndShowError();
 }

--- a/src/notation/tests/mocks/notationinteractionmock.h
+++ b/src/notation/tests/mocks/notationinteractionmock.h
@@ -287,6 +287,7 @@ public:
     MOCK_METHOD(muse::async::Channel<ShowItemRequest>, showItemRequested, (), (const, override));
 
     MOCK_METHOD(void, setGetViewRectFunc, (const std::function<muse::RectF()>&), (override));
+    MOCK_METHOD(void, checkAndShowError, (), (override));
     MOCK_METHOD(void, toggleDebugShowGapRests, (), (override));
 };
 }


### PR DESCRIPTION
Resolves: #31074

The problem here was that we were creating a new `MScoreErrorsController` object every time we wanted to check/show an error. This worked back when the error dialogs were synced but, now that they're async, the controller object goes out of scope before the promise can resolve and call `setNeedToShowMScoreError`.

This solution makes the controller a private member of `NotationInteraction`.