### PR TITLE
Add copy/paste and apply all to mixer settings

### DIFF
--- a/src/playback/CMakeLists.txt
+++ b/src/playback/CMakeLists.txt
@@ -71,6 +71,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/view/mixerpanelmodel.h
     ${CMAKE_CURRENT_LIST_DIR}/view/mixerpanelcontextmenumodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/mixerpanelcontextmenumodel.h
+    ${CMAKE_CURRENT_LIST_DIR}/view/mixerchannelcontextmenumodel.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/view/mixerchannelcontextmenumodel.h
     ${CMAKE_CURRENT_LIST_DIR}/view/playbacktoolbarmodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/playbacktoolbarmodel.h
     ${CMAKE_CURRENT_LIST_DIR}/view/playbackloadingmodel.cpp

--- a/src/playback/playbackmodule.cpp
+++ b/src/playback/playbackmodule.cpp
@@ -38,6 +38,7 @@
 #include "view/playbackloadingmodel.h"
 #include "view/mixerpanelmodel.h"
 #include "view/mixerpanelcontextmenumodel.h"
+#include "view/mixerchannelcontextmenumodel.h"
 #include "view/soundprofilesmodel.h"
 #include "view/internal/soundflag/soundflagsettingsmodel.h"
 #include "view/internal/onlinesoundsstatusmodel.h"
@@ -96,6 +97,7 @@ void PlaybackModule::registerUiTypes()
     qmlRegisterType<PlaybackLoadingModel>("MuseScore.Playback", 1, 0, "PlaybackLoadingModel");
     qmlRegisterType<MixerPanelModel>("MuseScore.Playback", 1, 0, "MixerPanelModel");
     qmlRegisterType<MixerPanelContextMenuModel>("MuseScore.Playback", 1, 0, "MixerPanelContextMenuModel");
+    qmlRegisterType<MixerChannelContextMenuModel>("MuseScore.Playback", 1, 0, "MixerChannelContextMenuModel");
     qmlRegisterType<SoundProfilesModel>("MuseScore.Playback", 1, 0, "SoundProfilesModel");
 
     qmlRegisterType<SoundFlagSettingsModel>("MuseScore.Playback", 1, 0, "SoundFlagSettingsModel");

--- a/src/playback/qml/MuseScore/Playback/MixerPanel.qml
+++ b/src/playback/qml/MuseScore/Playback/MixerPanel.qml
@@ -127,6 +127,59 @@ ColumnLayout {
         }
     }
 
+    MixerChannelContextMenuModel {
+        id: channelContextMenuModel
+    }
+
+    ContextMenuLoader {
+        id: channelContextMenu
+
+        property int channelIndex: -1
+
+        onHandleMenuItem: function(itemId) {
+            switch (itemId) {
+            case "copy":
+                mixerPanelModel.copyChannelSettings(channelContextMenu.channelIndex)
+                break
+            case "paste":
+                mixerPanelModel.pasteChannelSettings(channelContextMenu.channelIndex)
+                break
+            case "apply-to-all":
+                mixerPanelModel.applySettingsToAllChannels(channelContextMenu.channelIndex)
+                break
+            case "undo":
+                mixerPanelModel.undo()
+                break
+            case "redo":
+                mixerPanelModel.redo()
+                break
+            }
+        }
+    }
+
+    function showChannelContextMenu(channelIndex, anchorItem) {
+        var data = mixerPanelModel.get(channelIndex)
+        if (!data || !data.channelItem) {
+            return
+        }
+
+        var item = data.channelItem
+
+        // Only show menu for instrument channels
+        if (item.type === MixerChannelItem.Master ||
+            item.type === MixerChannelItem.Aux ||
+            item.type === MixerChannelItem.Metronome) {
+            return
+        }
+
+        channelContextMenu.channelIndex = channelIndex
+        channelContextMenuModel.loadForChannel(channelIndex, mixerPanelModel)
+        
+        // Map button position to root coordinate space
+        var pos = anchorItem.mapToItem(root, 0, 0)
+        channelContextMenu.show(Qt.point(pos.x, pos.y), channelContextMenuModel.items)
+    }
+
     StyledFlickable {
         id: flickable
 
@@ -341,6 +394,10 @@ ColumnLayout {
 
                 onNavigateControlIndexChanged: function(index) {
                     prv.setNavigateControlIndex(index)
+                }
+
+                onMenuButtonClicked: function(channelIndex, anchorItem) {
+                    showChannelContextMenu(channelIndex, anchorItem)
                 }
             }
         }

