### PR TITLE
Fix AbstractInspectorModel initialisation

### DIFF
--- a/src/inspector/qml/MuseScore/Inspector/abstractinspectormodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/abstractinspectormodel.cpp
@@ -157,13 +157,10 @@ QString AbstractInspectorModel::shortcutsForActionCode(std::string code) const
     return muse::shortcuts::sequencesToNativeText(shortcuts);
 }
 
-AbstractInspectorModel::AbstractInspectorModel(QObject* parent, IElementRepositoryService* repository,
+AbstractInspectorModel::AbstractInspectorModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                               IElementRepositoryService* repository,
                                                mu::engraving::ElementType elementType)
-    : QObject(parent), muse::Injectable(muse::iocCtxForQmlObject(this)), m_repository(repository), m_elementType(elementType)
-{
-}
-
-void AbstractInspectorModel::classBegin()
+    : QObject(parent), muse::Injectable(iocCtx), m_repository(repository), m_elementType(elementType)
 {
     if (!m_repository) {
         return;

--- a/src/inspector/qml/MuseScore/Inspector/abstractinspectormodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/abstractinspectormodel.h
@@ -25,7 +25,6 @@
 #include <set>
 
 #include <QList>
-#include <QQmlParserStatus>
 #include <qqmlintegration.h>
 
 #include "async/asyncable.h"
@@ -48,10 +47,9 @@
 namespace mu::inspector {
 using MeasurementUnits = CommonTypes::MeasurementUnits;
 
-class AbstractInspectorModel : public QObject, public QQmlParserStatus, public muse::async::Asyncable, public muse::Injectable
+class AbstractInspectorModel : public QObject, public muse::async::Asyncable, public muse::Injectable
 {
     Q_OBJECT
-    Q_INTERFACES(QQmlParserStatus)
 
     Q_PROPERTY(QString title READ title NOTIFY titleChanged)
     Q_PROPERTY(int icon READ icon CONSTANT)
@@ -162,7 +160,8 @@ public:
     };
     Q_ENUM(InspectorModelType)
 
-    explicit AbstractInspectorModel(QObject* parent, IElementRepositoryService* repository = nullptr,
+    explicit AbstractInspectorModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                    IElementRepositoryService* repository = nullptr,
                                     mu::engraving::ElementType elementType = mu::engraving::ElementType::INVALID);
 
     void init();
@@ -221,9 +220,6 @@ signals:
     void measurementUnitsChanged(MeasurementUnits measurementUnits);
 
 protected:
-    void classBegin() override;
-    void componentComplete() override {}
-
     void setElementType(mu::engraving::ElementType type);
 
     PropertyItem* buildPropertyItem(const mu::engraving::Pid& pid, std::function<void(const mu::engraving::Pid propertyId,

--- a/src/inspector/qml/MuseScore/Inspector/abstractinspectorproxymodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/abstractinspectorproxymodel.cpp
@@ -26,8 +26,9 @@
 
 using namespace mu::inspector;
 
-AbstractInspectorProxyModel::AbstractInspectorProxyModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository)
+AbstractInspectorProxyModel::AbstractInspectorProxyModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                                         IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
 }
 
@@ -189,7 +190,7 @@ void AbstractInspectorProxyModel::updateModels(const ElementKeySet& newElementKe
         auto model = dynamic_cast<AbstractInspectorModel*>(modelByType(modelType));
 
         if (!model) {
-            model = InspectorModelCreator::newInspectorModel(modelType, this, m_repository);
+            model = InspectorModelCreator::newInspectorModel(modelType, this, iocContext(), m_repository);
         }
 
         if (model) {

--- a/src/inspector/qml/MuseScore/Inspector/abstractinspectorproxymodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/abstractinspectorproxymodel.h
@@ -42,7 +42,8 @@ class AbstractInspectorProxyModel : public AbstractInspectorModel
         mu::inspector::AbstractInspectorModel::InspectorModelType defaultSubModelType READ defaultSubModelType NOTIFY defaultSubModelTypeChanged)
 
 public:
-    explicit AbstractInspectorProxyModel(QObject* parent, IElementRepositoryService* repository);
+    explicit AbstractInspectorProxyModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                         IElementRepositoryService* repository);
 
     bool isMultiModel() const;
     QVariantList models() const;

--- a/src/inspector/qml/MuseScore/Inspector/emptystaves/emptystavesvisiblitysettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/emptystaves/emptystavesvisiblitysettingsmodel.cpp
@@ -32,8 +32,9 @@ using namespace mu::notation;
 using namespace mu::engraving;
 using mu::engraving::rendering::score::SystemLayout;
 
-EmptyStavesVisibilitySettingsModel::EmptyStavesVisibilitySettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository)
+EmptyStavesVisibilitySettingsModel::EmptyStavesVisibilitySettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                                                       IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     setSectionType(InspectorSectionType::SECTION_EMPTY_STAVES);
     setTitle(muse::qtrc("inspector", "Empty staves visibility"));

--- a/src/inspector/qml/MuseScore/Inspector/emptystaves/emptystavesvisiblitysettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/emptystaves/emptystavesvisiblitysettingsmodel.h
@@ -37,7 +37,8 @@ class EmptyStavesVisibilitySettingsModel : public AbstractInspectorModel
     Q_PROPERTY(bool canResetEmptyStavesVisibility READ canResetEmptyStavesVisibility NOTIFY canResetEmptyStavesVisibilityChanged)
 
 public:
-    explicit EmptyStavesVisibilitySettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit EmptyStavesVisibilitySettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                                IElementRepositoryService* repository);
 
     void createProperties() override {}
     void loadProperties() override;

--- a/src/inspector/qml/MuseScore/Inspector/general/appearance/appearancesettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/general/appearance/appearancesettingsmodel.cpp
@@ -32,8 +32,9 @@ using namespace mu::engraving;
 
 static constexpr int REARRANGE_ORDER_STEP = 50;
 
-AppearanceSettingsModel::AppearanceSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository)
+AppearanceSettingsModel::AppearanceSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                                 IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     createProperties();
 

--- a/src/inspector/qml/MuseScore/Inspector/general/appearance/appearancesettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/general/appearance/appearancesettingsmodel.h
@@ -48,7 +48,7 @@ class AppearanceSettingsModel : public AbstractInspectorModel
     muse::GlobalInject<notation::INotationConfiguration> notationConfiguration;
 
 public:
-    explicit AppearanceSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit AppearanceSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     Q_INVOKABLE void pushBackwardsInOrder();
     Q_INVOKABLE void pushForwardsInOrder();

--- a/src/inspector/qml/MuseScore/Inspector/general/generalsettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/general/generalsettingsmodel.cpp
@@ -29,18 +29,19 @@
 using namespace mu::inspector;
 using namespace mu::engraving;
 
-GeneralSettingsModel::GeneralSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository)
+GeneralSettingsModel::GeneralSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                           IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     createProperties();
 
     setTitle(muse::qtrc("inspector", "General"));
     setSectionType(InspectorSectionType::SECTION_GENERAL);
 
-    m_playbackProxyModel = new PlaybackProxyModel(this, repository);
+    m_playbackProxyModel = new PlaybackProxyModel(this, iocCtx, repository);
     m_playbackProxyModel->init();
 
-    m_appearanceSettingsModel = new AppearanceSettingsModel(this, repository);
+    m_appearanceSettingsModel = new AppearanceSettingsModel(this, iocCtx, repository);
     m_appearanceSettingsModel->init();
 }
 

--- a/src/inspector/qml/MuseScore/Inspector/general/generalsettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/general/generalsettingsmodel.h
@@ -45,7 +45,7 @@ class GeneralSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(bool areGeneralPropertiesAvailable READ areGeneralPropertiesAvailable NOTIFY areGeneralPropertiesAvailableChanged)
 
 public:
-    explicit GeneralSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit GeneralSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     PropertyItem* isVisible() const;
     PropertyItem* isAutoPlaceAllowed() const;

--- a/src/inspector/qml/MuseScore/Inspector/general/playback/internal/arpeggioplaybackmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/general/playback/internal/arpeggioplaybackmodel.cpp
@@ -27,8 +27,9 @@
 
 using namespace mu::inspector;
 
-ArpeggioPlaybackModel::ArpeggioPlaybackModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository)
+ArpeggioPlaybackModel::ArpeggioPlaybackModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                             IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     setTitle(muse::qtrc("inspector", "Arpeggio"));
     setModelType(InspectorModelType::TYPE_ARPEGGIO);

--- a/src/inspector/qml/MuseScore/Inspector/general/playback/internal/arpeggioplaybackmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/general/playback/internal/arpeggioplaybackmodel.h
@@ -34,7 +34,7 @@ class ArpeggioPlaybackModel : public AbstractInspectorModel
 
     Q_PROPERTY(mu::inspector::PropertyItem * stretch READ stretch CONSTANT)
 public:
-    explicit ArpeggioPlaybackModel(QObject* parent, IElementRepositoryService* repository);
+    explicit ArpeggioPlaybackModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     PropertyItem* stretch() const;
 

--- a/src/inspector/qml/MuseScore/Inspector/general/playback/internal/breathplaybackmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/general/playback/internal/breathplaybackmodel.cpp
@@ -27,8 +27,8 @@
 
 using namespace mu::inspector;
 
-BreathPlaybackModel::BreathPlaybackModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository)
+BreathPlaybackModel::BreathPlaybackModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     setTitle(muse::qtrc("inspector", "Breaths & pauses"));
     setModelType(InspectorModelType::TYPE_BREATH);

--- a/src/inspector/qml/MuseScore/Inspector/general/playback/internal/breathplaybackmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/general/playback/internal/breathplaybackmodel.h
@@ -35,7 +35,7 @@ class BreathPlaybackModel : public AbstractInspectorModel
     Q_PROPERTY(mu::inspector::PropertyItem * pauseTime READ pauseTime CONSTANT)
 
 public:
-    explicit BreathPlaybackModel(QObject* parent, IElementRepositoryService* repository);
+    explicit BreathPlaybackModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
 public:
     PropertyItem* pauseTime() const;

--- a/src/inspector/qml/MuseScore/Inspector/general/playback/internal/fermataplaybackmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/general/playback/internal/fermataplaybackmodel.cpp
@@ -27,8 +27,9 @@
 
 using namespace mu::inspector;
 
-FermataPlaybackModel::FermataPlaybackModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository)
+FermataPlaybackModel::FermataPlaybackModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                           IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     setTitle(muse::qtrc("inspector", "Fermatas"));
     setModelType(InspectorModelType::TYPE_FERMATA);

--- a/src/inspector/qml/MuseScore/Inspector/general/playback/internal/fermataplaybackmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/general/playback/internal/fermataplaybackmodel.h
@@ -35,7 +35,7 @@ class FermataPlaybackModel : public AbstractInspectorModel
     Q_PROPERTY(mu::inspector::PropertyItem * timeStretch READ timeStretch CONSTANT)
 
 public:
-    explicit FermataPlaybackModel(QObject* parent, IElementRepositoryService* repository);
+    explicit FermataPlaybackModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
 public:
     PropertyItem* timeStretch() const;

--- a/src/inspector/qml/MuseScore/Inspector/general/playback/internal/glissandoplaybackmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/general/playback/internal/glissandoplaybackmodel.cpp
@@ -28,8 +28,9 @@
 using namespace mu::inspector;
 using namespace mu::engraving;
 
-GlissandoPlaybackModel::GlissandoPlaybackModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository)
+GlissandoPlaybackModel::GlissandoPlaybackModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                               IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     setTitle(muse::qtrc("inspector", "Glissando"));
     setModelType(InspectorModelType::TYPE_GLISSANDO);

--- a/src/inspector/qml/MuseScore/Inspector/general/playback/internal/glissandoplaybackmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/general/playback/internal/glissandoplaybackmodel.h
@@ -36,7 +36,7 @@ class GlissandoPlaybackModel : public AbstractInspectorModel
     Q_PROPERTY(bool isHarpGliss READ isHarpGliss NOTIFY isHarpGlissChanged)
 
 public:
-    explicit GlissandoPlaybackModel(QObject* parent, IElementRepositoryService* repository);
+    explicit GlissandoPlaybackModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     PropertyItem* styleType() const;
     bool isHarpGliss() const;

--- a/src/inspector/qml/MuseScore/Inspector/general/playback/internal/gradualtempochangeplaybackmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/general/playback/internal/gradualtempochangeplaybackmodel.cpp
@@ -27,8 +27,9 @@
 using namespace mu::inspector;
 using namespace mu::engraving;
 
-GradualTempoChangePlaybackModel::GradualTempoChangePlaybackModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository, ElementType::GRADUAL_TEMPO_CHANGE)
+GradualTempoChangePlaybackModel::GradualTempoChangePlaybackModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                                                 IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository, ElementType::GRADUAL_TEMPO_CHANGE)
 {
     setTitle(muse::qtrc("inspector", "Tempo change"));
     setModelType(InspectorModelType::TYPE_GRADUAL_TEMPO_CHANGE);

--- a/src/inspector/qml/MuseScore/Inspector/general/playback/internal/gradualtempochangeplaybackmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/general/playback/internal/gradualtempochangeplaybackmodel.h
@@ -36,7 +36,8 @@ class GradualTempoChangePlaybackModel : public AbstractInspectorModel
     Q_PROPERTY(mu::inspector::PropertyItem * tempoEasingMethod READ tempoEasingMethod CONSTANT)
 
 public:
-    explicit GradualTempoChangePlaybackModel(QObject* parent, IElementRepositoryService* repository);
+    explicit GradualTempoChangePlaybackModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                             IElementRepositoryService* repository);
 
     PropertyItem* tempoChangeFactor() const;
     PropertyItem* tempoEasingMethod() const;

