### PR TITLE
Tick for brackets

### DIFF
--- a/src/engraving/dom/bracket.cpp
+++ b/src/engraving/dom/bracket.cpp
@@ -325,6 +325,14 @@ void Bracket::undoChangeProperty(Pid id, const PropertyValue& v, PropertyFlags p
     bi->undoChangeProperty(id, v, ps);
 }
 
+Fraction Bracket::tick() const
+{
+    if (measure()) {
+        return measure()->tick();
+    }
+    return EngravingItem::tick();
+}
+
 //---------------------------------------------------------
 //   setSelected
 //---------------------------------------------------------

--- a/src/engraving/dom/bracket.h
+++ b/src/engraving/dom/bracket.h
@@ -91,6 +91,8 @@ public:
     void undoChangeProperty(Pid id, const PropertyValue& v, PropertyFlags ps) override;
     using EngravingObject::undoChangeProperty;
 
+    Fraction tick() const override;
+
     int gripsCount() const override { return 1; }
     Grip initialEditModeGrip() const override { return Grip::START; }
     Grip defaultGrip() const override { return Grip::START; }


### PR DESCRIPTION
When selecting a bracket and starting playback, a sensible position is now chosen (previously: start of score).

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
