### PR TITLE
Separate audio files for looping audio

### DIFF
--- a/src/framework/audio/common/audiotypes.h
+++ b/src/framework/audio/common/audiotypes.h
@@ -86,6 +86,7 @@ struct OutputSpec {
     sample_rate_t sampleRate = 0;
     samples_t samplesPerChannel = 0;
     audioch_t audioChannelCount = 0;
+    bool separateFilesForLooping = false;
 
     inline bool isValid() const { return sampleRate > 0 && samplesPerChannel > 0 && audioChannelCount > 0; }
 
@@ -93,7 +94,8 @@ struct OutputSpec {
     {
         return sampleRate == other.sampleRate
                && samplesPerChannel == other.samplesPerChannel
-               && audioChannelCount == other.audioChannelCount;
+               && audioChannelCount == other.audioChannelCount
+               && separateFilesForLooping == other.separateFilesForLooping;
     }
 
     inline bool operator!=(const OutputSpec& other) const { return !this->operator==(other); }

--- a/src/framework/audio/common/rpc/rpcpacker.h
+++ b/src/framework/audio/common/rpc/rpcpacker.h
@@ -135,12 +135,12 @@ inline void unpack_custom(muse::msgpack::UnPacker& p, muse::audio::AudioEngineCo
 
 inline void pack_custom(muse::msgpack::Packer& p, const muse::audio::OutputSpec& value)
 {
-    p.process(value.sampleRate, value.samplesPerChannel, value.audioChannelCount);
+    p.process(value.sampleRate, value.samplesPerChannel, value.audioChannelCount, value.separateFilesForLooping);
 }
 
 inline void unpack_custom(muse::msgpack::UnPacker& p, muse::audio::OutputSpec& value)
 {
-    p.process(value.sampleRate, value.samplesPerChannel, value.audioChannelCount);
+    p.process(value.sampleRate, value.samplesPerChannel, value.audioChannelCount, value.separateFilesForLooping);
 }
 
 inline void pack_custom(muse::msgpack::Packer& p, const muse::audio::PlaybackStatus& value)

--- a/src/framework/audio/engine/internal/export/soundtrackwriter.cpp
+++ b/src/framework/audio/engine/internal/export/soundtrackwriter.cpp
@@ -84,14 +84,28 @@ SoundTrackWriter::SoundTrackWriter(const io::path_t& destination, const SoundTra
         return;
     }
 
+    io::path_t startDestination = destination;
+    io::path_t loopDestination;
     io::path_t tailDestination;
+
+    // If looping, generate -start and -end path names, extra encoders
     if (outputSpec.separateFilesForLooping) {
-        // Generate path name for tail
         io::path_t dir = io::dirpath(destination);
         io::path_t base = io::completeBasename(destination);
-        base = io::path_t(base.toStdString() + "-tail");
         std::string ext = io::suffix(destination);
-        tailDestination = dir.appendingComponent(base.appendingSuffix(muse::io::path_t(ext)));
+
+        startDestination = io::path_t(base.toStdString() + "-start");
+        tailDestination = io::path_t(base.toStdString() + "-end");
+
+        startDestination = dir.appendingComponent(startDestination.appendingSuffix(io::path_t(ext)));
+        tailDestination = dir.appendingComponent(tailDestination.appendingSuffix(io::path_t(ext)));
+
+        loopDestination = destination;
+
+        m_loopEncoderPtr = createEncoder(format.type);
+        if (!m_loopEncoderPtr) {
+            return;
+        }
 
         m_tailEncoderPtr = createEncoder(format.type);
         if (!m_tailEncoderPtr) {
@@ -99,13 +113,25 @@ SoundTrackWriter::SoundTrackWriter(const io::path_t& destination, const SoundTra
         }
     }
 
-    m_encoderPtr->init(destination, format, totalSamplesNumber - tailSamplesNumber);
-    m_encoderPtr->progress().progressChanged().onReceive(this, [this](int64_t current, int64_t total, std::string) {
-        sendStepProgress(ENCODE_STEP, current, total);
-    });
+    m_encoderPtr->init(startDestination, format, totalSamplesNumber - tailSamplesNumber);
 
+    // If looping, initialize extra encoders, account for both loop and main making progress
     if (outputSpec.separateFilesForLooping) {
+        m_loopEncoderPtr->init(loopDestination, format, totalSamplesNumber - tailSamplesNumber);
         m_tailEncoderPtr->init(tailDestination, format, tailSamplesNumber);
+
+        m_encoderPtr->progress().progressChanged().onReceive(this, [this](int64_t current, int64_t total, std::string) {
+            sendStepProgress(ENCODE_STEP, current, total * 2);
+        });
+        m_encoderPtr->progress().progressChanged().onReceive(this, [this](int64_t current, int64_t total, std::string) {
+            sendStepProgress(ENCODE_STEP, current + total, total * 2);
+        });
+    }
+    // If not looping, only the main encoder makes progress
+    else {
+        m_encoderPtr->progress().progressChanged().onReceive(this, [this](int64_t current, int64_t total, std::string) {
+            sendStepProgress(ENCODE_STEP, current, total);
+        });
     }
 }
 
@@ -136,6 +162,10 @@ Ret SoundTrackWriter::write()
             m_tailEncoderPtr->flush();
         }
 
+        if (m_loopEncoderPtr) {
+            m_loopEncoderPtr->flush();
+        }
+
         audioEngine()->setMode(RenderMode::IdleMode);
 
         m_source->setOutputSpec(audioEngine()->outputSpec());
@@ -156,6 +186,8 @@ Ret SoundTrackWriter::write()
     size_t bytes = m_encoderPtr->encode(mainSamplesNumber, m_inputBuffer.data());
     if (outputSpec.separateFilesForLooping) {
         bytes += m_tailEncoderPtr->encode(tailSamplesNumber, m_inputBuffer.data() + mainSamplesNumber * outputSpec.audioChannelCount);
+        loopAudio(m_inputBuffer.data(), m_inputBuffer.data() + mainSamplesNumber * outputSpec.audioChannelCount, tailSamplesNumber);
+        bytes += m_loopEncoderPtr->encode(mainSamplesNumber, m_inputBuffer.data());
     }
 
     if (m_isAborted) {
@@ -217,6 +249,25 @@ Ret SoundTrackWriter::generateAudioData()
     }
 
     return muse::make_ok();
+}
+
+// based on Mixer::mixOutputFromChannel
+void SoundTrackWriter::loopAudio(float* head, const float* tail, unsigned int tailSamples)
+{
+    IF_ASSERT_FAILED(head && tail) {
+        return;
+    }
+
+    audioch_t audioChannelCount = m_encoderPtr->format().outputSpec.audioChannelCount;
+    for (samples_t s = 0; s < tailSamples; ++s) {
+        size_t samplePos = s * audioChannelCount;
+
+        for (audioch_t audioChNum = 0; audioChNum < audioChannelCount; ++audioChNum) {
+            size_t idx = samplePos + audioChNum;
+            float sample = tail[idx];
+            head[idx] += sample;
+        }
+    }
 }
 
 void SoundTrackWriter::sendStepProgress(int step, int64_t current, int64_t total)

--- a/src/framework/audio/engine/internal/export/soundtrackwriter.h
+++ b/src/framework/audio/engine/internal/export/soundtrackwriter.h
@@ -64,6 +64,7 @@ private:
     samples_t m_renderStep = 0;
 
     encode::AbstractAudioEncoderPtr m_encoderPtr = nullptr;
+    encode::AbstractAudioEncoderPtr m_tailEncoderPtr = nullptr;
 
     Progress m_progress;
     std::atomic<bool> m_isAborted = false;

--- a/src/framework/audio/engine/internal/export/soundtrackwriter.h
+++ b/src/framework/audio/engine/internal/export/soundtrackwriter.h
@@ -56,6 +56,7 @@ private:
     Ret generateAudioData();
 
     void sendStepProgress(int step, int64_t current, int64_t total);
+    void loopAudio(float* head, const float* tail, unsigned int tailSamples);
 
     engine::IAudioSourcePtr m_source = nullptr;
 
@@ -64,6 +65,7 @@ private:
     samples_t m_renderStep = 0;
 
     encode::AbstractAudioEncoderPtr m_encoderPtr = nullptr;
+    encode::AbstractAudioEncoderPtr m_loopEncoderPtr = nullptr;
     encode::AbstractAudioEncoderPtr m_tailEncoderPtr = nullptr;
 
     Progress m_progress;

--- a/src/framework/audio/tests/rpcpacker_tests.cpp
+++ b/src/framework/audio/tests/rpcpacker_tests.cpp
@@ -61,11 +61,13 @@ TEST_F(Audio_RpcPackerTests, OutputSpec)
     origin.sampleRate = 44000;
     origin.samplesPerChannel = 256;
     origin.audioChannelCount = 2;
+    origin.separateFilesForLooping = false;
 
     KNOWN_FIELDS(origin,
                  origin.sampleRate,
                  origin.samplesPerChannel,
-                 origin.audioChannelCount);
+                 origin.audioChannelCount,
+                 origin.separateFilesForLooping);
 
     ByteArray data = rpc::RpcPacker::pack(origin);
 

