### PR TITLE
Manually add dependencies for qmltyperegistration targets

### DIFF
--- a/buildscripts/cmake/DeclareModuleSetup.cmake
+++ b/buildscripts/cmake/DeclareModuleSetup.cmake
@@ -64,7 +64,7 @@ function(muse_create_module target_name)
     if (arg_ALIAS)
         add_library(${arg_ALIAS} ALIAS ${target_name})
     endif()
-    
+
     # Include directories
     if (NOT MUSE_FRAMEWORK_PATH)
         set(MUSE_FRAMEWORK_PATH ${PROJECT_SOURCE_DIR})
@@ -130,10 +130,10 @@ function(muse_create_qml_module target_name)
     if (arg_FOR)
         get_target_property(_for_dir ${arg_FOR} SOURCE_DIR)
         target_include_directories(${target_name} PRIVATE ${_for_dir})
-        
+
         target_link_libraries(${target_name} PRIVATE ${arg_FOR})
 
-        # This might not be the cleanest way to obtain this path, but it is a 
+        # This might not be the cleanest way to obtain this path, but it is a
         # good balance between simplicity and correctness
         get_target_property(_for_binary_dir ${arg_FOR} BINARY_DIR)
         add_qml_import_path(${_for_binary_dir}/qml)
@@ -184,6 +184,15 @@ function(muse_module_add_qrc target_name)
     endif()
 
     target_sources(${target_name} PRIVATE ${QRC_SOURCES})
+endfunction()
+
+function(fixup_qml_module_dependencies target_name)
+    if (CMAKE_GENERATOR MATCHES "Visual Studio")
+        # The Visual Studio generator doesn't correctly resolve the dependencies for "qmltyperegistration"
+        # generated code files, unless we add this explicit target-level dependency. Other generators
+        # don't seem to have this problem.
+        add_dependencies(${target_name}_qmltyperegistration ${target_name})
+    endif()
 endfunction()
 
 ### LEGACY MACROS
@@ -246,7 +255,7 @@ function(target_precompile_headers_clang_ccache target)
 
     # https://discourse.cmake.org/t/ccache-clang-and-fno-pch-timestamp/7253
     if (CC_IS_CLANG AND COMPILER_CACHE_PROGRAM)
