### PR TITLE
Make combinedTemplateSearch() take an Instrument parameter

### DIFF
--- a/src/engraving/dom/instrtemplate.h
+++ b/src/engraving/dom/instrtemplate.h
@@ -177,8 +177,7 @@ extern std::vector<MidiArticulation> midiArticulations;
 extern std::vector<ScoreOrder> instrumentOrders;
 extern void clearInstrumentTemplates();
 extern bool loadInstrumentTemplates(const muse::io::path_t& instrTemplatesPath);
-extern const InstrumentTemplate* combinedTemplateSearch(const String& mxmlId, const String& name, const int transposition, const int bank,
-                                                        const int program);
+extern const InstrumentTemplate* combinedTemplateSearch(const Instrument& instrument);
 extern InstrumentIndex searchTemplateIndexForTrackName(const String& trackName);
 extern InstrumentIndex searchTemplateIndexForId(const String& id);
 extern const InstrumentTemplate* searchTemplate(const String& name);

--- a/src/importexport/musicxml/tests/data/importTie2_ref.mscx
+++ b/src/importexport/musicxml/tests/data/importTie2_ref.mscx
@@ -166,14 +166,14 @@
           </StaffType>
         </Staff>
       <trackName>MusicXML Part</trackName>
-      <Instrument id="grand-piano">
+      <Instrument id="piano">
         <longName>MusicXML Part</longName>
         <trackName>MusicXML Part</trackName>
         <minPitchP>21</minPitchP>
         <maxPitchP>108</maxPitchP>
         <minPitchA>21</minPitchA>
         <maxPitchA>108</maxPitchA>
-        <instrumentId>keyboard.piano.grand</instrumentId>
+        <instrumentId>keyboard.piano</instrumentId>
         <clef staff="2">F</clef>
         <singleNoteDynamics>0</singleNoteDynamics>
         <Articulation>

--- a/src/importexport/musicxml/tests/data/testLyricExtensions_ref.mscx
+++ b/src/importexport/musicxml/tests/data/testLyricExtensions_ref.mscx
@@ -29,14 +29,14 @@
           </StaffType>
         </Staff>
       <trackName>Piano</trackName>
-      <Instrument id="grand-piano">
+      <Instrument id="piano">
         <longName>Piano</longName>
         <trackName>Staff 1</trackName>
         <minPitchP>21</minPitchP>
         <maxPitchP>108</maxPitchP>
         <minPitchA>21</minPitchA>
         <maxPitchA>108</maxPitchA>
-        <instrumentId>keyboard.piano.grand</instrumentId>
+        <instrumentId>keyboard.piano</instrumentId>
         <clef staff="2">F</clef>
         <singleNoteDynamics>0</singleNoteDynamics>
         <Articulation>


### PR DESCRIPTION
This paves the way for the function to be used with other import formats besides MusicXML (e.g. Guitar Pro, MIDI, etc.) for better instrument recognition across the board. This will help me fix the failed tests in PR #31516.

The idea of `combinedTemplateSearch()` is that you can specify different properties of the input `Instrument` depending on what information is available in an imported file, then the function will do the search based on whatever information was provided.

Ideally, it should search in the most efficient way possible while still returning the expected result. But if we're forced to choose, accuracy is more important than performance here because importing is a one-time operation.

I'll apply it to other formats in subsequent PRs, which I have split up for easier review.

**Note:** The logic is easier to follow if you ignore the diff and just look at the new version of the function.

