### PR TITLE
Fix crash when adding loop boundaries to an empty score [4.6.4 port]

### DIFF
--- a/src/notation/internal/notationplayback.cpp
+++ b/src/notation/internal/notationplayback.cpp
@@ -312,10 +312,16 @@ RetVal<muse::midi::tick_t> NotationPlayback::playPositionTickByElement(const Eng
 
 void NotationPlayback::addLoopBoundary(LoopBoundaryType boundaryType, tick_t tick)
 {
+    const Measure* first = score()->firstMeasure();
+    const Measure* last = score()->lastMeasure();
+    IF_ASSERT_FAILED(first && last) {
+        return;
+    }
+
     if (tick == BoundaryTick::FirstScoreTick) {
-        tick = score()->firstMeasure()->tick().ticks();
+        tick = first->tick().ticks();
     } else if (tick == BoundaryTick::LastScoreTick) {
-        tick = score()->lastMeasure()->endTick().ticks();
+        tick = last->endTick().ticks();
     }
 
     switch (boundaryType) {

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -25,6 +25,7 @@
 
 #include "playbacktypes.h"
 
+#include "engraving/dom/masterscore.h"
 #include "engraving/dom/stafftext.h"
 #include "engraving/dom/utils.h"
 #include "engraving/dom/factory.h"
@@ -851,6 +852,12 @@ void PlaybackController::toggleLoopPlayback()
 {
     if (isLoopEnabled()) {
         disableLoop();
+        return;
+    }
+
+    const MasterScore* score = m_masterNotation ? m_masterNotation->masterScore() : nullptr;
+    const Measure* first = score ? score->firstMeasure() : nullptr;
+    if (!first) {
         return;
     }
 


### PR DESCRIPTION
Ports: #31215