### PR TITLE
Fix enabledness of flag and stem properties

### DIFF
--- a/src/inspector/qml/MuseScore/Inspector/abstractinspectormodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/abstractinspectormodel.cpp
@@ -186,6 +186,11 @@ bool AbstractInspectorModel::shouldUpdateOnScoreChange() const
     return m_shouldUpdateOnScoreChange;
 }
 
+bool AbstractInspectorModel::shouldUpdateWhenEmpty() const
+{
+    return false;
+}
+
 bool AbstractInspectorModel::shouldUpdateOnEmptyPropertyAndStyleIdSets() const
 {
     return false;

--- a/src/inspector/qml/MuseScore/Inspector/abstractinspectormodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/abstractinspectormodel.h
@@ -192,6 +192,7 @@ public:
     MeasurementUnits measurementUnits() const;
 
     bool shouldUpdateOnScoreChange() const;
+    virtual bool shouldUpdateWhenEmpty() const;
     virtual bool shouldUpdateOnEmptyPropertyAndStyleIdSets() const;
 
     mu::engraving::PropertyIdSet propertyIdSetFromStyleIdSet(const mu::engraving::StyleIdSet& styleIdSet) const;

--- a/src/inspector/qml/MuseScore/Inspector/abstractinspectorproxymodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/abstractinspectorproxymodel.cpp
@@ -153,7 +153,11 @@ void AbstractInspectorProxyModel::onNotationChanged(const engraving::PropertyIdS
                                                     const engraving::StyleIdSet& changedStyleIdSet)
 {
     for (AbstractInspectorModel* model : modelList()) {
-        if (!model->shouldUpdateOnScoreChange() || model->isEmpty()) {
+        if (!model->shouldUpdateOnScoreChange()) {
+            continue;
+        }
+
+        if (!model->shouldUpdateWhenEmpty() && model->isEmpty()) {
             continue;
         }
 
@@ -194,6 +198,16 @@ void AbstractInspectorProxyModel::updateModels(const ElementKeySet& newElementKe
     }
 
     setModels(models);
+}
+
+bool AbstractInspectorProxyModel::shouldUpdateWhenEmpty() const
+{
+    for (const AbstractInspectorModel* model : modelList()) {
+        if (model->shouldUpdateWhenEmpty()) {
+            return true;
+        }
+    }
+    return false;
 }
 
 bool AbstractInspectorProxyModel::shouldUpdateOnEmptyPropertyAndStyleIdSets() const

--- a/src/inspector/qml/MuseScore/Inspector/abstractinspectorproxymodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/abstractinspectorproxymodel.h
@@ -63,6 +63,7 @@ public:
     bool isEmpty() const override;
 
     void updateModels(const ElementKeySet& newElementKeySet);
+    bool shouldUpdateWhenEmpty() const override;
     bool shouldUpdateOnEmptyPropertyAndStyleIdSets() const override;
 
     void onCurrentNotationChanged() override;

--- a/src/inspector/qml/MuseScore/Inspector/inspectorlistmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/inspectorlistmodel.cpp
@@ -400,7 +400,11 @@ void InspectorListModel::onScoreChanged(const mu::engraving::PropertyIdSet& chan
                                         const mu::engraving::StyleIdSet& changedStyleIdSet)
 {
     for (AbstractInspectorModel* model : m_modelList) {
-        if (!model->shouldUpdateOnScoreChange() || model->isEmpty()) {
+        if (!model->shouldUpdateOnScoreChange()) {
+            continue;
+        }
+
+        if (!model->shouldUpdateWhenEmpty() && model->isEmpty()) {
             continue;
         }
 

--- a/src/inspector/qml/MuseScore/Inspector/notation/notes/hooks/hooksettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/notes/hooks/hooksettingsmodel.cpp
@@ -47,11 +47,28 @@ void HookSettingsModel::requestElements()
 void HookSettingsModel::loadProperties()
 {
     loadPropertyItem(m_offset);
+    updatemeasurementUnits();
 }
 
 void HookSettingsModel::resetProperties()
 {
     m_offset->resetToDefault();
+}
+
+void HookSettingsModel::onNotationChanged(const mu::engraving::PropertyIdSet& changedPropertyIdSet, const mu::engraving::StyleIdSet&)
+{
+    if (muse::contains(changedPropertyIdSet, mu::engraving::Pid::DURATION)
+        || muse::contains(changedPropertyIdSet, mu::engraving::Pid::DURATION_TYPE_WITH_DOTS)
+        || muse::contains(changedPropertyIdSet, mu::engraving::Pid::NO_STEM)
+        || muse::contains(changedPropertyIdSet, mu::engraving::Pid::BEAM_MODE)) {
+        // Might affect `isEmpty`
+        updateProperties();
+    }
+}
+
+bool HookSettingsModel::shouldUpdateWhenEmpty() const
+{
+    return true;
 }
 
 PropertyItem* HookSettingsModel::offset() const

--- a/src/inspector/qml/MuseScore/Inspector/notation/notes/hooks/hooksettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/notes/hooks/hooksettingsmodel.h
@@ -44,6 +44,10 @@ protected:
     void requestElements() override;
     void loadProperties() override;
     void resetProperties() override;
+    void onNotationChanged(const mu::engraving::PropertyIdSet& changedPropertyIdSet,
+                           const mu::engraving::StyleIdSet& changedStyleIdSet) override;
+
+    bool shouldUpdateWhenEmpty() const override;
 
 private:
     PointFPropertyItem* m_offset = nullptr;

--- a/src/inspector/qml/MuseScore/Inspector/notation/notes/stems/StemSettings.qml
+++ b/src/inspector/qml/MuseScore/Inspector/notation/notes/stems/StemSettings.qml
@@ -174,6 +174,7 @@ FocusableItem {
 
                         titleText: qsTrc("inspector", "Thickness")
                         propertyItem: root.stemModel ? root.stemModel.thickness : null
+                        enabled: root.stemModel ? !root.stemModel.isEmpty && propertyItem.isEnabled : false
                         measureUnitsSymbol: qsTrc("global", "sp")
 
                         maxValue: 4
@@ -193,6 +194,7 @@ FocusableItem {
 
                         titleText: qsTrc("inspector", "Length")
                         propertyItem: root.stemModel ? root.stemModel.length : null
+                        enabled: root.stemModel ? !root.stemModel.isEmpty && propertyItem.isEnabled : false
                         measureUnitsSymbol: qsTrc("global", "sp")
 
                         maxValue: 10
@@ -208,6 +210,7 @@ FocusableItem {
                     id: stemOffsetSection
                     titleText: qsTrc("inspector", "Stem offset")
                     propertyItem: root.stemModel ? root.stemModel.offset : null
+                    enabled: root.stemModel ? !root.stemModel.isEmpty && propertyItem.isEnabled : false
                     measurementUnits: root.stemModel?.measurementUnits ?? CommonTypes.UNITS_UNKNOWN
 
                     navigationName: "StemOffset"
@@ -218,6 +221,7 @@ FocusableItem {
                 OffsetSection {
                     titleText: qsTrc("inspector", "Flag offset")
                     propertyItem: root.hookModel ? root.hookModel.offset : null
+                    enabled: root.hookModel ? !root.hookModel.isEmpty && propertyItem.isEnabled : false
                     measurementUnits: root.hookModel?.measurementUnits ?? CommonTypes.UNITS_UNKNOWN
 
                     navigationName: "FlagOffset"

--- a/src/inspector/qml/MuseScore/Inspector/notation/notes/stems/stemsettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/notes/stems/stemsettingsmodel.cpp
@@ -134,7 +134,14 @@ void StemSettingsModel::onStemDirectionChanged(DirectionV newDirection)
 
 void StemSettingsModel::onNotationChanged(const PropertyIdSet& changedPropertyIdSet, const StyleIdSet& changedStyleIdSet)
 {
-    loadProperties(changedPropertyIdSet);
+    if (muse::contains(changedPropertyIdSet, Pid::DURATION)
+        || muse::contains(changedPropertyIdSet, Pid::DURATION_TYPE_WITH_DOTS)
+        || muse::contains(changedPropertyIdSet, Pid::NO_STEM)) {
+        // Might affect `isEmpty`
+        updateProperties();
+    } else {
+        loadProperties(changedPropertyIdSet);
+    }
 
     if (muse::contains(changedStyleIdSet, Sid::useStraightNoteFlags)) {
         emit useStraightNoteFlagsChanged();
@@ -158,4 +165,9 @@ void StemSettingsModel::loadProperties(const PropertyIdSet& propertyIdSet)
     if (muse::contains(propertyIdSet, Pid::OFFSET)) {
         loadPropertyItem(m_offset);
     }
+}
+
+bool StemSettingsModel::shouldUpdateWhenEmpty() const
+{
+    return true;
 }

--- a/src/inspector/qml/MuseScore/Inspector/notation/notes/stems/stemsettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/notes/stems/stemsettingsmodel.h
@@ -66,6 +66,8 @@ private:
 
     void loadProperties(const mu::engraving::PropertyIdSet& propertyIdSet);
 
+    bool shouldUpdateWhenEmpty() const override;
+
     PropertyItem* m_thickness = nullptr;
     PropertyItem* m_length = nullptr;
     PointFPropertyItem* m_offset = nullptr;


### PR DESCRIPTION
based on whether the current selection does or doesn’t contain stems. Updates when changing durations, stemless property, and beam mode.

Resolves: https://github.com/musescore/MuseScore/issues/13524
Closes: https://github.com/musescore/MuseScore/pull/13642