### PR TITLE
Wrap text in InspectorPropertyViews (#29972)

### DIFF
--- a/src/inspector/qml/MuseScore/Inspector/common/InspectorPropertyView.qml
+++ b/src/inspector/qml/MuseScore/Inspector/common/InspectorPropertyView.qml
@@ -109,6 +109,9 @@ Column {
 
                     text: root.titleText
                     horizontalAlignment: Text.AlignLeft
+
+                    wrapMode: Text.Wrap
+                    maximumLineCount: 2
                 }
             }
         }


### PR DESCRIPTION
Most of our controls/components (for example `VisibilityBox.qml`) specify a `wrapMode` and `maximumLineCount`. We should also do this for the labels in `InspectorPropertyViews`:

<img width="301" height="291" alt="Screenshot 2026-01-22 at 10 09 21" src="https://github.com/user-attachments/assets/13447bc6-232c-420d-9fbb-f1582ef44ed5" />

...

While this PR brings `InspectorPropertyViews` in-line with our other components, it doesn't address the general (somewhat rare) problem where title text exceeds 2 lines (the value we normally give to `maximumLineCount`). This is why #29972 recommends adding tooltips for truncated text, which we can address separately.