### PR TITLE
removed default subtitle

### DIFF
--- a/src/project/qml/MuseScore/Project/internal/NewScore/GeneralInfoView.qml
+++ b/src/project/qml/MuseScore/Project/internal/NewScore/GeneralInfoView.qml
@@ -107,8 +107,6 @@ Column {
 
             title: qsTrc("project", "Subtitle")
 
-            defaultText: qsTrc("project", "Subtitle")
-
             navigationPanel: root.navigationPanel
             navigationColumn: 2
         }


### PR DESCRIPTION
Resolves: #24459

Removed the default subtitle text from the subtitle text field under "additional score information" upon creating a new score, preventing auto-generation of a default subtitle upon the generation of a new score.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
