### PR TITLE
Don't add AppShell module in console app

### DIFF
--- a/src/app/appfactory.cpp
+++ b/src/app/appfactory.cpp
@@ -443,10 +443,6 @@ static void addConsoleModules(std::shared_ptr<ConsoleApp> app)
     app->addModule(new muse::vst::VSTModule());
 #endif
 
-#ifdef MUE_BUILD_APPSHELL_MODULE
-    app->addModule(new mu::appshell::AppShellModule());
-#endif
-
 #ifdef MUSE_MODULE_AUTOBOT
     app->addModule(new muse::autobot::AutobotModule());
 #endif

--- a/src/app/internal/consoleapp.cpp
+++ b/src/app/internal/consoleapp.cpp
@@ -34,10 +34,10 @@
 #include "app_config.h"
 
 #include "log.h"
+#include "settings.h"
 
 using namespace muse;
 using namespace mu::app;
-using namespace mu::appshell;
 using namespace mu::converter;
 
 static std::optional<ConvertTarget> parseTarget(const QMap<CmdOptions::ParamKey, QVariant>& params)
@@ -369,7 +369,7 @@ void ConsoleApp::applyCommandLineOptions(const CmdOptions& options, IApplication
     guitarProConfiguration()->setExperimental(options.guitarPro.experimental);
 #endif
     if (options.app.revertToFactorySettings) {
-        appshellConfiguration()->revertToFactorySettings(options.app.revertToFactorySettings.value());
+        settings()->reset(options.app.revertToFactorySettings.value());
     }
 }
 

--- a/src/app/internal/consoleapp.h
+++ b/src/app/internal/consoleapp.h
@@ -44,7 +44,6 @@
 #include "notation/inotationconfiguration.h"
 #include "project/iprojectconfiguration.h"
 #include "playback/isoundprofilesrepository.h"
-#include "appshell/iappshellconfiguration.h"
 #include "importexport/imagesexport/iimagesexportconfiguration.h"
 #include "importexport/midi/imidiconfiguration.h"
 #include "importexport/audioexport/iaudioexportconfiguration.h"
@@ -56,7 +55,6 @@ namespace mu::app {
 class ConsoleApp : public muse::BaseApplication, public std::enable_shared_from_this<ConsoleApp>
 {
     muse::GlobalInject<muse::ui::IUiConfiguration> uiConfiguration;
-    muse::GlobalInject<appshell::IAppShellConfiguration> appshellConfiguration;
     muse::GlobalInject<notation::INotationConfiguration> notationConfiguration;
     muse::GlobalInject<project::IProjectConfiguration> projectConfiguration;
     muse::GlobalInject<iex::imagesexport::IImagesExportConfiguration> imagesExportConfiguration;

--- a/src/appshell/iappshellconfiguration.h
+++ b/src/appshell/iappshellconfiguration.h
@@ -19,8 +19,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef MU_APPSHELL_IAPPSHELLCONFIGURATION_H
-#define MU_APPSHELL_IAPPSHELLCONFIGURATION_H
+
+#pragma once
 
 #include "modularity/imoduleinterface.h"
 #include "types/ret.h"
@@ -58,8 +58,6 @@ public:
     virtual void setStartupScorePath(const muse::io::path_t& scorePath) = 0;
     virtual muse::async::Notification startupScorePathChanged() const = 0;
 
-    virtual muse::io::path_t userDataPath() const = 0;
-
     virtual std::string handbookUrl() const = 0;
     virtual std::string askForHelpUrl() const = 0;
     virtual std::string accessibilityStatementUrl() const = 0;
@@ -94,5 +92,3 @@ public:
     virtual muse::Ret setSessionProjectsPaths(const muse::io::paths_t& paths) = 0;
 };
 }
-
-#endif // MU_APPSHELL_IAPPSHELLCONFIGURATION_H

--- a/src/appshell/internal/appshellconfiguration.cpp
+++ b/src/appshell/internal/appshellconfiguration.cpp
@@ -173,11 +173,6 @@ async::Notification AppShellConfiguration::startupScorePathChanged() const
     return m_startupScorePathChanged;
 }
 
