### PR TITLE
[ext] added qml support for api docs

### DIFF
--- a/src/engraving/api/v1/elements.h
+++ b/src/engraving/api/v1/elements.h
@@ -2274,12 +2274,13 @@ public:
     /// \endcond
 };
 
-//---------------------------------------------------------
-//   Spanner
-///  Provides access to internal mu::engraving::Spanner objects.
-///  \since MuseScore 4.6
-//---------------------------------------------------------
-
+/** APIDOC
+ * Provides access to internal mu::engraving::Spanner objects.
+ * @class Spanner
+ * @memberof engraving
+ * @hideconstructor
+ * @since 4.6
+*/
 class Spanner : public EngravingItem
 {
     Q_OBJECT
@@ -2357,7 +2358,9 @@ public:
 /** APIDOC
  * Class representing a lyric.
  * @class Lyrics
+ * @memberof engraving
  * @hideconstructor
+ * @since 4.7
 */
 class Lyrics : public EngravingItem
 {

--- a/src/engraving/api/v1/engravingapiv1.cpp
+++ b/src/engraving/api/v1/engravingapiv1.cpp
@@ -30,6 +30,11 @@
 
 using namespace mu::engraving::apiv1;
 
+/** APIDOC
+ * Information and actions related to Score
+ * @namespace engraving
+ */
+
 EngravingApiV1::EngravingApiV1(muse::api::IApiEngine* e)
     : muse::api::ApiObject(e)
 {

--- a/src/engraving/api/v1/score.cpp
+++ b/src/engraving/api/v1/score.cpp
@@ -43,6 +43,7 @@ using namespace mu::engraving::apiv1;
  * Class representing a score.
  * We can get the current score by calling the `api.engraving.curScore`
  * @class Score
+ * @memberof engraving
  * @hideconstructor
 */
 
@@ -274,19 +275,29 @@ QQmlListProperty<System> Score::systems()
     return wrapContainerProperty<System>(this, score()->systems());
 }
 
-/** APIDOC @property {boolean} - has lyrics */
+/** APIDOC
+ * @readonly
+ * @member {Boolean}
+ */
 bool Score::hasLyrics() const
 {
     return score()->hasLyrics();
 }
 
-/** APIDOC @property {number} - count of lyrics */
+/** APIDOC
+ * @readonly
+ * @member {Number}
+ */
 int Score::lyricCount() const
 {
     return score()->lyricCount();
 }
 
-/** APIDOC @property {Lyric[]} - list of lyrics */
+/** APIDOC
+ * @readonly
+ * @member {engraving.Lyric[]}
+ * @since 4.7
+ */
 QQmlListProperty<Lyrics> Score::lyrics() const
 {
     static std::vector<engraving::Lyrics*> list;
@@ -297,14 +308,18 @@ QQmlListProperty<Lyrics> Score::lyrics() const
 /** APIDOC
 * Extracts all lyrics in the score and returns them in a single string.
 * @method
-* @return {string} - lyrics string
+* @return {String} - lyrics string
 */
 QString Score::extractLyrics() const
 {
     return score()->extractLyrics();
 }
 
-/** APIDOC @property {Spanner[]} - list of spanners */
+/** APIDOC
+ * @readonly
+ * @member {engraving.Spanner[]}
+ * @since 4.7
+ */
 QQmlListProperty<Spanner> Score::spanners()
 {
     static std::vector<mu::engraving::Spanner*> spannerList;

--- a/src/framework/extensions/api/MuseApi/Extensions/ExtensionBlank.qml
+++ b/src/framework/extensions/api/MuseApi/Extensions/ExtensionBlank.qml
@@ -1,5 +1,16 @@
 import QtQuick
 
+//! NOTE Root namespace for all Qml types
+/** APIDOC
+ * Qml UI Controls
+ * @namespace Qml
+ */
+
+/** APIDOC
+ * Base class for extension form
+ * @class ExtensionBlank
+ * @hideconstructor
+*/
 Rectangle {
 
     color: api.theme.backgroundPrimaryColor

--- a/src/framework/global/api/interactiveapi.cpp
+++ b/src/framework/global/api/interactiveapi.cpp
@@ -24,8 +24,6 @@
 
 #include <QUrl>
 
-#include "global/containers.h"
-
 using namespace muse::api;
 
 /** APIDOC

--- a/src/framework/uicomponents/qml/Muse/UiComponents/FlatButton.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/FlatButton.qml
@@ -27,10 +27,25 @@ import QtQuick.Layouts
 import Muse.Ui 
 import Muse.UiComponents
 
+/** APIDOC
+ * General button
+ * @class FlatButton
+ * @hideconstructor
+ * @example
+ * FlatButton {
+ *     text: "Click me"
+ *     onClicked: {
+ *         api.interactive.info("Test", "Clicked on button")
+ *     }
+ * }
+*/
 FocusScope {
     id: root
 
     property int icon: IconCode.NONE
+    /** APIDOC
+     * @member {String}
+     */
     property string text: ""
     property int textFormat: Text.AutoText
     property int maximumLineCount: 1
@@ -105,6 +120,10 @@ FocusScope {
         return FlatButton.TextOnly
     }
 
+    /** APIDOC
+     * @method
+     * @signal
+     */
     signal clicked(var mouse)
     // The `pressAndHold` signal is intentionally not "forwarded" here from the MouseArea for performance reasons.
     // Most buttons don't use it and Qt has optimizations if no signal is attached. If a component needs it,

--- a/tools/jsdoc/conf.json
+++ b/tools/jsdoc/conf.json
@@ -23,7 +23,7 @@
         "theme_opts": {
             "default_theme": "light",
             "title": "Home",
-            "__sections": ["Tutorials", "Namespaces", "Classes"]
+            "sections": ["Tutorials", "Namespaces", "Classes", "Global"]
         }                
 	},
     "markdown": {

--- a/tools/jsdoc/jsdoc_run.sh
+++ b/tools/jsdoc/jsdoc_run.sh
@@ -15,7 +15,7 @@ rm -rf ${GEN_APIDOCSRC_DIR}
 mkdir -p ${GEN_APIDOCSRC_DIR}
 
 echo "Extracting docs..."
-node ${HERE}/jsdoc_extractor.js -d ${SRC_DIR} -e .cpp,.h -o ${GEN_APIDOCSRC_DIR}
+node ${HERE}/jsdoc_extractor.js -d ${SRC_DIR} -e .cpp,.h,.qml -o ${GEN_APIDOCSRC_DIR}
 
 echo "Copying static..."
 cp -r ${APIDOC_STATIC_DIR}/* ${GEN_APIDOCSRC_DIR}/

--- a/tools/jsdoc/template/publish.js
+++ b/tools/jsdoc/template/publish.js
@@ -256,10 +256,25 @@ function addSignatureTypes(f) {
 }
 
 function addAttribs(f) {
-    const attribs = helper.getAttribs(f);
-    const attribsString = buildAttribsString(attribs);
 
-    f.attribs = `<span class="type-signature">${attribsString}</span>`;
+    // look signal 
+    let hasSignal = false;
+    if (f.tags) {
+        for (let t of f.tags) {
+            if (t.title === "signal") {
+                hasSignal = true;
+                break;
+            }
+        }
+    }
+
+    if (hasSignal) {
+        f.attribs = `<span class="type-signature">(signal) </span>`;
+    } else {
+        const attribs = helper.getAttribs(f);
+        const attribsString = buildAttribsString(attribs);
+        f.attribs = `<span class="type-signature">${attribsString}</span>`;
+    }
 }
 
 function shortenPaths(files, commonPrefix) {
@@ -685,7 +700,7 @@ exports.publish = async function (taffyData, opts, tutorials) {
         }
 
         // Added `api.` prefix
-        if (doclet.kind === "namespace") {
+        if (doclet.kind === "namespace" && doclet.name !== "Qml") {
             doclet.name = "api."+doclet.name
         }
     });

--- a/tools/jsdoc/template/tmpl/members.tmpl
+++ b/tools/jsdoc/template/tmpl/members.tmpl
@@ -16,6 +16,7 @@ var self = this;
 </div>
 <?js } ?>
 
+<!-- MUFIX
 <?js if (data.type && data.type.names) {?>
     <div class="member-item-container flex">
         <strong>Type: </strong>
@@ -26,6 +27,7 @@ var self = this;
         </ul>
     </div>
 <?js } ?>
+-->
 
 <?js= this.partial('details.tmpl', data) ?>
 


### PR DESCRIPTION

* I changed the way properties are documented. Previously, it was very concise, but we couldn't add attributes (readonly, since), and we couldn't add an example if needed. Now (after edit the template), it's also quite concise, and everything we need can be added. https://musescore.github.io/snapshots/4.7/engraving.Score.html 
* Added the ability to specify the namespace to which classes belong. Now the list of classes is visible on the namespace page, and the namespace is visible on the class page. https://musescore.github.io/snapshots/4.7/engraving.html 
* Added support for documentation of Qml components https://musescore.github.io/snapshots/4.7/Qml.html 


@XiaoMigros FYI