### PR TITLE
Fix crash with hidden staves popup

### DIFF
--- a/src/notation/view/internal/staffvisibilitypopupmodel.cpp
+++ b/src/notation/view/internal/staffvisibilitypopupmodel.cpp
@@ -37,6 +37,8 @@
 #include "engraving/types/fraction.h"
 #include "engraving/types/types.h"
 
+#include "log.h"
+
 using namespace mu::notation;
 using mu::engraving::rendering::score::SystemLayout;
 
@@ -169,8 +171,11 @@ QModelIndex EmptyStavesVisibilityModel::index(int row, int column, const QModelI
     }
 
     if (parent.isValid()) {
-        const PartItem* part = static_cast<const PartItem*>(parent.internalPointer());
-        assert(part);
+        const Item* item = static_cast<const Item*>(parent.internalPointer());
+        const PartItem* part = dynamic_cast<const PartItem*>(item);
+        IF_ASSERT_FAILED(part) {
+            return QModelIndex();
+        }
         return createIndex(row, column, part->staves[row].get());
     }
 
@@ -204,12 +209,15 @@ int EmptyStavesVisibilityModel::rowCount(const QModelIndex& parent) const
     }
 
     if (parent.isValid()) {
-        const PartItem* part = static_cast<const PartItem*>(parent.internalPointer());
-        assert(part);
-        if (part->staves.size() > 1) {
-            return static_cast<int>(part->staves.size());
+        const Item* item = static_cast<const Item*>(parent.internalPointer());
+        assert(item);
+        if (const PartItem* part = dynamic_cast<const PartItem*>(item)) {
+            if (part->staves.size() > 1) {
+                return static_cast<int>(part->staves.size());
+            }
+            return 0; // If part has only one staff, don't make it expandable
         }
-        return 0; // If part has only one staff, it is not displayed separately
+        return 0;
     }
 
     return static_cast<int>(m_parts.size());


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/30934

The "phantom arrows" mentioned in the issue were caused by an unsafe `static_cast` in `rowCount`, casting a `StaffItem` to a `PartItem`, resulting in garbage being read from the resulting `part->staves.size()`. This garbage might be a huge number, causing a huge number of rows to be inserted into the model, to the point that the application (or even the OS) crashes with out-of-memory errors.

The `index` method also contains a similar `static_cast`; this one is not problematic, but by principle, I've made this one safe(r) as well. Now we only ever `static_cast` to `Item`, which is justifiable.