### PR TITLE
Fix MSVC compiler warning

### DIFF
--- a/src/notationscene/widgets/editstyle.ui
+++ b/src/notationscene/widgets/editstyle.ui
@@ -6932,7 +6932,7 @@
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_35">
         <item>
-         <widget class="QGroupBox" name="groupBox">
+         <widget class="QGroupBox" name="groupBox_3">
           <property name="title">
            <string>Chord Brackets</string>
           </property>


### PR DESCRIPTION
reg.: declaration of 'groupBox' hides class member (C4458)