### PR TITLE
Speed up score writing a bit

### DIFF
--- a/src/engraving/infrastructure/mscwriter.cpp
+++ b/src/engraving/infrastructure/mscwriter.cpp
@@ -262,22 +262,18 @@ void MscWriter::Meta::addFile(const String& file)
 MscWriter::ZipFileWriter::~ZipFileWriter()
 {
     delete m_zip;
-    if (m_selfDeviceOwner) {
-        delete m_device;
-    }
 }
 
-Ret MscWriter::ZipFileWriter::open(io::IODevice* device, const path_t& filePath)
+Ret MscWriter::ZipFileWriter::open(io::IODevice* device, const path_t&)
 {
-    m_device = device;
-    if (!m_device) {
-        m_device = new File(filePath);
-        m_selfDeviceOwner = true;
+    IF_ASSERT_FAILED(device) {
+        return make_ret(Ret::Code::InternalError);
     }
+    m_device = device;
 
     if (!m_device->isOpen()) {
         if (!m_device->open(IODevice::WriteOnly)) {
-            LOGE() << "failed open file: " << filePath;
+            LOGE() << "failed to open device for writing";
             return make_ret(m_device->error(), m_device->errorString());
         }
     }
@@ -325,10 +321,9 @@ bool MscWriter::ZipFileWriter::addFileData(const String& fileName, const ByteArr
 
 Ret MscWriter::DirWriter::open(io::IODevice* device, const muse::io::path_t& filePath)
 {
-    if (device) {
-        NOT_SUPPORTED;
+    IF_ASSERT_FAILED(!device) {
         m_hasError = true;
-        return false;
+        return make_ret(Ret::Code::InternalError);
     }
 
     if (filePath.empty()) {
@@ -404,22 +399,18 @@ bool MscWriter::DirWriter::addFileData(const String& fileName, const ByteArray& 
 MscWriter::XmlFileWriter::~XmlFileWriter()
 {
     delete m_stream;
-    if (m_selfDeviceOwner) {
-        delete m_device;
-    }
 }
 
-Ret MscWriter::XmlFileWriter::open(io::IODevice* device, const path_t& filePath)
+Ret MscWriter::XmlFileWriter::open(io::IODevice* device, const path_t&)
 {
-    m_device = device;
-    if (!m_device) {
-        m_device = new File(filePath);
-        m_selfDeviceOwner = true;
+    IF_ASSERT_FAILED(device) {
+        return make_ret(Ret::Code::InternalError);
     }
+    m_device = device;
 
     if (!m_device->isOpen()) {
         if (!m_device->open(IODevice::WriteOnly)) {
-            LOGE() << "failed open file: " << filePath;
+            LOGE() << "failed to open device for writing";
             return make_ret(m_device->error(), m_device->errorString());
         }
     }

--- a/src/engraving/infrastructure/mscwriter.h
+++ b/src/engraving/infrastructure/mscwriter.h
@@ -92,7 +92,6 @@ private:
 
     private:
         muse::io::IODevice* m_device = nullptr;
-        bool m_selfDeviceOwner = false;
         muse::ZipWriter* m_zip = nullptr;
     };
 
@@ -118,7 +117,6 @@ private:
         bool addFileData(const muse::String& fileName, const muse::ByteArray& data) override;
     private:
         muse::io::IODevice* m_device = nullptr;
-        bool m_selfDeviceOwner = false;
         muse::TextStream* m_stream = nullptr;
     };
 


### PR DESCRIPTION
Resolves: #28288 
This was also the root cause of #31128

The `File` class has the undesirable property, that it writes to the underlying file on disk each time `IODevice::write` is invoked. This is resolved by using a `Buffer` as io-device and writing the file once via the `IFileSystem` interface.

This PR only touches score writing. Other uses of the File class when writing have the same issue.

Writing large Beethoven 9th score: before: 7.3s, after: 6.8s

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
