### PR TITLE
Fix #31733: Ensure grips are updated visually when tabbing

### DIFF
--- a/src/notation/internal/notationinteraction.cpp
+++ b/src/notation/internal/notationinteraction.cpp
@@ -4466,12 +4466,14 @@ bool NotationInteraction::handleKeyPress(QKeyEvent* event)
             return false;
         }
         editElem->nextGrip(m_editData);
+        notifyAboutNotationChanged();
         return true;
     case Qt::Key_Backtab:
         if (!editElem->hasGrips()) {
             return false;
         }
         editElem->prevGrip(m_editData);
+        notifyAboutNotationChanged();
         return true;
     case Qt::Key_Left:
         m_editData.delta = PointF(-nudgeDistance(m_editData, hRaster), 0);


### PR DESCRIPTION
Resolves: #31733

Caused by #31460 - changes to the control flow in that PR mean that `apply()` no longer gets a call. It was actually a bit overkill to use `apply()` for these cases because this would also notify about an undo stack change (even though nothing has changed in that regard). Instead we can simply use `notifyAboutNotationChanged()` to trigger a visual update.