### PR TITLE
Fix #31388: Prevent typing and shortcut triggers behind dropdowns

### DIFF
--- a/src/framework/uicomponents/qml/Muse/UiComponents/dropdownview.cpp
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/dropdownview.cpp
@@ -31,6 +31,33 @@ DropdownView::DropdownView(QQuickItem* parent)
 {
 }
 
+bool DropdownView::eventFilter(QObject* watched, QEvent* event)
+{
+    static QSet<Qt::Key> NAVIGATION_KEYS = {
+        Qt::Key_Enter,
+        Qt::Key_Return,
+        Qt::Key_Space,
+        Qt::Key_Up,
+        Qt::Key_Down,
+        Qt::Key_Left,
+        Qt::Key_Right,
+        Qt::Key_Tab,
+        Qt::Key_PageUp,
+        Qt::Key_PageDown,
+    };
+
+    if (event && event->type() == QEvent::ShortcutOverride) {
+        const QKeyEvent* keyEvent = static_cast<QKeyEvent*>(event);
+        const Qt::Key key = (Qt::Key)keyEvent->key();
+        if (!NAVIGATION_KEYS.contains(key)) {
+            event->accept();
+            return true;
+        }
+    }
+
+    return PopupView::eventFilter(watched, event);
+}
+
 void DropdownView::updateGeometry()
 {
     const QQuickItem* parent = parentItem();

--- a/src/framework/uicomponents/qml/Muse/UiComponents/dropdownview.h
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/dropdownview.h
@@ -46,6 +46,7 @@ signals:
     void focusItemYChanged();
 
 private:
+    bool eventFilter(QObject* watched, QEvent* event) override;
     void updateGeometry() override;
 
     int m_focusItemY = -1;


### PR DESCRIPTION
Resolves: #31388

Lightweight alternative to #31438 (intercept/accept non-navigation key events).