### PR TITLE
Enable transposing chord symbols by default

### DIFF
--- a/src/notationscene/widgets/transposedialog.h
+++ b/src/notationscene/widgets/transposedialog.h
@@ -42,7 +42,7 @@ struct TransposeDialogState {
     int diatonicIntervalIdx = 0;
     bool keepDegreeAlterationsChecked = true;
     bool needTransposeKeysChecked = true;
-    bool needTransposeChordNamesChecked = false;
+    bool needTransposeChordNamesChecked = true;
     int needTransposeDoubleSharpsFlatsIdx = 1;
 };
 


### PR DESCRIPTION
"Transpose chord symbols and fretboard diagrams" should be checked by default
<img width="480" height="617" alt="Screenshot 2026-01-28 at 10 39 39" src="https://github.com/user-attachments/assets/cf96bec6-d239-4103-b923-e75d08dfc6ca" />

