### PR TITLE
fixed #31300: Chord list in fretboard diagram legend properties is empty

### DIFF
--- a/src/inspector/qml/MuseScore/Inspector/notation/frames/internal/FretFrameChordsView.qml
+++ b/src/inspector/qml/MuseScore/Inspector/notation/frames/internal/FretFrameChordsView.qml
@@ -32,8 +32,6 @@ import MuseScore.Inspector
 StyledListView {
     id: root
 
-    required property FretFrameChordListModel model
-
     property NavigationPanel navigationPanel: null
     property int navigationRowStart: 1
     property int navigationRowEnd: navigationRowStart + (count * 2) - 1


### PR DESCRIPTION
Resolves: #31300

was added here https://github.com/musescore/MuseScore/pull/31172/files?diff=split&w=0#diff-9b9dfca3240caeb1ad391ad616c7bdd4d1c9d5367ac56105474297998e5e66deR35