### PR TITLE
Fix #29768: Undo add-fretboard-diagram in correct order

### DIFF
--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -7902,6 +7902,7 @@ void NotationInteraction::addFretboardDiagram()
     startEdit(TranslatableString("undoableAction", "Add fretboard diagram"));
 
     engraving::FretDiagram* lastAddedDiagram = nullptr;
+    std::vector<engraving::FretDiagram*> created;
 
     for (EngravingItem* element : filteredElements) {
         engraving::FretDiagram* diagram = engraving::Factory::createFretDiagram(score->dummy()->segment());
@@ -7912,9 +7913,16 @@ void NotationInteraction::addFretboardDiagram()
 
         diagram->setParent(harmony->parent());
         score->undoAddElement(diagram);
-        score->undoChangeParent(harmony, diagram, track2staff(element->track()));
-
+        created.push_back(diagram);
         lastAddedDiagram = diagram;
+    }
+
+    for (int i = int(created.size()) - 1; i >= 0; --i) {
+        FretDiagram* diagram = created[i];
+        Harmony* harmony = toHarmony(filteredElements[i]);
+
+        score->undoChangeParent(harmony, diagram,
+                                track2staff(filteredElements[i]->track()));
     }
 
     apply();


### PR DESCRIPTION
Resolves: #29768 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

## Summary ##
Previously, when using Cmd + K to add multiple chord symbols to a tick and then selecting all to add fretboard diagrams, undoing the action caused the chord symbols to be reversed in order. 
For example, the original order (A-B-C) would be reversed to (C-B-A) after undoing the action.
![IMG_5581](https://github.com/user-attachments/assets/86797c9d-8ab8-4187-9aec-80f346825c4e)

I've now fixed this issue. Adding the fretboard diagrams, undoing, and redoing now all behave as expected, with the order of the chord symbols staying consistent.
Here's a demonstration video of the fixed behavior below:

https://github.com/user-attachments/assets/b08f6e8d-18e1-4efa-aeac-8d716659a21e



## What I changed ##
I found that the issue was caused by calling score->undoChangeParent(harmony, diagram, track2staff(filteredElements[i]->track())) in sequence, which led to a disruption in the parenting structure. 

The order of creating the diagram and calling undoAddElement was correct, only the parenting structure was getting messed up.

To fix this, I used a vector to store the FretDiagram* objects while creating the diagrams and calling undoAddElement. Afterward, I iterated over the stored FretDiagram* objects in reverse order and called undoChangeParent on them. 

This ensures that the add, undo, and redo behaviors are now correct.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
