### PR TITLE
Fix #31892: Update notation action enabled states when notation changes

### DIFF
--- a/src/notationscene/internal/notationuiactions.cpp
+++ b/src/notationscene/internal/notationuiactions.cpp
@@ -2778,6 +2778,9 @@ void NotationUiActions::init()
         }
         m_actionCheckedChanged.send(actions);
 
+        m_actionEnabledMap.reserve(actionsList().size());
+        updateActionsEnabled(actionsList());
+
         const INotationInteractionPtr interaction = m_controller->currentNotationInteraction();
 
         if (interaction) {
@@ -2829,11 +2832,6 @@ void NotationUiActions::init()
         }
         m_actionCheckedChanged.send(actions);
     });
-
-    m_actionEnabledMap.reserve(s_actions.size());
-    for (const UiAction& action : s_actions) {
-        m_actionEnabledMap.insert({ action.code, false });
-    }
 }
 
 const UiActionList& NotationUiActions::actionsList() const


### PR DESCRIPTION
Resolves: #31892

Before #30368 there was a call to `notifyAboutContextChanged` whenever the `currentNotationChanged` lambda fired in `UiContextResolver::init` ([here](https://github.com/musescore/MuseScore/blob/5f27a6a2fef7b190b839e13751d4c3afe57458e7/src/context/internal/uicontextresolver.cpp#L90)). This eventually led to our notation action enabled states (incl. undo/redo states) being updated.

This appears to have been lost when we moved everything over to `NotationUiActions::init` - this PR ensures `updateActionsEnabled` is called when the notation changes.