### PR TITLE
Continuous View: Align playback cursor to 25% of screen width

### DIFF
--- a/src/notationscene/qml/MuseScore/NotationScene/abstractnotationpaintview.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/abstractnotationpaintview.cpp
@@ -1016,7 +1016,7 @@ bool AbstractNotationPaintView::adjustCanvasPosition(const RectF& logicRect, boo
 bool AbstractNotationPaintView::adjustCanvasPositionSmoothPan(const RectF& cursorRect)
 {
     RectF viewRect = viewport();
-    PointF pos(cursorRect.x() - (viewRect.width() / 2), viewRect.y());
+    PointF pos(cursorRect.x() - (viewRect.width() * 0.25), viewRect.y());
 
     if (!viewport().intersects(cursorRect)) {
         pos.setY(cursorRect.y() - (viewRect.height() / 2));


### PR DESCRIPTION
Resolves: #31841

Enable cursor on horizontal continuous view to be located on the left side of the screen.

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [ ] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
