### PR TITLE
Don't recompute Note shape at every call

### DIFF
--- a/src/engraving/dom/engravingitem.cpp
+++ b/src/engraving/dom/engravingitem.cpp
@@ -2815,6 +2815,7 @@ Shape EngravingItem::LayoutData::shape(LD_ACCESS mode) const
         case ElementType::TIE_SEGMENT:
         case ElementType::LAISSEZ_VIB_SEGMENT:
         case ElementType::PARTIAL_TIE_SEGMENT:
+        case ElementType::NOTE:
             return sh;
         case ElementType::CHORD:
         case ElementType::REST:
@@ -2827,12 +2828,6 @@ Shape EngravingItem::LayoutData::shape(LD_ACCESS mode) const
                 ChordRest::LayoutData* ldata = static_cast<ChordRest::LayoutData*>(const_cast<LayoutData*>(this));
                 ChordLayout::checkAndFillShape(toChordRest(m_item), ldata, ctx.conf());
             }
-            return m_shape.value(LD_ACCESS::CHECK);
-        } break;
-        case ElementType::NOTE: {
-            //! NOTE Temporary fix
-            //! We can remove it the moment we figure out the layout order of the elements
-            TLayout::fillNoteShape(toNote(m_item), static_cast<Note::LayoutData*>(const_cast<LayoutData*>(this)));
             return m_shape.value(LD_ACCESS::CHECK);
         } break;
         case ElementType::GUITAR_BEND_SEGMENT: {

--- a/src/engraving/rendering/score/chordlayout.cpp
+++ b/src/engraving/rendering/score/chordlayout.cpp
@@ -3198,6 +3198,8 @@ void ChordLayout::layoutNote2(Note* item, LayoutContext& ctx)
     }
 
     ParenthesisLayout::layoutParentheses(item, ctx);
+
+    TLayout::fillNoteShape(item, ldata);
 }
 
 void ChordLayout::checkStartEndSlurs(Chord* chord, LayoutContext& ctx)

--- a/src/engraving/rendering/score/guitarbendlayout.cpp
+++ b/src/engraving/rendering/score/guitarbendlayout.cpp
@@ -77,6 +77,8 @@ void GuitarBendLayout::updateSegmentsAndLayout(SLine* item, LayoutContext& ctx)
         segment->setTrack(item->track());
         TLayout::layoutLineSegment(toLineSegment(segment), ctx);
     }
+
+    TLayout::fillNoteShape(startNote, startNote->mutldata());
 }
 
 void GuitarBendLayout::layoutStandardStaff(GuitarBendSegment* item, LayoutContext& ctx)

--- a/src/engraving/rendering/score/slurtielayout.cpp
+++ b/src/engraving/rendering/score/slurtielayout.cpp
@@ -2061,7 +2061,7 @@ void SlurTieLayout::layoutLaissezVibChord(Chord* chord, LayoutContext& ctx)
 
     for (auto& segWithPos : lvSegmentsWithPositions) {
         LaissezVibSegment* lvSeg = segWithPos.first;
-        const Note* note = lvSeg->laissezVib()->startNote();
+        Note* note = lvSeg->laissezVib()->startNote();
         SlurTiePos sPos = segWithPos.second;
         const double xDiff = chordLvEndPoint - sPos.p2.x();
         sPos.p2.setX(chordLvEndPoint);
@@ -2081,6 +2081,8 @@ void SlurTieLayout::layoutLaissezVibChord(Chord* chord, LayoutContext& ctx)
         const PointF chordPos = chord->pos() + chord->segment()->pos() + chord->measure()->pos();
         const PointF notePos = chordPos + note->pos();
         ldata->posRelativeToNote = sPos.p1 - notePos;
+
+        TLayout::fillNoteShape(note, note->mutldata());
     }
 }
 


### PR DESCRIPTION
But update it when needed. This is something that eventually should be done for all elements, cause recomputing Shape at every call is very inefficient. 
