### PR TITLE
Fix #31471: Crash when realizing empty chord symbol

### DIFF
--- a/src/engraving/dom/harmony.cpp
+++ b/src/engraving/dom/harmony.cpp
@@ -267,6 +267,9 @@ String Harmony::harmonyName() const
 
 bool Harmony::isRealizable() const
 {
+    if (m_chords.empty()) {
+        return false;
+    }
     for (const HarmonyInfo* info : m_chords) {
         if (!tpcIsValid(info->rootTpc())) {
             return false;


### PR DESCRIPTION
Resolves: #31471

Quite straightforward - `Harmony::isRealizable` misses the case where `m_chords` is empty and returns true.