### PR TITLE
Enable QT_SUPPORT by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,6 +145,7 @@ set(QT_ADD_CONCURRENT ON)
 set(QT_ADD_WEBSOCKET OFF)
 set(QT_QPROCESS_SUPPORTED ON)
 set(QT_CONCURRENT_SUPPORTED ON)
+set(QT_SUPPORT ON) # if turned off, framework doesn't compile
 
 if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/SetupConfigure.local.cmake")
     include(${CMAKE_CURRENT_LIST_DIR}/SetupConfigure.local.cmake)

--- a/src/framework/cmake/MuseDeclareOptions.cmake
+++ b/src/framework/cmake/MuseDeclareOptions.cmake
@@ -1,3 +1,9 @@
+# ! NOTE Make sure QT_SUPPORT is ON
+if(NOT QT_SUPPORT)
+message(WARNING "QT_SUPPORT is disabled. You might not be able to use some Framework features.")
+message(WARNING "In most cases, QT_SUPPORT should always be set to ON")
+endif()
+
 
 macro(declare_muse_module_opt name def)
     option(MUSE_MODULE_${name} "Build ${name} module" ${def})


### PR DESCRIPTION
If QT_SUPPORT isn't set to ON, framework doesn't compile.

This PR stems from a long [conversation at MuseScore's Discord](https://discord.com/channels/818804595450445834/939880479887327302/1453124813517230173) where I couldn't get my application which uses [a Muse framework fork](https://gitlab.com/advanced-effects/framework) to compile because `QT_SUPPORT` wasn't ON.

This PR enables it by default and, if turned to OFF, emits a warning. (One is already emitted, but it may or may not not be emitted)

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
