### PR TITLE
Fix #12873: [MU4 Issue] Palette search command should open palette if not already visible

### DIFF
--- a/src/appshell/qml/NotationPage/NotationPage.qml
+++ b/src/appshell/qml/NotationPage/NotationPage.qml
@@ -42,7 +42,15 @@ DockPage {
 
     required property NavigationSection topToolbarKeyNavSec
 
-    property NotationPageModel pageModel: NotationPageModel {}
+    property bool isPalettesCreated: false
+
+    property NotationPageModel pageModel: NotationPageModel {
+       onCreatePaletteIfDestroyed: {
+         if (!isPalettesCreated) {
+            palettesPanel.open()
+         }
+       }
+    }
 
     property NavigationSection noteInputKeyNavSec: NavigationSection {
         name: "NoteInputSection"
@@ -270,6 +278,12 @@ DockPage {
 
                 Component.onCompleted: {
                     palettesPanel.contextMenuModel = contextMenuModel
+                    isPalettesCreated = true
+                }
+
+                Component.onDestruction: {
+                    palettesPanel.contextMenuModel = null
+                    isPalettesCreated = false
                 }
             }
         },

--- a/src/appshell/view/notationpagemodel.cpp
+++ b/src/appshell/view/notationpagemodel.cpp
@@ -76,6 +76,14 @@ void NotationPageModel::init()
         emit isBraillePanelVisibleChanged();
     });
 
+    dispatcher()->reg(this, "palette-search", [this]() {
+        // We re-create the palette if it has been destroyed
+        emit createPaletteIfDestroyed();
+
+        // Asking for search within the palette
+        dispatcher()->dispatch("palette-search-after-creation-requested");
+    });
+
     onNotationChanged();
 
     scheduleUpdateDrumsetPanelVisibility();

--- a/src/appshell/view/notationpagemodel.h
+++ b/src/appshell/view/notationpagemodel.h
@@ -82,6 +82,7 @@ public:
 signals:
     void isNavigatorVisibleChanged();
     void isBraillePanelVisibleChanged();
+    void createPaletteIfDestroyed();
 
 private:
     void onNotationChanged();

--- a/src/palette/view/paletterootmodel.cpp
+++ b/src/palette/view/paletterootmodel.cpp
@@ -26,7 +26,7 @@ using namespace mu::palette;
 PaletteRootModel::PaletteRootModel(QObject* parent)
     : QObject(parent)
 {
-    dispatcher()->reg(this, "palette-search", [this]() {
+    dispatcher()->reg(this, "palette-search-after-creation-requested", [this]() {
         emit paletteSearchRequested();
     });
     dispatcher()->reg(this, "apply-current-palette-element", [this]() {


### PR DESCRIPTION
Resolves: #12873 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
- This PR creates a new palette when necessary before searching 

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
