### PR TITLE
Maintain accidentals when adding unisons (like octaves)

### DIFF
--- a/src/engraving/editing/cmd.cpp
+++ b/src/engraving/editing/cmd.cpp
@@ -736,7 +736,7 @@ void Score::addInterval(int val, const std::vector<Note*>& nl)
     std::vector<EngravingItem*> notesToSelect;
     int deltaLine = val < 0 ? val + 1 : val - 1;
     bool accidental = m_is.noteEntryMode() && m_is.accidentalType() != AccidentalType::NONE;
-    bool useOctaveRule = std::abs(deltaLine) == 7 && !accidental;
+    bool useOctaveRule = (deltaLine % STEP_DELTA_OCTAVE == 0) && !accidental;  // Both octaves and unison
 
     for (Note* on : tmpnl) {
         Chord* chord = on->chord();
@@ -752,11 +752,8 @@ void Score::addInterval(int val, const std::vector<Note*>& nl)
             noteValid = ds->isValid(nval.pitch) && nval.headGroup != NoteHeadGroup::HEAD_INVALID;
         } else {
             if (useOctaveRule) {
-                Interval interval(7, 12);
-                if (val < 0) {
-                    interval.flip();
-                }
-                nval.pitch = on->pitch() + interval.chromatic;
+                int octaves = deltaLine / STEP_DELTA_OCTAVE;
+                nval.pitch = on->pitch() + octaves * PITCH_DELTA_OCTAVE;
                 nval.tpc1 = on->tpc1();
                 nval.tpc2 = on->tpc2();
             } else {
@@ -769,9 +766,9 @@ void Score::addInterval(int val, const std::vector<Note*>& nl)
                     AccidentalVal acci = Accidental::subtype2value(m_is.accidentalType());
                     int step = absStep(line, clef);
                     int octave = step / 7;
-                    nval.pitch = step2pitch(step) + octave * 12 + int(acci);
+                    nval.pitch = step2pitch(step) + octave * PITCH_DELTA_OCTAVE + int(acci);
                     forceAccidental = (nval.pitch == line2pitch(line, clef, key));
-                    ntpc = step2tpc(step % 7, acci);
+                    ntpc = step2tpc(step % STEP_DELTA_OCTAVE, acci);
                 } else {
                     nval.pitch = line2pitch(line, clef, key);
                     ntpc = pitch2tpc(nval.pitch, key, Prefer::NEAREST);


### PR DESCRIPTION
<!-- Add a short description of and motivation for the changes here -->

When using "add unison interval" (Alt+1), we didn't respect accidentals. If the original note was B flat, the newly added "unison" would be a B natural, for example (in key of C).

The code already has special logic for handling octaves that ensures the accidental is maintained. I extended that to work on unisons as well as octaves.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
