### PR TITLE
Fix #15395: Add tooltip for truncated instrument family names when creating a score

### DIFF
--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/FamilyView.qml
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/internal/FamilyView.qml
@@ -106,45 +106,32 @@ Item {
         }
 
         delegate: ListItemBlank {
-                    id: item
+            id: item
 
-                    property string groupName: modelData
+            property string groupName: modelData
 
-                    isSelected: groupsView.currentIndex === model.index
+            isSelected: groupsView.currentIndex === model.index
+            hint: itemTitleLabel.truncated ? groupName : ""
 
-                    navigation.name: modelData
-                    navigation.panel: groupsView.navigation
-                    navigation.row: 2 + model.index
-                    navigation.accessible.name: itemTitleLabel.text
-                    navigation.accessible.row: model.index
+            navigation.name: modelData
+            navigation.panel: groupsView.navigation
+            navigation.row: 2 + model.index
+            navigation.accessible.name: itemTitleLabel.text
+            navigation.accessible.row: model.index
 
-                    StyledTextLabel {
-                        id: itemTitleLabel
-                        anchors.fill: parent
-                        anchors.leftMargin: 12
+            StyledTextLabel {
+                id: itemTitleLabel
+                anchors.fill: parent
+                anchors.leftMargin: 12
 
-                        font: ui.theme.bodyBoldFont
-                        horizontalAlignment: Text.AlignLeft
-                        text: groupName
+                font: ui.theme.bodyBoldFont
+                horizontalAlignment: Text.AlignLeft
+                text: groupName
+            }
 
-                        MouseArea {
-                            id: tooltipArea
-                            anchors.fill: parent
-                            hoverEnabled: true
-                            
-                            onClicked: {
-                                root.groupSelected(model.index)
-                            }
-
-                            onContainsMouseChanged: {
-                                if (containsMouse && itemTitleLabel.truncated) {
-                                    ui.tooltip.show(tooltipArea, groupName)
-                                } else {
-                                    ui.tooltip.hide(tooltipArea)
-                                }
-                            }
-                        }
-                    }
-                }
+            onClicked: {
+                root.groupSelected(model.index)
+            }
+        }
     }
 }


### PR DESCRIPTION
Resolves: #15395 

Problem:
When instrument family names are too long and get truncated with "..." in the Family list, users cannot see the full name in the default window on Mac without stretching the entire window wider. This issue was specifically noted in the German language version, which has longer strings.

Solution:
Added a MouseArea with hover detection to display a tooltip showing the full name when the text is truncated. The tooltip only appears when hovering over truncated text. 

Testing:
- Tested in German locale where "Schlaginstrumente - ungestimmt" gets truncated
- Tooltip appears on hover showing full name if string is truncated (with ...)
- Tooltip disappears when not hovering

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
