### PR TITLE
Fix #30966: Loading audio samples never ends on score opening if you use a soundfont preset other than "Choose automatically"

### DIFF
--- a/src/framework/audio/engine/internal/enginerpccontroller.cpp
+++ b/src/framework/audio/engine/internal/enginerpccontroller.cpp
@@ -201,13 +201,17 @@ void EngineRpcController::init()
         }
         // Fluid
         else {
-            AudioResourceId sfname = params.in.resourceMeta.id;
+            std::string sfname = params.in.resourceMeta.attributeVal(SOUNDFONT_NAME_ATTRIBUTE).toStdString();
+            if (sfname.empty()) {
+                sfname = params.in.resourceMeta.id;
+            }
+
             if (soundFontRepository()->isSoundFontLoaded(sfname)) {
                 addTrackAndSendResponce(msg, seqId, trackName, playbackData, params);
             }
             // Waiting for SF to load
             else {
-                LOGI() << "Waiting for SF to load, trackName: " << trackName;
+                LOGI() << "Waiting for SF to load, trackName: " << trackName << ", SF name: " << sfname;
                 m_pendingTracks[sfname].emplace_back(PendingTrack { msg, seqId, trackName, playbackData, params });
 
                 //! NOTE We subscribe for the first track for which a soundfont is not found.


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/30966

Unless it's an old MS4 score, the resource ID will also include the bank and program (see FluidResolver::refresh)