### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/src/notation/internal/engravingfontscontroller.cpp
+++ b/src/notation/internal/engravingfontscontroller.cpp
@@ -57,7 +57,7 @@ void EngravingFontsController::scanAllDirectories() const
 #elif defined(Q_OS_MACOS)
     // MacOS is correctly handled by Qt
     QStringList globalFontsPaths = QStandardPaths::standardLocations(QStandardPaths::GenericDataLocation).first(2);
-#elif defined(Q_OS_LINUX)
+#elif defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
     // On Unix systems, we want $XDG_DATA_HOME (user-specific) and $XDG_DATA_DIRS (system-wide)
     QStringList globalFontsPaths { qgetenv("XDG_DATA_HOME") };
     globalFontsPaths.append(QString::fromLocal8Bit(qgetenv("XDG_DATA_DIRS")).split(':'));


### PR DESCRIPTION
(requires trival update of googletest to 1.17 as well) use the fontpath of linux systems on FreeBSD as well

- [X ] I signed the [CLA](https://musescore.org/en/cla)
- [X ] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [] I created a unit test or vtest to verify the changes I made (if applicable)
