### PR TITLE
Fix crash on template with system locks

### DIFF
--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -288,6 +288,7 @@ void MasterNotation::applyOptions(mu::engraving::MasterScore* score, const Score
             nvb->setAutoSizeEnabled(tvb->isAutoSizeEnabled());
         }
 
+        score->clearSystemLocks();
         clearMeasures(score);
 
         // for templates using built-in base page style, set score page style to default (may be user-defined)


### PR DESCRIPTION
Resolves: #31415 

The crash occurs because when creating a score from a template file, all measures are deleted and recreated, but system locks maintain references to the deleted measures. Given that no other layout element is preserved in templates, it makes sense for system locks to be removed when creating the template. Having templates retain some of the layout elements may be a valid improvement for the future.