### PR TITLE
Gitignore compile_commands.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,5 +83,8 @@ __pycache__/
 # CMake User presets
 CMakeUserPresets.json
 
+# Compile commands json
+compile_commands.json
+
 # QML language server
 **/.qmlls.ini


### PR DESCRIPTION
The ideal workflow:
* In CMakeUserPresets.json, tell CMake to generate compile_commands.json
(`"CMAKE_EXPORT_COMPILE_COMMANDS": "ON"`) 
* In VS Code settings, set `cmake.copyCompileCommands` to `${workspaceFolder}/compile_commands.json` so that VS Code copies the file from the build folder into the workspace after every successful configure
* Clangd will find the file