### PR TITLE
allow VST module when Audio module is disabled

### DIFF
--- a/src/framework/cmake/MuseSetupConfiguration.cmake
+++ b/src/framework/cmake/MuseSetupConfiguration.cmake
@@ -2,7 +2,6 @@
 # hard dependencies
 if (NOT MUSE_MODULE_AUDIO)
     set(MUSE_MODULE_MUSESAMPLER OFF)
-    set(MUSE_MODULE_VST OFF)
 endif()
 
 include(${CMAKE_CURRENT_LIST_DIR}/MuseModules.cmake)


### PR DESCRIPTION
VST module is used in Audacity without muse audio module

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
