### PR TITLE
Make curly quotes translatable, use unescaped text on undo (#31517)

### DIFF
--- a/src/engraving/dom/textbase.cpp
+++ b/src/engraving/dom/textbase.cpp
@@ -239,6 +239,7 @@ Char TextCursor::currentCharacter() const
 
     const TextBlock& t = ldata->blocks.at(row());
     String s = t.text(static_cast<int>(column()), 1);
+    s = TextBase::unEscape(s);
     if (s.isEmpty()) {
         return Char();
     }
@@ -2363,6 +2364,7 @@ String TextBase::unEscape(String s)
     s.replace(u"&lt;", u"<");
     s.replace(u"&gt;", u">");
     s.replace(u"&amp;", u"&");
+    s.replace(u"&apos;", u"'");
     s.replace(u"&quot;", u"\"");
     return s;
 }
@@ -2376,6 +2378,7 @@ String TextBase::escape(String s)
     s.replace(u"<", u"&lt;");
     s.replace(u">", u"&gt;");
     s.replace(u"&", u"&amp;");
+    s.replace(u"'", u"&apos;");
     s.replace(u"\"", u"&quot;");
     return s;
 }

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -4502,12 +4502,20 @@ bool NotationInteraction::doTextEdit(QKeyEvent* event, TextBase* tb)
     cursor->movePosition(TextCursor::MoveOperation::Left);
     score()->undo(new RemoveText(cursor, event->text()), &m_editData);
 
+    //: Single open quotation mark
+    const String singleOpenQuote = muse::mtrc("notation", u"‘");
+    //: Single close quotation mark
+    const String singleCloseQuote = muse::mtrc("notation", u"’");
+    //: Double open quotation mark
+    const String doubleOpenQuote = muse::mtrc("notation", u"“");
+    //: Double close quotation mark
+    const String doubleCloseQuote = muse::mtrc("notation", u"”");
+
     const String replacement = isSingleQuoteInput
-                               ? String(useCloseQuote ? u"’" : u"‘")
-                               : String(useCloseQuote ? u"”" : u"“");
+                               ? (useCloseQuote ? singleCloseQuote : singleOpenQuote)
+                               : (useCloseQuote ? doubleCloseQuote : doubleOpenQuote);
 
     tb->insertText(m_editData, replacement);
-
     apply();
 
     return true;


### PR DESCRIPTION
Resolves: #31517

This is a problem for any XML character entity (`&amp;`, `&lt;`, `&gt;`, `&apos;`, and `&quot;`). When we call `deleteSelectedText` we use `currentCharacter` which fails to consider escaped characters.

This PR also introduces translatable strings for curly quotes (follow-up to #31460).