--- a/src/inspector/qml/MuseScore/Inspector/general/playback/internal/noteplaybackmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/general/playback/internal/noteplaybackmodel.cpp
@@ -26,8 +26,8 @@
 
 using namespace mu::inspector;
 
-NotePlaybackModel::NotePlaybackModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository)
+NotePlaybackModel::NotePlaybackModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     setTitle(muse::qtrc("inspector", "Notes"));
     setModelType(InspectorModelType::TYPE_NOTE);

--- a/src/inspector/qml/MuseScore/Inspector/general/playback/internal/noteplaybackmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/general/playback/internal/noteplaybackmodel.h
@@ -36,7 +36,7 @@ class NotePlaybackModel : public AbstractInspectorModel
     Q_PROPERTY(mu::inspector::PropertyItem * velocity READ velocity CONSTANT)
 
 public:
-    explicit NotePlaybackModel(QObject* parent, IElementRepositoryService* repository);
+    explicit NotePlaybackModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     PropertyItem* tuning() const;
     PropertyItem* velocity() const;

--- a/src/inspector/qml/MuseScore/Inspector/general/playback/playbackproxymodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/general/playback/playbackproxymodel.cpp
@@ -31,16 +31,16 @@
 
 using namespace mu::inspector;
 
-PlaybackProxyModel::PlaybackProxyModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorProxyModel(parent, repository)
+PlaybackProxyModel::PlaybackProxyModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository)
+    : AbstractInspectorProxyModel(parent, iocCtx, repository)
 {
     QList<AbstractInspectorModel*> models {
-        new NotePlaybackModel(this, repository),
-        new ArpeggioPlaybackModel(this, repository),
-        new FermataPlaybackModel(this, repository),
-        new BreathPlaybackModel(this, repository),
-        new GlissandoPlaybackModel(this, repository),
-        new GradualTempoChangePlaybackModel(this, repository)
+        new NotePlaybackModel(this, iocCtx, repository),
+        new ArpeggioPlaybackModel(this, iocCtx, repository),
+        new FermataPlaybackModel(this, iocCtx, repository),
+        new BreathPlaybackModel(this, iocCtx, repository),
+        new GlissandoPlaybackModel(this, iocCtx, repository),
+        new GradualTempoChangePlaybackModel(this, iocCtx, repository)
     };
 
     for (AbstractInspectorModel* model : models) {

--- a/src/inspector/qml/MuseScore/Inspector/general/playback/playbackproxymodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/general/playback/playbackproxymodel.h
@@ -33,6 +33,6 @@ class PlaybackProxyModel : public AbstractInspectorProxyModel
     QML_UNCREATABLE("Not creatable from QML")
 
 public:
-    explicit PlaybackProxyModel(QObject* parent, IElementRepositoryService* repository);
+    explicit PlaybackProxyModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 };
 }

