### PR TITLE
Fix MSVC compiler warnings

### DIFF
--- a/src/inspector/qml/MuseScore/Inspector/measures/measuressettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/measures/measuressettingsmodel.cpp
@@ -216,7 +216,7 @@ void MeasuresSettingsModel::updateSystemCount()
     size_t count = selection()->selectedSystems().size();
     if (count != m_systemCount) {
         m_systemCount = count;
-        emit systemCountChanged(count);
+        emit systemCountChanged(static_cast<int>(count));
     }
 }
 

--- a/src/notation/view/abstractnotationpaintview.cpp
+++ b/src/notation/view/abstractnotationpaintview.cpp
@@ -710,7 +710,7 @@ void AbstractNotationPaintView::onNotationSetup()
         scheduleRedraw();
     }, async::Asyncable::Mode::SetReplace);
 
-    engravingConfiguration()->selectionColorChanged().onReceive(this, [this](int, const muse::draw::Color&) {
+    engravingConfiguration()->selectionColorChanged().onReceive(this, [this](voice_idx_t, const muse::draw::Color&) {
         scheduleRedraw();
     });
 


### PR DESCRIPTION
reg.: 'argument': conversion from 'size_t' to 'int', possible loss of data