### PR TITLE
Use correct type in constructor call

### DIFF
--- a/src/framework/global/thirdparty/kors_async/async/channel.h
+++ b/src/framework/global/thirdparty/kors_async/async/channel.h
@@ -103,7 +103,7 @@ public:
     void onClose(const Asyncable* receiver, Func f, Asyncable::Mode mode = Asyncable::Mode::SetOnce)
     {
         if (!m_data->closeCh) {
-            m_data->closeCh = std::make_unique<ChannelImpl<> >(m_data->mainCh.maxThreads());
+            m_data->closeCh = std::make_unique<ChannelImpl<> >(ChannelOpt().threads(m_data->mainCh.maxThreads()));
         }
 
         using CloseCall = std::function<void ()>;


### PR DESCRIPTION
Fixes compilation error in Audacity

<!-- Add a short description of and motivation for the changes here -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [ ] I created a unit test or vtest to verify the changes I made (if applicable)
