### PR TITLE
Add Feature for #30850 Consistent Default Score Visibility

### DIFF
--- a/src/project/internal/opensaveprojectscenario.cpp
+++ b/src/project/internal/opensaveprojectscenario.cpp
@@ -271,9 +271,7 @@ RetVal<CloudProjectInfo> OpenSaveProjectScenario::doAskCloudLocation(INotationPr
         switch (scoreInfo.ret.code()) {
         case int(Ret::Code::Ok):
             defaultName = scoreInfo.val.title;
-            if (!isPublishShare) {
-                defaultVisibility = scoreInfo.val.visibility;
-            }
+            defaultVisibility = scoreInfo.val.visibility;
             break;
 
         case int(cloud::Err::Status400_InvalidRequest):


### PR DESCRIPTION
Resolves: #30850 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

## Summary ##
Previously, when a user saved the same score to the cloud, the visibility setting for the previous save was reserved. However, when publishing that same score to MuseScore.com, the default visibility is always set to Public, requiring users to adjust it manually each time they publish it. 
<img width="461" height="399" alt="Screenshot 2025-11-30 at 8 38 46 PM" src="https://github.com/user-attachments/assets/0918d4c2-6437-4038-b929-bf44c252e2f5" />
Therefore, the user requested a feature to ensure that the default visibility when publishing a score was consistent with the visibility of the same score when it was previously published to the website. 

I then added this feature and conducted manual testing. Regardless of whether the app is restarted, the computer is restarted, or the score visibility is modified on the website, the score's default visibility remains consistent with the visibility of the version published on the website. If a user modifies the visibility during a republish, the default visibility would also be updated during subsequent republishes of the same score. The default visibility of different scores does not affect each other.

While discussing the original issue, we also considered a global default visibility option. However, I think it is more suitable for a separate preference-related feature, and I have included my detailed thoughts on this in the document: 
https://docs.google.com/document/d/1FYUVtQuyvbf7FxFApWO06yTbfau6PLvMsaj-jRfR1yE/edit?usp=sharing


## What I changed ##
At the code level, I simply removed an if condition. 

Originally, in the `doAskCloudLocation` method, `default visibility` was private for `save-to-cloud`, but public for `publish to MuseScore.com`. The code then checked if the score had ever been uploaded to the website. If so, an if condition would choose whether to update with the previous visibility: 
`"if (!isPublishShare) { defaultVisibility = scoreInfo.val.visibility; }"`. 

This condition was true for `save-to-cloud`, but false for `publish to MuseScore.com`. I removed this if condition, ensuring that regardless of how the score is uploaded to the cloud, the default visibility remains consistent with the previously published score version.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
