### PR TITLE
Fix VST timer and window lifetime issue

### DIFF
--- a/src/framework/vst/qml/Muse/Vst/vstview.cpp
+++ b/src/framework/vst/qml/Muse/Vst/vstview.cpp
@@ -140,7 +140,11 @@ void VstView::init()
     // Do not rely on `QWindow::screenChanged` signal, which often does not get emitted though it should.
     // Proactively check for screen resolution changes instead.
     connect(&m_screenMetricsTimer, &QTimer::timeout, this, [this]() {
-        const QScreen* const screen = window()->screen();
+        QWindow* win = window();
+        if (!win) {
+            return;
+        }
+        const QScreen* const screen = win->screen();
         if (m_currentScreen != screen || m_screenMetrics.availableSize != screen->availableSize()
             || !is_equal(m_screenMetrics.devicePixelRatio, screen->devicePixelRatio())) {
             updateScreenMetrics();
@@ -156,6 +160,8 @@ void VstView::init()
 
 void VstView::deinit()
 {
+    m_screenMetricsTimer.stop();
+
     if (m_view) {
         m_view->setFrame(nullptr);
         m_view->removed();


### PR DESCRIPTION
Resolves: issue when disabling VST Vendor UI

- Timer wasn't properly stopped leading to some issues
- Window can be destroyed before callback...

- [X] I signed the [CLA](https://musescore.org/en/cla)
- [X] The title of the PR describes the problem it addresses
- [X] Each commit's message describes its purpose and effects, and references the issue it resolves
- [X] If changes are extensive, there is a sequence of easily reviewable commits
- [X] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [X] There are no unnecessary changes
- [X] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
