### PR TITLE
Fix #31353: macOS Trackpad 'Tap to Click' causes stuck notes on Virtual Piano in MuseScore

### DIFF
--- a/src/framework/audio/engine/internal/abstracteventsequencer.h
+++ b/src/framework/audio/engine/internal/abstracteventsequencer.h
@@ -5,7 +5,7 @@
  * MuseScore
  * Music Composition & Notation
  *
- * Copyright (C) 2022 MuseScore Limited and others
+ * Copyright (C) 2025 MuseScore Limited and others
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -20,8 +20,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef MUSE_AUDIO_ABSTRACTEVENTSEQUENCER_H
-#define MUSE_AUDIO_ABSTRACTEVENTSEQUENCER_H
+#pragma once
 
 #include <map>
 #include <set>
@@ -38,7 +37,7 @@ class AbstractEventSequencer : public async::Asyncable
 {
 public:
     using EventType = std::variant<Types...>;
-    using EventSequence = std::set<EventType>;
+    using EventSequence = std::vector<EventType>;
     using EventSequenceMap = std::map<msecs_t, EventSequence>;
 
     typedef typename EventSequenceMap::const_iterator SequenceIterator;
@@ -237,7 +236,7 @@ protected:
         while (m_currentMainSequenceIt != m_mainStreamEvents.end()
                && m_currentMainSequenceIt->first <= m_playbackPosition) {
             EventSequence& sequence = result[m_currentMainSequenceIt->first];
-            sequence.insert(m_currentMainSequenceIt->second.cbegin(),
+            sequence.insert(sequence.end(), m_currentMainSequenceIt->second.cbegin(),
                             m_currentMainSequenceIt->second.cend());
             m_currentMainSequenceIt = std::next(m_currentMainSequenceIt);
         }
@@ -252,7 +251,7 @@ protected:
         while (m_currentOffSequenceIt != m_offStreamEvents.end()
                && m_currentOffSequenceIt->first <= m_offstreamPosition) {
             EventSequence& sequence = result[m_currentOffSequenceIt->first];
-            sequence.insert(std::make_move_iterator(m_currentOffSequenceIt->second.begin()),
+            sequence.insert(sequence.end(), std::make_move_iterator(m_currentOffSequenceIt->second.begin()),
                             std::make_move_iterator(m_currentOffSequenceIt->second.end()));
             m_currentOffSequenceIt = m_offStreamEvents.erase(m_currentOffSequenceIt);
         }
@@ -282,5 +281,3 @@ private:
     bool m_updateMainStreamWhenInactive = false;
 };
 }
-
-#endif // MUSE_AUDIO_ABSTRACTEVENTSEQUENCER_H

--- a/src/framework/audio/engine/internal/synthesizers/fluidsynth/fluidsequencer.cpp
+++ b/src/framework/audio/engine/internal/synthesizers/fluidsynth/fluidsequencer.cpp
@@ -132,7 +132,7 @@ void FluidSequencer::addDynamicEvents(EventSequenceMap& destination, const mpe::
             event.setIndex(midi::EXPRESSION_CONTROLLER);
             event.setData(expressionLevel(dynamic.second));
 
-            destination[dynamic.first].emplace(std::move(event));
+            destination[dynamic.first].emplace_back(std::move(event));
         }
     }
 }
