### PR TITLE
Fix assert when theme file is changed

### DIFF
--- a/src/framework/ui/internal/uiconfiguration.cpp
+++ b/src/framework/ui/internal/uiconfiguration.cpp
@@ -136,6 +136,10 @@ void UiConfiguration::init()
         m_musicalFontChanged.notify();
     });
 
+    platformTheme()->platformThemeChanged().onNotify(this, [this]() {
+        synchThemeWithSystemIfNecessary();
+    });
+
     m_uiArrangement.stateChanged(WINDOW_GEOMETRY_KEY).onNotify(this, [this]() {
         m_windowGeometryChanged.notify();
     });
@@ -164,10 +168,6 @@ void UiConfiguration::deinit()
 void UiConfiguration::initThemes()
 {
     m_isFollowSystemTheme.val = settings()->value(UI_FOLLOW_SYSTEM_THEME_KEY).toBool();
-
-    platformTheme()->platformThemeChanged().onNotify(this, [this]() {
-        synchThemeWithSystemIfNecessary();
-    });
 
     updateSystemThemeListeningStatus();
 


### PR DESCRIPTION
Fixes an assert when the theme file is changed because of the double connection to `platformThemeChanged().onNotify`
<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
