### PR TITLE
Fix crash on add section break to fret diagram legend

### DIFF
--- a/src/engraving/dom/measurebase.cpp
+++ b/src/engraving/dom/measurebase.cpp
@@ -290,11 +290,7 @@ Measure* MeasureBase::prevMeasureMM() const
     return nullptr;
 }
 
-//---------------------------------------------------------
-//   findPotentialSectionBreak
-//---------------------------------------------------------
-
-const MeasureBase* MeasureBase::findPotentialSectionBreak() const
+const MeasureBase* MeasureBase::mbWithPrecedingSectionBreak() const
 {
     // we're trying to find the MeasureBase that determines
     // if the next one after this starts a new section

--- a/src/engraving/dom/measurebase.h
+++ b/src/engraving/dom/measurebase.h
@@ -106,7 +106,7 @@ public:
     ElementList& el() { return m_el; }
     const ElementList& el() const { return m_el; }
 
-    const MeasureBase* findPotentialSectionBreak() const;
+    const MeasureBase* mbWithPrecedingSectionBreak() const;
     LayoutBreak* sectionBreakElement() const;
 
     void undoSetBreak(bool v, LayoutBreakType type);

--- a/src/engraving/rendering/score/scorepageviewlayout.cpp
+++ b/src/engraving/rendering/score/scorepageviewlayout.cpp
@@ -108,7 +108,7 @@ void ScorePageViewLayout::initLayoutContext(const Score* score, LayoutContext& c
         } else {
             const MeasureBase* mb = state.nextMeasure()->prev();
             if (mb) {
-                mb = mb->findPotentialSectionBreak();
+                mb = mb->mbWithPrecedingSectionBreak();
             }
 
             const LayoutBreak* layoutBreak = mb->sectionBreakElement();

--- a/src/engraving/rendering/score/scoreverticalviewlayout.cpp
+++ b/src/engraving/rendering/score/scoreverticalviewlayout.cpp
@@ -97,7 +97,7 @@ void ScoreVerticalViewLayout::layoutVerticalView(Score* score, LayoutContext& ct
         } else {
             const MeasureBase* mb = ctx.state().nextMeasure()->prev();
             if (mb) {
-                mb = mb->findPotentialSectionBreak();
+                mb = mb->mbWithPrecedingSectionBreak();
             }
 
             const LayoutBreak* layoutBreak = mb->sectionBreakElement();

--- a/src/engraving/rendering/score/systemlayout.cpp
+++ b/src/engraving/rendering/score/systemlayout.cpp
@@ -102,7 +102,7 @@ System* SystemLayout::collectSystem(LayoutContext& ctx)
 
     const MeasureBase* measure = ctx.dom().systems().empty() ? 0 : ctx.dom().systems().back()->measures().back();
     if (measure) {
-        measure = measure->findPotentialSectionBreak();
+        measure = measure->mbWithPrecedingSectionBreak();
     }
 
     bool firstSysLongName = ctx.conf().styleV(Sid::firstSystemInstNameVisibility).value<InstrumentLabelVisibility>()
@@ -110,12 +110,14 @@ System* SystemLayout::collectSystem(LayoutContext& ctx)
     bool subsSysLongName = ctx.conf().styleV(Sid::subsSystemInstNameVisibility).value<InstrumentLabelVisibility>()
                            == InstrumentLabelVisibility::LONG;
     if (measure) {
-        const LayoutBreak* layoutBreak = measure->sectionBreakElement();
         ctx.mutState().setFirstSystem(measure->sectionBreak() && !ctx.conf().isFloatMode());
-        ctx.mutState().setFirstSystemIndent(ctx.state().firstSystem()
-                                            && ctx.conf().firstSystemIndent()
-                                            && layoutBreak->firstSystemIndentation());
-        ctx.mutState().setStartWithLongNames(ctx.state().firstSystem() && firstSysLongName && layoutBreak->startWithLongNames());
+        if (const LayoutBreak* layoutBreak = measure->sectionBreakElement()) {
+            ctx.mutState().setFirstSystemIndent(ctx.state().firstSystem()
+                                                && ctx.conf().firstSystemIndent()
+                                                && layoutBreak->firstSystemIndentation());
+            ctx.mutState().setStartWithLongNames(
+                ctx.state().firstSystem() && firstSysLongName && layoutBreak->startWithLongNames());
+        }
     } else {
         ctx.mutState().setStartWithLongNames(ctx.state().firstSystem() && firstSysLongName);
     }
@@ -325,7 +327,7 @@ System* SystemLayout::collectSystem(LayoutContext& ctx)
                         s->setEnabled(true);
                     }
                 }
-                const MeasureBase* pbmb = ctx.state().prevMeasure()->findPotentialSectionBreak();
+                const MeasureBase* pbmb = ctx.state().prevMeasure()->mbWithPrecedingSectionBreak();
                 bool localFirstSystem = pbmb->sectionBreak() && !ctx.conf().isMode(LayoutMode::FLOAT);
                 MeasureBase* nm = breakMeasure ? breakMeasure : m;
                 if (prevMeasureState.curHeader) {

--- a/src/importexport/musicxml/internal/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/export/exportmusicxml.cpp
@@ -8186,7 +8186,7 @@ void MeasureNumberStateHandler::updateForMeasure(const Measure* const m)
     // check the previous MeasureBase instead of Measure to catch breaks in frames too
     const MeasureBase* previousMB = m->prev();
     if (previousMB) {
-        previousMB = previousMB->findPotentialSectionBreak();
+        previousMB = previousMB->mbWithPrecedingSectionBreak();
     }
 
     if (previousMB) {


### PR DESCRIPTION
Resolves: #31783

There is a deeper issue here. The LayoutBreak element gets normally added to the element list `m_el` of the MeasureBase. But because the FBox only accepts FretDiagram items in the element list, the LayoutBreak isn't added, even though the FBox is still flagged as containing a break. This can be seen by the fact that layout break elements don't show up when applied to the Fret legend.

 In future we should clean this up:
- The MeasureBase class should probably have a LayoutBreak* member, as opposed to putting it in the element list.
- The existance of a layout break is treated as a flag of the MeasureBase object but also as an actual LayoutBreak object that exists in the class. That's redundant. We can probably just rely on the existance of the object to determine if this MeasureBase has a break and of which type.