### PR TITLE
Fix deleting rests from voice 2/3/4 in local time signature

### DIFF
--- a/src/engraving/editing/edit.cpp
+++ b/src/engraving/editing/edit.cpp
@@ -2949,7 +2949,7 @@ void Score::deleteItem(EngravingItem* el)
                         undoRemoveElement(r);
                     }
 
-                    Fraction f = ticks;
+                    Fraction f = ticks * el->staff()->timeStretch(el->tick());
 
                     std::vector<TDuration> dList = toDurationList(f, true);
                     if (dList.empty()) {
@@ -2964,7 +2964,7 @@ void Score::deleteItem(EngravingItem* el)
                         rr->setTrack(track);
                         rr->setGap(true);
                         undoAddCR(rr, m, curTick);
-                        curTick += d.fraction();
+                        curTick += rr->actualTicks();
                     }
                 }
             }


### PR DESCRIPTION
<!-- Add a short description of and motivation for the changes here -->

Fix another corruption issue with local time signatures. Deleting rests from voices other than voice 1 could produce corruption due to consolidating gap rests together and replacing them with the wrong duration of rest.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
