### PR TITLE
Fix #31301: Unable to make grace note invisible

### DIFF
--- a/src/engraving/dom/select.cpp
+++ b/src/engraving/dom/select.cpp
@@ -540,6 +540,7 @@ void Selection::appendFiltered(const std::unordered_set<EngravingItem*>& elems)
         // Special handling for grace notes...
         if (elem->isChord() && toChord(elem)->isGrace()) {
             appendChordRest(toChordRest(elem));
+            continue;
         }
 
         appendFiltered(elem);


### PR DESCRIPTION
Resolves: #31301

As stated [here](https://github.com/musescore/MuseScore/blob/212d71aa7a7409398602ac4a49c6cb3ed7077ffd/src/engraving/dom/chord.cpp#L1555), we should only ever set the _elements_ of a `Chord` to invisible (head, stem, etc), not the chord itself.

The problem here is that, in our range selection logic, we add the grace note (a `Chord`) **_and_** its elements to our selection. We don't do this for other types of `Chord` so, in principle, we shouldn't do it for grace notes either.