### PR TITLE
[4.6.5] Avoid double seek when entering notes

### DIFF
--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -691,7 +691,7 @@ void NotationViewInputController::mousePressEvent(QMouseEvent* event)
 
     // note enter mode
     if (m_view->isNoteEnterMode()) {
-        handleClickInNoteInputMode(event);
+        handleClickInNoteInputMode(event, shouldSeek);
         return;
     }
 
@@ -754,7 +754,7 @@ void NotationViewInputController::mousePressEvent(QMouseEvent* event)
     }
 }
 
-void NotationViewInputController::handleClickInNoteInputMode(QMouseEvent* event)
+void NotationViewInputController::handleClickInNoteInputMode(QMouseEvent* event, bool& shouldSeek)
 {
     const PointF logicPos = m_view->toLogical(event->pos());
 
@@ -768,6 +768,7 @@ void NotationViewInputController::handleClickInNoteInputMode(QMouseEvent* event)
     const bool replace = keyState & Qt::ShiftModifier;
     const bool insert = keyState & Qt::ControlModifier;
     dispatcher()->dispatch("put-note", ActionData::make_arg3<PointF, bool, bool>(logicPos, replace, insert));
+    shouldSeek = false;
 }
 
 bool NotationViewInputController::mousePress_considerGrip(const ClickContext& ctx)

--- a/src/notation/view/notationviewinputcontroller.h
+++ b/src/notation/view/notationviewinputcontroller.h
@@ -187,7 +187,7 @@ private:
         bool isHitGrip = false;
     };
 
-    void handleClickInNoteInputMode(QMouseEvent* event);
+    void handleClickInNoteInputMode(QMouseEvent* event, bool& shouldSeek);
     bool mousePress_considerGrip(const ClickContext& ctx); // returns true if event is consumed
     bool mousePress_considerDragOutgoingElement(const ClickContext& ctx);
     void mousePress_considerSelect(const ClickContext& ctx);


### PR DESCRIPTION
See: https://github.com/musescore/MuseScore/pull/31491