### PR TITLE
CLI. Score meta. Added tracks info to meta

### DIFF
--- a/src/converter/internal/compat/notationmeta.h
+++ b/src/converter/internal/compat/notationmeta.h
@@ -45,6 +45,7 @@ private:
     static QJsonArray partsJsonArray(const mu::engraving::Score* score);
     static QJsonObject pageFormatJson(const mu::engraving::MStyle& style);
     static QJsonObject typeDataJson(mu::engraving::Score* score);
+    static QJsonArray tracksJsonArray(notation::INotationPtr notation, const mu::engraving::Score* score);
 };
 }
 

--- a/src/framework/audio/common/audiotypes.h
+++ b/src/framework/audio/common/audiotypes.h
@@ -175,6 +175,14 @@ enum class AudioResourceType {
     AudioUnit,
 };
 
+static const std::map<AudioResourceType, QString> RESOURCE_TYPE_MAP = {
+    { AudioResourceType::Undefined, "undefined" },
+    { AudioResourceType::MuseSamplerSoundPack, "muse_sampler_sound_pack" },
+    { AudioResourceType::FluidSoundfont, "fluid_soundfont" },
+    { AudioResourceType::VstPlugin, "vst_plugin" },
+    { AudioResourceType::MusePlugin, "muse_plugin" },
+};
+
 struct AudioResourceMeta {
     AudioResourceId id;
     AudioResourceVendor vendor;

--- a/src/framework/audio/common/audioutils.h
+++ b/src/framework/audio/common/audioutils.h
@@ -38,6 +38,17 @@ inline AudioResourceMeta makeReverbMeta()
     return meta;
 }
 
+inline String audioResourceTypeToString(const AudioResourceType& type)
+{
+    auto search = RESOURCE_TYPE_MAP.find(type);
+
+    if (search != RESOURCE_TYPE_MAP.end()) {
+        return search->second;
+    }
+
+    return RESOURCE_TYPE_MAP.at(AudioResourceType::Undefined);
+}
+
 inline String audioSourceName(const AudioInputParams& params)
 {
     if (params.type() == AudioSourceType::MuseSampler) {

--- a/src/project/internal/projectaudiosettings.cpp
+++ b/src/project/internal/projectaudiosettings.cpp
@@ -28,6 +28,8 @@
 
 #include "types/bytearray.h"
 
+#include "audio/common/audioutils.h"
+
 using namespace mu::project;
 using namespace muse;
 using namespace muse::audio;
@@ -39,14 +41,6 @@ static const std::map<AudioSourceType, QString> SOURCE_TYPE_MAP = {
     { AudioSourceType::MuseSampler, "musesampler" },
     { AudioSourceType::Fluid, "fluid" },
     { AudioSourceType::Vsti, "vsti" }
-};
-
-static const std::map<AudioResourceType, QString> RESOURCE_TYPE_MAP = {
-    { AudioResourceType::Undefined, "undefined" },
-    { AudioResourceType::MuseSamplerSoundPack, "muse_sampler_sound_pack" },
-    { AudioResourceType::FluidSoundfont, "fluid_soundfont" },
-    { AudioResourceType::VstPlugin, "vst_plugin" },
-    { AudioResourceType::MusePlugin, "muse_plugin" },
 };
 
 static void doCompatibilityConversions(AudioResourceMeta& meta)
@@ -522,7 +516,7 @@ QJsonObject ProjectAudioSettings::resourceMetaToJson(const AudioResourceMeta& me
     result.insert("id", QString::fromStdString(meta.id));
     result.insert("hasNativeEditorSupport", meta.hasNativeEditorSupport);
     result.insert("vendor", QString::fromStdString(meta.vendor));
-    result.insert("type", resourceTypeToString(meta.type));
+    result.insert("type", audioResourceTypeToString(meta.type).toQString());
     result.insert("attributes", attributesToJson(meta.attributes));
 
     return result;
@@ -582,17 +576,6 @@ QString ProjectAudioSettings::sourceTypeToString(const AudioSourceType& type) co
     }
 
     return SOURCE_TYPE_MAP.at(AudioSourceType::Undefined);
-}
-
-QString ProjectAudioSettings::resourceTypeToString(const AudioResourceType& type) const
-{
-    auto search = RESOURCE_TYPE_MAP.find(type);
-
-    if (search != RESOURCE_TYPE_MAP.end()) {
-        return search->second;
-    }
-
-    return RESOURCE_TYPE_MAP.at(AudioResourceType::Undefined);
 }
 
 QJsonObject ProjectAudioSettings::buildAuxObject(aux_channel_idx_t index, const AudioOutputParams& params) const

--- a/src/project/internal/projectaudiosettings.h
+++ b/src/project/internal/projectaudiosettings.h
@@ -103,7 +103,6 @@ private:
     muse::audio::AudioResourceType resourceTypeFromString(const QString& string) const;
 
     QString sourceTypeToString(const muse::audio::AudioSourceType& type) const;
-    QString resourceTypeToString(const muse::audio::AudioResourceType& type) const;
 
     QJsonObject buildAuxObject(muse::audio::aux_channel_idx_t index, const muse::audio::AudioOutputParams& params) const;
     QJsonObject buildTrackObject(notation::INotationSoloMuteStatePtr masterSoloMuteStatePtr, const engraving::InstrumentTrackId& id) const;


### PR DESCRIPTION
```
"tracks": [
        {
            "instrumentId": "piccolo",
            "name": "MS Basic",
            "partId": "2",
            "type": "fluid_soundfont"
        },
        {
            "category": "Muse Strings",
            "instrumentId": "flute",
            "name": "Violas",
            "partId": "3",
            "soundId": "93",
            "type": "muse_sampler_sound_pack",
            "vendor": "Muse"
        },
        {
            "instrumentId": "piano",
            "name": "MDrummer",
            "partId": "1",
            "type": "vst_plugin",
            "vendor": "MeldaProduction"
        }
    ]
```