### PR TITLE
Preserve all "lyric-language" and "lyric-font" elements in score

### DIFF
--- a/src/engraving/dom/textbase.h
+++ b/src/engraving/dom/textbase.h
@@ -316,6 +316,8 @@ public:
     void setPlainText(const String& t) { setXmlText(plainToXmlText(t)); }
     virtual void setXmlText(const String&);
     void setXmlText(const char* str) { setXmlText(String::fromUtf8(str)); }
+    void setLanguage(String s) { m_language = s; }
+    String language() const { return m_language; }
     void checkCustomFormatting(const String&);
     String xmlText() const;
     String plainText() const;
@@ -561,7 +563,7 @@ private:
 
     String m_text;                          // cached
     bool m_textInvalid = true;
-
+    String m_language = String(u"default");
     TextStyleType m_textStyleType = TextStyleType::DEFAULT;           // text style id
 
     int m_hexState = -1;

--- a/src/engraving/rw/write/writer.cpp
+++ b/src/engraving/rw/write/writer.cpp
@@ -174,7 +174,9 @@ void Writer::write(Score* score, XmlWriter& xml, WriteContext& ctx, compat::Writ
     for (const auto& t : score->m_metaTags) {
         // do not output "platform" and "creationDate" in test and save template mode
         if ((!MScore::testMode && !MScore::saveTemplateMode) || (t.first != "platform" && t.first != "creationDate")) {
-            xml.tag("metaTag", { { "name", t.first.toXmlEscaped() } }, t.second);
+            if (!t.first.contains(String(u"lyric-"))) {
+                xml.tag("metaTag", { { "name", t.first.toXmlEscaped() } }, t.second);
+            }
         }
     }
 

--- a/src/importexport/musicxml/internal/import/importmusicxmlpass1.cpp
+++ b/src/importexport/musicxml/internal/import/importmusicxmlpass1.cpp
@@ -1958,11 +1958,19 @@ void MusicXmlParserPass1::defaults()
 
     double millimeter = m_score->style().spatium() / 10.0;
     double tenths = 1.0;
-    String lyricFontFamily;
-    String lyricFontSize;
     String wordFontFamily;
     String wordFontSize;
-
+    String lyricFontFamily;
+    String lyricFontSize;
+    String lyricFontName;
+    String lyricFontNumber;
+    String lyricLanguage;
+    String lyricLangName;
+    String lyricLangNumber;
+    int lyricNameFontIndex   = 0;
+    int lyricNumberFontIndex = 0;
+    int lyricNameLangIndex   = 0;
+    int lyricNumberLangIndex = 0;
     bool isImportLayout = musicXmlImportLayout();
 
     while (m_e.readNextStartElement()) {
@@ -2065,16 +2073,48 @@ void MusicXmlParserPass1::defaults()
             wordFontFamily = m_e.attribute("font-family");
             wordFontSize = m_e.attribute("font-size");
             m_e.skipCurrentElement();
-        } else if (m_e.name() == "lyric-font") {
-            lyricFontFamily = m_e.attribute("font-family");
-            lyricFontSize = m_e.attribute("font-size");
-            m_e.skipCurrentElement();
-        } else if (m_e.name() == "lyric-language") {
-            m_e.skipCurrentElement();        // skip but don't log
+        } else if (m_e.name() == "lyric-font") { // Save the name and index number of the different Lyric Fonts
+            lyricFontFamily = m_e.attribute("font-family"); // Last one is default? Hopefully when this is done, we won't use default!
+            lyricFontSize = m_e.attribute("font-size");     // Last one is default?
+            // get name and number!
+            lyricFontName = m_e.attribute("name");
+            if (!lyricFontName.empty()) {
+                lyricNameFontIndex++;
+                m_score->setMetaTag(String(u"lyric-font-family%1").arg(lyricNameFontIndex), lyricFontFamily);
+                m_score->setMetaTag(String(u"lyric-font-size%1").arg(lyricNameFontIndex), lyricFontSize);
+                m_score->setMetaTag(String(u"lyric-font-name%1").arg(lyricNameFontIndex), lyricFontName);
+            }
+            lyricFontNumber = m_e.attribute("number");
+            if (!lyricFontNumber.empty()) {
+                lyricNumberFontIndex++;
+                m_score->setMetaTag(String(u"lyric-font-number%1").arg(lyricNumberFontIndex), lyricFontNumber);
+            }
+            m_e.skipCurrentElement();        // There should be no more arguments to skip!
+        } else if (m_e.name() == "lyric-language") { // Save the name and index number of the Lyric Family
+            lyricLanguage = m_e.attribute("xml:lang");
+            // get name and number!
+            lyricLangName = m_e.attribute("name");
+            if (!lyricLangName.empty()) {
+                lyricNameLangIndex++;
+                m_score->setMetaTag(String(u"lyric-language%1").arg(lyricNameLangIndex), lyricLanguage);
+                m_score->setMetaTag(String(u"lyric-lang-name%1").arg(lyricNameLangIndex), lyricLangName);
+            }
+            lyricLangNumber = m_e.attribute("number");
+            if (!lyricLangNumber.empty()) {
+                lyricNumberLangIndex++;
+                m_score->setMetaTag(String(u"lyric-lang-number%1").arg(lyricNumberLangIndex), lyricLangNumber);
+            }
+            m_e.skipCurrentElement();        // skip but don't log - there should be no more arguments to skip!
         } else {
             skipLogCurrElem();
         }
     }
+
+    // Save how many different languages the lyrics can be displayed in.
+    m_score->setMetaTag(String(u"lyric-name-font-count"), String(u"%1").arg(lyricNameFontIndex));
+    m_score->setMetaTag(String(u"lyric-number-font-count"), String(u"%1").arg(lyricNumberFontIndex));
+    m_score->setMetaTag(String(u"lyric-name-lang-count"), String(u"%1").arg(lyricNameLangIndex));
+    m_score->setMetaTag(String(u"lyric-number-lang-count"), String(u"%1").arg(lyricNumberLangIndex));
 
     /*
     LOGD("word font family '%s' size '%s' lyric font family '%s' size '%s'",


### PR DESCRIPTION
Until now, Musescore would ignore the musicxml element "lyric-language". If that element existed in the score, upon saving the file in Musescore, the element would disappear. If you had multiple "lyric-language" and "lyric-font" elements for multiple languages, only the last "lyric-font" element would remain and become the default font for all your lyrics without the "name" and "number" attributes, and all the former "lyric-font" elements as well as all "lyric-language" elements would not be saved. In this first batch of changes, I do not modify the UI. I only retain all the "lyric-language" and "lyric-font" elements when the musicXML file is saved so unmodified lyric data will not be lost.

MusicXML is designed with the ability to save with the same score, lyrics in multiple languages. The software then can display and/or modify the lyrics of any chosen language. The "lyric-language" elements define each included language giving them a unique "name" attribute. The "lyric-font" elements define which fonts are used for which languages based on the corresponding "name" attribute. Alternatively the "lyric-font" element can assign lines of verse to different fonts based on the "number" attribute. (not implemented)

The "Lyric" element did not preserve the "name" attribute in MuseScore. It will now save the "name" attribute of "lyric" elements in musicXML. It will continue to display all lyric text for "lyric" elements with "print-object" attribute NOT set to "No".

Each line of lyric text will now use the proper font for it's language ("name" atribute) if set.

Resolves: #NNNNN <!-- https://w3c.github.io/musicxml/musicxml-reference/elements/lyric-font/) -->

<!-- I use scores that have lyrics in multiple languages, MuseScore is not yet compatible with MusicXML -->

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
