### PR TITLE
Fix #30296: Switching between profiles is unavailable in Playback setup

### DIFF
--- a/src/playback/internal/soundprofilesrepository.cpp
+++ b/src/playback/internal/soundprofilesrepository.cpp
@@ -39,6 +39,18 @@ void SoundProfilesRepository::init()
     museProfile.type = SoundProfileType::Muse;
     museProfile.name = config()->museSoundsProfileName();
     m_profilesMap.emplace(museProfile.name, std::move(museProfile));
+
+    if (playback()->isAudioStarted()) {
+        refresh();
+        return;
+    }
+
+    playback()->isAudioStartedChanged().onReceive(this, [this](bool started) {
+        if (started) {
+            refresh();
+            playback()->isAudioStartedChanged().disconnect(this);
+        }
+    });
 }
 
 void SoundProfilesRepository::refresh()

--- a/src/playback/playbackmodule.cpp
+++ b/src/playback/playbackmodule.cpp
@@ -120,8 +120,3 @@ void PlaybackModule::onInit(const IApplication::RunMode& mode)
 
     m_playbackUiActions->init();
 }
-
-void PlaybackModule::onAllInited(const IApplication::RunMode&)
-{
-    m_soundProfileRepo->refresh();
-}

--- a/src/playback/playbackmodule.h
+++ b/src/playback/playbackmodule.h
@@ -41,7 +41,6 @@ public:
     void registerResources() override;
     void registerUiTypes() override;
     void onInit(const muse::IApplication::RunMode& mode) override;
-    void onAllInited(const muse::IApplication::RunMode& mode) override;
 
 private:
     std::shared_ptr<PlaybackConfiguration> m_configuration;


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/30296