### PR TITLE
When searching, select on same staff index as note input cursor

### DIFF
--- a/src/notationscene/qml/MuseScore/NotationScene/searchpopupmodel.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/searchpopupmodel.cpp
@@ -46,7 +46,7 @@ void SearchPopupModel::search(const QString& text)
 
     std::vector<EngravingItem*> elements = notation->elements()->search(text);
     if (!elements.empty()) {
-        NoteInputState inputState = notation->interaction()->noteInput()->state();
+        const NoteInputState& inputState = notation->interaction()->noteInput()->state();
         notation->interaction()->select(elements, elements.size() == 1 ? SelectType::SINGLE : SelectType::RANGE,
                                         inputState.isValid() ? inputState.staffIdx() : 0);
         notation->interaction()->showItem(elements.front());


### PR DESCRIPTION
Resolves: #29410  <!-- Replace `NNNNN` with a GitHub issue number, or a direct link if the issue is not on GitHub -->

<!-- Add a short description of and motivation for the changes here -->
Previously, searching with Ctrl-F would select a measure, rehearsal mark, or page number, always that measure in the first staff (or the rehearsal mark itself, or whole page); this change selects the measure in the staff where the note input cursor currently is, for convenience when editing various measures in large scores.  Behavior when selecting a rehearsal mark or a page is unchanged for simplicity, though chains of methods from either object could be lead to a measure (or some other object in a staff).

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
