### PR TITLE
[4.6.4] Fix #31114: Controls in new score wizard "additional score information" inoperative

### DIFF
--- a/src/framework/uicomponents/view/popupview.cpp
+++ b/src/framework/uicomponents/view/popupview.cpp
@@ -240,6 +240,7 @@ void PopupView::doOpen()
 
     beforeOpen();
 
+    resolveParentWindow();
     updateGeometry();
 
     if (!isDialog()) {


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/31114
Ports: https://github.com/musescore/MuseScore/pull/31134