### PR TITLE
Fix #30581: Don't change the note properties submenu if the selection is a range

### DIFF
--- a/src/inspector/qml/MuseScore/Inspector/notation/notes/notesettingsproxymodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/notes/notesettingsproxymodel.cpp
@@ -60,8 +60,11 @@ NoteSettingsProxyModel::NoteSettingsProxyModel(QObject* parent, IElementReposito
 
 void NoteSettingsProxyModel::onElementsUpdated(const QList<mu::engraving::EngravingItem*>& newElements)
 {
+    if (!selection() || selection()->isRange()) {
+        // Don't update the default sub model if the selection is a range (see issue #30581)
+        return;
+    }
     InspectorModelType defaultType = resolveDefaultSubModelType(newElements);
-
     setDefaultSubModelType(defaultType);
 }
 


### PR DESCRIPTION
Resolves: #30581

See [this comment](https://github.com/musescore/MuseScore/issues/30581#issuecomment-3432234469) for a detailed description of the issue.