### PR TITLE
Add chord symbol to fret diagram in correct score

### DIFF
--- a/src/engraving/editing/addremoveelement.cpp
+++ b/src/engraving/editing/addremoveelement.cpp
@@ -77,6 +77,9 @@ static void undoAddTuplet(DurationElement* cr)
 AddElement::AddElement(EngravingItem* e)
 {
     DO_ASSERT_X(!e->generated(), String(u"Generated item %1 passed to AddElement").arg(String::fromAscii(e->typeName())));
+    DO_ASSERT_X(e->parent()->score() == e->score(),
+                String(u"Item %1 is in a different score to its parent %2").arg(String::fromAscii(e->typeName()),
+                                                                                String::fromAscii(e->parent()->typeName())));
     element = e;
 }
 

--- a/src/engraving/editing/edit.cpp
+++ b/src/engraving/editing/edit.cpp
@@ -6991,6 +6991,12 @@ void Score::undoAddElement(EngravingItem* element, bool addToLinkedStaves, bool 
             }
             doUndoAddElement(ne);
         } else if (element->isHarmony() && element->explicitParent()->isFretDiagram()) {
+            EngravingItem* parentFd = element->parentItem();
+            if (parentFd->score() != score) {
+                // Find linked fret diagram
+                EngravingItem* linkedFd = parentFd->findLinkedInScore(score);
+                ne->setParent(linkedFd);
+            }
             doUndoAddElement(ne);
         }
         //


### PR DESCRIPTION
Resolves: #31195 

Chord symbols weren't being added to parts correctly when added to a fret diagram.  All cloned copies were being added to the same fret diagram.

I've added an assertion in `AddElement` to catch errors like these in future.
