### PR TITLE
feat: implement uninitialised excerpts to reduce memory, file size and fix rename persistence

### DIFF
--- a/src/converter/internal/compat/backendapi.cpp
+++ b/src/converter/internal/compat/backendapi.cpp
@@ -794,23 +794,22 @@ void BackendApi::renderExcerptsContents(IMasterNotationPtr masterNotation)
 
 ExcerptNotationList BackendApi::allExcerpts(notation::IMasterNotationPtr masterNotation)
 {
-    initPotentialExcerpts(masterNotation);
+    // Init any uninitialised excerpts for export
+    ExcerptNotationList excerptsToInit;
+    for (const IExcerptNotationPtr& excerpt : masterNotation->excerpts()) {
+        if (!excerpt->isInited()) {
+            excerptsToInit.push_back(excerpt);
+        }
+    }
+    if (!excerptsToInit.empty()) {
+        masterNotation->initExcerpts(excerptsToInit);
+        renderExcerptsContents(masterNotation);
+    }
 
     ExcerptNotationList excerpts = masterNotation->excerpts();
-    ExcerptNotationList potentialExcerpts = masterNotation->potentialExcerpts();
-    excerpts.insert(excerpts.end(), potentialExcerpts.begin(), potentialExcerpts.end());
-
     masterNotation->sortExcerpts(excerpts);
 
     return excerpts;
-}
-
-void BackendApi::initPotentialExcerpts(notation::IMasterNotationPtr masterNotation)
-{
-    ExcerptNotationList potentialExcerpts = masterNotation->potentialExcerpts();
-
-    masterNotation->initExcerpts(potentialExcerpts);
-    renderExcerptsContents(masterNotation);
 }
 
 Ret BackendApi::updateSource(const muse::io::path_t& in, const std::string& newSource, bool forceMode)

