### PR TITLE
EditStyle QML pages: extend group boxes to full page width

### DIFF
--- a/src/framework/uicomponents/qml/Muse/UiComponents/StyledGroupBox.qml
+++ b/src/framework/uicomponents/qml/Muse/UiComponents/StyledGroupBox.qml
@@ -19,6 +19,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import QtQuick.Controls
 
@@ -36,7 +39,6 @@ GroupBox {
            ? root.topInset + root.implicitLabelHeight + root.spacing
            : root.topInset
 
-        width: parent.width
         height: root.height - y
 
         color: ui.theme.backgroundPrimaryColor
@@ -44,24 +46,13 @@ GroupBox {
         radius: 3
     }
 
-    label: Loader {
-        sourceComponent: root.title ? titleLabel : emptyLabel
-    }
-
-    Component {
-        id: titleLabel
-        StyledTextLabel {
-            x: root.leftInset
-            y: root.topInset
-            width: root.availableWidth
-            text: root.title
-            horizontalAlignment: Text.AlignLeft
-            elide: Text.ElideRight
-        }
-    }
-
-    Component {
-        id: emptyLabel
-        Item {}
+    label: StyledTextLabel {
+        visible: !isEmpty
+        x: root.leftInset
+        y: root.topInset
+        width: Math.min(root.availableWidth, implicitWidth)
+        text: root.title
+        horizontalAlignment: Text.AlignLeft
+        elide: Text.ElideRight
     }
 }

--- a/src/notationscene/qml/MuseScore/NotationScene/styledialog/AccidentalsPage.qml
+++ b/src/notationscene/qml/MuseScore/NotationScene/styledialog/AccidentalsPage.qml
@@ -28,7 +28,7 @@ import Muse.UiComponents
 StyledFlickable {
     id: root
 
-    contentWidth: contentLayout.implicitWidth
+    contentWidth: Math.max(contentLayout.implicitWidth, root.width)
     contentHeight: contentLayout.implicitHeight
 
     AccidentalsPageModel {
@@ -37,7 +37,7 @@ StyledFlickable {
 
     ColumnLayout {
         id: contentLayout
-        anchors.fill: parent
+        width: parent.width
         spacing: 12
 
         StyledGroupBox {

--- a/src/notationscene/qml/MuseScore/NotationScene/styledialog/BeamsPage.qml
+++ b/src/notationscene/qml/MuseScore/NotationScene/styledialog/BeamsPage.qml
@@ -40,8 +40,7 @@ StyleDialogPage {
         title: qsTrc("notation", "Beam distance")
 
         RadioButtonGroup {
-            width: 224
-            height: 70
+            Layout.preferredHeight: 70
             spacing: 12
 
             model: [
@@ -87,7 +86,7 @@ StyleDialogPage {
         title: qsTrc("notation", "Beam thickness")
 
         IncrementalPropertyControl {
-            width: 106
+            Layout.preferredWidth: 106
 
             currentValue: beamsPageModel.beamWidth.value
 
@@ -107,7 +106,7 @@ StyleDialogPage {
         title: qsTrc("notation", "Broken beam minimum length")
 
         IncrementalPropertyControl {
-            width: 106
+            Layout.preferredWidth: 106
 
             currentValue: beamsPageModel.beamMinLen.value
 

--- a/src/notationscene/qml/MuseScore/NotationScene/styledialog/BendsPage.qml
+++ b/src/notationscene/qml/MuseScore/NotationScene/styledialog/BendsPage.qml
@@ -20,17 +20,17 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.15
+import QtQuick
 import QtQuick.Layouts
 
-import MuseScore.NotationScene 1.0
+import Muse.Ui
 import Muse.UiComponents
-import Muse.Ui 1.0
+import MuseScore.NotationScene
 
 StyledFlickable {
     id: root
 
-    contentWidth: content.implicitWidth
+    contentWidth: Math.max(content.implicitWidth, root.width)
     contentHeight: content.implicitHeight
 
     signal goToTextStylePage(string s)
@@ -41,6 +41,7 @@ StyledFlickable {
 
     ColumnLayout {
         id: content
+        width: parent.width
         spacing: 12
 
         StyledGroupBox {

--- a/src/notationscene/qml/MuseScore/NotationScene/styledialog/ChordSymbolsPage.qml
+++ b/src/notationscene/qml/MuseScore/NotationScene/styledialog/ChordSymbolsPage.qml
@@ -33,8 +33,8 @@ import MuseScore.NotationScene
 StyledFlickable {
     id: root
 
-    contentWidth: column.width
-    contentHeight: column.height
+    contentWidth: Math.max(column.implicitWidth, root.width)
+    contentHeight: column.implicitHeight
 
     ChordSymbolsPageModel {
         id: chordSymbolsModel
@@ -110,6 +110,7 @@ StyledFlickable {
 
     ColumnLayout {
         id: column
+        width: parent.width
         spacing: 12
 
         StyledGroupBox {

--- a/src/notationscene/qml/MuseScore/NotationScene/styledialog/ClefKeyTimeSigPage.qml
+++ b/src/notationscene/qml/MuseScore/NotationScene/styledialog/ClefKeyTimeSigPage.qml
@@ -33,8 +33,8 @@ import MuseScore.NotationScene
 StyledFlickable {
     id: root
 
-    contentWidth: column.width
-    contentHeight: column.height
+    contentWidth: Math.max(column.implicitWidth, root.width)
+    contentHeight: column.implicitHeight
 
     ClefKeyTimeSigPageModel {
         id: pageModel
@@ -69,6 +69,7 @@ StyledFlickable {
 
     ColumnLayout {
         id: column
+        width: parent.width
         spacing: 12
 
         StyledGroupBox {
@@ -556,8 +557,8 @@ StyledFlickable {
 
                     Layout.row: 0
                     Layout.column: 0
-                    Layout.maximumWidth: 232
                     Layout.preferredWidth: 232
+                    Layout.fillWidth: true
 
                     checked: gridLayout.showStyleItem.value === true
                     onToggled: {

--- a/src/notationscene/qml/MuseScore/NotationScene/styledialog/FretboardsPage.qml
+++ b/src/notationscene/qml/MuseScore/NotationScene/styledialog/FretboardsPage.qml
@@ -30,7 +30,7 @@ import MuseScore.NotationScene
 StyledFlickable {
     id: root
 
-    contentWidth: groupBox.implicitWidth
+    contentWidth: Math.max(groupBox.implicitWidth, root.width)
     contentHeight: groupBox.implicitHeight
 
     readonly property real controlAreaWidth: 204
@@ -43,7 +43,7 @@ StyledFlickable {
 
     StyledGroupBox {
         id: groupBox
-        anchors.fill: parent
+        width: parent.width
 
         title: qsTrc("notation", "Fretboard diagrams")
 

--- a/src/notationscene/qml/MuseScore/NotationScene/styledialog/HammerOnPullOffTappingPage.qml
+++ b/src/notationscene/qml/MuseScore/NotationScene/styledialog/HammerOnPullOffTappingPage.qml
@@ -35,8 +35,8 @@ StyledFlickable {
 
     signal goToTextStylePage(string s)
 
-    contentWidth: column.width
-    contentHeight: column.height
+    contentWidth: Math.max(column.implicitWidth, root.width)
+    contentHeight: column.implicitHeight
 
     HammerOnPullOffTappingPageModel {
         id: hopoPage
@@ -44,6 +44,7 @@ StyledFlickable {
 
     ColumnLayout {
         id: column
+        width: parent.width
         spacing: 12
 
         StyledGroupBox {

--- a/src/notationscene/qml/MuseScore/NotationScene/styledialog/ItemWithTitle.qml
+++ b/src/notationscene/qml/MuseScore/NotationScene/styledialog/ItemWithTitle.qml
@@ -20,20 +20,20 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 import QtQuick
+import QtQuick.Layouts
 
 import Muse.Ui
 import Muse.UiComponents
 import MuseScore.NotationScene
 
-Column {
-    width: parent.width
+ColumnLayout {
     spacing: 8
 
     property alias title: titleLabel.text
 
     StyledTextLabel {
         id: titleLabel
-        width: parent.width
+        Layout.fillWidth: true
         horizontalAlignment: Text.AlignLeft
     }
 }

--- a/src/notationscene/qml/MuseScore/NotationScene/styledialog/MeasureNumbersPage.qml
+++ b/src/notationscene/qml/MuseScore/NotationScene/styledialog/MeasureNumbersPage.qml
@@ -35,8 +35,8 @@ StyledFlickable {
 
     signal goToTextStylePage(int index)
 
-    contentWidth: column.width
-    contentHeight: column.height
+    contentWidth: Math.max(column.implicitWidth, root.width)
+    contentHeight: column.implicitHeight
 
     MeasureNumbersPageModel {
         id: barNumbersModel
@@ -44,6 +44,7 @@ StyledFlickable {
 
     ColumnLayout {
         id: column
+        width: parent.width
         spacing: 12
 
         StyledGroupBox {

--- a/src/notationscene/qml/MuseScore/NotationScene/styledialog/SlursAndTiesPage.qml
+++ b/src/notationscene/qml/MuseScore/NotationScene/styledialog/SlursAndTiesPage.qml
@@ -28,7 +28,7 @@ import Muse.UiComponents
 StyledFlickable {
     id: root
 
-    contentWidth: contentLayout.implicitWidth
+    contentWidth: Math.max(contentLayout.implicitWidth, root.width)
     contentHeight: contentLayout.implicitHeight
 
     SlursAndTiesPageModel {

--- a/src/notationscene/qml/MuseScore/NotationScene/styledialog/VoltasPage.qml
+++ b/src/notationscene/qml/MuseScore/NotationScene/styledialog/VoltasPage.qml
@@ -30,7 +30,7 @@ StyledFlickable {
     id: root
 
     contentWidth: Math.max(column.implicitWidth, width)
-    contentHeight: column.height
+    contentHeight: column.implicitHeight
 
     VoltasPageModel {
         id: voltasPage


### PR DESCRIPTION
Changes like in `StyledGroupBox` are because the `implicitWith` of a Loader can only increase, not decrease, so when the window is not scrollable and then you make it wider and smaller again, it unexpectedly becomes scrollable. Simplest solution is to avoid Loader, since it isn’t really necessary anyway.

Resolves: https://github.com/musescore/MuseScore/issues/30541
Closes https://github.com/musescore/MuseScore/pull/30547

Before:
<img width="1084" height="982" alt="Scherm­afbeelding 2026-01-29 om 14 47 25" src="https://github.com/user-attachments/assets/102f05a2-388a-4848-b722-2af5f097525c" />

After:
<img width="1084" height="982" alt="Scherm­afbeelding 2026-01-29 om 14 53 19" src="https://github.com/user-attachments/assets/a9142cb2-b631-42f3-bf15-ea955c4f3cf7" />

QA: pages should still properly become horizontally scrollable when there is not enough horizontal space (for example when the dialog has been resized or the left column is made very wide). Also, there should be no unexpected visual changes, such as increased width of random components. Affected pages:
* Accidentals
* Beams
* Bends
* Chord symbols
* Clef/key/time signatures
* Fretboards
* Hammer on/…
* Measure numbers
* Slurs and ties
* Voltas