### PR TITLE
Replace straight quotes with curly quotes (#17550)

### DIFF
--- a/src/notation/internal/notationinteraction.h
+++ b/src/notation/internal/notationinteraction.h
@@ -365,6 +365,7 @@ private:
 
     bool needStartEditGrip(QKeyEvent* event) const;
     bool handleKeyPress(QKeyEvent* event);
+    bool doTextEdit(QKeyEvent* event, TextBase* tb);
 
     void doEndEditElement();
     void doEndDrag();


### PR DESCRIPTION
Resolves: #17550

In this PR, straight quotes are automatically replaced with curly quotes. The replacement is performed as a separate undo action, so pressing `Ctrl+Z` restores the original straight quote.

Code-wise:
- Added a new private `NotationInteraction::doEditText` method which will detect straight quotes and perform the undoable replacement.
- Simplified `NotationInteraction::editElement(QKeyEvent*)` by moving key handling into `handleKeyPress`.
- Undoing while editing text no longer exits text edit mode.