### PR TITLE
[4.6.5] Fix #31430: send new events before audio export

### DIFF
--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -1748,6 +1748,14 @@ void PlaybackController::setIsExportingAudio(bool exporting)
     m_isExportingAudio = exporting;
     updateSoloMuteStates();
 
+    if (!exporting) {
+        return;
+    }
+
+    if (notationPlayback()) {
+        notationPlayback()->sendEventsForChangedTracks();
+    }
+
     if (!onlineSounds().empty() && !audioConfiguration()->autoProcessOnlineSoundsInBackground()) {
         dispatcher()->dispatch("process-online-sounds");
     }


### PR DESCRIPTION
Ports (partially): https://github.com/musescore/MuseScore/pull/31466
Resolves: https://github.com/musescore/MuseScore/issues/31430