### PR TITLE
Add single angle quotation marks to Common symbols (‹ ›) — Resolves #31135

### DIFF
--- a/src/palette/view/widgets/specialcharactersdialog.cpp
+++ b/src/palette/view/widgets/specialcharactersdialog.cpp
@@ -640,8 +640,10 @@ static constexpr char32_t commonTextSymbols[] = {
     0x2019,      // &lsquo;
     0x201C,      // &ldquo;
     0x201D,      // &rdquo;
-    0x2039,      // single left-pointing angle quotation mark (‹)
-    0x203A,      // single right-pointing angle quotation mark (›)
+    0x2039,      // &lsaquo;
+    0x203A,      // &rsaquo;
+    0x00AB,      // &laquo;
+    0x00BB,      // &raquo;
     0x2020,      // &dagger;
     0x2021,      // &Dagger;
     0x2022,      // &bull;


### PR DESCRIPTION
Resolves: #31135

Summary
This patch adds the two single angle quotation marks (U+2039 “‹” and U+203A “›”) to the "Common symbols" tab of the Special Characters dialog so they are easily available for insertion into text. These characters are commonly used for narrow brackets in tablature harmonics; the existing bracket symbols in the Common symbols tab are too wide for that use.

What I changed
- Added U+2039 and U+203A to the `commonTextSymbols` array in:
  - specialcharactersdialog.cpp

Checklist
- [x] I signed the CLA
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows the coding rules (style; change is small and follows existing pattern)
- [x] The code compiles and runs on my machine (I built and ran the app and validated the dialog)
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)