### PR TITLE
Fix #24075 (first part): new instrument (Castilian dulzaina) linked to oboe soundfont

### DIFF
--- a/share/instruments/instruments.xml
+++ b/share/instruments/instruments.xml
@@ -73,6 +73,9 @@
       <Family id="oboes">
             <name>Oboes</name>
       </Family>
+      <Family id="dulzainas">
+            <name>Dulzainas</name>
+      </Family>
       <Family id="shawms">
             <name>Shawms</name>
       </Family>
@@ -1531,6 +1534,26 @@
                   <Channel>
                         <!--MIDI: Bank 0, Prog 67; MS General: Baritone Sax-->
                         <program value="67"/> <!--Baritone Sax-->
+                  </Channel>
+                  <genre>world</genre>
+            </Instrument>
+            <Instrument id="fs-castilian-dulzaina">
+                  <family>dulzainas</family>
+                  <trackName>Castilian Dulzaina</trackName>
+                  <longName>Castilian Dulzaina</longName>
+                  <shortName>Cast. Dulz.</shortName>
+                  <traitName type="transposition">F♯</traitName>
+                  <description>Spanish double-reed folk instrument from the Castile region. In F♯.</description>
+                  <musicXMLid>wind.reed.dulzaina</musicXMLid>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>63-91</aPitchRange>
+                  <pPitchRange>63-96</pPitchRange>
+                  <transposeDiatonic>3</transposeDiatonic>
+                  <transposeChromatic>6</transposeChromatic>
+                  <Channel>
+                        <!--MIDI: Bank 0, Prog 68; MS General: Oboe-->
+                        <program value="68"/> <!--Oboe-->
                   </Channel>
                   <genre>world</genre>
             </Instrument>

--- a/share/instruments/instrumentsxml.h
+++ b/share/instruments/instrumentsxml.h
@@ -98,6 +98,7 @@ QT_TRANSLATE_NOOP("engraving/instruments/family", "Gemshorns"),
 QT_TRANSLATE_NOOP("engraving/instruments/family", "Pan Flutes"),
 QT_TRANSLATE_NOOP("engraving/instruments/family", "Quenas"),
 QT_TRANSLATE_NOOP("engraving/instruments/family", "Oboes"),
+QT_TRANSLATE_NOOP("engraving/instruments/family", "Dulzainas"),
 QT_TRANSLATE_NOOP("engraving/instruments/family", "Shawms"),
 QT_TRANSLATE_NOOP("engraving/instruments/family", "Cromornes"),
 QT_TRANSLATE_NOOP("engraving/instruments/family", "Crumhorns"),
@@ -813,6 +814,17 @@ QT_TRANSLATE_NOOP3("engraving/instruments", "D Quena", "d-quena longName"),
 QT_TRANSLATE_NOOP3("engraving/instruments", "D Qn.", "d-quena shortName"),
 //: traitName for Quena; tuning: D; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
 QT_TRANSLATE_NOOP3("engraving/instruments", "D", "d-quena traitName"),
+
+//: description for Castilian Dulzaina; transposition: F♯; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
+QT_TRANSLATE_NOOP3("engraving/instruments", "Spanish double-reed folk instrument from the Castile region. In F♯.", "fs-castilian-dulzaina description"),
+//: trackName for Castilian Dulzaina; transposition: F♯; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
+QT_TRANSLATE_NOOP3("engraving/instruments", "Castilian Dulzaina", "fs-castilian-dulzaina trackName"),
+//: longName for Castilian Dulzaina; transposition: F♯; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
+QT_TRANSLATE_NOOP3("engraving/instruments", "Castilian Dulzaina", "fs-castilian-dulzaina longName"),
+//: shortName for Castilian Dulzaina; transposition: F♯; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
+QT_TRANSLATE_NOOP3("engraving/instruments", "Cast. Dulz.", "fs-castilian-dulzaina shortName"),
+//: traitName for Castilian Dulzaina; transposition: F♯; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
+QT_TRANSLATE_NOOP3("engraving/instruments", "F♯", "fs-castilian-dulzaina traitName"),
 
 //: description for Piccolo Heckelphone; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
 QT_TRANSLATE_NOOP3("engraving/instruments", "Very rare variant of the heckelphone in F, sounding a fourth higher than the oboe.", "piccolo-heckelphone description"),

