### PR TITLE
Fix bug on pitched instrument change

### DIFF
--- a/src/engraving/dom/engravingitem.cpp
+++ b/src/engraving/dom/engravingitem.cpp
@@ -448,7 +448,7 @@ track_idx_t EngravingItem::track() const
 
 void EngravingItem::setTrack(track_idx_t val)
 {
-    IF_ASSERT_FAILED(val < m_score->ntracks() || val == 0 || val == muse::nidx) {
+    IF_ASSERT_FAILED(val < m_score->ntracks() || val == 0 || val == muse::nidx || m_score->isPaletteScore()) {
         // Zero and muse::nidx have special use cases.
         // In all other cases the track can't be larger than the total track count.
         return;

--- a/src/engraving/dom/score.cpp
+++ b/src/engraving/dom/score.cpp
@@ -1684,8 +1684,6 @@ void Score::removeElement(EngravingItem* element)
     }
     break;
     case ElementType::INSTRUMENT_CHANGE: {
-        InstrumentChange* ic = toInstrumentChange(element);
-        ic->part()->removeInstrument(ic->segment()->tick());
         addLayoutFlags(LayoutFlag::REBUILD_MIDI_MAPPING);
         cmdState().instrumentsChanged = true;
     }

--- a/src/engraving/dom/segment.cpp
+++ b/src/engraving/dom/segment.cpp
@@ -945,9 +945,11 @@ void Segment::remove(EngravingItem* el)
 
     case ElementType::INSTRUMENT_CHANGE:
     {
-        InstrumentChange* is = toInstrumentChange(el);
-        Part* part = is->part();
-        part->removeInstrument(tick());
+        if (!isMMRestSegment()) {
+            InstrumentChange* is = toInstrumentChange(el);
+            Part* part = is->part();
+            part->removeInstrument(tick());
+        }
     }
         removeAnnotation(el);
         break;


### PR DESCRIPTION
Resolves: #31903 

Entering the note caused the MMRest to be removed from the part score, and with it a copy of the InstrumentChange text got removed too, which in turn caused the Instrument to be deleted from the InstrumentList of the part hence the new notes were now picking up the wrong instrument.