### PR TITLE
Fix #30111: fix crash during audio plugin registration

### DIFF
--- a/src/framework/audio/main/audiomodule.cpp
+++ b/src/framework/audio/main/audiomodule.cpp
@@ -145,10 +145,16 @@ void AudioModule::onInit(const IApplication::RunMode& mode)
             pr->reg("soundfonts", p);
         }
     }
+
+    m_audioInited = true;
 }
 
 void AudioModule::onDeinit()
 {
+    if (!m_audioInited) {
+        return;
+    }
+
     m_mainPlayback->deinit();
     m_rpcTicker.stop();
 

--- a/src/framework/audio/main/audiomodule.h
+++ b/src/framework/audio/main/audiomodule.h
@@ -64,6 +64,8 @@ private:
     std::shared_ptr<rpc::IRpcChannel> m_rpcChannel;
 
     std::shared_ptr<AudioDriverController> m_audioDriverController;
+
+    bool m_audioInited = false;
 };
 }
 


### PR DESCRIPTION
Same as: https://github.com/musescore/MuseScore/pull/30126

Resolves: https://github.com/musescore/MuseScore/issues/30111