### PR TITLE
Fix #31363: Master channel shows metering pre Audio FX

### DIFF
--- a/src/framework/audio/engine/internal/mixer.cpp
+++ b/src/framework/audio/engine/internal/mixer.cpp
@@ -259,13 +259,14 @@ samples_t Mixer::process(float* outBuffer, samples_t samplesPerChannel)
     }
 
     processAuxChannels(outBuffer, samplesPerChannel);
-    completeOutput(outBuffer, samplesPerChannel);
 
     for (IFxProcessorPtr& fxProcessor : m_masterFxProcessors) {
         if (fxProcessor->active()) {
             fxProcessor->process(outBuffer, samplesPerChannel, playbackPosition());
         }
     }
+
+    completeOutput(outBuffer, samplesPerChannel);
 
     return samplesPerChannel;
 }


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/31363
Resolves: https://github.com/musescore/MuseScore/issues/15000