--- a/src/inspector/qml/MuseScore/Inspector/inspectorlistmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/inspectorlistmodel.cpp
@@ -214,31 +214,31 @@ void InspectorListModel::createModelsBySectionType(const InspectorSectionTypeSet
 
         switch (sectionType) {
         case InspectorSectionType::SECTION_GENERAL:
-            newModel = new GeneralSettingsModel(this, m_repository.get());
+            newModel = new GeneralSettingsModel(this, iocContext(), m_repository.get());
             break;
         case InspectorSectionType::SECTION_MEASURES:
-            newModel = new MeasuresSettingsModel(this, m_repository.get());
+            newModel = new MeasuresSettingsModel(this, iocContext(), m_repository.get());
             break;
         case InspectorSectionType::SECTION_EMPTY_STAVES:
-            newModel = new EmptyStavesVisibilitySettingsModel(this, m_repository.get());
+            newModel = new EmptyStavesVisibilitySettingsModel(this, iocContext(), m_repository.get());
             break;
         case InspectorSectionType::SECTION_NOTATION:
-            newModel = new NotationSettingsProxyModel(this, m_repository.get(), selectedElementKeySet);
+            newModel = new NotationSettingsProxyModel(this, iocContext(), m_repository.get(), selectedElementKeySet);
             break;
         case InspectorSectionType::SECTION_TEXT:
-            newModel = new TextSettingsModel(this, m_repository.get(), /*isTextLineText*/ false);
+            newModel = new TextSettingsModel(this, iocContext(), m_repository.get(), /*isTextLineText*/ false);
             break;
         case InspectorSectionType::SECTION_TEXT_LINES:
-            newModel = new TextSettingsModel(this, m_repository.get(), /*isTextLineText*/ true);
+            newModel = new TextSettingsModel(this, iocContext(), m_repository.get(), /*isTextLineText*/ true);
             break;
         case InspectorSectionType::SECTION_SCORE_DISPLAY:
-            newModel = new ScoreDisplaySettingsModel(this, m_repository.get());
+            newModel = new ScoreDisplaySettingsModel(this, iocContext(), m_repository.get());
             break;
         case InspectorSectionType::SECTION_SCORE_APPEARANCE:
-            newModel = new ScoreAppearanceSettingsModel(this, m_repository.get());
+            newModel = new ScoreAppearanceSettingsModel(this, iocContext(), m_repository.get());
             break;
         case InspectorSectionType::SECTION_PARTS:
-            newModel = new PartsSettingsModel(this, m_repository.get());
+            newModel = new PartsSettingsModel(this, iocContext(), m_repository.get());
             break;
         case AbstractInspectorModel::InspectorSectionType::SECTION_UNDEFINED:
             break;

--- a/src/inspector/qml/MuseScore/Inspector/inspectormodelcreator.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/inspectormodelcreator.cpp
@@ -87,149 +87,150 @@
 using namespace mu::inspector;
 
 AbstractInspectorModel* InspectorModelCreator::newInspectorModel(InspectorModelType modelType, QObject* parent,
+                                                                 const muse::modularity::ContextPtr& iocCtx,
                                                                  IElementRepositoryService* repository)
 {
     switch (modelType) {
     case InspectorModelType::TYPE_NOTE:
-        return new NoteSettingsProxyModel(parent, repository);
+        return new NoteSettingsProxyModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_NOTEHEAD:
-        return new NoteheadSettingsModel(parent, repository);
+        return new NoteheadSettingsModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_CHORD:
-        return new ChordSettingsModel(parent, repository);
+        return new ChordSettingsModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_STEM:
-        return new StemSettingsModel(parent, repository);
+        return new StemSettingsModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_HOOK:
-        return new HookSettingsModel(parent, repository);
+        return new HookSettingsModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_BEAM:
-        return new BeamSettingsModel(parent, repository);
+        return new BeamSettingsModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_FERMATA:
-        return new FermataSettingsModel(parent, repository);
+        return new FermataSettingsModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_TEMPO:
     case InspectorModelType::TYPE_A_TEMPO:
     case InspectorModelType::TYPE_TEMPO_PRIMO:
-        return new TempoSettingsModel(parent, repository, modelType);
+        return new TempoSettingsModel(parent, iocCtx, repository, modelType);
     case InspectorModelType::TYPE_GLISSANDO:
-        return new GlissandoSettingsModel(parent, repository);
+        return new GlissandoSettingsModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_BARLINE:
-        return new BarlineSettingsModel(parent, repository);
+        return new BarlineSettingsModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_PLAY_COUNT_TEXT:
-        return new PlayCountTextSettingsModel(parent, repository);
+        return new PlayCountTextSettingsModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_MARKER:
-        return new MarkerSettingsModel(parent, repository);
+        return new MarkerSettingsModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_SECTIONBREAK:
-        return new SectionBreakSettingsModel(parent, repository);
+        return new SectionBreakSettingsModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_JUMP:
-        return new JumpSettingsModel(parent, repository);
+        return new JumpSettingsModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_KEYSIGNATURE:
-        return new KeySignatureSettingsModel(parent, repository);
+        return new KeySignatureSettingsModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_ACCIDENTAL:
-        return new AccidentalSettingsModel(parent, repository);
+        return new AccidentalSettingsModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_FRET_DIAGRAM:
-        return new FretDiagramSettingsModel(parent, repository);
+        return new FretDiagramSettingsModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_PEDAL:
-        return new PedalSettingsModel(parent, repository);
+        return new PedalSettingsModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_SPACER:
-        return new SpacerSettingsModel(parent, repository);
+        return new SpacerSettingsModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_CLEF:
-        return new ClefSettingsModel(parent, repository);
+        return new ClefSettingsModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_HAIRPIN:
-        return new HairpinSettingsModel(parent, repository);
+        return new HairpinSettingsModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_CRESCENDO:
-        return new HairpinLineSettingsModel(parent, repository, HairpinLineSettingsModel::Crescendo);
+        return new HairpinLineSettingsModel(parent, iocCtx, repository, HairpinLineSettingsModel::Crescendo);
     case InspectorModelType::TYPE_DIMINUENDO:
-        return new HairpinLineSettingsModel(parent, repository, HairpinLineSettingsModel::Diminuendo);
+        return new HairpinLineSettingsModel(parent, iocCtx, repository, HairpinLineSettingsModel::Diminuendo);
     case InspectorModelType::TYPE_OTTAVA:
-        return new OttavaSettingsModel(parent, repository);
+        return new OttavaSettingsModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_VOLTA:
-        return new VoltaSettingsModel(parent, repository);
+        return new VoltaSettingsModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_TEXT_LINE:
-        return new TextLineSettingsModel(parent, repository);
+        return new TextLineSettingsModel(parent, iocCtx, repository);
     case mu::inspector::InspectorModelType::TYPE_NOTELINE:
-        return new NoteLineSettingsModel(parent, repository);
+        return new NoteLineSettingsModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_GRADUAL_TEMPO_CHANGE:
-        return new GradualTempoChangeSettingsModel(parent, repository);
+        return new GradualTempoChangeSettingsModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_VIBRATO:
-        return new VibratoSettingsModel(parent, repository);
+        return new VibratoSettingsModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_SLUR:
-        return new SlurAndTieSettingsModel(parent, repository, SlurAndTieSettingsModel::Slur);
+        return new SlurAndTieSettingsModel(parent, iocCtx, repository, SlurAndTieSettingsModel::Slur);
     case InspectorModelType::TYPE_TIE:
-        return new SlurAndTieSettingsModel(parent, repository, SlurAndTieSettingsModel::Tie);
+        return new SlurAndTieSettingsModel(parent, iocCtx, repository, SlurAndTieSettingsModel::Tie);
     case InspectorModelType::TYPE_LAISSEZ_VIB:
-        return new SlurAndTieSettingsModel(parent, repository, SlurAndTieSettingsModel::LaissezVib);
+        return new SlurAndTieSettingsModel(parent, iocCtx, repository, SlurAndTieSettingsModel::LaissezVib);
     case InspectorModelType::TYPE_PARTIAL_TIE:
-        return new SlurAndTieSettingsModel(parent, repository, SlurAndTieSettingsModel::PartialTie);
+        return new SlurAndTieSettingsModel(parent, iocCtx, repository, SlurAndTieSettingsModel::PartialTie);
     case InspectorModelType::TYPE_HAMMER_ON_PULL_OFF:
-        return new SlurAndTieSettingsModel(parent, repository, SlurAndTieSettingsModel::HammerOnPullOff);
+        return new SlurAndTieSettingsModel(parent, iocCtx, repository, SlurAndTieSettingsModel::HammerOnPullOff);
     case InspectorModelType::TYPE_STAFF_TYPE_CHANGES:
-        return new StaffTypeSettingsModel(parent, repository);
+        return new StaffTypeSettingsModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_TEXT_FRAME:
-        return new TextFrameSettingsModel(parent, repository);
+        return new TextFrameSettingsModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_VERTICAL_FRAME:
-        return new VerticalFrameSettingsModel(parent, repository);
+        return new VerticalFrameSettingsModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_HORIZONTAL_FRAME:
-        return new HorizontalFrameSettingsModel(parent, repository);
+        return new HorizontalFrameSettingsModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_FRET_FRAME:
-        return new FretFrameSettingsProxyModel(parent, repository);
+        return new FretFrameSettingsProxyModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_FRET_FRAME_CHORDS:
-        return new FretFrameChordsSettingsModel(parent, repository);
+        return new FretFrameChordsSettingsModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_FRET_FRAME_SETTINGS:
-        return new FretFrameSettingsModel(parent, repository);
+        return new FretFrameSettingsModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_ARTICULATION:
-        return new ArticulationSettingsModel(parent, repository);
+        return new ArticulationSettingsModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_TAPPING:
-        return new ArticulationSettingsModel(parent, repository, InspectorModelType::TYPE_TAPPING);
+        return new ArticulationSettingsModel(parent, iocCtx, repository, InspectorModelType::TYPE_TAPPING);
     case InspectorModelType::TYPE_ORNAMENT:
-        return new OrnamentSettingsModel(parent, repository);
+        return new OrnamentSettingsModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_AMBITUS:
-        return new AmbitusSettingsModel(parent, repository);
+        return new AmbitusSettingsModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_IMAGE:
-        return new ImageSettingsModel(parent, repository);
+        return new ImageSettingsModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_CHORD_SYMBOL:
-        return new ChordSymbolSettingsModel(parent, repository);
+        return new ChordSymbolSettingsModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_BRACKET:
-        return new BracketSettingsModel(parent, repository);
+        return new BracketSettingsModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_TIME_SIGNATURE:
-        return new TimeSignatureSettingsModel(parent, repository);
+        return new TimeSignatureSettingsModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_MMREST:
-        return new MMRestSettingsModel(parent, repository);
+        return new MMRestSettingsModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_BEND:
-        return new BendSettingsModel(parent, repository);
+        return new BendSettingsModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_TREMOLOBAR:
-        return new TremoloBarSettingsModel(parent, repository);
+        return new TremoloBarSettingsModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_TREMOLO:
-        return new TremoloSettingsModel(parent, repository);
+        return new TremoloSettingsModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_MEASURE_REPEAT:
-        return new MeasureRepeatSettingsModel(parent, repository);
+        return new MeasureRepeatSettingsModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_TUPLET:
-        return new TupletSettingsModel(parent, repository);
+        return new TupletSettingsModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_INSTRUMENT_NAME:
-        return new InstrumentNameSettingsModel(parent, repository);
+        return new InstrumentNameSettingsModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_LYRICS:
-        return new LyricsSettingsModel(parent, repository);
+        return new LyricsSettingsModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_LYRICS_LINE:
-        return new LyricsLineSettingsModel(parent, repository, LyricsLineSettingsModel::LyricsLine);
+        return new LyricsLineSettingsModel(parent, iocCtx, repository, LyricsLineSettingsModel::LyricsLine);
     case InspectorModelType::TYPE_PARTIAL_LYRICS_LINE:
-        return new LyricsLineSettingsModel(parent, repository, LyricsLineSettingsModel::PartialLyricsLine);
+        return new LyricsLineSettingsModel(parent, iocCtx, repository, LyricsLineSettingsModel::PartialLyricsLine);
     case InspectorModelType::TYPE_REST:
-        return new RestSettingsProxyModel(parent, repository);
+        return new RestSettingsProxyModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_REST_BEAM:
-        return new RestBeamSettingsModel(parent, repository);
+        return new RestBeamSettingsModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_REST_REST:
-        return new RestSettingsModel(parent, repository);
+        return new RestSettingsModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_DYNAMIC:
-        return new DynamicsSettingsModel(parent, repository);
+        return new DynamicsSettingsModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_EXPRESSION:
-        return new ExpressionSettingsModel(parent, repository);
+        return new ExpressionSettingsModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_STRING_TUNINGS:
-        return new StringTuningsSettingsModel(parent, repository);
+        return new StringTuningsSettingsModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_SYMBOL:
-        return new SymbolSettingsModel(parent, repository);
+        return new SymbolSettingsModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_CHORD_BRACKET:
-        return new ChordBracketSettingsModel(parent, repository);
+        return new ChordBracketSettingsModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_BREATH:
-        return new BreathPlaybackModel(parent, repository);
+        return new BreathPlaybackModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_ARPEGGIO:
-        return new ArpeggioPlaybackModel(parent, repository);
+        return new ArpeggioPlaybackModel(parent, iocCtx, repository);
     case InspectorModelType::TYPE_UNDEFINED:
         break;
     }

--- a/src/inspector/qml/MuseScore/Inspector/inspectormodelcreator.h
+++ b/src/inspector/qml/MuseScore/Inspector/inspectormodelcreator.h
@@ -28,6 +28,7 @@ namespace mu::inspector {
 class InspectorModelCreator
 {
 public:
-    static AbstractInspectorModel* newInspectorModel(InspectorModelType modelType, QObject* parent, IElementRepositoryService* repository);
+    static AbstractInspectorModel* newInspectorModel(InspectorModelType modelType, QObject* parent,
+                                                     const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 };
 }

--- a/src/inspector/qml/MuseScore/Inspector/inspectormodelwithvoiceandpositionoptions.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/inspectormodelwithvoiceandpositionoptions.cpp
@@ -24,9 +24,11 @@
 using namespace mu::inspector;
 using namespace mu::engraving;
 
-InspectorModelWithVoiceAndPositionOptions::InspectorModelWithVoiceAndPositionOptions(QObject* parent, IElementRepositoryService* repository,
+InspectorModelWithVoiceAndPositionOptions::InspectorModelWithVoiceAndPositionOptions(QObject* parent,
+                                                                                     const muse::modularity::ContextPtr& iocCtx,
+                                                                                     IElementRepositoryService* repository,
                                                                                      ElementType elementType)
-    : AbstractInspectorModel(parent, repository, elementType)
+    : AbstractInspectorModel(parent, iocCtx, repository, elementType)
 {
     createProperties();
 }

--- a/src/inspector/qml/MuseScore/Inspector/inspectormodelwithvoiceandpositionoptions.h
+++ b/src/inspector/qml/MuseScore/Inspector/inspectormodelwithvoiceandpositionoptions.h
@@ -44,7 +44,8 @@ class InspectorModelWithVoiceAndPositionOptions : public AbstractInspectorModel
         bool isStaveCenteringAvailable READ isStaveCenteringAvailable WRITE setIsStaveCenteringAvailable NOTIFY isStaveCenteringAvailableChanged)
 
 public:
-    explicit InspectorModelWithVoiceAndPositionOptions(QObject* parent, IElementRepositoryService* repository,
+    explicit InspectorModelWithVoiceAndPositionOptions(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                                       IElementRepositoryService* repository,
                                                        ElementType elementType = ElementType::INVALID);
 
     void createProperties() override;

--- a/src/inspector/qml/MuseScore/Inspector/measures/measuressettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/measures/measuressettingsmodel.cpp
@@ -30,8 +30,9 @@ using namespace mu::notation;
 using namespace muse::actions;
 using namespace mu::engraving;
 
-MeasuresSettingsModel::MeasuresSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository)
+MeasuresSettingsModel::MeasuresSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                             IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     setSectionType(InspectorSectionType::SECTION_MEASURES);
     setTitle(muse::qtrc("inspector", "Measures"));

--- a/src/inspector/qml/MuseScore/Inspector/measures/measuressettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/measures/measuressettingsmodel.h
@@ -43,7 +43,7 @@ class MeasuresSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(int systemCount READ systemCount NOTIFY systemCountChanged)
 
 public:
-    explicit MeasuresSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit MeasuresSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     void createProperties() override { }
     void loadProperties() override;

--- a/src/inspector/qml/MuseScore/Inspector/notation/accidentals/accidentalsettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/accidentals/accidentalsettingsmodel.cpp
@@ -28,8 +28,9 @@
 using namespace mu::inspector;
 using namespace mu::engraving;
 
-AccidentalSettingsModel::AccidentalSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository)
+AccidentalSettingsModel::AccidentalSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                                 IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     setModelType(InspectorModelType::TYPE_ACCIDENTAL);
     setTitle(muse::qtrc("inspector", "Accidental"));

--- a/src/inspector/qml/MuseScore/Inspector/notation/accidentals/accidentalsettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/accidentals/accidentalsettingsmodel.h
@@ -41,7 +41,7 @@ class AccidentalSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(bool isStackingOrderEnabled READ isStackingOrderEnabled NOTIFY isStackingOrderEnabledChanged)
 
 public:
-    explicit AccidentalSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit AccidentalSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     void createProperties() override;
     void requestElements() override;

--- a/src/inspector/qml/MuseScore/Inspector/notation/ambituses/ambitussettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/ambituses/ambitussettingsmodel.cpp
@@ -27,8 +27,9 @@
 
 using namespace mu::inspector;
 
-AmbitusSettingsModel::AmbitusSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository)
+AmbitusSettingsModel::AmbitusSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                           IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     setModelType(InspectorModelType::TYPE_AMBITUS);
     setTitle(muse::qtrc("inspector", "Ambitus"));

--- a/src/inspector/qml/MuseScore/Inspector/notation/ambituses/ambitussettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/ambituses/ambitussettingsmodel.h
@@ -46,7 +46,7 @@ class AmbitusSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(mu::inspector::PropertyItem * lineThickness READ lineThickness CONSTANT)
 
 public:
-    explicit AmbitusSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit AmbitusSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     Q_INVOKABLE void matchRangesToStaff();
 

--- a/src/inspector/qml/MuseScore/Inspector/notation/articulations/articulationsettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/articulations/articulationsettingsmodel.cpp
@@ -30,8 +30,9 @@
 using namespace mu::inspector;
 using namespace mu::engraving;
 
-ArticulationSettingsModel::ArticulationSettingsModel(QObject* parent, IElementRepositoryService* repository, InspectorModelType type)
-    : AbstractInspectorModel(parent, repository)
+ArticulationSettingsModel::ArticulationSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                                     IElementRepositoryService* repository, InspectorModelType type)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     setModelType(type);
     setTitle(type == InspectorModelType::TYPE_ARTICULATION ? muse::qtrc("inspector", "Articulation") : muse::qtrc("inspector", "Tapping"));

--- a/src/inspector/qml/MuseScore/Inspector/notation/articulations/articulationsettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/articulations/articulationsettingsmodel.h
@@ -36,7 +36,7 @@ class ArticulationSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(bool isPlacementAvailable READ isPlacementAvailable NOTIFY isPlacementAvailableChanged FINAL)
 
 public:
-    explicit ArticulationSettingsModel(QObject* parent, IElementRepositoryService* repository,
+    explicit ArticulationSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository,
                                        InspectorModelType type = InspectorModelType::TYPE_ARTICULATION);
 
     PropertyItem* placement() const;

--- a/src/inspector/qml/MuseScore/Inspector/notation/barlines/barlinesettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/barlines/barlinesettingsmodel.cpp
@@ -28,8 +28,9 @@
 using namespace mu::inspector;
 using namespace mu::engraving;
 
-BarlineSettingsModel::BarlineSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository)
+BarlineSettingsModel::BarlineSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                           IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     setModelType(InspectorModelType::TYPE_BARLINE);
     setTitle(muse::qtrc("inspector", "Barline"));

--- a/src/inspector/qml/MuseScore/Inspector/notation/barlines/barlinesettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/barlines/barlinesettingsmodel.h
@@ -45,7 +45,7 @@ class BarlineSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(bool showPlayCount READ showPlayCount NOTIFY showPlayCountChanged FINAL)
 
 public:
-    explicit BarlineSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit BarlineSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     Q_INVOKABLE void applySpanPreset(const int presetType);
     Q_INVOKABLE void setSpanIntervalAsStaffDefault();

--- a/src/inspector/qml/MuseScore/Inspector/notation/beams/beammodesmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/beams/beammodesmodel.cpp
@@ -23,8 +23,8 @@
 
 using namespace mu::inspector;
 
-BeamModesModel::BeamModesModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository)
+BeamModesModel::BeamModesModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     createProperties();
 }

--- a/src/inspector/qml/MuseScore/Inspector/notation/beams/beammodesmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/beams/beammodesmodel.h
@@ -37,7 +37,7 @@ class BeamModesModel : public AbstractInspectorModel
     Q_PROPERTY(mu::inspector::PropertyItem * isFeatheringAvailable READ isFeatheringAvailable CONSTANT)
 
 public:
-    explicit BeamModesModel(QObject* parent, IElementRepositoryService* repository);
+    explicit BeamModesModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     PropertyItem* mode() const;
     PropertyItem* isFeatheringAvailable() const;

--- a/src/inspector/qml/MuseScore/Inspector/notation/bends/bendsettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/bends/bendsettingsmodel.cpp
@@ -54,8 +54,8 @@ static int curvePitchToBendAmount(int pitch)
     return fulls * 4 + quarts;
 }
 
-BendSettingsModel::BendSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository)
+BendSettingsModel::BendSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     setModelType(InspectorModelType::TYPE_BEND);
     setTitle(muse::qtrc("inspector", "Bend/dive"));

--- a/src/inspector/qml/MuseScore/Inspector/notation/bends/bendsettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/bends/bendsettingsmodel.h
@@ -53,7 +53,7 @@ class BendSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(bool areSettingsAvailable READ areSettingsAvailable NOTIFY areSettingsAvailableChanged)
 
 public:
-    explicit BendSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit BendSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     void createProperties() override;
     void requestElements() override;

--- a/src/inspector/qml/MuseScore/Inspector/notation/brackets/bracketsettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/brackets/bracketsettingsmodel.cpp
@@ -30,8 +30,9 @@
 using namespace mu::inspector;
 using namespace mu::engraving;
 
