### PR TITLE
Fix changing elements' voice in local time signature

### DIFF
--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -5361,7 +5361,7 @@ void Score::changeSelectedElementsVoice(voice_idx_t voice)
                     if (voice && !dstCR) {
                         score->expandVoice(s, /*m->first(SegmentType::ChordRest,*/ dstTrack);
                     }
-                    score->makeGapVoice(s, dstTrack, chord->actualTicks(), s->tick());
+                    score->makeGapVoice(s, dstTrack, chord->ticks(), s->tick());
                 }
             }
 


### PR DESCRIPTION
<!-- Add a short description of and motivation for the changes here -->

I found another local time signature issue, likely introduced by my PR #31314. When changing the voice of an existing note/chord, in a local time signature, we'd create gaps of the wrong length, often leading to corruption.

~Also, fixed a debug-only assert that could fire after deleting a key signature.~ (Dropped as I couldn't repro the assert anymore.)

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
