### PR TITLE
Keep staff type up to date in edit staff type dialog

### DIFF
--- a/src/notation/view/widgets/editstaff.cpp
+++ b/src/notation/view/widgets/editstaff.cpp
@@ -653,6 +653,7 @@ QString EditStaff::midiCodeToStr(int midiCode)
 
 void EditStaff::showStaffTypeDialog()
 {
+    editStaffTypeDialog->setStaff(m_staff);
     editStaffTypeDialog->setStaffType(m_staff->staffType(mu::engraving::Fraction(0, 1)));
     editStaffTypeDialog->setInstrument(m_instrument);
 

--- a/src/notation/view/widgets/editstafftype.h
+++ b/src/notation/view/widgets/editstafftype.h
@@ -37,13 +37,14 @@ namespace mu::notation {
 //   EditStaffType
 //---------------------------------------------------------
 
-class EditStaffType : public QDialog, private Ui::EditStaffType, public muse::Injectable
+class EditStaffType : public QDialog, private Ui::EditStaffType, public muse::Injectable, public muse::async::Asyncable
 {
     Q_OBJECT
 
     INJECT(muse::IInteractive, interactive)
 
-    mu::engraving::StaffType staffType;
+    mu::engraving::StaffType m_staffType;
+    const mu::engraving::Staff* m_staff = nullptr;
 
     virtual void showEvent(QShowEvent*);
     virtual void hideEvent(QHideEvent*);
@@ -77,7 +78,8 @@ public:
     EditStaffType(QWidget* parent = nullptr);
     ~EditStaffType() {}
     void setStaffType(const mu::engraving::StaffType* staffType);
-    mu::engraving::StaffType getStaffType() const { return staffType; }
+    void setStaff(const mu::engraving::Staff* staff) { m_staff = staff; }
+    mu::engraving::StaffType getStaffType() const { return m_staffType; }
 
     void setInstrument(const Instrument& instrument);
 


### PR DESCRIPTION
Resolves: #30607 

`EditStaffType` makes a copy of the current staff type on opening. This gets out of sync when the style dialog is opened from within `EditStaffType` as the style dialog changes don't reach this copy.
We still really need to overhaul these dialogs and `StaffType` as a whole!
