### PR TITLE
Preserve more elements when changing CR durations

### DIFF
--- a/src/engraving/editing/edit.cpp
+++ b/src/engraving/editing/edit.cpp
@@ -3683,7 +3683,7 @@ void Score::deleteSlursFromRange(const Fraction& t1, const Fraction& t2, track_i
 
         if (sp->track() >= trackStart && sp->track() < trackEnd) {
             if ((spStartTick >= t1 && spStartTick < t2)
-                || (spEndTick >= t1 && spEndTick <= t2)) {
+                || (spEndTick >= t1 && spEndTick < t2)) {
                 undoRemoveElement(sp);
             }
         }


### PR DESCRIPTION
Resolves: #23066
Resolves: #31827 
Resolves: #26685

The problem here was twofold: On the one hand, `makeGap` was keeping track of the global tick in some instances, instead of the local tick. This was particularly visible when using tuplets, as demonstrated in the first two issues. For the third issue, a sign error in `deleteSlursFromRange` has been corrected, it now matches `deleteOrShortenOutSpannersFromRange`. Additionally, changing durations no longer deletes any elements that have time tick anchors, as those can float freely in the score even without the presence of an accompanying CR.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
