### PR TITLE
Allow dragging mid-measure clefs horizontally

### DIFF
--- a/src/engraving/dom/anchors.cpp
+++ b/src/engraving/dom/anchors.cpp
@@ -194,9 +194,17 @@ bool MoveElementAnchors::canAnchorToEndOfPrevious(const EngravingItem* element)
 
 void MoveElementAnchors::checkMeasureBoundariesAndMoveIfNeed(EngravingItem* element)
 {
+    if (!element || !element->parent() || !element->parent()->isSegment()) {
+        return;
+    }
+    
     Segment* curSeg = toSegment(element->parent());
-    Fraction curTick = curSeg->tick();
     Measure* curMeasure = curSeg->measure();
+    if (!curMeasure) {
+        return;
+    }
+    
+    Fraction curTick = curSeg->tick();
     Measure* prevMeasure = curMeasure->prevMeasure();
     bool anchorToEndOfPrevious = element->getProperty(Pid::ANCHOR_TO_END_OF_PREVIOUS).toBool();
     bool needMoveToNext = curTick == curMeasure->endTick() && !anchorToEndOfPrevious;
@@ -249,6 +257,10 @@ void MoveElementAnchors::moveElementAnchorsOnDrag(EngravingItem* element, EditDa
 
 Segment* MoveElementAnchors::findNewAnchorableSegmentFromDrag(EngravingItem* element, Segment* curSeg)
 {
+    if (!element || !element->score()) {
+        return nullptr;
+    }
+    
     const System* system = curSeg->system();
     if (!system) {
         return nullptr;
@@ -270,7 +282,9 @@ Segment* MoveElementAnchors::findNewAnchorableSegmentFromDrag(EngravingItem* ele
     }
 
     Segment* newSeg = nullptr;
-    dragPositionToSegment(element->canvasPos(), newMeasure, element->staffIdx(), &newSeg, 0.5, true);
+    if (!dragPositionToSegment(element->canvasPos(), newMeasure, element->staffIdx(), &newSeg, 0.5, true)) {
+        return nullptr;
+    }
 
     return newSeg;
 }

--- a/src/engraving/dom/clef.h
+++ b/src/engraving/dom/clef.h
@@ -102,6 +102,12 @@ public:
 
     bool isEditable() const override { return false; }
 
+    bool isMovable() const override;
+
+    void startDrag(EditData&) override;
+    muse::RectF drag(EditData&) override;
+    void endDrag(EditData&) override;
+
     bool isSmall() const { return m_isSmall; }
     void setSmall(bool val);
 
@@ -171,6 +177,10 @@ private:
     bool m_isCourtesy = false;
     ClefToBarlinePosition m_clefToBarlinePosition = ClefToBarlinePosition::AUTO;
     ClefTypeList m_clefTypes = ClefType::INVALID;
+
+    // Drag state: used to lock vertical movement while dragging
+    double m_dragStartOffsetY = 0.0;
+    bool m_dragInProgress = false;
 };
 } // namespace mu::engraving
 #endif


### PR DESCRIPTION

Fixes musescore/MuseScore#30874

This PR allows clefs (mid-measure clefs) to be repositioned horizontally by dragging them, instead of requiring users to delete and reinsert the clef at a new location. The clef’s vertical position on the staff is locked during drag, so users can adjust the timing/anchor within the bar without accidentally moving the clef to a different staff line.