--- a/src/importexport/audioexport/iaudioexportconfiguration.h
+++ b/src/importexport/audioexport/iaudioexportconfiguration.h
@@ -45,6 +45,9 @@ public:
     virtual void setExportSampleRate(int rate) = 0;
     virtual const std::vector<int>& availableSampleRates() const = 0;
 
+    virtual bool exportSeparateFilesForLooping() const = 0;
+    virtual void setExportSeparateFilesForLooping(bool separate) const = 0;
+
     virtual muse::audio::samples_t exportBufferSize() const = 0;
 
     virtual muse::audio::AudioSampleFormat exportSampleFormat() const = 0;

--- a/src/importexport/audioexport/internal/audioexportconfiguration.cpp
+++ b/src/importexport/audioexport/internal/audioexportconfiguration.cpp
@@ -34,6 +34,7 @@ static const Settings::Key EXPORT_SAMPLE_RATE_KEY("iex_audioexport", "export/aud
 static const Settings::Key EXPORT_MP3_BITRATE("iex_audioexport", "export/audio/mp3Bitrate");
 static const Settings::Key EXPORT_WAV_SAMPLE_FORMAT_KEY("iex_audioexport", "export/audio/wavSampleFormat");
 static const Settings::Key EXPORT_FLAC_SAMPLE_FORMAT_KEY("iex_audioexport", "export/audio/flacSampleFormat");
+static const Settings::Key EXPORT_SEPARATE_FILES_FOR_LOOPING_KEY("iex_audioexport", "export/audio/separateFilesForLooping");
 
 void AudioExportConfiguration::init()
 {
@@ -41,6 +42,7 @@ void AudioExportConfiguration::init()
     settings()->setDefaultValue(EXPORT_MP3_BITRATE, Val(128));
     settings()->setDefaultValue(EXPORT_WAV_SAMPLE_FORMAT_KEY, Val(static_cast<int>(AudioSampleFormat::Float32)));
     settings()->setDefaultValue(EXPORT_FLAC_SAMPLE_FORMAT_KEY, Val(static_cast<int>(AudioSampleFormat::Int16)));
+    settings()->setDefaultValue(EXPORT_SEPARATE_FILES_FOR_LOOPING_KEY, Val(false));
 }
 
 int AudioExportConfiguration::exportMp3Bitrate() const
@@ -78,6 +80,16 @@ const std::vector<int>& AudioExportConfiguration::availableSampleRates() const
 {
     static const std::vector<int> rates { 32000, 44100, 48000 };
     return rates;
+}
+
+bool AudioExportConfiguration::exportSeparateFilesForLooping() const
+{
+    return settings()->value(EXPORT_SEPARATE_FILES_FOR_LOOPING_KEY).toBool();
+}
+
+void AudioExportConfiguration::setExportSeparateFilesForLooping(bool separate) const
+{
+    settings()->setSharedValue(EXPORT_SEPARATE_FILES_FOR_LOOPING_KEY, Val(separate));
 }
 
 samples_t AudioExportConfiguration::exportBufferSize() const

--- a/src/importexport/audioexport/internal/audioexportconfiguration.h
+++ b/src/importexport/audioexport/internal/audioexportconfiguration.h
@@ -39,6 +39,9 @@ public:
     void setExportSampleRate(int rate) override;
     const std::vector<int>& availableSampleRates() const override;
 
+    bool exportSeparateFilesForLooping() const override;
+    void setExportSeparateFilesForLooping(bool separate) const override;
+
     muse::audio::samples_t exportBufferSize() const override;
 
     muse::audio::AudioSampleFormat exportSampleFormat() const override;

--- a/src/importexport/audioexport/internal/flacwriter.cpp
+++ b/src/importexport/audioexport/internal/flacwriter.cpp
@@ -35,7 +35,8 @@ muse::Ret FlacWriter::write(notation::INotationPtr notation, muse::io::IODevice&
         {
             static_cast<sample_rate_t>(configuration()->exportSampleRate()),
             configuration()->exportBufferSize(),
-            2 /* audioChannelsNumber */
+            2, /* audioChannelsNumber */
+            configuration()->exportSeparateFilesForLooping()
         },
         configuration()->exportSampleFormat(),
         0 /* bitRate */

--- a/src/importexport/audioexport/internal/mp3writer.cpp
+++ b/src/importexport/audioexport/internal/mp3writer.cpp
@@ -35,7 +35,8 @@ Ret Mp3Writer::write(notation::INotationPtr notation, io::IODevice& destinationD
         {
             static_cast<sample_rate_t>(configuration()->exportSampleRate()),
             configuration()->exportBufferSize(),
-            2 /* audioChannelsNumber */
+            2, /* audioChannelsNumber */
+            configuration()->exportSeparateFilesForLooping()
         },
         AudioSampleFormat::Undefined,
         configuration()->exportMp3Bitrate()

--- a/src/importexport/audioexport/internal/oggwriter.cpp
+++ b/src/importexport/audioexport/internal/oggwriter.cpp
@@ -36,7 +36,8 @@ Ret OggWriter::write(notation::INotationPtr notation, io::IODevice& destinationD
         {
             static_cast<sample_rate_t>(configuration()->exportSampleRate()),
             configuration()->exportBufferSize(),
-            2 /* audioChannelsNumber */
+            2, /* audioChannelsNumber */
+            configuration()->exportSeparateFilesForLooping()
         },
         AudioSampleFormat::Undefined,
         128 /* bitRate */

--- a/src/importexport/audioexport/internal/wavewriter.cpp
+++ b/src/importexport/audioexport/internal/wavewriter.cpp
@@ -35,7 +35,8 @@ Ret WaveWriter::write(notation::INotationPtr notation, io::IODevice& destination
         {
             static_cast<sample_rate_t>(configuration()->exportSampleRate()),
             configuration()->exportBufferSize(),
-            2 /* audioChannelsNumber */
+            2, /* audioChannelsNumber */
+            configuration()->exportSeparateFilesForLooping()
         },
         configuration()->exportSampleFormat(),
         0 /* bitRate */

--- a/src/project/iexportprojectscenario.h
+++ b/src/project/iexportprojectscenario.h
@@ -38,11 +38,11 @@ public:
 
     virtual muse::RetVal<muse::io::path_t> askExportPath(const notation::INotationPtrList& notations, const ExportType& exportType,
                                                          INotationWriter::UnitType unitType = INotationWriter::UnitType::PER_PART,
-                                                         muse::io::path_t defaultPath = "") const = 0;
+                                                         muse::io::path_t defaultPath = "", bool separateFilesForLooping = false) const = 0;
 
     virtual bool exportScores(notation::INotationPtrList notations, const muse::io::path_t destinationPath,
                               INotationWriter::UnitType unitType = INotationWriter::UnitType::PER_PART,
-                              bool openDestinationFolderOnExport = false) const = 0;
+                              bool openDestinationFolderOnExport = false, bool separateFilesForLooping = false) const = 0;
 
     virtual const ExportInfo& exportInfo() const = 0;
     virtual void setExportInfo(const ExportInfo& exportInfo) = 0;

--- a/src/project/internal/exportprojectscenario.h
+++ b/src/project/internal/exportprojectscenario.h
@@ -54,11 +54,12 @@ public:
 
     muse::RetVal<muse::io::path_t> askExportPath(const notation::INotationPtrList& notations, const ExportType& exportType,
                                                  INotationWriter::UnitType unitType = INotationWriter::UnitType::PER_PART,
-                                                 muse::io::path_t defaultPath = "") const override;
+                                                 muse::io::path_t defaultPath = "",
+                                                 bool separateFilesForLoopingOnExport = false) const override;
 
     bool exportScores(notation::INotationPtrList notations, const muse::io::path_t destinationPath,
-                      INotationWriter::UnitType unitType = INotationWriter::UnitType::PER_PART,
-                      bool openDestinationFolderOnExport = false) const override;
+                      INotationWriter::UnitType unitType = INotationWriter::UnitType::PER_PART, bool openDestinationFolderOnExport = false,
+                      bool separateFilesForLoopingOnExport = false) const override;
 
     const ExportInfo& exportInfo() const override;
     void setExportInfo(const ExportInfo& exportInfo) override;
@@ -74,7 +75,8 @@ private:
     /// is not initialized yet, so we can't be certain about the page count. We should not initialize
     /// these scores either, until the user really starts the export, because initializing these scores
     /// means making changes to the file, which can't be done without the user's consent.
-    bool guessIsCreatingOnlyOneFile(const notation::INotationPtrList& notations, INotationWriter::UnitType unitType) const;
+    bool guessIsCreatingOnlyOneFile(const notation::INotationPtrList& notations, INotationWriter::UnitType unitType,
+                                    bool separateFilesForLooping) const;
     size_t exportFileCount(const notation::INotationPtrList& notations, INotationWriter::UnitType unitType) const;
 
     bool isMainNotation(notation::INotationPtr notation) const;

--- a/src/project/qml/MuseScore/Project/internal/Export/AudioSettingsPage.qml
+++ b/src/project/qml/MuseScore/Project/internal/Export/AudioSettingsPage.qml
@@ -105,6 +105,20 @@ ExportSettingsPage {
         }
     }
 
