### PR TITLE
fixed #28866: Keyboard input broken for most spin boxes under KDE Plasma + Wayland (for 4.6.4 branch)

### DIFF
--- a/src/framework/uicomponents/view/popupwindow/popupwindow_qquickview.cpp
+++ b/src/framework/uicomponents/view/popupwindow/popupwindow_qquickview.cpp
@@ -32,29 +32,29 @@ using namespace muse::uicomponents;
 
 static Qt::WindowFlags resolveWindowFlags()
 {
-        Qt::WindowFlags flags;
+    Qt::WindowFlags flags;
 
-        static bool isWayland = qGuiApp->platformName().contains("wayland");
-        if (isWayland) {
-            flags = Qt::Popup;
-        } else {
-            flags = Qt::Tool;
-        }
+    static bool isWayland = qGuiApp->platformName().contains("wayland");
+    if (isWayland) {
+        flags = Qt::Popup;
+    } else {
+        flags = Qt::Tool;
+    }
 
-        static int sIsKde = -1;
-        if (sIsKde == -1) {
-            QString desktop = qEnvironmentVariable("XDG_CURRENT_DESKTOP").toLower();
-            QString session = qEnvironmentVariable("XDG_SESSION_DESKTOP").toLower();
-            sIsKde = desktop.contains("kde") || session.contains("kde");
-        }
-        if (!sIsKde) {
-            flags |= Qt::BypassWindowManagerHint;    // Otherwise, it does not work correctly on Gnome (Linux) when resizing)
-        }
+    static int sIsKde = -1;
+    if (sIsKde == -1) {
+        QString desktop = qEnvironmentVariable("XDG_CURRENT_DESKTOP").toLower();
+        QString session = qEnvironmentVariable("XDG_SESSION_DESKTOP").toLower();
+        sIsKde = desktop.contains("kde") || session.contains("kde");
+    }
+    if (!sIsKde) {
+        flags |= Qt::BypassWindowManagerHint;        // Otherwise, it does not work correctly on Gnome (Linux) when resizing)
+    }
 
-        flags |= Qt::FramelessWindowHint           // Without border
-                 | Qt::NoDropShadowWindowHint;      // Without system shadow
+    flags |= Qt::FramelessWindowHint               // Without border
+             | Qt::NoDropShadowWindowHint;          // Without system shadow
 
-        return flags;
+    return flags;
 }
 
 PopupWindow_QQuickView::PopupWindow_QQuickView(const modularity::ContextPtr& iocCtx, QObject* parent)


### PR DESCRIPTION
Keyboard input for spin boxes was broken in KDE Plasma under XWayland,
but worked correctly under Wayland. Unlike PR #29888, this fixes it in
XWayland without regressing menu positioning under Wayland. Tested on
Manjaro Linux, but this fix should be agnostic to the Linux
distribution.

Resolves: #28866

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
