### PR TITLE
Null check stems before using them

### DIFF
--- a/src/engraving/rendering/score/slurtielayout.cpp
+++ b/src/engraving/rendering/score/slurtielayout.cpp
@@ -578,7 +578,7 @@ void SlurTieLayout::slurPos(Slur* item, SlurTiePos* sp, LayoutContext& ctx)
         TremoloTwoChord* trem = sc ? sc->tremoloTwoChord() : nullptr;
         if (stem1 || trem) {     //sc not null
             Beam* beam1 = sc->beam();
-            if (beam1 && (beam1->elements().back() != sc) && (sc->up() == item->up())) {
+            if (stem1 && beam1 && (beam1->elements().back() != sc) && (sc->up() == item->up())) {
                 TLayout::layoutBeam(beam1, ctx);
                 // start chord is beamed but not the last chord of beam group
                 // and slur direction is same as start chord (stem side)
@@ -666,7 +666,7 @@ void SlurTieLayout::slurPos(Slur* item, SlurTiePos* sp, LayoutContext& ctx)
                     yd *= .5;
 
                     // float along stem according to differential
-                    double sh = stem1->height();
+                    double sh = stem1 ? stem1->height() : 0.0;
                     if (item->up() && yd < 0.0) {
                         po.ry() = std::max(po.y() + yd, sc->downNote()->pos().y() - sh - _spatium);
                     } else if (!item->up() && yd > 0.0) {
@@ -801,7 +801,7 @@ void SlurTieLayout::slurPos(Slur* item, SlurTiePos* sp, LayoutContext& ctx)
                         double yd = n2->pos().y() - (n1 ? n1->pos().y() : item->startCR()->pos().y());
                         yd *= .5;
 
-                        double mh = stem2->height();
+                        double mh = stem2 ? stem2->height() : 0.0;
                         if (item->up() && yd > 0.0) {
                             po.ry() = std::max(po.y() - yd, ec->downNote()->pos().y() - mh - _spatium);
                         } else if (!item->up() && yd < 0.0) {


### PR DESCRIPTION
Resolves: #31207

The issue is that both the slur and the tremolos are reacting to stems changing directions, except whole notes don't have stems. This doesn't fix the underlying problem but it avoids the crash. 

PS: the fix for the underlying problem is to throw away the slur positioning code and rewrite it properly.