-BracketSettingsModel::BracketSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository, mu::engraving::ElementType::BRACKET)
+BracketSettingsModel::BracketSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                           IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository, mu::engraving::ElementType::BRACKET)
 {
     setModelType(InspectorModelType::TYPE_BRACKET);
     setTitle(muse::qtrc("inspector", "Bracket"));

--- a/src/inspector/qml/MuseScore/Inspector/notation/brackets/bracketsettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/brackets/bracketsettingsmodel.h
@@ -41,7 +41,7 @@ class BracketSettingsModel : public AbstractInspectorModel
 
 public:
 
-    explicit BracketSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit BracketSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     void createProperties() override;
     void requestElements() override;

--- a/src/inspector/qml/MuseScore/Inspector/notation/chordsymbols/chordsymbolsettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/chordsymbols/chordsymbolsettingsmodel.cpp
@@ -25,8 +25,9 @@
 
 using namespace mu::inspector;
 
-ChordSymbolSettingsModel::ChordSymbolSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository)
+ChordSymbolSettingsModel::ChordSymbolSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                                   IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     setModelType(InspectorModelType::TYPE_CHORD_SYMBOL);
     setTitle(muse::qtrc("inspector", "Chord symbol"));

--- a/src/inspector/qml/MuseScore/Inspector/notation/chordsymbols/chordsymbolsettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/chordsymbols/chordsymbolsettingsmodel.h
@@ -44,7 +44,7 @@ class ChordSymbolSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(bool showStackModifiers READ showStackModifiers NOTIFY showStackModifiersChanged FINAL)
 
 public:
-    explicit ChordSymbolSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit ChordSymbolSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     void createProperties() override;
     void requestElements() override;

--- a/src/inspector/qml/MuseScore/Inspector/notation/clefs/clefsettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/clefs/clefsettingsmodel.cpp
@@ -28,8 +28,8 @@
 
 using namespace mu::inspector;
 
-ClefSettingsModel::ClefSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository)
+ClefSettingsModel::ClefSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     setModelType(InspectorModelType::TYPE_CLEF);
     setTitle(muse::qtrc("inspector", "Clef"));

--- a/src/inspector/qml/MuseScore/Inspector/notation/clefs/clefsettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/clefs/clefsettingsmodel.h
@@ -38,7 +38,7 @@ class ClefSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(bool isCourtesyClefAvailable READ isCourtesyClefAvailable NOTIFY isCourtesyClefAvailableChanged)
 
 public:
-    explicit ClefSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit ClefSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     void createProperties() override;
     void requestElements() override;

--- a/src/inspector/qml/MuseScore/Inspector/notation/dynamics/dynamicsettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/dynamics/dynamicsettingsmodel.cpp
@@ -28,8 +28,9 @@
 using namespace mu::inspector;
 using namespace mu::engraving;
 
-DynamicsSettingsModel::DynamicsSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : InspectorModelWithVoiceAndPositionOptions(parent, repository)
+DynamicsSettingsModel::DynamicsSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                             IElementRepositoryService* repository)
+    : InspectorModelWithVoiceAndPositionOptions(parent, iocCtx, repository)
 {
     setModelType(InspectorModelType::TYPE_DYNAMIC);
     setTitle(muse::qtrc("inspector ", "Dynamics"));

--- a/src/inspector/qml/MuseScore/Inspector/notation/dynamics/dynamicsettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/dynamics/dynamicsettingsmodel.h
@@ -45,7 +45,7 @@ class DynamicsSettingsModel : public InspectorModelWithVoiceAndPositionOptions
     Q_PROPERTY(mu::inspector::PropertyItem * frameCornerRadius READ frameCornerRadius CONSTANT)
 
 public:
-    explicit DynamicsSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit DynamicsSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     void createProperties() override;
     void requestElements() override;

--- a/src/inspector/qml/MuseScore/Inspector/notation/expressions/expressionsettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/expressions/expressionsettingsmodel.cpp
@@ -25,8 +25,9 @@
 
 using namespace mu::inspector;
 
-ExpressionSettingsModel::ExpressionSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : InspectorModelWithVoiceAndPositionOptions(parent, repository)
+ExpressionSettingsModel::ExpressionSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                                 IElementRepositoryService* repository)
+    : InspectorModelWithVoiceAndPositionOptions(parent, iocCtx, repository)
 {
     setModelType(InspectorModelType::TYPE_EXPRESSION);
     setTitle(muse::qtrc("inspector ", "Expression"));

--- a/src/inspector/qml/MuseScore/Inspector/notation/expressions/expressionsettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/expressions/expressionsettingsmodel.h
@@ -35,7 +35,7 @@ class ExpressionSettingsModel : public InspectorModelWithVoiceAndPositionOptions
     Q_PROPERTY(mu::inspector::PropertyItem * snapExpression READ snapExpression CONSTANT)
 
 public:
-    explicit ExpressionSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit ExpressionSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     void createProperties() override;
     void requestElements() override;

--- a/src/inspector/qml/MuseScore/Inspector/notation/fermatas/fermatasettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/fermatas/fermatasettingsmodel.cpp
@@ -25,8 +25,9 @@
 
 using namespace mu::inspector;
 
-FermataSettingsModel::FermataSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository)
+FermataSettingsModel::FermataSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                           IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     setModelType(InspectorModelType::TYPE_FERMATA);
     setTitle(muse::qtrc("inspector", "Fermata"));

--- a/src/inspector/qml/MuseScore/Inspector/notation/fermatas/fermatasettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/fermatas/fermatasettingsmodel.h
@@ -34,7 +34,7 @@ class FermataSettingsModel : public AbstractInspectorModel
 
     Q_PROPERTY(mu::inspector::PropertyItem * placementType READ placementType CONSTANT)
 public:
-    explicit FermataSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit FermataSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     void createProperties() override;
     void requestElements() override;

--- a/src/inspector/qml/MuseScore/Inspector/notation/frames/fretframe/fretframechordssettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/frames/fretframe/fretframechordssettingsmodel.cpp
@@ -26,8 +26,9 @@
 using namespace mu::inspector;
 using namespace mu::engraving;
 
-FretFrameChordsSettingsModel::FretFrameChordsSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository)
+FretFrameChordsSettingsModel::FretFrameChordsSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                                           IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     setModelType(InspectorModelType::TYPE_FRET_FRAME_CHORDS);
     createProperties();

--- a/src/inspector/qml/MuseScore/Inspector/notation/frames/fretframe/fretframechordssettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/frames/fretframe/fretframechordssettingsmodel.h
@@ -50,7 +50,8 @@ class FretFrameChordsSettingsModel : public AbstractInspectorModel
     muse::Inject<context::IGlobalContext> globalContext = { this };
 
 public:
-    explicit FretFrameChordsSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit FretFrameChordsSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                          IElementRepositoryService* repository);
 
     FretFrameChordListModel* chordListModel() const;
 

--- a/src/inspector/qml/MuseScore/Inspector/notation/frames/fretframe/fretframesettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/frames/fretframe/fretframesettingsmodel.cpp
@@ -28,8 +28,9 @@
 using namespace mu::inspector;
 using namespace mu::engraving;
 
-FretFrameSettingsModel::FretFrameSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository)
+FretFrameSettingsModel::FretFrameSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                               IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     setModelType(InspectorModelType::TYPE_FRET_FRAME_SETTINGS);
     createProperties();

--- a/src/inspector/qml/MuseScore/Inspector/notation/frames/fretframe/fretframesettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/frames/fretframe/fretframesettingsmodel.h
@@ -51,7 +51,7 @@ class FretFrameSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(mu::inspector::PropertyItem * paddingToNotationBelow READ paddingToNotationBelow CONSTANT)
 
 public:
-    explicit FretFrameSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit FretFrameSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     PropertyItem* textScale() const;
     PropertyItem* diagramScale() const;

--- a/src/inspector/qml/MuseScore/Inspector/notation/frames/fretframesettingsproxymodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/frames/fretframesettingsproxymodel.cpp
@@ -27,16 +27,17 @@
 
 using namespace mu::inspector;
 
-FretFrameSettingsProxyModel::FretFrameSettingsProxyModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorProxyModel(parent, repository)
+FretFrameSettingsProxyModel::FretFrameSettingsProxyModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                                         IElementRepositoryService* repository)
+    : AbstractInspectorProxyModel(parent, iocCtx, repository)
 {
     setModelType(InspectorModelType::TYPE_FRET_FRAME);
     setTitle(muse::qtrc("inspector", "Fretboard diagram legend"));
     setIcon(muse::ui::IconCode::Code::FRET_FRAME);
 
     QList<AbstractInspectorModel*> models {
-        InspectorModelCreator::newInspectorModel(InspectorModelType::TYPE_FRET_FRAME_CHORDS, this, repository),
-        InspectorModelCreator::newInspectorModel(InspectorModelType::TYPE_FRET_FRAME_SETTINGS, this, repository)
+        InspectorModelCreator::newInspectorModel(InspectorModelType::TYPE_FRET_FRAME_CHORDS, this, iocCtx, repository),
+        InspectorModelCreator::newInspectorModel(InspectorModelType::TYPE_FRET_FRAME_SETTINGS, this, iocCtx, repository)
     };
 
     for (AbstractInspectorModel* model : models) {

--- a/src/inspector/qml/MuseScore/Inspector/notation/frames/fretframesettingsproxymodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/frames/fretframesettingsproxymodel.h
@@ -34,6 +34,7 @@ class FretFrameSettingsProxyModel : public AbstractInspectorProxyModel
     QML_UNCREATABLE("Not creatable from QML")
 
 public:
-    explicit FretFrameSettingsProxyModel(QObject* parent, IElementRepositoryService* repository);
+    explicit FretFrameSettingsProxyModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                         IElementRepositoryService* repository);
 };
 }

--- a/src/inspector/qml/MuseScore/Inspector/notation/frames/horizontalframesettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/frames/horizontalframesettingsmodel.cpp
@@ -27,8 +27,9 @@
 using namespace mu::inspector;
 using namespace mu::engraving;
 
-HorizontalFrameSettingsModel::HorizontalFrameSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository)
+HorizontalFrameSettingsModel::HorizontalFrameSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                                           IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     setModelType(InspectorModelType::TYPE_HORIZONTAL_FRAME);
     setTitle(muse::qtrc("inspector", "Horizontal frame"));

--- a/src/inspector/qml/MuseScore/Inspector/notation/frames/horizontalframesettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/frames/horizontalframesettingsmodel.h
@@ -39,7 +39,8 @@ class HorizontalFrameSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(mu::inspector::PropertyItem * isSizeSpatiumDependent READ isSizeSpatiumDependent CONSTANT)
 
 public:
-    explicit HorizontalFrameSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit HorizontalFrameSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                          IElementRepositoryService* repository);
 
     PropertyItem* frameWidth() const;
     PropertyItem* leftGap() const;

--- a/src/inspector/qml/MuseScore/Inspector/notation/frames/textframesettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/frames/textframesettingsmodel.cpp
@@ -26,8 +26,9 @@
 using namespace mu::inspector;
 using namespace mu::engraving;
 
-TextFrameSettingsModel::TextFrameSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository)
+TextFrameSettingsModel::TextFrameSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                               IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     setModelType(InspectorModelType::TYPE_TEXT_FRAME);
     setTitle(muse::qtrc("inspector", "Text frame"));

--- a/src/inspector/qml/MuseScore/Inspector/notation/frames/textframesettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/frames/textframesettingsmodel.h
@@ -43,7 +43,7 @@ class TextFrameSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(mu::inspector::PropertyItem * paddingToNotationBelow READ paddingToNotationBelow CONSTANT)
 
 public:
-    explicit TextFrameSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit TextFrameSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     PropertyItem* gapAbove() const;
     PropertyItem* gapBelow() const;

--- a/src/inspector/qml/MuseScore/Inspector/notation/frames/verticalframesettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/frames/verticalframesettingsmodel.cpp
@@ -30,8 +30,9 @@
 using namespace mu::inspector;
 using namespace mu::engraving;
 
-VerticalFrameSettingsModel::VerticalFrameSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository)
+VerticalFrameSettingsModel::VerticalFrameSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                                       IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     setModelType(InspectorModelType::TYPE_VERTICAL_FRAME);
     setTitle(muse::qtrc("inspector", "Vertical frame"));

--- a/src/inspector/qml/MuseScore/Inspector/notation/frames/verticalframesettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/frames/verticalframesettingsmodel.h
@@ -46,7 +46,7 @@ class VerticalFrameSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(mu::inspector::PropertyItem * paddingToNotationBelow READ paddingToNotationBelow CONSTANT)
 
 public:
-    explicit VerticalFrameSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit VerticalFrameSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     PropertyItem* frameHeight() const;
     PropertyItem* gapAbove() const;

--- a/src/inspector/qml/MuseScore/Inspector/notation/fretdiagrams/fretdiagramsettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/fretdiagrams/fretdiagramsettingsmodel.cpp
@@ -28,8 +28,9 @@
 
 using namespace mu::inspector;
 
-FretDiagramSettingsModel::FretDiagramSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository)
+FretDiagramSettingsModel::FretDiagramSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                                   IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     setModelType(InspectorModelType::TYPE_FRET_DIAGRAM);
     setTitle(muse::qtrc("inspector", "Fretboard diagram"));

--- a/src/inspector/qml/MuseScore/Inspector/notation/fretdiagrams/fretdiagramsettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/fretdiagrams/fretdiagramsettingsmodel.h
@@ -59,7 +59,7 @@ class FretDiagramSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(QStringList fingerings READ fingerings NOTIFY fingeringsChanged)
 
 public:
-    explicit FretDiagramSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit FretDiagramSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     void createProperties() override;
     void requestElements() override;

