### PR TITLE
Tweak note input cursor to avoid overlapping previous segment

### DIFF
--- a/src/notationscene/qml/MuseScore/NotationScene/noteinputcursor.cpp
+++ b/src/notationscene/qml/MuseScore/NotationScene/noteinputcursor.cpp
@@ -54,7 +54,7 @@ void NoteInputCursor::paint(muse::draw::Painter* painter)
 
     const StaffType* staffType = state.staff()->staffType(state.tick());
     const double spatium = staffType->spatium();
-    const int leftLineWidth = 0.15 * spatium;
+    const int leftLineWidth = 0.14 * spatium;
 
     const RectF leftLine(cursorRect.topLeft().x(), cursorRect.topLeft().y(), leftLineWidth, cursorRect.height());
     const Color lineColor = fillColor;


### PR DESCRIPTION
Resolves: https://github.com/musescore/MuseScore/issues/31551