### PR TITLE
Add Help > Accessibility Statement

### DIFF
--- a/src/appshell/iappshellconfiguration.h
+++ b/src/appshell/iappshellconfiguration.h
@@ -62,6 +62,7 @@ public:
 
     virtual std::string handbookUrl() const = 0;
     virtual std::string askForHelpUrl() const = 0;
+    virtual std::string accessibilityStatementUrl() const = 0;
     virtual std::string museScoreUrl() const = 0;
     virtual std::string museScoreForumUrl() const = 0;
     virtual std::string museScoreContributionUrl() const = 0;

--- a/src/appshell/internal/applicationactioncontroller.cpp
+++ b/src/appshell/internal/applicationactioncontroller.cpp
@@ -65,6 +65,7 @@ void ApplicationActionController::init()
     dispatcher()->reg(this, "about-musicxml", this, &ApplicationActionController::openAboutMusicXMLDialog);
     dispatcher()->reg(this, "online-handbook", this, &ApplicationActionController::openOnlineHandbookPage);
     dispatcher()->reg(this, "ask-help", this, &ApplicationActionController::openAskForHelpPage);
+    dispatcher()->reg(this, "accessibility-statement", this, &ApplicationActionController::openAccessibilityStatementPage);
     dispatcher()->reg(this, "preference-dialog", this, &ApplicationActionController::openPreferencesDialog);
 
     dispatcher()->reg(this, "revert-factory", this, &ApplicationActionController::revertToFactorySettings);
@@ -291,6 +292,12 @@ void ApplicationActionController::openAskForHelpPage()
 {
     std::string askForHelpUrl = configuration()->askForHelpUrl();
     interactive()->openUrl(askForHelpUrl);
+}
+
+void ApplicationActionController::openAccessibilityStatementPage()
+{
+    std::string accessibilityStatementUrl = configuration()->accessibilityStatementUrl();
+    interactive()->openUrl(accessibilityStatementUrl);
 }
 
 void ApplicationActionController::openPreferencesDialog()

--- a/src/appshell/internal/applicationactioncontroller.h
+++ b/src/appshell/internal/applicationactioncontroller.h
@@ -101,6 +101,7 @@ private:
 
     void openOnlineHandbookPage();
     void openAskForHelpPage();
+    void openAccessibilityStatementPage();
     void openPreferencesDialog();
     void doOpenPreferencesDialog();
 

--- a/src/appshell/internal/applicationuiactions.cpp
+++ b/src/appshell/internal/applicationuiactions.cpp
@@ -86,6 +86,11 @@ const UiActionList ApplicationUiActions::m_actions = {
              mu::context::CTX_ANY,
              TranslatableString("action", "As&k for help")
              ),
+    UiAction("accessibility-statement",
+             mu::context::UiCtxAny,
+             mu::context::CTX_ANY,
+             TranslatableString("action", "Accessibility &statement")
+             ),
     UiAction("revert-factory",
              mu::context::UiCtxAny,
              mu::context::CTX_ANY,

--- a/src/appshell/internal/appshellconfiguration.cpp
+++ b/src/appshell/internal/appshellconfiguration.cpp
@@ -49,6 +49,7 @@ static const Settings::Key STARTUP_SCORE_PATH(module_name, "application/startup/
 static const std::string MUSESCORE_ONLINE_HANDBOOK_URL("https://handbook.musescore.org");
 
 static const std::string MUSESCORE_ASK_FOR_HELP_URL_PATH("/redirect/post/question");
+static const std::string MUSESCORE_ACCESSIBILITY_STATEMENT_URL_PATH("/about/musescore-studio-accessibility-statement");
 static const std::string MUSESCORE_FORUM_URL_PATH("/forum");
 static const std::string MUSESCORE_CONTRIBUTE_URL_PATH("/contribute");
 static const std::string MUSEHUB_FREE_MUSE_SOUNDS_URL("https://www.musehub.com/free-musesounds"
@@ -200,6 +201,11 @@ std::string AppShellConfiguration::askForHelpUrl() const
     };
 
     return museScoreUrl() + MUSESCORE_ASK_FOR_HELP_URL_PATH + "?" + params.join("&").toStdString();
+}
+
+std::string AppShellConfiguration::accessibilityStatementUrl() const
+{
+    return museScoreUrl() + MUSESCORE_ACCESSIBILITY_STATEMENT_URL_PATH;
 }
 
 std::string AppShellConfiguration::museScoreUrl() const

--- a/src/appshell/internal/appshellconfiguration.h
+++ b/src/appshell/internal/appshellconfiguration.h
@@ -81,6 +81,7 @@ public:
 
     std::string handbookUrl() const override;
     std::string askForHelpUrl() const override;
+    std::string accessibilityStatementUrl() const override;
     std::string museScoreUrl() const override;
     std::string museScoreForumUrl() const override;
     std::string museScoreContributionUrl() const override;

--- a/src/appshell/view/appmenumodel.cpp
+++ b/src/appshell/view/appmenumodel.cpp
@@ -461,6 +461,7 @@ MenuItem* AppMenuModel::makeHelpMenu(bool addDiagnosticsSubMenu)
     helpItems << makeMenuItem("about-musescore", MenuItemRole::AboutRole);
     helpItems << makeMenuItem("about-qt", MenuItemRole::AboutQtRole);
     helpItems << makeMenuItem("about-musicxml");
+    helpItems << makeMenuItem("accessibility-statement");
     helpItems << makeSeparator();
 
 #if defined(Q_OS_WIN) || defined(Q_OS_MACOS)


### PR DESCRIPTION
Add link to our [accessibility statement](https://musescore.org/en/about/musescore-studio-accessibility-statement) in the Help menu.

I've assigned it the `&S` mnemonic (i.e. `Alt`+`H`, `S` on non-macOS platforms).

<img height="400" alt="image" src="https://github.com/user-attachments/assets/8e904cbc-bf32-4196-ba06-d0d23ea98d0a" />

Note: We can't put it in the About dialog because links in that dialog are not currently navigable via the keyboard.