--- a/src/inspector/qml/MuseScore/Inspector/notation/images/imagesettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/images/imagesettingsmodel.cpp
@@ -28,8 +28,8 @@
 using namespace mu::inspector;
 using namespace mu::engraving;
 
-ImageSettingsModel::ImageSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository)
+ImageSettingsModel::ImageSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     setModelType(InspectorModelType::TYPE_IMAGE);
     setTitle(muse::qtrc("inspector", "Image"));

--- a/src/inspector/qml/MuseScore/Inspector/notation/images/imagesettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/images/imagesettingsmodel.h
@@ -40,7 +40,7 @@ class ImageSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(mu::inspector::PropertyItem * isImageFramed READ isImageFramed CONSTANT)
 
 public:
-    explicit ImageSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit ImageSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     PropertyItem* shouldScaleToFrameSize() const;
     PropertyItem* height() const;

--- a/src/inspector/qml/MuseScore/Inspector/notation/instrumentname/instrumentnamesettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/instrumentname/instrumentnamesettingsmodel.cpp
@@ -27,8 +27,9 @@
 using namespace mu::inspector;
 using namespace muse::actions;
 
-InstrumentNameSettingsModel::InstrumentNameSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository)
+InstrumentNameSettingsModel::InstrumentNameSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                                         IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     setTitle(muse::qtrc("inspector", "Instrument names"));
     setModelType(InspectorModelType::TYPE_INSTRUMENT_NAME);

--- a/src/inspector/qml/MuseScore/Inspector/notation/instrumentname/instrumentnamesettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/instrumentname/instrumentnamesettingsmodel.h
@@ -38,7 +38,8 @@ class InstrumentNameSettingsModel : public AbstractInspectorModel
     muse::Inject<muse::actions::IActionsDispatcher> dispatcher = { this };
 
 public:
-    explicit InstrumentNameSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit InstrumentNameSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                         IElementRepositoryService* repository);
 
     Q_INVOKABLE void openStyleSettings();
     Q_INVOKABLE void openStaffAndPartProperties();

--- a/src/inspector/qml/MuseScore/Inspector/notation/jumps/jumpsettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/jumps/jumpsettingsmodel.cpp
@@ -25,8 +25,8 @@
 
 using namespace mu::inspector;
 
-JumpSettingsModel::JumpSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository)
+JumpSettingsModel::JumpSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     setModelType(InspectorModelType::TYPE_JUMP);
     setTitle(muse::qtrc("inspector", "Jump"));

--- a/src/inspector/qml/MuseScore/Inspector/notation/jumps/jumpsettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/jumps/jumpsettingsmodel.h
@@ -37,7 +37,7 @@ class JumpSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(mu::inspector::PropertyItem * continueAt READ continueAt CONSTANT)
     Q_PROPERTY(mu::inspector::PropertyItem * hasToPlayRepeats READ hasToPlayRepeats CONSTANT)
 public:
-    explicit JumpSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit JumpSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     void createProperties() override;
     void requestElements() override;

--- a/src/inspector/qml/MuseScore/Inspector/notation/keysignatures/keysignaturesettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/keysignatures/keysignaturesettingsmodel.cpp
@@ -28,8 +28,9 @@
 
 using namespace mu::inspector;
 
-KeySignatureSettingsModel::KeySignatureSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository)
+KeySignatureSettingsModel::KeySignatureSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                                     IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     setModelType(InspectorModelType::TYPE_KEYSIGNATURE);
     setTitle(muse::qtrc("inspector", "Key signature"));

--- a/src/inspector/qml/MuseScore/Inspector/notation/keysignatures/keysignaturesettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/keysignatures/keysignaturesettingsmodel.h
@@ -35,7 +35,7 @@ class KeySignatureSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(mu::inspector::PropertyItem * hasToShowCourtesy READ hasToShowCourtesy CONSTANT)
     Q_PROPERTY(mu::inspector::PropertyItem * mode READ mode CONSTANT)
 public:
-    explicit KeySignatureSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit KeySignatureSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     void createProperties() override;
     void requestElements() override;

--- a/src/inspector/qml/MuseScore/Inspector/notation/lines/chordbracketsettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/lines/chordbracketsettingsmodel.cpp
@@ -27,8 +27,9 @@
 using namespace mu::inspector;
 using namespace mu::engraving;
 
-ChordBracketSettingsModel::ChordBracketSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel{parent, repository}
+ChordBracketSettingsModel::ChordBracketSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                                     IElementRepositoryService* repository)
+    : AbstractInspectorModel{parent, iocCtx, repository}
 {
     setModelType(InspectorModelType::TYPE_CHORD_BRACKET);
     setElementType(mu::engraving::ElementType::CHORD_BRACKET);

--- a/src/inspector/qml/MuseScore/Inspector/notation/lines/chordbracketsettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/lines/chordbracketsettingsmodel.h
@@ -39,7 +39,7 @@ class ChordBracketSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(bool isBracket READ isBracket NOTIFY isBracketChanged)
 
 public:
-    explicit ChordBracketSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit ChordBracketSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     PropertyItem* bracketRightSide() const { return m_bracketRightSide; }
     PropertyItem* hookPos() const { return m_hookPos; }

--- a/src/inspector/qml/MuseScore/Inspector/notation/lines/glissandosettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/lines/glissandosettingsmodel.cpp
@@ -26,8 +26,9 @@
 
 using namespace mu::inspector;
 
-GlissandoSettingsModel::GlissandoSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository, mu::engraving::ElementType::GLISSANDO)
+GlissandoSettingsModel::GlissandoSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                               IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository, mu::engraving::ElementType::GLISSANDO)
 {
     setModelType(InspectorModelType::TYPE_GLISSANDO);
     setTitle(muse::qtrc("inspector", "Glissando"));

--- a/src/inspector/qml/MuseScore/Inspector/notation/lines/glissandosettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/lines/glissandosettingsmodel.h
@@ -43,7 +43,7 @@ class GlissandoSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(mu::inspector::PropertyItem * dashGapLength READ dashGapLength CONSTANT)
 
 public:
-    explicit GlissandoSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit GlissandoSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     PropertyItem* lineType() const;
     PropertyItem* showText() const;

--- a/src/inspector/qml/MuseScore/Inspector/notation/lines/gradualtempochangesettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/lines/gradualtempochangesettingsmodel.cpp
@@ -25,8 +25,9 @@
 using namespace mu::inspector;
 using namespace mu::engraving;
 
-GradualTempoChangeSettingsModel::GradualTempoChangeSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : TextLineSettingsModel(parent, repository, ElementType::GRADUAL_TEMPO_CHANGE)
+GradualTempoChangeSettingsModel::GradualTempoChangeSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                                                 IElementRepositoryService* repository)
+    : TextLineSettingsModel(parent, iocCtx, repository, ElementType::GRADUAL_TEMPO_CHANGE)
 {
     setModelType(InspectorModelType::TYPE_GRADUAL_TEMPO_CHANGE);
     setTitle(muse::qtrc("inspector", "Tempo change"));

--- a/src/inspector/qml/MuseScore/Inspector/notation/lines/gradualtempochangesettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/lines/gradualtempochangesettingsmodel.h
@@ -36,7 +36,8 @@ class GradualTempoChangeSettingsModel : public TextLineSettingsModel
     Q_PROPERTY(mu::inspector::PropertyItem * snapAfter READ snapAfter CONSTANT)
 
 public:
-    explicit GradualTempoChangeSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit GradualTempoChangeSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                             IElementRepositoryService* repository);
 
     PropertyItem* snapBefore() const;
     PropertyItem* snapAfter() const;

--- a/src/inspector/qml/MuseScore/Inspector/notation/lines/hairpinlinesettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/lines/hairpinlinesettingsmodel.cpp
@@ -32,8 +32,9 @@ using namespace mu::inspector;
 
 using IconCode = muse::ui::IconCode::Code;
 
-HairpinLineSettingsModel::HairpinLineSettingsModel(QObject* parent, IElementRepositoryService* repository, HairpinLineType lineType)
-    : TextLineSettingsModel(parent, repository)
+HairpinLineSettingsModel::HairpinLineSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                                   IElementRepositoryService* repository, HairpinLineType lineType)
+    : TextLineSettingsModel(parent, iocCtx, repository)
 {
     if (lineType == Diminuendo) {
         setModelType(InspectorModelType::TYPE_DIMINUENDO);

--- a/src/inspector/qml/MuseScore/Inspector/notation/lines/hairpinlinesettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/lines/hairpinlinesettingsmodel.h
@@ -42,7 +42,8 @@ public:
         Diminuendo
     };
 
-    explicit HairpinLineSettingsModel(QObject* parent, IElementRepositoryService* repository, HairpinLineType lineType);
+    explicit HairpinLineSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository,
+                                      HairpinLineType lineType);
 
     PropertyItem* snapBefore() const;
     PropertyItem* snapAfter() const;

--- a/src/inspector/qml/MuseScore/Inspector/notation/lines/hairpinsettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/lines/hairpinsettingsmodel.cpp
@@ -30,8 +30,9 @@
 using namespace mu::inspector;
 using namespace mu::engraving;
 
-HairpinSettingsModel::HairpinSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : HairpinLineSettingsModel(parent, repository, HairpinLineSettingsModel::Unknown)
+HairpinSettingsModel::HairpinSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                           IElementRepositoryService* repository)
+    : HairpinLineSettingsModel(parent, iocCtx, repository, HairpinLineSettingsModel::Unknown)
 {
     setModelType(InspectorModelType::TYPE_HAIRPIN);
     setTitle(muse::qtrc("inspector", "Hairpin"));

--- a/src/inspector/qml/MuseScore/Inspector/notation/lines/hairpinsettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/lines/hairpinsettingsmodel.h
@@ -38,7 +38,7 @@ class HairpinSettingsModel : public HairpinLineSettingsModel
     Q_PROPERTY(mu::inspector::PropertyItem * continuousHeight READ continuousHeight CONSTANT)
 
 public:
-    explicit HairpinSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit HairpinSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     PropertyItem* isNienteCircleVisible() const;
 

--- a/src/inspector/qml/MuseScore/Inspector/notation/lines/lyricslinesettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/lines/lyricslinesettingsmodel.cpp
@@ -25,9 +25,10 @@
 
 using namespace mu::inspector;
 
-LyricsLineSettingsModel::LyricsLineSettingsModel(QObject* parent, IElementRepositoryService* repository,
+LyricsLineSettingsModel::LyricsLineSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                                 IElementRepositoryService* repository,
                                                  ElementType elementType)
-    : AbstractInspectorModel(parent, repository)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     if (elementType == ElementType::LyricsLine) {
         setTitle(muse::qtrc("inspector", "Lyrics line"));

--- a/src/inspector/qml/MuseScore/Inspector/notation/lines/lyricslinesettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/lines/lyricslinesettingsmodel.h
@@ -42,7 +42,8 @@ public:
         LyricsLine,
         PartialLyricsLine
     };
-    explicit LyricsLineSettingsModel(QObject* parent, IElementRepositoryService* repository, ElementType elementType);
+    explicit LyricsLineSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository,
+                                     ElementType elementType);
 
     PropertyItem* thickness() const;
     PropertyItem* verse() const;

--- a/src/inspector/qml/MuseScore/Inspector/notation/lines/notelinesettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/lines/notelinesettingsmodel.cpp
@@ -24,8 +24,9 @@
 
 using namespace mu::inspector;
 