-muse::io::path_t AppShellConfiguration::userDataPath() const
-{
-    return globalConfiguration()->userDataPath();
-}
-
 std::string AppShellConfiguration::handbookUrl() const
 {
     std::string utm = utmParameters(UTM_MEDIUM_MENU);

--- a/src/appshell/internal/appshellconfiguration.h
+++ b/src/appshell/internal/appshellconfiguration.h
@@ -19,8 +19,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef MU_APPSHELL_APPSHELLCONFIGURATION_H
-#define MU_APPSHELL_APPSHELLCONFIGURATION_H
+
+#pragma once
 
 #include "async/asyncable.h"
 
@@ -77,8 +77,6 @@ public:
     void setStartupScorePath(const muse::io::path_t& scorePath) override;
     muse::async::Notification startupScorePathChanged() const override;
 
-    muse::io::path_t userDataPath() const override;
-
     std::string handbookUrl() const override;
     std::string askForHelpUrl() const override;
     std::string accessibilityStatementUrl() const override;
@@ -133,5 +131,3 @@ private:
     muse::async::Notification m_startupScorePathChanged;
 };
 }
-
-#endif // MU_APPSHELL_APPSHELLCONFIGURATION_H

--- a/src/preferences/qml/MuseScore/Preferences/folderspreferencesmodel.cpp
+++ b/src/preferences/qml/MuseScore/Preferences/folderspreferencesmodel.cpp
@@ -111,7 +111,7 @@ void FoldersPreferencesModel::load()
         {
             FolderType::SoundFonts, muse::qtrc("preferences", "SoundFonts"), pathsToString(
                 audioConfiguration()->userSoundFontDirectories()),
-            configuration()->userDataPath().toQString(), FolderValueType::MultiDirectories
+            globalConfiguration()->userDataPath().toQString(), FolderValueType::MultiDirectories
         },
         {
             FolderType::MusicFonts, muse::qtrc("preferences", "Musical symbol fonts"),
@@ -121,7 +121,7 @@ void FoldersPreferencesModel::load()
 #ifdef MUSE_MODULE_VST
         {
             FolderType::VST3, muse::qtrc("preferences", "VST3"), pathsToString(vstConfiguration()->userVstDirectories()),
-            configuration()->userDataPath().toQString(), FolderValueType::MultiDirectories
+            globalConfiguration()->userDataPath().toQString(), FolderValueType::MultiDirectories
         }
 #endif
     };

--- a/src/preferences/qml/MuseScore/Preferences/folderspreferencesmodel.h
+++ b/src/preferences/qml/MuseScore/Preferences/folderspreferencesmodel.h
@@ -27,6 +27,7 @@
 
 #include "modularity/ioc.h"
 #include "async/asyncable.h"
+#include "iglobalconfiguration.h"
 #include "project/iprojectconfiguration.h"
 #include "notation/inotationconfiguration.h"
 #include "extensions/iextensionsconfiguration.h"
@@ -40,12 +41,12 @@ class FoldersPreferencesModel : public QAbstractListModel, public muse::Injectab
     Q_OBJECT
     QML_ELEMENT;
 
+    muse::GlobalInject<muse::IGlobalConfiguration> globalConfiguration;
     muse::GlobalInject<project::IProjectConfiguration> projectConfiguration;
     muse::GlobalInject<notation::INotationConfiguration> notationConfiguration;
     muse::GlobalInject<muse::extensions::IExtensionsConfiguration> extensionsConfiguration;
     muse::GlobalInject<muse::audio::IAudioConfiguration> audioConfiguration;
     muse::GlobalInject<muse::vst::IVstConfiguration> vstConfiguration;
-    muse::GlobalInject<appshell::IAppShellConfiguration> configuration;
 
 public:
     explicit FoldersPreferencesModel(QObject* parent = nullptr);


### PR DESCRIPTION
There is no good reason to have it in console mode, but the direct trigger to make this change now was a crash that occurred on deinitialisation in console mode because `SessionsManager::deinit` uses `multiwindowsProvider()` which uses something that is not initialised in non-gui mode.