--- a/src/playback/qml/MuseScore/Playback/internal/MixerTitleSection.qml
+++ b/src/playback/qml/MuseScore/Playback/internal/MixerTitleSection.qml
@@ -31,9 +31,15 @@ MixerPanelSection {
 
     headerTitle: qsTrc("playback", "Name")
 
+    signal menuButtonClicked(int channelIndex, var anchorItem)
+
     Rectangle {
+        id: titleRect
         width: root.channelItemWidth
         height: 22
+
+        property bool isInstrumentChannel: channelItem.type === MixerChannelItem.PrimaryInstrument ||
+                                           channelItem.type === MixerChannelItem.SecondaryInstrument
 
         function resolveLabelColor() {
             switch(channelItem.type) {
@@ -65,19 +71,41 @@ MixerPanelSection {
 
         StyledTextLabel {
             id: textLabel
-            anchors.centerIn: parent
+            anchors.left: parent.left
+            anchors.right: menuButton.visible ? menuButton.left : parent.right
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.leftMargin: 4
+            anchors.rightMargin: 2
 
             font: ui.theme.bodyBoldFont
-
-            readonly property int margin: -8
-            width: margin + parent.width + margin
+            horizontalAlignment: Text.AlignHCenter
 
             text: channelItem.title
+        }
+
+        FlatButton {
+            id: menuButton
+            anchors.right: parent.right
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.rightMargin: 2
+
+            visible: titleRect.isInstrumentChannel
+            width: 18
+            height: 18
+
+            icon: IconCode.MENU_THREE_DOTS
+            iconFont: ui.theme.toolbarIconsFont
+            transparent: true
+
+            onClicked: {
+                root.menuButtonClicked(model.index, menuButton)
+            }
         }
 
         MouseArea {
             id: mouseArea
             anchors.fill: parent
+            z: -1
 
             enabled: parent.enabled
             hoverEnabled: true

--- a/src/playback/view/internal/mixerchannelitem.cpp
+++ b/src/playback/view/internal/mixerchannelitem.cpp
@@ -751,3 +751,33 @@ const QMap<aux_channel_idx_t, AuxSendItem*>& MixerChannelItem::auxSendItems() co
 {
     return m_auxSendItems;
 }
+
+void MixerChannelItem::setAuxSends(const AuxSendsParams& auxSends)
+{
+    size_t count = std::min(auxSends.size(), m_outParams.auxSends.size());
+
+    bool changed = false;
+    for (size_t i = 0; i < count; ++i) {
+        const auto& src = auxSends[i];
+        auto& dst = m_outParams.auxSends[i];
+        if (!muse::RealIsEqual(dst.signalAmount, src.signalAmount) || dst.active != src.active) {
+            dst = src;
+            changed = true;
+        }
+    }
+
+    if (!changed) {
+        return;
+    }
+
+    // Update UI items
+    for (aux_channel_idx_t i = 0; i < count; ++i) {
+        auto it = m_auxSendItems.find(i);
+        if (it != m_auxSendItems.end()) {
+            it.value()->setAudioSignalPercentage(static_cast<int>(auxSends[i].signalAmount * 100.f));
+            it.value()->setIsActive(auxSends[i].active);
+        }
+    }
+
+    emit outputParamsChanged(m_outParams);
+}

--- a/src/playback/view/internal/mixerchannelitem.h
+++ b/src/playback/view/internal/mixerchannelitem.h
@@ -121,6 +121,8 @@ public:
     const muse::audio::AudioInputParams& inputParams() const;
     const muse::audio::AudioOutputParams& outputParams() const;
 
+    Q_INVOKABLE void setAuxSends(const muse::audio::AuxSendsParams& auxSends);
+
     InputResourceItem* inputResourceItem() const;
     QList<OutputResourceItem*> outputResourceItemList() const;
     QList<AuxSendItem*> auxSendItemList() const;

--- a/src/playback/view/mixerchannelcontextmenumodel.cpp
+++ b/src/playback/view/mixerchannelcontextmenumodel.cpp
@@ -1,0 +1,149 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "mixerchannelcontextmenumodel.h"
+
+#include "mixerpanelmodel.h"
+#include "types/translatablestring.h"
+
+using namespace mu::playback;
+using namespace muse;
+using namespace muse::uicomponents;
+
+MixerChannelContextMenuModel::MixerChannelContextMenuModel(QObject* parent)
+    : AbstractMenuModel(parent)
+{
+}
+
+void MixerChannelContextMenuModel::loadForChannel(int channelIndex, QObject* mixerModelObj)
+{
+    m_channelIndex = channelIndex;
+    m_mixerModel = qobject_cast<MixerPanelModel*>(mixerModelObj);
+
+    buildMenu();
+
+    emit canPasteChanged();
+}
+
+bool MixerChannelContextMenuModel::canPaste() const
+{
+    return m_mixerModel && m_mixerModel->hasClipboardData();
+}
+
+bool MixerChannelContextMenuModel::canUndo() const
+{
+    return m_mixerModel && m_mixerModel->canUndo();
+}
+
+bool MixerChannelContextMenuModel::canRedo() const
+{
+    return m_mixerModel && m_mixerModel->canRedo();
+}
+
+void MixerChannelContextMenuModel::buildMenu()
+{
+    MenuItemList items;
+
+    // Copy item
+    MenuItem* copyItem = new MenuItem(this);
+    copyItem->setId("copy");
+
+    ui::UiAction copyAction;
+    copyAction.title = TranslatableString("playback", "Copy channel settings");
+    copyAction.code = "copy";
+    copyItem->setAction(copyAction);
+
+    ui::UiActionState copyState;
+    copyState.enabled = true;
+    copyItem->setState(copyState);
+
+    items << copyItem;
+
+    // Paste item
+    MenuItem* pasteItem = new MenuItem(this);
+    pasteItem->setId("paste");
+
+    ui::UiAction pasteAction;
+    pasteAction.title = TranslatableString("playback", "Paste channel settings");
+    pasteAction.code = "paste";
+    pasteItem->setAction(pasteAction);
+
+    ui::UiActionState pasteState;
+    pasteState.enabled = canPaste();
+    pasteItem->setState(pasteState);
+
+    items << pasteItem;
+
+    // Separator
+    items << makeSeparator();
+
+    // Apply to all item
+    MenuItem* applyToAllItem = new MenuItem(this);
+    applyToAllItem->setId("apply-to-all");
+
+    ui::UiAction applyAction;
+    applyAction.title = TranslatableString("playback", "Apply to all channels");
+    applyAction.code = "apply-to-all";
+    applyToAllItem->setAction(applyAction);
+
+    ui::UiActionState applyState;
+    applyState.enabled = true;
+    applyToAllItem->setState(applyState);
+
+    items << applyToAllItem;
+
+    // Separator before undo/redo
+    items << makeSeparator();
+
+    // Undo item
+    MenuItem* undoItem = new MenuItem(this);
+    undoItem->setId("undo");
+
+    ui::UiAction undoAction;
+    undoAction.title = TranslatableString("playback", "Undo");
+    undoAction.code = "undo";
+    undoItem->setAction(undoAction);
+
+    ui::UiActionState undoState;
+    undoState.enabled = canUndo();
+    undoItem->setState(undoState);
+
+    items << undoItem;
+
+    // Redo item
+    MenuItem* redoItem = new MenuItem(this);
+    redoItem->setId("redo");
+
+    ui::UiAction redoAction;
+    redoAction.title = TranslatableString("playback", "Redo");
+    redoAction.code = "redo";
+    redoItem->setAction(redoAction);
+
+    ui::UiActionState redoState;
+    redoState.enabled = canRedo();
+    redoItem->setState(redoState);
+
+    items << redoItem;
+
+    setItems(items);
+}
+

--- a/src/playback/view/mixerchannelcontextmenumodel.h
+++ b/src/playback/view/mixerchannelcontextmenumodel.h
@@ -1,0 +1,61 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2021 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef MU_PLAYBACK_MIXERCHANNELCONTEXTMENUMODEL_H
+#define MU_PLAYBACK_MIXERCHANNELCONTEXTMENUMODEL_H
+
+#include "uicomponents/qml/Muse/UiComponents/abstractmenumodel.h"
+
+namespace mu::playback {
+class MixerPanelModel;
+
+class MixerChannelContextMenuModel : public muse::uicomponents::AbstractMenuModel
+{
+    Q_OBJECT
+
+    Q_PROPERTY(bool canPaste READ canPaste NOTIFY canPasteChanged)
+    Q_PROPERTY(bool canUndo READ canUndo NOTIFY undoStateChanged)
+    Q_PROPERTY(bool canRedo READ canRedo NOTIFY undoStateChanged)
+
+public:
+    explicit MixerChannelContextMenuModel(QObject* parent = nullptr);
+
+    Q_INVOKABLE void loadForChannel(int channelIndex, QObject* mixerModel);
+
+    bool canPaste() const;
+    bool canUndo() const;
+    bool canRedo() const;
+
+signals:
+    void canPasteChanged();
+    void undoStateChanged();
+
+private:
+    void buildMenu();
+
+    int m_channelIndex = -1;
+    MixerPanelModel* m_mixerModel = nullptr;
+};
+}
+
+#endif // MU_PLAYBACK_MIXERCHANNELCONTEXTMENUMODEL_H
+


### PR DESCRIPTION
Added a three dot menu to mixer channels in the editor to allow copy/paste of channel settings and ability to apply settings to all mixer channels (excluding aux & master channels)

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
