### PR TITLE
Fix #31623: Clicking a note after a Handbells "LV" articulation symbol causes the note to sound sustained forever

### DIFF
--- a/src/engraving/playback/metaparsers/notearticulationsparser.cpp
+++ b/src/engraving/playback/metaparsers/notearticulationsparser.cpp
@@ -131,11 +131,14 @@ ArticulationType NoteArticulationsParser::articulationTypeByNoteheadGroup(const 
     }
 }
 
-void NoteArticulationsParser::parsePlayingTechnique(const RenderingContext& ctx, mpe::ArticulationMap& result)
+void NoteArticulationsParser::parsePlayingTechnique(const RenderingContext& ctx, mpe::ArticulationMap& result, bool sustainAllowed)
 {
-    int chordPosTickWithOffset = ctx.nominalPositionStartTick + ctx.positionTickOffset;
-
+    const int chordPosTickWithOffset = ctx.nominalPositionStartTick + ctx.positionTickOffset;
     const std::pair<timestamp_t, PlayingTechniqueType> tech = ctx.playbackCtx->playingTechnique(ctx.score, chordPosTickWithOffset);
+    if (tech.second == PlayingTechniqueType::HandbellsLV && !sustainAllowed) {
+        return;
+    }
+
     const mpe::ArticulationType articulationType = articulationFromPlayTechType(tech.second);
     if (articulationType == ArticulationType::Standard || articulationType == ArticulationType::Undefined) {
         return;

--- a/src/engraving/playback/metaparsers/notearticulationsparser.h
+++ b/src/engraving/playback/metaparsers/notearticulationsparser.h
@@ -20,8 +20,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef MU_ENGRAVING_NOTEARTICULATIONSPARSER_H
-#define MU_ENGRAVING_NOTEARTICULATIONSPARSER_H
+#pragma once
 
 #include "../types/types.h"
 #include "metaparserbase.h"
@@ -34,7 +33,7 @@ class NoteArticulationsParser : public MetaParserBase<NoteArticulationsParser>
 public:
     static void buildNoteArticulationMap(const Note* note, const RenderingContext& ctx, muse::mpe::ArticulationMap& result);
 
-    static void parsePlayingTechnique(const RenderingContext& ctx, muse::mpe::ArticulationMap& result);
+    static void parsePlayingTechnique(const RenderingContext& ctx, muse::mpe::ArticulationMap& result, bool sustainAllowed = true);
     static void parseGhostNote(const Note* note, const RenderingContext& ctx, muse::mpe::ArticulationMap& result);
     static void parseNoteHead(const Note* note, const RenderingContext& ctx, muse::mpe::ArticulationMap& result);
     static void parseSymbols(const Note* note, const RenderingContext& ctx, muse::mpe::ArticulationMap& result);
@@ -52,5 +51,3 @@ private:
                                     muse::mpe::ArticulationMap& result);
 };
 }
-
-#endif // MU_ENGRAVING_NOTEARTICULATIONSPARSER_H

--- a/src/engraving/playback/playbackeventsrenderer.cpp
+++ b/src/engraving/playback/playbackeventsrenderer.cpp
@@ -366,7 +366,7 @@ void PlaybackEventsRenderer::renderFixedNoteEvent(const Note* note, const mpe::t
                           profile,
                           playbackCtx };
 
-    NoteArticulationsParser::parsePlayingTechnique(ctx, ctx.commonArticulations);
+    NoteArticulationsParser::parsePlayingTechnique(ctx, ctx.commonArticulations, false /*sustainAllowed*/);
     NoteArticulationsParser::parseGhostNote(note, ctx, ctx.commonArticulations);
     NoteArticulationsParser::parseNoteHead(note, ctx, ctx.commonArticulations);
     NoteArticulationsParser::parseSymbols(note, ctx, ctx.commonArticulations);


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/31623