### PR TITLE
Fix #31555: Assertion failure when clicking on empty space in score view

### DIFF
--- a/src/notation/view/notationviewinputcontroller.cpp
+++ b/src/notation/view/notationviewinputcontroller.cpp
@@ -879,8 +879,11 @@ void NotationViewInputController::mousePress_seekSelection(const ClickContext& c
 {
     const INotationSelectionPtr selection = viewInteraction()->selection();
     const std::vector<EngravingItem*>& elements = selection->elements();
+    if (elements.empty()) {
+        return;
+    }
 
-    if (!selection->isRange() && !elements.empty()) {
+    if (!selection->isRange()) {
         playbackController()->seekElement(elements.back());
         return;
     }


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/31555