### PR TITLE
Fix #31550: crash select all and cmnd+delete in continuous view

### DIFF
--- a/src/notationscene/qml/MuseScore/NotationScene/continuouspanel.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/continuouspanel.cpp
@@ -132,7 +132,12 @@ void ContinuousPanel::paint(Painter& painter, const NotationViewContext& ctx, co
     double leftMarginTotal = 0;   // Sum of all elements left margin
     double panelRightPadding = 5;    // Extra space for the panel after last element
 
-    const engraving::Measure* measure = score->firstMeasure()->coveringMMRestOrThis();
+    const engraving::Measure* measure = score->firstMeasure();
+    if (!measure) {
+        return;
+    }
+
+    measure = measure->coveringMMRestOrThis();
     if (!measure) {
         return;
     }


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/31550