--- a/src/converter/internal/compat/backendapi.cpp
+++ b/src/converter/internal/compat/backendapi.cpp
@@ -785,6 +785,9 @@ void BackendApi::renderExcerptsContents(IMasterNotationPtr masterNotation)
     //! NOTE: Due to optimization, only the master score is layouted
     //!       Let's layout all the scores of the excerpts
     for (const IExcerptNotationPtr& excerpt : masterNotation->excerpts()) {
+        if (!excerpt->isInited()) {
+            continue;
+        }
         Score* score = excerpt->notation()->elements()->msScore();
         if (!score->autoLayoutEnabled()) {
             score->doLayout();
@@ -803,6 +806,9 @@ ExcerptNotationList BackendApi::allExcerpts(notation::IMasterNotationPtr masterN
     }
     if (!excerptsToInit.empty()) {
         masterNotation->initExcerpts(excerptsToInit);
+        for (const IExcerptNotationPtr& excerpt : excerptsToInit) {
+            excerpt->notation()->setViewMode(ViewMode::PAGE);
+        }
         renderExcerptsContents(masterNotation);
     }
 

--- a/src/converter/internal/compat/backendapi.cpp
+++ b/src/converter/internal/compat/backendapi.cpp
@@ -805,23 +805,22 @@ void BackendApi::renderExcerptsContents(IMasterNotationPtr masterNotation)
 
 ExcerptNotationList BackendApi::allExcerpts(notation::IMasterNotationPtr masterNotation)
 {
-    initPotentialExcerpts(masterNotation);
+    // Init any uninitialised excerpts for export
+    ExcerptNotationList excerptsToInit;
+    for (const IExcerptNotationPtr& excerpt : masterNotation->excerpts()) {
+        if (!excerpt->isInited()) {
+            excerptsToInit.push_back(excerpt);
+        }
+    }
+    if (!excerptsToInit.empty()) {
+        masterNotation->initExcerpts(excerptsToInit);
+        renderExcerptsContents(masterNotation);
+    }
 
     ExcerptNotationList excerpts = masterNotation->excerpts();
-    ExcerptNotationList potentialExcerpts = masterNotation->potentialExcerpts();
-    excerpts.insert(excerpts.end(), potentialExcerpts.begin(), potentialExcerpts.end());
-
     masterNotation->sortExcerpts(excerpts);
 
     return excerpts;
-}
-
-void BackendApi::initPotentialExcerpts(notation::IMasterNotationPtr masterNotation)
-{
-    ExcerptNotationList potentialExcerpts = masterNotation->potentialExcerpts();
-
-    masterNotation->initExcerpts(potentialExcerpts);
-    renderExcerptsContents(masterNotation);
 }
 
 Ret BackendApi::updateSource(const muse::modularity::ContextPtr& iocCtx, const muse::io::path_t& in, const std::string& newSource,

--- a/src/converter/internal/compat/backendapi.cpp
+++ b/src/converter/internal/compat/backendapi.cpp
@@ -796,6 +796,9 @@ void BackendApi::renderExcerptsContents(IMasterNotationPtr masterNotation)
     //! NOTE: Due to optimization, only the master score is layouted
     //!       Let's layout all the scores of the excerpts
     for (const IExcerptNotationPtr& excerpt : masterNotation->excerpts()) {
+        if (!excerpt->isInited()) {
+            continue;
+        }
         Score* score = excerpt->notation()->elements()->msScore();
         if (!score->autoLayoutEnabled()) {
             score->doLayout();
@@ -814,6 +817,9 @@ ExcerptNotationList BackendApi::allExcerpts(notation::IMasterNotationPtr masterN
     }
     if (!excerptsToInit.empty()) {
         masterNotation->initExcerpts(excerptsToInit);
+        for (const IExcerptNotationPtr& excerpt : excerptsToInit) {
+            excerpt->notation()->setViewMode(ViewMode::PAGE);
+        }
         renderExcerptsContents(masterNotation);
     }
 

--- a/src/converter/internal/compat/backendapi.h
+++ b/src/converter/internal/compat/backendapi.h
@@ -100,6 +100,5 @@ private:
     static void renderExcerptsContents(notation::IMasterNotationPtr masterNotation);
 
     static notation::ExcerptNotationList allExcerpts(notation::IMasterNotationPtr masterNotation);
-    static void initPotentialExcerpts(notation::IMasterNotationPtr masterNotation);
 };
 }

--- a/src/converter/internal/compat/backendapi.h
+++ b/src/converter/internal/compat/backendapi.h
@@ -108,6 +108,5 @@ private:
     static void renderExcerptsContents(notation::IMasterNotationPtr masterNotation);
 
     static notation::ExcerptNotationList allExcerpts(notation::IMasterNotationPtr masterNotation);
-    static void initPotentialExcerpts(notation::IMasterNotationPtr masterNotation);
 };
 }

--- a/src/engraving/CMakeLists.txt
+++ b/src/engraving/CMakeLists.txt
@@ -217,6 +217,7 @@ target_sources(engraving PRIVATE
     editing/transpose.h
 
     rw/ireader.h
+    rw/ireader.cpp
     rw/iwriter.h
     rw/rwregister.cpp
     rw/rwregister.h

--- a/src/engraving/CMakeLists.txt
+++ b/src/engraving/CMakeLists.txt
@@ -223,6 +223,7 @@ target_sources(engraving PRIVATE
     editing/transpose.h
 
     rw/ireader.h
+    rw/ireader.cpp
     rw/iwriter.h
     rw/rwregister.cpp
     rw/rwregister.h

--- a/src/engraving/compat/writescorehook.cpp
+++ b/src/engraving/compat/writescorehook.cpp
@@ -63,7 +63,7 @@ void WriteScoreHook::onWriteExcerpts302(Score* score, XmlWriter& xml, WriteConte
     if (isWriteExcerpts && score->isMaster() && !ctx.shouldWriteRange()) {
         MasterScore* mScore = static_cast<MasterScore*>(score);
         for (const Excerpt* excerpt : mScore->excerpts()) {
-            if (excerpt->excerptScore() != score) {
+            if (excerpt->excerptScore() && excerpt->excerptScore() != score) {
                 write::Writer::write(excerpt->excerptScore(), xml, ctx, *this); // recursion write
             }
         }

--- a/src/engraving/dom/excerpt.cpp
+++ b/src/engraving/dom/excerpt.cpp
@@ -579,7 +579,7 @@ void MasterScore::initExcerpt(Excerpt* excerpt)
 
 void MasterScore::initParts(Excerpt* excerpt)
 {
-    // For lightweight excerpts (no excerptScore), parts and tracksMapping
+    // For uninitialised excerpts (no excerptScore), parts and tracksMapping
     // are already set from the file read, so we can skip this function
     if (!excerpt->excerptScore()) {
         return;

--- a/src/engraving/dom/excerpt.cpp
+++ b/src/engraving/dom/excerpt.cpp
@@ -579,6 +579,12 @@ void MasterScore::initExcerpt(Excerpt* excerpt)
 
 void MasterScore::initParts(Excerpt* excerpt)
 {
+    // For lightweight excerpts (no excerptScore), parts and tracksMapping
+    // are already set from the file read, so we can skip this function
+    if (!excerpt->excerptScore()) {
+        return;
+    }
+
     int nstaves { 1 }; // Initialise to 1 to force writing of the first part.
     std::set<ID> assignedStavesIds;
     for (Staff* excerptStaff : excerpt->excerptScore()->staves()) {

--- a/src/engraving/dom/excerpt.h
+++ b/src/engraving/dom/excerpt.h
@@ -98,6 +98,8 @@ public:
     static void cloneSpanner(Spanner* s, Score* score, track_idx_t dstTrack, track_idx_t dstTrack2);
     static void createLinkedTabs(MasterScore* score);
 
+    void setInited(bool inited);
+
 private:
     friend class MasterScore;
 
@@ -105,7 +107,6 @@ private:
     static void cloneMMRests(Score* sourceScore, Score* dstScore, const std::vector<staff_idx_t>& sourceStavesIndexes,
                              const TracksMap& trackList, TieMap& tieMap);
 
-    void setInited(bool inited);
     void writeNameToMetaTags();
 
     void updateTracksMapping();

--- a/src/engraving/dom/masterscore.cpp
+++ b/src/engraving/dom/masterscore.cpp
@@ -240,6 +240,16 @@ void MasterScore::addExcerpt(Excerpt* ex, size_t index)
 }
 
 //---------------------------------------------------------
+//   addLightweightExcerpt
+//---------------------------------------------------------
+
+void MasterScore::addLightweightExcerpt(Excerpt* ex, size_t index)
+{
+    excerpts().insert(excerpts().begin() + (index == muse::nidx ? excerpts().size() : index), ex);
+    setExcerptsChanged(true);
+}
+
+//---------------------------------------------------------
 //   removeExcerpt
 //---------------------------------------------------------
 

--- a/src/engraving/dom/masterscore.cpp
+++ b/src/engraving/dom/masterscore.cpp
@@ -229,22 +229,12 @@ const RepeatList& MasterScore::repeatList(bool expandRepeats, bool updateTies) c
 //   addExcerpt
 //---------------------------------------------------------
 
-void MasterScore::addExcerpt(Excerpt* ex, size_t index)
+void MasterScore::addExcerpt(Excerpt* ex, size_t index, bool initIfNeeded)
 {
-    if (!ex->inited()) {
+    if (initIfNeeded && !ex->inited()) {
         initParts(ex);
     }
 
-    excerpts().insert(excerpts().begin() + (index == muse::nidx ? excerpts().size() : index), ex);
-    setExcerptsChanged(true);
-}
-
-//---------------------------------------------------------
-//   addLightweightExcerpt
-//---------------------------------------------------------
-
-void MasterScore::addLightweightExcerpt(Excerpt* ex, size_t index)
-{
     excerpts().insert(excerpts().begin() + (index == muse::nidx ? excerpts().size() : index), ex);
     setExcerptsChanged(true);
 }

--- a/src/engraving/dom/masterscore.cpp
+++ b/src/engraving/dom/masterscore.cpp
@@ -250,6 +250,16 @@ void MasterScore::addExcerpt(Excerpt* ex, size_t index)
 }
 
 //---------------------------------------------------------
+//   addLightweightExcerpt
+//---------------------------------------------------------
+
+void MasterScore::addLightweightExcerpt(Excerpt* ex, size_t index)
+{
+    excerpts().insert(excerpts().begin() + (index == muse::nidx ? excerpts().size() : index), ex);
+    setExcerptsChanged(true);
+}
+
+//---------------------------------------------------------
 //   removeExcerpt
 //---------------------------------------------------------
 

--- a/src/engraving/dom/masterscore.cpp
+++ b/src/engraving/dom/masterscore.cpp
@@ -239,22 +239,12 @@ const RepeatList& MasterScore::repeatList(bool expandRepeats, bool updateTies) c
 //   addExcerpt
 //---------------------------------------------------------
 
-void MasterScore::addExcerpt(Excerpt* ex, size_t index)
+void MasterScore::addExcerpt(Excerpt* ex, size_t index, bool initIfNeeded)
 {
-    if (!ex->inited()) {
+    if (initIfNeeded && !ex->inited()) {
         initParts(ex);
     }
 
-    excerpts().insert(excerpts().begin() + (index == muse::nidx ? excerpts().size() : index), ex);
-    setExcerptsChanged(true);
-}
-
-//---------------------------------------------------------
-//   addLightweightExcerpt
-//---------------------------------------------------------
-
-void MasterScore::addLightweightExcerpt(Excerpt* ex, size_t index)
-{
     excerpts().insert(excerpts().begin() + (index == muse::nidx ? excerpts().size() : index), ex);
     setExcerptsChanged(true);
 }

--- a/src/engraving/dom/masterscore.h
+++ b/src/engraving/dom/masterscore.h
@@ -163,8 +163,7 @@ public:
     Fraction loopBoundaryTick(LoopBoundaryType type) const;
     void setLoopBoundaryTick(LoopBoundaryType type, Fraction tick);
 
-    void addExcerpt(Excerpt*, size_t index = muse::nidx);
-    void addLightweightExcerpt(Excerpt*, size_t index = muse::nidx);
+    void addExcerpt(Excerpt*, size_t index = muse::nidx, bool initIfNeeded = true);
     void removeExcerpt(Excerpt*);
     void deleteExcerpt(Excerpt*);
 

--- a/src/engraving/dom/masterscore.h
+++ b/src/engraving/dom/masterscore.h
@@ -164,6 +164,7 @@ public:
     void setLoopBoundaryTick(LoopBoundaryType type, Fraction tick);
 
     void addExcerpt(Excerpt*, size_t index = muse::nidx);
+    void addLightweightExcerpt(Excerpt*, size_t index = muse::nidx);
     void removeExcerpt(Excerpt*);
     void deleteExcerpt(Excerpt*);
 

--- a/src/engraving/dom/masterscore.h
+++ b/src/engraving/dom/masterscore.h
@@ -167,6 +167,7 @@ public:
     void setLoopBoundaryTick(LoopBoundaryType type, Fraction tick);
 
     void addExcerpt(Excerpt*, size_t index = muse::nidx);
+    void addLightweightExcerpt(Excerpt*, size_t index = muse::nidx);
     void removeExcerpt(Excerpt*);
     void deleteExcerpt(Excerpt*);
 

--- a/src/engraving/dom/masterscore.h
+++ b/src/engraving/dom/masterscore.h
@@ -166,8 +166,7 @@ public:
     Fraction loopBoundaryTick(LoopBoundaryType type) const;
     void setLoopBoundaryTick(LoopBoundaryType type, Fraction tick);
 
-    void addExcerpt(Excerpt*, size_t index = muse::nidx);
-    void addLightweightExcerpt(Excerpt*, size_t index = muse::nidx);
+    void addExcerpt(Excerpt*, size_t index = muse::nidx, bool initIfNeeded = true);
     void removeExcerpt(Excerpt*);
     void deleteExcerpt(Excerpt*);
 

--- a/src/engraving/dom/midimapping.cpp
+++ b/src/engraving/dom/midimapping.cpp
@@ -152,6 +152,9 @@ int MasterScore::getNextFreeDrumMidiMapping(std::set<int>& occupiedMidiChannels)
 void MasterScore::rebuildExcerptsMidiMapping()
 {
     for (Excerpt* ex : excerpts()) {
+        if (!ex->excerptScore()) {
+            continue;
+        }
         for (Part* p : ex->excerptScore()->parts()) {
             const Part* masterPart = p->masterPart();
             if (!masterPart->score()->isMaster()) {

--- a/src/engraving/editing/editexcerpt.cpp
+++ b/src/engraving/editing/editexcerpt.cpp
@@ -28,8 +28,8 @@ using namespace mu::engraving;
 //   AddExcerpt
 //---------------------------------------------------------
 
-AddExcerpt::AddExcerpt(Excerpt* ex)
-    : excerpt(ex)
+AddExcerpt::AddExcerpt(Excerpt* ex, bool initIfNeeded)
+    : excerpt(ex), m_initIfNeeded(initIfNeeded)
 {}
 
 AddExcerpt::~AddExcerpt()
@@ -49,7 +49,7 @@ void AddExcerpt::undo()
 void AddExcerpt::redo()
 {
     deleteExcerpt = false;
-    excerpt->masterScore()->addExcerpt(excerpt);
+    excerpt->masterScore()->addExcerpt(excerpt, muse::nidx, m_initIfNeeded);
 }
 
 std::vector<EngravingObject*> AddExcerpt::objectItems() const
@@ -68,7 +68,7 @@ std::vector<EngravingObject*> AddExcerpt::objectItems() const
 //---------------------------------------------------------
 
 RemoveExcerpt::RemoveExcerpt(Excerpt* ex)
-    : excerpt(ex)
+    : excerpt(ex), m_initIfNeeded(ex->inited())
 {
     index = muse::indexOf(excerpt->masterScore()->excerpts(), excerpt);
 }
@@ -84,7 +84,7 @@ RemoveExcerpt::~RemoveExcerpt()
 void RemoveExcerpt::undo()
 {
     deleteExcerpt = false;
-    excerpt->masterScore()->addExcerpt(excerpt, index);
+    excerpt->masterScore()->addExcerpt(excerpt, index, m_initIfNeeded);
 }
 
 void RemoveExcerpt::redo()

--- a/src/engraving/editing/editexcerpt.h
+++ b/src/engraving/editing/editexcerpt.h
@@ -35,9 +35,10 @@ class AddExcerpt : public UndoableCommand
 
     Excerpt* excerpt = nullptr;
     bool deleteExcerpt = false;
+    bool m_initIfNeeded = true;
 
 public:
-    AddExcerpt(Excerpt* ex);
+    AddExcerpt(Excerpt* ex, bool initIfNeeded = true);
     ~AddExcerpt() override;
 
     void undo() override;
@@ -56,6 +57,7 @@ class RemoveExcerpt : public UndoableCommand
     Excerpt* excerpt = nullptr;
     size_t index = muse::nidx;
     bool deleteExcerpt = false;
+    bool m_initIfNeeded = true;
 
 public:
     RemoveExcerpt(Excerpt* ex);

--- a/src/engraving/rw/compat/compatutils.cpp
+++ b/src/engraving/rw/compat/compatutils.cpp
@@ -193,6 +193,7 @@ void CompatUtils::doCompatibilityConversions(MasterScore* masterScore)
 
     if (masterScore->mscVersion() < 500) {
         removeMMRestElements(masterScore);
+        createUninitExcerptsForParts(masterScore);
     }
 }
 
@@ -1180,5 +1181,34 @@ void CompatUtils::removeMMRestElements(MasterScore* masterScore)
                 }
             }
         }
+    }
+}
+
+void CompatUtils::createUninitExcerptsForParts(MasterScore* masterScore)
+{
+    // Collect parts that already have an excerpt (matched by initialPartId)
+    std::set<ID> coveredPartIds;
+    for (const Excerpt* excerpt : masterScore->excerpts()) {
+        if (excerpt->initialPartId().isValid()) {
+            coveredPartIds.insert(excerpt->initialPartId());
+        }
+    }
+
+    // Find parts without an excerpt
+    std::vector<Part*> partsWithoutExcerpt;
+    for (Part* part : masterScore->parts()) {
+        if (coveredPartIds.find(part->id()) == coveredPartIds.end()) {
+            partsWithoutExcerpt.push_back(part);
+        }
+    }
+
+    if (partsWithoutExcerpt.empty()) {
+        return;
+    }
+
+    // Create uninitialised excerpts (no excerptScore) for uncovered parts
+    std::vector<Excerpt*> newExcerpts = Excerpt::createExcerptsFromParts(partsWithoutExcerpt, masterScore);
+    for (Excerpt* excerpt : newExcerpts) {
+        masterScore->addExcerpt(excerpt, muse::nidx, false);
     }
 }

--- a/src/engraving/rw/compat/compatutils.cpp
+++ b/src/engraving/rw/compat/compatutils.cpp
@@ -1186,9 +1186,12 @@ void CompatUtils::removeMMRestElements(MasterScore* masterScore)
 
 void CompatUtils::createUninitExcerptsForParts(MasterScore* masterScore)
 {
-    // Collect parts that already have an excerpt (matched by initialPartId)
+    // Collect parts that already have an excerpt
     std::set<ID> coveredPartIds;
     for (const Excerpt* excerpt : masterScore->excerpts()) {
+        for (const Part* part : excerpt->parts()) {
+            coveredPartIds.insert(part->id());
+        }
         if (excerpt->initialPartId().isValid()) {
             coveredPartIds.insert(excerpt->initialPartId());
         }

--- a/src/engraving/rw/compat/compatutils.cpp
+++ b/src/engraving/rw/compat/compatutils.cpp
@@ -1194,9 +1194,12 @@ void CompatUtils::removeMMRestElements(MasterScore* masterScore)
 
 void CompatUtils::createUninitExcerptsForParts(MasterScore* masterScore)
 {
-    // Collect parts that already have an excerpt (matched by initialPartId)
+    // Collect parts that already have an excerpt
     std::set<ID> coveredPartIds;
     for (const Excerpt* excerpt : masterScore->excerpts()) {
+        for (const Part* part : excerpt->parts()) {
+            coveredPartIds.insert(part->id());
+        }
         if (excerpt->initialPartId().isValid()) {
             coveredPartIds.insert(excerpt->initialPartId());
         }

--- a/src/engraving/rw/compat/compatutils.cpp
+++ b/src/engraving/rw/compat/compatutils.cpp
@@ -193,6 +193,7 @@ void CompatUtils::doCompatibilityConversions(MasterScore* masterScore)
 
     if (masterScore->mscVersion() < 500) {
         removeMMRestElements(masterScore);
+        createUninitExcerptsForParts(masterScore);
     }
 }
 
@@ -1188,5 +1189,34 @@ void CompatUtils::removeMMRestElements(MasterScore* masterScore)
                 }
             }
         }
+    }
+}
+
+void CompatUtils::createUninitExcerptsForParts(MasterScore* masterScore)
+{
+    // Collect parts that already have an excerpt (matched by initialPartId)
+    std::set<ID> coveredPartIds;
+    for (const Excerpt* excerpt : masterScore->excerpts()) {
+        if (excerpt->initialPartId().isValid()) {
+            coveredPartIds.insert(excerpt->initialPartId());
+        }
+    }
+
+    // Find parts without an excerpt
+    std::vector<Part*> partsWithoutExcerpt;
+    for (Part* part : masterScore->parts()) {
+        if (coveredPartIds.find(part->id()) == coveredPartIds.end()) {
+            partsWithoutExcerpt.push_back(part);
+        }
+    }
+
+    if (partsWithoutExcerpt.empty()) {
+        return;
+    }
+
+    // Create uninitialised excerpts (no excerptScore) for uncovered parts
+    std::vector<Excerpt*> newExcerpts = Excerpt::createExcerptsFromParts(partsWithoutExcerpt, masterScore);
+    for (Excerpt* excerpt : newExcerpts) {
+        masterScore->addExcerpt(excerpt, muse::nidx, false);
     }
 }

--- a/src/engraving/rw/compat/compatutils.cpp
+++ b/src/engraving/rw/compat/compatutils.cpp
@@ -1202,9 +1202,12 @@ void CompatUtils::createUninitExcerptsForParts(MasterScore* masterScore)
         }
     }
 
-    // Find parts without an excerpt
+    // Find parts without an excerpt. Shared parts never get one of their own.
     std::vector<Part*> partsWithoutExcerpt;
     for (Part* part : masterScore->parts()) {
+        if (part->isSharedPart()) {
+            continue;
+        }
         if (coveredPartIds.find(part->id()) == coveredPartIds.end()) {
             partsWithoutExcerpt.push_back(part);
         }

--- a/src/engraving/rw/compat/compatutils.h
+++ b/src/engraving/rw/compat/compatutils.h
@@ -77,5 +77,6 @@ private:
     static void convertTextLineToNoteAnchoredLine(MasterScore* masterScore);
     static void convertLaissezVibArticToTie(MasterScore* masterScore);
     static void removeMMRestElements(MasterScore* masterScore);
+    static void createUninitExcerptsForParts(MasterScore* masterScore);
 };
 }

--- a/src/engraving/rw/compat/compatutils.h
+++ b/src/engraving/rw/compat/compatutils.h
@@ -42,6 +42,7 @@ class CompatUtils
 public:
     static void assignInitialPartToExcerpts(const std::vector<Excerpt*>& excerpts);
     static void doCompatibilityConversions(MasterScore* masterScore);
+    static void createUninitExcerptsForParts(MasterScore* masterScore);
     static ArticulationAnchor translateToNewArticulationAnchor(int anchor);
     static double convertChordExtModUnits(double val);
     static void setHarmonyRootTpcFromFunction(HarmonyInfo* info, const Harmony* h, const muse::String& s);
@@ -77,6 +78,5 @@ private:
     static void convertTextLineToNoteAnchoredLine(MasterScore* masterScore);
     static void convertLaissezVibArticToTie(MasterScore* masterScore);
     static void removeMMRestElements(MasterScore* masterScore);
-    static void createUninitExcerptsForParts(MasterScore* masterScore);
 };
 }

--- a/src/engraving/rw/ireader.cpp
+++ b/src/engraving/rw/ireader.cpp
@@ -1,0 +1,56 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "ireader.h"
+
+#include "dom/excerpt.h"
+#include "dom/masterscore.h"
+
+using namespace mu::engraving;
+using namespace mu::engraving::rw;
+
+/// Default implementation: assumes all excerpts are initialised (pre-500 formats).
+/// Creates a Score, applies style, and delegates to readScoreFile.
+muse::Ret IReader::readExcerptScoreFile(Excerpt* excerpt, MasterScore* masterScore,
+                                        const muse::ByteArray& excerptData,
+                                        const muse::String& fileName,
+                                        ReadInOutData* out,
+                                        const ApplyStyleFn& applyStyleFn)
+{
+    Score* partScore = masterScore->createScore();
+    excerpt->setExcerptScore(partScore);
+
+    if (applyStyleFn) {
+        applyStyleFn(partScore);
+    }
+
+    XmlReader xml(excerptData);
+    xml.setDocName(fileName);
+
+    muse::Ret ret = readScoreFile(partScore, xml, out);
+    if (!ret) {
+        return ret;
+    }
+
+    Excerpt::linkMeasures(partScore, masterScore);
+
+    return muse::make_ok();
+}

--- a/src/engraving/rw/ireader.h
+++ b/src/engraving/rw/ireader.h
@@ -70,12 +70,9 @@ public:
     /// populates the Excerpt with name/parts/tracks only. If it is a regular excerpt,
     /// creates a Score, calls applyStyleFn so the caller can apply the style, then reads
     /// the full score content.
-    using ApplyStyleFn = std::function<void(Score*)>;
-    virtual muse::Ret readExcerptScoreFile(Excerpt* excerpt, MasterScore* masterScore,
-                                           const muse::ByteArray& excerptData,
-                                           const muse::String& fileName,
-                                           rw::ReadInOutData* out,
-                                           const ApplyStyleFn& applyStyleFn);
+    using ApplyStyleFn = std::function<void (Score*)>;
+    virtual muse::Ret readExcerptScoreFile(Excerpt* excerpt, MasterScore* masterScore, const muse::ByteArray& excerptData,
+                                           const muse::String& fileName, rw::ReadInOutData* out, const ApplyStyleFn& applyStyleFn);
 
     using Supported = std::variant<std::monostate,
                                    Accidental*,

--- a/src/engraving/rw/ireader.h
+++ b/src/engraving/rw/ireader.h
@@ -21,15 +21,20 @@
  */
 #pragma once
 
+#include <functional>
 #include <memory>
 #include <variant>
 
+#include "global/types/bytearray.h"
+#include "global/types/string.h"
 #include "types/ret.h"
 
 #include "../types/types.h"
 #include "xmlreader.h"
 
 namespace mu::engraving {
+class Excerpt;
+class MasterScore;
 class Score;
 class EngravingItem;
 
@@ -60,6 +65,17 @@ public:
     virtual ~IReader() = default;
 
     virtual muse::Ret readScoreFile(Score* score, XmlReader& xml, rw::ReadInOutData* out) = 0;
+
+    /// Read an excerpt from raw data. If the excerpt is uninitialised (no full score),
+    /// populates the Excerpt with name/parts/tracks only. If it is a regular excerpt,
+    /// creates a Score, calls applyStyleFn so the caller can apply the style, then reads
+    /// the full score content.
+    using ApplyStyleFn = std::function<void(Score*)>;
+    virtual muse::Ret readExcerptScoreFile(Excerpt* excerpt, MasterScore* masterScore,
+                                           const muse::ByteArray& excerptData,
+                                           const muse::String& fileName,
+                                           rw::ReadInOutData* out,
+                                           const ApplyStyleFn& applyStyleFn);
 
     using Supported = std::variant<std::monostate,
                                    Accidental*,

--- a/src/engraving/rw/iwriter.h
+++ b/src/engraving/rw/iwriter.h
@@ -29,6 +29,7 @@
 #include "xmlwriter.h"
 
 namespace mu::engraving {
+class Excerpt;
 class Score;
 class EngravingItem;
 class Segment;
@@ -43,6 +44,7 @@ public:
     virtual ~IWriter() = default;
 
     virtual bool writeScore(Score* score, muse::io::IODevice* device, WriteInOutData* out = nullptr) = 0;
+    virtual bool writeUninitExcerpt(Excerpt* excerpt, muse::io::IODevice* device) = 0;
 
     using Supported = std::variant<std::monostate
                                    >;

--- a/src/engraving/rw/iwriter.h
+++ b/src/engraving/rw/iwriter.h
@@ -31,6 +31,7 @@
 #include "xmlwriter.h"
 
 namespace mu::engraving {
+class Excerpt;
 class Score;
 class EngravingItem;
 class Segment;
@@ -51,6 +52,7 @@ public:
     virtual ~IWriter() = default;
 
     virtual bool writeScore(Score* score, muse::io::IODevice* device, WriteInOutData* out = nullptr) = 0;
+    virtual bool writeUninitExcerpt(Excerpt* excerpt, muse::io::IODevice* device) = 0;
 
     virtual muse::ByteArray writeStaffSelection(Score* score, const SelectionFilter& filter, staff_idx_t staffStart, staff_idx_t staffEnd,
                                                 const Fraction& tickStart, const Fraction& tickEnd, Segment* startSegment,

--- a/src/engraving/rw/mscloader.cpp
+++ b/src/engraving/rw/mscloader.cpp
@@ -199,6 +199,11 @@ Ret MscLoader::loadMscz(MasterScore* masterScore, const MscReader& mscReader, rw
 
             bool isUninit = !ex->excerptScore();
             masterScore->addExcerpt(ex, muse::nidx, !isUninit);
+
+            // Mark as inited after addExcerpt() so initParts() runs first
+            if (!isUninit) {
+                ex->setInited(true);
+            }
         }
     }
 

--- a/src/engraving/rw/mscloader.cpp
+++ b/src/engraving/rw/mscloader.cpp
@@ -33,6 +33,7 @@
 #include "../dom/masterscore.h"
 #include "../dom/excerpt.h"
 #include "../dom/imageStore.h"
+#include "../dom/part.h"
 
 #include "engraving/automation/internal/automationrw.h"
 
@@ -50,6 +51,99 @@ using namespace muse;
 using namespace muse::io;
 using namespace mu::engraving;
 using namespace mu::engraving::rw;
+
+//---------------------------------------------------------
+//   isLightweightExcerpt
+///   Check if excerpt data represents a lightweight excerpt
+///   by looking for the <lightweight>true</lightweight> element
+//---------------------------------------------------------
+
+static bool isLightweightExcerpt(const ByteArray& excerptData)
+{
+    XmlReader xml(excerptData);
+    while (xml.readNextStartElement()) {
+        if (xml.name() == "museScore") {
+            while (xml.readNextStartElement()) {
+                if (xml.name() == "Score") {
+                    while (xml.readNextStartElement()) {
+                        if (xml.name() == "lightweight") {
+                            return xml.readText().toInt() != 0;
+                        } else {
+                            xml.skipCurrentElement();
+                        }
+                    }
+                } else {
+                    xml.skipCurrentElement();
+                }
+            }
+        } else {
+            xml.skipCurrentElement();
+        }
+    }
+    return false;
+}
+
+//---------------------------------------------------------
+//   readLightweightExcerpt
+///   Read a lightweight excerpt that has no full excerptScore
+///   Restores name, parts references, and tracks mapping
+//---------------------------------------------------------
+
+static Excerpt* readLightweightExcerpt(MasterScore* masterScore, const ByteArray& excerptData, const String& fileName)
+{
+    Excerpt* excerpt = new Excerpt(masterScore);
+    excerpt->setFileName(fileName);
+    TracksMap tracksMap;
+
+    XmlReader xml(excerptData);
+    while (xml.readNextStartElement()) {
+        if (xml.name() == "museScore") {
+            while (xml.readNextStartElement()) {
+                if (xml.name() == "Score") {
+                    while (xml.readNextStartElement()) {
+                        const AsciiStringView tag = xml.name();
+                        if (tag == "lightweight") {
+                            xml.readText();  // consume the value
+                        } else if (tag == "name") {
+                            excerpt->setName(xml.readText(), false);
+                        } else if (tag == "Tracklist") {
+                            track_idx_t sTrack = static_cast<track_idx_t>(xml.intAttribute("sTrack", -1));
+                            track_idx_t dstTrack = static_cast<track_idx_t>(xml.intAttribute("dstTrack", -1));
+                            if (sTrack != muse::nidx && dstTrack != muse::nidx) {
+                                tracksMap.insert({ sTrack, dstTrack });
+                            }
+                            xml.readNext();
+                        } else if (tag == "initialPartId") {
+                            excerpt->setInitialPartId(ID(xml.readText().toStdString()));
+                        } else if (tag == "Part") {
+                            ID partId(static_cast<uint64_t>(xml.intAttribute("id", 0)));
+                            // Find the part in master score by ID
+                            for (Part* part : masterScore->parts()) {
+                                if (part->id() == partId) {
+                                    excerpt->parts().push_back(part);
+                                    break;
+                                }
+                            }
+                            xml.readNext();
+                        } else {
+                            xml.unknown();
+                        }
+                    }
+                } else {
+                    xml.skipCurrentElement();
+                }
+            }
+        } else {
+            xml.skipCurrentElement();
+        }
+    }
+
+    if (!tracksMap.empty()) {
+        excerpt->setTracksMapping(tracksMap);
+    }
+
+    return excerpt;
+}
 
 static RetVal<IReaderPtr> makeReader(int version, bool ignoreVersionError)
 {
@@ -156,6 +250,16 @@ Ret MscLoader::loadMscz(MasterScore* masterScore, const MscReader& mscReader, rw
     if (ret && masterScore->mscVersion() >= 400 && mscReader.isContainer()) {
         std::vector<String> excerptFileNames = mscReader.excerptFileNames();
         for (const String& excerptFileName : excerptFileNames) {
+            ByteArray excerptData = mscReader.readExcerptFile(excerptFileName);
+
+            // Check if this is a lightweight excerpt (potential excerpt without full score)
+            if (isLightweightExcerpt(excerptData)) {
+                Excerpt* ex = readLightweightExcerpt(masterScore, excerptData, excerptFileName);
+                masterScore->addLightweightExcerpt(ex);
+                continue;
+            }
+
+            // Regular excerpt with full score
             Score* partScore = masterScore->createScore();
 
             compat::ReadStyleHook::setupDefaultStyle(partScore);
@@ -167,8 +271,6 @@ Ret MscLoader::loadMscz(MasterScore* masterScore, const MscReader& mscReader, rw
             ByteArray excerptStyleData = mscReader.readExcerptStyleFile(excerptFileName);
             auto excerptStyleBuf = Buffer::opened(IODevice::ReadOnly, &excerptStyleData);
             partScore->style().read(&excerptStyleBuf);
-
-            ByteArray excerptData = mscReader.readExcerptFile(excerptFileName);
 
             XmlReader xml(excerptData);
             xml.setDocName(excerptFileName);

--- a/src/engraving/rw/mscloader.cpp
+++ b/src/engraving/rw/mscloader.cpp
@@ -53,46 +53,14 @@ using namespace mu::engraving;
 using namespace mu::engraving::rw;
 
 //---------------------------------------------------------
-//   isLightweightExcerpt
-///   Check if excerpt data represents a lightweight excerpt
-///   by looking for the <lightweight>true</lightweight> element
-//---------------------------------------------------------
-
-static bool isLightweightExcerpt(const ByteArray& excerptData)
-{
-    XmlReader xml(excerptData);
-    while (xml.readNextStartElement()) {
-        if (xml.name() == "museScore") {
-            while (xml.readNextStartElement()) {
-                if (xml.name() == "Score") {
-                    while (xml.readNextStartElement()) {
-                        if (xml.name() == "lightweight") {
-                            return xml.readText().toInt() != 0;
-                        } else {
-                            xml.skipCurrentElement();
-                        }
-                    }
-                } else {
-                    xml.skipCurrentElement();
-                }
-            }
-        } else {
-            xml.skipCurrentElement();
-        }
-    }
-    return false;
-}
-
-//---------------------------------------------------------
 //   readLightweightExcerpt
-///   Read a lightweight excerpt that has no full excerptScore
-///   Restores name, parts references, and tracks mapping
+///   Read a lightweight excerpt (no full excerptScore).
+///   Returns nullptr if not a lightweight excerpt.
 //---------------------------------------------------------
 
 static Excerpt* readLightweightExcerpt(MasterScore* masterScore, const ByteArray& excerptData, const String& fileName)
 {
-    Excerpt* excerpt = new Excerpt(masterScore);
-    excerpt->setFileName(fileName);
+    Excerpt* excerpt = nullptr;
     TracksMap tracksMap;
 
     XmlReader xml(excerptData);
@@ -103,7 +71,15 @@ static Excerpt* readLightweightExcerpt(MasterScore* masterScore, const ByteArray
                     while (xml.readNextStartElement()) {
                         const AsciiStringView tag = xml.name();
                         if (tag == "lightweight") {
-                            xml.readText();  // consume the value
+                            if (xml.readText().toInt() != 0) {
+                                excerpt = new Excerpt(masterScore);
+                                excerpt->setFileName(fileName);
+                            } else {
+                                return nullptr;
+                            }
+                        } else if (!excerpt) {
+                            // Not lightweight - first element must be <lightweight>
+                            return nullptr;
                         } else if (tag == "name") {
                             excerpt->setName(xml.readText(), false);
                         } else if (tag == "Tracklist") {
@@ -117,7 +93,6 @@ static Excerpt* readLightweightExcerpt(MasterScore* masterScore, const ByteArray
                             excerpt->setInitialPartId(ID(xml.readText().toStdString()));
                         } else if (tag == "Part") {
                             ID partId(static_cast<uint64_t>(xml.intAttribute("id", 0)));
-                            // Find the part in master score by ID
                             for (Part* part : masterScore->parts()) {
                                 if (part->id() == partId) {
                                     excerpt->parts().push_back(part);
@@ -138,7 +113,7 @@ static Excerpt* readLightweightExcerpt(MasterScore* masterScore, const ByteArray
         }
     }
 
-    if (!tracksMap.empty()) {
+    if (excerpt && !tracksMap.empty()) {
         excerpt->setTracksMapping(tracksMap);
     }
 
@@ -252,9 +227,8 @@ Ret MscLoader::loadMscz(MasterScore* masterScore, const MscReader& mscReader, rw
         for (const String& excerptFileName : excerptFileNames) {
             ByteArray excerptData = mscReader.readExcerptFile(excerptFileName);
 
-            // Check if this is a lightweight excerpt (potential excerpt without full score)
-            if (isLightweightExcerpt(excerptData)) {
-                Excerpt* ex = readLightweightExcerpt(masterScore, excerptData, excerptFileName);
+            // Try to read as lightweight excerpt first
+            if (Excerpt* ex = readLightweightExcerpt(masterScore, excerptData, excerptFileName)) {
                 masterScore->addLightweightExcerpt(ex);
                 continue;
             }

--- a/src/engraving/rw/mscloader.cpp
+++ b/src/engraving/rw/mscloader.cpp
@@ -54,46 +54,14 @@ using namespace mu::engraving;
 using namespace mu::engraving::rw;
 
 //---------------------------------------------------------
-//   isLightweightExcerpt
-///   Check if excerpt data represents a lightweight excerpt
-///   by looking for the <lightweight>true</lightweight> element
-//---------------------------------------------------------
-
-static bool isLightweightExcerpt(const ByteArray& excerptData)
-{
-    XmlReader xml(excerptData);
-    while (xml.readNextStartElement()) {
-        if (xml.name() == "museScore") {
-            while (xml.readNextStartElement()) {
-                if (xml.name() == "Score") {
-                    while (xml.readNextStartElement()) {
-                        if (xml.name() == "lightweight") {
-                            return xml.readText().toInt() != 0;
-                        } else {
-                            xml.skipCurrentElement();
-                        }
-                    }
-                } else {
-                    xml.skipCurrentElement();
-                }
-            }
-        } else {
-            xml.skipCurrentElement();
-        }
-    }
-    return false;
-}
-
-//---------------------------------------------------------
 //   readLightweightExcerpt
-///   Read a lightweight excerpt that has no full excerptScore
-///   Restores name, parts references, and tracks mapping
+///   Read a lightweight excerpt (no full excerptScore).
+///   Returns nullptr if not a lightweight excerpt.
 //---------------------------------------------------------
 
 static Excerpt* readLightweightExcerpt(MasterScore* masterScore, const ByteArray& excerptData, const String& fileName)
 {
-    Excerpt* excerpt = new Excerpt(masterScore);
-    excerpt->setFileName(fileName);
+    Excerpt* excerpt = nullptr;
     TracksMap tracksMap;
 
     XmlReader xml(excerptData);
@@ -104,7 +72,15 @@ static Excerpt* readLightweightExcerpt(MasterScore* masterScore, const ByteArray
                     while (xml.readNextStartElement()) {
                         const AsciiStringView tag = xml.name();
                         if (tag == "lightweight") {
-                            xml.readText();  // consume the value
+                            if (xml.readText().toInt() != 0) {
+                                excerpt = new Excerpt(masterScore);
+                                excerpt->setFileName(fileName);
+                            } else {
+                                return nullptr;
+                            }
+                        } else if (!excerpt) {
+                            // Not lightweight - first element must be <lightweight>
+                            return nullptr;
                         } else if (tag == "name") {
                             excerpt->setName(xml.readText(), false);
                         } else if (tag == "Tracklist") {
@@ -118,7 +94,6 @@ static Excerpt* readLightweightExcerpt(MasterScore* masterScore, const ByteArray
                             excerpt->setInitialPartId(ID(xml.readText().toStdString()));
                         } else if (tag == "Part") {
                             ID partId(static_cast<uint64_t>(xml.intAttribute("id", 0)));
-                            // Find the part in master score by ID
                             for (Part* part : masterScore->parts()) {
                                 if (part->id() == partId) {
                                     excerpt->parts().push_back(part);
@@ -139,7 +114,7 @@ static Excerpt* readLightweightExcerpt(MasterScore* masterScore, const ByteArray
         }
     }
 
-    if (!tracksMap.empty()) {
+    if (excerpt && !tracksMap.empty()) {
         excerpt->setTracksMapping(tracksMap);
     }
 
@@ -253,9 +228,8 @@ Ret MscLoader::loadMscz(MasterScore* masterScore, const MscReader& mscReader, rw
         for (const String& excerptFileName : excerptFileNames) {
             ByteArray excerptData = mscReader.readExcerptFile(excerptFileName);
 
-            // Check if this is a lightweight excerpt (potential excerpt without full score)
-            if (isLightweightExcerpt(excerptData)) {
-                Excerpt* ex = readLightweightExcerpt(masterScore, excerptData, excerptFileName);
+            // Try to read as lightweight excerpt first
+            if (Excerpt* ex = readLightweightExcerpt(masterScore, excerptData, excerptFileName)) {
                 masterScore->addLightweightExcerpt(ex);
                 continue;
             }

--- a/src/engraving/rw/mscloader.cpp
+++ b/src/engraving/rw/mscloader.cpp
@@ -200,6 +200,11 @@ Ret MscLoader::loadMscz(MasterScore* masterScore, const MscReader& mscReader, rw
 
             bool isUninit = !ex->excerptScore();
             masterScore->addExcerpt(ex, muse::nidx, !isUninit);
+
+            // Mark as inited after addExcerpt() so initParts() runs first
+            if (!isUninit) {
+                ex->setInited(true);
+            }
         }
     }
 

--- a/src/engraving/rw/mscloader.cpp
+++ b/src/engraving/rw/mscloader.cpp
@@ -230,7 +230,7 @@ Ret MscLoader::loadMscz(MasterScore* masterScore, const MscReader& mscReader, rw
 
             // Try to read as uninitialised excerpt first
             if (Excerpt* ex = readUninitExcerpt(masterScore, excerptData, excerptFileName)) {
-                masterScore->addLightweightExcerpt(ex);
+                masterScore->addExcerpt(ex, muse::nidx, false);
                 continue;
             }
 

--- a/src/engraving/rw/mscloader.cpp
+++ b/src/engraving/rw/mscloader.cpp
@@ -52,74 +52,6 @@ using namespace muse::io;
 using namespace mu::engraving;
 using namespace mu::engraving::rw;
 
-//---------------------------------------------------------
-//   readUninitExcerpt
-///   Read an uninitialised excerpt (no excerptScore).
-///   Returns nullptr if not an uninitialised excerpt.
-//---------------------------------------------------------
-
-static Excerpt* readUninitExcerpt(MasterScore* masterScore, const ByteArray& excerptData, const String& fileName)
-{
-    Excerpt* excerpt = nullptr;
-    TracksMap tracksMap;
-
-    XmlReader xml(excerptData);
-    while (xml.readNextStartElement()) {
-        if (xml.name() == "museScore") {
-            while (xml.readNextStartElement()) {
-                if (xml.name() == "Score") {
-                    while (xml.readNextStartElement()) {
-                        const AsciiStringView tag = xml.name();
-                        if (tag == "initialised") {
-                            if (xml.readText() == "false") {
-                                excerpt = new Excerpt(masterScore);
-                                excerpt->setFileName(fileName);
-                            } else {
-                                return nullptr;
-                            }
-                        } else if (!excerpt) {
-                            // Not uninitialised: first element must be <initialised>
-                            return nullptr;
-                        } else if (tag == "name") {
-                            excerpt->setName(xml.readText(), false);
-                        } else if (tag == "Tracklist") {
-                            track_idx_t sTrack = static_cast<track_idx_t>(xml.intAttribute("sTrack", -1));
-                            track_idx_t dstTrack = static_cast<track_idx_t>(xml.intAttribute("dstTrack", -1));
-                            if (sTrack != muse::nidx && dstTrack != muse::nidx) {
-                                tracksMap.insert({ sTrack, dstTrack });
-                            }
-                            xml.readNext();
-                        } else if (tag == "initialPartId") {
-                            excerpt->setInitialPartId(ID(xml.readText().toStdString()));
-                        } else if (tag == "Part") {
-                            ID partId(static_cast<uint64_t>(xml.intAttribute("id", 0)));
-                            for (Part* part : masterScore->parts()) {
-                                if (part->id() == partId) {
-                                    excerpt->parts().push_back(part);
-                                    break;
-                                }
-                            }
-                            xml.readNext();
-                        } else {
-                            xml.unknown();
-                        }
-                    }
-                } else {
-                    xml.skipCurrentElement();
-                }
-            }
-        } else {
-            xml.skipCurrentElement();
-        }
-    }
-
-    if (excerpt && !tracksMap.empty()) {
-        excerpt->setTracksMapping(tracksMap);
-    }
-
-    return excerpt;
-}
-
 static RetVal<IReaderPtr> makeReader(int version, bool ignoreVersionError)
 {
     if (!ignoreVersionError) {
@@ -227,30 +159,8 @@ Ret MscLoader::loadMscz(MasterScore* masterScore, const MscReader& mscReader, rw
         for (const String& excerptFileName : excerptFileNames) {
             ByteArray excerptData = mscReader.readExcerptFile(excerptFileName);
 
-            // Try to read as uninitialised excerpt first
-            if (Excerpt* ex = readUninitExcerpt(masterScore, excerptData, excerptFileName)) {
-                masterScore->addExcerpt(ex, muse::nidx, false);
-                continue;
-            }
-
-            // Regular excerpt with full score
-            Score* partScore = masterScore->createScore();
-
-            compat::ReadStyleHook::setupDefaultStyle(partScore);
-
             Excerpt* ex = new Excerpt(masterScore);
-            ex->setExcerptScore(partScore);
             ex->setFileName(excerptFileName);
-
-            ByteArray excerptStyleData = mscReader.readExcerptStyleFile(excerptFileName);
-            auto excerptStyleBuf = Buffer::opened(IODevice::ReadOnly, &excerptStyleData);
-            partScore->style().read(&excerptStyleBuf);
-
-            XmlReader xml(excerptData);
-            xml.setDocName(excerptFileName);
-
-            ReadInOutData partReadInData;
-            partReadInData.links = inOut->links;
 
             RetVal<IReaderPtr> reader = makeReader(masterScore->mscVersion(), ignoreVersionError);
             if (!reader.ret) {
@@ -258,26 +168,37 @@ Ret MscLoader::loadMscz(MasterScore* masterScore, const MscReader& mscReader, rw
                 break;
             }
 
-            ret = reader.val->readScoreFile(partScore, xml, &partReadInData);
+            ReadInOutData partReadInData;
+            partReadInData.links = inOut->links;
+
+            // Style callback: applied between Score creation and content reading
+            auto applyStyleFn = [&mscReader, &excerptFileName](Score* partScore) {
+                compat::ReadStyleHook::setupDefaultStyle(partScore);
+                ByteArray excerptStyleData = mscReader.readExcerptStyleFile(excerptFileName);
+                auto excerptStyleBuf = Buffer::opened(IODevice::ReadOnly, &excerptStyleData);
+                partScore->style().read(&excerptStyleBuf);
+            };
+
+            ret = reader.val->readExcerptScoreFile(ex, masterScore, excerptData,
+                                                   excerptFileName, &partReadInData,
+                                                   applyStyleFn);
             if (!ret) {
                 break;
             }
 
-            Excerpt::linkMeasures(partScore, masterScore);
-
-            if (ex->name().empty()) {
-                // If no excerpt name tag was found while reading, try the "partName" meta tag
-                const String nameFromMeta = partScore->metaTag(u"partName");
+            // For regular excerpts, set name from meta if needed
+            if (ex->excerptScore() && ex->name().empty()) {
+                const String nameFromMeta = ex->excerptScore()->metaTag(u"partName");
 
                 if (nameFromMeta.empty()) {
-                    // If that's also empty, fall back to the filename
                     ex->setName(excerptFileName, /*saveAndNotify=*/ false);
                 } else {
                     ex->setName(nameFromMeta, /*saveAndNotify=*/ false);
                 }
             }
 
-            masterScore->addExcerpt(ex);
+            bool isUninit = !ex->excerptScore();
+            masterScore->addExcerpt(ex, muse::nidx, !isUninit);
         }
     }
 

--- a/src/engraving/rw/mscloader.cpp
+++ b/src/engraving/rw/mscloader.cpp
@@ -54,12 +54,12 @@ using namespace mu::engraving;
 using namespace mu::engraving::rw;
 
 //---------------------------------------------------------
-//   readLightweightExcerpt
-///   Read a lightweight excerpt (no full excerptScore).
-///   Returns nullptr if not a lightweight excerpt.
+//   readUninitExcerpt
+///   Read an uninitialised excerpt (no excerptScore).
+///   Returns nullptr if not an uninitialised excerpt.
 //---------------------------------------------------------
 
-static Excerpt* readLightweightExcerpt(MasterScore* masterScore, const ByteArray& excerptData, const String& fileName)
+static Excerpt* readUninitExcerpt(MasterScore* masterScore, const ByteArray& excerptData, const String& fileName)
 {
     Excerpt* excerpt = nullptr;
     TracksMap tracksMap;
@@ -71,15 +71,15 @@ static Excerpt* readLightweightExcerpt(MasterScore* masterScore, const ByteArray
                 if (xml.name() == "Score") {
                     while (xml.readNextStartElement()) {
                         const AsciiStringView tag = xml.name();
-                        if (tag == "lightweight") {
-                            if (xml.readText().toInt() != 0) {
+                        if (tag == "initialised") {
+                            if (xml.readText() == "false") {
                                 excerpt = new Excerpt(masterScore);
                                 excerpt->setFileName(fileName);
                             } else {
                                 return nullptr;
                             }
                         } else if (!excerpt) {
-                            // Not lightweight - first element must be <lightweight>
+                            // Not uninitialised: first element must be <initialised>
                             return nullptr;
                         } else if (tag == "name") {
                             excerpt->setName(xml.readText(), false);
@@ -228,8 +228,8 @@ Ret MscLoader::loadMscz(MasterScore* masterScore, const MscReader& mscReader, rw
         for (const String& excerptFileName : excerptFileNames) {
             ByteArray excerptData = mscReader.readExcerptFile(excerptFileName);
 
-            // Try to read as lightweight excerpt first
-            if (Excerpt* ex = readLightweightExcerpt(masterScore, excerptData, excerptFileName)) {
+            // Try to read as uninitialised excerpt first
+            if (Excerpt* ex = readUninitExcerpt(masterScore, excerptData, excerptFileName)) {
                 masterScore->addLightweightExcerpt(ex);
                 continue;
             }

--- a/src/engraving/rw/mscloader.cpp
+++ b/src/engraving/rw/mscloader.cpp
@@ -53,12 +53,12 @@ using namespace mu::engraving;
 using namespace mu::engraving::rw;
 
 //---------------------------------------------------------
-//   readLightweightExcerpt
-///   Read a lightweight excerpt (no full excerptScore).
-///   Returns nullptr if not a lightweight excerpt.
+//   readUninitExcerpt
+///   Read an uninitialised excerpt (no excerptScore).
+///   Returns nullptr if not an uninitialised excerpt.
 //---------------------------------------------------------
 
-static Excerpt* readLightweightExcerpt(MasterScore* masterScore, const ByteArray& excerptData, const String& fileName)
+static Excerpt* readUninitExcerpt(MasterScore* masterScore, const ByteArray& excerptData, const String& fileName)
 {
     Excerpt* excerpt = nullptr;
     TracksMap tracksMap;
@@ -70,15 +70,15 @@ static Excerpt* readLightweightExcerpt(MasterScore* masterScore, const ByteArray
                 if (xml.name() == "Score") {
                     while (xml.readNextStartElement()) {
                         const AsciiStringView tag = xml.name();
-                        if (tag == "lightweight") {
-                            if (xml.readText().toInt() != 0) {
+                        if (tag == "initialised") {
+                            if (xml.readText() == "false") {
                                 excerpt = new Excerpt(masterScore);
                                 excerpt->setFileName(fileName);
                             } else {
                                 return nullptr;
                             }
                         } else if (!excerpt) {
-                            // Not lightweight - first element must be <lightweight>
+                            // Not uninitialised: first element must be <initialised>
                             return nullptr;
                         } else if (tag == "name") {
                             excerpt->setName(xml.readText(), false);
@@ -227,8 +227,8 @@ Ret MscLoader::loadMscz(MasterScore* masterScore, const MscReader& mscReader, rw
         for (const String& excerptFileName : excerptFileNames) {
             ByteArray excerptData = mscReader.readExcerptFile(excerptFileName);
 
-            // Try to read as lightweight excerpt first
-            if (Excerpt* ex = readLightweightExcerpt(masterScore, excerptData, excerptFileName)) {
+            // Try to read as uninitialised excerpt first
+            if (Excerpt* ex = readUninitExcerpt(masterScore, excerptData, excerptFileName)) {
                 masterScore->addLightweightExcerpt(ex);
                 continue;
             }

--- a/src/engraving/rw/mscloader.cpp
+++ b/src/engraving/rw/mscloader.cpp
@@ -229,7 +229,7 @@ Ret MscLoader::loadMscz(MasterScore* masterScore, const MscReader& mscReader, rw
 
             // Try to read as uninitialised excerpt first
             if (Excerpt* ex = readUninitExcerpt(masterScore, excerptData, excerptFileName)) {
-                masterScore->addLightweightExcerpt(ex);
+                masterScore->addExcerpt(ex, muse::nidx, false);
                 continue;
             }
 

--- a/src/engraving/rw/mscloader.cpp
+++ b/src/engraving/rw/mscloader.cpp
@@ -33,6 +33,7 @@
 #include "../dom/masterscore.h"
 #include "../dom/excerpt.h"
 #include "../dom/imageStore.h"
+#include "../dom/part.h"
 
 #include "engraving/automation/automationdata.h"
 #include "engraving/automation/internal/automationrw.h"
@@ -51,6 +52,99 @@ using namespace muse;
 using namespace muse::io;
 using namespace mu::engraving;
 using namespace mu::engraving::rw;
+
+//---------------------------------------------------------
+//   isLightweightExcerpt
+///   Check if excerpt data represents a lightweight excerpt
+///   by looking for the <lightweight>true</lightweight> element
+//---------------------------------------------------------
+
+static bool isLightweightExcerpt(const ByteArray& excerptData)
+{
+    XmlReader xml(excerptData);
+    while (xml.readNextStartElement()) {
+        if (xml.name() == "museScore") {
+            while (xml.readNextStartElement()) {
+                if (xml.name() == "Score") {
+                    while (xml.readNextStartElement()) {
+                        if (xml.name() == "lightweight") {
+                            return xml.readText().toInt() != 0;
+                        } else {
+                            xml.skipCurrentElement();
+                        }
+                    }
+                } else {
+                    xml.skipCurrentElement();
+                }
+            }
+        } else {
+            xml.skipCurrentElement();
+        }
+    }
+    return false;
+}
+
+//---------------------------------------------------------
+//   readLightweightExcerpt
+///   Read a lightweight excerpt that has no full excerptScore
+///   Restores name, parts references, and tracks mapping
+//---------------------------------------------------------
+
+static Excerpt* readLightweightExcerpt(MasterScore* masterScore, const ByteArray& excerptData, const String& fileName)
+{
+    Excerpt* excerpt = new Excerpt(masterScore);
+    excerpt->setFileName(fileName);
+    TracksMap tracksMap;
+
+    XmlReader xml(excerptData);
+    while (xml.readNextStartElement()) {
+        if (xml.name() == "museScore") {
+            while (xml.readNextStartElement()) {
+                if (xml.name() == "Score") {
+                    while (xml.readNextStartElement()) {
+                        const AsciiStringView tag = xml.name();
+                        if (tag == "lightweight") {
+                            xml.readText();  // consume the value
+                        } else if (tag == "name") {
+                            excerpt->setName(xml.readText(), false);
+                        } else if (tag == "Tracklist") {
+                            track_idx_t sTrack = static_cast<track_idx_t>(xml.intAttribute("sTrack", -1));
+                            track_idx_t dstTrack = static_cast<track_idx_t>(xml.intAttribute("dstTrack", -1));
+                            if (sTrack != muse::nidx && dstTrack != muse::nidx) {
+                                tracksMap.insert({ sTrack, dstTrack });
+                            }
+                            xml.readNext();
+                        } else if (tag == "initialPartId") {
+                            excerpt->setInitialPartId(ID(xml.readText().toStdString()));
+                        } else if (tag == "Part") {
+                            ID partId(static_cast<uint64_t>(xml.intAttribute("id", 0)));
+                            // Find the part in master score by ID
+                            for (Part* part : masterScore->parts()) {
+                                if (part->id() == partId) {
+                                    excerpt->parts().push_back(part);
+                                    break;
+                                }
+                            }
+                            xml.readNext();
+                        } else {
+                            xml.unknown();
+                        }
+                    }
+                } else {
+                    xml.skipCurrentElement();
+                }
+            }
+        } else {
+            xml.skipCurrentElement();
+        }
+    }
+
+    if (!tracksMap.empty()) {
+        excerpt->setTracksMapping(tracksMap);
+    }
+
+    return excerpt;
+}
 
 static RetVal<IReaderPtr> makeReader(int version, bool ignoreVersionError)
 {
@@ -157,6 +251,16 @@ Ret MscLoader::loadMscz(MasterScore* masterScore, const MscReader& mscReader, rw
     if (ret && masterScore->mscVersion() >= 400 && mscReader.isContainer()) {
         std::vector<String> excerptFileNames = mscReader.excerptFileNames();
         for (const String& excerptFileName : excerptFileNames) {
+            ByteArray excerptData = mscReader.readExcerptFile(excerptFileName);
+
+            // Check if this is a lightweight excerpt (potential excerpt without full score)
+            if (isLightweightExcerpt(excerptData)) {
+                Excerpt* ex = readLightweightExcerpt(masterScore, excerptData, excerptFileName);
+                masterScore->addLightweightExcerpt(ex);
+                continue;
+            }
+
+            // Regular excerpt with full score
             Score* partScore = masterScore->createScore();
 
             compat::ReadStyleHook::setupDefaultStyle(partScore);
@@ -168,8 +272,6 @@ Ret MscLoader::loadMscz(MasterScore* masterScore, const MscReader& mscReader, rw
             ByteArray excerptStyleData = mscReader.readExcerptStyleFile(excerptFileName);
             auto excerptStyleBuf = Buffer::opened(IODevice::ReadOnly, &excerptStyleData);
             partScore->style().read(&excerptStyleBuf);
-
-            ByteArray excerptData = mscReader.readExcerptFile(excerptFileName);
 
             XmlReader xml(excerptData);
             xml.setDocName(excerptFileName);

--- a/src/engraving/rw/mscloader.cpp
+++ b/src/engraving/rw/mscloader.cpp
@@ -53,74 +53,6 @@ using namespace muse::io;
 using namespace mu::engraving;
 using namespace mu::engraving::rw;
 
-//---------------------------------------------------------
-//   readUninitExcerpt
-///   Read an uninitialised excerpt (no excerptScore).
-///   Returns nullptr if not an uninitialised excerpt.
-//---------------------------------------------------------
-
-static Excerpt* readUninitExcerpt(MasterScore* masterScore, const ByteArray& excerptData, const String& fileName)
-{
-    Excerpt* excerpt = nullptr;
-    TracksMap tracksMap;
-
-    XmlReader xml(excerptData);
-    while (xml.readNextStartElement()) {
-        if (xml.name() == "museScore") {
-            while (xml.readNextStartElement()) {
-                if (xml.name() == "Score") {
-                    while (xml.readNextStartElement()) {
-                        const AsciiStringView tag = xml.name();
-                        if (tag == "initialised") {
-                            if (xml.readText() == "false") {
-                                excerpt = new Excerpt(masterScore);
-                                excerpt->setFileName(fileName);
-                            } else {
-                                return nullptr;
-                            }
-                        } else if (!excerpt) {
-                            // Not uninitialised: first element must be <initialised>
-                            return nullptr;
-                        } else if (tag == "name") {
-                            excerpt->setName(xml.readText(), false);
-                        } else if (tag == "Tracklist") {
-                            track_idx_t sTrack = static_cast<track_idx_t>(xml.intAttribute("sTrack", -1));
-                            track_idx_t dstTrack = static_cast<track_idx_t>(xml.intAttribute("dstTrack", -1));
-                            if (sTrack != muse::nidx && dstTrack != muse::nidx) {
-                                tracksMap.insert({ sTrack, dstTrack });
-                            }
-                            xml.readNext();
-                        } else if (tag == "initialPartId") {
-                            excerpt->setInitialPartId(ID(xml.readText().toStdString()));
-                        } else if (tag == "Part") {
-                            ID partId(static_cast<uint64_t>(xml.intAttribute("id", 0)));
-                            for (Part* part : masterScore->parts()) {
-                                if (part->id() == partId) {
-                                    excerpt->parts().push_back(part);
-                                    break;
-                                }
-                            }
-                            xml.readNext();
-                        } else {
-                            xml.unknown();
-                        }
-                    }
-                } else {
-                    xml.skipCurrentElement();
-                }
-            }
-        } else {
-            xml.skipCurrentElement();
-        }
-    }
-
-    if (excerpt && !tracksMap.empty()) {
-        excerpt->setTracksMapping(tracksMap);
-    }
-
-    return excerpt;
-}
-
 static RetVal<IReaderPtr> makeReader(int version, bool ignoreVersionError)
 {
     if (!ignoreVersionError) {
@@ -228,30 +160,8 @@ Ret MscLoader::loadMscz(MasterScore* masterScore, const MscReader& mscReader, rw
         for (const String& excerptFileName : excerptFileNames) {
             ByteArray excerptData = mscReader.readExcerptFile(excerptFileName);
 
-            // Try to read as uninitialised excerpt first
-            if (Excerpt* ex = readUninitExcerpt(masterScore, excerptData, excerptFileName)) {
-                masterScore->addExcerpt(ex, muse::nidx, false);
-                continue;
-            }
-
-            // Regular excerpt with full score
-            Score* partScore = masterScore->createScore();
-
-            compat::ReadStyleHook::setupDefaultStyle(partScore);
-
             Excerpt* ex = new Excerpt(masterScore);
-            ex->setExcerptScore(partScore);
             ex->setFileName(excerptFileName);
-
-            ByteArray excerptStyleData = mscReader.readExcerptStyleFile(excerptFileName);
-            auto excerptStyleBuf = Buffer::opened(IODevice::ReadOnly, &excerptStyleData);
-            partScore->style().read(&excerptStyleBuf);
-
-            XmlReader xml(excerptData);
-            xml.setDocName(excerptFileName);
-
-            ReadInOutData partReadInData;
-            partReadInData.links = inOut->links;
 
             RetVal<IReaderPtr> reader = makeReader(masterScore->mscVersion(), ignoreVersionError);
             if (!reader.ret) {
@@ -259,26 +169,37 @@ Ret MscLoader::loadMscz(MasterScore* masterScore, const MscReader& mscReader, rw
                 break;
             }
 
-            ret = reader.val->readScoreFile(partScore, xml, &partReadInData);
+            ReadInOutData partReadInData;
+            partReadInData.links = inOut->links;
+
+            // Style callback: applied between Score creation and content reading
+            auto applyStyleFn = [&mscReader, &excerptFileName](Score* partScore) {
+                compat::ReadStyleHook::setupDefaultStyle(partScore);
+                ByteArray excerptStyleData = mscReader.readExcerptStyleFile(excerptFileName);
+                auto excerptStyleBuf = Buffer::opened(IODevice::ReadOnly, &excerptStyleData);
+                partScore->style().read(&excerptStyleBuf);
+            };
+
+            ret = reader.val->readExcerptScoreFile(ex, masterScore, excerptData,
+                                                   excerptFileName, &partReadInData,
+                                                   applyStyleFn);
             if (!ret) {
                 break;
             }
 
-            Excerpt::linkMeasures(partScore, masterScore);
-
-            if (ex->name().empty()) {
-                // If no excerpt name tag was found while reading, try the "partName" meta tag
-                const String nameFromMeta = partScore->metaTag(u"partName");
+            // For regular excerpts, set name from meta if needed
+            if (ex->excerptScore() && ex->name().empty()) {
+                const String nameFromMeta = ex->excerptScore()->metaTag(u"partName");
 
                 if (nameFromMeta.empty()) {
-                    // If that's also empty, fall back to the filename
                     ex->setName(excerptFileName, /*saveAndNotify=*/ false);
                 } else {
                     ex->setName(nameFromMeta, /*saveAndNotify=*/ false);
                 }
             }
 
-            masterScore->addExcerpt(ex);
+            bool isUninit = !ex->excerptScore();
+            masterScore->addExcerpt(ex, muse::nidx, !isUninit);
         }
     }
 

--- a/src/engraving/rw/mscsaver.cpp
+++ b/src/engraving/rw/mscsaver.cpp
@@ -24,7 +24,6 @@
 #include <cmath>
 
 #include "global/io/buffer.h"
-#include "global/serialization/xmlstreamwriter.h"
 #include "muse_framework_config.h"
 
 #ifdef MUSE_THREADS_SUPPORT
@@ -35,14 +34,11 @@
 
 #include "dom/masterscore.h"
 #include "dom/excerpt.h"
-#include "dom/part.h"
 #include "dom/imageStore.h"
 #include "dom/mscore.h"
 #include "dom/page.h"
 
 #include "engraving/automation/internal/automationrw.h"
-#include "engraving/infrastructure/mscwriter.h"
-#include "engraving/types/constants.h"
 
 #include "rwregister.h"
 #include "inoutdata.h"
@@ -54,62 +50,6 @@ using namespace muse;
 using namespace muse::io;
 using namespace mu::engraving;
 using namespace mu::engraving::rw;
-
-//---------------------------------------------------------
-//   writeUninitExcerpt
-///   Write an uninitialised excerpt (no excerptScore) in a minimal
-///   XML format that preserves name, parts, and tracks
-//---------------------------------------------------------
-
-static void writeUninitExcerpt(Excerpt* excerpt, MscWriter& mscWriter)
-{
-    ByteArray excerptData;
-    Buffer excerptBuf(&excerptData);
-    excerptBuf.open(IODevice::WriteOnly);
-
-    {
-        XmlStreamWriter xml(&excerptBuf);
-        xml.startDocument();
-
-        xml.startElement("museScore", { { "version", Constants::MSC_VERSION_STR } });
-        xml.startElement("Score");
-
-        // Mark as uninitialised excerpt
-        xml.element("initialised", false);
-
-        // Write name if not empty
-        if (!excerpt->name().empty()) {
-            xml.element("name", excerpt->name());
-        }
-
-        // Write tracks mapping
-        const TracksMap& tracks = excerpt->tracksMapping();
-        if (!tracks.empty()) {
-            for (auto it = tracks.cbegin(); it != tracks.cend(); ++it) {
-                xml.element("Tracklist", { { "sTrack", String::number(it->first) },
-                                { "dstTrack", String::number(it->second) } });
-            }
-        }
-
-        // Write initialPartId if set
-        if (excerpt->initialPartId().isValid()) {
-            xml.element("initialPartId", excerpt->initialPartId().toUint64());
-        }
-
-        // Write parts (as Part element with id attribute)
-        for (const Part* part : excerpt->parts()) {
-            xml.element("Part", { { "id", part->id().toUint64() } });
-        }
-
-        xml.endElement();  // Score
-        xml.endElement();  // museScore
-        xml.flush();
-    }  // xml destructor ensures all data is flushed
-
-    excerptBuf.close();
-
-    mscWriter.addExcerptFile(excerpt->fileName(), excerptData);
-}
 
 bool MscSaver::writeMscz(MasterScore* score, MscWriter& mscWriter, bool createThumbnail,
                          const write::WriteContext* ctx)
@@ -185,9 +125,12 @@ bool MscSaver::writeMscz(MasterScore* score, MscWriter& mscWriter, bool createTh
                 Excerpt* excerpt = excerpts.at(excerptIndex);
                 excerpt->updateFileName(excerptIndex);
 
-                // Uninitialised excerpts have no excerptScore - write minimal XML directly
+                // Uninitialised excerpts have no excerptScore - write minimal XML
                 if (!excerpt->excerptScore()) {
-                    writeUninitExcerpt(excerpt, mscWriter);
+                    ByteArray excerptData;
+                    auto excerptBuf = Buffer::opened(IODevice::WriteOnly, &excerptData);
+                    RWRegister::writer()->writeUninitExcerpt(excerpt, &excerptBuf);
+                    mscWriter.addExcerptFile(excerpt->fileName(), excerptData);
                     continue;
                 }
 
@@ -208,9 +151,12 @@ bool MscSaver::writeMscz(MasterScore* score, MscWriter& mscWriter, bool createTh
                 Excerpt* excerpt = excerpts.at(excerptIndex);
                 excerpt->updateFileName(excerptIndex);
 
-                // Uninitialised excerpts have no excerptScore - write minimal XML directly
+                // Uninitialised excerpts have no excerptScore - write minimal XML
                 if (!excerpt->excerptScore()) {
-                    writeUninitExcerpt(excerpt, mscWriter);
+                    ByteArray excerptData;
+                    auto excerptBuf = Buffer::opened(IODevice::WriteOnly, &excerptData);
+                    RWRegister::writer()->writeUninitExcerpt(excerpt, &excerptBuf);
+                    mscWriter.addExcerptFile(excerpt->fileName(), excerptData);
                     continue;
                 }
 

--- a/src/engraving/rw/mscsaver.cpp
+++ b/src/engraving/rw/mscsaver.cpp
@@ -56,12 +56,12 @@ using namespace mu::engraving;
 using namespace mu::engraving::rw;
 
 //---------------------------------------------------------
-//   writeLightweightExcerpt
-///   Write an excerpt that has no excerptScore (potential excerpt)
-///   in a lightweight XML format that preserves name, parts, and tracks
+//   writeUninitExcerpt
+///   Write an uninitialised excerpt (no excerptScore) in a minimal
+///   XML format that preserves name, parts, and tracks
 //---------------------------------------------------------
 
-static void writeLightweightExcerpt(Excerpt* excerpt, MscWriter& mscWriter)
+static void writeUninitExcerpt(Excerpt* excerpt, MscWriter& mscWriter)
 {
     ByteArray excerptData;
     Buffer excerptBuf(&excerptData);
@@ -74,8 +74,8 @@ static void writeLightweightExcerpt(Excerpt* excerpt, MscWriter& mscWriter)
         xml.startElement("museScore", { { "version", Constants::MSC_VERSION_STR } });
         xml.startElement("Score");
 
-        // Mark as lightweight excerpt
-        xml.element("lightweight", 1);  // Use int, not bool
+        // Mark as uninitialised excerpt
+        xml.element("initialised", false);
 
         // Write name if not empty
         if (!excerpt->name().empty()) {
@@ -185,9 +185,9 @@ bool MscSaver::writeMscz(MasterScore* score, MscWriter& mscWriter, bool createTh
                 Excerpt* excerpt = excerpts.at(excerptIndex);
                 excerpt->updateFileName(excerptIndex);
 
-                // Lightweight excerpts have no excerptScore - write minimal XML directly
+                // Uninitialised excerpts have no excerptScore - write minimal XML directly
                 if (!excerpt->excerptScore()) {
-                    writeLightweightExcerpt(excerpt, mscWriter);
+                    writeUninitExcerpt(excerpt, mscWriter);
                     continue;
                 }
 
@@ -208,9 +208,9 @@ bool MscSaver::writeMscz(MasterScore* score, MscWriter& mscWriter, bool createTh
                 Excerpt* excerpt = excerpts.at(excerptIndex);
                 excerpt->updateFileName(excerptIndex);
 
-                // Lightweight excerpts have no excerptScore - write minimal XML directly
+                // Uninitialised excerpts have no excerptScore - write minimal XML directly
                 if (!excerpt->excerptScore()) {
-                    writeLightweightExcerpt(excerpt, mscWriter);
+                    writeUninitExcerpt(excerpt, mscWriter);
                     continue;
                 }
 

--- a/src/engraving/rw/mscsaver.cpp
+++ b/src/engraving/rw/mscsaver.cpp
@@ -24,6 +24,7 @@
 #include <cmath>
 
 #include "global/io/buffer.h"
+#include "global/serialization/xmlstreamwriter.h"
 #include "muse_framework_config.h"
 
 #ifdef MUSE_THREADS_SUPPORT
@@ -34,11 +35,14 @@
 
 #include "dom/masterscore.h"
 #include "dom/excerpt.h"
+#include "dom/part.h"
 #include "dom/imageStore.h"
 #include "dom/mscore.h"
 #include "dom/page.h"
 
 #include "engraving/automation/internal/automationrw.h"
+#include "engraving/infrastructure/mscwriter.h"
+#include "engraving/types/constants.h"
 
 #include "rwregister.h"
 #include "inoutdata.h"
@@ -50,6 +54,62 @@ using namespace muse;
 using namespace muse::io;
 using namespace mu::engraving;
 using namespace mu::engraving::rw;
+
+//---------------------------------------------------------
+//   writeLightweightExcerpt
+///   Write an excerpt that has no excerptScore (potential excerpt)
+///   in a lightweight XML format that preserves name, parts, and tracks
+//---------------------------------------------------------
+
+static void writeLightweightExcerpt(Excerpt* excerpt, MscWriter& mscWriter)
+{
+    ByteArray excerptData;
+    Buffer excerptBuf(&excerptData);
+    excerptBuf.open(IODevice::WriteOnly);
+
+    {
+        XmlStreamWriter xml(&excerptBuf);
+        xml.startDocument();
+
+        xml.startElement("museScore", { { "version", Constants::MSC_VERSION_STR } });
+        xml.startElement("Score");
+
+        // Mark as lightweight excerpt
+        xml.element("lightweight", 1);  // Use int, not bool
+
+        // Write name if not empty
+        if (!excerpt->name().empty()) {
+            xml.element("name", excerpt->name());
+        }
+
+        // Write tracks mapping
+        const TracksMap& tracks = excerpt->tracksMapping();
+        if (!tracks.empty()) {
+            for (auto it = tracks.cbegin(); it != tracks.cend(); ++it) {
+                xml.element("Tracklist", { { "sTrack", String::number(it->first) },
+                                { "dstTrack", String::number(it->second) } });
+            }
+        }
+
+        // Write initialPartId if set
+        if (excerpt->initialPartId().isValid()) {
+            xml.element("initialPartId", excerpt->initialPartId().toUint64());
+        }
+
+        // Write parts (as Part element with id attribute)
+        for (const Part* part : excerpt->parts()) {
+            xml.element("Part", { { "id", part->id().toUint64() } });
+        }
+
+        xml.endElement();  // Score
+        xml.endElement();  // museScore
+        xml.flush();
+    }  // xml destructor ensures all data is flushed
+
+    excerptBuf.close();
+
+    mscWriter.addExcerptFile(excerpt->fileName(), excerptData);
+}
 
 bool MscSaver::writeMscz(MasterScore* score, MscWriter& mscWriter, bool createThumbnail,
                          const write::WriteContext* ctx)
@@ -97,13 +157,11 @@ bool MscSaver::writeMscz(MasterScore* score, MscWriter& mscWriter, bool createTh
                 ByteArray scoreData;
             };
 
-            auto serializeExcerpt = [masterWriteOutData, score](Excerpt* excerpt, size_t excerptIndex) -> ExcerptData {
+            auto serializeExcerpt = [masterWriteOutData, score](Excerpt* excerpt) -> ExcerptData {
                 Score* partScore = excerpt->excerptScore();
                 IF_ASSERT_FAILED(partScore && partScore != score) {
                     return ExcerptData();
                 }
-
-                excerpt->updateFileName(excerptIndex);
 
                 ExcerptData data;
                 data.fileName = excerpt->fileName();
@@ -125,9 +183,16 @@ bool MscSaver::writeMscz(MasterScore* score, MscWriter& mscWriter, bool createTh
 
             for (size_t excerptIndex = 0; excerptIndex < excerpts.size(); ++excerptIndex) {
                 Excerpt* excerpt = excerpts.at(excerptIndex);
+                excerpt->updateFileName(excerptIndex);
 
-                futures.push_back(std::async(std::launch::async, [serializeExcerpt, excerpt, excerptIndex]() {
-                    return serializeExcerpt(excerpt, excerptIndex);
+                // Lightweight excerpts have no excerptScore - write minimal XML directly
+                if (!excerpt->excerptScore()) {
+                    writeLightweightExcerpt(excerpt, mscWriter);
+                    continue;
+                }
+
+                futures.push_back(std::async(std::launch::async, [serializeExcerpt, excerpt]() {
+                    return serializeExcerpt(excerpt);
                 }));
             }
 
@@ -141,8 +206,15 @@ bool MscSaver::writeMscz(MasterScore* score, MscWriter& mscWriter, bool createTh
 #else
             for (size_t excerptIndex = 0; excerptIndex < excerpts.size(); ++excerptIndex) {
                 Excerpt* excerpt = excerpts.at(excerptIndex);
+                excerpt->updateFileName(excerptIndex);
 
-                ExcerptData data = serializeExcerpt(excerpt, excerptIndex);
+                // Lightweight excerpts have no excerptScore - write minimal XML directly
+                if (!excerpt->excerptScore()) {
+                    writeLightweightExcerpt(excerpt, mscWriter);
+                    continue;
+                }
+
+                ExcerptData data = serializeExcerpt(excerpt);
                 mscWriter.addExcerptStyleFile(data.fileName, data.styleData);
                 mscWriter.addExcerptFile(data.fileName, data.scoreData);
             }

--- a/src/engraving/rw/read500/read500.cpp
+++ b/src/engraving/rw/read500/read500.cpp
@@ -141,11 +141,14 @@ static void readUninitExcerptData(Excerpt* excerpt, MasterScore* masterScore, Xm
         } else if (tag == "initialPartId") {
             excerpt->setInitialPartId(ID(e.readInt()));
         } else if (tag == "Part") {
-            ID partId(static_cast<uint64_t>(e.intAttribute("id", 0)));
-            for (Part* part : masterScore->parts()) {
-                if (part->id() == partId) {
-                    excerpt->parts().push_back(part);
-                    break;
+            int rawId = e.intAttribute("id", -1);
+            if (rawId > 0) {
+                ID partId(static_cast<uint64_t>(rawId));
+                for (Part* part : masterScore->parts()) {
+                    if (part->id() == partId) {
+                        excerpt->parts().push_back(part);
+                        break;
+                    }
                 }
             }
             e.skipCurrentElement();

--- a/src/engraving/rw/read500/read500.cpp
+++ b/src/engraving/rw/read500/read500.cpp
@@ -117,6 +117,110 @@ muse::Ret Read500::readScoreFile(Score* score, XmlReader& e, rw::ReadInOutData* 
     return muse::make_ok();
 }
 
+//---------------------------------------------------------
+//   readUninitExcerptData
+///   Read the contents of an uninitialised excerpt (name, tracks, parts)
+///   from within a <Score> element that starts with <initialised>false.
+//---------------------------------------------------------
+
+static void readUninitExcerptData(Excerpt* excerpt, MasterScore* masterScore, XmlReader& e)
+{
+    TracksMap tracksMap;
+
+    while (e.readNextStartElement()) {
+        const AsciiStringView tag = e.name();
+        if (tag == "initialised") {
+            e.readText();  // consume the "false" value
+        } else if (tag == "name") {
+            excerpt->setName(e.readText(), false);
+        } else if (tag == "Tracklist") {
+            track_idx_t sTrack = static_cast<track_idx_t>(e.intAttribute("sTrack", -1));
+            track_idx_t dstTrack = static_cast<track_idx_t>(e.intAttribute("dstTrack", -1));
+            if (sTrack != muse::nidx && dstTrack != muse::nidx) {
+                tracksMap.insert({ sTrack, dstTrack });
+            }
+            e.readNext();
+        } else if (tag == "initialPartId") {
+            excerpt->setInitialPartId(ID(e.readText().toStdString()));
+        } else if (tag == "Part") {
+            ID partId(static_cast<uint64_t>(e.intAttribute("id", 0)));
+            for (Part* part : masterScore->parts()) {
+                if (part->id() == partId) {
+                    excerpt->parts().push_back(part);
+                    break;
+                }
+            }
+            e.readNext();
+        } else {
+            e.unknown();
+        }
+    }
+
+    if (!tracksMap.empty()) {
+        excerpt->setTracksMapping(tracksMap);
+    }
+}
+
+//---------------------------------------------------------
+//   readExcerptScoreFile
+///   Read an excerpt, determining whether it is uninitialised or regular.
+///   For uninitialised excerpts, populates only name/parts/tracks.
+///   For regular excerpts, creates a Score, applies style, reads content.
+//---------------------------------------------------------
+
+muse::Ret Read500::readExcerptScoreFile(Excerpt* excerpt, MasterScore* masterScore,
+                                        const muse::ByteArray& excerptData,
+                                        const muse::String& fileName,
+                                        rw::ReadInOutData* out,
+                                        const ApplyStyleFn& applyStyleFn)
+{
+    // Check if this is an uninitialised excerpt by scanning for the marker
+    {
+        XmlReader probe(excerptData);
+        while (probe.readNextStartElement()) {
+            if (probe.name() == "museScore") {
+                while (probe.readNextStartElement()) {
+                    if (probe.name() == "Score") {
+                        if (probe.readNextStartElement() && probe.name() == "initialised") {
+                            if (probe.readText() == "false") {
+                                // Uninitialised excerpt: read the rest of the data
+                                readUninitExcerptData(excerpt, masterScore, probe);
+                                return muse::make_ok();
+                            }
+                        }
+                        break;
+                    } else {
+                        probe.skipCurrentElement();
+                    }
+                }
+                break;
+            } else {
+                probe.skipCurrentElement();
+            }
+        }
+    }
+
+    // Regular excerpt: create Score, apply style, then read using readScoreFile
+    Score* partScore = masterScore->createScore();
+    excerpt->setExcerptScore(partScore);
+
+    if (applyStyleFn) {
+        applyStyleFn(partScore);
+    }
+
+    XmlReader xml(excerptData);
+    xml.setDocName(fileName);
+
+    muse::Ret ret = readScoreFile(partScore, xml, out);
+    if (!ret) {
+        return ret;
+    }
+
+    Excerpt::linkMeasures(partScore, masterScore);
+
+    return muse::make_ok();
+}
+
 bool Read500::readScoreTag(Score* score, XmlReader& e, ReadContext& ctx)
 {
     std::vector<int> sysStaves;

--- a/src/engraving/rw/read500/read500.cpp
+++ b/src/engraving/rw/read500/read500.cpp
@@ -182,7 +182,7 @@ muse::Ret Read500::readExcerptScoreFile(Excerpt* excerpt, MasterScore* masterSco
                 while (probe.readNextStartElement()) {
                     if (probe.name() == "Score") {
                         if (probe.readNextStartElement() && probe.name() == "initialised") {
-                            if (probe.readText() == "false") {
+                            if (probe.readText().toInt() == 0) {
                                 // Uninitialised excerpt: read the rest of the data
                                 readUninitExcerptData(excerpt, masterScore, probe);
                                 return muse::make_ok();

--- a/src/engraving/rw/read500/read500.cpp
+++ b/src/engraving/rw/read500/read500.cpp
@@ -129,9 +129,7 @@ static void readUninitExcerptData(Excerpt* excerpt, MasterScore* masterScore, Xm
 
     while (e.readNextStartElement()) {
         const AsciiStringView tag = e.name();
-        if (tag == "initialised") {
-            e.readText();  // consume the "false" value
-        } else if (tag == "name") {
+        if (tag == "name") {
             excerpt->setName(e.readText(), false);
         } else if (tag == "Tracklist") {
             track_idx_t sTrack = static_cast<track_idx_t>(e.intAttribute("sTrack", -1));
@@ -139,9 +137,9 @@ static void readUninitExcerptData(Excerpt* excerpt, MasterScore* masterScore, Xm
             if (sTrack != muse::nidx && dstTrack != muse::nidx) {
                 tracksMap.insert({ sTrack, dstTrack });
             }
-            e.readNext();
+            e.skipCurrentElement();
         } else if (tag == "initialPartId") {
-            excerpt->setInitialPartId(ID(e.readText().toStdString()));
+            excerpt->setInitialPartId(ID(e.readInt()));
         } else if (tag == "Part") {
             ID partId(static_cast<uint64_t>(e.intAttribute("id", 0)));
             for (Part* part : masterScore->parts()) {
@@ -150,7 +148,7 @@ static void readUninitExcerptData(Excerpt* excerpt, MasterScore* masterScore, Xm
                     break;
                 }
             }
-            e.readNext();
+            e.skipCurrentElement();
         } else {
             e.unknown();
         }
@@ -200,25 +198,8 @@ muse::Ret Read500::readExcerptScoreFile(Excerpt* excerpt, MasterScore* masterSco
         }
     }
 
-    // Regular excerpt: create Score, apply style, then read using readScoreFile
-    Score* partScore = masterScore->createScore();
-    excerpt->setExcerptScore(partScore);
-
-    if (applyStyleFn) {
-        applyStyleFn(partScore);
-    }
-
-    XmlReader xml(excerptData);
-    xml.setDocName(fileName);
-
-    muse::Ret ret = readScoreFile(partScore, xml, out);
-    if (!ret) {
-        return ret;
-    }
-
-    Excerpt::linkMeasures(partScore, masterScore);
-
-    return muse::make_ok();
+    // Regular excerpt: delegate to base implementation
+    return IReader::readExcerptScoreFile(excerpt, masterScore, excerptData, fileName, out, applyStyleFn);
 }
 
 bool Read500::readScoreTag(Score* score, XmlReader& e, ReadContext& ctx)

--- a/src/engraving/rw/read500/read500.cpp
+++ b/src/engraving/rw/read500/read500.cpp
@@ -116,6 +116,110 @@ muse::Ret Read500::readScoreFile(Score* score, XmlReader& e, rw::ReadInOutData* 
     return muse::make_ok();
 }
 
+//---------------------------------------------------------
+//   readUninitExcerptData
+///   Read the contents of an uninitialised excerpt (name, tracks, parts)
+///   from within a <Score> element that starts with <initialised>false.
+//---------------------------------------------------------
+
+static void readUninitExcerptData(Excerpt* excerpt, MasterScore* masterScore, XmlReader& e)
+{
+    TracksMap tracksMap;
+
+    while (e.readNextStartElement()) {
+        const AsciiStringView tag = e.name();
+        if (tag == "initialised") {
+            e.readText();  // consume the "false" value
+        } else if (tag == "name") {
+            excerpt->setName(e.readText(), false);
+        } else if (tag == "Tracklist") {
+            track_idx_t sTrack = static_cast<track_idx_t>(e.intAttribute("sTrack", -1));
+            track_idx_t dstTrack = static_cast<track_idx_t>(e.intAttribute("dstTrack", -1));
+            if (sTrack != muse::nidx && dstTrack != muse::nidx) {
+                tracksMap.insert({ sTrack, dstTrack });
+            }
+            e.readNext();
+        } else if (tag == "initialPartId") {
+            excerpt->setInitialPartId(ID(e.readText().toStdString()));
+        } else if (tag == "Part") {
+            ID partId(static_cast<uint64_t>(e.intAttribute("id", 0)));
+            for (Part* part : masterScore->parts()) {
+                if (part->id() == partId) {
+                    excerpt->parts().push_back(part);
+                    break;
+                }
+            }
+            e.readNext();
+        } else {
+            e.unknown();
+        }
+    }
+
+    if (!tracksMap.empty()) {
+        excerpt->setTracksMapping(tracksMap);
+    }
+}
+
+//---------------------------------------------------------
+//   readExcerptScoreFile
+///   Read an excerpt, determining whether it is uninitialised or regular.
+///   For uninitialised excerpts, populates only name/parts/tracks.
+///   For regular excerpts, creates a Score, applies style, reads content.
+//---------------------------------------------------------
+
+muse::Ret Read500::readExcerptScoreFile(Excerpt* excerpt, MasterScore* masterScore,
+                                        const muse::ByteArray& excerptData,
+                                        const muse::String& fileName,
+                                        rw::ReadInOutData* out,
+                                        const ApplyStyleFn& applyStyleFn)
+{
+    // Check if this is an uninitialised excerpt by scanning for the marker
+    {
+        XmlReader probe(excerptData);
+        while (probe.readNextStartElement()) {
+            if (probe.name() == "museScore") {
+                while (probe.readNextStartElement()) {
+                    if (probe.name() == "Score") {
+                        if (probe.readNextStartElement() && probe.name() == "initialised") {
+                            if (probe.readText() == "false") {
+                                // Uninitialised excerpt: read the rest of the data
+                                readUninitExcerptData(excerpt, masterScore, probe);
+                                return muse::make_ok();
+                            }
+                        }
+                        break;
+                    } else {
+                        probe.skipCurrentElement();
+                    }
+                }
+                break;
+            } else {
+                probe.skipCurrentElement();
+            }
+        }
+    }
+
+    // Regular excerpt: create Score, apply style, then read using readScoreFile
+    Score* partScore = masterScore->createScore();
+    excerpt->setExcerptScore(partScore);
+
+    if (applyStyleFn) {
+        applyStyleFn(partScore);
+    }
+
+    XmlReader xml(excerptData);
+    xml.setDocName(fileName);
+
+    muse::Ret ret = readScoreFile(partScore, xml, out);
+    if (!ret) {
+        return ret;
+    }
+
+    Excerpt::linkMeasures(partScore, masterScore);
+
+    return muse::make_ok();
+}
+
 bool Read500::readScoreTag(Score* score, XmlReader& e, ReadContext& ctx)
 {
     std::vector<int> sysStaves;

--- a/src/engraving/rw/read500/read500.cpp
+++ b/src/engraving/rw/read500/read500.cpp
@@ -128,9 +128,7 @@ static void readUninitExcerptData(Excerpt* excerpt, MasterScore* masterScore, Xm
 
     while (e.readNextStartElement()) {
         const AsciiStringView tag = e.name();
-        if (tag == "initialised") {
-            e.readText();  // consume the "false" value
-        } else if (tag == "name") {
+        if (tag == "name") {
             excerpt->setName(e.readText(), false);
         } else if (tag == "Tracklist") {
             track_idx_t sTrack = static_cast<track_idx_t>(e.intAttribute("sTrack", -1));
@@ -138,9 +136,9 @@ static void readUninitExcerptData(Excerpt* excerpt, MasterScore* masterScore, Xm
             if (sTrack != muse::nidx && dstTrack != muse::nidx) {
                 tracksMap.insert({ sTrack, dstTrack });
             }
-            e.readNext();
+            e.skipCurrentElement();
         } else if (tag == "initialPartId") {
-            excerpt->setInitialPartId(ID(e.readText().toStdString()));
+            excerpt->setInitialPartId(ID(e.readInt()));
         } else if (tag == "Part") {
             ID partId(static_cast<uint64_t>(e.intAttribute("id", 0)));
             for (Part* part : masterScore->parts()) {
@@ -149,7 +147,7 @@ static void readUninitExcerptData(Excerpt* excerpt, MasterScore* masterScore, Xm
                     break;
                 }
             }
-            e.readNext();
+            e.skipCurrentElement();
         } else {
             e.unknown();
         }
@@ -199,25 +197,8 @@ muse::Ret Read500::readExcerptScoreFile(Excerpt* excerpt, MasterScore* masterSco
         }
     }
 
-    // Regular excerpt: create Score, apply style, then read using readScoreFile
-    Score* partScore = masterScore->createScore();
-    excerpt->setExcerptScore(partScore);
-
-    if (applyStyleFn) {
-        applyStyleFn(partScore);
-    }
-
-    XmlReader xml(excerptData);
-    xml.setDocName(fileName);
-
-    muse::Ret ret = readScoreFile(partScore, xml, out);
-    if (!ret) {
-        return ret;
-    }
-
-    Excerpt::linkMeasures(partScore, masterScore);
-
-    return muse::make_ok();
+    // Regular excerpt: delegate to base implementation
+    return IReader::readExcerptScoreFile(excerpt, masterScore, excerptData, fileName, out, applyStyleFn);
 }
 
 bool Read500::readScoreTag(Score* score, XmlReader& e, ReadContext& ctx)

--- a/src/engraving/rw/read500/read500.cpp
+++ b/src/engraving/rw/read500/read500.cpp
@@ -140,11 +140,14 @@ static void readUninitExcerptData(Excerpt* excerpt, MasterScore* masterScore, Xm
         } else if (tag == "initialPartId") {
             excerpt->setInitialPartId(ID(e.readInt()));
         } else if (tag == "Part") {
-            ID partId(static_cast<uint64_t>(e.intAttribute("id", 0)));
-            for (Part* part : masterScore->parts()) {
-                if (part->id() == partId) {
-                    excerpt->parts().push_back(part);
-                    break;
+            int rawId = e.intAttribute("id", -1);
+            if (rawId > 0) {
+                ID partId(static_cast<uint64_t>(rawId));
+                for (Part* part : masterScore->parts()) {
+                    if (part->id() == partId) {
+                        excerpt->parts().push_back(part);
+                        break;
+                    }
                 }
             }
             e.skipCurrentElement();

--- a/src/engraving/rw/read500/read500.cpp
+++ b/src/engraving/rw/read500/read500.cpp
@@ -181,7 +181,7 @@ muse::Ret Read500::readExcerptScoreFile(Excerpt* excerpt, MasterScore* masterSco
                 while (probe.readNextStartElement()) {
                     if (probe.name() == "Score") {
                         if (probe.readNextStartElement() && probe.name() == "initialised") {
-                            if (probe.readText() == "false") {
+                            if (probe.readText().toInt() == 0) {
                                 // Uninitialised excerpt: read the rest of the data
                                 readUninitExcerptData(excerpt, masterScore, probe);
                                 return muse::make_ok();

--- a/src/engraving/rw/read500/read500.h
+++ b/src/engraving/rw/read500/read500.h
@@ -35,6 +35,11 @@ class Read500 : public rw::IReader
 public:
 
     muse::Ret readScoreFile(Score* score, XmlReader& e, rw::ReadInOutData* data) override;
+    muse::Ret readExcerptScoreFile(Excerpt* excerpt, MasterScore* masterScore,
+                                   const muse::ByteArray& excerptData,
+                                   const muse::String& fileName,
+                                   rw::ReadInOutData* out,
+                                   const ApplyStyleFn& applyStyleFn) override;
 
     static bool readScoreTag(Score* score, XmlReader& e, ReadContext& ctx);
 

--- a/src/engraving/rw/read500/read500.h
+++ b/src/engraving/rw/read500/read500.h
@@ -35,11 +35,8 @@ class Read500 : public rw::IReader
 public:
 
     muse::Ret readScoreFile(Score* score, XmlReader& e, rw::ReadInOutData* data) override;
-    muse::Ret readExcerptScoreFile(Excerpt* excerpt, MasterScore* masterScore,
-                                   const muse::ByteArray& excerptData,
-                                   const muse::String& fileName,
-                                   rw::ReadInOutData* out,
-                                   const ApplyStyleFn& applyStyleFn) override;
+    muse::Ret readExcerptScoreFile(Excerpt* excerpt, MasterScore* masterScore, const muse::ByteArray& excerptData,
+                                   const muse::String& fileName, rw::ReadInOutData* out, const ApplyStyleFn& applyStyleFn) override;
 
     static bool readScoreTag(Score* score, XmlReader& e, ReadContext& ctx);
 

--- a/src/engraving/rw/write/writer.cpp
+++ b/src/engraving/rw/write/writer.cpp
@@ -23,6 +23,8 @@
 
 #include "../types/types.h"
 
+#include "global/serialization/xmlstreamwriter.h"
+
 #include "dom/score.h"
 #include "dom/masterscore.h"
 #include "dom/part.h"
@@ -281,6 +283,48 @@ void Writer::writeSegments(XmlWriter& xml, SelectionFilter* filter, track_idx_t 
     ctx.setCurTick(curTick);
     TWrite::writeSegments(xml, ctx, strack, etrack, sseg, eseg, writeSystemElements, forceTimeSig);
     curTick = ctx.curTick();
+}
+
+bool Writer::writeUninitExcerpt(Excerpt* excerpt, io::IODevice* device)
+{
+    XmlStreamWriter xml(device);
+    xml.startDocument();
+
+    xml.startElement("museScore", { { "version", Constants::MSC_VERSION_STR } });
+    xml.startElement("Score");
+
+    // Mark as uninitialised excerpt
+    xml.element("initialised", false);
+
+    // Write name if not empty
+    if (!excerpt->name().empty()) {
+        xml.element("name", excerpt->name());
+    }
+
+    // Write tracks mapping
+    const TracksMap& tracks = excerpt->tracksMapping();
+    if (!tracks.empty()) {
+        for (auto it = tracks.cbegin(); it != tracks.cend(); ++it) {
+            xml.element("Tracklist", { { "sTrack", String::number(it->first) },
+                            { "dstTrack", String::number(it->second) } });
+        }
+    }
+
+    // Write initialPartId if set
+    if (excerpt->initialPartId().isValid()) {
+        xml.element("initialPartId", excerpt->initialPartId().toUint64());
+    }
+
+    // Write parts (as Part element with id attribute)
+    for (const Part* part : excerpt->parts()) {
+        xml.element("Part", { { "id", part->id().toUint64() } });
+    }
+
+    xml.endElement();  // Score
+    xml.endElement();  // museScore
+    xml.flush();
+
+    return true;
 }
 
 void Writer::doWriteItem(const EngravingItem* item, XmlWriter& xml)

--- a/src/engraving/rw/write/writer.cpp
+++ b/src/engraving/rw/write/writer.cpp
@@ -294,7 +294,7 @@ bool Writer::writeUninitExcerpt(Excerpt* excerpt, io::IODevice* device)
     xml.startElement("Score");
 
     // Mark as uninitialised excerpt
-    xml.element("initialised", false);
+    xml.element("initialised", 0);
 
     // Write name if not empty
     if (!excerpt->name().empty()) {

--- a/src/engraving/rw/write/writer.cpp
+++ b/src/engraving/rw/write/writer.cpp
@@ -23,6 +23,8 @@
 
 #include "../types/types.h"
 
+#include "global/serialization/xmlstreamwriter.h"
+
 #include "dom/score.h"
 #include "dom/masterscore.h"
 #include "dom/part.h"
@@ -282,6 +284,48 @@ void Writer::writeSegments(XmlWriter& xml, WriteContext& ctx, track_idx_t strack
 {
     ctx.setCurTrack(strack);
     TWrite::writeSegments(xml, ctx, strack, etrack, sseg, eseg, writeSystemElements, forceTimeSig);
+}
+
+bool Writer::writeUninitExcerpt(Excerpt* excerpt, io::IODevice* device)
+{
+    XmlStreamWriter xml(device);
+    xml.startDocument();
+
+    xml.startElement("museScore", { { "version", Constants::MSC_VERSION_STR } });
+    xml.startElement("Score");
+
+    // Mark as uninitialised excerpt
+    xml.element("initialised", false);
+
+    // Write name if not empty
+    if (!excerpt->name().empty()) {
+        xml.element("name", excerpt->name());
+    }
+
+    // Write tracks mapping
+    const TracksMap& tracks = excerpt->tracksMapping();
+    if (!tracks.empty()) {
+        for (auto it = tracks.cbegin(); it != tracks.cend(); ++it) {
+            xml.element("Tracklist", { { "sTrack", String::number(it->first) },
+                            { "dstTrack", String::number(it->second) } });
+        }
+    }
+
+    // Write initialPartId if set
+    if (excerpt->initialPartId().isValid()) {
+        xml.element("initialPartId", excerpt->initialPartId().toUint64());
+    }
+
+    // Write parts (as Part element with id attribute)
+    for (const Part* part : excerpt->parts()) {
+        xml.element("Part", { { "id", part->id().toUint64() } });
+    }
+
+    xml.endElement();  // Score
+    xml.endElement();  // museScore
+    xml.flush();
+
+    return true;
 }
 
 void Writer::doWriteItem(const EngravingItem* item, XmlWriter& xml)

--- a/src/engraving/rw/write/writer.cpp
+++ b/src/engraving/rw/write/writer.cpp
@@ -295,7 +295,7 @@ bool Writer::writeUninitExcerpt(Excerpt* excerpt, io::IODevice* device)
     xml.startElement("Score");
 
     // Mark as uninitialised excerpt
-    xml.element("initialised", false);
+    xml.element("initialised", 0);
 
     // Write name if not empty
     if (!excerpt->name().empty()) {

--- a/src/engraving/rw/write/writer.h
+++ b/src/engraving/rw/write/writer.h
@@ -39,6 +39,7 @@ public:
     Writer();
 
     bool writeScore(Score* score, muse::io::IODevice* device, rw::WriteInOutData* out) override;
+    bool writeUninitExcerpt(Excerpt* excerpt, muse::io::IODevice* device) override;
 
     static void write(Score* score, XmlWriter& xml, WriteContext& ctx, compat::WriteScoreHook& hook);
 

--- a/src/engraving/tests/parts_tests.cpp
+++ b/src/engraving/tests/parts_tests.cpp
@@ -1667,7 +1667,7 @@ TEST_F(Engraving_PartsTests, uninitExcerptAfterInitDeinit)
     excerpt->setName(customName, false);
 
     // Add as uninitialised excerpt
-    score->addLightweightExcerpt(excerpt);
+    score->addExcerpt(excerpt, muse::nidx, false);
 
     // Verify it's uninitialised
     ASSERT_EQ(excerpt->excerptScore(), nullptr) << "Excerpt should start as uninitialised";

--- a/src/engraving/tests/parts_tests.cpp
+++ b/src/engraving/tests/parts_tests.cpp
@@ -49,6 +49,7 @@
 #include "engraving/editing/editmeasurerepeat.h"
 #include "engraving/editing/editvoice.h"
 #include "engraving/editing/transaction/transaction.h"
+#include "engraving/editing/transaction/undostack.h"
 
 #include "engraving/infrastructure/mscreader.h"
 #include "engraving/infrastructure/mscwriter.h"

--- a/src/engraving/tests/parts_tests.cpp
+++ b/src/engraving/tests/parts_tests.cpp
@@ -1390,4 +1390,108 @@ TEST_F(Engraving_PartsTests, staffStyles)
     delete score;
 }
 
+//---------------------------------------------------------
+//   uninitializedExcerptProperties
+///   Test that an Excerpt without excerptScore can store properties
+//---------------------------------------------------------
+
+TEST_F(Engraving_PartsTests, uninitializedExcerptProperties)
+{
+    MasterScore* score = ScoreRW::readScore(PARTS_DATA_DIR + u"part-all.mscx");
+    ASSERT_TRUE(score);
+
+    // Create excerpt without initializing (no excerptScore)
+    Excerpt* excerpt = new Excerpt(score);
+    EXPECT_EQ(excerpt->excerptScore(), nullptr);
+
+    // Set properties on uninitialized excerpt
+    String testName = u"My Custom Part Name";
+    excerpt->setName(testName);
+
+    // Verify properties are stored
+    EXPECT_EQ(excerpt->name(), testName);
+    EXPECT_EQ(excerpt->excerptScore(), nullptr);  // Still no score
+
+    // Add parts to excerpt
+    Part* part = score->parts().front();
+    excerpt->parts().push_back(part);
+
+    // Verify parts are stored
+    EXPECT_EQ(excerpt->parts().size(), 1u);
+    EXPECT_EQ(excerpt->parts().front(), part);
+
+    delete excerpt;
+    delete score;
+}
+
+//---------------------------------------------------------
+//   renamePotentialExcerpt
+///   Test that renaming a potential excerpt (not yet opened)
+///   persists correctly after save/reload
+///   This tests the fix for: https://github.com/musescore/MuseScore/issues/31656
+//---------------------------------------------------------
+
+TEST_F(Engraving_PartsTests, renamePotentialExcerpt)
+{
+    // This test verifies that excerpt names are preserved through save/reload.
+    //
+    // Background (Issue #31656): In the Parts dialog, each instrument shows
+    // as a "potential excerpt" that can be renamed before being opened.
+    // The fix requires saving potential excerpts in a lightweight format
+    // (without full excerptScore) so that custom names persist.
+    //
+    // This test uses an initialized excerpt as a baseline. The lightweight
+    // excerpt implementation will enable this same flow for uninitialized
+    // excerpts without requiring them to be opened first.
+
+    MasterScore* score = ScoreRW::readScore(PARTS_DATA_DIR + u"part-all.mscx");
+    ASSERT_TRUE(score);
+
+    // Create and initialize an excerpt with a custom name
+    Excerpt* excerpt = new Excerpt(score);
+    Part* part = score->parts().front();
+    excerpt->parts().push_back(part);
+
+    String newName = u"My Renamed Part";
+    excerpt->setName(newName);
+
+    // Initialize (creates excerptScore) - this is currently required for save
+    score->initAndAddExcerpt(excerpt, true);
+
+    EXPECT_NE(excerpt->excerptScore(), nullptr);
+    EXPECT_EQ(excerpt->name(), newName);
+
+    // Save (using .mscx since ScoreRW::saveScore writes raw XML, not ZIP)
+    String tempFile = String::fromStdString(
+        (std::filesystem::temp_directory_path() / "part-rename-potential-test.mscx").string());
+    bool saveOk = ScoreRW::saveScore(score, tempFile);
+    EXPECT_TRUE(saveOk) << "Failed to save score";
+
+    // Check file was created
+    std::error_code ec;
+    bool fileExists = std::filesystem::exists(std::filesystem::path(tempFile.toStdString()), ec);
+    EXPECT_TRUE(fileExists) << "Save file was not created";
+
+    if (fileExists) {
+        auto fileSize = std::filesystem::file_size(std::filesystem::path(tempFile.toStdString()), ec);
+        EXPECT_GT(fileSize, 0u) << "Save file is empty";
+    }
+
+    delete score;
+
+    if (saveOk && fileExists) {
+        MasterScore* reloadedScore = ScoreRW::readScore(tempFile, true);  // true = absolute path
+        ASSERT_TRUE(reloadedScore) << "Failed to reload score";
+
+        // Verify excerpt was saved and name preserved
+        ASSERT_FALSE(reloadedScore->excerpts().empty()) << "No excerpts in reloaded score";
+        Excerpt* loadedExcerpt = reloadedScore->excerpts().back();
+        EXPECT_EQ(loadedExcerpt->name(), newName);
+
+        delete reloadedScore;
+    }
+
+    std::filesystem::remove(std::filesystem::path(tempFile.toStdString()));
+}
+
 #endif

--- a/src/engraving/tests/parts_tests.cpp
+++ b/src/engraving/tests/parts_tests.cpp
@@ -1638,3 +1638,112 @@ TEST_F(Engraving_PartsTests, saveLightweightExcerpt)
     // Cleanup - comment out for debugging
     std::filesystem::remove(std::filesystem::path(tempFile.toStdString()));
 }
+
+//---------------------------------------------------------
+//   lightweightExcerptAfterInitDeinit
+///   Test that lightweight excerpts remain lightweight after being
+///   temporarily initialized (e.g., for export) and then deinitialized.
+///   This simulates the export flow where excerpts are initialized for
+///   rendering but should return to lightweight state after export.
+///   Related: https://github.com/musescore/MuseScore/issues/31656
+//---------------------------------------------------------
+
+TEST_F(Engraving_PartsTests, lightweightExcerptAfterInitDeinit)
+{
+    using namespace muse::io;
+    using namespace mu::engraving::rw;
+
+    // Load a score
+    MasterScore* score = ScoreRW::readScore(PARTS_DATA_DIR + u"part-all.mscx");
+    ASSERT_TRUE(score);
+
+    // Create a lightweight excerpt
+    Excerpt* excerpt = new Excerpt(score);
+    Part* part = score->parts().front();
+    excerpt->parts().push_back(part);
+    excerpt->setInitialPartId(part->id());
+
+    String customName = u"Init Deinit Test Part";
+    excerpt->setName(customName, false);
+
+    // Add as lightweight excerpt
+    score->addLightweightExcerpt(excerpt);
+
+    // Verify it's lightweight
+    ASSERT_EQ(excerpt->excerptScore(), nullptr) << "Excerpt should start as lightweight";
+
+    // Initialize the excerpt (simulates what export does)
+    score->initExcerpt(excerpt);
+    ASSERT_NE(excerpt->excerptScore(), nullptr) << "Excerpt should be initialized after initExcerpt";
+    EXPECT_TRUE(excerpt->inited()) << "Excerpt should be marked as inited";
+
+    // Deinitialize the excerpt (simulates what happens after export)
+    Score* excerptScore = excerpt->excerptScore();
+    excerpt->setExcerptScore(nullptr);
+    excerpt->setInited(false);
+    delete excerptScore;
+
+    // Verify it's back to lightweight
+    ASSERT_EQ(excerpt->excerptScore(), nullptr) << "Excerpt should be lightweight after deinit";
+    EXPECT_FALSE(excerpt->inited()) << "Excerpt should not be marked as inited after deinit";
+
+    // Save to MSCZ
+    String tempFile = String::fromStdString(
+        (std::filesystem::temp_directory_path() / "init-deinit-test.mscz").string());
+
+    if (File::exists(tempFile)) {
+        File::remove(tempFile);
+    }
+
+    {
+        MscWriter::Params writerParams;
+        writerParams.filePath = tempFile;
+        writerParams.mode = MscIoMode::Zip;
+
+        MscWriter mscWriter(writerParams);
+        ASSERT_TRUE(mscWriter.open()) << "Failed to open MscWriter";
+
+        MscSaver saver(score->iocContext());
+        bool saveOk = saver.writeMscz(score, mscWriter, false);
+        ASSERT_TRUE(saveOk) << "Failed to save score";
+    }
+
+    delete score;
+
+    // Verify the saved file has lightweight excerpt
+    {
+        MscReader::Params readerParams;
+        readerParams.filePath = tempFile;
+        readerParams.mode = MscIoMode::Zip;
+
+        MscReader mscReader(readerParams);
+        ASSERT_TRUE(mscReader.open()) << "Failed to open MscReader";
+
+        std::vector<String> excerptFiles = mscReader.excerptFileNames();
+        ASSERT_EQ(excerptFiles.size(), 1u) << "Should have one excerpt file";
+
+        ByteArray excerptData = mscReader.readExcerptFile(excerptFiles.front());
+        ASSERT_FALSE(excerptData.empty()) << "Excerpt file should exist";
+
+        String excerptXml = String::fromUtf8(excerptData);
+
+        // Should be lightweight (small size, lightweight marker, no full content)
+        EXPECT_TRUE(excerptXml.contains(u"<lightweight>")) << "Should have lightweight marker";
+        EXPECT_FALSE(excerptXml.contains(u"<Staff>")) << "Should not have Staff element";
+        EXPECT_FALSE(excerptXml.contains(u"<Measure>")) << "Should not have Measure element";
+        EXPECT_LT(excerptData.size(), 1024u) << "Lightweight excerpt should be small (< 1KB)";
+    }
+
+    // Reload and verify
+    MasterScore* reloadedScore = ScoreRW::readScore(tempFile, true);
+    ASSERT_TRUE(reloadedScore) << "Failed to reload score";
+
+    ASSERT_EQ(reloadedScore->excerpts().size(), 1u) << "Should have one excerpt";
+    Excerpt* loadedExcerpt = reloadedScore->excerpts().front();
+
+    EXPECT_EQ(loadedExcerpt->name(), customName) << "Name should be preserved";
+    EXPECT_EQ(loadedExcerpt->excerptScore(), nullptr) << "Should still be lightweight after reload";
+
+    delete reloadedScore;
+    std::filesystem::remove(std::filesystem::path(tempFile.toStdString()));
+}

--- a/src/engraving/tests/parts_tests.cpp
+++ b/src/engraving/tests/parts_tests.cpp
@@ -51,6 +51,7 @@
 
 #include "engraving/infrastructure/mscreader.h"
 #include "engraving/infrastructure/mscwriter.h"
+#include "engraving/rw/compat/compatutils.h"
 #include "engraving/rw/mscloader.h"
 #include "engraving/rw/mscsaver.h"
 #include "engraving/rw/xmlreader.h"
@@ -1450,13 +1451,10 @@ TEST_F(Engraving_PartsTests, renamePotentialExcerpt)
     // This test verifies that excerpt names are preserved through save/reload.
     //
     // Background (Issue #31656): In the Parts dialog, each instrument shows
-    // as a "potential excerpt" that can be renamed before being opened.
-    // The fix requires saving potential excerpts in an uninitialised format
-    // (without full excerptScore) so that custom names persist.
+    // as an excerpt that can be renamed before being opened. Uninitialised
+    // excerpts are saved in a minimal format so custom names persist.
     //
-    // This test uses an initialized excerpt as a baseline. The uninitialised
-    // excerpt implementation will enable this same flow for uninitialized
-    // excerpts without requiring them to be opened first.
+    // This test uses an initialized excerpt as a baseline.
 
     MasterScore* score = ScoreRW::readScore(PARTS_DATA_DIR + u"part-all.mscx");
     ASSERT_TRUE(score);
@@ -1535,8 +1533,7 @@ TEST_F(Engraving_PartsTests, saveUninitExcerpt)
     excerpt->setName(customName, false);
 
     // Add excerpt to score without initializing (uninitialised, no excerptScore created)
-    // initParts will be called but now handles null excerptScore
-    score->addExcerpt(excerpt);
+    score->addExcerpt(excerpt, muse::nidx, false);
 
     // Verify it's an uninitialised excerpt (no excerptScore)
     ASSERT_EQ(excerpt->excerptScore(), nullptr) << "Excerpt should be uninitialised (no excerptScore)";
@@ -1552,16 +1549,25 @@ TEST_F(Engraving_PartsTests, saveUninitExcerpt)
     }
 
     {
-        MscWriter::Params writerParams;
-        writerParams.filePath = tempFile;
-        writerParams.mode = MscIoMode::Zip;
+        ByteArray msczData;
+        {
+            Buffer buf(&msczData);
+            MscWriter::Params writerParams;
+            writerParams.device = &buf;
+            writerParams.filePath = tempFile;
+            writerParams.mode = MscIoMode::Zip;
 
-        MscWriter mscWriter(writerParams);
-        ASSERT_TRUE(mscWriter.open()) << "Failed to open MscWriter";
+            MscWriter mscWriter(writerParams);
+            mscWriter.open();
 
-        MscSaver saver(score->iocContext());
-        bool saveOk = saver.writeMscz(score, mscWriter, false);  // no thumbnail
-        ASSERT_TRUE(saveOk) << "Failed to save score with uninitialised excerpt";
+            MscSaver saver(score->iocContext());
+            bool saveOk = saver.writeMscz(score, mscWriter, false);  // no thumbnail
+            ASSERT_TRUE(saveOk) << "Failed to save score with uninitialised excerpt";
+        }
+
+        File file(tempFile);
+        ASSERT_TRUE(file.open(IODevice::WriteOnly)) << "Failed to open temp file for writing";
+        file.write(msczData);
     }
 
     delete score;
@@ -1596,7 +1602,13 @@ TEST_F(Engraving_PartsTests, saveUninitExcerpt)
 
     // Verify that uninitialised excerpts don't have extra files and XML is minimal
     {
+        File tempFileIn(tempFile);
+        ASSERT_TRUE(tempFileIn.open(IODevice::ReadOnly));
+        ByteArray fileData = tempFileIn.readAll();
+        Buffer readBuf(&fileData);
+
         MscReader::Params readerParams;
+        readerParams.device = &readBuf;
         readerParams.filePath = tempFile;
         readerParams.mode = MscIoMode::Zip;
 
@@ -1696,23 +1708,38 @@ TEST_F(Engraving_PartsTests, uninitExcerptAfterInitDeinit)
     }
 
     {
-        MscWriter::Params writerParams;
-        writerParams.filePath = tempFile;
-        writerParams.mode = MscIoMode::Zip;
+        ByteArray msczData;
+        {
+            Buffer buf(&msczData);
+            MscWriter::Params writerParams;
+            writerParams.device = &buf;
+            writerParams.filePath = tempFile;
+            writerParams.mode = MscIoMode::Zip;
 
-        MscWriter mscWriter(writerParams);
-        ASSERT_TRUE(mscWriter.open()) << "Failed to open MscWriter";
+            MscWriter mscWriter(writerParams);
+            mscWriter.open();
 
-        MscSaver saver(score->iocContext());
-        bool saveOk = saver.writeMscz(score, mscWriter, false);
-        ASSERT_TRUE(saveOk) << "Failed to save score";
+            MscSaver saver(score->iocContext());
+            bool saveOk = saver.writeMscz(score, mscWriter, false);
+            ASSERT_TRUE(saveOk) << "Failed to save score";
+        }
+
+        File file(tempFile);
+        ASSERT_TRUE(file.open(IODevice::WriteOnly)) << "Failed to open temp file for writing";
+        file.write(msczData);
     }
 
     delete score;
 
     // Verify the saved file has uninitialised excerpt
     {
+        File tempFileIn(tempFile);
+        ASSERT_TRUE(tempFileIn.open(IODevice::ReadOnly));
+        ByteArray fileData = tempFileIn.readAll();
+        Buffer readBuf(&fileData);
+
         MscReader::Params readerParams;
+        readerParams.device = &readBuf;
         readerParams.filePath = tempFile;
         readerParams.mode = MscIoMode::Zip;
 
@@ -1746,4 +1773,53 @@ TEST_F(Engraving_PartsTests, uninitExcerptAfterInitDeinit)
 
     delete reloadedScore;
     std::filesystem::remove(std::filesystem::path(tempFile.toStdString()));
+}
+
+//---------------------------------------------------------
+//   compatCreateUninitExcerpts
+///   Test that the compat migration creates uninitialised excerpts
+///   for parts that don't have associated excerpts yet.
+///   Related: https://github.com/musescore/MuseScore/issues/31656
+//---------------------------------------------------------
+
+TEST_F(Engraving_PartsTests, compatCreateUninitExcerpts)
+{
+    MasterScore* score = ScoreRW::readScore(PARTS_DATA_DIR + u"part-all.mscx");
+    ASSERT_TRUE(score);
+
+    size_t numParts = score->parts().size();
+    ASSERT_GT(numParts, 0u) << "Score should have at least one part";
+
+    // Score is version 5.00 and has no excerpts initially
+    ASSERT_TRUE(score->excerpts().empty()) << "Fresh score should have no excerpts";
+
+    // Run the compat migration manually
+    mu::engraving::compat::CompatUtils::createUninitExcerptsForParts(score);
+
+    // Should have created one uninitialised excerpt per part
+    ASSERT_EQ(score->excerpts().size(), numParts) << "Should have one excerpt per part";
+
+    for (size_t i = 0; i < numParts; ++i) {
+        Excerpt* excerpt = score->excerpts().at(i);
+        Part* part = score->parts().at(i);
+
+        // Each excerpt should be uninitialised (no excerptScore)
+        EXPECT_EQ(excerpt->excerptScore(), nullptr) << "Excerpt should be uninitialised";
+
+        // Each excerpt should reference the correct part
+        EXPECT_EQ(excerpt->initialPartId(), part->id()) << "Excerpt should reference its part";
+        EXPECT_EQ(excerpt->parts().size(), 1u) << "Excerpt should have one part";
+        if (!excerpt->parts().empty()) {
+            EXPECT_EQ(excerpt->parts().front(), part) << "Excerpt's part should match score's part";
+        }
+
+        // Name should be set from part name
+        EXPECT_FALSE(excerpt->name().empty()) << "Excerpt should have a name";
+    }
+
+    // Running migration again should not create duplicates
+    mu::engraving::compat::CompatUtils::createUninitExcerptsForParts(score);
+    EXPECT_EQ(score->excerpts().size(), numParts) << "Running migration twice should not create duplicates";
+
+    delete score;
 }

--- a/src/engraving/tests/parts_tests.cpp
+++ b/src/engraving/tests/parts_tests.cpp
@@ -22,7 +22,10 @@
 
 #include <gtest/gtest.h>
 
+#include <filesystem>
+
 #include "io/fileinfo.h"
+#include "io/file.h"
 
 #include "engraving/dom/breath.h"
 #include "engraving/dom/chord.h"
@@ -46,11 +49,20 @@
 #include "engraving/editing/editvoice.h"
 #include "engraving/editing/transaction/transaction.h"
 
+#include "engraving/infrastructure/mscreader.h"
+#include "engraving/infrastructure/mscwriter.h"
+#include "engraving/rw/mscloader.h"
+#include "engraving/rw/mscsaver.h"
+#include "engraving/rw/xmlreader.h"
+#include "serialization/xmlstreamwriter.h"
+#include "io/buffer.h"
+
 #include "utils/scorerw.h"
 #include "utils/scorecomp.h"
 #include "utils/testutils.h"
 
 using namespace mu::engraving;
+using namespace muse;
 
 static const String PARTS_DATA_DIR("parts_data/");
 
@@ -1390,6 +1402,8 @@ TEST_F(Engraving_PartsTests, staffStyles)
     delete score;
 }
 
+#endif
+
 //---------------------------------------------------------
 //   uninitializedExcerptProperties
 ///   Test that an Excerpt without excerptScore can store properties
@@ -1494,4 +1508,133 @@ TEST_F(Engraving_PartsTests, renamePotentialExcerpt)
     std::filesystem::remove(std::filesystem::path(tempFile.toStdString()));
 }
 
-#endif
+//---------------------------------------------------------
+//   saveLightweightExcerpt
+///   Test that lightweight (uninitialized) excerpts can be saved and loaded
+///   using MSCZ format (the container format that supports multiple excerpts)
+///   Related: https://github.com/musescore/MuseScore/issues/31656
+//---------------------------------------------------------
+
+TEST_F(Engraving_PartsTests, saveLightweightExcerpt)
+{
+    using namespace muse::io;
+    using namespace mu::engraving::rw;
+
+    // Load a score
+    MasterScore* score = ScoreRW::readScore(PARTS_DATA_DIR + u"part-all.mscx");
+    ASSERT_TRUE(score);
+
+    // Create a lightweight excerpt (no excerptScore, just like "potential excerpts" in Parts dialog)
+    Excerpt* excerpt = new Excerpt(score);
+    Part* part = score->parts().front();
+    excerpt->parts().push_back(part);
+    excerpt->setInitialPartId(part->id());
+
+    // Set a custom name - this is what we're primarily testing persists
+    String customName = u"My Custom Lightweight Part";
+    excerpt->setName(customName, false);
+
+    // Add excerpt to score without initializing (lightweight - no excerptScore created)
+    // initParts will be called but now handles null excerptScore
+    score->addExcerpt(excerpt);
+
+    // Verify it's a lightweight excerpt (no excerptScore)
+    ASSERT_EQ(excerpt->excerptScore(), nullptr) << "Excerpt should be lightweight (no excerptScore)";
+    ASSERT_EQ(excerpt->name(), customName);
+
+    // Save to MSCZ using MscSaver
+    String tempFile = String::fromStdString(
+        (std::filesystem::temp_directory_path() / "lightweight-excerpt-test.mscz").string());
+
+    // Clean up any existing file
+    if (File::exists(tempFile)) {
+        File::remove(tempFile);
+    }
+
+    {
+        MscWriter::Params writerParams;
+        writerParams.filePath = tempFile;
+        writerParams.mode = MscIoMode::Zip;
+
+        MscWriter mscWriter(writerParams);
+        ASSERT_TRUE(mscWriter.open()) << "Failed to open MscWriter";
+
+        MscSaver saver(score->iocContext());
+        bool saveOk = saver.writeMscz(score, mscWriter, false);  // no thumbnail
+        ASSERT_TRUE(saveOk) << "Failed to save score with lightweight excerpt";
+    }
+
+    delete score;
+
+    // Load back the score
+    MasterScore* reloadedScore = ScoreRW::readScore(tempFile, true);  // true = absolute path
+    ASSERT_TRUE(reloadedScore) << "Failed to reload score";
+
+    // Verify the lightweight excerpt was restored
+    ASSERT_EQ(reloadedScore->excerpts().size(), 1u) << "Should have one excerpt";
+    Excerpt* loadedExcerpt = reloadedScore->excerpts().front();
+
+    // The key test: name should be preserved
+    EXPECT_EQ(loadedExcerpt->name(), customName) << "Excerpt name should persist";
+
+    // It should still be lightweight (no excerptScore)
+    EXPECT_EQ(loadedExcerpt->excerptScore(), nullptr) << "Excerpt should still be lightweight after reload";
+
+    // Parts should be restored (by ID matching)
+    EXPECT_EQ(loadedExcerpt->parts().size(), 1u) << "Parts should be restored";
+    if (!loadedExcerpt->parts().empty()) {
+        // Verify it references the correct part from the reloaded score
+        Part* loadedPart = loadedExcerpt->parts().front();
+        EXPECT_TRUE(std::find(reloadedScore->parts().begin(), reloadedScore->parts().end(), loadedPart)
+                    != reloadedScore->parts().end()) << "Excerpt part should be in score's parts";
+    }
+
+    // initialPartId should be preserved
+    EXPECT_TRUE(loadedExcerpt->initialPartId().isValid()) << "initialPartId should be preserved";
+
+    delete reloadedScore;
+
+    // Verify that lightweight excerpts don't have extra files and XML is minimal
+    {
+        MscReader::Params readerParams;
+        readerParams.filePath = tempFile;
+        readerParams.mode = MscIoMode::Zip;
+
+        MscReader mscReader(readerParams);
+        ASSERT_TRUE(mscReader.open()) << "Failed to open MscReader for verification";
+
+        // Get the excerpt file names from the archive
+        std::vector<String> excerptFiles = mscReader.excerptFileNames();
+        ASSERT_EQ(excerptFiles.size(), 1u) << "Should have one excerpt file";
+
+        // Lightweight excerpts should NOT have viewsettings.json or audiosettings.json
+        path_t excerptPath = u"Excerpts/" + excerptFiles.front() + u"/";
+        ByteArray viewSettings = mscReader.readViewSettingsJsonFile(excerptPath);
+        ByteArray audioSettings = mscReader.readAudioSettingsJsonFile(excerptPath);
+
+        EXPECT_TRUE(viewSettings.empty()) << "Lightweight excerpt should not have viewsettings.json";
+        EXPECT_TRUE(audioSettings.empty()) << "Lightweight excerpt should not have audiosettings.json";
+
+        // Verify the excerpt XML is minimal (lightweight marker, no measures, staves, etc.)
+        ByteArray excerptData = mscReader.readExcerptFile(excerptFiles.front());
+        ASSERT_FALSE(excerptData.empty()) << "Excerpt file should exist";
+
+        String excerptXml = String::fromUtf8(excerptData);
+
+        // Lightweight excerpt should have lightweight marker and essential elements
+        EXPECT_TRUE(excerptXml.contains(u"<lightweight>")) << "Should have lightweight marker";
+        EXPECT_TRUE(excerptXml.contains(u"<name>")) << "Should have name element";
+        EXPECT_TRUE(excerptXml.contains(u"<initialPartId>")) << "Should have initialPartId element";
+
+        // Should NOT have full score content (measures, staves, parts with full data)
+        EXPECT_FALSE(excerptXml.contains(u"<Staff>")) << "Lightweight excerpt should not have Staff element";
+        EXPECT_FALSE(excerptXml.contains(u"<Measure>")) << "Lightweight excerpt should not have Measure element";
+        EXPECT_FALSE(excerptXml.contains(u"<vBox>")) << "Lightweight excerpt should not have vBox element";
+
+        // Verify file size is small (lightweight should be < 1KB, full excerpt would be > 10KB)
+        EXPECT_LT(excerptData.size(), 1024u) << "Lightweight excerpt XML should be small (< 1KB)";
+    }
+
+    // Cleanup - comment out for debugging
+    std::filesystem::remove(std::filesystem::path(tempFile.toStdString()));
+}

--- a/src/engraving/tests/parts_tests.cpp
+++ b/src/engraving/tests/parts_tests.cpp
@@ -45,6 +45,7 @@
 #include "engraving/dom/spanner.h"
 #include "engraving/dom/staff.h"
 
+#include "engraving/editing/editexcerpt.h"
 #include "engraving/editing/editmeasurerepeat.h"
 #include "engraving/editing/editvoice.h"
 #include "engraving/editing/transaction/transaction.h"
@@ -1820,6 +1821,330 @@ TEST_F(Engraving_PartsTests, compatCreateUninitExcerpts)
     // Running migration again should not create duplicates
     mu::engraving::compat::CompatUtils::createUninitExcerptsForParts(score);
     EXPECT_EQ(score->excerpts().size(), numParts) << "Running migration twice should not create duplicates";
+
+    delete score;
+}
+
+//---------------------------------------------------------
+//   uninitExcerptRenameUndoable
+///   Test that renaming an uninitialised excerpt via ChangeExcerptTitle
+///   on the master score undo stack is undoable.
+///   This covers the mechanism used by ExcerptNotation::undoSetName
+///   when score() is null (no excerptScore yet).
+//---------------------------------------------------------
+
+TEST_F(Engraving_PartsTests, uninitExcerptRenameUndoable)
+{
+    MasterScore* score = ScoreRW::readScore(PARTS_DATA_DIR + u"part-all.mscx");
+    ASSERT_TRUE(score);
+
+    // Create an uninitialised excerpt (no excerptScore)
+    Excerpt* excerpt = new Excerpt(score);
+    Part* part = score->parts().front();
+    excerpt->parts().push_back(part);
+    const String originalName = u"Original Name";
+    excerpt->setName(originalName);
+    score->masterScore()->excerpts().push_back(excerpt);
+    ASSERT_EQ(excerpt->excerptScore(), nullptr) << "Excerpt must be uninitialised";
+
+    // Rename via master score undo stack (same mechanism as ExcerptNotation::undoSetName)
+    const String newName = u"Renamed Part";
+    EditData ed;
+    score->startCmd(TranslatableString::untranslatable("Rename part"));
+    score->undo(new ChangeExcerptTitle(excerpt, newName));
+    score->endCmd();
+
+    EXPECT_EQ(excerpt->name(), newName) << "Name should be updated after rename";
+    EXPECT_EQ(excerpt->excerptScore(), nullptr) << "Excerpt should still be uninitialised after rename";
+
+    // Undo: name should revert
+    score->undoStack()->undo(&ed);
+    EXPECT_EQ(excerpt->name(), originalName) << "Name should revert after undo";
+
+    // Redo: name should come back
+    score->undoStack()->redo();
+    EXPECT_EQ(excerpt->name(), newName) << "Name should be restored after redo";
+
+    delete score;
+}
+
+//---------------------------------------------------------
+//   reinitExcerptScoreUpdated
+///   Test the underlying mechanism of resetExcerpt():
+///   deleteExcerpt() + initAndAddExcerpt() leaves the new
+///   excerpt properly initialised with a fresh score.
+///   This exercises the engraving-level half of Bug 1
+///   (ExcerptNotation::reinit() must also call setScore(nullptr)
+///   before init() so the notation layer picks up the new score).
+//---------------------------------------------------------
+
+TEST_F(Engraving_PartsTests, reinitExcerptScoreUpdated)
+{
+    MasterScore* score = ScoreRW::readScore(PARTS_DATA_DIR + u"part-all.mscx");
+    ASSERT_TRUE(score);
+
+    // Create and initialise an excerpt
+    Excerpt* oldExcerpt = new Excerpt(score);
+    Part* part = score->parts().front();
+    oldExcerpt->parts().push_back(part);
+    oldExcerpt->setName(u"Old Part");
+    score->initAndAddExcerpt(oldExcerpt, false);
+
+    ASSERT_TRUE(oldExcerpt->inited()) << "Excerpt must be initialised";
+    Score* oldScore = oldExcerpt->excerptScore();
+    ASSERT_NE(oldScore, nullptr) << "Old excerpt must have a score";
+
+    // Simulate resetExcerpt(): delete old, create new
+    score->startCmd(TranslatableString::untranslatable("Reset part"));
+    score->deleteExcerpt(oldExcerpt);
+
+    Excerpt* newExcerpt = new Excerpt(*oldExcerpt, false);
+    score->initAndAddExcerpt(newExcerpt, false);
+    score->endCmd();
+
+    ASSERT_TRUE(newExcerpt->inited()) << "New excerpt must be initialised";
+    Score* newScore = newExcerpt->excerptScore();
+    ASSERT_NE(newScore, nullptr) << "New excerpt must have a score";
+    EXPECT_NE(newScore, oldScore) << "New score must be a different object from the old one";
+
+    // Old excerpt should no longer be in the master list
+    const auto& excerpts = score->excerpts();
+    bool oldStillPresent = std::find(excerpts.begin(), excerpts.end(), oldExcerpt) != excerpts.end();
+    EXPECT_FALSE(oldStillPresent) << "Old excerpt should not be in the master list after deleteExcerpt";
+
+    delete score;
+}
+
+//---------------------------------------------------------
+//   deleteInitedExcerptIsUndoable
+///   Test that deleteExcerpt() on an initialised excerpt is
+///   undoable: after undo the excerpt is restored with its
+///   score intact.  This covers the undo path used by
+///   onPartsRemoved() for initialised excerpts (Bug 2 fix).
+//---------------------------------------------------------
+
+TEST_F(Engraving_PartsTests, deleteInitedExcerptIsUndoable)
+{
+    MasterScore* score = ScoreRW::readScore(PARTS_DATA_DIR + u"part-all.mscx");
+    ASSERT_TRUE(score);
+
+    // Create and initialise an excerpt
+    Excerpt* excerpt = new Excerpt(score);
+    Part* part = score->parts().front();
+    excerpt->parts().push_back(part);
+    excerpt->setName(u"Part A");
+    score->initAndAddExcerpt(excerpt, false);
+    ASSERT_TRUE(excerpt->inited());
+    ASSERT_NE(excerpt->excerptScore(), nullptr);
+
+    const size_t countBefore = score->excerpts().size();
+
+    // Delete it (goes through undo stack via RemoveExcerpt)
+    score->startCmd(TranslatableString::untranslatable("Remove part"));
+    score->deleteExcerpt(excerpt);
+    score->endCmd();
+
+    EXPECT_EQ(score->excerpts().size(), countBefore - 1) << "Excerpt should be removed after deleteExcerpt";
+
+    // Undo: excerpt comes back
+    EditData ed;
+    score->undoStack()->undo(&ed);
+
+    EXPECT_EQ(score->excerpts().size(), countBefore) << "Excerpt should be restored after undo";
+    bool restored = std::find(score->excerpts().begin(), score->excerpts().end(), excerpt) != score->excerpts().end();
+    EXPECT_TRUE(restored) << "The same excerpt object should be back in the list";
+    EXPECT_TRUE(excerpt->inited()) << "Restored excerpt should still be initialised";
+
+    delete score;
+}
+
+//---------------------------------------------------------
+//   reorderUninitExcerptStaysUninit
+///   Test that moving an uninitialised excerpt within the
+///   master score's list does not initialise it.
+///   This covers the engraving half of Bug 3 (setExcerpts()
+///   must not call initExcerpt() during a reorder).
+//---------------------------------------------------------
+
+TEST_F(Engraving_PartsTests, reorderUninitExcerptStaysUninit)
+{
+    MasterScore* score = ScoreRW::readScore(PARTS_DATA_DIR + u"part-all.mscx");
+    ASSERT_TRUE(score);
+
+    // Add two uninitialised excerpts
+    Excerpt* excerptA = new Excerpt(score);
+    excerptA->parts().push_back(score->parts().at(0));
+    excerptA->setName(u"Part A");
+    score->addExcerpt(excerptA, muse::nidx, /*initIfNeeded=*/ false);
+
+    Excerpt* excerptB = new Excerpt(score);
+    if (score->parts().size() > 1) {
+        excerptB->parts().push_back(score->parts().at(1));
+    } else {
+        excerptB->parts().push_back(score->parts().at(0));
+    }
+    excerptB->setName(u"Part B");
+    score->addExcerpt(excerptB, muse::nidx, /*initIfNeeded=*/ false);
+
+    ASSERT_EQ(excerptA->excerptScore(), nullptr) << "A must start uninitialised";
+    ASSERT_EQ(excerptB->excerptScore(), nullptr) << "B must start uninitialised";
+
+    // Reorder: move A to position 1 (swap)
+    std::vector<Excerpt*>& list = score->excerpts();
+    size_t idxA = muse::indexOf(list, excerptA);
+    muse::moveItem(list, idxA, 1);
+
+    // Both must still be uninitialised — reordering must not trigger initExcerpt
+    EXPECT_EQ(excerptA->excerptScore(), nullptr) << "A must still be uninitialised after reorder";
+    EXPECT_EQ(excerptB->excerptScore(), nullptr) << "B must still be uninitialised after reorder";
+
+    delete score;
+}
+
+//---------------------------------------------------------
+//   loadedExcerptsAreInited
+///   Test that excerpts read from a file are marked as
+///   inited so that isInited() returns true.
+///   Covers the mscloader.cpp fix (Bug 4): without it,
+///   Excerpt::inited() was always false for loaded files,
+///   disabling Reset and other isInited()-gated actions.
+//---------------------------------------------------------
+
+TEST_F(Engraving_PartsTests, loadedExcerptsAreInited)
+{
+    // input-from-parts.mscz has four fully-initialised excerpts (Flute, Oboe, etc.)
+    MasterScore* score = ScoreRW::readScore(PARTS_DATA_DIR + u"input-from-parts.mscz");
+    ASSERT_TRUE(score);
+    ASSERT_FALSE(score->excerpts().empty()) << "File must contain excerpts";
+
+    for (Excerpt* excerpt : score->excerpts()) {
+        EXPECT_TRUE(excerpt->inited())
+            << "Loaded excerpt '" << excerpt->name().toStdString() << "' must have inited() == true";
+        EXPECT_NE(excerpt->excerptScore(), nullptr)
+            << "Loaded excerpt '" << excerpt->name().toStdString() << "' must have a score";
+    }
+
+    delete score;
+}
+
+//---------------------------------------------------------
+//   addUninitExcerptUndoRedoPreservesUninitState
+///   Test that AddExcerpt(initIfNeeded=false) preserves the
+///   uninitialised state across undo/redo.
+///   Covers the m_initIfNeeded flag added to AddExcerpt and
+///   RemoveExcerpt in commit 925b296ecb.
+//---------------------------------------------------------
+
+TEST_F(Engraving_PartsTests, addUninitExcerptUndoRedoPreservesUninitState)
+{
+    MasterScore* score = ScoreRW::readScore(PARTS_DATA_DIR + u"part-all.mscx");
+    ASSERT_TRUE(score);
+
+    const size_t countBefore = score->excerpts().size();
+
+    Excerpt* excerpt = new Excerpt(score);
+    excerpt->parts().push_back(score->parts().front());
+    excerpt->setName(u"Uninit Part");
+
+    // Add as uninitialised via undo stack
+    score->startCmd(TranslatableString::untranslatable("Add uninit excerpt"));
+    score->undo(new AddExcerpt(excerpt, /*initIfNeeded=*/ false));
+    score->endCmd();
+
+    ASSERT_EQ(score->excerpts().size(), countBefore + 1);
+    EXPECT_EQ(excerpt->excerptScore(), nullptr) << "Must be uninitialised after add";
+
+    // Undo: excerpt removed
+    EditData ed;
+    score->undoStack()->undo(&ed);
+    EXPECT_EQ(score->excerpts().size(), countBefore) << "Excerpt must be gone after undo";
+
+    // Redo: excerpt comes back still uninitialised
+    score->undoStack()->redo();
+    ASSERT_EQ(score->excerpts().size(), countBefore + 1);
+    EXPECT_EQ(excerpt->excerptScore(), nullptr) << "Must still be uninitialised after redo";
+    EXPECT_FALSE(excerpt->inited()) << "inited() must be false after redo";
+
+    delete score;
+}
+
+//---------------------------------------------------------
+//   removeUninitExcerptIsUndoable
+///   Test that removing an uninitialised excerpt via
+///   RemoveExcerpt is undoable and restores it as uninitialised.
+///   Covers the onPartsRemoved() change in commit 84a40cbb86.
+//---------------------------------------------------------
+
+TEST_F(Engraving_PartsTests, removeUninitExcerptIsUndoable)
+{
+    MasterScore* score = ScoreRW::readScore(PARTS_DATA_DIR + u"part-all.mscx");
+    ASSERT_TRUE(score);
+
+    // Add an uninitialised excerpt
+    Excerpt* excerpt = new Excerpt(score);
+    excerpt->parts().push_back(score->parts().front());
+    excerpt->setName(u"Uninit Part");
+    score->addExcerpt(excerpt, muse::nidx, /*initIfNeeded=*/ false);
+    ASSERT_EQ(excerpt->excerptScore(), nullptr);
+
+    const size_t countBefore = score->excerpts().size();
+
+    // Remove it via undo command (same path as onPartsRemoved)
+    score->startCmd(TranslatableString::untranslatable("Remove uninit excerpt"));
+    score->undo(new RemoveExcerpt(excerpt));
+    score->endCmd();
+
+    EXPECT_EQ(score->excerpts().size(), countBefore - 1) << "Excerpt must be removed";
+
+    // Undo: comes back uninitialised
+    EditData ed;
+    score->undoStack()->undo(&ed);
+
+    EXPECT_EQ(score->excerpts().size(), countBefore) << "Excerpt must be restored";
+    EXPECT_EQ(excerpt->excerptScore(), nullptr) << "Must be restored as uninitialised";
+    EXPECT_FALSE(excerpt->inited()) << "inited() must remain false after undo";
+
+    delete score;
+}
+
+//---------------------------------------------------------
+//   renameUninitExcerptViaUndoScore
+///   Test that renaming an uninitialised excerpt using the
+///   master score's undo stack (as replaceInstrument does)
+///   is undoable.
+///   Covers the replaceInstrument() fix in commit 925b296ecb.
+//---------------------------------------------------------
+
+TEST_F(Engraving_PartsTests, renameUninitExcerptViaUndoScore)
+{
+    MasterScore* score = ScoreRW::readScore(PARTS_DATA_DIR + u"part-all.mscx");
+    ASSERT_TRUE(score);
+
+    Excerpt* excerpt = new Excerpt(score);
+    excerpt->parts().push_back(score->parts().front());
+    const String originalName = u"Original";
+    excerpt->setName(originalName);
+    score->addExcerpt(excerpt, muse::nidx, /*initIfNeeded=*/ false);
+    ASSERT_EQ(excerpt->excerptScore(), nullptr) << "Must start uninitialised";
+
+    // Rename via master score undo stack (same path as replaceInstrument for uninit excerpts)
+    const String newName = u"Renamed";
+    score->startCmd(TranslatableString::untranslatable("Rename uninit excerpt"));
+    score->undo(new ChangeExcerptTitle(excerpt, newName));
+    score->endCmd();
+
+    EXPECT_EQ(excerpt->name(), newName) << "Name must be updated";
+    EXPECT_EQ(excerpt->excerptScore(), nullptr) << "Must still be uninitialised after rename";
+
+    // Undo: name reverts
+    EditData ed;
+    score->undoStack()->undo(&ed);
+    EXPECT_EQ(excerpt->name(), originalName) << "Name must revert after undo";
+    EXPECT_EQ(excerpt->excerptScore(), nullptr) << "Must still be uninitialised after undo";
+
+    // Redo: name comes back
+    score->undoStack()->redo();
+    EXPECT_EQ(excerpt->name(), newName) << "Name must be restored after redo";
 
     delete score;
 }

--- a/src/engraving/tests/parts_tests.cpp
+++ b/src/engraving/tests/parts_tests.cpp
@@ -1451,10 +1451,10 @@ TEST_F(Engraving_PartsTests, renamePotentialExcerpt)
     //
     // Background (Issue #31656): In the Parts dialog, each instrument shows
     // as a "potential excerpt" that can be renamed before being opened.
-    // The fix requires saving potential excerpts in a lightweight format
+    // The fix requires saving potential excerpts in an uninitialised format
     // (without full excerptScore) so that custom names persist.
     //
-    // This test uses an initialized excerpt as a baseline. The lightweight
+    // This test uses an initialized excerpt as a baseline. The uninitialised
     // excerpt implementation will enable this same flow for uninitialized
     // excerpts without requiring them to be opened first.
 
@@ -1509,13 +1509,13 @@ TEST_F(Engraving_PartsTests, renamePotentialExcerpt)
 }
 
 //---------------------------------------------------------
-//   saveLightweightExcerpt
-///   Test that lightweight (uninitialized) excerpts can be saved and loaded
+//   saveUninitExcerpt
+///   Test that uninitialised excerpts can be saved and loaded
 ///   using MSCZ format (the container format that supports multiple excerpts)
 ///   Related: https://github.com/musescore/MuseScore/issues/31656
 //---------------------------------------------------------
 
-TEST_F(Engraving_PartsTests, saveLightweightExcerpt)
+TEST_F(Engraving_PartsTests, saveUninitExcerpt)
 {
     using namespace muse::io;
     using namespace mu::engraving::rw;
@@ -1524,27 +1524,27 @@ TEST_F(Engraving_PartsTests, saveLightweightExcerpt)
     MasterScore* score = ScoreRW::readScore(PARTS_DATA_DIR + u"part-all.mscx");
     ASSERT_TRUE(score);
 
-    // Create a lightweight excerpt (no excerptScore, just like "potential excerpts" in Parts dialog)
+    // Create an uninitialised excerpt (no excerptScore, just like "potential excerpts" in Parts dialog)
     Excerpt* excerpt = new Excerpt(score);
     Part* part = score->parts().front();
     excerpt->parts().push_back(part);
     excerpt->setInitialPartId(part->id());
 
     // Set a custom name - this is what we're primarily testing persists
-    String customName = u"My Custom Lightweight Part";
+    String customName = u"My Custom Uninitialised Part";
     excerpt->setName(customName, false);
 
-    // Add excerpt to score without initializing (lightweight - no excerptScore created)
+    // Add excerpt to score without initializing (uninitialised, no excerptScore created)
     // initParts will be called but now handles null excerptScore
     score->addExcerpt(excerpt);
 
-    // Verify it's a lightweight excerpt (no excerptScore)
-    ASSERT_EQ(excerpt->excerptScore(), nullptr) << "Excerpt should be lightweight (no excerptScore)";
+    // Verify it's an uninitialised excerpt (no excerptScore)
+    ASSERT_EQ(excerpt->excerptScore(), nullptr) << "Excerpt should be uninitialised (no excerptScore)";
     ASSERT_EQ(excerpt->name(), customName);
 
     // Save to MSCZ using MscSaver
     String tempFile = String::fromStdString(
-        (std::filesystem::temp_directory_path() / "lightweight-excerpt-test.mscz").string());
+        (std::filesystem::temp_directory_path() / "uninit-excerpt-test.mscz").string());
 
     // Clean up any existing file
     if (File::exists(tempFile)) {
@@ -1561,7 +1561,7 @@ TEST_F(Engraving_PartsTests, saveLightweightExcerpt)
 
         MscSaver saver(score->iocContext());
         bool saveOk = saver.writeMscz(score, mscWriter, false);  // no thumbnail
-        ASSERT_TRUE(saveOk) << "Failed to save score with lightweight excerpt";
+        ASSERT_TRUE(saveOk) << "Failed to save score with uninitialised excerpt";
     }
 
     delete score;
@@ -1570,15 +1570,15 @@ TEST_F(Engraving_PartsTests, saveLightweightExcerpt)
     MasterScore* reloadedScore = ScoreRW::readScore(tempFile, true);  // true = absolute path
     ASSERT_TRUE(reloadedScore) << "Failed to reload score";
 
-    // Verify the lightweight excerpt was restored
+    // Verify the uninitialised excerpt was restored
     ASSERT_EQ(reloadedScore->excerpts().size(), 1u) << "Should have one excerpt";
     Excerpt* loadedExcerpt = reloadedScore->excerpts().front();
 
     // The key test: name should be preserved
     EXPECT_EQ(loadedExcerpt->name(), customName) << "Excerpt name should persist";
 
-    // It should still be lightweight (no excerptScore)
-    EXPECT_EQ(loadedExcerpt->excerptScore(), nullptr) << "Excerpt should still be lightweight after reload";
+    // It should still be uninitialised (no excerptScore)
+    EXPECT_EQ(loadedExcerpt->excerptScore(), nullptr) << "Excerpt should still be uninitialised after reload";
 
     // Parts should be restored (by ID matching)
     EXPECT_EQ(loadedExcerpt->parts().size(), 1u) << "Parts should be restored";
@@ -1594,7 +1594,7 @@ TEST_F(Engraving_PartsTests, saveLightweightExcerpt)
 
     delete reloadedScore;
 
-    // Verify that lightweight excerpts don't have extra files and XML is minimal
+    // Verify that uninitialised excerpts don't have extra files and XML is minimal
     {
         MscReader::Params readerParams;
         readerParams.filePath = tempFile;
@@ -1607,32 +1607,32 @@ TEST_F(Engraving_PartsTests, saveLightweightExcerpt)
         std::vector<String> excerptFiles = mscReader.excerptFileNames();
         ASSERT_EQ(excerptFiles.size(), 1u) << "Should have one excerpt file";
 
-        // Lightweight excerpts should NOT have viewsettings.json or audiosettings.json
+        // Uninitialised excerpts should NOT have viewsettings.json or audiosettings.json
         path_t excerptPath = u"Excerpts/" + excerptFiles.front() + u"/";
         ByteArray viewSettings = mscReader.readViewSettingsJsonFile(excerptPath);
         ByteArray audioSettings = mscReader.readAudioSettingsJsonFile(excerptPath);
 
-        EXPECT_TRUE(viewSettings.empty()) << "Lightweight excerpt should not have viewsettings.json";
-        EXPECT_TRUE(audioSettings.empty()) << "Lightweight excerpt should not have audiosettings.json";
+        EXPECT_TRUE(viewSettings.empty()) << "Uninitialised excerpt should not have viewsettings.json";
+        EXPECT_TRUE(audioSettings.empty()) << "Uninitialised excerpt should not have audiosettings.json";
 
-        // Verify the excerpt XML is minimal (lightweight marker, no measures, staves, etc.)
+        // Verify the excerpt XML is minimal (initialised marker, no measures, staves, etc.)
         ByteArray excerptData = mscReader.readExcerptFile(excerptFiles.front());
         ASSERT_FALSE(excerptData.empty()) << "Excerpt file should exist";
 
         String excerptXml = String::fromUtf8(excerptData);
 
-        // Lightweight excerpt should have lightweight marker and essential elements
-        EXPECT_TRUE(excerptXml.contains(u"<lightweight>")) << "Should have lightweight marker";
+        // Uninitialised excerpt should have initialised=false marker and essential elements
+        EXPECT_TRUE(excerptXml.contains(u"<initialised>")) << "Should have initialised marker";
         EXPECT_TRUE(excerptXml.contains(u"<name>")) << "Should have name element";
         EXPECT_TRUE(excerptXml.contains(u"<initialPartId>")) << "Should have initialPartId element";
 
         // Should NOT have full score content (measures, staves, parts with full data)
-        EXPECT_FALSE(excerptXml.contains(u"<Staff>")) << "Lightweight excerpt should not have Staff element";
-        EXPECT_FALSE(excerptXml.contains(u"<Measure>")) << "Lightweight excerpt should not have Measure element";
-        EXPECT_FALSE(excerptXml.contains(u"<vBox>")) << "Lightweight excerpt should not have vBox element";
+        EXPECT_FALSE(excerptXml.contains(u"<Staff>")) << "Uninitialised excerpt should not have Staff element";
+        EXPECT_FALSE(excerptXml.contains(u"<Measure>")) << "Uninitialised excerpt should not have Measure element";
+        EXPECT_FALSE(excerptXml.contains(u"<vBox>")) << "Uninitialised excerpt should not have vBox element";
 
-        // Verify file size is small (lightweight should be < 1KB, full excerpt would be > 10KB)
-        EXPECT_LT(excerptData.size(), 1024u) << "Lightweight excerpt XML should be small (< 1KB)";
+        // Verify file size is small (uninitialised should be < 1KB, full excerpt would be > 10KB)
+        EXPECT_LT(excerptData.size(), 1024u) << "Uninitialised excerpt XML should be small (< 1KB)";
     }
 
     // Cleanup - comment out for debugging
@@ -1640,15 +1640,15 @@ TEST_F(Engraving_PartsTests, saveLightweightExcerpt)
 }
 
 //---------------------------------------------------------
-//   lightweightExcerptAfterInitDeinit
-///   Test that lightweight excerpts remain lightweight after being
+//   uninitExcerptAfterInitDeinit
+///   Test that uninitialised excerpts remain uninitialised after being
 ///   temporarily initialized (e.g., for export) and then deinitialized.
 ///   This simulates the export flow where excerpts are initialized for
-///   rendering but should return to lightweight state after export.
+///   rendering but should return to uninitialised state after export.
 ///   Related: https://github.com/musescore/MuseScore/issues/31656
 //---------------------------------------------------------
 
-TEST_F(Engraving_PartsTests, lightweightExcerptAfterInitDeinit)
+TEST_F(Engraving_PartsTests, uninitExcerptAfterInitDeinit)
 {
     using namespace muse::io;
     using namespace mu::engraving::rw;
@@ -1657,7 +1657,7 @@ TEST_F(Engraving_PartsTests, lightweightExcerptAfterInitDeinit)
     MasterScore* score = ScoreRW::readScore(PARTS_DATA_DIR + u"part-all.mscx");
     ASSERT_TRUE(score);
 
-    // Create a lightweight excerpt
+    // Create an uninitialised excerpt
     Excerpt* excerpt = new Excerpt(score);
     Part* part = score->parts().front();
     excerpt->parts().push_back(part);
@@ -1666,11 +1666,11 @@ TEST_F(Engraving_PartsTests, lightweightExcerptAfterInitDeinit)
     String customName = u"Init Deinit Test Part";
     excerpt->setName(customName, false);
 
-    // Add as lightweight excerpt
+    // Add as uninitialised excerpt
     score->addLightweightExcerpt(excerpt);
 
-    // Verify it's lightweight
-    ASSERT_EQ(excerpt->excerptScore(), nullptr) << "Excerpt should start as lightweight";
+    // Verify it's uninitialised
+    ASSERT_EQ(excerpt->excerptScore(), nullptr) << "Excerpt should start as uninitialised";
 
     // Initialize the excerpt (simulates what export does)
     score->initExcerpt(excerpt);
@@ -1683,8 +1683,8 @@ TEST_F(Engraving_PartsTests, lightweightExcerptAfterInitDeinit)
     excerpt->setInited(false);
     delete excerptScore;
 
-    // Verify it's back to lightweight
-    ASSERT_EQ(excerpt->excerptScore(), nullptr) << "Excerpt should be lightweight after deinit";
+    // Verify it's back to uninitialised
+    ASSERT_EQ(excerpt->excerptScore(), nullptr) << "Excerpt should be uninitialised after deinit";
     EXPECT_FALSE(excerpt->inited()) << "Excerpt should not be marked as inited after deinit";
 
     // Save to MSCZ
@@ -1710,7 +1710,7 @@ TEST_F(Engraving_PartsTests, lightweightExcerptAfterInitDeinit)
 
     delete score;
 
-    // Verify the saved file has lightweight excerpt
+    // Verify the saved file has uninitialised excerpt
     {
         MscReader::Params readerParams;
         readerParams.filePath = tempFile;
@@ -1727,11 +1727,11 @@ TEST_F(Engraving_PartsTests, lightweightExcerptAfterInitDeinit)
 
         String excerptXml = String::fromUtf8(excerptData);
 
-        // Should be lightweight (small size, lightweight marker, no full content)
-        EXPECT_TRUE(excerptXml.contains(u"<lightweight>")) << "Should have lightweight marker";
+        // Should be uninitialised (small size, initialised=false marker, no full content)
+        EXPECT_TRUE(excerptXml.contains(u"<initialised>")) << "Should have initialised marker";
         EXPECT_FALSE(excerptXml.contains(u"<Staff>")) << "Should not have Staff element";
         EXPECT_FALSE(excerptXml.contains(u"<Measure>")) << "Should not have Measure element";
-        EXPECT_LT(excerptData.size(), 1024u) << "Lightweight excerpt should be small (< 1KB)";
+        EXPECT_LT(excerptData.size(), 1024u) << "Uninitialised excerpt should be small (< 1KB)";
     }
 
     // Reload and verify
@@ -1742,7 +1742,7 @@ TEST_F(Engraving_PartsTests, lightweightExcerptAfterInitDeinit)
     Excerpt* loadedExcerpt = reloadedScore->excerpts().front();
 
     EXPECT_EQ(loadedExcerpt->name(), customName) << "Name should be preserved";
-    EXPECT_EQ(loadedExcerpt->excerptScore(), nullptr) << "Should still be lightweight after reload";
+    EXPECT_EQ(loadedExcerpt->excerptScore(), nullptr) << "Should still be uninitialised after reload";
 
     delete reloadedScore;
     std::filesystem::remove(std::filesystem::path(tempFile.toStdString()));

--- a/src/notation/imasternotation.h
+++ b/src/notation/imasternotation.h
@@ -58,6 +58,7 @@ public:
     virtual const ExcerptNotationList& potentialExcerpts() const = 0;
 
     virtual void initExcerpts(const ExcerptNotationList& excerpts) = 0;
+    virtual void deinitExcerpts(const ExcerptNotationList& excerpts) = 0;
     virtual void setExcerpts(const ExcerptNotationList& excerpts) = 0;
     virtual void resetExcerpt(IExcerptNotationPtr& excerpt) = 0;
     virtual void sortExcerpts(ExcerptNotationList& excerpts) = 0;

--- a/src/notation/imasternotation.h
+++ b/src/notation/imasternotation.h
@@ -55,7 +55,6 @@ public:
 
     virtual const ExcerptNotationList& excerpts() const = 0;
     virtual muse::async::Notification excerptsChanged() const = 0;
-    virtual const ExcerptNotationList& potentialExcerpts() const = 0;
 
     virtual void initExcerpts(const ExcerptNotationList& excerpts) = 0;
     virtual void deinitExcerpts(const ExcerptNotationList& excerpts) = 0;

--- a/src/notation/internal/excerptnotation.cpp
+++ b/src/notation/internal/excerptnotation.cpp
@@ -48,18 +48,16 @@ ExcerptNotation::~ExcerptNotation()
 
 void ExcerptNotation::init()
 {
-    if (m_inited) {
+    if (m_excerpt->inited()) {
         return;
     }
 
     setScore(m_excerpt->excerptScore());
-
-    m_inited = true;
 }
 
 void ExcerptNotation::deinit()
 {
-    if (!m_inited) {
+    if (!m_excerpt->inited()) {
         return;
     }
 
@@ -71,13 +69,10 @@ void ExcerptNotation::deinit()
         m_excerpt->setInited(false);
         delete excerptScore;
     }
-
-    m_inited = false;
 }
 
 void ExcerptNotation::reinit(engraving::Excerpt* newExcerpt)
 {
-    m_inited = false;
     m_excerpt = newExcerpt;
 
     init();
@@ -87,7 +82,7 @@ void ExcerptNotation::reinit(engraving::Excerpt* newExcerpt)
 
 bool ExcerptNotation::isInited() const
 {
-    return m_inited;
+    return m_excerpt->inited();
 }
 
 bool ExcerptNotation::isCustom() const
@@ -117,7 +112,7 @@ void ExcerptNotation::setName(const QString& name)
 
     if (changed) {
         // For potential excerpts, promote to uninitialised excerpt so they get saved
-        if (!m_inited && m_masterNotation) {
+        if (!m_excerpt->inited() && m_masterNotation) {
             m_masterNotation->promotePotentialExcerptToUninit(m_excerpt);
             // Mark project as unsaved so asterisk appears and save confirmation is shown
             if (m_masterNotation->project()) {

--- a/src/notation/internal/excerptnotation.cpp
+++ b/src/notation/internal/excerptnotation.cpp
@@ -111,13 +111,9 @@ void ExcerptNotation::setName(const QString& name)
     m_excerpt->setName(name);
 
     if (changed) {
-        // For potential excerpts, promote to uninitialised excerpt so they get saved
-        if (!m_excerpt->inited() && m_masterNotation) {
-            m_masterNotation->promotePotentialExcerptToUninit(m_excerpt);
-            // Mark project as unsaved so asterisk appears and save confirmation is shown
-            if (m_masterNotation->project()) {
-                m_masterNotation->project()->markAsUnsaved();
-            }
+        // Mark project as unsaved so asterisk appears and save confirmation is shown
+        if (m_masterNotation && m_masterNotation->project()) {
+            m_masterNotation->project()->markAsUnsaved();
         }
         notifyAboutNotationChanged();
     }

--- a/src/notation/internal/excerptnotation.cpp
+++ b/src/notation/internal/excerptnotation.cpp
@@ -57,6 +57,24 @@ void ExcerptNotation::init()
     m_inited = true;
 }
 
+void ExcerptNotation::deinit()
+{
+    if (!m_inited) {
+        return;
+    }
+
+    // Delete the excerptScore and reset to lightweight state
+    mu::engraving::Score* excerptScore = m_excerpt->excerptScore();
+    if (excerptScore) {
+        setScore(nullptr);
+        m_excerpt->setExcerptScore(nullptr);
+        m_excerpt->setInited(false);
+        delete excerptScore;
+    }
+
+    m_inited = false;
+}
+
 void ExcerptNotation::reinit(engraving::Excerpt* newExcerpt)
 {
     m_inited = false;

--- a/src/notation/internal/excerptnotation.cpp
+++ b/src/notation/internal/excerptnotation.cpp
@@ -63,7 +63,7 @@ void ExcerptNotation::deinit()
         return;
     }
 
-    // Delete the excerptScore and reset to lightweight state
+    // Delete the excerptScore and reset to uninitialised state
     mu::engraving::Score* excerptScore = m_excerpt->excerptScore();
     if (excerptScore) {
         setScore(nullptr);
@@ -116,9 +116,9 @@ void ExcerptNotation::setName(const QString& name)
     m_excerpt->setName(name);
 
     if (changed) {
-        // For potential excerpts, promote to lightweight excerpt so they get saved
+        // For potential excerpts, promote to uninitialised excerpt so they get saved
         if (!m_inited && m_masterNotation) {
-            m_masterNotation->promotePotentialExcerptToLightweight(m_excerpt);
+            m_masterNotation->promotePotentialExcerptToUninit(m_excerpt);
             // Mark project as unsaved so asterisk appears and save confirmation is shown
             if (m_masterNotation->project()) {
                 m_masterNotation->project()->markAsUnsaved();

--- a/src/notation/internal/excerptnotation.cpp
+++ b/src/notation/internal/excerptnotation.cpp
@@ -49,7 +49,7 @@ ExcerptNotation::~ExcerptNotation()
 
 void ExcerptNotation::init()
 {
-    if (m_excerpt->inited()) {
+    if (score()) {
         return;
     }
 
@@ -64,12 +64,10 @@ void ExcerptNotation::deinit()
 
     // Delete the excerptScore and reset to uninitialised state
     mu::engraving::Score* excerptScore = m_excerpt->excerptScore();
-    if (excerptScore) {
-        setScore(nullptr);
-        m_excerpt->setExcerptScore(nullptr);
-        m_excerpt->setInited(false);
-        delete excerptScore;
-    }
+    setScore(nullptr);
+    m_excerpt->setExcerptScore(nullptr);
+    m_excerpt->setInited(false);
+    delete excerptScore;
 }
 
 void ExcerptNotation::reinit(engraving::Excerpt* newExcerpt)

--- a/src/notation/internal/excerptnotation.cpp
+++ b/src/notation/internal/excerptnotation.cpp
@@ -126,7 +126,16 @@ void ExcerptNotation::undoSetName(const QString& name)
     }
 
     if (!score()) {
-        setName(name);
+        if (!m_masterNotation) {
+            setName(name);
+            return;
+        }
+        //: Means: "edit the name of a part score"
+        m_masterNotation->undoStack()->transaction(muse::TranslatableString("undoableAction", "Rename part"),
+                                                   [&](engraving::Transaction& tx) {
+            tx.push(new engraving::ChangeExcerptTitle(m_excerpt, name));
+        });
+        notifyAboutNotationChanged();
         return;
     }
 

--- a/src/notation/internal/excerptnotation.cpp
+++ b/src/notation/internal/excerptnotation.cpp
@@ -31,6 +31,7 @@
 
 #include "inotationundostack.h"
 #include "masternotation.h"
+#include "project/inotationproject.h"
 
 using namespace mu::notation;
 

--- a/src/notation/internal/excerptnotation.cpp
+++ b/src/notation/internal/excerptnotation.cpp
@@ -22,11 +22,15 @@
 
 #include "excerptnotation.h"
 
+#include <algorithm>
+
 #include "engraving/dom/excerpt.h"
+#include "engraving/dom/masterscore.h"
 #include "engraving/editing/editexcerpt.h"
 #include "engraving/editing/transaction/transaction.h"
 
 #include "inotationundostack.h"
+#include "masternotation.h"
 
 using namespace mu::notation;
 
@@ -94,6 +98,14 @@ void ExcerptNotation::setName(const QString& name)
     m_excerpt->setName(name);
 
     if (changed) {
+        // For potential excerpts, promote to lightweight excerpt so they get saved
+        if (!m_inited && m_masterNotation) {
+            m_masterNotation->promotePotentialExcerptToLightweight(m_excerpt);
+            // Mark project as unsaved so asterisk appears and save confirmation is shown
+            if (m_masterNotation->project()) {
+                m_masterNotation->project()->markAsUnsaved();
+            }
+        }
         notifyAboutNotationChanged();
     }
 }

--- a/src/notation/internal/excerptnotation.cpp
+++ b/src/notation/internal/excerptnotation.cpp
@@ -72,6 +72,7 @@ void ExcerptNotation::deinit()
 
 void ExcerptNotation::reinit(engraving::Excerpt* newExcerpt)
 {
+    setScore(nullptr);
     m_excerpt = newExcerpt;
 
     init();

--- a/src/notation/internal/excerptnotation.h
+++ b/src/notation/internal/excerptnotation.h
@@ -34,6 +34,7 @@ public:
     ~ExcerptNotation() override;
 
     void init();
+    void deinit();
     void reinit(engraving::Excerpt* newExcerpt);
 
     engraving::Excerpt* excerpt() const;

--- a/src/notation/internal/excerptnotation.h
+++ b/src/notation/internal/excerptnotation.h
@@ -56,6 +56,5 @@ public:
 
 private:
     mu::engraving::Excerpt* m_excerpt = nullptr;
-    bool m_inited = false;
 };
 }

--- a/src/notation/internal/excerptnotation.h
+++ b/src/notation/internal/excerptnotation.h
@@ -38,6 +38,7 @@ public:
     ~ExcerptNotation() override;
 
     void init();
+    void deinit();
     void reinit(engraving::Excerpt* newExcerpt);
 
     engraving::Excerpt* excerpt() const;

--- a/src/notation/internal/excerptnotation.h
+++ b/src/notation/internal/excerptnotation.h
@@ -60,6 +60,5 @@ public:
 
 private:
     mu::engraving::Excerpt* m_excerpt = nullptr;
-    bool m_inited = false;
 };
 }

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -159,7 +159,7 @@ void MasterNotation::initAfterSettingScore(const MasterScore* score, bool disabl
         m_notationPlayback->init();
     }
 
-    initExcerptNotations(score->excerpts());
+    createExcerptNotations(score->excerpts());
 }
 
 void MasterNotation::setMasterScore(mu::engraving::MasterScore* score, bool disablePlayback)
@@ -833,7 +833,7 @@ const ExcerptNotationList& MasterNotation::potentialExcerpts() const
     return m_potentialExcerpts;
 }
 
-void MasterNotation::initExcerptNotations(const std::vector<mu::engraving::Excerpt*>& excerpts)
+void MasterNotation::createExcerptNotations(const std::vector<mu::engraving::Excerpt*>& excerpts)
 {
     TRACEFUNC;
 

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -33,6 +33,7 @@
 
 #include "engraving/dom/factory.h"
 #include "engraving/dom/masterscore.h"
+#include "engraving/editing/editexcerpt.h"
 #include "engraving/dom/part.h"
 #include "engraving/dom/staff.h"
 #include "engraving/dom/excerpt.h"
@@ -627,8 +628,8 @@ void MasterNotation::promotePotentialExcerptToUninit(engraving::Excerpt* excerpt
         return;
     }
 
-    // Add to masterScore as uninitialised excerpt
-    masterScore()->addExcerpt(excerpt, muse::nidx, false);
+    // Add to masterScore as uninitialised excerpt via undo stack
+    masterScore()->undo(new mu::engraving::AddExcerpt(excerpt, false));
 
     // Find the ExcerptNotation in m_potentialExcerpts and move it to m_excerpts
     auto it = std::find_if(m_potentialExcerpts.begin(), m_potentialExcerpts.end(),

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -603,6 +603,35 @@ void MasterNotation::setExcerptIsOpen(const INotationPtr excerptNotation, bool o
     }
 }
 
+void MasterNotation::promotePotentialExcerptToLightweight(engraving::Excerpt* excerpt)
+{
+    if (!excerpt) {
+        return;
+    }
+
+    // Check if already in masterScore->excerpts()
+    const std::vector<mu::engraving::Excerpt*>& msExcerpts = masterScore()->excerpts();
+    if (std::find(msExcerpts.begin(), msExcerpts.end(), excerpt) != msExcerpts.end()) {
+        return;
+    }
+
+    // Add to masterScore as lightweight excerpt
+    masterScore()->addLightweightExcerpt(excerpt);
+
+    // Find the ExcerptNotation in m_potentialExcerpts and move it to m_excerpts
+    auto it = std::find_if(m_potentialExcerpts.begin(), m_potentialExcerpts.end(),
+                           [excerpt](const IExcerptNotationPtr& en) {
+        return get_impl(en)->excerpt() == excerpt;
+    });
+
+    if (it != m_potentialExcerpts.end()) {
+        m_excerpts.push_back(*it);
+        m_potentialExcerpts.erase(it);
+        m_excerptsChanged.notify();
+        static_cast<MasterNotationParts*>(m_parts.get())->setExcerpts(m_excerpts);
+    }
+}
+
 void MasterNotation::doSetExcerpts(const ExcerptNotationList& excerpts)
 {
     TRACEFUNC;
@@ -640,6 +669,13 @@ void MasterNotation::updateExcerpts()
     // create notations for new excerpts
     for (mu::engraving::Excerpt* excerpt : excerpts) {
         if (containsExcerpt(excerpt)) {
+            continue;
+        }
+
+        // For lightweight excerpts (no excerptScore), create notation without full init
+        if (!excerpt->excerptScore()) {
+            auto excerptNotation = std::make_shared<ExcerptNotation>(const_cast<MasterNotation*>(this), excerpt, iocContext());
+            updatedExcerpts.push_back(excerptNotation);
             continue;
         }
 
@@ -798,6 +834,13 @@ void MasterNotation::initExcerptNotations(const std::vector<mu::engraving::Excer
     ExcerptNotationList notationExcerpts;
 
     for (mu::engraving::Excerpt* excerpt : excerpts) {
+        // For lightweight excerpts (no excerptScore), create notation without full init
+        if (!excerpt->excerptScore()) {
+            auto excerptNotation = std::make_shared<ExcerptNotation>(const_cast<MasterNotation*>(this), excerpt, iocContext());
+            notationExcerpts.push_back(excerptNotation);
+            continue;
+        }
+
         if (excerpt->isEmpty()) {
             masterScore()->initEmptyExcerpt(excerpt);
         }

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -609,6 +609,15 @@ void MasterNotation::setExcerptIsOpen(const INotationPtr excerptNotation, bool o
         return;
     }
 
+    if (open) {
+        ExcerptNotation* excerptImpl = dynamic_cast<ExcerptNotation*>(excerptNotation.get());
+        if (excerptImpl && !excerptImpl->isInited()) {
+            masterScore()->initExcerpt(excerptImpl->excerpt());
+            excerptImpl->init();
+            initNotationSoloMuteState(excerptNotation);
+        }
+    }
+
     excerptNotation->setIsOpen(open);
 
     if (open) {

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -71,7 +71,7 @@ static ExcerptNotation* get_impl(const IExcerptNotationPtr& excerpt)
 }
 
 static IExcerptNotationPtr createExcerptNotation(MasterNotation* master, mu::engraving::Excerpt* excerpt,
-                                                  const muse::modularity::ContextPtr& iocCtx)
+                                                 const muse::modularity::ContextPtr& iocCtx)
 {
     auto excerptNotation = std::make_shared<ExcerptNotation>(master, excerpt, iocCtx);
 

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -628,7 +628,7 @@ void MasterNotation::promotePotentialExcerptToUninit(engraving::Excerpt* excerpt
     }
 
     // Add to masterScore as uninitialised excerpt
-    masterScore()->addLightweightExcerpt(excerpt);
+    masterScore()->addExcerpt(excerpt, muse::nidx, false);
 
     // Find the ExcerptNotation in m_potentialExcerpts and move it to m_excerpts
     auto it = std::find_if(m_potentialExcerpts.begin(), m_potentialExcerpts.end(),

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -271,7 +271,9 @@ Ret MasterNotation::setupNewScore(mu::engraving::MasterScore* score, const Score
 
     undoStack()->lock();
 
+    static_cast<MasterNotationParts*>(m_parts.get())->m_skipExcerptCreation = true;
     parts()->setParts(scoreOptions.parts, scoreOptions.order);
+    static_cast<MasterNotationParts*>(m_parts.get())->m_skipExcerptCreation = false;
 
     score->checkChordList();
     score->updateSwing();

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -75,7 +75,7 @@ static IExcerptNotationPtr createExcerptNotation(MasterNotation* master, mu::eng
 {
     auto excerptNotation = std::make_shared<ExcerptNotation>(master, excerpt, iocCtx);
 
-    // Only init if excerpt has a score (non-lightweight)
+    // Only init if excerpt has a score (not uninitialised)
     if (excerpt->excerptScore()) {
         excerptNotation->init();
     }
@@ -615,7 +615,7 @@ void MasterNotation::setExcerptIsOpen(const INotationPtr excerptNotation, bool o
     }
 }
 
-void MasterNotation::promotePotentialExcerptToLightweight(engraving::Excerpt* excerpt)
+void MasterNotation::promotePotentialExcerptToUninit(engraving::Excerpt* excerpt)
 {
     if (!excerpt) {
         return;
@@ -627,7 +627,7 @@ void MasterNotation::promotePotentialExcerptToLightweight(engraving::Excerpt* ex
         return;
     }
 
-    // Add to masterScore as lightweight excerpt
+    // Add to masterScore as uninitialised excerpt
     masterScore()->addLightweightExcerpt(excerpt);
 
     // Find the ExcerptNotation in m_potentialExcerpts and move it to m_excerpts

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -485,6 +485,14 @@ void MasterNotation::initExcerpts(const ExcerptNotationList& excerpts)
     }
 }
 
+void MasterNotation::deinitExcerpts(const ExcerptNotationList& excerpts)
+{
+    for (const IExcerptNotationPtr& excerptNotation : excerpts) {
+        ExcerptNotation* impl = get_impl(excerptNotation);
+        impl->deinit();
+    }
+}
+
 void MasterNotation::setExcerpts(const ExcerptNotationList& excerpts)
 {
     TRACEFUNC;

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -70,11 +70,15 @@ static ExcerptNotation* get_impl(const IExcerptNotationPtr& excerpt)
     return static_cast<ExcerptNotation*>(excerpt.get());
 }
 
-static IExcerptNotationPtr createAndInitExcerptNotation(MasterNotation* master, mu::engraving::Excerpt* excerpt,
-                                                        const muse::modularity::ContextPtr& iocCtx)
+static IExcerptNotationPtr createExcerptNotation(MasterNotation* master, mu::engraving::Excerpt* excerpt,
+                                                  const muse::modularity::ContextPtr& iocCtx)
 {
     auto excerptNotation = std::make_shared<ExcerptNotation>(master, excerpt, iocCtx);
-    excerptNotation->init();
+
+    // Only init if excerpt has a score (non-lightweight)
+    if (excerpt->excerptScore()) {
+        excerptNotation->init();
+    }
 
     return excerptNotation;
 }
@@ -680,20 +684,14 @@ void MasterNotation::updateExcerpts()
             continue;
         }
 
-        // For lightweight excerpts (no excerptScore), create notation without full init
-        if (!excerpt->excerptScore()) {
-            auto excerptNotation = std::make_shared<ExcerptNotation>(const_cast<MasterNotation*>(this), excerpt, iocContext());
-            updatedExcerpts.push_back(excerptNotation);
-            continue;
-        }
+        IExcerptNotationPtr excerptNotation = createExcerptNotation(this, excerpt, iocContext());
 
-        IExcerptNotationPtr excerptNotation = createAndInitExcerptNotation(this, excerpt, iocContext());
-        bool open = excerpt->excerptScore()->isOpen();
-        if (open) {
-            excerptNotation->notation()->elements()->msScore()->doLayout();
+        if (excerpt->excerptScore()) {
+            if (excerpt->excerptScore()->isOpen()) {
+                excerptNotation->notation()->elements()->msScore()->doLayout();
+            }
+            initNotationSoloMuteState(excerptNotation->notation());
         }
-
-        initNotationSoloMuteState(excerptNotation->notation());
 
         updatedExcerpts.push_back(excerptNotation);
     }
@@ -842,19 +840,11 @@ void MasterNotation::initExcerptNotations(const std::vector<mu::engraving::Excer
     ExcerptNotationList notationExcerpts;
 
     for (mu::engraving::Excerpt* excerpt : excerpts) {
-        // For lightweight excerpts (no excerptScore), create notation without full init
-        if (!excerpt->excerptScore()) {
-            auto excerptNotation = std::make_shared<ExcerptNotation>(const_cast<MasterNotation*>(this), excerpt, iocContext());
-            notationExcerpts.push_back(excerptNotation);
-            continue;
-        }
-
-        if (excerpt->isEmpty()) {
+        if (excerpt->excerptScore() && excerpt->isEmpty()) {
             masterScore()->initEmptyExcerpt(excerpt);
         }
 
-        IExcerptNotationPtr excerptNotation = createAndInitExcerptNotation(this, excerpt, iocContext());
-        notationExcerpts.push_back(excerptNotation);
+        notationExcerpts.push_back(createExcerptNotation(this, excerpt, iocContext()));
     }
 
     masterScore()->setExcerptsChanged(false);

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -119,8 +119,6 @@ MasterNotation::MasterNotation(project::INotationProject* project, const muse::m
 MasterNotation::~MasterNotation()
 {
     m_parts = nullptr;
-
-    unloadExcerpts(m_potentialExcerpts);
 }
 
 mu::project::INotationProject* MasterNotation::project() const
@@ -616,35 +614,6 @@ void MasterNotation::setExcerptIsOpen(const INotationPtr excerptNotation, bool o
     }
 }
 
-void MasterNotation::promotePotentialExcerptToUninit(engraving::Excerpt* excerpt)
-{
-    if (!excerpt) {
-        return;
-    }
-
-    // Check if already in masterScore->excerpts()
-    const std::vector<mu::engraving::Excerpt*>& msExcerpts = masterScore()->excerpts();
-    if (std::find(msExcerpts.begin(), msExcerpts.end(), excerpt) != msExcerpts.end()) {
-        return;
-    }
-
-    // Add to masterScore as uninitialised excerpt via undo stack
-    masterScore()->undo(new mu::engraving::AddExcerpt(excerpt, false));
-
-    // Find the ExcerptNotation in m_potentialExcerpts and move it to m_excerpts
-    auto it = std::find_if(m_potentialExcerpts.begin(), m_potentialExcerpts.end(),
-                           [excerpt](const IExcerptNotationPtr& en) {
-        return get_impl(en)->excerpt() == excerpt;
-    });
-
-    if (it != m_potentialExcerpts.end()) {
-        m_excerpts.push_back(*it);
-        m_potentialExcerpts.erase(it);
-        m_excerptsChanged.notify();
-        static_cast<MasterNotationParts*>(m_parts.get())->setExcerpts(m_excerpts);
-    }
-}
-
 void MasterNotation::doSetExcerpts(const ExcerptNotationList& excerpts)
 {
     TRACEFUNC;
@@ -653,8 +622,6 @@ void MasterNotation::doSetExcerpts(const ExcerptNotationList& excerpts)
     m_excerptsChanged.notify();
 
     static_cast<MasterNotationParts*>(m_parts.get())->setExcerpts(excerpts);
-
-    updatePotentialExcerpts();
 }
 
 void MasterNotation::updateExcerpts()
@@ -702,46 +669,6 @@ void MasterNotation::updateExcerpts()
     masterScore()->setExcerptsChanged(false);
 }
 
-void MasterNotation::updatePotentialExcerpts() const
-{
-    TRACEFUNC;
-
-    auto findExcerptByPart = [](const ExcerptNotationList& excerpts, const Part* part) {
-        return std::find_if(excerpts.cbegin(), excerpts.cend(), [part](const IExcerptNotationPtr& notation) {
-            return get_impl(notation)->excerpt()->initialPartId() == part->id();
-        });
-    };
-
-    ExcerptNotationList potentialExcerpts;
-    std::vector<Part*> partsWithoutExcerpt;
-
-    for (Part* part : score()->parts()) {
-        if (findExcerptByPart(m_excerpts, part) != m_excerpts.end()) {
-            continue;
-        }
-
-        if (!m_potentialExcerptsForcedDirty) {
-            auto it = findExcerptByPart(m_potentialExcerpts, part);
-            if (it != m_potentialExcerpts.cend()) {
-                potentialExcerpts.push_back(*it);
-                continue;
-            }
-        }
-
-        partsWithoutExcerpt.push_back(part);
-    }
-
-    std::vector<mu::engraving::Excerpt*> excerpts = mu::engraving::Excerpt::createExcerptsFromParts(partsWithoutExcerpt, masterScore());
-
-    for (mu::engraving::Excerpt* excerpt : excerpts) {
-        auto excerptNotation = std::make_shared<ExcerptNotation>(const_cast<MasterNotation*>(this), excerpt, iocContext());
-        potentialExcerpts.push_back(excerptNotation);
-    }
-
-    m_potentialExcerpts = std::move(potentialExcerpts);
-    m_potentialExcerptsForcedDirty = false;
-}
-
 bool MasterNotation::containsExcerpt(const mu::engraving::Excerpt* excerpt) const
 {
     for (const IExcerptNotationPtr& excerptNotation : m_excerpts) {
@@ -756,7 +683,6 @@ bool MasterNotation::containsExcerpt(const mu::engraving::Excerpt* excerpt) cons
 void MasterNotation::onPartsChanged()
 {
     m_hasPartsChanged.notify();
-    m_potentialExcerptsForcedDirty = true;
 }
 
 IExcerptNotationPtr MasterNotation::createEmptyExcerpt(const QString& name) const
@@ -825,13 +751,6 @@ void MasterNotation::initNotationSoloMuteState(const INotationPtr notation)
             excerptSoloMuteState->setTrackSoloMuteState(chordsId, state);
         }
     }
-}
-
-const ExcerptNotationList& MasterNotation::potentialExcerpts() const
-{
-    updatePotentialExcerpts();
-
-    return m_potentialExcerpts;
 }
 
 void MasterNotation::createExcerptNotations(const std::vector<mu::engraving::Excerpt*>& excerpts)

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -33,6 +33,7 @@
 
 #include "engraving/dom/factory.h"
 #include "engraving/dom/masterscore.h"
+#include "engraving/editing/editexcerpt.h"
 #include "engraving/dom/part.h"
 #include "engraving/dom/staff.h"
 #include "engraving/dom/excerpt.h"
@@ -633,8 +634,8 @@ void MasterNotation::promotePotentialExcerptToUninit(engraving::Excerpt* excerpt
         return;
     }
 
-    // Add to masterScore as uninitialised excerpt
-    masterScore()->addExcerpt(excerpt, muse::nidx, false);
+    // Add to masterScore as uninitialised excerpt via undo stack
+    masterScore()->undo(new mu::engraving::AddExcerpt(excerpt, false));
 
     // Find the ExcerptNotation in m_potentialExcerpts and move it to m_excerpts
     auto it = std::find_if(m_potentialExcerpts.begin(), m_potentialExcerpts.end(),

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -160,7 +160,7 @@ void MasterNotation::initAfterSettingScore(const MasterScore* score, bool disabl
         m_notationPlayback->init();
     }
 
-    initExcerptNotations(score->excerpts());
+    createExcerptNotations(score->excerpts());
 }
 
 void MasterNotation::setMasterScore(mu::engraving::MasterScore* score, bool disablePlayback)
@@ -839,7 +839,7 @@ const ExcerptNotationList& MasterNotation::potentialExcerpts() const
     return m_potentialExcerpts;
 }
 
-void MasterNotation::initExcerptNotations(const std::vector<mu::engraving::Excerpt*>& excerpts)
+void MasterNotation::createExcerptNotations(const std::vector<mu::engraving::Excerpt*>& excerpts)
 {
     TRACEFUNC;
 

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -71,11 +71,15 @@ static ExcerptNotation* get_impl(const IExcerptNotationPtr& excerpt)
     return static_cast<ExcerptNotation*>(excerpt.get());
 }
 
-static IExcerptNotationPtr createAndInitExcerptNotation(MasterNotation* master, mu::engraving::Excerpt* excerpt,
-                                                        const muse::modularity::ContextPtr& iocCtx)
+static IExcerptNotationPtr createExcerptNotation(MasterNotation* master, mu::engraving::Excerpt* excerpt,
+                                                  const muse::modularity::ContextPtr& iocCtx)
 {
     auto excerptNotation = std::make_shared<ExcerptNotation>(master, excerpt, iocCtx);
-    excerptNotation->init();
+
+    // Only init if excerpt has a score (non-lightweight)
+    if (excerpt->excerptScore()) {
+        excerptNotation->init();
+    }
 
     return excerptNotation;
 }
@@ -686,20 +690,14 @@ void MasterNotation::updateExcerpts()
             continue;
         }
 
-        // For lightweight excerpts (no excerptScore), create notation without full init
-        if (!excerpt->excerptScore()) {
-            auto excerptNotation = std::make_shared<ExcerptNotation>(const_cast<MasterNotation*>(this), excerpt, iocContext());
-            updatedExcerpts.push_back(excerptNotation);
-            continue;
-        }
+        IExcerptNotationPtr excerptNotation = createExcerptNotation(this, excerpt, iocContext());
 
-        IExcerptNotationPtr excerptNotation = createAndInitExcerptNotation(this, excerpt, iocContext());
-        bool open = excerpt->excerptScore()->isOpen();
-        if (open) {
-            excerptNotation->notation()->elements()->msScore()->doLayout();
+        if (excerpt->excerptScore()) {
+            if (excerpt->excerptScore()->isOpen()) {
+                excerptNotation->notation()->elements()->msScore()->doLayout();
+            }
+            initNotationSoloMuteState(excerptNotation->notation());
         }
-
-        initNotationSoloMuteState(excerptNotation->notation());
 
         updatedExcerpts.push_back(excerptNotation);
     }
@@ -848,19 +846,11 @@ void MasterNotation::initExcerptNotations(const std::vector<mu::engraving::Excer
     ExcerptNotationList notationExcerpts;
 
     for (mu::engraving::Excerpt* excerpt : excerpts) {
-        // For lightweight excerpts (no excerptScore), create notation without full init
-        if (!excerpt->excerptScore()) {
-            auto excerptNotation = std::make_shared<ExcerptNotation>(const_cast<MasterNotation*>(this), excerpt, iocContext());
-            notationExcerpts.push_back(excerptNotation);
-            continue;
-        }
-
-        if (excerpt->isEmpty()) {
+        if (excerpt->excerptScore() && excerpt->isEmpty()) {
             masterScore()->initEmptyExcerpt(excerpt);
         }
 
-        IExcerptNotationPtr excerptNotation = createAndInitExcerptNotation(this, excerpt, iocContext());
-        notationExcerpts.push_back(excerptNotation);
+        notationExcerpts.push_back(createExcerptNotation(this, excerpt, iocContext()));
     }
 
     masterScore()->setExcerptsChanged(false);

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -634,7 +634,7 @@ void MasterNotation::promotePotentialExcerptToUninit(engraving::Excerpt* excerpt
     }
 
     // Add to masterScore as uninitialised excerpt
-    masterScore()->addLightweightExcerpt(excerpt);
+    masterScore()->addExcerpt(excerpt, muse::nidx, false);
 
     // Find the ExcerptNotation in m_potentialExcerpts and move it to m_excerpts
     auto it = std::find_if(m_potentialExcerpts.begin(), m_potentialExcerpts.end(),

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -609,6 +609,35 @@ void MasterNotation::setExcerptIsOpen(const INotationPtr excerptNotation, bool o
     }
 }
 
+void MasterNotation::promotePotentialExcerptToLightweight(engraving::Excerpt* excerpt)
+{
+    if (!excerpt) {
+        return;
+    }
+
+    // Check if already in masterScore->excerpts()
+    const std::vector<mu::engraving::Excerpt*>& msExcerpts = masterScore()->excerpts();
+    if (std::find(msExcerpts.begin(), msExcerpts.end(), excerpt) != msExcerpts.end()) {
+        return;
+    }
+
+    // Add to masterScore as lightweight excerpt
+    masterScore()->addLightweightExcerpt(excerpt);
+
+    // Find the ExcerptNotation in m_potentialExcerpts and move it to m_excerpts
+    auto it = std::find_if(m_potentialExcerpts.begin(), m_potentialExcerpts.end(),
+                           [excerpt](const IExcerptNotationPtr& en) {
+        return get_impl(en)->excerpt() == excerpt;
+    });
+
+    if (it != m_potentialExcerpts.end()) {
+        m_excerpts.push_back(*it);
+        m_potentialExcerpts.erase(it);
+        m_excerptsChanged.notify();
+        static_cast<MasterNotationParts*>(m_parts.get())->setExcerpts(m_excerpts);
+    }
+}
+
 void MasterNotation::doSetExcerpts(const ExcerptNotationList& excerpts)
 {
     TRACEFUNC;
@@ -646,6 +675,13 @@ void MasterNotation::updateExcerpts()
     // create notations for new excerpts
     for (mu::engraving::Excerpt* excerpt : excerpts) {
         if (containsExcerpt(excerpt)) {
+            continue;
+        }
+
+        // For lightweight excerpts (no excerptScore), create notation without full init
+        if (!excerpt->excerptScore()) {
+            auto excerptNotation = std::make_shared<ExcerptNotation>(const_cast<MasterNotation*>(this), excerpt, iocContext());
+            updatedExcerpts.push_back(excerptNotation);
             continue;
         }
 
@@ -804,6 +840,13 @@ void MasterNotation::initExcerptNotations(const std::vector<mu::engraving::Excer
     ExcerptNotationList notationExcerpts;
 
     for (mu::engraving::Excerpt* excerpt : excerpts) {
+        // For lightweight excerpts (no excerptScore), create notation without full init
+        if (!excerpt->excerptScore()) {
+            auto excerptNotation = std::make_shared<ExcerptNotation>(const_cast<MasterNotation*>(this), excerpt, iocContext());
+            notationExcerpts.push_back(excerptNotation);
+            continue;
+        }
+
         if (excerpt->isEmpty()) {
             masterScore()->initEmptyExcerpt(excerpt);
         }

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -76,7 +76,7 @@ static IExcerptNotationPtr createExcerptNotation(MasterNotation* master, mu::eng
 {
     auto excerptNotation = std::make_shared<ExcerptNotation>(master, excerpt, iocCtx);
 
-    // Only init if excerpt has a score (non-lightweight)
+    // Only init if excerpt has a score (not uninitialised)
     if (excerpt->excerptScore()) {
         excerptNotation->init();
     }
@@ -621,7 +621,7 @@ void MasterNotation::setExcerptIsOpen(const INotationPtr excerptNotation, bool o
     }
 }
 
-void MasterNotation::promotePotentialExcerptToLightweight(engraving::Excerpt* excerpt)
+void MasterNotation::promotePotentialExcerptToUninit(engraving::Excerpt* excerpt)
 {
     if (!excerpt) {
         return;
@@ -633,7 +633,7 @@ void MasterNotation::promotePotentialExcerptToLightweight(engraving::Excerpt* ex
         return;
     }
 
-    // Add to masterScore as lightweight excerpt
+    // Add to masterScore as uninitialised excerpt
     masterScore()->addLightweightExcerpt(excerpt);
 
     // Find the ExcerptNotation in m_potentialExcerpts and move it to m_excerpts

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -120,8 +120,6 @@ MasterNotation::MasterNotation(project::INotationProject* project, const muse::m
 MasterNotation::~MasterNotation()
 {
     m_parts = nullptr;
-
-    unloadExcerpts(m_potentialExcerpts);
 }
 
 mu::project::INotationProject* MasterNotation::project() const
@@ -622,35 +620,6 @@ void MasterNotation::setExcerptIsOpen(const INotationPtr excerptNotation, bool o
     }
 }
 
-void MasterNotation::promotePotentialExcerptToUninit(engraving::Excerpt* excerpt)
-{
-    if (!excerpt) {
-        return;
-    }
-
-    // Check if already in masterScore->excerpts()
-    const std::vector<mu::engraving::Excerpt*>& msExcerpts = masterScore()->excerpts();
-    if (std::find(msExcerpts.begin(), msExcerpts.end(), excerpt) != msExcerpts.end()) {
-        return;
-    }
-
-    // Add to masterScore as uninitialised excerpt via undo stack
-    masterScore()->undo(new mu::engraving::AddExcerpt(excerpt, false));
-
-    // Find the ExcerptNotation in m_potentialExcerpts and move it to m_excerpts
-    auto it = std::find_if(m_potentialExcerpts.begin(), m_potentialExcerpts.end(),
-                           [excerpt](const IExcerptNotationPtr& en) {
-        return get_impl(en)->excerpt() == excerpt;
-    });
-
-    if (it != m_potentialExcerpts.end()) {
-        m_excerpts.push_back(*it);
-        m_potentialExcerpts.erase(it);
-        m_excerptsChanged.notify();
-        static_cast<MasterNotationParts*>(m_parts.get())->setExcerpts(m_excerpts);
-    }
-}
-
 void MasterNotation::doSetExcerpts(const ExcerptNotationList& excerpts)
 {
     TRACEFUNC;
@@ -659,8 +628,6 @@ void MasterNotation::doSetExcerpts(const ExcerptNotationList& excerpts)
     m_excerptsChanged.notify();
 
     static_cast<MasterNotationParts*>(m_parts.get())->setExcerpts(excerpts);
-
-    updatePotentialExcerpts();
 }
 
 void MasterNotation::updateExcerpts()
@@ -708,46 +675,6 @@ void MasterNotation::updateExcerpts()
     masterScore()->setExcerptsChanged(false);
 }
 
-void MasterNotation::updatePotentialExcerpts() const
-{
-    TRACEFUNC;
-
-    auto findExcerptByPart = [](const ExcerptNotationList& excerpts, const Part* part) {
-        return std::find_if(excerpts.cbegin(), excerpts.cend(), [part](const IExcerptNotationPtr& notation) {
-            return get_impl(notation)->excerpt()->initialPartId() == part->id();
-        });
-    };
-
-    ExcerptNotationList potentialExcerpts;
-    std::vector<Part*> partsWithoutExcerpt;
-
-    for (Part* part : score()->parts()) {
-        if (part->isSharedPart() || findExcerptByPart(m_excerpts, part) != m_excerpts.end()) {
-            continue;
-        }
-
-        if (!m_potentialExcerptsForcedDirty) {
-            auto it = findExcerptByPart(m_potentialExcerpts, part);
-            if (it != m_potentialExcerpts.cend()) {
-                potentialExcerpts.push_back(*it);
-                continue;
-            }
-        }
-
-        partsWithoutExcerpt.push_back(part);
-    }
-
-    std::vector<mu::engraving::Excerpt*> excerpts = mu::engraving::Excerpt::createExcerptsFromParts(partsWithoutExcerpt, masterScore());
-
-    for (mu::engraving::Excerpt* excerpt : excerpts) {
-        auto excerptNotation = std::make_shared<ExcerptNotation>(const_cast<MasterNotation*>(this), excerpt, iocContext());
-        potentialExcerpts.push_back(excerptNotation);
-    }
-
-    m_potentialExcerpts = std::move(potentialExcerpts);
-    m_potentialExcerptsForcedDirty = false;
-}
-
 bool MasterNotation::containsExcerpt(const mu::engraving::Excerpt* excerpt) const
 {
     for (const IExcerptNotationPtr& excerptNotation : m_excerpts) {
@@ -762,7 +689,6 @@ bool MasterNotation::containsExcerpt(const mu::engraving::Excerpt* excerpt) cons
 void MasterNotation::onPartsChanged()
 {
     m_hasPartsChanged.notify();
-    m_potentialExcerptsForcedDirty = true;
 }
 
 IExcerptNotationPtr MasterNotation::createEmptyExcerpt(const QString& name) const
@@ -831,13 +757,6 @@ void MasterNotation::initNotationSoloMuteState(const INotationPtr notation)
             excerptSoloMuteState->setTrackSoloMuteState(chordsId, state);
         }
     }
-}
-
-const ExcerptNotationList& MasterNotation::potentialExcerpts() const
-{
-    updatePotentialExcerpts();
-
-    return m_potentialExcerpts;
 }
 
 void MasterNotation::createExcerptNotations(const std::vector<mu::engraving::Excerpt*>& excerpts)

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -491,6 +491,14 @@ void MasterNotation::initExcerpts(const ExcerptNotationList& excerpts)
     }
 }
 
+void MasterNotation::deinitExcerpts(const ExcerptNotationList& excerpts)
+{
+    for (const IExcerptNotationPtr& excerptNotation : excerpts) {
+        ExcerptNotation* impl = get_impl(excerptNotation);
+        impl->deinit();
+    }
+}
+
 void MasterNotation::setExcerpts(const ExcerptNotationList& excerpts)
 {
     TRACEFUNC;

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -72,7 +72,7 @@ static ExcerptNotation* get_impl(const IExcerptNotationPtr& excerpt)
 }
 
 static IExcerptNotationPtr createExcerptNotation(MasterNotation* master, mu::engraving::Excerpt* excerpt,
-                                                  const muse::modularity::ContextPtr& iocCtx)
+                                                 const muse::modularity::ContextPtr& iocCtx)
 {
     auto excerptNotation = std::make_shared<ExcerptNotation>(master, excerpt, iocCtx);
 

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -615,6 +615,15 @@ void MasterNotation::setExcerptIsOpen(const INotationPtr excerptNotation, bool o
         return;
     }
 
+    if (open) {
+        ExcerptNotation* excerptImpl = dynamic_cast<ExcerptNotation*>(excerptNotation.get());
+        if (excerptImpl && !excerptImpl->isInited()) {
+            masterScore()->initExcerpt(excerptImpl->excerpt());
+            excerptImpl->init();
+            initNotationSoloMuteState(excerptNotation);
+        }
+    }
+
     excerptNotation->setIsOpen(open);
 
     if (open) {

--- a/src/notation/internal/masternotation.cpp
+++ b/src/notation/internal/masternotation.cpp
@@ -273,7 +273,9 @@ Ret MasterNotation::setupNewScore(mu::engraving::MasterScore* score, const Score
 
     undoStack()->lock();
 
+    static_cast<MasterNotationParts*>(m_parts.get())->m_skipExcerptCreation = true;
     parts()->setParts(scoreOptions.parts, scoreOptions.order);
+    static_cast<MasterNotationParts*>(m_parts.get())->m_skipExcerptCreation = false;
 
     score->checkChordList();
     score->updateSwing();

--- a/src/notation/internal/masternotation.h
+++ b/src/notation/internal/masternotation.h
@@ -65,6 +65,8 @@ public:
 
     void setExcerptIsOpen(const INotationPtr excerptNotation, bool open) override;
 
+    void promotePotentialExcerptToLightweight(engraving::Excerpt* excerpt);
+
     INotationPartsPtr parts() const override;
     bool hasParts() const override;
     muse::async::Notification hasPartsChanged() const override;

--- a/src/notation/internal/masternotation.h
+++ b/src/notation/internal/masternotation.h
@@ -66,7 +66,7 @@ public:
 
     void setExcerptIsOpen(const INotationPtr excerptNotation, bool open) override;
 
-    void promotePotentialExcerptToLightweight(engraving::Excerpt* excerpt);
+    void promotePotentialExcerptToUninit(engraving::Excerpt* excerpt);
 
     INotationPartsPtr parts() const override;
     bool hasParts() const override;

--- a/src/notation/internal/masternotation.h
+++ b/src/notation/internal/masternotation.h
@@ -83,7 +83,7 @@ private:
 
     void initAfterSettingScore(const engraving::MasterScore* score, bool disablePlayback = false);
 
-    void initExcerptNotations(const std::vector<engraving::Excerpt*>& excerpts);
+    void createExcerptNotations(const std::vector<engraving::Excerpt*>& excerpts);
     void addExcerptsToMasterScore(const std::vector<engraving::Excerpt*>& excerpts);
     void doSetExcerpts(const ExcerptNotationList& excerpts);
     void updateExcerpts();

--- a/src/notation/internal/masternotation.h
+++ b/src/notation/internal/masternotation.h
@@ -59,6 +59,7 @@ public:
     const ExcerptNotationList& potentialExcerpts() const override;
 
     void initExcerpts(const ExcerptNotationList& excerpts) override;
+    void deinitExcerpts(const ExcerptNotationList& excerpts) override;
     void setExcerpts(const ExcerptNotationList& excerpts) override;
     void resetExcerpt(IExcerptNotationPtr& excerptNotation) override;
     void sortExcerpts(ExcerptNotationList& excerpts) override;

--- a/src/notation/internal/masternotation.h
+++ b/src/notation/internal/masternotation.h
@@ -56,7 +56,6 @@ public:
 
     const ExcerptNotationList& excerpts() const override;
     muse::async::Notification excerptsChanged() const override;
-    const ExcerptNotationList& potentialExcerpts() const override;
 
     void initExcerpts(const ExcerptNotationList& excerpts) override;
     void deinitExcerpts(const ExcerptNotationList& excerpts) override;
@@ -65,8 +64,6 @@ public:
     void sortExcerpts(ExcerptNotationList& excerpts) override;
 
     void setExcerptIsOpen(const INotationPtr excerptNotation, bool open) override;
-
-    void promotePotentialExcerptToUninit(engraving::Excerpt* excerpt);
 
     INotationPartsPtr parts() const override;
     bool hasParts() const override;
@@ -87,7 +84,6 @@ private:
     void addExcerptsToMasterScore(const std::vector<engraving::Excerpt*>& excerpts);
     void doSetExcerpts(const ExcerptNotationList& excerpts);
     void updateExcerpts();
-    void updatePotentialExcerpts() const;
     void unloadExcerpts(ExcerptNotationList& excerpts);
 
     bool containsExcerpt(const engraving::Excerpt* excerpt) const;
@@ -105,14 +101,6 @@ private:
     INotationPlaybackPtr m_notationPlayback = nullptr;
     INotationAutomationPtr m_notationAutomation = nullptr;
     muse::async::Notification m_hasPartsChanged;
-
-    mutable ExcerptNotationList m_potentialExcerpts;
-
-    // When the user first removes instruments (`Parts`) and then adds new ones,
-    // the new ones might have the same ID as the removed ones. In this case,
-    // we need to regenerate potential excerpts, even though for all part IDs a
-    // potential excerpt already exists.
-    mutable bool m_potentialExcerptsForcedDirty = false;
 };
 
 using MasterNotationPtr = std::shared_ptr<MasterNotation>;

--- a/src/notation/internal/masternotation.h
+++ b/src/notation/internal/masternotation.h
@@ -67,7 +67,7 @@ public:
 
     void setExcerptIsOpen(const INotationPtr excerptNotation, bool open) override;
 
-    void promotePotentialExcerptToLightweight(engraving::Excerpt* excerpt);
+    void promotePotentialExcerptToUninit(engraving::Excerpt* excerpt);
 
     INotationPartsPtr parts() const override;
     bool hasParts() const override;

--- a/src/notation/internal/masternotation.h
+++ b/src/notation/internal/masternotation.h
@@ -84,7 +84,7 @@ private:
 
     void initAfterSettingScore(const engraving::MasterScore* score, bool disablePlayback = false);
 
-    void initExcerptNotations(const std::vector<engraving::Excerpt*>& excerpts);
+    void createExcerptNotations(const std::vector<engraving::Excerpt*>& excerpts);
     void addExcerptsToMasterScore(const std::vector<engraving::Excerpt*>& excerpts);
     void doSetExcerpts(const ExcerptNotationList& excerpts);
     void updateExcerpts();

--- a/src/notation/internal/masternotation.h
+++ b/src/notation/internal/masternotation.h
@@ -57,7 +57,6 @@ public:
 
     const ExcerptNotationList& excerpts() const override;
     muse::async::Notification excerptsChanged() const override;
-    const ExcerptNotationList& potentialExcerpts() const override;
 
     void initExcerpts(const ExcerptNotationList& excerpts) override;
     void deinitExcerpts(const ExcerptNotationList& excerpts) override;
@@ -66,8 +65,6 @@ public:
     void sortExcerpts(ExcerptNotationList& excerpts) override;
 
     void setExcerptIsOpen(const INotationPtr excerptNotation, bool open) override;
-
-    void promotePotentialExcerptToUninit(engraving::Excerpt* excerpt);
 
     INotationPartsPtr parts() const override;
     bool hasParts() const override;
@@ -88,7 +85,6 @@ private:
     void addExcerptsToMasterScore(const std::vector<engraving::Excerpt*>& excerpts);
     void doSetExcerpts(const ExcerptNotationList& excerpts);
     void updateExcerpts();
-    void updatePotentialExcerpts() const;
     void unloadExcerpts(ExcerptNotationList& excerpts);
 
     bool containsExcerpt(const engraving::Excerpt* excerpt) const;
@@ -106,14 +102,6 @@ private:
     INotationPlaybackPtr m_notationPlayback = nullptr;
     INotationAutomationPtr m_notationAutomation = nullptr;
     muse::async::Notification m_hasPartsChanged;
-
-    mutable ExcerptNotationList m_potentialExcerpts;
-
-    // When the user first removes instruments (`Parts`) and then adds new ones,
-    // the new ones might have the same ID as the removed ones. In this case,
-    // we need to regenerate potential excerpts, even though for all part IDs a
-    // potential excerpt already exists.
-    mutable bool m_potentialExcerptsForcedDirty = false;
 };
 
 using MasterNotationPtr = std::shared_ptr<MasterNotation>;

--- a/src/notation/internal/masternotation.h
+++ b/src/notation/internal/masternotation.h
@@ -66,6 +66,8 @@ public:
 
     void setExcerptIsOpen(const INotationPtr excerptNotation, bool open) override;
 
+    void promotePotentialExcerptToLightweight(engraving::Excerpt* excerpt);
+
     INotationPartsPtr parts() const override;
     bool hasParts() const override;
     muse::async::Notification hasPartsChanged() const override;

--- a/src/notation/internal/masternotation.h
+++ b/src/notation/internal/masternotation.h
@@ -60,6 +60,7 @@ public:
     const ExcerptNotationList& potentialExcerpts() const override;
 
     void initExcerpts(const ExcerptNotationList& excerpts) override;
+    void deinitExcerpts(const ExcerptNotationList& excerpts) override;
     void setExcerpts(const ExcerptNotationList& excerpts) override;
     void resetExcerpt(IExcerptNotationPtr& excerptNotation) override;
     void sortExcerpts(ExcerptNotationList& excerpts) override;

--- a/src/notation/internal/masternotationparts.cpp
+++ b/src/notation/internal/masternotationparts.cpp
@@ -277,17 +277,17 @@ void MasterNotationParts::onPartsRemoved(const std::vector<Part*>& parts)
             continue;
         }
 
-        // Only remove uninitialised (single-part) excerpts whose part was removed
-        if (excerpt->inited()) {
-            continue;
-        }
-
         bool shouldRemove = std::find_if(parts.cbegin(), parts.cend(), [initialPartId](const Part* part) {
             return part->id() == initialPartId;
         }) != parts.cend();
 
         if (shouldRemove) {
-            master->undo(new mu::engraving::RemoveExcerpt(excerpt));
+            if (excerpt->inited()) {
+                // deleteExcerpt unlinks staves before pushing RemoveExcerpt onto the undo stack
+                master->deleteExcerpt(excerpt);
+            } else {
+                master->undo(new mu::engraving::RemoveExcerpt(excerpt));
+            }
         }
     }
 }

--- a/src/notation/internal/masternotationparts.cpp
+++ b/src/notation/internal/masternotationparts.cpp
@@ -211,12 +211,20 @@ void MasterNotationParts::replaceInstrument(const InstrumentKey& instrumentKey, 
     engraving::Transpose::transpositionChanged(tx, score(), part, Part::MAIN_INSTRUMENT_TICK, oldTranspose);
 
     if (isMainInstrument) {
-        if (mu::engraving::Excerpt* excerpt = findExcerpt(part->id())) {
+        mu::engraving::Excerpt* excerpt = findExcerpt(part->id());
+        if (excerpt && !excerpt->excerptScore()) {
+            // Lightweight excerpt - rename directly without undo
             StringList allExcerptLowerNames;
             for (const mu::engraving::Excerpt* excerpt2 : score()->masterScore()->excerpts()) {
                 allExcerptLowerNames.push_back(excerpt2->name().toLower());
             }
-
+            String newName = mu::engraving::formatUniqueExcerptName(part->partName(), allExcerptLowerNames);
+            excerpt->setName(newName);
+        } else if (excerpt) {
+            StringList allExcerptLowerNames;
+            for (const mu::engraving::Excerpt* excerpt2 : score()->masterScore()->excerpts()) {
+                allExcerptLowerNames.push_back(excerpt2->name().toLower());
+            }
             String newName = mu::engraving::formatUniqueExcerptName(part->partName(), allExcerptLowerNames);
             excerpt->excerptScore()->undo(new mu::engraving::ChangeExcerptTitle(excerpt, newName));
         }
@@ -331,6 +339,10 @@ std::vector<INotationPartsPtr> MasterNotationParts::excerptsParts() const
     std::vector<INotationPartsPtr> result;
 
     for (const IExcerptNotationPtr& excerpt : m_excerpts) {
+        // Skip lightweight excerpts (not initialized, no score)
+        if (!excerpt->isInited()) {
+            continue;
+        }
         result.push_back(excerpt->notation()->parts());
     }
 

--- a/src/notation/internal/masternotationparts.cpp
+++ b/src/notation/internal/masternotationparts.cpp
@@ -245,6 +245,19 @@ void MasterNotationParts::replaceDrumset(const InstrumentKey& instrumentKey, con
     endGlobalEdit();
 }
 
+void MasterNotationParts::onPartsAdded(const std::vector<Part*>& parts)
+{
+    mu::engraving::MasterScore* master = score()->masterScore();
+
+    // Create uninitialised excerpts for newly added parts
+    std::vector<mu::engraving::Excerpt*> newExcerpts
+        = mu::engraving::Excerpt::createExcerptsFromParts(parts, master);
+
+    for (mu::engraving::Excerpt* excerpt : newExcerpts) {
+        master->undo(new mu::engraving::AddExcerpt(excerpt, false));
+    }
+}
+
 void MasterNotationParts::onPartsRemoved(const std::vector<Part*>& parts)
 {
     mu::engraving::MasterScore* master = score()->masterScore();

--- a/src/notation/internal/masternotationparts.cpp
+++ b/src/notation/internal/masternotationparts.cpp
@@ -219,12 +219,11 @@ void MasterNotationParts::replaceInstrument(const InstrumentKey& instrumentKey, 
             }
             String newName = mu::engraving::formatUniqueExcerptName(part->partName(), allExcerptLowerNames);
 
-            if (!excerpt->excerptScore()) {
-                // Uninitialised excerpt - rename directly without undo
-                excerpt->setName(newName);
-            } else {
-                excerpt->excerptScore()->undo(new mu::engraving::ChangeExcerptTitle(excerpt, newName));
-            }
+            // Use masterScore undo stack for uninitialised excerpts, excerptScore for initialised
+            mu::engraving::Score* undoScore = excerpt->excerptScore()
+                                              ? excerpt->excerptScore()
+                                              : static_cast<mu::engraving::Score*>(score()->masterScore());
+            undoScore->undo(new mu::engraving::ChangeExcerptTitle(excerpt, newName));
         }
     }
 

--- a/src/notation/internal/masternotationparts.cpp
+++ b/src/notation/internal/masternotationparts.cpp
@@ -212,21 +212,19 @@ void MasterNotationParts::replaceInstrument(const InstrumentKey& instrumentKey, 
 
     if (isMainInstrument) {
         mu::engraving::Excerpt* excerpt = findExcerpt(part->id());
-        if (excerpt && !excerpt->excerptScore()) {
-            // Lightweight excerpt - rename directly without undo
+        if (excerpt) {
             StringList allExcerptLowerNames;
-            for (const mu::engraving::Excerpt* excerpt2 : score()->masterScore()->excerpts()) {
-                allExcerptLowerNames.push_back(excerpt2->name().toLower());
+            for (const mu::engraving::Excerpt* ex : score()->masterScore()->excerpts()) {
+                allExcerptLowerNames.push_back(ex->name().toLower());
             }
             String newName = mu::engraving::formatUniqueExcerptName(part->partName(), allExcerptLowerNames);
-            excerpt->setName(newName);
-        } else if (excerpt) {
-            StringList allExcerptLowerNames;
-            for (const mu::engraving::Excerpt* excerpt2 : score()->masterScore()->excerpts()) {
-                allExcerptLowerNames.push_back(excerpt2->name().toLower());
+
+            if (!excerpt->excerptScore()) {
+                // Lightweight excerpt - rename directly without undo
+                excerpt->setName(newName);
+            } else {
+                excerpt->excerptScore()->undo(new mu::engraving::ChangeExcerptTitle(excerpt, newName));
             }
-            String newName = mu::engraving::formatUniqueExcerptName(part->partName(), allExcerptLowerNames);
-            excerpt->excerptScore()->undo(new mu::engraving::ChangeExcerptTitle(excerpt, newName));
         }
     }
 

--- a/src/notation/internal/masternotationparts.cpp
+++ b/src/notation/internal/masternotationparts.cpp
@@ -269,12 +269,17 @@ void MasterNotationParts::onPartsRemoved(const std::vector<Part*>& parts)
             continue;
         }
 
-        bool deleteExcerpt = std::find_if(parts.cbegin(), parts.cend(), [initialPartId](const Part* part) {
+        // Only remove uninitialised (single-part) excerpts whose part was removed
+        if (excerpt->inited()) {
+            continue;
+        }
+
+        bool shouldRemove = std::find_if(parts.cbegin(), parts.cend(), [initialPartId](const Part* part) {
             return part->id() == initialPartId;
         }) != parts.cend();
 
-        if (deleteExcerpt) {
-            master->deleteExcerpt(excerpt);
+        if (shouldRemove) {
+            master->undo(new mu::engraving::RemoveExcerpt(excerpt));
         }
     }
 }

--- a/src/notation/internal/masternotationparts.cpp
+++ b/src/notation/internal/masternotationparts.cpp
@@ -220,7 +220,7 @@ void MasterNotationParts::replaceInstrument(const InstrumentKey& instrumentKey, 
             String newName = mu::engraving::formatUniqueExcerptName(part->partName(), allExcerptLowerNames);
 
             if (!excerpt->excerptScore()) {
-                // Lightweight excerpt - rename directly without undo
+                // Uninitialised excerpt - rename directly without undo
                 excerpt->setName(newName);
             } else {
                 excerpt->excerptScore()->undo(new mu::engraving::ChangeExcerptTitle(excerpt, newName));
@@ -337,7 +337,7 @@ std::vector<INotationPartsPtr> MasterNotationParts::excerptsParts() const
     std::vector<INotationPartsPtr> result;
 
     for (const IExcerptNotationPtr& excerpt : m_excerpts) {
-        // Skip lightweight excerpts (not initialized, no score)
+        // Skip uninitialised excerpts (no score)
         if (!excerpt->isInited()) {
             continue;
         }

--- a/src/notation/internal/masternotationparts.cpp
+++ b/src/notation/internal/masternotationparts.cpp
@@ -215,6 +215,9 @@ void MasterNotationParts::replaceInstrument(const InstrumentKey& instrumentKey, 
         if (excerpt) {
             StringList allExcerptLowerNames;
             for (const mu::engraving::Excerpt* ex : score()->masterScore()->excerpts()) {
+                if (ex == excerpt) {
+                    continue;
+                }
                 allExcerptLowerNames.push_back(ex->name().toLower());
             }
             String newName = mu::engraving::formatUniqueExcerptName(part->partName(), allExcerptLowerNames);
@@ -247,6 +250,11 @@ void MasterNotationParts::replaceDrumset(const InstrumentKey& instrumentKey, con
 
 void MasterNotationParts::onPartsAdded(const std::vector<Part*>& parts)
 {
+    // During initial score setup, addExcerptsToMasterScore handles excerpt creation
+    if (m_skipExcerptCreation) {
+        return;
+    }
+
     mu::engraving::MasterScore* master = score()->masterScore();
 
     // Create uninitialised excerpts for newly added parts

--- a/src/notation/internal/masternotationparts.cpp
+++ b/src/notation/internal/masternotationparts.cpp
@@ -288,17 +288,17 @@ void MasterNotationParts::onPartsRemoved(const std::vector<Part*>& parts)
             continue;
         }
 
-        // Only remove uninitialised (single-part) excerpts whose part was removed
-        if (excerpt->inited()) {
-            continue;
-        }
-
         bool shouldRemove = std::find_if(parts.cbegin(), parts.cend(), [initialPartId](const Part* part) {
             return part->id() == initialPartId;
         }) != parts.cend();
 
         if (shouldRemove) {
-            master->undo(new mu::engraving::RemoveExcerpt(excerpt));
+            if (excerpt->inited()) {
+                // deleteExcerpt unlinks staves before pushing RemoveExcerpt onto the undo stack
+                master->deleteExcerpt(excerpt);
+            } else {
+                master->undo(new mu::engraving::RemoveExcerpt(excerpt));
+            }
         }
     }
 }

--- a/src/notation/internal/masternotationparts.cpp
+++ b/src/notation/internal/masternotationparts.cpp
@@ -222,12 +222,11 @@ void MasterNotationParts::replaceInstrument(const InstrumentKey& instrumentKey, 
             }
             String newName = mu::engraving::formatUniqueExcerptName(part->partName(), allExcerptLowerNames);
 
-            if (!excerpt->excerptScore()) {
-                // Uninitialised excerpt - rename directly without undo
-                excerpt->setName(newName);
-            } else {
-                excerpt->excerptScore()->undo(new mu::engraving::ChangeExcerptTitle(excerpt, newName));
-            }
+            // Use masterScore undo stack for uninitialised excerpts, excerptScore for initialised
+            mu::engraving::Score* undoScore = excerpt->excerptScore()
+                                              ? excerpt->excerptScore()
+                                              : static_cast<mu::engraving::Score*>(score()->masterScore());
+            undoScore->undo(new mu::engraving::ChangeExcerptTitle(excerpt, newName));
         }
     }
 

--- a/src/notation/internal/masternotationparts.cpp
+++ b/src/notation/internal/masternotationparts.cpp
@@ -248,6 +248,19 @@ void MasterNotationParts::replaceDrumset(const InstrumentKey& instrumentKey, con
     endGlobalEdit();
 }
 
+void MasterNotationParts::onPartsAdded(const std::vector<Part*>& parts)
+{
+    mu::engraving::MasterScore* master = score()->masterScore();
+
+    // Create uninitialised excerpts for newly added parts
+    std::vector<mu::engraving::Excerpt*> newExcerpts
+        = mu::engraving::Excerpt::createExcerptsFromParts(parts, master);
+
+    for (mu::engraving::Excerpt* excerpt : newExcerpts) {
+        master->undo(new mu::engraving::AddExcerpt(excerpt, false));
+    }
+}
+
 void MasterNotationParts::onPartsRemoved(const std::vector<Part*>& parts)
 {
     mu::engraving::MasterScore* master = score()->masterScore();

--- a/src/notation/internal/masternotationparts.cpp
+++ b/src/notation/internal/masternotationparts.cpp
@@ -223,7 +223,7 @@ void MasterNotationParts::replaceInstrument(const InstrumentKey& instrumentKey, 
             String newName = mu::engraving::formatUniqueExcerptName(part->partName(), allExcerptLowerNames);
 
             if (!excerpt->excerptScore()) {
-                // Lightweight excerpt - rename directly without undo
+                // Uninitialised excerpt - rename directly without undo
                 excerpt->setName(newName);
             } else {
                 excerpt->excerptScore()->undo(new mu::engraving::ChangeExcerptTitle(excerpt, newName));
@@ -340,7 +340,7 @@ std::vector<INotationPartsPtr> MasterNotationParts::excerptsParts() const
     std::vector<INotationPartsPtr> result;
 
     for (const IExcerptNotationPtr& excerpt : m_excerpts) {
-        // Skip lightweight excerpts (not initialized, no score)
+        // Skip uninitialised excerpts (no score)
         if (!excerpt->isInited()) {
             continue;
         }

--- a/src/notation/internal/masternotationparts.cpp
+++ b/src/notation/internal/masternotationparts.cpp
@@ -215,21 +215,19 @@ void MasterNotationParts::replaceInstrument(const InstrumentKey& instrumentKey, 
 
     if (isMainInstrument) {
         mu::engraving::Excerpt* excerpt = findExcerpt(part->id());
-        if (excerpt && !excerpt->excerptScore()) {
-            // Lightweight excerpt - rename directly without undo
+        if (excerpt) {
             StringList allExcerptLowerNames;
-            for (const mu::engraving::Excerpt* excerpt2 : score()->masterScore()->excerpts()) {
-                allExcerptLowerNames.push_back(excerpt2->name().toLower());
+            for (const mu::engraving::Excerpt* ex : score()->masterScore()->excerpts()) {
+                allExcerptLowerNames.push_back(ex->name().toLower());
             }
             String newName = mu::engraving::formatUniqueExcerptName(part->partName(), allExcerptLowerNames);
-            excerpt->setName(newName);
-        } else if (excerpt) {
-            StringList allExcerptLowerNames;
-            for (const mu::engraving::Excerpt* excerpt2 : score()->masterScore()->excerpts()) {
-                allExcerptLowerNames.push_back(excerpt2->name().toLower());
+
+            if (!excerpt->excerptScore()) {
+                // Lightweight excerpt - rename directly without undo
+                excerpt->setName(newName);
+            } else {
+                excerpt->excerptScore()->undo(new mu::engraving::ChangeExcerptTitle(excerpt, newName));
             }
-            String newName = mu::engraving::formatUniqueExcerptName(part->partName(), allExcerptLowerNames);
-            excerpt->excerptScore()->undo(new mu::engraving::ChangeExcerptTitle(excerpt, newName));
         }
     }
 

--- a/src/notation/internal/masternotationparts.cpp
+++ b/src/notation/internal/masternotationparts.cpp
@@ -214,12 +214,20 @@ void MasterNotationParts::replaceInstrument(const InstrumentKey& instrumentKey, 
     }
 
     if (isMainInstrument) {
-        if (mu::engraving::Excerpt* excerpt = findExcerpt(part->id())) {
+        mu::engraving::Excerpt* excerpt = findExcerpt(part->id());
+        if (excerpt && !excerpt->excerptScore()) {
+            // Lightweight excerpt - rename directly without undo
             StringList allExcerptLowerNames;
             for (const mu::engraving::Excerpt* excerpt2 : score()->masterScore()->excerpts()) {
                 allExcerptLowerNames.push_back(excerpt2->name().toLower());
             }
-
+            String newName = mu::engraving::formatUniqueExcerptName(part->partName(), allExcerptLowerNames);
+            excerpt->setName(newName);
+        } else if (excerpt) {
+            StringList allExcerptLowerNames;
+            for (const mu::engraving::Excerpt* excerpt2 : score()->masterScore()->excerpts()) {
+                allExcerptLowerNames.push_back(excerpt2->name().toLower());
+            }
             String newName = mu::engraving::formatUniqueExcerptName(part->partName(), allExcerptLowerNames);
             excerpt->excerptScore()->undo(new mu::engraving::ChangeExcerptTitle(excerpt, newName));
         }
@@ -334,6 +342,10 @@ std::vector<INotationPartsPtr> MasterNotationParts::excerptsParts() const
     std::vector<INotationPartsPtr> result;
 
     for (const IExcerptNotationPtr& excerpt : m_excerpts) {
+        // Skip lightweight excerpts (not initialized, no score)
+        if (!excerpt->isInited()) {
+            continue;
+        }
         result.push_back(excerpt->notation()->parts());
     }
 

--- a/src/notation/internal/masternotationparts.cpp
+++ b/src/notation/internal/masternotationparts.cpp
@@ -272,12 +272,17 @@ void MasterNotationParts::onPartsRemoved(const std::vector<Part*>& parts)
             continue;
         }
 
-        bool deleteExcerpt = std::find_if(parts.cbegin(), parts.cend(), [initialPartId](const Part* part) {
+        // Only remove uninitialised (single-part) excerpts whose part was removed
+        if (excerpt->inited()) {
+            continue;
+        }
+
+        bool shouldRemove = std::find_if(parts.cbegin(), parts.cend(), [initialPartId](const Part* part) {
             return part->id() == initialPartId;
         }) != parts.cend();
 
-        if (deleteExcerpt) {
-            master->deleteExcerpt(excerpt);
+        if (shouldRemove) {
+            master->undo(new mu::engraving::RemoveExcerpt(excerpt));
         }
     }
 }

--- a/src/notation/internal/masternotationparts.cpp
+++ b/src/notation/internal/masternotationparts.cpp
@@ -252,9 +252,17 @@ void MasterNotationParts::onPartsAdded(const std::vector<Part*>& parts)
 {
     mu::engraving::MasterScore* master = score()->masterScore();
 
-    // Create uninitialised excerpts for newly added parts
+    // Create uninitialised excerpts for newly added parts. Shared parts never get one of their own.
+    std::vector<mu::engraving::Part*> partsNeedingExcerpt;
+    partsNeedingExcerpt.reserve(parts.size());
+    for (mu::engraving::Part* part : parts) {
+        if (!part->isSharedPart()) {
+            partsNeedingExcerpt.push_back(part);
+        }
+    }
+
     std::vector<mu::engraving::Excerpt*> newExcerpts
-        = mu::engraving::Excerpt::createExcerptsFromParts(parts, master);
+        = mu::engraving::Excerpt::createExcerptsFromParts(partsNeedingExcerpt, master);
 
     for (mu::engraving::Excerpt* excerpt : newExcerpts) {
         master->undo(new mu::engraving::AddExcerpt(excerpt, false));

--- a/src/notation/internal/masternotationparts.cpp
+++ b/src/notation/internal/masternotationparts.cpp
@@ -218,6 +218,9 @@ void MasterNotationParts::replaceInstrument(const InstrumentKey& instrumentKey, 
         if (excerpt) {
             StringList allExcerptLowerNames;
             for (const mu::engraving::Excerpt* ex : score()->masterScore()->excerpts()) {
+                if (ex == excerpt) {
+                    continue;
+                }
                 allExcerptLowerNames.push_back(ex->name().toLower());
             }
             String newName = mu::engraving::formatUniqueExcerptName(part->partName(), allExcerptLowerNames);
@@ -250,6 +253,11 @@ void MasterNotationParts::replaceDrumset(const InstrumentKey& instrumentKey, con
 
 void MasterNotationParts::onPartsAdded(const std::vector<Part*>& parts)
 {
+    // During initial score setup, addExcerptsToMasterScore handles excerpt creation
+    if (m_skipExcerptCreation) {
+        return;
+    }
+
     mu::engraving::MasterScore* master = score()->masterScore();
 
     // Create uninitialised excerpts for newly added parts. Shared parts never get one of their own.

--- a/src/notation/internal/masternotationparts.h
+++ b/src/notation/internal/masternotationparts.h
@@ -64,6 +64,9 @@ private:
     mu::engraving::Excerpt* findExcerpt(const muse::ID& initialPartId) const;
 
     ExcerptNotationList m_excerpts;
+    bool m_skipExcerptCreation = false;
+
+    friend class MasterNotation;
 };
 }
 

--- a/src/notation/internal/masternotationparts.h
+++ b/src/notation/internal/masternotationparts.h
@@ -57,6 +57,7 @@ private:
     void startGlobalEdit(const muse::TranslatableString& actionName);
     void endGlobalEdit();
 
+    void onPartsAdded(const std::vector<Part*>& parts) override;
     void onPartsRemoved(const std::vector<Part*>& parts) override;
 
     std::vector<INotationPartsPtr> excerptsParts() const;

--- a/src/notation/internal/masternotationparts.h
+++ b/src/notation/internal/masternotationparts.h
@@ -62,5 +62,8 @@ private:
     mu::engraving::Excerpt* findExcerpt(const muse::ID& initialPartId) const;
 
     ExcerptNotationList m_excerpts;
+    bool m_skipExcerptCreation = false;
+
+    friend class MasterNotation;
 };
 }

--- a/src/notation/internal/masternotationparts.h
+++ b/src/notation/internal/masternotationparts.h
@@ -55,6 +55,7 @@ private:
     void startGlobalEdit(const muse::TranslatableString& actionName);
     void endGlobalEdit();
 
+    void onPartsAdded(const std::vector<Part*>& parts) override;
     void onPartsRemoved(const std::vector<Part*>& parts) override;
 
     std::vector<INotationPartsPtr> excerptsParts() const;

--- a/src/notation/internal/notationparts.cpp
+++ b/src/notation/internal/notationparts.cpp
@@ -985,6 +985,10 @@ void NotationParts::doRemoveParts(const std::vector<Part*>& parts)
     onPartsRemoved(parts);
 }
 
+void NotationParts::onPartsAdded(const std::vector<Part*>&)
+{
+}
+
 void NotationParts::onPartsRemoved(const std::vector<Part*>&)
 {
 }
@@ -1217,6 +1221,7 @@ void NotationParts::insertNewParts(const PartInstrumentList& parts, const mu::en
     TRACEFUNC;
 
     size_t partIdx = 0;
+    std::vector<Part*> addedParts;
 
     for (const PartInstrument& pi: parts) {
         if (pi.isExistingPart) {
@@ -1250,7 +1255,12 @@ void NotationParts::insertNewParts(const PartInstrumentList& parts, const mu::en
         appendStaves(part, pi.instrumentTemplate, keyList);
         ++partIdx;
 
+        addedParts.push_back(part);
         m_partChangedNotifier.itemAdded(part);
+    }
+
+    if (!addedParts.empty()) {
+        onPartsAdded(addedParts);
     }
 }
 

--- a/src/notation/internal/notationparts.cpp
+++ b/src/notation/internal/notationparts.cpp
@@ -989,6 +989,10 @@ void NotationParts::doRemoveParts(const std::vector<Part*>& parts)
     onPartsRemoved(parts);
 }
 
+void NotationParts::onPartsAdded(const std::vector<Part*>&)
+{
+}
+
 void NotationParts::onPartsRemoved(const std::vector<Part*>&)
 {
 }
@@ -1199,6 +1203,7 @@ void NotationParts::insertNewParts(const PartInstrumentList& parts, const mu::en
     TRACEFUNC;
 
     size_t partIdx = 0;
+    std::vector<Part*> addedParts;
 
     for (const PartInstrument& pi: parts) {
         if (pi.isExistingPart) {
@@ -1232,7 +1237,12 @@ void NotationParts::insertNewParts(const PartInstrumentList& parts, const mu::en
         appendStaves(part, pi.instrumentTemplate, keyList);
         ++partIdx;
 
+        addedParts.push_back(part);
         m_partChangedNotifier.itemAdded(part);
+    }
+
+    if (!addedParts.empty()) {
+        onPartsAdded(addedParts);
     }
 }
 

--- a/src/notation/internal/notationparts.h
+++ b/src/notation/internal/notationparts.h
@@ -111,6 +111,7 @@ protected:
     void apply();
     void rollback();
 
+    virtual void onPartsAdded(const std::vector<Part*>& parts);
     virtual void onPartsRemoved(const std::vector<Part*>& parts);
 
 private:

--- a/src/notation/internal/notationparts.h
+++ b/src/notation/internal/notationparts.h
@@ -109,6 +109,7 @@ protected:
     void apply();
     void rollback();
 
+    virtual void onPartsAdded(const std::vector<Part*>& parts);
     virtual void onPartsRemoved(const std::vector<Part*>& parts);
 
 private:

--- a/src/notation/internal/notationstyle.cpp
+++ b/src/notation/internal/notationstyle.cpp
@@ -99,6 +99,9 @@ void NotationStyle::applyToAllParts()
     mu::engraving::MStyle style = m_getScore->score()->style();
 
     for (mu::engraving::Excerpt* excerpt : score()->masterScore()->excerpts()) {
+        if (!excerpt->excerptScore()) {
+            continue;
+        }
         excerpt->excerptScore()->undo(new mu::engraving::ChangeStyle(excerpt->excerptScore(), style));
         excerpt->excerptScore()->update();
     }

--- a/src/notationscene/qml/MuseScore/NotationScene/partlistmodel.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/partlistmodel.cpp
@@ -70,8 +70,6 @@ void PartListModel::load()
     }
 
     ExcerptNotationList excerpts = masterNotation->excerpts();
-    ExcerptNotationList potentialExcerpts = masterNotation->potentialExcerpts();
-    excerpts.insert(excerpts.end(), potentialExcerpts.begin(), potentialExcerpts.end());
 
     masterNotation->sortExcerpts(excerpts);
 

--- a/src/notationscene/qml/MuseScore/NotationScene/partlistmodel.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/partlistmodel.cpp
@@ -68,8 +68,6 @@ void PartListModel::load()
     }
 
     ExcerptNotationList excerpts = masterNotation->excerpts();
-    ExcerptNotationList potentialExcerpts = masterNotation->potentialExcerpts();
-    excerpts.insert(excerpts.end(), potentialExcerpts.begin(), potentialExcerpts.end());
 
     masterNotation->sortExcerpts(excerpts);
 

--- a/src/notationscene/widgets/pagesettings.cpp
+++ b/src/notationscene/widgets/pagesettings.cpp
@@ -345,6 +345,9 @@ void PageSettings::applyToAllParts()
         return;
     }
     for (Excerpt* e : score()->masterScore()->excerpts()) {
+        if (!e->excerptScore()) {
+            continue;
+        }
         applyToScore(e->excerptScore());
     }
     _changeFlag = false;

--- a/src/notationscene/widgets/pagesettings.cpp
+++ b/src/notationscene/widgets/pagesettings.cpp
@@ -343,6 +343,9 @@ void PageSettings::applyToAllParts()
         return;
     }
     for (Excerpt* e : score()->masterScore()->excerpts()) {
+        if (!e->excerptScore()) {
+            continue;
+        }
         applyToScore(e->excerptScore());
     }
     _changeFlag = false;

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -1379,6 +1379,9 @@ void PlaybackController::removeTrack(const InstrumentTrackId& instrumentTrackId)
 void PlaybackController::onTrackNewlyAdded(const InstrumentTrackId& instrumentTrackId)
 {
     for (const IExcerptNotationPtr& excerpt : m_masterNotation->excerpts()) {
+        if (!excerpt->isInited()) {
+            continue;
+        }
         if (const INotationPtr& notation = excerpt->notation()) {
             if (notation == m_notation || notation->soloMuteState()->trackSoloMuteStateExists(instrumentTrackId)) {
                 continue;

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -1450,6 +1450,9 @@ void PlaybackController::removeTrack(const InstrumentTrackId& instrumentTrackId)
 void PlaybackController::onTrackNewlyAdded(const InstrumentTrackId& instrumentTrackId)
 {
     for (const IExcerptNotationPtr& excerpt : m_masterNotation->excerpts()) {
+        if (!excerpt->isInited()) {
+            continue;
+        }
         if (const INotationPtr& notation = excerpt->notation()) {
             if (notation == m_notation || notation->soloMuteState()->trackSoloMuteStateExists(instrumentTrackId)) {
                 continue;

--- a/src/project/internal/exportprojectscenario.cpp
+++ b/src/project/internal/exportprojectscenario.cpp
@@ -123,16 +123,29 @@ bool ExportProjectScenario::exportScores(notation::INotationPtrList notations, c
     bool isExportingOnlyOneScore = notations.size() == 1;
 
     // The user might have selected not-yet-inited excerpts
+    // Check both potentialExcerpts and regular excerpts (which may be lightweight/uninitialized)
     ExcerptNotationList excerptsToInit;
     ExcerptNotationList potentialExcerpts = masterNotation()->potentialExcerpts();
+    ExcerptNotationList regularExcerpts = masterNotation()->excerpts();
 
     for (const INotationPtr& notation : notations) {
+        // Check in potential excerpts
         auto it = std::find_if(potentialExcerpts.cbegin(), potentialExcerpts.cend(), [notation](const IExcerptNotationPtr& excerpt) {
             return excerpt->notation() == notation;
         });
 
         if (it != potentialExcerpts.cend()) {
             excerptsToInit.push_back(*it);
+            continue;
+        }
+
+        // Check in regular excerpts for uninitialized (lightweight) ones
+        auto it2 = std::find_if(regularExcerpts.cbegin(), regularExcerpts.cend(), [notation](const IExcerptNotationPtr& excerpt) {
+            return excerpt->notation() == notation && !excerpt->isInited();
+        });
+
+        if (it2 != regularExcerpts.cend()) {
+            excerptsToInit.push_back(*it2);
         }
     }
 

--- a/src/project/internal/exportprojectscenario.cpp
+++ b/src/project/internal/exportprojectscenario.cpp
@@ -185,6 +185,10 @@ bool ExportProjectScenario::exportScores(notation::INotationPtrList notations, c
         // Restore view modes
         setViewModes(notations, viewModes);
 
+        // Deinitialize excerpts that were only initialized for export
+        // This keeps them as lightweight excerpts so they don't get saved as full excerpts
+        masterNotation()->deinitExcerpts(excerptsToInit);
+
         if (writerProgress) {
             m_exportProgress.finish(muse::make_ok());
             writerProgress->progressChanged().disconnect(this);

--- a/src/project/internal/exportprojectscenario.cpp
+++ b/src/project/internal/exportprojectscenario.cpp
@@ -123,7 +123,7 @@ bool ExportProjectScenario::exportScores(notation::INotationPtrList notations, c
     bool isExportingOnlyOneScore = notations.size() == 1;
 
     // The user might have selected not-yet-inited excerpts
-    // Check both potentialExcerpts and regular excerpts (which may be lightweight/uninitialized)
+    // Check both potentialExcerpts and regular excerpts (which may be uninitialised)
     ExcerptNotationList excerptsToInit;
     ExcerptNotationList potentialExcerpts = masterNotation()->potentialExcerpts();
     ExcerptNotationList regularExcerpts = masterNotation()->excerpts();
@@ -139,7 +139,7 @@ bool ExportProjectScenario::exportScores(notation::INotationPtrList notations, c
             continue;
         }
 
-        // Check in regular excerpts for uninitialized (lightweight) ones
+        // Check in regular excerpts for uninitialised ones
         auto it2 = std::find_if(regularExcerpts.cbegin(), regularExcerpts.cend(), [notation](const IExcerptNotationPtr& excerpt) {
             return excerpt->notation() == notation && !excerpt->isInited();
         });
@@ -186,7 +186,7 @@ bool ExportProjectScenario::exportScores(notation::INotationPtrList notations, c
         setViewModes(notations, viewModes);
 
         // Deinitialize excerpts that were only initialized for export
-        // This keeps them as lightweight excerpts so they don't get saved as full excerpts
+        // This keeps them as uninitialised excerpts so they don't get saved as full excerpts
         masterNotation()->deinitExcerpts(excerptsToInit);
 
         if (writerProgress) {

--- a/src/project/internal/exportprojectscenario.cpp
+++ b/src/project/internal/exportprojectscenario.cpp
@@ -122,30 +122,17 @@ bool ExportProjectScenario::exportScores(notation::INotationPtrList notations, c
     bool isCreatingOnlyOneFile = guessIsCreatingOnlyOneFile(notations, unitType);
     bool isExportingOnlyOneScore = notations.size() == 1;
 
-    // The user might have selected not-yet-inited excerpts
-    // Check both potentialExcerpts and regular excerpts (which may be uninitialised)
+    // The user might have selected uninitialised excerpts that need init for export
     ExcerptNotationList excerptsToInit;
-    ExcerptNotationList potentialExcerpts = masterNotation()->potentialExcerpts();
-    ExcerptNotationList regularExcerpts = masterNotation()->excerpts();
+    ExcerptNotationList allExcerpts = masterNotation()->excerpts();
 
     for (const INotationPtr& notation : notations) {
-        // Check in potential excerpts
-        auto it = std::find_if(potentialExcerpts.cbegin(), potentialExcerpts.cend(), [notation](const IExcerptNotationPtr& excerpt) {
-            return excerpt->notation() == notation;
-        });
-
-        if (it != potentialExcerpts.cend()) {
-            excerptsToInit.push_back(*it);
-            continue;
-        }
-
-        // Check in regular excerpts for uninitialised ones
-        auto it2 = std::find_if(regularExcerpts.cbegin(), regularExcerpts.cend(), [notation](const IExcerptNotationPtr& excerpt) {
+        auto it = std::find_if(allExcerpts.cbegin(), allExcerpts.cend(), [notation](const IExcerptNotationPtr& excerpt) {
             return excerpt->notation() == notation && !excerpt->isInited();
         });
 
-        if (it2 != regularExcerpts.cend()) {
-            excerptsToInit.push_back(*it2);
+        if (it != allExcerpts.cend()) {
+            excerptsToInit.push_back(*it);
         }
     }
 
@@ -288,14 +275,14 @@ bool ExportProjectScenario::guessIsCreatingOnlyOneFile(const notation::INotation
         if (notations.size() == 1) {
             INotationPtr notation = notations.front();
 
-            // Check if it is not a potential (not-yet-initialized) excerpt
-            ExcerptNotationList potentialExcerpts = masterNotation()->potentialExcerpts();
+            // Check if it is an initialised excerpt (not an uninitialised one)
+            ExcerptNotationList allExcerpts = masterNotation()->excerpts();
 
-            auto it = std::find_if(potentialExcerpts.cbegin(), potentialExcerpts.cend(), [notation](const IExcerptNotationPtr& excerpt) {
-                    return excerpt->notation() == notation;
+            auto it = std::find_if(allExcerpts.cbegin(), allExcerpts.cend(), [notation](const IExcerptNotationPtr& excerpt) {
+                    return excerpt->notation() == notation && !excerpt->isInited();
                 });
 
-            if (it == potentialExcerpts.cend()) {
+            if (it == allExcerpts.cend()) {
                 ViewMode viewMode = notation->painting()->viewMode();
                 notation->painting()->setViewMode(ViewMode::PAGE);
 

--- a/src/project/internal/exportprojectscenario.cpp
+++ b/src/project/internal/exportprojectscenario.cpp
@@ -130,7 +130,7 @@ bool ExportProjectScenario::exportScores(notation::INotationPtrList notations, c
     bool isExportingOnlyOneScore = notations.size() == 1;
 
     // The user might have selected not-yet-inited excerpts
-    // Check both potentialExcerpts and regular excerpts (which may be lightweight/uninitialized)
+    // Check both potentialExcerpts and regular excerpts (which may be uninitialised)
     ExcerptNotationList excerptsToInit;
     ExcerptNotationList potentialExcerpts = masterNotation()->potentialExcerpts();
     ExcerptNotationList regularExcerpts = masterNotation()->excerpts();
@@ -146,7 +146,7 @@ bool ExportProjectScenario::exportScores(notation::INotationPtrList notations, c
             continue;
         }
 
-        // Check in regular excerpts for uninitialized (lightweight) ones
+        // Check in regular excerpts for uninitialised ones
         auto it2 = std::find_if(regularExcerpts.cbegin(), regularExcerpts.cend(), [notation](const IExcerptNotationPtr& excerpt) {
             return excerpt->notation() == notation && !excerpt->isInited();
         });
@@ -193,7 +193,7 @@ bool ExportProjectScenario::exportScores(notation::INotationPtrList notations, c
         setViewModes(notations, viewModes);
 
         // Deinitialize excerpts that were only initialized for export
-        // This keeps them as lightweight excerpts so they don't get saved as full excerpts
+        // This keeps them as uninitialised excerpts so they don't get saved as full excerpts
         masterNotation()->deinitExcerpts(excerptsToInit);
 
         if (writerProgress) {

--- a/src/project/internal/exportprojectscenario.cpp
+++ b/src/project/internal/exportprojectscenario.cpp
@@ -192,6 +192,10 @@ bool ExportProjectScenario::exportScores(notation::INotationPtrList notations, c
         // Restore view modes
         setViewModes(notations, viewModes);
 
+        // Deinitialize excerpts that were only initialized for export
+        // This keeps them as lightweight excerpts so they don't get saved as full excerpts
+        masterNotation()->deinitExcerpts(excerptsToInit);
+
         if (writerProgress) {
             m_exportProgress.finish(muse::make_ok());
             writerProgress->progressChanged().disconnect(this);

--- a/src/project/internal/exportprojectscenario.cpp
+++ b/src/project/internal/exportprojectscenario.cpp
@@ -129,30 +129,17 @@ bool ExportProjectScenario::exportScores(notation::INotationPtrList notations, c
     bool isCreatingOnlyOneFile = guessIsCreatingOnlyOneFile(notations, unitType);
     bool isExportingOnlyOneScore = notations.size() == 1;
 
-    // The user might have selected not-yet-inited excerpts
-    // Check both potentialExcerpts and regular excerpts (which may be uninitialised)
+    // The user might have selected uninitialised excerpts that need init for export
     ExcerptNotationList excerptsToInit;
-    ExcerptNotationList potentialExcerpts = masterNotation()->potentialExcerpts();
-    ExcerptNotationList regularExcerpts = masterNotation()->excerpts();
+    ExcerptNotationList allExcerpts = masterNotation()->excerpts();
 
     for (const INotationPtr& notation : notations) {
-        // Check in potential excerpts
-        auto it = std::find_if(potentialExcerpts.cbegin(), potentialExcerpts.cend(), [notation](const IExcerptNotationPtr& excerpt) {
-            return excerpt->notation() == notation;
-        });
-
-        if (it != potentialExcerpts.cend()) {
-            excerptsToInit.push_back(*it);
-            continue;
-        }
-
-        // Check in regular excerpts for uninitialised ones
-        auto it2 = std::find_if(regularExcerpts.cbegin(), regularExcerpts.cend(), [notation](const IExcerptNotationPtr& excerpt) {
+        auto it = std::find_if(allExcerpts.cbegin(), allExcerpts.cend(), [notation](const IExcerptNotationPtr& excerpt) {
             return excerpt->notation() == notation && !excerpt->isInited();
         });
 
-        if (it2 != regularExcerpts.cend()) {
-            excerptsToInit.push_back(*it2);
+        if (it != allExcerpts.cend()) {
+            excerptsToInit.push_back(*it);
         }
     }
 
@@ -295,14 +282,14 @@ bool ExportProjectScenario::guessIsCreatingOnlyOneFile(const notation::INotation
         if (notations.size() == 1) {
             INotationPtr notation = notations.front();
 
-            // Check if it is not a potential (not-yet-initialized) excerpt
-            ExcerptNotationList potentialExcerpts = masterNotation()->potentialExcerpts();
+            // Check if it is an initialised excerpt (not an uninitialised one)
+            ExcerptNotationList allExcerpts = masterNotation()->excerpts();
 
-            auto it = std::find_if(potentialExcerpts.cbegin(), potentialExcerpts.cend(), [notation](const IExcerptNotationPtr& excerpt) {
-                    return excerpt->notation() == notation;
+            auto it = std::find_if(allExcerpts.cbegin(), allExcerpts.cend(), [notation](const IExcerptNotationPtr& excerpt) {
+                    return excerpt->notation() == notation && !excerpt->isInited();
                 });
 
-            if (it == potentialExcerpts.cend()) {
+            if (it == allExcerpts.cend()) {
                 ViewMode viewMode = notation->painting()->viewMode();
                 notation->painting()->setViewMode(ViewMode::PAGE);
 

--- a/src/project/internal/exportprojectscenario.cpp
+++ b/src/project/internal/exportprojectscenario.cpp
@@ -130,16 +130,29 @@ bool ExportProjectScenario::exportScores(notation::INotationPtrList notations, c
     bool isExportingOnlyOneScore = notations.size() == 1;
 
     // The user might have selected not-yet-inited excerpts
+    // Check both potentialExcerpts and regular excerpts (which may be lightweight/uninitialized)
     ExcerptNotationList excerptsToInit;
     ExcerptNotationList potentialExcerpts = masterNotation()->potentialExcerpts();
+    ExcerptNotationList regularExcerpts = masterNotation()->excerpts();
 
     for (const INotationPtr& notation : notations) {
+        // Check in potential excerpts
         auto it = std::find_if(potentialExcerpts.cbegin(), potentialExcerpts.cend(), [notation](const IExcerptNotationPtr& excerpt) {
             return excerpt->notation() == notation;
         });
 
         if (it != potentialExcerpts.cend()) {
             excerptsToInit.push_back(*it);
+            continue;
+        }
+
+        // Check in regular excerpts for uninitialized (lightweight) ones
+        auto it2 = std::find_if(regularExcerpts.cbegin(), regularExcerpts.cend(), [notation](const IExcerptNotationPtr& excerpt) {
+            return excerpt->notation() == notation && !excerpt->isInited();
+        });
+
+        if (it2 != regularExcerpts.cend()) {
+            excerptsToInit.push_back(*it2);
         }
     }
 

--- a/src/project/internal/notationproject.cpp
+++ b/src/project/internal/notationproject.cpp
@@ -914,8 +914,11 @@ Ret NotationProject::writeProject(MscWriter& msczWriter, bool createThumbnail, c
         return make_ret(Ret::Code::Ok);
     }
 
-    // Write excerpt view settings and solo-mute state
+    // Write excerpt view settings and solo-mute state (skip lightweight excerpts)
     for (const IExcerptNotationPtr& excerpt : m_masterNotation->excerpts()) {
+        if (!excerpt->isInited()) {
+            continue;
+        }
         muse::io::path_t path = u"Excerpts/" + excerpt->fileName() + u"/";
         excerpt->notation()->viewState()->write(msczWriter, path);
 

--- a/src/project/internal/notationproject.cpp
+++ b/src/project/internal/notationproject.cpp
@@ -914,7 +914,7 @@ Ret NotationProject::writeProject(MscWriter& msczWriter, bool createThumbnail, c
         return make_ret(Ret::Code::Ok);
     }
 
-    // Write excerpt view settings and solo-mute state (skip lightweight excerpts)
+    // Write excerpt view settings and solo-mute state (skip uninitialised excerpts)
     for (const IExcerptNotationPtr& excerpt : m_masterNotation->excerpts()) {
         if (!excerpt->isInited()) {
             continue;

--- a/src/project/internal/notationproject.cpp
+++ b/src/project/internal/notationproject.cpp
@@ -255,6 +255,9 @@ Ret NotationProject::doLoad(const muse::io::path_t& path, const OpenParams& open
     m_masterNotation->notation()->soloMuteState()->read(reader);
     const int mscVersion = m_masterNotation->mscVersion();
     for (const IExcerptNotationPtr& excerpt : m_masterNotation->excerpts()) {
+        if (!excerpt->isInited()) {
+            continue;
+        }
         const INotationPtr excerptNotation = excerpt->notation();
         if (!excerpt->hasFileName() || mscVersion < 440) {
             m_masterNotation->initNotationSoloMuteState(excerptNotation);

--- a/src/project/internal/notationproject.cpp
+++ b/src/project/internal/notationproject.cpp
@@ -261,6 +261,9 @@ Ret NotationProject::doLoad(const muse::io::path_t& path, const OpenParams& open
     m_masterNotation->notation()->soloMuteState()->read(reader);
     const int mscVersion = m_masterNotation->mscVersion();
     for (const IExcerptNotationPtr& excerpt : m_masterNotation->excerpts()) {
+        if (!excerpt->isInited()) {
+            continue;
+        }
         const INotationPtr excerptNotation = excerpt->notation();
         if (!excerpt->hasFileName() || mscVersion < 440) {
             m_masterNotation->initNotationSoloMuteState(excerptNotation);

--- a/src/project/internal/notationproject.cpp
+++ b/src/project/internal/notationproject.cpp
@@ -923,8 +923,11 @@ Ret NotationProject::writeProject(MscWriter& msczWriter, bool createThumbnail, c
         return make_ret(Ret::Code::Ok);
     }
 
-    // Write excerpt view settings and solo-mute state
+    // Write excerpt view settings and solo-mute state (skip lightweight excerpts)
     for (const IExcerptNotationPtr& excerpt : m_masterNotation->excerpts()) {
+        if (!excerpt->isInited()) {
+            continue;
+        }
         muse::io::path_t path = u"Excerpts/" + excerpt->fileName() + u"/";
         excerpt->notation()->viewState()->write(msczWriter, path);
 

--- a/src/project/internal/notationproject.cpp
+++ b/src/project/internal/notationproject.cpp
@@ -923,7 +923,7 @@ Ret NotationProject::writeProject(MscWriter& msczWriter, bool createThumbnail, c
         return make_ret(Ret::Code::Ok);
     }
 
-    // Write excerpt view settings and solo-mute state (skip lightweight excerpts)
+    // Write excerpt view settings and solo-mute state (skip uninitialised excerpts)
     for (const IExcerptNotationPtr& excerpt : m_masterNotation->excerpts()) {
         if (!excerpt->isInited()) {
             continue;

--- a/src/project/internal/projectmigrator.cpp
+++ b/src/project/internal/projectmigrator.cpp
@@ -216,6 +216,9 @@ bool ProjectMigrator::applyLelandStyle(mu::engraving::MasterScore* score)
     muse::io::File styleFile(LELAND_STYLE_PATH);
     mu::engraving::Transaction& tx = score->transactionManager()->currentOrDummyTransaction();
     for (mu::engraving::Excerpt* excerpt : score->excerpts()) {
+        if (!excerpt->excerptScore()) {
+            continue;
+        }
         if (!mu::engraving::EditStyle::loadStyle(tx, excerpt->excerptScore(), styleFile, /*ign*/ false, /*overlap*/ true)) {
             return false;
         }
@@ -229,6 +232,9 @@ bool ProjectMigrator::applyEdwinStyle(mu::engraving::MasterScore* score)
     muse::io::File styleFile(EDWIN_STYLE_PATH);
     mu::engraving::Transaction& tx = score->transactionManager()->currentOrDummyTransaction();
     for (mu::engraving::Excerpt* excerpt : score->excerpts()) {
+        if (!excerpt->excerptScore()) {
+            continue;
+        }
         if (!mu::engraving::EditStyle::loadStyle(tx, excerpt->excerptScore(), styleFile, /*ign*/ false, /*overlap*/ true)) {
             return false;
         }

--- a/src/project/qml/MuseScore/Project/internal/Export/exportdialogmodel.cpp
+++ b/src/project/qml/MuseScore/Project/internal/Export/exportdialogmodel.cpp
@@ -173,8 +173,6 @@ void ExportDialogModel::init()
     m_notations << masterNotation->notation();
 
     ExcerptNotationList excerpts = masterNotation->excerpts();
-    ExcerptNotationList potentialExcerpts = masterNotation->potentialExcerpts();
-    excerpts.insert(excerpts.end(), potentialExcerpts.begin(), potentialExcerpts.end());
 
     masterNotation->sortExcerpts(excerpts);
 

--- a/src/project/qml/MuseScore/Project/internal/Export/exportdialogmodel.cpp
+++ b/src/project/qml/MuseScore/Project/internal/Export/exportdialogmodel.cpp
@@ -171,8 +171,6 @@ void ExportDialogModel::init()
     m_notations << masterNotation->notation();
 
     ExcerptNotationList excerpts = masterNotation->excerpts();
-    ExcerptNotationList potentialExcerpts = masterNotation->potentialExcerpts();
-    excerpts.insert(excerpts.end(), potentialExcerpts.begin(), potentialExcerpts.end());
 
     masterNotation->sortExcerpts(excerpts);
 


### PR DESCRIPTION
Resolves #31656
Supersedes #31658

## Summary

Part names in the Parts dialog now persist after save/reload, even for parts that were never opened as tabs.

Previously, all excerpts (parts) were fully initialised on load: each one created a complete `Score` object with all linked musical elements, regardless of whether the user ever opened that part. This PR replaces that approach with uninitialised excerpts: a part only creates its `Score` object the first time the user opens it.

This reduces memory usage (no `Score` object is allocated for unopened parts) and reduces file size (each uninitialised excerpt is stored as ~400 bytes of metadata instead of several KB of full score XML). For a large orchestral score with many instruments, the savings are significant.

## Changes

**Engraving layer:**
- Add uninitialised excerpt write support in `MscSaver`: stores name, parts, tracksMapping and initialPartId as minimal XML
- Add uninitialised excerpt read support in `MscLoader` and `Read500`: detects the `<initialised>0</initialised>` marker and skips full score creation
- Compat migration: `createUninitExcerptsForParts()` creates uninitialised excerpts for all parts in files loaded from older versions
- `AddExcerpt`/`RemoveExcerpt` undo commands preserve the initialised state across undo/redo
- Null checks in `initParts()`, MIDI mapping and style migration for excerpts without a score

**Notation layer:**
- Lazy initialisation: `setExcerptIsOpen()` initialises an excerpt the first time the user opens it
- `onPartsAdded()` automatically creates an uninitialised excerpt when an instrument is added
- `onPartsRemoved()` removes the corresponding uninitialised excerpt via the undo stack
- `replaceInstrument()` renames uninitialised excerpts through the undo stack
- `ExcerptNotation::undoSetName()` routes renames through the master undo stack when no score exists yet
- `ExcerptNotation::deinit()` and `MasterNotation::deinitExcerpts()` restore uninitialised state after export
- Remove the `potentialExcerpts` infrastructure: uninitialised excerpts now live directly in the excerpts list

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)