### PR TITLE
Fix #30277: Add API access to the ‘ornament’ property of Trills

### DIFF
--- a/src/engraving/api/v1/elements.cpp
+++ b/src/engraving/api/v1/elements.cpp
@@ -33,6 +33,7 @@
 #include "engraving/dom/spacer.h"
 #include "engraving/dom/system.h"
 #include "engraving/dom/tremolotwochord.h"
+#include "engraving/dom/trill.h"
 
 #include "engraving/editing/editnote.h"
 #include "engraving/editing/editsystemlocks.h"
@@ -655,7 +656,7 @@ bool Staff::isVoiceVisible(int voice)
 
 Ornament* Spanner::ornament() const
 {
-    if (spanner()->type() == mu::engraving::ElementType::TRILL) {
+    if (spanner()->isTrill()) {
         return wrap<Ornament>(toTrill(spanner())->ornament());
     }
     return nullptr;

--- a/src/engraving/api/v1/elements.h
+++ b/src/engraving/api/v1/elements.h
@@ -48,7 +48,6 @@
 #include "engraving/dom/timesig.h"
 #include "engraving/dom/tremolosinglechord.h"
 #include "engraving/dom/tremolotwochord.h"
-#include "engraving/dom/trill.h"
 #include "engraving/dom/tuplet.h"
 #include "engraving/dom/tie.h"
 #include "engraving/dom/accidental.h"
@@ -69,7 +68,6 @@ class Spanner;
 class Staff;
 class System;
 class Tie;
-class Trill;
 class Tuplet;
 class Measure;
 class Beam;


### PR DESCRIPTION
Resolves: #30277

Adds API access to the ‘ornament’ property of Trills, so that properties such as ‘ornamentShowCueNote’ and ‘ornamentShowAccidental‘ can also be accessed.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
