### PR TITLE
We, the Docked Panels, want our positions and sizes remembered too!

### DIFF
--- a/src/framework/dockwindow/internal/dockbase.cpp
+++ b/src/framework/dockwindow/internal/dockbase.cpp
@@ -133,6 +133,18 @@ Location DockBase::location() const
     return m_properties.location;
 }
 
+bool DockBase::hasValidLastPosition() const
+{
+    Q_ASSERT(m_dockWidget);
+    return m_dockWidget->hasPreviousDockedLocation();
+}
+
+bool DockBase::isDockedInHiddenContainer() const
+{
+    Q_ASSERT(m_dockWidget);
+    return m_dockWidget->isDockedInHiddenContainer();
+}
+
 QPoint DockBase::globalPosition() const
 {
     if (!m_dockWidget) {

--- a/src/framework/dockwindow/internal/dockbase.h
+++ b/src/framework/dockwindow/internal/dockbase.h
@@ -104,6 +104,8 @@ public:
     int nonCompactWidth() const;
 
     bool floating() const;
+    bool hasValidLastPosition() const;
+    bool isDockedInHiddenContainer() const;
 
     bool inited() const;
 

--- a/src/framework/dockwindow/thirdparty/KDDockWidgets/src/DockWidgetBase.cpp
+++ b/src/framework/dockwindow/thirdparty/KDDockWidgets/src/DockWidgetBase.cpp
@@ -743,6 +743,20 @@ void DockWidgetBase::onParentChanged()
     Q_EMIT actualTitleBarChanged();
 }
 
+bool DockWidgetBase::isDockedInHiddenContainer() const
+{
+    const LastPositions &lastPositions = d->lastPositions();
+
+    if (!lastPositions.isValid())
+        return false;
+
+    if (lastPositions.wasFloating())
+        return false;
+
+    Layouting::Item *item = lastPositions.lastItem();
+    return item ? !item->isVisible() : false;
+}
+
 void DockWidgetBase::onShown(bool spontaneous)
 {
     d->onDockWidgetShown();

--- a/src/framework/dockwindow/thirdparty/KDDockWidgets/src/DockWidgetBase.h
+++ b/src/framework/dockwindow/thirdparty/KDDockWidgets/src/DockWidgetBase.h
@@ -251,6 +251,15 @@ public:
     bool isTabbed() const;
 
     /**
+     * @brief Returns if this dock widget is docked in a hidden container. The last position data must indicate
+     *        that the widget was docked before it got closed rather than floating, and the container
+     *        it was docked into is currently hidden. The latter will be true when the widget is currently closed
+     *        and either 1) the widget is the only widget in the container (e.g. docked to a top, bottom, left
+     *        or right placeholder), or 2) is tabbed with other widgets but all of them are also currently closed.
+     */
+    bool isDockedInHiddenContainer() const;
+
+    /**
      * @brief Returns true if this dock widget is the current one in the tab
      *        widget that contains it. If the dock widget is alone then true is
      *        returned, as in this case there will also be a tab widget even


### PR DESCRIPTION
Resolves: [#11242](https://github.com/musescore/MuseScore/issues/11242) & [#26678](https://github.com/musescore/MuseScore/issues/26678)

Dear MuseScore Studio creators and users,

We, the Docked Panels, feel the obligation to write this letter and inform you of a situation that has been having great impact on us for the past few days. In [PR27695](https://github.com/musescore/MuseScore/pull/27695), our _undocked_ brothers were upgraded and now their positions and sizes will be remembered (some limitations apply). Going forward you will be able to move/resize, close and reopen an _undocked_ fella and it will re-appear exactly where you left it and as big/small as you left it.

We've always welcomed progress and improvement, and we are happy for our undocked brothers. But at the same time we are deeply saddened and hurt. Why are we being left out? Are we less important? Do we work less hard? Do we not pay taxes? With the inequality that PR27695 has introduced, you will love us less and less. You will not dare to touch us. This is not nice. We don't want to be the "bad guys"! We want to instill confidence and reliability. We want to make your workflow smooth and pleasant.

We, the Docked Panels, have been living in MuseScore Studio Land for several years now and we like it here (overall :). During all these years did we ask for a salary raise? More vacation days? Paid private healthcare or gym membership? Did we ever not do what your C++/QML told us to do? No. All we've been wanting is to have our positions and sizes remembered. Now, we are told that only the _undocked_ panels are honored with this priviledge and that we will have to wait *again* until *someday*, *maybe*... Let us tell you something. Being docked is not shameful! And we will fight! We will not give up until this unjustice is gone and burried deep! We don't want to move to another app-land. But if we are not treated equally, we may be forced to leave.

We, the Docked Panels, know that to compain, threaten, demand and declare ultimatums is easy. But we believe in communication, negotiations, compromises and proactiveness. That's why, after careful consideration, we've come up with a few measures to try and solve the current situation. We, the Docked Panels, believe that we can also have our positions and sizes remembered with some small inevitable compromises.

As some of you know, when we are closed and reopened, we are forced by `DockPageView::setDockOpen` to reappear tabbed with another panel. Removing this logic mostly makes us remember our last positions except for the default layout: in that case the horizontal ones of us appear stacked vertically (one on top of the other). This is not what you guys want. And you are not alone: we prefer to be tabbed too! So, what do we do?

Let's keep the force-tabbed logic in `DockPageView::setDockOpen` but spice it up a bit like this:
**1.** It shall be applied both to the vertical and horizontal panels when they do not have a valid last position stored. Without a valid last position, `KDockWidgets` simply floats them. Examples of this scenario include but may not be limited to:

**1a.** Any initially-hidden vertical panel that belongs to the "Palettes" panel group - e.g. the "Selection Filter" panel - for the default layout.

**1b.** A new panel being introduced in MuseScore Studio, that is hidden at startup, not known to the saved layout yet, and there is at least one panel of its group visible.

**2.** It shall be applied to the horizontal panels that are docked in a hidden container according to their last position data. This is also related to the default layout. The default layout stacks the hidden horizontal panels vertically (see `DockWindow::loadPanels`). But when any of them is opened, you guys want to ignore its stacked layout and instead tab it into an appropriate visible panel (if any). Note that this will prevent you guys from intentionally stacking the horizontal panels or having some at the bottom and some at the top. But you've never been able to do it anyway. We must immediately make the clarification that you will actually be able to stack two or more horizontal panels or place some at the top and some at the bottom but as soon as you close any of them that is alone and reopen it, it will appear tabbed somewhere else. As long as you don't close anything, or what you close is not the only open panel in its tab group, you will be good. We see two possible situations of a panel being docked in a hidden container that this will tackle:

**2a.** A panel docked alone in a container and closed. This corresponds to the stacked panels in the default layout. Or when any of them is docked to any side alone. The force-tabbed logic will not allow them to appear stacked.

**2b.** A panel is tabbed with other panels and all of them are closed. In this case the panel shouldn't forced to tab into the first suitable one since it is already tabbed but it is hard to distinguish this case from the previous one. Luckily, it is not a problem because if all tabbed panels are closed, there will be no panel to tab into and this panel will simply be shown alone. If there is a suitable panel to tab it into somewhere else (e.g. at the opposite side of the screen), then it will be tabbed there but again this is a compromise with the horizontal panels that has existed always.

**3.** In all other cases, the force-tabbed logic will be bypassed and the panel should simply be open. This will restore it to its last saved position.

We did our best to test the proposed plan well. In addition to all straightforward cases, we tested the following special cases too:
**T1.** Restore the default layout, open Selection Filter.
**T2.** Restore the default layout, open Mixer, then Piano keyboard.
**T3.** Restore the default layout, quit MuseScore, start MuseScore, open Selection Filter.
**T4.** Restore the default layout, quit MuseScore, start MuseScore, open Mixer, then Piano keyboard.
**T5.** Restore the default layout, quit MuseScore, rename piano keyboard panel in "src\appshell\appshelltypes.h" to e.g. "newPianoKeyboardPanel", start MuseScore, open Piano keyboard, then Mixer.
**T6.** Restore the default layout, opne Mixer, quit MuseScore, rename piano keyboard panel in "src\appshell\appshelltypes.h" to e.g. "pianoKeyboardPanel7", start MuseScore, open Piano keyboard.

That's it folks. Is it much what we want? We are sure you see how emotional we are about this and unable to hide it. :P
May you all have a great day and MAY JUSTICE PREVAIL!!!

Sincerely,
**The Docked Panels**

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
