### PR TITLE
Improve translatable texts

### DIFF
--- a/src/appshell/internal/applicationuiactions.cpp
+++ b/src/appshell/internal/applicationuiactions.cpp
@@ -226,8 +226,8 @@ const UiActionList ApplicationUiActions::m_actions = {
     UiAction("preference-dialog",
              mu::context::UiCtxAny,
              mu::context::CTX_ANY,
-             TranslatableString("action", "&Preferences"),
-             TranslatableString("action", "Preferences…")
+             TranslatableString("action", "&Preferences…"),
+             TranslatableString("action", "Preferences")
              ),
 
     UiAction("action://copy",

--- a/src/framework/autobot/internal/autobotactions.cpp
+++ b/src/framework/autobot/internal/autobotactions.cpp
@@ -34,12 +34,14 @@ const UiActionList AutobotActions::m_actions = {
     UiAction("autobot-show-batchtests",
              muse::ui::UiCtxAny,
              muse::shortcuts::CTX_ANY,
-             TranslatableString("action", "Show batch tests…")
+             TranslatableString("action", "Show batch tests…"),
+             TranslatableString("action", "Show batch tests")
              ),
     UiAction("autobot-show-scripts",
              muse::ui::UiCtxAny,
              muse::shortcuts::CTX_ANY,
-             TranslatableString("action", "Show &scripts…")
+             TranslatableString("action", "Show &scripts…"),
+             TranslatableString("action", "Show scripts")
              ),
 };
 

--- a/src/framework/diagnostics/internal/diagnosticsactions.cpp
+++ b/src/framework/diagnostics/internal/diagnosticsactions.cpp
@@ -39,52 +39,62 @@ const UiActionList DiagnosticsActions::m_actions = {
     UiAction("diagnostic-show-paths",
              muse::ui::UiCtxAny,
              muse::shortcuts::CTX_ANY,
-             TranslatableString("action", "Show p&aths…")
+             TranslatableString("action", "Show p&aths…"),
+             TranslatableString("action", "Show paths")
              ),
     UiAction("diagnostic-show-profiler",
              muse::ui::UiCtxAny,
              muse::shortcuts::CTX_ANY,
-             TranslatableString("action", "Show pr&ofiler…")
+             TranslatableString("action", "Show pr&ofiler…"),
+             TranslatableString("action", "Show profiler")
              ),
     UiAction("diagnostic-show-graphicsinfo",
              muse::ui::UiCtxAny,
              muse::shortcuts::CTX_ANY,
-             TranslatableString("action", "Show g&raphics info…")
+             TranslatableString("action", "Show g&raphics info…"),
+             TranslatableString("action", "Show graphics info")
              ),
     UiAction("diagnostic-show-navigation-tree",
              muse::ui::UiCtxAny,
              muse::shortcuts::CTX_ANY,
-             TranslatableString("action", "Show &navigation tree…")
+             TranslatableString("action", "Show &navigation tree…"),
+             TranslatableString("action", "Show navigation tree")
              ),
     UiAction("diagnostic-show-accessible-tree",
              muse::ui::UiCtxAny,
              muse::shortcuts::CTX_ANY,
-             TranslatableString("action", "Show &accessibility tree…")
+             TranslatableString("action", "Show &accessibility tree…"),
+             TranslatableString("action", "Show accessibility tree")
              ),
     UiAction("diagnostic-accessible-tree-dump",
              muse::ui::UiCtxAny,
              muse::shortcuts::CTX_ANY,
-             TranslatableString("action", "&Dump accessibility tree to console")
+             TranslatableString("action", "&Dump accessibility tree to console"),
+             TranslatableString("action", "Dump accessibility tree to console")
              ),
     UiAction("diagnostic-show-engraving-elements",
              muse::ui::UiCtxAny,
              muse::shortcuts::CTX_ANY,
-             TranslatableString("action", "Show engraving &elements")
+             TranslatableString("action", "Show engraving &elements"),
+             TranslatableString("action", "Show engraving elements")
              ),
     UiAction("diagnostic-show-engraving-undostack",
              muse::ui::UiCtxAny,
              muse::shortcuts::CTX_ANY,
-             TranslatableString("action", "Show engraving &undo stack")
+             TranslatableString("action", "Show engraving &undo stack"),
+             TranslatableString("action", "Show engraving undo stack")
              ),
     UiAction("diagnostic-show-engraving-style",
              muse::ui::UiCtxAny,
              muse::shortcuts::CTX_ANY,
-             TranslatableString("action", "Show engraving &style options list")
+             TranslatableString("action", "Show engraving &style options list"),
+             TranslatableString("action", "Show engraving style options list")
              ),
     UiAction("diagnostic-show-actions",
              muse::ui::UiCtxAny,
              muse::shortcuts::CTX_ANY,
-             TranslatableString("action", "Show &actions list")
+             TranslatableString("action", "Show &actions list"),
+             TranslatableString("action", "Show actions list")
              ),
     UiAction("action://diagnostic/actions/query",
              muse::ui::UiCtxAny,

--- a/src/framework/workspace/internal/workspaceuiactions.cpp
+++ b/src/framework/workspace/internal/workspaceuiactions.cpp
@@ -39,8 +39,8 @@ const UiActionList WorkspaceUiActions::m_actions = {
     UiAction("configure-workspaces",
              muse::ui::UiCtxAny,
              muse::shortcuts::CTX_ANY,
-             TranslatableString("action", "Edit workspaces"),
              TranslatableString("action", "Edit workspaces…"),
+             TranslatableString("action", "Edit workspaces"),
              IconCode::Code::EDIT
              ),
     UiAction("create-workspace",

--- a/src/instrumentsscene/internal/instrumentsuiactions.cpp
+++ b/src/instrumentsscene/internal/instrumentsuiactions.cpp
@@ -36,13 +36,13 @@ const UiActionList InstrumentsUiActions::m_actions = {
              mu::context::UiCtxProjectOpened,
              mu::context::CTX_ANY,
              TranslatableString("action", "Add/remove instruments…"),
-             TranslatableString("action", "Add/remove instruments…")
+             TranslatableString("action", "Add/remove instruments")
              ),
     UiAction("change-instrument",
              mu::context::UiCtxProjectOpened,
              mu::context::CTX_NOTATION_OPENED,
              TranslatableString("action", "Select instrument…"),
-             TranslatableString("action", "Select instrument…")
+             TranslatableString("action", "Select instrument")
              )
 };
 

--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -399,37 +399,37 @@ const UiActionList NotationUiActions::s_actions = {
              mu::context::UiCtxProjectOpened,
              mu::context::CTX_NOTATION_OPENED,
              TranslatableString("action", "More…"),
-             TranslatableString("action", "Select similar elements with more options…")
+             TranslatableString("action", "Select similar elements with more options")
              ),
     UiAction("edit-style",
              mu::context::UiCtxProjectOpened,
              mu::context::CTX_NOTATION_OPENED,
              TranslatableString("action", "&Style…"),
-             TranslatableString("action", "Format style…")
+             TranslatableString("action", "Format style")
              ),
     UiAction("page-settings",
              mu::context::UiCtxProjectOpened,
              mu::context::CTX_NOTATION_OPENED,
              TranslatableString("action", "&Page settings…"),
-             TranslatableString("action", "Page settings…")
+             TranslatableString("action", "Page settings")
              ),
     UiAction("load-style",
              mu::context::UiCtxProjectOpened,
              mu::context::CTX_NOTATION_OPENED,
              TranslatableString("action", "&Load style…"),
-             TranslatableString("action", "Load style…")
+             TranslatableString("action", "Load style")
              ),
     UiAction("save-style",
              mu::context::UiCtxProjectOpened,
              mu::context::CTX_NOTATION_OPENED,
              TranslatableString("action", "S&ave style…"),
-             TranslatableString("action", "Save style…")
+             TranslatableString("action", "Save style")
              ),
     UiAction("transpose",
              mu::context::UiCtxProjectOpened,
              mu::context::CTX_NOTATION_OPENED,
              TranslatableString("action", "&Transpose…"),
-             TranslatableString("action", "Transpose…")
+             TranslatableString("action", "Transpose")
              ),
     UiAction("explode",
              mu::context::UiCtxProjectOpened,
@@ -568,31 +568,31 @@ const UiActionList NotationUiActions::s_actions = {
              mu::context::UiCtxProjectOpened,
              mu::context::CTX_NOTATION_OPENED,
              TranslatableString("action", "Staff/Part properties…"),
-             TranslatableString("action", "Staff/Part properties…")
+             TranslatableString("action", "Staff/Part properties")
              ),
     UiAction("staff-text-properties",
              mu::context::UiCtxProjectOpened,
              mu::context::CTX_NOTATION_OPENED,
              TranslatableString("action", "Staff text properties…"),
-             TranslatableString("action", "Staff text properties…")
+             TranslatableString("action", "Staff text properties")
              ),
     UiAction("system-text-properties",
              mu::context::UiCtxProjectOpened,
              mu::context::CTX_NOTATION_OPENED,
              TranslatableString("action", "System text properties…"),
-             TranslatableString("action", "System text properties…")
+             TranslatableString("action", "System text properties")
              ),
     UiAction("measure-properties",
              mu::context::UiCtxProjectOpened,
              mu::context::CTX_NOTATION_OPENED,
              TranslatableString("action", "Measure properties…"),
-             TranslatableString("action", "Measure properties…")
+             TranslatableString("action", "Measure properties")
              ),
     UiAction("measures-per-system",
              mu::context::UiCtxProjectOpened,
              mu::context::CTX_NOTATION_OPENED,
              TranslatableString("action", "Measures per s&ystem…"),
-             TranslatableString("action", "Measures per system…")
+             TranslatableString("action", "Measures per system")
              ),
     UiAction("voice-x12",
              mu::context::UiCtxProjectOpened,
@@ -697,19 +697,19 @@ const UiActionList NotationUiActions::s_actions = {
              mu::context::UiCtxProjectOpened,
              mu::context::CTX_NOTATION_OPENED,
              TranslatableString("action", "Insert measures before selection…"),
-             TranslatableString("action", "Insert measures before selection…")
+             TranslatableString("action", "Insert measures before selection")
              ),
     UiAction("insert-measures-after-selection",
              mu::context::UiCtxProjectOpened,
              mu::context::CTX_NOTATION_OPENED,
              TranslatableString("action", "Insert measures after selection…"),
-             TranslatableString("action", "Insert measures after selection…")
+             TranslatableString("action", "Insert measures after selection")
              ),
     UiAction("insert-measures-at-start-of-score",
              mu::context::UiCtxProjectOpened,
              mu::context::CTX_NOTATION_OPENED,
              TranslatableString("action", "Insert measures at start of score…"),
-             TranslatableString("action", "Insert measures at start of score…")
+             TranslatableString("action", "Insert measures at start of score")
              ),
     UiAction("append-measure",
              mu::context::UiCtxProjectOpened,
@@ -721,7 +721,7 @@ const UiActionList NotationUiActions::s_actions = {
              mu::context::UiCtxProjectOpened,
              mu::context::CTX_NOTATION_OPENED,
              TranslatableString("action", "Insert measures at end of score…"),
-             TranslatableString("action", "Insert measures at end of score…")
+             TranslatableString("action", "Insert measures at end of score")
              ),
     UiAction("insert-hbox",
              mu::context::UiCtxProjectOpened,
@@ -1461,7 +1461,7 @@ const UiActionList NotationUiActions::s_actions = {
              mu::context::UiCtxProjectOpened,
              mu::context::CTX_NOTATION_FOCUSED,
              TranslatableString("action", "Othe&r…"),
-             TranslatableString("action", "Enter tuplet: other…")
+             TranslatableString("action", "Enter tuplet: other")
              ),
     UiAction("stretch-",
              mu::context::UiCtxProjectOpened,

--- a/src/palette/internal/paletteuiactions.cpp
+++ b/src/palette/internal/paletteuiactions.cpp
@@ -37,8 +37,8 @@ const UiActionList PaletteUiActions::m_actions = {
     UiAction(MASTERPALETTE_CODE,
              mu::context::UiCtxProjectOpened,
              mu::context::CTX_ANY,
-             TranslatableString("action", "&Master palette"),
-             TranslatableString("action", "Open master palette…"),
+             TranslatableString("action", "&Master palette…"),
+             TranslatableString("action", "Open master palette"),
              Checkable::Yes
              ),
     UiAction("palette-search",
@@ -51,13 +51,13 @@ const UiActionList PaletteUiActions::m_actions = {
              mu::context::UiCtxProjectOpened,
              mu::context::CTX_NOTATION_OPENED,
              TranslatableString("action", "Time signature properties…"),
-             TranslatableString("action", "Time signature properties…")
+             TranslatableString("action", "Time signature properties")
              ),
     UiAction("customize-kit",
              mu::context::UiCtxProjectOpened,
              mu::context::CTX_NOTATION_OPENED,
              TranslatableString("action", "Customize kit…"),
-             TranslatableString("action", "Customize kit…")
+             TranslatableString("action", "Customize kit")
              ),
     UiAction("apply-current-palette-element",
              mu::context::UiCtxProjectOpened,
@@ -68,8 +68,8 @@ const UiActionList PaletteUiActions::m_actions = {
     UiAction("show-keys",
              mu::context::UiCtxProjectOpened,
              mu::context::CTX_NOTATION_TEXT_EDITING,
-             TranslatableString("action", "Insert special characters"),
-             TranslatableString("action", "Insert special characters…")
+             TranslatableString("action", "Insert special characters…"),
+             TranslatableString("action", "Insert special characters")
              )
 };
 

--- a/src/project/internal/projectuiactions.cpp
+++ b/src/project/internal/projectuiactions.cpp
@@ -34,14 +34,14 @@ const UiActionList ProjectUiActions::m_actions = {
              mu::context::UiCtxAny,
              mu::context::CTX_ANY,
              TranslatableString("action", "&Open…"),
-             TranslatableString("action", "Open…"),
+             TranslatableString("action", "Open"),
              IconCode::Code::OPEN_FILE
              ),
     UiAction("file-new",
              mu::context::UiCtxAny,
              mu::context::CTX_ANY,
              TranslatableString("action", "&New…"),
-             TranslatableString("action", "New…"),
+             TranslatableString("action", "New"),
              IconCode::Code::NEW_FILE
              ),
     UiAction("file-close",
@@ -61,64 +61,66 @@ const UiActionList ProjectUiActions::m_actions = {
              mu::context::UiCtxAny,
              mu::context::CTX_ANY,
              TranslatableString("action", "Save &as…"),
-             TranslatableString("action", "Save as…")
+             TranslatableString("action", "Save as")
              ),
     UiAction("file-save-a-copy",
              mu::context::UiCtxAny,
              mu::context::CTX_ANY,
              TranslatableString("action", "Save a &copy…"),
-             TranslatableString("action", "Save a copy…")
+             TranslatableString("action", "Save a copy")
              ),
     UiAction("file-save-selection",
              mu::context::UiCtxAny,
              mu::context::CTX_ANY,
              TranslatableString("action", "Save &selection…"),
-             TranslatableString("action", "Save selection…")
+             TranslatableString("action", "Save selection")
              ),
     UiAction("file-save-to-cloud",
              mu::context::UiCtxAny,
              mu::context::CTX_ANY,
              TranslatableString("action", "Save to clo&ud…"),
-             TranslatableString("action", "Save to cloud…"),
+             TranslatableString("action", "Save to cloud"),
              IconCode::Code::CLOUD_FILE
              ),
     UiAction("file-publish",
              mu::context::UiCtxAny,
              mu::context::CTX_ANY,
              TranslatableString("action", "Publish to &MuseScore.com…"),
-             TranslatableString("action", "Publish to MuseScore.com…"),
+             TranslatableString("action", "Publish to MuseScore.com"),
              IconCode::Code::MUSESCORE_COM_LOGO
              ),
     UiAction("file-share-audio",
              mu::context::UiCtxAny,
              mu::context::CTX_ANY,
              TranslatableString("action", "Share on &Audio.com…"),
-             TranslatableString("action", "Share on Audio.com…"),
+             TranslatableString("action", "Share on Audio.com"),
              IconCode::Code::AUDIO_COM_LOGO
              ),
     UiAction("file-export",
              mu::context::UiCtxAny,
              mu::context::CTX_ANY,
              TranslatableString("action", "&Export…"),
+             TranslatableString("action", "Export"),
              IconCode::Code::SHARE_FILE
              ),
     UiAction("file-import-pdf",
              mu::context::UiCtxAny,
              mu::context::CTX_ANY,
              TranslatableString("action", "Import P&DF…"),
-             TranslatableString("action", "Import PDF…"),
+             TranslatableString("action", "Import PDF"),
              IconCode::Code::IMPORT
              ),
     UiAction("project-properties",
              mu::context::UiCtxAny,
              mu::context::CTX_ANY,
              TranslatableString("action", "Project propert&ies…"),
-             TranslatableString("action", "Project properties…")
+             TranslatableString("action", "Project properties")
              ),
     UiAction("print",
              mu::context::UiCtxAny,
              mu::context::CTX_ANY,
              TranslatableString("action", "&Print…"),
+             TranslatableString("action", "Print"),
              IconCode::Code::PRINT
              ),
     UiAction("clear-recent",


### PR DESCRIPTION
"…" only in menu entries (denoting a further dialog to show), not in the shortcuts dialog (nor in tooltips?).
Same for "&", denoting a mnemonic.