### PR TITLE
Playback fixes for hairpin end dynamics

### DIFF
--- a/src/engraving/dom/hairpin.cpp
+++ b/src/engraving/dom/hairpin.cpp
@@ -335,11 +335,11 @@ EngravingItem* HairpinSegment::findElementToSnapBefore(bool ignoreInvisible) con
     return nullptr;
 }
 
-EngravingItem* HairpinSegment::findElementToSnapAfter(bool ignoreInvisible) const
+EngravingItem* HairpinSegment::findElementToSnapAfter(bool ignoreInvisible, bool requirePlayable) const
 {
     // Note: we don't need to look for a hairpin after.
     // It is the next hairpin which looks for a hairpin before.
-    return findEndDynamicOrExpression(ignoreInvisible);
+    return findEndDynamicOrExpression(ignoreInvisible, requirePlayable);
 }
 
 void HairpinSegment::endDragGrip(EditData& ed)
@@ -406,7 +406,7 @@ TextBase* HairpinSegment::findStartDynamicOrExpression(bool ignoreInvisible) con
     return dynamicsAndExpr.back();
 }
 
-TextBase* HairpinSegment::findEndDynamicOrExpression(bool ignoreInvisible) const
+TextBase* HairpinSegment::findEndDynamicOrExpression(bool ignoreInvisible, bool requirePlayable) const
 {
     Fraction refTick = hairpin()->tick2();
     Measure* measure = score()->tick2measure(refTick - Fraction::eps());
@@ -430,6 +430,9 @@ TextBase* HairpinSegment::findEndDynamicOrExpression(bool ignoreInvisible) const
                 continue;
             }
             if (ignoreInvisible && !item->addToSkyline()) {
+                continue;
+            }
+            if (requirePlayable && (!item->isDynamic() || !toDynamic(item)->playDynamic())) {
                 continue;
             }
             bool endsMatch = item->track() == hairpin()->track()

--- a/src/engraving/dom/hairpin.h
+++ b/src/engraving/dom/hairpin.h
@@ -70,13 +70,13 @@ public:
     bool hasVoiceAssignmentProperties() const override { return spanner()->hasVoiceAssignmentProperties(); }
 
     EngravingItem* findElementToSnapBefore(bool ignoreInvisible = true) const;
-    EngravingItem* findElementToSnapAfter(bool ignoreInvisible = true) const;
+    EngravingItem* findElementToSnapAfter(bool ignoreInvisible = true, bool requirePlayable = false) const;
 
     void endDragGrip(EditData& ed) override;
 
 private:
     TextBase* findStartDynamicOrExpression(bool ignoreInvisible = true) const;
-    TextBase* findEndDynamicOrExpression(bool ignoreInvisible = true) const;
+    TextBase* findEndDynamicOrExpression(bool ignoreInvisible = true, bool requirePlayable = false) const;
 
     void startDragGrip(EditData&) override;
     void dragGrip(EditData&) override;

--- a/src/engraving/dom/segment.cpp
+++ b/src/engraving/dom/segment.cpp
@@ -1422,7 +1422,7 @@ EngravingItem* Segment::findAnnotation(ElementType type, track_idx_t minTrack, t
 //---------------------------------------------------------
 //   findAnnotations
 ///  Returns the list of found annotations
-///  or nullptr if nothing was found.
+///  or an empty list if nothing was found.
 //---------------------------------------------------------
 
 std::vector<EngravingItem*> Segment::findAnnotations(ElementType type, track_idx_t minTrack, track_idx_t maxTrack) const

--- a/src/engraving/playback/playbackcontext.cpp
+++ b/src/engraving/playback/playbackcontext.cpp
@@ -94,12 +94,14 @@ static mu::engraving::DynamicType findNominalEndDynamicType(const Hairpin* hairp
         }
 
         const track_idx_t trackIdx = hairpin->track();
-        const EngravingItem* dynamic = endSegment->findAnnotation(ElementType::DYNAMIC, trackIdx, trackIdx);
-        if (!dynamic || !dynamic->isDynamic() || !toDynamic(dynamic)->playDynamic()) {
-            return mu::engraving::DynamicType::OTHER;
+        const EngravingItemList dynamics = endSegment->findAnnotations(ElementType::DYNAMIC, trackIdx, trackIdx);
+        for (const EngravingItem* dynamic : dynamics) {
+            if (dynamic && dynamic->isDynamic() && toDynamic(dynamic)->playDynamic()) {
+                return toDynamic(dynamic)->dynamicType();
+            }
         }
 
-        return toDynamic(dynamic)->dynamicType();
+        return mu::engraving::DynamicType::OTHER;
     }
 
     const LineSegment* seg = hairpin->backSegment();
@@ -109,15 +111,11 @@ static mu::engraving::DynamicType findNominalEndDynamicType(const Hairpin* hairp
 
     // Optimization: first check if there is a cached dynamic
     const EngravingItem* snappedItem = seg->ldata()->itemSnappedAfter();
-    if (!snappedItem || !snappedItem->isDynamic()) {
-        snappedItem = toHairpinSegment(seg)->findElementToSnapAfter(false /*ignoreInvisible*/);
-        if (!snappedItem || !snappedItem->isDynamic()) {
+    if (!snappedItem || !snappedItem->isDynamic() || !toDynamic(snappedItem)->playDynamic()) {
+        snappedItem = toHairpinSegment(seg)->findElementToSnapAfter(false /*ignoreInvisible*/, true /* requirePlayable */);
+        if (!snappedItem || !snappedItem->isDynamic() || !toDynamic(snappedItem)->playDynamic()) {
             return mu::engraving::DynamicType::OTHER;
         }
-    }
-
-    if (!toDynamic(snappedItem)->playDynamic()) {
-        return mu::engraving::DynamicType::OTHER;
     }
 
     return toDynamic(snappedItem)->dynamicType();


### PR DESCRIPTION
Resolves: #31669 <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->

Playback would still use the hairpin's snapped end dynamic even if it had the "play" property unchecked. This PR adds checks for that property, so dynamics with "play" turned off are ignored; and also adds logic to search for a playable dynamic at the hairpin end point, if the one it's snapped to has "play" turned off.

This allows a setup like this, where the "ff" has play turned off, and the invisible "mf" has play enabled, to work as expected (the crescendo only goes to mf during playback).
<img width="236" height="192" alt="image" src="https://github.com/user-attachments/assets/4905c628-ad51-47ae-a0fa-4448bb24abbc" />
To link up for playback, the end dynamic must be at the exact time tick where the hairpin ends, and must have the same voice assignment (i.e. same rules as snapping).

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
