### PR TITLE
Fix incorrect missing plugin detection for certain plugin types

### DIFF
--- a/src/framework/audioplugins/internal/registeraudiopluginsscenario.h
+++ b/src/framework/audioplugins/internal/registeraudiopluginsscenario.h
@@ -27,7 +27,6 @@
 #include "global/iglobalconfiguration.h"
 #include "global/iinteractive.h"
 #include "global/async/asyncable.h"
-#include "global/io/ifilesystem.h"
 
 #include "../iregisteraudiopluginsscenario.h"
 #include "../iknownaudiopluginsregister.h"
@@ -40,7 +39,6 @@ class RegisterAudioPluginsScenario : public IRegisterAudioPluginsScenario, publi
 public:
     GlobalInject<IGlobalConfiguration> globalConfiguration;
     GlobalInject<IProcess> process;
-    GlobalInject<io::IFileSystem> fileSystem;
     ContextInject<IKnownAudioPluginsRegister> knownPluginsRegister = { this };
     ContextInject<IAudioPluginsScannerRegister> scannerRegister = { this };
     ContextInject<IAudioPluginMetaReaderRegister> metaReaderRegister = { this };
@@ -52,15 +50,16 @@ public:
 
     void init();
 
-    io::paths_t scanForNewPluginPaths() const override;
+    PluginScanResult scanPlugins() const override;
 
-    Ret updatePluginsRegistry(io::paths_t newPluginPaths = {}) override;
+    Ret updatePluginsRegistry() override;
+    void registerNewPlugins(const io::paths_t& pluginPaths) override;
+    Ret unregisterRemovedPlugins(const audio::AudioResourceIdList& pluginIds) override;
+
     Ret registerPlugin(const io::path_t& pluginPath) override;
     Ret registerFailedPlugin(const io::path_t& pluginPath, int failCode) override;
 
 private:
-    Ret unregisterUninstalledPlugins();
-
     void processPluginsRegistration(const io::paths_t& pluginPaths);
     IAudioPluginMetaReaderPtr metaReader(const io::path_t& pluginPath) const;
     audio::AudioResourceType metaType(const io::path_t& pluginPath) const;

--- a/src/framework/audioplugins/iregisteraudiopluginsscenario.h
+++ b/src/framework/audioplugins/iregisteraudiopluginsscenario.h
@@ -26,8 +26,14 @@
 
 #include "global/types/ret.h"
 #include "global/io/path.h"
+#include "audio/common/audiotypes.h"
 
 namespace muse::audioplugins {
+struct PluginScanResult {
+    io::paths_t newPluginPaths;
+    audio::AudioResourceIdList missingPluginIds;
+};
+
 class IRegisterAudioPluginsScenario : MODULE_CONTEXT_INTERFACE
 {
     INTERFACE_ID(IRegisterAudioPluginsScenario)
@@ -35,9 +41,12 @@ class IRegisterAudioPluginsScenario : MODULE_CONTEXT_INTERFACE
 public:
     virtual ~IRegisterAudioPluginsScenario() = default;
 
-    virtual io::paths_t scanForNewPluginPaths() const = 0;
+    virtual PluginScanResult scanPlugins() const = 0;
 
-    virtual Ret updatePluginsRegistry(io::paths_t newPluginPaths = {}) = 0;
+    virtual Ret updatePluginsRegistry() = 0;
+    virtual void registerNewPlugins(const io::paths_t& pluginPaths) = 0;
+    virtual Ret unregisterRemovedPlugins(const audio::AudioResourceIdList& pluginIds) = 0;
+
     virtual Ret registerPlugin(const io::path_t& pluginPath) = 0;
     virtual Ret registerFailedPlugin(const io::path_t& pluginPath, int failCode) = 0;
 };


### PR DESCRIPTION
AudioUnits are using virtual paths, for which filesystem()->exists(path) always returns false

Resolves: https://github.com/audacity/audacity/issues/10301

Instead of checking the file on the filesystem, use the scanner result.

<!-- Replace `[ ]` with `[x]` to fill the checkboxes below -->

- [x] I signed the [CLA](https://musescore.org/en/cla)
- [x] The title of the PR describes the problem it addresses
- [x] Each commit's message describes its purpose and effects, and references the issue it resolves
- [x] If changes are extensive, there is a sequence of easily reviewable commits
- [x] The code in the PR follows [the coding rules](https://github.com/musescore/muse_framework/wiki/CodeGuidelines)
- [x] There are no unnecessary changes
- [x] The code compiles and runs on my machine, preferably after each commit individually
- [x] I created a unit test or vtest to verify the changes I made (if applicable)
