### PR TITLE
notenames plugin: Don't name tied-to notes and don't (visibly) name invisible notes

### DIFF
--- a/share/plugins/note_names/notenames.qml
+++ b/share/plugins/note_names/notenames.qml
@@ -131,7 +131,7 @@ MuseScore {
                     }
                 }
                 // list selections / selection filter could be individual notes
-                if (!note.selected) {
+                if (!note.selected || note.tieBack) {
                     continue
                 }
                 // Then apply new names

--- a/share/plugins/note_names/notenames.qml
+++ b/share/plugins/note_names/notenames.qml
@@ -138,6 +138,7 @@ MuseScore {
                 var text = newElement(Element.TEXT) // This adds the text to the note: Better for grace notes and easier to remove
                 text.text = nameNote(note)
                 text.subStyle = Tid.STAFF
+                text.visible = note.visible
                 if (note.noteType != NoteType.NORMAL) {
                     text.fontSize *= curScore.style.value("graceNoteMag")
                 }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/387111