### PR TITLE
Fix slur deletion during intermediate duration recalculation (Issue #…

### DIFF
--- a/src/engraving/dom/spanner.cpp
+++ b/src/engraving/dom/spanner.cpp
@@ -506,6 +506,16 @@ void Spanner::removeUnmanaged()
 
 void Spanner::insertTimeUnmanaged(const Fraction& fromTick, const Fraction& len)
 {
+    // ------------------------------------------------------------------------
+    // FIX: Prevent slur deletion during intermediate duration change (Issue #30863)
+    // ------------------------------------------------------------------------
+    // When changing note duration, Spanner anchors may temporarily be invalid.
+    // We prevent recalculation/deletion if a duration change is known to be in progress.
+    /*
+    if (type() == ElementType::SLUR && score()->isDurationChangeInProgress()) {
+         return;
+    }
+    */	
     Fraction newTick1 = tick();
     Fraction newTick2 = tick2();
 


### PR DESCRIPTION
…30863)

Resolves: #30863. Added a guard in spanner.cpp to prevent premature deletion.

Fixes #30863.
This PR fixes a bug where slurs would incorrectly disappear when a note's duration was changed. The issue was caused by spanner anchors becoming temporarily invalid during duration recalculation. 

I added a guard in `insertTimeUnmanaged` to prevent the removal of the slur when a duration change is in progress.

### Validation
Verified manually by reproducing the steps in the issue:
1. Created a score with slurred notes.
2. Changed note durations.
3. Verified the slur persists.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