-NoteLineSettingsModel::NoteLineSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : TextLineSettingsModel(parent, repository, mu::engraving::ElementType::NOTELINE)
+NoteLineSettingsModel::NoteLineSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                             IElementRepositoryService* repository)
+    : TextLineSettingsModel(parent, iocCtx, repository, mu::engraving::ElementType::NOTELINE)
 {
     setModelType(InspectorModelType::TYPE_NOTELINE);
     setTitle(muse::qtrc("inspector", "Note-anchored line"));

--- a/src/inspector/qml/MuseScore/Inspector/notation/lines/notelinesettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/lines/notelinesettingsmodel.h
@@ -33,7 +33,7 @@ class NoteLineSettingsModel : public TextLineSettingsModel
     QML_UNCREATABLE("Not creatable from QML")
 
 public:
-    explicit NoteLineSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit NoteLineSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
 private:
     void createProperties() override;

--- a/src/inspector/qml/MuseScore/Inspector/notation/lines/ottavasettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/lines/ottavasettingsmodel.cpp
@@ -30,8 +30,8 @@ using namespace mu::inspector;
 
 using IconCode = muse::ui::IconCode::Code;
 
-OttavaSettingsModel::OttavaSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : TextLineSettingsModel(parent, repository, mu::engraving::ElementType::OTTAVA)
+OttavaSettingsModel::OttavaSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository)
+    : TextLineSettingsModel(parent, iocCtx, repository, mu::engraving::ElementType::OTTAVA)
 {
     setTitle(muse::qtrc("inspector", "Ottava"));
     setModelType(InspectorModelType::TYPE_OTTAVA);

--- a/src/inspector/qml/MuseScore/Inspector/notation/lines/ottavasettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/lines/ottavasettingsmodel.h
@@ -36,7 +36,7 @@ class OttavaSettingsModel : public TextLineSettingsModel
     Q_PROPERTY(mu::inspector::PropertyItem * showNumbersOnly READ showNumbersOnly CONSTANT)
 
 public:
-    explicit OttavaSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit OttavaSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     PropertyItem* ottavaType() const;
     PropertyItem* showNumbersOnly() const;

--- a/src/inspector/qml/MuseScore/Inspector/notation/lines/pedalsettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/lines/pedalsettingsmodel.cpp
@@ -30,8 +30,8 @@ using namespace mu::inspector;
 
 using IconCode = muse::ui::IconCode::Code;
 
-PedalSettingsModel::PedalSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : TextLineSettingsModel(parent, repository, mu::engraving::ElementType::PEDAL)
+PedalSettingsModel::PedalSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository)
+    : TextLineSettingsModel(parent, iocCtx, repository, mu::engraving::ElementType::PEDAL)
 {
     setModelType(InspectorModelType::TYPE_PEDAL);
     setTitle(muse::qtrc("inspector", "Pedal"));

--- a/src/inspector/qml/MuseScore/Inspector/notation/lines/pedalsettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/lines/pedalsettingsmodel.h
@@ -36,7 +36,7 @@ class PedalSettingsModel : public TextLineSettingsModel
     Q_PROPERTY(bool isChangingLineVisibilityAllowed READ isChangingLineVisibilityAllowed NOTIFY isChangingLineVisibilityAllowedChanged)
 
 public:
-    explicit PedalSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit PedalSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     PropertyItem* lineType() const;
     bool isChangingLineVisibilityAllowed() const;

--- a/src/inspector/qml/MuseScore/Inspector/notation/lines/slurandtiesettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/lines/slurandtiesettingsmodel.cpp
@@ -34,8 +34,9 @@ using namespace mu::engraving;
 
 using IconCode = muse::ui::IconCode::Code;
 
-SlurAndTieSettingsModel::SlurAndTieSettingsModel(QObject* parent, IElementRepositoryService* repository, ElementType elementType)
-    : AbstractInspectorModel(parent, repository)
+SlurAndTieSettingsModel::SlurAndTieSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                                 IElementRepositoryService* repository, ElementType elementType)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     if (elementType == ElementType::Slur) {
         setModelType(InspectorModelType::TYPE_SLUR);

--- a/src/inspector/qml/MuseScore/Inspector/notation/lines/slurandtiesettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/lines/slurandtiesettingsmodel.h
@@ -50,7 +50,8 @@ public:
         HammerOnPullOff,
     };
 
-    explicit SlurAndTieSettingsModel(QObject* parent, IElementRepositoryService* repository, ElementType elementType);
+    explicit SlurAndTieSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository,
+                                     ElementType elementType);
 
     PropertyItem* lineStyle() const;
     PropertyItem* direction() const;

--- a/src/inspector/qml/MuseScore/Inspector/notation/lines/textlinesettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/lines/textlinesettingsmodel.cpp
@@ -33,8 +33,9 @@ using namespace mu::engraving;
 
 using IconCode = muse::ui::IconCode::Code;
 
-TextLineSettingsModel::TextLineSettingsModel(QObject* parent, IElementRepositoryService* repository, mu::engraving::ElementType elementType)
-    : InspectorModelWithVoiceAndPositionOptions(parent, repository, elementType)
+TextLineSettingsModel::TextLineSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                             IElementRepositoryService* repository, mu::engraving::ElementType elementType)
+    : InspectorModelWithVoiceAndPositionOptions(parent, iocCtx, repository, elementType)
 {
     setModelType(InspectorModelType::TYPE_TEXT_LINE);
     setTitle(muse::qtrc("inspector", "Text line"));

--- a/src/inspector/qml/MuseScore/Inspector/notation/lines/textlinesettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/lines/textlinesettingsmodel.h
@@ -82,7 +82,7 @@ class TextLineSettingsModel : public InspectorModelWithVoiceAndPositionOptions
     Q_PROPERTY(bool endFilledArrow READ endFilledArrow NOTIFY endFilledArrowChanged)
 
 public:
-    explicit TextLineSettingsModel(QObject* parent, IElementRepositoryService* repository,
+    explicit TextLineSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository,
                                    mu::engraving::ElementType elementType = mu::engraving::ElementType::TEXTLINE_BASE);
 
     PropertyItem* isLineVisible() const;

--- a/src/inspector/qml/MuseScore/Inspector/notation/lines/vibratosettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/lines/vibratosettingsmodel.cpp
@@ -27,8 +27,9 @@
 
 using namespace mu::inspector;
 
-VibratoSettingsModel::VibratoSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository, mu::engraving::ElementType::VIBRATO)
+VibratoSettingsModel::VibratoSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                           IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository, mu::engraving::ElementType::VIBRATO)
 {
     setModelType(InspectorModelType::TYPE_VIBRATO);
     setTitle(muse::qtrc("inspector", "Vibrato"));

--- a/src/inspector/qml/MuseScore/Inspector/notation/lines/vibratosettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/lines/vibratosettingsmodel.h
@@ -36,7 +36,7 @@ class VibratoSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(mu::inspector::PropertyItem * placement READ placement CONSTANT)
 
 public:
-    explicit VibratoSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit VibratoSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     PropertyItem* lineType() const;
     PropertyItem* placement() const;

--- a/src/inspector/qml/MuseScore/Inspector/notation/lines/voltasettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/lines/voltasettingsmodel.cpp
@@ -30,8 +30,8 @@ using namespace mu::inspector;
 
 using IconCode = muse::ui::IconCode::Code;
 
-VoltaSettingsModel::VoltaSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : TextLineSettingsModel(parent, repository, mu::engraving::ElementType::VOLTA)
+VoltaSettingsModel::VoltaSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository)
+    : TextLineSettingsModel(parent, iocCtx, repository, mu::engraving::ElementType::VOLTA)
 {
     setModelType(InspectorModelType::TYPE_VOLTA);
     setTitle(muse::qtrc("inspector", "Volta"));

--- a/src/inspector/qml/MuseScore/Inspector/notation/lines/voltasettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/lines/voltasettingsmodel.h
@@ -35,7 +35,7 @@ class VoltaSettingsModel : public TextLineSettingsModel
     Q_PROPERTY(mu::inspector::PropertyItem * repeatCount READ repeatCount CONSTANT)
 
 public:
-    explicit VoltaSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit VoltaSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     PropertyItem* repeatCount() const;
 

--- a/src/inspector/qml/MuseScore/Inspector/notation/lyrics/lyricssettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/lyrics/lyricssettingsmodel.cpp
@@ -25,8 +25,8 @@
 
 using namespace mu::inspector;
 
-LyricsSettingsModel::LyricsSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository)
+LyricsSettingsModel::LyricsSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     setModelType(InspectorModelType::TYPE_LYRICS);
     setTitle(muse::qtrc("inspector", "Lyrics"));

--- a/src/inspector/qml/MuseScore/Inspector/notation/lyrics/lyricssettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/lyrics/lyricssettingsmodel.h
@@ -35,7 +35,7 @@ class LyricsSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(mu::inspector::PropertyItem * verse READ verse CONSTANT)
     Q_PROPERTY(mu::inspector::PropertyItem * avoidBarlines READ avoidBarlines CONSTANT)
 public:
-    explicit LyricsSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit LyricsSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     void createProperties() override;
     void requestElements() override;

--- a/src/inspector/qml/MuseScore/Inspector/notation/markers/markersettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/markers/markersettingsmodel.cpp
@@ -26,8 +26,8 @@
 
 using namespace mu::inspector;
 
-MarkerSettingsModel::MarkerSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository)
+MarkerSettingsModel::MarkerSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     setModelType(InspectorModelType::TYPE_MARKER);
     setTitle(muse::qtrc("inspector", "Marker"));

--- a/src/inspector/qml/MuseScore/Inspector/notation/markers/markersettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/markers/markersettingsmodel.h
@@ -38,7 +38,7 @@ class MarkerSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(mu::inspector::PropertyItem * centerOnSymbol READ centerOnSymbol CONSTANT)
 
 public:
-    explicit MarkerSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit MarkerSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     void createProperties() override;
     void requestElements() override;

--- a/src/inspector/qml/MuseScore/Inspector/notation/measurerepeats/measurerepeatsettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/measurerepeats/measurerepeatsettingsmodel.cpp
@@ -25,8 +25,9 @@
 
 using namespace mu::inspector;
 
-MeasureRepeatSettingsModel::MeasureRepeatSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository)
+MeasureRepeatSettingsModel::MeasureRepeatSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                                       IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     setModelType(InspectorModelType::TYPE_MEASURE_REPEAT);
     setTitle(muse::qtrc("inspector", "Measure repeat"));

--- a/src/inspector/qml/MuseScore/Inspector/notation/measurerepeats/measurerepeatsettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/measurerepeats/measurerepeatsettingsmodel.h
@@ -35,7 +35,7 @@ class MeasureRepeatSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(mu::inspector::PropertyItem * numberPosition READ numberPosition CONSTANT)
 
 public:
-    explicit MeasureRepeatSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit MeasureRepeatSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     void createProperties() override;
     void requestElements() override;

--- a/src/inspector/qml/MuseScore/Inspector/notation/mmrests/mmrestsettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/mmrests/mmrestsettingsmodel.cpp
@@ -28,8 +28,8 @@
 using namespace mu::inspector;
 using namespace mu::engraving;
 
-MMRestSettingsModel::MMRestSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository)
+MMRestSettingsModel::MMRestSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     setModelType(InspectorModelType::TYPE_MMREST);
     setTitle(muse::qtrc("inspector", "Multimeasure rest"));

--- a/src/inspector/qml/MuseScore/Inspector/notation/mmrests/mmrestsettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/mmrests/mmrestsettingsmodel.h
@@ -37,7 +37,7 @@ class MMRestSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(bool areNumberOptionsEnabled READ areNumberOptionsEnabled NOTIFY areNumberOptionsEnabledChanged)
 
 public:
-    explicit MMRestSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit MMRestSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     void createProperties() override;
     void requestElements() override;

--- a/src/inspector/qml/MuseScore/Inspector/notation/notationsettingsproxymodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/notationsettingsproxymodel.cpp
@@ -25,9 +25,10 @@
 
 using namespace mu::inspector;
 
-NotationSettingsProxyModel::NotationSettingsProxyModel(QObject* parent, IElementRepositoryService* repository,
+NotationSettingsProxyModel::NotationSettingsProxyModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                                       IElementRepositoryService* repository,
                                                        const ElementKeySet& elementKeySet)
-    : AbstractInspectorProxyModel(parent, repository)
+    : AbstractInspectorProxyModel(parent, iocCtx, repository)
 {
     connect(this, &AbstractInspectorProxyModel::modelsChanged, [this]() {
         auto models = modelList();

--- a/src/inspector/qml/MuseScore/Inspector/notation/notationsettingsproxymodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/notationsettingsproxymodel.h
@@ -33,6 +33,7 @@ class NotationSettingsProxyModel : public AbstractInspectorProxyModel
     QML_UNCREATABLE("Not creatable from QML")
 
 public:
-    explicit NotationSettingsProxyModel(QObject* parent, IElementRepositoryService* repository, const ElementKeySet& elementKeySet);
+    explicit NotationSettingsProxyModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository,
+                                        const ElementKeySet& elementKeySet);
 };
 }

--- a/src/inspector/qml/MuseScore/Inspector/notation/notes/beams/beamsettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/notes/beams/beamsettingsmodel.cpp
@@ -27,13 +27,13 @@
 using namespace mu::inspector;
 using namespace mu::engraving;
 
-BeamSettingsModel::BeamSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository)
+BeamSettingsModel::BeamSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     setModelType(InspectorModelType::TYPE_BEAM);
     setTitle(muse::qtrc("inspector", "Beam"));
 
-    m_beamModesModel = new BeamModesModel(this, repository);
+    m_beamModesModel = new BeamModesModel(this, iocCtx, repository);
     m_beamModesModel->init();
 
     connect(m_beamModesModel->isFeatheringAvailable(), &PropertyItem::propertyModified,

--- a/src/inspector/qml/MuseScore/Inspector/notation/notes/beams/beamsettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/notes/beams/beamsettingsmodel.h
@@ -58,7 +58,7 @@ class BeamSettingsModel : public AbstractInspectorModel
         bool isCrossStaffMoveAvailable READ isCrossStaffMoveAvailable WRITE setIsCrossStaffMoveAvailable NOTIFY isCrossStaffMoveAvailableChanged)
 
 public:
-    explicit BeamSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit BeamSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     PropertyItem* forceHorizontal();
 

--- a/src/inspector/qml/MuseScore/Inspector/notation/notes/chords/chordsettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/notes/chords/chordsettingsmodel.cpp
@@ -26,8 +26,8 @@
 using namespace mu::inspector;
 using namespace mu::engraving;
 
-ChordSettingsModel::ChordSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository)
+ChordSettingsModel::ChordSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     setModelType(InspectorModelType::TYPE_CHORD);
     setTitle(muse::qtrc("inspector", "Chord"));

--- a/src/inspector/qml/MuseScore/Inspector/notation/notes/chords/chordsettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/notes/chords/chordsettingsmodel.h
@@ -40,7 +40,7 @@ class ChordSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(bool showStemSlashEnabled READ showStemSlashEnabled NOTIFY showStemSlashEnabledChanged)
 
 public:
-    explicit ChordSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit ChordSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     PropertyItem* isStemless() const;
     PropertyItem* showStemSlash() const;

