### PR TITLE
Option to vertically align systems to page margins

### DIFF
--- a/src/engraving/style/styledef.cpp
+++ b/src/engraving/style/styledef.cpp
@@ -58,6 +58,7 @@ const std::array<StyleDef::StyleValue, size_t(Sid::STYLES)> StyleDef::styleValue
     styleDef(minSystemDistance,                          8.5_sp),
     styleDef(maxSystemDistance,                          15.0_sp),
     styleDef(alignSystemToMargin,                        true),
+    styleDef(alignSystemToMarginVertically,              false),
 
     styleDef(enableVerticalSpread,                       true),
     styleDef(spreadSystem,                               2.5),

--- a/src/engraving/style/styledef.h
+++ b/src/engraving/style/styledef.h
@@ -69,6 +69,7 @@ enum class Sid : short {
     minSystemDistance,
     maxSystemDistance,
     alignSystemToMargin,
+    alignSystemToMarginVertically,
 
     enableVerticalSpread,
     spreadSystem,


### PR DESCRIPTION
Resolves: #31652

Adding this option provides better control over page layout in MuseScore. Aligning systems to page margins is a common practice amongst publishers.
It will also facilitate Finale file import, as Finale systems often extend into the page margins, causing such pages to overflow currently.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
