### PR TITLE
Fix crash on linked cross staff

### DIFF
--- a/src/engraving/dom/chordrest.cpp
+++ b/src/engraving/dom/chordrest.cpp
@@ -1275,7 +1275,7 @@ bool ChordRest::isBelowCrossBeam(const BeamBase* beamBase) const
 
 void ChordRest::checkStaffMoveValidity()
 {
-    if (!staff() || !staff()->visible()) {
+    if (!staff()) {
         return;
     }
     staff_idx_t idx = m_staffMove ? vStaffIdx() : staffIdx() + m_storedStaffMove;

--- a/src/engraving/rendering/score/measurelayout.cpp
+++ b/src/engraving/rendering/score/measurelayout.cpp
@@ -1021,10 +1021,12 @@ void MeasureLayout::layoutMeasure(MeasureBase* currentMB, LayoutContext& ctx)
             continue;
         }
         for (EngravingItem* item : s.elist()) {
-            if (!item || !item->isChordRest() || !ctx.dom().staff(item->vStaffIdx())->show()) {
+            if (!item || !item->isChordRest()) {
                 continue;
             }
-            BeamLayout::layoutNonCrossBeams(toChordRest(item), ctx);
+            if (const Staff* staff = ctx.dom().staff(item->vStaffIdx()); staff && staff->show()) {
+                BeamLayout::layoutNonCrossBeams(toChordRest(item), ctx);
+            }
         }
     }
 


### PR DESCRIPTION
Resolves: #31238

The problem is due to the fact that the linked note was also trying to be set to cross-staff, but there is no other staff below. We have checks in place for this case but they were being mistakenly skipped if the original stave is invisible.

This PR resolves both the crash on opening the "damaged" file, but also fixes the underlying problem and ensures we don't create wrong cross-staff information.