### PR TITLE
Add temporary shortcuts migration hack to fix specific issue

### DIFF
--- a/src/notationscene/CMakeLists.txt
+++ b/src/notationscene/CMakeLists.txt
@@ -32,6 +32,8 @@ target_sources(notationscene PRIVATE
     internal/notationactioncontroller.h
     internal/notationuiactions.cpp
     internal/notationuiactions.h
+    internal/notationactionsshortcutsmigrator.cpp
+    internal/notationactionsshortcutsmigrator.h
 
     utilities/engravingitempreviewpainter.cpp
     utilities/engravingitempreviewpainter.h

--- a/src/notationscene/internal/notationactionsshortcutsmigrator.cpp
+++ b/src/notationscene/internal/notationactionsshortcutsmigrator.cpp
@@ -1,0 +1,90 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "notationactionsshortcutsmigrator.h"
+
+#include "containers.h"
+#include "modularity/ioc.h"
+#include "shortcuts/ishortcutsregister.h"
+#include "shortcuts/shortcutstypes.h"
+
+using namespace muse;
+using namespace mu::notation;
+
+// This class is a temporary hack to fix a specific shortcut migration issue:
+// https://github.com/musescore/MuseScore/issues/31327#issuecomment-3617247524
+// In the future, we should refactor the shortcuts module and the format of
+// shortcuts.xml, to make all shortcut migrations automatic. That is currently
+// not possible because it is not possible to know if a shortcut was deleted by
+// the user or simply did not exist in the version that created the
+// shortcuts.xml file.
+
+void NotationActionsShortcutsMigrator::migrate()
+{
+    auto shortcutsRegister = modularity::fixmeIoc()->resolve<shortcuts::IShortcutsRegister>("notationscene");
+    if (!shortcutsRegister) {
+        return;
+    }
+
+    int migratableShortcutsSeen = 0;
+    bool didMigrate = false;
+
+    shortcuts::ShortcutList shortcuts = shortcutsRegister->shortcuts();
+
+    for (shortcuts::Shortcut& shortcut : shortcuts) {
+        if (shortcut.action == "prev-text-element") {
+            const std::string backspaceSeq = "Backspace";
+
+            if (!muse::contains(shortcut.sequences, backspaceSeq)) {
+                shortcut.sequences.push_back(backspaceSeq);
+                didMigrate = true;
+            }
+            ++migratableShortcutsSeen;
+        } else if (shortcut.action == "zoomin") {
+            const std::string ctrlPlusSeq = "Ctrl++";
+
+            if (!muse::contains(shortcut.sequences, ctrlPlusSeq)) {
+                shortcut.sequences.push_back(ctrlPlusSeq);
+                didMigrate = true;
+            }
+            ++migratableShortcutsSeen;
+        } else if (shortcut.action == "zoomout") {
+            const std::string ctrlShiftMinusSeq = "Ctrl+Shift+-";
+
+            if (!muse::contains(shortcut.sequences, ctrlShiftMinusSeq)) {
+                shortcut.sequences.push_back(ctrlShiftMinusSeq);
+                didMigrate = true;
+            }
+            ++migratableShortcutsSeen;
+        }
+
+        if (migratableShortcutsSeen >= 3) {
+            break;
+        }
+    }
+
+    if (didMigrate) {
+        //! This way of migrating does not check for conflicts with customised shortcuts,
+        //! but the likelihood of such conflicts is too low to add complex logic for that.
+        shortcutsRegister->setShortcuts(shortcuts);
+    }
+}

--- a/src/notationscene/internal/notationactionsshortcutsmigrator.h
+++ b/src/notationscene/internal/notationactionsshortcutsmigrator.h
@@ -1,0 +1,31 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-Studio-CLA-applies
+ *
+ * MuseScore Studio
+ * Music Composition & Notation
+ *
+ * Copyright (C) 2026 MuseScore Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace mu::notation {
+class NotationActionsShortcutsMigrator
+{
+public:
+    static void migrate();
+};
+}

--- a/src/notationscene/notationscenemodule.cpp
+++ b/src/notationscene/notationscenemodule.cpp
@@ -28,6 +28,7 @@
 #include "internal/notationactioncontroller.h"
 #include "internal/midiinputoutputcontroller.h"
 #include "internal/notationuiactions.h"
+#include "internal/notationactionsshortcutsmigrator.h"
 
 #include "widgets/breaksdialog.h"
 #include "widgets/editstaff.h"
@@ -98,5 +99,12 @@ void NotationSceneModule::onInit(const IApplication::RunMode& mode)
 
     if (mode == IApplication::RunMode::GuiApp) {
         m_midiInputOutputController->init();
+    }
+}
+
+void NotationSceneModule::onAllInited(const IApplication::RunMode& mode)
+{
+    if (mode == IApplication::RunMode::GuiApp) {
+        NotationActionsShortcutsMigrator::migrate();
     }
 }

--- a/src/notationscene/notationscenemodule.h
+++ b/src/notationscene/notationscenemodule.h
@@ -37,6 +37,7 @@ public:
     void registerExports() override;
     void resolveImports() override;
     void onInit(const muse::IApplication::RunMode& mode) override;
+    void onAllInited(const muse::IApplication::RunMode& mode) override;
 
 private:
     std::shared_ptr<NotationActionController> m_actionController;


### PR DESCRIPTION
https://github.com/musescore/MuseScore/issues/31327#issuecomment-3617247524

A full fix for https://github.com/musescore/MuseScore/issues/31327 is not possible without significantly refactoring the shortcuts module and especially the shortcuts.xml format, which we can only do at the 5.0 release.