--- a/src/inspector/qml/MuseScore/Inspector/notation/notes/hooks/hooksettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/notes/hooks/hooksettingsmodel.cpp
@@ -25,8 +25,8 @@
 
 using namespace mu::inspector;
 
-HookSettingsModel::HookSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository)
+HookSettingsModel::HookSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     setModelType(InspectorModelType::TYPE_HOOK);
     setTitle(muse::qtrc("inspector", "Flag")); // internally called "Hook", but "Flag" in SMuFL, so here externally too

--- a/src/inspector/qml/MuseScore/Inspector/notation/notes/hooks/hooksettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/notes/hooks/hooksettingsmodel.h
@@ -35,7 +35,7 @@ class HookSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(mu::inspector::PropertyItem * offset READ offset CONSTANT)
 
 public:
-    explicit HookSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit HookSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     PropertyItem* offset() const;
 

--- a/src/inspector/qml/MuseScore/Inspector/notation/notes/noteheads/noteheadsettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/notes/noteheads/noteheadsettingsmodel.cpp
@@ -28,8 +28,9 @@
 using namespace mu::inspector;
 using namespace mu::engraving;
 
-NoteheadSettingsModel::NoteheadSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository)
+NoteheadSettingsModel::NoteheadSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                             IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     setTitle(muse::qtrc("inspector", "Head"));
     setModelType(InspectorModelType::TYPE_NOTEHEAD);

--- a/src/inspector/qml/MuseScore/Inspector/notation/notes/noteheads/noteheadsettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/notes/noteheads/noteheadsettingsmodel.h
@@ -44,7 +44,7 @@ class NoteheadSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(bool isTrillCueNote READ isTrillCueNote NOTIFY isTrillCueNoteChanged)
 
 public:
-    explicit NoteheadSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit NoteheadSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     PropertyItem* isHeadHidden() const;
     PropertyItem* isHeadSmall() const;

--- a/src/inspector/qml/MuseScore/Inspector/notation/notes/notesettingsproxymodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/notes/notesettingsproxymodel.cpp
@@ -34,8 +34,9 @@ static const QMap<mu::engraving::ElementType, InspectorModelType> NOTE_PART_TYPE
     { mu::engraving::ElementType::HOOK, InspectorModelType::TYPE_HOOK },
 };
 
-NoteSettingsProxyModel::NoteSettingsProxyModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorProxyModel(parent, repository)
+NoteSettingsProxyModel::NoteSettingsProxyModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                               IElementRepositoryService* repository)
+    : AbstractInspectorProxyModel(parent, iocCtx, repository)
 {
     setModelType(InspectorModelType::TYPE_NOTE);
     setTitle(muse::qtrc("inspector", "Note"));
@@ -43,7 +44,7 @@ NoteSettingsProxyModel::NoteSettingsProxyModel(QObject* parent, IElementReposito
 
     QList<AbstractInspectorModel*> models;
     for (InspectorModelType modelType : NOTE_PART_TYPES) {
-        models << InspectorModelCreator::newInspectorModel(modelType, this, repository);
+        models << InspectorModelCreator::newInspectorModel(modelType, this, iocCtx, repository);
     }
 
     for (AbstractInspectorModel* model : models) {

--- a/src/inspector/qml/MuseScore/Inspector/notation/notes/notesettingsproxymodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/notes/notesettingsproxymodel.h
@@ -33,7 +33,7 @@ class NoteSettingsProxyModel : public AbstractInspectorProxyModel
     QML_UNCREATABLE("Not creatable from QML")
 
 public:
-    explicit NoteSettingsProxyModel(QObject* parent, IElementRepositoryService* repository);
+    explicit NoteSettingsProxyModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
 private:
     void onElementsUpdated(const QList<mu::engraving::EngravingItem*>& newElements);

--- a/src/inspector/qml/MuseScore/Inspector/notation/notes/stems/stemsettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/notes/stems/stemsettingsmodel.cpp
@@ -29,8 +29,8 @@
 using namespace mu::inspector;
 using namespace mu::engraving;
 
-StemSettingsModel::StemSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository)
+StemSettingsModel::StemSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     setModelType(InspectorModelType::TYPE_STEM);
     setTitle(muse::qtrc("inspector", "Stem"));

--- a/src/inspector/qml/MuseScore/Inspector/notation/notes/stems/stemsettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/notes/stems/stemsettingsmodel.h
@@ -40,7 +40,7 @@ class StemSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(bool useStraightNoteFlags READ useStraightNoteFlags WRITE setUseStraightNoteFlags NOTIFY useStraightNoteFlagsChanged)
 
 public:
-    explicit StemSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit StemSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     PropertyItem* thickness() const;
     PropertyItem* length() const;

--- a/src/inspector/qml/MuseScore/Inspector/notation/ornaments/ornamentsettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/ornaments/ornamentsettingsmodel.cpp
@@ -37,8 +37,9 @@ using mu::engraving::IntervalType;
 using mu::engraving::P_TYPE;
 using mu::engraving::Ornament;
 
-OrnamentSettingsModel::OrnamentSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository)
+OrnamentSettingsModel::OrnamentSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                             IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     setModelType(InspectorModelType::TYPE_ORNAMENT);
     setTitle(muse::qtrc("inspector", "Ornament"));

--- a/src/inspector/qml/MuseScore/Inspector/notation/ornaments/ornamentsettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/ornaments/ornamentsettingsmodel.h
@@ -51,7 +51,7 @@ class OrnamentSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(mu::inspector::PropertyItem * showCueNote READ showCueNote CONSTANT)
 
 public:
-    explicit OrnamentSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit OrnamentSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     void createProperties() override;
     void requestElements() override;

--- a/src/inspector/qml/MuseScore/Inspector/notation/playcounttext/playcounttextsettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/playcounttext/playcounttextsettingsmodel.cpp
@@ -26,8 +26,9 @@
 using namespace mu::inspector;
 using namespace mu::engraving;
 
-PlayCountTextSettingsModel::PlayCountTextSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository)
+PlayCountTextSettingsModel::PlayCountTextSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                                       IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     setModelType(InspectorModelType::TYPE_PLAY_COUNT_TEXT);
     setTitle(muse::qtrc("inspector", "Play count text"));

--- a/src/inspector/qml/MuseScore/Inspector/notation/playcounttext/playcounttextsettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/playcounttext/playcounttextsettingsmodel.h
@@ -36,7 +36,7 @@ class PlayCountTextSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(mu::inspector::PropertyItem * playCountTextSetting READ playCountTextSetting CONSTANT)
 
 public:
-    explicit PlayCountTextSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit PlayCountTextSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     PropertyItem* playCountText() const;
     PropertyItem* playCountTextSetting() const;

--- a/src/inspector/qml/MuseScore/Inspector/notation/rests/beams/restbeamsettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/rests/beams/restbeamsettingsmodel.cpp
@@ -26,13 +26,14 @@
 using namespace mu::inspector;
 using namespace mu::engraving;
 
-RestBeamSettingsModel::RestBeamSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository)
+RestBeamSettingsModel::RestBeamSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                             IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     setModelType(InspectorModelType::TYPE_BEAM);
     setTitle(muse::qtrc("inspector", "Beam"));
 
-    m_beamModesModel = new BeamModesModel(this, repository);
+    m_beamModesModel = new BeamModesModel(this, iocCtx, repository);
     m_beamModesModel->init();
 
     connect(m_beamModesModel->mode(), &PropertyItem::propertyModified, this, &AbstractInspectorModel::requestReloadPropertyItems);

--- a/src/inspector/qml/MuseScore/Inspector/notation/rests/beams/restbeamsettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/rests/beams/restbeamsettingsmodel.h
@@ -36,7 +36,7 @@ class RestBeamSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(QObject * beamModesModel READ beamModesModel CONSTANT)
 
 public:
-    explicit RestBeamSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit RestBeamSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     QObject* beamModesModel() const;
 

--- a/src/inspector/qml/MuseScore/Inspector/notation/rests/restsettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/rests/restsettingsmodel.cpp
@@ -25,8 +25,8 @@
 using namespace mu::engraving;
 
 namespace mu::inspector {
-RestSettingsModel::RestSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository)
+RestSettingsModel::RestSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     setModelType(InspectorModelType::TYPE_REST_REST);
     createProperties();

--- a/src/inspector/qml/MuseScore/Inspector/notation/rests/restsettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/rests/restsettingsmodel.h
@@ -36,7 +36,7 @@ class RestSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(mu::inspector::PropertyItem * alignWithOtherRests READ alignWithOtherRests CONSTANT)
 
 public:
-    explicit RestSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit RestSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     PropertyItem* alignWithOtherRests() const;
 

--- a/src/inspector/qml/MuseScore/Inspector/notation/rests/restsettingsproxymodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/rests/restsettingsproxymodel.cpp
@@ -23,22 +23,21 @@
 #include "beams/restbeamsettingsmodel.h"
 #include "restsettingsmodel.h"
 
-#include "engraving/dom/rest.h"
-
 #include "translation.h"
 
 using namespace mu::inspector;
 
-RestSettingsProxyModel::RestSettingsProxyModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorProxyModel(parent, repository)
+RestSettingsProxyModel::RestSettingsProxyModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                               IElementRepositoryService* repository)
+    : AbstractInspectorProxyModel(parent, iocCtx, repository)
 {
     setModelType(InspectorModelType::TYPE_REST);
     setTitle(muse::qtrc("inspector", "Rest"));
     setIcon(muse::ui::IconCode::Code::REST_8TH);
 
     QList<AbstractInspectorModel*> models {
-        new RestBeamSettingsModel(this, repository),
-        new RestSettingsModel(this, repository)
+        new RestBeamSettingsModel(this, iocCtx, repository),
+        new RestSettingsModel(this, iocCtx, repository)
     };
 
     for (AbstractInspectorModel* model : models) {

--- a/src/inspector/qml/MuseScore/Inspector/notation/rests/restsettingsproxymodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/rests/restsettingsproxymodel.h
@@ -33,6 +33,6 @@ class RestSettingsProxyModel : public AbstractInspectorProxyModel
     QML_UNCREATABLE("Not creatable from QML")
 
 public:
-    explicit RestSettingsProxyModel(QObject* parent, IElementRepositoryService* repository);
+    explicit RestSettingsProxyModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 };
 }

--- a/src/inspector/qml/MuseScore/Inspector/notation/sectionbreaks/sectionbreaksettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/sectionbreaks/sectionbreaksettingsmodel.cpp
@@ -26,8 +26,9 @@
 
 using namespace mu::inspector;
 
-SectionBreakSettingsModel::SectionBreakSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository)
+SectionBreakSettingsModel::SectionBreakSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                                     IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     setModelType(InspectorModelType::TYPE_SECTIONBREAK);
     setTitle(muse::qtrc("inspector", "Section break"));

--- a/src/inspector/qml/MuseScore/Inspector/notation/sectionbreaks/sectionbreaksettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/sectionbreaks/sectionbreaksettingsmodel.h
@@ -39,7 +39,7 @@ class SectionBreakSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(mu::inspector::PropertyItem * showCourtesySignatures READ showCourtesySignatures CONSTANT)
 
 public:
-    explicit SectionBreakSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit SectionBreakSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     void createProperties() override;
     void requestElements() override;

--- a/src/inspector/qml/MuseScore/Inspector/notation/spacers/spacersettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/spacers/spacersettingsmodel.cpp
@@ -28,8 +28,8 @@
 using namespace mu::inspector;
 using namespace mu::engraving;
 
-SpacerSettingsModel::SpacerSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository)
+SpacerSettingsModel::SpacerSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     setModelType(InspectorModelType::TYPE_SPACER);
     setTitle(muse::qtrc("inspector", "Spacer"));

--- a/src/inspector/qml/MuseScore/Inspector/notation/spacers/spacersettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/spacers/spacersettingsmodel.h
@@ -35,7 +35,7 @@ class SpacerSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(mu::inspector::PropertyItem * spacerHeight READ spacerHeight CONSTANT)
 
 public:
-    explicit SpacerSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit SpacerSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     void createProperties() override;
     void requestElements() override;

--- a/src/inspector/qml/MuseScore/Inspector/notation/stafftype/stafftypesettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/stafftype/stafftypesettingsmodel.cpp
@@ -27,8 +27,9 @@
 
 using namespace mu::inspector;
 
-StaffTypeSettingsModel::StaffTypeSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository)
+StaffTypeSettingsModel::StaffTypeSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                               IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     setModelType(InspectorModelType::TYPE_STAFF_TYPE_CHANGES);
     setTitle(muse::qtrc("inspector", "Staff type changes"));

--- a/src/inspector/qml/MuseScore/Inspector/notation/stafftype/stafftypesettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/stafftype/stafftypesettingsmodel.h
@@ -50,7 +50,7 @@ class StaffTypeSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(mu::inspector::PropertyItem * shouldGenerateTimeSignatures READ shouldGenerateTimeSignatures CONSTANT)
     Q_PROPERTY(mu::inspector::PropertyItem * shouldGenerateKeySignatures READ shouldGenerateKeySignatures CONSTANT)
 public:
-    explicit StaffTypeSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit StaffTypeSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     void createProperties() override;
     void requestElements() override;

