### PR TITLE
Allow normal lyric lines in invalid repeat sections

### DIFF
--- a/src/engraving/dom/navigate.cpp
+++ b/src/engraving/dom/navigate.cpp
@@ -196,7 +196,7 @@ ChordRest* nextChordRest(const ChordRest* cr, const ChordRestNavigateOptions& op
     SegmentType st = SegmentType::ChordRest;
     Segment* curSeg = cr->segment();
     for (Segment* seg = curSeg->next1MM(st); seg; seg = seg->next1MM(st)) {
-        if (options.disableOverRepeats && !segmentsAreAdjacentInRepeatStructure(curSeg, seg)) {
+        if (options.disableOverRepeats && !segmentsAreAdjacent(curSeg, seg)) {
             return nullptr;
         }
         ChordRest* e = toChordRest(seg->element(track));
@@ -277,7 +277,7 @@ ChordRest* prevChordRest(const ChordRest* cr, const ChordRestNavigateOptions& op
     SegmentType st = SegmentType::ChordRest;
     Segment* curSeg = cr->segment();
     for (Segment* seg = cr->segment()->prev1MM(st); seg; seg = seg->prev1MM(st)) {
-        if (options.disableOverRepeats && !segmentsAreAdjacentInRepeatStructure(curSeg, seg)) {
+        if (options.disableOverRepeats && !segmentsAreAdjacent(curSeg, seg)) {
             return nullptr;
         }
 

--- a/src/engraving/dom/tie.cpp
+++ b/src/engraving/dom/tie.cpp
@@ -266,7 +266,7 @@ void Tie::updatePossibleJumpPoints()
         const Segment* endNoteSegment = endChord ? endChord->segment() : nullptr;
         const ChordRest* finalCROfMeasure = measure->lastChordRest(track());
         const bool finalCRHasFollowingJump = finalCROfMeasure ? finalCROfMeasure->hasFollowingJumpItem() : false;
-        const bool segsAreAdjacent = segmentsAreAdjacentInRepeatStructure(segment, endNoteSegment);
+        const bool segsAreAdjacent = segmentsAreAdjacent(segment, endNoteSegment);
         const bool segsAreInDifferentRepeatSegments = segmentsAreInDifferentRepeatSegments(segment, endNoteSegment);
 
         if (!(finalCRHasFollowingJump && segsAreAdjacent) || !segsAreInDifferentRepeatSegments) {

--- a/src/engraving/dom/utils.cpp
+++ b/src/engraving/dom/utils.cpp
@@ -594,7 +594,7 @@ Note* searchTieNote(const Note* note, const Segment* nextSegment, const bool dis
         return nullptr;
     }
 
-    if (disableOverRepeats && !segmentsAreAdjacentInRepeatStructure(seg, nextSegment)) {
+    if (disableOverRepeats && !segmentsAreAdjacent(seg, nextSegment)) {
         return nullptr;
     }
 
@@ -1596,7 +1596,7 @@ bool repeatHasPartialLyricLine(const Measure* endRepeatMeasure)
     return false;
 }
 
-bool segmentsAreAdjacentInRepeatStructure(const Segment* firstSeg, const Segment* secondSeg)
+bool segmentsAreAdjacent(const Segment* firstSeg, const Segment* secondSeg)
 {
     if (!firstSeg || !secondSeg) {
         return false;
@@ -1619,12 +1619,20 @@ bool segmentsAreAdjacentInRepeatStructure(const Segment* firstSeg, const Segment
 
     std::vector<const Measure*> measures;
 
+    bool firstMeasureSegmentFound = false;
+    bool secondMeasureSegmentFound = false;
+
     for (auto it = repeatList.begin(); it != repeatList.end(); it++) {
         const RepeatSegment* rs = *it;
         const auto nextSegIt = std::next(it);
 
         // Check if measures are in the same repeat segment
-        if (rs->containsMeasure(firstMasterMeasure) && rs->containsMeasure(secondMasterMeasure)) {
+        bool containsFirstMeasure = rs->containsMeasure(firstMasterMeasure);
+        bool containsSecondMeasure = rs->containsMeasure(secondMasterMeasure);
+        firstMeasureSegmentFound |= containsFirstMeasure;
+        secondMeasureSegmentFound |= containsSecondMeasure;
+
+        if (containsFirstMeasure && containsSecondMeasure) {
             return true;
         }
 
@@ -1648,6 +1656,11 @@ bool segmentsAreAdjacentInRepeatStructure(const Segment* firstSeg, const Segment
         if (m == secondMasterMeasure) {
             return true;
         }
+    }
+
+    if (!firstMeasureSegmentFound && !secondMeasureSegmentFound) {
+        // The measures are outside of the (invalid) repeat structure
+        return firstMasterMeasure->nextMeasure() == secondMasterMeasure;
     }
 
     return false;
@@ -1881,7 +1894,7 @@ Lyrics* searchNextLyrics(Segment* s, staff_idx_t staffIdx, int verse, PlacementV
     Lyrics* l = nullptr;
     const Segment* originalSeg = s;
     while ((s = s->next1(SegmentType::ChordRest))) {
-        if (!segmentsAreAdjacentInRepeatStructure(originalSeg, s)) {
+        if (!segmentsAreAdjacent(originalSeg, s)) {
             return nullptr;
         }
 

--- a/src/engraving/dom/utils.h
+++ b/src/engraving/dom/utils.h
@@ -120,7 +120,7 @@ extern InstrumentTrackId makeInstrumentTrackId(const EngravingItem* item);
 extern std::vector<Measure*> findFollowingRepeatMeasures(const Measure* measure);
 extern std::vector<Measure*> findPreviousRepeatMeasures(const Measure* measure);
 extern bool repeatHasPartialLyricLine(const Measure* endRepeatMeasure);
-extern bool segmentsAreAdjacentInRepeatStructure(const Segment* firstSeg, const Segment* secondSeg);
+extern bool segmentsAreAdjacent(const Segment* firstSeg, const Segment* secondSeg);
 extern bool segmentsAreInDifferentRepeatSegments(const Segment* firstSeg, const Segment* secondSeg);
 extern bool isValidBarLineForRepeatSection(const Segment* firstSeg, const Segment* secondSeg);
 

--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -6863,7 +6863,7 @@ void NotationInteraction::navigateToNextSyllable()
         }
     }
 
-    if (!segmentsAreAdjacentInRepeatStructure(segment, nextSegment)) {
+    if (!segmentsAreAdjacent(segment, nextSegment)) {
         nextSegment = nullptr;
     }
 
@@ -6877,7 +6877,7 @@ void NotationInteraction::navigateToNextSyllable()
     // we are extending with several dashes
     Lyrics* fromLyrics = nullptr;
     Segment* curSeg = segment;
-    while (segment && segmentsAreAdjacentInRepeatStructure(segment, curSeg)) {
+    while (segment && segmentsAreAdjacent(segment, curSeg)) {
         ChordRest* cr = toChordRest(segment->element(track));
         if (!cr) {
             segment = segment->prev1(SegmentType::ChordRest);
@@ -7721,7 +7721,7 @@ void NotationInteraction::addMelisma()
         }
     }
 
-    if (!segmentsAreAdjacentInRepeatStructure(segment, nextSegment)) {
+    if (!segmentsAreAdjacent(segment, nextSegment)) {
         nextSegment = nullptr;
     }
 
@@ -7730,7 +7730,7 @@ void NotationInteraction::addMelisma()
     Segment* curSeg = segment;
     Lyrics* fromLyrics = nullptr;
     PartialLyricsLine* prevPartialLyricsLine = nullptr;
-    while (segment && segmentsAreAdjacentInRepeatStructure(segment, curSeg)) {
+    while (segment && segmentsAreAdjacent(segment, curSeg)) {
         ChordRest* cr = toChordRest(segment->element(track));
         if (cr) {
             fromLyrics = cr->lyrics(verse, placement);


### PR DESCRIPTION
Resolves: #31393 
When the score's repeat structure is invalid/contains unreachable music, we should still allow regular lyric lines to be added