### PR TITLE
Fix #31781: Playback has different pitch and tempo when switching between audio devices (in Preferences) with different sample rate during one session

### DIFF
--- a/src/framework/audio/driver/platform/win/wasapiaudiodriver.cpp
+++ b/src/framework/audio/driver/platform/win/wasapiaudiodriver.cpp
@@ -412,7 +412,6 @@ bool WasapiAudioDriver::open(const Spec& spec, Spec* activeSpec)
 
     m_activeSpec = spec;
     m_activeSpec.output.sampleRate = m_data->mixFormat->nSamplesPerSec;
-    m_activeSpecChanged.send(m_activeSpec);
 
     if (activeSpec) {
         *activeSpec = m_activeSpec;
@@ -426,6 +425,7 @@ bool WasapiAudioDriver::open(const Spec& spec, Spec* activeSpec)
 void WasapiAudioDriver::th_audioThread()
 {
     m_opened = th_audioInitialize();
+    m_activeSpecChanged.send(m_activeSpec);
 
     while (m_opened) {
         DWORD waitResult = WaitForSingleObject(m_data->audioEvent, 100);


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/31781