### PR TITLE
Prevents popups from jumping while hovering

### DIFF
--- a/src/notationscene/qml/MuseScore/NotationScene/AbstractElementPopup.qml
+++ b/src/notationscene/qml/MuseScore/NotationScene/AbstractElementPopup.qml
@@ -38,6 +38,9 @@ StyledPopupView {
 
     HoverHandler {
         id: hoverHandler
+
+        // Include the margin and padding areas around the popup
+        parent: root.contentItem
     }
 
     Component.onCompleted: {

--- a/src/notationscene/qml/MuseScore/NotationScene/elementpopups/ElementPopupLoader.qml
+++ b/src/notationscene/qml/MuseScore/NotationScene/elementpopups/ElementPopupLoader.qml
@@ -67,8 +67,8 @@ Item {
                 return
             }
 
-            //! NOTE: If mouse is hovering over the popup dont update the position
-            //        to avoid jumps while the user is interacting with it
+            // If mouse is hovering over the popup, don't update the position
+            // to avoid jumps while the user is interacting with it
             if (container.popup.containsMouse) {
                 return
             }


### PR DESCRIPTION
Resolves: #30501  <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

Prevents element popups from repositioning while the mouse is over them. When editing text, the popup would jump as the text bounds changed. Now it stays in place during hover and repositions when the mouse leaves.


https://github.com/user-attachments/assets/c34b85b2-3caa-4862-9623-8768d489fb08


<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
