### PR TITLE
Fix #31702: Crash after enabling Note input mode and Quit MSS (macOS, one score)

### DIFF
--- a/src/app/internal/consoleapp.cpp
+++ b/src/app/internal/consoleapp.cpp
@@ -28,6 +28,7 @@
 #endif
 
 #include "modularity/ioc.h"
+#include "async/processevents.h"
 
 #include "muse_framework_config.h"
 #include "app_config.h"
@@ -204,6 +205,7 @@ void ConsoleApp::finish()
 #endif
 
     // Deinit
+    async::processMessages();
 
     for (modularity::IModuleSetup* m : m_modules) {
         m->onDeinit();

--- a/src/app/internal/guiapp.cpp
+++ b/src/app/internal/guiapp.cpp
@@ -8,6 +8,8 @@
 #include "ui/iuiengine.h"
 #include "ui/graphicsapiprovider.h"
 
+#include "async/processevents.h"
+
 #include "muse_framework_config.h"
 #include "app_config.h"
 #ifdef QT_CONCURRENT_SUPPORTED
@@ -272,6 +274,7 @@ void GuiApp::finish()
     ioc()->resolve<muse::ui::IUiEngine>("app")->quit();
 
     // Deinit
+    async::processMessages();
 
     for (modularity::IModuleSetup* m : m_modules) {
         m->onDeinit();


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/31702

Originally, there was a invokeQueuedCalls() call, which was added to solve a [very similar crash](https://github.com/musescore/MuseScore/pull/16306/commits/8cf9911eff48086e9cf082449a46badadfe8b308), but it was removed in [this commit](https://github.com/musescore/MuseScore/commit/0b933987acad87b166efa0e4c17af4328c1cd307)