### PR TITLE
Fix #27891: Show full instrument description in tooltip when truncated, for consistent accessibility

### DIFF
--- a/src/instrumentsscene/qml/MuseScore/InstrumentsScene/InstrumentsDialog.qml
+++ b/src/instrumentsscene/qml/MuseScore/InstrumentsScene/InstrumentsDialog.qml
@@ -96,6 +96,24 @@ StyledDialogView {
                 opacity: 0.7
                 horizontalAlignment: Text.AlignLeft
                 wrapMode: Text.Wrap
+                maximumLineCount: 2
+
+                // This property helps identify a truncated description, as a multi-line truncation flag is not exposed
+                property bool isTruncated: lineCount === maximumLineCount && contentWidth > (width - 11)
+
+                MouseArea {
+                    id: descMouse
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    onEntered: {
+                        if (descriptionLabel.isTruncated && descMouse.containsMouse) {
+                            ui.tooltip.show(descriptionLabel, qsTrc("instruments", "Full instrument description"), descriptionLabel.text, "")
+                        }
+                    }
+                    onExited: {
+                        ui.tooltip.hide(descriptionLabel)
+                    }
+                }
             }
 
             ButtonBox {


### PR DESCRIPTION
Resolves: #27891 

### Summary
This PR allows for the full descriptions of instruments to remain accessible to users even in the event that their original descriptions became truncated. In order to avoid crowding the description text, it also enforces a `maximumLineCount` of `2`, as decided in the linked report.

#### Specifics
As discussed, the targeted solution for this behavior was to expose a tooltip on hover of the description text. However, this tooltip should only show up if the text is truncated after taking up both lines. As far as I know, QML does not provide a native flag for detecting _multi-line_ text truncation. Therefore this PR implements the `isTruncated` property:

``` isTruncated: Number of text lines is equal to the maximumLineCount (2) AND the contentWidth exceeds the width ```

This allowed for pretty good truncation state tracking (note I specified a buffer of `11` here to handle some inconsistencies, where this was the largest difference I observed when manually testing).

Then, using this property, the description text can be hovered over and if truncated a tooltip (as shown in the attachments) will appear below as requested.

#### Testing
- Tested this locally, where the tooltip would be exposable only if the description was truncated and otherwise would not be.
- Ran ctests, all passing except for an unrelated audio-specific one.

---
- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)

<img width="1920" height="1080" alt="Screenshot_4" src="https://github.com/user-attachments/assets/a3a8d58f-3233-43d7-be1c-e18a3a3add31" />
<img width="1920" height="1080" alt="Screenshot_3" src="https://github.com/user-attachments/assets/c4fb7f7a-7299-4699-ab87-9ec2024e16ab" />
<img width="1920" height="1080" alt="Screenshot_2" src="https://github.com/user-attachments/assets/ae178acf-28d7-4d26-9339-f45bedada867" />
