### PR TITLE
Refactor symlink creation on Linux

### DIFF
--- a/buildscripts/packaging/Linux+BSD/SetupAppImagePackaging.cmake
+++ b/buildscripts/packaging/Linux+BSD/SetupAppImagePackaging.cmake
@@ -132,20 +132,9 @@ endif(GZIP_EXECUTABLE AND NOT CMAKE_SYSTEM_NAME MATCHES "OpenBSD")
 install(FILES ${MAN_BUILD} DESTINATION share/man/man1 COMPONENT doc)
 
 # Create symlink alias for man pages so `man musescore` = `man mscore`
-find_program(LN_EXECUTABLE ln DOC "A tool for creating symbolic link aliases (optional).")
-
-if(LN_EXECUTABLE)
-    message(STATUS "Found 'ln'. Symlink aliases will be created for MuseScore executable and the man pages.")
-    add_custom_command(
-        TARGET manpages
-        COMMAND echo "Creating symlink alias for man pages."
-        COMMAND ${LN_EXECUTABLE} -sf "${MAN_FULL_NAME}" "${MAN_FULL_ALIAS}"
-        COMMAND echo 'Symlink alias: ${MAN_FULL_ALIAS} -> ${MAN_FULL_NAME}'
-    )
-    install(FILES ${PROJECT_BINARY_DIR}/${MAN_FULL_ALIAS} DESTINATION share/man/man1 COMPONENT doc)
-else(LN_EXECUTABLE)
-    message(STATUS "'ln' not found (it is optional). No symlink aliases will be created.")
-endif(LN_EXECUTABLE)
+install(CODE "message(STATUS \"Creating symlink ${CMAKE_INSTALL_PREFIX}/share/man/man1/${MAN_FULL_ALIAS} -> ${CMAKE_INSTALL_PREFIX}/share/man/man1/${MAN_FULL_NAME}\")
+              execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink \"${CMAKE_INSTALL_PREFIX}/share/man/man1/${MAN_FULL_NAME}\" \"${CMAKE_INSTALL_PREFIX}/share/man/man1/${MAN_FULL_ALIAS}\")" 
+        COMPONENT doc)
 
 # Add .MSCZ, .MSCX and .MSCS to MIME database (informs system that filetypes .MSCZ, .MSCX and .MSCS are MuseScore files)
 configure_file(${CMAKE_CURRENT_LIST_DIR}/musescore.xml.in musescore${MUSE_APP_INSTALL_SUFFIX}.xml)

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -397,26 +397,16 @@ if (OS_IS_WIN)
 ###########################################
 elseif(OS_IS_LIN)
     # Install mscore executable (package maintainers may add "MuseScore" and/or "musescore" aliases that symlink to mscore)
-    if (LN_EXECUTABLE)
-       add_custom_target(mscore_alias ALL
-           COMMAND echo "Creating symlink alias for mscore executable."
-           COMMAND ${LN_EXECUTABLE} -sf "mscore${MUSE_APP_INSTALL_SUFFIX}" "musescore${MUSE_APP_INSTALL_SUFFIX}"
-           COMMAND echo 'Symlink alias: musescore${MUSE_APP_INSTALL_SUFFIX} -> mscore${MUSE_APP_INSTALL_SUFFIX}'
-           )
-       install(FILES ${PROJECT_BINARY_DIR}/src/app/musescore${MUSE_APP_INSTALL_SUFFIX} DESTINATION bin)
-    else (LN_EXECUTABLE)
-       add_custom_target(mscore_alias ALL COMMAND echo "No symlink aliases will be created." VERBATIM )
-    endif (LN_EXECUTABLE)
+    install(CODE "message(STATUS \"Creating symlink ${CMAKE_INSTALL_PREFIX}/bin/musescore${MUSE_APP_INSTALL_SUFFIX} -> ${CMAKE_INSTALL_PREFIX}/bin/mscore${MUSE_APP_INSTALL_SUFFIX}\")
+                  execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink \"${CMAKE_INSTALL_PREFIX}/bin/mscore${MUSE_APP_INSTALL_SUFFIX}\" \"${CMAKE_INSTALL_PREFIX}/bin/musescore${MUSE_APP_INSTALL_SUFFIX}\")")
 
-elseif(OS_IS_FBSD)
 ###########################################
 # FreeBSD
 ###########################################
-    add_custom_target(mscore_alias ALL
-           COMMAND echo "Creating symlink alias for mscore executable."
-           COMMAND ln -sfv "mscore" "musescore"
-           )
-   install(FILES ${PROJECT_BINARY_DIR}/src/app/musescore DESTINATION bin)
+elseif(OS_IS_FBSD)
+    # Install mscore executable (package maintainers may add "MuseScore" and/or "musescore" aliases that symlink to mscore)
+    install(CODE "message(STATUS \"Creating symlink ${CMAKE_INSTALL_PREFIX}/bin/musescore${MUSE_APP_INSTALL_SUFFIX} -> ${CMAKE_INSTALL_PREFIX}/bin/mscore${MUSE_APP_INSTALL_SUFFIX}\")
+                  execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink \"${CMAKE_INSTALL_PREFIX}/bin/mscore${MUSE_APP_INSTALL_SUFFIX}\" \"${CMAKE_INSTALL_PREFIX}/bin/musescore${MUSE_APP_INSTALL_SUFFIX}\")")
 
 ###########################################
 # macOS


### PR DESCRIPTION
Do it during install phase, rather than build phase, and in a portable way