### PR TITLE
Instruments: Small fixes to Timple and Guzheng

### DIFF
--- a/share/instruments/instruments.xml
+++ b/share/instruments/instruments.xml
@@ -352,6 +352,9 @@
       <Family id="lauds">
             <name>Laúds</name>
       </Family>
+      <Family id="timples">
+            <name>Timples</name>
+      </Family>
       <Family id="strings">
             <name>Strings</name>
       </Family>
@@ -15375,12 +15378,13 @@
                   <longName>Guzheng</longName>
                   <shortName>Gz.</shortName>
                   <description>Chinese plucked half-tube zither.</description>
-                  <musicXMLid>pluck.guzhen</musicXMLid>
+                  <musicXMLid>pluck.guzheng</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
                   <aPitchRange>38-86</aPitchRange>
                   <pPitchRange>38-86</pPitchRange>
                   <singleNoteDynamics>0</singleNoteDynamics>
+                  <glissandoStyle>portamento</glissandoStyle>
                   <Channel>
                         <!--MIDI: Bank 0, Prog 107; MS General: Koto-->
                         <program value="107"/> <!--Koto-->
@@ -15694,12 +15698,12 @@
                   <genre>popular</genre>
             </Instrument>
             <Instrument id="timple-canario">
-                  <family>guitars</family>
-                  <trackName>Timple Canario</trackName>
-                  <longName>Timple Canario</longName>
+                  <family>timples</family>
+                  <trackName>Canarian Timple</trackName>
+                  <longName>Timple</longName>
                   <shortName>Timpl.</shortName>
-                  <description>Small Spanish 5-string guitar (staff notation).</description>
-                  <musicXMLid>pluck.guitar</musicXMLid>
+                  <description>Small 5-string guitar originating in the Canary Islands. Like a ukulele with a high C string (re-entrant) and an added D string. (Staff notation).</description>
+                  <musicXMLid>pluck.timple</musicXMLid>
                   <StringData>
                         <frets>18</frets>
                         <string>67</string>
@@ -15713,15 +15717,21 @@
                   <aPitchRange>64-86</aPitchRange>
                   <pPitchRange>64-92</pPitchRange>
                   <singleNoteDynamics>0</singleNoteDynamics>
+                  <glissandoStyle>portamento</glissandoStyle>
+                  <Channel>
+                        <!--MIDI: Bank 8, Prog 24; MS General: Ukulele-->
+                        <controller ctrl="32" value="8"/> <!--Bank LSB-->
+                        <program value="24"/> <!--Acoustic Guitar (nylon)-->
+                  </Channel>
                   <genre>world</genre>
             </Instrument>
             <Instrument id="timple-canario-tablature">
                   <init>timple-canario</init>
-                  <family>guitars</family>
-                  <trackName>Timple Canario (tablature)</trackName>
-                  <longName>Timple Canario</longName>
-                  <description>Small Spanish 5-string guitar (tablature).</description>
-                  <musicXMLid>pluck.guitar</musicXMLid>
+                  <family>timples</family>
+                  <trackName>Canarian Timple (tablature)</trackName>
+                  <longName>Timple</longName>
+                  <description>Small 5-string guitar originating in the Canary Islands. Like a ukulele with a high C string (re-entrant) and an added D string. (Tablature).</description>
+                  <musicXMLid>pluck.timple</musicXMLid>
                   <stafftype staffTypePreset="tab5StrSimple">tablature</stafftype>
                   <genre>world</genre>
             </Instrument>

--- a/share/instruments/instrumentsxml.h
+++ b/share/instruments/instrumentsxml.h
@@ -183,6 +183,7 @@ QT_TRANSLATE_NOOP("engraving/instruments/family", "Mtn. Dulcimers"),
 QT_TRANSLATE_NOOP("engraving/instruments/family", "Lutes"),
 QT_TRANSLATE_NOOP("engraving/instruments/family", "Balalaikas"),
 QT_TRANSLATE_NOOP("engraving/instruments/family", "Bouzoukis"),
+QT_TRANSLATE_NOOP("engraving/instruments/family", "Guzhengs"),
 QT_TRANSLATE_NOOP("engraving/instruments/family", "Kotos"),
 QT_TRANSLATE_NOOP("engraving/instruments/family", "Ouds"),
 QT_TRANSLATE_NOOP("engraving/instruments/family", "Shamisens"),
