### PR TITLE
Fix #31661: Buffer size should not reset when switching between audio devices

### DIFF
--- a/src/framework/audio/main/iaudioconfiguration.h
+++ b/src/framework/audio/main/iaudioconfiguration.h
@@ -58,6 +58,8 @@ public:
     virtual void setSampleRate(unsigned int sampleRate) = 0;
     virtual async::Notification sampleRateChanged() const = 0;
 
+    virtual OutputSpec desiredOutputSpec() const = 0;
+
     // synthesizers
     virtual io::paths_t soundFontDirectories() const = 0;
     virtual io::paths_t userSoundFontDirectories() const = 0;

--- a/src/framework/audio/main/internal/audioconfiguration.cpp
+++ b/src/framework/audio/main/internal/audioconfiguration.cpp
@@ -175,6 +175,15 @@ async::Notification AudioConfiguration::sampleRateChanged() const
     return m_driverSampleRateChanged;
 }
 
+OutputSpec AudioConfiguration::desiredOutputSpec() const
+{
+    OutputSpec spec;
+    spec.sampleRate = sampleRate();
+    spec.samplesPerChannel = driverBufferSize();
+    spec.audioChannelCount = audioChannelsCount();
+    return spec;
+}
+
 io::paths_t AudioConfiguration::soundFontDirectories() const
 {
     io::paths_t paths = userSoundFontDirectories();

--- a/src/framework/audio/main/internal/audioconfiguration.h
+++ b/src/framework/audio/main/internal/audioconfiguration.h
@@ -63,6 +63,8 @@ public:
     void setSampleRate(unsigned int sampleRate) override;
     async::Notification sampleRateChanged() const override;
 
+    OutputSpec desiredOutputSpec() const override;
+
     io::paths_t soundFontDirectories() const override;
     io::paths_t userSoundFontDirectories() const override;
     void setUserSoundFontDirectories(const io::paths_t& paths) override;

--- a/src/framework/audio/main/internal/audiodrivercontroller.cpp
+++ b/src/framework/audio/main/internal/audiodrivercontroller.cpp
@@ -346,9 +346,10 @@ bool AudioDriverController::selectOutputDevice(const AudioDeviceID& deviceId)
            << " from: " << oldSpec.deviceId
            << ", to: " << deviceId;
 
-    IAudioDriver::Spec spec = defaultSpec();
+    IAudioDriver::Spec spec;
     spec.deviceId = deviceId;
     spec.callback = oldSpec.callback;
+    spec.output = configuration()->desiredOutputSpec();
 
     m_audioDriver->close();
     bool ok = m_audioDriver->open(spec, nullptr);

--- a/src/framework/audio/main/internal/startaudiocontroller.cpp
+++ b/src/framework/audio/main/internal/startaudiocontroller.cpp
@@ -166,9 +166,7 @@ void StartAudioController::startAudioProcessing(const IApplication::RunMode& mod
 {
     IAudioDriver::Spec requiredSpec;
     requiredSpec.deviceId = configuration()->audioOutputDeviceId();
-    requiredSpec.output.sampleRate = configuration()->sampleRate();
-    requiredSpec.output.audioChannelCount = configuration()->audioChannelsCount();
-    requiredSpec.output.samplesPerChannel = configuration()->driverBufferSize();
+    requiredSpec.output = configuration()->desiredOutputSpec();
 
 #ifndef Q_OS_WASM
 

--- a/src/framework/stubs/audio/audioconfigurationstub.cpp
+++ b/src/framework/stubs/audio/audioconfigurationstub.cpp
@@ -95,6 +95,11 @@ async::Notification AudioConfigurationStub::sampleRateChanged() const
     return async::Notification();
 }
 
+OutputSpec AudioConfigurationStub::desiredOutputSpec() const
+{
+    return OutputSpec();
+}
+
 // synthesizers
 io::paths_t AudioConfigurationStub::soundFontDirectories() const
 {

--- a/src/framework/stubs/audio/audioconfigurationstub.h
+++ b/src/framework/stubs/audio/audioconfigurationstub.h
@@ -48,8 +48,9 @@ public:
     void setSampleRate(unsigned int sampleRate) override;
     async::Notification sampleRateChanged() const override;
 
-    // synthesizers
+    OutputSpec desiredOutputSpec() const override;
 
+    // synthesizers
     io::paths_t soundFontDirectories() const override;
     io::paths_t userSoundFontDirectories() const override;
     void setUserSoundFontDirectories(const io::paths_t& paths) override;


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/31661