### PR TITLE
fix #31674: do not show courtesy for hidden time signature changes

### DIFF
--- a/src/engraving/rendering/score/measurelayout.cpp
+++ b/src/engraving/rendering/score/measurelayout.cpp
@@ -1821,8 +1821,8 @@ void MeasureLayout::setCourtesyTimeSig(Measure* m, const Fraction& refSigTick, c
             track) : isTrailer ? actualTimeSig->tick() == m->endTick() : sigsDifferent;
         // If there is a real key sig at this tick (in this bar or the previous), don't create a courtesy
         const bool hasSigAtTick = tsSegAtCourtesyTick && tsSegAtCourtesyTick->enabled() && tsSegAtCourtesyTick->element(track);
-        // Only show courtesy if its real signature has courtesies enabled
-        const bool actualShowCourtesy = actualTimeSig && actualTimeSig->showCourtesySig();
+        // Only show courtesy if its real signature has courtesies enabled and is visible
+        const bool actualShowCourtesy = actualTimeSig && actualTimeSig->showCourtesySig() && actualTimeSig->visible();
         const bool show = actualShowCourtesy && needsCourtesy && !hasSigAtTick && ctx.conf().styleB(Sid::genCourtesyTimesig);
 
         if (!courtesySigSeg) {


### PR DESCRIPTION
Resolves: #31674

Proposal to not show courtesy time signatures for invisible time signatures:

https://github.com/user-attachments/assets/fc66c6b0-c456-45cc-9489-5f91bb9d9cd5

Could be extended for invisble key or clef changes. 
