### PR TITLE
Navigate to previous lyric with backspace

### DIFF
--- a/src/app/configs/data/shortcuts.xml
+++ b/src/app/configs/data/shortcuts.xml
@@ -946,11 +946,9 @@
   <SC>
     <key>prev-text-element</key>
     <seq>Shift+Space</seq>
-    </SC>
-  <SC>
-    <key>prev-text-element</key>
     <seq>Left</seq>
-  </SC>
+    <seq>Backspace</seq>
+    </SC>
   <SC>
     <key>next-syllable</key>
     <seq>-</seq>

--- a/src/app/configs/data/shortcuts_azerty.xml
+++ b/src/app/configs/data/shortcuts_azerty.xml
@@ -983,6 +983,8 @@
   <SC>
     <key>prev-text-element</key>
     <seq>Shift+Space</seq>
+    <seq>Left</seq>
+    <seq>Backspace</seq>
     </SC>
   <SC>
     <key>toggle-visible</key>

--- a/src/app/configs/data/shortcuts_mac.xml
+++ b/src/app/configs/data/shortcuts_mac.xml
@@ -947,11 +947,9 @@
   <SC>
     <key>prev-text-element</key>
     <seq>Shift+Space</seq>
-    </SC>
-  <SC>
-    <key>prev-text-element</key>
     <seq>Left</seq>
-  </SC>
+    <seq>Backspace</seq>
+    </SC>
   <SC>
     <key>next-syllable</key>
     <seq>-</seq>

--- a/src/engraving/dom/lyrics.cpp
+++ b/src/engraving/dom/lyrics.cpp
@@ -280,7 +280,7 @@ bool Lyrics::isEditAllowed(EditData& ed) const
         }
     }
 
-    if (ed.key == Key_Left) {
+    if (ed.key == Key_Left || ed.key == Key_Backspace) {
         return cursor()->column() != 0 || cursor()->hasSelection();
     }
 


### PR DESCRIPTION
Resolves: #13042
When the cursor is at the start of a lyric, navigate to the previous lyric with backspace. 

https://github.com/user-attachments/assets/5d96bb83-fbd0-44a1-a3c0-ce16080e35de