-        target_compile_options(${target} PRIVATE 
+        target_compile_options(${target} PRIVATE
             "$<$<COMPILE_LANGUAGE:CXX>:SHELL:-Xclang -fno-pch-timestamp>"
         )
     endif()
@@ -303,7 +312,7 @@ macro(setup_module)
         set(MUSE_FRAMEWORK_PATH ${PROJECT_SOURCE_DIR})
     endif()
 
-    target_include_directories(${MODULE} 
+    target_include_directories(${MODULE}
         PRIVATE ${MODULE_INCLUDE_PRIVATE}
         PUBLIC ${MODULE_INCLUDE}
     )

--- a/sandbox/web_sandbox/CMakeLists.txt
+++ b/sandbox/web_sandbox/CMakeLists.txt
@@ -109,6 +109,8 @@ qt_add_qml_module(appweb_sandbox
     SOURCES interactivetestmodel.h interactivetestmodel.cpp
 )
 
+fixup_qml_module_dependencies(appweb_sandbox)
+
 target_link_options(appweb_sandbox PUBLIC -sASYNCIFY -Os)
 
 # Qt for iOS sets MACOSX_BUNDLE_GUI_IDENTIFIER automatically since Qt 6.1.

--- a/src/braille/qml/MuseScore/Braille/CMakeLists.txt
+++ b/src/braille/qml/MuseScore/Braille/CMakeLists.txt
@@ -12,3 +12,5 @@ qt_add_qml_module(braille_qml
         TARGET muse_ui_qml
         TARGET muse_uicomponents_qml
 )
+
+fixup_qml_module_dependencies(braille_qml)

--- a/src/engraving/qml/MuseScore/Engraving/CMakeLists.txt
+++ b/src/engraving/qml/MuseScore/Engraving/CMakeLists.txt
@@ -49,5 +49,7 @@ qt_add_qml_module(engraving_qml
         TARGET muse_uicomponents_qml
 )
 
+fixup_qml_module_dependencies(engraving_qml)
+
 # Necessary for the auto-generated sources
 target_include_directories(engraving_qml PRIVATE devtools)

--- a/src/framework/autobot/qml/Muse/Autobot/CMakeLists.txt
+++ b/src/framework/autobot/qml/Muse/Autobot/CMakeLists.txt
@@ -19,3 +19,5 @@ qt_add_qml_module(muse_autobot_qml
         TARGET muse_ui_qml
         TARGET muse_uicomponents_qml
 )
+
+fixup_qml_module_dependencies(muse_autobot_qml)

--- a/src/framework/dockwindow/qml/Muse/Dock/CMakeLists.txt
+++ b/src/framework/dockwindow/qml/Muse/Dock/CMakeLists.txt
@@ -42,4 +42,6 @@ qt_add_qml_module(muse_dockwindow_qml
         TARGET muse_uicomponents_qml
 )
 
+fixup_qml_module_dependencies(muse_dockwindow_qml)
+
 target_link_libraries(muse_dockwindow_qml PRIVATE kddockwidgets)

--- a/src/framework/learn/qml/Muse/Learn/CMakeLists.txt
+++ b/src/framework/learn/qml/Muse/Learn/CMakeLists.txt
@@ -37,3 +37,5 @@ qt_add_qml_module(muse_learn_qml
         TARGET muse_ui_qml
         TARGET muse_uicomponents_qml
 )
+
+fixup_qml_module_dependencies(muse_learn_qml)

--- a/src/framework/mpe/qml/Muse/Mpe/CMakeLists.txt
+++ b/src/framework/mpe/qml/Muse/Mpe/CMakeLists.txt
@@ -23,3 +23,5 @@ qt_add_qml_module(muse_mpe_qml
         TARGET muse_ui_qml
         TARGET muse_uicomponents_qml
 )
+
+fixup_qml_module_dependencies(muse_mpe_qml)

--- a/src/framework/multiinstances/qml/Muse/MultiInstances/CMakeLists.txt
+++ b/src/framework/multiinstances/qml/Muse/MultiInstances/CMakeLists.txt
@@ -13,3 +13,5 @@ qt_add_qml_module(muse_multiinstances_qml
         TARGET muse_ui_qml
         TARGET muse_uicomponents_qml
 )
+
+fixup_qml_module_dependencies(muse_multiinstances_qml)

--- a/src/framework/shortcuts/qml/Muse/Shortcuts/CMakeLists.txt
+++ b/src/framework/shortcuts/qml/Muse/Shortcuts/CMakeLists.txt
@@ -25,11 +25,13 @@ qt_add_qml_module(muse_shortcuts_qml
         MidiDeviceMappingPage.qml
         Shortcuts.qml
         ShortcutsPage.qml
-        StandardEditShortcutDialog.qml    
+        StandardEditShortcutDialog.qml
     IMPORTS
         TARGET muse_ui_qml
         TARGET muse_uicomponents_qml
 )
+
+fixup_qml_module_dependencies(muse_shortcuts_qml)
 
 if (OS_IS_MAC)
     find_library(CARBON_LIBRARY Carbon)

--- a/src/framework/stubs/learn/qml/Muse/Learn/CMakeLists.txt
+++ b/src/framework/stubs/learn/qml/Muse/Learn/CMakeLists.txt
@@ -28,3 +28,5 @@ qt_add_qml_module(muse_learn_qml
     DEPENDENCIES
         TARGET muse_uicomponents_qml
 )
+
+fixup_qml_module_dependencies(muse_learn_qml)

--- a/src/framework/stubs/shortcuts/qml/Muse/Shortcuts/CMakeLists.txt
+++ b/src/framework/stubs/shortcuts/qml/Muse/Shortcuts/CMakeLists.txt
@@ -9,3 +9,5 @@ qt_add_qml_module(muse_shortcuts_qml
         TARGET muse_ui_qml
         TARGET muse_uicomponents_qml
 )
+
+fixup_qml_module_dependencies(muse_shortcuts_qml)

--- a/src/framework/stubs/workspace/qml/Muse/Workspace/CMakeLists.txt
+++ b/src/framework/stubs/workspace/qml/Muse/Workspace/CMakeLists.txt
@@ -10,3 +10,5 @@ qt_add_qml_module(muse_workspace_qml
         TARGET muse_ui_qml
         TARGET muse_uicomponents_qml
 )
+
+fixup_qml_module_dependencies(muse_workspace_qml)

--- a/src/framework/ui/qml/Muse/Ui/CMakeLists.txt
+++ b/src/framework/ui/qml/Muse/Ui/CMakeLists.txt
@@ -59,6 +59,8 @@ qt_add_qml_module(muse_ui_qml
         QtQuick
 )
 
+fixup_qml_module_dependencies(muse_ui_qml)
+
 # Necessary for the auto-generated sources
 target_include_directories(muse_ui_qml PRIVATE dev internal)
 

--- a/src/framework/ui/qml/Muse/Ui/Dialogs/CMakeLists.txt
+++ b/src/framework/ui/qml/Muse/Ui/Dialogs/CMakeLists.txt
@@ -40,3 +40,5 @@ qt_add_qml_module(muse_ui_dialogs_qml
         TARGET muse_ui_qml
         TARGET muse_uicomponents_qml
 )
+
+fixup_qml_module_dependencies(muse_ui_dialogs_qml)

--- a/src/framework/uicomponents/api/MuseApi/Controls/CMakeLists.txt
+++ b/src/framework/uicomponents/api/MuseApi/Controls/CMakeLists.txt
@@ -110,3 +110,5 @@ qt_add_qml_module(muse_uicomponents_qmlapi
     IMPORTS
         QtQuick
 )
+
+fixup_qml_module_dependencies(muse_uicomponents_qmlapi)

--- a/src/framework/uicomponents/qml/Muse/GraphicalEffects/CMakeLists.txt
+++ b/src/framework/uicomponents/qml/Muse/GraphicalEffects/CMakeLists.txt
@@ -31,6 +31,8 @@ qt_add_qml_module(muse_graphicaleffects_qml
         RoundedCornersEffect.qml
 )
 
+fixup_qml_module_dependencies(muse_graphicaleffects_qml)
+
 qt_add_shaders(muse_graphicaleffects_qml muse_graphicaleffects_qml_shaders
     PREFIX
         "/qt/qml/Muse/GraphicalEffects"

--- a/src/framework/uicomponents/qml/Muse/UiComponents/CMakeLists.txt
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/CMakeLists.txt
@@ -191,6 +191,8 @@ qt_add_qml_module(muse_uicomponents_qml
         TARGET muse_ui_qml
 )
 
+fixup_qml_module_dependencies(muse_uicomponents_qml)
+
 if (OS_IS_MAC)
     target_sources(muse_uicomponents_qml PRIVATE
         internal/platform/macos/macospopupviewclosecontroller.mm

--- a/src/framework/workspace/qml/Muse/Workspace/CMakeLists.txt
+++ b/src/framework/workspace/qml/Muse/Workspace/CMakeLists.txt
@@ -19,3 +19,5 @@ qt_add_qml_module(muse_workspace_qml
         TARGET muse_ui_qml
         TARGET muse_uicomponents_qml
 )
+
+fixup_qml_module_dependencies(muse_workspace_qml)

--- a/src/inspector/qml/MuseScore/Inspector/CMakeLists.txt
+++ b/src/inspector/qml/MuseScore/Inspector/CMakeLists.txt
@@ -369,8 +369,10 @@ qt_add_qml_module(inspector_qml
         TARGET muse_uicomponents_qml
 )
 
+fixup_qml_module_dependencies(inspector_qml)
+
 # Necessary for the auto-generated sources
-target_include_directories(inspector_qml PRIVATE 
+target_include_directories(inspector_qml PRIVATE
     emptystaves
     general
     general/appearance

--- a/src/musesounds/qml/MuseScore/MuseSounds/CMakeLists.txt
+++ b/src/musesounds/qml/MuseScore/MuseSounds/CMakeLists.txt
@@ -18,3 +18,5 @@ qt_add_qml_module(musesounds_qml
         TARGET muse_ui_qml
         TARGET muse_uicomponents_qml
 )
+
+fixup_qml_module_dependencies(musesounds_qml)

--- a/src/notationscene/qml/MuseScore/NotationScene/CMakeLists.txt
+++ b/src/notationscene/qml/MuseScore/NotationScene/CMakeLists.txt
@@ -278,6 +278,8 @@ qt_add_qml_module(notationscene_qml
         TARGET muse_uicomponents_qml
 )
 
+fixup_qml_module_dependencies(notationscene_qml)
+
 # Necessary for the auto-generated sources
 target_include_directories(notationscene_qml PRIVATE
     elementpopups

--- a/src/preferences/qml/MuseScore/Preferences/CMakeLists.txt
+++ b/src/preferences/qml/MuseScore/Preferences/CMakeLists.txt
@@ -130,3 +130,5 @@ qt_add_qml_module(preferences_qml
         TARGET muse_ui_qml
         TARGET muse_uicomponents_qml
 )
+
+fixup_qml_module_dependencies(preferences_qml)

--- a/src/project/qml/MuseScore/Project/CMakeLists.txt
+++ b/src/project/qml/MuseScore/Project/CMakeLists.txt
@@ -129,6 +129,8 @@ qt_add_qml_module(project_qml
         TARGET notationscene_qml
 )
 
+fixup_qml_module_dependencies(project_qml)
+
 # Necessary for the auto-generated sources
 target_include_directories(project_qml PRIVATE
     internal

--- a/src/stubs/braille/qml/MuseScore/Braille/CMakeLists.txt
+++ b/src/stubs/braille/qml/MuseScore/Braille/CMakeLists.txt
@@ -9,3 +9,5 @@ qt_add_qml_module(braille_qml
         TARGET muse_ui_qml
         TARGET muse_uicomponents_qml
 )
+
+fixup_qml_module_dependencies(braille_qml)

--- a/src/stubs/inspector/qml/MuseScore/Inspector/CMakeLists.txt
+++ b/src/stubs/inspector/qml/MuseScore/Inspector/CMakeLists.txt
@@ -29,3 +29,5 @@ qt_add_qml_module(inspector_qml
     IMPORTS
         TARGET muse_uicomponents_qml
 )
+
+fixup_qml_module_dependencies(inspector_qml)

--- a/src/stubs/musesounds/qml/MuseScore/MuseSounds/CMakeLists.txt
+++ b/src/stubs/musesounds/qml/MuseScore/MuseSounds/CMakeLists.txt
@@ -9,3 +9,5 @@ qt_add_qml_module(musesounds_qml
         TARGET muse_ui_qml
         TARGET muse_uicomponents_qml
 )
+
+fixup_qml_module_dependencies(musesounds_qml)

--- a/src/stubs/notationscene/qml/MuseScore/NotationScene/CMakeLists.txt
+++ b/src/stubs/notationscene/qml/MuseScore/NotationScene/CMakeLists.txt
@@ -24,3 +24,5 @@ qt_add_qml_module(notationscene_qml
     URI MuseScore.NotationScene
     VERSION 1.0
 )
+
+fixup_qml_module_dependencies(notationscene_qml)

--- a/src/stubs/project/qml/MuseScore/Project/CMakeLists.txt
+++ b/src/stubs/project/qml/MuseScore/Project/CMakeLists.txt
@@ -29,3 +29,5 @@ qt_add_qml_module(project_qml
         TARGET muse_ui_qml
         TARGET muse_uicomponents_qml
 )
+
+fixup_qml_module_dependencies(project_qml)


### PR DESCRIPTION
<!-- Add a short description of and motivation for the changes here -->

Attempts to fix `error MSB8066` happening (sometimes, for some people) when building `qmltyperegistration` projects on Windows. The root cause appears to be a missing dependency in CMake between each auto-generated `foo_qml_qmltyperegistration` project, and the `foo_qml` module that it applies to.

I'm not sure if the missing dependency is a bug in Qt's CMake machinery, or something wrong about the way MuseScore is using it. In any case, I've worked around it by manually adding the requisite dependency using `add_dependencies`, after each call to `qt_add_qml_module` in the project.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
