### PR TITLE
Fix GCC compiler warning

### DIFF
--- a/src/importexport/tabledit/internal/importtef.cpp
+++ b/src/importexport/tabledit/internal/importtef.cpp
@@ -609,7 +609,8 @@ static void fillGap(Measure* measure, track_idx_t track, const Fraction& tstart,
     auto durList = toDurationList(restLen, true);
     LOGN("durList.size %zu", durList.size());
     for (const auto& dur : durList) {
-        LOGN("type %d dots %d fraction %d/%d", dur.type(), dur.dots(), dur.fraction().numerator(), dur.fraction().denominator());
+        LOGN("type %d dots %d fraction %d/%d", static_cast<int>(dur.type()), dur.dots(), dur.fraction().numerator(),
+             dur.fraction().denominator());
         Segment* s = measure->getSegment(SegmentType::ChordRest, ctick);
         addRest(s, track, dur, dur.fraction(), muse::draw::Color::BLACK, false);
         ctick += dur.fraction();


### PR DESCRIPTION
reg.: format ‘%d’ expects argument of type ‘int’, but argument 3 has type ‘mu::engraving::DurationType’ [-Wformat=]

Ports an earlier part of a PR for master (where the other parts don't apply to 4.6.4)