### PR TITLE
[MusicXML] fix export of jumps and direction marks

### DIFF
--- a/src/importexport/musicxml/internal/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/export/exportmusicxml.cpp
@@ -6277,7 +6277,7 @@ static void directionMarker(XmlWriter& xml, const Marker* const m, const std::ve
         }
         break;
     case MarkerType::FINE:
-        words = u"Fine";
+        words = m->xmlText();
         sound = u"fine=\"yes\"";
         break;
     case MarkerType::TOCODA:


### PR DESCRIPTION
This PR fixes the export of invisible jumps to only export the `sound` element without a `direction`.
Also it corrects the export of a "Fine" mark to write the actual text.