### PR TITLE
Fix #31230: Sound preview switches from arco to pizzicato without instruction to do so

### DIFF
--- a/src/engraving/playback/playbackeventsrenderer.cpp
+++ b/src/engraving/playback/playbackeventsrenderer.cpp
@@ -346,19 +346,23 @@ void PlaybackEventsRenderer::renderFixedNoteEvent(const Note* note, const mpe::t
 {
     static const ArticulationMap articulations;
 
-    int durationTicks = ticksFromTempoAndDuration(Constants::DEFAULT_TEMPO.val, actualDuration);
+    const Score* score = note->score();
+    const int durationTicks = ticksFromTempoAndDuration(Constants::DEFAULT_TEMPO.val, actualDuration);
+    const int tick = note->tick().ticks();
+    const int utick = score ? score->repeatList().tick2utick(tick) : tick;
+    const int tickOffset = utick - tick;
 
     RenderingContext ctx{ actualTimestamp,
                           actualDuration,
                           actualDynamicLevel,
-                          note->tick().ticks(), /*nominalPositionStartTick*/
+                          tick, /*nominalPositionStartTick*/
                           durationTicks, /*nominalPositionEndTick*/
                           durationTicks, /*nominalDurationTicks*/
-                          0, /*positionTickOffset*/
+                          tickOffset,
                           Constants::DEFAULT_TEMPO,
                           TimeSigMap::DEFAULT_TIME_SIGNATURE,
                           articulations,
-                          note->score(),
+                          score,
                           profile,
                           playbackCtx };
 

--- a/src/engraving/playback/playbackmodel.cpp
+++ b/src/engraving/playback/playbackmodel.cpp
@@ -326,10 +326,9 @@ void PlaybackModel::triggerEventsForItems(const std::vector<const EngravingItem*
     dynamic_level_t dynamicLevel = dynamicLevelFromType(muse::mpe::DynamicType::Natural);
 
     for (const EngravingItem* item : items) {
-        const int utick = repeats.tick2utick(item->tick().ticks());
-
         if (m_useScoreDynamicsForOffstreamPlayback) {
             if (!item->isNote() || toNote(item)->userVelocity() == 0) {
+                const int utick = repeats.tick2utick(item->tick().ticks());
                 dynamicLevel = ctx->appliableDynamicLevel(item->track(), utick);
             }
             dynamics[static_cast<muse::mpe::layer_idx_t>(item->track())][timestamp] = dynamicLevel;


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/31230