--- a/src/engraving/playback/mapping/windssetupdataresolver.cpp
+++ b/src/engraving/playback/mapping/windssetupdataresolver.cpp
@@ -102,6 +102,8 @@ PlaybackSetupData WindsSetupDataResolver::doResolve(const Instrument* instrument
         { "f-quena", { SoundId::Quena, SoundCategory::Winds } },
         { "d-quena", { SoundId::Quena, SoundCategory::Winds } },
 
+        { "fs-castilian-dulzaina", { SoundId::Dulzaina, SoundCategory::Winds, { SoundSubCategory::Castilian } } },
+
         { "piccolo-heckelphone", { SoundId::Heckelphone, SoundCategory::Winds } },
         { "heckelphone", { SoundId::Heckelphone, SoundCategory::Winds } },
         { "piccolo-oboe", { SoundId::Oboe, SoundCategory::Winds } },

--- a/src/framework/audio/engine/internal/synthesizers/fluidsynth/soundmapping.h
+++ b/src/framework/audio/engine/internal/synthesizers/fluidsynth/soundmapping.h
@@ -339,6 +339,8 @@ static const auto& mappingByCategory(const mpe::SoundCategory category)
 
         { { mpe::SoundId::Quena,  {} }, { midi::Program(0, 67) } },
 
+        { { mpe::SoundId::Dulzaina, { mpe::SoundSubCategory::Castilian } }, { midi::Program(0, 68) } },
+
         { { mpe::SoundId::Heckelphone,  {} }, { midi::Program(0, 68) } },
         { { mpe::SoundId::Oboe,  { mpe::SoundSubCategory::Baroque } }, { midi::Program(0, 69) } },
         { { mpe::SoundId::Oboe,  {} }, { midi::Program(0, 68) } },

--- a/src/framework/mpe/soundid.h
+++ b/src/framework/mpe/soundid.h
@@ -92,6 +92,7 @@ enum class SoundId
 
     WindsGroup,
     Piccolo,
+    Dulzaina,
     Heckelphone,
     HeckelphoneClarinet,
     Oboe,
@@ -288,6 +289,7 @@ enum class SoundSubCategory
     African,
     Indian,
     Spanish,
+    Castilian,
     Swedish,
     Hungarian,
     Romanian,
@@ -503,6 +505,7 @@ inline const std::unordered_map<SoundId, String> ID_STRINGS
 
     { SoundId::WindsGroup, String(u"winds_group") },
     { SoundId::Piccolo, String(u"piccolo") },
+    { SoundId::Dulzaina, String(u"dulzaina") },
     { SoundId::Heckelphone, String(u"heckelphone") },
     { SoundId::HeckelphoneClarinet, String(u"heckelphone_clarinet") },
     { SoundId::Oboe, String(u"oboe") },
@@ -746,6 +749,7 @@ inline const std::unordered_map<SoundSubCategory, String> SUBCATEGORY_STRINGS
     { SoundSubCategory::African, String(u"african") },
     { SoundSubCategory::Indian, String(u"indian") },
     { SoundSubCategory::Spanish, String(u"spanish") },
+    { SoundSubCategory::Castilian, String(u"castilian") },
     { SoundSubCategory::Swedish, String(u"swedish") },
     { SoundSubCategory::Hungarian, String(u"hungarian") },
     { SoundSubCategory::Romanian, String(u"romanian") },


### PR DESCRIPTION
Resolves: #24075  (first part)<!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
The issue aims to add a new Castilian (Spanish) woodwind instrument with a new SoundFont. It may take a while until new SoundFonts could be added to MuseScore. Therefore, I have created a first PR which adds the new instrument to MuseScore. 

Changes:
- New family has been created: Dulzaina
- A new subcategory has been added: Castilian. There are Castilian dulzainas, Aragonese dulzainas
- A new instrument (fsharp-castilian-dulzaina) with transposition in F# has been added as there may also be g-castilian-dulzaina with transposition in G

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/MuseScore/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
