### PR TITLE
Fix #30976: Collapse whitespace in titles for Layout panel & Empty Staves popup

### DIFF
--- a/src/instrumentsscene/view/parttreeitem.cpp
+++ b/src/instrumentsscene/view/parttreeitem.cpp
@@ -52,7 +52,10 @@ void PartTreeItem::init(const notation::Part* masterPart)
     }
 
     setId(part->id());
-    setTitle(part->instrument()->nameAsPlainText());
+
+    const String instName = part->instrument()->nameAsPlainText();
+    setTitle(instName.simplified()); // Collapse whitespace...
+
     setIsVisible(visible);
     setSettingsAvailable(m_partExists);
     setSettingsEnabled(m_partExists);
@@ -74,7 +77,8 @@ void PartTreeItem::onScoreChanged(const mu::engraving::ScoreChanges&)
         return;
     }
 
-    setTitle(m_part->instrument()->nameAsPlainText());
+    const String instName = m_part->instrument()->nameAsPlainText();
+    setTitle(instName.simplified()); // Collapse whitespace...
 
     m_ignoreVisibilityChange = true;
     setIsVisible(m_partExists && m_part->show());

--- a/src/notationscene/qml/MuseScore/NotationScene/elementpopups/staffvisibilitypopupmodel.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/elementpopups/staffvisibilitypopupmodel.cpp
@@ -116,7 +116,9 @@ void EmptyStavesVisibilityModel::reload()
     for (const Part* part : m_system->score()->parts()) {
         auto partItem = std::make_unique<PartItem>();
         partItem->id = part->id();
-        partItem->name = part->instrument(tick)->nameAsPlainText();
+
+        const muse::String instName = part->instrument(tick)->nameAsPlainText();
+        partItem->name = instName.simplified(); // Collapse whitespace...
 
         for (const Staff* staff : part->staves()) {
             auto staffItem = std::make_unique<StaffItem>();


### PR DESCRIPTION
Resolves: #30976

This problem has evolved since it was reported - track names in the mixer are no longer tied to long instrument names.