### PR TITLE
Shorten graphicaleffects target name to fix build issues on Windows

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -149,7 +149,7 @@ add_to_link_if_enabled(${MUSE_MODULE_MUSESAMPLER} muse::musesampler)
 add_to_link_if_enabled(${MUSE_MODULE_UI} muse::ui)
 add_to_link_if_enabled(${MUSE_MODULE_UI} muse::uicomponents)
 add_to_link_if_enabled(${MUSE_MODULE_UI} muse::uicomponents_qml)
-add_to_link_if_enabled(${MUSE_MODULE_UI} muse::uicomponents_graphicaleffects_qml)
+add_to_link_if_enabled(${MUSE_MODULE_UI} muse::graphicaleffects_qml)
 add_to_link_if_enabled(${MUSE_MODULE_DOCKWINDOW} muse::dockwindow)
 
 add_to_link_if_enabled(${MUE_BUILD_APPSHELL_MODULE} appshell)

--- a/src/framework/uicomponents/qml/Muse/GraphicalEffects/CMakeLists.txt
+++ b/src/framework/uicomponents/qml/Muse/GraphicalEffects/CMakeLists.txt
@@ -18,9 +18,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-muse_create_qml_module(muse_uicomponents_graphicaleffects_qml ALIAS muse::uicomponents_graphicaleffects_qml FOR muse_uicomponents)
+muse_create_qml_module(muse_graphicaleffects_qml ALIAS muse::graphicaleffects_qml FOR muse_uicomponents)
 
-qt_add_qml_module(muse_uicomponents_graphicaleffects_qml
+qt_add_qml_module(muse_graphicaleffects_qml
     URI Muse.GraphicalEffects
     VERSION 1.0
     QML_FILES
@@ -31,7 +31,7 @@ qt_add_qml_module(muse_uicomponents_graphicaleffects_qml
         RoundedCornersEffect.qml
 )
 
-qt_add_shaders(muse_uicomponents_graphicaleffects_qml muse_uicomponents_graphicaleffects_qml_shaders
+qt_add_shaders(muse_graphicaleffects_qml muse_graphicaleffects_qml_shaders
     PREFIX
         "/qt/qml/Muse/GraphicalEffects"
     FILES


### PR DESCRIPTION
@Jojo-Schmitz @mike-spa FYI; hopefully this fixes some problems