### PR TITLE
Fix #31531: Deleting a chord/rest at the end of a measure followed by…

### DIFF
--- a/src/engraving/editing/edit.cpp
+++ b/src/engraving/editing/edit.cpp
@@ -4974,7 +4974,7 @@ void Score::doTimeDelete(Segment* startSegment, Segment* endSegment)
     MeasureBase* mbEnd;
 
     if (endSegment) {
-        mbEnd = endSegment->prev(SegmentType::ChordRest) ? endSegment->measure() : endSegment->measure()->prev();
+        mbEnd = endSegment->prev(SegmentType::ChordRest) ? endSegment->measure() : endSegment->measure()->prevMeasure();
     } else {
         mbEnd = lastMeasure();
     }


### PR DESCRIPTION
… a horizontal frame additionally deletes that frame and the measure after it

Resolves: #31531 

See https://github.com/musescore/MuseScore/issues/31531 for further details of problem.
During testing of the issue, I realized that the MeasureBase* type was being used instead of Measure*, after verifying differences in the ticks when the score had a following frame. As a matter of fact, it's not absolutely just the frame's fault. If the score had've had a few more measures before the first measure, the problem wouldn't arise because of the prev() check (verified this). Anyways. This should get the ball rolling for the fix of this little issue.

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [] The code compiles and runs on my machine, preferably after each commit individually
- [] I created a unit test or vtest to verify the changes I made (if applicable)
