### PR TITLE
Use correct file reader for palettes and migrate old workspaces

### DIFF
--- a/src/palette/internal/palette.cpp
+++ b/src/palette/internal/palette.cpp
@@ -456,8 +456,8 @@ bool Palette::readFromFile(const QString& p)
         if (e.name() == "museScore") {
             QString version = e.attribute("version");
             QStringList sl = version.split('.');
-            int versionId = sl[0].toInt() * 100 + sl[1].toInt();
-            gpaletteScore->setMscVersion(versionId); // TODO: what is this?
+            int mscVersion = sl[0].toInt() * 100 + sl[1].toInt();
+            gpaletteScore->setMscVersion(mscVersion);
 
             while (e.readNextStartElement()) {
                 if (e.name() == "Palette") {

--- a/src/palette/internal/palettecell.cpp
+++ b/src/palette/internal/palettecell.cpp
@@ -222,7 +222,7 @@ bool PaletteCell::read(XmlReader& e, bool pasteMode)
         } else if (s == "Tremolo") {
             compat::TremoloCompat tc;
             tc.parent = gpaletteScore->dummy()->chord();
-            rw::RWRegister::reader()->readTremoloCompat(&tc, e);
+            rw::RWRegister::reader(gpaletteScore->mscVersion())->readTremoloCompat(&tc, e);
             if (tc.single) {
                 element.reset(tc.single);
             } else if (tc.two) {
@@ -239,7 +239,7 @@ bool PaletteCell::read(XmlReader& e, bool pasteMode)
             if (!element) {
                 e.unknown();
             } else {
-                rw::RWRegister::reader()->readItem(element.get(), e);
+                rw::RWRegister::reader(gpaletteScore->mscVersion())->readItem(element.get(), e);
             }
         }
     }

--- a/src/palette/internal/palettetree.cpp
+++ b/src/palette/internal/palettetree.cpp
@@ -57,7 +57,7 @@ bool PaletteTree::read(mu::engraving::XmlReader& e, bool pasteMode, const muse::
 
 void PaletteTree::write(mu::engraving::XmlWriter& xml, bool pasteMode) const
 {
-    xml.startElement("PaletteBox"); // for compatibility with old palettes file format
+    xml.startElement("PaletteBox", { { "version", engraving::Constants::MSC_VERSION_STR } }); // for compatibility with old palettes file format
 
     for (const PalettePtr& palette : palettes) {
         palette->write(xml, pasteMode);

--- a/src/palette/internal/paletteworkspacesetup.h
+++ b/src/palette/internal/paletteworkspacesetup.h
@@ -41,6 +41,10 @@ public:
     }
 
     void setup();
+
+private:
+    PaletteTreePtr readPalette(const muse::ByteArray& data, const muse::modularity::ContextPtr& iocCtx);
+    void writePalette(const PaletteTreePtr& tree, QByteArray& data);
 };
 }
 


### PR DESCRIPTION
This PR adds file version numbers to user's palette files. Previously, these were unversioned and the latest file reader would be used no matter which version the file had last been saved in. This has caused lots of bugs and complicated migration between versions. 

We probably won't need to add anything new to `PaletteCompat::migrateOldPaletteCellIfNeeded`. The migration in here should be covered by migration code we are adding in the mscx reader anyway.