### PR TITLE
Fix #30383: Init solo mute states when opening all parts

### DIFF
--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -506,6 +506,8 @@ void MasterNotation::setExcerpts(const ExcerptNotationList& excerpts)
 
         score->initAndAddExcerpt(excerptNotationImpl->excerpt(), false);
         excerptNotationImpl->init();
+
+        initNotationSoloMuteState(excerptNotationImpl->notation());
     }
 
     score->setExcerptsChanged(false);

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -1728,21 +1728,6 @@ void PlaybackController::setNotation(notation::INotationPtr notation)
         pause();
     }
 
-    // All invisible tracks should be muted in newly opened notations (initNotationSoloMuteState)
-    // Once the mute state has been edited, this "custom state" will be recalled from then onwards
-    bool emptyMuteStates = true;
-    InstrumentTrackIdSet existingTrackIdSet = notationPlayback()->existingTrackIdSet();
-    for (const InstrumentTrackId& instrumentTrackId : existingTrackIdSet) {
-        if (m_notation->soloMuteState()->trackSoloMuteStateExists(instrumentTrackId)) {
-            emptyMuteStates = false;
-            break;
-        }
-    }
-
-    if (emptyMuteStates) {
-        m_masterNotation->initNotationSoloMuteState(notation);
-    }
-
     updateSoloMuteStates();
 
     NotifyList<const Part*> partList = m_notation->parts()->partList();


### PR DESCRIPTION
Resolves: #30383

We normally init mute states in new excerpts by checking `emptyMuteStates` in `PlaybackController::setNotation`. But as the name suggests this only gets called when you actively switch to the notation - so it isn't called on all excerpts when opening _all_ parts. The problem here is that adding a new instrument sets that instrument's solo/mute state in each excerpt, which means that `emptyMuteStates` evaluates to false in all parts (they never got a chance to init).

Instead of using the `emptyMuteStates` logic, we should instead be able to detect new excerpts and init their solo/mute states in `MasterNotation::setExcerpts`.

The following issues should be re-checked in this build before merging: #24985, #27025, #27058