### PR TITLE
Fix potential crash on startup [4.6.5]

### DIFF
--- a/src/palette/internal/palettecompat.cpp
+++ b/src/palette/internal/palettecompat.cpp
@@ -129,7 +129,7 @@ void PaletteCompat::migrateOldPaletteCellIfNeeded(PaletteCell* cell, Score* pale
         return;
     }
 
-    if (item->isPedal()) {
+    if (item->isPedal() && !toPedal(item)->segmentsEmpty()) {
         Pedal* newPedal = Factory::createPedal(paletteScore->dummy());
         Pedal* oldPedal = toPedal(item);
 


### PR DESCRIPTION
Crash found by internal team. From what we can tell it's quite a rare one caused by switching MSS versions.