### PR TITLE
Fix size of some indicator icons in scores with modified spatium

### DIFF
--- a/src/engraving/dom/indicatoricon.cpp
+++ b/src/engraving/dom/indicatoricon.cpp
@@ -36,6 +36,6 @@ IndicatorIcon::IndicatorIcon(const ElementType& type, System* parent, ElementFla
 Font IndicatorIcon::font() const
 {
     Font font(configuration()->iconsFontFamily(), Font::Type::Icon);
-    font.setPointSizeF(UI_ICONS_DEFAULT_FONT_SIZE);
+    font.setPointSizeF(UI_ICONS_DEFAULT_FONT_SIZE * magS());
     return font;
 }

--- a/src/engraving/dom/layoutbreak.cpp
+++ b/src/engraving/dom/layoutbreak.cpp
@@ -259,9 +259,7 @@ void LayoutBreak::removed()
 Font LayoutBreak::font() const
 {
     Font font(configuration()->iconsFontFamily(), Font::Type::Icon);
-    static constexpr double STANDARD_POINT_SIZE = 12.0;
-    double scaling = spatium() / defaultSpatium();
-    font.setPointSizeF(STANDARD_POINT_SIZE * scaling);
+    font.setPointSizeF(UI_ICONS_DEFAULT_FONT_SIZE * magS());
     return font;
 }
 }

--- a/src/engraving/dom/soundflag.cpp
+++ b/src/engraving/dom/soundflag.cpp
@@ -228,7 +228,9 @@ char16_t SoundFlag::iconCode() const
 
 Font SoundFlag::iconFont() const
 {
-    return m_iconFont;
+    Font font = m_iconFont;
+    font.setPointSizeF(UI_ICONS_DEFAULT_FONT_SIZE * magS());
+    return font;
 }
 
 Color SoundFlag::iconBackgroundColor() const

--- a/src/engraving/rendering/score/tdraw.cpp
+++ b/src/engraving/rendering/score/tdraw.cpp
@@ -2865,24 +2865,21 @@ void TDraw::draw(const StringTunings* item, Painter* painter, const PaintOptions
     if (item->noStringVisible()) {
         const TextBase::LayoutData* data = item->ldata();
 
-        double spatium = item->spatium();
-        double lineWidth = spatium * .15;
+        const double spatium = item->spatium();
+        const double lineWidth = spatium * .15;
 
-        Pen pen(item->curColor(opt), lineWidth, PenStyle::SolidLine, PenCapStyle::RoundCap, PenJoinStyle::RoundJoin);
+        const Pen pen(item->curColor(opt), lineWidth, PenStyle::SolidLine, PenCapStyle::RoundCap, PenJoinStyle::RoundJoin);
         painter->setPen(pen);
         painter->setBrush(Brush(item->curColor(opt)));
 
-        Font f(item->font());
-        painter->setFont(f);
+        const RectF rect = data->bbox();
 
-        RectF rect = data->bbox();
-
-        double x = rect.x();
-        double y = rect.y();
-        double width = rect.width();
-        double height = rect.height();
-        double topPartHeight = height * .66;
-        double cornerRadius = 8.0;
+        const double x = rect.x();
+        const double y = rect.y();
+        const double width = rect.width();
+        const double height = rect.height();
+        const double topPartHeight = height * .66;
+        const double cornerRadius = height * .1;
 
         PainterPath path;
         path.moveTo(x, y);

--- a/src/engraving/rendering/score/tlayout.cpp
+++ b/src/engraving/rendering/score/tlayout.cpp
@@ -5298,8 +5298,8 @@ void TLayout::layoutStringTunings(StringTunings* item, LayoutContext& ctx)
         Font font(item->font());
 
         RectF rect;
-        rect.setTopLeft({ 0, item->ldata()->bbox().y() - font.weight() - spatium * .15 });
-        rect.setSize({ font.weight() - spatium, (font.weight() - spatium * .35) * 1.5 });
+        rect.setTopLeft({ 0, item->ldata()->bbox().y() - 2.5 * spatium });
+        rect.setSize({ spatium, 2.5 * spatium });
 
         item->setbbox(rect);
     }


### PR DESCRIPTION
Including the tuning fork icon for empty StringTunings elements.

Resolves: https://github.com/musescore/MuseScore/issues/31699

Note: I have not been able to test all cases, especially because sound flags don’t work in (local) debug builds.