+    CheckBox {
+        width: parent.width
+        text: qsTrc("project/export", "Separate files for looping")
+
+        navigation.name: "SeparateFilesForLoopingOnExportCheckbox"
+        navigation.panel: navPanel
+        navigation.row: 100000 + exportType.count
+
+        checked: root.model.shouldFilesBeSeparatedForLooping
+        onClicked: {
+            root.model.shouldFilesBeSeparatedForLooping = !checked
+        }
+    }
+
     StyledTextLabel {
         width: parent.width
         text: qsTrc("project/export", "Each selected part will be exported as a separate audio file.")

--- a/src/project/qml/MuseScore/Project/internal/Export/exportdialogmodel.h
+++ b/src/project/qml/MuseScore/Project/internal/Export/exportdialogmodel.h
@@ -77,6 +77,9 @@ class ExportDialogModel : public QAbstractListModel, public QQmlParserStatus, pu
     Q_PROPERTY(int bitRate READ bitRate WRITE setBitRate NOTIFY bitRateChanged)
     Q_PROPERTY(QVariantList availableSampleFormats READ availableSampleFormats NOTIFY availableSampleFormatsChanged)
     Q_PROPERTY(int selectedSampleFormat READ selectedSampleFormat WRITE setSelectedSampleFormat NOTIFY selectedSampleFormatChanged)
+    Q_PROPERTY(
+        bool shouldFilesBeSeparatedForLooping READ shouldFilesBeSeparatedForLooping WRITE setShouldFilesBeSeparatedForLooping NOTIFY
+        shouldFilesBeSeparatedForLoopingChanged)
 
     Q_PROPERTY(bool midiExpandRepeats READ midiExpandRepeats WRITE setMidiExpandRepeats NOTIFY midiExpandRepeatsChanged)
     Q_PROPERTY(bool midiExportRpns READ midiExportRpns WRITE setMidiExportRpns NOTIFY midiExportRpnsChanged)
@@ -166,6 +169,9 @@ public:
     int selectedSampleFormat() const;
     void setSelectedSampleFormat(int format);
 
+    bool shouldFilesBeSeparatedForLooping() const;
+    void setShouldFilesBeSeparatedForLooping(bool shouldFilesBeSeparatedForLooping);
+
     bool midiExpandRepeats() const;
     void setMidiExpandRepeats(bool expandRepeats);
 
@@ -221,6 +227,7 @@ signals:
     void bitRateChanged(int bitRate);
     void availableSampleFormatsChanged();
     void selectedSampleFormatChanged();
+    void shouldFilesBeSeparatedForLoopingChanged(bool shouldFilesBeSeparatedForLoopingChanged);
 
     void midiExpandRepeatsChanged(bool expandRepeats);
     void midiExportRpnsChanged(bool exportRpns);


### PR DESCRIPTION
Resolves: #16496 in part; [this forum discussion](https://musescore.org/en/node/373390) and [this one](https://musescore.org/en/node/304131) more thoroughly; [this one](https://musescore.org/en/node/268393) in part

<!-- Add a short description of and motivation for the changes here -->
This adds the option to, when exporting audio, export the "tail", the part of the audio after the time for the last note is allotted but the music still reverberates, and the head, the part before, and the overlay of the tail over the start of the head, as three separate files.  Prior to the last commit, only the tail was separated.
The mechanism for this, including naming the new files, is done in the SoundTrackWriter object with multiple encoders, rather than any higher level of abstraction, to prevent multiple calls to generateAllAudio() or modifications to higher-level abstractions of players.  Much of the code changes exist to transport the separateTail flag into the audio configuration and to the mechanism for noting whether multiple files are being created.

~~The decision to offer two files split at the seam resolves one primary user difficulty in identifying that seam (it isn't obvious that it's [hardcoded to be three seconds](https://github.com/musescore/MuseScore/blob/master/src/notation/internal/notationplayback.cpp)); and is simpler than attempting to use the mixer - or add a mechanism to the SoundTrackWriter - to overlay sound.  Simplified design from @MarcSabatella 's discussion, if they'd like to weigh in here as well.~~

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