--- a/src/inspector/qml/MuseScore/Inspector/notation/stringtunings/stringtuningssettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/stringtunings/stringtuningssettingsmodel.cpp
@@ -26,8 +26,9 @@
 using namespace mu::inspector;
 using namespace mu::notation;
 
-StringTuningsSettingsModel::StringTuningsSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository)
+StringTuningsSettingsModel::StringTuningsSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                                       IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     setModelType(InspectorModelType::TYPE_STRING_TUNINGS);
     setTitle(muse::qtrc("inspector", "Fretted instruments"));

--- a/src/inspector/qml/MuseScore/Inspector/notation/stringtunings/stringtuningssettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/stringtunings/stringtuningssettingsmodel.h
@@ -33,7 +33,7 @@ class StringTuningsSettingsModel : public AbstractInspectorModel
     QML_UNCREATABLE("Not creatable from QML")
 
 public:
-    explicit StringTuningsSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit StringTuningsSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     Q_INVOKABLE void editStrings();
 

--- a/src/inspector/qml/MuseScore/Inspector/notation/symbols/symbolsettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/symbols/symbolsettingsmodel.cpp
@@ -27,8 +27,8 @@
 
 using namespace mu::inspector;
 
-SymbolSettingsModel::SymbolSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository)
+SymbolSettingsModel::SymbolSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     setModelType(InspectorModelType::TYPE_SYMBOL);
     setTitle(muse::qtrc("inspector", "Symbol"));

--- a/src/inspector/qml/MuseScore/Inspector/notation/symbols/symbolsettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/symbols/symbolsettingsmodel.h
@@ -43,7 +43,7 @@ class SymbolSettingsModel : public AbstractInspectorModel
     muse::GlobalInject<engraving::IEngravingFontsProvider> engravingFonts;
 
 public:
-    explicit SymbolSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit SymbolSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     void createProperties() override;
     void requestElements() override;

--- a/src/inspector/qml/MuseScore/Inspector/notation/tempos/temposettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/tempos/temposettingsmodel.cpp
@@ -27,8 +27,9 @@
 
 using namespace mu::inspector;
 
-TempoSettingsModel::TempoSettingsModel(QObject* parent, IElementRepositoryService* repository, InspectorModelType modelType)
-    : AbstractInspectorModel(parent, repository)
+TempoSettingsModel::TempoSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository,
+                                       InspectorModelType modelType)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     Q_ASSERT(modelType == InspectorModelType::TYPE_TEMPO
              || modelType == InspectorModelType::TYPE_A_TEMPO

--- a/src/inspector/qml/MuseScore/Inspector/notation/tempos/temposettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/tempos/temposettingsmodel.h
@@ -36,7 +36,8 @@ class TempoSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(mu::inspector::PropertyItem * tempo READ tempo CONSTANT)
 
 public:
-    explicit TempoSettingsModel(QObject* parent, IElementRepositoryService* repository, InspectorModelType modelType);
+    explicit TempoSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository,
+                                InspectorModelType modelType);
 
     void createProperties() override;
     void requestElements() override;

--- a/src/inspector/qml/MuseScore/Inspector/notation/timesignatures/timesignaturesettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/timesignatures/timesignaturesettingsmodel.cpp
@@ -29,8 +29,9 @@
 
 using namespace mu::inspector;
 
-TimeSignatureSettingsModel::TimeSignatureSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository)
+TimeSignatureSettingsModel::TimeSignatureSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                                       IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     setModelType(InspectorModelType::TYPE_TIME_SIGNATURE);
     setTitle(muse::qtrc("inspector", "Time signature"));

--- a/src/inspector/qml/MuseScore/Inspector/notation/timesignatures/timesignaturesettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/timesignatures/timesignaturesettingsmodel.h
@@ -38,7 +38,7 @@ class TimeSignatureSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(bool isGenerated READ isGenerated CONSTANT)
 
 public:
-    explicit TimeSignatureSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit TimeSignatureSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     Q_INVOKABLE void showTimeSignatureProperties();
 

--- a/src/inspector/qml/MuseScore/Inspector/notation/tremolobars/tremolobarsettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/tremolobars/tremolobarsettingsmodel.cpp
@@ -28,8 +28,9 @@
 
 using namespace mu::inspector;
 
-TremoloBarSettingsModel::TremoloBarSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository)
+TremoloBarSettingsModel::TremoloBarSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                                 IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     setModelType(InspectorModelType::TYPE_TREMOLOBAR);
     setTitle(muse::qtrc("inspector", "Tremolo bar"));

--- a/src/inspector/qml/MuseScore/Inspector/notation/tremolobars/tremolobarsettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/tremolobars/tremolobarsettingsmodel.h
@@ -40,7 +40,7 @@ class TremoloBarSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(bool areSettingsAvailable READ areSettingsAvailable NOTIFY areSettingsAvailableChanged)
 
 public:
-    explicit TremoloBarSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit TremoloBarSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     void createProperties() override;
     void requestElements() override;

--- a/src/inspector/qml/MuseScore/Inspector/notation/tremolos/tremolosettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/tremolos/tremolosettingsmodel.cpp
@@ -30,8 +30,9 @@
 using namespace mu::inspector;
 using namespace mu::engraving;
 
-TremoloSettingsModel::TremoloSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository)
+TremoloSettingsModel::TremoloSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                           IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     setModelType(InspectorModelType::TYPE_TREMOLO);
     setTitle(muse::qtrc("inspector", "Tremolos"));

--- a/src/inspector/qml/MuseScore/Inspector/notation/tremolos/tremolosettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/tremolos/tremolosettingsmodel.h
@@ -36,7 +36,7 @@ class TremoloSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(mu::inspector::PropertyItem * direction READ direction CONSTANT)
 
 public:
-    explicit TremoloSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit TremoloSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     void createProperties() override;
     void requestElements() override;

--- a/src/inspector/qml/MuseScore/Inspector/notation/tuplets/tupletsettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/notation/tuplets/tupletsettingsmodel.cpp
@@ -30,8 +30,8 @@ using namespace mu::inspector;
 
 using Icon = muse::ui::IconCode::Code;
 
-TupletSettingsModel::TupletSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository, mu::engraving::ElementType::TUPLET)
+TupletSettingsModel::TupletSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository, mu::engraving::ElementType::TUPLET)
 {
     setModelType(InspectorModelType::TYPE_TUPLET);
     setTitle(muse::qtrc("inspector", "Tuplet"));

--- a/src/inspector/qml/MuseScore/Inspector/notation/tuplets/tupletsettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/notation/tuplets/tupletsettingsmodel.h
@@ -38,7 +38,7 @@ class TupletSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(mu::inspector::PropertyItem * lineThickness READ lineThickness CONSTANT)
 
 public:
-    explicit TupletSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit TupletSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     PropertyItem* directionType() const;
     PropertyItem* numberType() const;

--- a/src/inspector/qml/MuseScore/Inspector/parts/partssettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/parts/partssettingsmodel.cpp
@@ -27,8 +27,8 @@
 using namespace mu::inspector;
 using namespace mu::engraving;
 
-PartsSettingsModel::PartsSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository)
+PartsSettingsModel::PartsSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     setTitle(muse::qtrc("inspector", "Score and part synchronization"));
     setSectionType(InspectorSectionType::SECTION_PARTS);

--- a/src/inspector/qml/MuseScore/Inspector/parts/partssettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/parts/partssettingsmodel.h
@@ -43,7 +43,7 @@ class PartsSettingsModel : public AbstractInspectorModel
     Q_PROPERTY(bool isMasterScore READ isMasterScore NOTIFY isMasterScoreChanged)
 
 public:
-    explicit PartsSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit PartsSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     PropertyItem* positionLinkedToMaster() const;
     PropertyItem* appearanceLinkedToMaster() const;

--- a/src/inspector/qml/MuseScore/Inspector/score/scoreappearancesettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/score/scoreappearancesettingsmodel.cpp
@@ -26,8 +26,9 @@
 using namespace mu::inspector;
 using namespace mu::notation;
 
-ScoreAppearanceSettingsModel::ScoreAppearanceSettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository)
+ScoreAppearanceSettingsModel::ScoreAppearanceSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                                           IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     setSectionType(InspectorSectionType::SECTION_SCORE_APPEARANCE);
     setTitle(muse::qtrc("inspector", "Score appearance"));

--- a/src/inspector/qml/MuseScore/Inspector/score/scoreappearancesettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/score/scoreappearancesettingsmodel.h
@@ -40,7 +40,8 @@ class ScoreAppearanceSettingsModel : public AbstractInspectorModel
         bool showBracketsWhenSpanningSingleStaff READ showBracketsWhenSpanningSingleStaff WRITE setShowBracketsWhenSpanningSingleStaff NOTIFY showBracketsWhenSpanningSingleStaffChanged)
 
 public:
-    explicit ScoreAppearanceSettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit ScoreAppearanceSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                          IElementRepositoryService* repository);
 
     bool hideEmptyStaves() const;
     void setHideEmptyStaves(bool hide);

--- a/src/inspector/qml/MuseScore/Inspector/score/scoredisplaysettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/score/scoredisplaysettingsmodel.cpp
@@ -27,8 +27,9 @@
 using namespace mu::inspector;
 using namespace mu::notation;
 
-ScoreDisplaySettingsModel::ScoreDisplaySettingsModel(QObject* parent, IElementRepositoryService* repository)
-    : AbstractInspectorModel(parent, repository)
+ScoreDisplaySettingsModel::ScoreDisplaySettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx,
+                                                     IElementRepositoryService* repository)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     setSectionType(InspectorSectionType::SECTION_SCORE_DISPLAY);
     setTitle(muse::qtrc("inspector", "Show"));

--- a/src/inspector/qml/MuseScore/Inspector/score/scoredisplaysettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/score/scoredisplaysettingsmodel.h
@@ -41,7 +41,7 @@ class ScoreDisplaySettingsModel : public AbstractInspectorModel
     Q_PROPERTY(bool shouldShowSoundFlags READ shouldShowSoundFlags WRITE setShouldShowSoundFlags NOTIFY shouldShowSoundFlagsChanged)
 
 public:
-    explicit ScoreDisplaySettingsModel(QObject* parent, IElementRepositoryService* repository);
+    explicit ScoreDisplaySettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository);
 
     void createProperties() override;
     void requestElements() override;

--- a/src/inspector/qml/MuseScore/Inspector/text/textsettingsmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/text/textsettingsmodel.cpp
@@ -37,17 +37,12 @@
 using namespace mu::inspector;
 using namespace mu::engraving;
 
-TextSettingsModel::TextSettingsModel(QObject* parent, IElementRepositoryService* repository, bool isTextLineText)
-    : AbstractInspectorModel(parent, repository)
+TextSettingsModel::TextSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository,
+                                     bool isTextLineText)
+    : AbstractInspectorModel(parent, iocCtx, repository)
 {
     setSectionType(isTextLineText ? InspectorSectionType::SECTION_TEXT_LINES : InspectorSectionType::SECTION_TEXT);
     setTitle(muse::qtrc("inspector", "Text"));
-}
-
-void TextSettingsModel::classBegin()
-{
-    AbstractInspectorModel::classBegin();
-
     createProperties();
 
     isTextEditingChanged().onNotify(this, [this]() {

--- a/src/inspector/qml/MuseScore/Inspector/text/textsettingsmodel.h
+++ b/src/inspector/qml/MuseScore/Inspector/text/textsettingsmodel.h
@@ -80,9 +80,8 @@ class TextSettingsModel : public AbstractInspectorModel
     muse::Inject<muse::actions::IActionsDispatcher> dispatcher = { this };
 
 public:
-    explicit TextSettingsModel(QObject* parent, IElementRepositoryService* repository, bool isTextLineText);
-
-    void classBegin() override;
+    explicit TextSettingsModel(QObject* parent, const muse::modularity::ContextPtr& iocCtx, IElementRepositoryService* repository,
+                               bool isTextLineText);
 
     Q_INVOKABLE void insertSpecialCharacters();
     Q_INVOKABLE void showStaffTextProperties();

--- a/src/inspector/qml/MuseScore/Inspector/text/textstylepopup/textstylepopupmodel.cpp
+++ b/src/inspector/qml/MuseScore/Inspector/text/textstylepopup/textstylepopupmodel.cpp
@@ -30,7 +30,6 @@ using namespace mu::inspector;
 TextStylePopupModel::TextStylePopupModel(QObject* parent)
     : AbstractElementPopupModel(PopupModelType::TYPE_TEXT, parent)
     , m_elementRepositoryService{std::make_unique<ElementRepositoryService>()}
-    , m_textSettingsModel(new TextSettingsModel(this, m_elementRepositoryService.get(), /*isTextLineText*/ false))
 {
 }
 
@@ -40,7 +39,7 @@ void TextStylePopupModel::classBegin()
 {
     AbstractElementPopupModel::init();
 
-    m_textSettingsModel->classBegin();
+    m_textSettingsModel = new TextSettingsModel(this, iocContext(), m_elementRepositoryService.get(), /*isTextLineText*/ false);
     m_textSettingsModel->init();
 
     m_elementRepositoryService->updateElementList({ m_item }, notation::SelectionState::LIST);


### PR DESCRIPTION
For objects not instantiated in QML but in C++, `classBegin()` is not called.

Resolves: https://github.com/musescore/MuseScore/issues/31846