@@ -157,7 +157,7 @@ void FluidSequencer::addNoteEvent(EventSequenceMap& destination, const mpe::Note
         noteOn.setVelocity16(velocity);
         noteOn.setPitchNote(noteIdx, tuning);
 
-        destination[arrangementCtx.actualTimestamp].emplace(std::move(noteOn));
+        destination[arrangementCtx.actualTimestamp].emplace_back(std::move(noteOn));
     }
 
     if (arrangementCtx.hasEnd()) {
@@ -167,7 +167,7 @@ void FluidSequencer::addNoteEvent(EventSequenceMap& destination, const mpe::Note
         noteOff.setPitchNote(noteIdx, tuning);
 
         const timestamp_t timestampTo = arrangementCtx.actualTimestamp + noteEvent.arrangementCtx().actualDuration;
-        destination[timestampTo].emplace(std::move(noteOff));
+        destination[timestampTo].emplace_back(std::move(noteOff));
     }
 
     for (const auto& artPair : noteEvent.expressionCtx().articulations) {
@@ -247,7 +247,7 @@ void FluidSequencer::addControlChange(EventSequenceMap& destination, const mpe::
     cc.setChannel(channelIdx);
     cc.setData(value);
 
-    destination[timestamp].emplace(std::move(cc));
+    destination[timestamp].emplace_back(std::move(cc));
 }
 
 void FluidSequencer::addPitchCurve(EventSequenceMap& destination, const mpe::NoteEvent& noteEvent,
@@ -305,7 +305,7 @@ void FluidSequencer::addPitchBend(EventSequenceMap& destination, const mpe::time
     midi::Event event(Event::Opcode::PitchBend, Event::MessageType::ChannelVoice10);
     event.setChannel(channelIdx);
     event.setData(value);
-    destination[timestamp].insert(event);
+    destination[timestamp].push_back(event);
 }
 
 void FluidSequencer::addSostenutoEvents(EventSequenceMap& destination, const SostenutoTimeAndDurations& sostenutoTimeAndDurations)

--- a/src/framework/musesampler/internal/musesamplersequencer.cpp
+++ b/src/framework/musesampler/internal/musesamplersequencer.cpp
@@ -528,7 +528,7 @@ void MuseSamplerSequencer::addAuditionNoteEvent(const mpe::NoteEvent& noteEvent)
         msEvent._articulation_text_starts_at_note = m_auditionParamsCache.textArticulationStartsAtNote;
         msEvent._syllable_starts_at_note = m_auditionParamsCache.syllableStartsAtNote;
 
-        m_offStreamEvents[arrangementCtx.actualTimestamp].insert(noteOn);
+        m_offStreamEvents[arrangementCtx.actualTimestamp].push_back(noteOn);
     }
 
     if (arrangementCtx.hasEnd()) {
@@ -537,7 +537,7 @@ void MuseSamplerSequencer::addAuditionNoteEvent(const mpe::NoteEvent& noteEvent)
         noteOff.msTrack = track;
 
         timestamp_t timestampTo = arrangementCtx.actualTimestamp + arrangementCtx.actualDuration;
-        m_offStreamEvents[timestampTo].emplace(std::move(noteOff));
+        m_offStreamEvents[timestampTo].emplace_back(std::move(noteOff));
     }
 
     auto pedalIt = articulations.find(mpe::ArticulationType::Pedal);
@@ -554,12 +554,12 @@ void MuseSamplerSequencer::addAuditionPedalEvent(const mpe::ArticulationMeta& me
 
     if (meta.hasStart()) {
         event.value = 1;
-        m_offStreamEvents[meta.timestamp].emplace(event);
+        m_offStreamEvents[meta.timestamp].push_back(event);
     }
 
     if (meta.hasEnd()) {
         event.value = 0;
-        m_offStreamEvents[meta.timestamp + meta.overallDuration].emplace(event);
+        m_offStreamEvents[meta.timestamp + meta.overallDuration].push_back(event);
     }
 }
 
@@ -584,7 +584,7 @@ void MuseSamplerSequencer::addAuditionCCEvent(const mpe::ControllerChangeEvent& 
         return;
     }
 
-    m_offStreamEvents[positionUs].insert(ccEvent);
+    m_offStreamEvents[positionUs].push_back(ccEvent);
 }
 
 void MuseSamplerSequencer::pitchAndTuning(const pitch_level_t nominalPitch, int& pitch, int& centsOffset) const

--- a/src/framework/musesampler/internal/musesamplersequencer.h
+++ b/src/framework/musesampler/internal/musesamplersequencer.h
@@ -27,48 +27,6 @@
 #include "internal/apitypes.h"
 #include "internal/libhandler.h"
 
-typedef typename std::variant<muse::mpe::NoteEvent,
-                              muse::musesampler::AuditionStartNoteEvent,
-                              muse::musesampler::AuditionStopNoteEvent,
-                              muse::musesampler::AuditionCCEvent> MuseSamplerEvent;
-
-template<>
-struct std::less<MuseSamplerEvent>
-{
-    bool operator()(const MuseSamplerEvent& first,
-                    const MuseSamplerEvent& second) const
-    {
-        if (first.index() != second.index()) {
-            return first.index() < second.index();
-        }
-
-        if (std::holds_alternative<muse::musesampler::AuditionStartNoteEvent>(first)) {
-            const auto& e1 = std::get<muse::musesampler::AuditionStartNoteEvent>(first);
-            const auto& e2 = std::get<muse::musesampler::AuditionStartNoteEvent>(second);
-            if (e1.msEvent._pitch == e2.msEvent._pitch) {
-                return e1.msEvent._offset_cents < e2.msEvent._offset_cents;
-            }
-            return e1.msEvent._pitch < e2.msEvent._pitch;
-        }
-
-        if (std::holds_alternative<muse::musesampler::AuditionStopNoteEvent>(first)) {
-            return std::get<muse::musesampler::AuditionStopNoteEvent>(first).msEvent._pitch
-                   < std::get<muse::musesampler::AuditionStopNoteEvent>(second).msEvent._pitch;
-        }
-
-        if (std::holds_alternative<muse::musesampler::AuditionCCEvent>(first)) {
-            const auto& e1 = std::get<muse::musesampler::AuditionCCEvent>(first);
-            const auto& e2 = std::get<muse::musesampler::AuditionCCEvent>(second);
-            if (e1.cc == e2.cc) {
-                return e1.value < e2.value;
-            }
-            return e1.cc < e2.cc;
-        }
-
-        return false;
-    }
-};
-
 namespace muse::musesampler {
 class MuseSamplerSequencer : public audio::engine::AbstractEventSequencer<mpe::NoteEvent, AuditionStartNoteEvent, AuditionStopNoteEvent,
                                                                           AuditionCCEvent>

--- a/src/framework/vst/internal/synth/vstsequencer.cpp
+++ b/src/framework/vst/internal/synth/vstsequencer.cpp
@@ -121,7 +121,7 @@ void VstSequencer::addDynamicEvents(EventSequenceMap& destination, const mpe::Dy
 {
     for (const auto& layer : layers) {
         for (const auto& dynamic : layer.second) {
-            destination[dynamic.first].emplace(expressionLevel(dynamic.second));
+            destination[dynamic.first].emplace_back(expressionLevel(dynamic.second));
         }
     }
 }
@@ -135,12 +135,12 @@ void VstSequencer::addNoteEvent(EventSequenceMap& destination, const mpe::NoteEv
     const float tuning = noteTuning(noteEvent, noteId);
 
     if (arrangementCtx.hasStart()) {
-        destination[arrangementCtx.actualTimestamp].emplace(buildEvent(VstEvent::kNoteOnEvent, noteId, velocityFraction, tuning));
+        destination[arrangementCtx.actualTimestamp].emplace_back(buildEvent(VstEvent::kNoteOnEvent, noteId, velocityFraction, tuning));
     }
 
     if (arrangementCtx.hasEnd()) {
         const mpe::timestamp_t timestampTo = arrangementCtx.actualTimestamp + noteEvent.arrangementCtx().actualDuration;
-        destination[timestampTo].emplace(buildEvent(VstEvent::kNoteOffEvent, noteId, velocityFraction, tuning));
+        destination[timestampTo].emplace_back(buildEvent(VstEvent::kNoteOffEvent, noteId, velocityFraction, tuning));
     }
 
     for (const auto& artPair : noteEvent.expressionCtx().articulations) {
@@ -205,7 +205,7 @@ void VstSequencer::addParamChange(EventSequenceMap& destination, const mpe::time
         return;
     }
 
-    destination[timestamp].emplace(ParamChangeEvent { controlIt->second, value });
+    destination[timestamp].emplace_back(ParamChangeEvent { controlIt->second, value });
 }
 
 void VstSequencer::addPitchCurve(EventSequenceMap& destination, const mpe::NoteEvent& noteEvent,
@@ -222,7 +222,7 @@ void VstSequencer::addPitchCurve(EventSequenceMap& destination, const mpe::NoteE
     ParamChangeEvent event;
     event.paramId = pitchBendIt->second;
     event.value = 0.5f;
-    destination[pitchBendTimestampTo].insert(event);
+    destination[pitchBendTimestampTo].push_back(event);
 
     auto currIt = noteEvent.pitchCtx().pitchCurve.cbegin();
     auto nextIt = std::next(currIt);
@@ -255,7 +255,7 @@ void VstSequencer::addPitchCurve(EventSequenceMap& destination, const mpe::NoteE
             if (time < pitchBendTimestampTo) {
                 float bendValue = static_cast<float>(point.y);
                 event.value = bendValue;
-                destination[time].insert(event);
+                destination[time].push_back(event);
             }
         }
     }

--- a/src/framework/vst/internal/synth/vstsequencer.h
+++ b/src/framework/vst/internal/synth/vstsequencer.h
@@ -5,7 +5,7 @@
  * MuseScore
  * Music Composition & Notation
  *
- * Copyright (C) 2022 MuseScore Limited and others
+ * Copyright (C) 2025 MuseScore Limited and others
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -20,38 +20,11 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef MUSE_VST_VSTSEQUENCER_H
-#define MUSE_VST_VSTSEQUENCER_H
+#pragma once
 
 #include "audio/engine/internal/abstracteventsequencer.h"
 
 #include "vsttypes.h"
-
-typedef typename std::variant<Steinberg::Vst::Event, muse::vst::ParamChangeEvent, muse::audio::gain_t> VstSequencerEvent;
-
-template<>
-struct std::less<VstSequencerEvent>
-{
-    bool operator()(const VstSequencerEvent& first,
-                    const VstSequencerEvent& second) const
-    {
-        if (first.index() != second.index()) {
-            return first.index() < second.index();
-        }
-
-        if (std::holds_alternative<Steinberg::Vst::Event>(first)) {
-            return std::less<Steinberg::Vst::Event> {}(std::get<Steinberg::Vst::Event>(first),
-                                                       std::get<Steinberg::Vst::Event>(second));
-        }
-
-        if (std::holds_alternative<muse::vst::ParamChangeEvent>(first)) {
-            return std::less<muse::vst::ParamChangeEvent> {}(std::get<muse::vst::ParamChangeEvent>(first),
-                                                             std::get<muse::vst::ParamChangeEvent>(second));
-        }
-
-        return std::get<muse::audio::gain_t>(first) < std::get<muse::audio::gain_t>(second);
-    }
-};
 
 namespace muse::vst {
 class VstSequencer : public audio::engine::AbstractEventSequencer<VstEvent, ParamChangeEvent, muse::audio::gain_t>
@@ -91,5 +64,3 @@ private:
     ParamsMapping m_mapping;
 };
 }
-
-#endif // MUSE_VST_VSTSEQUENCER_H


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/31353

MIDI NoteOff < NoteOn. Thus, if we receive them in the order on -> off simultaneously (quick key press), their order later changes to off -> on, which causes the note to hang