### PR TITLE
Fix #31176: Unable to enter note input after editing trill

### DIFF
--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -2754,11 +2754,7 @@ void NotationUiActions::init()
                 updateActionsEnabled(s_actions);
             }, Asyncable::Mode::SetReplace);
 
-            interaction->textEditingStarted().onNotify(this, [this]() {
-                updateActionsEnabled(s_actions);
-            }, Asyncable::Mode::SetReplace);
-
-            interaction->textEditingEnded().onReceive(this, [this](TextBase*) {
+            interaction->isEditingElementChanged().onNotify(this, [this]() {
                 updateActionsEnabled(s_actions);
             }, Asyncable::Mode::SetReplace);
 


### PR DESCRIPTION
Resolves: #31176

This one made my head spin a little - there are a lot of moving parts. Probably the most important thing to note here is that `NotationActionController::startNoteInputAllowed` returns false if we're editing an element. The problem goes something like this:

1. We select the trill and the "selection changed" lambda goes off in `NotationUiActions::init`. At this point we haven't actually indicated that we're editing an element - so `NotationUiActions` tells `UiActionsRegister` to mark the note input action as **enabled**.

2. We make an edit in the properties panel which sets off the "context changed" lambda in `UiActionsRegister::init`. By this point we _have_ indicated that we're editing an element. For this reason `UiActionsRegister::init` marks the note input action as **disabled**.

3. We make a new selection and the first thing that happens in `NotationInteraction::doSelect` is `endEditElement`. So by the time the "selection changed" lambda goes off again in `NotationUiActions`, it (rightly) considers the note input action to be **enabled**.

What should happen at this point is that `NotationUiActions` notifies `UiActionsRegister` that the note input action has been enabled. However, it will only do so if it detects a change in the enabled state and from the perspective of `NotationUiActions`, this action _was always enabled_. No change is detected.

The fix I'm proposing here is simply to have `NotationUiActions` update its enabled states when the `isEditingElement` flag changes.

Sidenote: I am wondering whether it's cohesive for `UiActionsRegister` to update action states without notifying the relevant modules. That was part of the problem here and perhaps a question for the future...