@@ -190,6 +191,7 @@ QT_TRANSLATE_NOOP("engraving/instruments/family", "Sitars"),
 QT_TRANSLATE_NOOP("engraving/instruments/family", "Tamburicas"),
 QT_TRANSLATE_NOOP("engraving/instruments/family", "Bandurrias"),
 QT_TRANSLATE_NOOP("engraving/instruments/family", "Laúds"),
+QT_TRANSLATE_NOOP("engraving/instruments/family", "Timples"),
 QT_TRANSLATE_NOOP("engraving/instruments/family", "Strings"),
 QT_TRANSLATE_NOOP("engraving/instruments/family", "Orchestral Strings"),
 QT_TRANSLATE_NOOP("engraving/instruments/family", "Viols"),
@@ -6279,21 +6281,21 @@ QT_TRANSLATE_NOOP3("engraving/instruments", "Laúd (tablature)", "laud-tablature
 //: longName for Laúd (tablature); Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
 QT_TRANSLATE_NOOP3("engraving/instruments", "Laúd", "laud-tablature longName"),
 
-//: description for Timple Canario; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
-QT_TRANSLATE_NOOP3("engraving/instruments", "Small Spanish 5-string guitar (staff notation).", "timple-canario description"),
-//: trackName for Timple Canario; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
-QT_TRANSLATE_NOOP3("engraving/instruments", "Timple Canario", "timple-canario trackName"),
-//: longName for Timple Canario; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
-QT_TRANSLATE_NOOP3("engraving/instruments", "Timple Canario", "timple-canario longName"),
-//: shortName for Timple Canario; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
+//: description for Canarian Timple; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
+QT_TRANSLATE_NOOP3("engraving/instruments", "Small 5-string guitar originating in the Canary Islands. Like a ukulele with a high C string (re-entrant) and an added D string. (Staff notation).", "timple-canario description"),
+//: trackName for Canarian Timple; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
+QT_TRANSLATE_NOOP3("engraving/instruments", "Canarian Timple", "timple-canario trackName"),
+//: longName for Canarian Timple; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
+QT_TRANSLATE_NOOP3("engraving/instruments", "Timple", "timple-canario longName"),
+//: shortName for Canarian Timple; Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
 QT_TRANSLATE_NOOP3("engraving/instruments", "Timpl.", "timple-canario shortName"),
 
-//: description for Timple Canario (tablature); Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
-QT_TRANSLATE_NOOP3("engraving/instruments", "Small Spanish 5-string guitar (tablature).", "timple-canario-tablature description"),
-//: trackName for Timple Canario (tablature); Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
-QT_TRANSLATE_NOOP3("engraving/instruments", "Timple Canario (tablature)", "timple-canario-tablature trackName"),
-//: longName for Timple Canario (tablature); Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
-QT_TRANSLATE_NOOP3("engraving/instruments", "Timple Canario", "timple-canario-tablature longName"),
+//: description for Canarian Timple (tablature); Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
+QT_TRANSLATE_NOOP3("engraving/instruments", "Small 5-string guitar originating in the Canary Islands. Like a ukulele with a high C string (re-entrant) and an added D string. (Tablature).", "timple-canario-tablature description"),
+//: trackName for Canarian Timple (tablature); Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
+QT_TRANSLATE_NOOP3("engraving/instruments", "Canarian Timple (tablature)", "timple-canario-tablature trackName"),
+//: longName for Canarian Timple (tablature); Please see https://github.com/musescore/MuseScore/wiki/Translating-instrument-names
+QT_TRANSLATE_NOOP3("engraving/instruments", "Timple", "timple-canario-tablature longName"),
 
 // Strings - Bowed
 QT_TRANSLATE_NOOP("engraving/instruments/group", "Strings - Bowed"),


### PR DESCRIPTION
The Timple now shows as "Canarian Timple" in the Instruments dialog. This is the English way to write "Timple Canario".

In the score it just says "Timple" because that's what it's called on the [Wikipedia page](https://en.wikipedia.org/wiki/Timple). There is no non-Canarian Timple as far as I'm aware.

The description fits with room for translation. (At some point I'd like to make descriptions scrollable or dynamically steal space from the columns above when needed.)

<img width="1036" height="664" alt="Image" src="https://github.com/user-attachments/assets/4d7e1201-538f-45e7-944c-229c933ede67" />